### PR TITLE
Fix SLHCUpgradeSimulations/Geometry unit test after geometry scenarios cleaning

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -6,8 +6,8 @@
 import FWCore.ParameterSet.Config as cms
 
 
-from Configuration.Eras.Era_Phase2_cff import Phase2
-process = cms.Process('Phase2PixelNtuple',Phase2)
+from Configuration.Eras.Era_Phase2C8_timing_layer_bar_cff import Phase2C8_timing_layer_bar
+process = cms.Process('Phase2PixelNtuple',Phase2C8_timing_layer_bar)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -16,7 +16,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 #process.load('SimGeneral.MixingModule.mix_POISSON_average_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D21Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Digi_cff')
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
@@ -35,7 +35,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-       '/store/relval/CMSSW_10_0_0_pre1/RelValSingleMuPt10/GEN-SIM/94X_upgrade2023_realistic_v2_2023D21noPU-v2/10000/F2B83850-E6CE-E711-8185-0CC47A78A4B0.root'
+       '/store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root'
     )
 )
 


### PR DESCRIPTION
#### PR description:

The integration of #27449 has removed several obsolete upgrade geometry scenarios, among them D21, and this causes the unit test in SLHCUpgradeSimulations/Geometry to fail. This PR updates the test to the supported scenario D41.

#### PR validation:

```
15:14 cmsdev25 2698> scram b runtests
Reading cached build data
>> Local Products Rules ..... started
>> Local Products Rules ..... done
>> Entering Package SLHCUpgradeSimulations/Geometry
>> Creating project symlinks
>> Leaving Package SLHCUpgradeSimulations/Geometry
>> Package SLHCUpgradeSimulations/Geometry built
Creating test log file logs/slc7_amd64_gcc700/testing.log
Package SLHCUpgradeSimulations/Geometry: Running test testPhase2PixelNtuple
 
===== Test "testPhase2PixelNtuple" ====
argument 0: testPhase2PixelNtuple
argument 1: /bin/bash
argument 2: SLHCUpgradeSimulations/Geometry/test
argument 3: phase2_digi_reco_pixelntuple.sh
shell is: /bin/bash
Current directory is: /build/fabiocos/110X/code-fix/CMSSW_11_0_X_2019-07-11-1100
topdir is: /build/fabiocos/110X/code-fix/CMSSW_11_0_X_2019-07-11-1100
testdir is: /build/fabiocos/110X/code-fix/CMSSW_11_0_X_2019-07-11-1100/src/SLHCUpgradeSimulations/Geometry/test
tmpdir is: /build/fabiocos/110X/code-fix/CMSSW_11_0_X_2019-07-11-1100/tmp/slc7_amd64_gcc700
testbin is: /build/fabiocos/110X/code-fix/CMSSW_11_0_X_2019-07-11-1100/test/slc7_amd64_gcc700
Running script: /build/fabiocos/110X/code-fix/CMSSW_11_0_X_2019-07-11-1100/src/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple.sh
11-Jul-2019 15:14:50 CEST  Initiating request to open file root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root
%MSG-w XrdAdaptorInternal:  file_open 11-Jul-2019 15:14:51 CEST pre-events
Failed to open file at URL root://eoscms.cern.ch:1094//eos/cms/store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root.
%MSG
%MSG-w XrdAdaptorInternal:  file_open 11-Jul-2019 15:14:51 CEST pre-events
Failed to open file at URL root://eoscms.cern.ch:1094//eos/cms/store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root?tried=.
%MSG
11-Jul-2019 15:14:51 CEST  Fallback request to file root://xrootd-cms.infn.it//store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root
[2019-07-11 15:14:56.800621 +0200][Warning][XRootDTransport   ] [[2620:6a:0:8420::a5]:17287 #0.0] Logged in, accepting empty login response.
%MSG-w XrdAdaptor:  file_open 11-Jul-2019 15:14:56 CEST pre-events
Data is served from [2620 instead of original site infn.it
%MSG
11-Jul-2019 15:14:59 CEST  Successfully opened file root://xrootd-cms.infn.it//store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root
Begin processing the 1st record. Run 1, Event 2, LumiSection 1 on stream 0 at 11-Jul-2019 15:16:42.773 CEST
Begin processing the 2nd record. Run 1, Event 8, LumiSection 1 on stream 0 at 11-Jul-2019 15:16:55.987 CEST
Begin processing the 3rd record. Run 1, Event 7, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:03.432 CEST
Begin processing the 4th record. Run 1, Event 10, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:10.379 CEST
Begin processing the 5th record. Run 1, Event 9, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:17.487 CEST
Begin processing the 6th record. Run 1, Event 4, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:24.765 CEST
Begin processing the 7th record. Run 1, Event 11, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:32.851 CEST
Begin processing the 8th record. Run 1, Event 5, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:40.009 CEST
Begin processing the 9th record. Run 1, Event 12, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:47.353 CEST
Begin processing the 10th record. Run 1, Event 16, LumiSection 1 on stream 0 at 11-Jul-2019 15:17:54.330 CEST
11-Jul-2019 15:18:02 CEST  Closed file root://xrootd-cms.infn.it//store/relval/CMSSW_10_6_0_patch2/RelValSingleMuPt10/GEN-SIM/106X_upgrade2023_realistic_v3_2023D41noPU-v1/10000/7377ED92-245C-CC4D-9F05-25ABB5522A08.root

=============================================

MessageLogger Summary

 type     category        sev    module        subroutine        count    total
 ---- -------------------- -- ---------------- ----------------  -----    -----
    1 XrdAdaptor           -w file_open                              1        1
    2 XrdAdaptorInternal   -w file_open                              2        2
    3 fileAction           -s file_close                             1        1
    4 fileAction           -s file_open                              3        3

 type    category    Examples: run/evt        run/evt          run/evt
 ---- -------------------- ---------------- ---------------- ----------------
    1 XrdAdaptor           pre-events                        
    2 XrdAdaptorInternal   pre-events       pre-events       
    3 fileAction           PostGlobalEndRun                  
    4 fileAction           pre-events       pre-events       pre-events

Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
Warning                 3                   3
System                  4                   4

dropped waiting message count 0
status = 0

---> test testPhase2PixelNtuple succeeded
 
^^^^ End Test testPhase2PixelNtuple ^^^^
>> Tests for package SLHCUpgradeSimulations/Geometry ran.
```