### PR TITLE
import additions for UL-HLT in 10_2_X

### DIFF
--- a/Configuration/DataProcessing/python/Merge.py
+++ b/Configuration/DataProcessing/python/Merge.py
@@ -27,6 +27,8 @@ def mergeProcess(*inputFiles, **options):
     - newDQMIO : specifies if the new DQM format should be used to merge the files
     - output_file : sets the output file name
     - output_lfn : sets the output LFN
+    - mergeNANO : to merge NanoAOD
+    - bypassVersionCheck : to bypass version check in case merging happened in lower version of CMSSW (i.e. UL HLT case). This will be TRUE by default.
 
     """
     #  //
@@ -39,6 +41,7 @@ def mergeProcess(*inputFiles, **options):
     dropDQM = options.get("drop_dqm", False)
     newDQMIO = options.get("newDQMIO", False)
     mergeNANO = options.get("mergeNANO", False)
+    bypassVersionCheck = options.get("bypassVersionCheck", True)
     #  //
     # // build process
     #//
@@ -52,6 +55,7 @@ def mergeProcess(*inputFiles, **options):
         process.add_(Service("DQMStore"))
     else:
         process.source = Source("PoolSource")
+        process.source.bypassVersionCheck = CfgTypes.untracked.bool(bypassVersionCheck)
         if dropDQM:
             process.source.inputCommands = CfgTypes.untracked.vstring('keep *','drop *_EDMtoMEConverter_*_*')
     process.source.fileNames = CfgTypes.untracked(CfgTypes.vstring())

--- a/Configuration/DataProcessing/test/RunMerge.py
+++ b/Configuration/DataProcessing/test/RunMerge.py
@@ -22,7 +22,9 @@ class RunMerge:
         self.outputLFN = None
         self.inputFiles = []
         self.newDQMIO = False
-        
+        self.mergeNANO = False
+        self.bypassVersionCheck = True
+
 
     def __call__(self):
         if self.inputFiles == []:
@@ -36,7 +38,8 @@ class RunMerge:
                 output_file = self.outputFile,
                 output_lfn = self.outputLFN,
                 newDQMIO = self.newDQMIO,
-                mergeNANO = self.mergeNANO)
+                mergeNANO = self.mergeNANO
+                bypassVersionCheck = self.bypassVersionCheck)
         except Exception as ex:
             msg = "Error creating process for Merge:\n"
             msg += str(ex)
@@ -52,7 +55,7 @@ class RunMerge:
 
 
 if __name__ == '__main__':
-    valid = ["input-files=", "output-file=", "output-lfn=", "dqmroot", "mergeNANO" ]
+    valid = ["input-files=", "output-file=", "output-lfn=", "dqmroot", "mergeNANO", "bypassVersionCheck" ]
              
     usage = """RunMerge.py <options>"""
     try:
@@ -76,7 +79,9 @@ if __name__ == '__main__':
             merger.outputLFN = arg
         if opt == "--dqmroot" :
             merger.newDQMIO = True
-        if  opt == "--mergeNANO" :
+        if opt == "--mergeNANO" :
             merger.mergeNANO = True
+        if opt == "--bypassVersionCheck" :
+            merger.bypassVersionCheck = True
 
     merger()

--- a/DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h
+++ b/DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h
@@ -1,0 +1,152 @@
+#ifndef DataFormats_Provenance_StoredMergeableRunProductMetadata_h
+#define DataFormats_Provenance_StoredMergeableRunProductMetadata_h
+
+/** \class edm::StoredMergeableRunProductMetadata
+
+This class holds information used to decide how to merge together
+run products when multiple run entries with the same run number
+and ProcessHistoryID are read from input files contiguously. This
+class is persistent and stores the information that needs to be
+remembered from one process to the next. Most of the work related
+to this decision is performed by the class MergeableRunProductMetadata.
+The main purpose of this class is to hold the information that
+needs to be persistently stored. PoolSource and PoolOutputModule
+interface with this class to read and write it.
+
+Note that the information is not stored for each product.
+The information is stored for each run entry in Run TTree
+in the input file and also for each process in which at least
+one mergeable run product was selected to be written to the
+output file. It is not necessary to save information
+for each product individually, it will be the same for every
+product created in the same process and in the same run entry.
+
+The main piece of information stored is the list of luminosity
+block numbers processed when the product was created. Often,
+this list can be obtained from the IndexIntoFile and we do not
+need to duplicate this information here and so as an optimization
+we don't. There are also cases where we can detect that the merging
+has created invalid run products where part of the content
+has probably been double counted. We save a value to record
+this problem.
+
+To improve performance, the data structure has been flattened
+into 4 vectors instead of containing a vector containing vectors
+containing vectors.
+
+When the user of this class fails to find a run entry with a
+particular process, the assumption should be made that the lumi
+numbers are in IndexIntoFile and valid.
+
+Another optimization is that if in all cases the lumi numbers
+can be obtained from IndexIntoFile and are valid, then all
+the vectors are cleared and a boolean value is set to indicate
+this.
+
+\author W. David Dagenhart, created 23 May, 2018
+
+*/
+
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class StoredMergeableRunProductMetadata {
+  public:
+
+    // This constructor exists for ROOT I/O
+    StoredMergeableRunProductMetadata();
+
+    // This constructor is used when creating a new object
+    // each time an output file is opened.
+    StoredMergeableRunProductMetadata(std::vector<std::string> const& processesWithMergeableRunProducts);
+
+    std::vector<std::string> const& processesWithMergeableRunProducts() const {
+      return processesWithMergeableRunProducts_;
+    }
+
+    class SingleRunEntry {
+    public:
+
+      SingleRunEntry();
+      SingleRunEntry(unsigned long long iBeginProcess, unsigned long long iEndProcess);
+
+      unsigned long long beginProcess() const { return beginProcess_; }
+      unsigned long long endProcess() const { return endProcess_; }
+
+    private:
+
+      // indexes into singleRunEntryAndProcesses_ for a single run entry
+      unsigned long long beginProcess_;
+      unsigned long long endProcess_;
+    };
+
+    class SingleRunEntryAndProcess {
+    public:
+
+      SingleRunEntryAndProcess();
+      SingleRunEntryAndProcess(unsigned long long iBeginLumi,
+                               unsigned long long iEndLumi,
+                               unsigned int iProcess,
+                               bool iValid,
+                               bool iUseIndexIntoFile);
+
+
+      unsigned long long beginLumi() const { return beginLumi_; }
+      unsigned long long endLumi() const { return endLumi_; }
+
+      unsigned int process() const { return process_; }
+
+      bool valid() const { return valid_; }
+      bool useIndexIntoFile() const { return useIndexIntoFile_; }
+
+    private:
+
+      // indexes into lumis_ for products created in one process and
+      // written into a single run entry.
+      unsigned long long beginLumi_;
+      unsigned long long endLumi_;
+
+      // index into processesWithMergeableRunProducts_
+      unsigned int process_;
+
+      // If false this indicates the way files were split and merged
+      // has created run products that are invalid and probably
+      // double count some of their content.
+      bool valid_;
+
+      // If true the lumi numbers can be obtained from IndexIntoFile
+      // and are not stored in the vector named lumis_
+      bool useIndexIntoFile_;
+    };
+
+    // These four functions are called by MergeableRunProductMetadata which
+    // fills the vectors.
+    std::vector<SingleRunEntry>& singleRunEntries() { return singleRunEntries_; }
+    std::vector<SingleRunEntryAndProcess>& singleRunEntryAndProcesses() { return singleRunEntryAndProcesses_; }
+    std::vector<LuminosityBlockNumber_t>& lumis() { return lumis_; }
+    bool& allValidAndUseIndexIntoFile() { return allValidAndUseIndexIntoFile_; }
+
+    // Called by RootOutputFile immediately before writing the object
+    // when an output file is closed.
+    void optimizeBeforeWrite();
+
+    bool getLumiContent(unsigned long long runEntry,
+                        std::string const& process,
+                        bool& valid,
+                        std::vector<LuminosityBlockNumber_t>::const_iterator & lumisBegin,
+                        std::vector<LuminosityBlockNumber_t>::const_iterator & lumisEnd) const;
+
+  private:
+
+    std::vector<std::string> processesWithMergeableRunProducts_;
+    std::vector<SingleRunEntry> singleRunEntries_;  // index is the run entry
+    std::vector<SingleRunEntryAndProcess> singleRunEntryAndProcesses_;
+    std::vector<LuminosityBlockNumber_t> lumis_;
+    bool allValidAndUseIndexIntoFile_;
+  };
+}
+#endif

--- a/DataFormats/Provenance/src/StoredMergeableRunProductMetadata.cc
+++ b/DataFormats/Provenance/src/StoredMergeableRunProductMetadata.cc
@@ -1,0 +1,81 @@
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
+
+namespace edm {
+
+  StoredMergeableRunProductMetadata::StoredMergeableRunProductMetadata() :
+    allValidAndUseIndexIntoFile_(true) { }
+
+  StoredMergeableRunProductMetadata::
+  StoredMergeableRunProductMetadata(std::vector<std::string> const& processesWithMergeableRunProducts):
+    processesWithMergeableRunProducts_(processesWithMergeableRunProducts),
+    allValidAndUseIndexIntoFile_(true) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntry::SingleRunEntry() :
+    beginProcess_(0),
+    endProcess_(0) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntry::SingleRunEntry(unsigned long long iBeginProcess,
+                                                                    unsigned long long iEndProcess) :
+    beginProcess_(iBeginProcess),
+    endProcess_(iEndProcess) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntryAndProcess::SingleRunEntryAndProcess() :
+    beginLumi_(0),
+    endLumi_(0),
+    process_(0),
+    valid_(false),
+    useIndexIntoFile_(false) { }
+
+  StoredMergeableRunProductMetadata::SingleRunEntryAndProcess::
+  SingleRunEntryAndProcess(unsigned long long iBeginLumi,
+                           unsigned long long iEndLumi,
+                           unsigned int iProcess,
+                           bool iValid,
+                           bool iUseIndexIntoFile)  :
+    beginLumi_(iBeginLumi),
+    endLumi_(iEndLumi),
+    process_(iProcess),
+    valid_(iValid),
+    useIndexIntoFile_(iUseIndexIntoFile) { }
+
+  void StoredMergeableRunProductMetadata::optimizeBeforeWrite() {
+    if (allValidAndUseIndexIntoFile_) {
+      processesWithMergeableRunProducts_.clear();
+      singleRunEntries_.clear();
+      singleRunEntryAndProcesses_.clear();
+      lumis_.clear();
+    }
+  }
+
+  bool StoredMergeableRunProductMetadata::
+  getLumiContent(unsigned long long runEntry,
+                 std::string const& process,
+                 bool& valid,
+                 std::vector<LuminosityBlockNumber_t>::const_iterator & lumisBegin,
+                 std::vector<LuminosityBlockNumber_t>::const_iterator & lumisEnd) const {
+
+    valid = true;
+    if (allValidAndUseIndexIntoFile_) {
+      return false;
+    }
+
+    SingleRunEntry const& singleRunEntry = singleRunEntries_.at(runEntry);
+    for (unsigned long long j = singleRunEntry.beginProcess(); j < singleRunEntry.endProcess(); ++j) {
+      SingleRunEntryAndProcess const& singleRunEntryAndProcess = singleRunEntryAndProcesses_.at(j);
+      // This string comparison could be optimized away by storing an index mapping in
+      // MergeableRunProductMetadata that gets recalculated each time a new input
+      // file is opened
+      if (processesWithMergeableRunProducts_.at(singleRunEntryAndProcess.process()) == process) {
+        valid = singleRunEntryAndProcess.valid();
+        if (singleRunEntryAndProcess.useIndexIntoFile()) {
+          return false;
+        } else {
+          lumisBegin = lumis_.begin() + singleRunEntryAndProcess.beginLumi();
+          lumisEnd = lumis_.begin() + singleRunEntryAndProcess.endLumi();
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -25,6 +25,7 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
+#include "DataFormats/Provenance/interface/StoredMergeableRunProductMetadata.h"
 #include "DataFormats/Provenance/interface/StoredProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -131,6 +131,18 @@
   <version ClassVersion="10" checksum="262935904"/>
  </class>
  <class name="edm::IndexIntoFile::Transients" ClassVersion="0"/>
+
+ <class name="edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess" ClassVersion="3">
+  <version ClassVersion="3" checksum="3004083460"/>
+ </class>
+ <class name="std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>"/>
+ <class name="edm::StoredMergeableRunProductMetadata::SingleRunEntry" ClassVersion="3">
+  <version ClassVersion="3" checksum="294451415"/>
+ </class>
+ <class name="std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>"/>
+ <class name="edm::StoredMergeableRunProductMetadata" ClassVersion="3">
+  <version ClassVersion="3" checksum="2293482595"/>
+ </class>
  <class name="edm::ProcessHistoryID"/>
  <class name="std::set<edm::ProcessHistoryID >"/>
  <class name="std::vector<edm::ProcessHistory>"/>

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -72,6 +72,8 @@ namespace SimDataFormats_GeneratorProducts {
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy
 namespace hepmc_rootio {
+  void add_to_particles_in(HepMC::GenVertex*, HepMC::GenParticle*);
+  
   inline void weightcontainer_set_default_names(unsigned int n, std::map<std::string,HepMC::WeightContainer::size_type>& names) {
       std::ostringstream name;
       for ( HepMC::WeightContainer::size_type count = 0; count<n; ++count ) 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -13,6 +13,11 @@
 		<!-- <field name="itsParticleData" transient="true"/> -->
 		<!-- <field name="itsDecayData" transient="true"/> -->
 	</class>
+	<ioread sourceClass = "HepMC::GenParticle" source="int m_barcode" version="[11]" targetClass="HepMC::GenParticle" target="m_barcode">
+          <![CDATA[m_barcode = onfile.m_barcode;
+                   if(newObj->end_vertex()) { hepmc_rootio::add_to_particles_in(newObj->end_vertex(), newObj); }
+	  ]]>
+	</ioread>
     <class name="HepMC::GenCrossSection" ClassVersion="10">
      <version ClassVersion="10" checksum="920043842"/>
     </class>

--- a/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
+++ b/SimDataFormats/GeneratorProducts/src/hepmc_rootio.cc
@@ -1,0 +1,24 @@
+#include <HepMC/GenParticle.h>
+#include <HepMC/GenVertex.h>
+#include <iostream>
+
+//HACK We need to change the internals of GenVertex when reading
+// back via ROOT. We use the private access of GenEvent to 
+// accomplish it.
+namespace HepMC {
+  class GenEvent {
+  public:
+    static void clear_particles_in(HepMC::GenVertex* iVertex) {
+      iVertex->m_particles_in.clear();
+    }
+    static void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+      iVertex->m_particles_in.push_back(iPart);
+    }
+  };
+}
+
+namespace hepmc_rootio {      
+  void add_to_particles_in(HepMC::GenVertex* iVertex, HepMC::GenParticle* iPart) {
+    HepMC::GenEvent::add_to_particles_in(iVertex, iPart);
+  }
+}


### PR DESCRIPTION
#### PR description:

Preparation for the UL-HLT in 10_2_X. The content of this PR is based on https://github.com/cms-sw/cmssw/pull/26399 (except no need of backport of CSCDigi) and https://github.com/cms-sw/cmssw/pull/25171

#### PR validation:

This PR is tested by producing GEN-SIM-RAW using 10_6, then pass to 10_2 for the HLT step. The RAW is re-written from 10_2 and read again in 10_6 for RECO and DQM.

GEN-SIM; 10_6_1_patch1
`cmsDriver.py ZEE_13TeV_TuneCUETP8M1_cfi --conditions auto:phase1_2018_realistic -n 10 --era Run2_2018 --eventcontent RAWSIM --relval 9000,50 -s GEN,SIM --datatier GEN-SIM --beamspot Realistic25ns13TeVEarly2018Collision --geometry DB:Extended --io ProdZEE_13UP18.io --python ProdZEE_13UP18.py --no_exec --fileout file:step1.root --nThreads 4`

DIGI; 10_6_1_patch1
`cmsDriver.py step2 --datamix PreMix --conditions auto:phase1_2018_realistic --pileup_input das:/RelValPREMIXUP18_PU25/CMSSW_10_6_0-PU25ns_106X_upgrade2018_realistic_v4-v1/PREMIX --era Run2_2018 --eventcontent FEVTDEBUGHLT --procModifiers premix_stage2 -s DIGI:pdigi_valid,DATAMIX,L1,DIGI2RAW --datatier GEN-SIM-DIGI-RAW-HLTDEBUG --io DIGIPRMXUP18_PU25.io --python DIGIPRMXUP18_PU25.py -n -1 --no_exec --filein file:step1.root --fileout file:step2.root --nThreads 4`

HLT; CMSSW_10_2_15_patch2 with contents of this PR
`cmsDriver.py HLT --conditions auto:phase1_2018_realistic --era Run2_2018 --eventcontent FEVTDEBUGHLT -s HLT:@relval2018 --datatier GEN-SIM-DIGI-RAW-HLTDEBUG --io step2a_HLT.io --python step2a_HLT.py -n -1 --no_exec --filein filelist:step2.root --fileout file:step2a.root --nThreads 4`

RECO; 10_6_1_patch1
`cmsDriver.py step3 --conditions auto:phase1_2018_realistic -n 10 --era Run2_2018 --eventcontent RECOSIM,MINIAODSIM,DQM --runUnscheduled --procModifiers premix_stage2 -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO --io RECOPRMXUP18_PU25.io --python RECOPRMXUP18_PU25.py --no_exec --filein file:step2a.root --fileout file:step3.root --nThreads 4`

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
