### PR TITLE
Move Sequence to Task for RecoLocalCalo config files

### DIFF
--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Commissioning_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Commissioning_cff.py
@@ -26,11 +26,12 @@ hfreco.digiTimeFromDB = False
 #
 # sequence CaloLocalReco and CaloGlobalReco
 #
-calolocalreco = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence)
-caloglobalreco = cms.Sequence(hcalGlobalRecoSequence)
+calolocalrecoTask = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask)
+calolocalreco = cms.Sequence(calolocalrecoTask)
 
 #
 # R.Ofierzynski (29.Oct.2009): add NZS sequence
 #
 from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
-calolocalrecoNZS = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 
+calolocalrecoTaskNZS = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask,hcalLocalRecoTaskNZS) 
+calolocalrecoNZS = cms.Sequence(calolocalrecoTaskNZS) 

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Commissioning_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Commissioning_cff.py
@@ -26,11 +26,13 @@ hfreco.digiTimeFromDB = False
 #
 # sequence CaloLocalReco and CaloGlobalReco
 #
-calolocalreco = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence)
+calolocalrecoTask = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask)
+calolocalreco = cms.Sequence(calolocalrecoTask)
 caloglobalreco = cms.Sequence(hcalGlobalRecoSequence)
 
 #
 # R.Ofierzynski (29.Oct.2009): add NZS sequence
 #
 from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
-calolocalrecoNZS = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 
+calolocalrecoTaskNZS = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask,hcalLocalRecoTaskNZS) 
+calolocalrecoNZS = cms.Sequence(calolocalrecoTaskNZS) 

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -80,31 +80,32 @@ hfprereco = _hcalLocalReco_cff.hfprereco.clone(
 from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 
 # redefine hcal sequence
-hcalLocalRecoSequence = cms.Sequence(hbhereco+hfreco+horeco+zdcreco)
+hcalLocalRecoTask = cms.Task(hbhereco,hfreco,horeco,zdcreco)
+hcalLocalRecoSequence = cms.Sequence(hcalLocalRecoTask)
 
-_phase1_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
-_phase1_hcalLocalRecoSequence.insert(0,hfprereco)
-run2_HF_2017.toReplaceWith(hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence)
+_phase1_hcalLocalRecoTask = hcalLocalRecoTask.copy()
+_phase1_hcalLocalRecoTask.add(hfprereco)
+run2_HF_2017.toReplaceWith(hcalLocalRecoTask, _phase1_hcalLocalRecoTask)
 
 # shuffle modules so "hbheplan1" produces final collection of hits named "hbhereco"
-_plan1_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy()
+_plan1_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
 hbheprereco = hbhereco.clone()
-_plan1_hcalLocalRecoSequence.insert(0,hbheprereco)
+_plan1_hcalLocalRecoTask.add(hbheprereco)
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 run2_HEPlan1_2017.toReplaceWith(hbhereco, hbheplan1)
-run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequence, _plan1_hcalLocalRecoSequence)
+run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoTask, _plan1_hcalLocalRecoTask)
 
 hbhecollapse = hbheplan1.clone()
-_collapse_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy()
-_collapse_hcalLocalRecoSequence.insert(0,hbheprereco)
+_collapse_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
+_collapse_hcalLocalRecoTask.add(hbheprereco)
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
 run2_HECollapse_2018.toReplaceWith(hbhereco, hbhecollapse)
-run2_HECollapse_2018.toReplaceWith(hcalLocalRecoSequence, _collapse_hcalLocalRecoSequence)
-
-calolocalrecoCosmics = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence)
-
+run2_HECollapse_2018.toReplaceWith(hcalLocalRecoTask, _collapse_hcalLocalRecoTask)
+calolocalrecoTaskCosmics = cms.Task(ecalLocalRecoTaskCosmics,hcalLocalRecoTask)
+calolocalrecoCosmics = cms.Sequence(calolocalrecoTaskCosmics)
 #
 # R.Ofierzynski (29.Oct.2009): add NZS sequence
 #
 from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
-calolocalrecoCosmicsNZS = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 
+calolocalrecoTaskCosmicsNZS = cms.Task(ecalLocalRecoTaskCosmics,hcalLocalRecoTask,hcalLocalRecoTaskNZS) 
+calolocalrecoCosmicsNZS = cms.Sequence(calolocalrecoTaskCosmicsNZS) 

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_cff.py
@@ -20,8 +20,8 @@ from RecoLocalCalo.Configuration.hcalGlobalReco_cff import *
 #
 # sequence CaloLocalReco and CaloGlobalReco
 #
-calolocalreco = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence)
-caloglobalreco = cms.Sequence(hcalGlobalRecoSequence)
+calolocalrecoTask = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask)
+calolocalreco = cms.Sequence(calolocalrecoTask)
 
 from RecoLocalCalo.HcalRecProducers.HcalHitSelection_cfi import *
 reducedHcalRecHitsSequence = cms.Sequence( reducedHcalRecHits )
@@ -30,11 +30,12 @@ reducedHcalRecHitsSequence = cms.Sequence( reducedHcalRecHits )
 # R.Ofierzynski (29.Oct.2009): add NZS sequence
 #
 from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
-calolocalrecoNZS = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 
+calolocalrecoTaskNZS = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask,hcalLocalRecoTaskNZS)
+calolocalrecoNZS = cms.Sequence(calolocalrecoTaskNZS)
 
 from RecoLocalCalo.Configuration.hgcalLocalReco_cff import *
-_phase2_calolocalreco = calolocalreco.copy()
-_phase2_calolocalreco += hgcalLocalRecoSequence
+_phase2_calolocalrecoTask = calolocalrecoTask.copy()
+_phase2_calolocalrecoTask.add(hgcalLocalRecoTask)
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith( calolocalreco , _phase2_calolocalreco )
+phase2_hgcal.toReplaceWith( calolocalrecoTask , _phase2_calolocalrecoTask )

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_cff.py
@@ -20,7 +20,8 @@ from RecoLocalCalo.Configuration.hcalGlobalReco_cff import *
 #
 # sequence CaloLocalReco and CaloGlobalReco
 #
-calolocalreco = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence)
+calolocalrecoTask = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask)
+calolocalreco = cms.Sequence(calolocalrecoTask)
 caloglobalreco = cms.Sequence(hcalGlobalRecoSequence)
 
 from RecoLocalCalo.HcalRecProducers.HcalHitSelection_cfi import *
@@ -30,11 +31,12 @@ reducedHcalRecHitsSequence = cms.Sequence( reducedHcalRecHits )
 # R.Ofierzynski (29.Oct.2009): add NZS sequence
 #
 from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
-calolocalrecoNZS = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence+hcalLocalRecoSequenceNZS) 
+calolocalrecoTaskNZS = cms.Task(ecalLocalRecoTask,hcalLocalRecoTask,hcalLocalRecoTaskNZS)
+calolocalrecoNZS = cms.Sequence(calolocalrecoTaskNZS)
 
 from RecoLocalCalo.Configuration.hgcalLocalReco_cff import *
-_phase2_calolocalreco = calolocalreco.copy()
-_phase2_calolocalreco += hgcalLocalRecoSequence
+_phase2_calolocalrecoTask = calolocalrecoTask.copy()
+_phase2_calolocalrecoTask.add(hgcalLocalRecoTask)
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-phase2_hgcal.toReplaceWith( calolocalreco , _phase2_calolocalreco )
+phase2_hgcal.toReplaceWith( calolocalrecoTask , _phase2_calolocalrecoTask )

--- a/RecoLocalCalo/Configuration/python/ecalLocalRecoSequenceCosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalRecoSequenceCosmics_cff.py
@@ -15,7 +15,8 @@ from RecoLocalCalo.EcalRecProducers.ecalFixedAlphaBetaFitUncalibRecHit_cfi impor
 from RecoLocalCalo.EcalRecProducers.ecalRecHit_cfi import *
 from RecoLocalCalo.EcalRecProducers.ecalPreshowerRecHit_cfi import *
 from RecoLocalCalo.EcalRecProducers.ecalDetIdToBeRecovered_cfi import *
-ecalLocalRecoSequenceCosmics = cms.Sequence(ecalFixedAlphaBetaFitUncalibRecHit*ecalWeightUncalibRecHit*ecalDetIdToBeRecovered*ecalRecHit+ecalPreshowerRecHit)
+ecalLocalRecoTaskCosmics = cms.Task(ecalFixedAlphaBetaFitUncalibRecHit,ecalWeightUncalibRecHit,ecalDetIdToBeRecovered,ecalRecHit,ecalPreshowerRecHit)
+ecalLocalRecoSequenceCosmics = cms.Sequence(ecalLocalRecoTaskCosmics)
 ecalRecHit.EBuncalibRecHitCollection = 'ecalFixedAlphaBetaFitUncalibRecHit:EcalUncalibRecHitsEB'
 ecalRecHit.EEuncalibRecHitCollection = 'ecalFixedAlphaBetaFitUncalibRecHit:EcalUncalibRecHitsEE'
 ecalRecHit.ChannelStatusToBeExcluded = [

--- a/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
@@ -23,24 +23,29 @@ from RecoLocalCalo.EcalRecProducers.ecalDetailedTimeRecHit_cfi import *
 #ecalUncalibRecHitSequence = cms.Sequence(ecalGlobalUncalibRecHit*
 #                                         ecalDetIdToBeRecovered)
 
-ecalUncalibRecHitSequence = cms.Sequence(ecalMultiFitUncalibRecHit*
+ecalUncalibRecHitTask = cms.Task(ecalMultiFitUncalibRecHit,
                                         ecalDetIdToBeRecovered)
 
-ecalRecHitSequence        = cms.Sequence(ecalRecHit*
-                                         ecalCompactTrigPrim*
-                                         ecalTPSkim+
+ecalRecHitTask        = cms.Task(ecalRecHit,
+                                         ecalCompactTrigPrim,
+                                         ecalTPSkim,
                                          ecalPreshowerRecHit)
 
-ecalLocalRecoSequence     = cms.Sequence(ecalUncalibRecHitSequence*
-                                         ecalRecHitSequence)
+ecalLocalRecoTask     = cms.Task(ecalUncalibRecHitTask,
+                                         ecalRecHitTask)
+
+ecalUncalibRecHitSequence = cms.Sequence(ecalUncalibRecHitTask)
+ecalRecHitSequence = cms.Sequence(ecalRecHitTask)
+ecalLocalRecoSequence = cms.Sequence(ecalLocalRecoTask)
+
 
 from RecoLocalCalo.EcalRecProducers.ecalDetailedTimeRecHit_cfi import *
-_phase2_timing_ecalRecHitSequence = cms.Sequence( ecalRecHitSequence.copy() + ecalDetailedTimeRecHit )
+_phase2_timing_ecalRecHitTask = cms.Task( ecalRecHitTask.copy() , ecalDetailedTimeRecHit )
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-phase2_timing.toReplaceWith( ecalRecHitSequence, _phase2_timing_ecalRecHitSequence )
+phase2_timing.toReplaceWith( ecalRecHitTask, _phase2_timing_ecalRecHitTask )
 
-_fastSim_ecalRecHitSequence = ecalRecHitSequence.copyAndExclude([ecalCompactTrigPrim,ecalTPSkim])
-_fastSim_ecalUncalibRecHitSequence = ecalUncalibRecHitSequence.copyAndExclude([ecalDetIdToBeRecovered])
+_fastSim_ecalRecHitTask = ecalRecHitTask.copyAndExclude([ecalCompactTrigPrim,ecalTPSkim])
+_fastSim_ecalUncalibRecHitTask = ecalUncalibRecHitTask.copyAndExclude([ecalDetIdToBeRecovered])
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(ecalRecHitSequence, _fastSim_ecalRecHitSequence)
-fastSim.toReplaceWith(ecalUncalibRecHitSequence, _fastSim_ecalUncalibRecHitSequence)
+fastSim.toReplaceWith(ecalRecHitTask, _fastSim_ecalRecHitTask)
+fastSim.toReplaceWith(ecalUncalibRecHitTask, _fastSim_ecalUncalibRecHitTask)

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -29,7 +29,8 @@ horecoMB = RecoLocalCalo.HcalRecProducers.hosimplereco_cfi.hosimplereco.clone()
 hfrecoMB.dropZSmarkedPassed = cms.bool(False)
 horecoMB.dropZSmarkedPassed = cms.bool(False)
 
-hcalLocalRecoSequenceNZS = cms.Sequence(hbherecoMB*hfrecoMB*horecoMB) 
+hcalLocalRecoTaskNZS = cms.Task(hbherecoMB,hfrecoMB,horecoMB) 
+hcalLocalRecoSequenceNZS = cms.Sequence(hcalLocalRecoTaskNZS) 
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 import RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi
@@ -50,12 +51,13 @@ hbheplan1MB = RecoLocalCalo.HcalRecProducers.hbheplan1_cfi.hbheplan1.clone(
     hbheInput = cms.InputTag("hbheprerecoMB")
 )
 
-_phase1_hcalLocalRecoSequenceNZS = hcalLocalRecoSequenceNZS.copy()
-_phase1_hcalLocalRecoSequenceNZS.insert(0,hfprerecoMB)
-
+_phase1_hcalLocalRecoTaskNZS = hcalLocalRecoTaskNZS.copy()
+_phase1_hcalLocalRecoTaskNZS.add(hfprerecoMB)
+ 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
-run2_HF_2017.toReplaceWith( hcalLocalRecoSequenceNZS, _phase1_hcalLocalRecoSequenceNZS )
+run2_HF_2017.toReplaceWith( hcalLocalRecoTaskNZS, _phase1_hcalLocalRecoTaskNZS )
 run2_HF_2017.toReplaceWith( hfrecoMB, _phase1_hfrecoMB )
+
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hbherecoMB,
     processQIE11 = cms.bool(True),
@@ -63,16 +65,16 @@ run2_HCAL_2017.toModify( hbherecoMB,
 #    setNoiseFlagsQIE11 = cms.bool(True),
 )
 
-_plan1_hcalLocalRecoSequenceNZS = _phase1_hcalLocalRecoSequenceNZS.copy()
+_plan1_hcalLocalRecoTaskNZS = _phase1_hcalLocalRecoTaskNZS.copy()
 hbheprerecoMB = hbherecoMB.clone()
-_plan1_hcalLocalRecoSequenceNZS.insert(0,hbheprerecoMB)
+_plan1_hcalLocalRecoTaskNZS.add(hbheprerecoMB)
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 run2_HEPlan1_2017.toReplaceWith(hbherecoMB, hbheplan1MB)
-run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequenceNZS, _plan1_hcalLocalRecoSequenceNZS)
+run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoTaskNZS, _plan1_hcalLocalRecoTaskNZS)
 
 hbhecollapseMB = hbheplan1MB.clone()
-_collapse_hcalLocalRecoSequenceNZS = _phase1_hcalLocalRecoSequenceNZS.copy()
-_collapse_hcalLocalRecoSequenceNZS.insert(0,hbheprerecoMB)
+_collapse_hcalLocalRecoTaskNZS = _phase1_hcalLocalRecoTaskNZS.copy()
+_collapse_hcalLocalRecoTaskNZS.add(hbheprerecoMB)
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
 run2_HECollapse_2018.toReplaceWith(hbherecoMB, hbhecollapseMB)
-run2_HECollapse_2018.toReplaceWith(hcalLocalRecoSequenceNZS, _collapse_hcalLocalRecoSequenceNZS)
+run2_HECollapse_2018.toReplaceWith(hcalLocalRecoTaskNZS, _collapse_hcalLocalRecoTaskNZS)

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -15,7 +15,8 @@ hbheprereco = _phase1_hbheprereco.clone(
 from RecoLocalCalo.HcalRecProducers.HcalHitReconstructor_ho_cfi import *
 from RecoLocalCalo.HcalRecProducers.HcalHitReconstructor_hf_cfi import *
 from RecoLocalCalo.HcalRecProducers.HcalHitReconstructor_zdc_cfi import *
-hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)
+hcalLocalRecoTask = cms.Task(hbheprereco,hfreco,horeco,zdcreco)
+hcalLocalRecoSequence = cms.Sequence(hcalLocalRecoTask)
 
 from RecoLocalCalo.HcalRecProducers.hfprereco_cfi import hfprereco
 from RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi import hfreco as _phase1_hfreco
@@ -24,33 +25,33 @@ from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 # copy for cosmics
 _default_hfreco = hfreco.clone()
 
-_phase1_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
-_phase1_hcalLocalRecoSequence.insert(0,hfprereco)
+_phase1_hcalLocalRecoTask = hcalLocalRecoTask.copy()
+_phase1_hcalLocalRecoTask.add(hfprereco)
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
-run2_HF_2017.toReplaceWith( hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence )
+run2_HF_2017.toReplaceWith( hcalLocalRecoTask, _phase1_hcalLocalRecoTask )
 run2_HF_2017.toReplaceWith( hfreco, _phase1_hfreco )
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hbheprereco, _phase1_hbheprereco )
 
-_plan1_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy()
-_plan1_hcalLocalRecoSequence += hbheplan1
+_plan1_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
+_plan1_hcalLocalRecoTask.add(hbheplan1)
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
-run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequence, _plan1_hcalLocalRecoSequence)
+run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoTask, _plan1_hcalLocalRecoTask)
 
 hbhecollapse = hbheplan1.clone()
-_collapse_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy()
-_collapse_hcalLocalRecoSequence += hbhecollapse
+_collapse_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
+_collapse_hcalLocalRecoTask.add(hbhecollapse)
 from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
-run2_HECollapse_2018.toReplaceWith(hcalLocalRecoSequence, _collapse_hcalLocalRecoSequence)
+run2_HECollapse_2018.toReplaceWith(hcalLocalRecoTask, _collapse_hcalLocalRecoTask)
 
-_phase2_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
-_phase2_hcalLocalRecoSequence.remove(hbheprereco)
+_phase2_hcalLocalRecoTask = hcalLocalRecoTask.copy()
+_phase2_hcalLocalRecoTask.remove(hbheprereco)
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( hcalLocalRecoSequence, _phase2_hcalLocalRecoSequence )
+phase2_hcal.toReplaceWith( hcalLocalRecoTask, _phase2_hcalLocalRecoTask )
 
 
-_fastSim_hcalLocalRecoSequence = hcalLocalRecoSequence.copyAndExclude([zdcreco])
+_fastSim_hcalLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco])
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith( hcalLocalRecoSequence, _fastSim_hcalLocalRecoSequence )
+fastSim.toReplaceWith( hcalLocalRecoTask, _fastSim_hcalLocalRecoTask )

--- a/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
@@ -5,15 +5,16 @@ from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import *
 
 # patch particle flow clusters for HGC into local reco sequence
 # (for now until global reco is going with some sort of clustering)
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGC_cff import *
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGC_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHGC_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalMultiClusters_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cff import hgcalLayerClusters
 
-hgcalLocalRecoSequence = cms.Sequence( HGCalUncalibRecHit+
-                                       HGCalRecHit+
-                                       hgcalLayerClusters+
-                                       hgcalMultiClusters+
-                                       particleFlowRecHitHGCSeq+
-                                       particleFlowClusterHGCal+
+hgcalLocalRecoTask = cms.Task( HGCalUncalibRecHit,
+                                       HGCalRecHit,
+                                       hgcalLayerClusters,
+                                       hgcalMultiClusters,
+                                       particleFlowRecHitHGC,
+                                       particleFlowClusterHGCal,
                                        particleFlowClusterHGCalFromMultiCl )
+hgcalLocalRecoSequence = cms.Sequence(hgcalLocalRecoTask)

--- a/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
@@ -14,7 +14,7 @@ hgcalLocalRecoTask = cms.Task( HGCalUncalibRecHit,
                                        HGCalRecHit,
                                        hgcalLayerClusters,
                                        hgcalMultiClusters,
-                                       particleFlowRecHitHGCSeq,
+                                       particleFlowRecHitHGCTask,
                                        particleFlowClusterHGCal,
                                        particleFlowClusterHGCalFromMultiCl )
 hgcalLocalRecoSequence = cms.Sequence(hgcalLocalRecoTask)

--- a/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
@@ -10,10 +10,11 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterHGC_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalMultiClusters_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cff import hgcalLayerClusters
 
-hgcalLocalRecoSequence = cms.Sequence( HGCalUncalibRecHit+
-                                       HGCalRecHit+
-                                       hgcalLayerClusters+
-                                       hgcalMultiClusters+
-                                       particleFlowRecHitHGCSeq+
-                                       particleFlowClusterHGCal+
+hgcalLocalRecoTask = cms.Task( HGCalUncalibRecHit,
+                                       HGCalRecHit,
+                                       hgcalLayerClusters,
+                                       hgcalMultiClusters,
+                                       particleFlowRecHitHGCSeq,
+                                       particleFlowClusterHGCal,
                                        particleFlowClusterHGCalFromMultiCl )
+hgcalLocalRecoSequence = cms.Sequence(hgcalLocalRecoTask)

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalLocalRecoTestBeamSequence_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalLocalRecoTestBeamSequence_cff.py
@@ -6,4 +6,5 @@ from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cff import hgcalLayerClusters
 from RecoLocalCalo.HGCalRecProducers.hgcalMultiClusters_cfi import *
 
-HGCalLocalRecoTestBeamSequence = cms.Sequence(HGCalUncalibRecHit*HGCalRecHit*hgcalLayerClusters*hgcalMultiClusters)
+HGCalLocalRecoTestBeamTask = cms.Task(HGCalUncalibRecHit,HGCalRecHit,hgcalLayerClusters,hgcalMultiClusters)
+HGCalLocalRecoTestBeamSequence = cms.Sequence(HGCalLocalRecoTestBeamTask)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cff.py
@@ -1,3 +1,4 @@
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGC_cfi import *
 
-particleFlowRecHitHGCSeq = cms.Sequence( particleFlowRecHitHGC )
+particleFlowRecHitHGCTask = cms.Task( particleFlowRecHitHGC )
+particleFlowRecHitHGCSeq = cms.Sequence( particleFlowRecHitHGCTask )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cff.py
@@ -1,4 +1,3 @@
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGC_cfi import *
 
-particleFlowRecHitHGCTask = cms.Task( particleFlowRecHitHGC )
-particleFlowRecHitHGCSeq = cms.Sequence( particleFlowRecHitHGCTask )
+particleFlowRecHitHGCSeq = cms.Sequence( particleFlowRecHitHGC )

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -68,7 +68,7 @@ def customise(process):
             cms.InputTag("interestingEcalDetIdEE"),
             )            
 
-    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.bunchSpacingProducer * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
+    process.local_digireco = cms.Path(process.mix * process.addPileupInfo * process.bunchSpacingProducer * process.calDigi * process.ecalPacker * process.esDigiToRaw * process.hcalRawData * process.rawDataCollector * process.ecalDigis * process.ecalPreshowerDigis * process.hcalDigis * process.calolocalreco * process.hbhereco * process.hfreco * process.horeco *(process.ecalClustersNoPFBox+process.caloTowersRec) * process.reducedEcalRecHitsSequenceEcalOnly )
 
     process.schedule.append(process.local_digireco)
 


### PR DESCRIPTION
#### PR description: Move Sequence to Task for RecoLocalCalo's config files
1) For a cms.Sequence object that is built from modules or cms.Sequence objects introduce a cms.Task with an equivalent content and make this cms.Sequence object directly from the newly introduced cms.Task. [More details about Task objects](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideAboutPythonConfigFile#Task_Objects)
2) Remove cms.Sequence objects from the Reconstruction configuration.  
I replaced the sequence by instantiating it with a task.

#### PR validation: 
Tested in CMSSW_11_0_X_2019-07-07-2300 release.
The PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).