### PR TITLE
Fireworks: Change logs description

### DIFF
--- a/Fireworks/Core/src/FWGeometryTableViewManager.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewManager.cc
@@ -104,8 +104,7 @@ void FWGeometryTableViewManager::setGeoManagerFromFile() {
       throw std::runtime_error("Can't find TGeoManager object in selected file.");
 
   } catch (std::runtime_error& e) {
-    fwLog(fwlog::kError)
-        << "Failed to find simulation geometry file. Please set the file path with --sim-geom-file option.\n";
+    fwLog(fwlog::kError) << e.what();
     exit(0);
   }
 }

--- a/Fireworks/FWInterface/src/FWFFLooper.cc
+++ b/Fireworks/FWInterface/src/FWFFLooper.cc
@@ -453,7 +453,7 @@ void FWFFLooper::requestChanges(const std::string& moduleLabel, const edm::Param
 //______________________________________________________________________________
 
 void FWFFLooper::remakeGeometry(const DisplayGeomRecord& dgRec) {
-  fwLog(fwlog::kInfo) << "FWFFLooper set TGeo geomtery from DisplayGeomRecord.\n";
+  fwLog(fwlog::kInfo) << "FWFFLooper set TGeo geometry from DisplayGeomRecord.\n";
 
   edm::ESHandle<TGeoManager> geom;
   dgRec.get(geom);


### PR DESCRIPTION
#### PR description:

Let the `std::runtime_exception` shows its own description as the actual printout could be misleading. 
Same exception with different description are thrown in `try` block. `catch` block needs to provide exception description instead