### PR TITLE
Protect against a 0 length VLA when using DynArray

### DIFF
--- a/CommonTools/Utils/interface/DynArray.h
+++ b/CommonTools/Utils/interface/DynArray.h
@@ -78,14 +78,21 @@ public:
   }
 };
 
-#define unInitDynArray(T, n, x)                                 \
-  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * n]; \
+namespace dynarray {
+  template <typename T>
+  inline T num(T s) {
+    return s > 0 ? s : T(1);
+  }
+}  // namespace dynarray
+
+#define unInitDynArray(T, n, x)                                                \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]; \
   DynArray<T> x(x##_storage)
-#define declareDynArray(T, n, x)                                \
-  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * n]; \
+#define declareDynArray(T, n, x)                                               \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]; \
   DynArray<T> x(x##_storage, n)
-#define initDynArray(T, n, x, i)                                \
-  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * n]; \
+#define initDynArray(T, n, x, i)                                               \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]; \
   DynArray<T> x(x##_storage, n, i)
 
 #endif  // CommonTools_Utils_DynArray_H


### PR DESCRIPTION

#### PR description:

This fixes many UBSAN errors.

#### PR validation:

The code compiles. When re-running workflow 134.804 on step 3 using CMSSW_11_0_UBSAN_X_2019-07-12-2300 the previous UBSAN errors are gone.

This is a technical fix and should not affect output (unless the output was effected by the undefined behavior).