### PR TITLE
fixing typo in filename -71x

### DIFF
--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -363,7 +363,7 @@ void EvtGenInterface::init(){
   if (fPSet->exists("user_decay_embedded")){
     std::vector<std::string> user_decay_lines = fPSet->getParameter<std::vector<std::string> >("user_decay_embedded");
     auto tmp_dir = boost::filesystem::temp_directory_path();
-    tmp_dir += "%%%%-%%%%-%%%%-%%%%";
+    tmp_dir += "/%%%%-%%%%-%%%%-%%%%";
     auto tmp_path = boost::filesystem::unique_path(tmp_dir);
     std::string user_decay_tmp = std::string(tmp_path.c_str());
     FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");


### PR DESCRIPTION
#### PR description:

This should fix the bug introduced when tmpnam was replaced to boost::filesystem using 
an incorrect sintaxis for the file temporary file creation.

#### PR validation:

tested with BPH-RunIISummer15GS-00211

#### if this PR is a backport please specify the original PR:   #20734

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
