### PR TITLE
Activate Pixel Charge Reweighting for phase-0 detector (2016 only)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -14,15 +14,15 @@ autoCond = {
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '110X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '110X_mcRun2_design_Candidate_2019_07_24_16_36_56',
+    'run2_design'       :   '110X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2019_07_24_12_20_37',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_Candidate_2019_07_24_12_21_07',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '110X_mcRun2_pA_Candidate_2019_07_24_12_21_09',
+    'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '110X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -14,7 +14,7 @@ autoCond = {
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '110X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '110X_mcRun2_design_v1',
+    'run2_design'       :   '110X_mcRun2_design_Candidate_2019_07_24_16_36_56',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
     'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2019_07_24_12_20_37',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,7 +16,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '110X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_Candidate_2019_07_16_22_08_53',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,13 +16,13 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '106X_mcRun2_asymptotic_Candidate_2019_07_16_22_08_53',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2019_07_24_12_20_37',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_Candidate_2019_07_24_12_21_07',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '110X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '110X_mcRun2_pA_Candidate_2019_07_24_12_21_09',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '110X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -8,7 +8,8 @@ from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTcond
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
 from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
+from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 
 Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
- stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring)
+                              stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring,pixel_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -11,5 +11,5 @@ from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 
 Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
-                              stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring,pixel_2016)
+ stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -17,8 +17,9 @@ from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 
-Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016,run2_egamma_2016]), 
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016,run2_egamma_2016,pixel_2016]),
 phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
 trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017)
 

--- a/Configuration/Eras/python/Modifier_pixel_2016_cff.py
+++ b/Configuration/Eras/python/Modifier_pixel_2016_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+pixel_2016 =  cms.Modifier()

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -105,6 +105,10 @@ SiPixelSimBlock = cms.PSet(
 ###    DeadModules = cms.VPSet()
 )
 
+# activate charge reweighing for 2016 pixel detector (UL 2016)
+from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
+pixel_2016.toModify(SiPixelSimBlock,UseReweighting=True)
+
 #
 # Apply the changes for the different Run 2 running scenarios
 #


### PR DESCRIPTION
#### PR description:

In the scope of the preparations for the 2016 Ultra-Legacy MC campaigns, when looking at the data charge profiles, we have reached the conclusion that the radiation damage accumulated by the Phase-0 detector justifies the activation of the pixel cluster charge re-weighting (full details on the study of the radiation damage is presented here: [here](https://indico.cern.ch/event/808418/contributions/3495567/attachments/1878023/3093308/ultra_legacy_templates_2016_Update.pdf)).
This feature was up to now nominally switched off for the the Phase-0 detector and it is hereby activated by means of the era mechanism. 
A new modifier `Configuration/Eras/python/Modifier_pixel_2016_cff.py ` is introduced and used in the definition of the `Era_Run2_2016` to selectively switch on the feature only for 2016 which is targeted by the Ultra-Legacy.
An appropriate set of 2D template conditions for the radiation damage model has been derived together with update CPE conditions (Simulation Lorentz Angle, Lorentz Angle offset calibration, empry Lorentz Angle widths, generic errors and 1D templates), using the third IOV of the data conditions as an approximation of the "average" radiation damage in 2016.
They are proposed in this PR, by updating several `autoCond` keys with candidate Global Tags:
   * `run2_design`:  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_design_v1/110X_mcRun2_design_v2
   * `run2_mc`: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v1/110X_mcRun2_asymptotic_v2
   * `run2_mc_cosmics`: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2cosmics_startup_deco_v1/110X_mcRun2cosmics_startup_deco_v2
   * `run2_mc_pa`: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_pA_v1/110X_mcRun2_pA_v2

**N.B.**: in the design MC case only the 2D template tags are changed using the same payload both at the `numerator` and `denominator` label, resulting in no re-weigthing applied (design is assumed to be unirradiated).
~~If AlCa/DB can make these full-fledged Global Tags I will be gladly updating the autoCond file~~.

#### PR validation:
The PR passes standard tests (`addOnTests` and ```runTheMatrix.py -l limited -t 4 -j 8```.

Additionally the effect of the charge re-weighting has been tested in simulation by comparing the pixel charge profiles vs depth with two 2016 runs 278240 & 278308 ( falling into IOV 3  of the data CPE conditions) and the reference MC without re-weighting.
The comparison is shown [here](https://indico.cern.ch/event/808419/contributions/3509501/attachments/1884963/3106810/ccp_2016ULprep_reweighting_newTemplate.pdf)

![image](https://user-images.githubusercontent.com/5082376/61814570-a45dcd80-ae48-11e9-9c98-d9d3d7b8366f.png)

Post-reweighting DATA and MC profiles are found in satisfactory agreement. 

#### if this PR is a backport please specify the original PR:

This PR is not a backport
cc:
@tsusa @tvami @leaca 
