### PR TITLE
Avoid copying uninitialized value in PFDisplacedVertexCandidateFinder

### DIFF
--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -18,10 +18,9 @@ PFDisplacedVertexCandidateFinder::PFDisplacedVertexCandidateFinder()
       primaryVertexCut2_(0.0),
       dcaPInnerHitCut2_(1000.0),
       vertexCandidatesSize_(50),
-      debug_(false) {
-  TwoTrackMinimumDistance theMinimum(TwoTrackMinimumDistance::SlowMode);
-  theMinimum_ = theMinimum;
-}
+      theMinimum_(TwoTrackMinimumDistance::SlowMode),
+      debug_(false),
+      magField_(nullptr) {}
 
 PFDisplacedVertexCandidateFinder::~PFDisplacedVertexCandidateFinder() {
 #ifdef PFLOW_DEBUG


### PR DESCRIPTION

#### PR description:

Use constructor rather than operator= in order to avoid reading from
an uninitialized valued in TwoTrackMinimumDistance.

This was found by UBSAN.

#### PR validation:

Code compiles.