### PR TITLE
Remove all the ocurrences of SetCanExtend from TrackAnalyzer

### DIFF
--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -863,7 +863,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "DistanceOfClosestApproachToBSVsEta_";
       DistanceOfClosestApproachToBSVsEta = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, EtaBin, EtaMin, EtaMax, DxyBin, DxyMin, DxyMax, "");
-      DistanceOfClosestApproachToBSVsEta->getTH1()->SetCanExtend(TH1::kAllAxes);
       DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track #eta", 1);
       DistanceOfClosestApproachToBSVsEta->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
     }
@@ -877,7 +876,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
     histname = "DistanceOfClosestApproachToBSVsPhi_";
     DistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(
         histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
-    DistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
     DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi", 1);
     DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
 
@@ -960,7 +958,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
     histname = "DistanceOfClosestApproachToPVVsPhi_";
     DistanceOfClosestApproachToPVVsPhi = ibooker.bookProfile(
         histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
-    DistanceOfClosestApproachToPVVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
     DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track #phi", 1);
     DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track d_{xy} w.r.t. PV (cm)", 2);
 
@@ -996,7 +993,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "TESTDistanceOfClosestApproachToBSVsPhi_";
       TESTDistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax, "");
-      TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
       TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi", 1);
       TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)", 2);
     }
@@ -1047,7 +1043,6 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker& ibooker) {
       histname = "DistanceOfClosestApproachVsPhi_";
       DistanceOfClosestApproachVsPhi = ibooker.bookProfile(
           histname + CategoryName, histname + CategoryName, PhiBin, PhiMin, PhiMax, DxyMin, DxyMax, "");
-      DistanceOfClosestApproachVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
       DistanceOfClosestApproachVsPhi->setAxisTitle("Track #phi", 1);
       DistanceOfClosestApproachVsPhi->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)", 2);
     }


### PR DESCRIPTION
#### PR description:

This PR removes all the occurrences of SetCanExtend from TrackAnalyzer.cc. Solves the issue discussed in #27531


#### PR validation:

tested using runTheMatrix.py -l 10024 
