### PR TITLE
remove SetCanExtend for the histogram DistanceOfClosestApproachToBSVsEta

### DIFF
--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -863,7 +863,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "DistanceOfClosestApproachToBSVsEta_";
       DistanceOfClosestApproachToBSVsEta = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, DxyBin, DxyMin, DxyMax, "");
-      DistanceOfClosestApproachToBSVsEta->getTH1()->SetCanExtend(TH1::kAllAxes);
+      //      DistanceOfClosestApproachToBSVsEta->getTH1()->SetCanExtend(TH1::kAllAxes);   // causing issues with DQMIO merge
       DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track #eta", 1);
       DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
     }


### PR DESCRIPTION
#### PR description:

This PR addresses the problem #27528 by removing the option ```SetCanExtend``` for the ME ```DistanceOfClosestApproachToBSVsEta``` added in #27330. 

#### PR validation:

Splitting the step3 of test wf 136.85 into two parts, and merging the two DQM outputs, does not fail any more.