### PR TITLE
Account for layer offset when using waferZ in new geometry

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -138,7 +138,7 @@ GlobalPoint RecHitTools::getPosition(const DetId& id) const {
 }
 
 GlobalPoint RecHitTools::getPositionLayer(int layer, bool nose) const {
-  int lay = std::abs(layer);
+  unsigned int lay = std::abs(layer);
   double z(0);
   if (nose) {
     auto geomNose =
@@ -150,6 +150,10 @@ GlobalPoint RecHitTools::getPositionLayer(int layer, bool nose) const {
     }
   } else {
     const HGCalDDDConstants* ddd = get_ddd(geom_, geometryType_, fhOffset_, lay);
+    if (geometryType_ == 1) {
+      if (lay > fhOffset_)
+        lay -= fhOffset_;
+    }
     z = (layer > 0) ? ddd->waferZ(lay, true) : -ddd->waferZ(lay, true);
   }
   return GlobalPoint(0, 0, z);


### PR DESCRIPTION
#### PR description:

There is a bug in `RecHitTools::getPositionLayer(int layer, bool nose)`: when getting the z position of the wafer, one needs to account for the FH (HGCalSi) offset, starting the layer number at 1 instead of continuing to count up beyond EE.

#### PR validation:

Ran in D41 (`geometryType_ == 1`) and instead of getting z = 0 for layers > 28, I actually obtained increasing z values:

```
layer 1: z = 322.103
layer 2: z = 323.047
layer 3: z = 325.073
layer 4: z = 326.017
layer 5: z = 328.043
layer 6: z = 328.987
layer 7: z = 331.013
layer 8: z = 331.957
layer 9: z = 333.983
layer 10: z = 334.927
layer 11: z = 336.953
layer 12: z = 337.897
layer 13: z = 339.923
layer 14: z = 340.867
layer 15: z = 342.893
layer 16: z = 343.837
layer 17: z = 345.863
layer 18: z = 346.807
layer 19: z = 348.833
layer 20: z = 349.777
layer 21: z = 351.803
layer 22: z = 352.747
layer 23: z = 354.773
layer 24: z = 355.717
layer 25: z = 357.743
layer 26: z = 358.687
layer 27: z = 360.713
layer 28: z = 361.657
layer 29: z = 367.699
layer 30: z = 373.149
layer 31: z = 378.599
layer 32: z = 384.049
layer 33: z = 389.499
layer 34: z = 394.949
layer 35: z = 400.399
layer 36: z = 405.849
layer 37: z = 411.299
layer 38: z = 416.749
layer 39: z = 422.199
layer 40: z = 427.649
layer 41: z = 436.199
layer 42: z = 444.749
layer 43: z = 453.299
layer 44: z = 461.849
layer 45: z = 470.399
layer 46: z = 478.949
layer 47: z = 487.499
layer 48: z = 496.049
layer 49: z = 504.599
layer 50: z = 513.149
```

FYI @bsunanda 