### PR TITLE
cms.optional and obsolete now return None from call to value()

### DIFF
--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -95,6 +95,11 @@ class _OptionalParameter(_ProxyParameter):
         v = self.__dict__.get('_ProxyParameter__value', None)
         if v is not None:
             v.insertInto(parameterSet,myname)
+    def value(self):
+        v = self.__dict__.get('_ProxyParameter__value', None)
+        if v is not None:
+            return v.value()
+        return None
 
 class _ObsoleteParameter(_OptionalParameter):
     @staticmethod


### PR DESCRIPTION

#### PR description:

WMAgent code was failing when dealing with the new optional and obsolete parameter types. The code was always calling value() which was not available on parameters which were not set.

#### PR validation:

- FWCore/ParameterSet unit tests pass
- A 'hacked' up version of Configuration/PyReleaseValidation/python/MatrixInjector.py which was able to show the failure reported in #27453 runs to completion with this change.