### PR TITLE
Added consumes calls to ES modules in RecoLocalMuon/RPCRecHit

### DIFF
--- a/RecoLocalMuon/RPCRecHit/src/CSCObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCObjectMap.cc
@@ -5,18 +5,11 @@
 #include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
 #include "Geometry/RPCGeometry/interface/RPCChamber.h"
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "RecoLocalMuon/RPCRecHit/src/CSCObjectMap.h"
 #include "RecoLocalMuon/RPCRecHit/src/CSCStationIndex.h"
 
-CSCObjectMap::CSCObjectMap(MuonGeometryRecord const& record) {
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  record.get(rpcGeo);
-
-  edm::ESHandle<CSCGeometry> cscGeo;
-  record.get(cscGeo);
-
-  for (TrackingGeometry::DetContainer::const_iterator it = rpcGeo->dets().begin(); it < rpcGeo->dets().end(); it++) {
+CSCObjectMap::CSCObjectMap(RPCGeometry const& rpcGeo) {
+  for (TrackingGeometry::DetContainer::const_iterator it = rpcGeo.dets().begin(); it < rpcGeo.dets().end(); it++) {
     if (dynamic_cast<const RPCChamber*>(*it) != nullptr) {
       auto ch = dynamic_cast<const RPCChamber*>(*it);
       std::vector<const RPCRoll*> roles = (ch->rolls());

--- a/RecoLocalMuon/RPCRecHit/src/CSCObjectMap.h
+++ b/RecoLocalMuon/RPCRecHit/src/CSCObjectMap.h
@@ -1,17 +1,16 @@
 #ifndef RecoLocalMuon_RPCRecHit_CSCObjectMap_h
 #define RecoLocalMuon_RPCRecHit_CSCObjectMap_h
 
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "RecoLocalMuon/RPCRecHit/src/CSCStationIndex.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
 #include <set>
 #include <map>
 
 class CSCObjectMap {
 public:
-  CSCObjectMap(MuonGeometryRecord const& record);
+  CSCObjectMap(RPCGeometry const& rpcGeom);
 
   std::set<RPCDetId> const& getRolls(CSCStationIndex index) const;
 

--- a/RecoLocalMuon/RPCRecHit/src/CSCObjectMapESProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCObjectMapESProducer.cc
@@ -12,18 +12,19 @@
 
 class CSCObjectMapESProducer : public edm::ESProducer {
 public:
-  CSCObjectMapESProducer(const edm::ParameterSet&) { setWhatProduced(this); }
-
-  ~CSCObjectMapESProducer() override {}
+  CSCObjectMapESProducer(const edm::ParameterSet&) : rpcGeomToken_(setWhatProduced(this).consumes<RPCGeometry>()) {}
 
   std::unique_ptr<CSCObjectMap> produce(MuonGeometryRecord const& record) {
-    return std::make_unique<CSCObjectMap>(record);
+    return std::make_unique<CSCObjectMap>(record.get(rpcGeomToken_));
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     descriptions.add("cscObjectMapESProducer", desc);
   }
+
+private:
+  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };
 
 //define this as a plug-in

--- a/RecoLocalMuon/RPCRecHit/src/DTObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTObjectMap.cc
@@ -6,18 +6,11 @@
 #include "Geometry/RPCGeometry/interface/RPCGeomServ.h"
 #include "Geometry/RPCGeometry/interface/RPCChamber.h"
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "RecoLocalMuon/RPCRecHit/src/DTObjectMap.h"
 #include "RecoLocalMuon/RPCRecHit/src/DTStationIndex.h"
 
-DTObjectMap::DTObjectMap(MuonGeometryRecord const& record) {
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  record.get(rpcGeo);
-
-  edm::ESHandle<DTGeometry> dtGeo;
-  record.get(dtGeo);
-
-  for (TrackingGeometry::DetContainer::const_iterator it = rpcGeo->dets().begin(); it < rpcGeo->dets().end(); it++) {
+DTObjectMap::DTObjectMap(RPCGeometry const& rpcGeo) {
+  for (TrackingGeometry::DetContainer::const_iterator it = rpcGeo.dets().begin(); it < rpcGeo.dets().end(); it++) {
     if (dynamic_cast<const RPCChamber*>(*it) != nullptr) {
       auto ch = dynamic_cast<const RPCChamber*>(*it);
       std::vector<const RPCRoll*> roles = (ch->rolls());

--- a/RecoLocalMuon/RPCRecHit/src/DTObjectMap.h
+++ b/RecoLocalMuon/RPCRecHit/src/DTObjectMap.h
@@ -1,17 +1,16 @@
 #ifndef RecoLocalMuon_RPCRecHit_DTObjectMap_h
 #define RecoLocalMuon_RPCRecHit_DTObjectMap_h
 
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "RecoLocalMuon/RPCRecHit/src/DTStationIndex.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
 #include <set>
 #include <map>
 
 class DTObjectMap {
 public:
-  DTObjectMap(MuonGeometryRecord const& record);
+  DTObjectMap(RPCGeometry const& rpcGeometry);
 
   std::set<RPCDetId> const& getRolls(DTStationIndex index) const;
 

--- a/RecoLocalMuon/RPCRecHit/src/DTObjectMapESProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTObjectMapESProducer.cc
@@ -12,18 +12,19 @@
 
 class DTObjectMapESProducer : public edm::ESProducer {
 public:
-  DTObjectMapESProducer(const edm::ParameterSet&) { setWhatProduced(this); }
-
-  ~DTObjectMapESProducer() override {}
+  DTObjectMapESProducer(const edm::ParameterSet&) : rpcGeomToken_(setWhatProduced(this).consumes<RPCGeometry>()) {}
 
   std::unique_ptr<DTObjectMap> produce(MuonGeometryRecord const& record) {
-    return std::make_unique<DTObjectMap>(record);
+    return std::make_unique<DTObjectMap>(record.get(rpcGeomToken_));
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     descriptions.add("dtObjectMapESProducer", desc);
   }
+
+private:
+  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };
 
 //define this as a plug-in


### PR DESCRIPTION

#### PR description:

Modified the ESProducers in the package to make consumes calls. As part of that moved to using ESGetTokens.

In addition, removed Record get calls from ES data products and moved
them into their respective ES modules.

#### PR validation:

The code compiles. 
The changes are technical and should not change results.
