### PR TITLE
drop constness for modifiers in RecoTauQualityCuts; move auto_ptr to unique_ptr

### DIFF
--- a/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
@@ -38,7 +38,7 @@ namespace reco {
       typedef boost::ptr_vector<PFRecoTauChargedHadron> ChargedHadronVector;
       // Storing the result in an auto ptr on function return allows
       // allows us to safely release the ptr_vector in the virtual function
-      typedef std::auto_ptr<ChargedHadronVector> return_type;
+      typedef std::unique_ptr<ChargedHadronVector> return_type;
       explicit PFRecoTauChargedHadronBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
           : RecoTauEventHolderPlugin(pset) {}
       ~PFRecoTauChargedHadronBuilderPlugin() override {}

--- a/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h
@@ -56,7 +56,7 @@ namespace reco {
     class RecoTauBuilderPlugin : public RecoTauEventHolderPlugin {
     public:
       typedef boost::ptr_vector<reco::PFTau> output_type;
-      typedef std::auto_ptr<output_type> return_type;
+      typedef std::unique_ptr<output_type> return_type;
 
       explicit RecoTauBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
           : RecoTauEventHolderPlugin(pset),

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -121,7 +121,7 @@ namespace reco {
       }
 
       // Build and return the associated tau
-      std::auto_ptr<reco::PFTau> get(bool setupLeadingCandidates = true);
+      std::unique_ptr<reco::PFTau> get(bool setupLeadingCandidates = true);
 
       // Get the four vector of the signal objects added so far
       const reco::Candidate::LorentzVector& p4() const { return p4_; }
@@ -152,7 +152,7 @@ namespace reco {
       CandidatePtr convertToPtr(const CandidatePtr& candPtr) const;
 
       const edm::Handle<edm::View<reco::Candidate> >& pfCands_;
-      std::auto_ptr<reco::PFTau> tau_;
+      std::unique_ptr<reco::PFTau> tau_;
       CollectionMap collections_;
 
       // Keep sorted (by descending pt) collections

--- a/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauPiZeroPlugins.h
@@ -36,7 +36,7 @@ namespace reco {
       typedef boost::ptr_vector<RecoTauPiZero> PiZeroVector;
       // Storing the result in an auto ptr on function return allows
       // allows us to safely release the ptr_vector in the virtual function
-      typedef std::auto_ptr<PiZeroVector> return_type;
+      typedef std::unique_ptr<PiZeroVector> return_type;
       explicit RecoTauPiZeroBuilderPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
           : RecoTauEventHolderPlugin(pset) {}
       ~RecoTauPiZeroBuilderPlugin() override {}

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -43,7 +43,7 @@ namespace reco {
       explicit RecoTauQualityCuts(const edm::ParameterSet& qcuts);
 
       /// Update the primary vertex
-      void setPV(const reco::VertexRef& vtx) const { pv_ = vtx; }
+      void setPV(const reco::VertexRef& vtx) { pv_ = vtx; }
 
       /// Update the leading track
       void setLeadTrack(const reco::Track& leadTrack);
@@ -98,7 +98,7 @@ namespace reco {
       bool filterCandByType(const reco::Candidate& cand) const;
 
       // The current primary vertex
-      mutable reco::VertexRef pv_;
+      reco::VertexRef pv_;
       // The current lead track references
       const reco::Track* leadTrack_;
 

--- a/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauQualityCuts.h
@@ -46,12 +46,12 @@ namespace reco {
       void setPV(const reco::VertexRef& vtx) const { pv_ = vtx; }
 
       /// Update the leading track
-      void setLeadTrack(const reco::Track& leadTrack) const;
-      void setLeadTrack(const reco::Candidate& leadCand) const;
+      void setLeadTrack(const reco::Track& leadTrack);
+      void setLeadTrack(const reco::Candidate& leadCand);
 
       /// Update the leading track (using reference)
       /// If null, this will set the lead track ref null.
-      void setLeadTrack(const reco::CandidateRef& leadCand) const;
+      void setLeadTrack(const reco::CandidateRef& leadCand);
 
       /// Filter a single Track
       bool filterTrack(const reco::TrackBaseRef& track) const;
@@ -100,7 +100,7 @@ namespace reco {
       // The current primary vertex
       mutable reco::VertexRef pv_;
       // The current lead track references
-      mutable const reco::Track* leadTrack_;
+      const reco::Track* leadTrack_;
 
       double minTrackPt_;
       double maxTrackChi2_;

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -56,7 +56,7 @@ namespace reco {
     public:
       explicit PFRecoTauChargedHadronFromGenericTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
       ~PFRecoTauChargedHadronFromGenericTrackPlugin() override;
-      // Return type is auto_ptr<ChargedHadronVector>
+      // Return type is unique_ptr<ChargedHadronVector>
       return_type operator()(const reco::Jet&) const override;
       // Hook to update PV information
       void beginEvent() override;
@@ -262,7 +262,7 @@ namespace reco {
         if (vertexAssociator_.associatedVertex(jet).isNonnull())
           vtx = vertexAssociator_.associatedVertex(jet)->position();
 
-        std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(
+        std::unique_ptr<PFRecoTauChargedHadron> chargedHadron(
             new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
 
         setChargedHadronTrack(*chargedHadron, edm::Ptr<TrackClass>(tracks, iTrack));
@@ -341,7 +341,7 @@ namespace reco {
           edm::LogPrint("TauChHFromTrack") << *chargedHadron;
         }
 
-        output.push_back(chargedHadron);
+        output.push_back(std::move(chargedHadron));
       }
 
       return output.release();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -44,7 +44,7 @@ namespace reco {
     public:
       explicit PFRecoTauChargedHadronFromPFCandidatePlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
       ~PFRecoTauChargedHadronFromPFCandidatePlugin() override;
-      // Return type is auto_ptr<ChargedHadronVector>
+      // Return type is unique_ptr<ChargedHadronVector>
       return_type operator()(const reco::Jet&) const override;
       // Hook to update PV information
       void beginEvent() override;
@@ -183,7 +183,7 @@ namespace reco {
           algo = PFRecoTauChargedHadron::kChargedPFCandidate;
         else
           algo = PFRecoTauChargedHadron::kPFNeutralHadron;
-        std::auto_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
+        std::unique_ptr<PFRecoTauChargedHadron> chargedHadron(new PFRecoTauChargedHadron(**cand, algo));
 
         const reco::PFCandidate* pfCand = dynamic_cast<const reco::PFCandidate*>(&**cand);
         if (pfCand) {
@@ -278,7 +278,7 @@ namespace reco {
         // Update the vertex
         if (chargedHadron->daughterPtr(0).isNonnull())
           chargedHadron->setVertex(chargedHadron->daughterPtr(0)->vertex());
-        output.push_back(chargedHadron);
+        output.push_back(std::move(chargedHadron));
       }
 
       return output.release();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -84,10 +84,10 @@ private:
   builderList builders_;
   rankerList rankers_;
 
-  std::auto_ptr<ChargedHadronPredicate> predicate_;
+  std::unique_ptr<ChargedHadronPredicate> predicate_;
 
   // output selector
-  std::auto_ptr<StringCutObjectSelector<reco::PFRecoTauChargedHadron>> outputSelector_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFRecoTauChargedHadron>> outputSelector_;
 
   // flag to enable/disable debug print-out
   int verbosity_;
@@ -121,7 +121,7 @@ PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::Parame
   }
 
   // build the sorting predicate
-  predicate_ = std::auto_ptr<ChargedHadronPredicate>(new ChargedHadronPredicate(rankers_));
+  predicate_ = std::unique_ptr<ChargedHadronPredicate>(new ChargedHadronPredicate(rankers_));
 
   // check if we want to apply a final output selection
   std::string selection = cfg.getParameter<std::string>("outputSelection");
@@ -202,7 +202,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
 
     while (!uncleanedChargedHadrons.empty()) {
       // get next best ChargedHadron candidate
-      std::auto_ptr<reco::PFRecoTauChargedHadron> nextChargedHadron(uncleanedChargedHadrons.pop_front().release());
+      std::unique_ptr<reco::PFRecoTauChargedHadron> nextChargedHadron(uncleanedChargedHadrons.pop_front().release());
       if (verbosity_) {
         edm::LogPrint("PFRecoTauChHProducer") << "processing nextChargedHadron:";
         edm::LogPrint("PFRecoTauChHProducer") << (*nextChargedHadron);
@@ -303,7 +303,7 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
           edm::LogPrint("PFRecoTauChHProducer") << "--> removing non-unique neutral PFCandidates and reinserting "
                                                    "nextChargedHadron in uncleaned collection.";
         }
-        uncleanedChargedHadrons.insert(insertionPoint, nextChargedHadron);
+        uncleanedChargedHadrons.insert(insertionPoint, std::move(nextChargedHadron));
       }
     }
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -188,13 +188,13 @@ private:
   std::string moduleLabel_;
 
   edm::ParameterSet qualityCutsPSet_;
-  std::auto_ptr<tau::RecoTauQualityCuts> qcuts_;
+  std::unique_ptr<tau::RecoTauQualityCuts> qcuts_;
 
   // Inverted QCut which selects tracks with bad DZ/trackWeight
-  std::auto_ptr<tau::RecoTauQualityCuts> pileupQcutsPUTrackSelection_;
-  std::auto_ptr<tau::RecoTauQualityCuts> pileupQcutsGeneralQCuts_;
+  std::unique_ptr<tau::RecoTauQualityCuts> pileupQcutsPUTrackSelection_;
+  std::unique_ptr<tau::RecoTauQualityCuts> pileupQcutsGeneralQCuts_;
 
-  std::auto_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
+  std::unique_ptr<tau::RecoTauVertexAssociator> vertexAssociator_;
 
   bool includeTracks_;
   bool includeGammas_;
@@ -246,7 +246,7 @@ private:
   std::vector<reco::CandidatePtr> chargedPFCandidatesInEvent_;
   // Size of cone used to collect PU tracks
   double deltaBetaCollectionCone_;
-  std::auto_ptr<TFormula> deltaBetaFormula_;
+  std::unique_ptr<TFormula> deltaBetaFormula_;
   double deltaBetaFactorThisEvent_;
 
   // Rho correction

--- a/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
+++ b/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
@@ -85,7 +85,7 @@ struct PFTauSelectorDefinition {
 private:
   container selected_;
   DiscCutPairVec discriminators_;
-  std::auto_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFTau> > cut_;
 };
 
 #endif

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -459,7 +459,7 @@ namespace reco {
                            boost::make_filter_iterator(pfNeutralJunk, regionalJunk.begin(), regionalJunk.end()),
                            boost::make_filter_iterator(pfNeutralJunk, regionalJunk.end(), regionalJunk.end()));
 
-            std::auto_ptr<reco::PFTau> tauPtr = tau.get(true);
+            std::unique_ptr<reco::PFTau> tauPtr = tau.get(true);
 
             // Set event vertex position for tau
             reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
@@ -489,7 +489,7 @@ namespace reco {
             //edm::LogPrint("RecoTauBuilderCombinatoricPlugin") << "bendCorrMass2 = " << sqrt(bendCorrMass2) << std::endl;
             tauPtr->setBendCorrMass(sqrt(bendCorrMass2));
 
-            output.push_back(tauPtr);
+            output.push_back(std::move(tauPtr));
           }
         }
       }

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -37,7 +37,7 @@ namespace reco {
                              const std::vector<CandidatePtr>&) const override;
 
     private:
-      RecoTauQualityCuts qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
 
       double isolationConeSize_;
 
@@ -61,7 +61,7 @@ namespace reco {
     RecoTauBuilderCombinatoricPlugin::RecoTauBuilderCombinatoricPlugin(const edm::ParameterSet& pset,
                                                                        edm::ConsumesCollector&& iC)
         : RecoTauBuilderPlugin(pset, std::move(iC)),
-          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
+          qcuts_(new RecoTauQualityCuts(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
           isolationConeSize_(pset.getParameter<double>("isolationConeSize")),
           signalConeSize_(pset.getParameter<std::string>("signalConeSize")),
           minAbsPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_insideSignalCone")),
@@ -180,7 +180,7 @@ namespace reco {
 
       // Update the primary vertex used by the quality cuts.  The PV is supplied by
       // the base class.
-      qcuts_.setPV(primaryVertex(jet));
+      qcuts_->setPV(primaryVertex(jet));
 
       typedef std::vector<CandidatePtr> CandPtrs;
 
@@ -203,13 +203,13 @@ namespace reco {
         }
       }
 
-      CandPtrs pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
-      CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 130));
-      CandPtrs pfgammas = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 22));
+      CandPtrs pfchs = qcuts_->filterCandRefs(pfChargedCands(*jet));
+      CandPtrs pfnhs = qcuts_->filterCandRefs(pfCandidatesByPdgId(*jet, 130));
+      CandPtrs pfgammas = qcuts_->filterCandRefs(pfCandidatesByPdgId(*jet, 22));
 
       /// Apply quality cuts to the regional junk around the jet.  Note that the
       /// particle contents of the junk is exclusive to the jet content.
-      CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
+      CandPtrs regionalJunk = qcuts_->filterCandRefs(regionalExtras);
 
       // Loop over the decay modes we want to build
       for (std::vector<decayModeInfo>::const_iterator decayMode = decayModesToBuild_.begin();

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -43,7 +43,7 @@ namespace reco {
                              const std::vector<CandidatePtr>& regionalExtras) const override;
 
     private:
-      RecoTauQualityCuts qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
 
       bool usePFLeptonsAsChargedHadrons_;
 
@@ -76,7 +76,7 @@ namespace reco {
     // ctor - initialize all of our variables
     RecoTauBuilderConePlugin::RecoTauBuilderConePlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
         : RecoTauBuilderPlugin(pset, std::move(iC)),
-          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
+          qcuts_(new RecoTauQualityCuts(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
           usePFLeptonsAsChargedHadrons_(pset.getParameter<bool>("usePFLeptons")),
           leadObjecPtThreshold_(pset.getParameter<double>("leadObjectPt")),
           matchingCone_(pset.getParameter<std::string>("matchingCone")),
@@ -198,31 +198,31 @@ namespace reco {
                              minAbsPhotonSumPt_insideSignalCone_,
                              minRelPhotonSumPt_insideSignalCone_);
       // Setup our quality cuts to use the current vertex (supplied by base class)
-      qcuts_.setPV(primaryVertex(jet));
+      qcuts_->setPV(primaryVertex(jet));
 
       typedef std::vector<CandidatePtr> CandPtrs;
 
       // Get the PF Charged hadrons + quality cuts
       CandPtrs pfchs;
       if (!usePFLeptonsAsChargedHadrons_) {
-        pfchs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 211));
+        pfchs = qcuts_->filterCandRefs(pfCandidatesByPdgId(*jet, 211));
       } else {
         // Check if we want to include electrons in muons in "charged hadron"
         // collection.  This is the preferred behavior, as the PF lepton selections
         // are very loose.
-        pfchs = qcuts_.filterCandRefs(pfChargedCands(*jet));
+        pfchs = qcuts_->filterCandRefs(pfChargedCands(*jet));
       }
 
       // CV: sort collection of PF Charged hadrons by descending Pt
       std::sort(pfchs.begin(), pfchs.end(), SortPFCandsDescendingPt());
 
       // Get the PF gammas
-      CandPtrs pfGammas = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 22));
+      CandPtrs pfGammas = qcuts_->filterCandRefs(pfCandidatesByPdgId(*jet, 22));
       // Neutral hadrons
-      CandPtrs pfnhs = qcuts_.filterCandRefs(pfCandidatesByPdgId(*jet, 130));
+      CandPtrs pfnhs = qcuts_->filterCandRefs(pfCandidatesByPdgId(*jet, 130));
 
       // All the extra junk
-      CandPtrs regionalJunk = qcuts_.filterCandRefs(regionalExtras);
+      CandPtrs regionalJunk = qcuts_->filterCandRefs(regionalExtras);
 
       /***********************************************
    ******     Lead Candidate Finding    **********

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -408,7 +408,7 @@ namespace reco {
       // Put our built tau in the output - 'false' indicates don't build the
       // leading candidates, we already did that explicitly above.
 
-      std::auto_ptr<reco::PFTau> tauPtr = tau.get(false);
+      std::unique_ptr<reco::PFTau> tauPtr = tau.get(false);
 
       // Set event vertex position for tau
       reco::VertexRef primaryVertexRef = primaryVertex(*tauPtr);
@@ -418,7 +418,7 @@ namespace reco {
       // Set missing tau quantities
       setTauQuantities(*tauPtr, minAbsPhotonSumPt_insideSignalCone_, minRelPhotonSumPt_insideSignalCone_);
 
-      output.push_back(tauPtr);
+      output.push_back(std::move(tauPtr));
       return output.release();
     }
   }  // namespace tau

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -60,11 +60,11 @@ private:
 
   builderList builders_;
   rankerList rankers_;
-  std::auto_ptr<PiZeroPredicate> predicate_;
+  std::unique_ptr<PiZeroPredicate> predicate_;
   double piZeroMass_;
 
   // Output selector
-  std::auto_ptr<StringCutObjectSelector<reco::RecoTauPiZero>> outputSelector_;
+  std::unique_ptr<StringCutObjectSelector<reco::RecoTauPiZero>> outputSelector_;
 
   //consumes interface
   edm::EDGetTokenT<reco::JetView> cand_token;
@@ -103,7 +103,7 @@ RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) {
   }
 
   // Build the sorting predicate
-  predicate_ = std::auto_ptr<PiZeroPredicate>(new PiZeroPredicate(rankers_));
+  predicate_ = std::unique_ptr<PiZeroPredicate>(new PiZeroPredicate(rankers_));
 
   // now all producers apply a final output selection
   std::string selection = pset.getParameter<std::string>("outputSelection");
@@ -162,7 +162,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     std::set<reco::CandidatePtr> photonsInCleanCollection;
     while (!dirtyPiZeros.empty()) {
       // Pull our candidate pi zero from the front of the list
-      std::auto_ptr<reco::RecoTauPiZero> toAdd(dirtyPiZeros.pop_front().release());
+      std::unique_ptr<reco::RecoTauPiZero> toAdd(dirtyPiZeros.pop_front().release());
       // If this doesn't pass our basic selection, discard it.
       if (!(*outputSelector_)(*toAdd)) {
         continue;
@@ -197,7 +197,7 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
         // Put this pi zero back into the collection of sorted dirty pizeros
         PiZeroList::iterator insertionPoint =
             std::lower_bound(dirtyPiZeros.begin(), dirtyPiZeros.end(), *toAdd, *predicate_);
-        dirtyPiZeros.insert(insertionPoint, toAdd);
+        dirtyPiZeros.insert(insertionPoint, std::move(toAdd));
       }
     }
     // Apply the mass hypothesis if desired

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -51,7 +51,7 @@ namespace reco {
       void beginEvent() override;
 
     private:
-      RecoTauQualityCuts qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
       RecoTauVertexAssociator vertexAssociator_;
 
       std::vector<int> inputParticleIds_;  //type of candidates to clusterize
@@ -68,7 +68,7 @@ namespace reco {
 
     RecoTauPiZeroStripPlugin::RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
         : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
-          qcuts_(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts")),
+          qcuts_(new RecoTauQualityCuts(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
           vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {
       inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
       etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");
@@ -90,9 +90,9 @@ namespace reco {
       PiZeroVector output;
 
       // Get the candidates passing our quality cuts
-      qcuts_.setPV(vertexAssociator_.associatedVertex(jet));
-      CandPtrs candsVector = qcuts_.filterCandRefs(pfCandidates(jet, inputParticleIds_));
-      //PFCandPtrs candsVector = qcuts_.filterCandRefs(pfGammas(jet));
+      qcuts_->setPV(vertexAssociator_.associatedVertex(jet));
+      CandPtrs candsVector = qcuts_->filterCandRefs(pfCandidates(jet, inputParticleIds_));
+      //PFCandPtrs candsVector = qcuts_->filterCandRefs(pfGammas(jet));
 
       // Convert to stl::list to allow fast deletions
       typedef std::list<reco::CandidatePtr> CandPtrList;

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -53,7 +53,7 @@ namespace reco {
     public:
       explicit RecoTauPiZeroStripPlugin2(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
       ~RecoTauPiZeroStripPlugin2() override;
-      // Return type is auto_ptr<PiZeroVector>
+      // Return type is unique_ptr<PiZeroVector>
       return_type operator()(const reco::Jet&) const override;
       // Hook to update PV information
       void beginEvent() override;
@@ -254,7 +254,7 @@ namespace reco {
         seedCandIdsCurrentStrip.clear();
         addCandIdsCurrentStrip.clear();
 
-        std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+        std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
         strip->addDaughter(seedCands[idxSeed]);
         seedCandIdsCurrentStrip.insert(idxSeed);
 
@@ -282,7 +282,7 @@ namespace reco {
           // Update the vertex
           if (strip->daughterPtr(0).isNonnull())
             strip->setVertex(strip->daughterPtr(0)->vertex());
-          output.push_back(strip);
+          output.push_back(std::move(strip));
 
           // Mark daughters as being part of this strip
           markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
@@ -318,7 +318,7 @@ namespace reco {
             secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
             Candidate::LorentzVector totalP4 = firstP4 + secondP4;
             // Make our new combined strip
-            std::auto_ptr<RecoTauPiZero> combinedStrips(
+            std::unique_ptr<RecoTauPiZero> combinedStrips(
                 new RecoTauPiZero(0,
                                   totalP4,
                                   Candidate::Point(0, 0, 0),
@@ -339,7 +339,7 @@ namespace reco {
             if (combinedStrips->daughterPtr(0).isNonnull())
               combinedStrips->setVertex(combinedStrips->daughterPtr(0)->vertex());
             // Add to our collection of combined strips
-            stripCombinations.push_back(combinedStrips);
+            stripCombinations.push_back(std::move(combinedStrips));
           }
         }
         // When done doing all the combinations, add the combined strips to the

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -56,7 +56,7 @@ namespace reco {
     public:
       explicit RecoTauPiZeroStripPlugin3(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
       ~RecoTauPiZeroStripPlugin3() override;
-      // Return type is auto_ptr<PiZeroVector>
+      // Return type is unique_ptr<PiZeroVector>
       return_type operator()(const reco::Jet&) const override;
       // Hook to update PV information
       void beginEvent() override;
@@ -285,7 +285,7 @@ namespace reco {
         seedCandIdsCurrentStrip.clear();
         addCandIdsCurrentStrip.clear();
 
-        std::auto_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+        std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
         strip->addDaughter(seedCands[idxSeed]);
         seedCandIdsCurrentStrip.insert(idxSeed);
 
@@ -313,7 +313,7 @@ namespace reco {
           // Update the vertex
           if (strip->daughterPtr(0).isNonnull())
             strip->setVertex(strip->daughterPtr(0)->vertex());
-          output.push_back(strip);
+          output.push_back(std::move(strip));
 
           // Mark daughters as being part of this strip
           markCandsInStrip(seedCandFlags, seedCandIdsCurrentStrip);
@@ -349,7 +349,7 @@ namespace reco {
             secondP4 = applyMassConstraint(secondP4, combinatoricStripMassHypo_);
             Candidate::LorentzVector totalP4 = firstP4 + secondP4;
             // Make our new combined strip
-            std::auto_ptr<RecoTauPiZero> combinedStrips(
+            std::unique_ptr<RecoTauPiZero> combinedStrips(
                 new RecoTauPiZero(0,
                                   totalP4,
                                   Candidate::Point(0, 0, 0),
@@ -372,7 +372,7 @@ namespace reco {
             }
 
             // Add to our collection of combined strips
-            stripCombinations.push_back(combinedStrips);
+            stripCombinations.push_back(std::move(combinedStrips));
           }
         }
         // When done doing all the combinations, add the combined strips to the

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -41,10 +41,10 @@ namespace reco::tau {
     output.reserve(pfGammaCands.size());
 
     for (auto const& gamma : pfGammaCands) {
-      std::auto_ptr<RecoTauPiZero> piZero(
+      std::unique_ptr<RecoTauPiZero> piZero(
           new RecoTauPiZero(0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true, RecoTauPiZero::kTrivial));
       piZero->addDaughter(gamma);
-      output.push_back(piZero);
+      output.push_back(std::move(piZero));
     }
     return output.release();
   }

--- a/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauConstructor.cc
@@ -324,7 +324,7 @@ namespace reco::tau {
     }
   }  // namespace
 
-  std::auto_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects) {
+  std::unique_ptr<reco::PFTau> RecoTauConstructor::get(bool setupLeadingObjects) {
     LogDebug("TauConstructorGet") << "Start getting";
 
     // Copy the sorted collections into the interal tau refvectors
@@ -414,6 +414,6 @@ namespace reco::tau {
       if (leadingGammaCand != getCollection(kSignal, kGamma)->end())
         tau_->setleadNeutralCand(*leadingGammaCand);
     }
-    return tau_;
+    return std::move(tau_);
   }
 }  // end namespace reco::tau

--- a/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauQualityCuts.cc
@@ -547,11 +547,11 @@ namespace reco::tau {
     return result;
   }
 
-  void RecoTauQualityCuts::setLeadTrack(const reco::Track& leadTrack) const { leadTrack_ = &leadTrack; }
+  void RecoTauQualityCuts::setLeadTrack(const reco::Track& leadTrack) { leadTrack_ = &leadTrack; }
 
-  void RecoTauQualityCuts::setLeadTrack(const reco::Candidate& leadCand) const { leadTrack_ = getTrack(leadCand); }
+  void RecoTauQualityCuts::setLeadTrack(const reco::Candidate& leadCand) { leadTrack_ = getTrack(leadCand); }
 
-  void RecoTauQualityCuts::setLeadTrack(const reco::CandidateRef& leadCand) const {
+  void RecoTauQualityCuts::setLeadTrack(const reco::CandidateRef& leadCand) {
     if (leadCand.isNonnull()) {
       leadTrack_ = getTrack(*leadCand);
     } else {


### PR DESCRIPTION
- the first and last commits are related to the static analyzer category of issues "ConstThreadSafety | mutable member if accessed via const pointer" for RecoTauQualityCuts:
    - setXYZ methods are no longer declared const (and the corresponding members are no longer mutable)
    - calls to RecoTauQualityCuts in the client methods qualified as const now go via pointers to the instances of RecoTauQualityCuts. Incidentally, this was already used this way in some RecoTau code

The migration from auto_ptr to unique_ptr is a somewhat aside cleanup of a deprecated C++ feature (removed in C++17).

This was tested in re-miniAOD workflows and showed no differences in tau reco outputs.