### PR TITLE
[DQM] Migrated subsystem availability per lumi plot to softFED

### DIFF
--- a/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
@@ -34,6 +34,10 @@ process.load("EventFilter.ScalersRawToDigi.ScalersRawToDigi_cfi")
 from EventFilter.Utilities.tcdsRawToDigi_cfi import *
 process.tcdsDigis = tcdsRawToDigi.clone()
 
+# OnlineMetaDataRawToDigi will put DCSRecord to an event
+process.load('EventFilter.OnlineMetaDataRawToDigi.onlineMetaDataRawToDigi_cfi')
+process.onlineMetaDataDigis = cms.EDProducer('OnlineMetaDataRawToDigi')
+
 # DQMProvInfo is the DQM module to be run
 process.load("DQMServices.Components.DQMProvInfo_cfi")
 
@@ -42,6 +46,7 @@ process.dqmmodules = cms.Sequence(process.dqmEnv + process.dqmSaver)
 process.evfDQMmodulesPath = cms.Path(
                                      process.scalersRawToDigi*
                                      process.tcdsDigis*
+                                     process.onlineMetaDataRawToDigi*
                                      process.dqmProvInfo*
                                      process.dqmmodules
                                      )

--- a/DQMServices/Components/BuildFile.xml
+++ b/DQMServices/Components/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/RunInfo"/>
 <use   name="DataFormats/L1GlobalTrigger"/>
+<use   name="DataFormats/OnlineMetaData"/>
 <use   name="DataFormats/Provenance"/>
 <use   name="DataFormats/Scalers"/>
 <use   name="DataFormats/TCDS"/>

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -27,12 +27,13 @@ DQMProvInfo::DQMProvInfo(const edm::ParameterSet& ps) {
   runType_ = ps.getUntrackedParameter<std::string>("runType", "No run type selected");
 
   // Initialization of the input
-  // Used to get the DCS bits:
-  dcsStatusCollection_ =
-      consumes<DcsStatusCollection>(ps.getUntrackedParameter<std::string>("dcsStatusCollection", "scalersRawToDigi"));
   // Used to get the BST record from the TCDS information
   tcdsrecord_ = consumes<TCDSRecord>(
       ps.getUntrackedParameter<edm::InputTag>("tcdsData", edm::InputTag("tcdsDigis", "tcdsRecord")));
+
+  // Used to get DCS information per lumisection
+  dcsRecordToken_ = consumes<DCSRecord>(edm::InputTag("onlineMetaDataRawToDigi"));
+
   // Initialization of the global tag
   globalTag_ = "MODULE::DEFAULT";  // default
   globalTagRetrieved_ = false;     // set as soon as retrieved from first event
@@ -236,6 +237,7 @@ void DQMProvInfo::analyze(const edm::Event& event, const edm::EventSetup& c) {
   // and then at the end of each lumisection, we fill them in the MonitorElement
   // (Except for the global tag, which we only extract from the first event we
   //  ever encounter and put in the MonitorElement right away)
+
   analyzeLhcInfo(event);
   analyzeEventInfo(event);
   analyzeProvInfo(event);
@@ -259,57 +261,36 @@ void DQMProvInfo::analyzeLhcInfo(const edm::Event& event) {
 
 void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   // Part 1:
-  // Extract the DcsStatusCollection from the event
+  // Extract DCSRecord from the event
   // and put it into the dcsBits_ array
-  edm::Handle<DcsStatusCollection> dcsStatus;
-  event.getByToken(dcsStatusCollection_, dcsStatus);
-  // Loop over the DCSStatus entries in the DcsStatusCollection
-  // (Typically there is only one)
-  for (auto const& dcsStatusItr : *dcsStatus) {
-    // By default all the bits are false. We put all the bits on true only
-    // for the first DCSStatus that we encounter:
-    if (!foundFirstDcsBits_) {
-      for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
-        dcsBits_[vbin] = true;
-      }
-      foundFirstDcsBits_ = true;
-    }
-    // By default Physics Declared is false. We put it on true only for the
-    // first DCSStatus that we encounter:
-    if (!foundFirstPhysicsDeclared_) {
-      physicsDeclared_ = true;
-      foundFirstPhysicsDeclared_ = true;
-    }
 
-    // The DCS on lumi level is considered ON if the bit is set in EVERY event
-    dcsBits_[VBIN_CSC_P] &= dcsStatusItr.ready(DcsStatus::CSCp);
-    dcsBits_[VBIN_CSC_M] &= dcsStatusItr.ready(DcsStatus::CSCm);
-    dcsBits_[VBIN_DT_0] &= dcsStatusItr.ready(DcsStatus::DT0);
-    dcsBits_[VBIN_DT_P] &= dcsStatusItr.ready(DcsStatus::DTp);
-    dcsBits_[VBIN_DT_M] &= dcsStatusItr.ready(DcsStatus::DTm);
-    dcsBits_[VBIN_EB_P] &= dcsStatusItr.ready(DcsStatus::EBp);
-    dcsBits_[VBIN_EB_M] &= dcsStatusItr.ready(DcsStatus::EBm);
-    dcsBits_[VBIN_EE_P] &= dcsStatusItr.ready(DcsStatus::EEp);
-    dcsBits_[VBIN_EE_M] &= dcsStatusItr.ready(DcsStatus::EEm);
-    dcsBits_[VBIN_ES_P] &= dcsStatusItr.ready(DcsStatus::ESp);
-    dcsBits_[VBIN_ES_M] &= dcsStatusItr.ready(DcsStatus::ESm);
-    dcsBits_[VBIN_HBHE_A] &= dcsStatusItr.ready(DcsStatus::HBHEa);
-    dcsBits_[VBIN_HBHE_B] &= dcsStatusItr.ready(DcsStatus::HBHEb);
-    dcsBits_[VBIN_HBHE_C] &= dcsStatusItr.ready(DcsStatus::HBHEc);
-    dcsBits_[VBIN_HF] &= dcsStatusItr.ready(DcsStatus::HF);
-    dcsBits_[VBIN_HO] &= dcsStatusItr.ready(DcsStatus::HO);
-    dcsBits_[VBIN_BPIX] &= dcsStatusItr.ready(DcsStatus::BPIX);
-    dcsBits_[VBIN_FPIX] &= dcsStatusItr.ready(DcsStatus::FPIX);
-    dcsBits_[VBIN_RPC] &= dcsStatusItr.ready(DcsStatus::RPC);
-    dcsBits_[VBIN_TIBTID] &= dcsStatusItr.ready(DcsStatus::TIBTID);
-    dcsBits_[VBIN_TOB] &= dcsStatusItr.ready(DcsStatus::TOB);
-    dcsBits_[VBIN_TEC_P] &= dcsStatusItr.ready(DcsStatus::TECp);
-    dcsBits_[VBIN_TE_M] &= dcsStatusItr.ready(DcsStatus::TECm);
-    dcsBits_[VBIN_CASTOR] &= dcsStatusItr.ready(DcsStatus::CASTOR);
-    dcsBits_[VBIN_ZDC] &= dcsStatusItr.ready(DcsStatus::ZDC);
-    // Some info-level logging
-    edm::LogInfo("DQMProvInfo") << "DCS status: 0x" << std::hex << dcsStatusItr.ready() << std::dec << std::endl;
-  }
+  DCSRecord const& dcsRecord = event.get(dcsRecordToken_);
+
+  dcsBits_[VBIN_CSC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCp);
+  dcsBits_[VBIN_CSC_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCm);
+  dcsBits_[VBIN_DT_0] = dcsRecord.highVoltageReady(DCSRecord::Partition::DT0);
+  dcsBits_[VBIN_DT_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::DTp);
+  dcsBits_[VBIN_DT_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::DTm);
+  dcsBits_[VBIN_EB_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::EBp);
+  dcsBits_[VBIN_EB_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::EBm);
+  dcsBits_[VBIN_EE_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::EEp);
+  dcsBits_[VBIN_EE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::EEm);
+  dcsBits_[VBIN_ES_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::ESp);
+  dcsBits_[VBIN_ES_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::ESm);
+  dcsBits_[VBIN_HBHE_A] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEa);
+  dcsBits_[VBIN_HBHE_B] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEb);
+  dcsBits_[VBIN_HBHE_C] = dcsRecord.highVoltageReady(DCSRecord::Partition::HBHEc);
+  dcsBits_[VBIN_HF] = dcsRecord.highVoltageReady(DCSRecord::Partition::HF);
+  dcsBits_[VBIN_HO] = dcsRecord.highVoltageReady(DCSRecord::Partition::HO);
+  dcsBits_[VBIN_BPIX] = dcsRecord.highVoltageReady(DCSRecord::Partition::BPIX);
+  dcsBits_[VBIN_FPIX] = dcsRecord.highVoltageReady(DCSRecord::Partition::FPIX);
+  dcsBits_[VBIN_RPC] = dcsRecord.highVoltageReady(DCSRecord::Partition::RPC);
+  dcsBits_[VBIN_TIBTID] = dcsRecord.highVoltageReady(DCSRecord::Partition::TIBTID);
+  dcsBits_[VBIN_TOB] = dcsRecord.highVoltageReady(DCSRecord::Partition::TOB);
+  dcsBits_[VBIN_TEC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECp);
+  dcsBits_[VBIN_TE_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::TECm);
+  dcsBits_[VBIN_CASTOR] = dcsRecord.highVoltageReady(DCSRecord::Partition::CASTOR);
+  dcsBits_[VBIN_ZDC] = dcsRecord.highVoltageReady(DCSRecord::Partition::ZDC);
 
   // Part 2
   // Compute the PhysicsDeclared bit from the event
@@ -319,7 +300,7 @@ void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   // - at least one muon partition has DCSStatus ON
   // Basically: we do an AND of the physicsDeclared of ALL events.
   // As soon as one value is not "1", physicsDeclared_ becomes false.
-  physicsDeclared_ &= (beamMode_ == 11) &&
+  physicsDeclared_ = (beamMode_ == 11) &&
                       (dcsBits_[VBIN_BPIX] && dcsBits_[VBIN_FPIX] && dcsBits_[VBIN_TIBTID] && dcsBits_[VBIN_TOB] &&
                        dcsBits_[VBIN_TEC_P] && dcsBits_[VBIN_TE_M]) &&
                       (dcsBits_[VBIN_CSC_P] || dcsBits_[VBIN_CSC_M] || dcsBits_[VBIN_DT_0] || dcsBits_[VBIN_DT_P] ||

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -27,11 +27,15 @@ DQMProvInfo::DQMProvInfo(const edm::ParameterSet& ps) {
   runType_ = ps.getUntrackedParameter<std::string>("runType", "No run type selected");
 
   // Initialization of the input
+  // Used to get the DCS bits:
+  dcsStatusCollection_ =
+      consumes<DcsStatusCollection>(ps.getUntrackedParameter<std::string>("dcsStatusCollection", "scalersRawToDigi"));
+
   // Used to get the BST record from the TCDS information
   tcdsrecord_ = consumes<TCDSRecord>(
       ps.getUntrackedParameter<edm::InputTag>("tcdsData", edm::InputTag("tcdsDigis", "tcdsRecord")));
 
-  // Used to get DCS information per lumisection
+  // Used to get the DCS bits:
   dcsRecordToken_ = consumes<DCSRecord>(edm::InputTag("onlineMetaDataRawToDigi"));
 
   // Initialization of the global tag
@@ -260,11 +264,39 @@ void DQMProvInfo::analyzeLhcInfo(const edm::Event& event) {
 
 void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   // Part 1:
-  // Extract DCSRecord from the event
-  // and put it into the dcsBits_ array
+  // If FED#735 is available use it to extract DcsStatusCollection.
+  // If not, use softFED#1022 to extract DCSRecord.
+  // Populate dcsBits_ array with received information.
 
-  DCSRecord const& dcsRecord = event.get(dcsRecordToken_);
+  edm::Handle<DcsStatusCollection> dcsStatusCollection;
+  event.getByToken(dcsStatusCollection_, dcsStatusCollection);
 
+  if (dcsStatusCollection->size() != 0) {
+    fillDcsBitsFromDcsStatusCollection(dcsStatusCollection);
+  } else {
+    DCSRecord const& dcsRecord = event.get(dcsRecordToken_);
+    fillDcsBitsFromDCSRecord(dcsRecord);
+  }
+}
+
+void DQMProvInfo::analyzeProvInfo(const edm::Event& event) {
+  // Only trying to retrieve the global tag for the first event we ever
+  // encounter.
+  if (!globalTagRetrieved_) {
+    // Getting the real process name for the given event
+    std::string processName = event.processHistory()[event.processHistory().size() - 1].processName();
+    // Getting parameters for that process
+    edm::ParameterSet ps;
+    event.getProcessParameterSet(processName, ps);
+    // Getting the global tag
+    globalTag_ = ps.getParameterSet("PoolDBESSource@GlobalTag").getParameter<std::string>("globaltag");
+    versGlobaltag_->Fill(globalTag_);
+    // Finaly: Setting globalTagRetrieved_ to true, since we got it now
+    globalTagRetrieved_ = true;
+  }
+}
+
+void DQMProvInfo::fillDcsBitsFromDCSRecord(const DCSRecord& dcsRecord) {
   dcsBits_[VBIN_CSC_P] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCp);
   dcsBits_[VBIN_CSC_M] = dcsRecord.highVoltageReady(DCSRecord::Partition::CSCm);
   dcsBits_[VBIN_DT_0] = dcsRecord.highVoltageReady(DCSRecord::Partition::DT0);
@@ -291,7 +323,71 @@ void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   dcsBits_[VBIN_CASTOR] = dcsRecord.highVoltageReady(DCSRecord::Partition::CASTOR);
   dcsBits_[VBIN_ZDC] = dcsRecord.highVoltageReady(DCSRecord::Partition::ZDC);
 
-  // Part 2
+  // Part 2: Compute the PhysicsDeclared bit from the event
+  physicsDeclared_ &= isPhysicsDeclared();
+
+  // Some info-level logging
+  edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared_ << std::endl;
+}
+
+void DQMProvInfo::fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>& dcsStatusCollection) {
+  // Loop over the DCSStatus entries in the DcsStatusCollection
+  // (Typically there is only one)
+  for (auto const& dcsStatusItr : *dcsStatusCollection) {
+    // By default all the bits are false. We put all the bits on true only
+    // for the first DCSStatus that we encounter:
+    if (!foundFirstDcsBits_) {
+      for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
+        dcsBits_[vbin] = true;
+      }
+      foundFirstDcsBits_ = true;
+    }
+    // By default Physics Declared is false. We put it on true only for the
+    // first DCSStatus that we encounter:
+    if (!foundFirstPhysicsDeclared_) {
+      physicsDeclared_ = true;
+      foundFirstPhysicsDeclared_ = true;
+    }
+
+    // The DCS on lumi level is considered ON if the bit is set in EVERY event
+    dcsBits_[VBIN_CSC_P] &= dcsStatusItr.ready(DcsStatus::CSCp);
+    dcsBits_[VBIN_CSC_M] &= dcsStatusItr.ready(DcsStatus::CSCm);
+    dcsBits_[VBIN_DT_0] &= dcsStatusItr.ready(DcsStatus::DT0);
+    dcsBits_[VBIN_DT_P] &= dcsStatusItr.ready(DcsStatus::DTp);
+    dcsBits_[VBIN_DT_M] &= dcsStatusItr.ready(DcsStatus::DTm);
+    dcsBits_[VBIN_EB_P] &= dcsStatusItr.ready(DcsStatus::EBp);
+    dcsBits_[VBIN_EB_M] &= dcsStatusItr.ready(DcsStatus::EBm);
+    dcsBits_[VBIN_EE_P] &= dcsStatusItr.ready(DcsStatus::EEp);
+    dcsBits_[VBIN_EE_M] &= dcsStatusItr.ready(DcsStatus::EEm);
+    dcsBits_[VBIN_ES_P] &= dcsStatusItr.ready(DcsStatus::ESp);
+    dcsBits_[VBIN_ES_M] &= dcsStatusItr.ready(DcsStatus::ESm);
+    dcsBits_[VBIN_HBHE_A] &= dcsStatusItr.ready(DcsStatus::HBHEa);
+    dcsBits_[VBIN_HBHE_B] &= dcsStatusItr.ready(DcsStatus::HBHEb);
+    dcsBits_[VBIN_HBHE_C] &= dcsStatusItr.ready(DcsStatus::HBHEc);
+    dcsBits_[VBIN_HF] &= dcsStatusItr.ready(DcsStatus::HF);
+    dcsBits_[VBIN_HO] &= dcsStatusItr.ready(DcsStatus::HO);
+    dcsBits_[VBIN_BPIX] &= dcsStatusItr.ready(DcsStatus::BPIX);
+    dcsBits_[VBIN_FPIX] &= dcsStatusItr.ready(DcsStatus::FPIX);
+    dcsBits_[VBIN_RPC] &= dcsStatusItr.ready(DcsStatus::RPC);
+    dcsBits_[VBIN_TIBTID] &= dcsStatusItr.ready(DcsStatus::TIBTID);
+    dcsBits_[VBIN_TOB] &= dcsStatusItr.ready(DcsStatus::TOB);
+    dcsBits_[VBIN_TEC_P] &= dcsStatusItr.ready(DcsStatus::TECp);
+    dcsBits_[VBIN_TE_M] &= dcsStatusItr.ready(DcsStatus::TECm);
+    dcsBits_[VBIN_CASTOR] &= dcsStatusItr.ready(DcsStatus::CASTOR);
+    dcsBits_[VBIN_ZDC] &= dcsStatusItr.ready(DcsStatus::ZDC);
+
+    // Some info-level logging
+    edm::LogInfo("DQMProvInfo") << "DCS status: 0x" << std::hex << dcsStatusItr.ready() << std::dec << std::endl;
+  }
+
+  // Part 2: Compute the PhysicsDeclared bit from the event
+  physicsDeclared_ &= isPhysicsDeclared();
+
+  // Some info-level logging
+  edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared_ << std::endl;
+}
+
+bool DQMProvInfo::isPhysicsDeclared() {
   // Compute the PhysicsDeclared bit from the event
   // The bit is set to to true if:
   // - the LHC is in stable beams
@@ -299,30 +395,11 @@ void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   // - at least one muon partition has DCSStatus ON
   // Basically: we do an AND of the physicsDeclared of ALL events.
   // As soon as one value is not "1", physicsDeclared_ becomes false.
-  physicsDeclared_ = (beamMode_ == 11) &&
-                     (dcsBits_[VBIN_BPIX] && dcsBits_[VBIN_FPIX] && dcsBits_[VBIN_TIBTID] && dcsBits_[VBIN_TOB] &&
-                      dcsBits_[VBIN_TEC_P] && dcsBits_[VBIN_TE_M]) &&
-                     (dcsBits_[VBIN_CSC_P] || dcsBits_[VBIN_CSC_M] || dcsBits_[VBIN_DT_0] || dcsBits_[VBIN_DT_P] ||
-                      dcsBits_[VBIN_DT_M] || dcsBits_[VBIN_RPC]);
-  // Some info-level logging
-  edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared_ << std::endl;
-}
-
-void DQMProvInfo::analyzeProvInfo(const edm::Event& event) {
-  // Only trying to retrieve the global tag for the first event we ever
-  // encounter.
-  if (!globalTagRetrieved_) {
-    // Getting the real process name for the given event
-    std::string processName = event.processHistory()[event.processHistory().size() - 1].processName();
-    // Getting parameters for that process
-    edm::ParameterSet ps;
-    event.getProcessParameterSet(processName, ps);
-    // Getting the global tag
-    globalTag_ = ps.getParameterSet("PoolDBESSource@GlobalTag").getParameter<std::string>("globaltag");
-    versGlobaltag_->Fill(globalTag_);
-    // Finaly: Setting globalTagRetrieved_ to true, since we got it now
-    globalTagRetrieved_ = true;
-  }
+  return (beamMode_ == 11) &&
+         (dcsBits_[VBIN_BPIX] && dcsBits_[VBIN_FPIX] && dcsBits_[VBIN_TIBTID] && dcsBits_[VBIN_TOB] &&
+          dcsBits_[VBIN_TEC_P] && dcsBits_[VBIN_TE_M]) &&
+         (dcsBits_[VBIN_CSC_P] || dcsBits_[VBIN_CSC_M] || dcsBits_[VBIN_DT_0] || dcsBits_[VBIN_DT_P] ||
+          dcsBits_[VBIN_DT_M] || dcsBits_[VBIN_RPC]);
 }
 
 void DQMProvInfo::endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& c) {

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -272,8 +272,10 @@ void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   event.getByToken(dcsStatusCollection_, dcsStatusCollection);
 
   if (!dcsStatusCollection->empty()) {
+    edm::LogInfo("DQMProvInfo") << "Using FED#735 for reading DCS bits" << std::endl;
     fillDcsBitsFromDcsStatusCollection(dcsStatusCollection);
   } else {
+    edm::LogInfo("DQMProvInfo") << "Using softFED#1022 for reading DCS bits" << std::endl;
     DCSRecord const& dcsRecord = event.get(dcsRecordToken_);
     fillDcsBitsFromDCSRecord(dcsRecord);
   }

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -182,6 +182,8 @@ void DQMProvInfo::bookHistogramsEventInfo(DQMStore::IBooker& iBooker) {
   reportSummaryMap_->setBinLabel(VBIN_MOMENTUM, "13 TeV", 2);
   reportSummaryMap_->setBinLabel(VBIN_STABLE_BEAM, "Stable B", 2);
   reportSummaryMap_->setBinLabel(VBIN_VALID, "Valid", 2);
+
+  blankAllLumiSections();
 }
 
 void DQMProvInfo::bookHistogramsProvInfo(DQMStore::IBooker& iBooker) {
@@ -226,9 +228,6 @@ void DQMProvInfo::beginLuminosityBlock(const edm::LuminosityBlock& l, const edm:
   for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
     dcsBits_[vbin] = false;
   }
-  // Boolean that tells the analyse method that we encountered the first real
-  // dcs info
-  foundFirstDcsBits_ = false;
 }
 
 void DQMProvInfo::analyze(const edm::Event& event, const edm::EventSetup& c) {
@@ -301,10 +300,10 @@ void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   // Basically: we do an AND of the physicsDeclared of ALL events.
   // As soon as one value is not "1", physicsDeclared_ becomes false.
   physicsDeclared_ = (beamMode_ == 11) &&
-                      (dcsBits_[VBIN_BPIX] && dcsBits_[VBIN_FPIX] && dcsBits_[VBIN_TIBTID] && dcsBits_[VBIN_TOB] &&
-                       dcsBits_[VBIN_TEC_P] && dcsBits_[VBIN_TE_M]) &&
-                      (dcsBits_[VBIN_CSC_P] || dcsBits_[VBIN_CSC_M] || dcsBits_[VBIN_DT_0] || dcsBits_[VBIN_DT_P] ||
-                       dcsBits_[VBIN_DT_M] || dcsBits_[VBIN_RPC]);
+                     (dcsBits_[VBIN_BPIX] && dcsBits_[VBIN_FPIX] && dcsBits_[VBIN_TIBTID] && dcsBits_[VBIN_TOB] &&
+                      dcsBits_[VBIN_TEC_P] && dcsBits_[VBIN_TE_M]) &&
+                     (dcsBits_[VBIN_CSC_P] || dcsBits_[VBIN_CSC_M] || dcsBits_[VBIN_DT_0] || dcsBits_[VBIN_DT_P] ||
+                      dcsBits_[VBIN_DT_M] || dcsBits_[VBIN_RPC]);
   // Some info-level logging
   edm::LogInfo("DQMProvInfo") << "Physics declared bit: " << physicsDeclared_ << std::endl;
 }
@@ -406,6 +405,17 @@ void DQMProvInfo::blankPreviousLumiSections(const int currentLSNumber) {
     reportSummaryMap_->setBinContent(ls, VBIN_VALID, 0.);
     // Color all the other bins white (-1)
     for (int vBin = 1; vBin < VBIN_VALID; vBin++) {
+      reportSummaryMap_->setBinContent(ls, vBin, -1.);
+    }
+  }
+}
+
+void DQMProvInfo::blankAllLumiSections() {
+  // Initially we want all lumisection to be blank (-1) and
+  // white instead of red which is misleading.
+  for (int ls = 0; ls < MAX_LUMIS; ls++) {
+    // Color all the bins white (-1)
+    for (int vBin = 1; vBin <= MAX_VBINS; vBin++) {
       reportSummaryMap_->setBinContent(ls, vBin, -1.);
     }
   }

--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -271,7 +271,7 @@ void DQMProvInfo::analyzeEventInfo(const edm::Event& event) {
   edm::Handle<DcsStatusCollection> dcsStatusCollection;
   event.getByToken(dcsStatusCollection_, dcsStatusCollection);
 
-  if (dcsStatusCollection->size() != 0) {
+  if (!dcsStatusCollection->empty()) {
     fillDcsBitsFromDcsStatusCollection(dcsStatusCollection);
   } else {
     DCSRecord const& dcsRecord = event.get(dcsRecordToken_);

--- a/DQMServices/Components/plugins/DQMProvInfo.h
+++ b/DQMServices/Components/plugins/DQMProvInfo.h
@@ -15,6 +15,7 @@
 #include <DataFormats/Scalers/interface/DcsStatus.h>
 
 #include <DataFormats/TCDS/interface/TCDSRecord.h>
+#include <DataFormats/OnlineMetaData/interface/DCSRecord.h>
 
 #include <string>
 #include <vector>
@@ -105,8 +106,8 @@ private:
   std::string subsystemname_;
   std::string provinfofolder_;
 
-  edm::EDGetTokenT<DcsStatusCollection> dcsStatusCollection_;
   edm::EDGetTokenT<TCDSRecord> tcdsrecord_;
+  edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
 
   // MonitorElements for LhcInfo and corresponding variables
   MonitorElement* hBeamMode_;

--- a/DQMServices/Components/plugins/DQMProvInfo.h
+++ b/DQMServices/Components/plugins/DQMProvInfo.h
@@ -43,6 +43,10 @@ private:
   void analyzeEventInfo(const edm::Event& e);
   void analyzeProvInfo(const edm::Event& e);
 
+  void fillDcsBitsFromDCSRecord(const DCSRecord&);
+  void fillDcsBitsFromDcsStatusCollection(const edm::Handle<DcsStatusCollection>&);
+  bool isPhysicsDeclared();
+
   void endLuminosityBlockLhcInfo(const int currentLSNumber);
   void endLuminosityBlockEventInfo(const int currentLSNumber);
   void blankPreviousLumiSections(const int currentLSNumber);
@@ -107,6 +111,7 @@ private:
   std::string subsystemname_;
   std::string provinfofolder_;
 
+  edm::EDGetTokenT<DcsStatusCollection> dcsStatusCollection_;
   edm::EDGetTokenT<TCDSRecord> tcdsrecord_;
   edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
 

--- a/DQMServices/Components/plugins/DQMProvInfo.h
+++ b/DQMServices/Components/plugins/DQMProvInfo.h
@@ -46,6 +46,7 @@ private:
   void endLuminosityBlockLhcInfo(const int currentLSNumber);
   void endLuminosityBlockEventInfo(const int currentLSNumber);
   void blankPreviousLumiSections(const int currentLSNumber);
+  void blankAllLumiSections();
 
   // To max amount of lumisections we foresee for the plots
   // DQM GUI renderplugins provide scaling to actual amount


### PR DESCRIPTION
#### PR description:

`DSCRecord` data provided by softFED#1022 is now used to draw a subsystem availability per lumisection DQM plot. 

#### PR validation:

PR vas validated in the DQM playback system.