### PR TITLE
Reduce memory churn at Geant4 initialisation of geometry

### DIFF
--- a/SimG4Core/Geometry/interface/DDDWorld.h
+++ b/SimG4Core/Geometry/interface/DDDWorld.h
@@ -1,8 +1,9 @@
 #ifndef SimG4Core_DDDWorld_h
 #define SimG4Core_DDDWorld_h
 
+#include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
+#include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 #include "G4VPhysicalVolume.hh"
-#include "SimG4Core/Geometry/interface/DDGeometryReturnType.h"
 #include "DDG4/Geant4GeometryInfo.h"
 
 class DDG4Builder;
@@ -14,7 +15,7 @@ namespace cms {
 
 class DDDWorld {
 public:
-  DDDWorld(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap &, SensitiveDetectorCatalog &, bool check = false);
+  DDDWorld(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap &, SensitiveDetectorCatalog &, bool check);
   DDDWorld(const cms::DDDetector *, dd4hep::sim::Geant4GeometryMaps::VolumeMap &);
   ~DDDWorld();
   G4VPhysicalVolume *GetWorldVolume() const { return m_world; }

--- a/SimG4Core/Geometry/interface/DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DDG4Builder.h
@@ -1,8 +1,8 @@
 #ifndef SimG4Core_DDG4Builder_h
 #define SimG4Core_DDG4Builder_h
 
-#include "SimG4Core/Geometry/interface/DDGeometryReturnType.h"
 #include "SimG4Core/Notification/interface/DDG4DispContainer.h"
+#include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
 #include "DetectorDescription/Core/interface/DDMaterial.h"
@@ -18,31 +18,29 @@ class G4VPhysicalVolume;
 class G4Material;
 class G4VSolid;
 class DDCompactView;
+class SensitiveDetectorCatalog;
 
 class DDG4Builder {
 public:
-  DDG4Builder(const DDCompactView *, bool check = false);
+  DDG4Builder(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap&, bool check);
   ~DDG4Builder();
-  DDGeometryReturnType BuildGeometry();
-  static DDG4DispContainer *theVectorOfDDG4Dispatchables();
+  G4LogicalVolume* BuildGeometry(SensitiveDetectorCatalog&);
 
-protected:
+private:
   G4VSolid *convertSolid(const DDSolid &dSolid);
   G4LogicalVolume *convertLV(const DDLogicalPart &dLogical);
   G4Material *convertMaterial(const DDMaterial &dMaterial);
   int getInt(const std::string &s, const DDLogicalPart &dLogical);
   double getDouble(const std::string &s, const DDLogicalPart &dLogical);
 
-protected:
   DDG4SolidConverter *solidConverter_;
   std::map<DDMaterial, G4Material *> mats_;
   std::map<DDSolid, G4VSolid *> sols_;
   std::map<DDLogicalPart, G4LogicalVolume *> logs_;
 
-private:
-  const DDCompactView *compactView;
-  static DDG4DispContainer *theVectorOfDDG4Dispatchables_;
-  G4LogicalVolumeToDDLogicalPartMap map_;
+  const DDCompactView *compactView_;
+  G4LogicalVolumeToDDLogicalPartMap& map_;
+  DDG4DispContainer *theVectorOfDDG4Dispatchables_;
   bool check_;
 };
 

--- a/SimG4Core/Geometry/interface/DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DDG4Builder.h
@@ -22,9 +22,9 @@ class SensitiveDetectorCatalog;
 
 class DDG4Builder {
 public:
-  DDG4Builder(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap&, bool check);
+  DDG4Builder(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap &, bool check);
   ~DDG4Builder();
-  G4LogicalVolume* BuildGeometry(SensitiveDetectorCatalog&);
+  G4LogicalVolume *BuildGeometry(SensitiveDetectorCatalog &);
 
 private:
   G4VSolid *convertSolid(const DDSolid &dSolid);
@@ -39,7 +39,7 @@ private:
   std::map<DDLogicalPart, G4LogicalVolume *> logs_;
 
   const DDCompactView *compactView_;
-  G4LogicalVolumeToDDLogicalPartMap& map_;
+  G4LogicalVolumeToDDLogicalPartMap &map_;
   DDG4DispContainer *theVectorOfDDG4Dispatchables_;
   bool check_;
 };

--- a/SimG4Core/Geometry/interface/DDG4SensitiveConverter.h
+++ b/SimG4Core/Geometry/interface/DDG4SensitiveConverter.h
@@ -14,7 +14,7 @@ class DDG4SensitiveConverter {
 public:
   DDG4SensitiveConverter();
   virtual ~DDG4SensitiveConverter();
-  void upDate(const DDG4DispContainer &ddg4s, SensitiveDetectorCatalog&);
+  void upDate(const DDG4DispContainer &ddg4s, SensitiveDetectorCatalog &);
 
 private:
   std::string getString(const std::string &, const DDLogicalPart *);

--- a/SimG4Core/Geometry/interface/DDG4SensitiveConverter.h
+++ b/SimG4Core/Geometry/interface/DDG4SensitiveConverter.h
@@ -1,19 +1,20 @@
 #ifndef SimG4Core_DDG4SensitiveConverter_h
 #define SimG4Core_DDG4SensitiveConverter_h
 
-#include "DetectorDescription/Core/interface/DDLogicalPart.h"
-#include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 #include "SimG4Core/Notification/interface/DDG4DispContainer.h"
 
 #include <iostream>
 #include <string>
 #include <vector>
 
+class SensitiveDetectorCatalog;
+class DDLogicalPart;
+
 class DDG4SensitiveConverter {
 public:
   DDG4SensitiveConverter();
   virtual ~DDG4SensitiveConverter();
-  SensitiveDetectorCatalog upDate(const DDG4DispContainer &ddg4s);
+  void upDate(const DDG4DispContainer &ddg4s, SensitiveDetectorCatalog&);
 
 private:
   std::string getString(const std::string &, const DDLogicalPart *);

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -17,18 +17,15 @@ using namespace dd4hep;
 using namespace dd4hep::sim;
 
 DDDWorld::DDDWorld(const DDCompactView *cpv,
-                   G4LogicalVolumeToDDLogicalPartMap &map,
+                   G4LogicalVolumeToDDLogicalPartMap &lvmap,
                    SensitiveDetectorCatalog &catalog,
                    bool check) {
   LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialization of Geant4 geometry";
-  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, check));
+  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, lvmap, check));
 
-  DDGeometryReturnType ret = theBuilder->BuildGeometry();
-  G4LogicalVolume *world = ret.logicalVolume();
+  G4LogicalVolume *world = theBuilder->BuildGeometry(catalog);
 
   m_world = new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
-  map = ret.lvToDDLPMap();
-  catalog = ret.sdCatalog();
   LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialization of Geant4 geometry is done.";
 }
 

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -1,20 +1,17 @@
-#include "DetectorDescription/Core/interface/DDSpecifics.h"
-
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "SimG4Core/Geometry/interface/DDG4Builder.h"
 #include "SimG4Core/Geometry/interface/DDG4SensitiveConverter.h"
 #include "SimG4Core/Geometry/interface/DDG4SolidConverter.h"
+#include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 
-#include "G4Box.hh"
-#include "G4Cons.hh"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/Core/interface/DDSpecifics.h"
+
 #include "G4LogicalVolume.hh"
 #include "G4Material.hh"
 #include "G4PVPlacement.hh"
 #include "G4ReflectionFactory.hh"
-#include "G4Trap.hh"
-#include "G4Tubs.hh"
 #include "G4VPhysicalVolume.hh"
 #include "G4VSolid.hh"
 
@@ -25,12 +22,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-DDG4DispContainer *DDG4Builder::theVectorOfDDG4Dispatchables_ = nullptr;
-
-DDG4DispContainer *DDG4Builder::theVectorOfDDG4Dispatchables() { return theVectorOfDDG4Dispatchables_; }
-
-DDG4Builder::DDG4Builder(const DDCompactView *cpv, bool check)
-    : solidConverter_(new DDG4SolidConverter), compactView(cpv), check_(check) {
+DDG4Builder::DDG4Builder(const DDCompactView *cpv, G4LogicalVolumeToDDLogicalPartMap& lvmap, bool check)
+  : solidConverter_(new DDG4SolidConverter), compactView_(cpv), map_(lvmap), check_(check) {
   theVectorOfDDG4Dispatchables_ = new DDG4DispContainer();
 }
 
@@ -104,12 +97,12 @@ G4Material *DDG4Builder::convertMaterial(const DDMaterial &material) {
   return result;
 }
 
-DDGeometryReturnType DDG4Builder::BuildGeometry() {
+G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog& catalog) {
   G4ReflectionFactory *refFact = G4ReflectionFactory::Instance();
   refFact->SetScalePrecision(100. * refFact->GetScalePrecision());
 
   using Graph = DDCompactView::Graph;
-  const auto &gra = compactView->graph();
+  const auto &gra = compactView_->graph();
   using adjl_iterator = Graph::const_adj_iterator;
   adjl_iterator git = gra.begin();
   adjl_iterator gend = gra.end();
@@ -188,15 +181,15 @@ DDGeometryReturnType DDG4Builder::BuildGeometry() {
     }
   }
 
-  G4LogicalVolume *world = logs_[compactView->root()];
+  G4LogicalVolume *world = logs_[compactView_->root()];
 
   //
   //  needed for building sensitive detectors
   //
   DDG4SensitiveConverter conv_;
-  SensitiveDetectorCatalog catalog = conv_.upDate(*theVectorOfDDG4Dispatchables_);
+  conv_.upDate(*theVectorOfDDG4Dispatchables_, catalog);
 
-  return DDGeometryReturnType(world, map_, catalog);
+  return world;
 }
 
 int DDG4Builder::getInt(const std::string &ss, const DDLogicalPart &part) {

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -22,8 +22,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-DDG4Builder::DDG4Builder(const DDCompactView *cpv, G4LogicalVolumeToDDLogicalPartMap& lvmap, bool check)
-  : solidConverter_(new DDG4SolidConverter), compactView_(cpv), map_(lvmap), check_(check) {
+DDG4Builder::DDG4Builder(const DDCompactView *cpv, G4LogicalVolumeToDDLogicalPartMap &lvmap, bool check)
+    : solidConverter_(new DDG4SolidConverter), compactView_(cpv), map_(lvmap), check_(check) {
   theVectorOfDDG4Dispatchables_ = new DDG4DispContainer();
 }
 
@@ -97,7 +97,7 @@ G4Material *DDG4Builder::convertMaterial(const DDMaterial &material) {
   return result;
 }
 
-G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog& catalog) {
+G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
   G4ReflectionFactory *refFact = G4ReflectionFactory::Instance();
   refFact->SetScalePrecision(100. * refFact->GetScalePrecision());
 

--- a/SimG4Core/Geometry/src/DDG4SensitiveConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SensitiveConverter.cc
@@ -1,4 +1,7 @@
 #include "SimG4Core/Geometry/interface/DDG4SensitiveConverter.h"
+#include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
+
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -9,9 +12,8 @@ DDG4SensitiveConverter::DDG4SensitiveConverter() {}
 
 DDG4SensitiveConverter::~DDG4SensitiveConverter() {}
 
-SensitiveDetectorCatalog DDG4SensitiveConverter::upDate(const DDG4DispContainer &ddg4s) {
+void DDG4SensitiveConverter::upDate(const DDG4DispContainer &ddg4s, SensitiveDetectorCatalog &catalog) {
   LogDebug("SimG4CoreGeometry") << " DDG4SensitiveConverter::upDate() starts";
-  SensitiveDetectorCatalog catalog;
 
   for (auto ddg4 : ddg4s) {
     const DDLogicalPart *part = (ddg4->getDDLogicalPart());
@@ -27,7 +29,6 @@ SensitiveDetectorCatalog DDG4SensitiveConverter::upDate(const DDG4DispContainer 
       catalog.insert(sClassName, sROUName, fff);
     }
   }
-  return catalog;
 }
 
 std::string DDG4SensitiveConverter::getString(const std::string &ss, const DDLogicalPart *part) {


### PR DESCRIPTION
#### PR description:
Reduced number of copies of geometry objects during initialisation of Geant4 geometry.
Correctness of this PR should be confirmed by identical results.

#### PR validation:
private runs

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
