### PR TITLE
DD4hep: Add Access to Vectors from Namespace

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDNamespace.h
+++ b/DetectorDescription/DDCMS/interface/DDNamespace.h
@@ -5,11 +5,14 @@
 #include "DD4hep/Objects.h"
 #include "DD4hep/Shapes.h"
 #include "DD4hep/Volumes.h"
+#include "tbb/concurrent_unordered_map.h"
+#include "tbb/concurrent_vector.h"
 
 namespace cms {
 
   class DDParsingContext;
-
+  using DDVectorsMap = tbb::concurrent_unordered_map<std::string, tbb::concurrent_vector<double>>;
+  
   class DDNamespace {
   public:
     DDNamespace(DDParsingContext*, xml_h);
@@ -63,6 +66,8 @@ namespace cms {
     DDParsingContext* setContext() { return m_context; }
 
     std::string_view name() const { return m_name; }
+
+    std::vector<double> vecDbl(const std::string& name) const;
 
   private:
     DDParsingContext* m_context = nullptr;

--- a/DetectorDescription/DDCMS/interface/DDNamespace.h
+++ b/DetectorDescription/DDCMS/interface/DDNamespace.h
@@ -12,7 +12,7 @@ namespace cms {
 
   class DDParsingContext;
   using DDVectorsMap = tbb::concurrent_unordered_map<std::string, tbb::concurrent_vector<double>>;
-  
+
   class DDNamespace {
   public:
     DDNamespace(DDParsingContext*, xml_h);

--- a/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
@@ -1655,7 +1655,7 @@ void Converter<DDLVector>::operator()(xml_h element) const {
   cms::DDParsingContext* const context = ns.context();
   DDVectorsMap* registry = context->description.load()->extension<DDVectorsMap>();
   xml_dim_t e(element);
-  string name = e.nameStr();
+  string name = ns.prepend(e.nameStr());
   string type = ns.attr<string>(e, _U(type));
   string nEntries = ns.attr<string>(e, DD_CMU(nEntries));
   string val = e.text();

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -238,9 +238,9 @@ dd4hep::Solid DDNamespace::solid(const string& nam) const {
 std::vector<double> DDNamespace::vecDbl(const std::string& name) const {
   cms::DDVectorsMap* registry = m_context->description.load()->extension<cms::DDVectorsMap>();
   auto it = registry->find(name);
-  if( it != registry->end()) {
+  if (it != registry->end()) {
     std::vector<double> result;
-    for(auto in : it->second)
+    for (auto in : it->second)
       result.emplace_back(in);
     return result;
   } else

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -5,6 +5,8 @@
 #include "XML/XML.h"
 
 #include <TClass.h>
+#include "tbb/concurrent_unordered_map.h"
+#include "tbb/concurrent_vector.h"
 
 using namespace std;
 using namespace cms;
@@ -231,4 +233,16 @@ dd4hep::Solid DDNamespace::solid(const string& nam) const {
   if (i != m_context->shapes.end())
     return (*i).second;
   throw runtime_error("Unknown shape identifier:" + nam);
+}
+
+std::vector<double> DDNamespace::vecDbl(const std::string& name) const {
+  cms::DDVectorsMap* registry = m_context->description.load()->extension<cms::DDVectorsMap>();
+  auto it = registry->find(name);
+  if( it != registry->end()) {
+    std::vector<double> result;
+    for(auto in : it->second)
+      result.emplace_back(in);
+    return result;
+  } else
+    return std::vector<double>();
 }


### PR DESCRIPTION
#### PR description:

* Allow to get a previously defined elsewhere a ```vector<double>``` by name from ```DDNamespace```

#### PR validation:

@vargasa - FYI: here is how to access it from your code:

``` 
-  const std::string solidOutput = args.value<std::string>("SolidName");
-  const std::string material = args.value<std::string>("Material");
+  const string solidOutput = args.value<string>("SolidName");
+  const string material = args.value<string>("Material");
+  string phiVecName = args.str("Phi");
+  string zlVecName = args.str("z_l");
+  string ztVecName = args.str("z_t");
 
-  std::vector<std::string> phis = args.vecStr("Phi");
-  std::vector<std::string> z_ls = args.vecStr("z_l");
-  std::vector<std::string> z_ts = args.vecStr("z_t");
+  auto phis = ns.vecDbl(phiVecName);
+  auto z_ls = ns.vecDbl(zlVecName);
+  auto z_ts = ns.vecDbl(ztVecName);
 
   assert(phis.size() == z_ls.size());
   assert(phis.size() == z_ts.size());
 
   for (unsigned i = 0; i < phis.size(); i++) {
-    Section s = {dd4hep::_toDouble(phis[i]), dd4hep::_toDouble(z_ls[i]), dd4hep::_toDouble(z_ts[i])};
+    Section s = {phis[i], z_ls[i], z_ts[i]};
 
     sections.emplace_back(s);
```
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
