### PR TITLE
[BugFix]  DDG4ProductionCuts Debug Printout

### DIFF
--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -82,7 +82,7 @@ void DDG4ProductionCuts::initialize() {
   G4Region* region = nullptr;
   G4RegionStore* store = G4RegionStore::GetInstance();
   for (auto const& vv : vec_) {
-    unsigned int num = map_.toString(keywordRegion_, vv.second, regionName);
+    unsigned int num = map_->toString(keywordRegion_, vv.second, regionName);
     edm::LogVerbatim("Geometry") << "  num  " << num << " regionName: " << regionName << ", the store of size "
                                  << store->size();
     if (num != 1) {

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -63,13 +63,15 @@ void DDG4ProductionCuts::initialize() {
   G4RegionStore* store = G4RegionStore::GetInstance();
   for (auto const& vv : vec_) {
     unsigned int num = map_.toString(keywordRegion_, vv.second, regionName);
-    edm::LogVerbatim("Geometry") << "  num  " << num << " regionName: " << regionName << ", the store of size " << store->size();
+    edm::LogVerbatim("Geometry") << "  num  " << num << " regionName: " << regionName << ", the store of size "
+                                 << store->size();
 
     if (num != 1) {
       throw cms::Exception("SimG4CorePhysics", " DDG4ProductionCuts::initialize: Problem with Region tags.");
     }
     if (regionName != curName) {
-      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : regionName " << regionName << ", the store of size " << store->size();
+      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : regionName " << regionName << ", the store of size "
+                                   << store->size();
       region = store->FindOrCreateRegion(regionName);
       edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : region " << region->GetName();
       if (!region) {

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -63,15 +63,15 @@ void DDG4ProductionCuts::initialize() {
   G4RegionStore* store = G4RegionStore::GetInstance();
   for (auto const& vv : vec_) {
     unsigned int num = map_.toString(keywordRegion_, vv.second, regionName);
-    edm::LogVerbatim("Geometry") << "  num  " << num << " regionName: " << regionName << " " << store;
+    edm::LogVerbatim("Geometry") << "  num  " << num << " regionName: " << regionName << ", the store of size " << store->size();
 
     if (num != 1) {
       throw cms::Exception("SimG4CorePhysics", " DDG4ProductionCuts::initialize: Problem with Region tags.");
     }
     if (regionName != curName) {
-      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : regionName " << regionName << " " << store;
+      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : regionName " << regionName << ", the store of size " << store->size();
       region = store->FindOrCreateRegion(regionName);
-      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : region " << region;
+      edm::LogVerbatim("Geometry") << "DDG4ProductionCuts : region " << region->GetName();
       if (!region) {
         throw cms::Exception("SimG4CoreGeometry", " DDG4ProductionCuts::initialize: Problem with Region tags.");
       }


### PR DESCRIPTION
#### PR description:

* Instead of printing 
     *  a G4RegionStore pointer, print the G4RegionStore size 
     *  a G4Region pointer, print its name

```
  num  1 regionName: ZDCRegion, the store of size 2
DDG4ProductionCuts : regionName ZDCRegion, the store of size 2
DDG4ProductionCuts : region ZDCRegion
DDG4ProductionCuts : new G4Region ZDC
  num  1 regionName: TrackerDeadRegion, the store of size 3
DDG4ProductionCuts : regionName TrackerDeadRegion, the store of size 3
DDG4ProductionCuts : region TrackerDeadRegion
DDG4ProductionCuts : new G4Region Tracker
  num  1 regionName: TrackerSensRegion, the store of size 4
DDG4ProductionCuts : regionName TrackerSensRegion, the store of size 4
DDG4ProductionCuts : region TrackerSensRegion
DDG4ProductionCuts : new G4Region TOBWaferRphi4
  num  1 regionName: TrackerSensRegion, the store of size 5
  num  1 regionName: TrackerSensRegion, the store of size 5
```
here is how it was before:
```
  num  1 regionName: ZDCRegion 0x7fcdd78a12e0
DDG4ProductionCuts : regionName ZDCRegion 0x7fcdd78a12e0
DDG4ProductionCuts : region 0x7fcdcd3e9cc0
DDG4ProductionCuts : new G4Region ZDC
  num  1 regionName: TrackerDeadRegion 0x7fcdd78a12e0
DDG4ProductionCuts : regionName TrackerDeadRegion 0x7fcdd78a12e0
DDG4ProductionCuts : region 0x7fcdcd3e9d80
DDG4ProductionCuts : new G4Region Tracker
  num  1 regionName: TrackerSensRegion 0x7fcdd78a12e0
DDG4ProductionCuts : regionName TrackerSensRegion 0x7fcdd78a12e0
DDG4ProductionCuts : region 0x7fcdcd3e9e40
DDG4ProductionCuts : new G4Region TOBWaferRphi4
  num  1 regionName: TrackerSensRegion 0x7fcdd78a12e0
  num  1 regionName: TrackerSensRegion 0x7fcdd78a12e0
```
#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
