### PR TITLE
g4SimHits changes in the source code needed to include PPS 

### DIFF
--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -86,6 +86,8 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
   produces<edm::PSimHitContainer>("TotemHitsT1");
   produces<edm::PSimHitContainer>("TotemHitsT2Gem");
   produces<edm::PSimHitContainer>("TotemHitsRP");
+  produces<edm::PSimHitContainer>("CTPPSPixelHits");
+  produces<edm::PSimHitContainer>("CTPPSTimingHits");
   produces<edm::PSimHitContainer>("FP420SI");
   produces<edm::PSimHitContainer>("BSCHits");
   produces<edm::PSimHitContainer>("PLTHits");

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -88,6 +88,8 @@ OscarProducer::OscarProducer(edm::ParameterSet const& p) {
   produces<edm::PSimHitContainer>("TotemHitsT1");
   produces<edm::PSimHitContainer>("TotemHitsT2Gem");
   produces<edm::PSimHitContainer>("TotemHitsRP");
+  produces<edm::PSimHitContainer>("CTPPSPixelHits");
+  produces<edm::PSimHitContainer>("CTPPSTimingHits");
   produces<edm::PSimHitContainer>("FP420SI");
   produces<edm::PSimHitContainer>("BSCHits");
   produces<edm::PSimHitContainer>("PLTHits");


### PR DESCRIPTION
#### PR description:

Changes need in OscarProducer.cc and OscarMTProducer.cc (SimG4Core/Application) in order to include PPS sim hits (the config has not been changed yet, only source code).

#### PR validation:
scram b runtests
and 
runTheMatrix.py --job-reports -j 14 -s -l limited -i all --ibeos
with output:

31 25 16 13 9 1 0 0 0 tests passed, 2 5 9 0 0 0 0 0 0 failed

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
