### PR TITLE
New plots for Tracking Workspace (Backport to CMSSW_10_6_X of #27330)

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -1,6 +1,6 @@
 #ifndef TrackAnalyzer_H
 #define TrackAnalyzer_H
-// 
+//
 /**\class TrackingAnalyzer TrackingAnalyzer.cc 
 Monitoring source for general quantities related to tracks.
 */
@@ -31,443 +31,472 @@ Monitoring source for general quantities related to tracks.
 
 class BeamSpot;
 namespace dqm {
-class TrackAnalyzer 
-{
-    public:
-        TrackAnalyzer(const edm::ParameterSet&);
-        TrackAnalyzer(const edm::ParameterSet&, edm::ConsumesCollector& iC);
-        ~TrackAnalyzer();
-        void initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup &, const edm::ParameterSet&);
+  class TrackAnalyzer {
+  public:
+    TrackAnalyzer(const edm::ParameterSet&);
+    TrackAnalyzer(const edm::ParameterSet&, edm::ConsumesCollector& iC);
+    ~TrackAnalyzer();
+    void initHisto(DQMStore::IBooker& ibooker, const edm::EventSetup&, const edm::ParameterSet&);
 
-        void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Track& track);
+    void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Track& track);
 
-        void doSoftReset  (DQMStore * dqmStore_);
-        void doReset      ();
-        void undoSoftReset(DQMStore * dqmStore_);
-        void setLumiFlag();
-        // Compute and locally store the number of Good vertices found
-        // in the event. This information is used as X-axis value in
-        // the hit-efficiency plots derived from the hit patter. This
-        // ugly design to avoid comuting this very same quantity for
-        // each and every track while in the analyze method. A
-        // redesign of the class is needed in the future.
-        void setNumberOfGoodVertices(const edm::Event &);
-        void setBX(const edm::Event &);
-        void setLumi(const edm::Event &, const edm::EventSetup& iSetup);
+    void doSoftReset(DQMStore* dqmStore_);
+    void doReset();
+    void undoSoftReset(DQMStore* dqmStore_);
+    void setLumiFlag();
+    // Compute and locally store the number of Good vertices found
+    // in the event. This information is used as X-axis value in
+    // the hit-efficiency plots derived from the hit patter. This
+    // ugly design to avoid comuting this very same quantity for
+    // each and every track while in the analyze method. A
+    // redesign of the class is needed in the future.
+    void setNumberOfGoodVertices(const edm::Event&);
+    void setBX(const edm::Event&);
+    void setLumi(const edm::Event&, const edm::EventSetup& iSetup);
 
-    private:
-	void initHistos();
-        void fillHistosForState(const edm::EventSetup& iSetup, const reco::Track & track, std::string sname);
-        void bookHistosForState(std::string sname,DQMStore::IBooker & ibooker);
-        void bookHistosForHitProperties(DQMStore::IBooker & ibooker);
-	void bookHistosForLScertification(DQMStore::IBooker & ibooker);
-	void bookHistosForBeamSpot(DQMStore::IBooker & ibooker);
-        void bookHistosForTrackerSpecific(DQMStore::IBooker & ibooker);
-        void bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker &ibooker, const edm::EventSetup & iSetup, const std::string suffix, bool useInac);
-        void fillHistosForHitProperties(const edm::EventSetup& iSetup, const reco::Track & track, std::string sname);
-	void fillHistosForLScertification(const edm::EventSetup& iSetup, const reco::Track & track, std::string sname);
-        void fillHistosForTrackerSpecific(const reco::Track & track);
-        void fillHistosForEfficiencyFromHitPatter(const reco::Track & track, const std::string suffix, const float monitoring,bool useInac);
+  private:
+    void initHistos();
+    void fillHistosForState(const edm::EventSetup& iSetup, const reco::Track& track, std::string sname);
+    void bookHistosForState(std::string sname, DQMStore::IBooker& ibooker);
+    void bookHistosForHitProperties(DQMStore::IBooker& ibooker);
+    void bookHistosForLScertification(DQMStore::IBooker& ibooker);
+    void bookHistosForBeamSpot(DQMStore::IBooker& ibooker);
+    void bookHistosForTrackerSpecific(DQMStore::IBooker& ibooker);
+    void bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker& ibooker,
+                                              const edm::EventSetup& iSetup,
+                                              const std::string suffix,
+                                              bool useInac);
+    void fillHistosForHitProperties(const edm::EventSetup& iSetup, const reco::Track& track, std::string sname);
+    void fillHistosForLScertification(const edm::EventSetup& iSetup, const reco::Track& track, std::string sname);
+    void fillHistosForTrackerSpecific(const reco::Track& track);
+    void fillHistosForEfficiencyFromHitPatter(const reco::Track& track,
+                                              const std::string suffix,
+                                              const float monitoring,
+                                              bool useInac);
 
-        // ----------member data ---------------------------
-	std::string TopFolder_;
+    // ----------member data ---------------------------
+    std::string TopFolder_;
 
-	edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-	edm::EDGetTokenT<reco::VertexCollection> pvToken_;
-	edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
-	edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
-	float lumi_factor_per_bx_;
-	
-        edm::ParameterSet const* conf_;
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+    edm::EDGetTokenT<reco::VertexCollection> pvToken_;
+    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
+    edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+    float lumi_factor_per_bx_;
 
-        std::string stateName_;
+    edm::ParameterSet const* conf_;
 
-        bool doTrackerSpecific_;
-        bool doAllPlots_;
-        bool doBSPlots_;
-        bool doPVPlots_;
-	bool doDCAPlots_;
-	bool doGeneralPropertiesPlots_;
-	bool doMeasurementStatePlots_;
-	bool doHitPropertiesPlots_;
-	bool doRecHitVsPhiVsEtaPerTrack_;
-	bool doRecHitVsPtVsEtaPerTrack_;
-	// ADD by Mia
-	bool doLayersVsPhiVsEtaPerTrack_;
-	bool doTrackRecHitVsPhiVsEtaPerTrack_;
-	bool doTrackRecHitVsPtVsEtaPerTrack_;
-	bool doTrackLayersVsPhiVsEtaPerTrack_;
-	bool doTrack2DChi2Plots_;
-	bool doRecHitsPerTrackProfile_;
-	// ADD by Mia in order to clean the tracking MEs
-	// do not plot *Theta* and TrackPx* and TrackPy*
-	bool doThetaPlots_;
-	bool doTrackPxPyPlots_;
-	// ADD by Mia in order to not plot DistanceOfClosestApproach w.r.t. (0,0,0)
-	// the DistanceOfClosestApproach w.r.t. the beam-spot is already shown in DistanceOfClosestApproachToBS
-	bool doDCAwrtPVPlots_;
-	bool doDCAwrt000Plots_;
+    std::string stateName_;
 
-	bool doLumiAnalysis_;
+    bool doTrackerSpecific_;
+    bool doAllPlots_;
+    bool doBSPlots_;
+    bool doPVPlots_;
+    bool doDCAPlots_;
+    bool doGeneralPropertiesPlots_;
+    bool doMeasurementStatePlots_;
+    bool doHitPropertiesPlots_;
+    bool doRecHitVsPhiVsEtaPerTrack_;
+    bool doRecHitVsPtVsEtaPerTrack_;
+    // ADD by Mia
+    bool doLayersVsPhiVsEtaPerTrack_;
+    bool doTrackRecHitVsPhiVsEtaPerTrack_;
+    bool doTrackRecHitVsPtVsEtaPerTrack_;
+    bool doTrackLayersVsPhiVsEtaPerTrack_;
+    bool doTrack2DChi2Plots_;
+    bool doRecHitsPerTrackProfile_;
+    // ADD by Mia in order to clean the tracking MEs
+    // do not plot *Theta* and TrackPx* and TrackPy*
+    bool doThetaPlots_;
+    bool doTrackPxPyPlots_;
+    // ADD by Mia in order to not plot DistanceOfClosestApproach w.r.t. (0,0,0)
+    // the DistanceOfClosestApproach w.r.t. the beam-spot is already shown in DistanceOfClosestApproachToBS
+    bool doDCAwrtPVPlots_;
+    bool doDCAwrt000Plots_;
 
-	// ADD by Mia in order to turnON test MEs
-	bool doTestPlots_;
+    bool doLumiAnalysis_;
 
-	//For HI Plots
-	bool doHIPlots_;
+    // ADD by Mia in order to turnON test MEs
+    bool doTestPlots_;
 
-        // IP significance plots
-        bool doSIPPlots_;
+    //For HI Plots
+    bool doHIPlots_;
 
-        // Compute the hit-finding efficiency using the HitPattern of
-        // the reconstructed tracks
-        bool doEffFromHitPatternVsPU_;
-        bool doEffFromHitPatternVsBX_;
-        bool doEffFromHitPatternVsLUMI_;
-	int  pvNDOF_;
-	bool  useBPixLayer1_;
-	int   minNumberOfPixelsPerCluster_;
-	float minPixelClusterCharge_;	
-	std::string qualityString_;
-	
-        struct TkParameterMEs {
-	  TkParameterMEs() :
-	    TrackP(nullptr)
-	    , TrackPx(nullptr)
-	    , TrackPy(nullptr)
-	    , TrackPz(nullptr)
-	    , TrackPt(nullptr)
-	    
-	    , TrackPxErr(nullptr)
-	    , TrackPyErr(nullptr)
-	    , TrackPzErr(nullptr)
-	    , TrackPtErr(nullptr)
-	    , TrackPErr(nullptr)
-	    
-	    , TrackPtErrVsEta(nullptr)
-	    
-	    , TrackQ(nullptr)
-	    
-	    , TrackPhi(nullptr)
-	    , TrackEta(nullptr)
-	    , TrackTheta(nullptr)
-	    
-	    , TrackPhiErr(nullptr)
-	    , TrackEtaErr(nullptr)
-	    , TrackThetaErr(nullptr)
-	    
-	    , NumberOfRecHitsPerTrackVsPhi(nullptr)
-	    , NumberOfRecHitsPerTrackVsTheta(nullptr)
-	    , NumberOfRecHitsPerTrackVsEta(nullptr)
-	    , NumberOfRecHitVsPhiVsEtaPerTrack(nullptr)
-	    
-	    , NumberOfValidRecHitsPerTrackVsPhi(nullptr)
-	    , NumberOfValidRecHitsPerTrackVsTheta(nullptr)
-	    , NumberOfValidRecHitsPerTrackVsEta(nullptr)
-	    , NumberOfValidRecHitsPerTrackVsPt(nullptr)
-	    , NumberOfValidRecHitVsPhiVsEtaPerTrack(nullptr)
-	    , NumberOfValidRecHitVsPtVsEtaPerTrack(nullptr)
+    // IP significance plots
+    bool doSIPPlots_;
 
-            , NumberOfLostRecHitsPerTrackVsPhi(nullptr)
-            , NumberOfLostRecHitsPerTrackVsTheta(nullptr)
-            , NumberOfLostRecHitsPerTrackVsEta(nullptr)
-            , NumberOfLostRecHitsPerTrackVsPt(nullptr)
-            , NumberOfLostRecHitVsPhiVsEtaPerTrack(nullptr)
-            , NumberOfLostRecHitVsPtVsEtaPerTrack(nullptr)
+    // Compute the hit-finding efficiency using the HitPattern of
+    // the reconstructed tracks
+    bool doEffFromHitPatternVsPU_;
+    bool doEffFromHitPatternVsBX_;
+    bool doEffFromHitPatternVsLUMI_;
+    int pvNDOF_;
+    bool useBPixLayer1_;
+    int minNumberOfPixelsPerCluster_;
+    float minPixelClusterCharge_;
+    std::string qualityString_;
 
-            , NumberOfMIRecHitsPerTrackVsPhi(nullptr)
-            , NumberOfMIRecHitsPerTrackVsTheta(nullptr)
-            , NumberOfMIRecHitsPerTrackVsEta(nullptr)
-            , NumberOfMIRecHitsPerTrackVsPt(nullptr)
-            , NumberOfMIRecHitVsPhiVsEtaPerTrack(nullptr)
-            , NumberOfMIRecHitVsPtVsEtaPerTrack(nullptr)
+    struct TkParameterMEs {
+      TkParameterMEs()
+          : TrackP(nullptr),
+            TrackPx(nullptr),
+            TrackPy(nullptr),
+            TrackPz(nullptr),
+            TrackPt(nullptr)
 
-            , NumberOfMORecHitsPerTrackVsPhi(nullptr)
-            , NumberOfMORecHitsPerTrackVsTheta(nullptr)
-            , NumberOfMORecHitsPerTrackVsEta(nullptr)
-            , NumberOfMORecHitsPerTrackVsPt(nullptr)
-            , NumberOfMORecHitVsPhiVsEtaPerTrack(nullptr)
-            , NumberOfMORecHitVsPtVsEtaPerTrack(nullptr)
-    
-	    , NumberOfLayersPerTrackVsPhi(nullptr)
-	    , NumberOfLayersPerTrackVsTheta(nullptr)
-	    , NumberOfLayersPerTrackVsEta(nullptr)
+            ,
+            TrackPxErr(nullptr),
+            TrackPyErr(nullptr),
+            TrackPzErr(nullptr),
+            TrackPtErr(nullptr),
+            TrackPErr(nullptr)
 
-            , Chi2oNDFVsNHits(nullptr)
-            , Chi2oNDFVsPt(nullptr)
-	    , Chi2oNDFVsEta(nullptr)
-	    , Chi2oNDFVsPhi(nullptr)
-	    , Chi2oNDFVsTheta(nullptr)
+            ,
+            TrackPtErrVsEta(nullptr)
 
-	    , Chi2ProbVsEta(nullptr)
-	    , Chi2ProbVsPhi(nullptr)
-	    , Chi2ProbVsTheta(nullptr)
-	  {}
-	  
-	  MonitorElement* TrackP;
-	  MonitorElement* TrackPx;
-	  MonitorElement* TrackPy;
-	  MonitorElement* TrackPz;
-	  MonitorElement* TrackPt;
-	  
-	  MonitorElement* TrackPxErr;
-	  MonitorElement* TrackPyErr;
-	  MonitorElement* TrackPzErr;
-	  MonitorElement* TrackPtErr;
-	  MonitorElement* TrackPErr;
-	  
-	  MonitorElement* TrackPtErrVsEta;
-	  
-	  MonitorElement* TrackQ;
-	  
-	  MonitorElement* TrackPhi;
-	  MonitorElement* TrackEta;
-          MonitorElement* TrackEtaPhi=nullptr;
-          MonitorElement* TrackEtaPhiInner=nullptr;
-          MonitorElement* TrackEtaPhiOuter=nullptr;
+            ,
+            TrackQ(nullptr)
 
-	  MonitorElement* TrackTheta;
-	  
-	  MonitorElement* TrackPhiErr;
-	  MonitorElement* TrackEtaErr;
-	  MonitorElement* TrackThetaErr;
-	  
-	  MonitorElement* NumberOfRecHitsPerTrackVsPhi;
-	  MonitorElement* NumberOfRecHitsPerTrackVsTheta;
-	  MonitorElement* NumberOfRecHitsPerTrackVsEta;
-	  MonitorElement* NumberOfRecHitVsPhiVsEtaPerTrack;
-	  
-	  MonitorElement* NumberOfValidRecHitsPerTrackVsPhi;
-	  MonitorElement* NumberOfValidRecHitsPerTrackVsTheta;
-	  MonitorElement* NumberOfValidRecHitsPerTrackVsEta;
-	  MonitorElement* NumberOfValidRecHitsPerTrackVsPt;
-	  MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack;
-	  MonitorElement* NumberOfValidRecHitVsPtVsEtaPerTrack;
+            ,
+            TrackPhi(nullptr),
+            TrackEta(nullptr),
+            TrackTheta(nullptr)
 
-          MonitorElement* NumberOfLostRecHitsPerTrackVsPhi;
-          MonitorElement* NumberOfLostRecHitsPerTrackVsTheta;
-          MonitorElement* NumberOfLostRecHitsPerTrackVsEta;
-          MonitorElement* NumberOfLostRecHitsPerTrackVsPt;
-          MonitorElement* NumberOfLostRecHitVsPhiVsEtaPerTrack;
-          MonitorElement* NumberOfLostRecHitVsPtVsEtaPerTrack;
+            ,
+            TrackPhiErr(nullptr),
+            TrackEtaErr(nullptr),
+            TrackThetaErr(nullptr)
 
-          MonitorElement* NumberOfMIRecHitsPerTrackVsPhi;
-          MonitorElement* NumberOfMIRecHitsPerTrackVsTheta;
-          MonitorElement* NumberOfMIRecHitsPerTrackVsEta;
-          MonitorElement* NumberOfMIRecHitsPerTrackVsPt;
-          MonitorElement* NumberOfMIRecHitVsPhiVsEtaPerTrack;
-          MonitorElement* NumberOfMIRecHitVsPtVsEtaPerTrack;
+            ,
+            NumberOfRecHitsPerTrackVsPhi(nullptr),
+            NumberOfRecHitsPerTrackVsTheta(nullptr),
+            NumberOfRecHitsPerTrackVsEta(nullptr),
+            NumberOfRecHitVsPhiVsEtaPerTrack(nullptr)
 
-          MonitorElement* NumberOfMORecHitsPerTrackVsPhi;
-          MonitorElement* NumberOfMORecHitsPerTrackVsTheta;
-          MonitorElement* NumberOfMORecHitsPerTrackVsEta;
-          MonitorElement* NumberOfMORecHitsPerTrackVsPt;
-          MonitorElement* NumberOfMORecHitVsPhiVsEtaPerTrack;
-          MonitorElement* NumberOfMORecHitVsPtVsEtaPerTrack;
+            ,
+            NumberOfValidRecHitsPerTrackVsPhi(nullptr),
+            NumberOfValidRecHitsPerTrackVsTheta(nullptr),
+            NumberOfValidRecHitsPerTrackVsEta(nullptr),
+            NumberOfValidRecHitsPerTrackVsPt(nullptr),
+            NumberOfValidRecHitVsPhiVsEtaPerTrack(nullptr),
+            NumberOfValidRecHitVsPtVsEtaPerTrack(nullptr)
 
-	  MonitorElement* NumberOfLayersPerTrackVsPhi;
-	  MonitorElement* NumberOfLayersPerTrackVsTheta;
-	  MonitorElement* NumberOfLayersPerTrackVsEta;
+            ,
+            NumberOfLostRecHitsPerTrackVsPhi(nullptr),
+            NumberOfLostRecHitsPerTrackVsTheta(nullptr),
+            NumberOfLostRecHitsPerTrackVsEta(nullptr),
+            NumberOfLostRecHitsPerTrackVsPt(nullptr),
+            NumberOfLostRecHitVsPhiVsEtaPerTrack(nullptr),
+            NumberOfLostRecHitVsPtVsEtaPerTrack(nullptr)
 
-          MonitorElement* Chi2oNDFVsNHits;
-          MonitorElement* Chi2oNDFVsPt;
-	  MonitorElement* Chi2oNDFVsEta;
-	  MonitorElement* Chi2oNDFVsPhi;
-	  MonitorElement* Chi2oNDFVsTheta;
-	  
-	  MonitorElement* Chi2ProbVsEta;
-	  MonitorElement* Chi2ProbVsPhi;
-	  MonitorElement* Chi2ProbVsTheta;
-	
-	};
-        std::map<std::string, TkParameterMEs> TkParameterMEMap;
-	
-	
-	MonitorElement* NumberOfRecHitsPerTrack;
-	MonitorElement* NumberOfValidRecHitsPerTrack;
-	MonitorElement* NumberOfLostRecHitsPerTrack;
-        MonitorElement* NumberOfMIRecHitsPerTrack = nullptr;
-        MonitorElement* NumberOfMORecHitsPerTrack = nullptr;
+            ,
+            NumberOfMIRecHitsPerTrackVsPhi(nullptr),
+            NumberOfMIRecHitsPerTrackVsTheta(nullptr),
+            NumberOfMIRecHitsPerTrackVsEta(nullptr),
+            NumberOfMIRecHitsPerTrackVsPt(nullptr),
+            NumberOfMIRecHitVsPhiVsEtaPerTrack(nullptr),
+            NumberOfMIRecHitVsPtVsEtaPerTrack(nullptr)
 
-	
-	MonitorElement* NumberOfRecHitsPerTrackVsPhi = nullptr;
-	MonitorElement* NumberOfRecHitsPerTrackVsTheta = nullptr;
-	MonitorElement* NumberOfRecHitsPerTrackVsEta = nullptr;
-	MonitorElement* NumberOfRecHitVsPhiVsEtaPerTrack = nullptr;
-	
-	MonitorElement* NumberOfValidRecHitsPerTrackVsPhi = nullptr;
-	MonitorElement* NumberOfValidRecHitsPerTrackVsTheta = nullptr;
-	MonitorElement* NumberOfValidRecHitsPerTrackVsEta = nullptr;
-	MonitorElement* NumberOfValidRecHitsPerTrackVsPt = nullptr;
-	MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack = nullptr;
-	MonitorElement* NumberOfValidRecHitVsPtVsEtaPerTrack = nullptr;
+            ,
+            NumberOfMORecHitsPerTrackVsPhi(nullptr),
+            NumberOfMORecHitsPerTrackVsTheta(nullptr),
+            NumberOfMORecHitsPerTrackVsEta(nullptr),
+            NumberOfMORecHitsPerTrackVsPt(nullptr),
+            NumberOfMORecHitVsPhiVsEtaPerTrack(nullptr),
+            NumberOfMORecHitVsPtVsEtaPerTrack(nullptr)
 
-          MonitorElement* NumberOfLostRecHitsPerTrackVsPhi = nullptr;
-          MonitorElement* NumberOfLostRecHitsPerTrackVsTheta = nullptr;
-          MonitorElement* NumberOfLostRecHitsPerTrackVsEta = nullptr;
-          MonitorElement* NumberOfLostRecHitsPerTrackVsPt = nullptr;
-          MonitorElement* NumberOfLostRecHitVsPhiVsEtaPerTrack = nullptr;
-          MonitorElement* NumberOfLostRecHitVsPtVsEtaPerTrack = nullptr;
+            ,
+            NumberOfLayersPerTrackVsPhi(nullptr),
+            NumberOfLayersPerTrackVsTheta(nullptr),
+            NumberOfLayersPerTrackVsEta(nullptr)
 
-          MonitorElement* NumberOfMIRecHitsPerTrackVsPhi = nullptr;
-          MonitorElement* NumberOfMIRecHitsPerTrackVsTheta = nullptr;
-          MonitorElement* NumberOfMIRecHitsPerTrackVsEta = nullptr;
-          MonitorElement* NumberOfMIRecHitsPerTrackVsPt = nullptr;
-          MonitorElement* NumberOfMIRecHitVsPhiVsEtaPerTrack = nullptr;
-          MonitorElement* NumberOfMIRecHitVsPtVsEtaPerTrack = nullptr;
+            ,
+            Chi2oNDFVsNHits(nullptr),
+            Chi2oNDFVsPt(nullptr),
+            Chi2oNDFVsEta(nullptr),
+            Chi2oNDFVsPhi(nullptr),
+            Chi2oNDFVsTheta(nullptr)
 
-          MonitorElement* NumberOfMORecHitsPerTrackVsPhi = nullptr;
-          MonitorElement* NumberOfMORecHitsPerTrackVsTheta = nullptr;
-          MonitorElement* NumberOfMORecHitsPerTrackVsEta = nullptr;
-          MonitorElement* NumberOfMORecHitsPerTrackVsPt = nullptr;
-          MonitorElement* NumberOfMORecHitVsPhiVsEtaPerTrack = nullptr;
-          MonitorElement* NumberOfMORecHitVsPtVsEtaPerTrack = nullptr;
+            ,
+            Chi2ProbVsEta(nullptr),
+            Chi2ProbVsPhi(nullptr),
+            Chi2ProbVsTheta(nullptr) {}
 
-          MonitorElement* ValidFractionPerTrack = nullptr;
-          MonitorElement* ValidFractionVsPhiVsEtaPerTrack = nullptr;
+      MonitorElement* TrackP;
+      MonitorElement* TrackPx;
+      MonitorElement* TrackPy;
+      MonitorElement* TrackPz;
+      MonitorElement* TrackPt;
+      MonitorElement* TrackPt_NegEta_Phi_btw_neg16_neg32;
+      MonitorElement* TrackPt_NegEta_Phi_btw_0_neg16;
+      MonitorElement* TrackPt_NegEta_Phi_btw_16_0;
+      MonitorElement* TrackPt_NegEta_Phi_btw_32_16;
+      MonitorElement* TrackPt_PosEta_Phi_btw_neg16_neg32;
+      MonitorElement* TrackPt_PosEta_Phi_btw_0_neg16;
+      MonitorElement* TrackPt_PosEta_Phi_btw_16_0;
+      MonitorElement* TrackPt_PosEta_Phi_btw_32_16;
+      MonitorElement* Ratio_byFolding;
+      MonitorElement* Ratio_byFolding2;
+      MonitorElement* TrackPtHighPurity;
+      MonitorElement* TrackPtTight;
+      MonitorElement* TrackPtLoose;
+      MonitorElement* Quality;
 
-	
-	MonitorElement* NumberOfLayersPerTrack[4] = {nullptr,nullptr,nullptr,nullptr};
-	
-	MonitorElement* NumberOfLayersPerTrackVsPhi;
-	MonitorElement* NumberOfLayersPerTrackVsTheta;
-	MonitorElement* NumberOfLayersPerTrackVsEta;
+      MonitorElement* TrackPxErr;
+      MonitorElement* TrackPyErr;
+      MonitorElement* TrackPzErr;
+      MonitorElement* TrackPtErr;
+      MonitorElement* TrackPErr;
 
-	MonitorElement* NumberOfLayersVsPhiVsEtaPerTrack[5]= {nullptr,nullptr,nullptr,nullptr,nullptr};
+      MonitorElement* TrackPtErrVsEta;
 
+      MonitorElement* TrackQ;
+      MonitorElement* TrackQoverP;
 
-	MonitorElement* Chi2;
-	MonitorElement* Chi2Prob;
-	MonitorElement* Chi2oNDF;
+      MonitorElement* TrackPhi;
+      MonitorElement* TrackEta;
+      MonitorElement* TrackEtaHighPurity;
+      MonitorElement* TrackEtaTight;
+      MonitorElement* TrackEtaLoose;
+      MonitorElement* TrackEtaPhi = nullptr;
+      MonitorElement* TrackEtaPhiInverted = nullptr;
+      MonitorElement* TrackEtaPhiInvertedoutofphase = nullptr;
+      MonitorElement* TkEtaPhi_Ratio_byFoldingmap = nullptr;
+      MonitorElement* TkEtaPhi_Ratio_byFoldingmap_op = nullptr;
+      MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap = nullptr;
+      MonitorElement* TkEtaPhi_RelativeDifference_byFoldingmap_op = nullptr;
+      MonitorElement* TrackEtaPhiInner = nullptr;
+      MonitorElement* TrackEtaPhiOuter = nullptr;
 
-        MonitorElement* Chi2oNDFVsNHits = nullptr;
-        MonitorElement* Chi2oNDFVsPt = nullptr;
-	MonitorElement* Chi2oNDFVsEta = nullptr;
-	MonitorElement* Chi2oNDFVsPhi;
-	MonitorElement* Chi2oNDFVsTheta;
-	
-	MonitorElement* Chi2ProbVsEta;
-	MonitorElement* Chi2ProbVsPhi;
-	MonitorElement* Chi2ProbVsTheta;
-	
-	MonitorElement* DistanceOfClosestApproach;
-	MonitorElement* DistanceOfClosestApproachError;
-	MonitorElement* DistanceOfClosestApproachErrorVsPt;
-	MonitorElement* DistanceOfClosestApproachErrorVsEta;
-	MonitorElement* DistanceOfClosestApproachErrorVsPhi;
-	MonitorElement* DistanceOfClosestApproachErrorVsDxy;
-	MonitorElement* DistanceOfClosestApproachToBS;
-	MonitorElement* AbsDistanceOfClosestApproachToBS;
-	MonitorElement* DistanceOfClosestApproachToPV;
-        MonitorElement* DistanceOfClosestApproachToPVZoom;
-	MonitorElement* DeltaZToPV;
-        MonitorElement* DeltaZToPVZoom;
-	MonitorElement* DistanceOfClosestApproachVsTheta;
-	MonitorElement* DistanceOfClosestApproachVsPhi;
-	MonitorElement* DistanceOfClosestApproachToBSVsPhi;
-	MonitorElement* DistanceOfClosestApproachToPVVsPhi;
-	MonitorElement* DistanceOfClosestApproachVsEta;
-	MonitorElement* xPointOfClosestApproach;
-	MonitorElement* xPointOfClosestApproachToPV;
-	MonitorElement* xPointOfClosestApproachVsZ0wrt000;
-	MonitorElement* xPointOfClosestApproachVsZ0wrtBS;
-	MonitorElement* xPointOfClosestApproachVsZ0wrtPV;
-	MonitorElement* yPointOfClosestApproach;
-	MonitorElement* yPointOfClosestApproachToPV;
-	MonitorElement* yPointOfClosestApproachVsZ0wrt000;
-	MonitorElement* yPointOfClosestApproachVsZ0wrtBS;
-	MonitorElement* yPointOfClosestApproachVsZ0wrtPV;
-	MonitorElement* zPointOfClosestApproach;
-	MonitorElement* zPointOfClosestApproachToPV;
-	MonitorElement* zPointOfClosestApproachVsPhi;
-	MonitorElement *algorithm, *oriAlgo;
-	MonitorElement *stoppingSource;
-	MonitorElement *stoppingSourceVSeta;
-	MonitorElement *stoppingSourceVSphi;
-	// TESTING MEs
-	MonitorElement* TESTDistanceOfClosestApproachToBS;
-	MonitorElement* TESTDistanceOfClosestApproachToBSVsPhi;
-	
-	// add by Mia in order to deal w/ LS transitions
-	MonitorElement* Chi2oNDF_lumiFlag;
-	MonitorElement* NumberOfRecHitsPerTrack_lumiFlag;
+      MonitorElement* TrackTheta;
 
-	//new plots for Heavy Ion DQM
-	MonitorElement* LongDCASig;
-	MonitorElement* TransDCASig;
-	MonitorElement* dNdPhi_HighPurity;
-	MonitorElement* dNdEta_HighPurity;
-	MonitorElement* dNdPt_HighPurity;
-	MonitorElement* NhitVsEta_HighPurity;
-	MonitorElement* NhitVsPhi_HighPurity;
-	MonitorElement* Ptdist_HighPurity;
-	MonitorElement* dNhitdPt_HighPurity;
+      MonitorElement* TrackPhiErr;
+      MonitorElement* TrackEtaErr;
+      MonitorElement* TrackThetaErr;
 
-	// IP significance plots
-	MonitorElement *sipDxyToBS;
-	MonitorElement *sipDzToBS;
-	MonitorElement *sip3dToPV;
-	MonitorElement *sip2dToPV;
-	MonitorElement *sipDxyToPV;
-	MonitorElement *sipDzToPV;
-	
-	struct TkRecHitsPerSubDetMEs {
-	  MonitorElement* NumberOfRecHitsPerTrack;
-	  MonitorElement* NumberOfRecHitsPerTrackVsPhi;
-	  MonitorElement* NumberOfRecHitsPerTrackVsEta;
-	  MonitorElement* NumberOfRecHitsPerTrackVsPt;
-	  MonitorElement* NumberOfLayersPerTrack;
-	  MonitorElement* NumberOfLayersPerTrackVsPhi;
-	  MonitorElement* NumberOfLayersPerTrackVsEta;
-	  MonitorElement* NumberOfLayersPerTrackVsPt;
-          MonitorElement* RecHitChi2PerTrack;
-	  
-	  int         detectorId;
-	  std::string detectorTag;
-	};
-        std::map<std::string, TkRecHitsPerSubDetMEs> TkRecHitsPerSubDetMEMap;
-	
-        struct Key {
-          int det;
-          int subdet;
-	  int monitoring;
-          explicit Key(int det, int subdet,int monitoring):det(det),subdet(subdet),monitoring(monitoring){};
-          bool operator==(const Key & other) const {
-            return (det == other.det && subdet == other.subdet && monitoring == other.monitoring);
-          }
-        };
+      MonitorElement* NumberOfRecHitsPerTrackVsPhi;
+      MonitorElement* NumberOfRecHitsPerTrackVsTheta;
+      MonitorElement* NumberOfRecHitsPerTrackVsEta;
+      MonitorElement* NumberOfRecHitVsPhiVsEtaPerTrack;
 
-        struct KeyHasher {
-          std::size_t operator()(const Key& k) const {
-            // 3 bits (0x7) for kind of monitoring (7 kinds at most)
-            // next 8 bits to the subdetector (255 subdetectors at most)
-            // next 8 bits to the detector (255 detectors at most)
-            return (size_t)(
-                (k.monitoring & (0x7)) |
-                ((k.subdet & (0xff)) << 3) |
-                ((k.det & (0xff)) << 11));
-          }
-        };
+      MonitorElement* NumberOfValidRecHitsPerTrackVsPhi;
+      MonitorElement* NumberOfValidRecHitsPerTrackVsTheta;
+      MonitorElement* NumberOfValidRecHitsPerTrackVsEta;
+      MonitorElement* NumberOfValidRecHitsPerTrackVsPt;
+      MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack;
+      MonitorElement* NumberOfValidRecHitVsPtVsEtaPerTrack;
 
-        std::unordered_map<Key, MonitorElement *, KeyHasher> hits_valid_;
-        std::unordered_map<Key, MonitorElement *, KeyHasher> hits_missing_;
-        std::unordered_map<Key, MonitorElement *, KeyHasher> hits_inactive_;
-        std::unordered_map<Key, MonitorElement *, KeyHasher> hits_bad_;
-        std::unordered_map<Key, MonitorElement *, KeyHasher> hits_total_;
-        unsigned int good_vertices_;
-        unsigned int bx_;
-        float pixel_lumi_;
-        float scal_lumi_;
-	enum monQuantity {
-	  VsPU,
-	  VsBX,
-	  VsPIXELLUMI,
-	  VsSCALLUMI,
-	  END
-	};
-	std::string monName[monQuantity::END] = { "", "VsBX", "VsPIXELLUMI", "VsSCALLUMI" };
+      MonitorElement* NumberOfLostRecHitsPerTrackVsPhi;
+      MonitorElement* NumberOfLostRecHitsPerTrackVsTheta;
+      MonitorElement* NumberOfLostRecHitsPerTrackVsEta;
+      MonitorElement* NumberOfLostRecHitsPerTrackVsPt;
+      MonitorElement* NumberOfLostRecHitVsPhiVsEtaPerTrack;
+      MonitorElement* NumberOfLostRecHitVsPtVsEtaPerTrack;
 
-        std::string histname;  //for naming the histograms according to algorithm used
-};
-}
+      MonitorElement* NumberOfMIRecHitsPerTrackVsPhi;
+      MonitorElement* NumberOfMIRecHitsPerTrackVsTheta;
+      MonitorElement* NumberOfMIRecHitsPerTrackVsEta;
+      MonitorElement* NumberOfMIRecHitsPerTrackVsPt;
+      MonitorElement* NumberOfMIRecHitVsPhiVsEtaPerTrack;
+      MonitorElement* NumberOfMIRecHitVsPtVsEtaPerTrack;
+
+      MonitorElement* NumberOfMORecHitsPerTrackVsPhi;
+      MonitorElement* NumberOfMORecHitsPerTrackVsTheta;
+      MonitorElement* NumberOfMORecHitsPerTrackVsEta;
+      MonitorElement* NumberOfMORecHitsPerTrackVsPt;
+      MonitorElement* NumberOfMORecHitVsPhiVsEtaPerTrack;
+      MonitorElement* NumberOfMORecHitVsPtVsEtaPerTrack;
+
+      MonitorElement* NumberOfLayersPerTrackVsPhi;
+      MonitorElement* NumberOfLayersPerTrackVsTheta;
+      MonitorElement* NumberOfLayersPerTrackVsEta;
+
+      MonitorElement* Chi2oNDFVsNHits;
+      MonitorElement* Chi2oNDFVsPt;
+      MonitorElement* Chi2oNDFVsEta;
+      MonitorElement* Chi2oNDFVsPhi;
+      MonitorElement* Chi2oNDFVsTheta;
+
+      MonitorElement* Chi2ProbVsEta;
+      MonitorElement* Chi2ProbVsPhi;
+      MonitorElement* Chi2ProbVsTheta;
+    };
+    std::map<std::string, TkParameterMEs> TkParameterMEMap;
+
+    MonitorElement* NumberOfRecHitsPerTrack;
+    MonitorElement* NumberOfValidRecHitsPerTrack;
+    MonitorElement* NumberOfLostRecHitsPerTrack;
+    MonitorElement* NumberOfMIRecHitsPerTrack = nullptr;
+    MonitorElement* NumberOfMORecHitsPerTrack = nullptr;
+
+    MonitorElement* NumberOfRecHitsPerTrackVsPhi = nullptr;
+    MonitorElement* NumberOfRecHitsPerTrackVsTheta = nullptr;
+    MonitorElement* NumberOfRecHitsPerTrackVsEta = nullptr;
+    MonitorElement* NumberOfRecHitVsPhiVsEtaPerTrack = nullptr;
+
+    MonitorElement* NumberOfValidRecHitsPerTrackVsPhi = nullptr;
+    MonitorElement* NumberOfValidRecHitsPerTrackVsTheta = nullptr;
+    MonitorElement* NumberOfValidRecHitsPerTrackVsEta = nullptr;
+    MonitorElement* NumberOfValidRecHitsPerTrackVsPt = nullptr;
+    MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack = nullptr;
+    MonitorElement* NumberOfValidRecHitVsPtVsEtaPerTrack = nullptr;
+
+    MonitorElement* NumberOfLostRecHitsPerTrackVsPhi = nullptr;
+    MonitorElement* NumberOfLostRecHitsPerTrackVsTheta = nullptr;
+    MonitorElement* NumberOfLostRecHitsPerTrackVsEta = nullptr;
+    MonitorElement* NumberOfLostRecHitsPerTrackVsPt = nullptr;
+    MonitorElement* NumberOfLostRecHitVsPhiVsEtaPerTrack = nullptr;
+    MonitorElement* NumberOfLostRecHitVsPtVsEtaPerTrack = nullptr;
+
+    MonitorElement* NumberOfMIRecHitsPerTrackVsPhi = nullptr;
+    MonitorElement* NumberOfMIRecHitsPerTrackVsTheta = nullptr;
+    MonitorElement* NumberOfMIRecHitsPerTrackVsEta = nullptr;
+    MonitorElement* NumberOfMIRecHitsPerTrackVsPt = nullptr;
+    MonitorElement* NumberOfMIRecHitVsPhiVsEtaPerTrack = nullptr;
+    MonitorElement* NumberOfMIRecHitVsPtVsEtaPerTrack = nullptr;
+
+    MonitorElement* NumberOfMORecHitsPerTrackVsPhi = nullptr;
+    MonitorElement* NumberOfMORecHitsPerTrackVsTheta = nullptr;
+    MonitorElement* NumberOfMORecHitsPerTrackVsEta = nullptr;
+    MonitorElement* NumberOfMORecHitsPerTrackVsPt = nullptr;
+    MonitorElement* NumberOfMORecHitVsPhiVsEtaPerTrack = nullptr;
+    MonitorElement* NumberOfMORecHitVsPtVsEtaPerTrack = nullptr;
+
+    MonitorElement* ValidFractionPerTrack = nullptr;
+    MonitorElement* ValidFractionVsPhiVsEtaPerTrack = nullptr;
+
+    MonitorElement* NumberOfLayersPerTrack[4] = {nullptr, nullptr, nullptr, nullptr};
+
+    MonitorElement* NumberOfLayersPerTrackVsPhi;
+    MonitorElement* NumberOfLayersPerTrackVsTheta;
+    MonitorElement* NumberOfLayersPerTrackVsEta;
+
+    MonitorElement* NumberOfLayersVsPhiVsEtaPerTrack[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+
+    MonitorElement* Chi2;
+    MonitorElement* Chi2Prob;
+    MonitorElement* Chi2oNDF;
+
+    MonitorElement* Chi2oNDFVsNHits = nullptr;
+    MonitorElement* Chi2oNDFVsPt = nullptr;
+    MonitorElement* Chi2oNDFVsEta = nullptr;
+    MonitorElement* Chi2oNDFVsPhi;
+    MonitorElement* Chi2oNDFVsTheta;
+
+    MonitorElement* Chi2ProbVsEta;
+    MonitorElement* Chi2ProbVsPhi;
+    MonitorElement* Chi2ProbVsTheta;
+
+    MonitorElement* DistanceOfClosestApproach;
+    MonitorElement* DistanceOfClosestApproachError;
+    MonitorElement* DistanceOfClosestApproachErrorVsPt;
+    MonitorElement* DistanceOfClosestApproachErrorVsEta;
+    MonitorElement* DistanceOfClosestApproachErrorVsPhi;
+    MonitorElement* DistanceOfClosestApproachErrorVsDxy;
+    MonitorElement* DistanceOfClosestApproachToBS;
+    MonitorElement* DistanceOfClosestApproachToBSdz;
+    MonitorElement* AbsDistanceOfClosestApproachToBS;
+    MonitorElement* DistanceOfClosestApproachToPV;
+    MonitorElement* DistanceOfClosestApproachToPVZoom;
+    MonitorElement* DeltaZToPV;
+    MonitorElement* DeltaZToPVZoom;
+    MonitorElement* DistanceOfClosestApproachVsTheta;
+    MonitorElement* DistanceOfClosestApproachVsPhi;
+    MonitorElement* DistanceOfClosestApproachToBSVsPhi;
+    MonitorElement* DistanceOfClosestApproachToBSVsEta;
+    MonitorElement* DistanceOfClosestApproachToPVVsPhi;
+    MonitorElement* DistanceOfClosestApproachVsEta;
+    MonitorElement* xPointOfClosestApproach;
+    MonitorElement* xPointOfClosestApproachToPV;
+    MonitorElement* xPointOfClosestApproachVsZ0wrt000;
+    MonitorElement* xPointOfClosestApproachVsZ0wrtBS;
+    MonitorElement* xPointOfClosestApproachVsZ0wrtPV;
+    MonitorElement* yPointOfClosestApproach;
+    MonitorElement* yPointOfClosestApproachToPV;
+    MonitorElement* yPointOfClosestApproachVsZ0wrt000;
+    MonitorElement* yPointOfClosestApproachVsZ0wrtBS;
+    MonitorElement* yPointOfClosestApproachVsZ0wrtPV;
+    MonitorElement* zPointOfClosestApproach;
+    MonitorElement* zPointOfClosestApproachToPV;
+    MonitorElement* zPointOfClosestApproachVsPhi;
+    MonitorElement *algorithm, *oriAlgo;
+    MonitorElement* stoppingSource;
+    MonitorElement* stoppingSourceVSeta;
+    MonitorElement* stoppingSourceVSphi;
+    // TESTING MEs
+    MonitorElement* TESTDistanceOfClosestApproachToBS;
+    MonitorElement* TESTDistanceOfClosestApproachToBSVsPhi;
+
+    // add by Mia in order to deal w/ LS transitions
+    MonitorElement* Chi2oNDF_lumiFlag;
+    MonitorElement* NumberOfRecHitsPerTrack_lumiFlag;
+
+    //new plots for Heavy Ion DQM
+    MonitorElement* LongDCASig;
+    MonitorElement* TransDCASig;
+    MonitorElement* dNdPhi_HighPurity;
+    MonitorElement* dNdEta_HighPurity;
+    MonitorElement* dNdPt_HighPurity;
+    MonitorElement* NhitVsEta_HighPurity;
+    MonitorElement* NhitVsPhi_HighPurity;
+    MonitorElement* Ptdist_HighPurity;
+    MonitorElement* dNhitdPt_HighPurity;
+
+    // IP significance plots
+    MonitorElement* sipDxyToBS;
+    MonitorElement* sipDzToBS;
+    MonitorElement* sip3dToPV;
+    MonitorElement* sip2dToPV;
+    MonitorElement* sipDxyToPV;
+    MonitorElement* sipDzToPV;
+
+    struct TkRecHitsPerSubDetMEs {
+      MonitorElement* NumberOfRecHitsPerTrack;
+      MonitorElement* NumberOfRecHitsPerTrackVsPhi;
+      MonitorElement* NumberOfRecHitsPerTrackVsEta;
+      MonitorElement* NumberOfRecHitsPerTrackVsPt;
+      MonitorElement* NumberOfLayersPerTrack;
+      MonitorElement* NumberOfLayersPerTrackVsPhi;
+      MonitorElement* NumberOfLayersPerTrackVsEta;
+      MonitorElement* NumberOfLayersPerTrackVsPt;
+      MonitorElement* RecHitChi2PerTrack;
+
+      int detectorId;
+      std::string detectorTag;
+    };
+    std::map<std::string, TkRecHitsPerSubDetMEs> TkRecHitsPerSubDetMEMap;
+
+    struct Key {
+      int det;
+      int subdet;
+      int monitoring;
+      explicit Key(int det, int subdet, int monitoring) : det(det), subdet(subdet), monitoring(monitoring){};
+      bool operator==(const Key& other) const {
+        return (det == other.det && subdet == other.subdet && monitoring == other.monitoring);
+      }
+    };
+
+    struct KeyHasher {
+      std::size_t operator()(const Key& k) const {
+        // 3 bits (0x7) for kind of monitoring (7 kinds at most)
+        // next 8 bits to the subdetector (255 subdetectors at most)
+        // next 8 bits to the detector (255 detectors at most)
+        return (size_t)((k.monitoring & (0x7)) | ((k.subdet & (0xff)) << 3) | ((k.det & (0xff)) << 11));
+      }
+    };
+
+    std::unordered_map<Key, MonitorElement*, KeyHasher> hits_valid_;
+    std::unordered_map<Key, MonitorElement*, KeyHasher> hits_missing_;
+    std::unordered_map<Key, MonitorElement*, KeyHasher> hits_inactive_;
+    std::unordered_map<Key, MonitorElement*, KeyHasher> hits_bad_;
+    std::unordered_map<Key, MonitorElement*, KeyHasher> hits_total_;
+    unsigned int good_vertices_;
+    unsigned int bx_;
+    float pixel_lumi_;
+    float scal_lumi_;
+    enum monQuantity { VsPU, VsBX, VsPIXELLUMI, VsSCALLUMI, END };
+    std::string monName[monQuantity::END] = {"", "VsBX", "VsPIXELLUMI", "VsSCALLUMI"};
+
+    std::string histname;  //for naming the histograms according to algorithm used
+  };
+}  // namespace dqm
 #endif

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -4,7 +4,7 @@
 //
 // Package:    TrackingMonitor
 // Class:      TrackingMonitor
-// 
+//
 /**\class TrackingMonitor TrackingMonitor.cc DQM/TrackerMonitorTrack/src/TrackingMonitor.cc
 Monitoring source for general quantities related to tracks.
 */
@@ -30,8 +30,8 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h" 
-#include "DataFormats/TrackCandidate/interface/TrackCandidate.h" 
+#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
+#include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
@@ -57,174 +57,173 @@ class GetLumi;
 class TProfile;
 class GenericTriggerEventFlag;
 
-class TrackingMonitor : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElements>
-{
-    public:
-        using MVACollection = std::vector<float>;
-        using QualityMaskCollection = std::vector<unsigned char>;
+class TrackingMonitor : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElements> {
+public:
+  using MVACollection = std::vector<float>;
+  using QualityMaskCollection = std::vector<unsigned char>;
 
-        explicit TrackingMonitor(const edm::ParameterSet&);
-        ~TrackingMonitor() override;
+  explicit TrackingMonitor(const edm::ParameterSet&);
+  ~TrackingMonitor() override;
 
-	virtual void setMaxMinBin(std::vector<double> & ,std::vector<double> &  ,std::vector<int> &  ,double, double, int, double, double, int);
-	virtual void setNclus(const edm::Event&, std::vector<int> & );
+  virtual void setMaxMinBin(
+      std::vector<double>&, std::vector<double>&, std::vector<int>&, double, double, int, double, double, int);
+  virtual void setNclus(const edm::Event&, std::vector<int>&);
 
-        void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&  eSetup) override;
-        void analyze(const edm::Event&, const edm::EventSetup&) override;
-	void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-	//        virtual void beginRun(const edm::Run&, const edm::EventSetup&); 
-        void endRun(const edm::Run&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& eSetup) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  //        virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
 
-    private:
-        void doProfileX(TH2 * th2, MonitorElement* me);
-        void doProfileX(MonitorElement * th2m, MonitorElement* me);
+private:
+  void doProfileX(TH2* th2, MonitorElement* me);
+  void doProfileX(MonitorElement* th2m, MonitorElement* me);
 
+  // ----------member data ---------------------------
 
-        // ----------member data ---------------------------
+  std::string MEFolderName;
+  std::string histname;  //for naming the histograms according to algorithm used
 
-        std::string MEFolderName;
-        std::string histname;  //for naming the histograms according to algorithm used
+  //        DQMStore * dqmStore_;
 
-	//        DQMStore * dqmStore_;
+  edm::ParameterSetID confID_;
 
-        edm::ParameterSetID confID_;
+  // the track analyzer
+  edm::InputTag bsSrc_;
+  edm::InputTag pvSrc_;
+  edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
+  edm::EDGetTokenT<reco::VertexCollection> pvSrcToken_;
 
-        // the track analyzer
-        edm::InputTag bsSrc_;
-	edm::InputTag pvSrc_;
-	edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
-	edm::EDGetTokenT<reco::VertexCollection> pvSrcToken_;
+  edm::EDGetTokenT<edm::View<reco::Track> > allTrackToken_;
+  edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
+  edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
+  edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
+  edm::EDGetTokenT<std::vector<SeedStopInfo> > seedStopInfoToken_;
+  edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
+  edm::EDGetTokenT<TrackingRegionsSeedingLayerSets> regionLayerSetsToken_;
+  edm::EDGetTokenT<reco::CandidateView> regionCandidateToken_;
 
-	edm::EDGetTokenT<edm::View<reco::Track> > allTrackToken_;
-	edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
-	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
-	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
-	edm::EDGetTokenT<std::vector<SeedStopInfo> > seedStopInfoToken_;
-	edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
-	edm::EDGetTokenT<TrackingRegionsSeedingLayerSets> regionLayerSetsToken_;
-	edm::EDGetTokenT<reco::CandidateView> regionCandidateToken_;
+  edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
 
-	edm::EDGetTokenT<LumiScalersCollection>  lumiscalersToken_;	
+  edm::InputTag stripClusterInputTag_;
+  edm::InputTag pixelClusterInputTag_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
 
-	edm::InputTag stripClusterInputTag_;
-	edm::InputTag pixelClusterInputTag_;
-	edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
-	edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
+  std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection> > > mvaQualityTokens_;
+  edm::EDGetTokenT<edm::View<reco::Track> > mvaTrackToken_;
 
-	std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection> > > mvaQualityTokens_;
-	edm::EDGetTokenT<edm::View<reco::Track> > mvaTrackToken_;
+  std::string Quality_;
+  std::string AlgoName_;
 
-	std::string Quality_;
-	std::string AlgoName_;
+  dqm::TrackAnalyzer* theTrackAnalyzer;
+  TrackBuildingAnalyzer* theTrackBuildingAnalyzer;
+  std::vector<VertexMonitor*> theVertexMonitor;
+  GetLumi* theLumiDetails_;
 
+  // Tracks
+  MonitorElement* NumberOfTracks;
+  MonitorElement* NumberOfTracks_PUvtx;
+  MonitorElement* NumberofTracks_Hardvtx;
+  MonitorElement* NumberofTracks_Hardvtx_PUvtx;
+  MonitorElement* NumberOfMeanRecHitsPerTrack;
+  MonitorElement* NumberOfMeanLayersPerTrack;
 
-        dqm::TrackAnalyzer * theTrackAnalyzer;
-        TrackBuildingAnalyzer  * theTrackBuildingAnalyzer;
-	std::vector<VertexMonitor*> theVertexMonitor;
-	GetLumi*                    theLumiDetails_;
+  // Good Tracks
+  MonitorElement* FractionOfGoodTracks;
 
-        // Tracks 
-        MonitorElement * NumberOfTracks;
-        MonitorElement * NumberOfMeanRecHitsPerTrack;
-        MonitorElement * NumberOfMeanLayersPerTrack;  
+  // Tracking regions
+  MonitorElement* NumberOfTrackingRegions;
 
-	// Good Tracks 
-        MonitorElement * FractionOfGoodTracks;
+  // Track Seeds
+  MonitorElement* NumberOfSeeds;
+  MonitorElement* NumberOfSeeds_lumiFlag;
+  std::vector<MonitorElement*> SeedsVsClusters;
+  std::vector<std::string> ClusterLabels;
 
-	// Tracking regions
-	MonitorElement * NumberOfTrackingRegions;
+  // Track Candidates
+  MonitorElement* NumberOfTrackCandidates;
+  MonitorElement* FractionCandidatesOverSeeds;
 
-        // Track Seeds 
-        MonitorElement * NumberOfSeeds;
-        MonitorElement * NumberOfSeeds_lumiFlag;
-	std::vector<MonitorElement *> SeedsVsClusters;
-	std::vector<std::string> ClusterLabels;
+  // Cluster Properties
+  std::vector<MonitorElement*> NumberOfTrkVsClusters;
+  MonitorElement* NumberOfTrkVsClus;
+  MonitorElement* NumberOfTrkVsStripClus;
+  MonitorElement* NumberOfTrkVsPixelClus;
 
+  // Monitoring vs LS
+  MonitorElement* NumberEventsOfVsLS;
+  MonitorElement* NumberOfTracksVsLS;
+  MonitorElement* GoodTracksFractionVsLS;
+  MonitorElement* NumberOfRecHitsPerTrackVsLS;
+  MonitorElement* NumberOfGoodPVtxVsLS;
+  MonitorElement* NumberOfGoodPVtxWO0VsLS;
 
-        // Track Candidates
-        MonitorElement * NumberOfTrackCandidates;
-        MonitorElement * FractionCandidatesOverSeeds;
+  // Monitoring vs BX
+  MonitorElement* NumberEventsOfVsBX;
+  MonitorElement* NumberOfTracksVsBX;
+  MonitorElement* GoodTracksFractionVsBX;
+  MonitorElement* NumberOfRecHitsPerTrackVsBX;
+  MonitorElement* NumberOfGoodPVtxVsBX;
+  MonitorElement* NumberOfGoodPVtxWO0VsBX;
 
-        // Cluster Properties
-	std::vector<MonitorElement*> NumberOfTrkVsClusters;
-        MonitorElement* NumberOfTrkVsClus;
-        MonitorElement* NumberOfTrkVsStripClus;
-        MonitorElement* NumberOfTrkVsPixelClus;
+  MonitorElement* NumberOfTracksVsBXlumi;
 
-	// Monitoring vs LS
-	MonitorElement* NumberEventsOfVsLS;
-	MonitorElement* NumberOfTracksVsLS;
-	MonitorElement* GoodTracksFractionVsLS;
-	MonitorElement* NumberOfRecHitsPerTrackVsLS;
-	MonitorElement* NumberOfGoodPVtxVsLS;
-	MonitorElement* NumberOfGoodPVtxWO0VsLS;
+  // Monitoring PU
+  MonitorElement* NumberOfTracksVsGoodPVtx;
+  MonitorElement* NumberOfTracksVsPUPVtx;
+  MonitorElement* NumberEventsOfVsGoodPVtx;
+  MonitorElement* GoodTracksFractionVsGoodPVtx;
+  MonitorElement* NumberOfRecHitsPerTrackVsGoodPVtx;
+  MonitorElement* NumberOfPVtxVsGoodPVtx;
+  MonitorElement* NumberOfPixelClustersVsGoodPVtx;
+  MonitorElement* NumberOfStripClustersVsGoodPVtx;
 
-	// Monitoring vs BX
-	MonitorElement* NumberEventsOfVsBX;
-	MonitorElement* NumberOfTracksVsBX;
-	MonitorElement* GoodTracksFractionVsBX;
-	MonitorElement* NumberOfRecHitsPerTrackVsBX;
-	MonitorElement* NumberOfGoodPVtxVsBX;
-	MonitorElement* NumberOfGoodPVtxWO0VsBX;
+  // Monitoring vs lumi
+  MonitorElement* NumberEventsOfVsLUMI;
+  MonitorElement* NumberOfTracksVsLUMI;
+  MonitorElement* GoodTracksFractionVsLUMI;
+  MonitorElement* NumberOfRecHitsPerTrackVsLUMI;
+  MonitorElement* NumberOfGoodPVtxVsLUMI;
+  MonitorElement* NumberOfGoodPVtxWO0VsLUMI;
+  MonitorElement* NumberOfPixelClustersVsLUMI;
+  MonitorElement* NumberOfStripClustersVsLUMI;
 
-	MonitorElement* NumberOfTracksVsBXlumi;
+  // add in order to deal with LS transitions
+  MonitorElement* NumberOfTracks_lumiFlag;
 
-	// Monitoring PU
-	MonitorElement *NumberOfTracksVsGoodPVtx;
-	MonitorElement* NumberOfTracksVsPUPVtx;
-	MonitorElement* NumberEventsOfVsGoodPVtx;
-	MonitorElement* GoodTracksFractionVsGoodPVtx;
-	MonitorElement* NumberOfRecHitsPerTrackVsGoodPVtx;
-	MonitorElement* NumberOfPVtxVsGoodPVtx;
-	MonitorElement* NumberOfPixelClustersVsGoodPVtx;
-	MonitorElement* NumberOfStripClustersVsGoodPVtx;
+  std::string builderName;
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
 
-	// Monitoring vs lumi
-	MonitorElement* NumberEventsOfVsLUMI;
-	MonitorElement* NumberOfTracksVsLUMI;
-	MonitorElement* GoodTracksFractionVsLUMI;
-	MonitorElement* NumberOfRecHitsPerTrackVsLUMI;
-	MonitorElement* NumberOfGoodPVtxVsLUMI;
-	MonitorElement* NumberOfGoodPVtxWO0VsLUMI;
-	MonitorElement* NumberOfPixelClustersVsLUMI;
-	MonitorElement* NumberOfStripClustersVsLUMI;
+  bool doTrackerSpecific_;
+  bool doLumiAnalysis;
+  bool doProfilesVsLS_;
+  bool doAllSeedPlots;
+  bool doAllPlots;
+  bool doDCAPlots_;
+  bool doGeneralPropertiesPlots_;
+  bool doHitPropertiesPlots_;
+  bool doTkCandPlots;
+  bool doMVAPlots;
+  bool doRegionPlots;
+  bool doRegionCandidatePlots;
+  bool doSeedNumberPlot;
+  bool doSeedLumiAnalysis_;
+  bool doSeedVsClusterPlot;
+  bool runTrackBuildingAnalyzerForSeed;
+  // ADD by Mia in order to have GoodTrack plots only for collision
+  bool doPUmonitoring_;
+  bool doPlotsVsBXlumi_;
+  bool doPlotsVsGoodPVtx_;
+  bool doPlotsVsLUMI_;
+  bool doPlotsVsBX_;
+  bool doFractionPlot_;
 
-	// add in order to deal with LS transitions
-        MonitorElement * NumberOfTracks_lumiFlag;
+  GenericTriggerEventFlag* genTriggerEventFlag_;
 
-        std::string builderName;
-        edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
- 
-        bool doTrackerSpecific_; 
-        bool doLumiAnalysis;
-	bool doProfilesVsLS_;
-	bool doAllSeedPlots;
-	bool doAllPlots;
-	bool doDCAPlots_;
-	bool doGeneralPropertiesPlots_;
-	bool doHitPropertiesPlots_;
-	bool doTkCandPlots;
-	bool doMVAPlots;
-	bool doRegionPlots;
-	bool doRegionCandidatePlots;
-	bool doSeedNumberPlot;
-	bool doSeedLumiAnalysis_;
-	bool doSeedVsClusterPlot;
-	bool runTrackBuildingAnalyzerForSeed;
-	// ADD by Mia in order to have GoodTrack plots only for collision
-	bool doPUmonitoring_;
-	bool doPlotsVsBXlumi_;
-	bool doPlotsVsGoodPVtx_;
-	bool doPlotsVsLUMI_;
-	bool doPlotsVsBX_;
-	bool doFractionPlot_;
-
-        GenericTriggerEventFlag* genTriggerEventFlag_;
-
-	StringCutObjectSelector<reco::Track,true> numSelection_;
-	StringCutObjectSelector<reco::Track,true> denSelection_;
-	int pvNDOF_;
-
+  StringCutObjectSelector<reco::Track, true> numSelection_;
+  StringCutObjectSelector<reco::Track, true> denSelection_;
+  int pvNDOF_;
 };
 
-#endif //define TrackingMonitor_H
+#endif  //define TrackingMonitor_H

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -25,82 +25,76 @@ using namespace dqm;
 
 namespace {
   template <typename T, size_t N>
-  std::array<T, N+1> makeLogBins(const double min, const double max) {
+  std::array<T, N + 1> makeLogBins(const double min, const double max) {
     const double minLog10 = std::log10(min);
     const double maxLog10 = std::log10(max);
-    const double width = (maxLog10-minLog10)/N;
-    std::array<T, N+1> ret;
-    ret[0] = std::pow(10,minLog10);
+    const double width = (maxLog10 - minLog10) / N;
+    std::array<T, N + 1> ret;
+    ret[0] = std::pow(10, minLog10);
     const double mult = std::pow(10, width);
-    for(size_t i=1; i<= N; ++i) {
-      ret[i] = ret[i-1]*mult;
+    for (size_t i = 1; i <= N; ++i) {
+      ret[i] = ret[i - 1] * mult;
     }
     return ret;
   }
-}
+}  // namespace
 
-TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) 
-    : conf_( nullptr )
-    , stateName_                       (iConfig.getParameter<std::string>("MeasurementState") )
-    , doTrackerSpecific_               ( iConfig.getParameter<bool>("doTrackerSpecific") )
-    , doAllPlots_                      ( iConfig.getParameter<bool>("doAllPlots") )
-    , doBSPlots_                       ( iConfig.getParameter<bool>("doBeamSpotPlots") )
-    , doPVPlots_                       ( iConfig.getParameter<bool>("doPrimaryVertexPlots") )
-    , doDCAPlots_                      ( iConfig.getParameter<bool>("doDCAPlots") )
-    , doGeneralPropertiesPlots_        ( iConfig.getParameter<bool>("doGeneralPropertiesPlots") )
-    , doMeasurementStatePlots_         ( iConfig.getParameter<bool>("doMeasurementStatePlots") )
-    , doHitPropertiesPlots_            ( iConfig.getParameter<bool>("doHitPropertiesPlots") )
-    , doRecHitVsPhiVsEtaPerTrack_      ( iConfig.getParameter<bool>("doRecHitVsPhiVsEtaPerTrack") )
-    , doRecHitVsPtVsEtaPerTrack_       ( iConfig.getParameter<bool>("doRecHitVsPtVsEtaPerTrack") )
-    , doLayersVsPhiVsEtaPerTrack_      ( iConfig.getParameter<bool>("doLayersVsPhiVsEtaPerTrack") )
-    , doRecHitsPerTrackProfile_        ( iConfig.getParameter<bool>("doRecHitsPerTrackProfile") )
-    , doThetaPlots_                    ( iConfig.getParameter<bool>("doThetaPlots") )
-    , doTrackPxPyPlots_                ( iConfig.getParameter<bool>("doTrackPxPyPlots") )
-    , doDCAwrtPVPlots_                 ( iConfig.getParameter<bool>("doDCAwrtPVPlots") )
-    , doDCAwrt000Plots_                ( iConfig.getParameter<bool>("doDCAwrt000Plots") )
-    , doLumiAnalysis_                  ( iConfig.getParameter<bool>("doLumiAnalysis") )
-    , doTestPlots_                     ( iConfig.getParameter<bool>("doTestPlots") )
-    , doHIPlots_                       ( iConfig.getParameter<bool>("doHIPlots")  )
-    , doSIPPlots_                      ( iConfig.getParameter<bool>("doSIPPlots") )
-    , doEffFromHitPatternVsPU_         ( iConfig.getParameter<bool>("doEffFromHitPatternVsPU")   )
-    , doEffFromHitPatternVsBX_         ( iConfig.getParameter<bool>("doEffFromHitPatternVsBX")   )
-    , doEffFromHitPatternVsLUMI_       ( iConfig.getParameter<bool>("doEffFromHitPatternVsLUMI") )
-    , pvNDOF_                          ( iConfig.getParameter<int> ("pvNDOF") )
-    , useBPixLayer1_                   ( iConfig.getParameter<bool>("useBPixLayer1") )
-    , minNumberOfPixelsPerCluster_     ( iConfig.getParameter<int>("minNumberOfPixelsPerCluster") )
-    , minPixelClusterCharge_           ( iConfig.getParameter<double>("minPixelClusterCharge") )
-    , qualityString_                   ( iConfig.getParameter<std::string>("qualityString"))
-    , good_vertices_(0)
-    , bx_(0)
-    , pixel_lumi_(0.)
-    , scal_lumi_(0.)
-{
+TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig)
+    : conf_(nullptr),
+      stateName_(iConfig.getParameter<std::string>("MeasurementState")),
+      doTrackerSpecific_(iConfig.getParameter<bool>("doTrackerSpecific")),
+      doAllPlots_(iConfig.getParameter<bool>("doAllPlots")),
+      doBSPlots_(iConfig.getParameter<bool>("doBeamSpotPlots")),
+      doPVPlots_(iConfig.getParameter<bool>("doPrimaryVertexPlots")),
+      doDCAPlots_(iConfig.getParameter<bool>("doDCAPlots")),
+      doGeneralPropertiesPlots_(iConfig.getParameter<bool>("doGeneralPropertiesPlots")),
+      doMeasurementStatePlots_(iConfig.getParameter<bool>("doMeasurementStatePlots")),
+      doHitPropertiesPlots_(iConfig.getParameter<bool>("doHitPropertiesPlots")),
+      doRecHitVsPhiVsEtaPerTrack_(iConfig.getParameter<bool>("doRecHitVsPhiVsEtaPerTrack")),
+      doRecHitVsPtVsEtaPerTrack_(iConfig.getParameter<bool>("doRecHitVsPtVsEtaPerTrack")),
+      doLayersVsPhiVsEtaPerTrack_(iConfig.getParameter<bool>("doLayersVsPhiVsEtaPerTrack")),
+      doRecHitsPerTrackProfile_(iConfig.getParameter<bool>("doRecHitsPerTrackProfile")),
+      doThetaPlots_(iConfig.getParameter<bool>("doThetaPlots")),
+      doTrackPxPyPlots_(iConfig.getParameter<bool>("doTrackPxPyPlots")),
+      doDCAwrtPVPlots_(iConfig.getParameter<bool>("doDCAwrtPVPlots")),
+      doDCAwrt000Plots_(iConfig.getParameter<bool>("doDCAwrt000Plots")),
+      doLumiAnalysis_(iConfig.getParameter<bool>("doLumiAnalysis")),
+      doTestPlots_(iConfig.getParameter<bool>("doTestPlots")),
+      doHIPlots_(iConfig.getParameter<bool>("doHIPlots")),
+      doSIPPlots_(iConfig.getParameter<bool>("doSIPPlots")),
+      doEffFromHitPatternVsPU_(iConfig.getParameter<bool>("doEffFromHitPatternVsPU")),
+      doEffFromHitPatternVsBX_(iConfig.getParameter<bool>("doEffFromHitPatternVsBX")),
+      doEffFromHitPatternVsLUMI_(iConfig.getParameter<bool>("doEffFromHitPatternVsLUMI")),
+      pvNDOF_(iConfig.getParameter<int>("pvNDOF")),
+      useBPixLayer1_(iConfig.getParameter<bool>("useBPixLayer1")),
+      minNumberOfPixelsPerCluster_(iConfig.getParameter<int>("minNumberOfPixelsPerCluster")),
+      minPixelClusterCharge_(iConfig.getParameter<double>("minPixelClusterCharge")),
+      qualityString_(iConfig.getParameter<std::string>("qualityString")),
+      good_vertices_(0),
+      bx_(0),
+      pixel_lumi_(0.),
+      scal_lumi_(0.) {
   initHistos();
-  TopFolder_ = iConfig.getParameter<std::string>("FolderName"); 
+  TopFolder_ = iConfig.getParameter<std::string>("FolderName");
 }
 
-TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) 
-  : TrackAnalyzer(iConfig)
-{
-  edm::InputTag bsSrc                 = iConfig.getParameter<edm::InputTag>("beamSpot");
+TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : TrackAnalyzer(iConfig) {
+  edm::InputTag bsSrc = iConfig.getParameter<edm::InputTag>("beamSpot");
   edm::InputTag primaryVertexInputTag = iConfig.getParameter<edm::InputTag>("primaryVertex");
-  edm::InputTag pixelClusterInputTag  = iConfig.getParameter<edm::InputTag>("pixelCluster4lumi");
-  edm::InputTag scalInputTag          = iConfig.getParameter<edm::InputTag>("scal");
-  beamSpotToken_      = iC.consumes<reco::BeamSpot>(bsSrc);
-  pvToken_            = iC.consumes<reco::VertexCollection>(primaryVertexInputTag);
+  edm::InputTag pixelClusterInputTag = iConfig.getParameter<edm::InputTag>("pixelCluster4lumi");
+  edm::InputTag scalInputTag = iConfig.getParameter<edm::InputTag>("scal");
+  beamSpotToken_ = iC.consumes<reco::BeamSpot>(bsSrc);
+  pvToken_ = iC.consumes<reco::VertexCollection>(primaryVertexInputTag);
   pixelClustersToken_ = iC.mayConsume<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterInputTag);
-  lumiscalersToken_   = iC.mayConsume<LumiScalersCollection>(scalInputTag);
-  
-  if(useBPixLayer1_) 
-    lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::XSEC_PIXEL_CLUSTER  ;
+  lumiscalersToken_ = iC.mayConsume<LumiScalersCollection>(scalInputTag);
+
+  if (useBPixLayer1_)
+    lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::XSEC_PIXEL_CLUSTER;
   else
-    lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::rXSEC_PIXEL_CLUSTER  ;
-
-
+    lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::rXSEC_PIXEL_CLUSTER;
 }
 
-void TrackAnalyzer::initHistos()
-{
+void TrackAnalyzer::initHistos() {
   Chi2 = nullptr;
   Chi2Prob = nullptr;
   Chi2ProbVsPhi = nullptr;
@@ -109,7 +103,7 @@ void TrackAnalyzer::initHistos()
   Chi2oNDFVsEta = nullptr;
   Chi2oNDFVsPhi = nullptr;
   Chi2oNDFVsTheta = nullptr;
-  	    
+
   NumberOfRecHitsPerTrack = nullptr;
   NumberOfValidRecHitsPerTrack = nullptr;
   NumberOfLostRecHitsPerTrack = nullptr;
@@ -130,14 +124,16 @@ void TrackAnalyzer::initHistos()
   DistanceOfClosestApproachErrorVsPhi = nullptr;
   DistanceOfClosestApproachErrorVsDxy = nullptr;
   DistanceOfClosestApproachToBS = nullptr;
+  DistanceOfClosestApproachToBSdz = nullptr;
   AbsDistanceOfClosestApproachToBS = nullptr;
   DistanceOfClosestApproachToPV = nullptr;
   DistanceOfClosestApproachToPVZoom = nullptr;
   DeltaZToPV = nullptr;
   DeltaZToPVZoom = nullptr;
   DistanceOfClosestApproachVsTheta = nullptr;
-  DistanceOfClosestApproachVsPhi = nullptr;  
+  DistanceOfClosestApproachVsPhi = nullptr;
   DistanceOfClosestApproachToBSVsPhi = nullptr;
+  DistanceOfClosestApproachToBSVsEta = nullptr;
   DistanceOfClosestApproachToPVVsPhi = nullptr;
   DistanceOfClosestApproachVsEta = nullptr;
   xPointOfClosestApproach = nullptr;
@@ -153,17 +149,17 @@ void TrackAnalyzer::initHistos()
   stoppingSource = nullptr;
   stoppingSourceVSeta = nullptr;
   stoppingSourceVSphi = nullptr;
-    // TESTING
+  // TESTING
   TESTDistanceOfClosestApproachToBS = nullptr;
   TESTDistanceOfClosestApproachToBSVsPhi = nullptr;
 
-// by Mia in order to deal w/ LS transitions
+  // by Mia in order to deal w/ LS transitions
   Chi2oNDF_lumiFlag = nullptr;
   NumberOfRecHitsPerTrack_lumiFlag = nullptr;
 
-  ////////////////////////////////////////////////////////////                                                                                                                                             
-  //special Plots for HI DQM  //SHOULD I ADD THE BOOL HERE??                                                                                                                                               
-  ////////////////////////////////////////////////////////////                                                                                                                                             
+  ////////////////////////////////////////////////////////////
+  //special Plots for HI DQM  //SHOULD I ADD THE BOOL HERE??
+  ////////////////////////////////////////////////////////////
   LongDCASig = nullptr;
   TransDCASig = nullptr;
   dNdPhi_HighPurity = nullptr;
@@ -179,45 +175,43 @@ void TrackAnalyzer::initHistos()
   sip2dToPV = nullptr;
   sipDxyToPV = nullptr;
   sipDzToPV = nullptr;
-
 }
 
-TrackAnalyzer::~TrackAnalyzer() 
-{ 
-}
+TrackAnalyzer::~TrackAnalyzer() {}
 
-void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup & iSetup, const edm::ParameterSet& iConfig)
-{
+void TrackAnalyzer::initHisto(DQMStore::IBooker& ibooker,
+                              const edm::EventSetup& iSetup,
+                              const edm::ParameterSet& iConfig) {
   conf_ = &iConfig;
   bookHistosForHitProperties(ibooker);
   bookHistosForBeamSpot(ibooker);
-  bookHistosForLScertification( ibooker);
-  if (doEffFromHitPatternVsPU_   || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "",false);
-  if (doEffFromHitPatternVsBX_   || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsBX",false);
-  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsSCALLUMI",false);
+  bookHistosForLScertification(ibooker);
+  if (doEffFromHitPatternVsPU_ || doAllPlots_)
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "", false);
+  if (doEffFromHitPatternVsBX_ || doAllPlots_)
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsBX", false);
+  if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsSCALLUMI", false);
   //  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsPIXELLUMI");
-  if (doEffFromHitPatternVsPU_   || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "",true);
-  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsSCALLUMI",true);
+  if (doEffFromHitPatternVsPU_ || doAllPlots_)
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "", true);
+  if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsSCALLUMI", true);
 
   // book tracker specific related histograms
   // ---------------------------------------------------------------------------------//
-  if(doTrackerSpecific_ || doAllPlots_) bookHistosForTrackerSpecific(ibooker);
-    
+  if (doTrackerSpecific_ || doAllPlots_)
+    bookHistosForTrackerSpecific(ibooker);
+
   // book state related histograms
   // ---------------------------------------------------------------------------------//
   if (doMeasurementStatePlots_ || doAllPlots_) {
-
-    
     if (stateName_ == "All") {
       bookHistosForState("OuterSurface", ibooker);
       bookHistosForState("InnerSurface", ibooker);
-      bookHistosForState("ImpactPoint" , ibooker);
-    } else if (
-	       stateName_ != "OuterSurface" && 
-	       stateName_ != "InnerSurface" && 
-	       stateName_ != "ImpactPoint" &&
-	       stateName_ != "default" 
-	       ) {
+      bookHistosForState("ImpactPoint", ibooker);
+    } else if (stateName_ != "OuterSurface" && stateName_ != "InnerSurface" && stateName_ != "ImpactPoint" &&
+               stateName_ != "default") {
       bookHistosForState("default", ibooker);
 
     } else {
@@ -227,807 +221,884 @@ void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup
   }
 }
 
-void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker &ibooker,
-                                                         const edm::EventSetup & iSetup,
-							 const std::string suffix,bool useInac)
-{
+void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker& ibooker,
+                                                         const edm::EventSetup& iSetup,
+                                                         const std::string suffix,
+                                                         bool useInac) {
+  ibooker.setCurrentFolder(TopFolder_ + "/HitEffFromHitPattern" + (useInac ? "All" : "") + suffix);
 
-    ibooker.setCurrentFolder(TopFolder_ + "/HitEffFromHitPattern" + (useInac ? "All" :"") + suffix);
-    
-    constexpr int LUMIBin   = 300;   // conf_->getParameter<int>("LUMIBin");
-    float LUMIMin = conf_->getParameter<double>("LUMIMin");
-    float LUMIMax = conf_->getParameter<double>("LUMIMax");
-    
-    int   PVBin = conf_->getParameter<int>   ("PVBin");
-    float PVMin = conf_->getParameter<double>("PVMin");
-    float PVMax = conf_->getParameter<double>("PVMax");
+  constexpr int LUMIBin = 300;  // conf_->getParameter<int>("LUMIBin");
+  float LUMIMin = conf_->getParameter<double>("LUMIMin");
+  float LUMIMax = conf_->getParameter<double>("LUMIMax");
 
+  int PVBin = conf_->getParameter<int>("PVBin");
+  float PVMin = conf_->getParameter<double>("PVMin");
+  float PVMax = conf_->getParameter<double>("PVMax");
 
-    int NBINS[]        = { PVBin,   int(GetLumi::lastBunchCrossing),  LUMIBin, LUMIBin};
-    float MIN[]        = { PVMin,     0.5,  LUMIMin, LUMIMin };
-    float MAX[]        = { PVMax, float(GetLumi::lastBunchCrossing)+0.5,  LUMIMax, LUMIMax };
-    std::string NAME[] = { "", "VsBX", "VsLUMI", "VsLUMI" };
-   
-    auto logBins = makeLogBins<float,LUMIBin>(LUMIMin,LUMIMax);
- 
-    int mon = -1;
-    int nbins = -1;
-    float min = -1.;
-    float max = -1.;
-    bool logQ = false;
-    std::string name = "";
-    for (int i=0; i<monQuantity::END; i++) {
-      if (monName[i] == suffix) {
-        logQ =  (i>1); // VsLUMI
-	mon = i;
-        if (useInac) mon+=monQuantity::END;
-	nbins = NBINS[i];
-	min = MIN[i];
-	max = MAX[i];
-	name = NAME[i];
-      }
+  int NBINS[] = {PVBin, int(GetLumi::lastBunchCrossing), LUMIBin, LUMIBin};
+  float MIN[] = {PVMin, 0.5, LUMIMin, LUMIMin};
+  float MAX[] = {PVMax, float(GetLumi::lastBunchCrossing) + 0.5, LUMIMax, LUMIMax};
+  std::string NAME[] = {"", "VsBX", "VsLUMI", "VsLUMI"};
+
+  auto logBins = makeLogBins<float, LUMIBin>(LUMIMin, LUMIMax);
+
+  int mon = -1;
+  int nbins = -1;
+  float min = -1.;
+  float max = -1.;
+  bool logQ = false;
+  std::string name = "";
+  for (int i = 0; i < monQuantity::END; i++) {
+    if (monName[i] == suffix) {
+      logQ = (i > 1);  // VsLUMI
+      mon = i;
+      if (useInac)
+        mon += monQuantity::END;
+      nbins = NBINS[i];
+      min = MIN[i];
+      max = MAX[i];
+      name = NAME[i];
     }
-  
-    edm::ESHandle<TrackerGeometry> trackerGeometry;
-    iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
+  }
 
-    // Values are not ordered randomly, but the order is taken from
-    // http://cmslxr.fnal.gov/dxr/CMSSW/source/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h#15
-    const char * dets[] = { "None", "PXB", "PXF", "TIB", "TID", "TOB", "TEC"};
+  edm::ESHandle<TrackerGeometry> trackerGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
 
-    // Also in this case, ordering is not random but extracted from
-    // http://cmslxr.fnal.gov/dxr/CMSSW/source/DataFormats/TrackReco/interface/HitPattern.h
-    // The category "total" is an addition to ease the computation of
-    // the efficiencies and is not part of the original HitPattern.
-    const char * hit_category[] = { "valid", "missing", "inactive", "bad", "total"};
+  // Values are not ordered randomly, but the order is taken from
+  // http://cmslxr.fnal.gov/dxr/CMSSW/source/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h#15
+  const char* dets[] = {"None", "PXB", "PXF", "TIB", "TID", "TOB", "TEC"};
 
-    // We set sub_det to be a 1-based index since to it is the sub-sub-structure in the HitPattern
-    char title[50];
-    for (unsigned int det = 1; det < sizeof(dets)/sizeof(char*); ++det ) {
-      for (unsigned int sub_det = 1;
-           sub_det <= trackerGeometry->numberOfLayers(det); ++sub_det) {
-        for (unsigned int cat = 0;
-             cat < sizeof(hit_category)/sizeof(char *); ++cat) {
-          memset(title, 0, sizeof(title));
-          snprintf(title, sizeof(title), "Hits%s_%s_%s_Subdet%d", name.c_str(), hit_category[cat], dets[det], sub_det);
-          switch(cat) {
-            case 0:
-              hits_valid_.insert(std::make_pair(
-		  Key(det, sub_det, mon), logQ? 
-                  ibooker.book1D(title, title, nbins, &logBins[0]) :
-		  ibooker.book1D(title, title, nbins, min, max)));
-              break;
-            case 4:
-              hits_total_.insert(std::make_pair(
-		  Key(det, sub_det, mon), logQ?	
-                  ibooker.book1D(title, title, nbins, &logBins[0]) :
-                  ibooker.book1D(title, title, nbins, min, max)));
-              break;
-            default:
-              LogDebug("TrackAnalyzer") << "Invalid hit category used " << cat << " ignored\n";
-          }
+  // Also in this case, ordering is not random but extracted from
+  // http://cmslxr.fnal.gov/dxr/CMSSW/source/DataFormats/TrackReco/interface/HitPattern.h
+  // The category "total" is an addition to ease the computation of
+  // the efficiencies and is not part of the original HitPattern.
+  const char* hit_category[] = {"valid", "missing", "inactive", "bad", "total"};
+
+  // We set sub_det to be a 1-based index since to it is the sub-sub-structure in the HitPattern
+  char title[50];
+  for (unsigned int det = 1; det < sizeof(dets) / sizeof(char*); ++det) {
+    for (unsigned int sub_det = 1; sub_det <= trackerGeometry->numberOfLayers(det); ++sub_det) {
+      for (unsigned int cat = 0; cat < sizeof(hit_category) / sizeof(char*); ++cat) {
+        memset(title, 0, sizeof(title));
+        snprintf(title, sizeof(title), "Hits%s_%s_%s_Subdet%d", name.c_str(), hit_category[cat], dets[det], sub_det);
+        switch (cat) {
+          case 0:
+            hits_valid_.insert(std::make_pair(Key(det, sub_det, mon),
+                                              logQ ? ibooker.book1D(title, title, nbins, &logBins[0])
+                                                   : ibooker.book1D(title, title, nbins, min, max)));
+            break;
+          case 4:
+            hits_total_.insert(std::make_pair(Key(det, sub_det, mon),
+                                              logQ ? ibooker.book1D(title, title, nbins, &logBins[0])
+                                                   : ibooker.book1D(title, title, nbins, min, max)));
+            break;
+          default:
+            LogDebug("TrackAnalyzer") << "Invalid hit category used " << cat << " ignored\n";
         }
       }
     }
+  }
 }
 
 #include "DataFormats/TrackReco/interface/TrajectoryStopReasons.h"
-void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
-  
-    // parameters from the configuration
-    std::string QualName       = conf_->getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
-    std::string MEBSFolderName = conf_->getParameter<std::string>("BSFolderName"); 
+void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker& ibooker) {
+  // parameters from the configuration
+  std::string QualName = conf_->getParameter<std::string>("Quality");
+  std::string AlgoName = conf_->getParameter<std::string>("AlgoName");
+  std::string MEBSFolderName = conf_->getParameter<std::string>("BSFolderName");
 
-    // use the AlgoName and Quality Name 
-    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+  // use the AlgoName and Quality Name
+  std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
+  // get binning from the configuration
+  int TKHitBin = conf_->getParameter<int>("RecHitBin");
+  double TKHitMin = conf_->getParameter<double>("RecHitMin");
+  double TKHitMax = conf_->getParameter<double>("RecHitMax");
+
+  int TKLostBin = conf_->getParameter<int>("RecLostBin");
+  double TKLostMin = conf_->getParameter<double>("RecLostMin");
+  double TKLostMax = conf_->getParameter<double>("RecLostMax");
+
+  int TKLayBin = conf_->getParameter<int>("RecLayBin");
+  double TKLayMin = conf_->getParameter<double>("RecLayMin");
+  double TKLayMax = conf_->getParameter<double>("RecLayMax");
+
+  int PhiBin = conf_->getParameter<int>("PhiBin");
+  double PhiMin = conf_->getParameter<double>("PhiMin");
+  double PhiMax = conf_->getParameter<double>("PhiMax");
+
+  int EtaBin = conf_->getParameter<int>("EtaBin");
+  double EtaMin = conf_->getParameter<double>("EtaMin");
+  double EtaMax = conf_->getParameter<double>("EtaMax");
+
+  int PtBin = conf_->getParameter<int>("TrackPtBin");
+  double PtMin = conf_->getParameter<double>("TrackPtMin");
+  double PtMax = conf_->getParameter<double>("TrackPtMax");
+
+  int Phi2DBin = conf_->getParameter<int>("Phi2DBin");
+  int Eta2DBin = conf_->getParameter<int>("Eta2DBin");
+  int Pt2DBin = conf_->getParameter<int>("TrackPt2DBin");
+
+  int VXBin = conf_->getParameter<int>("VXBin");
+  double VXMin = conf_->getParameter<double>("VXMin");
+  double VXMax = conf_->getParameter<double>("VXMax");
+
+  int VYBin = conf_->getParameter<int>("VYBin");
+  double VYMin = conf_->getParameter<double>("VYMin");
+  double VYMax = conf_->getParameter<double>("VYMax");
+
+  int VZBin = conf_->getParameter<int>("VZBin");
+  double VZMin = conf_->getParameter<double>("VZMin");
+  double VZMax = conf_->getParameter<double>("VZMax");
+
+  ibooker.setCurrentFolder(TopFolder_);
+
+  // book the Hit Property histograms
+  // ---------------------------------------------------------------------------------//
+
+  TkParameterMEs tkmes;
+  if (doHitPropertiesPlots_ || doAllPlots_) {
+    ibooker.setCurrentFolder(TopFolder_ + "/HitProperties");
+
+    histname = "NumberOfRecHitsPerTrack_";
+    NumberOfRecHitsPerTrack =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, TKHitBin, TKHitMin, TKHitMax);
+    NumberOfRecHitsPerTrack->setAxisTitle("Number of all RecHits of each Track");
+    NumberOfRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+    histname = "NumberOfValidRecHitsPerTrack_";
+    NumberOfValidRecHitsPerTrack =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, TKHitBin, TKHitMin, TKHitMax);
+    NumberOfValidRecHitsPerTrack->setAxisTitle("Number of valid RecHits for each Track");
+
+    NumberOfValidRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+    histname = "NumberOfLostRecHitsPerTrack_";
+    NumberOfLostRecHitsPerTrack =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, TKLostBin, TKLostMin, TKLostMax);
+    NumberOfLostRecHitsPerTrack->setAxisTitle("Number of lost RecHits for each Track");
+    NumberOfLostRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+    histname = "NumberOfMissingInnerRecHitsPerTrack_";
+    NumberOfMIRecHitsPerTrack = ibooker.book1D(histname + CategoryName, histname + CategoryName, 10, -0.5, 9.5);
+    NumberOfMIRecHitsPerTrack->setAxisTitle("Number of missing-inner RecHits for each Track");
+    NumberOfMIRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+    histname = "NumberOfMissingOuterRecHitsPerTrack_";
+    NumberOfMORecHitsPerTrack = ibooker.book1D(histname + CategoryName, histname + CategoryName, 10, -0.5, 9.5);
+    NumberOfMORecHitsPerTrack->setAxisTitle("Number of missing-outer RecHits for each Track");
+    NumberOfMORecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+    histname = "ValidFractionPerTrack_";
+    ValidFractionPerTrack = ibooker.book1D(histname + CategoryName, histname + CategoryName, 101, 0., 1.01);
+    ValidFractionPerTrack->setAxisTitle("ValidFraction of RecHits for each Track");
+    ValidFractionPerTrack->setAxisTitle("Number of Tracks", 2);
+
+    if (doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_) {
+      histname = "NumberOfValidRecHitVsPhiVsEtaPerTrack_";
+      NumberOfValidRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname + CategoryName,
+                                                                    histname + CategoryName,
+                                                                    Eta2DBin,
+                                                                    EtaMin,
+                                                                    EtaMax,
+                                                                    Phi2DBin,
+                                                                    PhiMin,
+                                                                    PhiMax,
+                                                                    0,
+                                                                    40.,
+                                                                    "");
+      NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+      histname = "NumberOfLostRecHitVsPhiVsEtaPerTrack_";
+      NumberOfLostRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname + CategoryName,
+                                                                   histname + CategoryName,
+                                                                   Eta2DBin,
+                                                                   EtaMin,
+                                                                   EtaMax,
+                                                                   Phi2DBin,
+                                                                   PhiMin,
+                                                                   PhiMax,
+                                                                   0,
+                                                                   5.,
+                                                                   "");
+      NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+      histname = "NumberMIRecHitVsPhiVsEtaPerTrack_";
+      NumberOfMIRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname + CategoryName,
+                                                                 histname + CategoryName,
+                                                                 Eta2DBin,
+                                                                 EtaMin,
+                                                                 EtaMax,
+                                                                 Phi2DBin,
+                                                                 PhiMin,
+                                                                 PhiMax,
+                                                                 0,
+                                                                 15.,
+                                                                 "");
+      NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+      histname = "NumberMORecHitVsPhiVsEtaPerTrack_";
+      NumberOfMORecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname + CategoryName,
+                                                                 histname + CategoryName,
+                                                                 Eta2DBin,
+                                                                 EtaMin,
+                                                                 EtaMax,
+                                                                 Phi2DBin,
+                                                                 PhiMin,
+                                                                 PhiMax,
+                                                                 0,
+                                                                 15.,
+                                                                 "");
+      NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+      histname = "ValidFractionVsPhiVsEtaPerTrack_";
+      ValidFractionVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname + CategoryName,
+                                                              histname + CategoryName,
+                                                              Eta2DBin,
+                                                              EtaMin,
+                                                              EtaMax,
+                                                              Phi2DBin,
+                                                              PhiMin,
+                                                              PhiMax,
+                                                              0,
+                                                              2.,
+                                                              "");
+      ValidFractionVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      ValidFractionVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+    }
+
+    if (doRecHitVsPtVsEtaPerTrack_ || doAllPlots_) {
+      histname = "NumberOfValidRecHitVsPtVsEtaPerTrack_";
+      NumberOfValidRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(
+          histname + CategoryName, histname + CategoryName, Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 40., "");
+      NumberOfValidRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfValidRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
+
+      histname = "NumberOfLostRecHitVsPtVsEtaPerTrack_";
+      NumberOfLostRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(
+          histname + CategoryName, histname + CategoryName, Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 5., "");
+      NumberOfLostRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfLostRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
+
+      histname = "NumberMIRecHitVsPtVsEtaPerTrack_";
+      NumberOfMIRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(
+          histname + CategoryName, histname + CategoryName, Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 15., "");
+      NumberOfMIRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfMIRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
+
+      histname = "NumberMORecHitVsPtVsEtaPerTrack_";
+      NumberOfMORecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(
+          histname + CategoryName, histname + CategoryName, Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 15., "");
+      NumberOfMORecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+      NumberOfMORecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
+    }
+
+    histname = "NumberOfValidRecHitsPerTrackVsPt_";
+    NumberOfValidRecHitsPerTrackVsPt = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PtBin, PtMin, PtMax, TKHitMin, TKHitMax, "");
+    NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+    NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Number of valid RecHits in each Track", 2);
+
+    histname = "NumberOfLostRecHitsPerTrackVsPt_";
+    NumberOfLostRecHitsPerTrackVsPt = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PtBin, PtMin, PtMax, TKHitMin, TKHitMax, "");
+    NumberOfLostRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+    NumberOfLostRecHitsPerTrackVsPt->setAxisTitle("Average Number of Lost RecHits per Track", 2);
+
+    histname = "NumberMIRecHitsPerTrackVsPt_";
+    NumberOfMIRecHitsPerTrackVsPt = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PtBin, PtMin, PtMax, TKHitMin, TKHitMax, "");
+    NumberOfMIRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+    NumberOfMIRecHitsPerTrackVsPt->setAxisTitle("Average Number of Lost RecHits per Track", 2);
+
+    histname = "NumberMORecHitsPerTrackVsPt_";
+    NumberOfMORecHitsPerTrackVsPt = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PtBin, PtMin, PtMax, TKHitMin, TKHitMax, "");
+    NumberOfMORecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+    NumberOfMORecHitsPerTrackVsPt->setAxisTitle("Average Number of Lost RecHits per Track", 2);
+
+    std::string layerTypeName[5] = {"", "Off", "3D", "Missing", "Pixel"};
+    for (int i = 0; i < 4; ++i) {
+      histname = "NumberOf" + layerTypeName[i] + "LayersPerTrack_";
+      NumberOfLayersPerTrack[i] =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, TKLayBin, TKLayMin, TKLayMax);
+      NumberOfLayersPerTrack[i]->setAxisTitle("Number of " + layerTypeName[i] + " Layers of each Track", 1);
+      NumberOfLayersPerTrack[i]->setAxisTitle("Number of Tracks", 2);
+    }
+    if (doLayersVsPhiVsEtaPerTrack_ || doAllPlots_)
+      for (int i = 0; i < 5; ++i) {
+        histname = "NumberOf" + layerTypeName[i] + "LayersVsPhiVsEtaPerTrack_";
+        NumberOfLayersVsPhiVsEtaPerTrack[i] = ibooker.bookProfile2D(histname + CategoryName,
+                                                                    histname + CategoryName,
+                                                                    Eta2DBin,
+                                                                    EtaMin,
+                                                                    EtaMax,
+                                                                    Phi2DBin,
+                                                                    PhiMin,
+                                                                    PhiMax,
+                                                                    0,
+                                                                    40.,
+                                                                    "");
+        NumberOfLayersVsPhiVsEtaPerTrack[i]->setAxisTitle("Track #eta ", 1);
+        NumberOfLayersVsPhiVsEtaPerTrack[i]->setAxisTitle("Track #phi ", 2);
+      }
+  }
+
+  // book the General Property histograms
+  // ---------------------------------------------------------------------------------//
+
+  if (doGeneralPropertiesPlots_ || doAllPlots_) {
+    int Chi2Bin = conf_->getParameter<int>("Chi2Bin");
+    double Chi2Min = conf_->getParameter<double>("Chi2Min");
+    double Chi2Max = conf_->getParameter<double>("Chi2Max");
+
+    int Chi2NDFBin = conf_->getParameter<int>("Chi2NDFBin");
+    double Chi2NDFMin = conf_->getParameter<double>("Chi2NDFMin");
+    double Chi2NDFMax = conf_->getParameter<double>("Chi2NDFMax");
+
+    int Chi2ProbBin = conf_->getParameter<int>("Chi2ProbBin");
+    double Chi2ProbMin = conf_->getParameter<double>("Chi2ProbMin");
+    double Chi2ProbMax = conf_->getParameter<double>("Chi2ProbMax");
+
+    //HI PLOTS////
+    int TransDCABins = conf_->getParameter<int>("TransDCABins");
+    double TransDCAMin = conf_->getParameter<double>("TransDCAMin");
+    double TransDCAMax = conf_->getParameter<double>("TransDCAMax");
+
+    int LongDCABins = conf_->getParameter<int>("LongDCABins");
+    double LongDCAMin = conf_->getParameter<double>("LongDCAMin");
+    double LongDCAMax = conf_->getParameter<double>("LongDCAMax");
+    ///////////////////////////////////////////////////////////////////
+
+    ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
+
+    histname = "Chi2_";
+    Chi2 = ibooker.book1D(histname + CategoryName, histname + CategoryName, Chi2Bin, Chi2Min, Chi2Max);
+    Chi2->setAxisTitle("Track #chi^{2}", 1);
+    Chi2->setAxisTitle("Number of Tracks", 2);
+
+    histname = "Chi2Prob_";
+    Chi2Prob = ibooker.book1D(histname + CategoryName, histname + CategoryName, Chi2ProbBin, Chi2ProbMin, Chi2ProbMax);
+    Chi2Prob->setAxisTitle("Track #chi^{2} probability", 1);
+    Chi2Prob->setAxisTitle("Number of Tracks", 2);
+
+    histname = "Chi2oNDF_";
+    Chi2oNDF = ibooker.book1D(histname + CategoryName, histname + CategoryName, Chi2NDFBin, Chi2NDFMin, Chi2NDFMax);
+    Chi2oNDF->setAxisTitle("Track #chi^{2}/ndf", 1);
+    Chi2oNDF->setAxisTitle("Number of Tracks", 2);
+
+    //////////////
+    //HI PLOTS///
+    //////////////
+    if (doHIPlots_) {
+      histname = "LongDCASig_";
+      LongDCASig =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, LongDCABins, LongDCAMin, LongDCAMax);
+      LongDCASig->setAxisTitle("dz/#sigma_{dz}", 1);
+
+      histname = "TransDCASig_";
+      TransDCASig =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, TransDCABins, TransDCAMin, TransDCAMax);
+      TransDCASig->setAxisTitle("dxy/#sigma_{dxy}", 1);
+
+      histname = "dNdPhi_HighPurity_";
+      dNdPhi_HighPurity = ibooker.book1D(histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax);
+      dNdPhi_HighPurity->setAxisTitle("#phi", 1);
+
+      histname = "dNdEta_HighPurity_";
+      dNdEta_HighPurity = ibooker.book1D(histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax);
+      dNdEta_HighPurity->setAxisTitle("#eta", 1);
+
+      histname = "dNdPt_HighPurity_";
+      dNdPt_HighPurity = ibooker.book1D(histname + CategoryName, histname + CategoryName, 150, 0, 0.3);
+      dNdPt_HighPurity->setAxisTitle("#sigma_{p_{T}}/p_{T}", 1);
+
+      histname = "NhitVsEta_HighPurity_";
+      NhitVsEta_HighPurity =
+          ibooker.bookProfile(histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, -0.5, 39.5, "");
+      NhitVsEta_HighPurity->setAxisTitle("Track #eta", 1);
+      NhitVsEta_HighPurity->setAxisTitle("Number of Valid RecHits in each Track", 2);
+
+      histname = "NhitVsPhi_HighPurity_";
+      NhitVsPhi_HighPurity =
+          ibooker.bookProfile(histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, -0.5, 39.5, "");
+      NhitVsPhi_HighPurity->setAxisTitle("Track #phi", 1);
+      NhitVsPhi_HighPurity->setAxisTitle("Number of Valid RecHits in each Track", 2);
+
+      histname = "Ptdist_HighPurity_";
+      Ptdist_HighPurity = ibooker.book1D(histname + CategoryName, histname + CategoryName, 150, 0, 50.);
+      Ptdist_HighPurity->setAxisTitle("p_{T} (GeV/c)", 1);
+      Ptdist_HighPurity->setAxisTitle("Number of Tracks", 2);
+
+      histname = "dNhitdPt_HighPurity_";
+      dNhitdPt_HighPurity =
+          ibooker.bookProfile(histname + CategoryName, histname + CategoryName, 150, 0, 25., -0.5, 39.5, "");
+      dNhitdPt_HighPurity->setAxisTitle("p_{T} (GeV/c)", 1);
+      dNhitdPt_HighPurity->setAxisTitle("N_{hit}", 2);
+    }
+
+    if (doDCAPlots_ || doPVPlots_ || doSIPPlots_ || doAllPlots_) {
+      histname = "xPointOfClosestApproach_";
+      xPointOfClosestApproach = ibooker.book1D(histname + CategoryName, histname + CategoryName, VXBin, VXMin, VXMax);
+      xPointOfClosestApproach->setAxisTitle("x component of Track PCA to beam line (cm)", 1);
+      xPointOfClosestApproach->setAxisTitle("Number of Tracks", 2);
+
+      histname = "yPointOfClosestApproach_";
+      yPointOfClosestApproach = ibooker.book1D(histname + CategoryName, histname + CategoryName, VYBin, VYMin, VYMax);
+      yPointOfClosestApproach->setAxisTitle("y component of Track PCA to beam line (cm)", 1);
+      yPointOfClosestApproach->setAxisTitle("Number of Tracks", 2);
+
+      histname = "zPointOfClosestApproach_";
+      zPointOfClosestApproach = ibooker.book1D(histname + CategoryName, histname + CategoryName, VZBin, VZMin, VZMax);
+      zPointOfClosestApproach->setAxisTitle("z component of Track PCA to beam line (cm)", 1);
+      zPointOfClosestApproach->setAxisTitle("Number of Tracks", 2);
+
+      histname = "xPointOfClosestApproachToPV_";
+      xPointOfClosestApproachToPV =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, VXBin, VXMin, VXMax);
+      xPointOfClosestApproachToPV->setAxisTitle("x component of Track PCA to pv (cm)", 1);
+      xPointOfClosestApproachToPV->setAxisTitle("Number of Tracks", 2);
+
+      histname = "yPointOfClosestApproachToPV_";
+      yPointOfClosestApproachToPV =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, VYBin, VYMin, VYMax);
+      yPointOfClosestApproachToPV->setAxisTitle("y component of Track PCA to pv line (cm)", 1);
+      yPointOfClosestApproachToPV->setAxisTitle("Number of Tracks", 2);
+
+      histname = "zPointOfClosestApproachToPV_";
+      zPointOfClosestApproachToPV =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, VZBin, VZMin, VZMax);
+      zPointOfClosestApproachToPV->setAxisTitle("z component of Track PCA to pv line (cm)", 1);
+      zPointOfClosestApproachToPV->setAxisTitle("Number of Tracks", 2);
+    }
+
+    // See DataFormats/TrackReco/interface/TrackBase.h for track algorithm enum definition
+    // http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/DataFormats/TrackReco/interface/TrackBase.h?view=log
+    histname = "algorithm_";
+    algorithm = ibooker.book1D(histname + CategoryName,
+                               histname + CategoryName,
+                               reco::TrackBase::algoSize,
+                               0.,
+                               double(reco::TrackBase::algoSize));
+    algorithm->setAxisTitle("Tracking algorithm", 1);
+    algorithm->setAxisTitle("Number of Tracks", 2);
+
+    histname = "originalAlgorithm_";
+    oriAlgo = ibooker.book1D(histname + CategoryName,
+                             histname + CategoryName,
+                             reco::TrackBase::algoSize,
+                             0.,
+                             double(reco::TrackBase::algoSize));
+    oriAlgo->setAxisTitle("Tracking algorithm", 1);
+    oriAlgo->setAxisTitle("Number of Tracks", 2);
+
+    for (size_t ibin = 0; ibin < reco::TrackBase::algoSize - 1; ibin++) {
+      algorithm->setBinLabel(ibin + 1, reco::TrackBase::algoNames[ibin]);
+      oriAlgo->setBinLabel(ibin + 1, reco::TrackBase::algoNames[ibin]);
+    }
+
+    size_t StopReasonNameSize = sizeof(StopReasonName::StopReasonName) / sizeof(std::string);
+    histname = "stoppingSource_";
+    stoppingSource = ibooker.book1D(
+        histname + CategoryName, histname + CategoryName, StopReasonNameSize, 0., double(StopReasonNameSize));
+    stoppingSource->setAxisTitle("stopping reason", 1);
+    stoppingSource->setAxisTitle("Number of Tracks", 2);
+
+    histname = "stoppingSourceVSeta_";
+    stoppingSourceVSeta =
+        ibooker.bookProfile(histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, 2, 0., 2.);
+    stoppingSourceVSeta->setAxisTitle("track #eta", 1);
+    stoppingSourceVSeta->setAxisTitle("stopped fraction", 2);
+
+    histname = "stoppingSourceVSphi_";
+    stoppingSourceVSphi =
+        ibooker.bookProfile(histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, 2, 0., 2.);
+    stoppingSourceVSphi->setAxisTitle("track #phi", 1);
+    stoppingSourceVSphi->setAxisTitle("stopped fraction", 2);
+
+    for (size_t ibin = 0; ibin < StopReasonNameSize; ibin++) {
+      stoppingSource->setBinLabel(ibin + 1, StopReasonName::StopReasonName[ibin], 1);
+    }
+  }
+}
+
+void TrackAnalyzer::bookHistosForLScertification(DQMStore::IBooker& ibooker) {
+  // parameters from the configuration
+  std::string QualName = conf_->getParameter<std::string>("Quality");
+  std::string AlgoName = conf_->getParameter<std::string>("AlgoName");
+
+  // use the AlgoName and Quality Name
+  std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+
+  // book LS analysis related histograms
+  // -----------------------------------
+  if (doLumiAnalysis_) {
     // get binning from the configuration
-    int    TKHitBin     = conf_->getParameter<int>(   "RecHitBin");
-    double TKHitMin     = conf_->getParameter<double>("RecHitMin");
-    double TKHitMax     = conf_->getParameter<double>("RecHitMax");
+    int TKHitBin = conf_->getParameter<int>("RecHitBin");
+    double TKHitMin = conf_->getParameter<double>("RecHitMin");
+    double TKHitMax = conf_->getParameter<double>("RecHitMax");
 
-    int    TKLostBin    = conf_->getParameter<int>(   "RecLostBin");
-    double TKLostMin    = conf_->getParameter<double>("RecLostMin");
-    double TKLostMax    = conf_->getParameter<double>("RecLostMax");
+    int Chi2NDFBin = conf_->getParameter<int>("Chi2NDFBin");
+    double Chi2NDFMin = conf_->getParameter<double>("Chi2NDFMin");
+    double Chi2NDFMax = conf_->getParameter<double>("Chi2NDFMax");
 
-    int    TKLayBin     = conf_->getParameter<int>(   "RecLayBin");
-    double TKLayMin     = conf_->getParameter<double>("RecLayMin");
-    double TKLayMax     = conf_->getParameter<double>("RecLayMax");
+    // add by Mia in order to deal w/ LS transitions
+    ibooker.setCurrentFolder(TopFolder_ + "/LSanalysis");
 
-    int    PhiBin       = conf_->getParameter<int>(   "PhiBin");
-    double PhiMin       = conf_->getParameter<double>("PhiMin");
-    double PhiMax       = conf_->getParameter<double>("PhiMax");
+    histname = "NumberOfRecHitsPerTrack_lumiFlag_";
+    NumberOfRecHitsPerTrack_lumiFlag =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, TKHitBin, TKHitMin, TKHitMax);
+    NumberOfRecHitsPerTrack_lumiFlag->setAxisTitle("Number of all RecHits of each Track");
+    NumberOfRecHitsPerTrack_lumiFlag->setAxisTitle("Number of Tracks", 2);
 
-    int    EtaBin       = conf_->getParameter<int>(   "EtaBin");
-    double EtaMin       = conf_->getParameter<double>("EtaMin");
-    double EtaMax       = conf_->getParameter<double>("EtaMax");
-
-    int    PtBin        = conf_->getParameter<int>(   "TrackPtBin");
-    double PtMin        = conf_->getParameter<double>("TrackPtMin");
-    double PtMax        = conf_->getParameter<double>("TrackPtMax");
-
-    int    Phi2DBin     = conf_->getParameter<int>(   "Phi2DBin");
-    int    Eta2DBin     = conf_->getParameter<int>(   "Eta2DBin");
-    int    Pt2DBin      = conf_->getParameter<int>(   "TrackPt2DBin");
-
-    int    VXBin        = conf_->getParameter<int>(   "VXBin");
-    double VXMin        = conf_->getParameter<double>("VXMin");
-    double VXMax        = conf_->getParameter<double>("VXMax");
-
-    int    VYBin        = conf_->getParameter<int>(   "VYBin");
-    double VYMin        = conf_->getParameter<double>("VYMin");
-    double VYMax        = conf_->getParameter<double>("VYMax");
-
-    int    VZBin        = conf_->getParameter<int>(   "VZBin");
-    double VZMin        = conf_->getParameter<double>("VZMin");
-    double VZMax        = conf_->getParameter<double>("VZMax");
-
-    ibooker.setCurrentFolder(TopFolder_);
-
-    // book the Hit Property histograms
-    // ---------------------------------------------------------------------------------//
-
-    TkParameterMEs tkmes;
-    if ( doHitPropertiesPlots_ || doAllPlots_ ){
-
-      ibooker.setCurrentFolder(TopFolder_+"/HitProperties");
-      
-      histname = "NumberOfRecHitsPerTrack_";
-      NumberOfRecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, TKHitBin, TKHitMin, TKHitMax);
-      NumberOfRecHitsPerTrack->setAxisTitle("Number of all RecHits of each Track");
-      NumberOfRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
-
-      histname = "NumberOfValidRecHitsPerTrack_";
-      NumberOfValidRecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, TKHitBin, TKHitMin, TKHitMax);
-      NumberOfValidRecHitsPerTrack->setAxisTitle("Number of valid RecHits for each Track");
-
-      NumberOfValidRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
-
-      histname = "NumberOfLostRecHitsPerTrack_";
-      NumberOfLostRecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, TKLostBin, TKLostMin, TKLostMax);
-      NumberOfLostRecHitsPerTrack->setAxisTitle("Number of lost RecHits for each Track");
-      NumberOfLostRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
-
-      histname = "NumberOfMissingInnerRecHitsPerTrack_";
-      NumberOfMIRecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, 10, -0.5, 9.5);
-      NumberOfMIRecHitsPerTrack->setAxisTitle("Number of missing-inner RecHits for each Track");
-      NumberOfMIRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
-
-      histname = "NumberOfMissingOuterRecHitsPerTrack_";
-      NumberOfMORecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, 10, -0.5, 9.5);
-      NumberOfMORecHitsPerTrack->setAxisTitle("Number of missing-outer RecHits for each Track");
-      NumberOfMORecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
-
-      histname = "ValidFractionPerTrack_";
-      ValidFractionPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, 101, 0., 1.01);
-      ValidFractionPerTrack->setAxisTitle("ValidFraction of RecHits for each Track");
-      ValidFractionPerTrack->setAxisTitle("Number of Tracks", 2);
-
-
-
-      if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ ){
-	
-	histname = "NumberOfValidRecHitVsPhiVsEtaPerTrack_";
-	NumberOfValidRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
-								    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 40., "");
-	NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-	NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
-
-        histname = "NumberOfLostRecHitVsPhiVsEtaPerTrack_";
-        NumberOfLostRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 5., "");
-        NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
-
-
-        histname = "NumberMIRecHitVsPhiVsEtaPerTrack_";
-        NumberOfMIRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 15., "");
-        NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
-
-        histname = "NumberMORecHitVsPhiVsEtaPerTrack_";
-        NumberOfMORecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 15., "");
-        NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
-
-        histname = "ValidFractionVsPhiVsEtaPerTrack_";
-        ValidFractionVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 2., "");
-        ValidFractionVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        ValidFractionVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
-
-      }
-
-      if ( doRecHitVsPtVsEtaPerTrack_ || doAllPlots_ ){
-	
-	histname = "NumberOfValidRecHitVsPtVsEtaPerTrack_";
-	NumberOfValidRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
-								    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 40., "");
-	NumberOfValidRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-	NumberOfValidRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
-
-        histname = "NumberOfLostRecHitVsPtVsEtaPerTrack_";
-        NumberOfLostRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 5., "");
-        NumberOfLostRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        NumberOfLostRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
-
-
-        histname = "NumberMIRecHitVsPtVsEtaPerTrack_";
-        NumberOfMIRecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 15., "");
-        NumberOfMIRecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        NumberOfMIRecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
-
-        histname = "NumberMORecHitVsPtVsEtaPerTrack_";
-        NumberOfMORecHitVsPtVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
-                                                                    Eta2DBin, EtaMin, EtaMax, Pt2DBin, PtMin, PtMax, 0, 15., "");
-        NumberOfMORecHitVsPtVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-        NumberOfMORecHitVsPtVsEtaPerTrack->setAxisTitle("Track p_{T} [GeV] ", 2);
-
-      }
-
-      histname = "NumberOfValidRecHitsPerTrackVsPt_";
-      NumberOfValidRecHitsPerTrackVsPt = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PtBin, PtMin, PtMax, TKHitMin, TKHitMax,"");
-      NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]",1);
-      NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Number of valid RecHits in each Track",2);
-    
-      histname = "NumberOfLostRecHitsPerTrackVsPt_";
-      NumberOfLostRecHitsPerTrackVsPt = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PtBin, PtMin, PtMax,TKHitMin, TKHitMax,"");
-      NumberOfLostRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
-      NumberOfLostRecHitsPerTrackVsPt->setAxisTitle("Average Number of Lost RecHits per Track", 2);
-      
-      
-      histname = "NumberMIRecHitsPerTrackVsPt_";
-      NumberOfMIRecHitsPerTrackVsPt = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PtBin, PtMin, PtMax,TKHitMin, TKHitMax,"");
-      NumberOfMIRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
-      NumberOfMIRecHitsPerTrackVsPt->setAxisTitle("Average Number of Lost RecHits per Track", 2);
-      
-      histname = "NumberMORecHitsPerTrackVsPt_";
-      NumberOfMORecHitsPerTrackVsPt = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PtBin, PtMin, PtMax,TKHitMin, TKHitMax,"");
-      NumberOfMORecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
-      NumberOfMORecHitsPerTrackVsPt->setAxisTitle("Average Number of Lost RecHits per Track", 2);
-
-      std::string layerTypeName[5] = {"","Off","3D","Missing","Pixel"};
-      for (int i=0; i<4; ++i) {
-        histname = "NumberOf"+ layerTypeName[i] + "LayersPerTrack_";
-        NumberOfLayersPerTrack[i] = ibooker.book1D(histname+CategoryName, histname+CategoryName, TKLayBin, TKLayMin, TKLayMax);
-        NumberOfLayersPerTrack[i]->setAxisTitle("Number of " + layerTypeName[i] + " Layers of each Track", 1);
-        NumberOfLayersPerTrack[i]->setAxisTitle("Number of Tracks", 2);
-      }
-      if ( doLayersVsPhiVsEtaPerTrack_ || doAllPlots_ )
-	for (int i=0; i<5; ++i) {
-          histname = "NumberOf"+ layerTypeName[i] + "LayersVsPhiVsEtaPerTrack_";
-	  NumberOfLayersVsPhiVsEtaPerTrack[i] = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
-								    Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax, 0, 40., "");
-	  NumberOfLayersVsPhiVsEtaPerTrack[i]->setAxisTitle("Track #eta ", 1);
-	  NumberOfLayersVsPhiVsEtaPerTrack[i]->setAxisTitle("Track #phi ", 2);
-      }
-    }
-
-    // book the General Property histograms
-    // ---------------------------------------------------------------------------------//
-    
-    if (doGeneralPropertiesPlots_ || doAllPlots_){
-      
-      int    Chi2Bin      = conf_->getParameter<int>(   "Chi2Bin");
-      double Chi2Min      = conf_->getParameter<double>("Chi2Min");
-      double Chi2Max      = conf_->getParameter<double>("Chi2Max");
-      
-      int    Chi2NDFBin   = conf_->getParameter<int>(   "Chi2NDFBin");
-      double Chi2NDFMin   = conf_->getParameter<double>("Chi2NDFMin");
-      double Chi2NDFMax   = conf_->getParameter<double>("Chi2NDFMax");
-      
-      int    Chi2ProbBin  = conf_->getParameter<int>(   "Chi2ProbBin");
-      double Chi2ProbMin  = conf_->getParameter<double>("Chi2ProbMin");
-      double Chi2ProbMax  = conf_->getParameter<double>("Chi2ProbMax");
-    
-
-      //HI PLOTS////                                                       
-      int TransDCABins = conf_->getParameter<int>("TransDCABins");
-      double TransDCAMin = conf_->getParameter<double>("TransDCAMin");
-      double TransDCAMax = conf_->getParameter<double>("TransDCAMax");
-
-      int LongDCABins = conf_->getParameter<int>("LongDCABins");
-      double LongDCAMin = conf_->getParameter<double>("LongDCAMin");
-      double LongDCAMax = conf_->getParameter<double>("LongDCAMax");
-      ///////////////////////////////////////////////////////////////////  
-
-
-      ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-
-      histname = "Chi2_";
-      Chi2 = ibooker.book1D(histname+CategoryName, histname+CategoryName, Chi2Bin, Chi2Min, Chi2Max);
-      Chi2->setAxisTitle("Track #chi^{2}"  ,1);
-      Chi2->setAxisTitle("Number of Tracks",2);
-
-      histname = "Chi2Prob_";
-      Chi2Prob = ibooker.book1D(histname+CategoryName, histname+CategoryName, Chi2ProbBin, Chi2ProbMin, Chi2ProbMax);
-      Chi2Prob->setAxisTitle("Track #chi^{2} probability",1);
-      Chi2Prob->setAxisTitle("Number of Tracks"        ,2);
-      
-      histname = "Chi2oNDF_";
-      Chi2oNDF = ibooker.book1D(histname+CategoryName, histname+CategoryName, Chi2NDFBin, Chi2NDFMin, Chi2NDFMax);
-      Chi2oNDF->setAxisTitle("Track #chi^{2}/ndf",1);
-      Chi2oNDF->setAxisTitle("Number of Tracks"  ,2);
-
-
-      //////////////                                                                                                                                                                                       
-      //HI PLOTS///                                                                                                                                                                                       
-      //////////////                                                                                                                                                                                      
-      if (doHIPlots_)
-        {
-          histname = "LongDCASig_";
-          LongDCASig = ibooker.book1D(histname+CategoryName, histname+CategoryName,LongDCABins,LongDCAMin,LongDCAMax);
-          LongDCASig->setAxisTitle("dz/#sigma_{dz}",1);
-
-          histname = "TransDCASig_";
-          TransDCASig = ibooker.book1D(histname+CategoryName,histname+CategoryName,TransDCABins,TransDCAMin,TransDCAMax);
-          TransDCASig->setAxisTitle("dxy/#sigma_{dxy}",1);
-
-	  histname = "dNdPhi_HighPurity_";
-	  dNdPhi_HighPurity = ibooker.book1D(histname+CategoryName,histname+CategoryName,PhiBin,PhiMin,PhiMax);
-	  dNdPhi_HighPurity->setAxisTitle("#phi",1);
-
-	  histname = "dNdEta_HighPurity_";
-          dNdEta_HighPurity = ibooker.book1D(histname+CategoryName,histname+CategoryName,EtaBin,EtaMin,EtaMax);
-          dNdEta_HighPurity->setAxisTitle("#eta",1);
-
-          histname = "dNdPt_HighPurity_";
-          dNdPt_HighPurity = ibooker.book1D(histname+CategoryName,histname+CategoryName,150,0,0.3);
-          dNdPt_HighPurity->setAxisTitle("#sigma_{p_{T}}/p_{T}",1);
-
-	  histname = "NhitVsEta_HighPurity_";
-	  NhitVsEta_HighPurity = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,EtaBin,EtaMin,EtaMax,-0.5,39.5,"");
-	  NhitVsEta_HighPurity->setAxisTitle("Track #eta",1);
-	  NhitVsEta_HighPurity->setAxisTitle("Number of Valid RecHits in each Track",2);
-
-          histname = "NhitVsPhi_HighPurity_";
-          NhitVsPhi_HighPurity = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,PhiBin,PhiMin,PhiMax,-0.5,39.5,"");
-          NhitVsPhi_HighPurity->setAxisTitle("Track #phi",1);
-          NhitVsPhi_HighPurity->setAxisTitle("Number of Valid RecHits in each Track",2);
-
-	  histname = "Ptdist_HighPurity_";
-          Ptdist_HighPurity = ibooker.book1D(histname+CategoryName,histname+CategoryName,150,0,50.);
-          Ptdist_HighPurity->setAxisTitle("p_{T} (GeV/c)",1);
-          Ptdist_HighPurity->setAxisTitle("Number of Tracks",2);
-
-          histname = "dNhitdPt_HighPurity_";
-          dNhitdPt_HighPurity = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,150,0,25.,-0.5,39.5,"");
-          dNhitdPt_HighPurity->setAxisTitle("p_{T} (GeV/c)",1);
-          dNhitdPt_HighPurity->setAxisTitle("N_{hit}",2);
-	  
-        }
-
-
-      
-      if(doDCAPlots_ || doPVPlots_ || doSIPPlots_ || doAllPlots_)  {
-	histname = "xPointOfClosestApproach_";
-	xPointOfClosestApproach = ibooker.book1D(histname+CategoryName, histname+CategoryName, VXBin, VXMin, VXMax);
-	xPointOfClosestApproach->setAxisTitle("x component of Track PCA to beam line (cm)",1);
-	xPointOfClosestApproach->setAxisTitle("Number of Tracks",2);
-	
-	histname = "yPointOfClosestApproach_";
-	yPointOfClosestApproach = ibooker.book1D(histname+CategoryName, histname+CategoryName, VYBin, VYMin, VYMax);
-	yPointOfClosestApproach->setAxisTitle("y component of Track PCA to beam line (cm)",1);
-	yPointOfClosestApproach->setAxisTitle("Number of Tracks",2);
-	
-	histname = "zPointOfClosestApproach_";
-	zPointOfClosestApproach = ibooker.book1D(histname+CategoryName, histname+CategoryName, VZBin, VZMin, VZMax);
-	zPointOfClosestApproach->setAxisTitle("z component of Track PCA to beam line (cm)",1);
-	zPointOfClosestApproach->setAxisTitle("Number of Tracks",2);
-	
-	histname = "xPointOfClosestApproachToPV_";
-        xPointOfClosestApproachToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, VXBin, VXMin, VXMax);
-	xPointOfClosestApproachToPV->setAxisTitle("x component of Track PCA to pv (cm)",1);
-	xPointOfClosestApproachToPV->setAxisTitle("Number of Tracks",2);
-	
-	histname = "yPointOfClosestApproachToPV_";
-	yPointOfClosestApproachToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, VYBin, VYMin, VYMax);
-	yPointOfClosestApproachToPV->setAxisTitle("y component of Track PCA to pv line (cm)",1);
-	yPointOfClosestApproachToPV->setAxisTitle("Number of Tracks",2);
-	
-	histname = "zPointOfClosestApproachToPV_";
-	zPointOfClosestApproachToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, VZBin, VZMin, VZMax);
-	zPointOfClosestApproachToPV->setAxisTitle("z component of Track PCA to pv line (cm)",1);
-	zPointOfClosestApproachToPV->setAxisTitle("Number of Tracks",2);
-      }
-
-      // See DataFormats/TrackReco/interface/TrackBase.h for track algorithm enum definition
-      // http://cmssw.cvs.cern.ch/cgi-bin/cmssw.cgi/CMSSW/DataFormats/TrackReco/interface/TrackBase.h?view=log
-      histname = "algorithm_";
-      algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
-      algorithm->setAxisTitle("Tracking algorithm",1);
-      algorithm->setAxisTitle("Number of Tracks",2);
-
-      histname = "originalAlgorithm_";
-      oriAlgo = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
-      oriAlgo->setAxisTitle("Tracking algorithm",1);
-      oriAlgo->setAxisTitle("Number of Tracks",2);
-
-      for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++) {
-	algorithm->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
-        oriAlgo->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
-      }
-
-      size_t StopReasonNameSize = sizeof(StopReasonName::StopReasonName)/sizeof(std::string);
-      histname = "stoppingSource_";
-      stoppingSource = ibooker.book1D(histname+CategoryName, histname+CategoryName, StopReasonNameSize, 0., double(StopReasonNameSize));
-      stoppingSource->setAxisTitle("stopping reason",1);
-      stoppingSource->setAxisTitle("Number of Tracks",2);
-      
-      histname = "stoppingSourceVSeta_";
-      stoppingSourceVSeta = ibooker.bookProfile(histname+CategoryName, histname+CategoryName,
-                                            EtaBin, EtaMin, EtaMax, 2, 0., 2.);
-      stoppingSourceVSeta->setAxisTitle("track #eta",1);
-      stoppingSourceVSeta->setAxisTitle("stopped fraction",2);
-      
-      histname = "stoppingSourceVSphi_";
-      stoppingSourceVSphi = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, 
-                                           PhiBin, PhiMin, PhiMax, 2, 0., 2.);
-      stoppingSourceVSphi->setAxisTitle("track #phi",1);
-      stoppingSourceVSphi->setAxisTitle("stopped fraction",2);
-
-      for (size_t ibin=0; ibin<StopReasonNameSize; ibin++) {
-	stoppingSource->setBinLabel(ibin+1,StopReasonName::StopReasonName[ibin],1);
-      }
-
-    }
-
+    histname = "Chi2oNDF_lumiFlag_";
+    Chi2oNDF_lumiFlag =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, Chi2NDFBin, Chi2NDFMin, Chi2NDFMax);
+    Chi2oNDF_lumiFlag->setAxisTitle("Track #chi^{2}/ndf", 1);
+    Chi2oNDF_lumiFlag->setAxisTitle("Number of Tracks", 2);
+  }
 }
 
-void TrackAnalyzer::bookHistosForLScertification(DQMStore::IBooker & ibooker) {
+void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
+  // parameters from the configuration
+  std::string QualName = conf_->getParameter<std::string>("Quality");
+  std::string AlgoName = conf_->getParameter<std::string>("AlgoName");
 
-    // parameters from the configuration
-    std::string QualName       = conf_->getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
+  // use the AlgoName and Quality Name
+  std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+  std::string Folder = TopFolder_.substr(0, 2);
 
-    // use the AlgoName and Quality Name 
-    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+  // book the Beam Spot related histograms
+  // ---------------------------------------------------------------------------------//
 
+  if (doDCAPlots_ || doBSPlots_ || doAllPlots_) {
+    int DxyErrBin = conf_->getParameter<int>("DxyErrBin");
+    double DxyErrMax = conf_->getParameter<double>("DxyErrMax");
 
-    // book LS analysis related histograms
-    // -----------------------------------
-    if ( doLumiAnalysis_ ) {
+    int DxyBin = conf_->getParameter<int>("DxyBin");
+    double DxyMin = conf_->getParameter<double>("DxyMin");
+    double DxyMax = conf_->getParameter<double>("DxyMax");
 
-      // get binning from the configuration
-      int    TKHitBin     = conf_->getParameter<int>(   "RecHitBin");
-      double TKHitMin     = conf_->getParameter<double>("RecHitMin");
-      double TKHitMax     = conf_->getParameter<double>("RecHitMax");
+    int AbsDxyBin = conf_->getParameter<int>("AbsDxyBin");
+    double AbsDxyMin = conf_->getParameter<double>("AbsDxyMin");
+    double AbsDxyMax = conf_->getParameter<double>("AbsDxyMax");
 
-      int    Chi2NDFBin   = conf_->getParameter<int>(   "Chi2NDFBin");
-      double Chi2NDFMin   = conf_->getParameter<double>("Chi2NDFMin");
-      double Chi2NDFMax   = conf_->getParameter<double>("Chi2NDFMax");
+    int PhiBin = conf_->getParameter<int>("PhiBin");
+    double PhiMin = conf_->getParameter<double>("PhiMin");
+    double PhiMax = conf_->getParameter<double>("PhiMax");
 
-      // add by Mia in order to deal w/ LS transitions  
-      ibooker.setCurrentFolder(TopFolder_+"/LSanalysis");
+    int EtaBin = conf_->getParameter<int>("EtaBin");
+    double EtaMin = conf_->getParameter<double>("EtaMin");
+    double EtaMax = conf_->getParameter<double>("EtaMax");
 
-      histname = "NumberOfRecHitsPerTrack_lumiFlag_";
-      NumberOfRecHitsPerTrack_lumiFlag = ibooker.book1D(histname+CategoryName, histname+CategoryName, TKHitBin, TKHitMin, TKHitMax);
-      NumberOfRecHitsPerTrack_lumiFlag->setAxisTitle("Number of all RecHits of each Track");
-      NumberOfRecHitsPerTrack_lumiFlag->setAxisTitle("Number of Tracks", 2);
+    int PtBin = conf_->getParameter<int>("TrackPtBin");
+    double PtMin = conf_->getParameter<double>("TrackPtMin");
+    double PtMax = conf_->getParameter<double>("TrackPtMax");
 
-      histname = "Chi2oNDF_lumiFlag_";
-      Chi2oNDF_lumiFlag = ibooker.book1D(histname+CategoryName, histname+CategoryName, Chi2NDFBin, Chi2NDFMin, Chi2NDFMax);
-      Chi2oNDF_lumiFlag->setAxisTitle("Track #chi^{2}/ndf",1);
-      Chi2oNDF_lumiFlag->setAxisTitle("Number of Tracks"  ,2);
+    int X0Bin = conf_->getParameter<int>("X0Bin");
+    double X0Min = conf_->getParameter<double>("X0Min");
+    double X0Max = conf_->getParameter<double>("X0Max");
 
-    }
-}
+    int Y0Bin = conf_->getParameter<int>("Y0Bin");
+    double Y0Min = conf_->getParameter<double>("Y0Min");
+    double Y0Max = conf_->getParameter<double>("Y0Max");
 
-void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
+    int Z0Bin = conf_->getParameter<int>("Z0Bin");
+    double Z0Min = conf_->getParameter<double>("Z0Min");
+    double Z0Max = conf_->getParameter<double>("Z0Max");
 
-    // parameters from the configuration
-    std::string QualName       = conf_->getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
+    int VZBinProf = conf_->getParameter<int>("VZBinProf");
+    double VZMinProf = conf_->getParameter<double>("VZMinProf");
+    double VZMaxProf = conf_->getParameter<double>("VZMaxProf");
 
-    // use the AlgoName and Quality Name 
-    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+    ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
 
-    // book the Beam Spot related histograms
-    // ---------------------------------------------------------------------------------//
-    
-    if(doDCAPlots_ || doBSPlots_ || doAllPlots_) {
-	
-      int    DxyErrBin    = conf_->getParameter<int>(   "DxyErrBin");
-      double DxyErrMax    = conf_->getParameter<double>("DxyErrMax");
-      
-      int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
-      double DxyMin       = conf_->getParameter<double>("DxyMin");
-      double DxyMax       = conf_->getParameter<double>("DxyMax");
-      
-      int    AbsDxyBin    = conf_->getParameter<int>(   "AbsDxyBin");
-      double AbsDxyMin    = conf_->getParameter<double>("AbsDxyMin");
-      double AbsDxyMax    = conf_->getParameter<double>("AbsDxyMax");
-      
-      int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
-      double PhiMin     = conf_->getParameter<double>("PhiMin");
-      double PhiMax     = conf_->getParameter<double>("PhiMax");
-      
-      int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
-      double EtaMin     = conf_->getParameter<double>("EtaMin");
-      double EtaMax     = conf_->getParameter<double>("EtaMax");
+    histname = "DistanceOfClosestApproachError_";
+    DistanceOfClosestApproachError =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, DxyErrBin, 0., DxyErrMax);
+    DistanceOfClosestApproachError->setAxisTitle("Track d_{xy} error (cm)", 1);
+    DistanceOfClosestApproachError->setAxisTitle("Number of Tracks", 2);
 
-      int    PtBin      = conf_->getParameter<int>(   "TrackPtBin");
-      double PtMin      = conf_->getParameter<double>("TrackPtMin");
-      double PtMax      = conf_->getParameter<double>("TrackPtMax");
+    histname = "DistanceOfClosestApproachErrorVsPt_";
+    DistanceOfClosestApproachErrorVsPt =
+        ibooker.bookProfile(histname + CategoryName, histname + CategoryName, PtBin, PtMin, PtMax, 0., DxyErrMax);
+    DistanceOfClosestApproachErrorVsPt->setAxisTitle("Track p_{T} (GeV)", 1);
+    DistanceOfClosestApproachErrorVsPt->setAxisTitle("Track d_{xy} error (cm)", 2);
 
-      int    X0Bin        = conf_->getParameter<int>(   "X0Bin");
-      double X0Min        = conf_->getParameter<double>("X0Min");
-      double X0Max        = conf_->getParameter<double>("X0Max");
-      
-      int    Y0Bin        = conf_->getParameter<int>(   "Y0Bin");
-      double Y0Min        = conf_->getParameter<double>("Y0Min");
-      double Y0Max        = conf_->getParameter<double>("Y0Max");
-      
-      int    Z0Bin        = conf_->getParameter<int>(   "Z0Bin");
-      double Z0Min        = conf_->getParameter<double>("Z0Min");
-      double Z0Max        = conf_->getParameter<double>("Z0Max");
-      
-      int    VZBinProf    = conf_->getParameter<int>(   "VZBinProf");
-      double VZMinProf    = conf_->getParameter<double>("VZMinProf");
-      double VZMaxProf    = conf_->getParameter<double>("VZMaxProf");
-      
-      
-      ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-      
-      histname = "DistanceOfClosestApproachError_";
-      DistanceOfClosestApproachError = ibooker.book1D(histname+CategoryName,histname+CategoryName,DxyErrBin,0.,DxyErrMax);
-      DistanceOfClosestApproachError->setAxisTitle("Track d_{xy} error (cm)",1);
-      DistanceOfClosestApproachError->setAxisTitle("Number of Tracks",2);
-      
-      histname = "DistanceOfClosestApproachErrorVsPt_";
-      DistanceOfClosestApproachErrorVsPt = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,PtBin,PtMin,PtMax,0.,DxyErrMax);
-      DistanceOfClosestApproachErrorVsPt->setAxisTitle("Track p_{T} (GeV)",1);
-      DistanceOfClosestApproachErrorVsPt->setAxisTitle("Track d_{xy} error (cm)",2);
-      
-      histname = "DistanceOfClosestApproachErrorVsEta_";
-      DistanceOfClosestApproachErrorVsEta = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,EtaBin,EtaMin,EtaMax,0.,DxyErrMax);
-      DistanceOfClosestApproachErrorVsEta->setAxisTitle("Track #eta",1);
-      DistanceOfClosestApproachErrorVsEta->setAxisTitle("Track d_{xy} error (cm)",2);
-      
-      histname = "DistanceOfClosestApproachErrorVsPhi_";
-      DistanceOfClosestApproachErrorVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,PhiBin,PhiMin,PhiMax,0.,DxyErrMax);
-      DistanceOfClosestApproachErrorVsPhi->setAxisTitle("Track #phi",1);
-      DistanceOfClosestApproachErrorVsPhi->setAxisTitle("Track d_{xy} error (cm)",2);
-      
-      histname = "DistanceOfClosestApproachErrorVsDxy_";
-      DistanceOfClosestApproachErrorVsDxy = ibooker.bookProfile(histname+CategoryName,histname+CategoryName,DxyBin,DxyMin,DxyMax,0.,DxyErrMax);
-      DistanceOfClosestApproachErrorVsDxy->setAxisTitle("Track d_{xy}",1);
-      DistanceOfClosestApproachErrorVsDxy->setAxisTitle("Track d_{xy} error (cm)",2);
+    histname = "DistanceOfClosestApproachErrorVsEta_";
+    DistanceOfClosestApproachErrorVsEta =
+        ibooker.bookProfile(histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, 0., DxyErrMax);
+    DistanceOfClosestApproachErrorVsEta->setAxisTitle("Track #eta", 1);
+    DistanceOfClosestApproachErrorVsEta->setAxisTitle("Track d_{xy} error (cm)", 2);
 
-      histname = "DistanceOfClosestApproachToBS_";
-      DistanceOfClosestApproachToBS = ibooker.book1D(histname+CategoryName,histname+CategoryName,DxyBin,DxyMin,DxyMax);
-      DistanceOfClosestApproachToBS->setAxisTitle("Track d_{xy} wrt beam spot (cm)",1);
-      DistanceOfClosestApproachToBS->setAxisTitle("Number of Tracks",2);
-      
-      histname = "AbsDistanceOfClosestApproachToBS_";
-      AbsDistanceOfClosestApproachToBS = ibooker.book1D(histname+CategoryName,histname+CategoryName,AbsDxyBin,AbsDxyMin,AbsDxyMax);
-      AbsDistanceOfClosestApproachToBS->setAxisTitle("Track |d_{xy}| wrt beam spot (cm)",1);
-      AbsDistanceOfClosestApproachToBS->setAxisTitle("Number of Tracks",2);
-      
-      histname = "DistanceOfClosestApproachToBSVsPhi_";
-      DistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-      DistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
-      DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi",1);
-      DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
-      
-      histname = "xPointOfClosestApproachVsZ0wrt000_";
-      xPointOfClosestApproachVsZ0wrt000 = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, Z0Bin, Z0Min, Z0Max, X0Bin, X0Min, X0Max,"");
-      xPointOfClosestApproachVsZ0wrt000->setAxisTitle("d_{z} (cm)",1);
-      xPointOfClosestApproachVsZ0wrt000->setAxisTitle("x component of Track PCA to beam line (cm)",2);
-      
-      histname = "yPointOfClosestApproachVsZ0wrt000_";
-      yPointOfClosestApproachVsZ0wrt000 = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, Z0Bin, Z0Min, Z0Max, Y0Bin, Y0Min, Y0Max,"");
-      yPointOfClosestApproachVsZ0wrt000->setAxisTitle("d_{z} (cm)",1);
-      yPointOfClosestApproachVsZ0wrt000->setAxisTitle("y component of Track PCA to beam line (cm)",2);
-      
-      histname = "xPointOfClosestApproachVsZ0wrtBS_";
-      xPointOfClosestApproachVsZ0wrtBS = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, Z0Bin, Z0Min, Z0Max, X0Bin, X0Min, X0Max,"");
-      xPointOfClosestApproachVsZ0wrtBS->setAxisTitle("d_{z} w.r.t. Beam Spot  (cm)",1);
-      xPointOfClosestApproachVsZ0wrtBS->setAxisTitle("x component of Track PCA to BS (cm)",2);
-      
-      histname = "yPointOfClosestApproachVsZ0wrtBS_";
-      yPointOfClosestApproachVsZ0wrtBS = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, Z0Bin, Z0Min, Z0Max, Y0Bin, Y0Min, Y0Max,"");
-      yPointOfClosestApproachVsZ0wrtBS->setAxisTitle("d_{z} w.r.t. Beam Spot (cm)",1);
-      yPointOfClosestApproachVsZ0wrtBS->setAxisTitle("y component of Track PCA to BS (cm)",2);
-      
-      histname = "zPointOfClosestApproachVsPhi_";
-      zPointOfClosestApproachVsPhi = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PhiBin, PhiMin, PhiMax, VZBinProf, VZMinProf, VZMaxProf, "");
-      zPointOfClosestApproachVsPhi->setAxisTitle("Track #phi",1);
-      zPointOfClosestApproachVsPhi->setAxisTitle("z component of Track PCA to beam line (cm)",2);
-    }
-    
-    if(doDCAPlots_ || doPVPlots_ || doAllPlots_) {
-      
-      int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
-      double DxyMin       = conf_->getParameter<double>("DxyMin");
-      double DxyMax       = conf_->getParameter<double>("DxyMax");
-      
-      int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
-      double PhiMin     = conf_->getParameter<double>("PhiMin");
-      double PhiMax     = conf_->getParameter<double>("PhiMax");
-      
-      int    X0Bin        = conf_->getParameter<int>(   "X0Bin");
-      double X0Min        = conf_->getParameter<double>("X0Min");
-      double X0Max        = conf_->getParameter<double>("X0Max");
-      
-      int    Y0Bin        = conf_->getParameter<int>(   "Y0Bin");
-      double Y0Min        = conf_->getParameter<double>("Y0Min");
-      double Y0Max        = conf_->getParameter<double>("Y0Max");
-      
-      int    Z0Bin        = conf_->getParameter<int>(   "Z0Bin");
-      double Z0Min        = conf_->getParameter<double>("Z0Min");
-      double Z0Max        = conf_->getParameter<double>("Z0Max");
-      
-      ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-      
-      histname = "DistanceOfClosestApproachToPV_";
-      DistanceOfClosestApproachToPV = ibooker.book1D(histname+CategoryName,histname+CategoryName,DxyBin,DxyMin,DxyMax);
-      DistanceOfClosestApproachToPV->setAxisTitle("Track d_{xy} w.r.t. PV (cm)",1);
-      DistanceOfClosestApproachToPV->setAxisTitle("Number of Tracks",2);
-      
-      histname = "DistanceOfClosestApproachToPVZoom_";
-      DistanceOfClosestApproachToPVZoom = ibooker.book1D(histname+CategoryName,histname+CategoryName,100,-0.08,0.08);
-      DistanceOfClosestApproachToPVZoom->setAxisTitle("Track d_{xy} w.r.t. PV (cm)",1);
-      DistanceOfClosestApproachToPVZoom->setAxisTitle("Number of Tracks",2);
+    histname = "DistanceOfClosestApproachErrorVsPhi_";
+    DistanceOfClosestApproachErrorVsPhi =
+        ibooker.bookProfile(histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, 0., DxyErrMax);
+    DistanceOfClosestApproachErrorVsPhi->setAxisTitle("Track #phi", 1);
+    DistanceOfClosestApproachErrorVsPhi->setAxisTitle("Track d_{xy} error (cm)", 2);
 
+    histname = "DistanceOfClosestApproachErrorVsDxy_";
+    DistanceOfClosestApproachErrorVsDxy =
+        ibooker.bookProfile(histname + CategoryName, histname + CategoryName, DxyBin, DxyMin, DxyMax, 0., DxyErrMax);
+    DistanceOfClosestApproachErrorVsDxy->setAxisTitle("Track d_{xy}", 1);
+    DistanceOfClosestApproachErrorVsDxy->setAxisTitle("Track d_{xy} error (cm)", 2);
 
-      histname = "DeltaZToPV_";
-      DeltaZToPV = ibooker.book1D(histname+CategoryName,histname+CategoryName,Z0Bin,Z0Min,Z0Max);
-      DeltaZToPV->setAxisTitle("Track d_{z} w.r.t. PV (cm)",1);
-      DeltaZToPV->setAxisTitle("Number of Tracks",2);
+    histname = "DistanceOfClosestApproachToBS_";
+    DistanceOfClosestApproachToBS =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, DxyBin, DxyMin, DxyMax);
+    DistanceOfClosestApproachToBS->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 1);
+    DistanceOfClosestApproachToBS->setAxisTitle("Number of Tracks", 2);
 
-      histname = "DeltaZToPVZoom_";
-      DeltaZToPVZoom = ibooker.book1D(histname+CategoryName,histname+CategoryName,100,-0.15,0.15);
-      DeltaZToPVZoom->setAxisTitle("Track d_{z} w.r.t. PV (cm)",1);
-      DeltaZToPVZoom->setAxisTitle("Number of Tracks",2);
+    if (Folder == "Tr") {
+      histname = "DistanceOfClosestApproachToBSdz_";
+      DistanceOfClosestApproachToBSdz =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, 100, -1.1, 1.1);
+      DistanceOfClosestApproachToBSdz->setAxisTitle("Track d_{z} wrt beam spot (cm)", 1);
+      DistanceOfClosestApproachToBSdz->setAxisTitle("Number of Tracks", 2);
 
-      
-      histname = "DistanceOfClosestApproachToPVVsPhi_";
-      DistanceOfClosestApproachToPVVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-      DistanceOfClosestApproachToPVVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
-      DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track #phi",1);
-      DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track d_{xy} w.r.t. PV (cm)",2);
-      
-      histname = "xPointOfClosestApproachVsZ0wrtPV_";
-      xPointOfClosestApproachVsZ0wrtPV = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, Z0Bin, Z0Min, Z0Max, X0Bin, X0Min, X0Max,"");
-      xPointOfClosestApproachVsZ0wrtPV->setAxisTitle("d_{z} w.r.t. PV (cm)",1);
-      xPointOfClosestApproachVsZ0wrtPV->setAxisTitle("x component of Track PCA to PV (cm)",2);
-      
-      histname = "yPointOfClosestApproachVsZ0wrtPV_";
-      yPointOfClosestApproachVsZ0wrtPV = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, Z0Bin, Z0Min, Z0Max, Y0Bin, Y0Min, Y0Max,"");
-      yPointOfClosestApproachVsZ0wrtPV->setAxisTitle("d_{z} w.r.t. PV (cm)",1);
-      yPointOfClosestApproachVsZ0wrtPV->setAxisTitle("y component of Track PCA to PV (cm)",2);
-      
+      histname = "DistanceOfClosestApproachToBSVsEta_";
+      DistanceOfClosestApproachToBSVsEta = ibooker.bookProfile(
+          histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, DxyBin, DxyMin, DxyMax, "");
+      DistanceOfClosestApproachToBSVsEta->getTH1()->SetCanExtend(TH1::kAllAxes);
+      DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track #eta", 1);
+      DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
     }
 
-    if (doBSPlots_ || doAllPlots_) {
-      if (doTestPlots_) {
-	
-	int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
-	double DxyMin       = conf_->getParameter<double>("DxyMin");
-	double DxyMax       = conf_->getParameter<double>("DxyMax");
-      
-	int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
-	double PhiMin     = conf_->getParameter<double>("PhiMin");
-	double PhiMax     = conf_->getParameter<double>("PhiMax");
+    histname = "AbsDistanceOfClosestApproachToBS_";
+    AbsDistanceOfClosestApproachToBS =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, AbsDxyBin, AbsDxyMin, AbsDxyMax);
+    AbsDistanceOfClosestApproachToBS->setAxisTitle("Track |d_{xy}| wrt beam spot (cm)", 1);
+    AbsDistanceOfClosestApproachToBS->setAxisTitle("Number of Tracks", 2);
 
-	histname = "TESTDistanceOfClosestApproachToBS_";
-	TESTDistanceOfClosestApproachToBS = ibooker.book1D(histname+CategoryName,histname+CategoryName,DxyBin,DxyMin,DxyMax);
-	TESTDistanceOfClosestApproachToBS->setAxisTitle("Track d_{xy} wrt beam spot (cm)",1);
-	TESTDistanceOfClosestApproachToBS->setAxisTitle("Number of Tracks",2);
-	
-	histname = "TESTDistanceOfClosestApproachToBSVsPhi_";
-	TESTDistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-	TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
-	TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi",1);
-	TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
-	
+    histname = "DistanceOfClosestApproachToBSVsPhi_";
+    DistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
+    DistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+    DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi", 1);
+    DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
+
+    histname = "xPointOfClosestApproachVsZ0wrt000_";
+    xPointOfClosestApproachVsZ0wrt000 = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max, X0Bin, X0Min, X0Max, "");
+    xPointOfClosestApproachVsZ0wrt000->setAxisTitle("d_{z} (cm)", 1);
+    xPointOfClosestApproachVsZ0wrt000->setAxisTitle("x component of Track PCA to beam line (cm)", 2);
+
+    histname = "yPointOfClosestApproachVsZ0wrt000_";
+    yPointOfClosestApproachVsZ0wrt000 = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max, Y0Bin, Y0Min, Y0Max, "");
+    yPointOfClosestApproachVsZ0wrt000->setAxisTitle("d_{z} (cm)", 1);
+    yPointOfClosestApproachVsZ0wrt000->setAxisTitle("y component of Track PCA to beam line (cm)", 2);
+
+    histname = "xPointOfClosestApproachVsZ0wrtBS_";
+    xPointOfClosestApproachVsZ0wrtBS = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max, X0Bin, X0Min, X0Max, "");
+    xPointOfClosestApproachVsZ0wrtBS->setAxisTitle("d_{z} w.r.t. Beam Spot  (cm)", 1);
+    xPointOfClosestApproachVsZ0wrtBS->setAxisTitle("x component of Track PCA to BS (cm)", 2);
+
+    histname = "yPointOfClosestApproachVsZ0wrtBS_";
+    yPointOfClosestApproachVsZ0wrtBS = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max, Y0Bin, Y0Min, Y0Max, "");
+    yPointOfClosestApproachVsZ0wrtBS->setAxisTitle("d_{z} w.r.t. Beam Spot (cm)", 1);
+    yPointOfClosestApproachVsZ0wrtBS->setAxisTitle("y component of Track PCA to BS (cm)", 2);
+
+    histname = "zPointOfClosestApproachVsPhi_";
+    zPointOfClosestApproachVsPhi = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, VZBinProf, VZMinProf, VZMaxProf, "");
+    zPointOfClosestApproachVsPhi->setAxisTitle("Track #phi", 1);
+    zPointOfClosestApproachVsPhi->setAxisTitle("z component of Track PCA to beam line (cm)", 2);
+  }
+
+  if (doDCAPlots_ || doPVPlots_ || doAllPlots_) {
+    int DxyBin = conf_->getParameter<int>("DxyBin");
+    double DxyMin = conf_->getParameter<double>("DxyMin");
+    double DxyMax = conf_->getParameter<double>("DxyMax");
+
+    int PhiBin = conf_->getParameter<int>("PhiBin");
+    double PhiMin = conf_->getParameter<double>("PhiMin");
+    double PhiMax = conf_->getParameter<double>("PhiMax");
+
+    int X0Bin = conf_->getParameter<int>("X0Bin");
+    double X0Min = conf_->getParameter<double>("X0Min");
+    double X0Max = conf_->getParameter<double>("X0Max");
+
+    int Y0Bin = conf_->getParameter<int>("Y0Bin");
+    double Y0Min = conf_->getParameter<double>("Y0Min");
+    double Y0Max = conf_->getParameter<double>("Y0Max");
+
+    int Z0Bin = conf_->getParameter<int>("Z0Bin");
+    double Z0Min = conf_->getParameter<double>("Z0Min");
+    double Z0Max = conf_->getParameter<double>("Z0Max");
+
+    ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
+
+    histname = "DistanceOfClosestApproachToPV_";
+    DistanceOfClosestApproachToPV =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, DxyBin, DxyMin, DxyMax);
+    DistanceOfClosestApproachToPV->setAxisTitle("Track d_{xy} w.r.t. PV (cm)", 1);
+    DistanceOfClosestApproachToPV->setAxisTitle("Number of Tracks", 2);
+
+    histname = "DistanceOfClosestApproachToPVZoom_";
+    DistanceOfClosestApproachToPVZoom =
+        ibooker.book1D(histname + CategoryName, histname + CategoryName, 100, -0.08, 0.08);
+    DistanceOfClosestApproachToPVZoom->setAxisTitle("Track d_{xy} w.r.t. PV (cm)", 1);
+    DistanceOfClosestApproachToPVZoom->setAxisTitle("Number of Tracks", 2);
+
+    histname = "DeltaZToPV_";
+    DeltaZToPV = ibooker.book1D(histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max);
+    DeltaZToPV->setAxisTitle("Track d_{z} w.r.t. PV (cm)", 1);
+    DeltaZToPV->setAxisTitle("Number of Tracks", 2);
+
+    histname = "DeltaZToPVZoom_";
+    DeltaZToPVZoom = ibooker.book1D(histname + CategoryName, histname + CategoryName, 100, -0.15, 0.15);
+    DeltaZToPVZoom->setAxisTitle("Track d_{z} w.r.t. PV (cm)", 1);
+    DeltaZToPVZoom->setAxisTitle("Number of Tracks", 2);
+
+    histname = "DistanceOfClosestApproachToPVVsPhi_";
+    DistanceOfClosestApproachToPVVsPhi = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
+    DistanceOfClosestApproachToPVVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+    DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track #phi", 1);
+    DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track d_{xy} w.r.t. PV (cm)", 2);
+
+    histname = "xPointOfClosestApproachVsZ0wrtPV_";
+    xPointOfClosestApproachVsZ0wrtPV = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max, X0Bin, X0Min, X0Max, "");
+    xPointOfClosestApproachVsZ0wrtPV->setAxisTitle("d_{z} w.r.t. PV (cm)", 1);
+    xPointOfClosestApproachVsZ0wrtPV->setAxisTitle("x component of Track PCA to PV (cm)", 2);
+
+    histname = "yPointOfClosestApproachVsZ0wrtPV_";
+    yPointOfClosestApproachVsZ0wrtPV = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, Z0Bin, Z0Min, Z0Max, Y0Bin, Y0Min, Y0Max, "");
+    yPointOfClosestApproachVsZ0wrtPV->setAxisTitle("d_{z} w.r.t. PV (cm)", 1);
+    yPointOfClosestApproachVsZ0wrtPV->setAxisTitle("y component of Track PCA to PV (cm)", 2);
+  }
+
+  if (doBSPlots_ || doAllPlots_) {
+    if (doTestPlots_) {
+      int DxyBin = conf_->getParameter<int>("DxyBin");
+      double DxyMin = conf_->getParameter<double>("DxyMin");
+      double DxyMax = conf_->getParameter<double>("DxyMax");
+
+      int PhiBin = conf_->getParameter<int>("PhiBin");
+      double PhiMin = conf_->getParameter<double>("PhiMin");
+      double PhiMax = conf_->getParameter<double>("PhiMax");
+
+      histname = "TESTDistanceOfClosestApproachToBS_";
+      TESTDistanceOfClosestApproachToBS =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, DxyBin, DxyMin, DxyMax);
+      TESTDistanceOfClosestApproachToBS->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 1);
+      TESTDistanceOfClosestApproachToBS->setAxisTitle("Number of Tracks", 2);
+
+      histname = "TESTDistanceOfClosestApproachToBSVsPhi_";
+      TESTDistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(
+          histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
+      TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi", 1);
+      TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
+    }
+  }
+
+  // book the Profile plots for DCA related histograms
+  // ---------------------------------------------------------------------------------//
+  if (doDCAPlots_ || doAllPlots_) {
+    if (doDCAwrt000Plots_) {
+      int EtaBin = conf_->getParameter<int>("EtaBin");
+      double EtaMin = conf_->getParameter<double>("EtaMin");
+      double EtaMax = conf_->getParameter<double>("EtaMax");
+
+      int PhiBin = conf_->getParameter<int>("PhiBin");
+      double PhiMin = conf_->getParameter<double>("PhiMin");
+      double PhiMax = conf_->getParameter<double>("PhiMax");
+
+      int DxyBin = conf_->getParameter<int>("DxyBin");
+      double DxyMin = conf_->getParameter<double>("DxyMin");
+      double DxyMax = conf_->getParameter<double>("DxyMax");
+
+      if (doThetaPlots_) {
+        int ThetaBin = conf_->getParameter<int>("ThetaBin");
+        double ThetaMin = conf_->getParameter<double>("ThetaMin");
+        double ThetaMax = conf_->getParameter<double>("ThetaMax");
+
+        ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
+        histname = "DistanceOfClosestApproachVsTheta_";
+        DistanceOfClosestApproachVsTheta = ibooker.bookProfile(
+            histname + CategoryName, histname + CategoryName, ThetaBin, ThetaMin, ThetaMax, DxyMin, DxyMax, "");
+        DistanceOfClosestApproachVsTheta->setAxisTitle("Track #theta", 1);
+        DistanceOfClosestApproachVsTheta->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)", 2);
       }
-      
+
+      histname = "DistanceOfClosestApproachVsEta_";
+      DistanceOfClosestApproachVsEta = ibooker.bookProfile(
+          histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, DxyMin, DxyMax, "");
+      DistanceOfClosestApproachVsEta->setAxisTitle("Track #eta", 1);
+      DistanceOfClosestApproachVsEta->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)", 2);
+      // temporary patch in order to put back those MEs in Muon Workspace
+
+      histname = "DistanceOfClosestApproach_";
+      DistanceOfClosestApproach =
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, DxyBin, DxyMin, DxyMax);
+      DistanceOfClosestApproach->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)", 1);
+      DistanceOfClosestApproach->setAxisTitle("Number of Tracks", 2);
+
+      histname = "DistanceOfClosestApproachVsPhi_";
+      DistanceOfClosestApproachVsPhi = ibooker.bookProfile(
+          histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyMin, DxyMax, "");
+      DistanceOfClosestApproachVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      DistanceOfClosestApproachVsPhi->setAxisTitle("Track #phi", 1);
+      DistanceOfClosestApproachVsPhi->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)", 2);
     }
-    
-    // book the Profile plots for DCA related histograms
-    // ---------------------------------------------------------------------------------//
-    if(doDCAPlots_ || doAllPlots_) {
+  }
 
-      if (doDCAwrt000Plots_) {
+  if (doSIPPlots_ || doAllPlots_) {
+    const double sipBins = 200;
+    const double sipMin = -20;
+    const double sipMax = 20;
 
-	int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
-	double EtaMin     = conf_->getParameter<double>("EtaMin");
-	double EtaMax     = conf_->getParameter<double>("EtaMax");
-	
-	int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
-	double PhiMin     = conf_->getParameter<double>("PhiMin");
-	double PhiMax     = conf_->getParameter<double>("PhiMax");
+    ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
 
-	int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
-	double DxyMin       = conf_->getParameter<double>("DxyMin");
-	double DxyMax       = conf_->getParameter<double>("DxyMax");
-      
-	if (doThetaPlots_) {
-	  int    ThetaBin   = conf_->getParameter<int>(   "ThetaBin");
-	  double ThetaMin   = conf_->getParameter<double>("ThetaMin");
-	  double ThetaMax   = conf_->getParameter<double>("ThetaMax");
-	  
-	  ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-	  histname = "DistanceOfClosestApproachVsTheta_";
-	  DistanceOfClosestApproachVsTheta = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, ThetaBin, ThetaMin, ThetaMax, DxyMin,DxyMax,"");
-	  DistanceOfClosestApproachVsTheta->setAxisTitle("Track #theta",1);
-	  DistanceOfClosestApproachVsTheta->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)",2);
-	}
-	
-	histname = "DistanceOfClosestApproachVsEta_";
-	DistanceOfClosestApproachVsEta = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, EtaBin, EtaMin, EtaMax, DxyMin, DxyMax,"");
-	DistanceOfClosestApproachVsEta->setAxisTitle("Track #eta",1);
-	DistanceOfClosestApproachVsEta->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)",2);
-	// temporary patch in order to put back those MEs in Muon Workspace
-	
-	histname = "DistanceOfClosestApproach_";
-	DistanceOfClosestApproach = ibooker.book1D(histname+CategoryName,histname+CategoryName,DxyBin,DxyMin,DxyMax);
-	DistanceOfClosestApproach->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)",1);
-	DistanceOfClosestApproach->setAxisTitle("Number of Tracks",2);
-	
-	histname = "DistanceOfClosestApproachVsPhi_";
-	DistanceOfClosestApproachVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyMin,DxyMax,"");
-	DistanceOfClosestApproachVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
-	DistanceOfClosestApproachVsPhi->setAxisTitle("Track #phi",1);
-	DistanceOfClosestApproachVsPhi->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)",2);
-      }
-    }
+    // SIP wrt. beamspot
+    histname = "SIPDxyToBS_";
+    sipDxyToBS = ibooker.book1D(histname + CategoryName, histname + CategoryName, sipBins, sipMin, sipMax);
+    sipDxyToBS->setAxisTitle("Track dxy significance wrt beam spot", 1);
+    sipDxyToBS->setAxisTitle("Number of Tracks", 2);
 
+    histname = "SIPDzToBS_";
+    sipDzToBS = ibooker.book1D(histname + CategoryName, histname + CategoryName, sipBins, sipMin, sipMax);
+    sipDzToBS->setAxisTitle("Track dz significance wrt beam spot", 1);
+    sipDzToBS->setAxisTitle("Number of Tracks", 2);
 
-    if (doSIPPlots_ || doAllPlots_) {
-      const double sipBins = 200;
-      const double sipMin = -20;
-      const double sipMax = 20;
+    // SIP wrt. vertex
+    histname = "SIP3DToPV_";
+    sip3dToPV = ibooker.book1D(histname + CategoryName, histname + CategoryName, sipBins, sipMin, sipMax);
+    sip3dToPV->setAxisTitle("3D IP significance wrt primary vertex", 1);
+    sip3dToPV->setAxisTitle("Number of Tracks", 2);
 
-      ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
+    histname = "SIP2DToPV_";
+    sip2dToPV = ibooker.book1D(histname + CategoryName, histname + CategoryName, sipBins, sipMin, sipMax);
+    sip2dToPV->setAxisTitle("2D IP significance wrt primary vertex", 1);
+    sip2dToPV->setAxisTitle("Number of Tracks", 2);
 
-      // SIP wrt. beamspot
-      histname = "SIPDxyToBS_";
-      sipDxyToBS = ibooker.book1D(histname+CategoryName, histname+CategoryName, sipBins, sipMin, sipMax);
-      sipDxyToBS->setAxisTitle("Track dxy significance wrt beam spot",1);
-      sipDxyToBS->setAxisTitle("Number of Tracks",2);
+    histname = "SIPDxyToPV_";
+    sipDxyToPV = ibooker.book1D(histname + CategoryName, histname + CategoryName, sipBins, sipMin, sipMax);
+    sipDxyToPV->setAxisTitle("Track dxy significance wrt primary vertex", 1);
+    sipDxyToPV->setAxisTitle("Number of Tracks", 2);
 
-      histname = "SIPDzToBS_";
-      sipDzToBS = ibooker.book1D(histname+CategoryName, histname+CategoryName, sipBins, sipMin, sipMax);
-      sipDzToBS->setAxisTitle("Track dz significance wrt beam spot",1);
-      sipDzToBS->setAxisTitle("Number of Tracks",2);
-
-      // SIP wrt. vertex
-      histname = "SIP3DToPV_";
-      sip3dToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, sipBins, sipMin, sipMax);
-      sip3dToPV->setAxisTitle("3D IP significance wrt primary vertex",1);
-      sip3dToPV->setAxisTitle("Number of Tracks",2);
-
-      histname = "SIP2DToPV_";
-      sip2dToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, sipBins, sipMin, sipMax);
-      sip2dToPV->setAxisTitle("2D IP significance wrt primary vertex",1);
-      sip2dToPV->setAxisTitle("Number of Tracks",2);
-
-      histname = "SIPDxyToPV_";
-      sipDxyToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, sipBins, sipMin, sipMax);
-      sipDxyToPV->setAxisTitle("Track dxy significance wrt primary vertex",1);
-      sipDxyToPV->setAxisTitle("Number of Tracks",2);
-
-      histname = "SIPDzToPV_";
-      sipDzToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, sipBins, sipMin, sipMax);
-      sipDzToPV->setAxisTitle("Track dz significance wrt primary vertex",1);
-      sipDzToPV->setAxisTitle("Number of Tracks",2);
-    }
+    histname = "SIPDzToPV_";
+    sipDzToPV = ibooker.book1D(histname + CategoryName, histname + CategoryName, sipBins, sipMin, sipMax);
+    sipDzToPV->setAxisTitle("Track dz significance wrt primary vertex", 1);
+    sipDzToPV->setAxisTitle("Number of Tracks", 2);
+  }
 }
 
 // -- Analyse
 // ---------------------------------------------------------------------------------//
-void TrackAnalyzer::setNumberOfGoodVertices(const edm::Event & iEvent) {
-
+void TrackAnalyzer::setNumberOfGoodVertices(const edm::Event& iEvent) {
   good_vertices_ = 0;
-  
+
   edm::Handle<reco::VertexCollection> recoPrimaryVerticesHandle;
   iEvent.getByToken(pvToken_, recoPrimaryVerticesHandle);
   if (recoPrimaryVerticesHandle.isValid())
@@ -1037,26 +1108,23 @@ void TrackAnalyzer::setNumberOfGoodVertices(const edm::Event & iEvent) {
           ++good_vertices_;
 }
 
-void TrackAnalyzer::setBX(const edm::Event & iEvent) {
-  bx_ = iEvent.bunchCrossing();
-}
+void TrackAnalyzer::setBX(const edm::Event& iEvent) { bx_ = iEvent.bunchCrossing(); }
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-void TrackAnalyzer::setLumi(const edm::Event & iEvent, const edm::EventSetup& iSetup) {
+void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // as done by pixelLumi http://cmslxr.fnal.gov/source/DQM/PixelLumi/plugins/PixelLumiDQM.cc
 
   edm::Handle<LumiScalersCollection> lumiScalers;
   iEvent.getByToken(lumiscalersToken_, lumiScalers);
-  if ( lumiScalers.isValid() && !lumiScalers->empty() ) {
+  if (lumiScalers.isValid() && !lumiScalers->empty()) {
     LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
     scal_lumi_ = scalit->instantLumi();
-  } else 
+  } else
     scal_lumi_ = -1;
 
-  edm::Handle< edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
   iEvent.getByToken(pixelClustersToken_, pixelClusters);
-  if ( pixelClusters.isValid() ) {
-
+  if (pixelClusters.isValid()) {
     edm::ESHandle<TrackerTopology> tTopoHandle;
     iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
     const TrackerTopology* const tTopo = tTopoHandle.product();
@@ -1066,116 +1134,118 @@ void TrackAnalyzer::setLumi(const edm::Event & iEvent, const edm::EventSetup& iS
     size_t numClusters = 0;
     size_t tot = 0;
 
-    edmNew::DetSetVector<SiPixelCluster>::const_iterator  pixCluDet = pixelClusters->begin();
-    for ( ; pixCluDet!=pixelClusters->end(); ++pixCluDet) {
-    
+    edmNew::DetSetVector<SiPixelCluster>::const_iterator pixCluDet = pixelClusters->begin();
+    for (; pixCluDet != pixelClusters->end(); ++pixCluDet) {
       DetId detid = pixCluDet->detId();
       size_t subdetid = detid.subdetId();
       //      std::cout << tTopo->print(detid) << std::endl;
-      if ( subdetid == (int) PixelSubdetector::PixelBarrel ) 
-	if ( tTopo->layer(detid)==1 ) 
-	  continue;
-      
-      edmNew::DetSet<SiPixelCluster>::const_iterator  pixClu = pixCluDet->begin();    
-      for ( ; pixClu != pixCluDet->end(); ++pixClu ) {
-	++tot;
-	if ( (pixClu->size()   >= minNumberOfPixelsPerCluster_) &&
-	     (pixClu->charge() >= minPixelClusterCharge_      ) ) {
-	  ++numClusters;
-	}
+      if (subdetid == (int)PixelSubdetector::PixelBarrel)
+        if (tTopo->layer(detid) == 1)
+          continue;
+
+      edmNew::DetSet<SiPixelCluster>::const_iterator pixClu = pixCluDet->begin();
+      for (; pixClu != pixCluDet->end(); ++pixClu) {
+        ++tot;
+        if ((pixClu->size() >= minNumberOfPixelsPerCluster_) && (pixClu->charge() >= minPixelClusterCharge_)) {
+          ++numClusters;
+        }
       }
     }
-    pixel_lumi_ = lumi_factor_per_bx_ * numClusters / GetLumi::CM2_TO_NANOBARN ; // ?!?!
+    pixel_lumi_ = lumi_factor_per_bx_ * numClusters / GetLumi::CM2_TO_NANOBARN;  // ?!?!
   } else
     pixel_lumi_ = -1.;
-
 }
 
-void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Track& track)
-{
-  auto pt    = track.pt();
-  auto phi   = track.phi();
+void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Track& track) {
+  auto pt = track.pt();
+  auto phi = track.phi();
   // double eta   = track.eta();
-  auto phiIn =  track.innerPosition().phi();
-  auto etaIn =  track.innerPosition().eta();
-  auto phiOut =  track.outerPosition().phi();
-  auto etaOut =  track.outerPosition().eta();
+  auto phiIn = track.innerPosition().phi();
+  auto etaIn = track.innerPosition().eta();
+  auto phiOut = track.outerPosition().phi();
+  auto etaOut = track.outerPosition().eta();
 
-  int nRecHits      = track.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS);
+  int nRecHits = track.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS);
   int nValidRecHits = track.numberOfValidHits();
-  int nLostRecHits  = track.numberOfLostHits();
-  int nLostIn =      track.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS);
-  int nLostOut =     track.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_OUTER_HITS);
+  int nLostRecHits = track.numberOfLostHits();
+  int nLostIn = track.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS);
+  int nLostOut = track.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_OUTER_HITS);
 
-  auto chi2     = track.chi2();
-  auto chi2prob = TMath::Prob(track.chi2(),(int)track.ndof());
+  auto chi2 = track.chi2();
+  auto chi2prob = TMath::Prob(track.chi2(), (int)track.ndof());
   auto chi2oNDF = track.normalizedChi2();
-  
-  if ( doHitPropertiesPlots_ || doAllPlots_ ){
+
+  std::string Folder = TopFolder_.substr(0, 2);
+
+  if (doHitPropertiesPlots_ || doAllPlots_) {
     // rec hits
-    NumberOfRecHitsPerTrack     -> Fill(nRecHits);
-    NumberOfValidRecHitsPerTrack-> Fill(nValidRecHits);
-    NumberOfLostRecHitsPerTrack -> Fill(nLostRecHits);
-    NumberOfMIRecHitsPerTrack -> Fill(nLostIn);
-    NumberOfMORecHitsPerTrack -> Fill(nLostOut);
-    ValidFractionPerTrack -> Fill(track.validFraction());
+    NumberOfRecHitsPerTrack->Fill(nRecHits);
+    NumberOfValidRecHitsPerTrack->Fill(nValidRecHits);
+    NumberOfLostRecHitsPerTrack->Fill(nLostRecHits);
+    NumberOfMIRecHitsPerTrack->Fill(nLostIn);
+    NumberOfMORecHitsPerTrack->Fill(nLostOut);
+    ValidFractionPerTrack->Fill(track.validFraction());
 
-
-    // 2D plots    
-    if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ ) {
-      NumberOfValidRecHitVsPhiVsEtaPerTrack->Fill(etaIn,phiIn,nValidRecHits);
-      NumberOfLostRecHitVsPhiVsEtaPerTrack->Fill(etaIn,phiIn,nLostRecHits);
-      NumberOfMIRecHitVsPhiVsEtaPerTrack->Fill(etaIn,phiIn,nLostIn);
-      NumberOfMORecHitVsPhiVsEtaPerTrack->Fill(etaOut,phiOut,nLostOut);
-      ValidFractionVsPhiVsEtaPerTrack -> Fill(etaIn,phiIn,track.validFraction());
+    // 2D plots
+    if (doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_) {
+      NumberOfValidRecHitVsPhiVsEtaPerTrack->Fill(etaIn, phiIn, nValidRecHits);
+      NumberOfLostRecHitVsPhiVsEtaPerTrack->Fill(etaIn, phiIn, nLostRecHits);
+      NumberOfMIRecHitVsPhiVsEtaPerTrack->Fill(etaIn, phiIn, nLostIn);
+      NumberOfMORecHitVsPhiVsEtaPerTrack->Fill(etaOut, phiOut, nLostOut);
+      ValidFractionVsPhiVsEtaPerTrack->Fill(etaIn, phiIn, track.validFraction());
     }
-    if ( doRecHitVsPtVsEtaPerTrack_ || doAllPlots_ ) {
-      NumberOfValidRecHitVsPtVsEtaPerTrack->Fill(etaIn,pt,nValidRecHits);
-      NumberOfLostRecHitVsPtVsEtaPerTrack->Fill(etaIn,pt,nLostRecHits);
-      NumberOfMIRecHitVsPtVsEtaPerTrack->Fill(etaIn,pt,nLostIn);
-      NumberOfMORecHitVsPtVsEtaPerTrack->Fill(etaOut,pt,nLostOut);
+    if (doRecHitVsPtVsEtaPerTrack_ || doAllPlots_) {
+      NumberOfValidRecHitVsPtVsEtaPerTrack->Fill(etaIn, pt, nValidRecHits);
+      NumberOfLostRecHitVsPtVsEtaPerTrack->Fill(etaIn, pt, nLostRecHits);
+      NumberOfMIRecHitVsPtVsEtaPerTrack->Fill(etaIn, pt, nLostIn);
+      NumberOfMORecHitVsPtVsEtaPerTrack->Fill(etaOut, pt, nLostOut);
     }
-    NumberOfValidRecHitsPerTrackVsPt->Fill(pt,nValidRecHits);
-    NumberOfLostRecHitsPerTrackVsPt->Fill(pt,nLostRecHits);
-    NumberOfMIRecHitsPerTrackVsPt->Fill(pt,nLostIn);
-    NumberOfMORecHitsPerTrackVsPt->Fill(pt,nLostOut);
+    NumberOfValidRecHitsPerTrackVsPt->Fill(pt, nValidRecHits);
+    NumberOfLostRecHitsPerTrackVsPt->Fill(pt, nLostRecHits);
+    NumberOfMIRecHitsPerTrackVsPt->Fill(pt, nLostIn);
+    NumberOfMORecHitsPerTrackVsPt->Fill(pt, nLostOut);
 
-    int nLayers[5]   = { track.hitPattern().trackerLayersWithMeasurement(),
-                         track.hitPattern().trackerLayersTotallyOffOrBad(),
-                         track.hitPattern().numberOfValidStripLayersWithMonoAndStereo() +  track.hitPattern().pixelLayersWithMeasurement(),
-                         track.hitPattern().trackerLayersWithoutMeasurement(reco::HitPattern::TRACK_HITS),
-                         track.hitPattern().pixelLayersWithMeasurement()
-                       };
+    int nLayers[5] = {track.hitPattern().trackerLayersWithMeasurement(),
+                      track.hitPattern().trackerLayersTotallyOffOrBad(),
+                      track.hitPattern().numberOfValidStripLayersWithMonoAndStereo() +
+                          track.hitPattern().pixelLayersWithMeasurement(),
+                      track.hitPattern().trackerLayersWithoutMeasurement(reco::HitPattern::TRACK_HITS),
+                      track.hitPattern().pixelLayersWithMeasurement()};
 
     // layers
-    for (int i=0;i<4;++i) NumberOfLayersPerTrack[i]->Fill(nLayers[i]);
+    for (int i = 0; i < 4; ++i)
+      NumberOfLayersPerTrack[i]->Fill(nLayers[i]);
 
-    // 2D plots    
-    if ( doLayersVsPhiVsEtaPerTrack_ || doAllPlots_ )
-      for (int i=0;i<5;++i) NumberOfLayersVsPhiVsEtaPerTrack[i]->Fill(etaIn,phiIn,nLayers[i]);
-
+    // 2D plots
+    if (doLayersVsPhiVsEtaPerTrack_ || doAllPlots_)
+      for (int i = 0; i < 5; ++i)
+        NumberOfLayersVsPhiVsEtaPerTrack[i]->Fill(etaIn, phiIn, nLayers[i]);
   }
 
-  if (doEffFromHitPatternVsPU_   || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"",           float(good_vertices_), false );
-  if (doEffFromHitPatternVsBX_   || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"VsBX",       float(bx_), false            );
-  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"VsSCALLUMI", scal_lumi_, false            );
+  if (doEffFromHitPatternVsPU_ || doAllPlots_)
+    fillHistosForEfficiencyFromHitPatter(track, "", float(good_vertices_), false);
+  if (doEffFromHitPatternVsBX_ || doAllPlots_)
+    fillHistosForEfficiencyFromHitPatter(track, "VsBX", float(bx_), false);
+  if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
+    fillHistosForEfficiencyFromHitPatter(track, "VsSCALLUMI", scal_lumi_, false);
   //  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"VsPIXELLUMI", pixel_lumi_           );
-  if (doEffFromHitPatternVsPU_   || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"",           float(good_vertices_), true );
-  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"VsSCALLUMI", scal_lumi_, true            );
+  if (doEffFromHitPatternVsPU_ || doAllPlots_)
+    fillHistosForEfficiencyFromHitPatter(track, "", float(good_vertices_), true);
+  if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
+    fillHistosForEfficiencyFromHitPatter(track, "VsSCALLUMI", scal_lumi_, true);
 
-
-  if (doGeneralPropertiesPlots_ || doAllPlots_){
+  if (doGeneralPropertiesPlots_ || doAllPlots_) {
     // fitting
-    Chi2     -> Fill(chi2);
-    Chi2Prob -> Fill(chi2prob);
-    Chi2oNDF -> Fill(chi2oNDF);
+    Chi2->Fill(chi2);
+    Chi2Prob->Fill(chi2prob);
+    Chi2oNDF->Fill(chi2oNDF);
 
     // DCA
-    // temporary patch in order to put back those MEs in Muon Workspace 
+    // temporary patch in order to put back those MEs in Muon Workspace
     if (doDCAPlots_) {
       if (doDCAwrt000Plots_) {
-	DistanceOfClosestApproach->Fill(track.dxy());
-	DistanceOfClosestApproachVsPhi->Fill(phi, track.dxy());
+        DistanceOfClosestApproach->Fill(track.dxy());
+        DistanceOfClosestApproachVsPhi->Fill(phi, track.dxy());
       }
 
       // PCA
@@ -1190,896 +1260,1218 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
     // stopping source
     int max = stoppingSource->getNbinsX();
-    double stop = track.stopReason() > max ? double(max-1) : static_cast<double>(track.stopReason());
-    double stopped = int(StopReason::NOT_STOPPED)==track.stopReason() ? 0. : 1.;
+    double stop = track.stopReason() > max ? double(max - 1) : static_cast<double>(track.stopReason());
+    double stopped = int(StopReason::NOT_STOPPED) == track.stopReason() ? 0. : 1.;
     stoppingSource->Fill(stop);
-    stoppingSourceVSeta->Fill(track.eta(),stopped);
-    stoppingSourceVSphi->Fill(track.phi(),stopped);
+    stoppingSourceVSeta->Fill(track.eta(), stopped);
+    stoppingSourceVSphi->Fill(track.phi(), stopped);
   }
 
-  if ( doLumiAnalysis_ ) {
-    NumberOfRecHitsPerTrack_lumiFlag -> Fill(nRecHits);
-    Chi2oNDF_lumiFlag                -> Fill(chi2oNDF);
+  if (doLumiAnalysis_) {
+    NumberOfRecHitsPerTrack_lumiFlag->Fill(nRecHits);
+    Chi2oNDF_lumiFlag->Fill(chi2oNDF);
   }
 
-  if(doDCAPlots_ || doBSPlots_ || doSIPPlots_ || doAllPlots_) {
-    
+  if (doDCAPlots_ || doBSPlots_ || doSIPPlots_ || doAllPlots_) {
     edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-    iEvent.getByToken(beamSpotToken_,recoBeamSpotHandle);
+    iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle);
     const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
-    DistanceOfClosestApproachError      -> Fill(track.dxyError());
-    DistanceOfClosestApproachErrorVsPt  -> Fill(track.pt(),track.dxyError());
-    DistanceOfClosestApproachErrorVsEta -> Fill(track.eta(),track.dxyError());
-    DistanceOfClosestApproachErrorVsPhi -> Fill(track.phi(),track.dxyError());
-    DistanceOfClosestApproachErrorVsDxy -> Fill(track.dxy(bs.position()),track.dxyError());
+    DistanceOfClosestApproachError->Fill(track.dxyError());
+    DistanceOfClosestApproachErrorVsPt->Fill(track.pt(), track.dxyError());
+    DistanceOfClosestApproachErrorVsEta->Fill(track.eta(), track.dxyError());
+    DistanceOfClosestApproachErrorVsPhi->Fill(track.phi(), track.dxyError());
+    DistanceOfClosestApproachErrorVsDxy->Fill(track.dxy(bs.position()), track.dxyError());
 
-    DistanceOfClosestApproachToBS      -> Fill(track.dxy(bs.position()));
-    AbsDistanceOfClosestApproachToBS   -> Fill(std::abs(track.dxy(bs.position())));
-    DistanceOfClosestApproachToBSVsPhi -> Fill(track.phi(), track.dxy(bs.position()));
-    zPointOfClosestApproachVsPhi       -> Fill(track.phi(), track.vz());
-    xPointOfClosestApproachVsZ0wrt000  -> Fill(track.dz(),  track.vx());
-    yPointOfClosestApproachVsZ0wrt000  -> Fill(track.dz(),  track.vy());
-    xPointOfClosestApproachVsZ0wrtBS   -> Fill(track.dz(bs.position()),(track.vx()-bs.position(track.vz()).x()));
-    yPointOfClosestApproachVsZ0wrtBS   -> Fill(track.dz(bs.position()),(track.vy()-bs.position(track.vz()).y()));
-    if (doTestPlots_) {
-      TESTDistanceOfClosestApproachToBS      -> Fill(track.dxy(bs.position(track.vz())));
-      TESTDistanceOfClosestApproachToBSVsPhi -> Fill(track.phi(), track.dxy(bs.position(track.vz())));
+    DistanceOfClosestApproachToBS->Fill(track.dxy(bs.position()));
+
+    if (Folder == "Tr") {
+      DistanceOfClosestApproachToBSdz->Fill(track.dz(bs.position()));
+      DistanceOfClosestApproachToBSVsEta->Fill(track.eta(), track.dxy(bs.position()));
     }
 
-    if(doSIPPlots_) {
-      sipDxyToBS->Fill(track.dxy(bs.position())/track.dxyError());
-      sipDzToBS->Fill(track.dz(bs.position())/track.dzError());
+    AbsDistanceOfClosestApproachToBS->Fill(std::abs(track.dxy(bs.position())));
+    DistanceOfClosestApproachToBSVsPhi->Fill(track.phi(), track.dxy(bs.position()));
+    zPointOfClosestApproachVsPhi->Fill(track.phi(), track.vz());
+    xPointOfClosestApproachVsZ0wrt000->Fill(track.dz(), track.vx());
+    yPointOfClosestApproachVsZ0wrt000->Fill(track.dz(), track.vy());
+    xPointOfClosestApproachVsZ0wrtBS->Fill(track.dz(bs.position()), (track.vx() - bs.position(track.vz()).x()));
+    yPointOfClosestApproachVsZ0wrtBS->Fill(track.dz(bs.position()), (track.vy() - bs.position(track.vz()).y()));
+    if (doTestPlots_) {
+      TESTDistanceOfClosestApproachToBS->Fill(track.dxy(bs.position(track.vz())));
+      TESTDistanceOfClosestApproachToBSVsPhi->Fill(track.phi(), track.dxy(bs.position(track.vz())));
+    }
+
+    if (doSIPPlots_) {
+      sipDxyToBS->Fill(track.dxy(bs.position()) / track.dxyError());
+      sipDzToBS->Fill(track.dz(bs.position()) / track.dzError());
     }
   }
-  
-  if(doDCAPlots_ || doPVPlots_ || doSIPPlots_ || doAllPlots_) {
+
+  if (doDCAPlots_ || doPVPlots_ || doSIPPlots_ || doAllPlots_) {
     edm::Handle<reco::VertexCollection> recoPrimaryVerticesHandle;
-    iEvent.getByToken(pvToken_,recoPrimaryVerticesHandle);
+    iEvent.getByToken(pvToken_, recoPrimaryVerticesHandle);
     if (recoPrimaryVerticesHandle.isValid() && !recoPrimaryVerticesHandle->empty()) {
       const reco::Vertex& pv = (*recoPrimaryVerticesHandle)[0];
-    
 
       //////////////////
-      //HI PLOTS/////// 
-      //////////////// 
+      //HI PLOTS///////
+      ////////////////
 
-      if(doHIPlots_)
-	{
-	   double longDCAsig = 0, transDCAsig = 0;
-	   double zerr2 = track.dzError()*track.dzError()+pv.zError()*pv.zError();
-	   double xyerr2 = track.d0Error()*track.d0Error()+pv.xError()*pv.yError();
-	   if(zerr2 > 0) longDCAsig = track.dz(pv.position())/zerr2;
-           if(xyerr2 > 0) transDCAsig = track.dxy(pv.position())/xyerr2;	   
-	   LongDCASig->Fill(longDCAsig);
-	   TransDCASig->Fill(transDCAsig);
+      if (doHIPlots_) {
+        double longDCAsig = 0, transDCAsig = 0;
+        double zerr2 = track.dzError() * track.dzError() + pv.zError() * pv.zError();
+        double xyerr2 = track.d0Error() * track.d0Error() + pv.xError() * pv.yError();
+        if (zerr2 > 0)
+          longDCAsig = track.dz(pv.position()) / zerr2;
+        if (xyerr2 > 0)
+          transDCAsig = track.dxy(pv.position()) / xyerr2;
+        LongDCASig->Fill(longDCAsig);
+        TransDCASig->Fill(transDCAsig);
 
+        if (track.quality(reco::TrackBase::qualityByName(qualityString_)) == 1) {
+          dNdEta_HighPurity->Fill(track.eta());
+          dNdPhi_HighPurity->Fill(track.phi());
+          dNdPt_HighPurity->Fill(track.ptError() / track.pt());
+          NhitVsEta_HighPurity->Fill(track.eta(), track.numberOfValidHits());
+          NhitVsPhi_HighPurity->Fill(track.phi(), track.numberOfValidHits());
+          dNhitdPt_HighPurity->Fill(track.pt(), track.numberOfValidHits());
+          Ptdist_HighPurity->Fill(track.pt());
+        }  //end of high quality tracks requirement
+      }
 
-	   
-
-	   if(track.quality(reco::TrackBase::qualityByName(qualityString_)) ==1)
-	     {
-	       dNdEta_HighPurity->Fill(track.eta());
-	       dNdPhi_HighPurity->Fill(track.phi());
-	       dNdPt_HighPurity->Fill(track.ptError()/track.pt());
-	       NhitVsEta_HighPurity->Fill(track.eta(),track.numberOfValidHits());
-	       NhitVsPhi_HighPurity->Fill(track.phi(),track.numberOfValidHits());
-	       dNhitdPt_HighPurity->Fill(track.pt(),track.numberOfValidHits());
-	       Ptdist_HighPurity->Fill(track.pt());
-	     }//end of high quality tracks requirement
-        }
-
-
-      xPointOfClosestApproachToPV->Fill(track.vx()-pv.position().x());
-      yPointOfClosestApproachToPV->Fill(track.vy()-pv.position().y());
+      xPointOfClosestApproachToPV->Fill(track.vx() - pv.position().x());
+      yPointOfClosestApproachToPV->Fill(track.vy() - pv.position().y());
       zPointOfClosestApproachToPV->Fill(track.dz(pv.position()));
-      DistanceOfClosestApproachToPV      -> Fill(track.dxy(pv.position()));
-      DeltaZToPV                         -> Fill(track.dz (pv.position()));
-      DistanceOfClosestApproachToPVZoom  -> Fill(track.dxy(pv.position()));
-      DeltaZToPVZoom                     -> Fill(track.dz (pv.position()));
-      DistanceOfClosestApproachToPVVsPhi -> Fill(track.phi(), track.dxy(pv.position()));
-      xPointOfClosestApproachVsZ0wrtPV   -> Fill(track.dz(pv.position()),(track.vx()-pv.position().x()));
-      yPointOfClosestApproachVsZ0wrtPV   -> Fill(track.dz(pv.position()),(track.vy()-pv.position().y()));
+      DistanceOfClosestApproachToPV->Fill(track.dxy(pv.position()));
+      DeltaZToPV->Fill(track.dz(pv.position()));
+      DistanceOfClosestApproachToPVZoom->Fill(track.dxy(pv.position()));
+      DeltaZToPVZoom->Fill(track.dz(pv.position()));
+      DistanceOfClosestApproachToPVVsPhi->Fill(track.phi(), track.dxy(pv.position()));
+      xPointOfClosestApproachVsZ0wrtPV->Fill(track.dz(pv.position()), (track.vx() - pv.position().x()));
+      yPointOfClosestApproachVsZ0wrtPV->Fill(track.dz(pv.position()), (track.vy() - pv.position().y()));
 
-
-      if(doSIPPlots_) {
+      if (doSIPPlots_) {
         edm::ESHandle<TransientTrackBuilder> theB;
-        iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
+        iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
         reco::TransientTrack transTrack = theB->build(track);
 
         GlobalVector dir(track.px(), track.py(), track.pz());
         std::pair<bool, Measurement1D> ip3d = IPTools::signedImpactParameter3D(transTrack, dir, pv);
         std::pair<bool, Measurement1D> ip2d = IPTools::signedTransverseImpactParameter(transTrack, dir, pv);
-        if(ip3d.first) sip3dToPV->Fill(ip3d.second.value() / ip3d.second.error());
-        if(ip2d.first) sip2dToPV->Fill(ip2d.second.value() / ip2d.second.error());
-        sipDxyToPV->Fill(track.dxy(pv.position())/track.dxyError());
-        sipDzToPV->Fill(track.dz(pv.position())/track.dzError());
+        if (ip3d.first)
+          sip3dToPV->Fill(ip3d.second.value() / ip3d.second.error());
+        if (ip2d.first)
+          sip2dToPV->Fill(ip2d.second.value() / ip2d.second.error());
+        sipDxyToPV->Fill(track.dxy(pv.position()) / track.dxyError());
+        sipDzToPV->Fill(track.dz(pv.position()) / track.dzError());
       }
     }
   }
 
-  if(doDCAPlots_ || doAllPlots_) {
+  if (doDCAPlots_ || doAllPlots_) {
     if (doDCAwrt000Plots_) {
       if (doThetaPlots_) {
-	DistanceOfClosestApproachVsTheta->Fill(track.theta(), track.d0());
+        DistanceOfClosestApproachVsTheta->Fill(track.theta(), track.d0());
       }
       DistanceOfClosestApproachVsEta->Fill(track.eta(), track.d0());
-    }  
-    
+    }
   }
 
   //Tracker Specific Histograms
-  if(doTrackerSpecific_ || doAllPlots_) {
+  if (doTrackerSpecific_ || doAllPlots_) {
     fillHistosForTrackerSpecific(track);
   }
 
-  if (doMeasurementStatePlots_ || doAllPlots_){
-
+  if (doMeasurementStatePlots_ || doAllPlots_) {
     if (stateName_ == "All") {
       fillHistosForState(iSetup, track, std::string("OuterSurface"));
       fillHistosForState(iSetup, track, std::string("InnerSurface"));
       fillHistosForState(iSetup, track, std::string("ImpactPoint"));
-    } else if ( 
-	       stateName_ != "OuterSurface" && 
-	       stateName_ != "InnerSurface" && 
-	       stateName_ != "ImpactPoint" &&
-	       stateName_ != "default" 
-	       ) {
+    } else if (stateName_ != "OuterSurface" && stateName_ != "InnerSurface" && stateName_ != "ImpactPoint" &&
+               stateName_ != "default") {
       fillHistosForState(iSetup, track, std::string("default"));
     } else {
       fillHistosForState(iSetup, track, stateName_);
     }
   }
-  
-  if ( doAllPlots_ ) {
-  }
 
+  if (doAllPlots_) {
+  }
 }
 
-void TrackAnalyzer::fillHistosForEfficiencyFromHitPatter(const reco::Track & track, const std::string suffix, const float monitoring, bool useInac) {
+void TrackAnalyzer::fillHistosForEfficiencyFromHitPatter(const reco::Track& track,
+                                                         const std::string suffix,
+                                                         const float monitoring,
+                                                         bool useInac) {
+  int mon = -1;
+  for (int i = 0; i < monQuantity::END; i++) {
+    if (monName[i] == suffix)
+      mon = i;
+  }
+  if (useInac)
+    mon += monQuantity::END;
 
-    int mon = -1;
-    for (int i=0; i<monQuantity::END; i++) {
-      if (monName[i] == suffix) mon = i;
-    }
-    if (useInac) mon+=monQuantity::END;
-
-    //    if (track.pt() > 1.0 && track.dxy() < 0.1 and monitoring > 0) {
-    if (track.pt() > 1.0 && track.dxy() < 0.1 and monitoring > -9.) {
-      auto hp = track.hitPattern();
-      // Here hit_category is meant to iterate over
-      // reco::HitPattern::HitCategory, defined here:
-      // http://cmslxr.fnal.gov/dxr/CMSSW/source/DataFormats/TrackReco/interface/HitPattern.h
-      for (unsigned int category = 0; category < 3; ++category) {
-        for (int hit = 0; hit < hp.numberOfAllHits((reco::HitPattern::HitCategory)(category)); ++hit) {
-          auto pattern = hp.getHitPattern((reco::HitPattern::HitCategory)(category), hit);
-          // Boolean bad is missing simply because it is inferred and the only missing case.
-          bool valid = hp.validHitFilter(pattern);
-          bool missing = hp.missingHitFilter(pattern);
-          bool inactive = hp.inactiveHitFilter(pattern);
-          int hit_type = -1;
-          hit_type = valid ? 0 :
-              ( missing ? 1 :
-                ( inactive ? 2 : 3));
-          if (hits_valid_.find(Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)) == hits_valid_.end()) {
-            LogDebug("TrackAnalyzer") << "Invalid combination of detector and subdetector: ("
-                                      << hp.getSubStructure(pattern) << ", "
-                                      << hp.getSubSubStructure(pattern) << ", "
-                                      << mon
-				      << "): ignoring it.\n";
-            continue;
-	  }
-          switch (hit_type) {
-            case 0:
-              hits_valid_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
-              hits_total_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
+  //    if (track.pt() > 1.0 && track.dxy() < 0.1 and monitoring > 0) {
+  if (track.pt() > 1.0 && track.dxy() < 0.1 and monitoring > -9.) {
+    auto hp = track.hitPattern();
+    // Here hit_category is meant to iterate over
+    // reco::HitPattern::HitCategory, defined here:
+    // http://cmslxr.fnal.gov/dxr/CMSSW/source/DataFormats/TrackReco/interface/HitPattern.h
+    for (unsigned int category = 0; category < 3; ++category) {
+      for (int hit = 0; hit < hp.numberOfAllHits((reco::HitPattern::HitCategory)(category)); ++hit) {
+        auto pattern = hp.getHitPattern((reco::HitPattern::HitCategory)(category), hit);
+        // Boolean bad is missing simply because it is inferred and the only missing case.
+        bool valid = hp.validHitFilter(pattern);
+        bool missing = hp.missingHitFilter(pattern);
+        bool inactive = hp.inactiveHitFilter(pattern);
+        int hit_type = -1;
+        hit_type = valid ? 0 : (missing ? 1 : (inactive ? 2 : 3));
+        if (hits_valid_.find(Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)) ==
+            hits_valid_.end()) {
+          LogDebug("TrackAnalyzer") << "Invalid combination of detector and subdetector: ("
+                                    << hp.getSubStructure(pattern) << ", " << hp.getSubSubStructure(pattern) << ", "
+                                    << mon << "): ignoring it.\n";
+          continue;
+        }
+        switch (hit_type) {
+          case 0:
+            hits_valid_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
+            hits_total_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
+            break;
+          case 2:
+            if (!useInac)
               break;
-            case 2:
-              if (!useInac) break;
-            case 1:
-              hits_total_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
-              break;
-            default:
-              LogDebug("TrackAnalyzer") << "Invalid hit category used " << hit_type << " ignored\n";
-          }
+          case 1:
+            hits_total_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
+            break;
+          default:
+            LogDebug("TrackAnalyzer") << "Invalid hit category used " << hit_type << " ignored\n";
         }
       }
     }
-  
+  }
 }
 
 // book histograms at differnt measurement points
 // ---------------------------------------------------------------------------------//
-void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker & ibooker) 
-{
+void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker& ibooker) {
+  // parameters from the configuration
+  std::string QualName = conf_->getParameter<std::string>("Quality");
+  std::string AlgoName = conf_->getParameter<std::string>("AlgoName");
+  std::string Folder = TopFolder_.substr(0, 2);
 
-    // parameters from the configuration
-    std::string QualName       = conf_->getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
+  // use the AlgoName and Quality Name
+  std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
-    // use the AlgoName and Quality Name 
-    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+  // get binning from the configuration
+  double Chi2NDFMin = conf_->getParameter<double>("Chi2NDFMin");
+  double Chi2NDFMax = conf_->getParameter<double>("Chi2NDFMax");
 
-    // get binning from the configuration
-    double Chi2NDFMin = conf_->getParameter<double>("Chi2NDFMin");
-    double Chi2NDFMax = conf_->getParameter<double>("Chi2NDFMax");
+  int RecHitBin = conf_->getParameter<int>("RecHitBin");
+  double RecHitMin = conf_->getParameter<double>("RecHitMin");
+  double RecHitMax = conf_->getParameter<double>("RecHitMax");
 
-    int    RecHitBin   = conf_->getParameter<int>(   "RecHitBin");
-    double RecHitMin   = conf_->getParameter<double>("RecHitMin");
-    double RecHitMax   = conf_->getParameter<double>("RecHitMax");
+  int RecLayBin = conf_->getParameter<int>("RecHitBin");
+  double RecLayMin = conf_->getParameter<double>("RecHitMin");
+  double RecLayMax = conf_->getParameter<double>("RecHitMax");
 
-    int    RecLayBin   = conf_->getParameter<int>(   "RecHitBin");
-    double RecLayMin   = conf_->getParameter<double>("RecHitMin");
-    double RecLayMax   = conf_->getParameter<double>("RecHitMax");
+  int PhiBin = conf_->getParameter<int>("PhiBin");
+  double PhiMin = conf_->getParameter<double>("PhiMin");
+  double PhiMax = conf_->getParameter<double>("PhiMax");
 
+  int EtaBin = conf_->getParameter<int>("EtaBin");
+  double EtaMin = conf_->getParameter<double>("EtaMin");
+  double EtaMax = conf_->getParameter<double>("EtaMax");
 
-    int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
-    double PhiMin     = conf_->getParameter<double>("PhiMin");
-    double PhiMax     = conf_->getParameter<double>("PhiMax");
+  int Phi2DBin = conf_->getParameter<int>("Phi2DBin");
+  int Eta2DBin = conf_->getParameter<int>("Eta2DBin");
 
-    int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
-    double EtaMin     = conf_->getParameter<double>("EtaMin");
-    double EtaMax     = conf_->getParameter<double>("EtaMax");
+  int ThetaBin = conf_->getParameter<int>("ThetaBin");
+  double ThetaMin = conf_->getParameter<double>("ThetaMin");
+  double ThetaMax = conf_->getParameter<double>("ThetaMax");
 
-    int    Phi2DBin     = conf_->getParameter<int>(   "Phi2DBin");
-    int    Eta2DBin     = conf_->getParameter<int>(   "Eta2DBin");
+  int TrackQBin = conf_->getParameter<int>("TrackQBin");
+  double TrackQMin = conf_->getParameter<double>("TrackQMin");
+  double TrackQMax = conf_->getParameter<double>("TrackQMax");
 
-    int    ThetaBin   = conf_->getParameter<int>(   "ThetaBin");
-    double ThetaMin   = conf_->getParameter<double>("ThetaMin");
-    double ThetaMax   = conf_->getParameter<double>("ThetaMax");
+  int TrackPtBin = conf_->getParameter<int>("TrackPtBin");
+  double TrackPtMin = conf_->getParameter<double>("TrackPtMin");
+  double TrackPtMax = conf_->getParameter<double>("TrackPtMax");
 
-    int    TrackQBin  = conf_->getParameter<int>(   "TrackQBin");
-    double TrackQMin  = conf_->getParameter<double>("TrackQMin");
-    double TrackQMax  = conf_->getParameter<double>("TrackQMax");
+  int TrackPBin = conf_->getParameter<int>("TrackPBin");
+  double TrackPMin = conf_->getParameter<double>("TrackPMin");
+  double TrackPMax = conf_->getParameter<double>("TrackPMax");
 
-    int    TrackPtBin = conf_->getParameter<int>(   "TrackPtBin");
-    double TrackPtMin = conf_->getParameter<double>("TrackPtMin");
-    double TrackPtMax = conf_->getParameter<double>("TrackPtMax");
+  int TrackPxBin = conf_->getParameter<int>("TrackPxBin");
+  double TrackPxMin = conf_->getParameter<double>("TrackPxMin");
+  double TrackPxMax = conf_->getParameter<double>("TrackPxMax");
 
-    int    TrackPBin  = conf_->getParameter<int>(   "TrackPBin");
-    double TrackPMin  = conf_->getParameter<double>("TrackPMin");
-    double TrackPMax  = conf_->getParameter<double>("TrackPMax");
+  int TrackPyBin = conf_->getParameter<int>("TrackPyBin");
+  double TrackPyMin = conf_->getParameter<double>("TrackPyMin");
+  double TrackPyMax = conf_->getParameter<double>("TrackPyMax");
 
-    int    TrackPxBin = conf_->getParameter<int>(   "TrackPxBin");
-    double TrackPxMin = conf_->getParameter<double>("TrackPxMin");
-    double TrackPxMax = conf_->getParameter<double>("TrackPxMax");
+  int TrackPzBin = conf_->getParameter<int>("TrackPzBin");
+  double TrackPzMin = conf_->getParameter<double>("TrackPzMin");
+  double TrackPzMax = conf_->getParameter<double>("TrackPzMax");
 
-    int    TrackPyBin = conf_->getParameter<int>(   "TrackPyBin");
-    double TrackPyMin = conf_->getParameter<double>("TrackPyMin");
-    double TrackPyMax = conf_->getParameter<double>("TrackPyMax");
+  int ptErrBin = conf_->getParameter<int>("ptErrBin");
+  double ptErrMin = conf_->getParameter<double>("ptErrMin");
+  double ptErrMax = conf_->getParameter<double>("ptErrMax");
 
-    int    TrackPzBin = conf_->getParameter<int>(   "TrackPzBin");
-    double TrackPzMin = conf_->getParameter<double>("TrackPzMin");
-    double TrackPzMax = conf_->getParameter<double>("TrackPzMax");
+  int pxErrBin = conf_->getParameter<int>("pxErrBin");
+  double pxErrMin = conf_->getParameter<double>("pxErrMin");
+  double pxErrMax = conf_->getParameter<double>("pxErrMax");
 
-    int    ptErrBin   = conf_->getParameter<int>(   "ptErrBin");
-    double ptErrMin   = conf_->getParameter<double>("ptErrMin");
-    double ptErrMax   = conf_->getParameter<double>("ptErrMax");
+  int pyErrBin = conf_->getParameter<int>("pyErrBin");
+  double pyErrMin = conf_->getParameter<double>("pyErrMin");
+  double pyErrMax = conf_->getParameter<double>("pyErrMax");
 
-    int    pxErrBin   = conf_->getParameter<int>(   "pxErrBin");
-    double pxErrMin   = conf_->getParameter<double>("pxErrMin");
-    double pxErrMax   = conf_->getParameter<double>("pxErrMax");
+  int pzErrBin = conf_->getParameter<int>("pzErrBin");
+  double pzErrMin = conf_->getParameter<double>("pzErrMin");
+  double pzErrMax = conf_->getParameter<double>("pzErrMax");
 
-    int    pyErrBin   = conf_->getParameter<int>(   "pyErrBin");
-    double pyErrMin   = conf_->getParameter<double>("pyErrMin");
-    double pyErrMax   = conf_->getParameter<double>("pyErrMax");
+  int pErrBin = conf_->getParameter<int>("pErrBin");
+  double pErrMin = conf_->getParameter<double>("pErrMin");
+  double pErrMax = conf_->getParameter<double>("pErrMax");
 
-    int    pzErrBin   = conf_->getParameter<int>(   "pzErrBin");
-    double pzErrMin   = conf_->getParameter<double>("pzErrMin");
-    double pzErrMax   = conf_->getParameter<double>("pzErrMax");
+  int phiErrBin = conf_->getParameter<int>("phiErrBin");
+  double phiErrMin = conf_->getParameter<double>("phiErrMin");
+  double phiErrMax = conf_->getParameter<double>("phiErrMax");
 
-    int    pErrBin    = conf_->getParameter<int>(   "pErrBin");
-    double pErrMin    = conf_->getParameter<double>("pErrMin");
-    double pErrMax    = conf_->getParameter<double>("pErrMax");
+  int etaErrBin = conf_->getParameter<int>("etaErrBin");
+  double etaErrMin = conf_->getParameter<double>("etaErrMin");
+  double etaErrMax = conf_->getParameter<double>("etaErrMax");
 
-    int    phiErrBin  = conf_->getParameter<int>(   "phiErrBin");
-    double phiErrMin  = conf_->getParameter<double>("phiErrMin");
-    double phiErrMax  = conf_->getParameter<double>("phiErrMax");
+  double Chi2ProbMin = conf_->getParameter<double>("Chi2ProbMin");
+  double Chi2ProbMax = conf_->getParameter<double>("Chi2ProbMax");
 
-    int    etaErrBin  = conf_->getParameter<int>(   "etaErrBin");
-    double etaErrMin  = conf_->getParameter<double>("etaErrMin");
-    double etaErrMax  = conf_->getParameter<double>("etaErrMax");
+  ibooker.setCurrentFolder(TopFolder_);
 
+  TkParameterMEs tkmes;
 
-    double Chi2ProbMin  = conf_->getParameter<double>("Chi2ProbMin");
-    double Chi2ProbMax  = conf_->getParameter<double>("Chi2ProbMax");
+  std::string histTag = (sname == "default") ? CategoryName : sname + "_" + CategoryName;
 
-    ibooker.setCurrentFolder(TopFolder_);
-
-    TkParameterMEs tkmes;
-
-    std::string histTag = (sname == "default") ? CategoryName : sname + "_" + CategoryName;
-
-    if(doAllPlots_) {
-
-      // general properties
-      ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-      
-      if (doThetaPlots_) {
-	histname = "Chi2oNDFVsTheta_" + histTag;
-	tkmes.Chi2oNDFVsTheta = ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, Chi2NDFMin, Chi2NDFMax,"");
-	tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #theta",1);
-	tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #chi^{2}/ndf",2);
-      }
-      histname = "Chi2oNDFVsPhi_" + histTag;
-      tkmes.Chi2oNDFVsPhi   = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, Chi2NDFMin, Chi2NDFMax,"");
-      tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #phi",1);
-      tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #chi^{2}/ndf",2);
-      
-      histname = "Chi2ProbVsPhi_" + histTag;
-      tkmes.Chi2ProbVsPhi = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PhiBin, PhiMin, PhiMax, Chi2ProbMin, Chi2ProbMax);
-      tkmes.Chi2ProbVsPhi->setAxisTitle("Tracks #phi"  ,1);
-      tkmes.Chi2ProbVsPhi->setAxisTitle("Track #chi^{2} probability",2);
-      
-      histname = "Chi2ProbVsEta_" + histTag;
-      tkmes.Chi2ProbVsEta = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, EtaBin, EtaMin, EtaMax, Chi2ProbMin, Chi2ProbMax);
-      tkmes.Chi2ProbVsEta->setAxisTitle("Tracks #eta"  ,1);
-      tkmes.Chi2ProbVsEta->setAxisTitle("Track #chi^{2} probability",2);
-
-    }
-    
+  if (doAllPlots_) {
     // general properties
-    ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-
-
-    histname = "Chi2oNDFVsEta_" + histTag;
-    tkmes.Chi2oNDFVsEta   = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, Chi2NDFMin, Chi2NDFMax,"");
-    tkmes.Chi2oNDFVsEta->setAxisTitle("Track #eta",1);
-    tkmes.Chi2oNDFVsEta->setAxisTitle("Track #chi^{2}/ndf",2);
-
-    histname = "Chi2oNDFVsPt_" + histTag;
-    tkmes.Chi2oNDFVsPt   = ibooker.bookProfile(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax, Chi2NDFMin, Chi2NDFMax,"");
-    tkmes.Chi2oNDFVsPt->setAxisTitle("Track p_{T} (GeV/c)", 1);
-    tkmes.Chi2oNDFVsPt->setAxisTitle("Track #chi^{2}/ndf",2);
-
-    histname = "Chi2oNDFVsNHits_" + histTag;
-    tkmes.Chi2oNDFVsNHits   = ibooker.bookProfile(histname, histname, 50, 0, 50, Chi2NDFMin, Chi2NDFMax,"");
-    tkmes.Chi2oNDFVsNHits->setAxisTitle("Track NHits", 1);
-    tkmes.Chi2oNDFVsNHits->setAxisTitle("Track #chi^{2}/ndf",2);
-
-    histname = "TrackP_" + histTag;
-    tkmes.TrackP = ibooker.book1D(histname, histname, TrackPBin, TrackPMin, TrackPMax);
-    tkmes.TrackP->setAxisTitle("Track |p| (GeV/c)", 1);
-    tkmes.TrackP->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackPt_" + histTag;
-    tkmes.TrackPt = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
-    tkmes.TrackPt->setAxisTitle("Track p_{T} (GeV/c)", 1);
-    tkmes.TrackPt->setAxisTitle("Number of Tracks",2);
-
-    if (doTrackPxPyPlots_) {
-      histname = "TrackPx_" + histTag;
-      tkmes.TrackPx = ibooker.book1D(histname, histname, TrackPxBin, TrackPxMin, TrackPxMax);
-      tkmes.TrackPx->setAxisTitle("Track p_{x} (GeV/c)", 1);
-      tkmes.TrackPx->setAxisTitle("Number of Tracks",2);
-
-      histname = "TrackPy_" + histTag;
-      tkmes.TrackPy = ibooker.book1D(histname, histname, TrackPyBin, TrackPyMin, TrackPyMax);
-      tkmes.TrackPy->setAxisTitle("Track p_{y} (GeV/c)", 1);
-      tkmes.TrackPy->setAxisTitle("Number of Tracks",2);
-    }
-    histname = "TrackPz_" + histTag;
-    tkmes.TrackPz = ibooker.book1D(histname, histname, TrackPzBin, TrackPzMin, TrackPzMax);
-    tkmes.TrackPz->setAxisTitle("Track p_{z} (GeV/c)", 1);
-    tkmes.TrackPz->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackPhi_" + histTag;
-    tkmes.TrackPhi = ibooker.book1D(histname, histname, PhiBin, PhiMin, PhiMax);
-    tkmes.TrackPhi->setAxisTitle("Track #phi", 1);
-    tkmes.TrackPhi->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackEta_" + histTag;
-    tkmes.TrackEta = ibooker.book1D(histname, histname, EtaBin, EtaMin, EtaMax);
-    tkmes.TrackEta->setAxisTitle("Track #eta", 1);
-    tkmes.TrackEta->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackEtaPhi_" + histTag;
-    tkmes.TrackEtaPhi = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TrackEtaPhi->setAxisTitle("Track #eta", 1);
-    tkmes.TrackEtaPhi->setAxisTitle("Track #phi", 2);
-
-    histname = "TrackEtaPhiInner_" + histTag;
-    tkmes.TrackEtaPhiInner = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TrackEtaPhiInner->setAxisTitle("Track #eta", 1);
-    tkmes.TrackEtaPhiInner->setAxisTitle("Track #phi", 2);
-
-    histname = "TrackEtaPhiOuter_" + histTag;
-    tkmes.TrackEtaPhiOuter = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
-    tkmes.TrackEtaPhiOuter->setAxisTitle("Track #eta", 1);
-    tkmes.TrackEtaPhiOuter->setAxisTitle("Track #phi", 2);
-
-
-
-    if (doThetaPlots_) {  
-      histname = "TrackTheta_" + histTag;
-      tkmes.TrackTheta = ibooker.book1D(histname, histname, ThetaBin, ThetaMin, ThetaMax);
-      tkmes.TrackTheta->setAxisTitle("Track #theta", 1);
-      tkmes.TrackTheta->setAxisTitle("Number of Tracks",2);
-    }
-    histname = "TrackQ_" + histTag;
-    tkmes.TrackQ = ibooker.book1D(histname, histname, TrackQBin, TrackQMin, TrackQMax);
-    tkmes.TrackQ->setAxisTitle("Track Charge", 1);
-    tkmes.TrackQ->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackPErrOverP_" + histTag;
-    tkmes.TrackPErr = ibooker.book1D(histname, histname, pErrBin, pErrMin, pErrMax);
-    tkmes.TrackPErr->setAxisTitle("track error(p)/p", 1);
-    tkmes.TrackPErr->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackPtErrOverPt_" + histTag;
-    tkmes.TrackPtErr = ibooker.book1D(histname, histname, ptErrBin, ptErrMin, ptErrMax);
-    tkmes.TrackPtErr->setAxisTitle("track error(p_{T})/p_{T}", 1);
-    tkmes.TrackPtErr->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackPtErrOverPtVsEta_" + histTag;
-    tkmes.TrackPtErrVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, ptErrMin, ptErrMax);
-    tkmes.TrackPtErrVsEta->setAxisTitle("Track #eta",1);
-    tkmes.TrackPtErrVsEta->setAxisTitle("track error(p_{T})/p_{T}", 2);
-
-    if (doTrackPxPyPlots_) {
-      histname = "TrackPxErrOverPx_" + histTag;
-      tkmes.TrackPxErr = ibooker.book1D(histname, histname, pxErrBin, pxErrMin, pxErrMax);
-      tkmes.TrackPxErr->setAxisTitle("track error(p_{x})/p_{x}", 1);
-      tkmes.TrackPxErr->setAxisTitle("Number of Tracks",2);
-      
-      histname = "TrackPyErrOverPy_" + histTag;
-      tkmes.TrackPyErr = ibooker.book1D(histname, histname, pyErrBin, pyErrMin, pyErrMax);
-      tkmes.TrackPyErr->setAxisTitle("track error(p_{y})/p_{y}", 1);
-      tkmes.TrackPyErr->setAxisTitle("Number of Tracks",2);
-    }
-    histname = "TrackPzErrOverPz_" + histTag;
-    tkmes.TrackPzErr = ibooker.book1D(histname, histname, pzErrBin, pzErrMin, pzErrMax);
-    tkmes.TrackPzErr->setAxisTitle("track error(p_{z})/p_{z}", 1);
-    tkmes.TrackPzErr->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackPhiErr_" + histTag;
-    tkmes.TrackPhiErr = ibooker.book1D(histname, histname, phiErrBin, phiErrMin, phiErrMax);
-    tkmes.TrackPhiErr->setAxisTitle("track error(#phi)");
-    tkmes.TrackPhiErr->setAxisTitle("Number of Tracks",2);
-
-    histname = "TrackEtaErr_" + histTag;
-    tkmes.TrackEtaErr = ibooker.book1D(histname, histname, etaErrBin, etaErrMin, etaErrMax);
-    tkmes.TrackEtaErr->setAxisTitle("track error(#eta)");
-    tkmes.TrackEtaErr->setAxisTitle("Number of Tracks",2);
-
-    // rec hit profiles
-    ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
-    histname = "NumberOfRecHitsPerTrackVsPhi_" + histTag;
-    tkmes.NumberOfRecHitsPerTrackVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, RecHitBin, RecHitMin, RecHitMax,"");
-    tkmes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Track #phi",1);
-    tkmes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Number of RecHits in each Track",2);
-
-    if (doThetaPlots_) {
-      histname = "NumberOfRecHitsPerTrackVsTheta_" + histTag;
-      tkmes.NumberOfRecHitsPerTrackVsTheta = ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, RecHitBin, RecHitMin, RecHitMax,"");
-      tkmes.NumberOfRecHitsPerTrackVsTheta->setAxisTitle("Track #phi",1);
-      tkmes.NumberOfRecHitsPerTrackVsTheta->setAxisTitle("Number of RecHits in each Track",2);
-    }
-    histname = "NumberOfRecHitsPerTrackVsEta_" + histTag;
-    tkmes.NumberOfRecHitsPerTrackVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, RecHitBin, RecHitMin, RecHitMax,"");
-    tkmes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Track #eta",1);
-    tkmes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Number of RecHits in each Track",2);
-
-    histname = "NumberOfValidRecHitsPerTrackVsPhi_" + histTag;
-    tkmes.NumberOfValidRecHitsPerTrackVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, RecHitMin, RecHitMax,"");
-    tkmes.NumberOfValidRecHitsPerTrackVsPhi->setAxisTitle("Track #phi",1);
-    tkmes.NumberOfValidRecHitsPerTrackVsPhi->setAxisTitle("Number of valid RecHits in each Track",2);
-    
-    histname = "NumberOfValidRecHitsPerTrackVsEta_" + histTag;
-    tkmes.NumberOfValidRecHitsPerTrackVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, RecHitMin, RecHitMax,"");
-    tkmes.NumberOfValidRecHitsPerTrackVsEta->setAxisTitle("Track #eta",1);
-    tkmes.NumberOfValidRecHitsPerTrackVsEta->setAxisTitle("Number of valid RecHits in each Track",2);
-    
-    histname = "NumberOfValidRecHitsPerTrackVsPt_" + histTag;
-    tkmes.NumberOfValidRecHitsPerTrackVsPt = ibooker.bookProfile(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax, RecHitMin, RecHitMax,"");
-    tkmes.NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]",1);
-    tkmes.NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Number of valid RecHits in each Track",2);
-    
-    //////////////////////////////////////////
-    histname = "NumberOfLayersPerTrackVsPhi_" + histTag;
-    tkmes.NumberOfLayersPerTrackVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, RecLayBin, RecLayMin, RecLayMax,"");
-    tkmes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Track #phi",1);
-    tkmes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Number of Layers in each Track",2);
-
-    if (doThetaPlots_) {
-      histname = "NumberOfLayersPerTrackVsTheta_" + histTag;
-      tkmes.NumberOfLayersPerTrackVsTheta = ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, RecLayBin, RecLayMin, RecLayMax,"");
-      tkmes.NumberOfLayersPerTrackVsTheta->setAxisTitle("Track #phi",1);
-      tkmes.NumberOfLayersPerTrackVsTheta->setAxisTitle("Number of Layers in each Track",2);
-    }
-    histname = "NumberOfLayersPerTrackVsEta_" + histTag;
-    tkmes.NumberOfLayersPerTrackVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, RecLayBin, RecLayMin, RecLayMax,"");
-    tkmes.NumberOfLayersPerTrackVsEta->setAxisTitle("Track #eta",1);
-    tkmes.NumberOfLayersPerTrackVsEta->setAxisTitle("Number of Layers in each Track",2);
+    ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
 
     if (doThetaPlots_) {
       histname = "Chi2oNDFVsTheta_" + histTag;
-      tkmes.Chi2oNDFVsTheta = ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, Chi2NDFMin, Chi2NDFMax,"");
-      tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #theta",1);
-      tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #chi^{2}/ndf",2);
+      tkmes.Chi2oNDFVsTheta =
+          ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, Chi2NDFMin, Chi2NDFMax, "");
+      tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #theta", 1);
+      tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #chi^{2}/ndf", 2);
     }
-    if (doAllPlots_) {
-      histname = "Chi2oNDFVsPhi_" + histTag;
-      tkmes.Chi2oNDFVsPhi   = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, Chi2NDFMin, Chi2NDFMax,"");
-      tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #phi",1);
-      tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #chi^{2}/ndf",2);
-      
-      histname = "Chi2oNDFVsEta_" + histTag;
-      tkmes.Chi2oNDFVsEta   = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, Chi2NDFMin, Chi2NDFMax,"");
-      tkmes.Chi2oNDFVsEta->setAxisTitle("Track #eta",1);
-      tkmes.Chi2oNDFVsEta->setAxisTitle("Track #chi^{2}/ndf",2);
-      
-      histname = "Chi2ProbVsPhi_" + histTag;
-      tkmes.Chi2ProbVsPhi = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, PhiBin, PhiMin, PhiMax, Chi2ProbMin, Chi2ProbMax);
-      tkmes.Chi2ProbVsPhi->setAxisTitle("Tracks #phi"  ,1);
-      tkmes.Chi2ProbVsPhi->setAxisTitle("Track #chi^{2} probability",2);
-      
-      histname = "Chi2ProbVsEta_" + histTag;
-      tkmes.Chi2ProbVsEta = ibooker.bookProfile(histname+CategoryName, histname+CategoryName, EtaBin, EtaMin, EtaMax, Chi2ProbMin, Chi2ProbMax);
-      tkmes.Chi2ProbVsEta->setAxisTitle("Tracks #eta"  ,1);
-      tkmes.Chi2ProbVsEta->setAxisTitle("Track #chi^{2} probability",2);
+    histname = "Chi2oNDFVsPhi_" + histTag;
+    tkmes.Chi2oNDFVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, Chi2NDFMin, Chi2NDFMax, "");
+    tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #phi", 1);
+    tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #chi^{2}/ndf", 2);
+
+    histname = "Chi2ProbVsPhi_" + histTag;
+    tkmes.Chi2ProbVsPhi = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, Chi2ProbMin, Chi2ProbMax);
+    tkmes.Chi2ProbVsPhi->setAxisTitle("Tracks #phi", 1);
+    tkmes.Chi2ProbVsPhi->setAxisTitle("Track #chi^{2} probability", 2);
+
+    histname = "Chi2ProbVsEta_" + histTag;
+    tkmes.Chi2ProbVsEta = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, Chi2ProbMin, Chi2ProbMax);
+    tkmes.Chi2ProbVsEta->setAxisTitle("Tracks #eta", 1);
+    tkmes.Chi2ProbVsEta->setAxisTitle("Track #chi^{2} probability", 2);
+  }
+
+  // general properties
+  ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
+
+  histname = "Chi2oNDFVsEta_" + histTag;
+  tkmes.Chi2oNDFVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, Chi2NDFMin, Chi2NDFMax, "");
+  tkmes.Chi2oNDFVsEta->setAxisTitle("Track #eta", 1);
+  tkmes.Chi2oNDFVsEta->setAxisTitle("Track #chi^{2}/ndf", 2);
+
+  histname = "Chi2oNDFVsPt_" + histTag;
+  tkmes.Chi2oNDFVsPt =
+      ibooker.bookProfile(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax, Chi2NDFMin, Chi2NDFMax, "");
+  tkmes.Chi2oNDFVsPt->setAxisTitle("Track p_{T} (GeV/c)", 1);
+  tkmes.Chi2oNDFVsPt->setAxisTitle("Track #chi^{2}/ndf", 2);
+
+  histname = "Chi2oNDFVsNHits_" + histTag;
+  tkmes.Chi2oNDFVsNHits = ibooker.bookProfile(histname, histname, 50, 0., 50, Chi2NDFMin, Chi2NDFMax, "");
+  tkmes.Chi2oNDFVsNHits->setAxisTitle("Track NHits", 1);
+  tkmes.Chi2oNDFVsNHits->setAxisTitle("Track #chi^{2}/ndf", 2);
+
+  histname = "TrackP_" + histTag;
+  tkmes.TrackP = ibooker.book1D(histname, histname, TrackPBin, TrackPMin, TrackPMax);
+  tkmes.TrackP->setAxisTitle("Track |p| (GeV/c)", 1);
+  tkmes.TrackP->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackPt_" + histTag;
+  tkmes.TrackPt = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+  tkmes.TrackPt->setAxisTitle("Track p_{T} (GeV/c)", 1);
+  tkmes.TrackPt->setAxisTitle("Number of Tracks", 2);
+
+  if (doTrackPxPyPlots_) {
+    histname = "TrackPx_" + histTag;
+    tkmes.TrackPx = ibooker.book1D(histname, histname, TrackPxBin, TrackPxMin, TrackPxMax);
+    tkmes.TrackPx->setAxisTitle("Track p_{x} (GeV/c)", 1);
+    tkmes.TrackPx->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPy_" + histTag;
+    tkmes.TrackPy = ibooker.book1D(histname, histname, TrackPyBin, TrackPyMin, TrackPyMax);
+    tkmes.TrackPy->setAxisTitle("Track p_{y} (GeV/c)", 1);
+    tkmes.TrackPy->setAxisTitle("Number of Tracks", 2);
+  }
+  histname = "TrackPz_" + histTag;
+  tkmes.TrackPz = ibooker.book1D(histname, histname, TrackPzBin, TrackPzMin, TrackPzMax);
+  tkmes.TrackPz->setAxisTitle("Track p_{z} (GeV/c)", 1);
+  tkmes.TrackPz->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackPhi_" + histTag;
+  tkmes.TrackPhi = ibooker.book1D(histname, histname, PhiBin, PhiMin, PhiMax);
+  tkmes.TrackPhi->setAxisTitle("Track #phi", 1);
+  tkmes.TrackPhi->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackEta_" + histTag;
+  tkmes.TrackEta = ibooker.book1D(histname, histname, EtaBin, EtaMin, EtaMax);
+  tkmes.TrackEta->setAxisTitle("Track #eta", 1);
+  tkmes.TrackEta->setAxisTitle("Number of Tracks", 2);
+
+  if (Folder == "Tr") {
+    histname = "TrackPtHighPurity_" + histTag;
+    tkmes.TrackPtHighPurity = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPtHighPurity->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPtHighPurity->setAxisTitle("Number of High Purity Tracks", 2);
+
+    histname = "TrackPtTight_" + histTag;
+    tkmes.TrackPtTight = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPtTight->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPtTight->setAxisTitle("Number of Tight Tracks", 2);
+
+    histname = "TrackPtLoose_" + histTag;
+    tkmes.TrackPtLoose = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPtLoose->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPtLoose->setAxisTitle("Number of Loose Tracks", 2);
+
+    histname = "Quality_";
+    tkmes.Quality = ibooker.book1D(histname + CategoryName, histname + CategoryName, 3, 0., 3.);
+    tkmes.Quality->setAxisTitle("Track quality", 1);
+    tkmes.Quality->setAxisTitle("Number of Tracks", 2);
+
+    for (size_t ibin = 0; ibin < 3; ibin++) {
+      tkmes.Quality->setBinLabel(ibin + 1, reco::TrackBase::qualityNames[ibin]);
     }
 
-    // now put the MEs in the map
-    TkParameterMEMap.insert( std::make_pair(sname, tkmes) );
+    histname = "TrackPt_NegEta_Phi_btw_neg16_neg32_" + histTag;
+    tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->setAxisTitle("Number of Tracks", 2);
 
+    histname = "TrackPt_NegEta_Phi_btw_0_neg16_" + histTag;
+    tkmes.TrackPt_NegEta_Phi_btw_0_neg16 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_NegEta_Phi_btw_0_neg16->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_NegEta_Phi_btw_0_neg16->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPt_NegEta_Phi_btw_16_0_" + histTag;
+    tkmes.TrackPt_NegEta_Phi_btw_16_0 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_NegEta_Phi_btw_16_0->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_NegEta_Phi_btw_16_0->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPt_NegEta_Phi_btw_32_16_" + histTag;
+    tkmes.TrackPt_NegEta_Phi_btw_32_16 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_NegEta_Phi_btw_32_16->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_NegEta_Phi_btw_32_16->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPt_PosEta_Phi_btw_neg16_neg32_" + histTag;
+    tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPt_PosEta_Phi_btw_0_neg16_" + histTag;
+    tkmes.TrackPt_PosEta_Phi_btw_0_neg16 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_PosEta_Phi_btw_0_neg16->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_PosEta_Phi_btw_0_neg16->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPt_PosEta_Phi_btw_16_0_" + histTag;
+    tkmes.TrackPt_PosEta_Phi_btw_16_0 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_PosEta_Phi_btw_16_0->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_PosEta_Phi_btw_16_0->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPt_PosEta_Phi_btw_32_16_" + histTag;
+    tkmes.TrackPt_PosEta_Phi_btw_32_16 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.TrackPt_PosEta_Phi_btw_32_16->setAxisTitle("Track p_{T} (GeV/c)", 1);
+    tkmes.TrackPt_PosEta_Phi_btw_32_16->setAxisTitle("Number of Tracks", 2);
+
+    histname = "Ratio_byFolding_" + histTag;
+    tkmes.Ratio_byFolding = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.Ratio_byFolding->setAxisTitle("Track p_{T} (GeV/c)", 1);
+
+    histname = "Ratio_byFolding2_" + histTag;
+    tkmes.Ratio_byFolding2 = ibooker.book1D(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax);
+    tkmes.Ratio_byFolding2->setAxisTitle("Track p_{T} (GeV/c)", 1);
+
+    histname = "TrackEtaHighpurity_" + histTag;
+    tkmes.TrackEtaHighPurity = ibooker.book1D(histname, histname, EtaBin, EtaMin, EtaMax);
+    tkmes.TrackEtaHighPurity->setAxisTitle("Track #eta", 1);
+    tkmes.TrackEtaHighPurity->setAxisTitle("Number of High Purity Tracks", 2);
+
+    histname = "TrackEtaTight_" + histTag;
+    tkmes.TrackEtaTight = ibooker.book1D(histname, histname, EtaBin, EtaMin, EtaMax);
+    tkmes.TrackEtaTight->setAxisTitle("Track #eta", 1);
+    tkmes.TrackEtaTight->setAxisTitle("Number of Tight Tracks", 2);
+
+    histname = "TrackEtaLoose_" + histTag;
+    tkmes.TrackEtaLoose = ibooker.book1D(histname, histname, EtaBin, EtaMin, EtaMax);
+    tkmes.TrackEtaLoose->setAxisTitle("Track #eta", 1);
+    tkmes.TrackEtaLoose->setAxisTitle("Number of Loose Tracks", 2);
+
+    histname = "TrackEtaPhiInverted_" + histTag;
+    tkmes.TrackEtaPhiInverted = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+    tkmes.TrackEtaPhiInverted->setAxisTitle("Track #eta", 1);
+    tkmes.TrackEtaPhiInverted->setAxisTitle("Track #phi", 2);
+
+    histname = "TrackEtaPhiInvertedoutofphase_" + histTag;
+    tkmes.TrackEtaPhiInvertedoutofphase =
+        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+    tkmes.TrackEtaPhiInvertedoutofphase->setAxisTitle("Track #eta", 1);
+    tkmes.TrackEtaPhiInvertedoutofphase->setAxisTitle("Track #phi", 2);
+
+    histname = "TkEtaPhi_Ratio_byFoldingmap_" + histTag;
+    tkmes.TkEtaPhi_Ratio_byFoldingmap =
+        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+    tkmes.TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #eta", 1);
+    tkmes.TkEtaPhi_Ratio_byFoldingmap->setAxisTitle("Track #phi", 2);
+
+    histname = "TkEtaPhi_Ratio_byFoldingmap_op_" + histTag;
+    tkmes.TkEtaPhi_Ratio_byFoldingmap_op =
+        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+    tkmes.TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #eta", 1);
+    tkmes.TkEtaPhi_Ratio_byFoldingmap_op->setAxisTitle("Track #phi", 2);
+
+    histname = "TkEtaPhi_RelativeDifference_byFoldingmap_" + histTag;
+    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap =
+        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #eta", 1);
+    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setAxisTitle("Track #phi", 2);
+
+    histname = "TkEtaPhi_RelativeDifference_byFoldingmap_op_" + histTag;
+    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op =
+        ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #eta", 1);
+    tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setAxisTitle("Track #phi", 2);
+
+    histname = "TrackQoverP_" + histTag;
+    tkmes.TrackQoverP = ibooker.book1D(histname, histname, 10 * TrackQBin, TrackQMin, TrackQMax);
+    tkmes.TrackQoverP->setAxisTitle("Track QoverP", 1);
+    tkmes.TrackQoverP->setAxisTitle("Number of Tracks", 2);
+  }
+
+  histname = "TrackEtaPhi_" + histTag;
+  tkmes.TrackEtaPhi = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  tkmes.TrackEtaPhi->setAxisTitle("Track #eta", 1);
+  tkmes.TrackEtaPhi->setAxisTitle("Track #phi", 2);
+
+  histname = "TrackEtaPhiInner_" + histTag;
+  tkmes.TrackEtaPhiInner = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  tkmes.TrackEtaPhiInner->setAxisTitle("Track #eta", 1);
+  tkmes.TrackEtaPhiInner->setAxisTitle("Track #phi", 2);
+
+  histname = "TrackEtaPhiOuter_" + histTag;
+  tkmes.TrackEtaPhiOuter = ibooker.book2D(histname, histname, Eta2DBin, EtaMin, EtaMax, Phi2DBin, PhiMin, PhiMax);
+  tkmes.TrackEtaPhiOuter->setAxisTitle("Track #eta", 1);
+  tkmes.TrackEtaPhiOuter->setAxisTitle("Track #phi", 2);
+
+  if (doThetaPlots_) {
+    histname = "TrackTheta_" + histTag;
+    tkmes.TrackTheta = ibooker.book1D(histname, histname, ThetaBin, ThetaMin, ThetaMax);
+    tkmes.TrackTheta->setAxisTitle("Track #theta", 1);
+    tkmes.TrackTheta->setAxisTitle("Number of Tracks", 2);
+  }
+  histname = "TrackQ_" + histTag;
+  tkmes.TrackQ = ibooker.book1D(histname, histname, TrackQBin, TrackQMin, TrackQMax);
+  tkmes.TrackQ->setAxisTitle("Track Charge", 1);
+  tkmes.TrackQ->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackPErrOverP_" + histTag;
+  tkmes.TrackPErr = ibooker.book1D(histname, histname, pErrBin, pErrMin, pErrMax);
+  tkmes.TrackPErr->setAxisTitle("track error(p)/p", 1);
+  tkmes.TrackPErr->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackPtErrOverPt_" + histTag;
+  tkmes.TrackPtErr = ibooker.book1D(histname, histname, ptErrBin, ptErrMin, ptErrMax);
+  tkmes.TrackPtErr->setAxisTitle("track error(p_{T})/p_{T}", 1);
+  tkmes.TrackPtErr->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackPtErrOverPtVsEta_" + histTag;
+  tkmes.TrackPtErrVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, ptErrMin, ptErrMax);
+  tkmes.TrackPtErrVsEta->setAxisTitle("Track #eta", 1);
+  tkmes.TrackPtErrVsEta->setAxisTitle("track error(p_{T})/p_{T}", 2);
+
+  if (doTrackPxPyPlots_) {
+    histname = "TrackPxErrOverPx_" + histTag;
+    tkmes.TrackPxErr = ibooker.book1D(histname, histname, pxErrBin, pxErrMin, pxErrMax);
+    tkmes.TrackPxErr->setAxisTitle("track error(p_{x})/p_{x}", 1);
+    tkmes.TrackPxErr->setAxisTitle("Number of Tracks", 2);
+
+    histname = "TrackPyErrOverPy_" + histTag;
+    tkmes.TrackPyErr = ibooker.book1D(histname, histname, pyErrBin, pyErrMin, pyErrMax);
+    tkmes.TrackPyErr->setAxisTitle("track error(p_{y})/p_{y}", 1);
+    tkmes.TrackPyErr->setAxisTitle("Number of Tracks", 2);
+  }
+  histname = "TrackPzErrOverPz_" + histTag;
+  tkmes.TrackPzErr = ibooker.book1D(histname, histname, pzErrBin, pzErrMin, pzErrMax);
+  tkmes.TrackPzErr->setAxisTitle("track error(p_{z})/p_{z}", 1);
+  tkmes.TrackPzErr->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackPhiErr_" + histTag;
+  tkmes.TrackPhiErr = ibooker.book1D(histname, histname, phiErrBin, phiErrMin, phiErrMax);
+  tkmes.TrackPhiErr->setAxisTitle("track error(#phi)");
+  tkmes.TrackPhiErr->setAxisTitle("Number of Tracks", 2);
+
+  histname = "TrackEtaErr_" + histTag;
+  tkmes.TrackEtaErr = ibooker.book1D(histname, histname, etaErrBin, etaErrMin, etaErrMax);
+  tkmes.TrackEtaErr->setAxisTitle("track error(#eta)");
+  tkmes.TrackEtaErr->setAxisTitle("Number of Tracks", 2);
+
+  // rec hit profiles
+  ibooker.setCurrentFolder(TopFolder_ + "/GeneralProperties");
+  histname = "NumberOfRecHitsPerTrackVsPhi_" + histTag;
+  tkmes.NumberOfRecHitsPerTrackVsPhi =
+      ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, RecHitBin, RecHitMin, RecHitMax, "");
+  tkmes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Track #phi", 1);
+  tkmes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Number of RecHits in each Track", 2);
+
+  if (doThetaPlots_) {
+    histname = "NumberOfRecHitsPerTrackVsTheta_" + histTag;
+    tkmes.NumberOfRecHitsPerTrackVsTheta =
+        ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, RecHitBin, RecHitMin, RecHitMax, "");
+    tkmes.NumberOfRecHitsPerTrackVsTheta->setAxisTitle("Track #phi", 1);
+    tkmes.NumberOfRecHitsPerTrackVsTheta->setAxisTitle("Number of RecHits in each Track", 2);
+  }
+  histname = "NumberOfRecHitsPerTrackVsEta_" + histTag;
+  tkmes.NumberOfRecHitsPerTrackVsEta =
+      ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, RecHitBin, RecHitMin, RecHitMax, "");
+  tkmes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Track #eta", 1);
+  tkmes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Number of RecHits in each Track", 2);
+
+  histname = "NumberOfValidRecHitsPerTrackVsPhi_" + histTag;
+  tkmes.NumberOfValidRecHitsPerTrackVsPhi =
+      ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, RecHitMin, RecHitMax, "");
+  tkmes.NumberOfValidRecHitsPerTrackVsPhi->setAxisTitle("Track #phi", 1);
+  tkmes.NumberOfValidRecHitsPerTrackVsPhi->setAxisTitle("Number of valid RecHits in each Track", 2);
+
+  histname = "NumberOfValidRecHitsPerTrackVsEta_" + histTag;
+  tkmes.NumberOfValidRecHitsPerTrackVsEta =
+      ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, RecHitMin, RecHitMax, "");
+  tkmes.NumberOfValidRecHitsPerTrackVsEta->setAxisTitle("Track #eta", 1);
+  tkmes.NumberOfValidRecHitsPerTrackVsEta->setAxisTitle("Number of valid RecHits in each Track", 2);
+
+  histname = "NumberOfValidRecHitsPerTrackVsPt_" + histTag;
+  tkmes.NumberOfValidRecHitsPerTrackVsPt =
+      ibooker.bookProfile(histname, histname, TrackPtBin, TrackPtMin, TrackPtMax, RecHitMin, RecHitMax, "");
+  tkmes.NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+  tkmes.NumberOfValidRecHitsPerTrackVsPt->setAxisTitle("Number of valid RecHits in each Track", 2);
+
+  //////////////////////////////////////////
+  histname = "NumberOfLayersPerTrackVsPhi_" + histTag;
+  tkmes.NumberOfLayersPerTrackVsPhi =
+      ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, RecLayBin, RecLayMin, RecLayMax, "");
+  tkmes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Track #phi", 1);
+  tkmes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Number of Layers in each Track", 2);
+
+  if (doThetaPlots_) {
+    histname = "NumberOfLayersPerTrackVsTheta_" + histTag;
+    tkmes.NumberOfLayersPerTrackVsTheta =
+        ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, RecLayBin, RecLayMin, RecLayMax, "");
+    tkmes.NumberOfLayersPerTrackVsTheta->setAxisTitle("Track #phi", 1);
+    tkmes.NumberOfLayersPerTrackVsTheta->setAxisTitle("Number of Layers in each Track", 2);
+  }
+  histname = "NumberOfLayersPerTrackVsEta_" + histTag;
+  tkmes.NumberOfLayersPerTrackVsEta =
+      ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, RecLayBin, RecLayMin, RecLayMax, "");
+  tkmes.NumberOfLayersPerTrackVsEta->setAxisTitle("Track #eta", 1);
+  tkmes.NumberOfLayersPerTrackVsEta->setAxisTitle("Number of Layers in each Track", 2);
+
+  if (doThetaPlots_) {
+    histname = "Chi2oNDFVsTheta_" + histTag;
+    tkmes.Chi2oNDFVsTheta =
+        ibooker.bookProfile(histname, histname, ThetaBin, ThetaMin, ThetaMax, Chi2NDFMin, Chi2NDFMax, "");
+    tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #theta", 1);
+    tkmes.Chi2oNDFVsTheta->setAxisTitle("Track #chi^{2}/ndf", 2);
+  }
+  if (doAllPlots_) {
+    histname = "Chi2oNDFVsPhi_" + histTag;
+    tkmes.Chi2oNDFVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, Chi2NDFMin, Chi2NDFMax, "");
+    tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #phi", 1);
+    tkmes.Chi2oNDFVsPhi->setAxisTitle("Track #chi^{2}/ndf", 2);
+
+    histname = "Chi2oNDFVsEta_" + histTag;
+    tkmes.Chi2oNDFVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, Chi2NDFMin, Chi2NDFMax, "");
+    tkmes.Chi2oNDFVsEta->setAxisTitle("Track #eta", 1);
+    tkmes.Chi2oNDFVsEta->setAxisTitle("Track #chi^{2}/ndf", 2);
+
+    histname = "Chi2ProbVsPhi_" + histTag;
+    tkmes.Chi2ProbVsPhi = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, Chi2ProbMin, Chi2ProbMax);
+    tkmes.Chi2ProbVsPhi->setAxisTitle("Tracks #phi", 1);
+    tkmes.Chi2ProbVsPhi->setAxisTitle("Track #chi^{2} probability", 2);
+
+    histname = "Chi2ProbVsEta_" + histTag;
+    tkmes.Chi2ProbVsEta = ibooker.bookProfile(
+        histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, Chi2ProbMin, Chi2ProbMax);
+    tkmes.Chi2ProbVsEta->setAxisTitle("Tracks #eta", 1);
+    tkmes.Chi2ProbVsEta->setAxisTitle("Track #chi^{2} probability", 2);
+  }
+
+  // now put the MEs in the map
+  TkParameterMEMap.insert(std::make_pair(sname, tkmes));
 }
-
 
 // fill histograms at differnt measurement points
 // ---------------------------------------------------------------------------------//
-void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco::Track & track, std::string sname) 
-{
-    //get the kinematic parameters
-    double p, px, py, pz, pt, theta, phi, eta, q;
-    double pxerror, pyerror, pzerror, pterror, perror, phierror, etaerror;
+void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco::Track& track, std::string sname) {
+  //get the kinematic parameters
+  double p, px, py, pz, pt, theta, phi, eta, q;
+  double pxerror, pyerror, pzerror, pterror, perror, phierror, etaerror;
 
-    auto phiIn =  track.innerPosition().phi();
-    auto etaIn =  track.innerPosition().eta();
-    auto phiOut =  track.outerPosition().phi();
-    auto etaOut =  track.outerPosition().eta();
+  std::string Folder = TopFolder_.substr(0, 2);
 
+  auto phiIn = track.innerPosition().phi();
+  auto etaIn = track.innerPosition().eta();
+  auto phiOut = track.outerPosition().phi();
+  auto etaOut = track.outerPosition().eta();
 
-    if (sname == "default") {
+  if (sname == "default") {
+    p = track.p();
+    px = track.px();
+    py = track.py();
+    pz = track.pz();
+    pt = track.pt();
+    phi = track.phi();
+    theta = track.theta();
+    eta = track.eta();
+    q = track.charge();
 
-      p     = track.p();
-      px    = track.px();
-      py    = track.py();
-      pz    = track.pz();
-      pt    = track.pt();
-      phi   = track.phi();
-      theta = track.theta();
-      eta   = track.eta();
-      q     = track.charge();
-      
-      pterror  = (pt) ? track.ptError()/(pt*pt) : 0.0;
-      pxerror  = -1.0;
-      pyerror  = -1.0;
-      pzerror  = -1.0;
-      perror   = -1.0;
-      phierror = track.phiError();
-      etaerror = track.etaError();
-      
-    } else {
-      
-      edm::ESHandle<TransientTrackBuilder> theB;
-      iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
-      reco::TransientTrack TransTrack = theB->build(track);
-      
-      TrajectoryStateOnSurface TSOS;
+    pterror = (pt) ? track.ptError() / (pt * pt) : 0.0;
+    pxerror = -1.0;
+    pyerror = -1.0;
+    pzerror = -1.0;
+    perror = -1.0;
+    phierror = track.phiError();
+    etaerror = track.etaError();
 
-      if      (sname == "OuterSurface")  TSOS = TransTrack.outermostMeasurementState();
-      else if (sname == "InnerSurface")  TSOS = TransTrack.innermostMeasurementState();
-      else if (sname == "ImpactPoint")   TSOS = TransTrack.impactPointState();
+  } else {
+    edm::ESHandle<TransientTrackBuilder> theB;
+    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+    reco::TransientTrack TransTrack = theB->build(track);
 
-      p     = TSOS.globalMomentum().mag();
-      px    = TSOS.globalMomentum().x();
-      py    = TSOS.globalMomentum().y();
-      pz    = TSOS.globalMomentum().z();
-      pt    = TSOS.globalMomentum().perp();
-      phi   = TSOS.globalMomentum().phi();
-      theta = TSOS.globalMomentum().theta();
-      eta   = TSOS.globalMomentum().eta();
-      q     = TSOS.charge();
+    TrajectoryStateOnSurface TSOS;
 
-      //get the error of the kinimatic parameters
-      AlgebraicSymMatrix66 errors = TSOS.cartesianError().matrix();
-      double partialPterror = errors(3,3)*pow(TSOS.globalMomentum().x(),2) + errors(4,4)*pow(TSOS.globalMomentum().y(),2);
-      pterror  = sqrt(partialPterror)/TSOS.globalMomentum().perp();
-      pxerror  = sqrt(errors(3,3))/TSOS.globalMomentum().x();
-      pyerror  = sqrt(errors(4,4))/TSOS.globalMomentum().y();
-      pzerror  = sqrt(errors(5,5))/TSOS.globalMomentum().z();
-      perror   = sqrt(partialPterror+errors(5,5)*pow(TSOS.globalMomentum().z(),2))/TSOS.globalMomentum().mag();
-      phierror = sqrt(TSOS.curvilinearError().matrix()(2,2));
-      etaerror = sqrt(TSOS.curvilinearError().matrix()(1,1))*fabs(sin(TSOS.globalMomentum().theta()));
+    if (sname == "OuterSurface")
+      TSOS = TransTrack.outermostMeasurementState();
+    else if (sname == "InnerSurface")
+      TSOS = TransTrack.innermostMeasurementState();
+    else if (sname == "ImpactPoint")
+      TSOS = TransTrack.impactPointState();
 
+    p = TSOS.globalMomentum().mag();
+    px = TSOS.globalMomentum().x();
+    py = TSOS.globalMomentum().y();
+    pz = TSOS.globalMomentum().z();
+    pt = TSOS.globalMomentum().perp();
+    phi = TSOS.globalMomentum().phi();
+    theta = TSOS.globalMomentum().theta();
+    eta = TSOS.globalMomentum().eta();
+    q = TSOS.charge();
+
+    //get the error of the kinimatic parameters
+    AlgebraicSymMatrix66 errors = TSOS.cartesianError().matrix();
+    double partialPterror =
+        errors(3, 3) * pow(TSOS.globalMomentum().x(), 2) + errors(4, 4) * pow(TSOS.globalMomentum().y(), 2);
+    pterror = sqrt(partialPterror) / TSOS.globalMomentum().perp();
+    pxerror = sqrt(errors(3, 3)) / TSOS.globalMomentum().x();
+    pyerror = sqrt(errors(4, 4)) / TSOS.globalMomentum().y();
+    pzerror = sqrt(errors(5, 5)) / TSOS.globalMomentum().z();
+    perror = sqrt(partialPterror + errors(5, 5) * pow(TSOS.globalMomentum().z(), 2)) / TSOS.globalMomentum().mag();
+    phierror = sqrt(TSOS.curvilinearError().matrix()(2, 2));
+    etaerror = sqrt(TSOS.curvilinearError().matrix()(1, 1)) * fabs(sin(TSOS.globalMomentum().theta()));
+  }
+
+  std::map<std::string, TkParameterMEs>::iterator iPos = TkParameterMEMap.find(sname);
+  if (iPos != TkParameterMEMap.end()) {
+    TkParameterMEs tkmes = iPos->second;
+
+    // momentum
+    tkmes.TrackP->Fill(p);
+    if (doTrackPxPyPlots_) {
+      tkmes.TrackPx->Fill(px);
+      tkmes.TrackPy->Fill(py);
+    }
+    tkmes.TrackPz->Fill(pz);
+    tkmes.TrackPt->Fill(pt);
+
+    // angles
+    tkmes.TrackPhi->Fill(phi);
+    tkmes.TrackEta->Fill(eta);
+    tkmes.TrackEtaPhi->Fill(eta, phi);
+
+    if (Folder == "Tr") {
+      tkmes.TrackEtaPhiInverted->Fill(eta, -1 * phi);
+      tkmes.TrackEtaPhiInvertedoutofphase->Fill(eta, 3.141592654 + -1 * phi);
+      tkmes.TrackEtaPhiInvertedoutofphase->Fill(eta, -1 * phi - 3.141592654);
+      tkmes.TkEtaPhi_Ratio_byFoldingmap->getTH2F()->Divide(
+          tkmes.TrackEtaPhi->getTH2F(), tkmes.TrackEtaPhiInverted->getTH2F(), 1., 1., "");
+      tkmes.TkEtaPhi_Ratio_byFoldingmap_op->getTH2F()->Divide(
+          tkmes.TrackEtaPhi->getTH2F(), tkmes.TrackEtaPhiInvertedoutofphase->getTH2F(), 1., 1., "");
+
+      int nx = tkmes.TrackEtaPhi->getTH2F()->GetNbinsX();
+      int ny = tkmes.TrackEtaPhi->getTH2F()->GetNbinsY();
+
+      for (int ii = 1; ii <= nx; ii++) {
+        for (int jj = 1; jj <= ny; jj++) {
+          double Sum1 = tkmes.TrackEtaPhi->getTH2F()->GetBinContent(ii, jj) +
+                        tkmes.TrackEtaPhiInverted->getTH2F()->GetBinContent(ii, jj);
+          double Sum2 = tkmes.TrackEtaPhi->getTH2F()->GetBinContent(ii, jj) +
+                        tkmes.TrackEtaPhiInvertedoutofphase->getTH2F()->GetBinContent(ii, jj);
+
+          double Sub1 = tkmes.TrackEtaPhi->getTH2F()->GetBinContent(ii, jj) -
+                        tkmes.TrackEtaPhiInverted->getTH2F()->GetBinContent(ii, jj);
+          double Sub2 = tkmes.TrackEtaPhi->getTH2F()->GetBinContent(ii, jj) -
+                        tkmes.TrackEtaPhiInvertedoutofphase->getTH2F()->GetBinContent(ii, jj);
+
+          if (Sum1 == 0 || Sum2 == 0) {
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->getTH2F()->SetBinContent(ii, jj, 1);
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->getTH2F()->SetBinContent(ii, jj, 1);
+          } else {
+            double ratio1 = Sub1 / Sum1;
+            double ratio2 = Sub2 / Sum2;
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->getTH2F()->SetBinContent(ii, jj, ratio1);
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->getTH2F()->SetBinContent(ii, jj, ratio2);
+          }
+        }
+      }
+
+      //pT histograms to create efficiency vs pT plot, only for the most inefficient region.
+
+      if (eta < 0. && phi < -1.6) {
+        tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->Fill(pt);
+      }
+      if (eta < 0. && phi < 0 && phi >= -1.6) {
+        tkmes.TrackPt_NegEta_Phi_btw_0_neg16->Fill(pt);
+      }
+      if (eta < 0. && phi < 1.6 && phi >= 0) {
+        tkmes.TrackPt_NegEta_Phi_btw_16_0->Fill(pt);
+      }
+      if (eta < 0. && phi >= 1.6) {
+        tkmes.TrackPt_NegEta_Phi_btw_32_16->Fill(pt);
+      }
+      if (eta >= 0. && phi < -1.6) {
+        tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->Fill(pt);
+      }
+      if (eta >= 0. && phi < 0 && phi >= -1.6) {
+        tkmes.TrackPt_PosEta_Phi_btw_0_neg16->Fill(pt);
+      }
+      if (eta >= 0. && phi < 1.6 && phi >= 0) {
+        tkmes.TrackPt_PosEta_Phi_btw_16_0->Fill(pt);
+      }
+      if (eta >= 0. && phi >= 1.6) {
+        tkmes.TrackPt_PosEta_Phi_btw_32_16->Fill(pt);
+      }
+
+      float A[8];
+      A[0] = tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->getTH1()->Integral();
+      A[1] = tkmes.TrackPt_NegEta_Phi_btw_0_neg16->getTH1()->Integral();
+      A[2] = tkmes.TrackPt_NegEta_Phi_btw_16_0->getTH1()->Integral();
+      A[3] = tkmes.TrackPt_NegEta_Phi_btw_32_16->getTH1()->Integral();
+      A[4] = tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->getTH1()->Integral();
+      A[5] = tkmes.TrackPt_PosEta_Phi_btw_0_neg16->getTH1()->Integral();
+      A[6] = tkmes.TrackPt_PosEta_Phi_btw_16_0->getTH1()->Integral();
+      A[7] = tkmes.TrackPt_PosEta_Phi_btw_32_16->getTH1()->Integral();
+
+      //WZ (the worst zone)
+      int WZ = 0;
+      float minA = A[0];
+      for (int w = 1; w < 8; w++) {
+        if (minA > A[w]) {
+          minA = A[w];
+          WZ = w;
+        }
+      }
+
+      switch (WZ) {
+        case 1:
+          tkmes.Ratio_byFolding->getTH1()->Divide(tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->getTH1(),
+                                                  tkmes.TrackPt_NegEta_Phi_btw_32_16->getTH1(),
+                                                  1.,
+                                                  1.,
+                                                  "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->getTH1(),
+                                                   tkmes.TrackPt_NegEta_Phi_btw_0_neg16->getTH1(),
+                                                   1.,
+                                                   1.,
+                                                   "B");
+          break;
+        case 2:
+          tkmes.Ratio_byFolding->getTH1()->Divide(
+              tkmes.TrackPt_NegEta_Phi_btw_0_neg16->getTH1(), tkmes.TrackPt_NegEta_Phi_btw_16_0->getTH1(), 1., 1., "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(tkmes.TrackPt_NegEta_Phi_btw_0_neg16->getTH1(),
+                                                   tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->getTH1(),
+                                                   1.,
+                                                   1.,
+                                                   "B");
+          break;
+        case 3:
+          tkmes.Ratio_byFolding->getTH1()->Divide(
+              tkmes.TrackPt_NegEta_Phi_btw_16_0->getTH1(), tkmes.TrackPt_NegEta_Phi_btw_0_neg16->getTH1(), 1., 1., "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(
+              tkmes.TrackPt_NegEta_Phi_btw_16_0->getTH1(), tkmes.TrackPt_NegEta_Phi_btw_32_16->getTH1(), 1., 1., "B");
+          break;
+        case 4:
+          tkmes.Ratio_byFolding->getTH1()->Divide(tkmes.TrackPt_NegEta_Phi_btw_32_16->getTH1(),
+                                                  tkmes.TrackPt_NegEta_Phi_btw_neg16_neg32->getTH1(),
+                                                  1.,
+                                                  1.,
+                                                  "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(
+              tkmes.TrackPt_NegEta_Phi_btw_32_16->getTH1(), tkmes.TrackPt_NegEta_Phi_btw_16_0->getTH1(), 1., 1., "B");
+          break;
+        case 5:
+          tkmes.Ratio_byFolding->getTH1()->Divide(tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->getTH1(),
+                                                  tkmes.TrackPt_PosEta_Phi_btw_32_16->getTH1(),
+                                                  1.,
+                                                  1.,
+                                                  "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->getTH1(),
+                                                   tkmes.TrackPt_PosEta_Phi_btw_0_neg16->getTH1(),
+                                                   1.,
+                                                   1.,
+                                                   "B");
+          break;
+        case 6:
+          tkmes.Ratio_byFolding->getTH1()->Divide(
+              tkmes.TrackPt_PosEta_Phi_btw_0_neg16->getTH1(), tkmes.TrackPt_PosEta_Phi_btw_16_0->getTH1(), 1., 1., "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(tkmes.TrackPt_PosEta_Phi_btw_0_neg16->getTH1(),
+                                                   tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->getTH1(),
+                                                   1.,
+                                                   1.,
+                                                   "B");
+          break;
+        case 7:
+          tkmes.Ratio_byFolding->getTH1()->Divide(
+              tkmes.TrackPt_PosEta_Phi_btw_16_0->getTH1(), tkmes.TrackPt_PosEta_Phi_btw_0_neg16->getTH1(), 1., 1., "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(
+              tkmes.TrackPt_PosEta_Phi_btw_16_0->getTH1(), tkmes.TrackPt_PosEta_Phi_btw_32_16->getTH1(), 1., 1., "B");
+          break;
+        case 8:
+          tkmes.Ratio_byFolding->getTH1()->Divide(tkmes.TrackPt_PosEta_Phi_btw_32_16->getTH1(),
+                                                  tkmes.TrackPt_PosEta_Phi_btw_neg16_neg32->getTH1(),
+                                                  1.,
+                                                  1.,
+                                                  "B");
+          tkmes.Ratio_byFolding2->getTH1()->Divide(
+              tkmes.TrackPt_PosEta_Phi_btw_32_16->getTH1(), tkmes.TrackPt_PosEta_Phi_btw_16_0->getTH1(), 1., 1., "B");
+          break;
+      }
+      tkmes.Ratio_byFolding->setAxisTitle("Efficiency(Ratio)_" + std::to_string(WZ), 2);
+      tkmes.Ratio_byFolding2->setAxisTitle("Efficiency(Ratio)_" + std::to_string(WZ), 2);
+
+      if (track.quality(reco::TrackBase::highPurity)) {
+        tkmes.TrackPtHighPurity->Fill(pt);
+        tkmes.Quality->Fill(reco::TrackBase::highPurity, 1.);
+      }
+      if (track.quality(reco::TrackBase::tight)) {
+        tkmes.TrackPtTight->Fill(pt);
+        tkmes.Quality->Fill(reco::TrackBase::tight, 1.);
+      }
+      if (track.quality(reco::TrackBase::loose)) {
+        tkmes.TrackPtLoose->Fill(pt);
+        tkmes.Quality->Fill(reco::TrackBase::loose, 1.);
+      }
+      if (track.quality(reco::TrackBase::highPurity)) {
+        tkmes.TrackEtaHighPurity->Fill(eta);
+      }
+      if (track.quality(reco::TrackBase::tight)) {
+        tkmes.TrackEtaTight->Fill(eta);
+      }
+      if (track.quality(reco::TrackBase::loose)) {
+        tkmes.TrackEtaLoose->Fill(eta);
+      }
+
+      if (p > 0.) {
+        tkmes.TrackQoverP->Fill(q / p);
+      }
     }
 
-    std::map<std::string, TkParameterMEs>::iterator iPos = TkParameterMEMap.find(sname); 
-    if (iPos != TkParameterMEMap.end()) {
+    tkmes.TrackEtaPhiInner->Fill(etaIn, phiIn);
+    tkmes.TrackEtaPhiOuter->Fill(etaOut, phiOut);
 
-      TkParameterMEs tkmes = iPos->second;
-      
-      // momentum
-      tkmes.TrackP->Fill(p);
-      if (doTrackPxPyPlots_) {
-	tkmes.TrackPx->Fill(px);
-	tkmes.TrackPy->Fill(py);
-      }
-      tkmes.TrackPz->Fill(pz);
-      tkmes.TrackPt->Fill(pt);
-      
-      // angles
-      tkmes.TrackPhi->Fill(phi);
-      tkmes.TrackEta->Fill(eta);
-      tkmes.TrackEtaPhi->Fill(eta,phi);
-      tkmes.TrackEtaPhiInner->Fill(etaIn,phiIn);
-      tkmes.TrackEtaPhiOuter->Fill(etaOut,phiOut);
-
-      if (doThetaPlots_) {
-	tkmes.TrackTheta->Fill(theta);
-      }
-      tkmes.TrackQ->Fill(q);
-      
-      // errors
-      tkmes.TrackPtErr->Fill(pterror);
-      tkmes.TrackPtErrVsEta->Fill(eta,pterror);
-      if (doTrackPxPyPlots_) {
-	tkmes.TrackPxErr->Fill(pxerror);
-	tkmes.TrackPyErr->Fill(pyerror);
-      }
-      tkmes.TrackPzErr->Fill(pzerror);
-      tkmes.TrackPErr->Fill(perror);
-      tkmes.TrackPhiErr->Fill(phierror);
-      tkmes.TrackEtaErr->Fill(etaerror);
-      
-      int nRecHits      = track.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS);
-      int nValidRecHits = track.numberOfValidHits();
-      // rec hits 
-      tkmes.NumberOfRecHitsPerTrackVsPhi->Fill(phi,    nRecHits);
-      if (doThetaPlots_) {
-	tkmes.NumberOfRecHitsPerTrackVsTheta->Fill(theta,nRecHits);
-      }
-      tkmes.NumberOfRecHitsPerTrackVsEta->Fill(eta,    nRecHits);
-      
-      tkmes.NumberOfValidRecHitsPerTrackVsPhi->Fill(phi,    nValidRecHits);
-      tkmes.NumberOfValidRecHitsPerTrackVsEta->Fill(eta,    nValidRecHits);
-      tkmes.NumberOfValidRecHitsPerTrackVsPt ->Fill(pt,     nValidRecHits);
-
-      int nLayers = track.hitPattern().trackerLayersWithMeasurement();
-      // rec layers 
-      tkmes.NumberOfLayersPerTrackVsPhi->Fill(phi,     nLayers);
-      if (doThetaPlots_) {
-	tkmes.NumberOfLayersPerTrackVsTheta->Fill(theta, nLayers);
-      }
-      tkmes.NumberOfLayersPerTrackVsEta->Fill(eta,     nLayers);
-      
-      double chi2prob = TMath::Prob(track.chi2(),(int)track.ndof());
-      double chi2oNDF = track.normalizedChi2();
-
-      tkmes.Chi2oNDFVsEta->Fill(eta, chi2oNDF);
-      tkmes.Chi2oNDFVsPt->Fill(pt, chi2oNDF);
-      tkmes.Chi2oNDFVsNHits->Fill(nRecHits, chi2oNDF);
-
-      if(doAllPlots_) {
-	
-	// general properties
-	if (doThetaPlots_) {
-	  tkmes.Chi2oNDFVsTheta->Fill(theta, chi2oNDF);
-	}
-	tkmes.Chi2oNDFVsPhi->Fill(phi, chi2oNDF);
-	tkmes.Chi2ProbVsPhi->Fill(phi, chi2prob);
-	tkmes.Chi2ProbVsEta->Fill(eta, chi2prob);
-      }
-      
+    if (doThetaPlots_) {
+      tkmes.TrackTheta->Fill(theta);
     }
+    tkmes.TrackQ->Fill(q);
 
+    // errors
+    tkmes.TrackPtErr->Fill(pterror);
+    tkmes.TrackPtErrVsEta->Fill(eta, pterror);
+    if (doTrackPxPyPlots_) {
+      tkmes.TrackPxErr->Fill(pxerror);
+      tkmes.TrackPyErr->Fill(pyerror);
+    }
+    tkmes.TrackPzErr->Fill(pzerror);
+    tkmes.TrackPErr->Fill(perror);
+    tkmes.TrackPhiErr->Fill(phierror);
+    tkmes.TrackEtaErr->Fill(etaerror);
+
+    int nRecHits = track.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS);
+    int nValidRecHits = track.numberOfValidHits();
+    // rec hits
+    tkmes.NumberOfRecHitsPerTrackVsPhi->Fill(phi, nRecHits);
+    if (doThetaPlots_) {
+      tkmes.NumberOfRecHitsPerTrackVsTheta->Fill(theta, nRecHits);
+    }
+    tkmes.NumberOfRecHitsPerTrackVsEta->Fill(eta, nRecHits);
+    tkmes.NumberOfValidRecHitsPerTrackVsPhi->Fill(phi, nValidRecHits);
+    tkmes.NumberOfValidRecHitsPerTrackVsEta->Fill(eta, nValidRecHits);
+    tkmes.NumberOfValidRecHitsPerTrackVsPt->Fill(pt, nValidRecHits);
+
+    int nLayers = track.hitPattern().trackerLayersWithMeasurement();
+    // rec layers
+    tkmes.NumberOfLayersPerTrackVsPhi->Fill(phi, nLayers);
+    if (doThetaPlots_) {
+      tkmes.NumberOfLayersPerTrackVsTheta->Fill(theta, nLayers);
+    }
+    tkmes.NumberOfLayersPerTrackVsEta->Fill(eta, nLayers);
+
+    double chi2prob = TMath::Prob(track.chi2(), (int)track.ndof());
+    double chi2oNDF = track.normalizedChi2();
+
+    tkmes.Chi2oNDFVsEta->Fill(eta, chi2oNDF);
+    tkmes.Chi2oNDFVsPt->Fill(pt, chi2oNDF);
+    tkmes.Chi2oNDFVsNHits->Fill(nRecHits, chi2oNDF);
+
+    if (doAllPlots_) {
+      // general properties
+      if (doThetaPlots_) {
+        tkmes.Chi2oNDFVsTheta->Fill(theta, chi2oNDF);
+      }
+      tkmes.Chi2oNDFVsPhi->Fill(phi, chi2oNDF);
+      tkmes.Chi2ProbVsPhi->Fill(phi, chi2prob);
+      tkmes.Chi2ProbVsEta->Fill(eta, chi2prob);
+    }
+  }
 }
 
+void TrackAnalyzer::bookHistosForTrackerSpecific(DQMStore::IBooker& ibooker) {
+  // parameters from the configuration
+  std::string QualName = conf_->getParameter<std::string>("Quality");
+  std::string AlgoName = conf_->getParameter<std::string>("AlgoName");
 
-void TrackAnalyzer::bookHistosForTrackerSpecific(DQMStore::IBooker & ibooker) 
-{
+  // use the AlgoName and Quality Name
+  std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
 
-    // parameters from the configuration
-    std::string QualName     = conf_->getParameter<std::string>("Quality");
-    std::string AlgoName     = conf_->getParameter<std::string>("AlgoName");
+  int PhiBin = conf_->getParameter<int>("PhiBin");
+  double PhiMin = conf_->getParameter<double>("PhiMin");
+  double PhiMax = conf_->getParameter<double>("PhiMax");
 
-    // use the AlgoName and Quality Name 
-    std::string CategoryName = !QualName.empty() ? AlgoName + "_" + QualName : AlgoName;
+  int EtaBin = conf_->getParameter<int>("EtaBin");
+  double EtaMin = conf_->getParameter<double>("EtaMin");
+  double EtaMax = conf_->getParameter<double>("EtaMax");
 
-    int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
-    double PhiMin     = conf_->getParameter<double>("PhiMin");
-    double PhiMax     = conf_->getParameter<double>("PhiMax");
+  int PtBin = conf_->getParameter<int>("TrackPtBin");
+  double PtMin = conf_->getParameter<double>("TrackPtMin");
+  double PtMax = conf_->getParameter<double>("TrackPtMax");
 
-    int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
-    double EtaMin     = conf_->getParameter<double>("EtaMin");
-    double EtaMax     = conf_->getParameter<double>("EtaMax");
+  // book hit property histograms
+  // ---------------------------------------------------------------------------------//
+  ibooker.setCurrentFolder(TopFolder_ + "/HitProperties");
 
-    int    PtBin = conf_->getParameter<int>(   "TrackPtBin");
-    double PtMin = conf_->getParameter<double>("TrackPtMin");
-    double PtMax = conf_->getParameter<double>("TrackPtMax");
+  std::vector<std::string> subdetectors = conf_->getParameter<std::vector<std::string> >("subdetectors");
+  int detBin = conf_->getParameter<int>("subdetectorBin");
 
-    // book hit property histograms
-    // ---------------------------------------------------------------------------------//
-    ibooker.setCurrentFolder(TopFolder_+"/HitProperties");
+  for (auto det : subdetectors) {
+    // hits properties
+    ibooker.setCurrentFolder(TopFolder_ + "/HitProperties/" + det);
 
+    TkRecHitsPerSubDetMEs recHitsPerSubDet_mes;
 
+    recHitsPerSubDet_mes.detectorTag = det;
+    int detID = -1;
+    if (det == "TIB")
+      detID = StripSubdetector::TIB;  // 3
+    if (det == "TOB")
+      detID = StripSubdetector::TOB;  // 5
+    if (det == "TID")
+      detID = StripSubdetector::TID;  // 4
+    if (det == "TEC")
+      detID = StripSubdetector::TEC;  // 6
+    if (det == "PixBarrel")
+      detID = PixelSubdetector::PixelBarrel;  // 1
+    if (det == "PixEndcap")
+      detID = PixelSubdetector::PixelEndcap;  // 2
+    if (det == "Pixel")
+      detID = 0;
+    if (det == "Strip")
+      detID = 7;
 
-    std::vector<std::string> subdetectors = conf_->getParameter<std::vector<std::string> >("subdetectors");
-    int detBin = conf_->getParameter<int>("subdetectorBin");
+    recHitsPerSubDet_mes.detectorId = detID;
 
-    for ( auto det : subdetectors ) {
-      
-      // hits properties
-      ibooker.setCurrentFolder(TopFolder_+"/HitProperties/"+det);
-      
-      TkRecHitsPerSubDetMEs recHitsPerSubDet_mes;
+    histname = "NumberOfRecHitsPerTrack_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrack =
+        ibooker.book1D(histname, histname, detBin, -0.5, double(detBin) - 0.5);
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrack->setAxisTitle("Number of " + det + " valid RecHits in each Track", 1);
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
 
-      recHitsPerSubDet_mes.detectorTag = det;
-      int detID = -1;
-      if ( det == "TIB" ) detID = StripSubdetector::TIB; // 3
-      if ( det == "TOB" ) detID = StripSubdetector::TOB; // 5
-      if ( det == "TID" ) detID = StripSubdetector::TID; // 4
-      if ( det == "TEC" ) detID = StripSubdetector::TEC; // 6
-      if ( det == "PixBarrel" ) detID = PixelSubdetector::PixelBarrel; // 1
-      if ( det == "PixEndcap" ) detID = PixelSubdetector::PixelEndcap; // 2
-      if ( det == "Pixel" ) detID = 0;
-      if ( det == "Strip" ) detID = 7;
-      
-      recHitsPerSubDet_mes.detectorId  = detID;
+    histname = "NumberOfRecHitsPerTrackVsPhi_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPhi =
+        ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, detBin, -0.5, double(detBin) - 0.5, "");
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Track #phi", 1);
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Number of " + det + " valid RecHits in each Track",
+                                                                    2);
 
-      histname = "NumberOfRecHitsPerTrack_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrack = ibooker.book1D(histname, histname, detBin, -0.5, double(detBin)-0.5);
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrack->setAxisTitle("Number of " + det + " valid RecHits in each Track",1);
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+    histname = "NumberOfRecHitsPerTrackVsEta_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsEta =
+        ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, detBin, -0.5, double(detBin) - 0.5, "");
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Track #eta", 1);
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Number of " + det + " valid RecHits in each Track",
+                                                                    2);
 
-      histname = "NumberOfRecHitsPerTrackVsPhi_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, detBin, -0.5, double(detBin)-0.5,"");
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Track #phi",1);
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPhi->setAxisTitle("Number of " + det + " valid RecHits in each Track",2);
+    histname = "NumberOfRecHitsPerTrackVsPt_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPt =
+        ibooker.bookProfile(histname, histname, PtBin, PtMin, PtMax, detBin, -0.5, double(detBin) - 0.5, "");
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+    recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPt->setAxisTitle("Number of " + det + " valid RecHits in each Track",
+                                                                   2);
 
-      histname = "NumberOfRecHitsPerTrackVsEta_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, detBin, -0.5, double(detBin)-0.5,"");
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Track #eta",1);
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsEta->setAxisTitle("Number of " + det + " valid RecHits in each Track",2);
+    histname = "NumberOfLayersPerTrack_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfLayersPerTrack =
+        ibooker.book1D(histname, histname, detBin, -0.5, double(detBin) - 0.5);
+    recHitsPerSubDet_mes.NumberOfLayersPerTrack->setAxisTitle("Number of " + det + " valid Layers in each Track", 1);
+    recHitsPerSubDet_mes.NumberOfLayersPerTrack->setAxisTitle("Number of Tracks", 2);
 
-      histname = "NumberOfRecHitsPerTrackVsPt_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPt = ibooker.bookProfile(histname, histname, PtBin, PtMin, PtMax, detBin, -0.5, double(detBin)-0.5,"");
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]",1);
-      recHitsPerSubDet_mes.NumberOfRecHitsPerTrackVsPt->setAxisTitle("Number of " + det + " valid RecHits in each Track",2);
+    histname = "NumberOfLayersPerTrackVsPhi_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPhi =
+        ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, detBin, -0.5, double(detBin) - 0.5, "");
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Track #phi", 1);
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Number of " + det + " valid Layers in each Track",
+                                                                   2);
 
-      histname = "NumberOfLayersPerTrack_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfLayersPerTrack = ibooker.book1D(histname, histname, detBin, -0.5, double(detBin)-0.5);
-      recHitsPerSubDet_mes.NumberOfLayersPerTrack->setAxisTitle("Number of " + det + " valid Layers in each Track",1);
-      recHitsPerSubDet_mes.NumberOfLayersPerTrack->setAxisTitle("Number of Tracks", 2);
+    histname = "NumberOfLayersPerTrackVsEta_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsEta =
+        ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, detBin, -0.5, double(detBin) - 0.5, "");
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsEta->setAxisTitle("Track #eta", 1);
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsEta->setAxisTitle("Number of " + det + " valid Layers in each Track",
+                                                                   2);
 
-      histname = "NumberOfLayersPerTrackVsPhi_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPhi = ibooker.bookProfile(histname, histname, PhiBin, PhiMin, PhiMax, detBin, -0.5, double(detBin)-0.5,"");
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Track #phi",1);
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPhi->setAxisTitle("Number of " + det + " valid Layers in each Track",2);
+    histname = "NumberOfLayersPerTrackVsPt_" + det + "_" + CategoryName;
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPt =
+        ibooker.bookProfile(histname, histname, PtBin, PtMin, PtMax, detBin, -0.5, double(detBin) - 0.5, "");
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]", 1);
+    recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPt->setAxisTitle("Number of " + det + " valid Layers in each Track",
+                                                                  2);
 
-      histname = "NumberOfLayersPerTrackVsEta_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsEta = ibooker.bookProfile(histname, histname, EtaBin, EtaMin, EtaMax, detBin, -0.5, double(detBin)-0.5,"");
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsEta->setAxisTitle("Track #eta",1);
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsEta->setAxisTitle("Number of " + det + " valid Layers in each Track",2);
-
-      histname = "NumberOfLayersPerTrackVsPt_" + det + "_" + CategoryName;
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPt = ibooker.bookProfile(histname, histname, PtBin, PtMin, PtMax, detBin, -0.5, double(detBin)-0.5,"");
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPt->setAxisTitle("Track p_{T} [GeV]",1);
-      recHitsPerSubDet_mes.NumberOfLayersPerTrackVsPt->setAxisTitle("Number of " + det + " valid Layers in each Track",2);
-
-      TkRecHitsPerSubDetMEMap.insert(std::pair<std::string,TkRecHitsPerSubDetMEs>(det,recHitsPerSubDet_mes));
-
-      
-    }
-
-
+    TkRecHitsPerSubDetMEMap.insert(std::pair<std::string, TkRecHitsPerSubDetMEs>(det, recHitsPerSubDet_mes));
+  }
 }
 
+void TrackAnalyzer::fillHistosForTrackerSpecific(const reco::Track& track) {
+  double phi = track.phi();
+  double eta = track.eta();
+  double pt = track.pt();
 
-void TrackAnalyzer::fillHistosForTrackerSpecific(const reco::Track & track) 
-{
-    
-  double phi   = track.phi();
-  double eta   = track.eta();
-  double pt    = track.pt();
-
-  for ( std::map<std::string,TkRecHitsPerSubDetMEs>::iterator it = TkRecHitsPerSubDetMEMap.begin();
-       it != TkRecHitsPerSubDetMEMap.end(); it++ ) {
-
-    int nValidLayers  = 0;
+  for (std::map<std::string, TkRecHitsPerSubDetMEs>::iterator it = TkRecHitsPerSubDetMEMap.begin();
+       it != TkRecHitsPerSubDetMEMap.end();
+       it++) {
+    int nValidLayers = 0;
     int nValidRecHits = 0;
     int substr = it->second.detectorId;
-    switch(substr) {
-    case 0 :
-      nValidLayers  = track.hitPattern().pixelBarrelLayersWithMeasurement() 
-	+ track.hitPattern().pixelEndcapLayersWithMeasurement();    // case 0: pixel
-      nValidRecHits = track.hitPattern().numberOfValidPixelBarrelHits()
-	+ track.hitPattern().numberOfValidPixelEndcapHits();        // case 0: pixel
-      break;
-    case StripSubdetector::TIB :
-      nValidLayers  = track.hitPattern().stripTIBLayersWithMeasurement();       // case 3: strip TIB
-      nValidRecHits = track.hitPattern().numberOfValidStripTIBHits();           // case 3: strip TIB
-      break;
-    case StripSubdetector::TID :
-      nValidLayers  = track.hitPattern().stripTIDLayersWithMeasurement();       // case 4: strip TID
-      nValidRecHits = track.hitPattern().numberOfValidStripTIDHits();           // case 4: strip TID
-      break;
-    case StripSubdetector::TOB :
-      nValidLayers  = track.hitPattern().stripTOBLayersWithMeasurement();       // case 5: strip TOB
-      nValidRecHits = track.hitPattern().numberOfValidStripTOBHits();           // case 5: strip TOB
-      break;
-    case StripSubdetector::TEC :
-      nValidLayers  = track.hitPattern().stripTECLayersWithMeasurement();       // case 6: strip TEC
-      nValidRecHits = track.hitPattern().numberOfValidStripTECHits();           // case 6: strip TEC
-      break;
-    case PixelSubdetector::PixelBarrel :
-      nValidLayers  = track.hitPattern().pixelBarrelLayersWithMeasurement();    // case 1: pixel PXB
-      nValidRecHits = track.hitPattern().numberOfValidPixelBarrelHits();        // case 1: pixel PXB
-      break;
-    case PixelSubdetector::PixelEndcap :
-      nValidLayers  = track.hitPattern().pixelEndcapLayersWithMeasurement();    // case 2: pixel PXF
-      nValidRecHits = track.hitPattern().numberOfValidPixelEndcapHits();        // case 2: pixel PXF
-      break;
-    case 7 :
-      nValidLayers  = track.hitPattern().stripTIBLayersWithMeasurement()       // case 7: strip
-	+ track.hitPattern().stripTIDLayersWithMeasurement()
-	+ track.hitPattern().stripTOBLayersWithMeasurement()
-	+ track.hitPattern().stripTECLayersWithMeasurement();
-      nValidRecHits = track.hitPattern().numberOfValidStripTIBHits()           // case 7: strip
-	+ track.hitPattern().numberOfValidStripTIDHits()
-	+ track.hitPattern().numberOfValidStripTOBHits()
-	+ track.hitPattern().numberOfValidStripTECHits();
-      break;
-    default :
-      break;
+    switch (substr) {
+      case 0:
+        nValidLayers = track.hitPattern().pixelBarrelLayersWithMeasurement() +
+                       track.hitPattern().pixelEndcapLayersWithMeasurement();  // case 0: pixel
+        nValidRecHits = track.hitPattern().numberOfValidPixelBarrelHits() +
+                        track.hitPattern().numberOfValidPixelEndcapHits();  // case 0: pixel
+        break;
+      case StripSubdetector::TIB:
+        nValidLayers = track.hitPattern().stripTIBLayersWithMeasurement();  // case 3: strip TIB
+        nValidRecHits = track.hitPattern().numberOfValidStripTIBHits();     // case 3: strip TIB
+        break;
+      case StripSubdetector::TID:
+        nValidLayers = track.hitPattern().stripTIDLayersWithMeasurement();  // case 4: strip TID
+        nValidRecHits = track.hitPattern().numberOfValidStripTIDHits();     // case 4: strip TID
+        break;
+      case StripSubdetector::TOB:
+        nValidLayers = track.hitPattern().stripTOBLayersWithMeasurement();  // case 5: strip TOB
+        nValidRecHits = track.hitPattern().numberOfValidStripTOBHits();     // case 5: strip TOB
+        break;
+      case StripSubdetector::TEC:
+        nValidLayers = track.hitPattern().stripTECLayersWithMeasurement();  // case 6: strip TEC
+        nValidRecHits = track.hitPattern().numberOfValidStripTECHits();     // case 6: strip TEC
+        break;
+      case PixelSubdetector::PixelBarrel:
+        nValidLayers = track.hitPattern().pixelBarrelLayersWithMeasurement();  // case 1: pixel PXB
+        nValidRecHits = track.hitPattern().numberOfValidPixelBarrelHits();     // case 1: pixel PXB
+        break;
+      case PixelSubdetector::PixelEndcap:
+        nValidLayers = track.hitPattern().pixelEndcapLayersWithMeasurement();  // case 2: pixel PXF
+        nValidRecHits = track.hitPattern().numberOfValidPixelEndcapHits();     // case 2: pixel PXF
+        break;
+      case 7:
+        nValidLayers = track.hitPattern().stripTIBLayersWithMeasurement()  // case 7: strip
+                       + track.hitPattern().stripTIDLayersWithMeasurement() +
+                       track.hitPattern().stripTOBLayersWithMeasurement() +
+                       track.hitPattern().stripTECLayersWithMeasurement();
+        nValidRecHits = track.hitPattern().numberOfValidStripTIBHits()  // case 7: strip
+                        + track.hitPattern().numberOfValidStripTIDHits() +
+                        track.hitPattern().numberOfValidStripTOBHits() + track.hitPattern().numberOfValidStripTECHits();
+        break;
+      default:
+        break;
     }
 
     //Fill Layers and RecHits
-    it->second.NumberOfRecHitsPerTrack      -> Fill(nValidRecHits); 
-    it->second.NumberOfRecHitsPerTrackVsPhi -> Fill(phi,    nValidRecHits);
-    it->second.NumberOfRecHitsPerTrackVsEta -> Fill(eta,    nValidRecHits);
-    it->second.NumberOfRecHitsPerTrackVsPt  -> Fill(pt,     nValidRecHits);
-    
-    it->second.NumberOfLayersPerTrack      -> Fill(nValidLayers);
-    it->second.NumberOfLayersPerTrackVsPhi -> Fill(phi,     nValidLayers);
-    it->second.NumberOfLayersPerTrackVsEta -> Fill(eta,     nValidLayers);
-    it->second.NumberOfLayersPerTrackVsPt  -> Fill(pt,      nValidLayers);
-  }
+    it->second.NumberOfRecHitsPerTrack->Fill(nValidRecHits);
+    it->second.NumberOfRecHitsPerTrackVsPhi->Fill(phi, nValidRecHits);
+    it->second.NumberOfRecHitsPerTrackVsEta->Fill(eta, nValidRecHits);
+    it->second.NumberOfRecHitsPerTrackVsPt->Fill(pt, nValidRecHits);
 
+    it->second.NumberOfLayersPerTrack->Fill(nValidLayers);
+    it->second.NumberOfLayersPerTrackVsPhi->Fill(phi, nValidLayers);
+    it->second.NumberOfLayersPerTrackVsEta->Fill(eta, nValidLayers);
+    it->second.NumberOfLayersPerTrackVsPt->Fill(pt, nValidLayers);
+  }
 }
 //
 // -- Set Lumi Flag
 //
-void TrackAnalyzer::setLumiFlag() { 
-
+void TrackAnalyzer::setLumiFlag() {
   TkParameterMEs tkmes;
-  if ( Chi2oNDF_lumiFlag                ) Chi2oNDF_lumiFlag                -> setLumiFlag();
-  if ( NumberOfRecHitsPerTrack_lumiFlag ) NumberOfRecHitsPerTrack_lumiFlag -> setLumiFlag();
+  if (Chi2oNDF_lumiFlag)
+    Chi2oNDF_lumiFlag->setLumiFlag();
+  if (NumberOfRecHitsPerTrack_lumiFlag)
+    NumberOfRecHitsPerTrack_lumiFlag->setLumiFlag();
 }
 //
-// -- Apply SoftReset 
+// -- Apply SoftReset
 //
-void TrackAnalyzer::doSoftReset(DQMStore * dqmStore_) {
+void TrackAnalyzer::doSoftReset(DQMStore* dqmStore_) {
   TkParameterMEs tkmes;
   dqmStore_->softReset(Chi2oNDF);
   dqmStore_->softReset(NumberOfRecHitsPerTrack);
 }
 //
-// -- Apply Reset 
+// -- Apply Reset
 //
 void TrackAnalyzer::doReset() {
   TkParameterMEs tkmes;
-  if ( Chi2oNDF_lumiFlag                ) Chi2oNDF_lumiFlag                -> Reset();
-  if ( NumberOfRecHitsPerTrack_lumiFlag ) NumberOfRecHitsPerTrack_lumiFlag -> Reset();
+  if (Chi2oNDF_lumiFlag)
+    Chi2oNDF_lumiFlag->Reset();
+  if (NumberOfRecHitsPerTrack_lumiFlag)
+    NumberOfRecHitsPerTrack_lumiFlag->Reset();
 }
 //
 // -- Remove SoftReset
 //
-void TrackAnalyzer::undoSoftReset(DQMStore * dqmStore_) {
+void TrackAnalyzer::undoSoftReset(DQMStore* dqmStore_) {
   TkParameterMEs tkmes;
   dqmStore_->disableSoftReset(Chi2oNDF);
   dqmStore_->disableSoftReset(NumberOfRecHitsPerTrack);
 }
-
-

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -863,7 +863,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "DistanceOfClosestApproachToBSVsEta_";
       DistanceOfClosestApproachToBSVsEta = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, DxyBin, DxyMin, DxyMax, "");
-      DistanceOfClosestApproachToBSVsEta->getTH1()->SetCanExtend(TH1::kAllAxes);
       DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track #eta", 1);
       DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
     }
@@ -877,7 +876,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
     histname = "DistanceOfClosestApproachToBSVsPhi_";
     DistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(
         histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
-    DistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
     DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi", 1);
     DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
 
@@ -960,7 +958,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
     histname = "DistanceOfClosestApproachToPVVsPhi_";
     DistanceOfClosestApproachToPVVsPhi = ibooker.bookProfile(
         histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
-    DistanceOfClosestApproachToPVVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
     DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track #phi", 1);
     DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track d_{xy} w.r.t. PV (cm)", 2);
 
@@ -996,7 +993,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "TESTDistanceOfClosestApproachToBSVsPhi_";
       TESTDistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
-      TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
       TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi", 1);
       TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
     }
@@ -1047,7 +1043,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "DistanceOfClosestApproachVsPhi_";
       DistanceOfClosestApproachVsPhi = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyMin, DxyMax, "");
-      DistanceOfClosestApproachVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
       DistanceOfClosestApproachVsPhi->setAxisTitle("Track #phi", 1);
       DistanceOfClosestApproachVsPhi->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)", 2);
     }

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -1,6 +1,6 @@
 /*
  *  See header file for a description of this class.
- *
+ **
  *  \author Suchandra Dutta , Giorgia Mila
  */
 
@@ -22,10 +22,10 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -40,80 +40,83 @@
 #include <string>
 
 #ifdef VI_DEBUG
-#define COUT(x)  std::cout << x << ' '
+#define COUT(x) std::cout << x << ' '
 #else
-#define COUT(x)	LogDebug(x)
+#define COUT(x) LogDebug(x)
 #endif
 
-
-// TrackingMonitor 
+// TrackingMonitor
 // ----------------------------------------------------------------------------------//
 
-TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig) 
-    : confID_ ( iConfig.id() )
-    , theTrackBuildingAnalyzer( new TrackBuildingAnalyzer(iConfig) )
-    , NumberOfTracks(nullptr)
-    , NumberOfMeanRecHitsPerTrack(nullptr)
-    , NumberOfMeanLayersPerTrack(nullptr)
-				//    , NumberOfGoodTracks(NULL)
-    , FractionOfGoodTracks(nullptr)
-    , NumberOfTrackingRegions(nullptr)
-    , NumberOfSeeds(nullptr)
-    , NumberOfSeeds_lumiFlag(nullptr)
-    , NumberOfTrackCandidates(nullptr)
-    , FractionCandidatesOverSeeds(nullptr)
-				//    , NumberOfGoodTrkVsClus(NULL)
-    , NumberEventsOfVsLS(nullptr)
-    , NumberOfTracksVsLS(nullptr)
-				//    , NumberOfGoodTracksVsLS(NULL)
-    , GoodTracksFractionVsLS(nullptr)
-				//    , GoodTracksNumberOfRecHitsPerTrackVsLS(NULL)
-				// ADD by Mia for PU monitoring
-				// vertex plots to be moved in ad hoc class
-    , NumberOfGoodPVtxVsLS(nullptr)
-    , NumberOfGoodPVtxWO0VsLS(nullptr)
-    , NumberEventsOfVsBX (nullptr)
-    , NumberOfTracksVsBX(nullptr)
-    , GoodTracksFractionVsBX(nullptr)
-    , NumberOfRecHitsPerTrackVsBX(nullptr)
-    , NumberOfGoodPVtxVsBX(nullptr)
-    , NumberOfGoodPVtxWO0VsBX(nullptr)
-    , NumberOfTracksVsBXlumi(nullptr)
-    , NumberOfTracksVsGoodPVtx(nullptr)
-    , NumberOfTracksVsPUPVtx(nullptr)
-    , NumberEventsOfVsGoodPVtx(nullptr)
-    , GoodTracksFractionVsGoodPVtx(nullptr)
-    , NumberOfRecHitsPerTrackVsGoodPVtx(nullptr)
-    , NumberOfPVtxVsGoodPVtx(nullptr)
-    , NumberOfPixelClustersVsGoodPVtx(nullptr)
-    , NumberOfStripClustersVsGoodPVtx(nullptr)
-    , NumberEventsOfVsLUMI(nullptr)
-    , NumberOfTracksVsLUMI(nullptr)
-    , GoodTracksFractionVsLUMI(nullptr)
-    , NumberOfRecHitsPerTrackVsLUMI(nullptr)
-    , NumberOfGoodPVtxVsLUMI(nullptr)
-    , NumberOfGoodPVtxWO0VsLUMI(nullptr)
-    , NumberOfPixelClustersVsLUMI(nullptr)
-    , NumberOfStripClustersVsLUMI(nullptr)
-    , NumberOfTracks_lumiFlag(nullptr)
-				//    , NumberOfGoodTracks_lumiFlag(NULL)
+TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
+    : confID_(iConfig.id()),
+      theTrackBuildingAnalyzer(new TrackBuildingAnalyzer(iConfig)),
+      NumberOfTracks(nullptr),
+      NumberOfMeanRecHitsPerTrack(nullptr),
+      NumberOfMeanLayersPerTrack(nullptr)
+      //    , NumberOfGoodTracks(NULL)
+      ,
+      FractionOfGoodTracks(nullptr),
+      NumberOfTrackingRegions(nullptr),
+      NumberOfSeeds(nullptr),
+      NumberOfSeeds_lumiFlag(nullptr),
+      NumberOfTrackCandidates(nullptr),
+      FractionCandidatesOverSeeds(nullptr)
+      //    , NumberOfGoodTrkVsClus(NULL)
+      ,
+      NumberEventsOfVsLS(nullptr),
+      NumberOfTracksVsLS(nullptr)
+      //    , NumberOfGoodTracksVsLS(NULL)
+      ,
+      GoodTracksFractionVsLS(nullptr)
+      //    , GoodTracksNumberOfRecHitsPerTrackVsLS(NULL)
+      // ADD by Mia for PU monitoring
+      // vertex plots to be moved in ad hoc class
+      ,
+      NumberOfGoodPVtxVsLS(nullptr),
+      NumberOfGoodPVtxWO0VsLS(nullptr),
+      NumberEventsOfVsBX(nullptr),
+      NumberOfTracksVsBX(nullptr),
+      GoodTracksFractionVsBX(nullptr),
+      NumberOfRecHitsPerTrackVsBX(nullptr),
+      NumberOfGoodPVtxVsBX(nullptr),
+      NumberOfGoodPVtxWO0VsBX(nullptr),
+      NumberOfTracksVsBXlumi(nullptr),
+      NumberOfTracksVsGoodPVtx(nullptr),
+      NumberOfTracksVsPUPVtx(nullptr),
+      NumberEventsOfVsGoodPVtx(nullptr),
+      GoodTracksFractionVsGoodPVtx(nullptr),
+      NumberOfRecHitsPerTrackVsGoodPVtx(nullptr),
+      NumberOfPVtxVsGoodPVtx(nullptr),
+      NumberOfPixelClustersVsGoodPVtx(nullptr),
+      NumberOfStripClustersVsGoodPVtx(nullptr),
+      NumberEventsOfVsLUMI(nullptr),
+      NumberOfTracksVsLUMI(nullptr),
+      GoodTracksFractionVsLUMI(nullptr),
+      NumberOfRecHitsPerTrackVsLUMI(nullptr),
+      NumberOfGoodPVtxVsLUMI(nullptr),
+      NumberOfGoodPVtxWO0VsLUMI(nullptr),
+      NumberOfPixelClustersVsLUMI(nullptr),
+      NumberOfStripClustersVsLUMI(nullptr),
+      NumberOfTracks_lumiFlag(nullptr)
+      //    , NumberOfGoodTracks_lumiFlag(NULL)
 
-    , builderName              ( iConfig.getParameter<std::string>("TTRHBuilder"))
-    , doTrackerSpecific_       ( iConfig.getParameter<bool>("doTrackerSpecific") )
-    , doLumiAnalysis           ( iConfig.getParameter<bool>("doLumiAnalysis"))
-    , doProfilesVsLS_          ( iConfig.getParameter<bool>("doProfilesVsLS"))
-    , doAllPlots               ( iConfig.getParameter<bool>("doAllPlots"))
-    , doGeneralPropertiesPlots_( iConfig.getParameter<bool>("doGeneralPropertiesPlots"))
-    , doHitPropertiesPlots_    ( iConfig.getParameter<bool>("doHitPropertiesPlots"))
-    , doPUmonitoring_          ( iConfig.getParameter<bool>("doPUmonitoring") )
-    , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),consumesCollector(), *this))
-    , numSelection_       (iConfig.getParameter<std::string>("numCut"))
-    , denSelection_       (iConfig.getParameter<std::string>("denCut"))
-    , pvNDOF_             ( iConfig.getParameter<int> ("pvNDOF") )
-{
-
-  edm::ConsumesCollector c{ consumesCollector() };
-  theTrackAnalyzer = new dqm::TrackAnalyzer( iConfig,c );
+      ,
+      builderName(iConfig.getParameter<std::string>("TTRHBuilder")),
+      doTrackerSpecific_(iConfig.getParameter<bool>("doTrackerSpecific")),
+      doLumiAnalysis(iConfig.getParameter<bool>("doLumiAnalysis")),
+      doProfilesVsLS_(iConfig.getParameter<bool>("doProfilesVsLS")),
+      doAllPlots(iConfig.getParameter<bool>("doAllPlots")),
+      doGeneralPropertiesPlots_(iConfig.getParameter<bool>("doGeneralPropertiesPlots")),
+      doHitPropertiesPlots_(iConfig.getParameter<bool>("doHitPropertiesPlots")),
+      doPUmonitoring_(iConfig.getParameter<bool>("doPUmonitoring")),
+      genTriggerEventFlag_(new GenericTriggerEventFlag(
+          iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"), consumesCollector(), *this)),
+      numSelection_(iConfig.getParameter<std::string>("numCut")),
+      denSelection_(iConfig.getParameter<std::string>("denCut")),
+      pvNDOF_(iConfig.getParameter<int>("pvNDOF")) {
+  edm::ConsumesCollector c{consumesCollector()};
+  theTrackAnalyzer = new dqm::TrackAnalyzer(iConfig, c);
 
   // input tags for collections from the configuration
   bsSrc_ = iConfig.getParameter<edm::InputTag>("beamSpot");
@@ -121,584 +124,600 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   bsSrcToken_ = consumes<reco::BeamSpot>(bsSrc_);
   pvSrcToken_ = mayConsume<reco::VertexCollection>(pvSrc_);
 
-  lumiscalersToken_ = consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("scal") );
+  lumiscalersToken_ = consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("scal"));
 
   edm::InputTag alltrackProducer = iConfig.getParameter<edm::InputTag>("allTrackProducer");
-  edm::InputTag trackProducer    = iConfig.getParameter<edm::InputTag>("TrackProducer");
-  edm::InputTag tcProducer       = iConfig.getParameter<edm::InputTag>("TCProducer");
-  edm::InputTag seedProducer     = iConfig.getParameter<edm::InputTag>("SeedProducer");
-  allTrackToken_       = consumes<edm::View<reco::Track> >(alltrackProducer);
-  trackToken_          = consumes<edm::View<reco::Track> >(trackProducer);
-  trackCandidateToken_ = consumes<TrackCandidateCollection>(tcProducer); 
-  seedToken_           = consumes<edm::View<TrajectorySeed> >(seedProducer);
-  seedStopInfoToken_   = consumes<std::vector<SeedStopInfo> >(tcProducer);
+  edm::InputTag trackProducer = iConfig.getParameter<edm::InputTag>("TrackProducer");
+  edm::InputTag tcProducer = iConfig.getParameter<edm::InputTag>("TCProducer");
+  edm::InputTag seedProducer = iConfig.getParameter<edm::InputTag>("SeedProducer");
+  allTrackToken_ = consumes<edm::View<reco::Track> >(alltrackProducer);
+  trackToken_ = consumes<edm::View<reco::Track> >(trackProducer);
+  trackCandidateToken_ = consumes<TrackCandidateCollection>(tcProducer);
+  seedToken_ = consumes<edm::View<TrajectorySeed> >(seedProducer);
+  seedStopInfoToken_ = consumes<std::vector<SeedStopInfo> >(tcProducer);
 
   doMVAPlots = iConfig.getParameter<bool>("doMVAPlots");
-  if(doMVAPlots) {
-    mvaQualityTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<std::string> >("MVAProducers"),
-                                              [&](const std::string& tag) {
-                                                return std::make_tuple(consumes<MVACollection>(edm::InputTag(tag, "MVAValues")),
-                                                                       consumes<QualityMaskCollection>(edm::InputTag(tag, "QualityMasks")));
-                                              });
+  if (doMVAPlots) {
+    mvaQualityTokens_ = edm::vector_transform(
+        iConfig.getParameter<std::vector<std::string> >("MVAProducers"), [&](const std::string& tag) {
+          return std::make_tuple(consumes<MVACollection>(edm::InputTag(tag, "MVAValues")),
+                                 consumes<QualityMaskCollection>(edm::InputTag(tag, "QualityMasks")));
+        });
     mvaTrackToken_ = consumes<edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("TrackProducerForMVA"));
   }
 
   doRegionPlots = iConfig.getParameter<bool>("doRegionPlots");
   doRegionCandidatePlots = iConfig.getParameter<bool>("doRegionCandidatePlots");
-  if(doRegionPlots) {
+  if (doRegionPlots) {
     const auto& regionTag = iConfig.getParameter<edm::InputTag>("RegionProducer");
-    if(!regionTag.label().empty()) {
+    if (!regionTag.label().empty()) {
       regionToken_ = consumes<edm::OwnVector<TrackingRegion> >(regionTag);
     }
     const auto& regionLayersTag = iConfig.getParameter<edm::InputTag>("RegionSeedingLayersProducer");
-    if(!regionLayersTag.label().empty()) {
-      if(!regionToken_.isUninitialized()) {
-        throw cms::Exception("Configuration") << "Only one of 'RegionProducer' and 'RegionSeedingLayersProducer' can be non-empty, now both are.";
+    if (!regionLayersTag.label().empty()) {
+      if (!regionToken_.isUninitialized()) {
+        throw cms::Exception("Configuration")
+            << "Only one of 'RegionProducer' and 'RegionSeedingLayersProducer' can be non-empty, now both are.";
       }
       regionLayerSetsToken_ = consumes<TrackingRegionsSeedingLayerSets>(regionLayersTag);
-    }
-    else if(regionToken_.isUninitialized()) {
-      throw cms::Exception("Configuration") << "With doRegionPlots=True either 'RegionProducer' or 'RegionSeedingLayersProducer' must be non-empty, now both are empty.";
+    } else if (regionToken_.isUninitialized()) {
+      throw cms::Exception("Configuration") << "With doRegionPlots=True either 'RegionProducer' or "
+                                               "'RegionSeedingLayersProducer' must be non-empty, now both are empty.";
     }
 
-    if(doRegionCandidatePlots) {
+    if (doRegionCandidatePlots) {
       regionCandidateToken_ = consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("RegionCandidates"));
     }
   }
 
   edm::InputTag stripClusterInputTag_ = iConfig.getParameter<edm::InputTag>("stripCluster");
   edm::InputTag pixelClusterInputTag_ = iConfig.getParameter<edm::InputTag>("pixelCluster");
-  stripClustersToken_ = mayConsume<edmNew::DetSetVector<SiStripCluster> > (stripClusterInputTag_);
-  pixelClustersToken_ = mayConsume<edmNew::DetSetVector<SiPixelCluster> > (pixelClusterInputTag_);
+  stripClustersToken_ = mayConsume<edmNew::DetSetVector<SiStripCluster> >(stripClusterInputTag_);
+  pixelClustersToken_ = mayConsume<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterInputTag_);
 
   doFractionPlot_ = true;
-  if (alltrackProducer.label()==trackProducer.label()) doFractionPlot_ = false;
-  
-  Quality_  = iConfig.getParameter<std::string>("Quality");
-  AlgoName_ = iConfig.getParameter<std::string>("AlgoName");
-  
-  // get flag from the configuration
-  doPlotsVsBXlumi_   = iConfig.getParameter<bool>("doPlotsVsBXlumi");   
-  if ( doPlotsVsBXlumi_ )
-      theLumiDetails_ = new GetLumi( iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c );
-  doPlotsVsGoodPVtx_ = iConfig.getParameter<bool>("doPlotsVsGoodPVtx");
-  doPlotsVsLUMI_     = iConfig.getParameter<bool>("doPlotsVsLUMI");
-  doPlotsVsBX_       = iConfig.getParameter<bool>("doPlotsVsBX");
+  if (alltrackProducer.label() == trackProducer.label())
+    doFractionPlot_ = false;
 
-  if ( doPUmonitoring_ ) {
-    
-    std::vector<edm::InputTag> primaryVertexInputTags    = iConfig.getParameter<std::vector<edm::InputTag> >("primaryVertexInputTags");
-    std::vector<edm::InputTag> selPrimaryVertexInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("selPrimaryVertexInputTags");
-    std::vector<std::string>   pvLabels                  = iConfig.getParameter<std::vector<std::string> >  ("pvLabels");
-     
-    if (primaryVertexInputTags.size()==pvLabels.size() and primaryVertexInputTags.size()==selPrimaryVertexInputTags.size()) {
-      for (size_t i=0; i<primaryVertexInputTags.size(); i++) {
- 	edm::InputTag iPVinputTag    = primaryVertexInputTags[i];
- 	edm::InputTag iSelPVinputTag = selPrimaryVertexInputTags[i];
- 	std::string   iPVlabel       = pvLabels[i];
-	
- 	theVertexMonitor.push_back(new VertexMonitor(iConfig,iPVinputTag,iSelPVinputTag,iPVlabel,c) );
+  Quality_ = iConfig.getParameter<std::string>("Quality");
+  AlgoName_ = iConfig.getParameter<std::string>("AlgoName");
+
+  // get flag from the configuration
+  doPlotsVsBXlumi_ = iConfig.getParameter<bool>("doPlotsVsBXlumi");
+  if (doPlotsVsBXlumi_)
+    theLumiDetails_ = new GetLumi(iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c);
+  doPlotsVsGoodPVtx_ = iConfig.getParameter<bool>("doPlotsVsGoodPVtx");
+  doPlotsVsLUMI_ = iConfig.getParameter<bool>("doPlotsVsLUMI");
+  doPlotsVsBX_ = iConfig.getParameter<bool>("doPlotsVsBX");
+
+  if (doPUmonitoring_) {
+    std::vector<edm::InputTag> primaryVertexInputTags =
+        iConfig.getParameter<std::vector<edm::InputTag> >("primaryVertexInputTags");
+    std::vector<edm::InputTag> selPrimaryVertexInputTags =
+        iConfig.getParameter<std::vector<edm::InputTag> >("selPrimaryVertexInputTags");
+    std::vector<std::string> pvLabels = iConfig.getParameter<std::vector<std::string> >("pvLabels");
+
+    if (primaryVertexInputTags.size() == pvLabels.size() and
+        primaryVertexInputTags.size() == selPrimaryVertexInputTags.size()) {
+      for (size_t i = 0; i < primaryVertexInputTags.size(); i++) {
+        edm::InputTag iPVinputTag = primaryVertexInputTags[i];
+        edm::InputTag iSelPVinputTag = selPrimaryVertexInputTags[i];
+        std::string iPVlabel = pvLabels[i];
+
+        theVertexMonitor.push_back(new VertexMonitor(iConfig, iPVinputTag, iSelPVinputTag, iPVlabel, c));
       }
     }
   }
-  
 }
 
-
-TrackingMonitor::~TrackingMonitor() 
-{
-  if (theTrackAnalyzer)          delete theTrackAnalyzer;
-  if (theTrackBuildingAnalyzer)  delete theTrackBuildingAnalyzer;
-  if ( doPUmonitoring_ )
-    for (size_t i=0; i<theVertexMonitor.size(); i++)
-      if (theVertexMonitor[i]) delete theVertexMonitor[i];
-  if (genTriggerEventFlag_)      delete genTriggerEventFlag_;
+TrackingMonitor::~TrackingMonitor() {
+  if (theTrackAnalyzer)
+    delete theTrackAnalyzer;
+  if (theTrackBuildingAnalyzer)
+    delete theTrackBuildingAnalyzer;
+  if (doPUmonitoring_)
+    for (size_t i = 0; i < theVertexMonitor.size(); i++)
+      if (theVertexMonitor[i])
+        delete theVertexMonitor[i];
+  if (genTriggerEventFlag_)
+    delete genTriggerEventFlag_;
 }
 
+void TrackingMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) {
+  // parameters from the configuration
+  auto const* conf = edm::pset::Registry::instance()->getMapped(confID_);
+  assert(conf != nullptr);
+  std::string Quality = conf->getParameter<std::string>("Quality");
+  std::string AlgoName = conf->getParameter<std::string>("AlgoName");
+  MEFolderName = conf->getParameter<std::string>("FolderName");
+  std::string Folder = MEFolderName.substr(0, 2);
 
+  // test for the Quality veriable validity
+  if (!Quality_.empty()) {
+    if (Quality_ != "highPurity" && Quality_ != "tight" && Quality_ != "loose") {
+      edm::LogWarning("TrackingMonitor") << "Qualty Name is invalid, using no quality criterea by default";
+      Quality_ = "";
+    }
+  }
 
-void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
-				     edm::Run const & iRun,
-				     edm::EventSetup const & iSetup) 
-{
-   // parameters from the configuration
-   auto const* conf = edm::pset::Registry::instance()->getMapped(confID_);
-   assert(conf != nullptr);
-   std::string Quality      = conf->getParameter<std::string>("Quality");
-   std::string AlgoName     = conf->getParameter<std::string>("AlgoName");
-   MEFolderName = conf->getParameter<std::string>("FolderName"); 
+  // use the AlgoName and Quality Name
+  std::string CategoryName = !Quality_.empty() ? AlgoName_ + "_" + Quality_ : AlgoName_;
 
-   // test for the Quality veriable validity
-   if( !Quality_.empty()) {
-     if( Quality_ != "highPurity" && Quality_ != "tight" && Quality_ != "loose") {
-       edm::LogWarning("TrackingMonitor")  << "Qualty Name is invalid, using no quality criterea by default";
-       Quality_ = "";
-     }
-   }
+  // get binning from the configuration
+  int TKNoBin = conf->getParameter<int>("TkSizeBin");
+  double TKNoMin = conf->getParameter<double>("TkSizeMin");
+  double TKNoMax = conf->getParameter<double>("TkSizeMax");
 
-   // use the AlgoName and Quality Name
-   std::string CategoryName = !Quality_.empty() ? AlgoName_ + "_" + Quality_ : AlgoName_;
+  int TCNoBin = conf->getParameter<int>("TCSizeBin");
+  double TCNoMin = conf->getParameter<double>("TCSizeMin");
+  double TCNoMax = conf->getParameter<double>("TCSizeMax");
 
-   // get binning from the configuration
-   int    TKNoBin     = conf->getParameter<int>(   "TkSizeBin");
-   double TKNoMin     = conf->getParameter<double>("TkSizeMin");
-   double TKNoMax     = conf->getParameter<double>("TkSizeMax");
+  int TKNoSeedBin = conf->getParameter<int>("TkSeedSizeBin");
+  double TKNoSeedMin = conf->getParameter<double>("TkSeedSizeMin");
+  double TKNoSeedMax = conf->getParameter<double>("TkSeedSizeMax");
 
-   int    TCNoBin     = conf->getParameter<int>(   "TCSizeBin");
-   double TCNoMin     = conf->getParameter<double>("TCSizeMin");
-   double TCNoMax     = conf->getParameter<double>("TCSizeMax");
+  int MeanHitBin = conf->getParameter<int>("MeanHitBin");
+  double MeanHitMin = conf->getParameter<double>("MeanHitMin");
+  double MeanHitMax = conf->getParameter<double>("MeanHitMax");
 
-   int    TKNoSeedBin = conf->getParameter<int>(   "TkSeedSizeBin");
-   double TKNoSeedMin = conf->getParameter<double>("TkSeedSizeMin");
-   double TKNoSeedMax = conf->getParameter<double>("TkSeedSizeMax");
+  int MeanLayBin = conf->getParameter<int>("MeanLayBin");
+  double MeanLayMin = conf->getParameter<double>("MeanLayMin");
+  double MeanLayMax = conf->getParameter<double>("MeanLayMax");
 
-   int    MeanHitBin  = conf->getParameter<int>(   "MeanHitBin");
-   double MeanHitMin  = conf->getParameter<double>("MeanHitMin");
-   double MeanHitMax  = conf->getParameter<double>("MeanHitMax");
+  int LSBin = conf->getParameter<int>("LSBin");
+  int LSMin = conf->getParameter<double>("LSMin");
+  int LSMax = conf->getParameter<double>("LSMax");
 
-   int    MeanLayBin  = conf->getParameter<int>(   "MeanLayBin");
-   double MeanLayMin  = conf->getParameter<double>("MeanLayMin");
-   double MeanLayMax  = conf->getParameter<double>("MeanLayMax");
+  std::string StateName = conf->getParameter<std::string>("MeasurementState");
+  if (StateName != "OuterSurface" && StateName != "InnerSurface" && StateName != "ImpactPoint" &&
+      StateName != "default" && StateName != "All") {
+    // print warning
+    edm::LogWarning("TrackingMonitor") << "State Name is invalid, using 'ImpactPoint' by default";
+  }
 
-   int LSBin = conf->getParameter<int>(   "LSBin");
-   int LSMin = conf->getParameter<double>("LSMin");
-   int LSMax = conf->getParameter<double>("LSMax");
+  ibooker.setCurrentFolder(MEFolderName);
 
-   std::string StateName = conf->getParameter<std::string>("MeasurementState");
-   if (
-       StateName != "OuterSurface" &&
-       StateName != "InnerSurface" &&
-       StateName != "ImpactPoint"  &&
-       StateName != "default"      &&
-       StateName != "All"
-       ) {
-     // print warning
-     edm::LogWarning("TrackingMonitor")  << "State Name is invalid, using 'ImpactPoint' by default";
-   }
+  // book the General Property histograms
+  // ---------------------------------------------------------------------------------//
 
-   ibooker.setCurrentFolder(MEFolderName);
+  if (doGeneralPropertiesPlots_ || doAllPlots) {
+    ibooker.setCurrentFolder(MEFolderName + "/GeneralProperties");
 
-   // book the General Property histograms
-   // ---------------------------------------------------------------------------------//
+    histname = "NumberOfTracks_" + CategoryName;
+    // MODIFY by Mia in order to cope w/ high multiplicity
+    NumberOfTracks = ibooker.book1D(histname, histname, 3 * TKNoBin, TKNoMin, (TKNoMax + 0.5) * 3. - 0.5);
+    NumberOfTracks->setAxisTitle("Number of Tracks per Event", 1);
+    NumberOfTracks->setAxisTitle("Number of Events", 2);
 
-   if (doGeneralPropertiesPlots_ || doAllPlots){
-  
-     ibooker.setCurrentFolder(MEFolderName+"/GeneralProperties");
+    if (Folder == "Tr") {
+      histname = "NumberOfTracks_PUvtx_" + CategoryName;
+      NumberOfTracks_PUvtx = ibooker.book1D(histname, histname, 3 * TKNoBin, TKNoMin, (TKNoMax + 0.5) * 3. - 0.5);
+      NumberOfTracks_PUvtx->setAxisTitle("Number of Tracks per Event (matched a PU vertex)", 1);
+      NumberOfTracks_PUvtx->setAxisTitle("Number of Events", 2);
 
-     histname = "NumberOfTracks_" + CategoryName;
-       // MODIFY by Mia in order to cope w/ high multiplicity
-     NumberOfTracks = ibooker.book1D(histname, histname, 3*TKNoBin, TKNoMin, (TKNoMax+0.5)*3.-0.5);
-     NumberOfTracks->setAxisTitle("Number of Tracks per Event", 1);
-     NumberOfTracks->setAxisTitle("Number of Events", 2);
-  
-     histname = "NumberOfMeanRecHitsPerTrack_" + CategoryName;
-     NumberOfMeanRecHitsPerTrack = ibooker.book1D(histname, histname, MeanHitBin, MeanHitMin, MeanHitMax);
-     NumberOfMeanRecHitsPerTrack->setAxisTitle("Mean number of valid RecHits per Track", 1);
-     NumberOfMeanRecHitsPerTrack->setAxisTitle("Entries", 2);
-  
-     histname = "NumberOfMeanLayersPerTrack_" + CategoryName;
-     NumberOfMeanLayersPerTrack = ibooker.book1D(histname, histname, MeanLayBin, MeanLayMin, MeanLayMax);
-     NumberOfMeanLayersPerTrack->setAxisTitle("Mean number of Layers per Track", 1);
-     NumberOfMeanLayersPerTrack->setAxisTitle("Entries", 2);
-  
-     if (doFractionPlot_) {
-       histname = "FractionOfGoodTracks_" + CategoryName;
-       FractionOfGoodTracks = ibooker.book1D(histname, histname, 101, -0.005, 1.005);
-       FractionOfGoodTracks->setAxisTitle("Fraction of Tracks (w.r.t. generalTracks)", 1);
-       FractionOfGoodTracks->setAxisTitle("Entries", 2);
-     }
-   }
+      histname = "NumberofTracks_Hardvtx_" + CategoryName;
+      NumberofTracks_Hardvtx =
+          ibooker.book1D(histname, histname, TKNoBin / 10, TKNoMin, (TKNoMax / 10 + 0.5) * 3. - 0.5);
+      NumberofTracks_Hardvtx->setAxisTitle("Number of Tracks per Event (matched main vertex)", 1);
+      NumberofTracks_Hardvtx->setAxisTitle("Number of Events", 2);
 
-   if ( doLumiAnalysis ) {
-     // add by Mia in order to deal with LS transitions
-     ibooker.setCurrentFolder(MEFolderName+"/LSanalysis");
-  
-     histname = "NumberOfTracks_lumiFlag_" + CategoryName;
-     NumberOfTracks_lumiFlag = ibooker.book1D(histname, histname, 3*TKNoBin, TKNoMin, (TKNoMax+0.5)*3.-0.5);
-     NumberOfTracks_lumiFlag->setAxisTitle("Number of Tracks per Event", 1);
-     NumberOfTracks_lumiFlag->setAxisTitle("Number of Events", 2);
-  
-   }
+      histname = "NumberofTracks_Hardvtx_PUvtx_" + CategoryName;
+      NumberofTracks_Hardvtx_PUvtx = ibooker.book1D(histname, histname, 2, 0., 2.);
+      NumberofTracks_Hardvtx_PUvtx->setAxisTitle("Number of Tracks per PU/Hard vertex", 1);
+      NumberofTracks_Hardvtx_PUvtx->setAxisTitle("Number of Tracks", 2);
+      NumberofTracks_Hardvtx_PUvtx->setBinLabel(1, "PU_Vertex");
+      NumberofTracks_Hardvtx_PUvtx->setBinLabel(2, "Hard_Vertex");
+    }
 
-   // book profile plots vs LS :  
-   //---------------------------  
+    histname = "NumberOfMeanRecHitsPerTrack_" + CategoryName;
+    NumberOfMeanRecHitsPerTrack = ibooker.book1D(histname, histname, MeanHitBin, MeanHitMin, MeanHitMax);
+    NumberOfMeanRecHitsPerTrack->setAxisTitle("Mean number of valid RecHits per Track", 1);
+    NumberOfMeanRecHitsPerTrack->setAxisTitle("Entries", 2);
 
+    histname = "NumberOfMeanLayersPerTrack_" + CategoryName;
+    NumberOfMeanLayersPerTrack = ibooker.book1D(histname, histname, MeanLayBin, MeanLayMin, MeanLayMax);
+    NumberOfMeanLayersPerTrack->setAxisTitle("Mean number of Layers per Track", 1);
+    NumberOfMeanLayersPerTrack->setAxisTitle("Entries", 2);
 
-   if ( doProfilesVsLS_ || doAllPlots) {
-  
-     ibooker.setCurrentFolder(MEFolderName+"/GeneralProperties");
-  
-     histname = "NumberOfTracksVsLS_"+ CategoryName;
-     NumberOfTracksVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax, TKNoMin, TKNoMax*3.,"");
-     NumberOfTracksVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
-     NumberOfTracksVsLS->setAxisTitle("#Lumi section",1);
-     NumberOfTracksVsLS->setAxisTitle("Number of  Tracks",2);
-  
-     histname = "NumberOfRecHitsPerTrackVsLS_" + CategoryName;
-     NumberOfRecHitsPerTrackVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0.,200.,"");
-     NumberOfRecHitsPerTrackVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
-     NumberOfRecHitsPerTrackVsLS->setAxisTitle("#Lumi section",1);
-     NumberOfRecHitsPerTrackVsLS->setAxisTitle("Mean number of Valid RecHits per track",2);
-  
-     histname = "NumberEventsVsLS_" + CategoryName;
-     NumberEventsOfVsLS = ibooker.book1D(histname,histname, LSBin,LSMin,LSMax);
-     NumberEventsOfVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
-     NumberEventsOfVsLS->setAxisTitle("#Lumi section",1);
-     NumberEventsOfVsLS->setAxisTitle("Number of events",2);
-  
-     double GoodPVtxMin   = conf->getParameter<double>("GoodPVtxMin");
-     double GoodPVtxMax   = conf->getParameter<double>("GoodPVtxMax");
+    if (doFractionPlot_) {
+      histname = "FractionOfGoodTracks_" + CategoryName;
+      FractionOfGoodTracks = ibooker.book1D(histname, histname, 101, -0.005, 1.005);
+      FractionOfGoodTracks->setAxisTitle("Fraction of Tracks (w.r.t. generalTracks)", 1);
+      FractionOfGoodTracks->setAxisTitle("Entries", 2);
+    }
+  }
 
-     histname = "NumberOfGoodPVtxVsLS_" + CategoryName;
-     NumberOfGoodPVtxVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,GoodPVtxMin,3.*GoodPVtxMax,"");
-     NumberOfGoodPVtxVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
-     NumberOfGoodPVtxVsLS->setAxisTitle("#Lumi section",1);
-     NumberOfGoodPVtxVsLS->setAxisTitle("Mean number of good PV",2);
+  if (doLumiAnalysis) {
+    // add by Mia in order to deal with LS transitions
+    ibooker.setCurrentFolder(MEFolderName + "/LSanalysis");
 
-     histname = "NumberOfGoodPVtxWO0VsLS_" + CategoryName;
-     NumberOfGoodPVtxWO0VsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,GoodPVtxMin,3.*GoodPVtxMax,"");
-     NumberOfGoodPVtxWO0VsLS->setAxisTitle("#Lumi section",1);
-     NumberOfGoodPVtxWO0VsLS->setAxisTitle("Mean number of good PV",2);
+    histname = "NumberOfTracks_lumiFlag_" + CategoryName;
+    NumberOfTracks_lumiFlag = ibooker.book1D(histname, histname, 3 * TKNoBin, TKNoMin, (TKNoMax + 0.5) * 3. - 0.5);
+    NumberOfTracks_lumiFlag->setAxisTitle("Number of Tracks per Event", 1);
+    NumberOfTracks_lumiFlag->setAxisTitle("Number of Events", 2);
+  }
 
-     if (doFractionPlot_) {
-       histname = "GoodTracksFractionVsLS_"+ CategoryName;
-       GoodTracksFractionVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0,1.1,"");
-       GoodTracksFractionVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
-       GoodTracksFractionVsLS->setAxisTitle("#Lumi section",1);
-       GoodTracksFractionVsLS->setAxisTitle("Fraction of Good Tracks",2);
-     }
+  // book profile plots vs LS :
+  //---------------------------
 
-     if ( doPlotsVsBX_ || doAllPlots ) {
-       ibooker.setCurrentFolder(MEFolderName+"/BXanalysis");
-       int BXBin = 3564; double BXMin = 0.5; double BXMax = 3564.5;
-       
-       histname = "NumberEventsVsBX_" + CategoryName;
-       NumberEventsOfVsBX = ibooker.book1D(histname,histname, BXBin,BXMin,BXMax);
-       NumberEventsOfVsBX->setAxisTitle("BX",1);
-       NumberEventsOfVsBX->setAxisTitle("Number of events",2);
-       
-       histname = "NumberOfTracksVsBX_"+ CategoryName;
-       NumberOfTracksVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax, TKNoMin, TKNoMax*3.,"");
-       NumberOfTracksVsBX->setAxisTitle("BX",1);
-       NumberOfTracksVsBX->setAxisTitle("Number of  Tracks",2);
-       
-       histname = "NumberOfRecHitsPerTrackVsBX_" + CategoryName;
-       NumberOfRecHitsPerTrackVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,0.,200.,"");
-       NumberOfRecHitsPerTrackVsBX->setAxisTitle("BX",1);
-       NumberOfRecHitsPerTrackVsBX->setAxisTitle("Mean number of Valid RecHits per track",2);
-       
-       histname = "NumberOfGoodPVtxVsBX_" + CategoryName;
-       NumberOfGoodPVtxVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,GoodPVtxMin,3.*GoodPVtxMax,"");
-       NumberOfGoodPVtxVsBX->setAxisTitle("BX",1);
-       NumberOfGoodPVtxVsBX->setAxisTitle("Mean number of good PV",2);
-       
-       histname = "NumberOfGoodPVtxWO0VsBX_" + CategoryName;
-       NumberOfGoodPVtxWO0VsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,GoodPVtxMin,3.*GoodPVtxMax,"");
-       NumberOfGoodPVtxWO0VsBX->setAxisTitle("BX",1);
-       NumberOfGoodPVtxWO0VsBX->setAxisTitle("Mean number of good PV",2);
-       
-       if (doFractionPlot_) {
-	 histname = "GoodTracksFractionVsBX_"+ CategoryName;
-	 GoodTracksFractionVsBX = ibooker.bookProfile(histname,histname, BXBin,BXMin,BXMax,0,1.1,"");
-	 GoodTracksFractionVsBX->setAxisTitle("BX",1);
-	 GoodTracksFractionVsBX->setAxisTitle("Fraction of Good Tracks",2);
-       }
-     }
+  if (doProfilesVsLS_ || doAllPlots) {
+    ibooker.setCurrentFolder(MEFolderName + "/GeneralProperties");
 
-   }
+    histname = "NumberOfTracksVsLS_" + CategoryName;
+    NumberOfTracksVsLS = ibooker.bookProfile(histname, histname, LSBin, LSMin, LSMax, TKNoMin, TKNoMax * 3., "");
+    NumberOfTracksVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+    NumberOfTracksVsLS->setAxisTitle("#Lumi section", 1);
+    NumberOfTracksVsLS->setAxisTitle("Number of  Tracks", 2);
 
-   // book PU monitoring plots :  
-   //---------------------------  
+    histname = "NumberOfRecHitsPerTrackVsLS_" + CategoryName;
+    NumberOfRecHitsPerTrackVsLS = ibooker.bookProfile(histname, histname, LSBin, LSMin, LSMax, 0., 200., "");
+    NumberOfRecHitsPerTrackVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+    NumberOfRecHitsPerTrackVsLS->setAxisTitle("#Lumi section", 1);
+    NumberOfRecHitsPerTrackVsLS->setAxisTitle("Mean number of Valid RecHits per track", 2);
 
-   if ( doPUmonitoring_ ) {
-  
-     for (size_t i=0; i<theVertexMonitor.size(); i++)
-       theVertexMonitor[i]->initHisto(ibooker);
-   }
-  
-     if ( doPlotsVsGoodPVtx_ ) {
-      ibooker.setCurrentFolder(MEFolderName+"/PUmonitoring");
-      // get binning from the configuration
-      int   PVBin = conf->getParameter<int>   ("PVBin");
-      float PVMin = conf->getParameter<double>("PVMin");
-      float PVMax = conf->getParameter<double>("PVMax");
-    
-       histname = "NumberOfTracksVsGoodPVtx";
-       NumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,TKNoMin, TKNoMax*5.,"");
-       NumberOfTracksVsGoodPVtx->setAxisTitle("Number of PV",1);
-       NumberOfTracksVsGoodPVtx->setAxisTitle("Mean number of Tracks per Event",2);
+    histname = "NumberEventsVsLS_" + CategoryName;
+    NumberEventsOfVsLS = ibooker.book1D(histname, histname, LSBin, LSMin, LSMax);
+    NumberEventsOfVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+    NumberEventsOfVsLS->setAxisTitle("#Lumi section", 1);
+    NumberEventsOfVsLS->setAxisTitle("Number of events", 2);
 
-       histname = "NumberOfTracksVsPUPVtx";
-       NumberOfTracksVsPUPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,0., TKNoMax*5.,"");
-       NumberOfTracksVsPUPVtx->setAxisTitle("Number of PU",1);
-       NumberOfTracksVsPUPVtx->setAxisTitle("Mean number of Tracks per PUvtx",2);
+    double GoodPVtxMin = conf->getParameter<double>("GoodPVtxMin");
+    double GoodPVtxMax = conf->getParameter<double>("GoodPVtxMax");
 
-       histname = "NumberEventsVsGoodPVtx";
-       NumberEventsOfVsGoodPVtx = ibooker.book1D(histname,histname,PVBin,PVMin,PVMax);
-       NumberEventsOfVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
-       NumberEventsOfVsGoodPVtx->setAxisTitle("Number of events",2);
+    histname = "NumberOfGoodPVtxVsLS_" + CategoryName;
+    NumberOfGoodPVtxVsLS =
+        ibooker.bookProfile(histname, histname, LSBin, LSMin, LSMax, GoodPVtxMin, 3. * GoodPVtxMax, "");
+    NumberOfGoodPVtxVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+    NumberOfGoodPVtxVsLS->setAxisTitle("#Lumi section", 1);
+    NumberOfGoodPVtxVsLS->setAxisTitle("Mean number of good PV", 2);
 
-       if (doFractionPlot_) {
-	 histname = "GoodTracksFractionVsGoodPVtx";
-	 GoodTracksFractionVsGoodPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,0., 1.1,"");
-	 GoodTracksFractionVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
-	 GoodTracksFractionVsGoodPVtx->setAxisTitle("Mean fraction of good tracks",2);
-       }
+    histname = "NumberOfGoodPVtxWO0VsLS_" + CategoryName;
+    NumberOfGoodPVtxWO0VsLS =
+        ibooker.bookProfile(histname, histname, LSBin, LSMin, LSMax, GoodPVtxMin, 3. * GoodPVtxMax, "");
+    NumberOfGoodPVtxWO0VsLS->setAxisTitle("#Lumi section", 1);
+    NumberOfGoodPVtxWO0VsLS->setAxisTitle("Mean number of good PV", 2);
 
-       histname = "NumberOfRecHitsPerTrackVsGoodPVtx";
-       NumberOfRecHitsPerTrackVsGoodPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,0., 200.,"");
-       NumberOfRecHitsPerTrackVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
-       NumberOfRecHitsPerTrackVsGoodPVtx->setAxisTitle("Mean number of valid rechits per Tracks",2);
+    if (doFractionPlot_) {
+      histname = "GoodTracksFractionVsLS_" + CategoryName;
+      GoodTracksFractionVsLS = ibooker.bookProfile(histname, histname, LSBin, LSMin, LSMax, 0, 1.1, "");
+      GoodTracksFractionVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodTracksFractionVsLS->setAxisTitle("#Lumi section", 1);
+      GoodTracksFractionVsLS->setAxisTitle("Fraction of Good Tracks", 2);
+    }
 
-       histname = "NumberOfPVtxVsGoodPVtx";
-       NumberOfPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,0., 3.*PVMax,"");
-       NumberOfPVtxVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
-       NumberOfPVtxVsGoodPVtx->setAxisTitle("Mean number of vertices",2);
+    if (doPlotsVsBX_ || doAllPlots) {
+      ibooker.setCurrentFolder(MEFolderName + "/BXanalysis");
+      int BXBin = 3564;
+      double BXMin = 0.5;
+      double BXMax = 3564.5;
 
-       double NClusPxMin = conf->getParameter<double>("NClusPxMin");
-       double NClusPxMax = conf->getParameter<double>("NClusPxMax");
-       histname = "NumberOfPixelClustersVsGoodPVtx";
-       NumberOfPixelClustersVsGoodPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,NClusPxMin,3.*NClusPxMax,"");
-       NumberOfPixelClustersVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
-       NumberOfPixelClustersVsGoodPVtx->setAxisTitle("Mean number of pixel clusters",2);
-       
-       double NClusStrMin = conf->getParameter<double>("NClusStrMin");
-       double NClusStrMax = conf->getParameter<double>("NClusStrMax");
-       histname = "NumberOfStripClustersVsGoodPVtx";
-       NumberOfStripClustersVsGoodPVtx = ibooker.bookProfile(histname,histname,PVBin,PVMin,PVMax,NClusStrMin,3.*NClusStrMax,"");
-       NumberOfStripClustersVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
-       NumberOfStripClustersVsGoodPVtx->setAxisTitle("Mean number of strip clusters",2);
-  
-     }
-  
+      histname = "NumberEventsVsBX_" + CategoryName;
+      NumberEventsOfVsBX = ibooker.book1D(histname, histname, BXBin, BXMin, BXMax);
+      NumberEventsOfVsBX->setAxisTitle("BX", 1);
+      NumberEventsOfVsBX->setAxisTitle("Number of events", 2);
 
-     if ( doPlotsVsLUMI_ || doAllPlots ) {
-       ibooker.setCurrentFolder(MEFolderName+"/LUMIanalysis");
-       int LUMIBin = conf->getParameter<int>("LUMIBin");
-       float LUMIMin = conf->getParameter<double>("LUMIMin");
-       float LUMIMax = conf->getParameter<double>("LUMIMax");
-       
-       histname = "NumberEventsVsLUMI";
-       NumberEventsOfVsLUMI = ibooker.book1D(histname,histname,LUMIBin,LUMIMin,LUMIMax);
-       NumberEventsOfVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberEventsOfVsLUMI->setAxisTitle("Number of events",2);
-       
-       histname = "NumberOfTracksVsLUMI";
-       NumberOfTracksVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,0., 2000.,"");
-       NumberOfTracksVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberOfTracksVsLUMI->setAxisTitle("Mean number of vertices",2);
-       
-       if (doFractionPlot_) {
-	 histname = "GoodTracksFractionVsLUMI";
-	 GoodTracksFractionVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,0., 1.1,"");
-	 GoodTracksFractionVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-	 GoodTracksFractionVsLUMI->setAxisTitle("Mean number of vertices",2);
-       }
+      histname = "NumberOfTracksVsBX_" + CategoryName;
+      NumberOfTracksVsBX = ibooker.bookProfile(histname, histname, BXBin, BXMin, BXMax, TKNoMin, TKNoMax * 3., "");
+      NumberOfTracksVsBX->setAxisTitle("BX", 1);
+      NumberOfTracksVsBX->setAxisTitle("Number of  Tracks", 2);
 
-       histname = "NumberOfRecHitsPerTrackVsLUMI";
-       NumberOfRecHitsPerTrackVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,0., 200.,"");
-       NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("Mean number of vertices",2);
+      histname = "NumberOfRecHitsPerTrackVsBX_" + CategoryName;
+      NumberOfRecHitsPerTrackVsBX = ibooker.bookProfile(histname, histname, BXBin, BXMin, BXMax, 0., 200., "");
+      NumberOfRecHitsPerTrackVsBX->setAxisTitle("BX", 1);
+      NumberOfRecHitsPerTrackVsBX->setAxisTitle("Mean number of Valid RecHits per track", 2);
 
-       double PVMin   = conf->getParameter<double>("PVMin");
-       double PVMax   = conf->getParameter<double>("PVMax");
-       
-       histname = "NumberOfGoodPVtxVsLUMI";
-       NumberOfGoodPVtxVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,PVMin,3.*PVMax,"");
-       NumberOfGoodPVtxVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberOfGoodPVtxVsLUMI->setAxisTitle("Mean number of vertices",2);
+      histname = "NumberOfGoodPVtxVsBX_" + CategoryName;
+      NumberOfGoodPVtxVsBX =
+          ibooker.bookProfile(histname, histname, BXBin, BXMin, BXMax, GoodPVtxMin, 3. * GoodPVtxMax, "");
+      NumberOfGoodPVtxVsBX->setAxisTitle("BX", 1);
+      NumberOfGoodPVtxVsBX->setAxisTitle("Mean number of good PV", 2);
 
-       histname = "NumberOfGoodPVtxWO0VsLUMI";
-       NumberOfGoodPVtxWO0VsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,PVMin,3.*PVMax,"");
-       NumberOfGoodPVtxWO0VsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberOfGoodPVtxWO0VsLUMI->setAxisTitle("Mean number of vertices",2);
+      histname = "NumberOfGoodPVtxWO0VsBX_" + CategoryName;
+      NumberOfGoodPVtxWO0VsBX =
+          ibooker.bookProfile(histname, histname, BXBin, BXMin, BXMax, GoodPVtxMin, 3. * GoodPVtxMax, "");
+      NumberOfGoodPVtxWO0VsBX->setAxisTitle("BX", 1);
+      NumberOfGoodPVtxWO0VsBX->setAxisTitle("Mean number of good PV", 2);
 
-       double NClusPxMin = conf->getParameter<double>("NClusPxMin");
-       double NClusPxMax = conf->getParameter<double>("NClusPxMax");
-       histname = "NumberOfPixelClustersVsGoodPVtx";
-       NumberOfPixelClustersVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,NClusPxMin,3.*NClusPxMax,"");
-       NumberOfPixelClustersVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberOfPixelClustersVsLUMI->setAxisTitle("Mean number of pixel clusters",2);
-       
-       double NClusStrMin = conf->getParameter<double>("NClusStrMin");
-       double NClusStrMax = conf->getParameter<double>("NClusStrMax");
-       histname = "NumberOfStripClustersVsLUMI";
-       NumberOfStripClustersVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,NClusStrMin,3.*NClusStrMax,"");
-       NumberOfStripClustersVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
-       NumberOfStripClustersVsLUMI->setAxisTitle("Mean number of strip clusters",2);
-  
-     }
-     
+      if (doFractionPlot_) {
+        histname = "GoodTracksFractionVsBX_" + CategoryName;
+        GoodTracksFractionVsBX = ibooker.bookProfile(histname, histname, BXBin, BXMin, BXMax, 0, 1.1, "");
+        GoodTracksFractionVsBX->setAxisTitle("BX", 1);
+        GoodTracksFractionVsBX->setAxisTitle("Fraction of Good Tracks", 2);
+      }
+    }
+  }
 
-     if ( doPlotsVsBXlumi_ ) {
-       ibooker.setCurrentFolder(MEFolderName+"/PUmonitoring");
-       // get binning from the configuration
-       edm::ParameterSet BXlumiParameters = conf->getParameter<edm::ParameterSet>("BXlumiSetup");
-       int    BXlumiBin   = BXlumiParameters.getParameter<int>("BXlumiBin");
-       double BXlumiMin   = BXlumiParameters.getParameter<double>("BXlumiMin");
-       double BXlumiMax   = BXlumiParameters.getParameter<double>("BXlumiMax");
-    
-       histname = "NumberOfTracksVsBXlumi_"+ CategoryName;
-       NumberOfTracksVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax, TKNoMin, 3.*TKNoMax,"");
-       NumberOfTracksVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
-       NumberOfTracksVsBXlumi->setAxisTitle("Mean number of Tracks",2);
-    
-     }
-   
+  // book PU monitoring plots :
+  //---------------------------
 
-     theTrackAnalyzer->initHisto(ibooker, iSetup, *conf);
+  if (doPUmonitoring_) {
+    for (size_t i = 0; i < theVertexMonitor.size(); i++)
+      theVertexMonitor[i]->initHisto(ibooker);
+  }
 
-   // book the Seed Property histograms
-   // ---------------------------------------------------------------------------------//
+  if (doPlotsVsGoodPVtx_) {
+    ibooker.setCurrentFolder(MEFolderName + "/PUmonitoring");
+    // get binning from the configuration
+    int PVBin = conf->getParameter<int>("PVBin");
+    float PVMin = conf->getParameter<double>("PVMin");
+    float PVMax = conf->getParameter<double>("PVMax");
 
-   ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
+    histname = "NumberOfTracksVsGoodPVtx";
+    NumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, TKNoMin, TKNoMax * 5., "");
+    NumberOfTracksVsGoodPVtx->setAxisTitle("Number of PV", 1);
+    NumberOfTracksVsGoodPVtx->setAxisTitle("Mean number of Tracks per Event", 2);
 
-   doAllSeedPlots      = conf->getParameter<bool>("doSeedParameterHistos");
-   doSeedNumberPlot    = conf->getParameter<bool>("doSeedNumberHisto");
-   doSeedLumiAnalysis_ = conf->getParameter<bool>("doSeedLumiAnalysis");
-   doSeedVsClusterPlot = conf->getParameter<bool>("doSeedVsClusterHisto");
-   //    if (doAllPlots) doAllSeedPlots=true;
+    histname = "NumberOfTracksVsPUPVtx";
+    NumberOfTracksVsPUPVtx = ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, 0., TKNoMax * 5., "");
+    NumberOfTracksVsPUPVtx->setAxisTitle("Number of PU", 1);
+    NumberOfTracksVsPUPVtx->setAxisTitle("Mean number of Tracks per PUvtx", 2);
 
-   runTrackBuildingAnalyzerForSeed=(doAllSeedPlots || conf->getParameter<bool>("doSeedPTHisto") ||conf->getParameter<bool>("doSeedETAHisto") || conf->getParameter<bool>("doSeedPHIHisto") || conf->getParameter<bool>("doSeedPHIVsETAHisto") || conf->getParameter<bool>("doSeedThetaHisto") || conf->getParameter<bool>("doSeedQHisto") || conf->getParameter<bool>("doSeedDxyHisto") || conf->getParameter<bool>("doSeedDzHisto") || conf->getParameter<bool>("doSeedNRecHitsHisto") || conf->getParameter<bool>("doSeedNVsPhiProf")|| conf->getParameter<bool>("doSeedNVsEtaProf"));
+    histname = "NumberEventsVsGoodPVtx";
+    NumberEventsOfVsGoodPVtx = ibooker.book1D(histname, histname, PVBin, PVMin, PVMax);
+    NumberEventsOfVsGoodPVtx->setAxisTitle("Number of good PV (PU)", 1);
+    NumberEventsOfVsGoodPVtx->setAxisTitle("Number of events", 2);
 
-   edm::InputTag seedProducer   = conf->getParameter<edm::InputTag>("SeedProducer");
+    if (doFractionPlot_) {
+      histname = "GoodTracksFractionVsGoodPVtx";
+      GoodTracksFractionVsGoodPVtx = ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, 0., 1.1, "");
+      GoodTracksFractionVsGoodPVtx->setAxisTitle("Number of good PV (PU)", 1);
+      GoodTracksFractionVsGoodPVtx->setAxisTitle("Mean fraction of good tracks", 2);
+    }
 
-   if (doAllSeedPlots || doSeedNumberPlot){
-     ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
-     histname = "NumberOfSeeds_"+ seedProducer.label() + "_"+ CategoryName;
-     NumberOfSeeds = ibooker.book1D(histname, histname, TKNoSeedBin, TKNoSeedMin, TKNoSeedMax);
-     NumberOfSeeds->setAxisTitle("Number of Seeds per Event", 1);
-     NumberOfSeeds->setAxisTitle("Number of Events", 2);
-     
-     if ( doSeedLumiAnalysis_ ) {
-       ibooker.setCurrentFolder(MEFolderName+"/LSanalysis");
-       histname = "NumberOfSeeds_lumiFlag_"+ seedProducer.label() + "_"+ CategoryName;
-       NumberOfSeeds_lumiFlag = ibooker.book1D(histname, histname, TKNoSeedBin, TKNoSeedMin, TKNoSeedMax);
-       NumberOfSeeds_lumiFlag->setAxisTitle("Number of Seeds per Event", 1);
-       NumberOfSeeds_lumiFlag->setAxisTitle("Number of Events", 2);
-     }
+    histname = "NumberOfRecHitsPerTrackVsGoodPVtx";
+    NumberOfRecHitsPerTrackVsGoodPVtx = ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, 0., 200., "");
+    NumberOfRecHitsPerTrackVsGoodPVtx->setAxisTitle("Number of good PV (PU)", 1);
+    NumberOfRecHitsPerTrackVsGoodPVtx->setAxisTitle("Mean number of valid rechits per Tracks", 2);
 
-   }
+    histname = "NumberOfPVtxVsGoodPVtx";
+    NumberOfPVtxVsGoodPVtx = ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, 0., 3. * PVMax, "");
+    NumberOfPVtxVsGoodPVtx->setAxisTitle("Number of good PV (PU)", 1);
+    NumberOfPVtxVsGoodPVtx->setAxisTitle("Mean number of vertices", 2);
 
-   if (doAllSeedPlots || doSeedVsClusterPlot){
-     ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
+    double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+    double NClusPxMax = conf->getParameter<double>("NClusPxMax");
+    histname = "NumberOfPixelClustersVsGoodPVtx";
+    NumberOfPixelClustersVsGoodPVtx =
+        ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, NClusPxMin, 3. * NClusPxMax, "");
+    NumberOfPixelClustersVsGoodPVtx->setAxisTitle("Number of good PV (PU)", 1);
+    NumberOfPixelClustersVsGoodPVtx->setAxisTitle("Mean number of pixel clusters", 2);
 
-     ClusterLabels=  conf->getParameter<std::vector<std::string> >("ClusterLabels");
-  
-     std::vector<double> histoMin,histoMax;
-     std::vector<int> histoBin; //these vectors are for max min and nbins in histograms 
-  
-     int    NClusPxBin = conf->getParameter<int>(   "NClusPxBin");
-     double NClusPxMin = conf->getParameter<double>("NClusPxMin");
-     double NClusPxMax = conf->getParameter<double>("NClusPxMax");
-  
-     int    NClusStrBin = conf->getParameter<int>(   "NClusStrBin");
-     double NClusStrMin = conf->getParameter<double>("NClusStrMin");
-     double NClusStrMax = conf->getParameter<double>("NClusStrMax");
-  
-     setMaxMinBin(histoMin,histoMax,histoBin,NClusStrMin,NClusStrMax,NClusStrBin,NClusPxMin,NClusPxMax,NClusPxBin);
-  
-     for (uint i=0; i<ClusterLabels.size(); i++){
-       histname = "SeedsVsClusters_" + seedProducer.label() + "_Vs_" + ClusterLabels[i] + "_" + CategoryName;
-       SeedsVsClusters.push_back(dynamic_cast<MonitorElement*>(ibooker.book2D(histname, histname, histoBin[i], histoMin[i], histoMax[i],
-										 TKNoSeedBin, TKNoSeedMin, TKNoSeedMax)));
-       SeedsVsClusters[i]->setAxisTitle("Number of Clusters", 1);
-       SeedsVsClusters[i]->setAxisTitle("Number of Seeds", 2);
-       SeedsVsClusters[i]->getTH2F()->SetCanExtend(TH1::kAllAxes);
-     }
-   }
-  
-   if(doRegionPlots) {
-     ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
+    double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+    double NClusStrMax = conf->getParameter<double>("NClusStrMax");
+    histname = "NumberOfStripClustersVsGoodPVtx";
+    NumberOfStripClustersVsGoodPVtx =
+        ibooker.bookProfile(histname, histname, PVBin, PVMin, PVMax, NClusStrMin, 3. * NClusStrMax, "");
+    NumberOfStripClustersVsGoodPVtx->setAxisTitle("Number of good PV (PU)", 1);
+    NumberOfStripClustersVsGoodPVtx->setAxisTitle("Mean number of strip clusters", 2);
+  }
 
-     int    regionBin = conf->getParameter<int>(   "RegionSizeBin");
-     double regionMin = conf->getParameter<double>("RegionSizeMin");
-     double regionMax = conf->getParameter<double>("RegionSizeMax");
+  if (doPlotsVsLUMI_ || doAllPlots) {
+    ibooker.setCurrentFolder(MEFolderName + "/LUMIanalysis");
+    int LUMIBin = conf->getParameter<int>("LUMIBin");
+    float LUMIMin = conf->getParameter<double>("LUMIMin");
+    float LUMIMax = conf->getParameter<double>("LUMIMax");
 
-     histname = "TrackingRegionsNumberOf_"+ seedProducer.label() + "_"+ CategoryName;
-     NumberOfTrackingRegions = ibooker.book1D(histname, histname, regionBin, regionMin, regionMax);
-     NumberOfTrackingRegions->setAxisTitle("Number of TrackingRegions per Event", 1);
-     NumberOfTrackingRegions->setAxisTitle("Number of Events", 2);
-   }
+    histname = "NumberEventsVsLUMI";
+    NumberEventsOfVsLUMI = ibooker.book1D(histname, histname, LUMIBin, LUMIMin, LUMIMax);
+    NumberEventsOfVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberEventsOfVsLUMI->setAxisTitle("Number of events", 2);
 
-   doTkCandPlots=conf->getParameter<bool>("doTrackCandHistos");
+    histname = "NumberOfTracksVsLUMI";
+    NumberOfTracksVsLUMI = ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, 0., 2000., "");
+    NumberOfTracksVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberOfTracksVsLUMI->setAxisTitle("Mean number of vertices", 2);
+
+    if (doFractionPlot_) {
+      histname = "GoodTracksFractionVsLUMI";
+      GoodTracksFractionVsLUMI = ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, 0., 1.1, "");
+      GoodTracksFractionVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+      GoodTracksFractionVsLUMI->setAxisTitle("Mean number of vertices", 2);
+    }
+
+    histname = "NumberOfRecHitsPerTrackVsLUMI";
+    NumberOfRecHitsPerTrackVsLUMI = ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, 0., 200., "");
+    NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("Mean number of vertices", 2);
+
+    double PVMin = conf->getParameter<double>("PVMin");
+    double PVMax = conf->getParameter<double>("PVMax");
+
+    histname = "NumberOfGoodPVtxVsLUMI";
+    NumberOfGoodPVtxVsLUMI = ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, PVMin, 3. * PVMax, "");
+    NumberOfGoodPVtxVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberOfGoodPVtxVsLUMI->setAxisTitle("Mean number of vertices", 2);
+
+    histname = "NumberOfGoodPVtxWO0VsLUMI";
+    NumberOfGoodPVtxWO0VsLUMI =
+        ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, PVMin, 3. * PVMax, "");
+    NumberOfGoodPVtxWO0VsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberOfGoodPVtxWO0VsLUMI->setAxisTitle("Mean number of vertices", 2);
+
+    double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+    double NClusPxMax = conf->getParameter<double>("NClusPxMax");
+    histname = "NumberOfPixelClustersVsGoodPVtx";
+    NumberOfPixelClustersVsLUMI =
+        ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, NClusPxMin, 3. * NClusPxMax, "");
+    NumberOfPixelClustersVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberOfPixelClustersVsLUMI->setAxisTitle("Mean number of pixel clusters", 2);
+
+    double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+    double NClusStrMax = conf->getParameter<double>("NClusStrMax");
+    histname = "NumberOfStripClustersVsLUMI";
+    NumberOfStripClustersVsLUMI =
+        ibooker.bookProfile(histname, histname, LUMIBin, LUMIMin, LUMIMax, NClusStrMin, 3. * NClusStrMax, "");
+    NumberOfStripClustersVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]", 1);
+    NumberOfStripClustersVsLUMI->setAxisTitle("Mean number of strip clusters", 2);
+  }
+
+  if (doPlotsVsBXlumi_) {
+    ibooker.setCurrentFolder(MEFolderName + "/PUmonitoring");
+    // get binning from the configuration
+    edm::ParameterSet BXlumiParameters = conf->getParameter<edm::ParameterSet>("BXlumiSetup");
+    int BXlumiBin = BXlumiParameters.getParameter<int>("BXlumiBin");
+    double BXlumiMin = BXlumiParameters.getParameter<double>("BXlumiMin");
+    double BXlumiMax = BXlumiParameters.getParameter<double>("BXlumiMax");
+
+    histname = "NumberOfTracksVsBXlumi_" + CategoryName;
+    NumberOfTracksVsBXlumi =
+        ibooker.bookProfile(histname, histname, BXlumiBin, BXlumiMin, BXlumiMax, TKNoMin, 3. * TKNoMax, "");
+    NumberOfTracksVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]", 1);
+    NumberOfTracksVsBXlumi->setAxisTitle("Mean number of Tracks", 2);
+  }
+
+  theTrackAnalyzer->initHisto(ibooker, iSetup, *conf);
+
+  // book the Seed Property histograms
+  // ---------------------------------------------------------------------------------//
+
+  ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
+
+  doAllSeedPlots = conf->getParameter<bool>("doSeedParameterHistos");
+  doSeedNumberPlot = conf->getParameter<bool>("doSeedNumberHisto");
+  doSeedLumiAnalysis_ = conf->getParameter<bool>("doSeedLumiAnalysis");
+  doSeedVsClusterPlot = conf->getParameter<bool>("doSeedVsClusterHisto");
+  //    if (doAllPlots) doAllSeedPlots=true;
+
+  runTrackBuildingAnalyzerForSeed =
+      (doAllSeedPlots || conf->getParameter<bool>("doSeedPTHisto") || conf->getParameter<bool>("doSeedETAHisto") ||
+       conf->getParameter<bool>("doSeedPHIHisto") || conf->getParameter<bool>("doSeedPHIVsETAHisto") ||
+       conf->getParameter<bool>("doSeedThetaHisto") || conf->getParameter<bool>("doSeedQHisto") ||
+       conf->getParameter<bool>("doSeedDxyHisto") || conf->getParameter<bool>("doSeedDzHisto") ||
+       conf->getParameter<bool>("doSeedNRecHitsHisto") || conf->getParameter<bool>("doSeedNVsPhiProf") ||
+       conf->getParameter<bool>("doSeedNVsEtaProf"));
+
+  edm::InputTag seedProducer = conf->getParameter<edm::InputTag>("SeedProducer");
+
+  if (doAllSeedPlots || doSeedNumberPlot) {
+    ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
+    histname = "NumberOfSeeds_" + seedProducer.label() + "_" + CategoryName;
+    NumberOfSeeds = ibooker.book1D(histname, histname, TKNoSeedBin, TKNoSeedMin, TKNoSeedMax);
+    NumberOfSeeds->setAxisTitle("Number of Seeds per Event", 1);
+    NumberOfSeeds->setAxisTitle("Number of Events", 2);
+
+    if (doSeedLumiAnalysis_) {
+      ibooker.setCurrentFolder(MEFolderName + "/LSanalysis");
+      histname = "NumberOfSeeds_lumiFlag_" + seedProducer.label() + "_" + CategoryName;
+      NumberOfSeeds_lumiFlag = ibooker.book1D(histname, histname, TKNoSeedBin, TKNoSeedMin, TKNoSeedMax);
+      NumberOfSeeds_lumiFlag->setAxisTitle("Number of Seeds per Event", 1);
+      NumberOfSeeds_lumiFlag->setAxisTitle("Number of Events", 2);
+    }
+  }
+
+  if (doAllSeedPlots || doSeedVsClusterPlot) {
+    ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
+
+    ClusterLabels = conf->getParameter<std::vector<std::string> >("ClusterLabels");
+
+    std::vector<double> histoMin, histoMax;
+    std::vector<int> histoBin;  //these vectors are for max min and nbins in histograms
+
+    int NClusPxBin = conf->getParameter<int>("NClusPxBin");
+    double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+    double NClusPxMax = conf->getParameter<double>("NClusPxMax");
+
+    int NClusStrBin = conf->getParameter<int>("NClusStrBin");
+    double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+    double NClusStrMax = conf->getParameter<double>("NClusStrMax");
+
+    setMaxMinBin(
+        histoMin, histoMax, histoBin, NClusStrMin, NClusStrMax, NClusStrBin, NClusPxMin, NClusPxMax, NClusPxBin);
+
+    for (uint i = 0; i < ClusterLabels.size(); i++) {
+      histname = "SeedsVsClusters_" + seedProducer.label() + "_Vs_" + ClusterLabels[i] + "_" + CategoryName;
+      SeedsVsClusters.push_back(dynamic_cast<MonitorElement*>(ibooker.book2D(
+          histname, histname, histoBin[i], histoMin[i], histoMax[i], TKNoSeedBin, TKNoSeedMin, TKNoSeedMax)));
+      SeedsVsClusters[i]->setAxisTitle("Number of Clusters", 1);
+      SeedsVsClusters[i]->setAxisTitle("Number of Seeds", 2);
+      SeedsVsClusters[i]->getTH2F()->SetCanExtend(TH1::kAllAxes);
+    }
+  }
+
+  if (doRegionPlots) {
+    ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
+
+    int regionBin = conf->getParameter<int>("RegionSizeBin");
+    double regionMin = conf->getParameter<double>("RegionSizeMin");
+    double regionMax = conf->getParameter<double>("RegionSizeMax");
+
+    histname = "TrackingRegionsNumberOf_" + seedProducer.label() + "_" + CategoryName;
+    NumberOfTrackingRegions = ibooker.book1D(histname, histname, regionBin, regionMin, regionMax);
+    NumberOfTrackingRegions->setAxisTitle("Number of TrackingRegions per Event", 1);
+    NumberOfTrackingRegions->setAxisTitle("Number of Events", 2);
+  }
+
+  doTkCandPlots = conf->getParameter<bool>("doTrackCandHistos");
   //    if (doAllPlots) doTkCandPlots=true;
-  
-  if (doTkCandPlots){
-    ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
-    
-    edm::InputTag tcProducer     = conf->getParameter<edm::InputTag>("TCProducer");
-    
-    histname = "NumberOfTrackCandidates_"+ tcProducer.label() + "_"+ CategoryName;
+
+  if (doTkCandPlots) {
+    ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
+
+    edm::InputTag tcProducer = conf->getParameter<edm::InputTag>("TCProducer");
+
+    histname = "NumberOfTrackCandidates_" + tcProducer.label() + "_" + CategoryName;
     NumberOfTrackCandidates = ibooker.book1D(histname, histname, TCNoBin, TCNoMin, TCNoMax);
     NumberOfTrackCandidates->setAxisTitle("Number of Track Candidates per Event", 1);
     NumberOfTrackCandidates->setAxisTitle("Number of Event", 2);
 
-    histname = "FractionOfCandOverSeeds_"+ tcProducer.label() + "_"+ CategoryName;
+    histname = "FractionOfCandOverSeeds_" + tcProducer.label() + "_" + CategoryName;
     FractionCandidatesOverSeeds = ibooker.book1D(histname, histname, 101, 0., 1.01);
     FractionCandidatesOverSeeds->setAxisTitle("Number of Track Candidates / Number of Seeds per Event", 1);
     FractionCandidatesOverSeeds->setAxisTitle("Number of Event", 2);
-
   }
-  
-  theTrackBuildingAnalyzer->initHisto(ibooker,*conf);
-  
-  
+
+  theTrackBuildingAnalyzer->initHisto(ibooker, *conf);
+
   if (doLumiAnalysis) {
-    if ( NumberOfTracks_lumiFlag ) NumberOfTracks_lumiFlag -> setLumiFlag();
-    theTrackAnalyzer->setLumiFlag();    
+    if (NumberOfTracks_lumiFlag)
+      NumberOfTracks_lumiFlag->setLumiFlag();
+    theTrackAnalyzer->setLumiFlag();
   }
 
-  if(doAllSeedPlots || doSeedNumberPlot){
-    if ( doSeedLumiAnalysis_ )
+  if (doAllSeedPlots || doSeedNumberPlot) {
+    if (doSeedLumiAnalysis_)
       NumberOfSeeds_lumiFlag->setLumiFlag();
   }
-  
+
   if (doTrackerSpecific_ || doAllPlots) {
-    
-    ClusterLabels=  conf->getParameter<std::vector<std::string> >("ClusterLabels");
-    
-    std::vector<double> histoMin,histoMax;
-    std::vector<int> histoBin; //these vectors are for max min and nbins in histograms 
-    
-    int    NClusStrBin = conf->getParameter<int>(   "NClusStrBin");
+    ClusterLabels = conf->getParameter<std::vector<std::string> >("ClusterLabels");
+
+    std::vector<double> histoMin, histoMax;
+    std::vector<int> histoBin;  //these vectors are for max min and nbins in histograms
+
+    int NClusStrBin = conf->getParameter<int>("NClusStrBin");
     double NClusStrMin = conf->getParameter<double>("NClusStrMin");
     double NClusStrMax = conf->getParameter<double>("NClusStrMax");
-    
-    int    NClusPxBin = conf->getParameter<int>(   "NClusPxBin");
+
+    int NClusPxBin = conf->getParameter<int>("NClusPxBin");
     double NClusPxMin = conf->getParameter<double>("NClusPxMin");
     double NClusPxMax = conf->getParameter<double>("NClusPxMax");
-    
-    int    NTrk2DBin     = conf->getParameter<int>(   "NTrk2DBin");
-    double NTrk2DMin     = conf->getParameter<double>("NTrk2DMin");
-    double NTrk2DMax     = conf->getParameter<double>("NTrk2DMax");
-    
-    setMaxMinBin(histoMin,histoMax,histoBin,
-		 NClusStrMin,NClusStrMax,NClusStrBin,
-		 NClusPxMin,  NClusPxMax,  NClusPxBin);
-    
-    ibooker.setCurrentFolder(MEFolderName+"/HitProperties");
-    
-    for (uint i=0; i<ClusterLabels.size(); i++){
-      
-      ibooker.setCurrentFolder(MEFolderName+"/HitProperties");
+
+    int NTrk2DBin = conf->getParameter<int>("NTrk2DBin");
+    double NTrk2DMin = conf->getParameter<double>("NTrk2DMin");
+    double NTrk2DMax = conf->getParameter<double>("NTrk2DMax");
+
+    setMaxMinBin(
+        histoMin, histoMax, histoBin, NClusStrMin, NClusStrMax, NClusStrBin, NClusPxMin, NClusPxMax, NClusPxBin);
+
+    ibooker.setCurrentFolder(MEFolderName + "/HitProperties");
+
+    for (uint i = 0; i < ClusterLabels.size(); i++) {
+      ibooker.setCurrentFolder(MEFolderName + "/HitProperties");
       histname = "TracksVs" + ClusterLabels[i] + "Cluster_" + CategoryName;
-      NumberOfTrkVsClusters.push_back(dynamic_cast<MonitorElement*>(ibooker.book2D(histname, histname,
-										      histoBin[i], histoMin[i], histoMax[i],
-										      NTrk2DBin,NTrk2DMin,NTrk2DMax
-										      )));
+      NumberOfTrkVsClusters.push_back(dynamic_cast<MonitorElement*>(
+          ibooker.book2D(histname, histname, histoBin[i], histoMin[i], histoMax[i], NTrk2DBin, NTrk2DMin, NTrk2DMax)));
       std::string title = "Number of " + ClusterLabels[i] + " Clusters";
-      if(ClusterLabels[i]=="Tot")
-	title = "# of Clusters in (Pixel+Strip) Detectors";
+      if (ClusterLabels[i] == "Tot")
+        title = "# of Clusters in (Pixel+Strip) Detectors";
       NumberOfTrkVsClusters[i]->setAxisTitle(title, 1);
       NumberOfTrkVsClusters[i]->setAxisTitle("Number of Tracks", 2);
       NumberOfTrkVsClusters[i]->getTH1()->SetCanExtend(TH1::kXaxis);
     }
   }
-  
+
   // Initialize the GenericTriggerEventFlag
-  if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );
-  
+  if (genTriggerEventFlag_->on())
+    genTriggerEventFlag_->initRun(iRun, iSetup);
 }
 
 /*
@@ -712,431 +731,458 @@ void TrackingMonitor::beginRun(const edm::Run& iRun, const edm::EventSetup& iSet
 
 // - BeginLumi
 // ---------------------------------------------------------------------------------//
-void TrackingMonitor::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&  eSetup) {
-
+void TrackingMonitor::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& eSetup) {
   if (doLumiAnalysis) {
-    if ( NumberOfTracks_lumiFlag ) NumberOfTracks_lumiFlag -> Reset();
-    theTrackAnalyzer->doReset();    
+    if (NumberOfTracks_lumiFlag)
+      NumberOfTracks_lumiFlag->Reset();
+    theTrackAnalyzer->doReset();
   }
-  if(doAllSeedPlots || doSeedNumberPlot) {
-    if ( doSeedLumiAnalysis_ )
+  if (doAllSeedPlots || doSeedNumberPlot) {
+    if (doSeedLumiAnalysis_)
       NumberOfSeeds_lumiFlag->Reset();
   }
 }
 
 // -- Analyse
 // ---------------------------------------------------------------------------------//
-void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
-{
-  
-    // Filter out events if Trigger Filtering is requested
-    if (genTriggerEventFlag_->on()&& ! genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // Filter out events if Trigger Filtering is requested
+  if (genTriggerEventFlag_->on() && !genTriggerEventFlag_->accept(iEvent, iSetup))
+    return;
+  auto const* conf = edm::pset::Registry::instance()->getMapped(confID_);
+  MEFolderName = conf->getParameter<std::string>("FolderName");
+  std::string Folder = MEFolderName.substr(0, 2);
+  float lumi = -1.;
+  edm::Handle<LumiScalersCollection> lumiScalers;
+  iEvent.getByToken(lumiscalersToken_, lumiScalers);
+  if (lumiScalers.isValid() && !lumiScalers->empty()) {
+    LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
+    lumi = scalit->instantLumi();
+  } else
+    lumi = -1.;
 
-    float lumi = -1.;
-    edm::Handle<LumiScalersCollection> lumiScalers;
-    iEvent.getByToken(lumiscalersToken_, lumiScalers);
-    if ( lumiScalers.isValid() && !lumiScalers->empty() ) {
-      LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
-      lumi = scalit->instantLumi();
-    } else 
-      lumi = -1.;
+  if (doPlotsVsLUMI_ || doAllPlots)
+    NumberEventsOfVsLUMI->Fill(lumi);
 
-    if (doPlotsVsLUMI_ || doAllPlots) 
-      NumberEventsOfVsLUMI->Fill(lumi);
-    
-    //  Analyse the tracks
+  //  Analyse the tracks
+  //  if the collection is empty, do not fill anything
+  // ---------------------------------------------------------------------------------//
+
+  size_t bx = iEvent.bunchCrossing();
+  if (doPlotsVsBX_ || doAllPlots)
+    NumberEventsOfVsBX->Fill(bx);
+
+  // get the track collection
+  edm::Handle<edm::View<reco::Track> > trackHandle;
+  iEvent.getByToken(trackToken_, trackHandle);
+
+  int numberOfTracks_den = 0;
+  edm::Handle<edm::View<reco::Track> > allTrackHandle;
+  iEvent.getByToken(allTrackToken_, allTrackHandle);
+  if (allTrackHandle.isValid()) {
+    for (edm::View<reco::Track>::const_iterator track = allTrackHandle->begin(); track != allTrackHandle->end();
+         ++track) {
+      if (denSelection_(*track))
+        numberOfTracks_den++;
+    }
+  }
+
+  edm::Handle<reco::VertexCollection> pvHandle;
+  iEvent.getByToken(pvSrcToken_, pvHandle);
+  reco::Vertex const* pv0 = nullptr;
+  if (pvHandle.isValid()) {
+    pv0 = &pvHandle->front();
+    //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
+    if (pv0->isFake() ||
+        pv0->tracksSize() == 0
+        // definition of goodOfflinePrimaryVertex
+        || pv0->ndof() < pvNDOF_ || pv0->z() > 24.)
+      pv0 = nullptr;
+  }
+
+  if (trackHandle.isValid()) {
+    int numberOfTracks = trackHandle->size();
+    int numberOfTracks_num = 0;
+    int numberOfTracks_pv0 = 0;
+
+    const edm::View<reco::Track>& trackCollection = *trackHandle;
+    // calculate the mean # rechits and layers
+    int totalRecHits = 0, totalLayers = 0;
+
+    theTrackAnalyzer->setNumberOfGoodVertices(iEvent);
+    theTrackAnalyzer->setBX(iEvent);
+    theTrackAnalyzer->setLumi(iEvent, iSetup);
+    for (edm::View<reco::Track>::const_iterator track = trackCollection.begin(); track != trackCollection.end();
+         ++track) {
+      if (doPlotsVsBX_ || doAllPlots)
+        NumberOfRecHitsPerTrackVsBX->Fill(bx, track->numberOfValidHits());
+      if (numSelection_(*track)) {
+        numberOfTracks_num++;
+        if (pv0 && std::abs(track->dz(pv0->position())) < 0.15)
+          ++numberOfTracks_pv0;
+      }
+
+      if (doProfilesVsLS_ || doAllPlots)
+        NumberOfRecHitsPerTrackVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()),
+                                          track->numberOfValidHits());
+
+      if (doPlotsVsLUMI_ || doAllPlots)
+        NumberOfRecHitsPerTrackVsLUMI->Fill(lumi, track->numberOfValidHits());
+
+      totalRecHits += track->numberOfValidHits();
+      totalLayers += track->hitPattern().trackerLayersWithMeasurement();
+
+      // do analysis per track
+      theTrackAnalyzer->analyze(iEvent, iSetup, *track);
+    }
+
+    double frac = -1.;
+    //      if (numberOfAllTracks > 0) frac = static_cast<double>(numberOfTracks)/static_cast<double>(numberOfAllTracks);
+    if (numberOfTracks_den > 0)
+      frac = static_cast<double>(numberOfTracks_num) / static_cast<double>(numberOfTracks_den);
+
+    if (doGeneralPropertiesPlots_ || doAllPlots) {
+      NumberOfTracks->Fill(double(numberOfTracks));
+
+      if (Folder == "Tr") {
+        NumberofTracks_Hardvtx->Fill(double(numberOfTracks_pv0));
+        NumberOfTracks_PUvtx->Fill(double(numberOfTracks - numberOfTracks_pv0));
+        NumberofTracks_Hardvtx_PUvtx->Fill(0.5, double(numberOfTracks_pv0));
+        NumberofTracks_Hardvtx_PUvtx->Fill(1.5, double(numberOfTracks - numberOfTracks_pv0));
+      }
+
+      if (doPlotsVsBX_ || doAllPlots)
+        NumberOfTracksVsBX->Fill(bx, numberOfTracks);
+      if (doPlotsVsLUMI_ || doAllPlots)
+        NumberOfTracksVsLUMI->Fill(lumi, numberOfTracks);
+      if (doFractionPlot_) {
+        FractionOfGoodTracks->Fill(frac);
+
+        if (doFractionPlot_) {
+          if (doPlotsVsBX_ || doAllPlots)
+            GoodTracksFractionVsBX->Fill(bx, frac);
+          if (doPlotsVsLUMI_ || doAllPlots)
+            GoodTracksFractionVsLUMI->Fill(lumi, frac);
+        }
+      }
+      if (numberOfTracks > 0) {
+        double meanRecHits = static_cast<double>(totalRecHits) / static_cast<double>(numberOfTracks);
+        double meanLayers = static_cast<double>(totalLayers) / static_cast<double>(numberOfTracks);
+        NumberOfMeanRecHitsPerTrack->Fill(meanRecHits);
+        NumberOfMeanLayersPerTrack->Fill(meanLayers);
+      }
+    }
+
+    if (doProfilesVsLS_ || doAllPlots) {
+      float nLS = static_cast<double>(iEvent.id().luminosityBlock());
+      NumberEventsOfVsLS->Fill(nLS);
+      NumberOfTracksVsLS->Fill(nLS, numberOfTracks);
+      if (doFractionPlot_)
+        GoodTracksFractionVsLS->Fill(nLS, frac);
+    }
+
+    if (doLumiAnalysis) {
+      NumberOfTracks_lumiFlag->Fill(numberOfTracks);
+    }
+
+    //  Analyse the Track Building variables
     //  if the collection is empty, do not fill anything
     // ---------------------------------------------------------------------------------//
 
-    size_t bx = iEvent.bunchCrossing();
-    if ( doPlotsVsBX_ || doAllPlots )
-      NumberEventsOfVsBX->Fill(bx);
+    // fill the TrackCandidate info
+    if (doTkCandPlots) {
+      // magnetic field
+      edm::ESHandle<MagneticField> theMF;
+      iSetup.get<IdealMagneticFieldRecord>().get(theMF);
 
-    // get the track collection
-    edm::Handle<edm::View<reco::Track> > trackHandle;
-    iEvent.getByToken(trackToken_, trackHandle);
+      // get the candidate collection
+      edm::Handle<TrackCandidateCollection> theTCHandle;
+      iEvent.getByToken(trackCandidateToken_, theTCHandle);
+      const TrackCandidateCollection& theTCCollection = *theTCHandle;
 
-    int numberOfTracks_den = 0;
-    edm::Handle<edm::View<reco::Track> > allTrackHandle;
-    iEvent.getByToken(allTrackToken_,allTrackHandle);
-    if (allTrackHandle.isValid()) {
-      for ( edm::View<reco::Track>::const_iterator track = allTrackHandle->begin();
-	    track != allTrackHandle->end(); ++track ) {
+      if (theTCHandle.isValid()) {
+        // get the beam spot
+        edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
+        iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
+        const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
-	if ( denSelection_(*track) )
-	  numberOfTracks_den++;
+        NumberOfTrackCandidates->Fill(theTCCollection.size());
+
+        // get the seed collection
+        edm::Handle<edm::View<TrajectorySeed> > seedHandle;
+        iEvent.getByToken(seedToken_, seedHandle);
+        const edm::View<TrajectorySeed>& seedCollection = *seedHandle;
+        if (seedHandle.isValid() && !seedCollection.empty())
+          FractionCandidatesOverSeeds->Fill(double(theTCCollection.size()) / double(seedCollection.size()));
+
+        iSetup.get<TransientRecHitRecord>().get(builderName, theTTRHBuilder);
+        for (TrackCandidateCollection::const_iterator cand = theTCCollection.begin(); cand != theTCCollection.end();
+             ++cand) {
+          theTrackBuildingAnalyzer->analyze(iEvent, iSetup, *cand, bs, theMF, theTTRHBuilder);
+        }
+      } else {
+        edm::LogWarning("TrackingMonitor") << "No Track Candidates in the event.  Not filling associated histograms";
+      }
+
+      if (doMVAPlots) {
+        // Get MVA and quality mask collections
+        std::vector<const MVACollection*> mvaCollections;
+        std::vector<const QualityMaskCollection*> qualityMaskCollections;
+
+        edm::Handle<edm::View<reco::Track> > htracks;
+        iEvent.getByToken(mvaTrackToken_, htracks);
+
+        edm::Handle<MVACollection> hmva;
+        edm::Handle<QualityMaskCollection> hqual;
+        for (const auto& tokenTpl : mvaQualityTokens_) {
+          iEvent.getByToken(std::get<0>(tokenTpl), hmva);
+          iEvent.getByToken(std::get<1>(tokenTpl), hqual);
+
+          mvaCollections.push_back(hmva.product());
+          qualityMaskCollections.push_back(hqual.product());
+        }
+        theTrackBuildingAnalyzer->analyze(*htracks, mvaCollections, qualityMaskCollections);
       }
     }
-      
-    edm::Handle< reco::VertexCollection > pvHandle;
-    iEvent.getByToken(pvSrcToken_, pvHandle );
-    reco::Vertex const * pv0 = nullptr;  
-    if (pvHandle.isValid()) {
-      pv0 = &pvHandle->front();
-      //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
-      if (   pv0->isFake() || pv0->tracksSize()==0
-      // definition of goodOfflinePrimaryVertex
-          || pv0->ndof() < pvNDOF_ || pv0->z() > 24.)  pv0 = nullptr;
+
+    //plots for trajectory seeds
+
+    if (doAllSeedPlots || doSeedNumberPlot || doSeedVsClusterPlot || runTrackBuildingAnalyzerForSeed) {
+      // get the seed collection
+      edm::Handle<edm::View<TrajectorySeed> > seedHandle;
+      iEvent.getByToken(seedToken_, seedHandle);
+
+      // fill the seed info
+      if (seedHandle.isValid()) {
+        const auto& seedCollection = *seedHandle;
+
+        if (doAllSeedPlots || doSeedNumberPlot) {
+          NumberOfSeeds->Fill(seedCollection.size());
+          if (doSeedLumiAnalysis_)
+            NumberOfSeeds_lumiFlag->Fill(seedCollection.size());
+        }
+
+        if (doAllSeedPlots || doSeedVsClusterPlot) {
+          std::vector<int> NClus;
+          setNclus(iEvent, NClus);
+          for (uint i = 0; i < ClusterLabels.size(); i++) {
+            SeedsVsClusters[i]->Fill(NClus[i], seedCollection.size());
+          }
+        }
+
+        if (doAllSeedPlots || runTrackBuildingAnalyzerForSeed) {
+          edm::Handle<std::vector<SeedStopInfo> > stopHandle;
+          iEvent.getByToken(seedStopInfoToken_, stopHandle);
+          const auto& seedStopInfo = *stopHandle;
+
+          if (seedStopInfo.size() == seedCollection.size()) {
+            //here duplication of mag field and be informations is needed to allow seed and track cand histos to be independent
+            // magnetic field
+            edm::ESHandle<MagneticField> theMF;
+            iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+
+            // get the beam spot
+            edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
+            iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
+            const reco::BeamSpot& bs = *recoBeamSpotHandle;
+
+            iSetup.get<TransientRecHitRecord>().get(builderName, theTTRHBuilder);
+            for (size_t i = 0; i < seedCollection.size(); ++i) {
+              theTrackBuildingAnalyzer->analyze(
+                  iEvent, iSetup, seedCollection[i], seedStopInfo[i], bs, theMF, theTTRHBuilder);
+            }
+          } else {
+            edm::LogWarning("TrackingMonitor")
+                << "Seed collection size (" << seedCollection.size()
+                << ") differs from seed stop info collection size (" << seedStopInfo.size()
+                << "). This is a sign of inconsistency in the configuration. Not filling associated histograms.";
+          }
+        }
+
+      } else {
+        edm::LogWarning("TrackingMonitor") << "No Trajectory seeds in the event.  Not filling associated histograms";
+      }
     }
 
+    // plots for tracking regions
+    if (doRegionPlots) {
+      if (!regionToken_.isUninitialized()) {
+        edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
+        iEvent.getByToken(regionToken_, hregions);
+        const auto& regions = *hregions;
+        NumberOfTrackingRegions->Fill(regions.size());
 
-    if (trackHandle.isValid()) {
-      
-      int numberOfTracks = trackHandle->size();
-      int numberOfTracks_num = 0;
-      int numberOfTracks_pv0 = 0;
+        theTrackBuildingAnalyzer->analyze(regions);
+      } else if (!regionLayerSetsToken_.isUninitialized()) {
+        edm::Handle<TrackingRegionsSeedingLayerSets> hregions;
+        iEvent.getByToken(regionLayerSetsToken_, hregions);
+        const auto& regions = *hregions;
+        NumberOfTrackingRegions->Fill(regions.regionsSize());
 
-      const edm::View<reco::Track>& trackCollection = *trackHandle;
-      // calculate the mean # rechits and layers
-      int totalRecHits = 0, totalLayers = 0;
-
-      theTrackAnalyzer->setNumberOfGoodVertices(iEvent);
-      theTrackAnalyzer->setBX(iEvent);
-      theTrackAnalyzer->setLumi(iEvent,iSetup);
-      for ( edm::View<reco::Track>::const_iterator track = trackCollection.begin();
-	    track != trackCollection.end(); ++track ) {
-
-	if ( doPlotsVsBX_ || doAllPlots )
-	  NumberOfRecHitsPerTrackVsBX->Fill(bx,track->numberOfValidHits());
-	if ( numSelection_(*track) ) {
-	  numberOfTracks_num++;
-          if (pv0 && std::abs(track->dz(pv0->position()))<0.15) ++numberOfTracks_pv0;
-        } 
-
-	if ( doProfilesVsLS_ || doAllPlots)
-	  NumberOfRecHitsPerTrackVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()),track->numberOfValidHits());
-
-	if (doPlotsVsLUMI_ || doAllPlots) 
-	  NumberOfRecHitsPerTrackVsLUMI->Fill(lumi,track->numberOfValidHits());
-
-	totalRecHits    += track->numberOfValidHits();
-	totalLayers     += track->hitPattern().trackerLayersWithMeasurement();
-	
-	// do analysis per track
-	theTrackAnalyzer->analyze(iEvent, iSetup, *track);
+        theTrackBuildingAnalyzer->analyze(regions);
       }
 
-      double frac = -1.;
-      //      if (numberOfAllTracks > 0) frac = static_cast<double>(numberOfTracks)/static_cast<double>(numberOfAllTracks);
-      if (numberOfTracks_den > 0) frac = static_cast<double>(numberOfTracks_num)/static_cast<double>(numberOfTracks_den);
-      
-      if (doGeneralPropertiesPlots_ || doAllPlots){
-	NumberOfTracks       -> Fill(numberOfTracks);
-	if ( doPlotsVsBX_ || doAllPlots )
-	  NumberOfTracksVsBX   -> Fill(bx,numberOfTracks);
-	if (doPlotsVsLUMI_ || doAllPlots) 
-	  NumberOfTracksVsLUMI -> Fill(lumi,numberOfTracks);
-	if (doFractionPlot_) {
-	  FractionOfGoodTracks     -> Fill(frac);
-
-	  if (doFractionPlot_) {
-	    if ( doPlotsVsBX_ || doAllPlots )
-	      GoodTracksFractionVsBX   -> Fill(bx,  frac);
-	    if (doPlotsVsLUMI_ || doAllPlots) 
-	      GoodTracksFractionVsLUMI -> Fill(lumi,frac);
-	  }
-	}
-	if( numberOfTracks > 0 ) {
-	  double meanRecHits = static_cast<double>(totalRecHits) / static_cast<double>(numberOfTracks);
-	  double meanLayers  = static_cast<double>(totalLayers)  / static_cast<double>(numberOfTracks);
-	  NumberOfMeanRecHitsPerTrack -> Fill(meanRecHits);
-	  NumberOfMeanLayersPerTrack  -> Fill(meanLayers);
-	}
+      if (doRegionCandidatePlots) {
+        edm::Handle<reco::CandidateView> hcandidates;
+        iEvent.getByToken(regionCandidateToken_, hcandidates);
+        theTrackBuildingAnalyzer->analyze(*hcandidates);
       }
-      
-      if ( doProfilesVsLS_ || doAllPlots) {
-	float nLS = static_cast<double>(iEvent.id().luminosityBlock());
-	NumberEventsOfVsLS    ->Fill(nLS);
-	NumberOfTracksVsLS    ->Fill(nLS,numberOfTracks);
-	if (doFractionPlot_) 
-	  GoodTracksFractionVsLS->Fill(nLS,frac);
+    }
+
+    if (doTrackerSpecific_ || doAllPlots) {
+      std::vector<int> NClus;
+      setNclus(iEvent, NClus);
+      for (uint i = 0; i < ClusterLabels.size(); i++) {
+        NumberOfTrkVsClusters[i]->Fill(NClus[i], numberOfTracks);
       }
-      
-      if ( doLumiAnalysis ) {
-	NumberOfTracks_lumiFlag       -> Fill(numberOfTracks);
-      }
-      
-      
-      //  Analyse the Track Building variables 
-      //  if the collection is empty, do not fill anything
-      // ---------------------------------------------------------------------------------//
-      
-      
-      // fill the TrackCandidate info
-      if (doTkCandPlots) {
-	// magnetic field
-	edm::ESHandle<MagneticField> theMF;
-	iSetup.get<IdealMagneticFieldRecord>().get(theMF);  
-	
-	// get the candidate collection
-	edm::Handle<TrackCandidateCollection> theTCHandle;
-	iEvent.getByToken( trackCandidateToken_, theTCHandle );
-	const TrackCandidateCollection& theTCCollection = *theTCHandle;
-	
-	if (theTCHandle.isValid()) {
-	  
-	  // get the beam spot
-	  edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-	  iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle );
-	  const reco::BeamSpot& bs = *recoBeamSpotHandle;      
-	  
-	  NumberOfTrackCandidates->Fill(theTCCollection.size());
+    }
 
-          // get the seed collection
-          edm::Handle<edm::View<TrajectorySeed> > seedHandle;
-          iEvent.getByToken(seedToken_, seedHandle );
-          const edm::View<TrajectorySeed>& seedCollection = *seedHandle;
-          if (seedHandle.isValid() && !seedCollection.empty()) 
-            FractionCandidatesOverSeeds->Fill(double(theTCCollection.size())/double(seedCollection.size()));
+    if (doPUmonitoring_) {
+      // do vertex monitoring
+      for (size_t i = 0; i < theVertexMonitor.size(); i++)
+        theVertexMonitor[i]->analyze(iEvent, iSetup);
+    }
+    if (doPlotsVsGoodPVtx_) {
+      size_t totalNumGoodPV = 0;
+      if (pvHandle.isValid()) {
+        for (reco::VertexCollection::const_iterator pv = pvHandle->begin(); pv != pvHandle->end(); ++pv) {
+          //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
+          if (pv->isFake() || pv->tracksSize() == 0)
+            continue;
 
-	  iSetup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
-	  for( TrackCandidateCollection::const_iterator cand = theTCCollection.begin(); cand != theTCCollection.end(); ++cand) {
-	    
-	    theTrackBuildingAnalyzer->analyze(iEvent, iSetup, *cand, bs, theMF, theTTRHBuilder);
-	  }
-	} else {
-	  edm::LogWarning("TrackingMonitor") << "No Track Candidates in the event.  Not filling associated histograms";
-	}
-
-	if(doMVAPlots) {
-	  // Get MVA and quality mask collections
-	  std::vector<const MVACollection *> mvaCollections;
-	  std::vector<const QualityMaskCollection *> qualityMaskCollections;
-
-	  edm::Handle<edm::View<reco::Track> > htracks;
-	  iEvent.getByToken(mvaTrackToken_, htracks);
-
-	  edm::Handle<MVACollection> hmva;
-	  edm::Handle<QualityMaskCollection> hqual;
-	  for(const auto& tokenTpl: mvaQualityTokens_) {
-	    iEvent.getByToken(std::get<0>(tokenTpl), hmva);
-	    iEvent.getByToken(std::get<1>(tokenTpl), hqual);
-
-	    mvaCollections.push_back(hmva.product());
-	    qualityMaskCollections.push_back(hqual.product());
-	  }
-	  theTrackBuildingAnalyzer->analyze(*htracks, mvaCollections, qualityMaskCollections);
-	}
-      }
-      
-      //plots for trajectory seeds
-      
-      if (doAllSeedPlots || doSeedNumberPlot || doSeedVsClusterPlot || runTrackBuildingAnalyzerForSeed) {
-	
-	// get the seed collection
-	edm::Handle<edm::View<TrajectorySeed> > seedHandle;
-	iEvent.getByToken(seedToken_, seedHandle );
-	
-	// fill the seed info
-	if (seedHandle.isValid()) {
-          const auto& seedCollection = *seedHandle;
-	  
-	  if(doAllSeedPlots || doSeedNumberPlot) {
-	    NumberOfSeeds->Fill(seedCollection.size());
-	    if ( doSeedLumiAnalysis_ )
-	      NumberOfSeeds_lumiFlag->Fill(seedCollection.size());	           
-	  }
-	  
-	  if(doAllSeedPlots || doSeedVsClusterPlot){
-	    
-	    std::vector<int> NClus;
-	    setNclus(iEvent,NClus);
-	    for (uint  i=0; i< ClusterLabels.size(); i++){
-	      SeedsVsClusters[i]->Fill(NClus[i],seedCollection.size());
-	    }
-	  }
-	  
-	  if (doAllSeedPlots || runTrackBuildingAnalyzerForSeed){
-            edm::Handle<std::vector<SeedStopInfo> > stopHandle;
-            iEvent.getByToken(seedStopInfoToken_, stopHandle);
-            const auto& seedStopInfo = *stopHandle;
-
-            if(seedStopInfo.size() == seedCollection.size()) {
-              //here duplication of mag field and be informations is needed to allow seed and track cand histos to be independent
-              // magnetic field
-              edm::ESHandle<MagneticField> theMF;
-              iSetup.get<IdealMagneticFieldRecord>().get(theMF);
-	    
-              // get the beam spot
-              edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-              iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
-              const reco::BeamSpot& bs = *recoBeamSpotHandle;
-	    
-              iSetup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
-              for(size_t i=0; i < seedCollection.size(); ++i) {
-                theTrackBuildingAnalyzer->analyze(iEvent, iSetup, seedCollection[i], seedStopInfo[i], bs, theMF, theTTRHBuilder);
-              }
-            }
-            else {
-              edm::LogWarning("TrackingMonitor") << "Seed collection size (" << seedCollection.size()
-                                                 << ") differs from seed stop info collection size (" << seedStopInfo.size()
-                                                 << "). This is a sign of inconsistency in the configuration. Not filling associated histograms.";
-            }
-	  }
-	  
-	} else {
-	  edm::LogWarning("TrackingMonitor") << "No Trajectory seeds in the event.  Not filling associated histograms";
-	}
-      }
-      
-
-      // plots for tracking regions
-      if (doRegionPlots) {
-        if(!regionToken_.isUninitialized()) {
-          edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
-          iEvent.getByToken(regionToken_, hregions);
-          const auto& regions = *hregions;
-          NumberOfTrackingRegions->Fill(regions.size());
-
-          theTrackBuildingAnalyzer->analyze(regions);
-        }
-        else if(!regionLayerSetsToken_.isUninitialized()) {
-          edm::Handle<TrackingRegionsSeedingLayerSets> hregions;
-          iEvent.getByToken(regionLayerSetsToken_, hregions);
-          const auto& regions = *hregions;
-          NumberOfTrackingRegions->Fill(regions.regionsSize());
-
-          theTrackBuildingAnalyzer->analyze(regions);
+          // definition of goodOfflinePrimaryVertex
+          if (pv->ndof() < pvNDOF_ || pv->z() > 24.)
+            continue;
+          totalNumGoodPV++;
         }
 
-        if (doRegionCandidatePlots) {
-          edm::Handle<reco::CandidateView> hcandidates;
-          iEvent.getByToken(regionCandidateToken_, hcandidates);
-          theTrackBuildingAnalyzer->analyze(*hcandidates);
+        NumberEventsOfVsGoodPVtx->Fill(float(totalNumGoodPV));
+        NumberOfTracksVsGoodPVtx->Fill(float(totalNumGoodPV), numberOfTracks);
+        if (totalNumGoodPV > 1)
+          NumberOfTracksVsPUPVtx->Fill(totalNumGoodPV - 1,
+                                       double(numberOfTracks - numberOfTracks_pv0) / double(totalNumGoodPV - 1));
+        NumberOfPVtxVsGoodPVtx->Fill(float(totalNumGoodPV), pvHandle->size());
+
+        for (edm::View<reco::Track>::const_iterator track = trackCollection.begin(); track != trackCollection.end();
+             ++track) {
+          NumberOfRecHitsPerTrackVsGoodPVtx->Fill(float(totalNumGoodPV), track->numberOfValidHits());
         }
+
+        if (doProfilesVsLS_ || doAllPlots)
+          NumberOfGoodPVtxVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()), totalNumGoodPV);
+        if (doPlotsVsBX_ || doAllPlots)
+          NumberOfGoodPVtxVsBX->Fill(bx, float(totalNumGoodPV));
+
+        if (doFractionPlot_)
+          GoodTracksFractionVsGoodPVtx->Fill(float(totalNumGoodPV), frac);
+
+        if (doPlotsVsLUMI_ || doAllPlots)
+          NumberOfGoodPVtxVsLUMI->Fill(lumi, float(totalNumGoodPV));
       }
-      
-      if (doTrackerSpecific_ || doAllPlots) {
-	
-	std::vector<int> NClus;
-	setNclus(iEvent,NClus);
-	for (uint  i=0; i< ClusterLabels.size(); i++) {
-	  NumberOfTrkVsClusters[i]->Fill(NClus[i],numberOfTracks);
-	}
+
+      std::vector<int> NClus;
+      setNclus(iEvent, NClus);
+      std::ostringstream ss;
+      ss << "VI stat " << totalNumGoodPV << ' ' << numberOfTracks;
+      for (uint i = 0; i < ClusterLabels.size(); i++) {
+        ss << ' ' << NClus[i];
+        if (doPlotsVsLUMI_ || doAllPlots) {
+          if (ClusterLabels[i] == "Pix")
+            NumberOfPixelClustersVsLUMI->Fill(lumi, NClus[i]);
+          if (ClusterLabels[i] == "Strip")
+            NumberOfStripClustersVsLUMI->Fill(lumi, NClus[i]);
+        }
+        if (ClusterLabels[i] == "Pix")
+          NumberOfPixelClustersVsGoodPVtx->Fill(float(totalNumGoodPV), NClus[i]);
+        if (ClusterLabels[i] == "Strip")
+          NumberOfStripClustersVsGoodPVtx->Fill(float(totalNumGoodPV), NClus[i]);
       }
-      
-      if ( doPUmonitoring_ ) {
-	
-	// do vertex monitoring
-	for (size_t i=0; i<theVertexMonitor.size(); i++)
-	  theVertexMonitor[i]->analyze(iEvent, iSetup);
+      COUT(MEFolderName) << ss.str() << std::endl;
+      if (doPlotsVsBXlumi_) {
+        double bxlumi = theLumiDetails_->getValue(iEvent);
+        NumberOfTracksVsBXlumi->Fill(bxlumi, numberOfTracks);
       }
-      if ( doPlotsVsGoodPVtx_ ) {
-	  
-	  size_t totalNumGoodPV = 0;
-	  if (pvHandle.isValid()) {
-	    
-	    for (reco::VertexCollection::const_iterator pv = pvHandle->begin();
-		 pv != pvHandle->end(); ++pv) {
-	      
-	      //--- pv fake (the pv collection should have size==1 and the pv==beam spot) 
-	      if (pv->isFake() || pv->tracksSize()==0) continue;
-	      
-	      // definition of goodOfflinePrimaryVertex
-	      if (pv->ndof() < pvNDOF_ || pv->z() > 24.)  continue;
-	      totalNumGoodPV++;
-	    }
-	    
-	    NumberEventsOfVsGoodPVtx       -> Fill( float(totalNumGoodPV) );
-            NumberOfTracksVsGoodPVtx	   -> Fill( float(totalNumGoodPV), numberOfTracks	);
-	    if (totalNumGoodPV>1) NumberOfTracksVsPUPVtx-> Fill( totalNumGoodPV-1, double(numberOfTracks-numberOfTracks_pv0)/double(totalNumGoodPV-1)      );
-	    NumberOfPVtxVsGoodPVtx          -> Fill(float(totalNumGoodPV),pvHandle->size());
 
-	    for ( edm::View<reco::Track>::const_iterator track = trackCollection.begin();
-		  track != trackCollection.end(); ++track ) {
+      if (doProfilesVsLS_ || doAllPlots)
+        if (totalNumGoodPV != 0)
+          NumberOfGoodPVtxWO0VsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()), float(totalNumGoodPV));
+      if (doPlotsVsBX_ || doAllPlots)
+        if (totalNumGoodPV != 0)
+          NumberOfGoodPVtxWO0VsBX->Fill(bx, float(totalNumGoodPV));
+      if (doPlotsVsLUMI_ || doAllPlots)
+        if (totalNumGoodPV != 0)
+          NumberOfGoodPVtxWO0VsLUMI->Fill(lumi, float(totalNumGoodPV));
 
-	      NumberOfRecHitsPerTrackVsGoodPVtx -> Fill(float(totalNumGoodPV), track->numberOfValidHits());
-	    }
+    }  // PU monitoring
 
-	    if ( doProfilesVsLS_ || doAllPlots)
-	      NumberOfGoodPVtxVsLS->Fill(static_cast<double>(iEvent.id().luminosityBlock()),totalNumGoodPV);
-	    if ( doPlotsVsBX_ || doAllPlots )
-	      NumberOfGoodPVtxVsBX->Fill(bx,  float(totalNumGoodPV));
-
-	    if (doFractionPlot_)
-	      GoodTracksFractionVsGoodPVtx->Fill(float(totalNumGoodPV),frac);
-
-	    if ( doPlotsVsLUMI_ || doAllPlots )	    
-	      NumberOfGoodPVtxVsLUMI->Fill(lumi,float(totalNumGoodPV));
-	  }
-      
-	  std::vector<int> NClus;
-	  setNclus(iEvent,NClus);
-          std::ostringstream ss;
-          ss << "VI stat " << totalNumGoodPV << ' ' << numberOfTracks; 
-	  for (uint  i=0; i< ClusterLabels.size(); i++){
-            ss << ' ' << NClus[i];
-	    if ( doPlotsVsLUMI_ || doAllPlots )	{
-	      if (ClusterLabels[i]  =="Pix") NumberOfPixelClustersVsLUMI->Fill(lumi,NClus[i]);
-	      if (ClusterLabels[i]=="Strip") NumberOfStripClustersVsLUMI->Fill(lumi,NClus[i]);
-	    }
-	    if (ClusterLabels[i]  =="Pix") NumberOfPixelClustersVsGoodPVtx->Fill(float(totalNumGoodPV),NClus[i]);
-	    if (ClusterLabels[i]=="Strip") NumberOfStripClustersVsGoodPVtx->Fill(float(totalNumGoodPV),NClus[i]);
-	  }
-	  COUT(MEFolderName) << ss.str() << std::endl;
-	if ( doPlotsVsBXlumi_ ) {
-	  double bxlumi = theLumiDetails_->getValue(iEvent);
-	  NumberOfTracksVsBXlumi       -> Fill( bxlumi, numberOfTracks      );
-	}
-	
-	if ( doProfilesVsLS_ || doAllPlots ) if ( totalNumGoodPV != 0 ) NumberOfGoodPVtxWO0VsLS  -> Fill(static_cast<double>(iEvent.id().luminosityBlock()),float(totalNumGoodPV));
-	if ( doPlotsVsBX_    || doAllPlots ) if ( totalNumGoodPV != 0 ) NumberOfGoodPVtxWO0VsBX  -> Fill(bx,  float(totalNumGoodPV));
-	if ( doPlotsVsLUMI_  || doAllPlots ) if ( totalNumGoodPV != 0 ) NumberOfGoodPVtxWO0VsLUMI-> Fill(lumi,float(totalNumGoodPV));
-
-      } // PU monitoring
-      
-    } // trackHandle is valid
-    
+  }  // trackHandle is valid
 }
 
+void TrackingMonitor::endRun(const edm::Run&, const edm::EventSetup&) {}
 
-void TrackingMonitor::endRun(const edm::Run&, const edm::EventSetup&) 
-{
-}
-
-void TrackingMonitor::setMaxMinBin(std::vector<double> &arrayMin,  std::vector<double> &arrayMax, std::vector<int> &arrayBin, double smin, double smax, int sbin, double pmin, double pmax, int pbin) 
-{
+void TrackingMonitor::setMaxMinBin(std::vector<double>& arrayMin,
+                                   std::vector<double>& arrayMax,
+                                   std::vector<int>& arrayBin,
+                                   double smin,
+                                   double smax,
+                                   int sbin,
+                                   double pmin,
+                                   double pmax,
+                                   int pbin) {
   arrayMin.resize(ClusterLabels.size());
   arrayMax.resize(ClusterLabels.size());
   arrayBin.resize(ClusterLabels.size());
 
-  for (uint i=0; i<ClusterLabels.size(); ++i) {
-
-    if     (ClusterLabels[i]=="Pix"  ) {arrayMin[i]=pmin; arrayMax[i]=pmax;      arrayBin[i]=pbin;}
-    else if(ClusterLabels[i]=="Strip") {arrayMin[i]=smin; arrayMax[i]=smax;      arrayBin[i]=sbin;}
-    else if(ClusterLabels[i]=="Tot"  ) {arrayMin[i]=smin; arrayMax[i]=smax+pmax; arrayBin[i]=sbin;}
-    else {edm::LogWarning("TrackingMonitor")  << "Cluster Label " << ClusterLabels[i] << " not defined, using strip parameters "; 
-      arrayMin[i]=smin; arrayMax[i]=smax; arrayBin[i]=sbin;}
-
+  for (uint i = 0; i < ClusterLabels.size(); ++i) {
+    if (ClusterLabels[i] == "Pix") {
+      arrayMin[i] = pmin;
+      arrayMax[i] = pmax;
+      arrayBin[i] = pbin;
+    } else if (ClusterLabels[i] == "Strip") {
+      arrayMin[i] = smin;
+      arrayMax[i] = smax;
+      arrayBin[i] = sbin;
+    } else if (ClusterLabels[i] == "Tot") {
+      arrayMin[i] = smin;
+      arrayMax[i] = smax + pmax;
+      arrayBin[i] = sbin;
+    } else {
+      edm::LogWarning("TrackingMonitor") << "Cluster Label " << ClusterLabels[i]
+                                         << " not defined, using strip parameters ";
+      arrayMin[i] = smin;
+      arrayMax[i] = smax;
+      arrayBin[i] = sbin;
+    }
   }
-    
 }
 
-void TrackingMonitor::setNclus(const edm::Event& iEvent,std::vector<int> &arrayNclus) 
-{
+void TrackingMonitor::setNclus(const edm::Event& iEvent, std::vector<int>& arrayNclus) {
+  int ncluster_pix = -1;
+  int ncluster_strip = -1;
 
-  int ncluster_pix=-1;
-  int ncluster_strip=-1;
-
-  edm::Handle< edmNew::DetSetVector<SiStripCluster> > strip_clusters;
-  iEvent.getByToken(stripClustersToken_, strip_clusters );
-  edm::Handle< edmNew::DetSetVector<SiPixelCluster> > pixel_clusters;
-  iEvent.getByToken(pixelClustersToken_, pixel_clusters );
+  edm::Handle<edmNew::DetSetVector<SiStripCluster> > strip_clusters;
+  iEvent.getByToken(stripClustersToken_, strip_clusters);
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixel_clusters;
+  iEvent.getByToken(pixelClustersToken_, pixel_clusters);
 
   if (strip_clusters.isValid() && pixel_clusters.isValid()) {
-    ncluster_pix   = (*pixel_clusters).dataSize(); 
-    ncluster_strip = (*strip_clusters).dataSize(); 
+    ncluster_pix = (*pixel_clusters).dataSize();
+    ncluster_strip = (*strip_clusters).dataSize();
   }
 
   arrayNclus.resize(ClusterLabels.size());
-  for (uint i=0; i<ClusterLabels.size(); ++i){
-    
-    if     (ClusterLabels[i]=="Pix"  ) arrayNclus[i]=ncluster_pix ;
-    else if(ClusterLabels[i]=="Strip") arrayNclus[i]=ncluster_strip;
-    else if(ClusterLabels[i]=="Tot"  ) arrayNclus[i]=ncluster_pix+ncluster_strip;
-    else {edm::LogWarning("TrackingMonitor") << "Cluster Label " << ClusterLabels[i] << " not defined using stri parametrs ";
-      arrayNclus[i]=ncluster_strip ;}
+  for (uint i = 0; i < ClusterLabels.size(); ++i) {
+    if (ClusterLabels[i] == "Pix")
+      arrayNclus[i] = ncluster_pix;
+    else if (ClusterLabels[i] == "Strip")
+      arrayNclus[i] = ncluster_strip;
+    else if (ClusterLabels[i] == "Tot")
+      arrayNclus[i] = ncluster_pix + ncluster_strip;
+    else {
+      edm::LogWarning("TrackingMonitor") << "Cluster Label " << ClusterLabels[i]
+                                         << " not defined using stri parametrs ";
+      arrayNclus[i] = ncluster_strip;
+    }
   }
-    
 }
 DEFINE_FWK_MODULE(TrackingMonitor);


### PR DESCRIPTION
PR description:

Add new plots in the Tracking Workspace

dz with respect to BS
dxy with respect to the BS vs eta and phi,
q over p
track quality (isLoose, isTight, isHighQuality),
"inclusively" but also vs pT and eta
number of tracks per vertex, for the hard vertex and
for the other (PU) vertices
tracking efficiency plots from the folding method, for the
"eta vs phi map"
tracking efficiency vs pT of the tracks

Validated with runTheMatrix.py -l 10024
