### PR TITLE
add DQMOfflineCosmics_SecondStep_FakeHLT for Cosmics harvesting

### DIFF
--- a/Configuration/StandardSequences/python/HarvestingCosmics_cff.py
+++ b/Configuration/StandardSequences/python/HarvestingCosmics_cff.py
@@ -7,6 +7,7 @@ from Validation.Configuration.postValidation_cff import *
 from HLTriggerOffline.Common.HLTValidationHarvest_cff import *
 
 dqmHarvesting = cms.Path(DQMOfflineCosmics_SecondStep*DQMOfflineCosmics_Certification)
+dqmHarvestingFakeHLT = cms.Path(DQMOfflineCosmics_SecondStep_FakeHLT*DQMOfflineCosmics_Certification)
 dqmHarvestingPOG = cms.Path(DQMOfflineCosmics_SecondStep_PrePOG)
 
 validationHarvesting = cms.Path(postValidationCosmics)

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_SecondStep_cff.py
@@ -46,7 +46,7 @@ DQMOfflineCosmics_SecondStep_PrePOG = cms.Sequence( TrackingCosmicDQMClient *
                                                     triggerOfflineDQMClient *
                                                     hltOfflineDQMClient *
                                                     SusyPostProcessorSequence )
- 
+
 DQMOfflineCosmics_SecondStep_PrePOG.remove(fsqClient)
 DQMOfflineCosmics_SecondStepPOG = cms.Sequence(
                                                 DQMOfflineCosmics_SecondStep_PrePOG *
@@ -57,3 +57,11 @@ DQMOfflineCosmics_SecondStep = cms.Sequence(
                                              DQMOfflineCosmics_SecondStep_PreDPG *
                                              DQMOfflineCosmics_SecondStep_PrePOG *
                                              DQMMessageLoggerClientSeq )
+
+DQMOfflineCosmics_SecondStep_FakeHLT = cms.Sequence(DQMOfflineCosmics_SecondStep_PreDPG *
+                                                    TrackingCosmicDQMClient *
+                                                    cosmicMuonQualityTests *
+                                                    photonOfflineDQMClient *
+                                                    l1TriggerDqmOfflineCosmicsClient *
+                                                    SusyPostProcessorSequence*
+                                                    DQMMessageLoggerClientSeq)


### PR DESCRIPTION
#### PR description:
After the integration of PR https://github.com/cms-sw/cmssw/pull/27467 I noticed that the logs of the harvesting step of several cosmics based workflows was flooded with messages of the type:
```
dqmHarvestingFakeHLT is not a possible harvesting type. Available are ['FH_DR_GROUP', 'SusyPostProcessorSequence',  ....] 
```
(message is stripped, it is several hundred lines long, see e.g. [here](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc700/CMSSW_11_0_X_2019-07-19-2300/pyRelValMatrixLogs/run/7.2_Cosmics_UP18+Cosmics_UP18+DIGICOS_UP18+RECOCOS_UP18+ALCACOS_UP18+HARVESTCOS_UP18/step5_Cosmics_UP18+Cosmics_UP18+DIGICOS_UP18+RECOCOS_UP18+ALCACOS_UP18+HARVESTCOS_UP18.log) ).
While apparently the cosmics workflows are running successfully, even the HARVESTING step,  it is not clear to me what exactly is being run.
At any rate I've traced the issue in the lack of definition of the sequence `dqmHarvestingFakeHLT` in 
 `Configuration/StandardSequences/python/HarvestingCosmics_cff.py` which is now created removing the HLT monitoring clients which cannot meaningfully in absence of an HLT menu.
As a side comment, I tried to remove the offending sequences via:
```python
DQMOfflineCosmics_SecondStep_FakeHLT = cms.Sequence(DQMOfflineCosmics_SecondStep)
DQMOfflineCosmics_SecondStep_FakeHLT.remove(triggerOfflineDQMClient)
DQMOfflineCosmics_SecondStep_FakeHLT.remove(hltOfflineDQMClient)
```
e.g. as proposed here: https://github.com/cms-sw/cmssw/pull/27467/files#diff-8660299b2ade38cf3638eb31ccb685f6R104 but this appears not to work. I would be curious to understand what is the most economic approach.

#### PR validation:
Passes tests of a real data and 2018 Cosmics MC workflows:
```
runTheMatrix.py -l 4.22,7.2 --ibeos 
```
and inspection of the harvesting step logs shows lack of warning messages. 

#### if this PR is a backport please specify the original PR:
This PR is not a backport.
cc:

@mtosi 

