### PR TITLE
customize HLT to activate IrradiationBiasCorrection in PixelCPEGenericESProducer

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -57,11 +57,18 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+def customiseFor27183(process) :
+ 
+   for producer in esproducers_by_type(process, "PixelCPEGenericESProducer"):
+      producer.IrradiationBiasCorrection = cms.bool(True)
+      
+   return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     process = customiseFor27220(process)
+    process = customiseFor27183(process)
 
     return process


### PR DESCRIPTION
#### PR description:
As it was discussed in PR https://github.com/cms-sw/cmssw/pull/27183 it is needed to activate the `IrradiationBiasCorrection` at HLT as well for the Run3 HLT menus as the PixelCPEGeneric algorithm is used everywhere at HLT. 
The outcome of the activation of this parameter is to mitigate the position bias (and related loss of resolution) of the pixel clusters due to high sensor irradiation as expected at the end of life of the phase-1 pixel detector.
The effects of the activation of the parameter have been studied in details and have been collected in this [presentation](https://mmasciov.web.cern.ch/mmasciov/HLTTracking/TrackingHLT_PixelCPE_2019July19th.pdf) from @mmasciov.    

The most striking effect is a drastic improvement (in the 2023 scenario) of the impact parameter pulls (especially in dz): 

![image](https://user-images.githubusercontent.com/5082376/61578133-3173f000-aaf2-11e9-8969-26c629a9a8f8.png)

Now that "GRun" menu is used for the 2021 workflows (due to PR https://github.com/cms-sw/cmssw/pull/27331 ) and eventually lately for other Run3 workflows (as proposed in PR https://github.com/cms-sw/cmssw/pull/27433 ) it is possible to apply the customization directly from `customizeHLTforCMSSW`.
**N.B.**: the issue is tracked also at https://its.cern.ch/jira/browse/CMSHLT-2093.

#### PR validation:

Proposed code changes pass `addOnTests` and also explicit tests of a 2021 workflow:
```
runTheMatrix.py -l 12024.0 -t 4 -j 8 --comman='-n 1'
```
Inspection of the resulting step2 configuration via:
```
edmConfigDump step2_DIGI_L1_DIGI2RAW_HLT.py > dumped.py
less dumped.py | grep -A 18 -B 8 IrradiationBiasCorrection
```
reveals the customization has been applied correctly:
```python
process.hltESPPixelCPEGeneric = cms.ESProducer("PixelCPEGenericESProducer",
    Alpha2Order = cms.bool(True),
    ClusterProbComputationFlag = cms.int32(0),
    ComponentName = cms.string('hltESPPixelCPEGeneric'),
    DoCosmics = cms.bool(False),
    EdgeClusterErrorX = cms.double(50.0),
    EdgeClusterErrorY = cms.double(85.0),
    IrradiationBiasCorrection = cms.bool(True),
    LoadTemplatesFromDB = cms.bool(True),
    MagneticFieldRecord = cms.ESInputTag("",""),
    PixelErrorParametrization = cms.string('NOTcmsim'),
    TruncatePixelCharge = cms.bool(True),
    UseErrorsFromTemplates = cms.bool(True),
    eff_charge_cut_highX = cms.double(1.0),
    eff_charge_cut_highY = cms.double(1.0),
    eff_charge_cut_lowX = cms.double(0.0),
    eff_charge_cut_lowY = cms.double(0.0),
    inflate_all_errors_no_trk_angle = cms.bool(False),
    inflate_errors = cms.bool(False),
    size_cutX = cms.double(3.0),
    size_cutY = cms.double(3.0),
    useLAAlignmentOffsets = cms.bool(False),
    useLAWidthFromDB = cms.bool(False)
)

```

#### if this PR is a backport please specify the original PR:

This is not a backport.
cc:
@tsusa @mtosi @JanFSchulte

