### PR TITLE
Fix undefined behaviour problems in  RecoTracker/TkHitPairs

### DIFF
--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -38,7 +38,12 @@ private:
 
       for (size_t i = 0, size = other.theContainer.size(); i != size; ++i) {
         assert(get(i) == nullptr);               // We don't want to override any existing value
-        theContainer[i].reset(*(other.get(i)));  // pass by reference to denote that we don't own it
+        auto v = other.get(i);                   // pass by reference to denote that we don't own it
+        if(v) {
+          theContainer[i].reset(*(other.get(i)));  
+        } else {
+          theContainer[i].reset();
+        }
       }
     }
     /// emptify cache, delete values associated to Key

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -37,10 +37,10 @@ private:
         resize(other.theContainer.size());
 
       for (size_t i = 0, size = other.theContainer.size(); i != size; ++i) {
-        assert(get(i) == nullptr);               // We don't want to override any existing value
-        auto v = other.get(i);                   // pass by reference to denote that we don't own it
-        if(v) {
-          theContainer[i].reset(*(other.get(i)));  
+        assert(get(i) == nullptr);  // We don't want to override any existing value
+        auto v = other.get(i);      // pass by reference to denote that we don't own it
+        if (v) {
+          theContainer[i].reset(*(other.get(i)));
         } else {
           theContainer[i].reset();
         }

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -38,8 +38,9 @@ private:
 
       for (size_t i = 0, size = other.theContainer.size(); i != size; ++i) {
         assert(get(i) == nullptr);  // We don't want to override any existing value
-        auto v = other.get(i);      // pass by reference to denote that we don't own it
+        auto v = other.get(i);
         if (v) {
+          // pass by reference to denote that we don't own it
           theContainer[i].reset(*(other.get(i)));
         } else {
           theContainer[i].reset();

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -152,7 +152,8 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
     for (int j = 0; j < 3; j += 2) {
       auto b = innerRange[j];
       auto e = innerRange[j + 1];
-      if( e == b) continue;
+      if (e == b)
+        continue;
       bool ok[e - b];
       switch (checkRZ->algo()) {
         case (HitRZCompatibility::zAlgo):

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -152,6 +152,7 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
     for (int j = 0; j < 3; j += 2) {
       auto b = innerRange[j];
       auto e = innerRange[j + 1];
+      if( e == b) continue;
       bool ok[e - b];
       switch (checkRZ->algo()) {
         case (HitRZCompatibility::zAlgo):


### PR DESCRIPTION
#### PR description:

The following are meant to fix problems seen in the UBSAN IB.
- Avoid dereference of nullptr in LayerHitMapCache
- Avoid making a 0 length VLA in HitPairGeneratorFromLayerPair

#### PR validation:

The code compiles.