### PR TITLE
Moving Sequence to Task :RecoLocalMuon RecoMuon RecoEgamma RecoEcal RecoHI

### DIFF
--- a/RecoEcal/Configuration/python/RecoEcalCosmics_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcalCosmics_cff.py
@@ -17,5 +17,6 @@ from RecoEcal.EgammaClusterProducers.hybridClusteringSequence_cff import *
 from RecoEcal.EgammaClusterProducers.cosmicClusteringSequence_cff import *
 # create path with all clustering algos
 # NB: preshower MUST be run after island clustering in the endcap
-ecalClustersCosmics = cms.Sequence(hybridClusteringSequence*cosmicClusteringSequence)
+ecalClustersCosmicsTask = cms.Task(hybridClusteringTask,cosmicClusteringTask)
+ecalClustersCosmics = cms.Sequence(ecalClustersCosmicsTask)
 

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -17,7 +17,6 @@ from RecoEcal.EgammaCoreTools.EcalNextToDeadChannelESProducer_cff import *
 
 #particle flow super clustering sequence
 from RecoEcal.EgammaClusterProducers.particleFlowSuperClusteringSequence_cff import *
-#from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 
 ecalClustersNoPFBoxTask = cms.Task(hybridClusteringTask,
                               multi5x5ClusteringTask,

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -16,10 +16,14 @@ from RecoEcal.EgammaCoreTools.EcalNextToDeadChannelESProducer_cff import *
 # NB: preshower MUST be run after multi5x5 clustering in the endcap
 
 #particle flow super clustering sequence
-from RecoEcal.EgammaClusterProducers.particleFlowSuperClusteringSequence_cff import *
+from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 
-ecalClustersNoPFBox = cms.Sequence(hybridClusteringSequence*multi5x5ClusteringSequence*multi5x5PreshowerClusteringSequence)
-ecalClusters = cms.Sequence(ecalClustersNoPFBox*particleFlowSuperClusteringSequence)
+ecalClustersNoPFBoxTask = cms.Task(hybridClusteringTask,
+                              multi5x5ClusteringTask,
+                              multi5x5PreshowerClusteringTask)
+ecalClustersNoPFBox = cms.Sequence(ecalClustersNoPFBoxTask)
+ecalClustersTask = cms.Task(ecalClustersNoPFBoxTask, particleFlowSuperClusterECAL)
+ecalClusters = cms.Sequence(ecalClustersTask)
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
@@ -29,7 +33,7 @@ from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 
 from RecoEcal.EgammaClusterProducers.islandClusteringSequence_cff import *
 
-_ecalClustersHI = ecalClusters.copy()
-_ecalClustersHI += islandClusteringSequence
+_ecalClustersHITask = ecalClustersTask.copy()
+_ecalClustersHITask.add(islandClusteringTask)
 for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
-    e.toReplaceWith(ecalClusters, _ecalClustersHI)
+    e.toReplaceWith(ecalClustersTask, _ecalClustersHITask)

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -16,13 +16,14 @@ from RecoEcal.EgammaCoreTools.EcalNextToDeadChannelESProducer_cff import *
 # NB: preshower MUST be run after multi5x5 clustering in the endcap
 
 #particle flow super clustering sequence
-from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
+from RecoEcal.EgammaClusterProducers.particleFlowSuperClusteringSequence_cff import *
+#from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 
 ecalClustersNoPFBoxTask = cms.Task(hybridClusteringTask,
                               multi5x5ClusteringTask,
                               multi5x5PreshowerClusteringTask)
 ecalClustersNoPFBox = cms.Sequence(ecalClustersNoPFBoxTask)
-ecalClustersTask = cms.Task(ecalClustersNoPFBoxTask, particleFlowSuperClusterECAL)
+ecalClustersTask = cms.Task(ecalClustersNoPFBoxTask, particleFlowSuperClusteringTask)
 ecalClusters = cms.Sequence(ecalClustersTask)
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016

--- a/RecoEcal/EgammaClusterProducers/python/cosmicClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/cosmicClusteringSequence_cff.py
@@ -13,4 +13,5 @@ from RecoEcal.EgammaClusterProducers.cosmicSuperClusters_cfi import *
 #  SuperCluster with Preshower producer
 #include "RecoEcal/EgammaClusterProducers/data/SuperClustersWithPreshower.cfi"
 # create sequence for  clustering
-cosmicClusteringSequence = cms.Sequence(cosmicBasicClusters * cosmicSuperClusters)
+cosmicClusteringTask = cms.Task(cosmicBasicClusters, cosmicSuperClusters)
+cosmicClusteringSequence = cms.Sequence(cosmicClusteringTask)

--- a/RecoEcal/EgammaClusterProducers/python/dynamicHybridClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/dynamicHybridClusteringSequence_cff.py
@@ -8,5 +8,6 @@ from RecoEcal.EgammaClusterProducers.dynamicHybridSuperClusters_cfi import *
 # Producer for energy corrections
 from RecoEcal.EgammaClusterProducers.correctedDynamicHybridSuperClusters_cfi import *
 # hybrid clustering sequence
-dynamicHybridClusteringSequence = cms.Sequence(dynamicHybridSuperClusters*correctedDynamicHybridSuperClusters)
+dynamicHybridClusteringTask = cms.Task(dynamicHybridSuperClusters, correctedDynamicHybridSuperClusters)
+dynamicHybridClusteringSequence = cms.Sequence(dynamicHybridClusteringTask)
 

--- a/RecoEcal/EgammaClusterProducers/python/ecalClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/ecalClusteringSequence_cff.py
@@ -20,5 +20,12 @@ from RecoEcal.EgammaClusterProducers.multi5x5PreshowerClusteringSequence_cff imp
 from RecoEcal.EgammaClusterProducers.ecalDigiSelector_cff import *
 # create path with all clustering algos
 # NB: preshower MUST be run after island clustering in the endcap
-ecalClusteringSequence = cms.Sequence(islandClusteringSequence*hybridClusteringSequence*preshowerClusteringSequence*dynamicHybridClusteringSequence*multi5x5ClusteringSequence*multi5x5PreshowerClusteringSequence * seldigis)
+ecalClusteringTask = cms.Task(islandClusteringTask,
+                              hybridClusteringTask,
+                              preshowerClusteringTask,
+                              dynamicHybridClusteringTask,
+                              multi5x5ClusteringTask,
+                              multi5x5PreshowerClusteringTask,
+                              seldigisTask)
+ecalClusteringSequence = cms.Sequence(ecalClusteringTask)
 

--- a/RecoEcal/EgammaClusterProducers/python/fixedMatrixClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/fixedMatrixClusteringSequence_cff.py
@@ -10,5 +10,8 @@ from RecoEcal.EgammaClusterProducers.fixedMatrixSuperClusters_cfi import *
 # FixedMatrix SuperCluster with Preshower producer
 from RecoEcal.EgammaClusterProducers.fixedMatrixSuperClustersWithPreshower_cfi import *
 # create sequence for fixedMatrix clustering
-fixedMatrixClusteringSequence = cms.Sequence(fixedMatrixBasicClusters*fixedMatrixSuperClusters*fixedMatrixSuperClustersWithPreshower)
+fixedMatrixClusteringTask = cms.Task(fixedMatrixBasicClusters,
+                                     fixedMatrixSuperClusters,
+                                     fixedMatrixSuperClustersWithPreshower)
+fixedMatrixClusteringSequence = cms.Sequence(fixedMatrixClusteringTask)
 

--- a/RecoEcal/EgammaClusterProducers/python/fixedMatrixPreshowerClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/fixedMatrixPreshowerClusteringSequence_cff.py
@@ -10,5 +10,6 @@ from RecoEcal.EgammaClusterProducers.correctedFixedMatrixSuperClustersWithPresho
 # producer for preshower cluster shapes
 from RecoEcal.EgammaClusterProducers.fixedMatrixPreshowerClusterShape_cfi import *
 # create sequence for preshower clustering
-fixedMatrixPreshowerClusteringSequence = cms.Sequence(correctedFixedMatrixSuperClustersWithPreshower*fixedMatrixPreshowerClusterShape)
+fixedMatrixPreshowerClusteringTask = cms.Task(correctedFixedMatrixSuperClustersWithPreshower,fixedMatrixPreshowerClusterShape)
+fixedMatrixPreshowerClusteringSequence = cms.Sequence(fixedMatrixPreshowerClusteringTask)
 

--- a/RecoEcal/EgammaClusterProducers/python/islandClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/islandClusteringSequence_cff.py
@@ -13,5 +13,9 @@ from RecoEcal.EgammaClusterProducers.islandSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.correctedIslandBarrelSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.correctedIslandEndcapSuperClusters_cfi import *
 # create sequence for island clustering
-islandClusteringSequence = cms.Sequence(islandBasicClusters*islandSuperClusters*correctedIslandBarrelSuperClusters*correctedIslandEndcapSuperClusters)
+islandClusteringTask = cms.Task(islandBasicClusters,
+                                islandSuperClusters,
+                                correctedIslandBarrelSuperClusters,
+                                correctedIslandEndcapSuperClusters)
+islandClusteringSequence = cms.Sequence(islandClusteringTask)
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -9,7 +9,7 @@ from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 #from RecoEcal.EgammaClusterProducers.correctedDynamicHybridSuperClusters_cfi import *
 # PFECAL super clusters, either hybrid-clustering clone (Box) or mustache.
 particleFlowSuperClusteringTask = cms.Task(particleFlowSuperClusterECAL)
-#particleFlowSuperClusteringSequence = cms.Sequence(particleFlowSuperClusterECAL)
+particleFlowSuperClusteringSequence = cms.Sequence(particleFlowSuperClusteringTask)
 
 particleFlowSuperClusterHGCal = particleFlowSuperClusterECAL.clone()
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -8,6 +8,7 @@ from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 # Producer for energy corrections
 #from RecoEcal.EgammaClusterProducers.correctedDynamicHybridSuperClusters_cfi import *
 # PFECAL super clusters, either hybrid-clustering clone (Box) or mustache.
+particleFlowSuperClusteringTask = cms.Task(particleFlowSuperClusterECAL)
 #particleFlowSuperClusteringSequence = cms.Sequence(particleFlowSuperClusterECAL)
 
 particleFlowSuperClusterHGCal = particleFlowSuperClusterECAL.clone()
@@ -29,9 +30,9 @@ phase2_hgcal.toModify(
     particleFlowSuperClusterHGCalFromMultiCl,
     PFClusters = cms.InputTag('particleFlowClusterHGCalFromMultiCl')
 )
-_phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusterECAL.copy()
+_phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusteringTask.copy()
 _phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCal)
 _phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCalFromMultiCl)
 
-phase2_hgcal.toReplaceWith( particleFlowSuperClusterECAL, _phase2_hgcal_particleFlowSuperClusteringTask )
+phase2_hgcal.toReplaceWith( particleFlowSuperClusteringTask, _phase2_hgcal_particleFlowSuperClusteringTask )
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -8,7 +8,7 @@ from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 # Producer for energy corrections
 #from RecoEcal.EgammaClusterProducers.correctedDynamicHybridSuperClusters_cfi import *
 # PFECAL super clusters, either hybrid-clustering clone (Box) or mustache.
-particleFlowSuperClusteringSequence = cms.Sequence(particleFlowSuperClusterECAL)
+#particleFlowSuperClusteringSequence = cms.Sequence(particleFlowSuperClusterECAL)
 
 particleFlowSuperClusterHGCal = particleFlowSuperClusterECAL.clone()
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
@@ -29,9 +29,9 @@ phase2_hgcal.toModify(
     particleFlowSuperClusterHGCalFromMultiCl,
     PFClusters = cms.InputTag('particleFlowClusterHGCalFromMultiCl')
 )
-_phase2_hgcal_particleFlowSuperClusteringSequence = particleFlowSuperClusteringSequence.copy()
-_phase2_hgcal_particleFlowSuperClusteringSequence += particleFlowSuperClusterHGCal
-_phase2_hgcal_particleFlowSuperClusteringSequence += particleFlowSuperClusterHGCalFromMultiCl
+_phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusterECAL.copy()
+_phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCal)
+_phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCalFromMultiCl)
 
-phase2_hgcal.toReplaceWith( particleFlowSuperClusteringSequence, _phase2_hgcal_particleFlowSuperClusteringSequence )
+phase2_hgcal.toReplaceWith( particleFlowSuperClusterECAL, _phase2_hgcal_particleFlowSuperClusteringTask )
 

--- a/RecoEcal/EgammaClusterProducers/python/preshowerClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/preshowerClusteringSequence_cff.py
@@ -10,5 +10,6 @@ from RecoEcal.EgammaClusterProducers.correctedEndcapSuperClustersWithPreshower_c
 # producer for preshower cluster shapes
 from RecoEcal.EgammaClusterProducers.preshowerClusterShape_cfi import *
 # create sequence for preshower clustering
-preshowerClusteringSequence = cms.Sequence(correctedEndcapSuperClustersWithPreshower*preshowerClusterShape)
+preshowerClusteringTask = cms.Task(correctedEndcapSuperClustersWithPreshower, preshowerClusterShape)
+preshowerClusteringSequence = cms.Sequence(preshowerClusteringTask)
 

--- a/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
@@ -7,16 +7,18 @@ import FWCore.ParameterSet.Config as cms
 from RecoEgamma.EgammaPhotonProducers.photonCore_cfi import *
 from RecoEgamma.EgammaPhotonProducers.photons_cfi import *
 
-photonSequence = cms.Sequence( photonCore + photons )
-_photonSequenceFromMultiCl = photonSequence.copy()
-_photonSequenceFromMultiCl += ( photonCoreFromMultiCl + photonsFromMultiCl)
-_photonSequenceWithIsland = photonSequence.copy()
-_photonSequenceWithIsland += ( islandPhotonCore + islandPhotons )
+photonTask = cms.Task(photonCore,photons)
+photonSequence = cms.Sequence(photonTask)
+
+_photonTaskFromMultiCl = photonTask.copy()
+_photonTaskFromMultiCl.add(photonCoreFromMultiCl,photonsFromMultiCl)
+_photonTaskWithIsland = photonTask.copy()
+_photonTaskWithIsland.add(islandPhotonCore,islandPhotons)
 
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith(
- photonSequence, _photonSequenceFromMultiCl
+ photonTask, _photonTaskFromMultiCl
 )
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
@@ -25,4 +27,4 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
 for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
-    e.toReplaceWith(photonSequence, _photonSequenceWithIsland)
+    e.toReplaceWith(photonTask, _photonTaskWithIsland)

--- a/RecoHI/HiEgammaAlgos/python/HiEgamma_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiEgamma_cff.py
@@ -7,11 +7,12 @@ from RecoEcal.EgammaClusterProducers.multi5x5ClusteringSequence_cff import *
 from RecoEcal.EgammaClusterProducers.multi5x5PreshowerClusteringSequence_cff import *
 from RecoEcal.EgammaClusterProducers.preshowerClusteringSequence_cff import *
 from RecoHI.HiEgammaAlgos.HiIsolationCommonParameters_cff import *
-from RecoEcal.EgammaClusterProducers.particleFlowSuperClusteringSequence_cff import *
+from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 
 particleFlowSuperClusterECAL.regressionConfig.vertexCollection = 'hiSelectedVertex'
 
-hiEcalClusteringSequence = cms.Sequence(islandClusteringSequence*hybridClusteringSequence*multi5x5ClusteringSequence*multi5x5PreshowerClusteringSequence*preshowerClusteringSequence*particleFlowSuperClusteringSequence)
+hiEcalClusteringTask = cms.Task(islandClusteringTask,hybridClusteringTask,multi5x5ClusteringTask,multi5x5PreshowerClusteringTask,preshowerClusteringTask,particleFlowSuperClusterECAL)
+hiEcalClusteringSequence = cms.Sequence(hiEcalClusteringTask)
 
 
 # reco photon producer
@@ -31,7 +32,8 @@ photons.primaryVertexProducer = cms.InputTag('hiSelectedVertex') # replace the p
 photons.isolationSumsCalculatorSet.trackProducer = isolationInputParameters.track    # cms.InputTag("highPurityTracks")
 
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducer
-hiPhotonSequence = cms.Sequence(photonSequence * photonIsolationHIProducer)
+hiPhotonTask = cms.Task(photonTask,photonIsolationHIProducer)
+hiPhotonSequence = cms.Sequence(hiPhotonTask)
 
 # HI Ecal reconstruction
 hiEcalClusters = cms.Sequence(hiEcalClusteringSequence)
@@ -47,6 +49,7 @@ cleanPhotons = photons.clone(
     photonCoreProducer = cms.InputTag("cleanPhotonCore")
 )
 
-hiPhotonCleaningSequence = cms.Sequence(hiSpikeCleanedSC *
-                                        cleanPhotonCore  *
-                                        cleanPhotons)
+hiPhotonCleaningTask = cms.Task(hiSpikeCleanedSC,
+                                cleanPhotonCore,
+                                cleanPhotons)
+hiPhotonCleaningSequence = cms.Sequence(hiPhotonCleaningTask)

--- a/RecoHI/HiEgammaAlgos/python/HiIslandClusteringSequence_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiIslandClusteringSequence_cff.py
@@ -13,5 +13,9 @@ from RecoHI.HiEgammaAlgos.HiIslandSuperClusters_cfi import *
 from RecoHI.HiEgammaAlgos.HiCorrectedIslandBarrelSuperClusters_cfi import *
 from RecoHI.HiEgammaAlgos.HiCorrectedIslandEndcapSuperClusters_cfi import *
 # create sequence for island clustering
-islandClusteringSequence = cms.Sequence(islandBasicClusters*islandSuperClusters*correctedIslandBarrelSuperClusters*correctedIslandEndcapSuperClusters)
+islandClusteringTask = cms.Task(islandBasicClusters,
+                                islandSuperClusters,
+                                correctedIslandBarrelSuperClusters,
+                                correctedIslandEndcapSuperClusters)
+islandClusteringSequence = cms.Sequence(islandClusteringTask)
 

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_cff.py
@@ -26,56 +26,64 @@ from RecoLocalMuon.RPCRecHit.rpcRecHits_cfi import *
 # DT sequence for the standard reconstruction chain 
 # The reconstruction of the 2D segments are not required for the 4D segments reconstruction, they are used
 # only for debuging purpose and for specific studies
-dtlocalreco = cms.Sequence(dt1DRecHits*dt4DSegments)
+dtlocalrecoTask = cms.Task(dt1DRecHits,dt4DSegments)
+dtlocalreco = cms.Sequence(dtlocalrecoTask)
 # DT sequence with the 2D segment reconstruction
-dtlocalreco_with_2DSegments = cms.Sequence(dt1DRecHits*dt2DSegments*dt4DSegments)
+dtlocalreco_with_2DSegmentsTask = cms.Task(dt1DRecHits,dt2DSegments,dt4DSegments)
+dtlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegmentsTask)
 # DT sequence with T0seg correction
-dtlocalrecoT0Seg = cms.Sequence(dt1DRecHits*dt4DSegments*dt4DSegmentsT0Seg)
+dtlocalrecoT0SegTask = cms.Task(dt1DRecHits,dt4DSegments,dt4DSegmentsT0Seg)
+dtlocalrecoT0Seg = cms.Sequence(dtlocalrecoT0SegTask)
 # CSC sequence
-csclocalreco = cms.Sequence(csc2DRecHits*cscSegments)
+csclocalrecoTask = cms.Task(csc2DRecHits,cscSegments)
+csclocalreco = cms.Sequence(csclocalrecoTask)
 # DT, CSC and RPC together
-muonlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegments+csclocalreco+rpcRecHits)
+muonlocalreco_with_2DSegmentsTask = cms.Task(dtlocalreco_with_2DSegmentsTask,csclocalrecoTask,rpcRecHits)
+muonlocalreco_with_2DSegments = cms.Sequence(muonlocalreco_with_2DSegmentsTask)
 # DT, CSC and RPC together (correct sequence for the standard path)
-muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
+muonlocalrecoTask = cms.Task(dtlocalrecoTask,csclocalrecoTask,rpcRecHits)
+muonlocalreco = cms.Sequence(muonlocalrecoTask)
 # DT, CSC and RPC together (with t0seg correction for DTs)
-muonlocalrecoT0Seg = cms.Sequence(dtlocalrecoT0Seg+csclocalreco+rpcRecHits)
+muonlocalrecoT0SegTask = cms.Task(dtlocalrecoT0SegTask,csclocalrecoTask,rpcRecHits)
+muonlocalrecoT0Seg = cms.Sequence(muonlocalrecoT0SegTask)
 # all sequences to be used for GR
-muonLocalRecoGR = cms.Sequence(muonlocalreco+muonlocalrecoT0Seg)
+muonLocalRecoGRTask = cms.Task(muonlocalrecoTask,muonlocalrecoT0SegTask)
+muonLocalRecoGR = cms.Sequence(muonLocalRecoGRTask)
 
 from RecoLocalMuon.GEMRecHit.gemLocalReco_cff import *
 from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import *
 
-_run2_GEM_2017_muonlocalreco = muonlocalreco.copy()
-_run2_GEM_2017_muonlocalreco += gemLocalReco
+_run2_GEM_2017_muonlocalrecoTask = muonlocalrecoTask.copy()
+_run2_GEM_2017_muonlocalrecoTask.add(gemLocalRecoTask)
 
-_run3_muonlocalreco = muonlocalreco.copy()
-_run3_muonlocalreco += gemLocalReco
+_run3_muonlocalrecoTask = muonlocalrecoTask.copy()
+_run3_muonlocalrecoTask.add(gemLocalRecoTask)
 
-_phase2_muonlocalreco = _run3_muonlocalreco.copy()
-_phase2_muonlocalreco += me0LocalReco
+_phase2_muonlocalrecoTask = _run3_muonlocalrecoTask.copy()
+_phase2_muonlocalrecoTask.add(me0LocalRecoTask)
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-run2_GEM_2017.toReplaceWith( muonlocalreco , _run2_GEM_2017_muonlocalreco )
+run2_GEM_2017.toReplaceWith( muonlocalrecoTask , _run2_GEM_2017_muonlocalrecoTask )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toReplaceWith( muonlocalreco , _run3_muonlocalreco )
+run3_GEM.toReplaceWith( muonlocalrecoTask , _run3_muonlocalrecoTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toReplaceWith( muonlocalreco , _phase2_muonlocalreco )
+phase2_muon.toReplaceWith( muonlocalrecoTask , _phase2_muonlocalrecoTask )
 
 
 # RPC New Readout Validation
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegments = muonlocalreco_with_2DSegments.copy()
-_rpc_NewReadoutVal_muonlocalreco = muonlocalreco.copy()
-_rpc_NewReadoutVal_muonlocalrecoT0Seg = muonlocalrecoT0Seg.copy()
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegments += rpcNewRecHits
-_rpc_NewReadoutVal_muonlocalreco += rpcNewRecHits
-_rpc_NewReadoutVal_muonlocalrecoT0Seg += rpcNewRecHits
-stage2L1Trigger_2017.toReplaceWith(muonlocalreco_with_2DSegments, _rpc_NewReadoutVal_muonlocalreco_with_2DSegments)
-stage2L1Trigger_2017.toReplaceWith(muonlocalreco, _rpc_NewReadoutVal_muonlocalreco)
-stage2L1Trigger_2017.toReplaceWith(muonlocalrecoT0Seg, _rpc_NewReadoutVal_muonlocalrecoT0Seg)
+_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask = muonlocalreco_with_2DSegmentsTask.copy()
+_rpc_NewReadoutVal_muonlocalrecoTask = muonlocalrecoTask.copy()
+_rpc_NewReadoutVal_muonlocalrecoT0SegTask = muonlocalrecoT0SegTask.copy()
+_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask.add(rpcNewRecHits)
+_rpc_NewReadoutVal_muonlocalrecoTask.add(rpcNewRecHits)
+_rpc_NewReadoutVal_muonlocalrecoT0SegTask.add(rpcNewRecHits)
+stage2L1Trigger_2017.toReplaceWith(muonlocalreco_with_2DSegmentsTask, _rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask)
+stage2L1Trigger_2017.toReplaceWith(muonlocalrecoTask, _rpc_NewReadoutVal_muonlocalrecoTask)
+stage2L1Trigger_2017.toReplaceWith(muonlocalrecoT0SegTask, _rpc_NewReadoutVal_muonlocalrecoT0SegTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(muonlocalreco_with_2DSegments, muonlocalreco_with_2DSegments.copyAndExclude([rpcNewRecHits]))
-fastSim.toReplaceWith(muonlocalreco, muonlocalreco.copyAndExclude([rpcNewRecHits]))
-fastSim.toReplaceWith(muonlocalrecoT0Seg, muonlocalrecoT0Seg.copyAndExclude([rpcNewRecHits]))
+fastSim.toReplaceWith(muonlocalreco_with_2DSegmentsTask, muonlocalreco_with_2DSegmentsTask.copyAndExclude([rpcNewRecHits]))
+fastSim.toReplaceWith(muonlocalrecoTask, muonlocalrecoTask.copyAndExclude([rpcNewRecHits]))
+fastSim.toReplaceWith(muonlocalrecoT0SegTask, muonlocalrecoT0SegTask.copyAndExclude([rpcNewRecHits]))
 

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -26,45 +26,50 @@ from RecoLocalMuon.RPCRecHit.rpcRecHits_cfi import *
 # DT sequence for the standard reconstruction chain 
 # The reconstruction of the 2D segments are not required for the 4D segments reconstruction, they are used
 # only for debuging purpose and for specific studies
-dtlocalreco = cms.Sequence(dt1DRecHits*dt4DSegments + dt1DCosmicRecHits*dt4DCosmicSegments)
+dtlocalrecoTask = cms.Task(dt1DRecHits,dt4DSegments,dt1DCosmicRecHits,dt4DCosmicSegments)
+dtlocalreco = cms.Sequence(dtlocalrecoTask)
 # DT sequence with the 2D segment reconstruction
-dtlocalreco_with_2DSegments = cms.Sequence(dt1DRecHits*dt2DSegments*dt4DSegments + dt1DCosmicRecHits*dt2DCosmicSegments*dt4DCosmicSegments)
+dtlocalreco_with_2DSegmentsTask = cms.Task(dt1DRecHits,dt2DSegments,dt4DSegments,dt1DCosmicRecHits,dt2DCosmicSegments,dt4DCosmicSegments)
+dtlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegmentsTask)
 # DT sequence with T0seg correction
 # CSC sequence
-csclocalreco = cms.Sequence(csc2DRecHits*cscSegments)
+csclocalrecoTask = cms.Task(csc2DRecHits,cscSegments)
+csclocalreco = cms.Sequence(csclocalrecoTask)
 # DT, CSC and RPC together
-muonlocalreco_with_2DSegments = cms.Sequence(dtlocalreco_with_2DSegments+csclocalreco+rpcRecHits)
+muonlocalreco_with_2DSegmentsTask = cms.Task(dtlocalreco_with_2DSegmentsTask,csclocalrecoTask,rpcRecHits)
+muonlocalreco_with_2DSegments = cms.Sequence(muonlocalreco_with_2DSegmentsTask)
 # DT, CSC and RPC together (correct sequence for the standard path)
-muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
+muonlocalrecoTask = cms.Task(dtlocalrecoTask,csclocalrecoTask,rpcRecHits)
+muonlocalreco = cms.Sequence(muonlocalrecoTask)
 
 from RecoLocalMuon.GEMRecHit.gemLocalReco_cff import *
 from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import *
 
-_run2_GEM_2017_muonlocalreco = muonlocalreco.copy()
-_run2_GEM_2017_muonlocalreco += gemLocalReco
+_run2_GEM_2017_muonlocalrecoTask = muonlocalrecoTask.copy()
+_run2_GEM_2017_muonlocalrecoTask.add(gemLocalRecoTask)
 
-_run3_muonlocalreco = muonlocalreco.copy()
-_run3_muonlocalreco += gemLocalReco
+_run3_muonlocalrecoTask = muonlocalrecoTask.copy()
+_run3_muonlocalrecoTask.add(gemLocalRecoTask)
 
-_phase2_muonlocalreco = _run3_muonlocalreco.copy()
-_phase2_muonlocalreco += me0LocalReco
+_phase2_muonlocalrecoTask = _run3_muonlocalrecoTask.copy()
+_phase2_muonlocalrecoTask.add(me0LocalRecoTask)
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-run2_GEM_2017.toReplaceWith( muonlocalreco , _run2_GEM_2017_muonlocalreco )
+run2_GEM_2017.toReplaceWith( muonlocalrecoTask , _run2_GEM_2017_muonlocalrecoTask )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-run3_GEM.toReplaceWith( muonlocalreco , _run3_muonlocalreco )
+run3_GEM.toReplaceWith( muonlocalrecoTask , _run3_muonlocalrecoTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-phase2_muon.toReplaceWith( muonlocalreco , _phase2_muonlocalreco )
+phase2_muon.toReplaceWith( muonlocalrecoTask , _phase2_muonlocalrecoTask )
 
 # RPC New Readout Validation
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegments = muonlocalreco_with_2DSegments.copy()
-_rpc_NewReadoutVal_muonlocalreco = muonlocalreco.copy()
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegments += rpcNewRecHits
-_rpc_NewReadoutVal_muonlocalreco += rpcNewRecHits
-stage2L1Trigger_2017.toReplaceWith(muonlocalreco_with_2DSegments, _rpc_NewReadoutVal_muonlocalreco_with_2DSegments)
-stage2L1Trigger_2017.toReplaceWith(muonlocalreco, _rpc_NewReadoutVal_muonlocalreco)
+_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask = muonlocalreco_with_2DSegmentsTask.copy()
+_rpc_NewReadoutVal_muonlocalrecoTask = muonlocalrecoTask.copy()
+_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask.add(rpcNewRecHits)
+_rpc_NewReadoutVal_muonlocalrecoTask.add(rpcNewRecHits)
+stage2L1Trigger_2017.toReplaceWith(muonlocalreco_with_2DSegmentsTask, _rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask)
+stage2L1Trigger_2017.toReplaceWith(muonlocalrecoTask, _rpc_NewReadoutVal_muonlocalrecoTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(muonlocalreco_with_2DSegments, muonlocalreco_with_2DSegments.copyAndExclude([rpcNewRecHits]))
-fastSim.toReplaceWith(muonlocalreco, muonlocalreco.copyAndExclude([rpcNewRecHits]))
+fastSim.toReplaceWith(muonlocalreco_with_2DSegmentsTask, muonlocalreco_with_2DSegmentsTask.copyAndExclude([rpcNewRecHits]))
+fastSim.toReplaceWith(muonlocalrecoTask, muonlocalrecoTask.copyAndExclude([rpcNewRecHits]))

--- a/RecoLocalMuon/GEMRecHit/python/gemLocalReco_cff.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemLocalReco_cff.py
@@ -3,4 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalMuon.GEMRecHit.gemRecHits_cfi import *
 from RecoLocalMuon.GEMSegment.gemSegments_cfi import *
 
-gemLocalReco = cms.Sequence(gemRecHits*gemSegments)
+gemLocalRecoTask = cms.Task(gemRecHits,gemSegments)
+gemLocalReco = cms.Sequence(gemLocalRecoTask)

--- a/RecoLocalMuon/GEMRecHit/python/me0LocalReco_cff.py
+++ b/RecoLocalMuon/GEMRecHit/python/me0LocalReco_cff.py
@@ -3,4 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalMuon.GEMRecHit.me0RecHits_cfi import *
 from RecoLocalMuon.GEMSegment.me0Segments_cfi import *
 
-me0LocalReco = cms.Sequence(me0RecHits*me0Segments)
+me0LocalRecoTask = cms.Task(me0RecHits,me0Segments)
+me0LocalReco = cms.Sequence(me0LocalRecoTask)

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -47,8 +47,6 @@ muonsFromCosmics.fillGlobalTrackRefits = False
 # Stand Alone Tracking
 STAmuontrackingforcosmicsTask = cms.Task(CosmicMuonSeed,cosmicMuons)
 STAmuontrackingforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
-# Stand Alone Tracking plus muon ID
-STAmuonrecoforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
 
 # Stand Alone Tracking plus global tracking
 muontrackingforcosmicsTask = cms.Task(STAmuontrackingforcosmicsTask,globalCosmicMuons)
@@ -81,11 +79,7 @@ allmuonsTask = cms.Task(glbTrackQual,
 allmuons = cms.Sequence(allmuonsTask)
 
 # Final sequence
-muonrecoforcosmicsTask = cms.Task(muontrackingforcosmicsTask,
-                                  allmuonsTask,
-                                  muonsFromCosmics)
-muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
-#muonRecoAllGR = cms.Sequence(muonrecoforcosmicsTask)
+muonrecoforcosmicsTask = cms.Task(muontrackingforcosmicsTask)
 
 # 1 leg mode
 
@@ -168,9 +162,6 @@ muontrackingforcosmicsWitht0Correction = cms.Sequence(muontrackingforcosmicsWith
 # Stand Alone Tracking plus muon ID
 STAmuonrecoforcosmicsWitht0Correction = cms.Sequence(STAmuontrackingforcosmicsWitht0CorrectionTask)
 
-# all muons id
-#allmuonsWitht0Correction = cms.Sequence(muonsWitht0Correction)
-
 # Final sequence
 muonrecoforcosmicsWitht0CorrectionTask = cms.Task(muontrackingforcosmicsWitht0CorrectionTask,muonsWitht0Correction)
 muonrecoforcosmicsWitht0Correction = cms.Sequence(muonrecoforcosmicsWitht0CorrectionTask)
@@ -245,15 +236,9 @@ muonsNoRPC.fillGlobalTrackRefits = False
 
 #Sequences
 
-# Stand Alone Tracking
-#STAmuontrackingforcosmicsNoRPC = cms.Sequence(cosmicMuonsNoRPC)
-
 # Stand Alone Tracking plus global tracking
 muontrackingforcosmicsNoRPCTask = cms.Task(cosmicMuonsNoRPC,globalCosmicMuonsNoRPC)
 muontrackingforcosmicsNoRPC = cms.Sequence(muontrackingforcosmicsNoRPCTask)
-
-# all muons id
-#allmuonsNoRPC = cms.Sequence(muonsNoRPC)
 
 # Final sequence
 muonrecoforcosmicsNoRPCTask = cms.Task(muontrackingforcosmicsNoRPCTask,muonsNoRPC)

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -113,9 +113,6 @@ STAmuontrackingforcosmics1LegTask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 # Stand Alone Tracking plus global tracking
 muontrackingforcosmics1LegTask = cms.Task(STAmuontrackingforcosmics1LegTask, globalCosmicMuons1Leg)
 
-# Stand Alone Tracking plus muon ID
-STAmuonrecoforcosmics1Leg = cms.Sequence(STAmuontrackingforcosmics1LegTask)
-
 # Final sequence
 muonrecoforcosmics1LegTask = cms.Task(muontrackingforcosmics1LegTask,muons1Leg)
 

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -79,7 +79,10 @@ allmuonsTask = cms.Task(glbTrackQual,
 allmuons = cms.Sequence(allmuonsTask)
 
 # Final sequence
-muonrecoforcosmicsTask = cms.Task(muontrackingforcosmicsTask)
+muonrecoforcosmicsTask = cms.Task(muontrackingforcosmicsTask,
+				  allmuonsTask,
+                                  muonsFromCosmics)
+muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
 
 # 1 leg mode
 

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -77,7 +77,7 @@ glbTrackQual.InputCollection = "globalCosmicMuons"
 allmuonsTask = cms.Task(glbTrackQual,
                         tevMuons,
                         muons,
-                        muIsolation)
+                        muIsolationTask)
 allmuons = cms.Sequence(allmuonsTask)
 
 # Final sequence
@@ -117,7 +117,7 @@ STAmuontrackingforcosmics1LegTask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 muontrackingforcosmics1LegTask = cms.Task(STAmuontrackingforcosmics1LegTask, globalCosmicMuons1Leg)
 
 # Stand Alone Tracking plus muon ID
-STAmuonrecoforcosmics1Leg = cms.Sequence(STAmuontrackingforcosmics1Leg)
+STAmuonrecoforcosmics1Leg = cms.Sequence(STAmuontrackingforcosmics1LegTask)
 
 # Final sequence
 muonrecoforcosmics1LegTask = cms.Task(muontrackingforcosmics1LegTask,muons1Leg)

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -45,12 +45,14 @@ muonsFromCosmics.fillGlobalTrackRefits = False
 ## Sequences
 
 # Stand Alone Tracking
-STAmuontrackingforcosmics = cms.Sequence(CosmicMuonSeed*cosmicMuons)
+STAmuontrackingforcosmicsTask = cms.Task(CosmicMuonSeed,cosmicMuons)
+STAmuontrackingforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
 # Stand Alone Tracking plus muon ID
-STAmuonrecoforcosmics = cms.Sequence(STAmuontrackingforcosmics)
+STAmuonrecoforcosmics = cms.Sequence(STAmuontrackingforcosmicsTask)
 
 # Stand Alone Tracking plus global tracking
-muontrackingforcosmics = cms.Sequence(STAmuontrackingforcosmics*globalCosmicMuons)
+muontrackingforcosmicsTask = cms.Task(STAmuontrackingforcosmicsTask,globalCosmicMuons)
+muontrackingforcosmics = cms.Sequence(muontrackingforcosmicsTask)
 
 # Muon Isolation sequence
 from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
@@ -72,11 +74,18 @@ from RecoMuon.GlobalTrackingTools.GlobalTrackQuality_cfi import *
 glbTrackQual.InputCollection = "globalCosmicMuons"
 
 # all muons id
-allmuons = cms.Sequence(glbTrackQual*tevMuons*muons*muIsolation)
+allmuonsTask = cms.Task(glbTrackQual,
+                        tevMuons,
+                        muons,
+                        muIsolation)
+allmuons = cms.Sequence(allmuonsTask)
 
 # Final sequence
-muonrecoforcosmics = cms.Sequence(muontrackingforcosmics*allmuons*muonsFromCosmics)
-muonRecoAllGR = cms.Sequence(muonrecoforcosmics)
+muonrecoforcosmicsTask = cms.Task(muontrackingforcosmicsTask,
+                                  allmuonsTask,
+                                  muonsFromCosmics)
+muonrecoforcosmics = cms.Sequence(muonrecoforcosmicsTask)
+#muonRecoAllGR = cms.Sequence(muonrecoforcosmicsTask)
 
 # 1 leg mode
 
@@ -102,19 +111,16 @@ muons1Leg.TimingFillerParameters.CSCTimingParameters.PruneCut = 9999
 # Sequences
 
 # Stand Alone Tracking
-STAmuontrackingforcosmics1Leg = cms.Sequence(CosmicMuonSeed*cosmicMuons1Leg)
+STAmuontrackingforcosmics1LegTask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
 
 # Stand Alone Tracking plus global tracking
-muontrackingforcosmics1Leg = cms.Sequence(STAmuontrackingforcosmics1Leg*globalCosmicMuons1Leg)
-
-# all muons id
-allmuons1Leg = cms.Sequence(muons1Leg)
+muontrackingforcosmics1LegTask = cms.Task(STAmuontrackingforcosmics1LegTask, globalCosmicMuons1Leg)
 
 # Stand Alone Tracking plus muon ID
 STAmuonrecoforcosmics1Leg = cms.Sequence(STAmuontrackingforcosmics1Leg)
 
 # Final sequence
-muonrecoforcosmics1Leg = cms.Sequence(muontrackingforcosmics1Leg*allmuons1Leg)
+muonrecoforcosmics1LegTask = cms.Task(muontrackingforcosmics1LegTask,muons1Leg)
 
 #####################################################
 
@@ -152,22 +158,26 @@ muonsWitht0Correction.fillGlobalTrackRefits = False
 
 
 # Stand Alone Tracking
-STAmuontrackingforcosmicsWitht0Correction = cms.Sequence(CosmicMuonSeedWitht0Correction*cosmicMuonsWitht0Correction)
+STAmuontrackingforcosmicsWitht0CorrectionTask = cms.Task(CosmicMuonSeedWitht0Correction,cosmicMuonsWitht0Correction)
+STAmuontrackingforcosmicsWitht0Correction = cms.Sequence(STAmuontrackingforcosmicsWitht0CorrectionTask)
 
 # Stand Alone Tracking plus global tracking
-muontrackingforcosmicsWitht0Correction = cms.Sequence(STAmuontrackingforcosmicsWitht0Correction*globalCosmicMuonsWitht0Correction)
+muontrackingforcosmicsWitht0CorrectionTask = cms.Task(STAmuontrackingforcosmicsWitht0CorrectionTask,globalCosmicMuonsWitht0Correction)
+muontrackingforcosmicsWitht0Correction = cms.Sequence(muontrackingforcosmicsWitht0CorrectionTask)
 
 # Stand Alone Tracking plus muon ID
-STAmuonrecoforcosmicsWitht0Correction = cms.Sequence(STAmuontrackingforcosmicsWitht0Correction)
+STAmuonrecoforcosmicsWitht0Correction = cms.Sequence(STAmuontrackingforcosmicsWitht0CorrectionTask)
 
 # all muons id
-allmuonsWitht0Correction = cms.Sequence(muonsWitht0Correction)
+#allmuonsWitht0Correction = cms.Sequence(muonsWitht0Correction)
 
 # Final sequence
-muonrecoforcosmicsWitht0Correction = cms.Sequence(muontrackingforcosmicsWitht0Correction*allmuonsWitht0Correction)
+muonrecoforcosmicsWitht0CorrectionTask = cms.Task(muontrackingforcosmicsWitht0CorrectionTask,muonsWitht0Correction)
+muonrecoforcosmicsWitht0Correction = cms.Sequence(muonrecoforcosmicsWitht0CorrectionTask)
 
 ### Final sequence ###
-muonRecoGR = cms.Sequence(muonrecoforcosmics1Leg+muonrecoforcosmicsWitht0Correction)
+muonRecoGRTask = cms.Task(muonrecoforcosmics1LegTask,muonrecoforcosmicsWitht0CorrectionTask)
+muonRecoGR = cms.Sequence(muonRecoGRTask)
 
 #####################################################
 
@@ -202,7 +212,11 @@ muonsBeamHaloEndCapsOnly.CaloExtractorPSet.DR_Max = 1.0
 muonsBeamHaloEndCapsOnly.fillGlobalTrackRefits = False
 
 # Sequences
-muonrecoBeamHaloEndCapsOnly = cms.Sequence(CosmicMuonSeedEndCapsOnly*cosmicMuonsEndCapsOnly*globalBeamHaloMuonEndCapslOnly*muonsBeamHaloEndCapsOnly)
+muonrecoBeamHaloEndCapsOnlyTask = cms.Task(CosmicMuonSeedEndCapsOnly,
+                                           cosmicMuonsEndCapsOnly,
+                                           globalBeamHaloMuonEndCapslOnly,
+                                           muonsBeamHaloEndCapsOnly)
+muonrecoBeamHaloEndCapsOnly = cms.Sequence(muonrecoBeamHaloEndCapsOnlyTask)
 
 ########
 
@@ -232,16 +246,18 @@ muonsNoRPC.fillGlobalTrackRefits = False
 #Sequences
 
 # Stand Alone Tracking
-STAmuontrackingforcosmicsNoRPC = cms.Sequence(cosmicMuonsNoRPC)
+#STAmuontrackingforcosmicsNoRPC = cms.Sequence(cosmicMuonsNoRPC)
 
 # Stand Alone Tracking plus global tracking
-muontrackingforcosmicsNoRPC = cms.Sequence(STAmuontrackingforcosmicsNoRPC*globalCosmicMuonsNoRPC)
+muontrackingforcosmicsNoRPCTask = cms.Task(cosmicMuonsNoRPC,globalCosmicMuonsNoRPC)
+muontrackingforcosmicsNoRPC = cms.Sequence(muontrackingforcosmicsNoRPCTask)
 
 # all muons id
-allmuonsNoRPC = cms.Sequence(muonsNoRPC)
+#allmuonsNoRPC = cms.Sequence(muonsNoRPC)
 
 # Final sequence
-muonrecoforcosmicsNoRPC = cms.Sequence(muontrackingforcosmicsNoRPC*allmuonsNoRPC)
+muonrecoforcosmicsNoRPCTask = cms.Task(muontrackingforcosmicsNoRPCTask,muonsNoRPC)
+muonrecoforcosmicsNoRPC = cms.Sequence(muonrecoforcosmicsNoRPCTask)
 
 ##############################################
 
@@ -268,7 +284,8 @@ splitMuons.fillGlobalTrackRefits = False
 #Sequences
 
 # Final sequence
-muonrecoforsplitcosmics = cms.Sequence(globalCosmicSplitMuons*splitMuons)
+muonrecoforsplitcosmicsTask = cms.Task(globalCosmicSplitMuons,splitMuons)
+muonrecoforsplitcosmics = cms.Sequence(muonrecoforsplitcosmicsTask)
 
 ##############################################
 
@@ -290,13 +307,22 @@ lhcSTAMuons.CaloExtractorPSet.DR_Max = 1.0
 lhcSTAMuons.fillGlobalTrackRefits = False
 
 # Final sequence
-muonRecoLHC = cms.Sequence(ancientMuonSeed*standAloneMuons*lhcSTAMuons)
+muonRecoLHCTask = cms.Task(ancientMuonSeed,
+                           standAloneMuons,
+                           lhcSTAMuons)
+muonRecoLHC = cms.Sequence(muonRecoLHCTask)
 
 
 
 ########################### SEQUENCE TO BE ADDED in ReconstructionGR_cff ##############################################
 
-muonRecoGR = cms.Sequence(muonRecoAllGR*muonRecoGR*muonrecoBeamHaloEndCapsOnly*muonrecoforcosmicsNoRPC*muonrecoforsplitcosmics*muonRecoLHC)
+muonRecoGRTask = cms.Task(muonrecoforcosmicsTask,
+                          muonRecoGRTask,
+                          muonrecoBeamHaloEndCapsOnlyTask,
+                          muonrecoforcosmicsNoRPCTask,
+                          muonrecoforsplitcosmicsTask,
+                          muonRecoLHCTask)
+muonRecoGR = cms.Sequence(muonRecoGRTask)
 
 #######################################################################################################################
 

--- a/RecoMuon/MuonIdentification/python/me0MuonReco_cff.py
+++ b/RecoMuon/MuonIdentification/python/me0MuonReco_cff.py
@@ -5,4 +5,5 @@ from RecoMuon.MuonIdentification.me0SegmentMatcher_cfi import *
 from RecoMuon.MuonIdentification.me0MuonConverter_cfi import *
 
 #me0MuonReco = cms.Sequence(me0SegmentProducer*me0SegmentMatcher*me0MuonConverter)
-me0MuonReco = cms.Sequence(me0SegmentMatching*me0MuonConverting)
+me0MuonRecoTask = cms.Task(me0SegmentMatching,me0MuonConverting)
+me0MuonReco = cms.Sequence(me0MuonRecoTask)

--- a/RecoMuon/StandAloneMuonProducer/python/standAloneCosmicMuons_cff.py
+++ b/RecoMuon/StandAloneMuonProducer/python/standAloneCosmicMuons_cff.py
@@ -24,7 +24,8 @@ from RecoMuon.StandAloneMuonProducer.standAloneMuons_cfi import *
 #replace standAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableRPCMeasurement = false
 #replace standAloneMuons.STATrajBuilderParameters.RefitterParameters.EnableDTMeasurement = false
 #replace standAloneMuons.STATrajBuilderParameters.BWFilterParameters.EnableDTMeasurement = false
-standAloneCosmicMuons = cms.Sequence(CosmicMuonSeed*standAloneMuons)
+standAloneCosmicMuonsTask = cms.Task(CosmicMuonSeed,standAloneMuons)
+standAloneCosmicMuons = cms.Sequence(standAloneCosmicMuonsTask)
 standAloneMuons.InputObjects = 'CosmicMuonSeed'
 standAloneMuons.STATrajBuilderParameters.NavigationType = 'Direct'
 standAloneMuons.TrackLoaderParameters.VertexConstraint = False


### PR DESCRIPTION
Move Sequence to Task for RecoLocalMuon/RecoMuon/RecoEgamma/RecoEcal/RecoHI  config files
(An extension of the previous task [PR#27474](https://github.com/cms-sw/cmssw/pull/27474))

Tested in CMSSW_11_0_X_2019-07-28-2300 release, The PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).