### PR TITLE
Fixed and clean-up initialisation of Geant4

### DIFF
--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -41,7 +41,6 @@ class SteppingAction;
 class CMSSteppingVerbose;
 
 class DDDWorld;
-class DDG4ProductionCuts;
 class CustomUIsession;
 
 class G4RunManagerKernel;
@@ -132,7 +131,6 @@ private:
   std::vector<SensitiveTkDetector*> m_sensTkDets;
   std::vector<SensitiveCaloDetector*> m_sensCaloDets;
 
-  std::unique_ptr<DDG4ProductionCuts> m_prodCuts;
   std::unique_ptr<CMSSteppingVerbose> m_sVerbose;
   SimActivityRegistry m_registry;
   std::vector<std::shared_ptr<SimWatcher> > m_watchers;

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -31,7 +31,6 @@ namespace cms {
 }
 
 class DDDWorld;
-class DDG4ProductionCuts;
 class MagneticField;
 
 class G4MTRunManagerKernel;
@@ -112,7 +111,6 @@ private:
   edm::ParameterSet m_p;
 
   std::unique_ptr<DDDWorld> m_world;
-  std::unique_ptr<DDG4ProductionCuts> m_prodCuts;
   SimActivityRegistry m_registry;
   SensitiveDetectorCatalog m_catalog;
 };

--- a/SimG4Core/Application/src/CustomUIsessionThreadPrefix.cc
+++ b/SimG4Core/Application/src/CustomUIsessionThreadPrefix.cc
@@ -22,7 +22,7 @@ namespace {
 }  // namespace
 
 G4int CustomUIsessionThreadPrefix::ReceiveG4cout(const G4String& coutString) {
-  // edm::LogInfo("G4cout") << addThreadPrefix(m_threadPrefix, trim(coutString));
+  //edm::LogInfo("G4cout") << addThreadPrefix(m_threadPrefix, trim(coutString));
   edm::LogVerbatim("G4cout") << addThreadPrefix(m_threadPrefix, trim(coutString));
   return 0;
 }

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -74,11 +74,11 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
       m_notifyMasterCv.wait(lk2, [&] { return m_masterCanProceed; });
 
       // Act according to the state
-      edm::LogInfo("OscarMTMasterThread") 
-	<< "Master thread: Woke up, state is " << static_cast<int>(m_masterThreadState);
+      edm::LogInfo("OscarMTMasterThread")
+          << "Master thread: Woke up, state is " << static_cast<int>(m_masterThreadState);
       if (m_masterThreadState == ThreadState::BeginRun) {
         // Initialize Geant4
-	edm::LogInfo("OscarMTMasterThread") << "Master thread: Initializing Geant4";
+        edm::LogInfo("OscarMTMasterThread") << "Master thread: Initializing Geant4";
         runManagerMaster->initG4(m_pDD, m_pDD4hep, m_pMF, m_pTable);
         isG4Alive = true;
       } else if (m_masterThreadState == ThreadState::EndRun) {

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -57,7 +57,7 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
     runManagerMaster = std::make_shared<RunManagerMT>(iConfig);
     m_runManagerMaster = runManagerMaster;
 
-    edm::LogVerbatim("SimG4CoreApplication") << "OscarMTMasterThread: initialization of RunManagerMT finished";
+    LogDebug("SimG4CoreApplication") << "OscarMTMasterThread: initialization of RunManagerMT finished";
 
     /////////////
     // State loop
@@ -65,19 +65,20 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
     while (true) {
       // Signal main thread that it can proceed
       m_mainCanProceed = true;
-      LogDebug("OscarMTMasterThread") << "Master thread: State loop, notify main thread";
+      edm::LogVerbatim("OscarMTMasterThread") << "Master thread: State loop, notify main thread";
       m_notifyMainCv.notify_one();
 
       // Wait until the main thread sends signal
       m_masterCanProceed = false;
-      LogDebug("OscarMTMasterThread") << "Master thread: State loop, starting wait";
+      edm::LogVerbatim("OscarMTMasterThread") << "Master thread: State loop, starting wait";
       m_notifyMasterCv.wait(lk2, [&] { return m_masterCanProceed; });
 
       // Act according to the state
-      LogDebug("OscarMTMasterThread") << "Master thread: Woke up, state is " << static_cast<int>(m_masterThreadState);
+      edm::LogInfo("OscarMTMasterThread") 
+	<< "Master thread: Woke up, state is " << static_cast<int>(m_masterThreadState);
       if (m_masterThreadState == ThreadState::BeginRun) {
         // Initialize Geant4
-        LogDebug("OscarMTMasterThread") << "Master thread: Initializing Geant4";
+	edm::LogInfo("OscarMTMasterThread") << "Master thread: Initializing Geant4";
         runManagerMaster->initG4(m_pDD, m_pDD4hep, m_pMF, m_pTable);
         isG4Alive = true;
       } else if (m_masterThreadState == ThreadState::EndRun) {

--- a/SimG4Core/Application/src/ParametrisedEMPhysics.cc
+++ b/SimG4Core/Application/src/ParametrisedEMPhysics.cc
@@ -132,7 +132,7 @@ void ParametrisedEMPhysics::ConstructParticle() {
 }
 
 void ParametrisedEMPhysics::ConstructProcess() {
-  G4cout << "ParametrisedEMPhysics::ConstructProcess() " << G4endl;
+  edm::LogVerbatim("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess() started";
 
   // GFlash part
   bool gem = theParSet.getParameter<bool>("GflashEcal");
@@ -304,7 +304,7 @@ void ParametrisedEMPhysics::ConstructProcess() {
     ModifyTransportation(G4Positron::Positron(), nt, th1, th2);
     ModifyTransportation(G4Proton::Proton(), nt, th1, th2);
   }
-  G4cout << "ParametrisedEMPhysics::ConstructProcess() is done" << G4endl;
+  edm::LogVerbatim("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess() is done";
 }
 
 void ParametrisedEMPhysics::ModifyTransportation(const G4ParticleDefinition* part, int ntry, double th1, double th2) {

--- a/SimG4Core/Application/src/ParametrisedEMPhysics.cc
+++ b/SimG4Core/Application/src/ParametrisedEMPhysics.cc
@@ -101,8 +101,7 @@ ParametrisedEMPhysics::ParametrisedEMPhysics(const std::string& name, const edm:
         param->ActivateSecondaryBiasing("hIoni", rname[i], rrfact[i], energyLim);
         edm::LogVerbatim("SimG4CoreApplication")
             << "ParametrisedEMPhysics: Russian Roulette"
-            << " for e- Prob= " << rrfact[i] << " Elimit(MeV)= " 
-	    << energyLim / CLHEP::MeV << " inside " << rname[i];
+            << " for e- Prob= " << rrfact[i] << " Elimit(MeV)= " << energyLim / CLHEP::MeV << " inside " << rname[i];
       }
     }
   }
@@ -133,7 +132,6 @@ void ParametrisedEMPhysics::ConstructParticle() {
 }
 
 void ParametrisedEMPhysics::ConstructProcess() {
-
   G4cout << "ParametrisedEMPhysics::ConstructProcess() " << G4endl;
 
   // GFlash part
@@ -147,9 +145,8 @@ void ParametrisedEMPhysics::ConstructProcess() {
     if (!m_tpmod) {
       m_tpmod = new TLSmod;
     }
-    edm::LogVerbatim("SimG4CoreApplication") 
-      << "ParametrisedEMPhysics: GFlash Construct for e+-: " << gem << "  "
-      << ghad << " for hadrons: " << gemHad << "  " << ghadHad;
+    edm::LogVerbatim("SimG4CoreApplication") << "ParametrisedEMPhysics: GFlash Construct for e+-: " << gem << "  "
+                                             << ghad << " for hadrons: " << gemHad << "  " << ghadHad;
 
     m_tpmod->theFastSimulationManagerProcess.reset(new G4FastSimulationManagerProcess());
 
@@ -167,11 +164,11 @@ void ParametrisedEMPhysics::ConstructProcess() {
     }
 
     if (gem || gemHad) {
-      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("EcalRegion",false);
+      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("EcalRegion", false);
 
       if (!aRegion) {
         edm::LogWarning("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess: "
-                                                 << "EcalRegion is not defined, GFlash will not be enabled for ECAL!";
+                                                << "EcalRegion is not defined, GFlash will not be enabled for ECAL!";
 
       } else {
         if (gem) {
@@ -186,10 +183,10 @@ void ParametrisedEMPhysics::ConstructProcess() {
       }
     }
     if (ghad || ghadHad) {
-      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion",false);
+      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
       if (!aRegion) {
         edm::LogWarning("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess: "
-                                                 << "HcalRegion is not defined, GFlash will not be enabled for HCAL!";
+                                                << "HcalRegion is not defined, GFlash will not be enabled for HCAL!";
 
       } else {
         if (ghad) {
@@ -243,7 +240,7 @@ void ParametrisedEMPhysics::ConstructProcess() {
         nlimitsH = (limitsH[i] > 0) ? 1 : 0;
         break;
       }
-      const G4Region* r = store->GetRegion(regnames[i],false);
+      const G4Region* r = store->GetRegion(regnames[i], false);
       // apply for concrete G4Region
       if (r && (limitsE[i] > 0.0 || limitsH[i] > 0.0)) {
         reg.emplace_back(r);

--- a/SimG4Core/Application/src/ParametrisedEMPhysics.cc
+++ b/SimG4Core/Application/src/ParametrisedEMPhysics.cc
@@ -101,7 +101,8 @@ ParametrisedEMPhysics::ParametrisedEMPhysics(const std::string& name, const edm:
         param->ActivateSecondaryBiasing("hIoni", rname[i], rrfact[i], energyLim);
         edm::LogVerbatim("SimG4CoreApplication")
             << "ParametrisedEMPhysics: Russian Roulette"
-            << " for e- Prob= " << rrfact[i] << " Elimit(MeV)= " << energyLim / CLHEP::MeV << " inside " << rname[i];
+            << " for e- Prob= " << rrfact[i] << " Elimit(MeV)= " 
+	    << energyLim / CLHEP::MeV << " inside " << rname[i];
       }
     }
   }
@@ -132,6 +133,9 @@ void ParametrisedEMPhysics::ConstructParticle() {
 }
 
 void ParametrisedEMPhysics::ConstructProcess() {
+
+  G4cout << "ParametrisedEMPhysics::ConstructProcess() " << G4endl;
+
   // GFlash part
   bool gem = theParSet.getParameter<bool>("GflashEcal");
   bool ghad = theParSet.getParameter<bool>("GflashHcal");
@@ -143,8 +147,9 @@ void ParametrisedEMPhysics::ConstructProcess() {
     if (!m_tpmod) {
       m_tpmod = new TLSmod;
     }
-    edm::LogVerbatim("SimG4CoreApplication") << "ParametrisedEMPhysics: GFlash Construct for e+-: " << gem << "  "
-                                             << ghad << " for hadrons: " << gemHad << "  " << ghadHad;
+    edm::LogVerbatim("SimG4CoreApplication") 
+      << "ParametrisedEMPhysics: GFlash Construct for e+-: " << gem << "  "
+      << ghad << " for hadrons: " << gemHad << "  " << ghadHad;
 
     m_tpmod->theFastSimulationManagerProcess.reset(new G4FastSimulationManagerProcess());
 
@@ -162,10 +167,10 @@ void ParametrisedEMPhysics::ConstructProcess() {
     }
 
     if (gem || gemHad) {
-      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("EcalRegion");
+      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("EcalRegion",false);
 
       if (!aRegion) {
-        edm::LogVerbatim("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess: "
+        edm::LogWarning("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess: "
                                                  << "EcalRegion is not defined, GFlash will not be enabled for ECAL!";
 
       } else {
@@ -181,9 +186,9 @@ void ParametrisedEMPhysics::ConstructProcess() {
       }
     }
     if (ghad || ghadHad) {
-      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion");
+      G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion",false);
       if (!aRegion) {
-        edm::LogVerbatim("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess: "
+        edm::LogWarning("SimG4CoreApplication") << "ParametrisedEMPhysics::ConstructProcess: "
                                                  << "HcalRegion is not defined, GFlash will not be enabled for HCAL!";
 
       } else {
@@ -238,7 +243,7 @@ void ParametrisedEMPhysics::ConstructProcess() {
         nlimitsH = (limitsH[i] > 0) ? 1 : 0;
         break;
       }
-      const G4Region* r = store->GetRegion(regnames[i]);
+      const G4Region* r = store->GetRegion(regnames[i],false);
       // apply for concrete G4Region
       if (r && (limitsE[i] > 0.0 || limitsH[i] > 0.0)) {
         reg.emplace_back(r);
@@ -302,6 +307,7 @@ void ParametrisedEMPhysics::ConstructProcess() {
     ModifyTransportation(G4Positron::Positron(), nt, th1, th2);
     ModifyTransportation(G4Proton::Proton(), nt, th1, th2);
   }
+  G4cout << "ParametrisedEMPhysics::ConstructProcess() is done" << G4endl;
 }
 
 void ParametrisedEMPhysics::ModifyTransportation(const G4ParticleDefinition* part, int ntry, double th1, double th2) {

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -213,7 +213,7 @@ void RunManager::initG4(const edm::EventSetup& es) {
       std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
   m_kernel->SetVerboseLevel(verb);
   auto cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
-  if(cuts) {
+  if (cuts) {
     DDG4ProductionCuts pcuts(map_, verb, m_pPhysics);
   }
 
@@ -290,7 +290,7 @@ void RunManager::initG4(const edm::EventSetup& es) {
   }
   edm::LogInfo("SimG4CoreApplication") << "RunManager: start initialisation of PhysicsList";
 
-  if(!cuts) {
+  if (!cuts) {
     m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
     m_physicsList->SetCutsWithDefault();
   }

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -290,10 +290,8 @@ void RunManager::initG4(const edm::EventSetup& es) {
   }
   edm::LogInfo("SimG4CoreApplication") << "RunManager: start initialisation of PhysicsList";
 
-  if (!cuts) {
-    m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
-    m_physicsList->SetCutsWithDefault();
-  }
+  m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
+  m_physicsList->SetCutsWithDefault();
   m_kernel->SetPhysics(phys);
   m_kernel->InitializePhysics();
 

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -144,7 +144,6 @@ RunManager::RunManager(edm::ParameterSet const& p, edm::ConsumesCollector&& iC)
   G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler());
 
   m_physicsList.reset(nullptr);
-  m_prodCuts.reset(nullptr);
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap", false);
   m_WriteFile = p.getUntrackedParameter<std::string>("FileNameGDML", "");
@@ -209,6 +208,14 @@ void RunManager::initG4(const edm::EventSetup& es) {
   SensitiveDetectorCatalog catalog_;
   const DDDWorld* world = new DDDWorld(&(*pDD), map_, catalog_, false);
   m_registry.dddWorldSignal_(world);
+
+  int verb =
+      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
+  m_kernel->SetVerboseLevel(verb);
+  auto cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
+  if(cuts) {
+    DDG4ProductionCuts pcuts(map_, verb, m_pPhysics);
+  }
 
   if (m_pUseMagneticField) {
     // setup the magnetic field
@@ -283,17 +290,10 @@ void RunManager::initG4(const edm::EventSetup& es) {
   }
   edm::LogInfo("SimG4CoreApplication") << "RunManager: start initialisation of PhysicsList";
 
-  int verb =
-      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
-  m_kernel->SetVerboseLevel(verb);
-
-  m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
-  m_physicsList->SetCutsWithDefault();
-  if (m_pPhysics.getParameter<bool>("CutsPerRegion")) {
-    m_prodCuts.reset(new DDG4ProductionCuts(map_, verb, m_pPhysics));
-    m_prodCuts->update();
+  if(!cuts) {
+    m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
+    m_physicsList->SetCutsWithDefault();
   }
-
   m_kernel->SetPhysics(phys);
   m_kernel->InitializePhysics();
 

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -104,7 +104,6 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
                           const cms::DDCompactView* pDD4hep,
                           const MagneticField* pMF,
                           const HepPDT::ParticleDataTable* fPDGTable) {
-  edm::LogWarning("SimG4CoreApplication") << "### RunManagerMT::initG4";
   if (m_managerInitialized) {
     edm::LogWarning("SimG4CoreApplication") << "RunManagerMT::initG4 was already done - exit";
     return;
@@ -176,22 +175,19 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   if (m_RestorePhysicsTables) {
     m_physicsList->SetPhysicsTableRetrieved(m_PhysicsTablesDir);
   }
-  edm::LogInfo("SimG4CoreApplication") << "RunManagerMT: start initialisation of PhysicsList for master";
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: start initialisation of PhysicsList for master";
 
-  if (!cuts) {
-    m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
-    m_physicsList->SetCutsWithDefault();
-  }
-
+  m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
+  m_physicsList->SetCutsWithDefault();
   m_kernel->SetPhysics(phys);
 
-  edm::LogInfo("SimG4CoreApplication") << "RunManagerMT: PhysicsList and cuts are defined";
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: PhysicsList and cuts are defined";
 
   // Geant4 UI commands before initialisation of physics
   if (!m_G4Commands.empty()) {
-    G4cout << "RunManagerMT: Requested UI commands: " << G4endl;
+    edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: Requested UI commands: ";
     for (const std::string& command : m_G4Commands) {
-      G4cout << "    " << command << G4endl;
+      edm::LogVerbatim("SimG4CoreApplication") << "    " << command;
       G4UImanager::GetUIpointer()->ApplyCommand(command);
     }
   }

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -104,15 +104,13 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
                           const cms::DDCompactView* pDD4hep,
                           const MagneticField* pMF,
                           const HepPDT::ParticleDataTable* fPDGTable) {
-  edm::LogWarning("SimG4CoreApplication") << "### RunManagerMT::initG4";   
+  edm::LogWarning("SimG4CoreApplication") << "### RunManagerMT::initG4";
   if (m_managerInitialized) {
-    edm::LogWarning("SimG4CoreApplication") 
-      << "RunManagerMT::initG4 was already done - exit";
+    edm::LogWarning("SimG4CoreApplication") << "RunManagerMT::initG4 was already done - exit";
     return;
   }
   auto geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
-  edm::LogVerbatim("SimG4CoreApplication") 
-    << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep;
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep;
 
   // DDDWorld: get the DDCV from the ES and use it to build the World
   G4LogicalVolumeToDDLogicalPartMap map_lv;
@@ -122,27 +120,26 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   } else {
     m_world.reset(new DDDWorld(pDD, map_lv, m_catalog, false));
   }
-  G4VPhysicalVolume *world = m_world.get()->GetWorldVolume();
+  G4VPhysicalVolume* world = m_world.get()->GetWorldVolume();
 
   bool cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
-  int verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), 
-                      m_p.getParameter<int>("SteppingVerbosity"));
+  int verb =
+      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
   m_kernel->SetVerboseLevel(verb);
-  edm::LogVerbatim("SimG4CoreApplication") 
-    << "RunManagerMT: Define cuts: " << cuts << " Geant4 run manager verbosity: " << verb;
+  edm::LogVerbatim("SimG4CoreApplication")
+      << "RunManagerMT: Define cuts: " << cuts << " Geant4 run manager verbosity: " << verb;
 
   if (cuts) {
     DDG4ProductionCuts pcuts(map_lv, verb, m_pPhysics);
   }
-  const G4RegionStore *regStore = G4RegionStore::GetInstance();
-  const G4PhysicalVolumeStore *pvs = G4PhysicalVolumeStore::GetInstance();
-  const G4LogicalVolumeStore *lvs = G4LogicalVolumeStore::GetInstance();
+  const G4RegionStore* regStore = G4RegionStore::GetInstance();
+  const G4PhysicalVolumeStore* pvs = G4PhysicalVolumeStore::GetInstance();
+  const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
   unsigned int numPV = pvs->size();
   unsigned int numLV = lvs->size();
   unsigned int nn = regStore->size();
-  edm::LogVerbatim("SimG4CoreApplication") 
-    << "###RunManagerMT: " << numPV << " PhysVolumes; " << numLV << " LogVolumes; " 
-    << nn << " Regions.";
+  edm::LogVerbatim("SimG4CoreApplication")
+      << "###RunManagerMT: " << numPV << " PhysVolumes; " << numLV << " LogVolumes; " << nn << " Regions.";
 
   m_kernel->DefineWorldVolume(world, true);
   m_registry.dddWorldSignal_(m_world.get());
@@ -153,8 +150,7 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   std::unique_ptr<PhysicsListMakerBase> physicsMaker(
       PhysicsListFactory::get()->create(m_pPhysics.getParameter<std::string>("type")));
   if (physicsMaker.get() == nullptr) {
-    throw edm::Exception(edm::errors::Configuration) 
-      << "Unable to find the Physics list requested";
+    throw edm::Exception(edm::errors::Configuration) << "Unable to find the Physics list requested";
   }
   m_physicsList = physicsMaker->make(m_pPhysics, m_registry);
 
@@ -180,18 +176,16 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   if (m_RestorePhysicsTables) {
     m_physicsList->SetPhysicsTableRetrieved(m_PhysicsTablesDir);
   }
-  edm::LogInfo("SimG4CoreApplication") 
-    << "RunManagerMT: start initialisation of PhysicsList for master";
+  edm::LogInfo("SimG4CoreApplication") << "RunManagerMT: start initialisation of PhysicsList for master";
 
-  if(!cuts) {
+  if (!cuts) {
     m_physicsList->SetDefaultCutValue(m_pPhysics.getParameter<double>("DefaultCutValue") * CLHEP::cm);
     m_physicsList->SetCutsWithDefault();
   }
 
   m_kernel->SetPhysics(phys);
 
-  edm::LogInfo("SimG4CoreApplication") 
-    << "RunManagerMT: PhysicsList and cuts are defined";
+  edm::LogInfo("SimG4CoreApplication") << "RunManagerMT: PhysicsList and cuts are defined";
 
   // Geant4 UI commands before initialisation of physics
   if (!m_G4Commands.empty()) {
@@ -233,8 +227,7 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   if (verb > 1) {
     m_physicsList->DumpCutValuesTable();
   }
-  edm::LogVerbatim("SimG4CoreApplication") 
-    << "RunManagerMT: Physics is initilized, now initialise user actions";
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: Physics is initilized, now initialise user actions";
 
   initializeUserActions();
 

--- a/SimG4Core/Geometry/interface/DDDWorld.h
+++ b/SimG4Core/Geometry/interface/DDDWorld.h
@@ -20,8 +20,6 @@ public:
   G4VPhysicalVolume *GetWorldVolume() const { return m_world; }
 
 private:
-  void SetAsWorld(G4VPhysicalVolume *pv);
-
   G4VPhysicalVolume *m_world;
 };
 

--- a/SimG4Core/Geometry/interface/DDG4ProductionCuts.h
+++ b/SimG4Core/Geometry/interface/DDG4ProductionCuts.h
@@ -16,19 +16,12 @@ class DDG4ProductionCuts {
 public:
   DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap&, int, const edm::ParameterSet&);
   ~DDG4ProductionCuts();
-  void update();
-  void SetVerbosity(int verb) {
-    verbosity_ = verb;
-    return;
-  }
 
 private:
   void initialize();
-  void setProdCuts(const DDLogicalPart, G4LogicalVolume*);
-  G4Region* getRegion(const std::string&);
-  G4ProductionCuts* getProductionCuts(G4Region*);
+  void setProdCuts(const DDLogicalPart, G4Region*);
 
-  G4LogicalVolumeToDDLogicalPartMap map_;
+  const G4LogicalVolumeToDDLogicalPartMap& map_;
   // Legacy flag
   bool protonCut_;
   std::string keywordRegion_;

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -20,8 +20,7 @@ DDDWorld::DDDWorld(const DDCompactView *cpv,
                    G4LogicalVolumeToDDLogicalPartMap &map,
                    SensitiveDetectorCatalog &catalog,
                    bool check) {
-  LogVerbatim("SimG4CoreApplication") 
-    << "DDDWorld: initialization of Geant4 geometry";
+  LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialization of Geant4 geometry";
   std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
 
   DDGeometryReturnType ret = theBuilder->BuildGeometry();
@@ -30,13 +29,11 @@ DDDWorld::DDDWorld(const DDCompactView *cpv,
   m_world = new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
   map = ret.lvToDDLPMap();
   catalog = ret.sdCatalog();
-  LogVerbatim("SimG4CoreApplication") 
-    << "DDDWorld: initialization of Geant4 geometry is done.";
+  LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialization of Geant4 geometry is done.";
 }
 
 DDDWorld::DDDWorld(const cms::DDDetector *ddd, dd4hep::sim::Geant4GeometryMaps::VolumeMap &map) {
-  LogVerbatim("SimG4CoreApplication") 
-    << "DD4hep_DDDWorld: initialization of Geant4 geometry";
+  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of Geant4 geometry";
 
   DetElement world = ddd->description()->world();
   const Detector &detector = *ddd->description();
@@ -45,8 +42,7 @@ DDDWorld::DDDWorld(const cms::DDDetector *ddd, dd4hep::sim::Geant4GeometryMaps::
   map = geometry->g4Volumes;
   m_world = geometry->world();
 
-  LogVerbatim("SimG4CoreApplication") 
-    << "DD4hep_DDDWorld: initialization of Geant4 geometry is done.";
+  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of Geant4 geometry is done.";
 }
 
 DDDWorld::~DDDWorld() {}

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -11,7 +11,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4PVPlacement.hh"
-#include "G4RunManagerKernel.hh"
 
 using namespace edm;
 using namespace dd4hep;
@@ -21,19 +20,23 @@ DDDWorld::DDDWorld(const DDCompactView *cpv,
                    G4LogicalVolumeToDDLogicalPartMap &map,
                    SensitiveDetectorCatalog &catalog,
                    bool check) {
+  LogVerbatim("SimG4CoreApplication") 
+    << "DDDWorld: initialization of Geant4 geometry";
   std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
 
   DDGeometryReturnType ret = theBuilder->BuildGeometry();
   G4LogicalVolume *world = ret.logicalVolume();
 
   m_world = new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
-  SetAsWorld(m_world);
   map = ret.lvToDDLPMap();
   catalog = ret.sdCatalog();
+  LogVerbatim("SimG4CoreApplication") 
+    << "DDDWorld: initialization of Geant4 geometry is done.";
 }
 
 DDDWorld::DDDWorld(const cms::DDDetector *ddd, dd4hep::sim::Geant4GeometryMaps::VolumeMap &map) {
-  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of DDDWorld...";
+  LogVerbatim("SimG4CoreApplication") 
+    << "DD4hep_DDDWorld: initialization of Geant4 geometry";
 
   DetElement world = ddd->description()->world();
   const Detector &detector = *ddd->description();
@@ -41,19 +44,9 @@ DDDWorld::DDDWorld(const cms::DDDetector *ddd, dd4hep::sim::Geant4GeometryMaps::
   Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
   map = geometry->g4Volumes;
   m_world = geometry->world();
-  SetAsWorld(m_world);
 
-  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of DDDWorld done.";
+  LogVerbatim("SimG4CoreApplication") 
+    << "DD4hep_DDDWorld: initialization of Geant4 geometry is done.";
 }
 
 DDDWorld::~DDDWorld() {}
-
-void DDDWorld::SetAsWorld(G4VPhysicalVolume *pv) {
-  G4RunManagerKernel *kernel = G4RunManagerKernel::GetRunManagerKernel();
-  if (kernel) {
-    kernel->DefineWorldVolume(m_world);
-  } else {
-    edm::LogError("SimG4CoreGeometry") << "No G4RunManagerKernel?";
-  }
-  edm::LogVerbatim("SimG4CoreGeometry") << " World volume defined " << pv->GetName();
-}

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -54,7 +54,7 @@ void DDG4ProductionCuts::initialize() {
     edm::LogVerbatim("Geometry") << " DDG4ProductionCuts : got " << vec_.size() << " region roots.\n"
                                  << " DDG4ProductionCuts : List of all roots:";
     for (auto const& vv : vec_)
-      edm::LogVerbatim("Physics") << "    " << vv.first->GetName() << " : " << vv.second.name();
+      edm::LogVerbatim("Geometry") << "    " << vv.first->GetName() << " : " << vv.second.name();
   }
 
   // Now generate all the regions

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -69,9 +69,9 @@ void DDG4ProductionCuts::initialize() {
     if (num != 1) {
       throw cms::Exception("SimG4CorePhysics", " DDG4ProductionCuts::initialize: Problem with Region tags.");
     }
-    if(regionName != curName) {
+    if (regionName != curName) {
       region = store->FindOrCreateRegion(regionName);
-      if(!region) {
+      if (!region) {
         throw cms::Exception("SimG4CoreGeometry", " DDG4ProductionCuts::initialize: Problem with Region tags.");
       }
       curName = regionName;
@@ -82,8 +82,7 @@ void DDG4ProductionCuts::initialize() {
     region->AddRootLogicalVolume(vv.first);
 
     if (verbosity_ > 0)
-      edm::LogVerbatim("Geometry") << "  added " << vv.first->GetName() << " to region "
-				   << region->GetName();
+      edm::LogVerbatim("Geometry") << "  added " << vv.first->GetName() << " to region " << region->GetName();
   }
 }
 
@@ -144,8 +143,6 @@ void DDG4ProductionCuts::setProdCuts(const DDLogicalPart lpart, G4Region* region
   if (verbosity_ > 0) {
     edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : Setting cuts for " << region->GetName()
                                  << "\n    Electrons: " << electroncut << "\n    Positrons: " << positroncut
-                                 << "\n    Gamma    : " << gammacut
-                                 << "\n    Proton   : " << protoncut;
+                                 << "\n    Gamma    : " << gammacut << "\n    Proton   : " << protoncut;
   }
 }
-

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -13,7 +13,6 @@ DDG4ProductionCuts::DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap& 
                                        const edm::ParameterSet& p)
     : map_(map), verbosity_(verb) {
   keywordRegion_ = "CMSCutsRegion";
-  // Legacy flag
   protonCut_ = p.getUntrackedParameter<bool>("CutsOnProton", true);
   initialize();
 }
@@ -44,15 +43,6 @@ bool dd_is_greater(const std::pair<G4LogicalVolume*, DDLogicalPart>& p1,
   return result;
 }
 
-void DDG4ProductionCuts::update() {
-  //
-  // Loop over all DDLP and provide the cuts for each region
-  //
-  for (auto const& tit : vec_) {
-    setProdCuts(tit.second, tit.first);
-  }
-}
-
 void DDG4ProductionCuts::initialize() {
   vec_ = map_.all(keywordRegion_);
   // sort all root volumes - to get the same sequence at every run of the application.
@@ -61,55 +51,51 @@ void DDG4ProductionCuts::initialize() {
   // higher (or lower) address when allocating an object of the same type ...
   sort(vec_.begin(), vec_.end(), &dd_is_greater);
   if (verbosity_ > 0) {
-    edm::LogVerbatim("Physics") << " DDG4ProductionCuts (New) : starting\n"
-                                << " DDG4ProductionCuts : Got " << vec_.size() << " region roots.\n"
-                                << " DDG4ProductionCuts : List of all roots:";
-    for (size_t jj = 0; jj < vec_.size(); ++jj)
-      edm::LogVerbatim("Physics") << "   DDG4ProductionCuts : root=" << vec_[jj].second.name();
+    edm::LogVerbatim("Geometry") << " DDG4ProductionCuts : got " << vec_.size() << " region roots.\n"
+                                 << " DDG4ProductionCuts : List of all roots:";
+    for (auto const& vv : vec_)
+      edm::LogVerbatim("Physics") << "    " << vv.first->GetName() << " : " << vv.second.name();
   }
 
   // Now generate all the regions
-  for (G4LogicalVolumeToDDLogicalPartMap::Vector::iterator tit = vec_.begin(); tit != vec_.end(); tit++) {
-    std::string regionName;
-    unsigned int num = map_.toString(keywordRegion_, (*tit).second, regionName);
+  std::string curName = "";
+  std::string regionName = "";
+  G4Region* region = nullptr;
+  G4RegionStore* store = G4RegionStore::GetInstance();
+  for (auto const& vv : vec_) {
+    //for (G4LogicalVolumeToDDLogicalPartMap::Vector::iterator tit = vec_.begin(); tit != vec_.end(); ++tit) {
+    unsigned int num = map_.toString(keywordRegion_, vv.second, regionName);
 
     if (num != 1) {
       throw cms::Exception("SimG4CorePhysics", " DDG4ProductionCuts::initialize: Problem with Region tags.");
     }
-    G4Region* region = getRegion(regionName);
-    region->AddRootLogicalVolume((*tit).first);
+    if(regionName != curName) {
+      region = store->FindOrCreateRegion(regionName);
+      if(!region) {
+        throw cms::Exception("SimG4CoreGeometry", " DDG4ProductionCuts::initialize: Problem with Region tags.");
+      }
+      curName = regionName;
+      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : new G4Region " << vv.first->GetName();
+      setProdCuts(vv.second, region);
+    }
+
+    region->AddRootLogicalVolume(vv.first);
 
     if (verbosity_ > 0)
-      edm::LogVerbatim("Physics") << " MakeRegions: added " << ((*tit).first)->GetName() << " to region "
-                                  << region->GetName();
+      edm::LogVerbatim("Geometry") << "  added " << vv.first->GetName() << " to region "
+				   << region->GetName();
   }
 }
 
-void DDG4ProductionCuts::setProdCuts(const DDLogicalPart lpart, G4LogicalVolume* lvol) {
-  if (verbosity_ > 0)
-    edm::LogVerbatim("Physics") << " DDG4ProductionCuts: inside setProdCuts";
-
-  G4Region* region = nullptr;
-
-  std::string regionName;
-  unsigned int num = map_.toString(keywordRegion_, lpart, regionName);
-
-  if (num != 1) {
-    throw cms::Exception("SimG4CorePhysics", " DDG4ProductionCuts::setProdCuts: Problem with Region tags.");
-  }
-  if (verbosity_ > 0)
-    edm::LogVerbatim("Physics") << "Using region " << regionName;
-
-  region = getRegion(regionName);
-
+void DDG4ProductionCuts::setProdCuts(const DDLogicalPart lpart, G4Region* region) {
   //
   // search for production cuts
   // you must have four of them: e+ e- gamma proton
   //
-  double gammacut;
-  double electroncut;
-  double positroncut;
-  double protoncut;
+  double gammacut = 0.0;
+  double electroncut = 0.0;
+  double positroncut = 0.0;
+  double protoncut = 0.0;
   int temp = map_.toDouble("ProdCutsForGamma", lpart, gammacut);
   if (temp != 1) {
     throw cms::Exception(
@@ -144,30 +130,22 @@ void DDG4ProductionCuts::setProdCuts(const DDLogicalPart lpart, G4LogicalVolume*
   }
 
   //
-  // For the moment I assume all of the four are set
+  // Create and fill production cuts
   //
-  G4ProductionCuts* prodCuts = getProductionCuts(region);
+  G4ProductionCuts* prodCuts = region->GetProductionCuts();
+  if (!prodCuts) {
+    prodCuts = new G4ProductionCuts();
+    region->SetProductionCuts(prodCuts);
+  }
   prodCuts->SetProductionCut(gammacut, idxG4GammaCut);
   prodCuts->SetProductionCut(electroncut, idxG4ElectronCut);
   prodCuts->SetProductionCut(positroncut, idxG4PositronCut);
   prodCuts->SetProductionCut(protoncut, idxG4ProtonCut);
   if (verbosity_ > 0) {
-    edm::LogVerbatim("Physics") << "DDG4ProductionCuts : Setting cuts for " << regionName
-                                << "\n    Electrons: " << electroncut << "\n    Positrons: " << positroncut
-                                << "\n    Gamma    : " << gammacut;
+    edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : Setting cuts for " << region->GetName()
+                                 << "\n    Electrons: " << electroncut << "\n    Positrons: " << positroncut
+                                 << "\n    Gamma    : " << gammacut
+                                 << "\n    Proton   : " << protoncut;
   }
 }
 
-G4Region* DDG4ProductionCuts::getRegion(const std::string& regName) {
-  G4Region* reg = G4RegionStore::GetInstance()->FindOrCreateRegion(regName);
-  return reg;
-}
-
-G4ProductionCuts* DDG4ProductionCuts::getProductionCuts(G4Region* reg) {
-  G4ProductionCuts* prodCuts = reg->GetProductionCuts();
-  if (!prodCuts) {
-    prodCuts = new G4ProductionCuts();
-    reg->SetProductionCuts(prodCuts);
-  }
-  return prodCuts;
-}

--- a/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
@@ -130,7 +130,7 @@ void CMSEmNoDeltaRay::ConstructProcess() {
   G4Region* reg = nullptr;
   if (region != " ") {
     G4RegionStore* regStore = G4RegionStore::GetInstance();
-    reg = regStore->GetRegion(region, true);
+    reg = regStore->GetRegion(region, false);
   }
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
@@ -154,13 +154,11 @@ void CMSEmNoDeltaRay::ConstructProcess() {
         msc_el->SetRangeFactor(0.04);
         msc->AddEmModel(0, msc_el, reg);
       }
-      pmanager->AddProcess(msc, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
-      pmanager->AddProcess(new G4eBremsstrahlung, -1, -3, 3);
+      pmanager->AddProcess(msc, -1, 1, -1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 1);
+      pmanager->AddProcess(new G4eBremsstrahlung, -1, -3, 2);
 
     } else if (particleName == "e+") {
-      //      G4eIonisation* eioni = new G4eIonisation();
-      //      eioni->SetStepFunction(0.8, 1.0*mm);
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetStepLimitType(fMinimal);
       if (reg != nullptr) {
@@ -168,27 +166,27 @@ void CMSEmNoDeltaRay::ConstructProcess() {
         msc_pos->SetRangeFactor(0.04);
         msc->AddEmModel(0, msc_pos, reg);
       }
-      pmanager->AddProcess(msc, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
-      pmanager->AddProcess(new G4eBremsstrahlung, -1, -3, 3);
-      pmanager->AddProcess(new G4eplusAnnihilation, 0, -1, 4);
+      pmanager->AddProcess(msc, -1, 1, -1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, -1);
+      pmanager->AddProcess(new G4eBremsstrahlung, -1, -3, 1);
+      pmanager->AddProcess(new G4eplusAnnihilation, 0, -1, 2);
 
     } else if (particleName == "mu+" || particleName == "mu-") {
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
-      pmanager->AddProcess(new G4MuBremsstrahlung, -1, -3, 3);
-      pmanager->AddProcess(new G4MuPairProduction, -1, -4, 4);
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, -1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, -1);
+      pmanager->AddProcess(new G4MuBremsstrahlung, -1, -3, 1);
+      pmanager->AddProcess(new G4MuPairProduction, -1, -4, 2);
 
     } else if (particleName == "alpha" || particleName == "He3" || particleName == "GenericIon") {
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, -1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, -1);
 
     } else if (particleName == "pi+" || particleName == "kaon+" || particleName == "kaon-" ||
                particleName == "proton" || particleName == "pi-") {
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
-      pmanager->AddProcess(new G4hBremsstrahlung(), -1, -3, 3);
-      pmanager->AddProcess(new G4hPairProduction(), -1, -4, 4);
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, -1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, -1);
+      pmanager->AddProcess(new G4hBremsstrahlung(), -1, -3, 1);
+      pmanager->AddProcess(new G4hPairProduction(), -1, -4, 2);
 
     } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
                particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_lambda_c+" ||
@@ -199,8 +197,8 @@ void CMSEmNoDeltaRay::ConstructProcess() {
                particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
                particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
                particleName == "xi_c+" || particleName == "xi-") {
-      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
+      pmanager->AddProcess(new G4hMultipleScattering, -1, 1, -1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, -1);
     }
   }
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
@@ -1,5 +1,8 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmNoDeltaRay.h"
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "G4EmParameters.hh"
 #include "G4ParticleTable.hh"
 
@@ -139,7 +142,7 @@ void CMSEmNoDeltaRay::ConstructProcess() {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     G4ProcessManager* pmanager = particle->GetProcessManager();
     if (verbose > 1)
-      G4cout << "### " << GetPhysicsName() << " instantiates for " << particleName << " at " << particle << G4endl;
+      edm::LogVerbatim("PhysicsList") << "### " << GetPhysicsName() << " instantiates for " << particleName;
 
     if (particleName == "gamma") {
       pmanager->AddDiscreteProcess(new G4PhotoElectricEffect);
@@ -188,15 +191,7 @@ void CMSEmNoDeltaRay::ConstructProcess() {
       pmanager->AddProcess(new G4hBremsstrahlung(), -1, -3, 1);
       pmanager->AddProcess(new G4hPairProduction(), -1, -4, 2);
 
-    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
-               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" || particleName == "anti_proton" || particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" || particleName == "anti_sigma+" || particleName == "anti_sigma-" ||
-               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
-               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
-               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
-               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
-               particleName == "xi_c+" || particleName == "xi-") {
+    } else if (particle->GetPDGCharge() != 0.0) {
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, -1);
       pmanager->AddProcess(new G4hhIonisation, -1, 2, -1);
     }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -291,16 +291,7 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(pss, particle);
 
-    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
-               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
-               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
-               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
-               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
-               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
-               particleName == "xi_c+" || particleName == "xi-") {
+    } else if (particle->GetPDGCharge() != 0.0) {
       if (nullptr == hmsc) {
         hmsc = new G4hMultipleScattering("ionmsc");
       }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -1,5 +1,8 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h"
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "G4EmParameters.hh"
 #include "G4ParticleTable.hh"
 
@@ -133,7 +136,7 @@ void CMSEmStandardPhysics::ConstructParticle() {
 
 void CMSEmStandardPhysics::ConstructProcess() {
   if (verbose > 0) {
-    G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
+    edm::LogVerbatim("PhysicsList") << "### " << GetPhysicsName() << " Construct Processes ";
   }
 
   // This EM builder takes default models of Geant4 10 EMV.

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -240,16 +240,7 @@ void CMSEmStandardPhysics95::ConstructProcess() {
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
 
-    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
-               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
-               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
-               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
-               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
-               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
-               particleName == "xi_c+" || particleName == "xi-") {
+    } else if (particle->GetPDGCharge() != 0.0) {
       if (nullptr == hmsc) {
         hmsc = new G4hMultipleScattering("ionmsc");
       }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -1,5 +1,8 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95.h"
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "G4EmParameters.hh"
 #include "G4ParticleTable.hh"
 
@@ -159,7 +162,7 @@ void CMSEmStandardPhysics95::ConstructProcess() {
   for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     if (verbose > 1)
-      G4cout << "### " << GetPhysicsName() << " instantiates for " << particleName << G4endl;
+      edm::LogVerbatim("PhysicsList") << "### " << GetPhysicsName() << " instantiates for " << particleName;
 
     if (particleName == "gamma") {
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -1,6 +1,9 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h"
 #include "SimG4Core/PhysicsLists/interface/UrbanMscModel93.h"
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "G4EmParameters.hh"
 #include "G4ParticleTable.hh"
 
@@ -160,7 +163,7 @@ void CMSEmStandardPhysics95msc93::ConstructProcess() {
   for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     if (verbose > 1)
-      G4cout << "### " << GetPhysicsName() << " instantiates for " << particleName << " at " << particle << G4endl;
+      edm::LogVerbatim("PhysicsList") << "### " << GetPhysicsName() << " instantiates for " << particleName;
 
     if (particleName == "gamma") {
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -247,15 +247,7 @@ void CMSEmStandardPhysics95msc93::ConstructProcess() {
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
 
-    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
-               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" || particleName == "anti_proton" || particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" || particleName == "anti_sigma+" || particleName == "anti_sigma-" ||
-               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
-               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
-               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
-               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
-               particleName == "xi_c+" || particleName == "xi-") {
+    } else if (particle->GetPDGCharge() != 0.0) {
       if (nullptr == hmsc) {
         hmsc = new G4hMultipleScattering("ionmsc");
       }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -74,7 +74,8 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
+CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) 
+: G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
@@ -134,7 +135,7 @@ void CMSEmStandardPhysicsLPM::ConstructParticle() {
 }
 
 void CMSEmStandardPhysicsLPM::ConstructProcess() {
-  if (verbose > 0) {
+  if (verbose > 1) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
@@ -171,7 +172,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 
   G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
   G4Region* bRegion = G4RegionStore::GetInstance()->GetRegion("HGCalRegion", false);
-
+  if (verbose > 1) {
+    G4cout << "CMSEmStandardPhysicsLPM: HcalRegion " << aRegion << G4endl;
+    G4cout << "CMSEmStandardPhysicsLPM: HGCalRegion " << bRegion << G4endl;
+  }
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
   for (const auto& particleName : emList.PartNames()) {
@@ -189,7 +193,7 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       G4UrbanMscModel* msc1 = new G4UrbanMscModel();
       G4WentzelVIModel* msc2 = new G4WentzelVIModel();
       G4UrbanMscModel* msc3 = new G4UrbanMscModel();
-      //--- VI: these line should be moved down
+      //---VI: these line should be moved down
       msc3->SetLocked(true);
       //---
       msc1->SetHighEnergyLimit(highEnergyLimit);
@@ -197,9 +201,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc3->SetHighEnergyLimit(highEnergyLimit);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
-      msc->AddEmModel(-1, msc3, aRegion);
-      if (bRegion)
-        msc->AddEmModel(-1, msc3, bRegion);
+      if (aRegion) { msc->AddEmModel(-1, msc3, aRegion); }
+      if (bRegion) { msc->AddEmModel(-1, msc3, bRegion); }
 
       G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
@@ -226,9 +229,8 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc3->SetLocked(true);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
-      msc->AddEmModel(-1, msc3, aRegion);
-      if (bRegion)
-        msc->AddEmModel(-1, msc3, bRegion);
+      if (aRegion) { msc->AddEmModel(-1, msc3, aRegion); }
+      if (bRegion) { msc->AddEmModel(-1, msc3, bRegion); }
 
       G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
@@ -312,16 +314,7 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(new G4CoulombScattering(), particle);
 
-    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
-               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
-               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
-               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
-               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
-               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
-               particleName == "xi_c+" || particleName == "xi-") {
+    } else if (particle->GetPDGCharge() != 0.0) {
       if (nullptr == hmsc) {
         hmsc = new G4hMultipleScattering("ionmsc");
       }
@@ -329,4 +322,5 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }
+  G4cout << "CMSEmStandardPhysicsLPM: EM physics is instantiated " << G4endl;
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -1,5 +1,8 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h"
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "G4EmParameters.hh"
 #include "G4ParticleTable.hh"
 
@@ -135,7 +138,7 @@ void CMSEmStandardPhysicsLPM::ConstructParticle() {
 
 void CMSEmStandardPhysicsLPM::ConstructProcess() {
   if (verbose > 1) {
-    G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
+    edm::LogVerbatim("PhysicsList") << "### " << GetPhysicsName() << " Construct Processes";
   }
 
   // This EM builder takes default models of Geant4 10 EMV.
@@ -172,8 +175,7 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
   G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
   G4Region* bRegion = G4RegionStore::GetInstance()->GetRegion("HGCalRegion", false);
   if (verbose > 1) {
-    G4cout << "CMSEmStandardPhysicsLPM: HcalRegion " << aRegion << G4endl;
-    G4cout << "CMSEmStandardPhysicsLPM: HGCalRegion " << bRegion << G4endl;
+    edm::LogVerbatim("PhysicsList") << "CMSEmStandardPhysicsLPM: HcalRegion " << aRegion << "; HGCalRegion " << bRegion;
   }
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
@@ -329,5 +331,5 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }
-  G4cout << "CMSEmStandardPhysicsLPM: EM physics is instantiated " << G4endl;
+  edm::LogVerbatim("PhysicsList") << "CMSEmStandardPhysicsLPM: EM physics is instantiated";
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -74,8 +74,7 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) 
-: G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
+CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
@@ -201,8 +200,12 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc3->SetHighEnergyLimit(highEnergyLimit);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
-      if (aRegion) { msc->AddEmModel(-1, msc3, aRegion); }
-      if (bRegion) { msc->AddEmModel(-1, msc3, bRegion); }
+      if (aRegion) {
+        msc->AddEmModel(-1, msc3, aRegion);
+      }
+      if (bRegion) {
+        msc->AddEmModel(-1, msc3, bRegion);
+      }
 
       G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
@@ -229,8 +232,12 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc3->SetLocked(true);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
-      if (aRegion) { msc->AddEmModel(-1, msc3, aRegion); }
-      if (bRegion) { msc->AddEmModel(-1, msc3, bRegion); }
+      if (aRegion) {
+        msc->AddEmModel(-1, msc3, aRegion);
+      }
+      if (bRegion) {
+        msc->AddEmModel(-1, msc3, bRegion);
+      }
 
       G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -1,5 +1,8 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsXS.h"
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "G4EmParameters.hh"
 #include "G4ParticleTable.hh"
 
@@ -153,7 +156,7 @@ void CMSEmStandardPhysicsXS::ConstructParticle() {
 
 void CMSEmStandardPhysicsXS::ConstructProcess() {
   if (verbose > 0) {
-    G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
+    edm::LogVerbatim("PhysicsList") << "### " << GetPhysicsName() << " Construct Processes";
   }
 
   // This EM builder takes default models of Geant4 10 EMV.
@@ -193,8 +196,7 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
   G4Region* bRegion = G4RegionStore::GetInstance()->GetRegion("HGCalRegion", false);
   if (verbose > 1) {
-    G4cout << "CMSEmStandardPhysicsLPM: HcalRegion " << aRegion << G4endl;
-    G4cout << "CMSEmStandardPhysicsLPM: HGCalRegion " << bRegion << G4endl;
+    edm::LogVerbatim("PhysicsList") << "CMSEmStandardPhysicsLPM: HcalRegion " << aRegion << "; HGCalRegion " << bRegion;
   }
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -192,6 +192,10 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
 
   G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
   G4Region* bRegion = G4RegionStore::GetInstance()->GetRegion("HGCalRegion", false);
+  if (verbose > 1) {
+    G4cout << "CMSEmStandardPhysicsLPM: HcalRegion " << aRegion << G4endl;
+    G4cout << "CMSEmStandardPhysicsLPM: HGCalRegion " << bRegion << G4endl;
+  }
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
@@ -223,7 +227,8 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       msc3->SetLocked(true);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
-      msc->AddEmModel(-1, msc3, aRegion);
+      if (aRegion)
+        msc->AddEmModel(-1, msc3, aRegion);
       if (bRegion)
         msc->AddEmModel(-1, msc3, bRegion);
 
@@ -270,7 +275,8 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       msc3->SetLocked(true);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
-      msc->AddEmModel(-1, msc3, aRegion);
+      if (aRegion)
+        msc->AddEmModel(-1, msc3, aRegion);
       if (bRegion)
         msc->AddEmModel(-1, msc3, bRegion);
 
@@ -384,16 +390,7 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(pss, particle);
 
-    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
-               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
-               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
-               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
-               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
-               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
-               particleName == "xi_c+" || particleName == "xi-") {
+    } else if (particle->GetPDGCharge() != 0.0) {
       if (nullptr == hmsc) {
         hmsc = new G4hMultipleScattering("ionmsc");
       }


### PR DESCRIPTION
#### PR description:
In this PR a fix of order of initialisation is introduced and clean up/optimisation:

1) G4Regions and cuts should be initialized before physics list is created. This is the main fix of this PR, which provides correct initialisation of physics for special physics lists

2) DDWorld class should not communicate with Geant4 kernel

3) DDProductionCuts - memory churn is reduced (each G4Region and G4ProductionCuts is instantiated and filled only once)

4) EM physics constructors are cleaned up

5) Improved info messages and substituted G4cout by LogVerbatim

Should provide small reduction of memory churn and not change results of mainstream simulation. 

#### PR validation:
Checked SIM hits with private test

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
