### PR TITLE
Add 11_0_X global tags for 2021 and later MC scenarios

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,13 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_upgrade2021_design_v3', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v3',
-    # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '106X_upgrade2023_realistic_v5'
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v1',
+    # GlobalTag for MC production with realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
+    # GlobalTag for MC production with realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
+    # GlobalTag for MC production with realistic conditions for Phase2
+    'phase2_realistic'         : '110X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

With the submission of workflows for Run-3 samples, AlCa plans to close the 10_6_X Run 3 queues to all but bug fixes and therefore needs to open queues for conditions development in 11_0_X. Also, we would like to introduce new keys into autoCond to support the Run 3 relvals in PR #27433. This PR is needed to support but could be merged before PR #27433.

New GT naming conventions are necessary to avoid confusion between the end of Run 3 scenario and the so-called "upgrade2023" scenario. The later is now referred to as "Run4".

We have taken this opportunity to clean up some obsolete tags for the pixel [1] and make a technical change to avoid maintaining two `SiPixelLorentzAngleRcd` payloads when the payloads are identical.

There is one change relative to the previous autoCond contents: the tracker alignment scenario has been updated for 2021 realistic scenarios for both cosmics and collisions [3, 4].

Attn: @mmusich

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_design_v1/106X_upgrade2021_design_v3
- Removed obsolete pixel tags [1]
- Use `SiPixelLorentzAngleRcd` payload with label "forWidth" that has all zeros [2]

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_v1/106X_upgrade2021_realistic_v8
- Removed obsolete pixel tags [1]
- Use `SiPixelLorentzAngleRcd` payload with label "forWidth" that has all zeros [2]
- Update tracker alignment scenario [3, 4]

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021cosmics_realistic_deco_v1/106X_upgrade2021cosmics_realistic_deco_v3
- Removed obsolete pixel tags [1]
- Use `SiPixelLorentzAngleRcd` payload with label "forWidth" that has all zeros [2]
- Update tracker alignment scenario [3, 4]

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_v1/106X_mcRun3_2023_realistic_v3
- Removed obsolete pixel tags [1]
- Tracker alignment scenario [3] and labeled `SiPixelLorentzAngleRcd` updated already in `106X_mcRun3_2023_realistic_v3` GT
- Addition of payloads that were introduced by PR #26892 into all collisions GTs in autoCond at the time and then subsequently ignored by an era mechanism in a later revision of that PR. The payloads are added here for consistency in case during the preparation of the 2018 UL it is decided to switch back to using conditions. If this turns out to be unnecessary, these payloads will be removed in a later cleanup.

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2024_realistic_v1/106X_mcRun3_2024_realistic_v4
- Removed obsolete pixel tags [1]
- Tracker alignment scenario [3] and labeled `SiPixelLorentzAngleRcd` updated already in `106X_mcRun3_2024_realistic_v4` GT
- Addition of payloads that were introduced by PR #26892

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun4_realistic_Queue/106X_upgrade2023_realistic_v5 
- No changes in move to 11_0_X queue; renaming only

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4159/1/1.html
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4168.html 
[3] https://indico.cern.ch/event/831067/contributions/3481130/attachments/1871760/3080376/20190701_AlCaDB_ULandRun3.pdf
[4] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4171/1.html

#### PR validation:

`runTheMatrix.py -l limited -i all --ibeos` was executed successfully.

#### if this PR is a backport please specify the original PR:

This PR should not be backported.