### PR TITLE
[RFC]  Phase-2 InnerTracker conditions from DB (version 1)

### DIFF
--- a/Configuration/Geometry/python/GeometryExtended2023D45_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023D45_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2023D45XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkT14_cff import *
+from SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkT15_cff import *
 from Geometry.HcalCommonData.hcalParameters_cfi      import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cfi import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -68,7 +68,7 @@ run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True
 # FIXME::Is the Upgrade variable actually used?
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(PixelCPEGenericESProducer, 
-  useLAWidthFromDB = False,
+  #useLAWidthFromDB = False,
   UseErrorsFromTemplates = False,
   LoadTemplatesFromDB = False,
   TruncatePixelCharge = False,

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -68,7 +68,6 @@ run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True
 # FIXME::Is the Upgrade variable actually used?
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(PixelCPEGenericESProducer, 
-  #useLAWidthFromDB = False,
   UseErrorsFromTemplates = False,
   LoadTemplatesFromDB = False,
   TruncatePixelCharge = False,

--- a/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
+++ b/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
@@ -20,7 +20,7 @@ loadPhase2InneTrackerConditions = cms.ESSource( "PoolDBESSource",
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 class DBConfiguration():
     '''Helper class to store the configuration object DB'''
-    def __init__(self,vGeometry=None,vLA=None,vLAwidth=None,vSimLA=None,vGenError=None,vTemplate1D=None,vTemplate2Dnum=None,vTemplate2Dden=None):
+    def __init__(self,vGeometry=None, vLA=None, vLAwidth=None, vSimLA=None, vGenError=None, vTemplate1D=None, vTemplate2Dnum=None, vTemplate2Dden=None):
         self._vGeometry      = vGeometry
         self._vLA            = vLA 
         self._vLAwidth       = vLAwidth
@@ -29,50 +29,31 @@ class DBConfiguration():
         self._vTemplate1D    = vTemplate1D 
         self._vTemplate2Dnum = vTemplate2Dnum 
         self._vTemplate2Dden = vTemplate2Dden 
+        self._records = {}
 
-    def retAssociations(self):
+    # define the (record,label) :tag matrix
+    def customizeRecords(self):
+        if self.vLA            is not None: self._records.update({"SiPixelLorentzAngleRcd:"                  : "SiPixelLorentzAngle_phase2_T%s_v%s_mc"          % (self.vGeometry,self.vLA)})
+        if self.vSimLA         is not None: self._records.update({"SiPixelLorentzAngleSimRcd:"               : "SiPixelSimLorentzAngle_phase2_T%s_v%s_mc"       % (self.vGeometry,self.vSimLA)})
+        if self.vLAwidth       is not None: self._records.update({"SiPixelLorentzAngleRcd:forWidth"          : "SiPixelLorentzAngle_phase2_forWidth_T%s_v%s_mc" % (self.vGeometry,self.vLAwidth)})
+        if self.vGenError      is not None: self._records.update({"SiPixelGenErrorDBObjectRcd:"              : "SiPixelGenErrorDBObject_phase2_T%s_v%s_mc"      % (self.vGeometry,self.vGenError)})
+        if self.vTemplate1D    is not None: self._records.update({"SiPixelTemplateDBObjectRcd:"              : "SiPixelTemplateDBObject_phase2_T%s_v%s_mc"      % (self.vGeometry,self.vTemplate1D)})
+        if self.vTemplate2Dden is not None: self._records.update({"SiPixel2DTemplateDBObjectRcd:denominator" : "SiPixel2DTemplateDBObject_phase2_T%s_v%s_den"   % (self.vGeometry,self.vTemplate2Dden)})
+        if self.vTemplate2Dnum is not None: self._records.update({"SiPixel2DTemplateDBObjectRcd:numerator"   : "SiPixel2DTemplateDBObject_phase2_T%s_v%s_num"   % (self.vGeometry,self.vTemplate2Dnum)})
 
-        records = {
-            "SiPixelLorentzAngleSimRcd:"               : "SiPixelSimLorentzAngle_phase2_T%s_v%s_mc"       % (self.vGeometry,self.vSimLA),
-            "SiPixelLorentzAngleRcd:forWidth"          : "SiPixelLorentzAngle_phase2_forWidth_T%s_v%s_mc" % (self.vGeometry,self.vLAwidth),
-            "SiPixelLorentzAngleRcd:"                  : "SiPixelLorentzAngle_phase2_T%s_v%s_mc"          % (self.vGeometry,self.vLA),
-            #########################################
-            # Not yet implemented
-            #########################################
-            #"SiPixelGenErrorDBObjectRcd:"              : "SiPixelGenErrorDBObject_phase2_T%s_v%s_mc"      % (self.vGeometry,self.vGenError),
-            #"SiPixelTemplateDBObjectRcd:"              : "SiPixelTemplateDBObject_phase2_T%s_v%s_mc"      % (self.vGeometry,self.vTemplate1D),
-            #"SiPixel2DTemplateDBObjectRcd:denominator" : "SiPixel2DTemplateDBObject_phase2_T%s_v%s_den"   % (self.vGeometry,self.vTemplate2Dden),
-            #"SiPixel2DTemplateDBObjectRcd:numerator"   : "SiPixel2DTemplateDBObject_phase2_T%s_v%s_num"   % (self.vGeometry,self.vTemplate2Dnum)
-        }
-        
-        return records
+        if(not self._records):
+            raise RuntimeError("No customization possible, not specified any custom record!")
 
-    ###################################
+        return self._records
+
     # Print version used
-    ###################################
     def printConfig(self):
-    
-        associations = dict(
-            vGeometry      = None,
-            vLA            = 'SiPixelLorentzAngleRcd',
-            vLAwidth       = 'SiPixelLorentzAngleRcd (forWidth)',
-            vSimLA         = 'SiPixelLorentzAngleSimRcd', 
-            vGenError      = 'SiPixelGenErrorDBObjectRcd',  
-            vTemplate1D    = 'SiPixelTemplatedDBOjectRcd',
-            vTemplate2Dnum = 'SiPixel2DTemplateDBObjectRcd (numerator)',
-            vTemplate2Dden = 'SiPixel2DTemplateDBObjectRcd (denominator)',
-        )    
-
-        attrs = self.__dict__
         print(" ===>>> Customization of Inner Tracker conditions for geometry T%s" % self.vGeometry)
-        for key,value in attrs.items():
-            if value is not None:
-                if associations[key] is not None:
-                    print (" Customizing %s with Tag version n. %s" % (associations[key],value))
+        for key,value in self._records.iteritems():
+            rcd, label = tuple(key.split(':'))
+            print (" Customizing %s (%s) with tag: %s " % (rcd,label,value))
             
-    ###################################
     # Geometry version
-    ###################################
     @property
     def vGeometry(self):
         """version of the Tracker Geometry."""
@@ -81,9 +62,7 @@ class DBConfiguration():
     def vGeometry(self, value):
         self._vGeometry = value       
 
-    ###################################
     # LorentzAngle version
-    ###################################
     @property
     def vLA(self):
         """version of the Lorentz Angle payload."""
@@ -92,9 +71,7 @@ class DBConfiguration():
     def vLA(self, value):
         self._vLA = value  
 
-    ###################################
-    # LorentzAngle width version
-    ###################################
+    # LorentzAngle forWidth version
     @property
     def vLAwidth(self):
         """version of the Lorentz Angle width payload."""
@@ -103,9 +80,7 @@ class DBConfiguration():
     def vLAwidth(self, value):
         self._vLAwidth = value  
     
-    ###################################
-    # Sim LA version
-    ###################################
+    # Sim Lorentz Angle version
     @property
     def vSimLA(self):
         """version of the Simulation Lorentz Angle payload."""
@@ -114,9 +89,7 @@ class DBConfiguration():
     def vSimLA(self, value):
         self._vSimLA = value  
 
-    ###################################
     # Generic Errors version
-    ###################################
     @property
     def vGenError(self):
         """version of the Generic Error payload."""
@@ -125,9 +98,7 @@ class DBConfiguration():
     def vGenError(self, value):
         self._vGenError = value  
 
-    ###################################
     # 1D Template version
-    ###################################
     @property
     def vTemplate1D(self):
         """version of the Template 1D payload."""
@@ -136,9 +107,7 @@ class DBConfiguration():
     def vTemplate1D(self, value):
         self._vTemplate1D = value  
 
-    ###################################
     # 2D template (numerator) version
-    ###################################
     @property
     def vTemplate2Dnum(self):
         """version of the Template 2D (numerator) payload."""
@@ -147,9 +116,7 @@ class DBConfiguration():
     def vTemplate2Dnum(self, value):
         self._vTemplate2Dnum = value  
 
-    ###################################
     # 2D template (denominator) version
-    ###################################
     @property
     def vTemplate2Dden(self):
         """version of the Template 2D (denominator) payload."""
@@ -165,8 +132,11 @@ def appendConditions(DBConfig):
     if not hasattr(loadPhase2InneTrackerConditions ,'toGet'):
         loadPhase2InneTrackerConditions.toGet=cms.VPSet()
     
+    recordMap = DBConfig.customizeRecords()
+    DBConfig.printConfig()
+
     toExtend=[]
-    for record,tag in DBConfig.retAssociations().iteritems():
+    for record,tag in recordMap.iteritems():
         rcd, label = tuple(record.split(':'))
         toExtend.append(
             cms.PSet(
@@ -175,6 +145,5 @@ def appendConditions(DBConfig):
                 label = cms.untracked.string(label)
                 )
         )
-        
     ### extend the list of Records to be changed
     loadPhase2InneTrackerConditions.toGet.extend(cms.VPSet(*toExtend))

--- a/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
+++ b/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
@@ -18,17 +18,37 @@ loadPhase2InneTrackerConditions = cms.ESSource( "PoolDBESSource",
                                               )
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 class DBConfiguration():
     '''Helper class to store the  configuration object DB'''
-    def __init__(self,vGeometry=None,vLA=None,vLAwidth=None,vSimLA=None,vGenError=None,vTemplate1D=None,vTemplate2Dn=None,vTemplate2Dd=None):
-        self._vGeometry    = vGeometry
-        self._vLA          = vLA 
-        self._vLAwidth     = vLAwidth
-        self._vSimLA       = vSimLA
-        self._vGenError    = vGenError
-        self._vTemplate1D  = vTemplate1D 
-        self._vTemplate2Dn = vTemplate2Dn 
-        self._vTemplate2Dd = vTemplate2Dd 
+    def __init__(self,vGeometry=None,vLA=None,vLAwidth=None,vSimLA=None,vGenError=None,vTemplate1D=None,vTemplate2Dnum=None,vTemplate2Dden=None):
+        self._vGeometry      = vGeometry
+        self._vLA            = vLA 
+        self._vLAwidth       = vLAwidth
+        self._vSimLA         = vSimLA
+        self._vGenError      = vGenError
+        self._vTemplate1D    = vTemplate1D 
+        self._vTemplate2Dnum = vTemplate2Dnum 
+        self._vTemplate2Dden = vTemplate2Dden 
+
+    def retAssociations(self):
+
+        records = {
+            "SiPixelLorentzAngleSimRcd:"               : "SiPixelSimLorentzAngle_phase2_T%s_v%s_mc"       % (self.vGeometry,self.vSimLA),
+            "SiPixelLorentzAngleRcd:forWidth"          : "SiPixelLorentzAngle_phase2_forWidth_T%s_v%s_mc" % (self.vGeometry,self.vLAwidth),
+            "SiPixelLorentzAngleRcd:"                  : "SiPixelLorentzAngle_phase2_T%s_v%s_mc"          % (self.vGeometry,self.vLA),
+            #########################################
+            # Not yet implemented
+            #########################################
+            #"SiPixelGenErrorDBObjectRcd:"              : "SiPixelGenErrorDBObject_phase2_T%s_v%s_mc"      % (self.vGeometry,self.vGenError),
+            #"SiPixelTemplateDBObjectRcd:"              : "SiPixelTemplateDBObject_phase2_T%s_v%s_mc"      % (self.vGeometry,self.vTemplate1D),
+            #"SiPixel2DTemplateDBObjectRcd:denominator" : "SiPixel2DTemplateDBObject_phase2_T%s_v%s_den"   % (self.vGeometry,self.vTemplate2Dden),
+            #"SiPixel2DTemplateDBObjectRcd:numerator"   : "SiPixel2DTemplateDBObject_phase2_T%s_v%s_num"   % (self.vGeometry,self.vTemplate2Dnum)
+        }
+        
+        return records
 
     ###################################
     # Print version used
@@ -36,14 +56,14 @@ class DBConfiguration():
     def printConfig(self):
     
         associations = dict(
-            vGeometry    = None,
-            vLA          = 'SiPixelLorentzAngleRcd',
-            vLAwidth     = 'SiPixelLorentzAngleRcd (forWidth)',
-            vSimLA       = 'SiPixelLorentzAngleSimRcd', 
-            vGenError    = 'SiPixelGenErrorDBObjectRcd',  
-            vTemplate1D  = 'SiPixelTemplatedDBOjectRcd',
-            vTemplate2Dn = 'SiPixel2DTemplateDBObjectRcd (numerator)',
-            vTemplate2Dd = 'SiPixel2DTemplateDBObjectRcd (denominator)',
+            vGeometry      = None,
+            vLA            = 'SiPixelLorentzAngleRcd',
+            vLAwidth       = 'SiPixelLorentzAngleRcd (forWidth)',
+            vSimLA         = 'SiPixelLorentzAngleSimRcd', 
+            vGenError      = 'SiPixelGenErrorDBObjectRcd',  
+            vTemplate1D    = 'SiPixelTemplatedDBOjectRcd',
+            vTemplate2Dnum = 'SiPixel2DTemplateDBObjectRcd (numerator)',
+            vTemplate2Dden = 'SiPixel2DTemplateDBObjectRcd (denominator)',
         )    
 
         attrs = self.__dict__
@@ -56,7 +76,6 @@ class DBConfiguration():
     ###################################
     # Geometry version
     ###################################
-
     @property
     def vGeometry(self):
         """version of the Tracker Geometry."""
@@ -69,7 +88,6 @@ class DBConfiguration():
     ###################################
     # LorentzAngle version
     ###################################
-
     @property
     def vLA(self):
         """version of the Lorentz Angle payload."""
@@ -82,7 +100,6 @@ class DBConfiguration():
     ###################################
     # LorentzAngle width version
     ###################################
-
     @property
     def vLAwidth(self):
         """version of the Lorentz Angle width payload."""
@@ -95,7 +112,6 @@ class DBConfiguration():
     ###################################
     # Sim LA version
     ###################################
-
     @property
     def vSimLA(self):
         """version of the Simulation Lorentz Angle payload."""
@@ -108,7 +124,6 @@ class DBConfiguration():
     ###################################
     # Generic Errors version
     ###################################
-
     @property
     def vGenError(self):
         """version of the Generic Error payload."""
@@ -121,7 +136,6 @@ class DBConfiguration():
     ###################################
     # 1D Template version
     ###################################
-
     @property
     def vTemplate1D(self):
         """version of the Template 1D payload."""
@@ -134,29 +148,27 @@ class DBConfiguration():
     ###################################
     # 2D template (numerator) version
     ###################################
-
     @property
-    def vTemplate2Dn(self):
+    def vTemplate2Dnum(self):
         """version of the Template 2D (numerator) payload."""
-        return self._vTemplate2Dn
+        return self._vTemplate2Dnum
 
-    @vTemplate2Dn.setter
-    def vTemplate2Dn(self, value):
-        self._vTemplate2Dn = value  
+    @vTemplate2Dnum.setter
+    def vTemplate2Dnum(self, value):
+        self._vTemplate2Dnum = value  
 
     ###################################
     # 2D template (denominator) version
     ###################################
-
     @property
-    def vTemplate2Dd(self):
+    def vTemplate2Dden(self):
         """version of the Template 2D (denominator) payload."""
-        return self._vTemplate2Dd
+        return self._vTemplate2Dden
 
-    @vTemplate2Dd.setter
-    def vTemplate2Dd(self, value):
-        print("setter of vTemplate2Dd called")
-        self._vTemplate2Dd = value  
+    @vTemplate2Dden.setter
+    def vTemplate2Dden(self, value):
+        print("setter of vTemplate2Dden called")
+        self._vTemplate2Dden = value  
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 def appendConditions(DBConfig):
@@ -165,35 +177,21 @@ def appendConditions(DBConfig):
     if not hasattr(loadPhase2InneTrackerConditions ,'toGet'):
         loadPhase2InneTrackerConditions.toGet=cms.VPSet()
     
-    loadPhase2InneTrackerConditions.toGet.extend(cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                    tag = cms.string("SiPixelLorentzAngle_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vLA))
-                                                                   ),
-                                                           cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                    tag = cms.string("SiPixelSimLorentzAngle_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vSimLA))
-                                                                   ),                                            
-                                                           cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                    tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vLAwidth)),
-                                                                    label = cms.untracked.string("forWidth")
-                                                                   ),
-                                                           #
-                                                           # NOT YET IMPLEMENTED, BUT SOON TO BE INTRODUCED
-                                                           #
-                                                           # cms.PSet(record = cms.string('SiPixelGenErrorDBObjectRcd'),
-                                                           #          tag = cms.string("SiPixelGenErrorDBObject_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vGenError))
-                                                           #         ),
-                                                           # cms.PSet(record = cms.string('SiPixelTemplateDBObjectRcd'),
-                                                           #          tag = cms.string("SiPixelTemplateDBObject_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vTemplate1D))
-                                                           #         ),
-                                                           # cms.PSet(record = cms.string('SiPixel2DTemplateDBObjectRcd'),
-                                                           #          tag = cms.string("SiPixel2DTemplateDBObject_phase2_T%s_v%s_den" % (DBConfig.vGeometry,DBConfig.vTemplate2Dd) ),
-                                                           #          label = cms.untracked.string("denominator")
-                                                           #         ),                                            
-                                                           # cms.PSet(record = cms.string('SiPixel2DTemplateDBObjectRcd'),
-                                                           #          tag = cms.string("SiPixel2DTemplateDBObject_phase2_T%s_v%s_num" % (DBConfig.vGeometry,DBConfig.vTemplate2Dn) ),
-                                                           #          label = cms.untracked.string("numerator")
-                                                           #         )
-                                                           )
-                                                 )
-                                                 
+    toExtend=[]
+    for record,tag in DBConfig.retAssociations().iteritems():
+        rcd, label = tuple(record.split(':'))
+        toExtend.append(
+            cms.PSet(
+                record = cms.string(rcd),
+                tag    = cms.string(tag),
+                label = cms.untracked.string(label)
+                )
+        )
+    
+
+    print toExtend
+    loadPhase2InneTrackerConditions.toGet.extend(cms.VPSet(*toExtend))
+
+    
                                                  
     

--- a/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
+++ b/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
@@ -2,7 +2,7 @@ import socket
 from CondCore.CondDB.CondDB_cfi import *
 '''Helper procedure that loads phase-2 Inner Trackers Conditions from database'''
 
-CondDBPhase2ITConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierPrep/CMS_CONDITIONS' ) )
+CondDBPhase2ITConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ) )
 loadPhase2InneTrackerConditions = cms.ESSource( "PoolDBESSource",
                                                 CondDBPhase2ITConnection,
                                                 globaltag        = cms.string( '' ),
@@ -18,7 +18,7 @@ loadPhase2InneTrackerConditions = cms.ESSource( "PoolDBESSource",
                                               )
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-class DBConfiguration():
+class SiPhase2DBConfiguration():
     '''Helper class to store the configuration object DB'''
     def __init__(self,vGeometry=None, vLA=None, vLAwidth=None, vSimLA=None, vGenError=None, vTemplate1D=None, vTemplate2Dnum=None, vTemplate2Dden=None):
         self._vGeometry      = vGeometry
@@ -51,7 +51,7 @@ class DBConfiguration():
         print(" ===>>> Customization of Inner Tracker conditions for geometry T%s" % self.vGeometry)
         for key,value in self._records.iteritems():
             rcd, label = tuple(key.split(':'))
-            print (" Customizing %s (%s) with tag: %s " % (rcd,label,value))
+            print (" Customizing tag: %45s for record: %30s" % (value,rcd) + (" (%s)."%label if label is not None else ".") )
             
     # Geometry version
     @property

--- a/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
+++ b/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
@@ -1,0 +1,199 @@
+import socket
+from CondCore.CondDB.CondDB_cfi import *
+'''Helper procedure that loads phase-2 Inner Trackers Conditions from database'''
+
+CondDBPhase2ITConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierPrep/CMS_CONDITIONS' ) )
+loadPhase2InneTrackerConditions = cms.ESSource( "PoolDBESSource",
+                                                CondDBPhase2ITConnection,
+                                                globaltag        = cms.string( '' ),
+                                                snapshotTime     = cms.string( '' ),
+                                                toGet            = cms.VPSet(),   # hook to override or add single payloads
+                                                DumpStat         = cms.untracked.bool( False ),
+                                                ReconnectEachRun = cms.untracked.bool( False ),
+                                                RefreshAlways    = cms.untracked.bool( False ),
+                                                RefreshEachRun   = cms.untracked.bool( False ),
+                                                RefreshOpenIOVs  = cms.untracked.bool( False ),
+                                                pfnPostfix       = cms.untracked.string( '' ),
+                                                pfnPrefix        = cms.untracked.string( '' ),
+                                              )
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+class DBConfiguration():
+    '''Helper class to store the  configuration object DB'''
+    def __init__(self,vGeometry=None,vLA=None,vLAwidth=None,vSimLA=None,vGenError=None,vTemplate1D=None,vTemplate2Dn=None,vTemplate2Dd=None):
+        self._vGeometry    = vGeometry
+        self._vLA          = vLA 
+        self._vLAwidth     = vLAwidth
+        self._vSimLA       = vSimLA
+        self._vGenError    = vGenError
+        self._vTemplate1D  = vTemplate1D 
+        self._vTemplate2Dn = vTemplate2Dn 
+        self._vTemplate2Dd = vTemplate2Dd 
+
+    ###################################
+    # Print version used
+    ###################################
+    def printConfig(self):
+    
+        associations = dict(
+            vGeometry    = None,
+            vLA          = 'SiPixelLorentzAngleRcd',
+            vLAwidth     = 'SiPixelLorentzAngleRcd (forWidth)',
+            vSimLA       = 'SiPixelLorentzAngleSimRcd', 
+            vGenError    = 'SiPixelGenErrorDBObjectRcd',  
+            vTemplate1D  = 'SiPixelTemplatedDBOjectRcd',
+            vTemplate2Dn = 'SiPixel2DTemplateDBObjectRcd (numerator)',
+            vTemplate2Dd = 'SiPixel2DTemplateDBObjectRcd (denominator)',
+        )    
+
+        attrs = self.__dict__
+        print(" ===>>> Customization of Inner Tracker conditions for geometry T%s" % self.vGeometry)
+        for key,value in attrs.items():
+            if value is not None:
+                if associations[key] is not None:
+                    print (" Customizing %s with Tag version n. %s" % (associations[key],value))
+            
+    ###################################
+    # Geometry version
+    ###################################
+
+    @property
+    def vGeometry(self):
+        """version of the Tracker Geometry."""
+        return self._vGeometry
+
+    @vGeometry.setter
+    def vGeometry(self, value):
+        self._vGeometry = value       
+
+    ###################################
+    # LorentzAngle version
+    ###################################
+
+    @property
+    def vLA(self):
+        """version of the Lorentz Angle payload."""
+        return self._vLA
+
+    @vLA.setter
+    def vLA(self, value):
+        self._vLA = value  
+
+    ###################################
+    # LorentzAngle width version
+    ###################################
+
+    @property
+    def vLAwidth(self):
+        """version of the Lorentz Angle width payload."""
+        return self._vLAwidth
+
+    @vLAwidth.setter
+    def vLAwidth(self, value):
+        self._vLAwidth = value  
+    
+    ###################################
+    # Sim LA version
+    ###################################
+
+    @property
+    def vSimLA(self):
+        """version of the Simulation Lorentz Angle payload."""
+        return self._vSimLA
+
+    @vSimLA.setter
+    def vSimLA(self, value):
+        self._vSimLA = value  
+
+    ###################################
+    # Generic Errors version
+    ###################################
+
+    @property
+    def vGenError(self):
+        """version of the Generic Error payload."""
+        return self._vGenError
+
+    @vGenError.setter
+    def vGenError(self, value):
+        self._vGenError = value  
+
+    ###################################
+    # 1D Template version
+    ###################################
+
+    @property
+    def vTemplate1D(self):
+        """version of the Template 1D payload."""
+        return self._vTemplate1D
+
+    @vTemplate1D.setter
+    def vTemplate1D(self, value):
+        self._vTemplate1D = value  
+
+    ###################################
+    # 2D template (numerator) version
+    ###################################
+
+    @property
+    def vTemplate2Dn(self):
+        """version of the Template 2D (numerator) payload."""
+        return self._vTemplate2Dn
+
+    @vTemplate2Dn.setter
+    def vTemplate2Dn(self, value):
+        self._vTemplate2Dn = value  
+
+    ###################################
+    # 2D template (denominator) version
+    ###################################
+
+    @property
+    def vTemplate2Dd(self):
+        """version of the Template 2D (denominator) payload."""
+        return self._vTemplate2Dd
+
+    @vTemplate2Dd.setter
+    def vTemplate2Dd(self, value):
+        print("setter of vTemplate2Dd called")
+        self._vTemplate2Dd = value  
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+def appendConditions(DBConfig):
+    '''function to load all the addtional Inner Tracker payload (geometry dependent)'''
+
+    if not hasattr(loadPhase2InneTrackerConditions ,'toGet'):
+        loadPhase2InneTrackerConditions.toGet=cms.VPSet()
+    
+    loadPhase2InneTrackerConditions.toGet.extend(cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
+                                                                    tag = cms.string("SiPixelLorentzAngle_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vLA))
+                                                                   ),
+                                                           cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
+                                                                    tag = cms.string("SiPixelSimLorentzAngle_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vSimLA))
+                                                                   ),                                            
+                                                           cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
+                                                                    tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vLAwidth)),
+                                                                    label = cms.untracked.string("forWidth")
+                                                                   ),
+                                                           #
+                                                           # NOT YET IMPLEMENTED, BUT SOON TO BE INTRODUCED
+                                                           #
+                                                           # cms.PSet(record = cms.string('SiPixelGenErrorDBObjectRcd'),
+                                                           #          tag = cms.string("SiPixelGenErrorDBObject_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vGenError))
+                                                           #         ),
+                                                           # cms.PSet(record = cms.string('SiPixelTemplateDBObjectRcd'),
+                                                           #          tag = cms.string("SiPixelTemplateDBObject_phase2_T%s_v%s_mc" % (DBConfig.vGeometry,DBConfig.vTemplate1D))
+                                                           #         ),
+                                                           # cms.PSet(record = cms.string('SiPixel2DTemplateDBObjectRcd'),
+                                                           #          tag = cms.string("SiPixel2DTemplateDBObject_phase2_T%s_v%s_den" % (DBConfig.vGeometry,DBConfig.vTemplate2Dd) ),
+                                                           #          label = cms.untracked.string("denominator")
+                                                           #         ),                                            
+                                                           # cms.PSet(record = cms.string('SiPixel2DTemplateDBObjectRcd'),
+                                                           #          tag = cms.string("SiPixel2DTemplateDBObject_phase2_T%s_v%s_num" % (DBConfig.vGeometry,DBConfig.vTemplate2Dn) ),
+                                                           #          label = cms.untracked.string("numerator")
+                                                           #         )
+                                                           )
+                                                 )
+                                                 
+                                                 
+    

--- a/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
+++ b/SLHCUpgradeSimulations/Configuration/python/loadInnerTrackerConditionFromDB.py
@@ -18,11 +18,8 @@ loadPhase2InneTrackerConditions = cms.ESSource( "PoolDBESSource",
                                               )
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 class DBConfiguration():
-    '''Helper class to store the  configuration object DB'''
+    '''Helper class to store the configuration object DB'''
     def __init__(self,vGeometry=None,vLA=None,vLAwidth=None,vSimLA=None,vGenError=None,vTemplate1D=None,vTemplate2Dnum=None,vTemplate2Dden=None):
         self._vGeometry      = vGeometry
         self._vLA            = vLA 
@@ -80,7 +77,6 @@ class DBConfiguration():
     def vGeometry(self):
         """version of the Tracker Geometry."""
         return self._vGeometry
-
     @vGeometry.setter
     def vGeometry(self, value):
         self._vGeometry = value       
@@ -92,7 +88,6 @@ class DBConfiguration():
     def vLA(self):
         """version of the Lorentz Angle payload."""
         return self._vLA
-
     @vLA.setter
     def vLA(self, value):
         self._vLA = value  
@@ -104,7 +99,6 @@ class DBConfiguration():
     def vLAwidth(self):
         """version of the Lorentz Angle width payload."""
         return self._vLAwidth
-
     @vLAwidth.setter
     def vLAwidth(self, value):
         self._vLAwidth = value  
@@ -116,7 +110,6 @@ class DBConfiguration():
     def vSimLA(self):
         """version of the Simulation Lorentz Angle payload."""
         return self._vSimLA
-
     @vSimLA.setter
     def vSimLA(self, value):
         self._vSimLA = value  
@@ -128,7 +121,6 @@ class DBConfiguration():
     def vGenError(self):
         """version of the Generic Error payload."""
         return self._vGenError
-
     @vGenError.setter
     def vGenError(self, value):
         self._vGenError = value  
@@ -140,7 +132,6 @@ class DBConfiguration():
     def vTemplate1D(self):
         """version of the Template 1D payload."""
         return self._vTemplate1D
-
     @vTemplate1D.setter
     def vTemplate1D(self, value):
         self._vTemplate1D = value  
@@ -152,7 +143,6 @@ class DBConfiguration():
     def vTemplate2Dnum(self):
         """version of the Template 2D (numerator) payload."""
         return self._vTemplate2Dnum
-
     @vTemplate2Dnum.setter
     def vTemplate2Dnum(self, value):
         self._vTemplate2Dnum = value  
@@ -164,10 +154,8 @@ class DBConfiguration():
     def vTemplate2Dden(self):
         """version of the Template 2D (denominator) payload."""
         return self._vTemplate2Dden
-
     @vTemplate2Dden.setter
     def vTemplate2Dden(self, value):
-        print("setter of vTemplate2Dden called")
         self._vTemplate2Dden = value  
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -187,11 +175,6 @@ def appendConditions(DBConfig):
                 label = cms.untracked.string(label)
                 )
         )
-    
-
-    print toExtend
+        
+    ### extend the list of Records to be changed
     loadPhase2InneTrackerConditions.toGet.extend(cms.VPSet(*toExtend))
-
-    
-                                                 
-    

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
@@ -12,7 +12,5 @@ DBConfig.vGeometry = "11"
 DBConfig.vLA       = "0"
 DBConfig.vLAwidth  = "0"
 DBConfig.vSimLA    = "0"
-DBConfig.printConfig()
-
 appendConditions(DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
@@ -6,20 +6,13 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-from CondCore.CondDB.CondDB_cfi import CondDB
-CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
-siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
-                                           CondDB,
-                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T11_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T11_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T11_v0_mc"),
-                                                                      label = cms.untracked.string("forWidth")
-                                                                  )
-                                                             )
-                                            )
-es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
+from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
+DBConfig = DBConfiguration()
+DBConfig.vGeometry = "11"
+DBConfig.vLA       = "0"
+DBConfig.vLAwidth  = "0"
+DBConfig.vSimLA    = "0"
+DBConfig.printConfig()
+
+appendConditions(DBConfig)
+es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
@@ -11,19 +11,15 @@ CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
 siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
                                            CondDB,
                                            toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T5_v0_mc")
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T11_v0_mc")
                                                                   ),
                                                              cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T5_v0_mc")
+                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T11_v0_mc")
                                                                   ),
                                                              cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T5_v0_mc"),
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T11_v0_mc"),
                                                                       label = cms.untracked.string("forWidth")
                                                                   )
                                                              )
                                             )
 es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
-
-
-
-

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT11_cff.py
@@ -7,10 +7,10 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
 from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
-DBConfig = DBConfiguration()
-DBConfig.vGeometry = "11"
-DBConfig.vLA       = "0"
-DBConfig.vLAwidth  = "0"
-DBConfig.vSimLA    = "0"
-appendConditions(DBConfig)
+SiPhase2DBConfig = SiPhase2DBConfiguration()
+SiPhase2DBConfig.vGeometry = "11"
+SiPhase2DBConfig.vLA       = "0" # uH = 0.106 everywhere
+SiPhase2DBConfig.vLAwidth  = "0" # empty payload
+SiPhase2DBConfig.vSimLA    = "0" # uH = 0.106 everywhere
+appendConditions(SiPhase2DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
@@ -6,8 +6,20 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-siPixelFakeLorentzAngleESSource = cms.ESSource("SiPixelFakeLorentzAngleESSource",
-        file = 
-cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometryT14.txt')
-        )
-es_prefer_fake_lorentz = cms.ESPrefer("SiPixelFakeLorentzAngleESSource","siPixelFakeLorentzAngleESSource")
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
+siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
+                                           CondDB,
+                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T14_v0_mc")
+                                                                  ),
+                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
+                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T14_v0_mc")
+                                                                  ),
+                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc"),
+                                                                      label = cms.untracked.string("forWidth")
+                                                                  )
+                                                             )
+                                            )
+es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
@@ -12,8 +12,6 @@ DBConfig.vGeometry = "14"
 DBConfig.vLA       = "0"
 DBConfig.vLAwidth  = "0"
 DBConfig.vSimLA    = "0"
-DBConfig.printConfig()
-
 appendConditions(DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")
 

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
@@ -7,11 +7,11 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
 from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
-DBConfig = DBConfiguration()
-DBConfig.vGeometry = "14"
-DBConfig.vLA       = "0"
-DBConfig.vLAwidth  = "0"
-DBConfig.vSimLA    = "0"
-appendConditions(DBConfig)
+SiPhase2DBConfig = SiPhase2DBConfiguration()
+SiPhase2DBConfig.vGeometry = "14"
+SiPhase2DBConfig.vLA       = "0" # uH = 0.106 everywhere
+SiPhase2DBConfig.vLAwidth  = "0" # empty payload
+SiPhase2DBConfig.vSimLA    = "0" # uH = 0.106 everywhere
+appendConditions(SiPhase2DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")
 

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py
@@ -6,20 +6,14 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-from CondCore.CondDB.CondDB_cfi import CondDB
-CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
-siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
-                                           CondDB,
-                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T14_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T14_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc"),
-                                                                      label = cms.untracked.string("forWidth")
-                                                                  )
-                                                             )
-                                            )
-es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
+from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
+DBConfig = DBConfiguration()
+DBConfig.vGeometry = "14"
+DBConfig.vLA       = "0"
+DBConfig.vLAwidth  = "0"
+DBConfig.vSimLA    = "0"
+DBConfig.printConfig()
+
+appendConditions(DBConfig)
+es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")
+

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
@@ -11,19 +11,15 @@ CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
 siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
                                            CondDB,
                                            toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T5_v0_mc")
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T15_v0_mc")
                                                                   ),
                                                              cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T5_v0_mc")
+                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T15_v0_mc")
                                                                   ),
                                                              cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T5_v0_mc"),
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc"),
                                                                       label = cms.untracked.string("forWidth")
                                                                   )
                                                              )
                                             )
 es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
-
-
-
-

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
@@ -7,10 +7,10 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
 from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
-DBConfig = DBConfiguration()
-DBConfig.vGeometry = "15"
-DBConfig.vLA       = "0"
-DBConfig.vLAwidth  = "0"
-DBConfig.vSimLA    = "0"
-appendConditions(DBConfig)
+SiPhase2DBConfig = SiPhase2DBConfiguration()
+SiPhase2DBConfig.vGeometry = "15"
+SiPhase2DBConfig.vLA       = "0" # uH = 0.053 everywhere
+SiPhase2DBConfig.vLAwidth  = "0" # empty payload
+SiPhase2DBConfig.vSimLA    = "0" # uH = 0.053 everywhere
+appendConditions(SiPhase2DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
@@ -6,20 +6,13 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-from CondCore.CondDB.CondDB_cfi import CondDB
-CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
-siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
-                                           CondDB,
-                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T15_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T15_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc"),
-                                                                      label = cms.untracked.string("forWidth")
-                                                                  )
-                                                             )
-                                            )
-es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
+from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
+DBConfig = DBConfiguration()
+DBConfig.vGeometry = "15"
+DBConfig.vLA       = "0"
+DBConfig.vLAwidth  = "0"
+DBConfig.vSimLA    = "0"
+DBConfig.printConfig()
+
+appendConditions(DBConfig)
+es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT15_cff.py
@@ -12,7 +12,5 @@ DBConfig.vGeometry = "15"
 DBConfig.vLA       = "0"
 DBConfig.vLAwidth  = "0"
 DBConfig.vSimLA    = "0"
-DBConfig.printConfig()
-
 appendConditions(DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT5_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT5_cff.py
@@ -12,7 +12,5 @@ DBConfig.vGeometry = "5"
 DBConfig.vLA       = "0"
 DBConfig.vLAwidth  = "0"
 DBConfig.vSimLA    = "0"
-DBConfig.printConfig()
-
 appendConditions(DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT5_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT5_cff.py
@@ -7,10 +7,10 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
 from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
-DBConfig = DBConfiguration()
-DBConfig.vGeometry = "5"
-DBConfig.vLA       = "0"
-DBConfig.vLAwidth  = "0"
-DBConfig.vSimLA    = "0"
-appendConditions(DBConfig)
+SiPhase2DBConfig = SiPhase2DBConfiguration()
+SiPhase2DBConfig.vGeometry = "5"
+SiPhase2DBConfig.vLA       = "0" # uH = 0.106 everywhere
+SiPhase2DBConfig.vLAwidth  = "0" # empty payload
+SiPhase2DBConfig.vSimLA    = "0" # uH = 0.106 everywhere
+appendConditions(SiPhase2DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT5_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT5_cff.py
@@ -6,24 +6,13 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-from CondCore.CondDB.CondDB_cfi import CondDB
-CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
-siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
-                                           CondDB,
-                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T5_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T5_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T5_v0_mc"),
-                                                                      label = cms.untracked.string("forWidth")
-                                                                  )
-                                                             )
-                                            )
-es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
+from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
+DBConfig = DBConfiguration()
+DBConfig.vGeometry = "5"
+DBConfig.vLA       = "0"
+DBConfig.vLAwidth  = "0"
+DBConfig.vSimLA    = "0"
+DBConfig.printConfig()
 
-
-
-
+appendConditions(DBConfig)
+es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
@@ -6,8 +6,20 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-siPixelFakeLorentzAngleESSource = cms.ESSource("SiPixelFakeLorentzAngleESSource",
-        file = 
-cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometryT6.txt')
-        )
-es_prefer_fake_lorentz = cms.ESPrefer("SiPixelFakeLorentzAngleESSource","siPixelFakeLorentzAngleESSource")
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
+siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
+                                           CondDB,
+                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T6_v0_mc")
+                                                                  ),
+                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
+                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T6_v0_mc")
+                                                                  ),
+                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
+                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc"),
+                                                                      label = cms.untracked.string("forWidth")
+                                                                  )
+                                                             )
+                                            )
+es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
@@ -7,10 +7,10 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
 from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
-DBConfig = DBConfiguration()
-DBConfig.vGeometry = "6"
-DBConfig.vLA       = "0"
-DBConfig.vLAwidth  = "0"
-DBConfig.vSimLA    = "0"
-appendConditions(DBConfig)
+SiPhase2DBConfig = SiPhase2DBConfiguration()
+SiPhase2DBConfig.vGeometry = "6"
+SiPhase2DBConfig.vLA       = "0" # uH = 0.106 everywhere
+SiPhase2DBConfig.vLAwidth  = "0" # empty payload
+SiPhase2DBConfig.vSimLA    = "0" # uH = 0.106 everywhere
+appendConditions(SiPhase2DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
@@ -6,20 +6,13 @@ cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/EmptyPixelSk
         )
 es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
 
-from CondCore.CondDB.CondDB_cfi import CondDB
-CondDB.connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
-siPixelLorentzAngleESSource = cms.ESSource("PoolDBESSource",
-                                           CondDB,
-                                           toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_T6_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleSimRcd'),
-                                                                      tag = cms.string("SiPixelSimLorentzAngle_phase2_T6_v0_mc")
-                                                                  ),
-                                                             cms.PSet(record = cms.string('SiPixelLorentzAngleRcd'),
-                                                                      tag = cms.string("SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc"),
-                                                                      label = cms.untracked.string("forWidth")
-                                                                  )
-                                                             )
-                                            )
-es_prefer_lorentz = cms.ESPrefer("PoolDBESSource","siPixelLorentzAngleESSource")
+from SLHCUpgradeSimulations.Configuration.loadInnerTrackerConditionFromDB import *
+DBConfig = DBConfiguration()
+DBConfig.vGeometry = "6"
+DBConfig.vLA       = "0"
+DBConfig.vLAwidth  = "0"
+DBConfig.vSimLA    = "0"
+DBConfig.printConfig()
+
+appendConditions(DBConfig)
+es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT6_cff.py
@@ -12,7 +12,5 @@ DBConfig.vGeometry = "6"
 DBConfig.vLA       = "0"
 DBConfig.vLAwidth  = "0"
 DBConfig.vSimLA    = "0"
-DBConfig.printConfig()
-
 appendConditions(DBConfig)
 es_prefer_ITconditions = cms.ESPrefer("PoolDBESSource","loadPhase2InneTrackerConditions")

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -46,7 +46,7 @@ phase2TrackerDigitizer = cms.PSet(
       SigmaZero = cms.double(0.00037),  		#D.B.: 3.7um spread for 300um-thick sensor, renormalized in digitizerAlgo
       SigmaCoeff = cms.double(1.80),  		#D.B.: to be confirmed with simulations in CMSSW_6.X
       ClusterWidth = cms.double(3),		#D.B.: this is used as number of sigmas for charge collection (3=+-3sigmas)
-      LorentzAngle_DB = cms.bool(False),			
+      LorentzAngle_DB = cms.bool(True),
       TanLorentzAnglePerTesla_Endcap = cms.double(0.106),
       TanLorentzAnglePerTesla_Barrel = cms.double(0.106),
       KillModules = cms.bool(False),


### PR DESCRIPTION
#### PR description:
Upcoming developments in the Phase-2 Inner Tracker digitization and local reconstruction require access to several conditions related to the CPE, namely per-module Pixel Lorentz Angle (both for simulation and reconstruction) and in future also Pixel 1D, 2D Templates and Generic Errors.
Currently only the generic CPE algorithm is used for the Inner Tracker local reconstruction (hence only the Lorentz Angle is accessed) and it is is provided via a fake conditions `ESSource`:  [SiPixelFakeLorentzAngleESSource](https://github.com/cms-sw/cmssw/blob/master/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc).  This `ESSource` makes use of the `DetId` list from a “Skimmed Geometry” external file: one DetId list for each geometry ([example](https://github.com/cms-sw/cmssw/blob/master/SLHCUpgradeSimulations/Geometry/python/fakeConditions_phase2TkT14_cff.py#L11)) and only one single LA (μH =0.106) for all IT modules is used ([hardcoded](https://github.com/cms-sw/cmssw/blob/master/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeLorentzAngleESSource.cc#L53)).
Moreover the `“forWidth” ` label is not taken from DB  (see [PixelCPEGeneric_cfi ](https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py#L72) configuration) hence no correction is applied, and the simulation LA value is passed as a configuration parameter in the digitizer (see [phase2TrackerDigitizer_cfi.](https://github.com/cms-sw/cmssw/blob/master/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py#L50-L51)).
Finally the Generic Errors are also not taken from DB (see [PixelCPEGeneric_cfi](https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py#L72)) but are  hard-coded in C++ (see [PixelCPEGeneric.cc](https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc#L114)).
This PR is meant to change part of this situation, switching on the reading of conditions from Database where payloads are available, and provide such payloads in the production DB.
The implementation is complicated by the co-existence in release of several geometries, with different `DetId`s lists, and all need to be supported, hence the needed conditions cannot simply be added to the `phase2_realistic` autoCond Global Tag key to satisfy all use-cases. 
In this PR we propose a solution based on an additional `ESSource` configured differently for each Tracker `T*` geometry via the `fakeConditions_phase2TkT*_cff.py` files (already included in the geometry definition).  
For the D45 geometry a new `SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkT15_cff` file is created, in order to allow for a different set of LA values (μH =0.053) to be applied (T14 geometry is supposed to stay with the current value μH =0.106).
A complementary approach, based on the dynamical creation of more autoCond keys one for each of the Tracker geometry, has been implemented in PR #27517, though **we prefer this implementation as it automatically binds the conditions to the geometry**. 
More information has been collected in [this presentation](https://indico.cern.ch/event/832785/contributions/3492905/attachments/1876286/3089720/ts_mm_AlCaDBMeeting_8Jul2019.pdf) at the AlCa/DB meeting of 7th July 2019.
This PR is RFC and in draft state as it is at odds with the purpose of issue https://github.com/cms-sw/cmssw/issues/27393.

#### PR validation:
The PR was tested running 1 event of SingleMuPt10 for all the currently supported phase-2 geometry combinations: D35 (T6), D41 (T14), D43 (T14), D44 (T14), D45 (T5) via:
```
runTheMatrix.py --what upgrade -l 20007.0,20407.0,20807.0,21207.0,21607.0 --command='-n 1' -j 4
```
#### if this PR is a backport please specify the original PR:

This PR is not a backport
cc:
@tsusa @emiglior @pwittich @christopheralanwest @tlampen @ggovi 