### PR TITLE
Removed CTPSS from DQMOffline since it was breaking configuration in …

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -81,15 +81,6 @@ DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            # dqmFastTimerServiceLuminosity *
                            DQMMessageLogger )
 
-_ctpps_2016_DQMOffline = DQMOffline.copy()
-_ctpps_2016_DQMOffline *= ctppsDQM
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-ctpps_2016.toReplaceWith(DQMOffline, _ctpps_2016_DQMOffline)
-
-_ctpps_2016_DQMOffline = DQMOffline.copy()
-#_ctpps_2016_DQMOffline *= ctppsDQM
-ctpps_2016.toReplaceWith(DQMOffline, _ctpps_2016_DQMOffline)
-
 DQMOfflineExtraHLT = cms.Sequence(
     offlineValidationHLTSource
 )


### PR DESCRIPTION
#### PR description:

This PR fixes issue with CTPPSDiamondDQMSource which was breaking the Run2017C for the recent relvals using DQM:@standardDQM+@ExtraHLT+@miniAODDQM

https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?campaign=CMSSW_10_6_1__dataUL2017C_stdDQM-1562786386

DQMOffline/Configuration/python/DQMOffline_cff.py was being modified by CTPSS in a wrong way, modifying 2016 Eras but apparently affecting any Run2 year data

CTPSS should propose to DQM another strategy for the inclusion of validation in Run2 wf

#### PR validation:

Checked that RelVals are now produced as expected

#### if this PR is a backport please specify the original PR:

It is a backport, same change will ported to master
