### PR TITLE
Fix for L1 EG emulation in 2018 HI

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,7 +56,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:

The 103X 2018 HI MC GT contains an incorrect L1TCaloParams condition. To maintain consistency with the existing 103X HI samples, it was decided to not use a corrected 103X GT for new HI samples, but conditions in the development GT should be updated in case new HI samples for 2018 are ever generated in a future release.

Only the 2018 HI MC GT is changed and so differences in the comparison tests should only be seen in 2018 HI MC samples.

GT diff:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HI_v2/110X_upgrade2018_realistic_HI_v1

#### PR validation:

The payload validation was described in https://indico.cern.ch/event/829647/#4-updated-l1tcalo-conditions-f

A technical validation of the GT changes was performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This PR is not a backport and should not be backported.
