### PR TITLE
Fix UBSAN errors in RecoJets/JetProducers

### DIFF
--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -649,77 +649,79 @@ void VirtualJetProducer::writeJets(edm::Event& iEvent, edm::EventSetup const& iS
   // allocate fjJets_.size() Ts in vector
   auto jets = std::make_unique<std::vector<T>>(fjJets_.size());
 
-  // Distance between jet centers and overlap area -- for disk-based area calculation
-  using RIJ = std::pair<double, double>;
-  std::vector<RIJ> rijStorage(fjJets_.size() * (fjJets_.size() / 2));
-  RIJ* rij[fjJets_.size()];
-  unsigned int k = 0;
-  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
-    rij[ijet] = &rijStorage[k];
-    k += ijet;
-  }
+  if (!fjJets_.empty()) {
+    // Distance between jet centers and overlap area -- for disk-based area calculation
+    using RIJ = std::pair<double, double>;
+    std::vector<RIJ> rijStorage(fjJets_.size() * (fjJets_.size() / 2));
+    RIJ* rij[fjJets_.size()];
+    unsigned int k = 0;
+    for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+      rij[ijet] = &rijStorage[k];
+      k += ijet;
+    }
 
-  float etaJ[fjJets_.size()], phiJ[fjJets_.size()];
+    float etaJ[fjJets_.size()], phiJ[fjJets_.size()];
 
-  auto orParam_ = 1. / rParam_;
-  // fill jets
-  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
-    auto& jet = (*jets)[ijet];
-    // get the fastjet jet
-    const fastjet::PseudoJet& fjJet = fjJets_[ijet];
-    // get the constituents from fastjet
-    std::vector<fastjet::PseudoJet> const& fjConstituents = fastjet::sorted_by_pt(fjJet.constituents());
-    // convert them to CandidatePtr vector
-    std::vector<CandidatePtr> const& constituents = getConstituents(fjConstituents);
+    auto orParam_ = 1. / rParam_;
+    // fill jets
+    for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+      auto& jet = (*jets)[ijet];
+      // get the fastjet jet
+      const fastjet::PseudoJet& fjJet = fjJets_[ijet];
+      // get the constituents from fastjet
+      std::vector<fastjet::PseudoJet> const& fjConstituents = fastjet::sorted_by_pt(fjJet.constituents());
+      // convert them to CandidatePtr vector
+      std::vector<CandidatePtr> const& constituents = getConstituents(fjConstituents);
 
-    // write the specifics to the jet (simultaneously sets 4-vector, vertex).
-    // These are overridden functions that will call the appropriate
-    // specific allocator.
-    writeSpecific(
-        jet, Particle::LorentzVector(fjJet.px(), fjJet.py(), fjJet.pz(), fjJet.E()), vertex_, constituents, iSetup);
-    phiJ[ijet] = jet.phi();
-    etaJ[ijet] = jet.eta();
-  }
+      // write the specifics to the jet (simultaneously sets 4-vector, vertex).
+      // These are overridden functions that will call the appropriate
+      // specific allocator.
+      writeSpecific(
+          jet, Particle::LorentzVector(fjJet.px(), fjJet.py(), fjJet.pz(), fjJet.E()), vertex_, constituents, iSetup);
+      phiJ[ijet] = jet.phi();
+      etaJ[ijet] = jet.eta();
+    }
 
-  // calcuate the jet area
-  for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
     // calcuate the jet area
-    double jetArea = 0.0;
-    // get the fastjet jet
-    const auto& fjJet = fjJets_[ijet];
-    if (doAreaFastjet_ && fjJet.has_area()) {
-      jetArea = fjJet.area();
-    } else if (doAreaDiskApprox_) {
-      // Here it is assumed that fjJets_ is in decreasing order of pT,
-      // which should happen in FastjetJetProducer::runAlgorithm()
-      jetArea = M_PI;
-      RIJ* distance = rij[ijet];
-      for (unsigned jJet = 0; jJet < ijet; ++jJet) {
-        distance[jJet].first = std::sqrt(reco::deltaR2(etaJ[ijet], phiJ[ijet], etaJ[jJet], phiJ[jJet])) * orParam_;
-        distance[jJet].second = reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first);
-        jetArea -= distance[jJet].second;
-        for (unsigned kJet = 0; kJet < jJet; ++kJet) {
-          jetArea += reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first,
-                                                                          distance[kJet].first,
-                                                                          rij[jJet][kJet].first,
-                                                                          distance[jJet].second,
-                                                                          distance[kJet].second,
-                                                                          rij[jJet][kJet].second);
-        }  // end loop over harder jets
-      }    // end loop over harder jets
-      jetArea *= (rParam_ * rParam_);
-    }
-    auto& jet = (*jets)[ijet];
-    jet.setJetArea(jetArea);
+    for (unsigned int ijet = 0; ijet < fjJets_.size(); ++ijet) {
+      // calcuate the jet area
+      double jetArea = 0.0;
+      // get the fastjet jet
+      const auto& fjJet = fjJets_[ijet];
+      if (doAreaFastjet_ && fjJet.has_area()) {
+        jetArea = fjJet.area();
+      } else if (doAreaDiskApprox_) {
+        // Here it is assumed that fjJets_ is in decreasing order of pT,
+        // which should happen in FastjetJetProducer::runAlgorithm()
+        jetArea = M_PI;
+        RIJ* distance = rij[ijet];
+        for (unsigned jJet = 0; jJet < ijet; ++jJet) {
+          distance[jJet].first = std::sqrt(reco::deltaR2(etaJ[ijet], phiJ[ijet], etaJ[jJet], phiJ[jJet])) * orParam_;
+          distance[jJet].second = reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first);
+          jetArea -= distance[jJet].second;
+          for (unsigned kJet = 0; kJet < jJet; ++kJet) {
+            jetArea += reco::helper::VirtualJetProducerHelper::intersection(distance[jJet].first,
+                                                                            distance[kJet].first,
+                                                                            rij[jJet][kJet].first,
+                                                                            distance[jJet].second,
+                                                                            distance[kJet].second,
+                                                                            rij[jJet][kJet].second);
+          }  // end loop over harder jets
+        }    // end loop over harder jets
+        jetArea *= (rParam_ * rParam_);
+      }
+      auto& jet = (*jets)[ijet];
+      jet.setJetArea(jetArea);
 
-    if (doPUOffsetCorr_) {
-      jet.setPileup(subtractor_->getPileUpEnergy(ijet));
-    } else {
-      jet.setPileup(0.0);
-    }
+      if (doPUOffsetCorr_) {
+        jet.setPileup(subtractor_->getPileUpEnergy(ijet));
+      } else {
+        jet.setPileup(0.0);
+      }
 
-    // std::cout << "area " << ijet << " " << jetArea << " " << Area<T>::get(jet) << std::endl;
-    // std::cout << "JetVI " << ijet << ' '<< jet.pt() << " " << jet.et() << ' '<< jet.energy() << ' '<< jet.mass() << std::endl;
+      // std::cout << "area " << ijet << " " << jetArea << " " << Area<T>::get(jet) << std::endl;
+      // std::cout << "JetVI " << ijet << ' '<< jet.pt() << " " << jet.et() << ' '<< jet.energy() << ' '<< jet.mass() << std::endl;
+    }
   }
   // put the jets in the collection
   iEvent.put(std::move(jets), jetCollInstanceName_);


### PR DESCRIPTION
#### PR description:

- Avoid dereference of nullptr in PileupJetIdProducer
- Avoid 0 length VLAs in VirtualJetProducer
#### PR validation:

The code compiles.

This is a technical change and is not expected to cause any changes to results.