### PR TITLE
enabling UL regression for 2018 (and likely Run3)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v4',
+    'run1_data'         :   '110X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v4',
+    'run2_data'         :   '110X_dataRun2_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_12_11_41_41',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v5',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_12_11_48_40',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_Candidate_2019_08_12_11_45_43',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_Candidate_2019_08_12_11_50_53',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v3',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -56,25 +56,25 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_06_14_38_06',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_Candidate_2019_08_08_14_56_36',
+    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_06_14_36_17',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_Candidate_2019_08_06_14_25_50',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_Candidate_2019_08_06_14_23_53',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_Candidate_2019_08_06_14_28_01', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_08_06_14_29_57', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_08_06_14_32_29', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_08_06_14_34_24', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,12 +28,12 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '110X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_06_15_34_14',
+    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_12_11_41_41',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_06_15_40_24',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_12_11_48_40',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_Candidate_2019_08_06_15_38_32',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_Candidate_2019_08_06_15_42_12',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_Candidate_2019_08_12_11_45_43',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_Candidate_2019_08_12_11_50_53',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -28,12 +28,12 @@ autoCond = {
     # GlobalTag for Run2 data reprocessing
     'run2_data'         :   '110X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_06_15_34_14',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_02_16_55_52',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_06_15_40_24',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_Candidate_2019_08_02_16_53_14',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_Candidate_2019_08_02_16_55_18',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_Candidate_2019_08_06_15_38_32',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_Candidate_2019_08_06_15_42_12',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -56,25 +56,25 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_03_11_37_17',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_06_14_38_06',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_Candidate_2019_08_08_14_56_36',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_03_11_39_50',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_06_14_36_17',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_Candidate_2019_08_06_14_25_50',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_Candidate_2019_08_06_14_23_53',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_Candidate_2019_08_06_14_28_01', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_08_06_14_29_57', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_08_06_14_32_29', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_08_06_14_34_24', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v1'
 }

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -152,3 +152,6 @@ regressionModifier = regressionModifier94X.clone()
 
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 run2_egamma_2017.toReplaceWith(regressionModifier,regressionModifier106XUL)
+
+from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
+run2_egamma_2018.toReplaceWith(regressionModifier,regressionModifier106XUL)


### PR DESCRIPTION
#### PR description:
This PR enables the 106X UL regressions for 2018, given the imminent update of these conditions in the GT. 

The 2017UL is already in the global tags so matrix tests ran locally without errors.  Of course they are not fully correct yet as they are not the 2018UL corrections.

Also from looking around at the modifiers it appears Run3 activates the egamma 2018 modifier so Run3 also gets this. Which is good, they should be using this.

