### PR TITLE
[Sim]: Sensitive Detector Catalog Cleanup

### DIFF
--- a/SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h
+++ b/SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h
@@ -3,20 +3,23 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
+#include <unordered_set>
 
 class SensitiveDetectorCatalog {
 public:
-  using MapType = std::map<std::string, std::vector<std::string>>;
+  using MapType = std::map<std::string, std::unordered_set<std::string>>;
   void insert(const std::string &, const std::string &, const std::string &);
-  const std::vector<std::string> &logicalNames(const std::string &readoutName) const;
-  const std::vector<std::string> &readoutNames(const std::string &className) const;
-  std::vector<std::string> readoutNames() const;
-  std::string className(const std::string &readoutName) const;
+  const std::vector<std::string_view> logicalNames(const std::string &readoutName) const;
+  const std::vector<std::string_view> readoutNames(const std::string &className) const;
+  std::vector<std::string_view> readoutNames() const;
+  std::string_view className(const std::string &readoutName) const;
+  void printMe() const;
 
 private:
-  std::vector<std::string> logicalNamesFromClassName(const std::string &className) const;
-  std::vector<std::string> classNames() const;
+  std::vector<std::string_view> logicalNamesFromClassName(const std::string &className) const;
+  std::vector<std::string_view> classNames() const;
 
   MapType theClassNameMap;
   MapType theROUNameMap;

--- a/SimG4Core/Geometry/src/SensitiveDetectorCatalog.cc
+++ b/SimG4Core/Geometry/src/SensitiveDetectorCatalog.cc
@@ -6,8 +6,8 @@
 #include <iostream>
 
 void SensitiveDetectorCatalog::insert(const std::string &cN, const std::string &rN, const std::string &lvN) {
-  theClassNameMap[cN].emplace_back(rN);
-  theROUNameMap[rN].emplace_back(lvN);
+  theClassNameMap[cN].insert(rN);
+  theROUNameMap[rN].insert(lvN);
 #ifdef DEBUG
   edm::LogVerbatim("SimG4CoreGeometry") << "SenstiveDetectorCatalog: insert (" << cN << "," << rN << "," << lvN << ")\n"
                                         << "                         has     " << readoutNames().size() << " ROUs "
@@ -17,32 +17,32 @@ void SensitiveDetectorCatalog::insert(const std::string &cN, const std::string &
 #endif
 }
 
-std::vector<std::string> SensitiveDetectorCatalog::readoutNames() const {
-  std::vector<std::string> temp;
+std::vector<std::string_view> SensitiveDetectorCatalog::readoutNames() const {
+  std::vector<std::string_view> temp;
   for (auto const &it : theROUNameMap)
     temp.emplace_back(it.first);
   return temp;
 }
 
-const std::vector<std::string> &SensitiveDetectorCatalog::readoutNames(const std::string &className) const {
-  return theClassNameMap.at(className);
+const std::vector<std::string_view> SensitiveDetectorCatalog::readoutNames(const std::string &className) const {
+  return std::vector<std::string_view>(theClassNameMap.at(className).begin(), theClassNameMap.at(className).end());
 }
 
-const std::vector<std::string> &SensitiveDetectorCatalog::logicalNames(const std::string &readoutName) const {
-  return theROUNameMap.at(readoutName);
+const std::vector<std::string_view> SensitiveDetectorCatalog::logicalNames(const std::string &readoutName) const {
+  return std::vector<std::string_view>(theROUNameMap.at(readoutName).begin(), theROUNameMap.at(readoutName).end());
 }
 
-std::vector<std::string> SensitiveDetectorCatalog::logicalNamesFromClassName(const std::string &className) const {
-  std::vector<std::string> temp;
-  const std::vector<std::string> &rous = theClassNameMap.at(className);
+std::vector<std::string_view> SensitiveDetectorCatalog::logicalNamesFromClassName(const std::string &className) const {
+  std::vector<std::string_view> temp;
+  const std::vector<std::string_view> rous(theClassNameMap.at(className).begin(), theClassNameMap.at(className).end());
   for (auto const &it : rous)
     temp.emplace_back(it);
   return temp;
 }
 
-std::string SensitiveDetectorCatalog::className(const std::string &readoutName) const {
+std::string_view SensitiveDetectorCatalog::className(const std::string &readoutName) const {
   for (auto const &it : theClassNameMap) {
-    std::vector<std::string> temp = it.second;
+    std::vector<std::string_view> temp(it.second.begin(), it.second.end());
     for (auto const &it2 : temp) {
       if (it2 == readoutName)
         return it.first;
@@ -51,9 +51,47 @@ std::string SensitiveDetectorCatalog::className(const std::string &readoutName) 
   return "NotFound";
 }
 
-std::vector<std::string> SensitiveDetectorCatalog::classNames() const {
-  std::vector<std::string> temp;
+std::vector<std::string_view> SensitiveDetectorCatalog::classNames() const {
+  std::vector<std::string_view> temp;
   for (auto const &it : theClassNameMap)
     temp.emplace_back(it.first);
   return temp;
+}
+
+void SensitiveDetectorCatalog::printMe() const {
+  edm::LogVerbatim("SimG4CoreGeometry") << "Class names map size is: " << theClassNameMap.size() << "\n";
+  edm::LogVerbatim("SimG4CoreGeometry").log([&](auto &log) {
+    int i(0);
+    for (auto cn : theClassNameMap) {
+      log << "#" << ++i << ": " << cn.first << " has " << cn.second.size() << " class names:\n";
+      for (auto cnv : cn.second)
+        log << cnv << ", ";
+      log << "\n";
+    }
+    log << "\n";
+  });
+  edm::LogVerbatim("SimG4CoreGeometry") << "\nROU names map: " << theROUNameMap.size() << "\n";
+  edm::LogVerbatim("SimG4CoreGeometry").log([&](auto &log) {
+    int i(0);
+    for (auto rn : theROUNameMap) {
+      log << "#" << ++i << ": " << rn.first << " has " << rn.second.size() << " ROU names:\n";
+      for (auto rnv : rn.second)
+        log << rnv << ", ";
+      log << "\n";
+    }
+    log << "\n";
+  });
+
+  edm::LogVerbatim("SimG4CoreGeometry") << "\n========== Here are the accessors =================\n";
+  edm::LogVerbatim("SimG4CoreGeometry").log([&](auto &log) {
+    for (auto c : classNames()) {
+      log << "ClassName:" << c << "\n";
+      for (auto r : readoutNames({c.data(), c.size()})) {
+        log << "       RedoutName:" << r << "\n";
+        for (auto l : logicalNames({r.data(), r.size()})) {
+          log << "              LogicalName:" << l << "\n";
+        }
+      }
+    }
+  });
 }

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -19,13 +19,14 @@ std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>
     const SimTrackManager* man,
     SimActivityRegistry& reg) const {
   std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*> > detList;
-  const std::vector<std::string>& rouNames = clg.readoutNames();
+  const std::vector<std::string_view>& rouNames = clg.readoutNames();
   edm::LogVerbatim("SimG4CoreSensitiveDetector") << " AttachSD: Initialising " << rouNames.size() << " SDs";
   for (auto& rname : rouNames) {
-    std::string className = clg.className(rname);
-    std::unique_ptr<SensitiveDetectorMakerBase> temp{SensitiveDetectorPluginFactory::get()->create(className)};
+    std::string_view className = clg.className({rname.data(), rname.size()});
+    std::unique_ptr<SensitiveDetectorMakerBase> temp{
+        SensitiveDetectorPluginFactory::get()->create({className.data(), className.size()})};
 
-    std::unique_ptr<SensitiveDetector> sd{temp->make(rname, es, clg, p, man, reg)};
+    std::unique_ptr<SensitiveDetector> sd{temp->make({rname.data(), rname.size()}, es, clg, p, man, reg)};
 
     std::stringstream ss;
     ss << " AttachSD: created a " << className << " with name " << rname;

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -31,10 +31,10 @@ SensitiveDetector::SensitiveDetector(const std::string& iname,
   G4SDManager* SDman = G4SDManager::GetSDMpointer();
   SDman->AddNewDetector(this);
 
-  const std::vector<std::string>& lvNames = clg.logicalNames(iname);
+  const std::vector<std::string_view>& lvNames = clg.logicalNames(iname);
   std::stringstream ss;
   for (auto& lvname : lvNames) {
-    this->AssignSD(lvname);
+    this->AssignSD({lvname.data(), lvname.size()});
     ss << " " << lvname;
   }
   edm::LogVerbatim("SensitiveDetector") << " <" << iname << "> : Assigns SD to LVs " << ss.str();


### PR DESCRIPTION
#### PR description:

* Make sure the class name is registered only once. The original version places the same class name as many times as the number of its ROUs. This feature is not used anywhere. Besides the accessors would return almost endless lists. Hence the question if the methods are still needed.
* Provide its ```printMe``` for debugging purposes

@civanch - we need to discuss if all the methods of the class are useful

```
Class names map size is: 8

#1: BSCSensitiveDetector has 1 class names:
BSCHits, 
#2: CaloTrkProcessing has 1 class names:
CaloHitsTk, 
#3: CastorSensitiveDetector has 1 class names:
CastorFI, 
#4: EcalSensitiveDetector has 3 class names:
EcalHitsES, EcalHitsEB, EcalHitsEE, 
#5: HcalSensitiveDetector has 1 class names:
HcalHits, 
#6: MuonSensitiveDetector has 4 class names:
MuonGEMHits, MuonCSCHits, MuonRPCHits, MuonDTHits, 
#7: TkAccumulatingSensitiveDetector has 6 class names:
TrackerHitsTEC, TrackerHitsTIB, TrackerHitsPixelEndcap, TrackerHitsTOB, TrackerHitsTID, TrackerHitsPixelBarrel, 
#8: ZdcSensitiveDetector has 1 class names:
ZDCHITS, 
```

```
ROU names map: 18

#1: BSCHits has 4 ROU names:
BSCPadActive, BSCBottomTrapezoid, BSC2Pad, BSCTopTrapezoid, 
#2: CaloHitsTk has 1 ROU names:
CALO, 
#3: CastorFI has 5 ROU names:
C4HF, C3HF, C4EF, CAST, C3EF, 
#4: EcalHitsEB has 102 ROU names:
EATJ_15_refl, EAPD_13_refl, EATJ_13_refl, EATJ_12_refl, EBRY_12_refl, EAPD_11_refl, EBRY_15_refl, EATJ_11_refl, EBRY_11_refl, EAPD_10_refl, EATJ_10_refl, EBRY_10_refl, EBRY_09_refl, EBRY_13_refl, EAPD_08_refl, EBRY_08_refl, EBRY_12, EAPD_01_refl, EAPD_11, EBRY_05_refl, EBRY_07_refl, EATJ_10, EAPD_08, EAPD_13, EAPD_07_refl, EATJ_12, EATJ_07, EAPD_06_refl, EBRY_10, EAPD_07, EATJ_06, EBRY_09, EAPD_05, EAPD_06, EBRY_03_refl, EAPD_15_refl, EAPD_05_refl, EAPD_02, EATJ_06_refl, EATJ_04, EBRY_02, EBRY_15, EBRY_04_refl, EAPD_03, EBRY_14, EATJ_01_refl, EBRY_01, EAPD_12, EAPD_10, EBRY_08, EBRY_11, EATJ_09, EBRY_06, EATJ_14, EAPD_01, EBRY_03, EAPD_17_refl, EATJ_03, EBRY_05, EATJ_05, EAPD_09, EATJ_14_refl, EAPD_16, EBRY_13, EATJ_13, EAPD_15, EATJ_15, EATJ_02, EBRY_17, EBRY_04, EAPD_17, EAPD_12_refl, EBRY_07, EATJ_16_refl, EATJ_17, EBRY_01_refl, EATJ_07_refl, EBRY_16, EBRY_02_refl, EATJ_09_refl, EATJ_02_refl, EBRY_16_refl, EAPD_02_refl, EAPD_14_refl, EAPD_09_refl, EATJ_03_refl, EAPD_03_refl, EATJ_11, EATJ_04_refl, EAPD_04, EAPD_14, EAPD_04_refl, EATJ_08_refl, EATJ_16, EAPD_16_refl, EATJ_08, EATJ_17_refl, EBRY_17_refl, EBRY_14_refl, EATJ_01, EBRY_06_refl, EATJ_05_refl, 
#5: EcalHitsEE has 2 ROU names:
EFRY_refl, EFRY, 
#6: EcalHitsES has 2 ROU names:
SFSY, SFSX, 
#7: HcalHits has 135 ROU names:
FibreBundle13, FibreBundle1, FibreBundle7, FibreBundle2, FibreBundle4, FibreBundle6, FibreBundle8, FibreBundle10, FibreBundle12, VcalElecCathode, VcalFibreBundleR1, VcalFibreBundleR3, VcalFibreBundleR5, VcalFibreBundleR12, VcalFibreBundleR4, VcalFibreBundleR8, VcalFibreBundleL0, FibreBundle5, VcalFibreBundleL2, VcalFibreBundleR10, VcalFibreBundleL6, VcalFibreBundleL8, VcalFibreBundleL10, VcalFibreBundleL1, VcalFibreBundleL7, VcalFibreBundleL11, HVQX, HTS1_T6_S, HTS1_T6, HTS1C_T6, HTS1_T5_S, HTS1C_T5, FibreBundle9, HTS1_T4_S, VcalFibreBundleR7, HTS1_T4, HTS1_T3_S, HTS1_T3, HTS1C_T2, HTS1_T1, HTS1C_T1, HTS0_T5, HEScintillatorPart0Layer00Phi1, HBScintillatorLayer8In2, HEScintillatorPart5Layer16Phi0, HBScintillatorLayer14In1, HBScintillatorLayer13In1, VcalFibreBundleR6, HBScintillatorLayer15In1, HBScintillatorLayer0In2, HBScintillatorLayer11In2, HTS1_T2, HBScintillatorLayer13In2, HBScintillatorLayer9In1, HBScintillatorLayer2In2, HBScintillatorLayer2In1, VcalFibreBundleL4, HBScintillatorLayer8In1, HBScintillatorLayer7In1, HBScintillatorLayer12In2, HBScintillatorLayer3In1, HBScintillatorLayer7In2, HEScintillatorPart4Layer07Phi1, HEScintillatorPart4Layer12Phi0, HBScintillatorLayer3In2, VcalFibreBundleL3, HBScintillatorLayer10In2, HTS1_T5, HEScintillatorPart1Layer00Phi0, HBScintillatorLayer4In1, HBScintillatorLayer5In1, HBScintillatorLayer14In2, HEScintillatorPart3Layer06Phi0, HBScintillatorLayer6In2, HEScintillatorPart5Layer18Phi0, HTS1C_T4, HBScintillatorLayer6In1, VcalFibreBundleL5, HEScintillatorPart2Layer01Phi1, HBScintillatorLayer1In2, HBScintillatorLayer10In1, HBScintillatorLayer4In2, HEScintillatorPart5Layer13Phi0, HEScintillatorPart1Layer00Phi1, HEScintillatorPart2Layer01Phi0, HEScintillatorPart4Layer08Phi1, HEScintillatorPart0Layer00Phi0, HEScintillatorPart5Layer14Phi1, HEScintillatorPart3Layer02Phi1, VcalFibreBundleR2, HEScintillatorPart4Layer09Phi1, HBScintillatorLayer1In1, HEScintillatorPart3Layer03Phi0, HEScintillatorPart3Layer05Phi0, FibreBundle11, HEScintillatorPart3Layer05Phi1, HEScintillatorPart3Layer06Phi1, HEScintillatorPart4Layer07Phi0, VcalFibreBundleR0, HTS1C_T3, HEScintillatorPart4Layer08Phi0, HBScintillatorLayer9In2, HBScintillatorLayer16In2, HTS0_T4, HEScintillatorPart4Layer09Phi0, HBScintillatorLayer5In2, HEScintillatorPart5Layer15Phi1, HEScintillatorPart4Layer10Phi0, HEScintillatorPart3Layer04Phi0, HEScintillatorPart5Layer13Phi1, FibreBundle3, HBScintillatorLayer16In1, HEScintillatorPart3Layer04Phi1, HEScintillatorPart4Layer10Phi1, VcalFibreBundleL9, HBScintillatorLayer11In1, HTS0_T2, HEScintillatorPart4Layer11Phi0, HEScintillatorPart4Layer11Phi1, HBScintillatorLayer15In2, HEScintillatorPart4Layer12Phi1, HTS0_T1, HEScintillatorPart3Layer03Phi1, HEScintillatorPart5Layer14Phi0, HBScintillatorLayer0In1, HEScintillatorPart5Layer15Phi0, HBScintillatorLayer12In1, HEScintillatorPart5Layer17Phi0, HEScintillatorPart3Layer02Phi0, HEScintillatorPart5Layer16Phi1, HEScintillatorPart5Layer17Phi1, VcalFibreBundleR9, HTS0_T6, HEScintillatorPart5Layer18Phi1, HTS0_T3, 
#8: MuonCSCHits has 20 ROU names:
ME32_ActiveGasVol_refl, ME31_ActiveGasVol_refl, ME22_ActiveGasVol_refl, ME21_ActiveGasVol_refl, ME21_ActiveGasVol, ME13_ActiveGasVol, ME11_ActiveGasVol, ME32_ActiveGasVol, ME31_ActiveGasVol, ME12_ActiveGasVol, ME1A_ActiveGasVol, ME42_ActiveGasVol, ME13_ActiveGasVol_refl, ME42_ActiveGasVol_refl, ME11_ActiveGasVol_refl, ME22_ActiveGasVol, ME41_ActiveGasVol, ME1A_ActiveGasVol_refl, ME12_ActiveGasVol_refl, ME41_ActiveGasVol_refl, 
#9: MuonDTHits has 5 ROU names:
MB3SLZGas, MB2SLZGas, MBChimSLPhiGas, MBSLPhiGas, MB1SLZGas, 
#10: MuonGEMHits has 16 ROU names:
GHA118, GHA114, GHA111, GHA108, GHA117, GHA107, GHA115, GHA113, GHA102, GHA103, GHA116, GHA112, GHA101, GHA105, GHA106, GHA104, 
#11: MuonRPCHits has 55 ROU names:
REF2, REF1, REE3, REE2, REC3, REB3, REB2, MB4BigChimRPC_GasLeft, MB4TopChimRPC_GasLeft, MB4BottomRPC_GasRight, MB4BottomRPC_GasLeft, MB4FeetRPC_GasRight, MB23RPC_IGasMiddle, MB22RPC_IGasLeft, MB22RPC_OGasRight, MB4TopRPC_GasLeft, MB23RPC_IGasRight, MB22RPC_IGasRight, REE1, MB2ChimRPC_IGasRight, MB3ChimRPC_GasRight, MB23RPC_IGasLeft, MB1RPC_IGasRight, REC1, MB4TopChimRPC_GasRight, MB1RPC_OGasRight, MB1RPC_IGasLeft, MB23RPC_OGasRight, MB1RPC_OGasLeft, MB4TopRPC_GasRight, REB1, MB2ChimRPC_IGasMiddle, MB1ChimRPC_OGasRight, MB4SmallRPC_SmallerGasRight, MB1ChimRPC_IGasLeft, MB22RPC_OGasLeft, MB1ChimRPC_OGasLeft, MB23RPC_OGasMiddle, MB4BigChimRPC_GasRight, MB2ChimRPC_OGasRight, MB2ChimRPC_IGasLeft, MB23RPC_OGasLeft, REC2, MB3RPC_GasLeft, MB2ChimRPC_OGasLeft, MB4SmallRPC_BiggerGasRight, MB1ChimRPC_IGasRight, MB3RPC_GasRight, MB3ChimRPC_GasLeft, MB4RPC_GasLeft, MB4RPC_GasRight, MB4SmallRPC_SmallerGasLeft, REF3, MB4SmallRPC_BiggerGasLeft, MB4FeetRPC_GasLeft, 
#12: TrackerHitsPixelBarrel has 4 ROU names:
PixelBarrelActiveFull3, PixelBarrelActiveFull0, PixelBarrelActiveFull2, PixelBarrelActiveFull1, 
#13: TrackerHitsPixelEndcap has 1 ROU names:
PixelForwardSensor, 
#14: TrackerHitsTEC has 10 ROU names:
TECModule6RphiActive, TECModule5RphiActive, TECModule4StereoActive, TECModule4RphiActive, TECModule0StereoActive, TECModule1RphiActive, TECModule0RphiActive, TECModule2RphiActive, TECModule1StereoActive, TECModule3RphiActive, 
#15: TrackerHitsTIB has 3 ROU names:
TIBActiveRphi2, TIBActiveRphi0, TIBActiveSter0, 
#16: TrackerHitsTID has 5 ROU names:
TIDModule2RphiActive, TIDModule1RphiActive, TIDModule0RphiActive, TIDModule1StereoActive, TIDModule0StereoActive, 
#17: TrackerHitsTOB has 4 ROU names:
TOBActiveRphi4, TOBActiveRphi2, TOBActiveRphi0, TOBActiveSter0, 
#18: ZDCHITS has 2 ROU names:
ZDC_EMFiber, ZDC_HadFiber, 

```

```
========== Here are the accessors =================

ClassName:BSCSensitiveDetector
       RedoutName:BSCHits
              LogicalName:BSCPadActive
              LogicalName:BSCBottomTrapezoid
              LogicalName:BSC2Pad
              LogicalName:BSCTopTrapezoid
ClassName:CaloTrkProcessing
       RedoutName:CaloHitsTk
              LogicalName:CALO
ClassName:CastorSensitiveDetector
       RedoutName:CastorFI
              LogicalName:C4HF
              LogicalName:C3HF
              LogicalName:C4EF
              LogicalName:CAST
              LogicalName:C3EF
ClassName:EcalSensitiveDetector
       RedoutName:EcalHitsES
              LogicalName:SFSY
              LogicalName:SFSX
       RedoutName:EcalHitsEB
              LogicalName:EATJ_15_refl
              LogicalName:EAPD_13_refl
              LogicalName:EATJ_13_refl
              LogicalName:EATJ_12_refl
              LogicalName:EBRY_12_refl
              LogicalName:EAPD_11_refl
              LogicalName:EBRY_15_refl
              LogicalName:EATJ_11_refl
              LogicalName:EBRY_11_refl
              LogicalName:EAPD_10_refl
              LogicalName:EATJ_10_refl
              LogicalName:EBRY_10_refl
              LogicalName:EBRY_09_refl
              LogicalName:EBRY_13_refl
              LogicalName:EAPD_08_refl
              LogicalName:EBRY_08_refl
              LogicalName:EBRY_12
              LogicalName:EAPD_01_refl
              LogicalName:EAPD_11
              LogicalName:EBRY_05_refl
              LogicalName:EBRY_07_refl
              LogicalName:EATJ_10
              LogicalName:EAPD_08
              LogicalName:EAPD_13
              LogicalName:EAPD_07_refl
              LogicalName:EATJ_12
              LogicalName:EATJ_07
              LogicalName:EAPD_06_refl
              LogicalName:EBRY_10
              LogicalName:EAPD_07
              LogicalName:EATJ_06
              LogicalName:EBRY_09
              LogicalName:EAPD_05
              LogicalName:EAPD_06
              LogicalName:EBRY_03_refl
              LogicalName:EAPD_15_refl
              LogicalName:EAPD_05_refl
              LogicalName:EAPD_02
              LogicalName:EATJ_06_refl
              LogicalName:EATJ_04
              LogicalName:EBRY_02
              LogicalName:EBRY_15
              LogicalName:EBRY_04_refl
              LogicalName:EAPD_03
              LogicalName:EBRY_14
              LogicalName:EATJ_01_refl
              LogicalName:EBRY_01
              LogicalName:EAPD_12
              LogicalName:EAPD_10
              LogicalName:EBRY_08
              LogicalName:EBRY_11
              LogicalName:EATJ_09
              LogicalName:EBRY_06
              LogicalName:EATJ_14
              LogicalName:EAPD_01
              LogicalName:EBRY_03
              LogicalName:EAPD_17_refl
              LogicalName:EATJ_03
              LogicalName:EBRY_05
              LogicalName:EATJ_05
              LogicalName:EAPD_09
              LogicalName:EATJ_14_refl
              LogicalName:EAPD_16
              LogicalName:EBRY_13
              LogicalName:EATJ_13
              LogicalName:EAPD_15
              LogicalName:EATJ_15
              LogicalName:EATJ_02
              LogicalName:EBRY_17
              LogicalName:EBRY_04
              LogicalName:EAPD_17
              LogicalName:EAPD_12_refl
              LogicalName:EBRY_07
              LogicalName:EATJ_16_refl
              LogicalName:EATJ_17
              LogicalName:EBRY_01_refl
              LogicalName:EATJ_07_refl
              LogicalName:EBRY_16
              LogicalName:EBRY_02_refl
              LogicalName:EATJ_09_refl
              LogicalName:EATJ_02_refl
              LogicalName:EBRY_16_refl
              LogicalName:EAPD_02_refl
              LogicalName:EAPD_14_refl
              LogicalName:EAPD_09_refl
              LogicalName:EATJ_03_refl
              LogicalName:EAPD_03_refl
              LogicalName:EATJ_11
              LogicalName:EATJ_04_refl
              LogicalName:EAPD_04
              LogicalName:EAPD_04
              LogicalName:EAPD_14
              LogicalName:EAPD_04_refl
              LogicalName:EATJ_08_refl
              LogicalName:EATJ_16
              LogicalName:EAPD_16_refl
              LogicalName:EATJ_08
              LogicalName:EATJ_17_refl
              LogicalName:EBRY_17_refl
              LogicalName:EBRY_14_refl
              LogicalName:EATJ_01
              LogicalName:EBRY_06_refl
              LogicalName:EATJ_05_refl
       RedoutName:EcalHitsEE
              LogicalName:EFRY_refl
              LogicalName:EFRY
ClassName:HcalSensitiveDetector
       RedoutName:HcalHits
              LogicalName:FibreBundle13
              LogicalName:FibreBundle1
              LogicalName:FibreBundle7
              LogicalName:FibreBundle2
              LogicalName:FibreBundle4
              LogicalName:FibreBundle6
              LogicalName:FibreBundle8
              LogicalName:FibreBundle10
              LogicalName:FibreBundle12
              LogicalName:VcalElecCathode
              LogicalName:VcalFibreBundleR1
              LogicalName:VcalFibreBundleR3
              LogicalName:VcalFibreBundleR5
              LogicalName:VcalFibreBundleR12
              LogicalName:VcalFibreBundleR4
              LogicalName:VcalFibreBundleR8
              LogicalName:VcalFibreBundleL0
              LogicalName:FibreBundle5
              LogicalName:VcalFibreBundleL2
              LogicalName:VcalFibreBundleR10
              LogicalName:VcalFibreBundleL6
              LogicalName:VcalFibreBundleL8
              LogicalName:VcalFibreBundleL10
              LogicalName:VcalFibreBundleL1
              LogicalName:VcalFibreBundleL7
              LogicalName:VcalFibreBundleL11
              LogicalName:HVQX
              LogicalName:HTS1_T6_S
              LogicalName:HTS1_T6
              LogicalName:HTS1C_T6
              LogicalName:HTS1_T5_S
              LogicalName:HTS1C_T5
              LogicalName:FibreBundle9
              LogicalName:HTS1_T4_S
              LogicalName:VcalFibreBundleR7
              LogicalName:HTS1_T4
              LogicalName:HTS1_T3_S
              LogicalName:HTS1_T3
              LogicalName:HTS1C_T2
              LogicalName:HTS1_T1
              LogicalName:HTS1C_T1
              LogicalName:HTS0_T5
              LogicalName:HEScintillatorPart0Layer00Phi1
              LogicalName:HBScintillatorLayer8In2
              LogicalName:HEScintillatorPart5Layer16Phi0
              LogicalName:HBScintillatorLayer14In1
              LogicalName:HBScintillatorLayer13In1
              LogicalName:VcalFibreBundleR6
              LogicalName:HBScintillatorLayer15In1
              LogicalName:HBScintillatorLayer0In2
              LogicalName:HBScintillatorLayer11In2
              LogicalName:HTS1_T2
              LogicalName:HBScintillatorLayer13In2
              LogicalName:HBScintillatorLayer9In1
              LogicalName:HBScintillatorLayer2In2
              LogicalName:HBScintillatorLayer2In1
              LogicalName:VcalFibreBundleL4
              LogicalName:HBScintillatorLayer8In1
              LogicalName:HBScintillatorLayer7In1
              LogicalName:HBScintillatorLayer12In2
              LogicalName:HBScintillatorLayer3In1
              LogicalName:HBScintillatorLayer7In2
              LogicalName:HEScintillatorPart4Layer07Phi1
              LogicalName:HEScintillatorPart4Layer12Phi0
              LogicalName:HBScintillatorLayer3In2
              LogicalName:VcalFibreBundleL3
              LogicalName:HBScintillatorLayer10In2
              LogicalName:HTS1_T5
              LogicalName:HEScintillatorPart1Layer00Phi0
              LogicalName:HBScintillatorLayer4In1
              LogicalName:HBScintillatorLayer5In1
              LogicalName:HBScintillatorLayer14In2
              LogicalName:HEScintillatorPart3Layer06Phi0
              LogicalName:HBScintillatorLayer6In2
              LogicalName:HEScintillatorPart5Layer18Phi0
              LogicalName:HTS1C_T4
              LogicalName:HBScintillatorLayer6In1
              LogicalName:VcalFibreBundleL5
              LogicalName:HEScintillatorPart2Layer01Phi1
              LogicalName:HBScintillatorLayer1In2
              LogicalName:HBScintillatorLayer10In1
              LogicalName:HBScintillatorLayer4In2
              LogicalName:HEScintillatorPart5Layer13Phi0
              LogicalName:HEScintillatorPart1Layer00Phi1
              LogicalName:HEScintillatorPart2Layer01Phi0
              LogicalName:HEScintillatorPart4Layer08Phi1
              LogicalName:HEScintillatorPart0Layer00Phi0
              LogicalName:HEScintillatorPart5Layer14Phi1
              LogicalName:HEScintillatorPart3Layer02Phi1
              LogicalName:VcalFibreBundleR2
              LogicalName:HEScintillatorPart4Layer09Phi1
              LogicalName:HBScintillatorLayer1In1
              LogicalName:HEScintillatorPart3Layer03Phi0
              LogicalName:HEScintillatorPart3Layer05Phi0
              LogicalName:FibreBundle11
              LogicalName:HEScintillatorPart3Layer05Phi1
              LogicalName:HEScintillatorPart3Layer06Phi1
              LogicalName:HEScintillatorPart4Layer07Phi0
              LogicalName:VcalFibreBundleR0
              LogicalName:HTS1C_T3
              LogicalName:HEScintillatorPart4Layer08Phi0
              LogicalName:HBScintillatorLayer9In2
              LogicalName:HBScintillatorLayer16In2
              LogicalName:HTS0_T4
              LogicalName:HEScintillatorPart4Layer09Phi0
              LogicalName:HBScintillatorLayer5In2
              LogicalName:HEScintillatorPart5Layer15Phi1
              LogicalName:HEScintillatorPart4Layer10Phi0
              LogicalName:HEScintillatorPart3Layer04Phi0
              LogicalName:HEScintillatorPart5Layer13Phi1
              LogicalName:FibreBundle3
              LogicalName:HBScintillatorLayer16In1
              LogicalName:HEScintillatorPart3Layer04Phi1
              LogicalName:HEScintillatorPart4Layer10Phi1
              LogicalName:VcalFibreBundleL9
              LogicalName:HBScintillatorLayer11In1
              LogicalName:HTS0_T2
              LogicalName:HEScintillatorPart4Layer11Phi0
              LogicalName:HEScintillatorPart4Layer11Phi1
              LogicalName:HBScintillatorLayer15In2
              LogicalName:HEScintillatorPart4Layer12Phi1
              LogicalName:HTS0_T1
              LogicalName:HEScintillatorPart3Layer03Phi1
              LogicalName:HEScintillatorPart5Layer14Phi0
              LogicalName:HBScintillatorLayer0In1
              LogicalName:HEScintillatorPart5Layer15Phi0
              LogicalName:HBScintillatorLayer12In1
              LogicalName:HEScintillatorPart5Layer17Phi0
              LogicalName:HEScintillatorPart3Layer02Phi0
              LogicalName:HEScintillatorPart5Layer16Phi1
              LogicalName:HEScintillatorPart5Layer17Phi1
              LogicalName:VcalFibreBundleR9
              LogicalName:HTS0_T6
              LogicalName:HEScintillatorPart5Layer18Phi1
              LogicalName:HTS0_T3
ClassName:MuonSensitiveDetector
       RedoutName:MuonGEMHits
              LogicalName:GHA118
              LogicalName:GHA114
              LogicalName:GHA111
              LogicalName:GHA108
              LogicalName:GHA117
              LogicalName:GHA107
              LogicalName:GHA115
              LogicalName:GHA113
              LogicalName:GHA102
              LogicalName:GHA103
              LogicalName:GHA116
              LogicalName:GHA112
              LogicalName:GHA101
              LogicalName:GHA105
              LogicalName:GHA106
              LogicalName:GHA104
       RedoutName:MuonCSCHits
              LogicalName:ME32_ActiveGasVol_refl
              LogicalName:ME31_ActiveGasVol_refl
              LogicalName:ME22_ActiveGasVol_refl
              LogicalName:ME21_ActiveGasVol_refl
              LogicalName:ME21_ActiveGasVol
              LogicalName:ME13_ActiveGasVol
              LogicalName:ME11_ActiveGasVol
              LogicalName:ME32_ActiveGasVol
              LogicalName:ME31_ActiveGasVol
              LogicalName:ME12_ActiveGasVol
              LogicalName:ME1A_ActiveGasVol
              LogicalName:ME42_ActiveGasVol
              LogicalName:ME13_ActiveGasVol_refl
              LogicalName:ME42_ActiveGasVol_refl
              LogicalName:ME11_ActiveGasVol_refl
              LogicalName:ME22_ActiveGasVol
              LogicalName:ME41_ActiveGasVol
              LogicalName:ME1A_ActiveGasVol_refl
              LogicalName:ME12_ActiveGasVol_refl
              LogicalName:ME41_ActiveGasVol_refl
       RedoutName:MuonRPCHits
              LogicalName:REF2
              LogicalName:REF1
              LogicalName:REE3
              LogicalName:REE2
              LogicalName:REC3
              LogicalName:REB3
              LogicalName:REB2
              LogicalName:MB4BigChimRPC_GasLeft
              LogicalName:MB4TopChimRPC_GasLeft
              LogicalName:MB4BottomRPC_GasRight
              LogicalName:MB4BottomRPC_GasLeft
              LogicalName:MB4FeetRPC_GasRight
              LogicalName:MB23RPC_IGasMiddle
              LogicalName:MB22RPC_IGasLeft
              LogicalName:MB22RPC_OGasRight
              LogicalName:MB4TopRPC_GasLeft
              LogicalName:MB23RPC_IGasRight
              LogicalName:MB22RPC_IGasRight
              LogicalName:REE1
              LogicalName:MB2ChimRPC_IGasRight
              LogicalName:MB3ChimRPC_GasRight
              LogicalName:MB23RPC_IGasLeft
              LogicalName:MB1RPC_IGasRight
              LogicalName:REC1
              LogicalName:MB4TopChimRPC_GasRight
              LogicalName:MB1RPC_OGasRight
              LogicalName:MB1RPC_IGasLeft
              LogicalName:MB23RPC_OGasRight
              LogicalName:MB1RPC_OGasLeft
              LogicalName:MB4TopRPC_GasRight
              LogicalName:REB1
              LogicalName:MB2ChimRPC_IGasMiddle
              LogicalName:MB1ChimRPC_OGasRight
              LogicalName:MB4SmallRPC_SmallerGasRight
              LogicalName:MB1ChimRPC_IGasLeft
              LogicalName:MB22RPC_OGasLeft
              LogicalName:MB1ChimRPC_OGasLeft
              LogicalName:MB23RPC_OGasMiddle
              LogicalName:MB4BigChimRPC_GasRight
              LogicalName:MB2ChimRPC_OGasRight
              LogicalName:MB2ChimRPC_IGasLeft
              LogicalName:MB23RPC_OGasLeft
              LogicalName:REC2
              LogicalName:MB3RPC_GasLeft
              LogicalName:MB2ChimRPC_OGasLeft
              LogicalName:MB4SmallRPC_BiggerGasRight
              LogicalName:MB1ChimRPC_IGasRight
              LogicalName:MB3RPC_GasRight
              LogicalName:MB3ChimRPC_GasLeft
              LogicalName:MB4RPC_GasLeft
              LogicalName:MB4RPC_GasRight
              LogicalName:MB4SmallRPC_SmallerGasLeft
              LogicalName:REF3
              LogicalName:MB4SmallRPC_BiggerGasLeft
              LogicalName:MB4FeetRPC_GasLeft
       RedoutName:MuonDTHits
              LogicalName:MB3SLZGas
              LogicalName:MB2SLZGas
              LogicalName:MBChimSLPhiGas
              LogicalName:MBSLPhiGas
              LogicalName:MB1SLZGas
ClassName:TkAccumulatingSensitiveDetector
       RedoutName:TrackerHitsTEC
              LogicalName:TECModule6RphiActive
              LogicalName:TECModule5RphiActive
              LogicalName:TECModule4StereoActive
              LogicalName:TECModule4RphiActive
              LogicalName:TECModule0StereoActive
              LogicalName:TECModule1RphiActive
              LogicalName:TECModule0RphiActive
              LogicalName:TECModule2RphiActive
              LogicalName:TECModule1StereoActive
              LogicalName:TECModule3RphiActive
       RedoutName:TrackerHitsTIB
              LogicalName:TIBActiveRphi2
              LogicalName:TIBActiveRphi0
              LogicalName:TIBActiveSter0
       RedoutName:TrackerHitsPixelEndcap
              LogicalName:PixelForwardSensor
       RedoutName:TrackerHitsTOB
              LogicalName:TOBActiveRphi4
              LogicalName:TOBActiveRphi2
              LogicalName:TOBActiveRphi0
              LogicalName:TOBActiveSter0
       RedoutName:TrackerHitsTID
              LogicalName:TIDModule2RphiActive
              LogicalName:TIDModule1RphiActive
              LogicalName:TIDModule0RphiActive
              LogicalName:TIDModule1StereoActive
              LogicalName:TIDModule0StereoActive
       RedoutName:TrackerHitsPixelBarrel
              LogicalName:PixelBarrelActiveFull3
              LogicalName:PixelBarrelActiveFull0
              LogicalName:PixelBarrelActiveFull2
              LogicalName:PixelBarrelActiveFull1
ClassName:ZdcSensitiveDetector
       RedoutName:ZDCHITS
              LogicalName:ZDC_EMFiber
              LogicalName:ZDC_HadFiber
```
#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
