### PR TITLE
Fix for relval_8.2 job splitting issue

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -253,6 +253,8 @@ class MatrixInjector(object):
             wmsplit['RECOCOS_UP17']=1
             wmsplit['DIGICOS_UP18']=1
             wmsplit['RECOCOS_UP18']=1
+            wmsplit['DIGICOS_UP21']=1
+            wmsplit['RECOCOS_UP21']=1
             wmsplit['HYBRIDRepackHI2015VR']=1
             wmsplit['HYBRIDZSHI2015']=1
             wmsplit['RECOHID15']=1


### PR DESCRIPTION
New relval 8.2 (Beamhalo 2021) was introduced in PR#26510 (https://github.com/cms-sw/cmssw/pull/26510). It had issue with job splitting, relvals was failing because of too much Wall Clock time. In this PR just two lines added to fix this issue. The discussion for the issue can be seen at following ticket 
https://its.cern.ch/jira/browse/CMSCOMPPR-6894

Thanking you . 
Best, 
Muhammad Ahmad