### PR TITLE
Introduce remaining 11_0_X global tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,38 +2,38 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '106X_mcRun1_design_v3',
+    'run1_design'       :   '110X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '106X_mcRun1_realistic_v3',
+    'run1_mc'           :   '110X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '110X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '106X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '110X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '106X_mcRun2_startup_v4',
+    'run2_mc_50ns'      :   '110X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v4',
+    'run2_mc_l1stage1'  :   '110X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '106X_mcRun2_design_v5',
+    'run2_design'       :   '110X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '106X_mcRun2_asymptotic_v5',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v2',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v4',
+    'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
+    'run2_mc_pa'        :   '110X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v17',
+    'run1_data'         :   '110X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v17',
+    'run2_data'         :   '110X_dataRun2_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v16',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v10',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v10',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -44,25 +44,25 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '110X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v7',
+    'phase1_2017_realistic'    :  '110X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v5',
+    'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v4',
+    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR introduces the 11_0_X global tags that have not yet been migrated to 11_0_X, aside from frozen GTs. Some cleanup is also performed. The changes vary from queue to queue but involve:

- removal of obsolete pixel tags [1]
- introduction of a labeled SiPixelLorentzAngleRcd tag for Phase-I MC that with simplify queue maintenance [2] 
- Replace a PF calibration tag with a tag that has the same payload but different tag synchronization. The existing tag had wrong synchronization assigned.

None of these changes will have any impact on any reconstructed quantities but we would like to implement these purely technical changes all at once rather than mixing them with changes that involve physics content.

We also renamed the "mc2017_design_IdealBS" GT to remove the "_IdealBS" string as there is no other "mc2017_design" GT. This is purely a renaming, with no change in content.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4159/1/1.html
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4168.html

Diffs with respect to current autoCond:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v17/110X_dataRun2_v1 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_v9/110X_dataRun2_PromptLike_HEfail_v1 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_v10/110X_dataRun2_PromptLike_HI_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_v10/110X_dataRun2_PromptLike_v1 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v16/110X_dataRun2_relval_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_design_IdealBS_v5/110X_mc2017_design_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_v7/110X_mc2017_realistic_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017cosmics_realistic_deco_v2/110X_mc2017cosmics_realistic_deco_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017cosmics_realistic_peak_v2/110X_mc2017cosmics_realistic_peak_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_HeavyIon_v3/110X_mcRun1_HeavyIon_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_design_v3/110X_mcRun1_design_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_pA_v3/110X_mcRun1_pA_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_realistic_v3/110X_mcRun1_realistic_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_HeavyIon_v4/110X_mcRun2_HeavyIon_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_v5/110X_mcRun2_asymptotic_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_l1stage1_Queue/110X_mcRun2_asymptotic_l1stage1_v1   
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_design_v5/110X_mcRun2_design_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_pA_v4/110X_mcRun2_pA_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_startup_v4/110X_mcRun2_startup_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2cosmics_startup_deco_v2/110X_mcRun2cosmics_startup_deco_v1 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_design_v5/110X_upgrade2018_design_v1 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v6/110X_upgrade2018_realistic_HEfail_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HI_v4/110X_upgrade2018_realistic_HI_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v6/110X_upgrade2018_realistic_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_deco_v3/110X_upgrade2018cosmics_realistic_deco_v1  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_peak_v3/110X_upgrade2018cosmics_realistic_peak_v1 

#### PR validation:

`runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This PR should not be backported.