### PR TITLE
Backporting EG UL regression code to 1030

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -41,7 +41,7 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
-       applySigmaIetaIphiBug = cms.bool(False)
+       applySigmaIetaIphiBug = cms.bool(True)
        ),
 
     #threshold for final SuperCluster Et
@@ -117,7 +117,7 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
-       applySigmaIetaIphiBug = cms.bool(False)
+       applySigmaIetaIphiBug = cms.bool(True)
        ),
        
     #threshold for final SuperCluster Et

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -40,7 +40,8 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
+       applySigmaIetaIphiBug = cms.bool(False)
        ),
 
     #threshold for final SuperCluster Et
@@ -115,7 +116,8 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
+       applySigmaIetaIphiBug = cms.bool(False)
        ),
        
     #threshold for final SuperCluster Et

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -330,6 +330,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   {
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("isHLT", false);
+    psd0.add<bool>("applySigmaIetaIphiBug", false);
     psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
     psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
     psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -330,7 +330,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   {
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("isHLT", false);
-    psd0.add<bool>("applySigmaIetaIphiBug", false);
+    psd0.add<bool>("applySigmaIetaIphiBug", true);
     psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
     psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
     psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");

--- a/RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h
@@ -36,7 +36,8 @@ public:
   bool useLowEtBin(const float et,const bool isSaturated)const;
 
 private:
-  const EgammaBDTOutputTransformer outputTransformer_;
+  const EgammaBDTOutputTransformer outputTransformerLowEt_;
+  const EgammaBDTOutputTransformer outputTransformerHighEt_;
   
   bool forceHighEnergyTrainingIfSaturated_;
   const float lowEtHighEtBoundary_;

--- a/RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h
@@ -33,9 +33,9 @@ public:
 
   float operator()(const float et,const bool isEB,const bool isSaturated,const float* data)const;
 
-private:
   bool useLowEtBin(const float et,const bool isSaturated)const;
 
+private:
   const EgammaBDTOutputTransformer outputTransformer_;
   
   bool forceHighEnergyTrainingIfSaturated_;

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -68,6 +68,7 @@ class SCEnergyCorrectorSemiParm {
 
  private:
   bool isHLT_;
+  bool applySigmaIetaIphiBug_; //there was a bug in sigmaIetaIphi for the 74X application
   int nHitsAboveThreshold_;
   float eThreshold_;
 };

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
@@ -1,0 +1,398 @@
+#include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
+
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+
+#include "RecoEgamma/EgammaTools/interface/EgammaRegressionContainer.h"
+#include "RecoEgamma/EgammaTools/interface/EpCombinationTool.h"
+#include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+
+#include <vdt/vdtMath.h>
+
+class EGRegressionModifierV3 : public ModifyObjectValueBase {
+public: 
+  struct EleRegs {
+    EleRegs(const edm::ParameterSet& iConfig);
+    void setEventContent(const edm::EventSetup& iSetup);
+    EgammaRegressionContainer ecalOnlyMean;
+    EgammaRegressionContainer ecalOnlySigma;
+    EpCombinationTool epComb;
+  };
+
+  struct PhoRegs {
+    PhoRegs(const edm::ParameterSet& iConfig);
+    void setEventContent(const edm::EventSetup& iSetup);
+    EgammaRegressionContainer ecalOnlyMean;
+    EgammaRegressionContainer ecalOnlySigma;    
+  };
+
+  EGRegressionModifierV3(const edm::ParameterSet& conf, edm::ConsumesCollector& cc);
+  ~EGRegressionModifierV3() override;
+    
+  void setEvent(const edm::Event&) final;
+  void setEventContent(const edm::EventSetup&) final;
+  
+  void modifyObject(reco::GsfElectron&) const final;
+  void modifyObject(reco::Photon&) const final;
+  
+  // just calls reco versions
+  void modifyObject(pat::Electron&) const final; 
+  void modifyObject(pat::Photon&) const final;
+
+private:
+  std::array<float,32> getRegData(const reco::GsfElectron& ele)const;
+  std::array<float,32> getRegData(const reco::Photon& pho)const;
+  void getSeedCrysCoord(const reco::CaloCluster& clus,int& iEtaOrX,int& iPhiOrY)const;
+
+  std::unique_ptr<EleRegs> eleRegs_;
+  std::unique_ptr<PhoRegs> phoRegs_;
+  
+  float rhoValue_;
+  edm::EDGetTokenT<double> rhoToken_;
+
+  bool useClosestToCentreSeedCrysDef_;
+  float maxRawEnergyForLowPtEBSigma_;
+  float maxRawEnergyForLowPtEESigma_;
+  edm::ESHandle<CaloGeometry> caloGeomHandle_;
+
+};
+
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
+		  EGRegressionModifierV3,
+		  "EGRegressionModifierV3");
+
+EGRegressionModifierV3::EGRegressionModifierV3(const edm::ParameterSet& conf, 
+					       edm::ConsumesCollector& cc) :
+  ModifyObjectValueBase(conf),
+  rhoValue_(0.),
+  rhoToken_(cc.consumes<double>(conf.getParameter<edm::InputTag>("rhoTag"))),
+  useClosestToCentreSeedCrysDef_(conf.getParameter<bool>("useClosestToCentreSeedCrysDef")),
+  maxRawEnergyForLowPtEBSigma_(conf.getParameter<double>("maxRawEnergyForLowPtEBSigma")),
+  maxRawEnergyForLowPtEESigma_(conf.getParameter<double>("maxRawEnergyForLowPtEESigma"))
+{   
+  if(conf.exists("eleRegs")) {
+    eleRegs_ = std::make_unique<EleRegs>(conf.getParameter<edm::ParameterSet>("eleRegs"));
+  }
+  if(conf.exists("phoRegs")) {
+    phoRegs_ = std::make_unique<PhoRegs>(conf.getParameter<edm::ParameterSet>("phoRegs"));
+  }
+}
+
+EGRegressionModifierV3::~EGRegressionModifierV3(){}
+
+void EGRegressionModifierV3::setEvent(const edm::Event& evt)
+{
+  edm::Handle<double> rhoHandle;
+  evt.getByToken(rhoToken_, rhoHandle);
+  rhoValue_ = *rhoHandle;
+}
+
+void EGRegressionModifierV3::setEventContent(const edm::EventSetup& iSetup)
+{
+  if(eleRegs_) eleRegs_->setEventContent(iSetup);
+  if(phoRegs_) phoRegs_->setEventContent(iSetup);
+  if(useClosestToCentreSeedCrysDef_) iSetup.get<CaloGeometryRecord>().get(caloGeomHandle_);
+}
+
+void EGRegressionModifierV3::modifyObject(reco::GsfElectron& ele) const
+{
+  //check if we have specified an electron regression correction and
+  //return the object unmodified if so
+  if(!eleRegs_) return;
+
+  const reco::SuperClusterRef& superClus = ele.superCluster();
+  
+  // skip HGCAL for now
+  if( superClus->seed()->seed().det() == DetId::Forward ) return;
+
+  // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
+  if(!superClus->clusters().isAvailable()) return; 
+
+  //check if fbrem is filled as its needed for E/p combination so abort if its set to the default value 
+  //this will be the case for <5 (or current cuts) for miniAOD electrons
+  if(ele.fbrem()==reco::GsfElectron::ClassificationVariables::kDefaultValue) return;
+  
+  auto regData = getRegData(ele);
+  const float rawEnergy = superClus->rawEnergy(); 
+  const float rawESEnergy = superClus->preshowerEnergy();
+  //bug here, it should include the ES, kept for backwards compat
+  const float rawEt = rawEnergy*superClus->position().rho()/superClus->position().r();
+  const bool isSaturated = ele.nSaturatedXtals()!=0;
+
+  const float ecalMean = eleRegs_->ecalOnlyMean(rawEt,ele.isEB(),isSaturated,regData.data());
+  const float ecalMeanCorr = ecalMean > 0. ? ecalMean : 1.0;
+  //as the sample is trained flat in pt, the regression's only source of very high energy
+  //electrons is in the high endcap and therefore it gives a very poor resolution estimate
+  //to any electrons with this energy, regardless of their actual eta
+  //hence this lovely hack
+  if(ele.isEB() && maxRawEnergyForLowPtEBSigma_>=0 && 
+     eleRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
+    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEBSigma_);
+  }
+  if(!ele.isEB() && maxRawEnergyForLowPtEESigma_>=0 && 
+     eleRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
+    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEESigma_);
+  }
+  const float ecalSigma = eleRegs_->ecalOnlySigma(rawEt,ele.isEB(),isSaturated,regData.data());
+
+  const float corrEnergy = (rawEnergy + rawESEnergy)*ecalMeanCorr;
+  const float corrEnergyErr = corrEnergy*ecalSigma;
+
+  ele.setCorrectedEcalEnergy(corrEnergy);
+  ele.setCorrectedEcalEnergyError(corrEnergyErr);
+
+  std::pair<float,float> combEnergyAndErr =  eleRegs_->epComb.combine(ele);
+  const math::XYZTLorentzVector newP4 = ele.p4()*combEnergyAndErr.first/ele.p4().t();
+  ele.correctMomentum(newP4, ele.trackMomentumError(), combEnergyAndErr.second);
+}
+
+void EGRegressionModifierV3::modifyObject(pat::Electron& ele) const
+{
+  modifyObject(static_cast<reco::GsfElectron&>(ele));
+}
+
+void EGRegressionModifierV3::modifyObject(reco::Photon& pho) const
+{
+  //check if we have specified an photon regression correction and
+  //return the object unmodified if so
+  if(!phoRegs_) return;
+  
+  const reco::SuperClusterRef& superClus = pho.superCluster();
+
+  // skip HGCAL for now
+  if(superClus->seed()->seed().det() == DetId::Forward ) return;
+
+  // do not apply corrections in case of missing info (happens for some slimmed MiniAOD photons)
+  if(!superClus->clusters().isAvailable()) return; 
+
+  auto regData = getRegData(pho); 
+
+  const float rawEnergy = superClus->rawEnergy(); 
+  const float rawESEnergy = superClus->preshowerEnergy();
+  //bug here, it should include the ES, kept for backwards compat
+  const float rawEt = rawEnergy*superClus->position().rho()/superClus->position().r();
+  const bool isSaturated = pho.nSaturatedXtals();
+  const float ecalMean = phoRegs_->ecalOnlyMean(rawEt,pho.isEB(),isSaturated,regData.data());
+  const float ecalMeanCorr = ecalMean > 0. ? ecalMean : 1.0;
+
+  //see the electrons for explaination of this lovely feature
+  if(pho.isEB() && maxRawEnergyForLowPtEBSigma_>=0 && 
+     phoRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
+    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEBSigma_);
+  }
+  if(!pho.isEB() && maxRawEnergyForLowPtEESigma_>=0 && 
+     phoRegs_->ecalOnlySigma.useLowEtBin(rawEt,isSaturated)){
+    regData[0] = std::min(regData[0],maxRawEnergyForLowPtEESigma_);
+  }
+  const float ecalSigma = phoRegs_->ecalOnlySigma(rawEt,pho.isEB(),isSaturated,regData.data());
+    
+  const double corrEnergy = (rawEnergy + rawESEnergy)*ecalMeanCorr;
+  const double corrEnergyErr = corrEnergy*ecalSigma;
+
+  pho.setCorrectedEnergy(reco::Photon::P4type::regression2, corrEnergy, corrEnergyErr, true);     
+}
+
+void EGRegressionModifierV3::modifyObject(pat::Photon& pho) const {
+  modifyObject(static_cast<reco::Photon&>(pho));
+}
+
+std::array<float,32> EGRegressionModifierV3::getRegData(const reco::GsfElectron& ele)const
+{
+  std::array<float, 32> data;  
+
+  const reco::SuperClusterRef& superClus = ele.superCluster();
+  const edm::Ptr<reco::CaloCluster>& seedClus = superClus->seed();
+  
+  const bool isEB = ele.isEB();  
+  const double rawEnergy = superClus->rawEnergy(); 
+  const double rawESEnergy = superClus->preshowerEnergy();
+  const int numberOfClusters =  superClus->clusters().size();
+  const auto& ssFull5x5 = ele.full5x5_showerShape();
+
+  float e5x5Inverse = ssFull5x5.e5x5 != 0. ? vdt::fast_inv(ssFull5x5.e5x5) : 0.;
+
+  data[0]  = rawEnergy;
+  data[1]  = superClus->etaWidth();
+  data[2]  = superClus->phiWidth(); 
+  data[3]  = superClus->seed()->energy()/rawEnergy;
+  data[4]  = ssFull5x5.e5x5/rawEnergy;
+  data[5]  = ele.hcalOverEcalBc();
+  data[6]  = rhoValue_;
+  data[7]  = seedClus->eta() - superClus->position().Eta();
+  data[8]  = reco::deltaPhi( seedClus->phi(),superClus->position().Phi());
+  data[9]  = ssFull5x5.r9;
+  data[10]  = ssFull5x5.sigmaIetaIeta;
+  data[11]  = ssFull5x5.sigmaIetaIphi;
+  data[12]  = ssFull5x5.sigmaIphiIphi;
+  data[13]  = ssFull5x5.eMax*e5x5Inverse;
+  data[14]  = ssFull5x5.e2nd*e5x5Inverse;
+  data[15]  = ssFull5x5.eTop*e5x5Inverse;
+  data[16]  = ssFull5x5.eBottom*e5x5Inverse;
+  data[17]  = ssFull5x5.eLeft*e5x5Inverse;
+  data[18]  = ssFull5x5.eRight*e5x5Inverse;
+  data[19]  = ssFull5x5.e2x5Max*e5x5Inverse;
+  data[20]  = ssFull5x5.e2x5Left*e5x5Inverse;
+  data[21]  = ssFull5x5.e2x5Right*e5x5Inverse;
+  data[22]  = ssFull5x5.e2x5Top*e5x5Inverse;
+  data[23]  = ssFull5x5.e2x5Bottom*e5x5Inverse;
+  data[24]  = ele.nSaturatedXtals();
+  data[25]  = std::max(0,numberOfClusters);
+  
+  if(isEB){
+    int iEta,iPhi;
+    getSeedCrysCoord(*seedClus,iEta,iPhi);
+    int signIEta = iEta > 0 ? +1 : -1;
+    data[26] = iEta;
+    data[27] = iPhi;
+    data[28] = (iEta-signIEta)%5;
+    data[29] = (iPhi-1)%2; 
+    const int iEtaCorr = iEta - (iEta > 0 ? +1 : -1);
+    const int iEtaCorr26 = iEta - (iEta > 0 ? +26 : -26);
+    data[30] = std::abs(iEta)<=25 ? iEtaCorr%20 : iEtaCorr26%20;
+    data[31] = (iPhi-1)%20;
+  }else{
+    int iX,iY;
+    getSeedCrysCoord(*seedClus,iX,iY);
+    data[26] = iX;
+    data[27] = iY;
+    data[28] = rawESEnergy/rawEnergy;
+  }
+
+  return data;
+}
+
+std::array<float,32> EGRegressionModifierV3::getRegData(const reco::Photon& pho)const
+{
+  std::array<float, 32> data;  
+
+  const reco::SuperClusterRef& superClus = pho.superCluster();
+  const edm::Ptr<reco::CaloCluster>& seedClus = superClus->seed();
+  
+  const bool isEB = pho.isEB();  
+  const double rawEnergy = superClus->rawEnergy(); 
+  const double rawESEnergy = superClus->preshowerEnergy(); 
+  const int numberOfClusters =  superClus->clusters().size();
+  const auto& ssFull5x5 = pho.full5x5_showerShapeVariables();
+
+  float e5x5Inverse = ssFull5x5.e5x5 != 0. ? vdt::fast_inv(ssFull5x5.e5x5) : 0.;
+
+  data[0]  = rawEnergy;
+  data[1]  = superClus->etaWidth();
+  data[2]  = superClus->phiWidth(); 
+  data[3]  = superClus->seed()->energy()/rawEnergy;
+  data[4]  = ssFull5x5.e5x5/rawEnergy;
+  //interestingly enough this differs from electrons where it uses cone based
+  //naively Sam would have thought using cone based is even worse than tower based
+  data[5]  = pho.hadronicOverEm();
+  data[6]  = rhoValue_;
+  data[7]  = seedClus->eta() - superClus->position().Eta();
+  data[8]  = reco::deltaPhi( seedClus->phi(),superClus->position().Phi());
+  data[9]  = pho.full5x5_r9();
+  data[10]  = ssFull5x5.sigmaIetaIeta;
+  //interestingly sigmaIEtaIPhi differs in defination here from 
+  //electron & sc definations of sigmaIEtaIPhi
+  data[11]  = ssFull5x5.sigmaIetaIphi;
+  data[12]  = ssFull5x5.sigmaIphiIphi;
+  data[13]  = ssFull5x5.maxEnergyXtal*e5x5Inverse;
+  data[14]  = ssFull5x5.e2nd*e5x5Inverse;
+  data[15]  = ssFull5x5.eTop*e5x5Inverse;
+  data[16]  = ssFull5x5.eBottom*e5x5Inverse;
+  data[17]  = ssFull5x5.eLeft*e5x5Inverse;
+  data[18]  = ssFull5x5.eRight*e5x5Inverse;
+  data[19]  = ssFull5x5.e2x5Max*e5x5Inverse;
+  data[20]  = ssFull5x5.e2x5Left*e5x5Inverse;
+  data[21]  = ssFull5x5.e2x5Right*e5x5Inverse;
+  data[22]  = ssFull5x5.e2x5Top*e5x5Inverse;
+  data[23]  = ssFull5x5.e2x5Bottom*e5x5Inverse;
+  data[24]  = pho.nSaturatedXtals();
+  data[25]  = std::max(0,numberOfClusters);
+      
+  if(isEB){
+    int iEta,iPhi;
+    getSeedCrysCoord(*seedClus,iEta,iPhi);
+    data[26] = iEta;
+    data[27] = iPhi;
+    int signIEta = iEta > 0 ? +1 : -1;
+    data[28] = (iEta-signIEta)%5;
+    data[29] = (iPhi-1)%2;
+    const int iEtaCorr = iEta - (iEta > 0 ? +1 : -1);
+    const int iEtaCorr26 = iEta - (iEta > 0 ? +26 : -26);
+    data[30] = std::abs(iEta)<=25 ? iEtaCorr%20 : iEtaCorr26%20;
+    data[31] = (iPhi-1)%20;
+  }else{
+    int iX,iY;
+    getSeedCrysCoord(*seedClus,iX,iY);
+    data[26] = iX;
+    data[27] = iY;
+    data[28] = rawESEnergy/rawEnergy;
+  }
+
+  return data;
+}
+
+void EGRegressionModifierV3::getSeedCrysCoord(const reco::CaloCluster& clus,int& iEtaOrX,int& iPhiOrY)const
+{
+  iEtaOrX = 0;
+  iPhiOrY = 0;
+
+  const bool isEB = clus.seed().subdetId()==EcalBarrel;
+
+  if(useClosestToCentreSeedCrysDef_){
+    float dummy;
+    if(isEB){
+      egammaTools::localEcalClusterCoordsEB(clus, *caloGeomHandle_, dummy, dummy, 
+					    iEtaOrX, iPhiOrY, dummy, dummy);
+    }else{
+      egammaTools::localEcalClusterCoordsEE(clus, *caloGeomHandle_, dummy, dummy, 
+					    iEtaOrX, iPhiOrY, dummy, dummy);
+    }
+  }else{
+    if(isEB){
+      const EBDetId ebId(clus.seed());
+      iEtaOrX = ebId.ieta();
+      iPhiOrY = ebId.iphi();
+    }else{
+      const EEDetId eeId(clus.seed());
+      iEtaOrX = eeId.ix();
+      iPhiOrY = eeId.iy();
+    }
+  }
+}
+
+EGRegressionModifierV3::EleRegs::EleRegs(const edm::ParameterSet& iConfig):
+  ecalOnlyMean(iConfig.getParameter<edm::ParameterSet>("ecalOnlyMean")),
+  ecalOnlySigma(iConfig.getParameter<edm::ParameterSet>("ecalOnlySigma")),
+  epComb(iConfig.getParameter<edm::ParameterSet>("epComb"))
+{
+  
+}
+
+void EGRegressionModifierV3::EleRegs::setEventContent(const edm::EventSetup& iSetup)
+{
+  ecalOnlyMean.setEventContent(iSetup);
+  ecalOnlySigma.setEventContent(iSetup);
+  epComb.setEventContent(iSetup);
+}
+
+EGRegressionModifierV3::PhoRegs::PhoRegs(const edm::ParameterSet& iConfig):
+  ecalOnlyMean(iConfig.getParameter<edm::ParameterSet>("ecalOnlyMean")),
+  ecalOnlySigma(iConfig.getParameter<edm::ParameterSet>("ecalOnlySigma"))
+{
+  
+}
+  
+void EGRegressionModifierV3::PhoRegs::setEventContent(const edm::EventSetup& iSetup)
+{
+  ecalOnlyMean.setEventContent(iSetup);
+  ecalOnlySigma.setEventContent(iSetup);
+}

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -20,8 +20,10 @@ calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
 
 ecalTrkCombinationRegression = cms.PSet(
     ecalTrkRegressionConfig = cms.PSet(
-        rangeMin = cms.double(-1.),
-        rangeMax = cms.double(3.0),
+        rangeMinLowEt = cms.double(-1.),
+        rangeMaxLowEt = cms.double(3.0),
+        rangeMinHighEt = cms.double(-1.),
+        rangeMaxHighEt = cms.double(3.0),
         lowEtHighEtBoundary = cms.double(50.),
         forceHighEnergyTrainingIfSaturated = cms.bool(False),
         ebLowEtForestName = cms.string('electron_eb_ECALTRK_lowpt'),
@@ -30,8 +32,10 @@ ecalTrkCombinationRegression = cms.PSet(
         eeHighEtForestName = cms.string('electron_ee_ECALTRK')
         ),
     ecalTrkRegressionUncertConfig = cms.PSet(
-        rangeMin = cms.double(0.0002),
-        rangeMax = cms.double(0.5),
+        rangeMinLowEt = cms.double(0.0002),
+        rangeMaxLowEt = cms.double(0.5),
+        rangeMinHighEt = cms.double(0.0002),
+        rangeMaxHighEt = cms.double(0.5),
         lowEtHighEtBoundary = cms.double(50.),  
         forceHighEnergyTrainingIfSaturated = cms.bool(False),
         ebLowEtForestName = cms.string('electron_eb_ECALTRK_lowpt_var'),

--- a/RecoEgamma/EgammaTools/src/EgammaRegressionContainer.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaRegressionContainer.cc
@@ -8,7 +8,8 @@
 #include "CondFormats/EgammaObjects/interface/GBRForestD.h"
 
 EgammaRegressionContainer::EgammaRegressionContainer(const edm::ParameterSet& iConfig):
-  outputTransformer_(iConfig.getParameter<double>("rangeMin"),iConfig.getParameter<double>("rangeMax")),
+  outputTransformerLowEt_(iConfig.getParameter<double>("rangeMinLowEt"),iConfig.getParameter<double>("rangeMaxLowEt")),
+  outputTransformerHighEt_(iConfig.getParameter<double>("rangeMinHighEt"),iConfig.getParameter<double>("rangeMaxHighEt")),
   forceHighEnergyTrainingIfSaturated_(iConfig.getParameter<bool>("forceHighEnergyTrainingIfSaturated")),
   lowEtHighEtBoundary_(iConfig.getParameter<double>("lowEtHighEtBoundary")),
   ebLowEtForestName_(iConfig.getParameter<std::string>("ebLowEtForestName")),
@@ -24,8 +25,10 @@ EgammaRegressionContainer::EgammaRegressionContainer(const edm::ParameterSet& iC
 edm::ParameterSetDescription EgammaRegressionContainer::makePSetDescription()
 {
   edm::ParameterSetDescription desc;
-  desc.add<double>("rangeMin",-1.);
-  desc.add<double>("rangeMax",3.0);
+  desc.add<double>("rangeMinLowEt",-1.);
+  desc.add<double>("rangeMaxLowEt",3.0);
+  desc.add<double>("rangeMinHighEt",-1.);
+  desc.add<double>("rangeMaxHighEt",3.0);
   desc.add<double>("lowEtHighEtBoundary",50.);
   desc.add<bool>("forceHighEnergyTrainingIfSaturated",false);
   desc.add<std::string>("ebLowEtForestName","electron_eb_ECALTRK_lowpt");
@@ -54,11 +57,11 @@ void EgammaRegressionContainer::setEventContent(const edm::EventSetup& iSetup)
 float EgammaRegressionContainer::operator()(const float et,const bool isEB,const bool isSaturated,const float* data)const
 {
   if(useLowEtBin(et,isSaturated)){
-    if(isEB) return outputTransformer_(ebLowEtForest_->GetResponse(data));
-    else return outputTransformer_(eeLowEtForest_->GetResponse(data));
+    if(isEB) return outputTransformerLowEt_(ebLowEtForest_->GetResponse(data));
+    else return outputTransformerLowEt_(eeLowEtForest_->GetResponse(data));
   }else{
-    if(isEB) return outputTransformer_(ebHighEtForest_->GetResponse(data));
-    else return outputTransformer_(eeHighEtForest_->GetResponse(data));
+    if(isEB) return outputTransformerHighEt_(ebHighEtForest_->GetResponse(data));
+    else return outputTransformerHighEt_(eeHighEtForest_->GetResponse(data));
   }
 }
  


### PR DESCRIPTION
#### PR description:

The custom reco for the light by light analysis also needs custom energy regressions. Therefore the code for the new regressions needs backported, both sc and ele/pho.  The SC code is being used in the release but its defaults are set to the correct setting for 103X. The ele/pho is just additional code mostly except for a minor modification to deal with the changes. 

We do not expect any changes to any workflow that exists. 


backport of https://github.com/cms-sw/cmssw/pull/26892, https://github.com/cms-sw/cmssw/pull/26763


#### if this PR is a backport please specify the original PR:
https://github.com/cms-sw/cmssw/pull/26892
https://github.com/cms-sw/cmssw/pull/26763
