### PR TITLE
Layer Clustering for HGCal Scintillator

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -44,6 +44,8 @@ namespace hgcal {
 
     bool isHalfCell(const DetId&) const;
 
+    bool isSilicon(const DetId&) const;
+
     // 4-vector helper functions using GlobalPoint
     float getEta(const GlobalPoint& position, const float& vertex_z = 0.) const;
     float getPhi(const GlobalPoint& position) const;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -46,6 +46,8 @@ namespace hgcal {
 
     bool isSilicon(const DetId&) const;
 
+    bool isOnlySilicon(const unsigned int layer) const;
+
     // 4-vector helper functions using GlobalPoint
     float getEta(const GlobalPoint& position, const float& vertex_z = 0.) const;
     float getPhi(const GlobalPoint& position) const;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -66,6 +66,7 @@ namespace hgcal {
     unsigned int maxNumberOfWafersPerLayer(bool nose = false) const {
       return (nose ? maxNumberOfWafersNose_ : maxNumberOfWafersPerLayer_);
     }
+    inline int getScintMaxIphi() const { return bhMaxIphi_; }
     inline int getGeometryType() const { return geometryType_; }
     bool maskCell(const DetId& id, int corners = 3) const;
 
@@ -74,6 +75,7 @@ namespace hgcal {
     unsigned int fhOffset_, bhOffset_, bhLastLayer_, fhLastLayer_;
     unsigned int maxNumberOfWafersPerLayer_, maxNumberOfWafersNose_;
     int geometryType_;
+    int bhMaxIphi_;
   };
 }  // namespace hgcal
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -98,7 +98,7 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
   }
   else {
     geometryType_ = 0;
-    geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
     wmaxEE    = 1 + (geomEE->topology().dddConstants()).waferMax();
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
@@ -394,6 +394,13 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
   }
   //new geometry is always false
   return ishalf;
+}
+
+bool RecHitTools::isSilicon( const DetId& id ) const {
+  bool isSilicon_ = false;
+  if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) 
+    isSilicon_ = true;
+  return isSilicon_;
 }
 
 float RecHitTools::getEta(const GlobalPoint& position, const float& vertex_z) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -416,6 +416,11 @@ bool RecHitTools::isSilicon(const DetId& id) const {
   return issilicon;
 }
 
+bool RecHitTools::isOnlySilicon(const unsigned int layer) const {
+  bool isonlysilicon = (layer % bhLastLayer_) < bhOffset_;
+  return isonlysilicon;
+}
+
 float RecHitTools::getEta(const GlobalPoint& position, const float& vertex_z) const {
   GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z() - vertex_z);
   return corrected_position.eta();

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -90,7 +90,7 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
   }
   else {
     geometryType_ = 0;
-    geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
+    auto geomEE = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCEE));
     fhOffset_ = (geomEE->topology().dddConstants()).layers(true);
     wmaxEE    = 1 + (geomEE->topology().dddConstants()).waferMax();
     auto geomFH = static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward,ForwardSubdetector::HGCHEF));
@@ -335,6 +335,13 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
   }
   //new geometry is always false
   return ishalf;
+}
+
+bool RecHitTools::isSilicon( const DetId& id ) const {
+  bool isSilicon_ = false;
+  if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) 
+    isSilicon_ = true;
+  return isSilicon_;
 }
 
 float RecHitTools::getEta(const GlobalPoint& position, const float& vertex_z) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -409,9 +409,9 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
   return ishalf;
 }
 
-bool RecHitTools::isSilicon( const DetId& id ) const {
+bool RecHitTools::isSilicon(const DetId& id) const {
   bool isSilicon_ = false;
-  if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) 
+  if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi)
     isSilicon_ = true;
   return isSilicon_;
 }

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -410,10 +410,10 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
 }
 
 bool RecHitTools::isSilicon(const DetId& id) const {
-  bool isSilicon_ = false;
+  bool issilicon = false;
   if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi)
-    isSilicon_ = true;
-  return isSilicon_;
+    issilicon = true;
+  return issilicon;
 }
 
 float RecHitTools::getEta(const GlobalPoint& position, const float& vertex_z) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -89,6 +89,7 @@ void RecHitTools::getEventSetup(const edm::EventSetup& es) {
     bhOffset_ =
         fhOffset_ + (geomBH->topology().dddConstants()).firstLayer() - (geomEE->topology().dddConstants()).firstLayer();
     bhLastLayer_ = bhOffset_ + (geomBH->topology().dddConstants()).layers(true);
+    bhMaxIphi_ = geomBH->topology().dddConstants().maxCells(true);
   } else {
     geometryType_ = 0;
     geomEE =

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -143,8 +143,11 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
   struct CellsOnLayer {
     std::vector<DetId> detid;
+    std::vector<bool> isSilic;
     std::vector<float> x; 
     std::vector<float> y;
+    std::vector<float> eta; 
+    std::vector<float> phi;
 
     std::vector<float> weight; 
     std::vector<float> rho;
@@ -159,8 +162,11 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
     void clear()
     {
       detid.clear();
+      isSilic.clear();
       x.clear();
       y.clear();
+      eta.clear();
+      phi.clear();
       weight.clear();
       rho.clear();
       delta.clear();
@@ -176,15 +182,25 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
   
   std::vector<int> numberOfClustersPerLayer_;
 
-  inline float distance2(int cell1, int cell2, int layerId) const {  // distance squared
-    const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
-    const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
-    return (dx * dx + dy * dy);
+  inline float distance2(int cell1, int cell2, int layerId, bool isEtaPhi) const {  // distance squared
+    if (isEtaPhi) {
+      const float dphi = (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] : cells_[layerId].phi[cell1] > 0 ?
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; 
+      //if (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]<0) std::cout << "cell 1 phi: " << cells_[layerId].phi[cell1] << "\n";
+      const float deta = cells_[layerId].eta[cell1] - cells_[layerId].eta[cell2];
+      return (deta * deta + dphi * dphi);
+    } else {
+      const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
+      const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
+      //std::cout << "distance2: " << dx * dx + dy * dy << std::endl;
+      return (dx * dx + dy * dy);
+    }
   }  
 
   inline float distance(int cell1,
-                         int cell2, int layerId) const {  // 2-d distance on the layer (x-y)
-    return std::sqrt(distance2(cell1, cell2, layerId));
+			int cell2, int layerId, bool isEtaPhi) const {  // 2-d distance on the layer (x-y)
+    return std::sqrt(distance2(cell1, cell2, layerId, isEtaPhi));
   }
   
   void prepareDataStructures(const unsigned int layerId);

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -86,6 +86,7 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
         1.3,
         1.3,
         5.0,
+	0.0315, // for scintillator
         });
     iDesc.add<bool>("dependSensor", true);
     iDesc.add<double>("ecut", 3.0);
@@ -184,16 +185,14 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
   inline float distance2(int cell1, int cell2, int layerId, bool isEtaPhi) const {  // distance squared
     if (isEtaPhi) {
-      const float dphi = (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] : cells_[layerId].phi[cell1] > 0 ?
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; 
-      //if (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]<0) std::cout << "cell 1 phi: " << cells_[layerId].phi[cell1] << "\n";
+      const float dphi = (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?  // this+search box size guarantee cell1 and cell2 do not located in phi=+/-pi 
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] : cells_[layerId].phi[cell1] > 0 ?  // if cell1 has phi=pi and cell2 has phi=-pi
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; // if cell1 has phi=-pi and cell2 has phi=pi
       const float deta = cells_[layerId].eta[cell1] - cells_[layerId].eta[cell2];
       return (deta * deta + dphi * dphi);
     } else {
       const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
       const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
-      //std::cout << "distance2: " << dx * dx + dy * dy << std::endl;
       return (dx * dx + dy * dy);
     }
   }  
@@ -204,9 +203,9 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
   }
   
   void prepareDataStructures(const unsigned int layerId);
-  void calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);  // return max density
-  void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);
-  int findAndAssignClusters(const unsigned int layerId, float delta_c);
+  void calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c, float delta_r);  // return max density
+  void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c, float delta_r);
+  int findAndAssignClusters(const unsigned int layerId, float delta_c, float delta_r);
   math::XYZPoint calculatePosition(const std::vector<int> &v, const unsigned int layerId) const;
   void setDensity(const unsigned int layerId);
 };

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -75,12 +75,12 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     iDesc.add<std::vector<double>>("thresholdW0", {2.9, 2.9, 2.9});
     iDesc.add<std::vector<double>>("deltac",
-				   {
-				    1.3,
-				    1.3,
-				    5.0,
-				    0.0315, // for scintillator
-				   });
+                                   {
+                                       1.3,
+                                       1.3,
+                                       5.0,
+                                       0.0315,  // for scintillator
+                                   });
     iDesc.add<bool>("dependSensor", true);
     iDesc.add<double>("ecut", 3.0);
     iDesc.add<double>("kappa", 9.0);
@@ -138,9 +138,9 @@ private:
   struct CellsOnLayer {
     std::vector<DetId> detid;
     std::vector<bool> isSilic;
-    std::vector<float> x; 
+    std::vector<float> x;
     std::vector<float> y;
-    std::vector<float> eta; 
+    std::vector<float> eta;
     std::vector<float> phi;
 
     std::vector<float> weight;
@@ -178,11 +178,13 @@ private:
   inline float distance2(int cell1, int cell2, int layerId, bool isEtaPhi) const {  // distance squared
     if (isEtaPhi) {
       const float dphi =
-	(cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?  // this guarantee cell1 and cell2 do not located in phi=+/-pi 
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] :
-	cells_[layerId].phi[cell1] > 0 ?  // if cell1 has phi=pi and cell2 has phi=-pi
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI :
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; // if cell1 has phi=-pi and cell2 has phi=pi
+          (cells_[layerId].phi[cell1] * cells_[layerId].phi[cell2] >= 0 || abs(cells_[layerId].phi[cell1]) < 1.)
+              ?  // this guarantee cell1 and cell2 do not located in phi=+/-pi
+              cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2]
+              : cells_[layerId].phi[cell1] > 0 ?  // if cell1 has phi=pi and cell2 has phi=-pi
+                    cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2 * M_PI
+                                               : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] +
+                                                     2 * M_PI;  // if cell1 has phi=-pi and cell2 has phi=pi
       const float deta = cells_[layerId].eta[cell1] - cells_[layerId].eta[cell2];
       return (deta * deta + dphi * dphi);
     } else {
@@ -190,7 +192,7 @@ private:
       const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
       return (dx * dx + dy * dy);
     }
-  }  
+  }
 
   inline float distance(int cell1, int cell2, int layerId, bool isEtaPhi) const {  // 2-d distance on the layer (x-y)
     return std::sqrt(distance2(cell1, cell2, layerId, isEtaPhi));
@@ -198,15 +200,12 @@ private:
 
   void prepareDataStructures(const unsigned int layerId);
   void calculateLocalDensity(const HGCalLayerTiles& lt,
-			     const unsigned int layerId,
-			     float delta_c,
-			     float delta_r);  // return max density
-  void calculateDistanceToHigher(const HGCalLayerTiles& lt,
-				 const unsigned int layerId,
-				 float delta_c,
-				 float delta_r);
+                             const unsigned int layerId,
+                             float delta_c,
+                             float delta_r);  // return max density
+  void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c, float delta_r);
   int findAndAssignClusters(const unsigned int layerId, float delta_c, float delta_r);
-  math::XYZPoint calculatePosition(const std::vector<int> &v, const unsigned int layerId) const;
+  math::XYZPoint calculatePosition(const std::vector<int>& v, const unsigned int layerId) const;
   void setDensity(const unsigned int layerId);
 };
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -101,7 +101,7 @@ public:
     iDesc.add<edm::ParameterSetDescription>("doseMap", descNestedNoiseMIP);
     descNestedNoiseMIP.add<double>("noise_MIP", 1. / 100.);
     iDesc.add<edm::ParameterSetDescription>("noiseMip", descNestedNoiseMIP);
-    iDesc.add<bool>("use2x2", true);  // use 2x2 for 3x3 scenario for scint density calculation
+    iDesc.add<bool>("use2x2", true);  // use 2x2 or 3x3 scenario for scint density calculation
   }
 
   /// point in the space

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -86,6 +86,7 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
         1.3,
         1.3,
         5.0,
+	0.0315, // for scintillator
         });
     iDesc.add<bool>("dependSensor", true);
     iDesc.add<double>("ecut", 3.0);
@@ -180,16 +181,14 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
   inline float distance2(int cell1, int cell2, int layerId, bool isEtaPhi) const {  // distance squared
     if (isEtaPhi) {
-      const float dphi = (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] : cells_[layerId].phi[cell1] > 0 ?
-	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; 
-      //if (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]<0) std::cout << "cell 1 phi: " << cells_[layerId].phi[cell1] << "\n";
+      const float dphi = (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?  // this+search box size guarantee cell1 and cell2 do not located in phi=+/-pi 
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] : cells_[layerId].phi[cell1] > 0 ?  // if cell1 has phi=pi and cell2 has phi=-pi
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; // if cell1 has phi=-pi and cell2 has phi=pi
       const float deta = cells_[layerId].eta[cell1] - cells_[layerId].eta[cell2];
       return (deta * deta + dphi * dphi);
     } else {
       const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
       const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
-      //std::cout << "distance2: " << dx * dx + dy * dy << std::endl;
       return (dx * dx + dy * dy);
     }
   }  
@@ -200,9 +199,9 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
   }
   
   void prepareDataStructures(const unsigned int layerId);
-  void calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);  // return max density
-  void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c);
-  int findAndAssignClusters(const unsigned int layerId, float delta_c);
+  void calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c, float delta_r);  // return max density
+  void calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c, float delta_r);
+  int findAndAssignClusters(const unsigned int layerId, float delta_c, float delta_r);
   math::XYZPoint calculatePosition(const std::vector<int> &v, const unsigned int layerId) const;
   void setDensity(const unsigned int layerId);
 };

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalCLUEAlgo.h
@@ -139,8 +139,11 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
 
   struct CellsOnLayer {
     std::vector<DetId> detid;
+    std::vector<bool> isSilic;
     std::vector<float> x; 
     std::vector<float> y;
+    std::vector<float> eta; 
+    std::vector<float> phi;
 
     std::vector<float> weight; 
     std::vector<float> rho;
@@ -155,8 +158,11 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
     void clear()
     {
       detid.clear();
+      isSilic.clear();
       x.clear();
       y.clear();
+      eta.clear();
+      phi.clear();
       weight.clear();
       rho.clear();
       delta.clear();
@@ -172,15 +178,25 @@ class HGCalCLUEAlgo : public HGCalClusteringAlgoBase {
   
   std::vector<int> numberOfClustersPerLayer_;
 
-  inline float distance2(int cell1, int cell2, int layerId) const {  // distance squared
-    const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
-    const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
-    return (dx * dx + dy * dy);
+  inline float distance2(int cell1, int cell2, int layerId, bool isEtaPhi) const {  // distance squared
+    if (isEtaPhi) {
+      const float dphi = (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]>=0 || abs(cells_[layerId].phi[cell1])<1.) ?
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] : cells_[layerId].phi[cell1] > 0 ?
+	cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] - 2*M_PI : cells_[layerId].phi[cell1] - cells_[layerId].phi[cell2] + 2*M_PI; 
+      //if (cells_[layerId].phi[cell1]*cells_[layerId].phi[cell2]<0) std::cout << "cell 1 phi: " << cells_[layerId].phi[cell1] << "\n";
+      const float deta = cells_[layerId].eta[cell1] - cells_[layerId].eta[cell2];
+      return (deta * deta + dphi * dphi);
+    } else {
+      const float dx = cells_[layerId].x[cell1] - cells_[layerId].x[cell2];
+      const float dy = cells_[layerId].y[cell1] - cells_[layerId].y[cell2];
+      //std::cout << "distance2: " << dx * dx + dy * dy << std::endl;
+      return (dx * dx + dy * dy);
+    }
   }  
 
   inline float distance(int cell1,
-                         int cell2, int layerId) const {  // 2-d distance on the layer (x-y)
-    return std::sqrt(distance2(cell1, cell2, layerId));
+			int cell2, int layerId, bool isEtaPhi) const {  // 2-d distance on the layer (x-y)
+    return std::sqrt(distance2(cell1, cell2, layerId, isEtaPhi));
   }
   
   void prepareDataStructures(const unsigned int layerId);

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h
@@ -64,6 +64,7 @@ public:
     lastLayerEE_ = rhtools_.lastLayerEE();
     lastLayerFH_ = rhtools_.lastLayerFH();
     firstLayerBH_ = rhtools_.firstLayerBH();
+    scintMaxIphi_ = rhtools_.getScintMaxIphi();
     getEventSetupPerAlgorithm(es);
   }
   inline void setVerbosity(VerbosityLevel the_verbosity) { verbosity_ = the_verbosity; }
@@ -75,6 +76,7 @@ public:
   unsigned int lastLayerEE_;
   unsigned int lastLayerFH_;
   unsigned int firstLayerBH_;
+  int scintMaxIphi_;
 
 protected:
   // The verbosity level

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -15,10 +15,33 @@
 class HGCalLayerTiles {
 public:
 
-  void fill(const std::vector<float>& x, const std::vector<float>& y) {
+  void fill(const std::vector<float>& x, const std::vector<float>& y, const std::vector<float>& eta, const std::vector<float>& phi, const std::vector<bool>& isSilic) {
     auto cellsSize = x.size();
+    //std::cout << "constants: " << hgcaltilesconstants::nColumnsEta << " " << hgcaltilesconstants::nRowsPhi << std::endl;
     for (unsigned int i = 0; i < cellsSize; ++i) {
       tiles_[getGlobalBin(x[i], y[i])].push_back(i);
+      if (!isSilic[i]) {
+	tiles_[getGlobalBinEtaPhi(eta[i], phi[i])].push_back(i);
+	if (getPhiBin(phi[i]) == 1) {
+	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI)].push_back(i); 
+//	  std::cout << " fill: " << i 
+//		    << " x: " << x[i]
+//		    << " y: " << y[i]
+//		    << " binXY: " << getGlobalBin(x[i], y[i])
+//		    << " eta: " << eta[i]
+//		    << " phi: " << phi[i]
+//		    << " binEta: " << getEtaBin(eta[i])
+//		    << " binPhi: " << getPhiBin(phi[i]) 
+//		    << " binEP: " << getGlobalBinEtaPhi(eta[i], phi[i])
+//		    << " newPhi: " << phi[i]+2*M_PI
+//		    << " binNewPhi: " << getPhiBin(phi[i]+2*M_PI)
+//		    << " binNewEP: " << getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI)
+//		    << "\n";
+	}
+	if (getPhiBin(phi[i]) == 42) {
+	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]-2*M_PI)].push_back(i); 
+	}
+      }
     }
   }
 
@@ -40,9 +63,32 @@ public:
     return yBin;
   }
 
+  int getEtaBin(float eta) const {
+    constexpr float etaRange = hgcaltilesconstants::maxEta - hgcaltilesconstants::minEta;
+    static_assert(etaRange >= 0.);
+    constexpr float r = hgcaltilesconstants::nColumnsEta / etaRange;
+    int etaBin = (eta - hgcaltilesconstants::minEta) * r;
+    etaBin = std::clamp(etaBin, 0, hgcaltilesconstants::nColumnsEta);
+    return etaBin;
+  }
+
+  int getPhiBin(float phi) const {
+    constexpr float phiRange = hgcaltilesconstants::maxPhi - hgcaltilesconstants::minPhi;
+    static_assert(phiRange >= 0.);
+    constexpr float r = hgcaltilesconstants::nRowsPhi / phiRange;
+    int phiBin = (phi - hgcaltilesconstants::minPhi) * r;
+    phiBin = std::clamp(phiBin, 0, hgcaltilesconstants::nRowsPhi);
+    return phiBin;
+  }
+
   int getGlobalBin(float x, float y) const { return getXBin(x) + getYBin(y) * hgcaltilesconstants::nColumns; }
 
   int getGlobalBinByBin(int xBin, int yBin) const { return xBin + yBin * hgcaltilesconstants::nColumns; }
+
+  int getGlobalBinEtaPhi(float eta, float phi) const { return hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows + getEtaBin(eta) + getPhiBin(phi) * hgcaltilesconstants::nColumnsEta; }
+
+  int getGlobalBinByBinEtaPhi(int etaBin, int phiBin) const {
+    return hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows + etaBin + phiBin * hgcaltilesconstants::nColumnsEta; }
 
   std::array<int, 4> searchBox(float xMin, float xMax, float yMin, float yMax) const {
     int xBinMin = getXBin(xMin);
@@ -52,15 +98,22 @@ public:
     return std::array<int, 4>({{xBinMin, xBinMax, yBinMin, yBinMax}});
   }
 
+  std::array<int, 4> searchBoxEtaPhi(float etaMin, float etaMax, float phiMin, float phiMax) const {
+    int etaBinMin = getEtaBin(etaMin);
+    int etaBinMax = getEtaBin(etaMax);
+    int phiBinMin = getPhiBin(phiMin);
+    int phiBinMax = getPhiBin(phiMax);
+    return std::array<int, 4>({{etaBinMin, etaBinMax, phiBinMin, phiBinMax}});
+  }
+
   void clear() {
-    for (auto& t : tiles_)
-      t.clear();
+    for (auto& t : tiles_) t.clear();
   }
 
   const std::vector<int>& operator[](int globalBinId) const { return tiles_[globalBinId]; }
 
 private:
-  std::array<std::vector<int>, hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows  > tiles_;
+  std::array<std::vector<int>, hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows + hgcaltilesconstants::nColumnsEta * hgcaltilesconstants::nRowsPhi > tiles_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -17,7 +17,6 @@ public:
 
   void fill(const std::vector<float>& x, const std::vector<float>& y, const std::vector<float>& eta, const std::vector<float>& phi, const std::vector<bool>& isSilic) {
     auto cellsSize = x.size();
-    //std::cout << "constants: " << hgcaltilesconstants::nColumnsEta << " " << hgcaltilesconstants::nRowsPhi << std::endl;
     for (unsigned int i = 0; i < cellsSize; ++i) {
       tiles_[getGlobalBin(x[i], y[i])].push_back(i);
       if (!isSilic[i]) {

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -18,16 +18,18 @@ public:
             const std::vector<float>& y,
             const std::vector<float>& eta,
             const std::vector<float>& phi,
-            const std::vector<bool>& isSilic) {
+            const std::vector<bool>& isSi) {
     auto cellsSize = x.size();
     for (unsigned int i = 0; i < cellsSize; ++i) {
       tiles_[getGlobalBin(x[i], y[i])].push_back(i);
-      if (!isSilic[i]) {
+      if (!isSi[i]) {
         tiles_[getGlobalBinEtaPhi(eta[i], phi[i])].push_back(i);
-        if (getPhiBin(phi[i]) == 1) {  // need to do this to handle cells at phi=+/-pi
+        // Copy cells in phi=[-3.15,-3.] to the last bin
+        if (getPhiBin(phi[i]) == mPiPhiBin) {
           tiles_[getGlobalBinEtaPhi(eta[i], phi[i] + 2 * M_PI)].push_back(i);
         }
-        if (getPhiBin(phi[i]) == 42) {
+        // Copy cells in phi=[3.,3.15] to the first bin
+        if (getPhiBin(phi[i]) == pPiPhiBin) {
           tiles_[getGlobalBinEtaPhi(eta[i], phi[i] - 2 * M_PI)].push_back(i);
         }
       }
@@ -70,6 +72,9 @@ public:
     return phiBin;
   }
 
+  int mPiPhiBin = getPhiBin(-M_PI);
+  int pPiPhiBin = getPhiBin(M_PI);
+
   int getGlobalBin(float x, float y) const { return getXBin(x) + getYBin(y) * hgcaltilesconstants::nColumns; }
 
   int getGlobalBinByBin(int xBin, int yBin) const { return xBin + yBin * hgcaltilesconstants::nColumns; }
@@ -108,10 +113,7 @@ public:
   const std::vector<int>& operator[](int globalBinId) const { return tiles_[globalBinId]; }
 
 private:
-  std::array<std::vector<int>,
-             hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows +
-                 hgcaltilesconstants::nColumnsEta * hgcaltilesconstants::nRowsPhi>
-      tiles_;
+  std::array<std::vector<int>, hgcaltilesconstants::nTiles> tiles_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -26,15 +26,6 @@ public:
         tiles_[getGlobalBinEtaPhi(eta[i], phi[i])].push_back(i);
         if (getPhiBin(phi[i]) == 1) {  // need to do this to handle cells at phi=+/-pi
           tiles_[getGlobalBinEtaPhi(eta[i], phi[i] + 2 * M_PI)].push_back(i);
-          LogDebug("HGCalLayerTiles") << "Debugging fill for cells at phi=pi: \n"
-                                      << "  fill: " << i << " x: " << x[i] << " y: " << y[i]
-                                      << " binXY: " << getGlobalBin(x[i], y[i]) << " eta: " << eta[i]
-                                      << " phi: " << phi[i] << " binEta: " << getEtaBin(eta[i])
-                                      << " binPhi: " << getPhiBin(phi[i])
-                                      << " binEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i])
-                                      << " newPhi: " << phi[i] + 2 * M_PI
-                                      << " binNewPhi: " << getPhiBin(phi[i] + 2 * M_PI)
-                                      << " binNewEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i] + 2 * M_PI) << "\n";
         }
         if (getPhiBin(phi[i]) == 42) {
           tiles_[getGlobalBinEtaPhi(eta[i], phi[i] - 2 * M_PI)].push_back(i);

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -15,34 +15,30 @@
 class HGCalLayerTiles {
 public:
   void fill(const std::vector<float>& x,
-	    const std::vector<float>& y,
-	    const std::vector<float>& eta,
-	    const std::vector<float>& phi,
-	    const std::vector<bool>& isSilic) {
+            const std::vector<float>& y,
+            const std::vector<float>& eta,
+            const std::vector<float>& phi,
+            const std::vector<bool>& isSilic) {
     auto cellsSize = x.size();
     for (unsigned int i = 0; i < cellsSize; ++i) {
       tiles_[getGlobalBin(x[i], y[i])].push_back(i);
       if (!isSilic[i]) {
-	tiles_[getGlobalBinEtaPhi(eta[i], phi[i])].push_back(i);
-	if (getPhiBin(phi[i]) == 1) {     // need to do this to handle cells at phi=+/-pi
-	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI)].push_back(i);
-	  LogDebug("HGCalLayerTiles") << "Debugging fill for cells at phi=pi: \n"
-				      << "  fill: " << i 
-				      << " x: " << x[i]
-				      << " y: " << y[i]
-				      << " binXY: " << getGlobalBin(x[i], y[i])
-				      << " eta: " << eta[i]
-				      << " phi: " << phi[i]
-				      << " binEta: " << getEtaBin(eta[i])
-				      << " binPhi: " << getPhiBin(phi[i]) 
-				      << " binEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i])
-				      << " newPhi: " << phi[i]+2*M_PI
-				      << " binNewPhi: " << getPhiBin(phi[i]+2*M_PI)
-				      << " binNewEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI) << "\n";
-	}
-	if (getPhiBin(phi[i]) == 42) {
-	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]-2*M_PI)].push_back(i); 
-	}
+        tiles_[getGlobalBinEtaPhi(eta[i], phi[i])].push_back(i);
+        if (getPhiBin(phi[i]) == 1) {  // need to do this to handle cells at phi=+/-pi
+          tiles_[getGlobalBinEtaPhi(eta[i], phi[i] + 2 * M_PI)].push_back(i);
+          LogDebug("HGCalLayerTiles") << "Debugging fill for cells at phi=pi: \n"
+                                      << "  fill: " << i << " x: " << x[i] << " y: " << y[i]
+                                      << " binXY: " << getGlobalBin(x[i], y[i]) << " eta: " << eta[i]
+                                      << " phi: " << phi[i] << " binEta: " << getEtaBin(eta[i])
+                                      << " binPhi: " << getPhiBin(phi[i])
+                                      << " binEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i])
+                                      << " newPhi: " << phi[i] + 2 * M_PI
+                                      << " binNewPhi: " << getPhiBin(phi[i] + 2 * M_PI)
+                                      << " binNewEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i] + 2 * M_PI) << "\n";
+        }
+        if (getPhiBin(phi[i]) == 42) {
+          tiles_[getGlobalBinEtaPhi(eta[i], phi[i] - 2 * M_PI)].push_back(i);
+        }
       }
     }
   }
@@ -88,15 +84,13 @@ public:
   int getGlobalBinByBin(int xBin, int yBin) const { return xBin + yBin * hgcaltilesconstants::nColumns; }
 
   int getGlobalBinEtaPhi(float eta, float phi) const {
-    return hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows +
-      getEtaBin(eta) +
-      getPhiBin(phi) * hgcaltilesconstants::nColumnsEta;
+    return hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows + getEtaBin(eta) +
+           getPhiBin(phi) * hgcaltilesconstants::nColumnsEta;
   }
 
   int getGlobalBinByBinEtaPhi(int etaBin, int phiBin) const {
-    return hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows +
-      etaBin +
-      phiBin * hgcaltilesconstants::nColumnsEta;
+    return hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows + etaBin +
+           phiBin * hgcaltilesconstants::nColumnsEta;
   }
 
   std::array<int, 4> searchBox(float xMin, float xMax, float yMin, float yMax) const {
@@ -116,15 +110,17 @@ public:
   }
 
   void clear() {
-    for (auto& t : tiles_) t.clear();
+    for (auto& t : tiles_)
+      t.clear();
   }
 
   const std::vector<int>& operator[](int globalBinId) const { return tiles_[globalBinId]; }
 
 private:
   std::array<std::vector<int>,
-	     hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows +
-	     hgcaltilesconstants::nColumnsEta * hgcaltilesconstants::nRowsPhi > tiles_;
+             hgcaltilesconstants::nColumns * hgcaltilesconstants::nRows +
+                 hgcaltilesconstants::nColumnsEta * hgcaltilesconstants::nRowsPhi>
+      tiles_;
 };
 
 #endif

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -17,26 +17,25 @@ public:
 
   void fill(const std::vector<float>& x, const std::vector<float>& y, const std::vector<float>& eta, const std::vector<float>& phi, const std::vector<bool>& isSilic) {
     auto cellsSize = x.size();
-    //std::cout << "constants: " << hgcaltilesconstants::nColumnsEta << " " << hgcaltilesconstants::nRowsPhi << std::endl;
     for (unsigned int i = 0; i < cellsSize; ++i) {
       tiles_[getGlobalBin(x[i], y[i])].push_back(i);
       if (!isSilic[i]) {
 	tiles_[getGlobalBinEtaPhi(eta[i], phi[i])].push_back(i);
-	if (getPhiBin(phi[i]) == 1) {
-	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI)].push_back(i); 
-//	  std::cout << " fill: " << i 
-//		    << " x: " << x[i]
-//		    << " y: " << y[i]
-//		    << " binXY: " << getGlobalBin(x[i], y[i])
-//		    << " eta: " << eta[i]
-//		    << " phi: " << phi[i]
-//		    << " binEta: " << getEtaBin(eta[i])
-//		    << " binPhi: " << getPhiBin(phi[i]) 
-//		    << " binEP: " << getGlobalBinEtaPhi(eta[i], phi[i])
-//		    << " newPhi: " << phi[i]+2*M_PI
-//		    << " binNewPhi: " << getPhiBin(phi[i]+2*M_PI)
-//		    << " binNewEP: " << getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI)
-//		    << "\n";
+	if (getPhiBin(phi[i]) == 1) {     // need to do this to handle cells at phi=+/-pi
+	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI)].push_back(i);
+	  LogDebug("HGCalLayerTiles") << "Debugging fill for cells at phi=pi: \n"
+				      << "  fill: " << i 
+				      << " x: " << x[i]
+				      << " y: " << y[i]
+				      << " binXY: " << getGlobalBin(x[i], y[i])
+				      << " eta: " << eta[i]
+				      << " phi: " << phi[i]
+				      << " binEta: " << getEtaBin(eta[i])
+				      << " binPhi: " << getPhiBin(phi[i]) 
+				      << " binEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i])
+				      << " newPhi: " << phi[i]+2*M_PI
+				      << " binNewPhi: " << getPhiBin(phi[i]+2*M_PI)
+				      << " binNewEtaPhi: " << getGlobalBinEtaPhi(eta[i], phi[i]+2*M_PI) << "\n";
 	}
 	if (getPhiBin(phi[i]) == 42) {
 	  tiles_[getGlobalBinEtaPhi(eta[i], phi[i]-2*M_PI)].push_back(i); 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
@@ -21,6 +21,13 @@ namespace hgcaltilesconstants {
   constexpr float tileSize = 5.f;
   constexpr int nColumns = hgcaltilesconstants::ceil((maxX - minX) / tileSize);
   constexpr int nRows = hgcaltilesconstants::ceil((maxY - minY) / tileSize);
+  constexpr float minEta = -3.f;
+  constexpr float maxEta = 3.f;
+  constexpr float minPhi = -3.3;
+  constexpr float maxPhi = 3.3;
+  constexpr float tileSizeEtaPhi = 0.15;
+  constexpr int nColumnsEta = hgcaltilesconstants::ceil((maxEta - minEta) / tileSizeEtaPhi);
+  constexpr int nRowsPhi = hgcaltilesconstants::ceil((maxPhi - minPhi) / tileSizeEtaPhi);
 
 }  // namespace hgcaltilesconstants
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
@@ -24,7 +24,7 @@ namespace hgcaltilesconstants {
   constexpr float tileSizeEtaPhi = 0.15f;
   constexpr float minEta = -3.f;
   constexpr float maxEta = 3.f;
-  //To properly construct search box for cells in phi=[-3.15,-3.], cells in phi=[3.,3.15] are copied to the first bin and cells in phi=[-3.15,-3.] are copied to the last bin
+  //To properly construct search box for cells in phi=[-3.15,-3.] and [3.,3.15], cells in phi=[3.,3.15] are copied to the first bin and cells in phi=[-3.15,-3.] are copied to the last bin
   constexpr float minPhi = -3.3f;
   constexpr float maxPhi = 3.3f;
   constexpr int nColumnsEta = hgcaltilesconstants::ceil((maxEta - minEta) / tileSizeEtaPhi);

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
@@ -14,20 +14,23 @@ namespace hgcaltilesconstants {
                                                                   : static_cast<int32_t>(num) + ((num > 0) ? 1 : 0);
   }
 
+  constexpr float tileSize = 5.f;
   constexpr float minX = -285.f;
   constexpr float maxX = 285.f;
   constexpr float minY = -285.f;
   constexpr float maxY = 285.f;
-  constexpr float tileSize = 5.f;
   constexpr int nColumns = hgcaltilesconstants::ceil((maxX - minX) / tileSize);
   constexpr int nRows = hgcaltilesconstants::ceil((maxY - minY) / tileSize);
+  constexpr float tileSizeEtaPhi = 0.15f;
   constexpr float minEta = -3.f;
   constexpr float maxEta = 3.f;
-  constexpr float minPhi = -3.3;
-  constexpr float maxPhi = 3.3;
-  constexpr float tileSizeEtaPhi = 0.15;
+  constexpr float minPhi =
+      -3.3f;  //To properly construct search box for cells in phi=[-3.15,-3.], cells in phi=[3.,3.15] are copied to the first bin
+  constexpr float maxPhi =
+      3.3f;  //To properly construct search box for cells in phi=[3.,3.15], cells in phi=[-3.15,-3.] are copied to the last bin
   constexpr int nColumnsEta = hgcaltilesconstants::ceil((maxEta - minEta) / tileSizeEtaPhi);
   constexpr int nRowsPhi = hgcaltilesconstants::ceil((maxPhi - minPhi) / tileSizeEtaPhi);
+  constexpr int nTiles = nColumns * nRows + nColumnsEta * nRowsPhi;
 
 }  // namespace hgcaltilesconstants
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h
@@ -24,10 +24,9 @@ namespace hgcaltilesconstants {
   constexpr float tileSizeEtaPhi = 0.15f;
   constexpr float minEta = -3.f;
   constexpr float maxEta = 3.f;
-  constexpr float minPhi =
-      -3.3f;  //To properly construct search box for cells in phi=[-3.15,-3.], cells in phi=[3.,3.15] are copied to the first bin
-  constexpr float maxPhi =
-      3.3f;  //To properly construct search box for cells in phi=[3.,3.15], cells in phi=[-3.15,-3.] are copied to the last bin
+  //To properly construct search box for cells in phi=[-3.15,-3.], cells in phi=[3.,3.15] are copied to the first bin and cells in phi=[-3.15,-3.] are copied to the last bin
+  constexpr float minPhi = -3.3f;
+  constexpr float maxPhi = 3.3f;
   constexpr int nColumnsEta = hgcaltilesconstants::ceil((maxEta - minEta) / tileSizeEtaPhi);
   constexpr int nRowsPhi = hgcaltilesconstants::ceil((maxPhi - minPhi) / tileSizeEtaPhi);
   constexpr int nTiles = nColumns * nRows + nColumnsEta * nRowsPhi;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -13,7 +13,6 @@
 #include "tbb/tbb.h"
 #include <limits>
 
-
 using namespace hgcal_clustering;
 
 
@@ -50,14 +49,15 @@ void HGCalCLUEAlgo::populate(const HGCRecHitCollection &hits) {
     int offset = ((rhtools_.zside(detid) + 1) >> 1)*maxlayer;
     int layer = layerOnSide + offset;
     cells_[layer].detid.emplace_back(detid);
+    cells_[layer].isSilic.emplace_back(rhtools_.isSilicon(detid));
     cells_[layer].x.emplace_back(position.x());
     cells_[layer].y.emplace_back(position.y());
+    cells_[layer].eta.emplace_back(position.eta());
+    cells_[layer].phi.emplace_back(position.phi());
     cells_[layer].weight.emplace_back(hgrh.energy());
     cells_[layer].sigmaNoise.emplace_back(sigmaNoise);
   }
-
 }
-
 
 void HGCalCLUEAlgo::prepareDataStructures(unsigned int l)
 {
@@ -79,8 +79,13 @@ void HGCalCLUEAlgo::makeClusters() {
   // assign all hits in each layer to a cluster core
   tbb::this_task_arena::isolate([&] {
     tbb::parallel_for(size_t(0), size_t(2 * maxlayer + 2), [&](size_t i) {
+      prepareDataStructures(i);
+      //std::cout << "---Starting process layer " << i << std::endl;
+      //if (i!=58) return;
       HGCalLayerTiles lt;
-      lt.fill(cells_[i].x,cells_[i].y);
+      lt.clear();
+      lt.fill(cells_[i].x,cells_[i].y, cells_[i].eta, cells_[i].phi, cells_[i].isSilic);
+      
       float delta_c;  // maximum search distance (critical distance) for local
                   // density calculation
       if (i%maxlayer < lastLayerEE)
@@ -90,18 +95,25 @@ void HGCalCLUEAlgo::makeClusters() {
       else
         delta_c = vecDeltas_[2];
 
-      prepareDataStructures(i);
+      //float delta_r = 0.0315;
+      
+      //prepareDataStructures(i);
+      //if (i!=94) return;
       calculateLocalDensity(lt, i, delta_c);
       calculateDistanceToHigher(lt, i, delta_c);
-      numberOfClustersPerLayer_[i] = findAndAssignClusters(i,delta_c);  
+      numberOfClustersPerLayer_[i] = findAndAssignClusters(i,delta_c);
+      //std::cout << "makeClusters: " << i << " | " << numberOfClustersPerLayer_[i] << " | " << cells_[i].x.size() << std::endl;
     });
   });
   //Now that we have the density per point we can store it
-  for(unsigned int i=0; i< 2 * maxlayer + 2; ++i) { setDensity(i); }
+  for(unsigned int i=0; i< 2 * maxlayer + 2; ++i) {
+    //std::cout << i << std::endl; //}
+    setDensity(i); }
+  //std::cout << "end makeClusters" << std::endl;
 }
 
 std::vector<reco::BasicCluster> HGCalCLUEAlgo::getClusters(bool) {
-
+  //std::cout << "debug5" << std::endl;
   std::vector<int> offsets(numberOfClustersPerLayer_.size(),0);
 
   int maxClustersOnLayer = numberOfClustersPerLayer_[0];
@@ -113,7 +125,7 @@ std::vector<reco::BasicCluster> HGCalCLUEAlgo::getClusters(bool) {
     maxClustersOnLayer = std::max(maxClustersOnLayer, numberOfClustersPerLayer_[layerId]);
   }
 
-
+  //std::cout << "debug6" << std::endl;
   auto totalNumberOfClusters = offsets.back()+numberOfClustersPerLayer_.back();
   clusters_v_.resize(totalNumberOfClusters);
   std::vector<std::vector<int> > cellsIdInCluster;
@@ -135,7 +147,7 @@ std::vector<reco::BasicCluster> HGCalCLUEAlgo::getClusters(bool) {
     
 
     std::vector<std::pair<DetId, float>> thisCluster;
-    
+    //std::cout << "debug7" << std::endl;
     for(auto& cl: cellsIdInCluster)
     {
       auto position = calculatePosition(cl, layerId);
@@ -161,7 +173,7 @@ std::vector<reco::BasicCluster> HGCalCLUEAlgo::getClusters(bool) {
     cellsIdInCluster.clear();
 
   }
-
+  //std::cout << "debug8" << std::endl;
   return clusters_v_;
 
 }
@@ -235,35 +247,85 @@ math::XYZPoint HGCalCLUEAlgo::calculatePosition(const std::vector<int> &v, const
 
 void HGCalCLUEAlgo::calculateLocalDensity(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c)  
 {
-
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
-
-  for(unsigned int i = 0; i < numberOfCells; i++) 
-  {
-    std::array<int,4> search_box = lt.searchBox(cellsOnLayer.x[i] - delta_c, cellsOnLayer.x[i] + delta_c, cellsOnLayer.y[i] - delta_c, cellsOnLayer.y[i] + delta_c);
+  for(unsigned int i = 0; i < numberOfCells; i++) {
+    //std::cout << "CELL: " << i << "\n";
+    float delta_c_(0);
+    if (cellsOnLayer.isSilic[i]) {
+      delta_c_=delta_c;
+      //std::cout << "delta for silicon: " << delta_c_ << std::endl;
+      //std::cout << "x-y: " << cellsOnLayer.x[i] << "|" << cellsOnLayer.y[i] << "|" << lt.getXBin(cellsOnLayer.x[i]) << "|" << lt.getYBin(cellsOnLayer.y[i]) << std::endl;
+      //std::cout << "eta-phi: " << cellsOnLayer.eta[i] << "|" << cellsOnLayer.phi[i] << "|" << lt.getEtaBin(cellsOnLayer.eta[i]) << "|" << lt.getPhiBin(cellsOnLayer.phi[i]) << std::endl;
+      std::array<int,4> search_box = lt.searchBox(cellsOnLayer.x[i] - delta_c_, cellsOnLayer.x[i] + delta_c_, cellsOnLayer.y[i] - delta_c_, cellsOnLayer.y[i] + delta_c_);
     
-    for(int xBin = search_box[0]; xBin < search_box[1]+1; ++xBin) {
-      for(int yBin = search_box[2]; yBin < search_box[3]+1; ++yBin) {
+      for(int xBin = search_box[0]; xBin < search_box[1]+1; ++xBin) {
+	for(int yBin = search_box[2]; yBin < search_box[3]+1; ++yBin) {
         
-        int binId = lt.getGlobalBinByBin(xBin,yBin);
-        size_t binSize = lt[binId].size();
+	  int binId = lt.getGlobalBinByBin(xBin,yBin);
+	  size_t binSize = lt[binId].size();
         
-        for (unsigned int j = 0; j < binSize; j++) {
-          unsigned int otherId = lt[binId][j];
-          if(distance(i, otherId, layerId) < delta_c) {
-            cellsOnLayer.rho[i] += (i == otherId ? 1.f : 0.5f) * cellsOnLayer.weight[otherId];
-          }
-        }
+	  for (unsigned int j = 0; j < binSize; j++) {
+	    unsigned int otherId = lt[binId][j];
+	    //std::cout << otherId << std::endl;
+	    //std::cout << "x-y in search bin:" << xBin << "|" << yBin << "|" << binId << "|" << lt[binId].size() << std::endl;
+	    if (!cellsOnLayer.isSilic[otherId]) continue;
+	    if(distance(i, otherId, layerId, false) < delta_c_) {
+	      cellsOnLayer.rho[i] += (i == otherId ? 1.f : 0.5f) * cellsOnLayer.weight[otherId];
+	    }
+	  }
+	}
       }
-    }    
+      //std::cout << "calculate local density: " << i << " rho: " << cellsOnLayer.rho[i] << std::endl;
+      //std::cout << "calculate local density: " << i << " delta: " << cellsOnLayer.delta[i] << std::endl;
+    } else {
+      delta_c_ = 0.0315;
+      //std::cout << "delta for scintillator: " << delta_c_ << std::endl;
+      //std::cout << "eta-phi: " << cellsOnLayer.eta[i] << "|" << cellsOnLayer.phi[i] << "|" << lt.getEtaBin(cellsOnLayer.eta[i]) << "|" << lt.getPhiBin(cellsOnLayer.phi[i]) << std::endl;
+      std::array<int,4> search_box = lt.searchBoxEtaPhi(cellsOnLayer.eta[i] - delta_c_, cellsOnLayer.eta[i] + delta_c_, cellsOnLayer.phi[i] - delta_c_, cellsOnLayer.phi[i] + delta_c_);
+      //std::cout << "search box: " << search_box[0] << "|" << search_box[1] << "|" << search_box[2] << "|" << search_box[3] << std::endl;
+      cellsOnLayer.rho[i] += cellsOnLayer.weight[i];
+	
+      float northeast(0), northwest(0), southeast(0), southwest(0);
+      
+      for(int etaBin = search_box[0]; etaBin < search_box[1]+1; ++etaBin) {
+	for(int phiBin = search_box[2]; phiBin < search_box[3]+1; ++phiBin) {
+	  
+	  int binId = lt.getGlobalBinByBinEtaPhi(etaBin,phiBin);
+	  //std::cout << "eta-phi in search bin:" << etaBin << "|" << phiBin << "|" << binId << "|" << lt[binId].size() << std::endl;
+	  size_t binSize = lt[binId].size();
+	  for (unsigned int j = 0; j < binSize; j++) {
+	    unsigned int otherId = lt[binId][j];
+	    //std::cout << "otherId: " << otherId << " binId: " << binId << " i: "<< i << std::endl;
+	    if (cellsOnLayer.isSilic[otherId]) continue;
+	    if(distance(i, otherId, layerId, true) < delta_c_) {
+	      float otherPhi=cellsOnLayer.phi[otherId];
+	      float iPhi=cellsOnLayer.phi[i];
+	      otherPhi += (otherPhi*iPhi >= 0 || abs(iPhi) < 1.) ? 0. : iPhi > 0. ? 2*M_PI : -2*M_PI;
+	      float otherEta=cellsOnLayer.eta[otherId];
+	      float iEta=cellsOnLayer.eta[i];
+	      if ((otherEta > iEta && otherPhi > iPhi) || (otherEta > iEta && otherPhi == iPhi) || (otherEta == iEta && otherPhi > iPhi)) northwest+=0.5*cellsOnLayer.weight[otherId];
+	      if ((otherEta > iEta && otherPhi < iPhi) || (otherEta > iEta && otherPhi == iPhi) || (otherEta == iEta && otherPhi < iPhi)) northeast+=0.5*cellsOnLayer.weight[otherId];
+	      if ((otherEta < iEta && otherPhi > iPhi) || (otherEta < iEta && otherPhi == iPhi) || (otherEta == iEta && otherPhi > iPhi)) southwest+=0.5*cellsOnLayer.weight[otherId];
+	      if ((otherEta < iEta && otherPhi < iPhi) || (otherEta == iEta && otherPhi < iPhi) || (otherEta < iEta && otherPhi == iPhi)) southeast+=0.5*cellsOnLayer.weight[otherId];
+	    }
+	  }
+	}
+      }
+      float neighborsval = (std::max(northeast, northwest) > std::max(southeast, southwest)) ? std::max(northeast, northwest) : std::max(southeast, southwest);
+      cellsOnLayer.rho[i] += neighborsval;
+//      std::cout << " Cell: " << i
+//		<< " eta: " <<  cellsOnLayer.eta[i]
+//		<< " phi: " << cellsOnLayer.phi[i]
+//		<< " energy: " << cellsOnLayer.weight[i]
+//		<< " density: " << cellsOnLayer.rho[i]
+//		<< "\n";
+    }
   }
-
 }
 
 
 void HGCalCLUEAlgo::calculateDistanceToHigher(const HGCalLayerTiles& lt, const unsigned int layerId, float delta_c) {
-
 
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
@@ -273,51 +335,102 @@ void HGCalCLUEAlgo::calculateDistanceToHigher(const HGCalLayerTiles& lt, const u
     float maxDelta = std::numeric_limits<float>::max();
     float i_delta = maxDelta;
     int i_nearestHigher = -1;
-
-    // get search box for ith hit
-    // guarantee to cover a range "outlierDeltaFactor_*delta_c"
-    auto range = outlierDeltaFactor_*delta_c;
-    std::array<int,4> search_box = lt.searchBox(cellsOnLayer.x[i]  - range, cellsOnLayer.x[i] + range, cellsOnLayer.y[i] - range, cellsOnLayer.y[i] + range);
-    
-    // loop over all bins in the search box
-    for(int xBin = search_box[0]; xBin < search_box[1]+1; ++xBin) {
-      for(int yBin = search_box[2]; yBin < search_box[3]+1; ++yBin) {
+    float delta_c_ = 0;
+    if (cellsOnLayer.isSilic[i]) {
+      delta_c_=delta_c;
+      // get search box for ith hit
+      // guarantee to cover a range "outlierDeltaFactor_*delta_c"
+      auto range = outlierDeltaFactor_*delta_c_;
+      std::array<int,4> search_box = lt.searchBox(cellsOnLayer.x[i]  - range, cellsOnLayer.x[i] + range, cellsOnLayer.y[i] - range, cellsOnLayer.y[i] + range);
+      // loop over all bins in the search box
+      for(int xBin = search_box[0]; xBin < search_box[1]+1; ++xBin) {
+	for(int yBin = search_box[2]; yBin < search_box[3]+1; ++yBin) {
         
-        // get the id of this bin
-        size_t binId = lt.getGlobalBinByBin(xBin,yBin);
-        // get the size of this bin
-        size_t binSize = lt[binId].size();
+	  // get the id of this bin
+	  size_t binId = lt.getGlobalBinByBin(xBin,yBin);
+	  // get the size of this bin
+	  size_t binSize = lt[binId].size();
 
-        // loop over all hits in this bin
-        for (unsigned int j = 0; j < binSize; j++) {
-          unsigned int otherId = lt[binId][j];
-
-          float dist = distance(i, otherId, layerId);
-          bool foundHigher = cellsOnLayer.rho[otherId] > cellsOnLayer.rho[i];
+	  // loop over all hits in this bin
+	  for (unsigned int j = 0; j < binSize; j++) {
+	    unsigned int otherId = lt[binId][j];
+	    if (!cellsOnLayer.isSilic[otherId]) continue;
+	    float dist = distance(i, otherId, layerId, false);
+	    bool foundHigher = cellsOnLayer.rho[otherId] > cellsOnLayer.rho[i];
 
 
           // if dist == i_delta, then last comer being the nearest higher
-          if(foundHigher && dist <= i_delta) {
-
-            // update i_delta
-            i_delta = dist;
-            // update i_nearestHigher
-            i_nearestHigher = otherId;
-            
-          }
-        }
+	    if(foundHigher && dist <= i_delta) {
+	      // update i_delta
+	      i_delta = dist;
+	      // update i_nearestHigher
+	      i_nearestHigher = otherId;            
+	    }
+	  }
+	}
       }
-    }
 
-    bool foundNearestHigherInSearchBox = (i_delta != maxDelta);
-    if (foundNearestHigherInSearchBox){
-      cellsOnLayer.delta[i] = i_delta;
-      cellsOnLayer.nearestHigher[i] = i_nearestHigher;
+      bool foundNearestHigherInSearchBox = (i_delta != maxDelta);
+      if (foundNearestHigherInSearchBox){
+	cellsOnLayer.delta[i] = i_delta;
+	cellsOnLayer.nearestHigher[i] = i_nearestHigher;
+      } else {
+	// otherwise delta is guaranteed to be larger outlierDeltaFactor_*delta_c
+	// we can safely maximize delta to be maxDelta
+	cellsOnLayer.delta[i] = maxDelta;
+	cellsOnLayer.nearestHigher[i] = -1;
+      }
+      //std::cout << "calculate distance: " << i << " rho: " << cellsOnLayer.rho[i] << std::endl;
+      //std::cout << "calculate distance: " << i << " delta: " << cellsOnLayer.delta[i] << std::endl;
     } else {
-      // otherwise delta is guaranteed to be larger outlierDeltaFactor_*delta_c
-      // we can safely maximize delta to be maxDelta
-      cellsOnLayer.delta[i] = maxDelta;
-      cellsOnLayer.nearestHigher[i] = -1;
+
+      //std::cout << "calculateDistanceToHigher, cell: " << i << std::endl;
+      // get search box for ith hit
+      // guarantee to cover a range "outlierDeltaFactor_*delta_c"
+
+      delta_c_ = 0.0315;
+      auto range = outlierDeltaFactor_*delta_c_;
+      std::array<int,4> search_box = lt.searchBoxEtaPhi(cellsOnLayer.eta[i]  - range, cellsOnLayer.eta[i] + range, cellsOnLayer.phi[i] - range, cellsOnLayer.phi[i] + range);
+      //std::cout << "search box: " << search_box[0] << "|" << search_box[1] << "|" << search_box[2] << "|" << search_box[3] << std::endl;
+      // loop over all bins in the search box
+      for(int xBin = search_box[0]; xBin < search_box[1]+1; ++xBin) {
+	for(int yBin = search_box[2]; yBin < search_box[3]+1; ++yBin) {
+        
+	  // get the id of this bin
+	  //std::cout << "debug: " << xBin << "|" << yBin << std::endl;
+	  size_t binId = lt.getGlobalBinByBinEtaPhi(xBin,yBin);
+	  // get the size of this bin
+	  size_t binSize = lt[binId].size();
+	  //std::cout << "eta-phi in search bin:" << xBin << "|" << yBin << "|" << binId << "|" << lt[binId].size() << std::endl;
+	  // loop over all hits in this bin
+	  for (unsigned int j = 0; j < binSize; j++) {
+	    unsigned int otherId = lt[binId][j];
+	    if (cellsOnLayer.isSilic[otherId]) continue;
+	    //std::cout << "otherId: " << otherId << " binId: " << binId << " i: "<< i << std::endl;
+	    float dist = distance(i, otherId, layerId, true);
+	    bool foundHigher = cellsOnLayer.rho[otherId] > cellsOnLayer.rho[i];
+
+          // if dist == i_delta, then last comer being the nearest higher
+	    if(foundHigher && dist <= i_delta) {
+	      // update i_delta
+	      i_delta = dist;
+	      // update i_nearestHigher
+	      i_nearestHigher = otherId;
+	    }
+	  }
+	}
+      }
+
+      bool foundNearestHigherInSearchBox = (i_delta != maxDelta);
+      if (foundNearestHigherInSearchBox){
+	cellsOnLayer.delta[i] = i_delta;
+	cellsOnLayer.nearestHigher[i] = i_nearestHigher;
+      } else {
+	// otherwise delta is guaranteed to be larger outlierDeltaFactor_*delta_c
+	// we can safely maximize delta to be maxDelta
+	cellsOnLayer.delta[i] = maxDelta;
+	cellsOnLayer.nearestHigher[i] = -1;
+      }
     }
   }
 }
@@ -336,10 +449,17 @@ int HGCalCLUEAlgo::findAndAssignClusters(const unsigned int layerId, float delta
   // find cluster seeds and outlier  
   for(unsigned int i = 0; i < numberOfCells; i++) {
     float rho_c = kappa_ * cellsOnLayer.sigmaNoise[i];
+    float delta_c_ = 0;
+    if (!cellsOnLayer.isSilic[i]) {
+      delta_c_ = 0.0315;
+    } else {
+      delta_c_ = delta_c;
+    }
+
     // initialize clusterIndex
     cellsOnLayer.clusterIndex[i] = -1;
-    bool isSeed = (cellsOnLayer.delta[i] > delta_c) && (cellsOnLayer.rho[i] >= rho_c);
-    bool isOutlier = (cellsOnLayer.delta[i] > outlierDeltaFactor_*delta_c) && (cellsOnLayer.rho[i] < rho_c);
+    bool isSeed = (cellsOnLayer.delta[i] > delta_c_) && (cellsOnLayer.rho[i] >= rho_c);
+    bool isOutlier = (cellsOnLayer.delta[i] > outlierDeltaFactor_*delta_c_) && (cellsOnLayer.rho[i] < rho_c);
     if (isSeed) 
     {
       cellsOnLayer.clusterIndex[i] = nClustersOnLayer;
@@ -349,8 +469,11 @@ int HGCalCLUEAlgo::findAndAssignClusters(const unsigned int layerId, float delta
     
     } else if (!isOutlier) {
       cellsOnLayer.followers[cellsOnLayer.nearestHigher[i]].push_back(i);   
-    } 
+    }
+    //std::cout << "assign clusters: " << i << " rho: " << cellsOnLayer.rho[i] << std::endl;
+    //std::cout << "assign clusters: " << i << " delta: " << cellsOnLayer.delta[i] << std::endl;
   }
+  
   // need to pass clusterIndex to their followers
   while (!localStack.empty()) {
     int endStack = localStack.back();
@@ -364,8 +487,8 @@ int HGCalCLUEAlgo::findAndAssignClusters(const unsigned int layerId, float delta
       // push this follower to localStack
       localStack.push_back(j);
     }
-    
   }
+  //std::cout << "nClustersOnLayer: " << nClustersOnLayer << std::endl; 
   return nClustersOnLayer;
 }
 
@@ -404,8 +527,11 @@ void HGCalCLUEAlgo::setDensity(const unsigned int layerId){
 
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
-  for (unsigned int i = 0; i< numberOfCells; ++i) density_[ cellsOnLayer.detid[i] ] =   cellsOnLayer.rho[i] ;
-  
+  //std::cout << numberOfCells << std::endl;
+  for (unsigned int i = 0; i< numberOfCells; ++i) {
+    //std::cout << i << " density: " << cellsOnLayer.rho[i] << std::endl;
+    density_[ cellsOnLayer.detid[i] ] =   cellsOnLayer.rho[i] ;
+  }
 }
 
 Density HGCalCLUEAlgo::getDensity() {

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -459,7 +459,7 @@ int HGCalCLUEAlgo::findAndAssignClusters(const unsigned int layerId, float delta
     // initialize clusterIndex
     cellsOnLayer.clusterIndex[i] = -1;
     bool isSeed = (cellsOnLayer.delta[i] > delta_c_) && (cellsOnLayer.rho[i] >= rho_c);
-    bool isOutlier = (cellsOnLayer.delta[i] > outlierDeltaFactor_*delta_c_) && (cellsOnLayer.rho[i] < rho_c);
+    bool isOutlier = (cellsOnLayer.delta[i] > outlierDeltaFactor_ * delta_c_) && (cellsOnLayer.rho[i] < rho_c);
     if (isSeed) {
       cellsOnLayer.clusterIndex[i] = nClustersOnLayer;
       cellsOnLayer.isSeed[i] = true;
@@ -532,8 +532,8 @@ void HGCalCLUEAlgo::computeThreshold() {
 void HGCalCLUEAlgo::setDensity(const unsigned int layerId) {
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
-  for (unsigned int i = 0; i< numberOfCells; ++i)
-    density_[cellsOnLayer.detid[i]] = cellsOnLayer.rho[i] ;
+  for (unsigned int i = 0; i < numberOfCells; ++i)
+    density_[cellsOnLayer.detid[i]] = cellsOnLayer.rho[i];
 }
 
 Density HGCalCLUEAlgo::getDensity() { return density_; }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -102,10 +102,7 @@ void HGCalCLUEAlgo::makeClusters() {
     });
   });
   //Now that we have the density per point we can store it
-  for(unsigned int i=0; i< 2 * maxlayer + 2; ++i) {
-    //std::cout << i << std::endl; //}
-    setDensity(i); }
-  //std::cout << "end makeClusters" << std::endl;
+  for(unsigned int i=0; i< 2 * maxlayer + 2; ++i) { setDensity(i); }
 }
 
 std::vector<reco::BasicCluster> HGCalCLUEAlgo::getClusters(bool) {
@@ -481,7 +478,6 @@ int HGCalCLUEAlgo::findAndAssignClusters(const unsigned int layerId, float delta
       localStack.push_back(j);
     }
   }
-  //std::cout << "nClustersOnLayer: " << nClustersOnLayer << std::endl; 
   return nClustersOnLayer;
 }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -274,12 +274,12 @@ void HGCalCLUEAlgo::calculateLocalDensity(const HGCalLayerTiles& lt, const unsig
 	    if(distance(i, otherId, layerId, true) < delta_c_) {
 	      // need to round these numbers to 5 decimals to be able to compare floats
 	      float roundDec=100000.;
-	      float iPhi=round(cellsOnLayer.phi[i]*roundDec)/roundDec.;
+	      float iPhi=round(cellsOnLayer.phi[i]*roundDec)/roundDec;
 	      float otherPhi_=cellsOnLayer.phi[otherId];
 	      otherPhi_ += (otherPhi_*iPhi >= 0 || abs(iPhi) < 1.) ? 0. : iPhi > 0. ? 2*M_PI : -2*M_PI;
-	      float otherPhi = round(otherPhi_*roundDec)/roundDec.;
-	      float otherEta=round(cellsOnLayer.eta[otherId]*roundDec)/roundDec.;
-	      float iEta=round(cellsOnLayer.eta[i]*roundDec)/roundDec.;
+	      float otherPhi = round(otherPhi_*roundDec)/roundDec;
+	      float otherEta=round(cellsOnLayer.eta[otherId]*roundDec)/roundDec;
+	      float iEta=round(cellsOnLayer.eta[i]*roundDec)/roundDec;
 	      LogDebug("HGCalCLUEAlgo") << "  Debugging calculateLocalDensity for Scintillator: \n"
 					<< "    cell: " << otherId
 					<< " energy: "<< cellsOnLayer.weight[otherId]
@@ -393,7 +393,6 @@ void HGCalCLUEAlgo::calculateDistanceToHigher(const HGCalLayerTiles& lt, const u
 	    unsigned int otherId = lt[binId][j];
 	    if (cellsOnLayer.isSilic[otherId]) continue; //cells in the silicon cannot talk to cells in scintillator
 	    float dist = distance(i, otherId, layerId, true);
-	    //bool foundHigher = cellsOnLayer.rho[otherId] > cellsOnLayer.rho[i];
 	    bool foundHigher = (cellsOnLayer.rho[otherId] > cellsOnLayer.rho[i]) || (cellsOnLayer.rho[otherId] == cellsOnLayer.rho[i] && otherId > i);
 
           // if dist == i_delta, then last comer being the nearest higher


### PR DESCRIPTION
#### PR description:

This PR modifies the CLUE algorithm for the scintillator section of the HGCal. It basically changes the distance calculation from x-y space to eta-phi space for the scintillator. This is motivated by the fact that the scintillator cells are uniform in eta-phi rather than x-y. The implementation has been presented in the following HGCal DPG meetings:
 - https://indico.cern.ch/event/827633/contributions/3463809/attachments/1861051/3058641/LC-June-12.pdf 
 - https://indico.cern.ch/event/832849/contributions/3492963/attachments/1878032/3093327/LC-July-10.pdf

@rovere @felicepantaleo 

#### PR validation:

The PR was validated locally and passes:
`scram build code-checks`
`scram b runtests`
`runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR: No. 

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
