### PR TITLE
Updates to E(H)CalEnergy definitions for PF hadrons.

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -2315,8 +2315,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
           particleDirection.push_back(std::get<1>(pae));
           ecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters);
           hcalEnergy.push_back(0.);
-          rawecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated /
-                                  sumEcalClusters);  // "raw" not well defined. use the corrected value.
+          rawecalEnergy.push_back(totalEcal);
           rawhcalEnergy.push_back(0.);
           pivotalClusterRef.push_back(elements[std::get<0>(pae)].clusterRef());
           iPivotal.push_back(std::get<0>(pae));
@@ -2344,8 +2343,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
           ecalEnergy.push_back(0.);
           hcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters);
           rawecalEnergy.push_back(0.);
-          rawhcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated /
-                                  sumEcalClusters);  // "raw" not well defined. use the corrected value.
+          rawhcalEnergy.push_back(totalHcal);
           pivotalClusterRef.push_back(hclusterref);
           iPivotal.push_back(iHcal);
         }
@@ -2371,10 +2369,15 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
         if (!useHO_) {
           neutral.setHcalEnergy(rawhcalEnergy[iPivot], hcalEnergy[iPivot]);
           neutral.setHoEnergy(0., 0.);
-        } else {
-          neutral.setHcalEnergy(max(rawhcalEnergy[iPivot] - totalHO, 0.0),
-                                hcalEnergy[iPivot] * (1. - totalHO / rawhcalEnergy[iPivot]));
-          neutral.setHoEnergy(totalHO, totalHO * hcalEnergy[iPivot] / rawhcalEnergy[iPivot]);
+        } else {                              // useHO_
+          if (rawhcalEnergy[iPivot] == 0.) {  // photons should be here
+            neutral.setHcalEnergy(0., 0.);
+            neutral.setHoEnergy(0., 0.);
+          } else {
+            neutral.setHcalEnergy(max(rawhcalEnergy[iPivot] - totalHO, 0.0),
+                                  hcalEnergy[iPivot] * max(1. - totalHO / rawhcalEnergy[iPivot], 0.));
+            neutral.setHoEnergy(totalHO, totalHO * hcalEnergy[iPivot] / rawhcalEnergy[iPivot]);
+          }
         }
         neutral.setPs1Energy(0.);
         neutral.setPs2Energy(0.);

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -890,7 +890,7 @@ void PFAlgo::elementLoop(const reco::PFBlock& block,
     }
 
     //Check if the track is a primary track of a secondary interaction
-    //If that is the case reconstruct a charged hadron noly using that
+    //If that is the case reconstruct a charged hadron only using that
     //track
     if (active[iTrack] && isFromSecInt(elements[iEle], "primary")) {
       bool isPrimaryTrack =
@@ -1605,7 +1605,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
         nMuons += 1;
 
       // ... and keep anyway the pt error for possible fake rejection
-      // ... blow up errors of 5th anf 4th iteration, to reject those
+      // ... blow up errors of 5th and 4th iteration, to reject those
       // ... tracks first (in case it's needed)
       double Dpt = trackRef->ptError();
       double blowError = PFTrackAlgoTools::errorScale(trackRef->algo(), factors45_);
@@ -2086,6 +2086,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
       }
 
       if (iTrack == corrTrack) {
+	if (corrFact<0.) corrFact=0.; // protect against negative scaling
         (*pfCandidates_)[tmpi].rescaleMomentum(corrFact);
         trackMomentum *= corrFact;
       }
@@ -2172,6 +2173,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
             //      unsigned iTrack = trackInfos[i].index;
             unsigned ich = chargedHadronsIndices[i];
             double rescaleFactor = x(i) / hcalP[i];
+	    if (rescaleFactor<0.) rescaleFactor=0.; // protect against negative scaling
             (*pfCandidates_)[ich].rescaleMomentum(rescaleFactor);
 
             if (debug_) {
@@ -2311,8 +2313,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
           particleDirection.push_back(std::get<1>(pae));
           ecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters);
           hcalEnergy.push_back(0.);
-          rawecalEnergy.push_back(totalEcal);
-          rawhcalEnergy.push_back(totalHcal);
+          rawecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters); // "raw" not well defined. use the corrected value.
+          rawhcalEnergy.push_back(0.);
           pivotalClusterRef.push_back(elements[std::get<0>(pae)].clusterRef());
           iPivotal.push_back(std::get<0>(pae));
         }
@@ -2338,8 +2340,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
           particleDirection.push_back(std::get<1>(pae));
           ecalEnergy.push_back(0.);
           hcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters);
-          rawecalEnergy.push_back(totalEcal);
-          rawhcalEnergy.push_back(totalHcal);
+          rawecalEnergy.push_back(0.);
+          rawhcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters); // "raw" not well defined. use the corrected value.
           pivotalClusterRef.push_back(hclusterref);
           iPivotal.push_back(iHcal);
         }
@@ -2373,7 +2375,7 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
         neutral.setPs1Energy(0.);
         neutral.setPs2Energy(0.);
         neutral.set_mva_nothing_gamma(-1.);
-        //       neutral.addElement(&elements[iPivotal]);
+        // neutral.addElement(&elements[iPivotal]);
         // neutral.addElementInBlock(blockref, iPivotal[iPivot]);
         neutral.addElementInBlock(blockref, iHcal);
         for (unsigned iTrack : chargedHadronsInBlock) {
@@ -2398,25 +2400,14 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
     // will now share the hcal energy between the various charged hadron
     // candidates, taking into account the potential neutral hadrons
 
-    double totalHcalEnergyCalibrated = calibHcal;
-    double totalEcalEnergyCalibrated = calibEcal;
     //JB: The question is: we've resolved the merged photons cleanly, but how should
     //the remaining hadrons be assigned the remaining ecal energy?
     //*Temporary solution*: follow HCAL example with fractions...
 
-    /*
-    if(totalEcal>0) {
-      // removing ecal energy from abc calibration
-      totalHcalEnergyCalibrated  -= calibEcal;
-      // totalHcalEnergyCalibrated -= calibration_.paramECALplusHCAL_slopeECAL() * totalEcal;
-    }
-    */
-    // else caloEnergy = hcal only calibrated energy -> ok.
-
     // remove the energy of the potential neutral hadron
-    totalHcalEnergyCalibrated -= mergedNeutralHadronEnergy;
+    double totalHcalEnergyCalibrated = std::max(calibHcal - mergedNeutralHadronEnergy, 0.);
     // similarly for the merged photons
-    totalEcalEnergyCalibrated -= mergedPhotonEnergy;
+    double totalEcalEnergyCalibrated = std::max(calibEcal - mergedPhotonEnergy, 0.);
     // share between the charged hadrons
 
     //COLIN can compute this before

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -2086,7 +2086,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
       }
 
       if (iTrack == corrTrack) {
-	if (corrFact<0.) corrFact=0.; // protect against negative scaling
+        if (corrFact < 0.)
+          corrFact = 0.;  // protect against negative scaling
         (*pfCandidates_)[tmpi].rescaleMomentum(corrFact);
         trackMomentum *= corrFact;
       }
@@ -2173,7 +2174,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
             //      unsigned iTrack = trackInfos[i].index;
             unsigned ich = chargedHadronsIndices[i];
             double rescaleFactor = x(i) / hcalP[i];
-	    if (rescaleFactor<0.) rescaleFactor=0.; // protect against negative scaling
+            if (rescaleFactor < 0.)
+              rescaleFactor = 0.;  // protect against negative scaling
             (*pfCandidates_)[ich].rescaleMomentum(rescaleFactor);
 
             if (debug_) {
@@ -2313,7 +2315,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
           particleDirection.push_back(std::get<1>(pae));
           ecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters);
           hcalEnergy.push_back(0.);
-          rawecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated / sumEcalClusters); // "raw" not well defined. use the corrected value.
+          rawecalEnergy.push_back(mergedPhotonEnergy * clusterEnergyCalibrated /
+                                  sumEcalClusters);  // "raw" not well defined. use the corrected value.
           rawhcalEnergy.push_back(0.);
           pivotalClusterRef.push_back(elements[std::get<0>(pae)].clusterRef());
           iPivotal.push_back(std::get<0>(pae));
@@ -2341,7 +2344,8 @@ void PFAlgo::createCandidatesHCAL(const reco::PFBlock& block,
           ecalEnergy.push_back(0.);
           hcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters);
           rawecalEnergy.push_back(0.);
-          rawhcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated / sumEcalClusters); // "raw" not well defined. use the corrected value.
+          rawhcalEnergy.push_back(mergedNeutralHadronEnergy * clusterEnergyCalibrated /
+                                  sumEcalClusters);  // "raw" not well defined. use the corrected value.
           pivotalClusterRef.push_back(hclusterref);
           iPivotal.push_back(iHcal);
         }


### PR DESCRIPTION
#### PR description:

Based on recent discussion in the PF meeting, the following changes are being implemented:
+ Improve rawE(H)CalEnergy definitions for neutral hadrons.
   - Neutral hadrons (photons) from "loop hcal" are not associated with ECAL (HCAL) clusters, as they are defined based on excess energies in HCAL (ECAL) energies only. rawE(H)CalEnergy is now set to zero for neutral hadrons (photons), as done for corrected energies to avoid confusions.
+ protect against the major source of negative ecal energy for charged hadrons.
   - Occasionally ecal energy for charged hadrons went negative, when photons are also created and the ecal energy corrected by PF hadron calibration is smaller than ecal energy from egamma's ecal cluster calibration. Now this is protected against going negative.
+ also protect against negative energy scaling.
   - Very rarely, charged hadron momentum scaling went negative, after rejecting of "bad" tracks. Now we protect against it as well. 

https://indico.cern.ch/event/832017/contributions/3485635/attachments/1871517/3102604/PF_NeutralHadron_CaloFractions_v4.pdf
for further information.

#### PR validation:

It compiles. Also, some validation plots in the above pdf file.

#### if this PR is a backport please specify the original PR:

This is not a backport.

@bendavid @zdemirag @ahinzmann 