### PR TITLE
Update globalreco_tracking sequence for Phase2

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -120,6 +120,12 @@ trackingLowPU.toReplaceWith(globalreco_tracking, _globalreco_tracking_LowPU)
 _fastSim_globalreco_tracking = globalreco_tracking.copyAndExclude([offlineBeamSpot,MeasurementTrackerEventPreSplitting,siPixelClusterShapeCachePreSplitting])
 fastSim.toReplaceWith(globalreco_tracking,_fastSim_globalreco_tracking)
 
+_phase2_timing_layer_globalreco_tracking = globalreco_tracking.copy()
+_phase2_timing_layer_globalreco_tracking += fastTimingGlobalReco
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco_tracking,_phase2_timing_layer_globalreco_tracking)
+
 globalreco = cms.Sequence(globalreco_tracking*
                           particleFlowCluster*
                           ecalClusters*
@@ -133,15 +139,6 @@ globalreco = cms.Sequence(globalreco_tracking*
 
 _run3_globalreco = globalreco.copyAndExclude([CastorFullReco])
 run3_common.toReplaceWith(globalreco, _run3_globalreco)
-
-_phase2_timing_layer_globalreco = _run3_globalreco.copy()
-_phase2_timing_layer_globalreco_tracking = globalreco_tracking.copy()
-_phase2_timing_layer_globalreco_tracking += fastTimingGlobalReco
-_phase2_timing_layer_globalreco.replace(globalreco_tracking,_phase2_timing_layer_globalreco_tracking)
-from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
-from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
-(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco_tracking,_phase2_timing_layer_globalreco_tracking)
-(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco,_phase2_timing_layer_globalreco)
 
 _fastSim_globalreco = globalreco.copyAndExclude([CastorFullReco,muoncosmicreco])
 # insert the few tracking modules to be run after mixing back in the globalreco sequence

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -140,6 +140,11 @@ from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timi
 from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
 (phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco,_phase2_timing_layer_globalreco)
 
+_phase2_timing_layer_globalreco_tracking = globalreco_tracking.copy()
+_phase2_timing_layer_globalreco_tracking += fastTimingGlobalReco
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco_tracking,_phase2_timing_layer_globalreco_tracking)
+
+
 _fastSim_globalreco = globalreco.copyAndExclude([CastorFullReco,muoncosmicreco])
 # insert the few tracking modules to be run after mixing back in the globalreco sequence
 _fastSim_globalreco.insert(0,newCombinedSeeds+trackExtrapolator+caloTowerForTrk+firstStepPrimaryVerticesUnsorted+ak4CaloJetsForTrk+initialStepTrackRefsForJets+firstStepPrimaryVertices)

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -135,15 +135,13 @@ _run3_globalreco = globalreco.copyAndExclude([CastorFullReco])
 run3_common.toReplaceWith(globalreco, _run3_globalreco)
 
 _phase2_timing_layer_globalreco = _run3_globalreco.copy()
-_phase2_timing_layer_globalreco += fastTimingGlobalReco
-from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
-from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
-(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco,_phase2_timing_layer_globalreco)
-
 _phase2_timing_layer_globalreco_tracking = globalreco_tracking.copy()
 _phase2_timing_layer_globalreco_tracking += fastTimingGlobalReco
+_phase2_timing_layer_globalreco.replace(globalreco_tracking,_phase2_timing_layer_globalreco_tracking)
+from Configuration.Eras.Modifier_phase2_timing_layer_tile_cff import phase2_timing_layer_tile
+from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
 (phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco_tracking,_phase2_timing_layer_globalreco_tracking)
-
+(phase2_timing_layer_tile | phase2_timing_layer_bar).toReplaceWith(globalreco,_phase2_timing_layer_globalreco)
 
 _fastSim_globalreco = globalreco.copyAndExclude([CastorFullReco,muoncosmicreco])
 # insert the few tracking modules to be run after mixing back in the globalreco sequence


### PR DESCRIPTION
#### PR description:

Minimal update to the globalreco_tracking sequence for Phase2 in order to include MTD. This is needed by the new test wf 20434.1, so far systematically failing because the sequence is not running the needed module:
```
----- Begin Fatal Exception 16-Jul-2019 03:02:20 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 2 event: 105 stream: 0
   [1] Running path 'RECOSIMoutput_step'
   [2] Prefetching for module PoolOutputModule/'RECOSIMoutput'
   [3] Prefetching for module RecoChargedRefCandidatePrimaryVertexSorter/'offlinePrimaryVertices4D'
   [4] Prefetching for module ChargedRefCandidateProducer/'trackRefsForJetsBeforeSorting4D'
   [5] Prefetching for module TrackWithVertexRefSelector/'trackWithVertexRefSelectorBeforeSorting4D'
   [6] Prefetching for module PrimaryVertexProducer/'unsortedOfflinePrimaryVertices4D'
   [7] Prefetching for module TOFPIDProducer/'tofPID'
   [8] Calling method for module PrimaryVertexProducer/'unsortedOfflinePrimaryVertices4DnoPID'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: edm::ValueMap&lt;float&gt;
Looking for module label: trackExtenderWithMTD
Looking for productInstanceName: generalTracksigmat0

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```

See issue #27507 for details.

#### PR validation:

Test workflow 20434.1 runs to completion without apparent issues.