### PR TITLE
Added consumes to EcalNextToDeadChannelESProducer

### DIFF
--- a/RecoEcal/EgammaCoreTools/plugins/EcalNextToDeadChannelESProducer.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalNextToDeadChannelESProducer.cc
@@ -37,15 +37,13 @@ private:
 
   edm::ReusableObjectHolder<HostType> holder_;
 
+  edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> const channelToken_;
   // threshold above which a channel will be considered "dead"
   int statusThreshold_;
 };
 
-EcalNextToDeadChannelESProducer::EcalNextToDeadChannelESProducer(const edm::ParameterSet& iConfig) {
-  //the following line is needed to tell the framework what
-  // data is being produced
-  setWhatProduced(this);
-
+EcalNextToDeadChannelESProducer::EcalNextToDeadChannelESProducer(const edm::ParameterSet& iConfig)
+    : channelToken_(setWhatProduced(this).consumesFrom<EcalChannelStatus, EcalChannelStatusRcd>()) {
   statusThreshold_ = iConfig.getParameter<int>("channelStatusThresholdForDead");
 }
 
@@ -65,8 +63,7 @@ void EcalNextToDeadChannelESProducer::setupNextToDeadChannels(const EcalChannelS
 
   // Find channels next to dead ones and fill corresponding record
 
-  edm::ESHandle<EcalChannelStatus> h;
-  chs.get(h);
+  EcalChannelStatus const& h = chs.get(channelToken_);
 
   for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
     if (ieta == 0)
@@ -75,7 +72,7 @@ void EcalNextToDeadChannelESProducer::setupNextToDeadChannels(const EcalChannelS
       if (EBDetId::validDetId(ieta, iphi)) {
         EBDetId detid(ieta, iphi);
 
-        if (EcalTools::isNextToDeadFromNeighbours(detid, *h, statusThreshold_)) {
+        if (EcalTools::isNextToDeadFromNeighbours(detid, h, statusThreshold_)) {
           rcd->setValue(detid, 1);
         };
       }
@@ -89,7 +86,7 @@ void EcalNextToDeadChannelESProducer::setupNextToDeadChannels(const EcalChannelS
       if (EEDetId::validDetId(iX, iY, 1)) {
         EEDetId detid(iX, iY, 1);
 
-        if (EcalTools::isNextToDeadFromNeighbours(detid, *h, statusThreshold_)) {
+        if (EcalTools::isNextToDeadFromNeighbours(detid, h, statusThreshold_)) {
           rcd->setValue(detid, 1);
         };
       }
@@ -97,7 +94,7 @@ void EcalNextToDeadChannelESProducer::setupNextToDeadChannels(const EcalChannelS
       if (EEDetId::validDetId(iX, iY, -1)) {
         EEDetId detid(iX, iY, -1);
 
-        if (EcalTools::isNextToDeadFromNeighbours(detid, *h, statusThreshold_)) {
+        if (EcalTools::isNextToDeadFromNeighbours(detid, h, statusThreshold_)) {
           rcd->setValue(detid, 1);
         };
       }


### PR DESCRIPTION
#### PR description:

Also use ESGetToken returned by consumes.

#### PR validation:

The code compiles.
This is a technical change so should not change results.