### PR TITLE
Geant4 initialisation clean-up for DD4Hep migration

### DIFF
--- a/SimG4Core/Application/interface/OscarMTMasterThread.h
+++ b/SimG4Core/Application/interface/OscarMTMasterThread.h
@@ -46,7 +46,6 @@ private:
 
   enum class ThreadState { NotExist = 0, BeginRun = 1, EndRun = 2, Destruct = 3 };
 
-  const bool m_pUseMagneticField;
   const bool m_pGeoFromDD4hep;
 
   std::shared_ptr<RunManagerMT> m_runManagerMaster;
@@ -57,7 +56,6 @@ private:
   mutable edm::ESWatcher<IdealMagneticFieldRecord> idealMagRcdWatcher_;
   mutable const DDCompactView* m_pDD;
   mutable const cms::DDCompactView* m_pDD4hep;
-  mutable const MagneticField* m_pMF;
   mutable const HepPDT::ParticleDataTable* m_pTable;
 
   mutable std::mutex m_protectMutex;

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -31,7 +31,6 @@ namespace cms {
 }
 
 class DDDWorld;
-class MagneticField;
 
 class G4MTRunManagerKernel;
 class G4Run;
@@ -60,7 +59,8 @@ public:
   explicit RunManagerMT(edm::ParameterSet const&);
   ~RunManagerMT();
 
-  void initG4(const DDCompactView*, const cms::DDCompactView*, const MagneticField*, const HepPDT::ParticleDataTable*);
+  //  void initG4(const DDCompactView*, const cms::DDCompactView*, const MagneticField*, const HepPDT::ParticleDataTable*);
+  void initG4(const DDCompactView*, const cms::DDCompactView*, const HepPDT::ParticleDataTable*);
 
   void initializeUserActions();
 
@@ -92,7 +92,6 @@ private:
   std::unique_ptr<PhysicsList> m_physicsList;
   bool m_managerInitialized;
   bool m_runTerminated;
-  bool m_pUseMagneticField;
   RunAction* m_userRunAction;
   G4Run* m_currentRun;
   G4StateManager* m_stateManager;

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -18,7 +18,7 @@
 #include "G4PhysicalVolumeStore.hh"
 
 OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
-   :  m_pGeoFromDD4hep(iConfig.getParameter<bool>("g4GeometryDD4hepSource")),
+    : m_pGeoFromDD4hep(iConfig.getParameter<bool>("g4GeometryDD4hepSource")),
       m_pDD(nullptr),
       m_pDD4hep(nullptr),
       m_pTable(nullptr),

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -12,9 +12,7 @@
 #include "SimG4Core/Application/interface/ExceptionHandler.h"
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
-#include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
-#include "SimG4Core/Geometry/interface/DDG4ProductionCuts.h"
 
 #include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 
@@ -187,6 +185,17 @@ void RunManager::initG4(const edm::EventSetup& es) {
                                       << "The Geometry configuration is changed during the job execution\n"
                                       << "this is not allowed, the geometry must stay unchanged\n";
   }
+  bool geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
+  bool cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
+  bool protonCut = m_pPhysics.getUntrackedParameter<bool>("CutsOnProton", true);
+  int  verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), 
+                       m_p.getParameter<int>("SteppingVerbosity"));
+  edm::LogVerbatim("SimG4CoreApplication") 
+      << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep << "\n"
+      << "              cutsPerRegion: " << cuts << " cutForProton: " << protonCut << "\n"
+      << "              G4 verbosity: " << verb;
+
+
   if (m_pUseMagneticField) {
     bool magChanged = idealMagRcdWatcher_.check(es);
     if (magChanged && (!firstRun)) {
@@ -200,22 +209,22 @@ void RunManager::initG4(const edm::EventSetup& es) {
   if (m_managerInitialized)
     return;
 
-  // DDDWorld: get the DDCV from the ES and use it to build the World
-  edm::ESTransientHandle<DDCompactView> pDD;
-  es.get<IdealGeometryRecord>().get(pDD);
-
-  G4LogicalVolumeToDDLogicalPartMap map_;
-  SensitiveDetectorCatalog catalog_;
-  const DDDWorld* world = new DDDWorld(&(*pDD), map_, catalog_, false);
-  m_registry.dddWorldSignal_(world);
-
-  int verb =
-      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
-  m_kernel->SetVerboseLevel(verb);
-  auto cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
-  if (cuts) {
-    DDG4ProductionCuts pcuts(map_, verb, m_pPhysics);
+  // initialise geometry
+  const DDCompactView* pDD = nullptr;
+  const cms::DDCompactView* pDD4hep = nullptr;
+  if (geoFromDD4hep) {
+    edm::ESTransientHandle<cms::DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    pDD4hep = pDD.product();
+  } else {
+    edm::ESTransientHandle<DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    pDD = pDD.product();
   }
+  SensitiveDetectorCatalog catalog;
+  const DDDWorld* world = new DDDWorld(pDD, pDD4hep, catalog, verb, cuts, protonCut);
+  G4VPhysicalVolume* pworld = world->GetWorldVolume();
+  m_registry.dddWorldSignal_(world);
 
   if (m_pUseMagneticField) {
     // setup the magnetic field
@@ -237,20 +246,18 @@ void RunManager::initG4(const edm::EventSetup& es) {
   // we need the track manager now
   m_trackManager = std::unique_ptr<SimTrackManager>(new SimTrackManager);
 
-  {
-    // attach sensitive detector
+  // attach sensitive detector
+  AttachSD attach;
+  auto sensDets = attach.create(es, catalog, m_p, m_trackManager.get(), m_registry);
 
-    AttachSD attach;
-    auto sensDets = attach.create(es, catalog_, m_p, m_trackManager.get(), m_registry);
+  m_sensTkDets.swap(sensDets.first);
+  m_sensCaloDets.swap(sensDets.second);
 
-    m_sensTkDets.swap(sensDets.first);
-    m_sensCaloDets.swap(sensDets.second);
-  }
-
-  edm::LogInfo("SimG4CoreApplication") << " RunManager: Sensitive Detector "
-                                       << "building finished; found " << m_sensTkDets.size()
-                                       << " Tk type Producers, and " << m_sensCaloDets.size()
-                                       << " Calo type producers ";
+  edm::LogVerbatim("SimG4CoreApplication") 
+      << " RunManager: Sensitive Detector "
+      << "building finished; found " << m_sensTkDets.size()
+      << " Tk type Producers, and " << m_sensCaloDets.size()
+      << " Calo type producers ";
 
   edm::ESHandle<HepPDT::ParticleDataTable> fTable;
   es.get<PDTRecord>().get(fTable);
@@ -337,7 +344,7 @@ void RunManager::initG4(const edm::EventSetup& es) {
     G4GDMLParser gdml;
     gdml.SetRegionExport(true);
     gdml.SetEnergyCutsExport(true);
-    gdml.Write(m_WriteFile, world->GetWorldVolume(), true);
+    gdml.Write(m_WriteFile, pworld, true);
   }
 
   if (!m_RegionFile.empty()) {

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -188,13 +188,12 @@ void RunManager::initG4(const edm::EventSetup& es) {
   bool geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
   bool cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
   bool protonCut = m_pPhysics.getUntrackedParameter<bool>("CutsOnProton", true);
-  int  verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), 
-                       m_p.getParameter<int>("SteppingVerbosity"));
-  edm::LogVerbatim("SimG4CoreApplication") 
+  int verb =
+      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
+  edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep << "\n"
       << "              cutsPerRegion: " << cuts << " cutForProton: " << protonCut << "\n"
       << "              G4 verbosity: " << verb;
-
 
   if (m_pUseMagneticField) {
     bool magChanged = idealMagRcdWatcher_.check(es);
@@ -253,10 +252,9 @@ void RunManager::initG4(const edm::EventSetup& es) {
   m_sensTkDets.swap(sensDets.first);
   m_sensCaloDets.swap(sensDets.second);
 
-  edm::LogVerbatim("SimG4CoreApplication") 
+  edm::LogVerbatim("SimG4CoreApplication")
       << " RunManager: Sensitive Detector "
-      << "building finished; found " << m_sensTkDets.size()
-      << " Tk type Producers, and " << m_sensCaloDets.size()
+      << "building finished; found " << m_sensTkDets.size() << " Tk type Producers, and " << m_sensCaloDets.size()
       << " Calo type producers ";
 
   edm::ESHandle<HepPDT::ParticleDataTable> fTable;

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -1,3 +1,4 @@
+
 #include "SimG4Core/Application/interface/RunManagerMT.h"
 #include "SimG4Core/Application/interface/PrimaryTransformer.h"
 #include "SimG4Core/Application/interface/SimRunInterface.h"
@@ -7,21 +8,12 @@
 #include "SimG4Core/Application/interface/ExceptionHandler.h"
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
-#include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
-#include "SimG4Core/Geometry/interface/DDG4ProductionCuts.h"
-
-#include "SimG4Core/SensitiveDetector/interface/AttachSD.h"
 
 #include "SimG4Core/Physics/interface/PhysicsListFactory.h"
 #include "SimG4Core/PhysicsLists/interface/CMSMonopolePhysics.h"
 #include "SimG4Core/CustomPhysics/interface/CMSExoticaPhysics.h"
 
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
-#include "SimG4Core/MagneticField/interface/FieldBuilder.h"
-#include "SimG4Core/MagneticField/interface/Field.h"
-#include "SimG4Core/MagneticField/interface/CMSFieldManager.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
 
 #include "SimG4Core/Notification/interface/G4SimEvent.h"
 #include "SimG4Core/Notification/interface/SimTrackManager.h"
@@ -60,8 +52,6 @@
 #include "G4Region.hh"
 #include "G4RegionStore.hh"
 
-#include "DDG4/Geant4Mapping.h"
-
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -72,7 +62,6 @@
 RunManagerMT::RunManagerMT(edm::ParameterSet const& p)
     : m_managerInitialized(false),
       m_runTerminated(false),
-      m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
       m_PhysicsTablesDir(p.getParameter<std::string>("PhysicsTablesDirectory")),
       m_StorePhysicsTables(p.getParameter<bool>("StorePhysicsTables")),
       m_RestorePhysicsTables(p.getParameter<bool>("RestorePhysicsTables")),
@@ -102,35 +91,29 @@ RunManagerMT::~RunManagerMT() { stopG4(); }
 
 void RunManagerMT::initG4(const DDCompactView* pDD,
                           const cms::DDCompactView* pDD4hep,
-                          const MagneticField* pMF,
                           const HepPDT::ParticleDataTable* fPDGTable) {
   if (m_managerInitialized) {
     edm::LogWarning("SimG4CoreApplication") << "RunManagerMT::initG4 was already done - exit";
     return;
   }
-  auto geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
-  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep;
+  bool geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
+  bool cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
+  bool protonCut = m_pPhysics.getUntrackedParameter<bool>("CutsOnProton", true);
+  int  verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), 
+                       m_p.getParameter<int>("SteppingVerbosity"));
+  edm::LogVerbatim("SimG4CoreApplication") 
+      << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep << "\n"
+      << "              cutsPerRegion: " << cuts << " cutForProton: " << protonCut << "\n"
+      << "              G4 verbosity: " << verb;
 
-  // DDDWorld: get the DDCV from the ES and use it to build the World
-  G4LogicalVolumeToDDLogicalPartMap map_lv;
-  dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
-  if (geoFromDD4hep) {
-    m_world.reset(new DDDWorld(pDD4hep->detector(), lvMap));
-  } else {
-    m_world.reset(new DDDWorld(pDD, map_lv, m_catalog, false));
-  }
+  m_world.reset(new DDDWorld(pDD, pDD4hep, m_catalog, verb, cuts, protonCut));
   G4VPhysicalVolume* world = m_world.get()->GetWorldVolume();
 
-  bool cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
-  int verb =
-      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
   m_kernel->SetVerboseLevel(verb);
   edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMT: Define cuts: " << cuts << " Geant4 run manager verbosity: " << verb;
 
-  if (cuts) {
-    DDG4ProductionCuts pcuts(map_lv, verb, m_pPhysics);
-  }
+
   const G4RegionStore* regStore = G4RegionStore::GetInstance();
   const G4PhysicalVolumeStore* pvs = G4PhysicalVolumeStore::GetInstance();
   const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -99,9 +99,9 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   bool geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
   bool cuts = m_pPhysics.getParameter<bool>("CutsPerRegion");
   bool protonCut = m_pPhysics.getUntrackedParameter<bool>("CutsOnProton", true);
-  int  verb = std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), 
-                       m_p.getParameter<int>("SteppingVerbosity"));
-  edm::LogVerbatim("SimG4CoreApplication") 
+  int verb =
+      std::max(m_pPhysics.getUntrackedParameter<int>("Verbosity", 0), m_p.getParameter<int>("SteppingVerbosity"));
+  edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMT: start initialising of geometry DD4Hep: " << geoFromDD4hep << "\n"
       << "              cutsPerRegion: " << cuts << " cutForProton: " << protonCut << "\n"
       << "              G4 verbosity: " << verb;
@@ -112,7 +112,6 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
   m_kernel->SetVerboseLevel(verb);
   edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMT: Define cuts: " << cuts << " Geant4 run manager verbosity: " << verb;
-
 
   const G4RegionStore* regStore = G4RegionStore::GetInstance();
   const G4PhysicalVolumeStore* pvs = G4PhysicalVolumeStore::GetInstance();

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -32,8 +32,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DetectorDescription/Core/interface/DDCompactView.h"
-#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/MagneticField/interface/FieldBuilder.h"
@@ -66,7 +64,6 @@
 #include <thread>
 #include <sstream>
 #include <vector>
-//#include <mutex>
 
 static std::once_flag applyOnce;
 thread_local bool RunManagerMTWorker::dumpMF = false;
@@ -288,17 +285,6 @@ void RunManagerMTWorker::initializeThread(RunManagerMT& runManagerMaster, const 
 
   // we need the track manager now
   m_tls->trackManager.reset(new SimTrackManager());
-
-  // Get DDCompactView, or would it be better to get the object from
-  // runManagerMaster instead of EventSetup in here?
-  auto geoFromDD4hep = m_p.getParameter<bool>("g4GeometryDD4hepSource");
-  edm::ESTransientHandle<cms::DDCompactView> pDD4hep;
-  edm::ESTransientHandle<DDCompactView> pDD;
-  if (geoFromDD4hep) {
-    es.get<IdealGeometryRecord>().get(pDD4hep);
-  } else {
-    es.get<IdealGeometryRecord>().get(pDD);
-  }
 
   // setup the magnetic field
   if (m_pUseMagneticField) {

--- a/SimG4Core/Geometry/interface/DDDWorld.h
+++ b/SimG4Core/Geometry/interface/DDDWorld.h
@@ -13,8 +13,12 @@ namespace cms {
 
 class DDDWorld {
 public:
-  DDDWorld(const DDCompactView* pDD, const cms::DDCompactView* pDD4hep,
-           SensitiveDetectorCatalog &, int verb, bool cuts, bool pcut);
+  DDDWorld(const DDCompactView *pDD,
+           const cms::DDCompactView *pDD4hep,
+           SensitiveDetectorCatalog &,
+           int verb,
+           bool cuts,
+           bool pcut);
   DDDWorld(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap &, SensitiveDetectorCatalog &, bool check);
   ~DDDWorld();
   G4VPhysicalVolume *GetWorldVolume() const { return m_world; }

--- a/SimG4Core/Geometry/interface/DDDWorld.h
+++ b/SimG4Core/Geometry/interface/DDDWorld.h
@@ -4,19 +4,18 @@
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 #include "G4VPhysicalVolume.hh"
-#include "DDG4/Geant4GeometryInfo.h"
 
-class DDG4Builder;
 class DDCompactView;
 
 namespace cms {
-  class DDDetector;
-}  // namespace cms
+  class DDCompactView;
+}
 
 class DDDWorld {
 public:
+  DDDWorld(const DDCompactView* pDD, const cms::DDCompactView* pDD4hep,
+           SensitiveDetectorCatalog &, int verb, bool cuts, bool pcut);
   DDDWorld(const DDCompactView *, G4LogicalVolumeToDDLogicalPartMap &, SensitiveDetectorCatalog &, bool check);
-  DDDWorld(const cms::DDDetector *, dd4hep::sim::Geant4GeometryMaps::VolumeMap &);
   ~DDDWorld();
   G4VPhysicalVolume *GetWorldVolume() const { return m_world; }
 

--- a/SimG4Core/Geometry/interface/DDG4ProductionCuts.h
+++ b/SimG4Core/Geometry/interface/DDG4ProductionCuts.h
@@ -1,7 +1,6 @@
 #ifndef SimG4Core_DDG4ProductionCuts_H
 #define SimG4Core_DDG4ProductionCuts_H
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
 
 #include <string>
@@ -10,11 +9,10 @@
 class DDLogicalPart;
 class G4Region;
 class G4LogicalVolume;
-class G4ProductionCuts;
 
 class DDG4ProductionCuts {
 public:
-  DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap&, int, const edm::ParameterSet&);
+  explicit DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap&, int, bool);
   ~DDG4ProductionCuts();
 
 private:
@@ -22,11 +20,10 @@ private:
   void setProdCuts(const DDLogicalPart, G4Region*);
 
   const G4LogicalVolumeToDDLogicalPartMap& map_;
-  // Legacy flag
-  bool protonCut_;
-  std::string keywordRegion_;
-  int verbosity_;
   G4LogicalVolumeToDDLogicalPartMap::Vector vec_;
+  const std::string keywordRegion_;
+  const int verbosity_;
+  const bool protonCut_;
 };
 
 #endif

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -19,10 +19,14 @@ using namespace edm;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 
-DDDWorld::DDDWorld(const DDCompactView* pDD, const cms::DDCompactView* pDD4hep, 
-		   SensitiveDetectorCatalog &catalog, int verb, bool cuts, bool pcut) {
+DDDWorld::DDDWorld(const DDCompactView *pDD,
+                   const cms::DDCompactView *pDD4hep,
+                   SensitiveDetectorCatalog &catalog,
+                   int verb,
+                   bool cuts,
+                   bool pcut) {
   LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialisation of Geant4 geometry";
-  if(pDD4hep) {
+  if (pDD4hep) {
     // DD4Hep
     const cms::DDDetector *det = pDD4hep->detector();
     dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -1,7 +1,10 @@
 #include "SimG4Core/Geometry/interface/DDDWorld.h"
 #include "SimG4Core/Geometry/interface/DDG4Builder.h"
+#include "SimG4Core/Geometry/interface/G4LogicalVolumeToDDLogicalPartMap.h"
+#include "SimG4Core/Geometry/interface/DDG4ProductionCuts.h"
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DDG4/Geant4Converter.h"
 #include "DDG4/Geant4GeometryInfo.h"
@@ -16,30 +19,47 @@ using namespace edm;
 using namespace dd4hep;
 using namespace dd4hep::sim;
 
+DDDWorld::DDDWorld(const DDCompactView* pDD, const cms::DDCompactView* pDD4hep, 
+		   SensitiveDetectorCatalog &catalog, int verb, bool cuts, bool pcut) {
+  LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialisation of Geant4 geometry";
+  if(pDD4hep) {
+    // DD4Hep
+    const cms::DDDetector *det = pDD4hep->detector();
+    dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
+
+    DetElement world = det->description()->world();
+    const Detector &detector = *det->description();
+    Geant4Converter g4Geo(detector);
+    Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
+    lvMap = geometry->g4Volumes;
+    m_world = geometry->world();
+
+  } else {
+    // old DD code
+    G4LogicalVolumeToDDLogicalPartMap lvMap;
+
+    DDG4Builder theBuilder(pDD, lvMap, false);
+    G4LogicalVolume *world = theBuilder.BuildGeometry(catalog);
+    LogVerbatim("SimG4CoreApplication") << "DDDWorld: worldLV: " << world->GetName();
+    m_world = new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
+    if (cuts) {
+      DDG4ProductionCuts pcuts(lvMap, verb, pcut);
+    }
+  }
+  LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialisation of Geant4 geometry is done.";
+}
+
 DDDWorld::DDDWorld(const DDCompactView *cpv,
                    G4LogicalVolumeToDDLogicalPartMap &lvmap,
                    SensitiveDetectorCatalog &catalog,
                    bool check) {
   LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialization of Geant4 geometry";
-  std::unique_ptr<DDG4Builder> theBuilder(new DDG4Builder(cpv, lvmap, check));
+  DDG4Builder theBuilder(cpv, lvmap, check);
 
-  G4LogicalVolume *world = theBuilder->BuildGeometry(catalog);
+  G4LogicalVolume *world = theBuilder.BuildGeometry(catalog);
 
   m_world = new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
   LogVerbatim("SimG4CoreApplication") << "DDDWorld: initialization of Geant4 geometry is done.";
-}
-
-DDDWorld::DDDWorld(const cms::DDDetector *ddd, dd4hep::sim::Geant4GeometryMaps::VolumeMap &map) {
-  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of Geant4 geometry";
-
-  DetElement world = ddd->description()->world();
-  const Detector &detector = *ddd->description();
-  Geant4Converter g4Geo(detector);
-  Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
-  map = geometry->g4Volumes;
-  m_world = geometry->world();
-
-  LogVerbatim("SimG4CoreApplication") << "DD4hep_DDDWorld: initialization of Geant4 geometry is done.";
 }
 
 DDDWorld::~DDDWorld() {}

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -40,8 +40,8 @@ G4LogicalVolume *DDG4Builder::convertLV(const DDLogicalPart &part) {
     DDG4Dispatchable *disp = new DDG4Dispatchable(&part, result);
     theVectorOfDDG4Dispatchables_->push_back(disp);
     LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): new G4LogicalVolume " << part.name().name()
-                                  << "\nDDG4Builder: newEvent: dd=" << part.ddname() 
-                                  << " g4=" << result->GetName() << "\n";
+                                  << "\nDDG4Builder: newEvent: dd=" << part.ddname() << " g4=" << result->GetName()
+                                  << "\n";
     logs_[part] = result;  // DDD -> GEANT4
   }
   return result;
@@ -144,13 +144,12 @@ G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
           edm::LogVerbatim("SimG4CoreGeometry")
               << "DDG4Builder: Reflection: " << gra.edgeData(cit->second)->ddrot()
               << ">>Placement d=" << gra.nodeData(cit->first).ddname() << " m=" << ddLP.ddname()
-              << " cp=" << gra.edgeData(cit->second)->copyno() << " r=" 
-              << gra.edgeData(cit->second)->ddrot().ddname();
+              << " cp=" << gra.edgeData(cit->second)->copyno() << " r=" << gra.edgeData(cit->second)->ddrot().ddname();
         G4ThreeVector tempTran(gra.edgeData(cit->second)->trans().X(),
                                gra.edgeData(cit->second)->trans().Y(),
                                gra.edgeData(cit->second)->trans().Z());
         G4Translate3D transl = tempTran;
-        CLHEP::HepRep3x3 temp(x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()); // matrix 
+        CLHEP::HepRep3x3 temp(x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z());  // matrix
         CLHEP::HepRotation hr(temp);
 
         // G3 convention of defining rot-matrices ...
@@ -177,8 +176,8 @@ G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
       map_.insert(reflLogicalVolume, ddlv);
       DDG4Dispatchable *disp = new DDG4Dispatchable(&(ddg4_it->first), reflLogicalVolume);
       theVectorOfDDG4Dispatchables_->push_back(disp);
-      edm::LogVerbatim("SimG4CoreGeometry") << "DDG4Builder: dd=" << ddlv.ddname()
-                                            << " g4=" << reflLogicalVolume->GetName();
+      edm::LogVerbatim("SimG4CoreGeometry")
+          << "DDG4Builder: dd=" << ddlv.ddname() << " g4=" << reflLogicalVolume->GetName();
     }
   }
 

--- a/SimG4Core/Geometry/src/DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DDG4Builder.cc
@@ -40,8 +40,8 @@ G4LogicalVolume *DDG4Builder::convertLV(const DDLogicalPart &part) {
     DDG4Dispatchable *disp = new DDG4Dispatchable(&part, result);
     theVectorOfDDG4Dispatchables_->push_back(disp);
     LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): new G4LogicalVolume " << part.name().name()
-                                  << "\nDDG4Builder: newEvent: dd=" << part.ddname() << " g4=" << result->GetName()
-                                  << "\n";
+                                  << "\nDDG4Builder: newEvent: dd=" << part.ddname() 
+                                  << " g4=" << result->GetName() << "\n";
     logs_[part] = result;  // DDD -> GEANT4
   }
   return result;
@@ -141,15 +141,16 @@ G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
         DD3Vector x, y, z;
         rm.GetComponents(x, y, z);
         if ((x.Cross(y)).Dot(z) < 0)
-          edm::LogInfo("SimG4CoreGeometry")
-              << ">>Reflection encountered: " << gra.edgeData(cit->second)->ddrot()
+          edm::LogVerbatim("SimG4CoreGeometry")
+              << "DDG4Builder: Reflection: " << gra.edgeData(cit->second)->ddrot()
               << ">>Placement d=" << gra.nodeData(cit->first).ddname() << " m=" << ddLP.ddname()
-              << " cp=" << gra.edgeData(cit->second)->copyno() << " r=" << gra.edgeData(cit->second)->ddrot().ddname();
+              << " cp=" << gra.edgeData(cit->second)->copyno() << " r=" 
+              << gra.edgeData(cit->second)->ddrot().ddname();
         G4ThreeVector tempTran(gra.edgeData(cit->second)->trans().X(),
                                gra.edgeData(cit->second)->trans().Y(),
                                gra.edgeData(cit->second)->trans().Z());
         G4Translate3D transl = tempTran;
-        CLHEP::HepRep3x3 temp(x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z());  // matrix representation
+        CLHEP::HepRep3x3 temp(x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()); // matrix 
         CLHEP::HepRotation hr(temp);
 
         // G3 convention of defining rot-matrices ...
@@ -176,8 +177,8 @@ G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
       map_.insert(reflLogicalVolume, ddlv);
       DDG4Dispatchable *disp = new DDG4Dispatchable(&(ddg4_it->first), reflLogicalVolume);
       theVectorOfDDG4Dispatchables_->push_back(disp);
-      edm::LogInfo("SimG4CoreGeometry") << "DDG4Builder: newEvent: dd=" << ddlv.ddname()
-                                        << " g4=" << reflLogicalVolume->GetName();
+      edm::LogVerbatim("SimG4CoreGeometry") << "DDG4Builder: dd=" << ddlv.ddname()
+                                            << " g4=" << reflLogicalVolume->GetName();
     }
   }
 
@@ -186,8 +187,8 @@ G4LogicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
   //
   //  needed for building sensitive detectors
   //
-  DDG4SensitiveConverter conv_;
-  conv_.upDate(*theVectorOfDDG4Dispatchables_, catalog);
+  DDG4SensitiveConverter conv;
+  conv.upDate(*theVectorOfDDG4Dispatchables_, catalog);
 
   return world;
 }

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -1,19 +1,19 @@
 #include "SimG4Core/Geometry/interface/DDG4ProductionCuts.h"
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4ProductionCuts.hh"
 #include "G4RegionStore.hh"
+#include "G4Region.hh"
+#include "G4LogicalVolume.hh"
 
 #include <algorithm>
 
 DDG4ProductionCuts::DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap& map,
-                                       int verb,
-                                       const edm::ParameterSet& p)
-    : map_(map), verbosity_(verb) {
-  keywordRegion_ = "CMSCutsRegion";
-  protonCut_ = p.getUntrackedParameter<bool>("CutsOnProton", true);
+                                       int verb, bool pcut)
+  : map_(map), keywordRegion_("CMSCutsRegion"), verbosity_(verb), protonCut_(pcut) {
   initialize();
 }
 
@@ -50,7 +50,7 @@ void DDG4ProductionCuts::initialize() {
   // involved objects, because 'new' does no guarantee that you allways get a
   // higher (or lower) address when allocating an object of the same type ...
   sort(vec_.begin(), vec_.end(), &dd_is_greater);
-  if (verbosity_ > 0) {
+  if (verbosity_ > -1) {
     edm::LogVerbatim("Geometry") << " DDG4ProductionCuts : got " << vec_.size() << " region roots.\n"
                                  << " DDG4ProductionCuts : List of all roots:";
     for (auto const& vv : vec_)
@@ -63,14 +63,16 @@ void DDG4ProductionCuts::initialize() {
   G4Region* region = nullptr;
   G4RegionStore* store = G4RegionStore::GetInstance();
   for (auto const& vv : vec_) {
-    //for (G4LogicalVolumeToDDLogicalPartMap::Vector::iterator tit = vec_.begin(); tit != vec_.end(); ++tit) {
     unsigned int num = map_.toString(keywordRegion_, vv.second, regionName);
+    edm::LogVerbatim("Geometry") << "  num  " << num << " regionName: " << regionName << " " << store;
 
     if (num != 1) {
       throw cms::Exception("SimG4CorePhysics", " DDG4ProductionCuts::initialize: Problem with Region tags.");
     }
     if (regionName != curName) {
+      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : regionName " << regionName << " " << store;
       region = store->FindOrCreateRegion(regionName);
+      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : region " << region;
       if (!region) {
         throw cms::Exception("SimG4CoreGeometry", " DDG4ProductionCuts::initialize: Problem with Region tags.");
       }
@@ -81,7 +83,7 @@ void DDG4ProductionCuts::initialize() {
 
     region->AddRootLogicalVolume(vv.first);
 
-    if (verbosity_ > 0)
+    if (verbosity_ > -1)
       edm::LogVerbatim("Geometry") << "  added " << vv.first->GetName() << " to region " << region->GetName();
   }
 }
@@ -140,7 +142,7 @@ void DDG4ProductionCuts::setProdCuts(const DDLogicalPart lpart, G4Region* region
   prodCuts->SetProductionCut(electroncut, idxG4ElectronCut);
   prodCuts->SetProductionCut(positroncut, idxG4PositronCut);
   prodCuts->SetProductionCut(protoncut, idxG4ProtonCut);
-  if (verbosity_ > 0) {
+  if (verbosity_ > -1) {
     edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : Setting cuts for " << region->GetName()
                                  << "\n    Electrons: " << electroncut << "\n    Positrons: " << positroncut
                                  << "\n    Gamma    : " << gammacut << "\n    Proton   : " << protoncut;

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -49,7 +49,7 @@ void DDG4ProductionCuts::initialize() {
   // involved objects, because 'new' does no guarantee that you allways get a
   // higher (or lower) address when allocating an object of the same type ...
   sort(vec_.begin(), vec_.end(), &dd_is_greater);
-  if (verbosity_ > -1) {
+  if (verbosity_ > 0) {
     edm::LogVerbatim("Geometry") << " DDG4ProductionCuts : got " << vec_.size() << " region roots.\n"
                                  << " DDG4ProductionCuts : List of all roots:";
     for (auto const& vv : vec_)
@@ -82,7 +82,7 @@ void DDG4ProductionCuts::initialize() {
 
     region->AddRootLogicalVolume(vv.first);
 
-    if (verbosity_ > -1)
+    if (verbosity_ > 0)
       edm::LogVerbatim("Geometry") << "  added " << vv.first->GetName() << " to region " << region->GetName();
   }
 }
@@ -141,7 +141,7 @@ void DDG4ProductionCuts::setProdCuts(const DDLogicalPart lpart, G4Region* region
   prodCuts->SetProductionCut(electroncut, idxG4ElectronCut);
   prodCuts->SetProductionCut(positroncut, idxG4PositronCut);
   prodCuts->SetProductionCut(protoncut, idxG4ProtonCut);
-  if (verbosity_ > -1) {
+  if (verbosity_ > 0) {
     edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : Setting cuts for " << region->GetName()
                                  << "\n    Electrons: " << electroncut << "\n    Positrons: " << positroncut
                                  << "\n    Gamma    : " << gammacut << "\n    Proton   : " << protoncut;

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -11,9 +11,8 @@
 
 #include <algorithm>
 
-DDG4ProductionCuts::DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap& map,
-                                       int verb, bool pcut)
-  : map_(map), keywordRegion_("CMSCutsRegion"), verbosity_(verb), protonCut_(pcut) {
+DDG4ProductionCuts::DDG4ProductionCuts(const G4LogicalVolumeToDDLogicalPartMap& map, int verb, bool pcut)
+    : map_(map), keywordRegion_("CMSCutsRegion"), verbosity_(verb), protonCut_(pcut) {
   initialize();
 }
 


### PR DESCRIPTION
#### PR description:
Initialisations of Geant4 geometry, regions, and production cuts are concentrated in DDDWorld class from SimG4Core/Geometry sub-package. Initialisation of magnetic field is performed together with SensitiveDetector definition only inside RunManagerMTWorker class. This modifications make transition to DD4Hep more transparent.

Correctness of this PR means identical results.

#### PR validation:
private

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
