### PR TITLE
MTV protection for samples without jets info

### DIFF
--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -723,7 +723,7 @@ void MultiTrackValidator::dqmAnalyze(const edm::Event& event,
   if (not cores_.isUninitialized()) {
     Handle<edm::View<reco::Candidate>> cores;
     event.getByToken(cores_, cores);
-    coresVector = cores.product();
+    if(cores.isValid()) coresVector = cores.product();
   }
   declareDynArray(float, tPCeff.size(), dR_tPCeff_jet);
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -723,7 +723,9 @@ void MultiTrackValidator::dqmAnalyze(const edm::Event& event,
   if (not cores_.isUninitialized()) {
     Handle<edm::View<reco::Candidate>> cores;
     event.getByToken(cores_, cores);
-    if(cores.isValid()) coresVector = cores.product();
+    if(cores.isValid()) {
+      coresVector = cores.product();
+    }
   }
   declareDynArray(float, tPCeff.size(), dR_tPCeff_jet);
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -723,7 +723,7 @@ void MultiTrackValidator::dqmAnalyze(const edm::Event& event,
   if (not cores_.isUninitialized()) {
     Handle<edm::View<reco::Candidate>> cores;
     event.getByToken(cores_, cores);
-    if(cores.isValid()) {
+    if (cores.isValid()) {
       coresVector = cores.product();
     }
   }


### PR DESCRIPTION
#### PR description:

Added protection to run the Validation on a sample without the jets information. Without this protection the user should add cores = cms.InputTag("") in the configuration file if the jet information is missing.

#### PR validation:

- specific validation on a sample without jet information
- runTheMatrix
