### PR TITLE
Fix PixelCPEBase::fillDetParams() for Phase-2 IT, using new GeomDetEnumerators methods

### DIFF
--- a/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h
+++ b/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h
@@ -49,6 +49,9 @@ namespace GeomDetEnumerators {
   bool isTrackerPixel(GeomDetEnumerators::SubDetector m);
   bool isTrackerStrip(GeomDetEnumerators::SubDetector m);
   bool isTracker(GeomDetEnumerators::SubDetector m);
+  bool isInnerTracker(GeomDetEnumerators::SubDetector m);
+  bool isOuterTracker(GeomDetEnumerators::SubDetector m);
+
   bool isDT(GeomDetEnumerators::SubDetector m);
   bool isCSC(GeomDetEnumerators::SubDetector m);
   bool isRPC(GeomDetEnumerators::SubDetector m);

--- a/Geometry/CommonDetUnit/interface/GeomDetType.h
+++ b/Geometry/CommonDetUnit/interface/GeomDetType.h
@@ -25,6 +25,8 @@ public:
 
   bool isTrackerStrip() const;
   bool isTrackerPixel() const;
+  bool isInnerTracker() const;
+  bool isOuterTracker() const;
   bool isTracker() const;
   bool isDT() const;
   bool isCSC() const;

--- a/Geometry/CommonDetUnit/src/GeomDetEnumerators.cc
+++ b/Geometry/CommonDetUnit/src/GeomDetEnumerators.cc
@@ -70,6 +70,15 @@ bool GeomDetEnumerators::isTrackerPixel(const GeomDetEnumerators::SubDetector su
           subdet == P2PXEC || subdet == P2OTB || subdet == P2OTEC);
 }
 
+bool GeomDetEnumerators::isInnerTracker(const GeomDetEnumerators::SubDetector subdet) {
+  return (subdet == PixelBarrel || subdet == PixelEndcap || subdet == P1PXB || subdet == P1PXEC || subdet == P2PXB ||
+          subdet == P2PXEC);
+}
+
+bool GeomDetEnumerators::isOuterTracker(const GeomDetEnumerators::SubDetector subdet) {
+  return (subdet == TIB || subdet == TOB || subdet == TID || subdet == TEC || subdet == P2OTB || subdet == P2OTEC);
+}
+
 bool GeomDetEnumerators::isTracker(const GeomDetEnumerators::SubDetector subdet) {
   return (isTrackerStrip(subdet) || isTrackerPixel(subdet));
 }

--- a/Geometry/CommonDetUnit/src/GeomDetType.cc
+++ b/Geometry/CommonDetUnit/src/GeomDetType.cc
@@ -14,6 +14,10 @@ bool GeomDetType::isTrackerStrip() const { return GeomDetEnumerators::isTrackerS
 
 bool GeomDetType::isTrackerPixel() const { return GeomDetEnumerators::isTrackerPixel(theSubDet); }
 
+bool GeomDetType::isInnerTracker() const { return GeomDetEnumerators::isInnerTracker(theSubDet); }
+
+bool GeomDetType::isOuterTracker() const { return GeomDetEnumerators::isOuterTracker(theSubDet); }
+
 bool GeomDetType::isTracker() const { return GeomDetEnumerators::isTracker(theSubDet); }
 
 bool GeomDetType::isDT() const { return GeomDetEnumerators::isDT(theSubDet); }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -124,8 +124,9 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const& conf,
 //  Fill all variables which are constant for an event (geometry)
 //-----------------------------------------------------------------------------
 void PixelCPEBase::fillDetParams() {
-  // &&& PM: I have no idea what this code is doing, and what it is doing here!???
-  //
+  // MM: this code finds the last Pixel (Inner Tracker) DetUnit to loop upon when filling the det params, by looking the first detId which is from
+  // the Outer Tracker (Strips in case of the Phase-0/1 detector).
+
   auto const& dus = geom_.detUnits();
   unsigned m_detectors = dus.size();
   for (unsigned int i = 1; i < 7; ++i) {
@@ -133,12 +134,14 @@ void PixelCPEBase::fillDetParams() {
         << "Subdetector " << i << " GeomDetEnumerator " << GeomDetEnumerators::tkDetEnum[i] << " offset "
         << geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) << " is it strip? "
         << (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) != dus.size()
-                ? dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isTrackerStrip()
+                ? dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isOuterTracker()
                 : false);
+
     if (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) != dus.size() &&
-        dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isTrackerStrip()) {
-      if (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) < m_detectors)
+        dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isOuterTracker()) {
+      if (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) < m_detectors) {
         m_detectors = geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]);
+      }
     }
   }
   LogDebug("LookingForFirstStrip") << " Chosen offset: " << m_detectors;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -80,10 +80,13 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const& conf,
   speed_ = conf.getParameter<int>("speed");
   LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") << "Template speed = " << speed_ << "\n";
 
-  GlobalPoint center(0.0, 0.0, 0.0);
-  float theMagField = mag->inTesla(center).mag();
+  // this returns the magnetic field value in kgauss (1T = 10 kgauss)
+  int theMagField = mag->nominalValue();
 
-  if (theMagField >= 3.65 && theMagField < 3.9) {
+  if (theMagField >= 36 && theMagField < 39) {
+    LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:")
+        << "Magnetic field value is: " << theMagField << " kgauss. Algorithm is being run \n";
+
     templateDBobject2D_ = templateDBobject2D;
     fill2DTemplIDs();
   }
@@ -103,8 +106,8 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const& conf,
     recommend2D_.push_back(str);
   }
 
-  // do not recommend 2D if theMagField!=3.8
-  if (theMagField < 3.65 || theMagField > 3.9) {
+  // do not recommend 2D if theMagField!=3.8T
+  if (theMagField < 36 || theMagField > 39) {
     recommend2D_.clear();
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -123,10 +123,10 @@ void PixelCPEClusterRepair::fill2DTemplIDs() {
         << "Subdetector " << i << " GeomDetEnumerator " << GeomDetEnumerators::tkDetEnum[i] << " offset "
         << geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) << " is it strip? "
         << (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) != dus.size()
-                ? dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isTrackerStrip()
+                ? dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isOuterTracker()
                 : false);
     if (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) != dus.size() &&
-        dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isTrackerStrip()) {
+        dus[geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i])]->type().isOuterTracker()) {
       if (geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]) < m_detectors)
         m_detectors = geom_.offsetDU(GeomDetEnumerators::tkDetEnum[i]);
     }


### PR DESCRIPTION
#### PR description:

While trying to move the reading of the Lorentz Angle for the phase-2 Inner Tracker detector to DataBase, we noticed that when not providing the LA value for all the `DetId`s (even OuterTracker ones), the ` SiPixelRecHitConverter` was complaining with errors of the type:

```
%MSG-e SiPixelLorentzAngle: SiPixelRecHitConverter:siPixelRecHits 04-Jul-2019 18:56:11 CEST Run: 1 Event: 3
SiPixelLorentzAngle for DetID 419697669 is not stored
%MSG
```
while not effectively crashing or giving bogus results.
We traced back the issue to the logic implemented in the `fillDetParams` method of `PixelCPEBase` which looks for the first not-Inner Tracker `DetUnit` to determine the size of the DetUnit list to loop over.
Currently the list is stopped at the first not Strip `DetUnit` via the method `GeomDetEnumerators::isTrackerStrip`. 
This unfortunately doesn't work in the case of the Phase-2 detector as the `GeomDetEnumerators::isTrackerStrip` takes into account only the current Strip Subdetectors.
We solved this inconvenience by add new methods:
  * `isInnerTracker`
  * `isOuterTracker`

in `GeomDetEnumerators` and `GeomDetType` and use them to fix the logic to hold also for Phase-2.
These methods seem to be quite handy, therefore I am wondering if there is a specific reason why they were not implemented before?
The reason why the current setup is not producing these error messages is because the Lorentz Angle used in the reconstruction comes from a Fake conditions ESProducer: [SiPixelFakeLorentzAngleESSource](https://github.com/cms-sw/cmssw/blob/master/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc) which produces a value for all the DetId list from “Skimmed Geometry” [external file](https://github.com/cms-data/SLHCUpgradeSimulations-Geometry/tree/master/PhaseII/Tilted) (so **all** of them).
Some more information about this can be found in this presentation at the [Tracker Phase-2 simulation,modeling and performance meeting ](https://indico.cern.ch/event/809436/#2-impelentation-on-innertracke).

I profit of this PR to make two other light fixes:
   * apply the same logic fix also the `PixelCPEClusterRepair::fill2DTemplIDs()` method (72cee37)
   * purely technical change, use `MagneticField::nominalValue()` as suggested [here](https://github.com/cms-sw/cmssw/pull/27043#pullrequestreview-248117632) (59ee713)

#### PR validation:

Code proposes passes all tests of:
```
runTheMatrix.py -l limited -t 4 -j 8
```
#### if this PR is a backport please specify the original PR:

This is not a backport.

cc:
@tsusa, @pmaksim1, @OzAmram, @cmantill, @emiglior 