### PR TITLE
HCALDQM: Require HB/HE for QIE11 and HF for QIE10 (9_4_X backport)

### DIFF
--- a/DQM/HcalTasks/plugins/DigiPhase1Task.cc
+++ b/DQM/HcalTasks/plugins/DigiPhase1Task.cc
@@ -333,10 +333,14 @@ DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps):
 		if (rawid==0) 
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
 		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalBarrel)
+		if (did.subdet()==HcalBarrel) {
 			rawidHBValid = did.rawId();
-		else if (did.subdet()==HcalEndcap) 
+		} else if (did.subdet()==HcalEndcap) {
 			rawidHEValid = did.rawId();
+		} else {
+			// Skip non-HB or HE detids
+			continue;
+		}
 
 		//  filter out channels that are masked out
 		if (_xQuality.exists(did)) 
@@ -556,8 +560,12 @@ DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps):
 		if (rawid==0) 
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
 		HcalElectronicsId const& eid(rawid);
-		if (did.subdet()==HcalForward)
+		if (did.subdet()==HcalForward) {
 			rawidValid = did.rawId();
+		} else {
+			// Skip non-HF detids
+			continue;
+		}
 
 		//  filter out channels that are masked out
 		if (_xQuality.exists(did)) 


### PR DESCRIPTION
#### PR description:

This PR addresses issue https://github.com/cms-sw/cmssw/issues/27456, which we believe is the 9_4_X version of the year-old (solved) issue #23259.

DigiPhase1Task is crashing due to calibration DetIds in the QIE10/11 digi collections (the DetIds are not in the emap, so histograms are not created for them).

It's not entirely obvious to me why this crash is only occurring now, but this fix should have no impact on the intended behavior of the module (which is no longer used, anyways).


#### PR validation:
Successfully ran runTheMatrix with the following workflows:
```
10024.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017_GenSimFull+DigiFull_2017+RecoFull_2017+ALCAFull_2017+HARVESTFull_2017
11624.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2019_GenSimFull+DigiFull_2019+RecoFull_2019+ALCAFull_2019+HARVESTFull_2019
136.795_RunJetHT2017C+RunJetHT2017C+HLTDR2_2017+RECODR2_2017reHLT_skimJetHT_Prompt+HARVEST2017
```

as well as the cmsDriver command provided by @franzoni (starting from 136.795 step1 and step2):
```
cmsDriver.py Configuration/GenProduction/python/superfragment_cfi.py --fileout file:HiggsLLP_test.GENSIM.root --mc --eventcontent RAWSIM --datatier GEN-SIM --conditions 102X_upgrade2018_realistic_v11 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands="process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(10)" --step GEN,SIM --nThreads 8 --geometry DB:Extended --era Run2_2018 --python_filename superfragment_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 100
```

#### if this PR is a backport please specify the original PR: 
https://github.com/cms-sw/cmssw/pull/23262

