### PR TITLE
Initialize m_muonBitsType in RPCTBMuon's default ctr

### DIFF
--- a/L1Trigger/RPCTrigger/src/RPCTBMuon.cc
+++ b/L1Trigger/RPCTrigger/src/RPCTBMuon.cc
@@ -18,6 +18,8 @@ RPCTBMuon::RPCTBMuon() : RPCMuon() {
 
   m_EtaAddress = 0;
   m_PhiAddress = 0;
+
+  m_muonBitsType = mbtUnset;
 }
 //---------------------------------------------------------------------------
 RPCTBMuon::RPCTBMuon(int ptCode, int quality, int sign, int patternNum, unsigned short firedPlanes)


### PR DESCRIPTION

#### PR description:

This was found by UBSAN.

#### PR validation:

Code compiles.