### PR TITLE
Avoid switch statement fallthrough in edm::Path

### DIFF
--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -89,6 +89,7 @@ namespace edm {
         if (stopProcessingEvent_) {
           *stopProcessingEvent_ = true;
         }
+        break;
       }
       default: {
         if (isEvent)


### PR DESCRIPTION
#### PR description:
The switch statement used to control exception handling should not have fallen through to the default handling in the case of SkipEvent.

#### PR validation:

The code compiles and all framework unit tests pass.