### PR TITLE
fix segfault in DQMCertCommonFakeHLT

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
@@ -15,9 +15,6 @@ DQMCertCommon = cms.Sequence(siStripDaqInfo * sipixelDaqInfo *
                              egammaDataCertificationTask *
                              dqmOfflineTriggerCert)
 
-DQMCertCommonFakeHLT = cms.Sequence( DQMCertCommon )
-DQMCertCommonFakeHLT.remove( dqmOfflineTriggerCert )
-
 DQMCertMuon = cms.Sequence(dtDAQInfo * rpcDaqInfo * cscDaqInfo *
                            dtDCSByLumiSummary * rpcDCSSummary * cscDcsInfo *
                            dtCertificationSummary * rpcDataCertification * cscCertificationInfo)
@@ -34,3 +31,6 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith(DQMCertCommon, DQMCertCommon.copyAndExclude([ # FIXME
     sipixelCertification # segfaults when included
 ]))
+
+DQMCertCommonFakeHLT = cms.Sequence( DQMCertCommon )
+DQMCertCommonFakeHLT.remove( dqmOfflineTriggerCert )


### PR DESCRIPTION
#### PR description:
In PR #27467 a new sequence `DQMCertCommonFakeHLT` was introduced without taking into account one needs to exclude (for the time being) the `sipixelCertification` part. 
This lead to failures in the  IB CMSSW_11_0_X_2019-07-16-2300 (see [logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc700/CMSSW_11_0_X_2019-07-16-2300/pyRelValMatrixLogs/run/136.789_RunZeroBias2017B+RunZeroBias2017B+HLTDR2_2017+RECODR2_2017reHLT_ZBPrompt+HARVEST2017ZB/step4_RunZeroBias2017B+RunZeroBias2017B+HLTDR2_2017+RECODR2_2017reHLT_ZBPrompt+HARVEST2017ZB.log)  ):
```
----- Begin Fatal Exception 17-Jul-2019 03:58:39 CEST-----------------------
An exception of category 'StdException' occurred while
   [0] Processing global end LuminosityBlock run: 297557 luminosityBlock: 36
   [1] Calling method for module SiPixelCertification/'sipixelCertification'
Exception Message:
A std::exception was thrown.
DQM object not found: Pixel/EventInfo/reportSummary
----- End Fatal Exception -------------------------------------------------
```
I just move the definition of the sequence (which is basically a copy of the existing `DQMCertCommon`) after the `copyAndExclude` instruction is executed. 
This makes the new sequence to inherit the exclusion of the offending sequence.
**N.B.** this is a temporary solution, as the ultimate fix would be to improve `SiPixelCertification` not to segfault for phase-1 pixel setup and remove all the `copyAndExclude` instructions. 
@arossi83 is working on this, and an appropriate fix should come at later time. 

#### PR validation:

I've re-run successfully the HARVESTING step of wf 136.789 with the changes proposed here.
```
runTheMatrix.py -l 136.789 -j 8 -t 4 
```

#### if this PR is a backport please specify the original PR:

This is not a backport