### PR TITLE
Miscellanous fixes to SiPixel Bad Components db loaders

### DIFF
--- a/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker_cfg.py
@@ -36,7 +36,7 @@ process.source = cms.Source("EmptyIOVSource",
 ##
 from CondCore.CondDB.CondDB_cfi import *
 #CondDBQualityCollection = CondDB.clone(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"))
-CondDBQualityCollection = CondDB.clone(connect = cms.string("sqlite_file:SiPixelStatusScenarios_UltraLegacy2018_v0_mc.db"))
+CondDBQualityCollection = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"))
 process.dbInput = cms.ESSource("PoolDBESSource",
                                CondDBQualityCollection,
                                toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
@@ -46,7 +46,7 @@ process.dbInput = cms.ESSource("PoolDBESSource",
                                )
 
 #CondDBProbabilities = CondDB.clone(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"))
-CondDBProbabilities = CondDB.clone(connect = cms.string("sqlite_file:SiPixelQualityProbabilities_UltraLegacy2018_v0_mc.db"))
+CondDBProbabilities = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"))
 process.dbInput2 = cms.ESSource("PoolDBESSource",
                                 CondDBProbabilities,
                                 toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),

--- a/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelBadFEDChannelSimulationSanityChecker_cfg.py
@@ -36,23 +36,21 @@ process.source = cms.Source("EmptyIOVSource",
 ##
 from CondCore.CondDB.CondDB_cfi import *
 #CondDBQualityCollection = CondDB.clone(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"))
-CondDBQualityCollection = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"))
+CondDBQualityCollection = CondDB.clone(connect = cms.string("sqlite_file:SiPixelStatusScenarios_UltraLegacy2018_v0_mc.db"))
 process.dbInput = cms.ESSource("PoolDBESSource",
                                CondDBQualityCollection,
                                toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
-                                                          #tag = cms.string('SiPixelFEDChannelContainer_StuckTBM_2018_v0_mc') # choose tag you want
-                                                          tag = cms.string('SiPixelFEDChannelContainer_2018_run_322633_v0_mc') # choose tag you want
+                                                          tag = cms.string('SiPixelStatusScenarios_UltraLegacy2018_v0_mc') # choose tag you want
                                                           )
                                                  )
                                )
 
 #CondDBProbabilities = CondDB.clone(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"))
-CondDBProbabilities = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"))
+CondDBProbabilities = CondDB.clone(connect = cms.string("sqlite_file:SiPixelQualityProbabilities_UltraLegacy2018_v0_mc.db"))
 process.dbInput2 = cms.ESSource("PoolDBESSource",
                                 CondDBProbabilities,
                                 toGet = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),
-                                                           #tag = cms.string('SiPixelQualityProbabilities_2018_noPU_v0_mc') # choose tag you want
-                                                           tag = cms.string('SiPixelQualityProbabilities_2018_322633_v0_mc') # choose tag you want
+                                                           tag = cms.string('SiPixelQualityProbabilities_UltraLegacy2018_v0_mc') # choose tag you want
                                                            )
                                                   )
                                 )

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
@@ -88,8 +88,8 @@ void SiPixelFEDChannelContainerWriteFromASCII::analyze(const edm::Event& iEvent,
 
   if (mysnapshots.is_open()) {
     while (getline(mysnapshots, line)) {
-      if(printdebug_){
-	edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << line << std::endl;
+      if (printdebug_) {
+        edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << line << std::endl;
       }
       std::istringstream iss(line);
       unsigned int run, ls, detid, fed, link, roc_first, roc_last;
@@ -114,9 +114,9 @@ void SiPixelFEDChannelContainerWriteFromASCII::analyze(const edm::Event& iEvent,
       }
 
       if (detid != thedetid) {
-        if (printdebug_){
+        if (printdebug_) {
           edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << "found a new detid!" << detid << std::endl;
-	}
+        }
         thedetid = detid;
       }
       theBadFEDChannels[thedetid].push_back(theBadChannel);

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII.cc
@@ -88,7 +88,9 @@ void SiPixelFEDChannelContainerWriteFromASCII::analyze(const edm::Event& iEvent,
 
   if (mysnapshots.is_open()) {
     while (getline(mysnapshots, line)) {
-      //edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << line << std::endl;
+      if(printdebug_){
+	edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << line << std::endl;
+      }
       std::istringstream iss(line);
       unsigned int run, ls, detid, fed, link, roc_first, roc_last;
       iss >> run >> ls >> detid >> fed >> link >> roc_first >> roc_last;
@@ -112,8 +114,9 @@ void SiPixelFEDChannelContainerWriteFromASCII::analyze(const edm::Event& iEvent,
       }
 
       if (detid != thedetid) {
-        if (printdebug_)
+        if (printdebug_){
           edm::LogVerbatim("SiPixelFEDChannelContainerWriteFromASCII") << "found a new detid!" << detid << std::endl;
+	}
         thedetid = detid;
       }
       theBadFEDChannels[thedetid].push_back(theBadChannel);

--- a/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelFEDChannelContainerWriteFromASCII_cfg.py
@@ -37,34 +37,24 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1))
 ##
 process.load("CondCore.CondDB.CondDB_cfi")
 
-# DB input service: 
-process.CondDB.connect = "frontier://FrontierProd/CMS_CONDITIONS"
-process.dbInput = cms.ESSource("PoolDBESSource",
-                               process.CondDB,
-                               toGet = cms.VPSet(cms.PSet(record = cms.string("SiPixelQualityFromDbRcd"),
-                                                          tag = cms.string("SiPixelQuality_byPCL_stuckTBM_v1")
-                                                          ),
-                                                 cms.PSet(record = cms.string("SiPixelFedCablingMapRcd"),
-                                                          tag = cms.string("SiPixelFedCablingMap_phase1_v7")
-                                                          )
-                                                 )
-                               )
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:SiPixelStatusScenarios_fromFED25.db'
+process.CondDB.connect = 'sqlite_file:SiPixelStatusScenarios_UltraLegacy2018_v0_mc.db'
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenariosRcd'),
-                                                                     tag = cms.string('SiPixelFEDChannelContainer_StuckTBM_2018_v1_mc')
+                                                                     tag = cms.string('SiPixelStatusScenarios_UltraLegacy2018_v0_mc')
                                                                      )
                                                             )
                                           )
 
 process.WriteInDB = cms.EDAnalyzer("SiPixelFEDChannelContainerWriteFromASCII",
-                                   record= cms.string('SiPixelStatusScenariosRcd'),
-                                   snapshots = cms.string('snapshots_fromFED25.txt')
+                                   record     = cms.string('SiPixelStatusScenariosRcd'),
+                                   snapshots  = cms.string('scenarios_2018_-1.txt'),
+                                   printDebug = cms.untracked.bool(False),
+                                   addDefault = cms.untracked.bool(False)
                                    )
 
 process.p = cms.Path(process.WriteInDB)

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -80,7 +80,9 @@ void SiPixelQualityProbabilitiesWriteFromASCII::analyze(const edm::Event& iEvent
 
   if (myfile.is_open()) {
     while (getline(myfile, line)) {
-      //edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
+      if(printdebug_){
+	edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
+      }
       std::istringstream iss(line);
       int pileupBinId, nEntries;
       iss >> pileupBinId >> nEntries;

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -80,8 +80,8 @@ void SiPixelQualityProbabilitiesWriteFromASCII::analyze(const edm::Event& iEvent
 
   if (myfile.is_open()) {
     while (getline(myfile, line)) {
-      if(printdebug_){
-	edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
+      if (printdebug_) {
+        edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
       }
       std::istringstream iss(line);
       int pileupBinId, nEntries;

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII.cc
@@ -80,15 +80,27 @@ void SiPixelQualityProbabilitiesWriteFromASCII::analyze(const edm::Event& iEvent
 
   if (myfile.is_open()) {
     while (getline(myfile, line)) {
-      edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
+      //edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << line << std::endl;
       std::istringstream iss(line);
-      std::string scenario = "";
-      float prob(0.);
-      iss >> scenario >> prob;
-      auto idAndProb = std::make_pair(scenario, prob);
-      myProbVector.push_back(idAndProb);
+      int pileupBinId, nEntries;
+      iss >> pileupBinId >> nEntries;
+      edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII")
+          << "PILEUP BIN/ENTRIES:  " << pileupBinId << " " << nEntries << std::endl;
+      std::vector<std::string> ids(nEntries, "");
+      std::vector<float> probs(nEntries, 0.0);
+      for (int i = 0; i < nEntries; ++i) {
+        iss >> ids.at(i) >> probs.at(i);
+        if (printdebug_) {
+          edm::LogInfo("SiPixelQualityProbabilitiesWriteFromASCII") << ids.at(i) << " " << probs.at(i) << std::endl;
+        }
+        auto idAndProb = std::make_pair(ids.at(i), probs.at(i));
+        myProbVector.push_back(idAndProb);
+      }
+      if (nEntries > 0) {
+        myProbabilities->setProbabilities(pileupBinId, myProbVector);
+      }
+      myProbVector.clear();
     }
-    myProbabilities->setProbabilities(0, myProbVector);
     myfile.close();
   }
 

--- a/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII_cfg.py
+++ b/CondFormats/SiPixelObjects/test/SiPixelQualityProbabilitiesWriteFromASCII_cfg.py
@@ -39,21 +39,21 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:SiPixelStatusScenarioProbabilities_noPU.db'
+process.CondDB.connect = 'sqlite_file:SiPixelQualityProbabilities_UltraLegacy2018_v0_mc.db'
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('SiPixelStatusScenarioProbabilityRcd'),
-                                                                     tag = cms.string('SiPixelQualityProbabilities_noPU_v0_mc')
+                                                                     tag = cms.string('SiPixelQualityProbabilities_UltraLegacy2018_v0_mc')
                                                                      )
                                                             )
                                           )
 
 
 process.WriteInDB = cms.EDAnalyzer("SiPixelQualityProbabilitiesWriteFromASCII",
-                                   printDebug    = cms.untracked.bool(True),
+                                   printDebug    = cms.untracked.bool(False),
                                    record        = cms.string('SiPixelStatusScenarioProbabilityRcd'),
-                                   probabilities = cms.string('prob_noPU_2018.txt'),
+                                   probabilities = cms.string('prob_2018_-1.txt'),
                                    )
 
 process.p = cms.Path(process.WriteInDB)

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
@@ -102,31 +102,31 @@ std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
       //std::cout<<"New module read "<<name<<" "<<roc<<" --> "<<detId<<" "<<std::bitset<32>(it->second)<<std::endl;
     }
 
-    for (std::map<uint32_t, uint32_t>::iterator it = disabledModules.begin(); it != disabledModules.end(); it++) {
+    for (const auto& it : disabledModules) {
       SiPixelQuality::disabledModuleType BadModule;
-      BadModule.DetID = it->first;
-      if (it->second == 65535) {  // "whole"
+      BadModule.DetID = it.first;
+      if (it.second == 65535) {  // "whole"
         BadModule.errorType = 0;
         BadModule.BadRocs = 65535;
-      }                              //corresponds to all rocs being bad
-      else if (it->second == 255) {  // "tbmA"
+      }                             //corresponds to all rocs being bad
+      else if (it.second == 255) {  // "tbmA"
         BadModule.errorType = 1;
         BadModule.BadRocs = 255;
-      }                                //corresponds to Rocs 0-7 being bad
-      else if (it->second == 65280) {  // "tbmB"
+      }                               //corresponds to Rocs 0-7 being bad
+      else if (it.second == 65280) {  // "tbmB"
         BadModule.errorType = 2;
         BadModule.BadRocs = 65280;
       }       //corresponds to Rocs 8-15 being bad
       else {  // "none"
         BadModule.errorType = 3;
-        BadModule.BadRocs = it->second;
+        BadModule.BadRocs = it.second;
       }
 
       obj->addDisabledModule(BadModule);
       if (printdebug_) {
         edm::LogVerbatim("SiPixelBadModuleByHandBuilder")
             << "New module added: " << tTopo_->print(BadModule.DetID) << ", errorType: " << BadModule.errorType
-            << ", BadRocs: " << std::bitset<16>(it->second) << std::endl;
+            << ", BadRocs: " << std::bitset<16>(it.second) << std::endl;
       }
     }
   }

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
@@ -29,7 +29,8 @@ std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
     BadModule.DetID = it->getParameter<uint32_t>("detid");
     std::string errorstring = it->getParameter<std::string>("errortype");
     if (printdebug_) {
-      edm::LogInfo("SiPixelBadModuleByHandBuilder") << "now looking at detid " << BadModule.DetID << ", string " << errorstring << std::endl;
+      edm::LogInfo("SiPixelBadModuleByHandBuilder")
+          << "now looking at detid " << BadModule.DetID << ", string " << errorstring << std::endl;
     }
 
     //////////////////////////////////////
@@ -123,7 +124,9 @@ std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
 
       obj->addDisabledModule(BadModule);
       if (printdebug_) {
-	edm::LogVerbatim("SiPixelBadModuleByHandBuilder") << "New module added: " << tTopo_->print(BadModule.DetID) << ", errorType: " << BadModule.errorType << ", BadRocs: " << std::bitset<16>(it->second) << std::endl;
+        edm::LogVerbatim("SiPixelBadModuleByHandBuilder")
+            << "New module added: " << tTopo_->print(BadModule.DetID) << ", errorType: " << BadModule.errorType
+            << ", BadRocs: " << std::bitset<16>(it->second) << std::endl;
       }
     }
   }

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
@@ -16,7 +16,7 @@ SiPixelBadModuleByHandBuilder::SiPixelBadModuleByHandBuilder(const edm::Paramete
 SiPixelBadModuleByHandBuilder::~SiPixelBadModuleByHandBuilder() {}
 
 std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
-  SiPixelQuality* obj = new SiPixelQuality();
+  auto obj = std::make_unique<SiPixelQuality>();
 
   for (Parameters::iterator it = BadModuleList_.begin(); it != BadModuleList_.end(); ++it) {
     if (printdebug_) {
@@ -128,5 +128,5 @@ std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
     }
   }
 
-  return std::unique_ptr<SiPixelQuality>(obj);
+  return obj;
 }

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.cc
@@ -1,4 +1,6 @@
-#include "CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h"
+#include "SiPixelBadModuleByHandBuilder.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 
 #include <math.h>
 #include <iostream>
@@ -8,23 +10,27 @@ SiPixelBadModuleByHandBuilder::SiPixelBadModuleByHandBuilder(const edm::Paramete
     : ConditionDBWriter<SiPixelQuality>(iConfig) {
   printdebug_ = iConfig.getUntrackedParameter<bool>("printDebug", false);
   BadModuleList_ = iConfig.getUntrackedParameter<Parameters>("BadModuleList");
+  ROCListFile_ = iConfig.getUntrackedParameter<std::string>("ROCListFile");
 }
 
 SiPixelBadModuleByHandBuilder::~SiPixelBadModuleByHandBuilder() {}
 
 std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
-  auto obj = std::make_unique<SiPixelQuality>();
+  SiPixelQuality* obj = new SiPixelQuality();
 
   for (Parameters::iterator it = BadModuleList_.begin(); it != BadModuleList_.end(); ++it) {
-    if (printdebug_)
+    if (printdebug_) {
       edm::LogInfo("SiPixelBadModuleByHandBuilder") << " BadModule " << *it << " \t" << std::endl;
+    }
 
     SiPixelQuality::disabledModuleType BadModule;
     BadModule.errorType = 3;
     BadModule.BadRocs = 0;
     BadModule.DetID = it->getParameter<uint32_t>("detid");
     std::string errorstring = it->getParameter<std::string>("errortype");
-    std::cout << "now looking at detid " << BadModule.DetID << ", string " << errorstring << std::endl;
+    if (printdebug_) {
+      edm::LogInfo("SiPixelBadModuleByHandBuilder") << "now looking at detid " << BadModule.DetID << ", string " << errorstring << std::endl;
+    }
 
     //////////////////////////////////////
     //  errortype "whole" = int 0 in DB //
@@ -70,5 +76,57 @@ std::unique_ptr<SiPixelQuality> SiPixelBadModuleByHandBuilder::getNewObject() {
       edm::LogError("SiPixelQuality") << "trying to fill error type " << errorstring << ", which is not defined!";
     obj->addDisabledModule(BadModule);
   }
-  return obj;
+
+  // fill DB from DQM list
+  if (ROCListFile_ != "") {
+    std::map<uint32_t, uint32_t> disabledModules;
+    std::ifstream aFile(ROCListFile_.c_str());
+    std::string aLine;
+    while (std::getline(aFile, aLine)) {
+      char name[100];
+      int roc;
+      sscanf(aLine.c_str(), "%s %d", name, &roc);
+      uint32_t detId;
+      if (name[0] == 'B') {
+        PixelBarrelName bn(name, true);
+        detId = bn.getDetId(tTopo_);
+      } else {
+        PixelEndcapName en(name, true);
+        detId = en.getDetId(tTopo_);
+      }
+      std::map<uint32_t, uint32_t>::iterator it = disabledModules.find(detId);
+      if (it == disabledModules.end())
+        it = disabledModules.insert(disabledModules.begin(), std::make_pair(detId, 0));
+      it->second |= 1 << roc;
+      //std::cout<<"New module read "<<name<<" "<<roc<<" --> "<<detId<<" "<<std::bitset<32>(it->second)<<std::endl;
+    }
+
+    for (std::map<uint32_t, uint32_t>::iterator it = disabledModules.begin(); it != disabledModules.end(); it++) {
+      SiPixelQuality::disabledModuleType BadModule;
+      BadModule.DetID = it->first;
+      if (it->second == 65535) {  // "whole"
+        BadModule.errorType = 0;
+        BadModule.BadRocs = 65535;
+      }                              //corresponds to all rocs being bad
+      else if (it->second == 255) {  // "tbmA"
+        BadModule.errorType = 1;
+        BadModule.BadRocs = 255;
+      }                                //corresponds to Rocs 0-7 being bad
+      else if (it->second == 65280) {  // "tbmB"
+        BadModule.errorType = 2;
+        BadModule.BadRocs = 65280;
+      }       //corresponds to Rocs 8-15 being bad
+      else {  // "none"
+        BadModule.errorType = 3;
+        BadModule.BadRocs = it->second;
+      }
+
+      obj->addDisabledModule(BadModule);
+      if (printdebug_) {
+	edm::LogVerbatim("SiPixelBadModuleByHandBuilder") << "New module added: " << tTopo_->print(BadModule.DetID) << ", errorType: " << BadModule.errorType << ", BadRocs: " << std::bitset<16>(it->second) << std::endl;
+      }
+    }
+  }
+
+  return std::unique_ptr<SiPixelQuality>(obj);
 }

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h
@@ -9,6 +9,9 @@
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <vector>
 #include <ext/hash_map>
@@ -19,12 +22,19 @@ public:
   ~SiPixelBadModuleByHandBuilder();
 
 private:
-  std::unique_ptr<SiPixelQuality> getNewObject();
+  std::unique_ptr<SiPixelQuality> getNewObject() override;
+  void algoBeginJob(const edm::EventSetup& es) {
+    edm::ESHandle<TrackerTopology> htopo;
+    es.get<TrackerTopologyRcd>().get(htopo);
+    tTopo_ = htopo.product();
+  };
 
 private:
   bool printdebug_;
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters BadModuleList_;
+  std::string ROCListFile_;
+  const TrackerTopology* tTopo_;
 };
 
 #endif

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder.h
@@ -23,7 +23,7 @@ public:
 
 private:
   std::unique_ptr<SiPixelQuality> getNewObject() override;
-  void algoBeginJob(const edm::EventSetup& es) {
+  void algoBeginJob(const edm::EventSetup& es) override {
     edm::ESHandle<TrackerTopology> htopo;
     es.get<TrackerTopologyRcd>().get(htopo);
     tTopo_ = htopo.product();

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("ICALIB")
+
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string('')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:SiPixelQuality_phase1_2018_permanentlyBad.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiPixelQualityFromDbRcd'),
+        tag = cms.string('SiPixelQuality_phase1_2018_permanentlyBad')
+    ))
+)
+
+process.prod = cms.EDAnalyzer("SiPixelBadModuleByHandBuilder",
+                              BadModuleList = cms.untracked.VPSet(),
+                              Record = cms.string('SiPixelQualityFromDbRcd'),
+                              SinceAppendMode = cms.bool(True),
+                              IOVMode = cms.string('Run'),
+                              printDebug = cms.untracked.bool(True),
+                              doStoreOnDB = cms.bool(True),
+                              ROCListFile = cms.untracked.string("forPermanentSiPixelQuality_unlabeled.txt"),
+                              )
+
+#process.print = cms.OutputModule("AsciiOutputModule")
+
+process.p = cms.Path(process.prod)
+#process.ep = cms.EndPath(process.print)
+
+

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
@@ -49,5 +49,3 @@ process.prod = cms.EDAnalyzer("SiPixelBadModuleByHandBuilder",
 
 process.p = cms.Path(process.prod)
 #process.ep = cms.EndPath(process.print)
-
-

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder_cfg.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
+
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
 process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
@@ -32,6 +37,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 )
 
 process.prod = cms.EDAnalyzer("SiPixelBadModuleByHandBuilder",
+    ROCListFile = cms.untracked.string(""), 
     BadModuleList = cms.untracked.VPSet(cms.PSet(
         errortype = cms.string('whole'),
         detid = cms.uint32(302197784)


### PR DESCRIPTION
#### PR description:

While producing MC bad component payloads for the Ultra-Legacy campaign we realized that several of the DB loaders for the various sources of Pixel bad components committed in release are not up-to-date with the latest recommendations. 
In this PR `SiPixelFEDChannelContainerWriteFromASCII.cc`, `SiPixelQualityProbabilitiesWriteFromASCII.cc` (used to produce stuck-TBM simulation payloads) and `SiPixelBadModuleByHandBuilder.cc` ( used to produce permanently bad SiPixelQuality payloads) are updated together with the corresponding  configuration files.

#### PR validation:
Changes concern only `EDAnalyzers` in test directories, which have all been privately tested.
No change is expected in any production workflow.

#### if this PR is a backport please specify the original PR:

This PR is not a backport
cc:
@tsusa @tvami 
