### PR TITLE
shared_ptr has arrived to the standard. NFC

### DIFF
--- a/JetMETCorrections/FFTJetModules/interface/FFTJetESParameterParser.h
+++ b/JetMETCorrections/FFTJetModules/interface/FFTJetESParameterParser.h
@@ -53,7 +53,7 @@ std::shared_ptr<AbsFFTJetScaleCalculator<Jet, Adjustable> > parseFFTJetScaleCalc
 
   // Load the table from the archive
   CPP11_auto_ptr<npstat::StorableMultivariateFunctor> autof = loadFFTJetInterpolationTable(ps, ar, verbose);
-  CPP11_shared_ptr<npstat::StorableMultivariateFunctor> f(autof.release());
+  std::shared_ptr<npstat::StorableMultivariateFunctor> f(autof.release());
 
   // Swap the class name if it is supposed to be determined
   // from the table description

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
@@ -97,7 +97,7 @@ void FFTJetCorrectorDBReader::analyze(const edm::Event& iEvent, const edm::Event
       unsigned long long count = 0;
       for (unsigned long long id = idSmall; id <= idLarge; ++id)
         if (par->itemExists(id)) {
-          CPP11_shared_ptr<const gs::CatalogEntry> e = par->catalogEntry(id);
+          std::shared_ptr<const gs::CatalogEntry> e = par->catalogEntry(id);
           std::cout << '\n';
           e->humanReadable(std::cout);
           ++count;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
@@ -85,7 +85,7 @@ static void buildLookupTables(const FFTJetCorrectorParameters& tablePars,
       if (loadedSet.insert(id).second) {
         CPP11_auto_ptr<npstat::StorableMultivariateFunctor> p(ref.get(item));
         StorableFunctorPtr fptr(p.release());
-        CPP11_shared_ptr<const gs::CatalogEntry> e = ar->catalogEntry(id);
+        std::shared_ptr<const gs::CatalogEntry> e = ar->catalogEntry(id);
         insertLUTItem(*ptr, fptr, e->name(), e->category());
         if (verbose)
           std::cout << "In buildLookupTables: loaded table with name \"" << e->name() << "\" and category \""

--- a/JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h
+++ b/JetMETCorrections/FFTJetObjects/interface/AbsFFTJetScaleCalculator.h
@@ -1,9 +1,10 @@
 #ifndef JetMETCorrections_FFTJetObjects_AbsFFTJetScaleCalculator_h
 #define JetMETCorrections_FFTJetObjects_AbsFFTJetScaleCalculator_h
 
-#include <vector>
-#include "Alignment/Geners/interface/CPP11_shared_ptr.hh"
 #include "JetMETCorrections/InterpolationTables/interface/AbsMultivariateFunctor.h"
+
+#include <memory>
+#include <vector>
 
 template <class Jet, class Adjustable>
 class AbsFFTJetScaleCalculator {
@@ -11,7 +12,7 @@ public:
   typedef Jet jet_type;
   typedef Adjustable adjustable_type;
 
-  inline explicit AbsFFTJetScaleCalculator(CPP11_shared_ptr<npstat::AbsMultivariateFunctor> f)
+  inline explicit AbsFFTJetScaleCalculator(std::shared_ptr<npstat::AbsMultivariateFunctor> f)
       : functor(f), buffer_(f->minDim()) {}
 
   inline virtual ~AbsFFTJetScaleCalculator() {}
@@ -28,7 +29,7 @@ private:
 
   virtual void map(const Jet& jet, const Adjustable& current, double* buf, unsigned dim) const = 0;
 
-  CPP11_shared_ptr<npstat::AbsMultivariateFunctor> functor;
+  std::shared_ptr<npstat::AbsMultivariateFunctor> functor;
   mutable std::vector<double> buffer_;
 };
 

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetScaleCalculators.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetScaleCalculators.h
@@ -11,7 +11,7 @@
 template <class MyJet, class Adjustable>
 class FFTEtaLogPtConeRadiusMapper : public AbsFFTJetScaleCalculator<MyJet, Adjustable> {
 public:
-  inline explicit FFTEtaLogPtConeRadiusMapper(CPP11_shared_ptr<npstat::AbsMultivariateFunctor> f)
+  inline explicit FFTEtaLogPtConeRadiusMapper(std::shared_ptr<npstat::AbsMultivariateFunctor> f)
       : AbsFFTJetScaleCalculator<MyJet, Adjustable>(f) {}
 
 private:
@@ -34,7 +34,7 @@ public:
   // AbsFFTSpecificScaleCalculator object provided
   // in the constructor
   //
-  inline FFTSpecificScaleCalculator(CPP11_shared_ptr<npstat::AbsMultivariateFunctor> f,
+  inline FFTSpecificScaleCalculator(std::shared_ptr<npstat::AbsMultivariateFunctor> f,
                                     const AbsFFTSpecificScaleCalculator* p)
       : AbsFFTJetScaleCalculator<MyJet, Adjustable>(f), calc_(p) {
     assert(p);

--- a/JetMETCorrections/FFTJetObjects/src/loadFFTJetInterpolationTable.cc
+++ b/JetMETCorrections/FFTJetObjects/src/loadFFTJetInterpolationTable.cc
@@ -16,7 +16,7 @@ static void dumpArchiveMetadata(gs::StringArchive& ar, std::ostream& os) {
     unsigned long long count = 0;
     for (unsigned long long id = idSmall; id <= idLarge; ++id)
       if (ar.itemExists(id)) {
-        CPP11_shared_ptr<const gs::CatalogEntry> e = ar.catalogEntry(id);
+        std::shared_ptr<const gs::CatalogEntry> e = ar.catalogEntry(id);
         os << '\n';
         e->humanReadable(os);
         ++count;
@@ -55,7 +55,7 @@ CPP11_auto_ptr<npstat::StorableMultivariateFunctor> loadFFTJetInterpolationTable
   CPP11_auto_ptr<npstat::StorableMultivariateFunctor> p = ref.get(0);
   if (verbose) {
     std::cout << "In loadFFTJetInterpolationTable: loaded table with metadata" << std::endl;
-    CPP11_shared_ptr<const gs::CatalogEntry> e = ref.indexedCatalogEntry(0);
+    std::shared_ptr<const gs::CatalogEntry> e = ref.indexedCatalogEntry(0);
     e->humanReadable(std::cout);
     std::cout << std::endl;
     std::cout << "Actual table class name is \"" << p->classId().name() << '"' << std::endl;


### PR DESCRIPTION
We replace the CPP11_shared_ptr macro with its actual expansion to
std::shared_ptr nowadays.
