### PR TITLE
MTD validation update

### DIFF
--- a/SimGeneral/MixingModule/python/fullMixCustomize_cff.py
+++ b/SimGeneral/MixingModule/python/fullMixCustomize_cff.py
@@ -60,5 +60,11 @@ def setCrossingFrameOn(process):
             crossingFrames = process.mix.mixObjects.mixSH.crossingFrames + [ 'MuonME0Hits' ]
         )
     )
+    from Configuration.Eras.Modifier_phase2_timing_layer_bar_cff import phase2_timing_layer_bar
+    phase2_timing_layer_bar.toModify( process.mix.mixObjects,
+        mixSH = dict(
+            crossingFrames = process.mix.mixObjects.mixSH.crossingFrames + [ 'FastTimerHitsBarrel', 'FastTimerHitsEndcap' ]
+        )
+    )
 
     return(process)

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -22,8 +22,13 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/Common/interface/ValidHandle.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
@@ -32,6 +37,15 @@
 
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
+
+
+struct MTDHit {
+  float energy;
+  float time;
+  float x_local;
+  float y_local;
+  float z_local;
+};
 
 class BtlRecHitsValidation : public DQMEDAnalyzer {
 public:
@@ -48,8 +62,10 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
+  const float hitMinEnergy_;
 
   edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit> > btlSimHitsToken_;
 
   // --- histograms declaration
 
@@ -73,12 +89,20 @@ private:
   MonitorElement* meHitTvsPhi_;
   MonitorElement* meHitTvsEta_;
   MonitorElement* meHitTvsZ_;
+
+  MonitorElement* meTimeRes_;
+  MonitorElement* meEnergyRes_;
+  MonitorElement* meTresvsE_;
+  MonitorElement* meEresvsE_;
+
 };
 
 // ------------ constructor and destructor --------------
 BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig)
-    : folder_(iConfig.getParameter<std::string>("folder")) {
+  : folder_(iConfig.getParameter<std::string>("folder")),
+    hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
+  btlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
 }
 
 BtlRecHitsValidation::~BtlRecHitsValidation() {}
@@ -86,6 +110,7 @@ BtlRecHitsValidation::~BtlRecHitsValidation() {}
 // ------------ method called for each event  ------------
 void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
+  using namespace geant_units::operators;
 
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
@@ -96,6 +121,35 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   const MTDTopology* topology = topologyHandle.product();
 
   auto btlRecHitsHandle = makeValid(iEvent.getHandle(btlRecHitsToken_));
+  auto btlSimHitsHandle = makeValid(iEvent.getHandle(btlSimHitsToken_));
+  MixCollection<PSimHit> btlSimHits(btlSimHitsHandle.product());
+
+  // --- Loop over the BLT SIM hits
+  std::unordered_map<uint32_t, MTDHit> m_btlSimHits;
+  for (auto const& simHit : btlSimHits) {
+    // --- Use only hits compatible with the in-time bunch-crossing
+    if (simHit.tof() < 0 || simHit.tof() > 25.)
+      continue;
+
+    DetId id = simHit.detUnitId();
+
+    auto simHitIt = m_btlSimHits.emplace(id.rawId(), MTDHit()).first;
+
+    // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
+    (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
+
+    // --- Get the time of the first SIM hit in the cell
+    if ((simHitIt->second).time == 0 || simHit.tof() < (simHitIt->second).time) {
+      (simHitIt->second).time = simHit.tof();
+
+      auto hit_pos = simHit.entryPoint();
+      (simHitIt->second).x_local = hit_pos.x();
+      (simHitIt->second).y_local = hit_pos.y();
+      (simHitIt->second).z_local = hit_pos.z();
+
+    }
+
+  }  // simHit loop
 
   // --- Loop over the BLT RECO hits
 
@@ -134,11 +188,26 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meHitTvsEta_->Fill(global_point.eta(), recHit.time());
     meHitTvsZ_->Fill(global_point.z(), recHit.time());
 
+    // Resolution histograms
+    if ( m_btlSimHits.count(detId.rawId()) == 1 && m_btlSimHits[detId.rawId()].energy > hitMinEnergy_ ) {
+
+      float time_res   = recHit.time() - m_btlSimHits[detId.rawId()].time;
+      float energy_res = recHit.energy() - m_btlSimHits[detId.rawId()].energy;
+
+      meTimeRes_->Fill(time_res);
+      meEnergyRes_->Fill(energy_res);
+
+      meTresvsE_->Fill(m_btlSimHits[detId.rawId()].energy,time_res);
+      meEresvsE_->Fill(m_btlSimHits[detId.rawId()].energy,energy_res);
+
+    }
+
     n_reco_btl++;
 
   }  // recHit loop
 
   meNhits_->Fill(n_reco_btl);
+
 }
 
 // ------------ method for histogram booking ------------
@@ -177,6 +246,13 @@ void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.bookProfile("BtlHitTvsEta", "BTL RECO ToA vs #eta;#eta_{RECO};ToA_{RECO} [ns]", 50, -1.6, 1.6, 0., 100.);
   meHitTvsZ_ =
       ibook.bookProfile("BtlHitTvsZ", "BTL RECO ToA vs Z;Z_{RECO} [cm];ToA_{RECO} [ns]", 50, -260., 260., 0., 100.);
+
+  meTimeRes_   = ibook.book1D("BtlTimeRes", "BTL time resolution;T_{RECO} - T_{SIM} [ns]", 100, -0.5, 0.5);
+  meEnergyRes_ = ibook.book1D("BtlEnergyRes", "BTL energy resolution;E_{RECO} - E_{SIM} [MeV]", 100, -0.5, 0.5);
+
+  meTresvsE_ = ibook.bookProfile("BtlTresvsE", "BTL time resolution vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM} [ns]", 50, 0., 20., 0., 100.);
+  meEresvsE_ = ibook.bookProfile("BtlEresvsE", "BTL energy resolution vs E;E_{SIM} [MeV];E_{RECO}-E_{SIM} [MeV]", 50, 0., 20., 0., 100.);
+
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -185,6 +261,8 @@ void BtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("folder", "MTD/BTL/RecHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mtdRecHits", "FTLBarrel"));
+  desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix","g4SimHitsFastTimerHitsBarrel"));
+  desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
 
   descriptions.add("btlRecHits", desc);
 }

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -38,7 +38,6 @@
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 
-
 struct MTDHit {
   float energy;
   float time;
@@ -94,13 +93,12 @@ private:
   MonitorElement* meEnergyRes_;
   MonitorElement* meTresvsE_;
   MonitorElement* meEresvsE_;
-
 };
 
 // ------------ constructor and destructor --------------
 BtlRecHitsValidation::BtlRecHitsValidation(const edm::ParameterSet& iConfig)
-  : folder_(iConfig.getParameter<std::string>("folder")),
-    hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
   btlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
 }
@@ -146,7 +144,6 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       (simHitIt->second).x_local = hit_pos.x();
       (simHitIt->second).y_local = hit_pos.y();
       (simHitIt->second).z_local = hit_pos.z();
-
     }
 
   }  // simHit loop
@@ -189,17 +186,15 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meHitTvsZ_->Fill(global_point.z(), recHit.time());
 
     // Resolution histograms
-    if ( m_btlSimHits.count(detId.rawId()) == 1 && m_btlSimHits[detId.rawId()].energy > hitMinEnergy_ ) {
-
-      float time_res   = recHit.time() - m_btlSimHits[detId.rawId()].time;
+    if (m_btlSimHits.count(detId.rawId()) == 1 && m_btlSimHits[detId.rawId()].energy > hitMinEnergy_) {
+      float time_res = recHit.time() - m_btlSimHits[detId.rawId()].time;
       float energy_res = recHit.energy() - m_btlSimHits[detId.rawId()].energy;
 
       meTimeRes_->Fill(time_res);
       meEnergyRes_->Fill(energy_res);
 
-      meTresvsE_->Fill(m_btlSimHits[detId.rawId()].energy,time_res);
-      meEresvsE_->Fill(m_btlSimHits[detId.rawId()].energy,energy_res);
-
+      meTresvsE_->Fill(m_btlSimHits[detId.rawId()].energy, time_res);
+      meEresvsE_->Fill(m_btlSimHits[detId.rawId()].energy, energy_res);
     }
 
     n_reco_btl++;
@@ -207,7 +202,6 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   }  // recHit loop
 
   meNhits_->Fill(n_reco_btl);
-
 }
 
 // ------------ method for histogram booking ------------
@@ -247,12 +241,13 @@ void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitTvsZ_ =
       ibook.bookProfile("BtlHitTvsZ", "BTL RECO ToA vs Z;Z_{RECO} [cm];ToA_{RECO} [ns]", 50, -260., 260., 0., 100.);
 
-  meTimeRes_   = ibook.book1D("BtlTimeRes", "BTL time resolution;T_{RECO} - T_{SIM} [ns]", 100, -0.5, 0.5);
+  meTimeRes_ = ibook.book1D("BtlTimeRes", "BTL time resolution;T_{RECO} - T_{SIM} [ns]", 100, -0.5, 0.5);
   meEnergyRes_ = ibook.book1D("BtlEnergyRes", "BTL energy resolution;E_{RECO} - E_{SIM} [MeV]", 100, -0.5, 0.5);
 
-  meTresvsE_ = ibook.bookProfile("BtlTresvsE", "BTL time resolution vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM} [ns]", 50, 0., 20., 0., 100.);
-  meEresvsE_ = ibook.bookProfile("BtlEresvsE", "BTL energy resolution vs E;E_{SIM} [MeV];E_{RECO}-E_{SIM} [MeV]", 50, 0., 20., 0., 100.);
-
+  meTresvsE_ = ibook.bookProfile(
+      "BtlTresvsE", "BTL time resolution vs E;E_{SIM} [MeV];T_{RECO}-T_{SIM} [ns]", 50, 0., 20., 0., 100.);
+  meEresvsE_ = ibook.bookProfile(
+      "BtlEresvsE", "BTL energy resolution vs E;E_{SIM} [MeV];E_{RECO}-E_{SIM} [MeV]", 50, 0., 20., 0., 100.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -261,7 +256,7 @@ void BtlRecHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("folder", "MTD/BTL/RecHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mtdRecHits", "FTLBarrel"));
-  desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix","g4SimHitsFastTimerHitsBarrel"));
+  desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
 
   descriptions.add("btlRecHits", desc);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -26,7 +26,9 @@
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
@@ -56,20 +58,28 @@ private:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+
   // ------------ member data ------------
 
-  const std::string folder_;
+  int eventCounter_;
+  TH1D* hEnergyFullRange_;
 
+  const std::string folder_;
   const float hitMinEnergy_;
 
-  edm::EDGetTokenT<edm::PSimHitContainer> btlSimHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit> > btlSimHitsToken_;
 
   // --- histograms declaration
 
   MonitorElement* meNhits_;
   MonitorElement* meNtrkPerCell_;
 
+  MonitorElement* meHitOccupancy_;
+
   MonitorElement* meHitEnergy_;
+  MonitorElement* meHitLogEnergy_;
   MonitorElement* meHitTime_;
 
   MonitorElement* meHitXlocal_;
@@ -95,12 +105,16 @@ private:
 
 // ------------ constructor and destructor --------------
 BtlSimHitsValidation::BtlSimHitsValidation(const edm::ParameterSet& iConfig)
-    : folder_(iConfig.getParameter<std::string>("folder")),
-      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
-  btlSimHitsToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("inputTag"));
+  : eventCounter_(0),
+    folder_(iConfig.getParameter<std::string>("folder")),
+    hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
+  hEnergyFullRange_ = new TH1D("hEnergyFullRange","",1000,0.01,20.);
+  btlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 
-BtlSimHitsValidation::~BtlSimHitsValidation() {}
+BtlSimHitsValidation::~BtlSimHitsValidation() {
+  delete hEnergyFullRange_;
+}
 
 // ------------ method called for each event  ------------
 void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -116,12 +130,13 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   const MTDTopology* topology = topologyHandle.product();
 
   auto btlSimHitsHandle = makeValid(iEvent.getHandle(btlSimHitsToken_));
+  MixCollection<PSimHit> btlSimHits(btlSimHitsHandle.product());
 
   std::unordered_map<uint32_t, MTDHit> m_btlHits;
   std::unordered_map<uint32_t, std::set<int> > m_btlTrkPerCell;
 
   // --- Loop over the BLT SIM hits
-  for (auto const& simHit : *btlSimHitsHandle) {
+  for (auto const& simHit : btlSimHits) {
     // --- Use only hits compatible with the in-time bunch-crossing
     if (simHit.tof() < 0 || simHit.tof() > 25.)
       continue;
@@ -157,6 +172,10 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meNtrkPerCell_->Fill((hit.second).size());
 
   for (auto const& hit : m_btlHits) {
+
+    meHitLogEnergy_->Fill(log10((hit.second).energy));
+    hEnergyFullRange_->Fill((hit.second).energy);
+
     if ((hit.second).energy < hitMinEnergy_)
       continue;
 
@@ -201,7 +220,29 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meHitTvsZ_->Fill(global_point.z(), (hit.second).time);
 
   }  // hit loop
+
+  eventCounter_++;
+
 }
+
+// ------------ method called at run end -----------------
+void BtlSimHitsValidation::endLuminosityBlock(edm::LuminosityBlock const& iLumBlock, edm::EventSetup const& iSetup) {
+
+  const float NBtlCrystals = BTLDetId::kCrystalsPerRODBarPhiFlat*BTLDetId::MAX_ROD;
+  const float scale = ( eventCounter_>0 ? 1./(eventCounter_*NBtlCrystals) : 1. );
+
+  double bin_sum = hEnergyFullRange_->GetBinContent(hEnergyFullRange_->GetNbinsX()+1);
+  for (int ibin=hEnergyFullRange_->GetNbinsX(); ibin>0; --ibin){
+
+    bin_sum += hEnergyFullRange_->GetBinContent(ibin);
+    meHitOccupancy_->setBinContent(ibin, scale*bin_sum);
+
+  }
+
+  eventCounter_ = 0;
+  hEnergyFullRange_->Reset();
+
+};
 
 // ------------ method for histogram booking ------------
 void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
@@ -214,7 +255,10 @@ void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meNhits_ = ibook.book1D("BtlNhits", "Number of BTL cells with SIM hits;N_{BTL cells}", 100, 0., 5000.);
   meNtrkPerCell_ = ibook.book1D("BtlNtrkPerCell", "Number of tracks per BTL cell;N_{trk}", 10, 0., 10.);
 
+  meHitOccupancy_ = ibook.book1D("BtlHitOccupancy", "BTL cell occupancy vs hit energy;E_{SIM} [MeV]; Occupancy per event", 1000, 0.01, 20.);
+
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 100, 0., 20.);
+  meHitLogEnergy_ = ibook.book1D("BtlHitLogEnergy", "BTL SIM hits energy;log_{10}(E_{SIM} [MeV])", 100, -6., 3.);
   meHitTime_ = ibook.book1D("BtlHitTime", "BTL SIM hits ToA;ToA_{SIM} [ns]", 100, 0., 25.);
 
   meHitXlocal_ = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -30., 30.);
@@ -251,7 +295,7 @@ void BtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/BTL/SimHits");
-  desc.add<edm::InputTag>("inputTag", edm::InputTag("g4SimHits", "FastTimerHitsBarrel"));
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("mix","g4SimHitsFastTimerHitsBarrel"));
   desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
 
   descriptions.add("btlSimHits", desc);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -60,7 +60,6 @@ private:
 
   void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
-
   // ------------ member data ------------
 
   int eventCounter_;
@@ -105,16 +104,14 @@ private:
 
 // ------------ constructor and destructor --------------
 BtlSimHitsValidation::BtlSimHitsValidation(const edm::ParameterSet& iConfig)
-  : eventCounter_(0),
-    folder_(iConfig.getParameter<std::string>("folder")),
-    hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
-  hEnergyFullRange_ = new TH1D("hEnergyFullRange","",1000,0.01,20.);
+    : eventCounter_(0),
+      folder_(iConfig.getParameter<std::string>("folder")),
+      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
+  hEnergyFullRange_ = new TH1D("hEnergyFullRange", "", 1000, 0.01, 20.);
   btlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 
-BtlSimHitsValidation::~BtlSimHitsValidation() {
-  delete hEnergyFullRange_;
-}
+BtlSimHitsValidation::~BtlSimHitsValidation() { delete hEnergyFullRange_; }
 
 // ------------ method called for each event  ------------
 void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -172,7 +169,6 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     meNtrkPerCell_->Fill((hit.second).size());
 
   for (auto const& hit : m_btlHits) {
-
     meHitLogEnergy_->Fill(log10((hit.second).energy));
     hEnergyFullRange_->Fill((hit.second).energy);
 
@@ -222,26 +218,21 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   }  // hit loop
 
   eventCounter_++;
-
 }
 
 // ------------ method called at run end -----------------
 void BtlSimHitsValidation::endLuminosityBlock(edm::LuminosityBlock const& iLumBlock, edm::EventSetup const& iSetup) {
+  const float NBtlCrystals = BTLDetId::kCrystalsPerRODBarPhiFlat * BTLDetId::MAX_ROD;
+  const float scale = (eventCounter_ > 0 ? 1. / (eventCounter_ * NBtlCrystals) : 1.);
 
-  const float NBtlCrystals = BTLDetId::kCrystalsPerRODBarPhiFlat*BTLDetId::MAX_ROD;
-  const float scale = ( eventCounter_>0 ? 1./(eventCounter_*NBtlCrystals) : 1. );
-
-  double bin_sum = hEnergyFullRange_->GetBinContent(hEnergyFullRange_->GetNbinsX()+1);
-  for (int ibin=hEnergyFullRange_->GetNbinsX(); ibin>0; --ibin){
-
+  double bin_sum = hEnergyFullRange_->GetBinContent(hEnergyFullRange_->GetNbinsX() + 1);
+  for (int ibin = hEnergyFullRange_->GetNbinsX(); ibin > 0; --ibin) {
     bin_sum += hEnergyFullRange_->GetBinContent(ibin);
-    meHitOccupancy_->setBinContent(ibin, scale*bin_sum);
-
+    meHitOccupancy_->setBinContent(ibin, scale * bin_sum);
   }
 
   eventCounter_ = 0;
   hEnergyFullRange_->Reset();
-
 };
 
 // ------------ method for histogram booking ------------
@@ -255,7 +246,8 @@ void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meNhits_ = ibook.book1D("BtlNhits", "Number of BTL cells with SIM hits;N_{BTL cells}", 100, 0., 5000.);
   meNtrkPerCell_ = ibook.book1D("BtlNtrkPerCell", "Number of tracks per BTL cell;N_{trk}", 10, 0., 10.);
 
-  meHitOccupancy_ = ibook.book1D("BtlHitOccupancy", "BTL cell occupancy vs hit energy;E_{SIM} [MeV]; Occupancy per event", 1000, 0.01, 20.);
+  meHitOccupancy_ = ibook.book1D(
+      "BtlHitOccupancy", "BTL cell occupancy vs hit energy;E_{SIM} [MeV]; Occupancy per event", 1000, 0.01, 20.);
 
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL SIM hits energy;E_{SIM} [MeV]", 100, 0., 20.);
   meHitLogEnergy_ = ibook.book1D("BtlHitLogEnergy", "BTL SIM hits energy;log_{10}(E_{SIM} [MeV])", 100, -6., 3.);
@@ -295,7 +287,7 @@ void BtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/BTL/SimHits");
-  desc.add<edm::InputTag>("inputTag", edm::InputTag("mix","g4SimHitsFastTimerHitsBarrel"));
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
 
   descriptions.add("btlSimHits", desc);

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -4,4 +4,5 @@
 <use name="Geometry/Records"/>
 <use name="Geometry/MTDGeometryBuilder"/>
 <use name="DQMServices/Core"/>
+<use name="hepmc"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -263,7 +263,7 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
-  desc.add<edm::InputTag>("inputTag", edm::InputTag("mix","g4SimHitsFastTimerHitsEndcap"));
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
   desc.add<double>("hitMinimumEnergy", 0.1);  // [MeV]
 
   descriptions.add("etlSimHits", desc);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -25,7 +25,9 @@
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
@@ -53,10 +55,9 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
-
   const float hitMinEnergy_;
 
-  edm::EDGetTokenT<edm::PSimHitContainer> etlSimHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit> > etlSimHitsToken_;
 
   // --- histograms declaration
 
@@ -89,7 +90,7 @@ private:
 EtlSimHitsValidation::EtlSimHitsValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
       hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
-  etlSimHitsToken_ = consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("inputTag"));
+  etlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 
 EtlSimHitsValidation::~EtlSimHitsValidation() {}
@@ -104,12 +105,13 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   const MTDGeometry* geom = geometryHandle.product();
 
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
+  MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
 
   std::unordered_map<uint32_t, MTDHit> m_etlHits[2];
   std::unordered_map<uint32_t, std::set<int> > m_etlTrkPerCell[2];
 
   // --- Loop over the BLT SIM hits
-  for (auto const& simHit : *etlSimHitsHandle) {
+  for (auto const& simHit : etlSimHits) {
     // --- Use only hits compatible with the in-time bunch-crossing
     if (simHit.tof() < 0 || simHit.tof() > 25.)
       continue;
@@ -261,7 +263,7 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
-  desc.add<edm::InputTag>("inputTag", edm::InputTag("g4SimHits", "FastTimerHitsEndcap"));
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("mix","g4SimHitsFastTimerHitsEndcap"));
   desc.add<double>("hitMinimumEnergy", 0.1);  // [MeV]
 
   descriptions.add("etlSimHits", desc);


### PR DESCRIPTION
#### PR description:

This is an update of the MTD validation package:

-  the CrossingFrames for the BTL and ETL SimHits have been switched on in order to add the PU SimHits to the SIM monitoring plots;
-  energy and time resolution histograms have been added for BTL;
-  an occupancy plot vs hit energy has been added for BTL.

#### PR validation:

The updated code has been compiled in the release CMSSW_11_0_X_2019-07-24-2300 and tested with the 2026D41 WFs 20434 and 20634 with PU200.

The total size of the MTD monitoring plots is:
476.28 KiB       MTD/ETL
237.66 KiB       MTD/BTL

--------------------------------------------------------------------------------------------------
WF 20434 report (step 3):

MemoryReport> Peak virtual size 4673.77 Mbytes
 Key events increasing vsize: 
[5] run: 1 lumi: 1 event: 5  vsize = 4641.77 deltaVsize = 0.0351562 rss = 3226.27 delta = 29.5234
[2] run: 1 lumi: 1 event: 2  vsize = 4641.74 deltaVsize = 0.304688 rss = 3196.74 delta = 1.77734
[7] run: 1 lumi: 1 event: 7  vsize = 4673.77 deltaVsize = 32 rss = 3273.65 delta = 76.9062
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[9] run: 1 lumi: 1 event: 9  vsize = 4673.77 deltaVsize = 0 rss = 3287.06 delta = 13.4141
[8] run: 1 lumi: 1 event: 8  vsize = 4673.77 deltaVsize = 0 rss = 3287.99 delta = 14.3438
[7] run: 1 lumi: 1 event: 7  vsize = 4673.77 deltaVsize = 32 rss = 3273.65 delta = 47.3828
TimeReport> Time report complete in 506.789 seconds
 Time Summary: 
 - Min event:   1.74964
 - Max event:   12.5869
 - Avg event:   3.23466
 - Total loop:  385.479
 - Total init:  111.365
 - Total job:   506.789
 - EventSetup Lock:   0.000208378
 - EventSetup Get:   84.7993
 Event Throughput: 0.259417 ev/s
 CPU Summary: 
 - Total loop:  367.605
 - Total init:  143.27
 - Total extra: 0
 - Total job:   520.702
 Processing Summary: 
 - Number of Events:  100
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

--------------------------------------------------------------------------------------------------
WF 20634 report (step 3):

MemoryReport> Peak virtual size 9869.82 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 8169.59 deltaVsize = 0 rss = 6721.41 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 9833.69 deltaVsize = 1664.11 rss = 6793.38 delta = 71.9688
[7] run: 1 lumi: 1 event: 7  vsize = 9865.82 deltaVsize = 32 rss = 6828.83 delta = 35.4531
[10] run: 1 lumi: 1 event: 10  vsize = 9869.82 deltaVsize = 4 rss = 6832.15 delta = 3.31641
[8] run: 1 lumi: 1 event: 8  vsize = 9865.82 deltaVsize = 0 rss = 6842.48 delta = 13.6445
[7] run: 1 lumi: 1 event: 7  vsize = 9865.82 deltaVsize = 32 rss = 6828.83 delta = -288.48
[10] run: 1 lumi: 1 event: 10  vsize = 9869.82 deltaVsize = 4 rss = 6832.15 delta = 3.31641
TimeReport> Time report complete in 2705.11 seconds
 Time Summary: 
 - Min event:   137.084
 - Max event:   372.577
 - Avg event:   236.689
 - Total loop:  2488.53
 - Total init:  212.354
 - Total job:   2705.11
 - EventSetup Lock:   0.000253677
 - EventSetup Get:   106.802
 Event Throughput: 0.00401843 ev/s
 CPU Summary: 
 - Total loop:  2186.06
 - Total init:  115.821
 - Total extra: 0
 - Total job:   2306
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1