### PR TITLE
Improve L1MuGMTMatrix

### DIFF
--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTDebugBlock.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTDebugBlock.cc
@@ -40,8 +40,9 @@ L1MuGMTDebugBlock::L1MuGMTDebugBlock(int minbx, int maxbx)
       _phisel(maxbx - minbx + 1, std::vector<unsigned>(32, 0)),
       _etasel(maxbx - minbx + 1, std::vector<unsigned>(32, 0)),
       _isMIPISO(maxbx - minbx + 1, std::vector<unsigned>(32, 0)),
-      _pairMatrices(maxbx - minbx + 1, std::vector<L1MuGMTMatrix<bool> >(NumMatrices, L1MuGMTMatrix<bool>(4, 4))),
-      _mqMatrices(maxbx - minbx + 1, std::vector<L1MuGMTMatrix<int> >(NumMatrices, L1MuGMTMatrix<int>(4, 4))),
+      _pairMatrices(maxbx - minbx + 1,
+                    std::vector<L1MuGMTMatrix<bool> >(NumMatrices, L1MuGMTMatrix<bool>(4, 4, false))),
+      _mqMatrices(maxbx - minbx + 1, std::vector<L1MuGMTMatrix<int> >(NumMatrices, L1MuGMTMatrix<int>(4, 4, 0))),
       _cancelbits(maxbx - minbx + 1, std::vector<unsigned>(4)),
       _brlmuons(maxbx - minbx + 1, std::vector<L1MuGMTExtendedCand>(4)),
       _fwdmuons(maxbx - minbx + 1, std::vector<L1MuGMTExtendedCand>(4))
@@ -107,8 +108,8 @@ void L1MuGMTDebugBlock::reset() {
       _isMIPISO[bx][i] = 0;
     }
     for (int i = 0; i < NumMatrices; i++) {
-      _pairMatrices[bx][i].init(false);
-      _mqMatrices[bx][i].init(0);
+      _pairMatrices[bx][i].reset(false);
+      _mqMatrices[bx][i].reset(0);
     }
     for (int i = 0; i < 4; i++) {
       _brlmuons[bx][i].reset();

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTInputEvent.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTInputEvent.cc
@@ -33,7 +33,13 @@
 //----------------
 // Constructors --
 //----------------
-L1MuGMTInputEvent::L1MuGMTInputEvent() : m_runnr(0L), m_evtnr(0L), m_mip_bits(14, 18), m_iso_bits(14, 18) {
+L1MuGMTInputEvent::L1MuGMTInputEvent()
+    : m_runnr(0L),
+      m_evtnr(0L),
+      m_mip_bits(14, 18, false),
+      m_iso_bits(14, 18, true)  //this is more useful when reading a standalone input file
+                                //since "not-quiet" bits are stored there
+{
   std::vector<L1MuRegionalCand> empty_vec;
   m_inputmuons["INC"] = empty_vec;
   m_inputmuons["IND"] = empty_vec;
@@ -48,10 +54,6 @@ L1MuGMTInputEvent::L1MuGMTInputEvent() : m_runnr(0L), m_evtnr(0L), m_mip_bits(14
   m_inputmuons["IND"].reserve(4);
   m_inputmuons["INB"].reserve(4);
   m_inputmuons["INF"].reserve(4);
-
-  m_mip_bits.init(false);
-  m_iso_bits.init(true);  //this is more useful when reading a standalone input file
-                          //since "not-quiet" bits are stored there
 }
 
 //--------------
@@ -77,8 +79,8 @@ void L1MuGMTInputEvent::reset() {
     it->second.clear();
   }
 
-  m_mip_bits.init(false);
-  m_iso_bits.init(true);  //see CTOR for info on this
+  m_mip_bits.reset(false);
+  m_iso_bits.reset(true);  //see CTOR for info on this
 }
 
 const L1MuRegionalCand* L1MuGMTInputEvent::getInputMuon(std::string chipid, unsigned index) const {

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatcher.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatcher.cc
@@ -62,8 +62,8 @@ L1MuGMTMatcher::L1MuGMTMatcher(const L1MuGlobalMuonTrigger& gmt, int id)
       m_id(id),
       first(MaxMatch),
       second(MaxMatch),
-      matchQuality(MaxMatch, MaxMatch),
-      pairMatrix(MaxMatch, MaxMatch) {
+      matchQuality(MaxMatch, MaxMatch, 0),
+      pairMatrix(MaxMatch, MaxMatch, false) {
   first.reserve(MaxMatch);
   second.reserve(MaxMatch);
 }
@@ -89,8 +89,8 @@ void L1MuGMTMatcher::run() {
 // clear Matcher
 //
 void L1MuGMTMatcher::reset() {
-  matchQuality.init(0);
-  pairMatrix.init(false);
+  matchQuality.reset(0);
+  pairMatrix.reset(false);
 
   for (unsigned i = 0; i < MaxMatch; i++) {
     first[i] = nullptr;
@@ -183,10 +183,8 @@ void L1MuGMTMatcher::load() {
 // match muons
 //
 void L1MuGMTMatcher::match() {
-  L1MuGMTMatrix<bool> maxMatrix(MaxMatch, MaxMatch);
-  L1MuGMTMatrix<bool> disableMatrix(MaxMatch, MaxMatch);
-  maxMatrix.init(false);
-  disableMatrix.init(false);
+  L1MuGMTMatrix<bool> maxMatrix(MaxMatch, MaxMatch, false);
+  L1MuGMTMatrix<bool> disableMatrix(MaxMatch, MaxMatch, false);
 
   // loop over all combinations
 

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h
@@ -45,7 +45,7 @@ template <class T>
 class L1MuGMTMatrix {
 public:
   /// constructor
-  L1MuGMTMatrix(int r, int c);
+  L1MuGMTMatrix(int r, int c, T v);
 
   /// copy constructor
   L1MuGMTMatrix(const L1MuGMTMatrix<T>&);
@@ -61,8 +61,8 @@ public:
   ///
   const T& operator()(int r, int c) const;
 
-  /// initialize matrix
-  void init(T v = 0);
+  /// reset all elements
+  void reset(T v);
 
   /// set matrix element
   void set(int r, int c, T v);
@@ -105,7 +105,11 @@ private:
 };
 
 template <class T>
-L1MuGMTMatrix<T>::L1MuGMTMatrix(int r, int c) : r_size(r), c_size(c), p_(new T[r * c]) {}
+L1MuGMTMatrix<T>::L1MuGMTMatrix(int r, int c, T v) : r_size(r), c_size(c), p_(new T[r * c]) {
+  for (int i = 0; i < r_size * c_size; ++i) {
+    p_[i] = v;
+  }
+}
 
 // copy constructor
 
@@ -138,10 +142,10 @@ const T& L1MuGMTMatrix<T>::operator()(int r, int c) const {
 }
 
 //
-// initialize matrix
+// reset elements
 //
 template <class T>
-void L1MuGMTMatrix<T>::init(T v) {
+void L1MuGMTMatrix<T>::reset(T v) {
   for (int i = 0; i < r_size * c_size; ++i) {
     p_[i] = v;
   }

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <string>
 #include <sstream>
+#include <memory>
 
 //----------------------
 // Base Class Headers --
@@ -49,8 +50,10 @@ public:
   /// copy constructor
   L1MuGMTMatrix(const L1MuGMTMatrix<T>&);
 
+  L1MuGMTMatrix(L1MuGMTMatrix<T>&&) = default;
+
   /// destructor
-  virtual ~L1MuGMTMatrix();
+  virtual ~L1MuGMTMatrix() = default;
 
   ///
   T& operator()(int r, int c);
@@ -92,49 +95,26 @@ public:
   void print() const;
 
 private:
+  T& get(int r, int c) { return p_[r * c_size + c]; }
+
+  T const& get(int r, int c) const { return p_[r * c_size + c]; }
+
   int r_size, c_size;
 
-  T** p;
+  std::unique_ptr<T[]> p_;
 };
 
 template <class T>
-L1MuGMTMatrix<T>::L1MuGMTMatrix(int r, int c) : r_size(r), c_size(c) {
-  p = new T*[r];
-
-  assert(p != nullptr);
-
-  for (int i = 0; i < r; i++) {
-    p[i] = new T[c];
-    assert(p[i] != nullptr);
-  }
-}
+L1MuGMTMatrix<T>::L1MuGMTMatrix(int r, int c) : r_size(r), c_size(c), p_(new T[r * c]) {}
 
 // copy constructor
 
 template <class T>
-L1MuGMTMatrix<T>::L1MuGMTMatrix(const L1MuGMTMatrix<T>& mat) : r_size(mat.r_size), c_size(mat.c_size) {
-  p = new T*[r_size];
-
-  assert(p != nullptr);
-
-  for (int i = 0; i < r_size; i++) {
-    p[i] = new T[c_size];
-    assert(p[i] != nullptr);
-    for (int j = 0; j < c_size; j++)
-      p[i][j] = mat.p[i][j];
+L1MuGMTMatrix<T>::L1MuGMTMatrix(const L1MuGMTMatrix<T>& mat)
+    : r_size(mat.r_size), c_size(mat.c_size), p_(new T[r_size * c_size]) {
+  for (int i = 0; i < r_size * c_size; ++i) {
+    p_[i] = mat.p_[i];
   }
-}
-
-//--------------
-// Destructor --
-//--------------
-template <class T>
-L1MuGMTMatrix<T>::~L1MuGMTMatrix() {
-  for (int i = 0; i < r_size; i++) {
-    delete[] p[i];
-  }
-
-  delete[] p;
 }
 
 //
@@ -144,7 +124,7 @@ template <class T>
 T& L1MuGMTMatrix<T>::operator()(int r, int c) {
   assert(r >= 0 && r < r_size && c >= 0 && c < c_size);
 
-  return p[r][c];
+  return get(r, c);
 }
 
 //
@@ -154,7 +134,7 @@ template <class T>
 const T& L1MuGMTMatrix<T>::operator()(int r, int c) const {
   assert(r >= 0 && r < r_size && c >= 0 && c < c_size);
 
-  return p[r][c];
+  return get(r, c);
 }
 
 //
@@ -162,9 +142,8 @@ const T& L1MuGMTMatrix<T>::operator()(int r, int c) const {
 //
 template <class T>
 void L1MuGMTMatrix<T>::init(T v) {
-  for (int r = 0; r < r_size; r++) {
-    for (int c = 0; c < c_size; c++)
-      p[r][c] = v;
+  for (int i = 0; i < r_size * c_size; ++i) {
+    p_[i] = v;
   }
 }
 
@@ -175,7 +154,7 @@ template <class T>
 void L1MuGMTMatrix<T>::set(int r, int c, T v) {
   assert(r >= 0 && r < r_size && c >= 0 && c < c_size);
 
-  p[r][c] = v;
+  get(r, c) = v;
 }
 
 //
@@ -186,9 +165,8 @@ L1MuGMTMatrix<T>& L1MuGMTMatrix<T>::operator=(const L1MuGMTMatrix& m) {
   if (this != &m) {
     assert(m.c_size == c_size && m.r_size == r_size);
 
-    for (int r = 0; r < r_size; r++) {
-      for (int c = 0; c < c_size; c++)
-        p[r][c] = m.p[r][c];
+    for (int i = 0; i < r_size * c_size; ++i) {
+      p_[i] = m.p_[i];
     }
   }
 
@@ -202,10 +180,8 @@ template <class T>
 L1MuGMTMatrix<T>& L1MuGMTMatrix<T>::operator+=(const L1MuGMTMatrix& m) {
   assert(m.c_size == c_size && m.r_size == r_size);
 
-  for (int r = 0; r < r_size; r++) {
-    for (int c = 0; c < c_size; c++) {
-      p[r][c] += m.p[r][c];
-    }
+  for (int i = 0; i < r_size * c_size; ++i) {
+    p_[i] += m.p_[i];
   }
 
   return *this;
@@ -216,9 +192,8 @@ L1MuGMTMatrix<T>& L1MuGMTMatrix<T>::operator+=(const L1MuGMTMatrix& m) {
 //
 template <class T>
 L1MuGMTMatrix<T>& L1MuGMTMatrix<T>::operator+=(const T& s) {
-  for (int r = 0; r < r_size; r++) {
-    for (int c = 0; c < c_size; c++)
-      p[r][c] += s;
+  for (int i = 0; i < r_size * c_size; ++i) {
+    p_[i] += s;
   }
 
   return *this;
@@ -229,9 +204,8 @@ L1MuGMTMatrix<T>& L1MuGMTMatrix<T>::operator+=(const T& s) {
 //
 template <class T>
 L1MuGMTMatrix<T>& L1MuGMTMatrix<T>::operator*=(const T& s) {
-  for (int r = 0; r < r_size; r++) {
-    for (int c = 0; c < c_size; c++)
-      p[r][c] *= s;
+  for (int i = 0; i < r_size * c_size; ++i) {
+    p_[i] *= s;
   }
 
   return *this;
@@ -245,17 +219,17 @@ bool L1MuGMTMatrix<T>::isMax(int r, int c) const {
   bool max = true;
 
   for (int i = 0; i < c; i++) {
-    max = max && (this->p[r][c] > this->p[r][i]);
+    max = max && (this->get(r, c) > this->get(r, i));
   }
   for (int i = c + 1; i < c_size; i++) {
-    max = max && (this->p[r][c] >= this->p[r][i]);
+    max = max && (this->get(r, c) >= this->get(r, i));
   }
 
   for (int j = 0; j < r; j++) {
-    max = max && (this->p[r][c] > this->p[j][c]);
+    max = max && (this->get(r, c) > this->get(j, c));
   }
   for (int j = r + 1; j < r_size; j++) {
-    max = max && (this->p[r][c] >= this->p[j][c]);
+    max = max && (this->get(r, c) >= this->get(j, c));
   }
 
   return max;
@@ -268,10 +242,10 @@ template <class T>
 bool L1MuGMTMatrix<T>::isMin(int r, int c) const {
   bool min = true;
   for (int i = 0; i < c_size; i++) {
-    min = min && (this->p[r][c] <= this->p[r][i]);
+    min = min && (this->get(r, c) <= this->get(r, i));
   }
   for (int j = 0; j < r_size; j++) {
-    min = min && (this->p[r][c] <= this->p[j][c]);
+    min = min && (this->get(r, c) <= this->get(j, c));
   }
 
   return min;
@@ -284,7 +258,7 @@ template <class T>
 int L1MuGMTMatrix<T>::colAny(int c) const {
   int stat = -1;
   for (int i = 0; i < r_size; i++) {
-    if (this->p[i][c] > 0)
+    if (this->get(i, c) > 0)
       stat = i;
   }
 
@@ -298,7 +272,7 @@ template <class T>
 int L1MuGMTMatrix<T>::rowAny(int r) const {
   int stat = -1;
   for (int i = 0; i < c_size; i++) {
-    if (this->p[r][i] > 0)
+    if (this->get(r, i) > 0)
       stat = i;
   }
 
@@ -313,7 +287,7 @@ void L1MuGMTMatrix<T>::print() const {
   for (int r = 0; r < r_size; r++) {
     std::stringstream output;
     for (int c = 0; c < c_size; c++)
-      output << p[r][c] << "\t";
+      output << get(r, c) << "\t";
     edm::LogVerbatim("GMTMatrix_print") << output.str();
   }
   edm::LogVerbatim("GMTMatrix_print");

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPSB.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTPSB.cc
@@ -54,13 +54,11 @@ L1MuGMTPSB::L1MuGMTPSB(const L1MuGlobalMuonTrigger& gmt, edm::ConsumesCollector&
       m_RpcMuons(L1MuGMTConfig::MAXRPC),
       m_DtbxMuons(L1MuGMTConfig::MAXDTBX),
       m_CscMuons(L1MuGMTConfig::MAXCSC),
-      m_Isol(14, 18),
-      m_Mip(14, 18) {
+      m_Isol(14, 18, false),
+      m_Mip(14, 18, false) {
   m_RpcMuons.reserve(L1MuGMTConfig::MAXRPC);
   m_DtbxMuons.reserve(L1MuGMTConfig::MAXDTBX);
   m_CscMuons.reserve(L1MuGMTConfig::MAXCSC);
-  m_Isol.init(false);
-  m_Mip.init(false);
   iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getDTInputTag());
   iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getCSCInputTag());
   iC.consumes<std::vector<L1MuRegionalCand> >(L1MuGMTConfig::getRPCbInputTag());
@@ -204,8 +202,8 @@ void L1MuGMTPSB::reset() {
   while (iter != m_CscMuons.end())
     (*(iter++)).reset();
 
-  m_Isol.init(false);
-  m_Mip.init(false);
+  m_Isol.reset(false);
+  m_Mip.reset(false);
 }
 
 //

--- a/L1Trigger/GlobalMuonTrigger/test/BuildFile.xml
+++ b/L1Trigger/GlobalMuonTrigger/test/BuildFile.xml
@@ -12,6 +12,10 @@
 <use   name="hepmc"/>
 <use   name="root"/>
 <use   name="CLHEP"/>
+<bin file="test_*.cc" name="L1TriggerGlobalMuonTriggerTest">
+  <use name="catch2"/>
+  <use name="L1Trigger/GlobalMuonTrigger"/>
+</bin>
 <library   file="CruzetL1DTfilter.cc" name="CruzetL1DTfilter">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/GlobalMuonTrigger/test/test_L1MuGMTMatrix.cc
+++ b/L1Trigger/GlobalMuonTrigger/test/test_L1MuGMTMatrix.cc
@@ -1,0 +1,120 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "L1Trigger/GlobalMuonTrigger/src/L1MuGMTMatrix.h"
+
+namespace {
+  template <int I, int J, typename T>
+  bool compare(const L1MuGMTMatrix<T>& iMatrix, std::array<T, I * J> const& iValues) {
+    for (int i = 0; i < I; ++i) {
+      for (int j = 0; j < J; ++j) {
+        if (iMatrix(i, j) != iValues[j + i * J]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}  // namespace
+
+TEST_CASE("Test L1MuGMTMatrix", "L1MuGMTMatrix") {
+  SECTION("empty") {
+    L1MuGMTMatrix<int> m(2, 3);
+    m.init();
+    REQUIRE(compare<2, 3>(m, {{0, 0, 0, 0, 0, 0}}) == true);
+  }
+
+  SECTION("set all to 1") {
+    L1MuGMTMatrix<int> m(2, 3);
+    m.init(1);
+    REQUIRE(compare<2, 3>(m, {{1, 1, 1, 1, 1, 1}}) == true);
+  }
+
+  SECTION("set different values") {
+    L1MuGMTMatrix<int> m(2, 3);
+    m.set(0, 0, 0);
+    m.set(0, 1, 1);
+    m.set(0, 2, 2);
+
+    m.set(1, 0, 3);
+    m.set(1, 1, 4);
+    m.set(1, 2, 5);
+
+    REQUIRE(compare<2, 3>(m, {{0, 1, 2, 3, 4, 5}}) == true);
+
+    REQUIRE(m.isMax(0, 0) == false);
+    REQUIRE(m.isMax(0, 1) == false);
+    REQUIRE(m.isMax(0, 2) == false);
+    REQUIRE(m.isMax(1, 0) == false);
+    REQUIRE(m.isMax(1, 1) == false);
+    REQUIRE(m.isMax(1, 2) == true);
+
+    REQUIRE(m.isMin(0, 0) == true);
+    REQUIRE(m.isMin(0, 1) == false);
+    REQUIRE(m.isMin(0, 2) == false);
+
+    REQUIRE(m.isMin(1, 0) == false);
+    REQUIRE(m.isMin(1, 1) == false);
+    REQUIRE(m.isMin(1, 2) == false);
+  }
+
+  SECTION("Copy and operator=") {
+    L1MuGMTMatrix<int> m(2, 3);
+    m.set(0, 0, 0);
+    m.set(0, 1, 1);
+    m.set(0, 2, 2);
+
+    m.set(1, 0, 3);
+    m.set(1, 1, 4);
+    m.set(1, 2, 5);
+
+    L1MuGMTMatrix<int> cp(m);
+
+    REQUIRE(compare<2, 3>(cp, {{0, 1, 2, 3, 4, 5}}) == true);
+
+    L1MuGMTMatrix<int> opEq(2, 3);
+    opEq.init(0);
+    opEq = m;
+
+    REQUIRE(compare<2, 3>(opEq, {{0, 1, 2, 3, 4, 5}}) == true);
+  }
+
+  SECTION("Arithmetics") {
+    L1MuGMTMatrix<int> m(2, 3);
+    m.set(0, 0, 0);
+    m.set(0, 1, 1);
+    m.set(0, 2, 2);
+
+    m.set(1, 0, 3);
+    m.set(1, 1, 4);
+    m.set(1, 2, 5);
+
+    SECTION("Scalar addition") { REQUIRE(compare<2, 3>(m += 1, {{1, 2, 3, 4, 5, 6}}) == true); }
+
+    SECTION("Scalar multiplication") { REQUIRE(compare<2, 3>(m *= 2, {{0, 2, 4, 6, 8, 10}}) == true); }
+
+    SECTION("Matrix addition") {
+      L1MuGMTMatrix<int> cp(m);
+      REQUIRE(compare<2, 3>(m += cp, {{0, 2, 4, 6, 8, 10}}) == true);
+    }
+  }
+
+  SECTION("Look for non 0") {
+    L1MuGMTMatrix<int> m(2, 3);
+
+    m.set(0, 0, 0);
+    m.set(0, 1, 0);
+    m.set(0, 2, 2);
+
+    m.set(1, 0, 0);
+    m.set(1, 1, 0);
+    m.set(1, 2, 0);
+
+    REQUIRE(m.colAny(0) == -1);
+    REQUIRE(m.colAny(1) == -1);
+    REQUIRE(m.colAny(2) == 0);
+
+    REQUIRE(m.rowAny(0) == 2);
+    REQUIRE(m.rowAny(1) == -1);
+  }
+}

--- a/L1Trigger/GlobalMuonTrigger/test/test_L1MuGMTMatrix.cc
+++ b/L1Trigger/GlobalMuonTrigger/test/test_L1MuGMTMatrix.cc
@@ -19,19 +19,17 @@ namespace {
 
 TEST_CASE("Test L1MuGMTMatrix", "L1MuGMTMatrix") {
   SECTION("empty") {
-    L1MuGMTMatrix<int> m(2, 3);
-    m.init();
+    L1MuGMTMatrix<int> m(2, 3, 0);
     REQUIRE(compare<2, 3>(m, {{0, 0, 0, 0, 0, 0}}) == true);
   }
 
   SECTION("set all to 1") {
-    L1MuGMTMatrix<int> m(2, 3);
-    m.init(1);
+    L1MuGMTMatrix<int> m(2, 3, 1);
     REQUIRE(compare<2, 3>(m, {{1, 1, 1, 1, 1, 1}}) == true);
   }
 
   SECTION("set different values") {
-    L1MuGMTMatrix<int> m(2, 3);
+    L1MuGMTMatrix<int> m(2, 3, 0);
     m.set(0, 0, 0);
     m.set(0, 1, 1);
     m.set(0, 2, 2);
@@ -59,7 +57,7 @@ TEST_CASE("Test L1MuGMTMatrix", "L1MuGMTMatrix") {
   }
 
   SECTION("Copy and operator=") {
-    L1MuGMTMatrix<int> m(2, 3);
+    L1MuGMTMatrix<int> m(2, 3, 0);
     m.set(0, 0, 0);
     m.set(0, 1, 1);
     m.set(0, 2, 2);
@@ -72,15 +70,14 @@ TEST_CASE("Test L1MuGMTMatrix", "L1MuGMTMatrix") {
 
     REQUIRE(compare<2, 3>(cp, {{0, 1, 2, 3, 4, 5}}) == true);
 
-    L1MuGMTMatrix<int> opEq(2, 3);
-    opEq.init(0);
+    L1MuGMTMatrix<int> opEq(2, 3, 0);
     opEq = m;
 
     REQUIRE(compare<2, 3>(opEq, {{0, 1, 2, 3, 4, 5}}) == true);
   }
 
   SECTION("Arithmetics") {
-    L1MuGMTMatrix<int> m(2, 3);
+    L1MuGMTMatrix<int> m(2, 3, 0);
     m.set(0, 0, 0);
     m.set(0, 1, 1);
     m.set(0, 2, 2);
@@ -100,7 +97,7 @@ TEST_CASE("Test L1MuGMTMatrix", "L1MuGMTMatrix") {
   }
 
   SECTION("Look for non 0") {
-    L1MuGMTMatrix<int> m(2, 3);
+    L1MuGMTMatrix<int> m(2, 3, 0);
 
     m.set(0, 0, 0);
     m.set(0, 1, 0);


### PR DESCRIPTION
#### PR description:

- Use just a single contiguous memory location instead of an array of arrays.
- Use std::unique_ptr<T[]> to manage the memory
- Initialize matrix elements in the constructor
- Added a unit test to prove no functional changes happened

Not initializing the matrix elements in the constructor was causing a complaint by UBSAN.
#### PR validation:

Code compiles and the new unit test passes.

This is a technical change and should have no impact on the results. It should take less memory and be faster.