### PR TITLE
PPS: update of association cuts

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -16,8 +16,9 @@ from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 
 Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016,run2_egamma_2016]), 
 phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
-trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017)
+trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -15,8 +15,9 @@ from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017]),
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017]),
 run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
 run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018)

--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -15,7 +15,8 @@ from Configuration.Eras.Modifier_run2_muon_2017_cff import run2_muon_2017
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
 Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017]),
 run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
-run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018)
+run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018)

--- a/Configuration/Eras/python/Modifier_ctpps_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_ctpps_2017_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+ctpps_2017 =  cms.Modifier()
+

--- a/Configuration/Eras/python/Modifier_ctpps_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_ctpps_2018_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+ctpps_2018 =  cms.Modifier()
+

--- a/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -14,7 +14,7 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
-def ApplyDefaultSettings(ctppsProtons):
+def applyDefaultSettings(ctppsProtons):
   ctppsProtons.association_cuts_45.x_cut_apply = False
   ctppsProtons.association_cuts_45.y_cut_apply = False
   ctppsProtons.association_cuts_45.xi_cut_apply = True
@@ -27,15 +27,15 @@ def ApplyDefaultSettings(ctppsProtons):
   ctppsProtons.association_cuts_56.xi_cut_value = 0.015
   ctppsProtons.association_cuts_56.th_y_cut_apply = False
 
-ctpps_2016.toModify(ctppsProtons, ApplyDefaultSettings) # applied for all Run2 years (2016, 2017 and 2018)
+ctpps_2016.toModify(ctppsProtons, applyDefaultSettings) # applied for all Run2 years (2016, 2017 and 2018)
 
-def Apply2017Settings(ctppsProtons):
+def apply2017Settings(ctppsProtons):
   ctppsProtons.association_cuts_45.xi_cut_value = 0.010
   ctppsProtons.association_cuts_56.xi_cut_value = 0.015
 
-ctpps_2017.toModify(ctppsProtons, Apply2017Settings)
+ctpps_2017.toModify(ctppsProtons, apply2017Settings)
 
-def Apply2018Settings(ctppsProtons):
+def apply2018Settings(ctppsProtons):
   ctppsProtons.association_cuts_45.xi_cut_value = 0.013
   ctppsProtons.association_cuts_45.th_y_cut_apply = True
   ctppsProtons.association_cuts_45.th_y_cut_value = 30E-6
@@ -44,4 +44,4 @@ def Apply2018Settings(ctppsProtons):
   ctppsProtons.association_cuts_56.th_y_cut_apply = True
   ctppsProtons.association_cuts_56.th_y_cut_value = 20E-6
 
-ctpps_2018.toModify(ctppsProtons, Apply2018Settings)
+ctpps_2018.toModify(ctppsProtons, apply2018Settings)

--- a/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -1,7 +1,47 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoCTPPS.ProtonReconstruction.ctppsProtons_cfi import *
+# import default alignment settings
+from CalibPPS.ESProducers.ctppsAlignment_cff import *
 
-# TODO: remove these lines once conditions data are available in DB
+# import default optics settings
 from CalibPPS.ESProducers.ctppsOpticalFunctions_cff import *
+
+# import and adjust proton-reconstructions settings
+from RecoCTPPS.ProtonReconstruction.ctppsProtons_cfi import *
 ctppsProtons.lhcInfoLabel = ctppsLHCInfoLabel
+
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+
+def ApplyDefaultSettings(ctppsProtons):
+  ctppsProtons.association_cuts_45.x_cut_apply = False
+  ctppsProtons.association_cuts_45.y_cut_apply = False
+  ctppsProtons.association_cuts_45.xi_cut_apply = True
+  ctppsProtons.association_cuts_45.xi_cut_value = 0.010
+  ctppsProtons.association_cuts_45.th_y_cut_apply = False
+
+  ctppsProtons.association_cuts_56.x_cut_apply = False
+  ctppsProtons.association_cuts_56.y_cut_apply = False
+  ctppsProtons.association_cuts_56.xi_cut_apply = True
+  ctppsProtons.association_cuts_56.xi_cut_value = 0.015
+  ctppsProtons.association_cuts_56.th_y_cut_apply = False
+
+ctpps_2016.toModify(ctppsProtons, ApplyDefaultSettings) # applied for all Run2 years (2016, 2017 and 2018)
+
+def Apply2017Settings(ctppsProtons):
+  ctppsProtons.association_cuts_45.xi_cut_value = 0.010
+  ctppsProtons.association_cuts_56.xi_cut_value = 0.015
+
+ctpps_2017.toModify(ctppsProtons, Apply2017Settings)
+
+def Apply2018Settings(ctppsProtons):
+  ctppsProtons.association_cuts_45.xi_cut_value = 0.013
+  ctppsProtons.association_cuts_45.th_y_cut_apply = True
+  ctppsProtons.association_cuts_45.th_y_cut_value = 30E-6
+
+  ctppsProtons.association_cuts_56.xi_cut_value = 0.013
+  ctppsProtons.association_cuts_56.th_y_cut_apply = True
+  ctppsProtons.association_cuts_56.th_y_cut_value = 20E-6
+
+ctpps_2018.toModify(ctppsProtons, Apply2018Settings)


### PR DESCRIPTION
This PR adjusts the "association cuts" used in multi-RP proton reconstruction. This update has been presented in RECO/AT meeting:
https://indico.cern.ch/event/830302/contributions/3477928/attachments/1871174/3079130/jan_kaspar_pps.pdf
and PPS POG meeting:
https://indico.cern.ch/event/832270/contributions/3487106/attachments/1872773/3082425/jan_kaspar_pps.pdf

The new association cuts are different for 2016, 2017 and 2018 - which is achieved by introducing new era modifiers. For backward compatibility the meaning of  ``ctpps_2016`` is unchanged and this modifier still applies to all 2016, 17 and 18.

The association cuts are modified for all 2016, 2017 and 2018.

This update is backported to the 10_6 cycle for later stages of UL re-reco in #27475.