### PR TITLE
Validation/RecoEgamma/plugins recOfflineVertices histogram parameters modification V2

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -463,8 +463,13 @@ void ElectronMcFakeValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Ru
   h1_recCoreNum_ = bookH1(iBooker, "recCoreNum", "# rec electron cores", 21, -0.5, 20.5, "N_{core}");
   h1_recTrackNum_ = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum_ = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
-  h1_recOfflineVertices_ = bookH1(
-      iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 61, -0.5, 60.5, "N_{Vertices}");  // new 2015.04.02
+  h1_recOfflineVertices_ = bookH1(iBooker, 
+                                  "recOfflineVertices", 
+                                  "# rec Offline Primary Vertices", 
+                                  81, 
+                                  -0.5, 
+                                  161.5, 
+                                  "N_{Vertices}"); 
 
   // mc
   h1_matchingObjectEta =

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -463,13 +463,8 @@ void ElectronMcFakeValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Ru
   h1_recCoreNum_ = bookH1(iBooker, "recCoreNum", "# rec electron cores", 21, -0.5, 20.5, "N_{core}");
   h1_recTrackNum_ = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum_ = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
-  h1_recOfflineVertices_ = bookH1(iBooker, 
-                                  "recOfflineVertices", 
-                                  "# rec Offline Primary Vertices", 
-                                  81, 
-                                  -0.5, 
-                                  161.5, 
-                                  "N_{Vertices}"); 
+  h1_recOfflineVertices_ =
+      bookH1(iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 81, -0.5, 161.5, "N_{Vertices}");
 
   // mc
   h1_matchingObjectEta =

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -575,13 +575,8 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_recCoreNum = bookH1(iBooker, "recCoreNum", "# rec electron cores", 21, -0.5, 20.5, "N_{core}");
   h1_recTrackNum = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
-  h1_recOfflineVertices = bookH1(iBooker, 
-                                 "recOfflineVertices", 
-                                 "# rec Offline Primary Vertices", 
-                                 81, 
-                                 -0.5, 
-                                 161.5, 
-                                 "N_{Vertices}");
+  h1_recOfflineVertices =
+      bookH1(iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 81, -0.5, 161.5, "N_{Vertices}");
   h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker,
                                               "scl_EoEtrueVsrecOfflineVertices",
                                               "E/Etrue vs number of primary vertices",

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -575,8 +575,13 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
   h1_recCoreNum = bookH1(iBooker, "recCoreNum", "# rec electron cores", 21, -0.5, 20.5, "N_{core}");
   h1_recTrackNum = bookH1(iBooker, "recTrackNum", "# rec gsf tracks", 41, -0.5, 40.5, "N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum", "# rec electron seeds", 101, -0.5, 100.5, "N_{seed}");
-  h1_recOfflineVertices =
-      bookH1(iBooker, "recOfflineVertices", "# rec Offline Primary Vertices", 61, -0.5, 60.5, "N_{Vertices}");
+  h1_recOfflineVertices = bookH1(iBooker, 
+                                 "recOfflineVertices", 
+                                 "# rec Offline Primary Vertices", 
+                                 81, 
+                                 -0.5, 
+                                 161.5, 
+                                 "N_{Vertices}");
   h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker,
                                               "scl_EoEtrueVsrecOfflineVertices",
                                               "E/Etrue vs number of primary vertices",


### PR DESCRIPTION
#### PR description:

in the electron validation (Validation/RecoEgamma/plugins) we made a small modification in the recOfflineVertices histogram (nb of bins and nb of vertices shown) to adapt the nvertices plot range to the Run 3 PU conditions.
we can show the new conformation on linked picture.
![recOfflineVertices-4](https://user-images.githubusercontent.com/5586847/61518162-3b6df400-aa09-11e9-8891-d70ffa97b32f.png)


#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK to.
runTheMatrix.py -l limited -i all --ibeos tests are fine.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch -> OK.
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html) -> OK. 
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) -> OK.

@beaudett 