### PR TITLE
New features for the conddb tools

### DIFF
--- a/CondCore/Utilities/python/conddb_time.py
+++ b/CondCore/Utilities/python/conddb_time.py
@@ -1,0 +1,33 @@
+import datetime
+
+datetime_string_fmt = '%Y-%m-%d %H:%M:%S.%f'
+
+def to_lumi_time( runNumber, lumiSectionId ):
+    return (runNumber<<32) + lumiSectionId
+
+def from_lumi_time( lumiTime ):
+    run = lumiTime>>32
+    lumisection_id = lumiTime-( run << 32 )
+    return run, lumisection_id
+
+def to_timestamp( dt ):
+    timespan_from_epoch = dt - datetime.datetime(1970,1,1)
+    seconds_from_epoch = int( timespan_from_epoch.total_seconds() )
+    nanoseconds_from_epoch = timespan_from_epoch.microseconds * 1000
+    return ( seconds_from_epoch << 32 ) + nanoseconds_from_epoch
+
+def from_timestamp( ts ):
+    seconds_from_epoch = ts >> 32
+    nanoseconds_from_epoch = ts - ( seconds_from_epoch << 32 )
+    dt = datetime.datetime.utcfromtimestamp(seconds_from_epoch)
+    return dt + datetime.timedelta( microseconds=int(nanoseconds_from_epoch/1000) )
+
+def string_to_timestamp( sdt ):
+    dt = datetime.datetime.strptime( sdt, datetime_string_fmt )
+    return to_timestamp( dt )
+
+def string_from_timestamp( ts ):
+    dt = from_timestamp( ts )
+    return dt.strftime( datetime_string_fmt )
+
+

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -23,6 +23,7 @@ import sqlalchemy
 import CondCore.Utilities.conddblib as conddb
 import CondCore.Utilities.cond2xml as cond2xml
 import CondCore.Utilities.conddb_serialization_metadata as serialization_metadata
+import CondCore.Utilities.conddb_time as conddb_time
 
 from CondCore.Utilities.tier0 import Tier0Handler, Tier0Error, tier0Url
 # -------------------------------------------------------------------------------------------------------
@@ -2077,6 +2078,35 @@ def dump(args):
 
     if xmlProcessor: del xmlProcessor
 
+def toLumi_(args):
+    lumiTime = conddb_time.to_lumi_time( int(args.run), int(args.lumi_id) )
+    if args.quiet:
+        print('%s' %lumiTime)
+    else:
+        output(args,'Lumi timetype for run=%s, lumisection id=%s: %s' %(args.run,args.lumi_id, lumiTime))
+
+def fromLumi_(args):
+    run, lumisection_id = conddb_time.from_lumi_time( int(args.lumiTime) )
+    if args.quiet:
+        print('%s,%s' %(run, lumisection_id))
+    else:
+        output(args,'For Lumi timetype %s: run=%s, lumisection id=%s' %(args.lumiTime,run,lumisection_id))
+
+
+def toTimestamp_( args ):
+    ts = conddb_time.string_to_timestamp( args.datetime )
+    if args.quiet:
+        print('%s' %ts)
+    else:
+        output(args,"Time timetype for string '%s': %s" %(args.datetime, ts))
+
+def fromTimestamp_( args ):
+    sdt = conddb_time.string_from_timestamp( int(args.timestamp) )
+    if args.quiet:
+        print('%s' %sdt)
+    else:
+        output(args,"String date time for timestamp %s: '%s'" %(args.timestamp, sdt))
+    
 def main():
     '''Entry point.
     '''
@@ -2188,6 +2218,23 @@ def main():
 
     parser_showFcsr =  parser_subparsers.add_parser('showFCSR', description='Dumps the FCSR values for hlt and pcl')
     parser_showFcsr.set_defaults(func=showFcsr_)
+
+    parser_toLumi = parser_subparsers.add_parser('toLumi', description='Generates the Lumi timetype from run number and lumisection id') 
+    parser_toLumi.add_argument('run', help="Run id")
+    parser_toLumi.add_argument('lumi_id', help="Lumisection id")
+    parser_toLumi.set_defaults(func=toLumi_)
+
+    parser_fromLumi = parser_subparsers.add_parser('fromLumi', description='Decodes the Lumi timetype extracting run number and lumisection id') 
+    parser_fromLumi.add_argument('lumiTime', help="The Lumi timetype value")
+    parser_fromLumi.set_defaults(func=fromLumi_)
+
+    parser_toTimestamp = parser_subparsers.add_parser('toTimestamp', description='Generates the Time timetype from the date string') 
+    parser_toTimestamp.add_argument('datetime', help="The string representing the date time, in the format 'Y-m-d H:M:S.f'" )
+    parser_toTimestamp.set_defaults(func=toTimestamp_)
+
+    parser_fromTimestamp = parser_subparsers.add_parser('fromTimestamp', description='Decodes the Time timetype extracting the date time string') 
+    parser_fromTimestamp.add_argument('timestamp', help="The Time timetype value")
+    parser_fromTimestamp.set_defaults(func=fromTimestamp_)
 
     args = parser.parse_args()
 

--- a/CondCore/Utilities/scripts/conddb_version_mgr.py
+++ b/CondCore/Utilities/scripts/conddb_version_mgr.py
@@ -8,6 +8,7 @@ import sys
 import logging
 import CondCore.Utilities.conddb_serialization_metadata as sm
 import CondCore.Utilities.credentials as auth
+import CondCore.Utilities.conddb_time as conddb_time
 import os
 
 authPathEnvVar = 'COND_AUTH_PATH'
@@ -75,13 +76,18 @@ class version_db(object):
             self.boost_run_map.append( (r[0],r[1],r[2],str(r[3])) )
         return self.boost_run_map
 
-    def insert_boost_run_range( self, run, boost_version ):
+    def insert_boost_run_range( self, run, boost_version, min_ts ):
         cursor = self.db.cursor()
         cursor.execute('SELECT MIN(RUN_NUMBER) FROM RUN_INFO WHERE RUN_NUMBER >= :RUN',(run,))
-        min_run = cursor.fetchone()[0]
-        cursor.execute('SELECT START_TIME FROM RUN_INFO WHERE RUN_NUMBER=:RUN',(min_run,))
-        min_run_time = cursor.fetchone()[0]
-        min_run_ts = calendar.timegm( min_run_time.utctimetuple() ) << 32
+        res = cursor.fetchone()
+        if res is not None and res[0] is not None:
+            min_run = res[0]
+            cursor.execute('SELECT START_TIME FROM RUN_INFO WHERE RUN_NUMBER=:RUN',(min_run,))
+            min_run_time = cursor.fetchone()[0]
+            min_run_ts = calendar.timegm( min_run_time.utctimetuple() ) << 32
+        else:
+            min_run = run
+            min_run_ts = conddb_time.string_to_timestamp(min_ts)
         now = datetime.datetime.utcnow()
         cursor.execute('INSERT INTO BOOST_RUN_MAP ( RUN_NUMBER, RUN_START_TIME, BOOST_VERSION, INSERTION_TIME ) VALUES (:RUN, :RUN_START_T, :BOOST, :TIME)',(run,min_run_ts,boost_version,now) )
 
@@ -368,7 +374,9 @@ class conddb_tool(object):
     def insert_boost_run( self ):
         cursor = self.db.cursor()
         self.version_db = version_db( self.db )
-        self.version_db.insert_boost_run_range( self.args.since, self.args.label )
+        if self.args.min_ts is None:
+            raise Exception("Run %s has not been found in the database - please provide an explicit TimeType value with the min_ts parameter ." %self.args.since )
+        self.version_db.insert_boost_run_range( self.args.since, self.args.label, self.args.min_ts )
         self.db.commit()
         logging.info('boost version %s inserted with since %s' %(self.args.label,self.args.since))
 
@@ -449,6 +457,7 @@ def main():
     parser_insert_boost_version = parser_subparsers.add_parser('insert', description='Insert a new boost version range in the run map')
     parser_insert_boost_version.add_argument('--label', '-l',type=str, help='The boost version label',required=True)
     parser_insert_boost_version.add_argument('--since', '-s',type=int, help='The since validity (run number)',required=True)
+    parser_insert_boost_version.add_argument('--min_ts', '-t',type=str, help='The since validity (Time timetype)', required=False)
     parser_insert_boost_version.set_defaults(func=tool.insert_boost_run,accessType='w')
     parser_list_boost_versions = parser_subparsers.add_parser('list', description='list the boost versions in the run map')
     parser_list_boost_versions.set_defaults(func=tool.list_boost_run,accessType='r') 


### PR DESCRIPTION
#### PR description:

New features added to conddb command line tools:
- toLumi => generates "Lumi" time type from the pair ( run, lumiId )
- fromLumi => decodes the pair ( run, lumiId ) from the lumi time type
- toTimestamp => generates the "Time" time type from the date string
- fromTimestamp => decodes the "Time" time type, delivering a date string

Changes to conddb_version_mgr cli:
Added option to force a "Time" time type since value when the "Run" time type since does not correspond to an existing run number

#### PR validation:

The various command have been executed locally

