### PR TITLE
Fix energy fractions after jet resolution smearing [106X backport]

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -159,6 +159,9 @@ namespace pat {
       /// p4 of the jet corrected up to the given level for the set
       /// of jet energy correction factors, which is currently in use
       const LorentzVector correctedP4(const unsigned int& level, const JetCorrFactors::Flavor& flavor=JetCorrFactors::NONE, const unsigned int& set=0) const { return correctedJet(level, flavor, set).p4(); };
+      /// Scale energy and correspondingly adjust raw jec factors
+      void scaleEnergy(double fScale) override { scaleEnergy(fScale, "Unscaled"); }
+      void scaleEnergy(double fScale, const std::string& level);
 
   private:
       /// index of the set of jec factors with given label; returns -1 if no set

--- a/DataFormats/PatCandidates/interface/JetCorrFactors.h
+++ b/DataFormats/PatCandidates/interface/JetCorrFactors.h
@@ -53,6 +53,8 @@ namespace pat {
     JetCorrFactors() {};
     // constructor by value
     JetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec);
+    // add correction factor
+    void insertFactor(const unsigned int& position, const CorrectionFactor& factor);
 
     // instance label of the jet energy corrections set 
     std::string jecSet() const { return label_; }
@@ -86,7 +88,7 @@ namespace pat {
     // check consistency of input vector
     bool flavorIndependent(const CorrectionFactor& jec) const { return (jec.second.size()==1); }
     // check consistency of input vector
-    bool isValid(const CorrectionFactor& jec) const { return (flavorDependent(jec) || flavorIndependent(jec)); }    
+    bool isValid(const CorrectionFactor& jec) const { return (flavorDependent(jec) || flavorIndependent(jec)); }     void invalidFactor() const;   
     
   private:
     // instance label of jet energy correction factors

--- a/DataFormats/PatCandidates/interface/JetCorrFactors.h
+++ b/DataFormats/PatCandidates/interface/JetCorrFactors.h
@@ -88,7 +88,8 @@ namespace pat {
     // check consistency of input vector
     bool flavorIndependent(const CorrectionFactor& jec) const { return (jec.second.size()==1); }
     // check consistency of input vector
-    bool isValid(const CorrectionFactor& jec) const { return (flavorDependent(jec) || flavorIndependent(jec)); }     void invalidFactor() const;   
+    bool isValid(const CorrectionFactor& jec) const { return (flavorDependent(jec) || flavorIndependent(jec)); }
+    void invalidFactor() const;
     
   private:
     // instance label of jet energy correction factors

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -272,6 +272,15 @@ const reco::JetFlavourInfo & Jet::jetFlavourInfo() const {
 
 /// ============= Jet Energy Correction methods ============
 
+/// Scale energy and correspondingly add jec factor
+void Jet::scaleEnergy(double fScale, const std::string& level) {
+  if (jecSetsAvailable()) {
+    std::vector<float> factors = {float(jec_[0].correction(0, JetCorrFactors::NONE) / fScale)};
+    jec_[0].insertFactor(0, std::make_pair(level, factors));
+  }
+  setP4(p4() * fScale);
+}
+
 // initialize the jet to a given JEC level during creation starting from Uncorrected
 void Jet::initializeJEC(unsigned int level, const JetCorrFactors::Flavor& flavor, unsigned int set)
 {

--- a/DataFormats/PatCandidates/src/JetCorrFactors.cc
+++ b/DataFormats/PatCandidates/src/JetCorrFactors.cc
@@ -14,28 +14,15 @@ using namespace pat;
 JetCorrFactors::JetCorrFactors(const std::string& label, const std::vector<CorrectionFactor>& jec): label_(label), jec_(jec)
 {
   for(std::vector<CorrectionFactor>::const_iterator corrFactor=jec.begin(); corrFactor!=jec.end(); ++corrFactor){
-    if(!isValid(*corrFactor)){
-      throw cms::Exception("InvalidRequest") << "You try to create a CorrectionFactor which is neither flavor dependent nor \n"
-					     << "flavor independent. The CorrectionFactor should obey the following rules:  \n"
-					     << "\n"
-					     << " * CorrectionFactor is a std::pair<std::string, std::vector<float> >.      \n"
-					     << " * The std::string holds the label of the correction level (following the  \n"
-					     << "   conventions of JetMET.                                                  \n"
-					     << " * The std::vector<float> holds the correction factors, these factors are  \n"
-					     << "   up to the given level. They include all previous correction steps.      \n"
-					     << " * The vector has the length *1* for flavor independent correction factors \n"
-					     << "   or *5* for flavor dependent correction factors.                         \n"
-					     << " * The expected order of flavor dependent correction factors is: NONE,     \n"
-					     << "   GLUON, UDS, CHARM, BOTTOM. If follows the JetMET conventions and is     \n"
-					     << "   in the Flavor enumerator of the JetCorrFactos class.                    \n"
-					     << " * For flavor depdendent correction factors the first entry in the vector  \n"
-					     << "   (corresponding to NONE) is invalid and should be set to -1. It will not \n"
-					     << "   be considered by the class structure though.                            \n"
-					     << "\n"
-					     << "Make sure that all elements of the argument vector to this contructor are  \n"
-					     << "in accordance with these rules.\n";
-    }
+    if (!isValid(*corrFactor))
+      invalidFactor();
   }
+}
+
+void JetCorrFactors::insertFactor(const unsigned int& position, const CorrectionFactor& corrFactor) {
+  if (!isValid(corrFactor))
+    invalidFactor();
+  jec_.insert(jec_.begin() + position, corrFactor);
 }
 
 std::string 
@@ -124,4 +111,27 @@ JetCorrFactors::print() const
     }
     message << "\n";
   }
+}
+
+void JetCorrFactors::invalidFactor() const {
+  throw cms::Exception("InvalidRequest")
+      << "You try to create a CorrectionFactor which is neither flavor dependent nor \n"
+      << "flavor independent. The CorrectionFactor should obey the following rules:  \n"
+      << "\n"
+      << " * CorrectionFactor is a std::pair<std::string, std::vector<float> >.      \n"
+      << " * The std::string holds the label of the correction level (following the  \n"
+      << "   conventions of JetMET.						      \n"
+      << " * The std::vector<float> holds the correction factors, these factors are  \n"
+      << "   up to the given level. They include all previous correction steps.      \n"
+      << " * The vector has the length *1* for flavor independent correction factors \n"
+      << "   or *5* for flavor dependent correction factors.			      \n"
+      << " * The expected order of flavor dependent correction factors is: NONE,     \n"
+      << "   GLUON, UDS, CHARM, BOTTOM. If follows the JetMET conventions and is     \n"
+      << "   in the Flavor enumerator of the JetCorrFactos class.		      \n"
+      << " * For flavor depdendent correction factors the first entry in the vector  \n"
+      << "   (corresponding to NONE) is invalid and should be set to -1. It will not \n"
+      << "   be considered by the class structure though.			      \n"
+      << "\n"
+      << "Make sure that all elements of the argument vector to this contructor are  \n"
+      << "in accordance with these rules.\n";
 }


### PR DESCRIPTION
Backport of #27428

PR description:

As currently implemented, jet resolution smearing breaks the jet energy fraction variables of pat::Jets.
This line of code changes the four-vector of a pat::Jet, but not the correction factors stored in the pat::Jet:
https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L267
Jet energy fraction calculation relies on the fact that one can retried the raw jet energy with the stored correction factors:
https://github.com/cms-sw/cmssw/blob/master/DataFormats/PatCandidates/interface/Jet.h#L376

This fix to the scaleEnergy method adjusts the stored correction factors, to be able to retrieve the raw jet energy again.

Jet resolution smearing is run during MiniAOD production and also in this test:
https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatAlgos/test/corMETFromMiniAOD.py

Small changes are expected in MET corrections and uncertainties related to jet resolution smearing in MiniAOD.
PR validation:

It was checked that jet energy fractions are the same before and after jet energy resolution smearing with this fix.