### PR TITLE
Update ECAL conditions to provide correct reference for 2016 and 2018 UL [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v17',
+    'run1_data'         :   '106X_dataRun2_v18',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v17',
+    'run2_data'         :   '106X_dataRun2_v18',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v16',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v17',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #27604. The diff with respect to the previous autoCond contents is:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v18/106X_dataRun2_v17
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v17/106X_dataRun2_relval_v16

which are the same as in the 11_0_X branch.

The backport is nontrivial because the 11_0_X and 10_6_X offline data GT queues have diverged to accommodate new developments in 11_0_X.

#### PR validation:

See [talk at 22 Jul 2019 AlCaDB meeting](https://indico.cern.ch/event/834561/#26-fixes-in-data-reference-gt) for details of the tag content.

A technical test has been performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This is a backport of #27604.