### PR TITLE
Validation/RecoEgamma/plugins recOfflineVertices histogram parameters modification

### DIFF
--- a/DQMOffline/EGamma/python/electronDataDiscovery.py
+++ b/DQMOffline/EGamma/python/electronDataDiscovery.py
@@ -31,7 +31,7 @@ from __future__ import print_function
 #===================================================================
 
 #import httplib, urllib, urllib2, types, string, os, sys
-import os, sys, re, das_client
+import os, sys, re#, das_client
 
 if 'DD_SOURCE' not in os.environ:
   os.environ['DD_SOURCE'] = 'das'

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -463,8 +463,13 @@ void ElectronMcFakeValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Ru
   h1_recCoreNum_ = bookH1(iBooker, "recCoreNum", "# rec electron cores", 21, -0.5, 20.5, "N_{core}");
   h1_recTrackNum_ = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum_ = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
-  h1_recOfflineVertices_ = bookH1(
-      iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 81, -0.5, 161.5, "N_{Vertices}");  // new 2015.04.02
+  h1_recOfflineVertices_ = bookH1(iBooker,
+                                  "recOfflineVertices",
+                                  "# rec Offline Primary Vertices",
+                                  81,
+                                  -0.5,
+                                  161.5,
+                                  "N_{Vertices}");  // new 2015.04.02
 
   // mc
   h1_matchingObjectEta =

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -464,7 +464,7 @@ void ElectronMcFakeValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Ru
   h1_recTrackNum_ = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum_ = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
   h1_recOfflineVertices_ = bookH1(
-      iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 61, -0.5, 60.5, "N_{Vertices}");  // new 2015.04.02
+      iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 81, -0.5, 161.5, "N_{Vertices}");  // new 2015.04.02
 
   // mc
   h1_matchingObjectEta =

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -576,7 +576,7 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_recTrackNum = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
   h1_recOfflineVertices =
-      bookH1(iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 61, -0.5, 60.5, "N_{Vertices}");
+      bookH1(iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 81, -0.5, 161.5, "N_{Vertices}");
   h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker,
                                               "scl_EoEtrueVsrecOfflineVertices",
                                               "E/Etrue vs number of primary vertices",

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -575,8 +575,13 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_recCoreNum = bookH1(iBooker, "recCoreNum", "# rec electron cores", 21, -0.5, 20.5, "N_{core}");
   h1_recTrackNum = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
-  h1_recOfflineVertices =
-      bookH1(iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 81, -0.5, 161.5, "N_{Vertices}");
+  h1_recOfflineVertices = bookH1(iBooker, 
+                                 "recOfflineVertices", 
+                                 "# rec Offline Primary Vertices", 
+                                 81, 
+                                 -0.5, 
+                                 161.5, 
+                                 "N_{Vertices}");
   h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker,
                                               "scl_EoEtrueVsrecOfflineVertices",
                                               "E/Etrue vs number of primary vertices",

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -34,12 +34,12 @@ max_number = -1 # 10 # number of events
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
 #process.source = cms.Source ("PoolSource",skipEvents = cms.untracked.uint32(max_skipped), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 
-process.source = cms.Source ("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring()) # std value
-process.source.fileNames.extend(dd.search())  # to be commented for local run only
+#process.source = cms.Source ("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring()) # std value
+#process.source.fileNames.extend(dd.search())  # to be commented for local run only
 
-#process.source = cms.Source ("PoolSource",
-#    fileNames = cms.untracked.vstring(
-#    [
+process.source = cms.Source ("PoolSource",
+    fileNames = cms.untracked.vstring(
+    [
     #'file:/eos/user/a/archiron/HGCal_Shares/step3_A8F750A4-6D87-E711-A476-0CC47A4D7600.root',
     #'file:/eos/user/a/archiron/HGCal_Shares/step3_AE79E794-7287-E711-9D2A-0CC47A78A3EE.root',
     #'file:/eos/user/a/archiron/HGCal_Shares/step3_D801BDAF-7087-E711-AEF8-0CC47A7C354A.root',
@@ -47,9 +47,11 @@ process.source.fileNames.extend(dd.search())  # to be commented for local run on
     #'file:/eos/user/r/rovere/www/shared/step3.root',
 
     #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_9_3_2/RelValQCD_Pt-15To7000_Flat_14TeV/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/00FF6760-F8A6-E711-AA68-0025905A60D6.root',
-#    ]
-#    )
-#)  # for local run only
+    '/store/relval/CMSSW_11_0_0_pre2/RelValZEE_13/GEN-SIM-RECO/106X_upgrade2018_realistic_v6-v1/10000/1144EDB9-5DEF-114A-B9F7-32A7472BD9AC.root',
+    '/store/relval/CMSSW_11_0_0_pre2/RelValZEE_13/GEN-SIM-RECO/106X_upgrade2018_realistic_v6-v1/10000/B3E09A3C-DB50-FC42-A4EE-02A5AA6D54EE.root',
+    ]
+    )
+)  # for local run only
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
@@ -66,9 +68,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG'] + '::All'
-process.GlobalTag.globaltag = '93X_upgrade2023_realistic_v2'
-#process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
-#process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
+process.GlobalTag.globaltag = '106X_upgrade2018_realistic_v6'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,25 +1,51 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="9_3_0_pre2_pmx_DQM_std_1">
-<var name="TEST_REF" value="9_3_0_pre2_pmx_DQM_std">
+<var name="TEST_NEW" value="11_0_0_pre2_DQM_dev">
+<var name="TEST_REF" value="10_6_0_DQM_dev">
 
-<var name="TAG_STARTUP" value="92X_upgrade2017_realistic_v7">
+<var name="TAG_STARTUP" value="106X_upgrade2018_realistic_v6">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="PU25ns_92X_upgrade2017_realistic_v7-v1">
+<var name="DD_COND_REF" value="106X_upgrade2018_realistic_v4-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
+<!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
 
-<var name="STORE_DIR" value="/afs/cern.ch/work/a/archiron/private/CMSSW_9_3_0_pre2_ValELE/src/Validation/RecoEgamma/test/9_3_0_pre2">
-<var name="STORE_REF" value="/afs/cern.ch/work/a/archiron/private/CMSSW_9_3_0_pre2_ValELE/src/Validation/RecoEgamma/test/9_3_0_pre2">
+<var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
+<var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
+ 
+<!--var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev"-->
+<var name="WEB_DIR" value="/eos/project/c/cmsweb/www/egamma/validation/Electrons/Dev/">
 
-<var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Releases">
+<!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
+<!--var name="WEB_URL" value="https://chamont.web.cern.ch/chamont/validation"-->
 
 The value of OVAL_ENVNAME is automatically set by Oval to the name
 of the current environment, before running any executable. Using it below,
 we have an output file name which is unique for each execution.
 
+<var name="TEST_HISTOS_FILE" value="electronHistos.${OVAL_ENVNAME}.root">
 <var name="TEST_OUTPUT_LOGS" value="*.${OVAL_ENVNAME}.olog">
+<!--var name="TEST_HISTOS_FILE" value="DQM_V0001_R000000001__${DD_SAMPLE}__${DD_RELEASE}-${DD_COND}__DQM.root"-->
+<!--difffile name="electronHistos.root"-->
+
+The DD_* variables are configuration variables for the script electronDataDiscovery.py,
+which prepares and send a query to the Data Discovery web server,
+and receive as a result the corresponding list of input data files.
+<!--var name="DD_SOURCE" value="das"-->
+
+The tags below are to be used when DAS seems not up-to-date,
+as compared to what you see within castor directories.
+These parameters have been added to each RelVal sample environment
+<!--var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}"-->
+<!--var name="DD_TIER" value="GEN-SIM-RECO"-->
+  
+  
+The tags below are to be used when you want to process some files
+made with a modified code, and generated locally, thanks to the
+targets RedoFrom% defined later on.
+<!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
+<!--var name="DD_COND" value="STARTUP"-->
 
 Oval is able to check the output channel of an execution and compare it with a reference output.
 The tags below are defining which are lines to be compared. The currently specification is a
@@ -36,6 +62,28 @@ first draft, and we do not yet check the differences that Oval could raise.
 <diffnumber expr="^h_\S+ has \d+ entries of mean value (\S+)$" tolerance="10%">
 <!diffvar name="HISTO" expr="^TH1.Print Name = [a-zA-Z_]+, Entries= \d+, Total sum= (\S+)$" tolerance="10%">
 
+The file defined below is used by the script electronDataDiscovery.py when we want to analyze
+some RelVal reco files which have been regenerated locally.
+
+<var name="TEST_AFS_DIR" value="/afs/cern.ch/cms/CAF/CMSPHYS/PHYS_EGAMMA/electrons/chamont/ReleaseValidationTmp/SeedsRemaker3">
+<!--var name="TEST_AFS_DIR" value="/afs/cern.ch/user/a/archiron/private/Root_Regress"-->
+<file name="electronInputDataFiles.txt">
+file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValSingleElectronPt35-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValSingleElectronPt1000-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValTTbar-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValZEE-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValQCD_Pt_80_120-STARTUP-RECO.root
+</file>
+  
+Here comes the concrete executables to run. They are split among few different
+environments, each one defining the relevant variales for a given scenario and/or
+data sample. Running electronDataDiscovery.py is only usefull to check the correctness
+of the list of input data files returned by the data discovery web server. We guess
+that from time to time we will have to upgrade the values DD_* variable so to keep in
+touch with changes in data catalog structure.
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ================================================================================
 FullSim
@@ -46,60 +94,330 @@ FullSim
 
   This set of targets is currently used for the validation of electrons.
 
+  Used if DD_SOURCE=das
+  <!--var name="DD_TIER" value="*RECO*"-->
+
   Used if DD_source=/eos/...
   <var name="DD_TIER" value="GEN-SIM-RECO">
-
+  
   <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
+  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
   <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
   <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
   <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
-
-  <environment name="ValPileUpStartup">
-
-    <var name="TAG_STARTUP" value="${TAG_STARTUP}">
+      
+  <environment name="ValFullStdStatsStartup">
+  
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
     <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-
-    <environment name="Valdummy">
-
-      <var name="DD_SAMPLE" value="dummy">
-
-        <var name="RED_FILE" value="DQM_DUMMY.root">
- <var name="BLUE_FILE" value="DQM_DUMMY.root">
- <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <environment name="ValFullPt10Startup_UP15_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
     </environment>
 
-    <var name="DD_COND" value="PUpmx25ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+    <environment name="ValFullPt35Startup_UP15_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      
+    </environment>
+    
+    <environment name="ValFullPt1000Startup_UP15_gedGsfE">
+    
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-    <var name="DD_COND_REF" value="PU25ns_92X_upgrade2017_realistic_v7-v1">
+    </environment>
 
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
+    <environment name="ValFullPt10Startup_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
+    </environment>
 
-      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValTTbar_13__CMSSW_9_3_0_pre2-PUpmx25ns_92X_upgrade2017_realistic_v7-v1__DQMIO.root">
-      <var name="BLUE_FILE" value="9_3_0_pre2/DQM_V0001_R000000001__RelValTTbar_13__CMSSW_9_3_0_pre2-PU25ns_92X_upgrade2017_realistic_v7-v1__DQMIO.root">
+    <environment name="ValFullPt35Startup_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      
+    </environment>
+    
+    <environment name="ValFullPt1000Startup_gedGsfE">
+    
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PUpmx25ns_${DD_SAMPLE}_gedGsfE_Startup'>
+    </environment>
 
-      </environment>
+    <environment name="ValFullTTbarStartup_13_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-    <var name="DD_COND" value="PUpmx25ns_${TEST_GLOBAL_TAG}-${DATA_VERSION}">
+    </environment>
+  
+    <environment name="ValFullZEEStartup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/CMSSW_11_0_0_pre2/RelValZEE_13/GEN-SIM-RECO/106X_upgrade2018_realistic_v6-v1/10000/">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+  
+    </environment>
 
-    <var name="DD_COND_REF" value="PU25ns_92X_upgrade2017_realistic_v7-v1">
+    <environment name="ValFullQcdPt80Pt120Startup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
 
-      <environment name="ValPileUpZEEStartup_gedGsfE">
-
-        <var name="DD_SAMPLE" value="RelValZEE_13">
-
-      <var name="RED_FILE" value="DQM_V0001_R000000001__RelValZEE_13__CMSSW_9_3_0_pre2-PUpmx25ns_92X_upgrade2017_realistic_v7-v1__DQMIO.root">
-      <var name="BLUE_FILE" value="9_3_0_pre2/DQM_V0001_R000000001__RelValZEE_13__CMSSW_9_3_0_pre2-PU25ns_92X_upgrade2017_realistic_v7-v1__DQMIO.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/PUpmx25ns_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
+    </environment>  
+  
   </environment>
+  
+  <environment name="ValFullgedvsged">
+  
+    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
+       
+    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
+    
+    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
 
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullPt35Startup_UP15_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      
+    </environment>
+    
+    <environment name="ValgedvsgedFullPt1000Startup_UP15_gedGsfE">
+    
+      <var name="VAL_HISTOS" value="ElectronMcSignalHistosPt1000.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullPt10Startup_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullPt35Startup_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      
+    </environment>
+    
+    <environment name="ValgedvsgedFullPt1000Startup_gedGsfE">
+    
+      <var name="VAL_HISTOS" value="ElectronMcSignalHistosPt1000.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValTTbar_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+  
+    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValZEE_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+  
+    </environment>
+
+    <environment name="ValgedvsgedFullQcdPt80Pt120Startup_13_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
+
+      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
+      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
+      
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>  
+  
+  </environment>
+    
 </environment>
+
+
+

--- a/Validation/RecoEgamma/test/electronValidationCheck_Env.py
+++ b/Validation/RecoEgamma/test/electronValidationCheck_Env.py
@@ -18,8 +18,9 @@ class env:
                 quit()
 
     def beginTag(self):
-	beginTag = 'Phase2'
-#	beginTag = 'Run2_2017'
+#	beginTag = 'Phase2'
+	beginTag = 'Run2_2017'
+#    beginTag = 'upgrade2018'
 	return beginTag
 
     def dd_tier(self):
@@ -27,7 +28,7 @@ class env:
         return dd_tier 
 
     def tag_startup(self):
-        tag_startup = '93X_upgrade2023_realistic_v2_2023D17noPU'
+        tag_startup = '106X_upgrade2018_realistic_v6'
 #        tag_startup = '93X_upgrade2023_realistic_v2_2023D17PU140'
 #        tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'
 #        tag_startup = '92X_upgrade2023_realistic_v2_2023D17noPU' 

--- a/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
@@ -52,7 +52,9 @@ then
 	CHOIX_INTERACTION="./electronBsub ${CHOIX_JOB} /afs/cern.ch/cms/utils/oval run ${CHOIX_ETAPE}.Val"
 else
 	echo "interaction"
-	CHOIX_INTERACTION="/afs/cern.ch/cms/utils/oval run ${CHOIX_ETAPE}.Val"
+	#CHOIX_INTERACTION="/afs/cern.ch/cms/utils/oval run ${CHOIX_ETAPE}.Val"
+    #CHOIX_INTERACTION="/afs/cern.ch/user/a/archiron/lbin/OVAL/5_11_4/bin/oval run ${CHOIX_ETAPE}.Val"
+    CHOIX_INTERACTION="/home/llr/info/chiron_u/OVAL/5_11_4/bin/oval run ${CHOIX_ETAPE}.Val"
 fi
 
 echo "*** CHOIX_INTERACTION : " $2 $CHOIX_INTERACTION
@@ -112,9 +114,9 @@ else
 #    list="Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 "
 #    list="Pt10Startup Pt1000Startup Pt35Startup TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
 #	list="TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
-	list="TTbarStartup_13 ZEEStartup_13 Pt10Startup"
+#	list="TTbarStartup_13 ZEEStartup_13 Pt10Startup"
 #	list="Pt1000Startup_UP15 "
-#	list="TTbarStartup_13 "
+	list="ZEEStartup_13 "
     for element in $list    
     do   
         echo "element =" $element   


### PR DESCRIPTION
#### PR description:

in the electron validation (Validation/RecoEgamma/plugins) we made a small modification in the recOfflineVertices histogram (nb of bins and nb of vertices shown) to adapt the nvertices plot range to the Run 3 PU conditions.
we can show the new conformation on linked picture.
![recOfflineVertices-4](https://user-images.githubusercontent.com/5586847/61518162-3b6df400-aa09-11e9-8891-d70ffa97b32f.png)


#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK to.
runTheMatrix.py -l limited -i all --ibeos tests are fine.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch -> OK.
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html) -> OK. 
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) -> OK.

@beaudett 