### PR TITLE
Enable Ecal DQM in Phase 2 workflows

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -103,7 +103,28 @@ for _entry in [hltvalidation_prod]:
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(validation_prod,_validation_prod_fastsim)
 
-from SimGeneral.MixingModule.mix_POISSON_average_cfi import mix
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mixNoPileUp = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-5), ## in terms of 25 ns
+
+    bunchspace = cms.int32(450),
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+from IOMC.RandomEngine.IOMC_cff import RandomNumberGeneratorService
+RandomNumberGeneratorService.mixNoPileUp = RandomNumberGeneratorService.mix.clone()
+
 from Validation.EcalClusters.ecalClustersValidationSequence_cff import ecalClustersValidationSequence
 from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
 from DQM.EcalMonitorTasks.EcalFEDMonitor_cfi import *
@@ -119,7 +140,7 @@ ecalDQMSequencePhase2 = cms.Sequence(
 
 validationECALPhase2 = cms.Sequence(
     ecalSimHitsValidationSequence*
-    mix*
+    mixNoPileUp*
     ecalDigisValidationSequence*
     ecalRecHitsValidationSequencePhase2*
     ecalClustersValidationSequence*

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -103,28 +103,6 @@ for _entry in [hltvalidation_prod]:
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(validation_prod,_validation_prod_fastsim)
 
-from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
-from SimGeneral.MixingModule.mixPoolSource_cfi import *
-from SimGeneral.MixingModule.digitizers_cfi import *
-
-mixNoPileUp = cms.EDProducer("MixingModule",
-    digitizers = cms.PSet(theDigitizers),
-    LabelPlayback = cms.string(''),
-    maxBunch = cms.int32(3),
-    minBunch = cms.int32(-5), ## in terms of 25 ns
-
-    bunchspace = cms.int32(450),
-    mixProdStep1 = cms.bool(False),
-    mixProdStep2 = cms.bool(False),
-
-    playback = cms.untracked.bool(False),
-    useCurrentProcessOnly = cms.bool(False),
-    mixObjects = cms.PSet(theMixObjects)
-)
-
-from IOMC.RandomEngine.IOMC_cff import RandomNumberGeneratorService
-RandomNumberGeneratorService.mixNoPileUp = RandomNumberGeneratorService.mix.clone()
-
 from Validation.EcalClusters.ecalClustersValidationSequence_cff import ecalClustersValidationSequence
 from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
 from DQM.EcalMonitorTasks.EcalFEDMonitor_cfi import *
@@ -140,7 +118,6 @@ ecalDQMSequencePhase2 = cms.Sequence(
 
 validationECALPhase2 = cms.Sequence(
     ecalSimHitsValidationSequence*
-    mixNoPileUp*
     ecalDigisValidationSequence*
     ecalRecHitsValidationSequencePhase2*
     ecalClustersValidationSequence*

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -103,3 +103,25 @@ for _entry in [hltvalidation_prod]:
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(validation_prod,_validation_prod_fastsim)
 
+from SimGeneral.MixingModule.mix_POISSON_average_cfi import mix
+from Validation.EcalClusters.ecalClustersValidationSequence_cff import ecalClustersValidationSequence
+from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
+from DQM.EcalMonitorTasks.EcalFEDMonitor_cfi import *
+from DQMOffline.Ecal.EcalZmassTask_cfi import *
+from DQMOffline.Ecal.EcalPileUpDepMonitor_cfi import *
+
+ecalDQMSequencePhase2 = cms.Sequence(
+    ecalMonitorTask +
+    ecalFEDMonitor +
+    ecalzmasstask +
+    ecalPileUpDepMonitor
+)
+
+validationECALPhase2 = cms.Sequence(
+    ecalSimHitsValidationSequence*
+    mix*
+    ecalDigisValidationSequence*
+    ecalRecHitsValidationSequencePhase2*
+    ecalClustersValidationSequence*
+    ecalDQMSequencePhase2
+)

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -103,23 +103,3 @@ for _entry in [hltvalidation_prod]:
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(validation_prod,_validation_prod_fastsim)
 
-from Validation.EcalClusters.ecalClustersValidationSequence_cff import ecalClustersValidationSequence
-from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
-from DQM.EcalMonitorTasks.EcalFEDMonitor_cfi import *
-from DQMOffline.Ecal.EcalZmassTask_cfi import *
-from DQMOffline.Ecal.EcalPileUpDepMonitor_cfi import *
-
-ecalDQMSequencePhase2 = cms.Sequence(
-    ecalMonitorTask +
-    ecalFEDMonitor +
-    ecalzmasstask +
-    ecalPileUpDepMonitor
-)
-
-validationECALPhase2 = cms.Sequence(
-    ecalSimHitsValidationSequence*
-    ecalDigisValidationSequence*
-    ecalRecHitsValidationSequencePhase2*
-    ecalClustersValidationSequence*
-    ecalDQMSequencePhase2
-)

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -15,9 +15,10 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
                    'MTDValidation' : ['', 'globalValidationMTD', ''],
                    'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],
+                   'ecalValidation_phase2' : ['', 'validationECALPhase2', ''],
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'bTagOnlyValidation', 'tauOnlyValidation', 'hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'bTagOnlyValidation', 'tauOnlyValidation', 'hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])

--- a/Validation/Configuration/python/ecalSimValid_cff.py
+++ b/Validation/Configuration/python/ecalSimValid_cff.py
@@ -6,6 +6,25 @@ from Validation.EcalHits.ecalSimHitsValidationSequence_cff import *
 from Validation.EcalDigis.ecalDigisValidationSequence_cff import *
 from Validation.EcalRecHits.ecalRecHitsValidationSequence_cff import *
 from Validation.EcalClusters.ecalClustersValidationSequence_cff import *
+
 ecalSimValid = cms.Sequence(ecalSimHitsValidationSequence+ecalDigisValidationSequence+ecalRecHitsValidationSequence+ecalClustersValidationSequence)
 
+from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
+from DQM.EcalMonitorTasks.EcalFEDMonitor_cfi import *
+from DQMOffline.Ecal.EcalZmassTask_cfi import *
+from DQMOffline.Ecal.EcalPileUpDepMonitor_cfi import *
 
+ecalDQMSequencePhase2 = cms.Sequence(
+    ecalMonitorTask +
+    ecalFEDMonitor +
+    ecalzmasstask +
+    ecalPileUpDepMonitor
+)
+
+validationECALPhase2 = cms.Sequence(
+    ecalSimHitsValidationSequence*
+    ecalDigisValidationSequence*
+    ecalRecHitsValidationSequencePhase2*
+    ecalClustersValidationSequence*
+    ecalDQMSequencePhase2
+)

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -44,6 +44,7 @@ from Validation.RecoB.BDHadronTrackValidation_cff import *
 from Validation.Configuration.hgcalSimValid_cff import *
 from Validation.Configuration.mtdSimValid_cff import *
 from Validation.SiOuterTrackerV.OuterTrackerSourceConfigV_cff import *
+from Validation.Configuration.ecalSimValid_cff import *
 
 
 # filter/producer "pre-" sequence for globalValidation

--- a/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
@@ -855,6 +855,8 @@ void EcalSelectiveReadoutValidation::endRun(const edm::Run& r, const edm::EventS
 void EcalSelectiveReadoutValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                                     edm::Run const&,
                                                     edm::EventSetup const&) {
+  ibooker.setCurrentFolder("EcalDigisV/SelectiveReadout");
+
   meL1aRate_ = bookFloat(ibooker, "l1aRate_");
 
   meDccVol_ = bookProfile(ibooker,

--- a/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
+++ b/Validation/EcalRecHits/interface/EcalRecHitsValidation.h
@@ -73,6 +73,7 @@ private:
   edm::InputTag ESrechitCollection_;
   edm::InputTag EBuncalibrechitCollection_;
   edm::InputTag EEuncalibrechitCollection_;
+  bool enableEndcaps_;
   // fix for consumes
   edm::EDGetTokenT<edm::HepMCProduct> HepMCLabel_Token_;
   edm::EDGetTokenT<EBRecHitCollection> EBrechitCollection_Token_;

--- a/Validation/EcalRecHits/python/ecalRecHitsValidationSequence_cff.py
+++ b/Validation/EcalRecHits/python/ecalRecHitsValidationSequence_cff.py
@@ -7,4 +7,5 @@ from Validation.EcalRecHits.ecalEndcapRecHitsValidation_cfi import *
 from Validation.EcalRecHits.ecalPreshowerRecHitsValidation_cfi import *
 ecalRecHitsValidationSequence = cms.Sequence(ecalRecHitsValidation*ecalBarrelRecHitsValidation*ecalEndcapRecHitsValidation*ecalPreshowerRecHitsValidation)
 
-
+ecalRecHitsValidationPhase2 = ecalRecHitsValidation.clone(enableEndcaps = False)
+ecalRecHitsValidationSequencePhase2 = cms.Sequence(ecalRecHitsValidationPhase2*ecalBarrelRecHitsValidation)

--- a/Validation/EcalRecHits/python/ecalRecHitsValidation_cfi.py
+++ b/Validation/EcalRecHits/python/ecalRecHitsValidation_cfi.py
@@ -10,7 +10,8 @@ ecalRecHitsValidation = DQMEDAnalyzer('EcalRecHitsValidation',
     ESrechitCollection = cms.InputTag("ecalPreshowerRecHit","EcalRecHitsES"),
     EBuncalibrechitCollection = cms.InputTag("ecalMultiFitUncalibRecHit","EcalUncalibRecHitsEB"),
     EBrechitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
-    moduleLabelMC = cms.string('generatorSmeared')
+    moduleLabelMC = cms.string('generatorSmeared'),
+    enableEndcaps = cms.untracked.bool(True)
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Validation/EcalRecHits/src/EcalRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalRecHitsValidation.cc
@@ -37,15 +37,18 @@ EcalRecHitsValidation::EcalRecHitsValidation(const ParameterSet &ps) {
   EBrechitCollection_Token_ = consumes<EBRecHitCollection>(ps.getParameter<edm::InputTag>("EBrechitCollection"));
   EBuncalibrechitCollection_Token_ =
       consumes<EBUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EBuncalibrechitCollection"));
-  
+
   EBHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
       edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEB")));
   if (enableEndcaps_) {
     EErechitCollection_Token_ = consumes<EERecHitCollection>(ps.getParameter<edm::InputTag>("EErechitCollection"));
     ESrechitCollection_Token_ = consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("ESrechitCollection"));
-    EEuncalibrechitCollection_Token_ = consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
-    EEHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")));
-    ESHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")));
+    EEuncalibrechitCollection_Token_ =
+        consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
+    EEHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
+        edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")));
+    ESHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
+        edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")));
   }
 
   // ----------------------
@@ -180,7 +183,6 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run 
                                                        100,
                                                        0.,
                                                        1.);
-  
 
   histo = "EB Occupancy Flag=5 6";
   meEBRecHitsOccupancyFlag5_6_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
@@ -232,8 +234,10 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run 
     histo = "EcalRecHitsTask Endcap Rec E5x5 over gun energy";
     meEEe5x5OverGun_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
-    meEERecHitLog10Energy_ = ibooker.book1D("EcalRecHitsTask Endcap Log10 Energy", "EcalRecHitsTask Endcap Log10 Energy", 90, -5., 4.);
-    meESRecHitLog10Energy_ = ibooker.book1D("EcalRecHitsTask Preshower Log10 Energy", "EcalRecHitsTask Preshower Log10 Energy", 90, -5., 4.);
+    meEERecHitLog10Energy_ =
+        ibooker.book1D("EcalRecHitsTask Endcap Log10 Energy", "EcalRecHitsTask Endcap Log10 Energy", 90, -5., 4.);
+    meESRecHitLog10Energy_ =
+        ibooker.book1D("EcalRecHitsTask Preshower Log10 Energy", "EcalRecHitsTask Preshower Log10 Energy", 90, -5., 4.);
 
     meEERecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En vs Hit Contribution",
                                                       "EcalRecHits Endcap Log10En vs Hit Contribution",
@@ -272,14 +276,13 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run 
 
     histo = "EcalRecHitsTask Endcap Reco Flags";
     meEERecHitFlags_ = ibooker.book1D(histo.c_str(), histo.c_str(), 10, 0., 10.);
-  
-    
+
     histo = "EcalRecHitsTask Endcap RecSimHit Ratio vs SimHit Flag=5 6";
     meEERecHitSimHitvsSimHitFlag5_6_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
-  
+
     histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=6";
     meEERecHitSimHitFlag6_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-    
+
     histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=7";
     meEERecHitSimHitFlag7_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   }
@@ -326,8 +329,8 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     } else {
       skipEndcap = true;
     }
-  }
-  else skipEndcap = true;
+  } else
+    skipEndcap = true;
 
   const EBRecHitCollection *EBRecHit = nullptr;
   Handle<EBRecHitCollection> EcalRecHitEB;
@@ -359,8 +362,8 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
     } else {
       skipPreshower = true;
     }
-  }
-  else skipPreshower = true;
+  } else
+    skipPreshower = true;
 
   // ----------------------
   // gun

--- a/Validation/EcalRecHits/src/EcalRecHitsValidation.cc
+++ b/Validation/EcalRecHits/src/EcalRecHitsValidation.cc
@@ -29,21 +29,24 @@ EcalRecHitsValidation::EcalRecHitsValidation(const ParameterSet &ps) {
   ESrechitCollection_ = ps.getParameter<edm::InputTag>("ESrechitCollection");
   EBuncalibrechitCollection_ = ps.getParameter<edm::InputTag>("EBuncalibrechitCollection");
   EEuncalibrechitCollection_ = ps.getParameter<edm::InputTag>("EEuncalibrechitCollection");
+  // switch to allow disabling endcaps for phase 2
+  enableEndcaps_ = ps.getUntrackedParameter<bool>("enableEndcaps", true);
+
   // fix for consumes
   HepMCLabel_Token_ = consumes<HepMCProduct>(ps.getParameter<std::string>("moduleLabelMC"));
   EBrechitCollection_Token_ = consumes<EBRecHitCollection>(ps.getParameter<edm::InputTag>("EBrechitCollection"));
-  EErechitCollection_Token_ = consumes<EERecHitCollection>(ps.getParameter<edm::InputTag>("EErechitCollection"));
-  ESrechitCollection_Token_ = consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("ESrechitCollection"));
   EBuncalibrechitCollection_Token_ =
       consumes<EBUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EBuncalibrechitCollection"));
-  EEuncalibrechitCollection_Token_ =
-      consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
+  
   EBHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
       edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEB")));
-  EEHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
-      edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")));
-  ESHits_Token_ = consumes<CrossingFrame<PCaloHit>>(
-      edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")));
+  if (enableEndcaps_) {
+    EErechitCollection_Token_ = consumes<EERecHitCollection>(ps.getParameter<edm::InputTag>("EErechitCollection"));
+    ESrechitCollection_Token_ = consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("ESrechitCollection"));
+    EEuncalibrechitCollection_Token_ = consumes<EEUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EEuncalibrechitCollection"));
+    EEHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEE")));
+    ESHits_Token_ = consumes<CrossingFrame<PCaloHit>>(edm::InputTag(std::string("mix"), ps.getParameter<std::string>("hitsProducer") + std::string("EcalHitsES")));
+  }
 
   // ----------------------
   // DQM ROOT output
@@ -132,47 +135,23 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio";
   meEBRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio";
-  meEERecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-
-  histo = "EcalRecHitsTask Preshower RecSimHit Ratio";
-  meESRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio gt 3p5 GeV";
   meEBRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
-
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio gt 3p5 GeV";
-  meEERecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Barrel Unc RecSimHit Ratio";
   meEBUnRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
-  histo = "EcalRecHitsTask Endcap Unc RecSimHit Ratio";
-  meEEUnRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Channel Status=10 11";
   meEBRecHitSimHitRatio1011_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=10 11";
-  meEERecHitSimHitRatio1011_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Channel Status=12";
   meEBRecHitSimHitRatio12_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=12";
-  meEERecHitSimHitRatio12_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Channel Status=13";
   meEBRecHitSimHitRatio13_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
 
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=13";
-  meEERecHitSimHitRatio13_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-
   histo = "EcalRecHitsTask Barrel Unc RecSimHit Ratio gt 3p5 GeV";
   meEBUnRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
-
-  histo = "EcalRecHitsTask Endcap Unc RecSimHit Ratio gt 3p5 GeV";
-  meEEUnRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
   histo = "EcalRecHitsTask Barrel Rec E5x5";
   meEBe5x5_ = ibooker.book1D(histo.c_str(), histo.c_str(), 4000, 0., 400.);
@@ -183,39 +162,10 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run 
   histo = "EcalRecHitsTask Barrel Rec E5x5 over gun energy";
   meEBe5x5OverGun_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
 
-  histo = "EcalRecHitsTask Endcap Rec E5x5";
-  meEEe5x5_ = ibooker.book1D(histo.c_str(), histo.c_str(), 4000, 0., 400.);
-
-  histo = "EcalRecHitsTask Endcap Rec E5x5 over Sim E5x5";
-  meEEe5x5OverSimHits_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
-
-  histo = "EcalRecHitsTask Endcap Rec E5x5 over gun energy";
-  meEEe5x5OverGun_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
-
   meEBRecHitLog10Energy_ =
       ibooker.book1D("EcalRecHitsTask Barrel Log10 Energy", "EcalRecHitsTask Barrel Log10 Energy", 90, -5., 4.);
-  meEERecHitLog10Energy_ =
-      ibooker.book1D("EcalRecHitsTask Endcap Log10 Energy", "EcalRecHitsTask Endcap Log10 Energy", 90, -5., 4.);
-  meESRecHitLog10Energy_ =
-      ibooker.book1D("EcalRecHitsTask Preshower Log10 Energy", "EcalRecHitsTask Preshower Log10 Energy", 90, -5., 4.);
   meEBRecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Barrel Log10En vs Hit Contribution",
                                                     "EcalRecHits Barrel Log10En vs Hit Contribution",
-                                                    90,
-                                                    -5.,
-                                                    4.,
-                                                    100,
-                                                    0.,
-                                                    1.);
-  meEERecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En vs Hit Contribution",
-                                                    "EcalRecHits Endcap Log10En vs Hit Contribution",
-                                                    90,
-                                                    -5.,
-                                                    4.,
-                                                    100,
-                                                    0.,
-                                                    1.);
-  meESRecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Preshower Log10En vs Hit Contribution",
-                                                    "EcalRecHits Preshower Log10En vs Hit Contribution",
                                                     90,
                                                     -5.,
                                                     4.,
@@ -230,47 +180,109 @@ void EcalRecHitsValidation::bookHistograms(DQMStore::IBooker &ibooker, edm::Run 
                                                        100,
                                                        0.,
                                                        1.);
-  meEERecHitLog10Energy5x5Contr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
-                                                       "EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
-                                                       90,
-                                                       -5.,
-                                                       4.,
-                                                       100,
-                                                       0.,
-                                                       1.);
+  
 
   histo = "EB Occupancy Flag=5 6";
   meEBRecHitsOccupancyFlag5_6_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
   histo = "EB Occupancy Flag=8 9";
   meEBRecHitsOccupancyFlag8_9_ = ibooker.book2D(histo, histo, 170, -85., 85., 360, 0., 360.);
 
-  histo = "EE+ Occupancy Flag=5 6";
-  meEERecHitsOccupancyPlusFlag5_6_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
-  histo = "EE- Occupancy Flag=5 6";
-  meEERecHitsOccupancyMinusFlag5_6_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
-  histo = "EE+ Occupancy Flag=8 9";
-  meEERecHitsOccupancyPlusFlag8_9_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
-  histo = "EE- Occupancy Flag=8 9";
-  meEERecHitsOccupancyMinusFlag8_9_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
-
   histo = "EcalRecHitsTask Barrel Reco Flags";
   meEBRecHitFlags_ = ibooker.book1D(histo.c_str(), histo.c_str(), 10, 0., 10.);
-  histo = "EcalRecHitsTask Endcap Reco Flags";
-  meEERecHitFlags_ = ibooker.book1D(histo.c_str(), histo.c_str(), 10, 0., 10.);
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio vs SimHit Flag=5 6";
   meEBRecHitSimHitvsSimHitFlag5_6_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio vs SimHit Flag=5 6";
-  meEERecHitSimHitvsSimHitFlag5_6_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Flag=6";
   meEBRecHitSimHitFlag6_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=6";
-  meEERecHitSimHitFlag6_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   histo = "EcalRecHitsTask Barrel RecSimHit Ratio Flag=7";
   meEBRecHitSimHitFlag7_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
-  histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=7";
-  meEERecHitSimHitFlag7_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
   histo = "EcalRecHitsTask Barrel 5x5 RecSimHit Ratio vs SimHit Flag=8";
   meEB5x5RecHitSimHitvsSimHitFlag8_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
+
+  if (enableEndcaps_) {
+    histo = "EcalRecHitsTask Preshower RecSimHit Ratio";
+    meESRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio";
+    meEERecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio gt 3p5 GeV";
+    meEERecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+
+    histo = "EcalRecHitsTask Endcap Unc RecSimHit Ratio";
+    meEEUnRecHitSimHitRatio_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=10 11";
+    meEERecHitSimHitRatio1011_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=12";
+    meEERecHitSimHitRatio12_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio Channel Status=13";
+    meEERecHitSimHitRatio13_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+
+    histo = "EcalRecHitsTask Endcap Unc RecSimHit Ratio gt 3p5 GeV";
+    meEEUnRecHitSimHitRatioGt35_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+
+    histo = "EcalRecHitsTask Endcap Rec E5x5";
+    meEEe5x5_ = ibooker.book1D(histo.c_str(), histo.c_str(), 4000, 0., 400.);
+
+    histo = "EcalRecHitsTask Endcap Rec E5x5 over Sim E5x5";
+    meEEe5x5OverSimHits_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+
+    histo = "EcalRecHitsTask Endcap Rec E5x5 over gun energy";
+    meEEe5x5OverGun_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0.9, 1.1);
+
+    meEERecHitLog10Energy_ = ibooker.book1D("EcalRecHitsTask Endcap Log10 Energy", "EcalRecHitsTask Endcap Log10 Energy", 90, -5., 4.);
+    meESRecHitLog10Energy_ = ibooker.book1D("EcalRecHitsTask Preshower Log10 Energy", "EcalRecHitsTask Preshower Log10 Energy", 90, -5., 4.);
+
+    meEERecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En vs Hit Contribution",
+                                                      "EcalRecHits Endcap Log10En vs Hit Contribution",
+                                                      90,
+                                                      -5.,
+                                                      4.,
+                                                      100,
+                                                      0.,
+                                                      1.);
+    meESRecHitLog10EnergyContr_ = ibooker.bookProfile("EcalRecHits Preshower Log10En vs Hit Contribution",
+                                                      "EcalRecHits Preshower Log10En vs Hit Contribution",
+                                                      90,
+                                                      -5.,
+                                                      4.,
+                                                      100,
+                                                      0.,
+                                                      1.);
+
+    meEERecHitLog10Energy5x5Contr_ = ibooker.bookProfile("EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
+                                                         "EcalRecHits Endcap Log10En5x5 vs Hit Contribution",
+                                                         90,
+                                                         -5.,
+                                                         4.,
+                                                         100,
+                                                         0.,
+                                                         1.);
+
+    histo = "EE+ Occupancy Flag=5 6";
+    meEERecHitsOccupancyPlusFlag5_6_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+    histo = "EE- Occupancy Flag=5 6";
+    meEERecHitsOccupancyMinusFlag5_6_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+    histo = "EE+ Occupancy Flag=8 9";
+    meEERecHitsOccupancyPlusFlag8_9_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+    histo = "EE- Occupancy Flag=8 9";
+    meEERecHitsOccupancyMinusFlag8_9_ = ibooker.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+
+    histo = "EcalRecHitsTask Endcap Reco Flags";
+    meEERecHitFlags_ = ibooker.book1D(histo.c_str(), histo.c_str(), 10, 0., 10.);
+  
+    
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio vs SimHit Flag=5 6";
+    meEERecHitSimHitvsSimHitFlag5_6_ = ibooker.book2D(histo.c_str(), histo.c_str(), 80, 0., 2., 4000, 0., 400.);
+  
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=6";
+    meEERecHitSimHitFlag6_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+    
+    histo = "EcalRecHitsTask Endcap RecSimHit Ratio Flag=7";
+    meEERecHitSimHitFlag7_ = ibooker.book1D(histo.c_str(), histo.c_str(), 80, 0., 2.);
+  }
 }
 
 void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
@@ -307,12 +319,15 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
   bool skipEndcap = false;
   const EEUncalibratedRecHitCollection *EEUncalibRecHit = nullptr;
   Handle<EEUncalibratedRecHitCollection> EcalUncalibRecHitEE;
-  e.getByToken(EEuncalibrechitCollection_Token_, EcalUncalibRecHitEE);
-  if (EcalUncalibRecHitEE.isValid()) {
-    EEUncalibRecHit = EcalUncalibRecHitEE.product();
-  } else {
-    skipEndcap = true;
+  if (enableEndcaps_) {
+    e.getByToken(EEuncalibrechitCollection_Token_, EcalUncalibRecHitEE);
+    if (EcalUncalibRecHitEE.isValid()) {
+      EEUncalibRecHit = EcalUncalibRecHitEE.product();
+    } else {
+      skipEndcap = true;
+    }
   }
+  else skipEndcap = true;
 
   const EBRecHitCollection *EBRecHit = nullptr;
   Handle<EBRecHitCollection> EcalRecHitEB;
@@ -325,22 +340,27 @@ void EcalRecHitsValidation::analyze(const Event &e, const EventSetup &c) {
 
   const EERecHitCollection *EERecHit = nullptr;
   Handle<EERecHitCollection> EcalRecHitEE;
-  e.getByToken(EErechitCollection_Token_, EcalRecHitEE);
-  if (EcalRecHitEE.isValid()) {
-    EERecHit = EcalRecHitEE.product();
-  } else {
-    skipEndcap = true;
+  if (enableEndcaps_) {
+    e.getByToken(EErechitCollection_Token_, EcalRecHitEE);
+    if (EcalRecHitEE.isValid()) {
+      EERecHit = EcalRecHitEE.product();
+    } else {
+      skipEndcap = true;
+    }
   }
 
   bool skipPreshower = false;
   const ESRecHitCollection *ESRecHit = nullptr;
   Handle<ESRecHitCollection> EcalRecHitES;
-  e.getByToken(ESrechitCollection_Token_, EcalRecHitES);
-  if (EcalRecHitES.isValid()) {
-    ESRecHit = EcalRecHitES.product();
-  } else {
-    skipPreshower = true;
+  if (enableEndcaps_) {
+    e.getByToken(ESrechitCollection_Token_, EcalRecHitES);
+    if (EcalRecHitES.isValid()) {
+      ESRecHit = EcalRecHitES.product();
+    } else {
+      skipPreshower = true;
+    }
   }
+  else skipPreshower = true;
 
   // ----------------------
   // gun


### PR DESCRIPTION
#### PR description:

This PR enables the ECAL DQM validation (simhits, digis, rechits, clusters, DQM) In the new phase2 workflows. This validation was so far not run for the phase2 workflows.

With this PR, the DQMIO output should fill the plots needed in the DataLayouts/Ecal subdirectory.

#### PR validation:

We have run the basic battery of tests:

`runTheMatrix.py -l limited -i all --ibeos
`

#### if this PR is a backport please specify the original PR:

This PR is not a backport. Corresponding PR to 10_6_X: https://github.com/cms-sw/cmssw/pull/27483
