### PR TITLE
Update ECAL conditions to provide correct reference for 2016 and 2018 UL

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v1',
+    'run1_data'         :   '110X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v1',
+    'run2_data'         :   '110X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v1',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR updates the channel status and PF RecHit thresholds for the ECAL in order to have a sensible baseline with which to compare the completed 2016 and 2018 UL. The fixes to these conditions are described in the links below:

https://indico.cern.ch/event/834561/#26-fixes-in-data-reference-gt
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4177.html

The GT diffs are below:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v2/110X_dataRun2_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v2/110X_dataRun2_relval_v1

Only 2016 and earlier data should be affected by the EcalPFRecHitThresholds update; for a discussion of the impact on Run-1 data, see the [Hypernews subthread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4177/1/1.html). For the channel status update, only 2018 data should be affected.

This PR will be backported to 10_6_X.

#### PR validation:

See [talk at 22 Jul 2019 AlCaDB meeting](https://indico.cern.ch/event/834561/#26-fixes-in-data-reference-gt) for details of the tag content.

A technical test has been performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This PR is not a backport.
