### PR TITLE
Backport fixed monopole ionisation for SIM

### DIFF
--- a/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
@@ -106,8 +106,8 @@ void CMSmplIonisationWithDeltaModel::Initialise(const G4ParticleDefinition* p, c
     for (G4int i = 0; i < numOfCouples; ++i) {
       const G4Material* material = theCoupleTable->GetMaterialCutsCouple(i)->GetMaterial();
       G4double eDensity = material->GetElectronDensity();
-      G4double vF = electron_Compton_length * g4calc->A13(3. * pi * pi * eDensity);
-      (*dedx0)[i] = pi_hbarc2_over_mc2 * eDensity * nmpl * nmpl * (G4Log(2 * vF / fine_structure_const) - 0.5) / vF;
+      G4double vF2 = 2 * electron_Compton_length * g4calc->A13(3. * pi * pi * eDensity);
+      (*dedx0)[i] = pi_hbarc2_over_mc2 * eDensity * nmpl * nmpl * (G4Log(vF2 / fine_structure_const) - 0.5) / vF2;
     }
   }
 }


### PR DESCRIPTION
#### PR description:
The fix for the problem, which was reported to Geant4
https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2169
This fix affect slow magnetic monopole ionisation (beta < 0.01).

#### PR validation:
private


#### if this PR is a backport please specify the original PR: #27426 

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
