### PR TITLE
Avoid unrepresentable int value in BitSet

### DIFF
--- a/PhysicsTools/MVAComputer/interface/BitSet.h
+++ b/PhysicsTools/MVAComputer/interface/BitSet.h
@@ -85,7 +85,8 @@ namespace PhysicsTools {
       /// increment iterator to point at the next set bit
       Iterator &operator++() {
         if (++pos < wordSize) {
-          Word_t word = *store & -(1 << pos);
+          //Only look at bits at and beyond pos
+          Word_t word = *store & ((~(1U << pos)) + 1);
           if (word) {
             pos = ffs(word) - 1;
             return *this;

--- a/PhysicsTools/MVAComputer/test/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/test/BuildFile.xml
@@ -17,6 +17,6 @@
    <use name="CondCore/PluginSystem"/>
    <flags EDM_PLUGIN="1"/>
 </library>
-<bin   name="testPhysicsToolsMVAComputer" file="testMVAComputer.cppunit.cc">
+<bin   name="testPhysicsToolsMVAComputer" file="*.cppunit.cc">
   <use   name="cppunit"/>
 </bin>

--- a/PhysicsTools/MVAComputer/test/testBitSet.cppunit.cc
+++ b/PhysicsTools/MVAComputer/test/testBitSet.cppunit.cc
@@ -1,0 +1,116 @@
+// -*- C++ -*-
+//
+// Package:     PhysicsTools/MVAComputer
+// Class  :     testBitSet.cppunit
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 23 Jan 2015 18:54:27 GMT
+//
+
+// system include files
+
+// user include files
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "PhysicsTools/MVAComputer/interface/BitSet.h"
+
+class testBitSet : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testBitSet);
+
+  CPPUNIT_TEST(bitManipulationTest);
+  CPPUNIT_TEST(multiWordTest);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void multiWordTest();
+  void bitManipulationTest();
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testBitSet);
+
+using namespace PhysicsTools;
+
+namespace {
+  unsigned int bit(int pos) { return (~(1U << pos)) + 1; }
+
+  unsigned int neg(int pos) { return -(1 << pos); }
+}  // namespace
+
+void testBitSet::bitManipulationTest() {
+  for (unsigned int i = 0; i < 31; ++i) {
+    CPPUNIT_ASSERT(bit(i) == neg(i));
+  }
+
+  //bit 31 was causing UBSAN problems for neg
+  // so if neg != bit it is from the undefined
+  // behavior
+  CPPUNIT_ASSERT(bit(31) == 0x80000000);
+  CPPUNIT_ASSERT(neg(31) == 0x80000000);
+}
+
+void testBitSet::multiWordTest() {
+  BitSet b33(33);
+
+  CPPUNIT_ASSERT(b33.size() == 33);
+  CPPUNIT_ASSERT(b33.bits() == 0);
+
+  CPPUNIT_ASSERT(bool(b33.iter()) == false);
+
+  for (int i = 0; i < 33; ++i) {
+    CPPUNIT_ASSERT(b33[i] == false);
+  }
+
+  b33[1] = true;
+  CPPUNIT_ASSERT(b33[1] == true);
+  CPPUNIT_ASSERT(b33.bits() == 1);
+
+  {
+    auto it = b33.iter();
+    CPPUNIT_ASSERT(bool(it) == true);
+    CPPUNIT_ASSERT(it() == 1);
+
+    ++it;
+    CPPUNIT_ASSERT(bool(it) == false);
+  }
+
+  b33[30] = true;
+  CPPUNIT_ASSERT(b33.bits() == 2);
+  {
+    auto it = b33.iter();
+    CPPUNIT_ASSERT(bool(it) == true);
+    CPPUNIT_ASSERT(it() == 1);
+
+    ++it;
+    CPPUNIT_ASSERT(bool(it) == true);
+    CPPUNIT_ASSERT(it() == 30);
+
+    ++it;
+    CPPUNIT_ASSERT(bool(it) == false);
+  }
+
+  b33[32] = true;
+  CPPUNIT_ASSERT(b33.bits() == 3);
+  {
+    auto it = b33.iter();
+    CPPUNIT_ASSERT(bool(it) == true);
+    CPPUNIT_ASSERT(it() == 1);
+
+    ++it;
+    CPPUNIT_ASSERT(bool(it) == true);
+    CPPUNIT_ASSERT(it() == 30);
+
+    ++it;
+    CPPUNIT_ASSERT(bool(it) == true);
+    CPPUNIT_ASSERT(it() == 32);
+
+    ++it;
+    CPPUNIT_ASSERT(bool(it) == false);
+  }
+}


### PR DESCRIPTION
#### PR description:

The bit manipulation used to iterate over the BitSet required a negative value to be negated and the number obtained could not be represented by an int when the bit in question was # 31. The new bit manipulation gives the same results (as tested in the unit test) but avoids the undefined behavior.

This was found by UBSAN.

#### PR validation:

The code compiles and the new unit test succeeds. The unit test also shows that the UBSAN error goes away.