### PR TITLE
[HGCal] Run HGCalValidator only on the hard scatterer event and correcting the mess from merging

### DIFF
--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -174,11 +174,13 @@ public:
   void layerClusters_to_CaloParticles(const Histograms& histograms,
                                       const reco::CaloClusterCollection& clusters,
                                       std::vector<CaloParticle> const& cP,
+                                      std::vector<size_t> const& cPIndices,
                                       std::map<DetId, const HGCRecHit*> const&,
                                       unsigned layers) const;
   void multiClusters_to_CaloParticles(const Histograms& histograms,
                                       const std::vector<reco::HGCalMultiCluster>& multiClusters,
                                       std::vector<CaloParticle> const& cP,
+                                      std::vector<size_t> const& cPIndices,
                                       std::map<DetId, const HGCRecHit*> const&,
                                       unsigned layers,
                                       std::vector<bool> contimulti) const;
@@ -193,6 +195,7 @@ public:
                                    const reco::CaloClusterCollection& clusters,
                                    const Density& densities,
                                    std::vector<CaloParticle> const& cP,
+                                   std::vector<size_t> const& cPIndices,
                                    std::map<DetId, const HGCRecHit*> const&,
                                    std::map<double, double> cummatbudg,
                                    unsigned layers,
@@ -201,6 +204,7 @@ public:
                                  int count,
                                  const std::vector<reco::HGCalMultiCluster>& multiClusters,
                                  std::vector<CaloParticle> const& cP,
+                                 std::vector<size_t> const& cPIndices,
                                  std::map<DetId, const HGCRecHit*> const&,
                                  unsigned layers) const;
   double distance2(const double x1, const double y1, const double x2, const double y2) const;
@@ -212,14 +216,14 @@ public:
 
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster& o) const { return clusterId == o.clusterId; };
-    unsigned int clusterId;
+    long unsigned int clusterId;
     float fraction;
   };
 
   struct detIdInfoInMultiCluster {
     bool operator==(const detIdInfoInMultiCluster& o) const { return multiclusterId == o.multiclusterId; };
     unsigned int multiclusterId;
-    unsigned int clusterId;
+    long unsigned int clusterId;
     float fraction;
   };
 

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -192,6 +192,18 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
     histoProducerAlgo_->fill_info_histos(histograms.histoProducerAlgo, totallayers_to_monitor_);
   }
 
+  //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
+  std::vector<CaloParticle> caloParticlesFromHardScat; 
+  for ( auto& it_caloPart : caloParticles) {
+    if (it_caloPart.g4Tracks()[0].eventId().event() != 0 or it_caloPart.g4Tracks()[0].eventId().bunchCrossing() != 0) {
+      LogDebug("HGCalValidator") << "Excluding CaloParticles from event: "
+				 << it_caloPart.g4Tracks()[0].eventId().event()
+				 << " with BX: " << it_caloPart.g4Tracks()[0].eventId().bunchCrossing() << std::endl;
+      continue;
+    }
+    caloParticlesFromHardScat.push_back(it_caloPart);
+  }
+
   // ##############################################
   // fill caloparticles histograms
   // ##############################################

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -192,17 +192,20 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
     histoProducerAlgo_->fill_info_histos(histograms.histoProducerAlgo, totallayers_to_monitor_);
   }
 
-  //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
-  // std::vector<CaloParticle*> caloParticlesFromHardScat;
-  std::vector<CaloParticle> caloParticlesFromHardScat;
-  for (const auto& it_caloPart : caloParticles) {
-    if (it_caloPart.g4Tracks()[0].eventId().event() != 0 or it_caloPart.g4Tracks()[0].eventId().bunchCrossing() != 0) {
+  auto nCaloParticles = caloParticles.size();
+  std::vector<size_t> cPIndices;
+  //Consider CaloParticles coming from the hard scatterer
+  //excluding the PU contribution and save the indices.
+  for (unsigned int cpId = 0; cpId < nCaloParticles; ++cpId) {
+    if (caloParticles[cpId].g4Tracks()[0].eventId().event() != 0 or
+        caloParticles[cpId].g4Tracks()[0].eventId().bunchCrossing() != 0) {
       LogDebug("HGCalValidator") << "Excluding CaloParticles from event: "
-                                 << it_caloPart.g4Tracks()[0].eventId().event()
-                                 << " with BX: " << it_caloPart.g4Tracks()[0].eventId().bunchCrossing() << std::endl;
+                                 << caloParticles[cpId].g4Tracks()[0].eventId().event()
+                                 << " with BX: " << caloParticles[cpId].g4Tracks()[0].eventId().bunchCrossing()
+                                 << std::endl;
       continue;
     }
-    caloParticlesFromHardScat.emplace_back(it_caloPart);
+    cPIndices.emplace_back(cpId);
   }
 
   // ##############################################
@@ -237,8 +240,8 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
                                                     w,
                                                     clusters,
                                                     densities,
-                                                    // caloParticles,
-                                                    caloParticlesFromHardScat,
+                                                    caloParticles,
+                                                    cPIndices,
                                                     hitMap,
                                                     cummatbudg,
                                                     totallayers_to_monitor_,
@@ -251,13 +254,8 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
 
   if (domulticlustersPlots_) {
     w++;
-    histoProducerAlgo_->fill_multi_cluster_histos(histograms.histoProducerAlgo,
-                                                  w,
-                                                  multiClusters,
-                                                  // caloParticles,
-                                                  caloParticlesFromHardScat,
-                                                  hitMap,
-                                                  totallayers_to_monitor_);
+    histoProducerAlgo_->fill_multi_cluster_histos(
+        histograms.histoProducerAlgo, w, multiClusters, caloParticles, cPIndices, hitMap, totallayers_to_monitor_);
   }
 
   //General Info

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -193,15 +193,16 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   }
 
   //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
+  // std::vector<CaloParticle*> caloParticlesFromHardScat;
   std::vector<CaloParticle> caloParticlesFromHardScat;
-  for (auto& it_caloPart : caloParticles) {
+  for (const auto& it_caloPart : caloParticles) {
     if (it_caloPart.g4Tracks()[0].eventId().event() != 0 or it_caloPart.g4Tracks()[0].eventId().bunchCrossing() != 0) {
       LogDebug("HGCalValidator") << "Excluding CaloParticles from event: "
                                  << it_caloPart.g4Tracks()[0].eventId().event()
                                  << " with BX: " << it_caloPart.g4Tracks()[0].eventId().bunchCrossing() << std::endl;
       continue;
     }
-    caloParticlesFromHardScat.push_back(it_caloPart);
+    caloParticlesFromHardScat.emplace_back(it_caloPart);
   }
 
   // ##############################################

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -193,12 +193,12 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   }
 
   //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
-  std::vector<CaloParticle> caloParticlesFromHardScat; 
-  for ( auto& it_caloPart : caloParticles) {
+  std::vector<CaloParticle> caloParticlesFromHardScat;
+  for (auto& it_caloPart : caloParticles) {
     if (it_caloPart.g4Tracks()[0].eventId().event() != 0 or it_caloPart.g4Tracks()[0].eventId().bunchCrossing() != 0) {
       LogDebug("HGCalValidator") << "Excluding CaloParticles from event: "
-				 << it_caloPart.g4Tracks()[0].eventId().event()
-				 << " with BX: " << it_caloPart.g4Tracks()[0].eventId().bunchCrossing() << std::endl;
+                                 << it_caloPart.g4Tracks()[0].eventId().event()
+                                 << " with BX: " << it_caloPart.g4Tracks()[0].eventId().bunchCrossing() << std::endl;
       continue;
     }
     caloParticlesFromHardScat.push_back(it_caloPart);
@@ -237,7 +237,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
                                                     clusters,
                                                     densities,
                                                     // caloParticles,
-						    caloParticlesFromHardScat,
+                                                    caloParticlesFromHardScat,
                                                     hitMap,
                                                     cummatbudg,
                                                     totallayers_to_monitor_,
@@ -250,11 +250,13 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
 
   if (domulticlustersPlots_) {
     w++;
-    histoProducerAlgo_->fill_multi_cluster_histos(
-        histograms.histoProducerAlgo, w, multiClusters, 
-	// caloParticles, 
-	caloParticlesFromHardScat,
-	hitMap, totallayers_to_monitor_);
+    histoProducerAlgo_->fill_multi_cluster_histos(histograms.histoProducerAlgo,
+                                                  w,
+                                                  multiClusters,
+                                                  // caloParticles,
+                                                  caloParticlesFromHardScat,
+                                                  hitMap,
+                                                  totallayers_to_monitor_);
   }
 
   //General Info

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -236,7 +236,8 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
                                                     w,
                                                     clusters,
                                                     densities,
-                                                    caloParticles,
+                                                    // caloParticles,
+						    caloParticlesFromHardScat,
                                                     hitMap,
                                                     cummatbudg,
                                                     totallayers_to_monitor_,
@@ -250,7 +251,10 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   if (domulticlustersPlots_) {
     w++;
     histoProducerAlgo_->fill_multi_cluster_histos(
-        histograms.histoProducerAlgo, w, multiClusters, caloParticles, hitMap, totallayers_to_monitor_);
+        histograms.histoProducerAlgo, w, multiClusters, 
+	// caloParticles, 
+	caloParticlesFromHardScat,
+	hitMap, totallayers_to_monitor_);
   }
 
   //General Info

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -2156,54 +2156,6 @@ void HGVHistoProducerAlgo::multiClusters_to_CaloParticles(const Histograms& hist
         }
       }  //end of loop through sim hits of current calo particle
 
-      LogDebug("HGCalValidator") << std::setw(8) << "LayerId:\t" << std::setw(12) << "caloparticle\t" << std::setw(15)
-                                 << "cp total energy\t" << std::setw(15) << "cpEnergyOnLayer\t" << std::setw(14)
-                                 << "CPNhitsOnLayer\t" << std::setw(18) << "mclWithMaxEnergyInCP\t" << std::setw(15)
-                                 << "maxEnergyMCLinCP\t" << std::setw(20) << "CPEnergyFractionInMCL"
-                                 << "\n";
-      LogDebug("HGCalValidator") << std::setw(8) << layerId << "\t" << std::setw(12) << cpId << "\t" << std::setw(15)
-                                 << cP[cpId].energy() << "\t" << std::setw(15) << CPenergy << "\t" << std::setw(14)
-                                 << CPNumberOfHits << "\t" << std::setw(18) << mclWithMaxEnergyInCP << "\t"
-                                 << std::setw(15) << maxEnergyMCLperlayerinCP << "\t" << std::setw(20)
-                                 << CPEnergyFractionInMCLperlayer << "\n";
-
-      for (unsigned int i = 0; i < CPNumberOfHits; ++i) {
-        auto& cp_hitDetId = cPOnLayer[cpId][layerId].hits_and_fractions[i].first;
-        auto& cpFraction = cPOnLayer[cpId][layerId].hits_and_fractions[i].second;
-
-        bool hitWithNoMCL = false;
-        if (cpFraction == 0.f)
-          continue;  //hopefully this should never happen
-        auto hit_find_in_MCL = detIdToMultiClusterId_Map.find(cp_hitDetId);
-        if (hit_find_in_MCL == detIdToMultiClusterId_Map.end())
-          hitWithNoMCL = true;
-        auto itcheck = hitMap.find(cp_hitDetId);
-        const HGCRecHit* hit = itcheck->second;
-        float hitEnergyWeight = hit->energy() * hit->energy();
-        for (auto& lcPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
-          unsigned int multiClusterId = lcPair.first;
-          float mclFraction = 0.f;
-
-          if (!hitWithNoMCL) {
-            auto findHitIt = std::find(detIdToMultiClusterId_Map[cp_hitDetId].begin(),
-                                       detIdToMultiClusterId_Map[cp_hitDetId].end(),
-                                       HGVHistoProducerAlgo::detIdInfoInMultiCluster{multiClusterId, 0, 0.f});
-            if (findHitIt != detIdToMultiClusterId_Map[cp_hitDetId].end())
-              mclFraction = findHitIt->fraction;
-          }
-          if (mclFraction == 0.) {
-            mclFraction = -1.;
-          }
-          //Observe here that we do not divide as before by the layer cluster energy weight. We should sum first
-          //over all layers and divide with the total CP energy over all layers.
-          lcPair.second.second += (mclFraction - cpFraction) * (mclFraction - cpFraction) * hitEnergyWeight;
-          LogDebug("HGCalValidator") << "multiClusterId:\t" << multiClusterId << "\t"
-                                     << "mclfraction,cpfraction:\t" << mclFraction << ", " << cpFraction << "\t"
-                                     << "hitEnergyWeight:\t" << hitEnergyWeight << "\t"
-                                     << "currect score numerator:\t" << lcPair.second.second << "\n";
-        }
-      }  //end of loop through sim hits of current calo particle
-
       if (cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore.empty())
         LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t MCL id:\t-1 "
                                    << "\t layer \t " << layerId << " Sub score in \t -1"


### PR DESCRIPTION
#### PR description:

This PR addresses the issue #27417. We decided (@rovere , @felicepantaleo , @amartelli )
to follow PR #26915 and consider only CaloParticles coming from the hard scatterer, 
excluding the PU contribution. Running the Timing Service on 10 events of workflow 20234.99 
we see that the timing of the hgcalValidator module is on average 2.88 s/event. 

We should also note that the hgcalValidator module will for sure be even faster in cooperation 
with TICL multiclusters, since at the moment the number of multiclusters produced is huge 
(~10^4 multiclusters per event for wf 20234.99). 

Furthermore, we noted: 

- A duplication of a loop coming from the git rebasing/merging. 
- An incorrect initialization of the 3D score, shared energy and shared energy fraction inside the CaloParticles loop.
- An incorrect iteration over the full collection of multiclusters. At that point we should iterate only to the multiclusters that are related to CaloParticles. Iterating over the full multicluster collection contained cases for the score where the numerator and denominator had their initialized values,which is zero and lead to nan's in the histograms. 

#### PR validation:

We tested the PR with wf 20234.99 (TTbar with 200PU).
