### PR TITLE
Make mutable counters as static atomic in RecoTau plugins

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -82,11 +82,14 @@ namespace reco {
 
       math::XYZVector magneticFieldStrength_;
 
-      mutable std::atomic<unsigned int> numWarnings_;
+      static std::atomic<unsigned int> numWarnings_;
       static constexpr unsigned int maxWarnings_ = 3;
 
       int verbosity_;
     };
+
+    template <class TrackClass>
+    std::atomic<unsigned int> PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::numWarnings_{0};
 
     template <class TrackClass>
     PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::PFRecoTauChargedHadronFromGenericTrackPlugin(
@@ -105,7 +108,6 @@ namespace reco {
       dRmergeNeutralHadron_ = pset.getParameter<double>("dRmergeNeutralHadron");
       dRmergePhoton_ = pset.getParameter<double>("dRmergePhoton");
 
-      numWarnings_ = 0;
       verbosity_ = pset.getParameter<int>("verbosity");
     }
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -47,6 +47,7 @@
 #include <memory>
 #include <cmath>
 #include <algorithm>
+#include <atomic>
 
 namespace reco {
   namespace tau {
@@ -81,8 +82,8 @@ namespace reco {
 
       math::XYZVector magneticFieldStrength_;
 
-      mutable int numWarnings_;
-      int maxWarnings_;
+      mutable std::atomic<unsigned int> numWarnings_;
+      static constexpr unsigned int maxWarnings_ = 3;
 
       int verbosity_;
     };
@@ -105,8 +106,6 @@ namespace reco {
       dRmergePhoton_ = pset.getParameter<double>("dRmergePhoton");
 
       numWarnings_ = 0;
-      maxWarnings_ = 3;
-
       verbosity_ = pset.getParameter<int>("verbosity");
     }
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
@@ -69,7 +69,6 @@ namespace {
       maskHitsDT_ = cfg.getParameter<vint>("maskHitsDT");
       maskHitsCSC_ = cfg.getParameter<vint>("maskHitsCSC");
       maskHitsRPC_ = cfg.getParameter<vint>("maskHitsRPC");
-      numWarnings_ = 0;
       verbosity_ = cfg.getParameter<int>("verbosity");
     }
     ~PFRecoTauDiscriminationAgainstMuon2() override {}
@@ -99,10 +98,12 @@ namespace {
     std::vector<int> maskHitsDT_;
     std::vector<int> maskHitsCSC_;
     std::vector<int> maskHitsRPC_;
-    mutable std::atomic<unsigned int> numWarnings_;
+    static std::atomic<unsigned int> numWarnings_;
     static constexpr unsigned int maxWarnings_ = 3;
     int verbosity_;
   };
+
+  std::atomic<unsigned int> PFRecoTauDiscriminationAgainstMuon2::numWarnings_{0};
 
   void PFRecoTauDiscriminationAgainstMuon2::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
     if (!srcMuons_.label().empty()) {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
@@ -29,6 +29,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <atomic>
 
 using reco::tau::format_vint;
 
@@ -69,7 +70,6 @@ namespace {
       maskHitsCSC_ = cfg.getParameter<vint>("maskHitsCSC");
       maskHitsRPC_ = cfg.getParameter<vint>("maskHitsRPC");
       numWarnings_ = 0;
-      maxWarnings_ = 3;
       verbosity_ = cfg.getParameter<int>("verbosity");
     }
     ~PFRecoTauDiscriminationAgainstMuon2() override {}
@@ -99,8 +99,8 @@ namespace {
     std::vector<int> maskHitsDT_;
     std::vector<int> maskHitsCSC_;
     std::vector<int> maskHitsRPC_;
-    mutable int numWarnings_;
-    int maxWarnings_;
+    mutable std::atomic<unsigned int> numWarnings_;
+    static constexpr unsigned int maxWarnings_ = 3;
     int verbosity_;
   };
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
@@ -27,6 +27,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <atomic>
 
 using reco::tau::format_vint;
 
@@ -56,7 +57,6 @@ namespace {
       maxNumberOfRPCMuons_ = cfg.getParameter<int>("maxNumberOfRPCMuons");
 
       numWarnings_ = 0;
-      maxWarnings_ = 3;
       verbosity_ = cfg.exists("verbosity") ? cfg.getParameter<int>("verbosity") : 0;
     }
     ~PFRecoTauDiscriminationAgainstMuonSimple() override {}
@@ -86,8 +86,8 @@ namespace {
     std::vector<int> maskHitsRPC_;
     int maxNumberOfSTAMuons_, maxNumberOfRPCMuons_;
 
-    mutable int numWarnings_;
-    int maxWarnings_;
+    mutable std::atomic<unsigned int> numWarnings_;
+    static constexpr unsigned int maxWarnings_ = 3;
     int verbosity_;
   };
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuonSimple.cc
@@ -56,7 +56,6 @@ namespace {
       maxNumberOfSTAMuons_ = cfg.getParameter<int>("maxNumberOfSTAMuons");
       maxNumberOfRPCMuons_ = cfg.getParameter<int>("maxNumberOfRPCMuons");
 
-      numWarnings_ = 0;
       verbosity_ = cfg.exists("verbosity") ? cfg.getParameter<int>("verbosity") : 0;
     }
     ~PFRecoTauDiscriminationAgainstMuonSimple() override {}
@@ -86,10 +85,12 @@ namespace {
     std::vector<int> maskHitsRPC_;
     int maxNumberOfSTAMuons_, maxNumberOfRPCMuons_;
 
-    mutable std::atomic<unsigned int> numWarnings_;
+    static std::atomic<unsigned int> numWarnings_;
     static constexpr unsigned int maxWarnings_ = 3;
     int verbosity_;
   };
+
+  std::atomic<unsigned int> PFRecoTauDiscriminationAgainstMuonSimple::numWarnings_{0};
 
   void PFRecoTauDiscriminationAgainstMuonSimple::beginEvent(const edm::Event& evt, const edm::EventSetup& es) {
     evt.getByToken(Muons_token, muons_);


### PR DESCRIPTION
#### PR description:

Make std::atomic a few mutable counters in some RecoTauTag/RecoTau plugins, for thread safety.
Issue originally reported by the static analyzer during PR automatic tests

#### PR validation:

scram build succeeds