### PR TITLE
[PPS] Diamond DQM patch for 2017

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -119,7 +119,7 @@ private:
 
   /// plots related to one Diamond detector package
   struct PotPlots {
-    std::map<unsigned int,MonitorElement*> activity_per_bx;
+    std::unordered_map<unsigned int,MonitorElement*> activity_per_bx;
 
     MonitorElement* hitDistribution2d = nullptr;
     MonitorElement* hitDistribution2d_lumisection = nullptr;
@@ -183,7 +183,7 @@ private:
 
   /// plots related to one Diamond channel
   struct ChannelPlots {
-    std::map<unsigned int, MonitorElement*> activity_per_bx;
+    std::unordered_map<unsigned int, MonitorElement*> activity_per_bx;
 
     MonitorElement* HPTDCErrorFlags = nullptr;
     MonitorElement *leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_le = nullptr,

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -905,11 +905,11 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         for (const auto& lt : ds) {
           if (lt.isValid() && pixId.arm() == detId_pot.arm()) {
             if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
+                rechit.getOOTIndex() >= 0  &&
                 potPlots_[detId_pot].pixelTomographyAll.count(rechit.getOOTIndex()) > 0 &&
-                rechit.getOOTIndex() >= 0 && lt.getX0() - horizontalShiftBwDiamondPixels_ < 24)
-              potPlots_[detId_pot]
-                  .pixelTomographyAll.at(rechit.getOOTIndex())
-                  ->Fill(lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * detId.plane(), lt.getY0());
+                lt.getX0() - horizontalShiftBwDiamondPixels_ < 24)
+              potPlots_[detId_pot].pixelTomographyAll.at(rechit.getOOTIndex())
+                ->Fill(lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * detId.plane(), lt.getY0());
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -133,7 +133,7 @@ private:
     MonitorElement* pixelTomographyAll_0_25 = nullptr;
     MonitorElement* pixelTomographyAll_25_50 = nullptr;
     MonitorElement* pixelTomographyAll_50_75 = nullptr;
-    std::vector<MonitorElement*> pixelTomographyAll;
+    std::unordered_map<unsigned int,MonitorElement*> pixelTomographyAll;
 
     MonitorElement *leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_all = nullptr,
                    *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
@@ -297,7 +297,7 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
                                         -0.5,
                                         18.5);
 
-  pixelTomographyAll_0_25 =
+  pixelTomographyAll[0] =
       ibooker.book2D("tomography pixel 0 25",
                      title + " tomography with pixel 0 - 25 ns (all planes);x + 25*plane(mm);y (mm)",
                      100,
@@ -306,8 +306,7 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
                      8,
                      0,
                      8);
-  pixelTomographyAll.emplace_back(pixelTomographyAll_0_25);
-  pixelTomographyAll_25_50 =
+  pixelTomographyAll[1] =
       ibooker.book2D("tomography pixel 25 50",
                      title + " tomography with pixel 25 - 50 ns (all planes);x + 25*plane(mm);y (mm)",
                      100,
@@ -316,8 +315,7 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
                      8,
                      0,
                      8);
-  pixelTomographyAll.emplace_back(pixelTomographyAll_25_50);
-  pixelTomographyAll_50_75 =
+  pixelTomographyAll[2] =
       ibooker.book2D("tomography pixel 50 75",
                      title + " tomography with pixel 50 - 75 ns (all planes);x + 25*plane(mm);y (mm)",
                      100,
@@ -326,7 +324,6 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
                      8,
                      0,
                      8);
-  pixelTomographyAll.emplace_back(pixelTomographyAll_50_75);
 
   leadingEdgeCumulative_both = ibooker.book1D(
       "leading edge (le and te)", title + " leading edge (le and te) (recHits); leading edge (ns)", 75, 0, 75);
@@ -911,7 +908,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         for (const auto& lt : ds) {
           if (lt.isValid() && pixId.arm() == detId_pot.arm()) {
             if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
-                rechit.getOOTIndex() < (int)potPlots_[detId_pot].pixelTomographyAll.size() &&
+                potPlots_[detId_pot].pixelTomographyAll.count(rechit.getOOTIndex()) > 0 &&
                 rechit.getOOTIndex() >= 0 && lt.getX0() - horizontalShiftBwDiamondPixels_ < 24)
               potPlots_[detId_pot]
                   .pixelTomographyAll.at(rechit.getOOTIndex())

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -130,9 +130,6 @@ private:
     MonitorElement* trackDistribution = nullptr;
     MonitorElement* trackDistributionOOT = nullptr;
 
-    MonitorElement* pixelTomographyAll_0_25 = nullptr;
-    MonitorElement* pixelTomographyAll_25_50 = nullptr;
-    MonitorElement* pixelTomographyAll_50_75 = nullptr;
     std::unordered_map<unsigned int,MonitorElement*> pixelTomographyAll;
 
     MonitorElement *leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_all = nullptr,

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -119,7 +119,7 @@ private:
 
   /// plots related to one Diamond detector package
   struct PotPlots {
-    std::unordered_map<unsigned int,MonitorElement*> activity_per_bx;
+    std::unordered_map<unsigned int, MonitorElement*> activity_per_bx;
 
     MonitorElement* hitDistribution2d = nullptr;
     MonitorElement* hitDistribution2d_lumisection = nullptr;
@@ -130,7 +130,7 @@ private:
     MonitorElement* trackDistribution = nullptr;
     MonitorElement* trackDistributionOOT = nullptr;
 
-    std::unordered_map<unsigned int,MonitorElement*> pixelTomographyAll;
+    std::unordered_map<unsigned int, MonitorElement*> pixelTomographyAll;
 
     MonitorElement *leadingEdgeCumulative_both = nullptr, *leadingEdgeCumulative_all = nullptr,
                    *leadingEdgeCumulative_le = nullptr, *trailingEdgeCumulative_te = nullptr;
@@ -238,9 +238,12 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
 
   CTPPSDiamondDetId(id).rpName(title, CTPPSDiamondDetId::nFull);
 
-  activity_per_bx[0] = ibooker.book1D("activity per BX 0 25", title + " Activity per BX 0 - 25 ns;Event.BX", 3600, -1.5, 3598. + 0.5);
-  activity_per_bx[1] = ibooker.book1D("activity per BX 25 50", title + " Activity per BX 25 - 50 ns;Event.BX", 3600, -1.5, 3598. + 0.5);
-  activity_per_bx[2] = ibooker.book1D("activity per BX 50 75", title + " Activity per BX 50 - 75 ns;Event.BX", 3600, -1.5, 3598. + 0.5);
+  activity_per_bx[0] =
+      ibooker.book1D("activity per BX 0 25", title + " Activity per BX 0 - 25 ns;Event.BX", 3600, -1.5, 3598. + 0.5);
+  activity_per_bx[1] =
+      ibooker.book1D("activity per BX 25 50", title + " Activity per BX 25 - 50 ns;Event.BX", 3600, -1.5, 3598. + 0.5);
+  activity_per_bx[2] =
+      ibooker.book1D("activity per BX 50 75", title + " Activity per BX 50 - 75 ns;Event.BX", 3600, -1.5, 3598. + 0.5);
 
   hitDistribution2d = ibooker.book2D("hits in planes",
                                      title + " hits in planes;plane number;x (mm)",
@@ -429,9 +432,12 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, un
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel(2, "Trailing only");
   leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel(3, "Full");
 
-  activity_per_bx[0] = ibooker.book1D("activity per BX 0 25", title + " Activity per BX 0 - 25 ns;Event.BX", 500, -1.5, 498. + 0.5);
-  activity_per_bx[1] = ibooker.book1D("activity per BX 25 50", title + " Activity per BX 25 - 50 ns;Event.BX", 500, -1.5, 498. + 0.5);
-  activity_per_bx[2] = ibooker.book1D("activity per BX 50 75", title + " Activity per BX 50 - 75 ns;Event.BX", 500, -1.5, 498. + 0.5);
+  activity_per_bx[0] =
+      ibooker.book1D("activity per BX 0 25", title + " Activity per BX 0 - 25 ns;Event.BX", 500, -1.5, 498. + 0.5);
+  activity_per_bx[1] =
+      ibooker.book1D("activity per BX 25 50", title + " Activity per BX 25 - 50 ns;Event.BX", 500, -1.5, 498. + 0.5);
+  activity_per_bx[2] =
+      ibooker.book1D("activity per BX 50 75", title + " Activity per BX 50 - 75 ns;Event.BX", 500, -1.5, 498. + 0.5);
 
   HPTDCErrorFlags = ibooker.book1D("hptdc_Errors", title + " HPTDC Errors", 16, -0.5, 16.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
@@ -904,12 +910,12 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
           continue;
         for (const auto& lt : ds) {
           if (lt.isValid() && pixId.arm() == detId_pot.arm()) {
-            if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
-                rechit.getOOTIndex() >= 0  &&
+            if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() >= 0 &&
                 potPlots_[detId_pot].pixelTomographyAll.count(rechit.getOOTIndex()) > 0 &&
                 lt.getX0() - horizontalShiftBwDiamondPixels_ < 24)
-              potPlots_[detId_pot].pixelTomographyAll.at(rechit.getOOTIndex())
-                ->Fill(lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * detId.plane(), lt.getY0());
+              potPlots_[detId_pot]
+                  .pixelTomographyAll.at(rechit.getOOTIndex())
+                  ->Fill(lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * detId.plane(), lt.getY0());
           }
         }
       }


### PR DESCRIPTION
#### PR description:

This PR allows rechits with negative OOT index to be discarded in the population of the per-BX activity and pixel tomography monitoring plots for the PPS diamond detector. This allows to fix a `std::out_of_range` exception raised in e.g. 2017C relvals workflows (see e.g. [here](https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?campaign=CMSSW_10_6_1__dataUL2017C_stdDQM-1562786386)), as the time acquisition window was significantly larger (thus increasing the multiplicity of OOT hits).

@fabferro, @prebello, @vavati, @jfernan2

#### PR validation:

Successfully tested on the "faulty" workflow on a `10_6_1`, and forward-ported on this `11_0_X` master branch.

```sh
$ cmsDriver.py step3 --conditions 106X_dataRun2_v15 \
  -s RAW2DIGI,L1Reco,RECO,SKIM:ZElectron,EI,PAT,ALCA:EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkFilter,DQM:@standardDQM+@ExtraHLT+@miniAODDQM 
  --runUnscheduled --process reRECO --data --era Run2_2017 \
  --eventcontent RECO,MINIAOD,DQM --hltProcess reHLT --scenario pp \
  --datatier RECO,MINIAOD,DQMIO \
  --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017 \
  --filein=/store/relval/CMSSW_10_6_1/DoubleEG/FEVTDEBUGHLT/103X_dataRun2_HLT_relval_v8_stdDQM_RelVal_2017C-v1/20000/9894C3EA-791C-4E47-B4F4-537828FFEF62.root
```

#### if this PR is a backport please specify the original PR: N/A

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
