### PR TITLE
DD4hep: Add 2021 CMS Geometry Scenario

### DIFF
--- a/Configuration/Geometry/python/DD4hep_GeometrySim_cff.py
+++ b/Configuration/Geometry/python/DD4hep_GeometrySim_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 #
 # Ideal geometry, needed for simulation
 DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                    confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
+                                    confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-geometry-2021.xml'),
                                     appendToDataLabel = cms.string('')
 )
 

--- a/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
@@ -58,6 +58,7 @@
     <Include ref='Geometry/MuonCommonData/data/muonNumbering/2015/v2/muonNumbering.xml'/>
     <Include ref='Geometry/DTGeometryBuilder/data/dtSpecsFilter/2021/v1/dtSpecsFilter.xml'/>
     <Include ref='Geometry/MuonSimData/data/muonProdCuts/2021/v2/muonProdCuts.xml'/>
+    <Include ref='Geometry/MuonSimData/data/muonSens.xml'/>
     <Include ref='DetectorDescription/DDCMS/data/trackerParameters.xml'/>
   </IncludeSection>
   

--- a/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
+++ b/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
@@ -12,6 +12,9 @@
     <debug_algorithms/>
     <debug_visattr/>
   </debug>
+
+  <DisabledAlgo  name="track:DDCutTubsFromPoints"/>
+  <DisabledAlgo  name="track:DDTOBRadCableAlgo"/>
   
   <open_geometry/>
   <close_geometry/>
@@ -26,7 +29,8 @@
   </ConstantsSection>
 
   <IncludeSection>
-    <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/materials/2021/v1/materials.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/Run2/trackermaterial.xml'/>
     <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
     <Include ref='Geometry/CMSCommonData/data/extend/v2/cmsextent.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cms/2021/v1/cms.xml'/>
@@ -46,7 +50,7 @@
     <Include ref='Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml'/>
     <Include ref='Geometry/CMSCommonData/data/cavernFloor/2017/v1/cavernFloor.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml'/>
-    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v1/pixfwdMaterials.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/pixfwdCommon.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml'/> 
     <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdDisks.xml'/> 
@@ -217,7 +221,6 @@
     <Include ref='Geometry/TrackerCommonData/data/tecservices.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/tecbackplate.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/tec.xml'/>
-    <Include ref='Geometry/TrackerCommonData/data/Run2/trackermaterial.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/Run2/tracker.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/trackerpixbar.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/PhaseI/trackerpixfwd.xml'/>
@@ -271,10 +274,10 @@
     <Include ref='Geometry/ForwardCommonData/data/lumimaterials.xml'/>
     <Include ref='Geometry/ForwardCommonData/data/zdcrotations.xml'/>
     <Include ref='Geometry/ForwardCommonData/data/lumirotations.xml'/>
-    <Include ref='Geometry/ForwardCommonData/data/zdc.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/zdc/2021/v1/zdc.xml'/>
     <Include ref='Geometry/ForwardCommonData/data/zdclumi/2021/v1/zdclumi.xml'/>
     <Include ref='Geometry/ForwardCommonData/data/cmszdc.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/muonNumbering/2017/v1/muonNumbering.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/muonNumbering/2021/v2/muonNumbering.xml'/>
     <Include ref='Geometry/TrackerCommonData/data/PhaseI/trackerStructureTopology.xml'/>
     <Include ref='Geometry/TrackerSimData/data/PhaseI/trackersens.xml'/>
     <Include ref='Geometry/TrackerRecoData/data/PhaseI/trackerRecoMaterial.xml'/>

--- a/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
+++ b/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug> 
+    <debug_rotations/>
+    <debug_materials/>
+    <debug_shapes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_includes/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_visattr/>
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <ConstantsSection label="" eval="true">
+    <Constant name="world_x" value="5*m"/>
+    <Constant name="world_y" value="5*m"/>
+    <Constant name="world_z" value="5*m"/>
+    <Constant name="fm"      value="1e-12*m"/>
+    <Constant name="Air"     value="materials:Air"     type="string"/>
+    <Constant name="Vacuum"  value="materials:Vacuum"  type="string"/>
+  </ConstantsSection>
+
+  <IncludeSection>
+    <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/rotations.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/extend/v2/cmsextent.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cms/2021/v1/cms.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMother.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/eta3/etaMax.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsTracker.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/caloBase/2017/v1/caloBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsCalo.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonBase/2018/v1/muonBase.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsMuon.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/mgnt.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/beampipe/2026/v1/beampipe.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cmsBeam/2026/v1/cmsBeam.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMB.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/muonMagnet.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavern/2018/v1/cavern.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/cavernFloor/2017/v1/cavernFloor.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdMaterials.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/pixfwdCommon.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdCylinder.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdDisks.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwd.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdSupportRingParameters.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZplus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdInnerDiskZminus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZplus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdOuterDiskZminus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZplus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeInnerZminus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZplus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixfwdbladeOuterZminus.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarmaterial.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarlayer.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarlayer0.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarlayer1.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarlayer2.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbarlayer3.xml'/> 
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/pixbar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/Run2/trackerpatchpannel.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/Run2/trackerpixelnose.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibtidcommonmaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibmaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibmodpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibmodule0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibmodule0a.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibmodule0b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibmodule2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstringpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring0ll.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring0lr.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring0ul.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring0ur.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring1ll.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring1lr.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring1ul.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring1ur.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring2ll.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring2lr.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring2ul.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring2ur.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring3ll.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring3lr.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring3ul.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring3ur.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibstring3.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tiblayerpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tiblayer0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tiblayer1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tiblayer2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tiblayer3.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tib.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule0r.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule0l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule1r.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule1l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidmodule2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidringpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring0f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring0b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring1f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring1b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidring2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tid.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidf.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tidb.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibtidservices.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibtidservicesf.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tibtidservicesb.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobmaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobmodpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobmodule0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobmodule2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobmodule4.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrodpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod0c.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod0l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod0h.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod1l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod1h.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod2c.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod2l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod2h.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod3l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod3h.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod3.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod4c.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod4l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod4h.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod4.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod5l.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod5h.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tobrod5.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/v2/tob.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule0r.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule0s.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule1r.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule1s.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule3.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule4.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule4r.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule4s.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule5.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecmodule6.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetpar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring1.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring2.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring3.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring4.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring5.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring6.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring0f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring1f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring2f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring3f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring4f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring5f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring6f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring0b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring1b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring2b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring3b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring4b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring5b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecring6b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetalf.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetalb.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal0.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal0f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal0b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal3.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal3f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal3b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal6f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal6b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal8f.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecpetal8b.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecwheel.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecwheela.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecwheelb.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecwheelc.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecwheeld.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecwheel6.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecservices.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tecbackplate.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/tec.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/Run2/trackermaterial.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/Run2/tracker.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackerpixbar.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/trackerpixfwd.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackertibtidservices.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackertib.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackertid.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackertob.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackertec.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/v2/trackerbulkhead.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/trackerother.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eregalgo/2017/v1/eregalgo.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ebalgo.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ebcon.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ebrot.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eecon.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eefixed.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eehier.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eealgo.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/escon.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/esalgo.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eeF.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/eeB.xml'/>
+    <Include ref='Geometry/EcalCommonData/data/ectkcable.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalrotations.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcal/PhaseI/hcalalgo.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalcablealgo.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalbarrelalgo.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalendcap/PhaseI/hcalendcapalgo.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalouteralgo.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalforwardalgo.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/average/hcalforwardmaterial.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalSimNumbering/2021/hcalSimNumbering.xml'/> 
+    <Include ref='Geometry/HcalCommonData/data/hcalRecNumbering/2021/hcalRecNumbering.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mbCommon/2015/v2/mbCommon.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb1/2015/v2/mb1.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb2/2015/v2/mb2.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb3/2015/v2/mb3.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb4/2015/v2/mb4.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mb4Shield/2018/v1/mb4Shield.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/design/2021/v1/muonYoke.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mf/2021/v1/mf.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/csc/2021/v1/csc.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/mfshield/2017/v1/mfshield.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/forwardshield/2017/v1/forwardshield.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/brmrotations.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/PostLS2/brm.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/zdcmaterials.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/lumimaterials.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/zdcrotations.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/lumirotations.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/zdc.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/zdclumi/2021/v1/zdclumi.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/cmszdc.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/muonNumbering/2017/v1/muonNumbering.xml'/>
+    <Include ref='Geometry/TrackerCommonData/data/PhaseI/trackerStructureTopology.xml'/>
+    <Include ref='Geometry/TrackerSimData/data/PhaseI/trackersens.xml'/>
+    <Include ref='Geometry/TrackerRecoData/data/PhaseI/trackerRecoMaterial.xml'/>
+    <Include ref='Geometry/EcalSimData/data/ecalsens.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalsenspmf.xml'/>
+    <Include ref='Geometry/HcalSimData/data/hf.xml'/>
+    <Include ref='Geometry/HcalSimData/data/hfpmt.xml'/>
+    <Include ref='Geometry/HcalSimData/data/hffibrebundle.xml'/>
+    <Include ref='Geometry/HcalSimData/data/CaloUtil.xml'/>
+    <Include ref='Geometry/MuonSimData/data/v2/muonSens.xml'/>
+    <Include ref='Geometry/DTGeometryBuilder/data/dtSpecsFilter.xml'/>
+    <Include ref='Geometry/CSCGeometryBuilder/data/cscSpecsFilter.xml'/>
+    <Include ref='Geometry/CSCGeometryBuilder/data/cscSpecs.xml'/>
+    <Include ref='Geometry/RPCGeometryBuilder/data/RPCSpecs.xml'/>
+    <Include ref='Geometry/GEMGeometryBuilder/data/GEMSpecsFilter17.xml'/>
+    <Include ref='Geometry/GEMGeometryBuilder/data/v4/GEMSpecs.xml'/>
+    <Include ref='Geometry/ForwardCommonData/data/brmsens.xml'/>
+    <Include ref='Geometry/ForwardSimData/data/zdcsens.xml'/>
+    <Include ref='Geometry/HcalSimData/data/HcalProdCuts.xml'/>
+    <Include ref='Geometry/EcalSimData/data/EcalProdCuts.xml'/>
+    <Include ref='Geometry/EcalSimData/data/ESProdCuts.xml'/>
+    <Include ref='Geometry/TrackerSimData/data/PhaseI/trackerProdCuts.xml'/>
+    <Include ref='Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml'/>
+    <Include ref='Geometry/MuonSimData/data/muonProdCuts/2021/v1/muonProdCuts.xml'/>
+    <Include ref='Geometry/ForwardSimData/data/zdcProdCuts.xml'/>
+    <Include ref='Geometry/ForwardSimData/data/ForwardShieldProdCuts.xml'/>
+    <Include ref='Geometry/CMSCommonData/data/FieldParameters.xml'/>
+  </IncludeSection>
+  
+  <PosPartSection label="">
+    <PosPart copyNumber="2">
+	<rParent name=":world_volume"/>
+	<rChild name="cms:OCMS"/>
+   </PosPart>
+  </PosPartSection>
+
+</DDDefinition>

--- a/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
@@ -1777,6 +1777,7 @@ static long load_dddefinition(Detector& det, xml_h element) {
   ns.addConstantNS("Air", "materials:Air", "string");
   ns.addConstantNS("Vacuum", "materials:Vacuum", "string");
   ns.addConstantNS("fm", "1e-12*m", "number");
+  ns.addConstantNS("mum", "1e-6*m", "number");
 
   xml_elt_t dddef(element);
   string fname = xml::DocumentHandler::system_path(element);

--- a/DetectorDescription/DDCMS/test/python/testGeometry2021.py
+++ b/DetectorDescription/DDCMS/test/python/testGeometry2021.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DDCMSDetectorTest")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-geometry-2021.xml'),
+                                            appendToDataLabel = cms.string('CMS')
+                                            )
+
+process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                                    appendToDataLabel = cms.string('CMS')
+                                                    )
+
+process.test = cms.EDAnalyzer("DDCMSDetector",
+                              DDDetector = cms.ESInputTag('','CMS')
+                              )
+
+process.testVectors = cms.EDAnalyzer("DDTestVectors",
+                                     DDDetector = cms.ESInputTag('','CMS')
+                                     )
+
+process.testDump = cms.EDAnalyzer("DDTestDumpFile",
+                                  DDDetector = cms.ESInputTag('','CMS')
+                              )
+
+process.testGeoIter = cms.EDAnalyzer("DDTestDumpGeometry",
+                                     DDDetector = cms.ESInputTag('','CMS')
+                                     )
+
+process.p = cms.Path(
+    process.test
+    +process.testVectors
+    +process.testDump
+    +process.testGeoIter)

--- a/Geometry/CMSCommonData/data/materials/2021/v1/materials.xml
+++ b/Geometry/CMSCommonData/data/materials/2021/v1/materials.xml
@@ -1,0 +1,4694 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <MaterialSection label="materials.xml">
+  <ElementaryMaterial name="Aluminium" density="2.7*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
+  <ElementaryMaterial name="TD_Aluminium" density="8.1*g/cm3" symbol=" " atomicWeight="26.98*g/mole" atomicNumber="13"/>
+  <ElementaryMaterial name="Antimony" density="6.679*g/cm3" symbol=" " atomicWeight="121.75*g/mole" atomicNumber="51"/>
+  <ElementaryMaterial name="Argon" density="1.639*mg/cm3" symbol=" " atomicWeight="39.948*g/mole" atomicNumber="18"/>
+  <ElementaryMaterial name="Arsenic" density="5.72*g/cm3" symbol=" " atomicWeight="74.922*g/mole" atomicNumber="33"/>
+  <ElementaryMaterial name="Barium" density="3.5*g/cm3" symbol=" " atomicWeight="137.33*g/mole" atomicNumber="56"/>
+  <ElementaryMaterial name="Beryllium" density="1.848*g/cm3" symbol=" " atomicWeight="9.0122*g/mole" atomicNumber="4"/>
+  <ElementaryMaterial name="Bismuth" density="9.37*g/cm3" symbol=" " atomicWeight="208.98*g/mole" atomicNumber="83"/>
+  <ElementaryMaterial name="Bor 10" density="2.34*g/cm3" symbol=" " atomicWeight="10*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bor 11" density="2.34*g/cm3" symbol=" " atomicWeight="11*g/mole" atomicNumber="5"/>
+  <ElementaryMaterial name="Bromine" density="3.11*g/cm3" symbol=" " atomicWeight="79.904*g/mole" atomicNumber="35"/>
+  <ElementaryMaterial name="Cadmium" density="8.63*g/cm3" symbol=" " atomicWeight="112.41*g/mole" atomicNumber="48"/>
+  <ElementaryMaterial name="Calcium" density="1.55*g/cm3" symbol=" " atomicWeight="40.078*g/mole" atomicNumber="20"/>
+  <ElementaryMaterial name="Carbon" density="2.265*g/cm3" symbol=" " atomicWeight="12.011*g/mole" atomicNumber="6"/>
+  <ElementaryMaterial name="Cerium" density="6.637*g/cm3" symbol=" " atomicWeight="140.12*g/mole" atomicNumber="58"/>
+  <ElementaryMaterial name="Cesium" density="1.87*g/cm3" symbol=" " atomicWeight="132.9054*g/mole" atomicNumber="55"/>
+  <ElementaryMaterial name="Chlorine" density="1.56*g/cm3" symbol=" " atomicWeight="35.45*g/mole" atomicNumber="17"/>
+  <ElementaryMaterial name="Chromium" density="7.18*g/cm3" symbol=" " atomicWeight="51.996*g/mole" atomicNumber="24"/>
+  <ElementaryMaterial name="Cobalt" density="8.9*g/cm3" symbol=" " atomicWeight="58.933*g/mole" atomicNumber="27"/>
+  <ElementaryMaterial name="Copper" density="8.96*g/cm3" symbol=" " atomicWeight="63.546*g/mole" atomicNumber="29"/>
+  <ElementaryMaterial name="Deuterium" density="162*mg/cm3" symbol=" " atomicWeight="2.01*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Fluorine" density="1.108*g/cm3" symbol=" " atomicWeight="18.998*g/mole" atomicNumber="9"/>
+  <ElementaryMaterial name="Gallium" density="5.877*g/cm3" symbol=" " atomicWeight="69.723*g/mole" atomicNumber="31"/>
+  <ElementaryMaterial name="Germanium" density="5.323*g/cm3" symbol=" " atomicWeight="72.61*g/mole" atomicNumber="32"/>
+  <ElementaryMaterial name="Gold" density="18.85*g/cm3" symbol=" " atomicWeight="196.97*g/mole" atomicNumber="79"/>
+  <ElementaryMaterial name="Helium" density="125*mg/cm3" symbol=" " atomicWeight="4.0026*g/mole" atomicNumber="2"/>
+  <ElementaryMaterial name="Hydrogen" density="70.8*mg/cm3" symbol=" " atomicWeight="1.00794*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Indium" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="49"/>
+  <ElementaryMaterial name="Iodine" density="7.3*g/cm3" symbol=" " atomicWeight="114.82*g/mole" atomicNumber="53"/>
+  <ElementaryMaterial name="Iron" density="7.87*g/cm3" symbol=" " atomicWeight="55.85*g/mole" atomicNumber="26"/>
+  <ElementaryMaterial name="Krypton" density="2.6*g/cm3" symbol=" " atomicWeight="83.8*g/mole" atomicNumber="36"/>
+  <ElementaryMaterial name="Lanthanum" density="6.127*g/cm3" symbol=" " atomicWeight="138.9055*g/mole" atomicNumber="57"/>
+  <ElementaryMaterial name="Lead" density="11.35*g/cm3" symbol=" " atomicWeight="207.19*g/mole" atomicNumber="82"/>
+  <ElementaryMaterial name="Lithium" density="534*mg/cm3" symbol=" " atomicWeight="6.941*g/mole" atomicNumber="3"/>
+   <ElementaryMaterial name="Lutecium" density="9.841*g/cm3" symbol=" " atomicWeight="174.96*g/mole" atomicNumber="71"/>
+  <ElementaryMaterial name="Magnesium" density="1.735*g/cm3" symbol=" " atomicWeight="24.305*g/mole" atomicNumber="12"/>
+  <ElementaryMaterial name="Manganese" density="7.43*g/cm3" symbol=" " atomicWeight="54.938*g/mole" atomicNumber="25"/>
+  <ElementaryMaterial name="Molybdenum" density="10.2*g/cm3" symbol=" " atomicWeight="95.94*g/mole" atomicNumber="42"/>
+  <ElementaryMaterial name="Neodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="144.24*g/mole" atomicNumber="60"/>
+  <ElementaryMaterial name="Neon" density="1.207*g/cm3" symbol=" " atomicWeight="20.18*g/mole" atomicNumber="10"/>
+  <ElementaryMaterial name="Nickel" density="8.876*g/cm3" symbol=" " atomicWeight="58.693*g/mole" atomicNumber="28"/>
+  <ElementaryMaterial name="Niobium" density="8.55*g/cm3" symbol=" " atomicWeight="92.906*g/mole" atomicNumber="41"/>
+  <ElementaryMaterial name="Nitrogen" density="808*mg/cm3" symbol=" " atomicWeight="14.007*g/mole" atomicNumber="7"/>
+  <ElementaryMaterial name="Oxygen" density="1.43*mg/cm3" symbol=" " atomicWeight="15.999*g/mole" atomicNumber="8"/>
+  <ElementaryMaterial name="Palladium" density="12*g/cm3" symbol=" " atomicWeight="106.42*g/mole" atomicNumber="46"/>
+  <ElementaryMaterial name="Phosphor" density="1.82*g/cm3" symbol=" " atomicWeight="30.974*g/mole" atomicNumber="15"/>
+  <ElementaryMaterial name="Potassium" density="860*mg/cm3" symbol=" " atomicWeight="39.098*g/mole" atomicNumber="19"/>
+  <ElementaryMaterial name="Praseodymium" density="1e-22*mg/cm3" symbol=" " atomicWeight="140.9077*g/mole" atomicNumber="59"/>
+  <ElementaryMaterial name="Rhodium" density="12.39*g/cm3" symbol=" " atomicWeight="102.9055*g/mole" atomicNumber="45"/>
+  <ElementaryMaterial name="Rubidium" density="1.529*g/cm3" symbol=" " atomicWeight="85.4678*g/mole" atomicNumber="37"/>
+  <ElementaryMaterial name="Ruthenium" density="12.39*g/cm3" symbol=" " atomicWeight="101.07*g/mole" atomicNumber="44"/>
+  <ElementaryMaterial name="Scandium" density="2.98*g/cm3" symbol=" " atomicWeight="44.956*g/mole" atomicNumber="21"/>
+  <ElementaryMaterial name="Selenium" density="4.78*g/cm3" symbol=" " atomicWeight="78.96*g/mole" atomicNumber="34"/>
+  <ElementaryMaterial name="Silicon" density="2.33*g/cm3" symbol=" " atomicWeight="28.09*g/mole" atomicNumber="14"/>
+  <ElementaryMaterial name="Silver" density="10.48*g/cm3" symbol=" " atomicWeight="107.87*g/mole" atomicNumber="47"/>
+  <ElementaryMaterial name="Sodium" density="969*mg/cm3" symbol=" " atomicWeight="22.99*g/mole" atomicNumber="11"/>
+  <ElementaryMaterial name="Strontium" density="2.54*g/cm3" symbol=" " atomicWeight="87.62*g/mole" atomicNumber="38"/>
+  <ElementaryMaterial name="Sulfur" density="2.07*g/cm3" symbol=" " atomicWeight="32.066*g/mole" atomicNumber="16"/>
+  <ElementaryMaterial name="Tantalum" density="16.65*g/cm3" symbol=" " atomicWeight="180.9479*g/mole" atomicNumber="73"/>
+  <ElementaryMaterial name="Technetium" density="11.48*g/cm3" symbol=" " atomicWeight="98*g/mole" atomicNumber="43"/>
+  <ElementaryMaterial name="Tellurium" density="6.23*g/cm3" symbol=" " atomicWeight="127.6*g/mole" atomicNumber="52"/>
+  <ElementaryMaterial name="Tin" density="7.31*g/cm3" symbol=" " atomicWeight="118.69*g/mole" atomicNumber="50"/>
+  <ElementaryMaterial name="Titanium" density="4.53*g/cm3" symbol=" " atomicWeight="47.88*g/mole" atomicNumber="22"/>
+  <ElementaryMaterial name="Tungsten" density="19.3*g/cm3" symbol=" " atomicWeight="183.85*g/mole" atomicNumber="74"/>
+  <ElementaryMaterial name="Uranium" density="18.95*g/cm3" symbol=" " atomicWeight="238.03*g/mole" atomicNumber="92"/>
+  <ElementaryMaterial name="Vacuum" density="1e-13*mg/cm3" symbol=" " atomicWeight="1*g/mole" atomicNumber="1"/>
+  <ElementaryMaterial name="Vanadium" density="6.1*g/cm3" symbol=" " atomicWeight="50.941*g/mole" atomicNumber="23"/>
+  <ElementaryMaterial name="Xenon" density="3.057*g/cm3" symbol=" " atomicWeight="131.29*g/mole" atomicNumber="54"/>
+  <ElementaryMaterial name="Yttrium" density="4.456*g/cm3" symbol=" " atomicWeight="88.9059*g/mole" atomicNumber="39"/>
+  <ElementaryMaterial name="Zinc" density="7.112*g/cm3" symbol=" " atomicWeight="65.39*g/mole" atomicNumber="30"/>
+  <ElementaryMaterial name="Zirconium" density="6.494*g/cm3" symbol=" " atomicWeight="91.22*g/mole" atomicNumber="40"/>
+  <CompositeMaterial name="FPix_Thermflow" density="0.7625*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3787448">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21575329">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3239468">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08155498">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_TPG" density="2.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterOuterRing" density="2.2677*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterInnerRing" density="1.000035*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerOuterRing" density="1.77*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerInnerRing" density="1.1744*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterOuterRing" density="1.612*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.0">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="80pct Argon plus 20pct CO_2" density="1.675*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.78405896">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058934941">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1570061">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1006-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9938">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AISI-1018-Steel" density="7.83*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0001">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9854">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel_Upgrade" density="0.4915*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:AISI-1018-Steel"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="AISI-1045-Steel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.009">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9851">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bpix_Pipe_Steel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.7195">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AQBB borated concre" density="2.135*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032142361">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47563465">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20400656">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051371319">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20008524">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048537181">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02135636">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010549802">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001119">
+    <rMaterial name="materials:Water"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Heavy Boron concrete" density="3.574*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5203954">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34702">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080099">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0296094">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0684299">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006620977">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008010562">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004774732">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004804022">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000555229">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001653212">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000118189">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>   
+  </CompositeMaterial>
+  <CompositeMaterial name="Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al support" density="254*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-MMC" density="1.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al-silicate plus Zi" density="3.3196*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.34196227">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11867705">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43936068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Al_2 O_3" density="3.91*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219" density="2.84*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9168">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Vanadium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0025">
+    <rMaterial name="materials:Zirconium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 light" density="1.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium 2219 very light" density="0.067558*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.065">
+    <rMaterial name="materials:Aluminium 2219"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.935">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Alumina" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium Pix_b" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium honeycomb" density="0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminium silicate" density="3.156*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37995808">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13186339">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48817853">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Aluminized Mylar" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45014471">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030220222">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23984232">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27979275">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 50pct plus CO_2 50pct" density="1.729*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.475815">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14306133">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38112367">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar 40pct plus Ethane 60pct " density="1.4692*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46968659">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42365618">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10665723">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixt. for Cors" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30224783">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4919464">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17112881">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020145463">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012041684">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017214762">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.002658102">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00074786557">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.032220584">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93514796">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.018242877">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0021475706">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0056206649">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0048079473">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010151454">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079724857">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26749417">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54605374">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15145173">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017829057">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010657083">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015235339">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023524628">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.000661873">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0043106974">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="WCu" density="14.979*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Catcher section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W Hadron section" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ar/W mixt. for E.M." density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="9.6146597e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99990385">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon 50pct CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Argon CF_4 CO_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2a concrete plus Poly" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.75468049">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070780535">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0095602944">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.079376542">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035227691">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040083658">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0057520693">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00084050447">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036982197">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BET2b concrete plus Poly" density="1.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.86250534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080265403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0031685162">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026156529">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011497209">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013100008">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017629095">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00028594245">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012581468">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="B_2 O_3" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.057473742">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25288446">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68964179">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ba O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.89565575">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10434425">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003866475">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31286387">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055278003">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036870588">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042359836">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017690768">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00036536456">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.49076686">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11459208">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015333135">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067465796">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium sulfate" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5884092">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13739117">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27419963">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Beryllia" density="2.63*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36032657">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.63967343">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bi_4 Ge_3 O_12" density="7.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67102392">
+    <rMaterial name="materials:Bismuth"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1748602">
+    <rMaterial name="materials:Germanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15411587">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borated Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.612">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.222">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron" density="2.34*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18518519">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81481481">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron-Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0067292668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34051688">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013925946">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0080541549">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013576194">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044652146">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011660794">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088239182">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.8572377e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023924499">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01052678">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45198295">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10553619">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron_frits-Lumnite" density="3.1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006189139">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33104107">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054553968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016633648">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029078398">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020734192">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052224672">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00060798896">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00045402481">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015404679">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0067780588">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012029137">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46123883">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1076974">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C F_4" density="3.7037*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13648398">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.86351602">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C O_2" density="1.8182*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14" density="1.76*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.21318905">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.78681095">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CF_4 CO_2 50:50" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18196831">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57564464">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24238706">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2Ar Freon" density="2.04*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017209441">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25354028">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.030543441">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016368527">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68233831">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CSC Electronics" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00046948789">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00014841431">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.081657e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.0118803e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32063924">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39047805">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28825623">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Al cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.67273024">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31187538">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015319366">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.5010078e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CT Cu cable" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87214714">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12183881">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0059847409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9303816e-05">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_New Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca C O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40043563">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47955758">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12000679">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ca O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71469586">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28530414">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_0" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.47272949">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16266859">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041785423">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23271447">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.143868e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039129523">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050901068">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_2" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3625772">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12348903">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.036468221">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30679798">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.0189302e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074162202">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096475172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_MSGC_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.37934415">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12285748">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035749337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29734771">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.9095785e-05">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.071569642">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.093102596">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cable_Si_1" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.61618264">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082694045">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044364552">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2563757">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00037658981">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="6.4825308e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fib.str." density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6470534">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3529466">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade2" density="0.845*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <CompositeMaterial name="Carbon fibre st_b" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX CFStrip material as defined by W. Bertl-->
+  <CompositeMaterial name="CFK" density="1.575*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX micro-twisted pairs signal cables material as defined by W. Bertl -->
+  <CompositeMaterial name="micro_twisted_signal_cable" density="4.09*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.476683">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.274139">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1494102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02006116">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07960754">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Phase1 BPIX micro-twisted pairs power cables material as defined by W. Bertl -->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.42*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.751011">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138483">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066287">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0353182">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <!--OUTDATED Phase1 BPIX micro-twisted pairs boundle material as defined by W. Bertl, effective density defined to matcht the measured weigth (0.0071+0.0208 g/cm) in a single 1.5mm diam. boundle-->
+  <CompositeMaterial name="micro_twisted_boundle" density="1.585*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7455">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2545">
+    <rMaterial name="materials:micro_twisted_signal_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <!--Phase1 BPIX micro-twisted pairs boundle material as defined by L. Caminada-->
+  <CompositeMaterial name="micro_twisted_power_cable" density="3.639*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.36933">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.63067">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_1" density="2.93382*g/cm3" symbol=" " method="mixture by weight"> <!--for L1-->
+   <MaterialFraction fraction="0.04631">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95369">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="micro_twisted_boundle_2" density="2.91735*g/cm3" symbol=" " method="mixture by weight"> <!--for L2,3,4-->
+   <MaterialFraction fraction="0.04964">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.95036">
+    <rMaterial name="materials:micro_twisted_power_cable"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Carbon_fibre_str_Upgrade" density="0.293*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Carbon fibre str."/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ce F_3" density="6.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71085768">
+    <rMaterial name="materials:Cerium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28914232">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ceramic" density="3.96525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.52924272">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47075728">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coil average" density="5.10794*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98933034">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010669663">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Colmanite Barite" density="3.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0033244208">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32054568">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019644903">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00631619">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.021681066">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024762714">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00091831559">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0071874954">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057930956">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.1400861e-05">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019024847">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0083709328">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47400649">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1106786">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Connector" density="1.119*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12175975">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029972928">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075860931">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77184835">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00054859821">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.4434439e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Crack average" density="1.85*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.1922">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0242">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2836">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Quartz" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0081131524">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092418886">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0011862487">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00011002641">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98134868">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012637483">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017671321">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040177288">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010044322">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022298395">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98286333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cu/Scintillator/PolB" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.013621137">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018577191">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.98179207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040133497">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00010033374">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0022274091">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DTBX gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Dead_Argon CF_4 CO_2" density="2.14154*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Doped Quartz" density="2.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.28638718">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32623058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38738224">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGC el" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15487536">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0062815446">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062222733">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30743601">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12068891">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30724234">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041253098">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided MSGCsub" density="2.207*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.20936607">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36666251">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01999014">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36881246">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035168818">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Double-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.25534309">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013472574">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058711815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1751292">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023514409">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24970935">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22411956">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DropsPolyethylene" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EAPD_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP1" density="1.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP2" density="700*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP3" density="400*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_CablPP4" density="300*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_E_Cables" density="5.36*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+   <CompositeMaterial name="E_Carbon Fibre" density="1.45*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Lead" density="11.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PbWO4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Polythene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Rohacell" density="71*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11190083">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88809917">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ec_Cable_1" density="2.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.51322876">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33317259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12086275">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032735911">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="EE_Aveolar" density="0.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Epoxy" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ethane" density="1.356*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.79887887">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20112113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fe_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69944958">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30055042">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Fibre_connector" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Flushing gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0010671918">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00033736021">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.8370396e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1392493e-06">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99857594">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Freon-12" density="4.93*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.099340816">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.58640112">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31425807">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FrontEnd Electronics" density="1.03441*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00065963049">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002085221">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.1354728e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0416919e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45049813">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.54862165">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.13232243">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032572448">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.48316123">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35194389">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="G_conntr" density="2.007*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36065118">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38351407">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.051494019">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20434074">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Gas" density="1.9573*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49078595">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50287777">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0063362788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Glass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.36611059">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53173295">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.007820091">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0344084">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059927964">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graph.Epoxy Sup." density="138.3*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Graphite Epoxy suprt" density="1.383*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.80947966">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.073636829">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11688351">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HFE" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV Light Guides" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46726616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53238309">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034445206">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.9293189e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.677097e-07">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Brass" density="8.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="H_Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98854345">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="2.2305277e-06">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.0511343e-07">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="3.8395793e-08">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00034716943">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011106403">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hcal sci" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.92257895">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.07742105">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hexel for CSC" density="165*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0002303291">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.046295939">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35049864">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.47901437">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11791403">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0060466926">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="High Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45726783">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44778783">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070543148">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.024401185">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Honeycomb" density="280*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Hybrids" density="1.785*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6459597">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21237145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028514885">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11315397">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ICB" density="2.309*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.26383847">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.097410682">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023978583">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35568471">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25908755">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Insulation" density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.008091404">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043705226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0029341267">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.023286651">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10908214">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.81290046">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Isobutane" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="K_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.83015022">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16984978">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kapton" density="1.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Cu mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.054145746">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017829582">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020989171">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054933281">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0046990226">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00099214713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007791868">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.91396207">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for EM" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38570939">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.45792903">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12700974">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001495172">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0089371927">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012776589">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019728114">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00055505683">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0036150168">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kr/Pb mixture for HD" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.043537564">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.93041049">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014336428">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0016876993">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0044170805">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037783947">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00079776662">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00062652927">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00040805081">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadBPolymer" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0037037037">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016296296">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.102">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.088">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.618">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LeadLoadedPolymerCon" density="3.53*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.023512713">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041643122">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11416406">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10198306">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.087818747">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01869691">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028328615">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013031207">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59631732">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite" density="2.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0097839501">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36018046">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012566469">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.008172324">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57297034">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035392035">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00093441511">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite Iron" density="4.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0077950891">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25025334">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.035888928">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020743458">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61983399">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.062339683">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0020806726">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010648449">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Limonite magetite" density="3.41*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0046317534">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33176807">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010582504">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006612936">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.61641603">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.029106142">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00088255997">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Ar Detector" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Argon" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Kr Detector" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Liquid Krypton" density="2.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Krypton"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lithium Polyethyl." density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.113">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.596">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075">
+    <rMaterial name="materials:Lithium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.216">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron Polyethyl." density="1.02*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Boron PolyethylHD" density="1.40*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81347018">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1365297">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0092592584">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040740732">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AntiLead" density="11.16*g/cm3 " symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.96">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Low Tension cables" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98029046">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016876977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028325668">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Lucite" density="1.16*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="ME_free_space" density="0.254467*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.003218">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.157312">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.5388547e-05">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020068">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.249899">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013999">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.555499">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC cooling pipe" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30132877">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.053356059">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42345953">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22185565">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MSGC-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0016109746">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11608918">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.87746662">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004833228">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al36" density="1.403*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.379586">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27524785">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26823734">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045019923">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03190889">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al48" density="1.373*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.40684004">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25552552">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26144891">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043880579">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032304952">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al60" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.43940244">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22781143">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25517545">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042827665">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.034783015">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Al_cable" density="1.95062*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.69471035">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2614148">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043874854">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_Cu_cable" density="9.4537*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91351941">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.074051989">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012428601">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MS_cntr" density="2.049*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27792206">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36612478">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.21351888">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028668949">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11376533">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Aluminium" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon 50pct CF_4 CO_2" density="2.1057*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.39336475">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11827135">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29931485">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18904904">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_B_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Copper" density="8.96*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Thick_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_DTBX Gas" density="1.695*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.049996061">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25927645">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.69072749">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Electronics averag" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_F_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA FR4 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Bakelite" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.074565894">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.77748634">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14794776">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_RPC_Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_honeycomb" density=" 0.0511415*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.97670111">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017460186">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0055195064">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00030055565">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="1.863911e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Cables" density="2.68*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.586">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.259">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.138">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magetite" density="3.12*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0068217712">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34582528">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011586696">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0079728988">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59461377">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032281783">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00089780071">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Magnet Conductor" density="3.157*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.097336411">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014292995">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017134031">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054482651">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75894659">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10684171">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteBoron" density="3.637*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.007">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.35">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.55">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_MagnetiteConc" density="3.65*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0035">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0026">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0104">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3512">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0131">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0201">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0271">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5519">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Marble" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46021905">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53804265">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017382968">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Methane" density="0.717*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74868663">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25131337">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg O" density="3.58*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60304188">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.39695812">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mg-MMC" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mn O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.77446185">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22553815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon Al" density="2.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Muon average" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012744281">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001149531">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002893993">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99728664">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Mylar" density="1.39*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62502108">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041960452">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33301847">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="NEMA FR4 plate" density="1.025*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18077359">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.4056325">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.27804208">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.068442752">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.067109079">
+    <rMaterial name="materials:Bromine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_NEMA G10 plate" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.2198829">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.41718655">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26819334">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.066018389">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028718811">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Na_2 O" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.74186418">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.25813582">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ne30_DME70" density="1.7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.15805943">
+    <rMaterial name="materials:Neon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43902091">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29239429">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11052537">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ni_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.70978275">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29021725">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex" density="32*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.027815941">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31653768">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00047881724">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077581544">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.57758601">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Nomex for CSC" density="28.9*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Noryl" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="O_Hybrid" density="2.838*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.17862818">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0038859926">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012801535">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11166264">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13680825">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096505544">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.238333">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027828501">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17363266">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.019913693">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Optical fibre" density="1.05*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Outer_pipes" density="2.533*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.49604605">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.006094006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032243322">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12103086">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.34458577">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="P_pipes" density="2.3285*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.32927494">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0007222183">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0019399576">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="8.087907e-05">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="5.7963526e-05">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.2979215e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00013442846">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00031610699">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.44804883">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.044156804">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17522489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb W O_4" density="8.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45532661">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40403397">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14063942">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pb/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.018845478">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0017479474">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.97940657">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Peek" density="1.32*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.53539691">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13179314">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33280996">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="PhotoCathode" density="1.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pigtails" density="3.145*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.65753522">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20542786">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.027582577">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10945434">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with Water" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.092022289">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.082576264">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29261257">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53278887">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Pipe with gas" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.18514234">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.13149061">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24084727">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24888489">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1936349">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Plexiglas" density="1.18*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polycarbonate" density="7*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyethylene" density="950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="DD_Polyethylene" density="2*950*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polymer Concrete" density="450*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.23789097">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43443755">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.26294502">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064726463">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polystyrene" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Polyvinylchloride" density="1.38*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.38437771">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048384356">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.56723794">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Px_cool_pipe" density="2.72629*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.54838378">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0054611179">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028894718">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1084613">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30879909">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Quartz support" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzBundle" density="1.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.41130114">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.46868914">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056403482">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0052320714">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.057839878">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00052523876">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.0413398e-06">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="QuartzFibers" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RPC Gas" density="1.87685*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017572792">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2588934">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031188319">
+    <rMaterial name="materials:Chlorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016714124">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.67563137">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Rohacell" density="0.052*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.08">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SITRA-Average" density="7*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="SMD_metal" density="10.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.045444306">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.80484958">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14970612">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="S_2 O_3" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.57194838">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.42805162">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Scintillator" density="1.032*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.91512109">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.084878906">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine - Iron" density="3.765*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0089840293">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31549151">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11229814">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017986016">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0023751734">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.40725359">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.049064913">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085014416">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015322121">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Serpentine 2" density="2.01*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.017056138">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52511018">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22286408">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028434767">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.055055747">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.048338182">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.095947828">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010639801">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042627075">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0018663973">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si O_2" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Si cooling pipe" density="1.921*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.56814774">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19928206">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.026024798">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2065454">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silica" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Siliecal" density="1.0859*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.87264263">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12735737">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGC el" density="2.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.30413689">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0014717137">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.058467105">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36931633">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15011919">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10269944">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.013789342">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided MSGCsub" density="2.3258*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33240081">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.43382861">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.017726182">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19998078">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.016063621">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Single-sided Si elec" density="2.392*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.31484492">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014476209">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.050561611">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.114528">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015377551">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2652606">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.22495111">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="StainlessSteel" density="8.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Thick_Stand.Concrete" density="2.35*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.006">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.5">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.014">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Standard Serpentine" density="2.302*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0096577278">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.52863475">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.32556232">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.054746312">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.022623255">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028372381">
+    <rMaterial name="materials:Calcium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0012881659">
+    <rMaterial name="materials:Magnesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00095487516">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01557902">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.012581187">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-008" density="7.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.00089992039">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015987127">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042943177">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017903506">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012830888">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5139401e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00029757275">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069973892">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99180725">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Steel-light" density="520*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6996">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0004">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Super Conductor" density="4.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.81579799">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.077846795">
+    <rMaterial name="materials:Niobium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.096238669">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.010116543">
+    <rMaterial name="materials:Helium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Brass" density="8.5*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.63">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="BGA" density="8.82*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.62">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36">
+    <rMaterial name="materials:Lead"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Silver"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Air" density="1.214*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Argon CF_4 CO_2" density="2.1416*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.22960113">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16306585">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.29868266">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.30865037">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Bronze" density="8.89*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.94059406">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.059405941">
+    <rMaterial name="materials:Tin"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Carbon fibre str." density="1.69*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84491305">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.042542086">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11254487">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Foam" density="100*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.59985105">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.080541353">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.31960759">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_MSGC-Average" density="230*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.8">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OPC" density="1.05917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.33154227">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38182349">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.064261825">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.16677931">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.052722204">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0028709009">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_OP_cable" density="601.463*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0086851733">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.10083068">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.51167977">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.086185453">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.28766708">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0049518353">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Det" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Hybrid" density="3.918*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.12227401">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.020384302">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.23710889">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24417229">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17802235">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19803815">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Bar_Readout" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Fwd_Det" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Pix_Fwd_Readout" density="2.17525*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.84842968">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063360581">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.015596821">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.039385794">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.033227128">
+    <rMaterial name="materials:Indium"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Silicon" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="T_Silicon Detector" density="2.33*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Teflon" density="2.2*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.24018637">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.75981363">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Ti_2 O_3" density="4.6*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.66612408">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.33387592">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_Cable_1" density="942.8*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.4364364">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.19550706">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.031331664">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.060965631">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043156039">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.041667015">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.15813109">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032805106">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_square_bundles" density="971*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45591441">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.20422984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.032729696">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063679098">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.045081214">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.043521896">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12057473">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.03426911">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Tk_support" density="5.25617*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Air" density="1.205*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7494">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2369">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0129">
+    <rMaterial name="materials:Argon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0008">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Iron" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="V_Quartz" density="2.64*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.46748103">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.53251897">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal C4H10" density="2.67*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.82658619">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.17341381">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal CO2" density="1.98*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Vcal average" density="7.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0012701968">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015979957">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0042923919">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00017895477">
+    <rMaterial name="materials:Sulfur"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00012825134">
+    <rMaterial name="materials:Phosphor"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="9.5096736e-05">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0002974393">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00069942512">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99136248">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="7.7766882e-05">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="W/Sci spaghetti mix" density="1*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0059212984">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00082799058">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00018825087">
+    <rMaterial name="materials:Bor 11"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="4.7062717e-05">
+    <rMaterial name="materials:Bor 10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0010447923">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.99197061">
+    <rMaterial name="materials:Tungsten"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Wood" density="500*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.11684213">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.88315787">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="YokeSteel" density="7.87*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.001">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.004">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.9825">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="active_screen" density="11.197*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.025418913">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.085235146">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.50483588">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.38451007">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="c_Peek" density="1.8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.45427914">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11182521">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.36306779">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.070827858">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="HV_Cu/QFib_mx." density="7.30515*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0247913">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00471238  ">
+    <rMaterial name="materials:Polystyrene"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04296 ">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.927536">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Borosilicate_Glass" density="2.51*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.303594">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0452533">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0556199">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0449903">
+    <rMaterial name="materials:Zinc"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0222285">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0245335">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0239803">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00459437">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.475195">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Silicone_Gel" density="0.965*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.3866">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0973">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3616">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1545">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Barium_Titanate" density="6.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.5889">
+    <rMaterial name="materials:Barium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2053">
+    <rMaterial name="materials:Titanium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2058">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="E_PolyGrains" density="589*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.85628451">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.14371549">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CuNi" density="8.94*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Acrylate" density="1170*mg/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.55814">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.06977">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.37209">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Inconel600" density="8.47*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7200">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0285">
+    <rMaterial name="materials:Cobalt"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1500">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0800">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0015">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0100">
+    <rMaterial name="materials:Manganese"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0050">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Kevlar" density="1.44*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.71180785">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.11852895">
+    <rMaterial name="materials:Nitrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.12699531">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.04266788">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- Tracker Cooling Fluids INIT -->
+  <!-- 3M type is the old one used for Thermal Screen only -->
+  <CompositeMaterial name="C6F14_3M_-15C" density="1.80340*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <!-- F2 type is the new one used for subdetectors and preshower -->
+  <CompositeMaterial name="C6F14_F2_-30C" density="1.87917*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-20C" density="1.84675*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C6F14_F2_-10C" density="1.82033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:C6F14"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="CO2_Upgrade" density="0.2033*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00000000">
+    <rMaterial name="materials:Vcal CO2"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bpix_CO2_-20C" density="1.0327*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.27292145">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.72707855">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  <!-- Tracker Cooling Fluids END -->
+  <!-- CASTOR materials -->
+  <CompositeMaterial name="Castor_QuartzFibers/Air_mx" density="2.1743080*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9999233027749">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0000766972251">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle6_QF/Air_mx" density="0.4808336*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99800842127">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00199157873">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle5_QF/Air_mx" density="0.5726188*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99841066074">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00158933926">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle4_QF/Air_mx" density="0.7092276*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99881654262">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00118345738">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle3_QF/Air_mx" density="1.1048788*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99942577695">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00057422305">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle2_QF/Air_mx" density="1.5612536*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99974500842">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00025499158">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Bundle1_QF/Air_mx" density="2.2522530*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998212349">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001787651">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_LMixer_QF/Air_mx" density="2.2834241*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.99998943692">
+    <rMaterial name="materials:QuartzFibers"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.00001056308">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Electronics averag" density="1.4881*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.000560">
+    <rMaterial name="materials:Air"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.999440">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Paper" density="1.55*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.448">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.056">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.496">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Castor_Coolant" density="1.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.012092387">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.063980691">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.24016253">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.68376439">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="AlBeMet" density="2.071*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.380">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.615">
+    <rMaterial name="materials:Beryllium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0045">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Rdout_Brd" density="1.79*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.98667">
+    <rMaterial name="materials:G10"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.01333">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_Kapton_Cu" density="1.24*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.9836">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0164">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Gas" density="1.8*mg/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.60">
+    <rMaterial name="materials:Argon"/>
+    </MaterialFraction>
+   <MaterialFraction fraction="0.083">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.145">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.172">
+    <rMaterial name="materials:Fluorine"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="M_GEM_Foil" density="1.74*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.6565">
+    <rMaterial name="materials:Kapton"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1013">
+    <rMaterial name="materials:Copper"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2422">
+    <rMaterial name="materials:M_GEM_Gas"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Diamond" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>   
+  <!--Materials added for BHM-->
+    <CompositeMaterial name="BorosilicateGlass" density="2.23*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.377220">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.028191">
+    <rMaterial name="materials:Sodium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.003321">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.539562">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.011644">
+    <rMaterial name="materials:Aluminium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.040064">
+    <rMaterial name="materials:Boron"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="Bialkali" density="4.28*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.133">
+    <rMaterial name="materials:Potassium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.452">
+    <rMaterial name="materials:Cesium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.415">
+    <rMaterial name="materials:Antimony"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="RTV" density="1.02*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0811">
+    <rMaterial name="materials:Hydrogen"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3790">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.3241">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.2158">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="LYSO" density="7.11*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.7145">
+    <rMaterial name="materials:Lutecium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0403">
+    <rMaterial name="materials:Yttrium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.0637">
+    <rMaterial name="materials:Silicon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1815">
+    <rMaterial name="materials:Oxygen"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+ </MaterialSection>
+</DDDefinition>

--- a/Geometry/ForwardCommonData/data/zdc/2021/v1/zdc.xml
+++ b/Geometry/ForwardCommonData/data/zdc/2021/v1/zdc.xml
@@ -1,0 +1,1720 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="zdc" eval="true">
+		<Constant name="zdcHadThetaDeg" value="45.0"/>
+		<Constant name="zdcHadTheta" value="([zdcHadThetaDeg]*acos(-1)/180.)*rad"/>
+		<Constant name="zdcHadZinitial" value="(-29.0+ 6.25*cos([zdcHadTheta]))*cm"/>
+		<Constant name="zdcHadZDelta" value="2.32*cm"/>
+		<Constant name="zdcHadXinitial" value="-47.57525*mm"/>
+		<Constant name="zdcHadXDelta" value="0.8495*mm"/>
+		<Constant name="zdcEMZinitial" value="-49.85*cm"/>
+		<Constant name="zdcEMZDelta" value="3.0*mm"/>
+		<Constant name="zdcEMXinitial" value="-47.56365*mm"/>
+		<Constant name="zdcEMXDelta" value="0.8727*mm"/>
+	</ConstantsSection>
+	<SolidSection label="zdcSolids">
+		<Box name="ZDC" dx="8.0*cm" dy="64.0*cm" dz="90.0*cm"/>
+		<Box name="ZDC_HadLayer" dx="4.8*cm" dy="6.25*cm" dz="8.2*mm"/>
+		<Box name="ZDC_HadAbsorber" dx="4.8*cm" dy="6.25*cm" dz="7.75*mm"/>
+		<Tube name="ZDC_HadFiber" rMin="0.*mum" rMax="350.0*mum" dz="6.25*cm"/>
+		<Box name="ZDC_EMLayer" dx="4.8*cm" dy="6.25*cm" dz="1.5*mm"/>
+		<Box name="ZDC_EMAbsorber" dx="4.8*cm" dy="6.25*cm" dz="1.0*mm"/>
+		<Tube name="ZDC_EMFiber" rMin="0.*mum" rMax="350.0*mum" dz="6.25*cm"/>
+	</SolidSection>
+	<LogicalPartSection label="zdcLog">
+		<LogicalPart name="ZDC" category="unspecified">
+			<rSolid name="ZDC"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="ZDC_HadLayer" category="unspecified">
+			<rSolid name="ZDC_HadLayer"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="ZDC_HadAbsorber" category="unspecified">
+			<rSolid name="ZDC_HadAbsorber"/>
+			<rMaterial name="materials:Tungsten"/>
+		</LogicalPart>
+		<LogicalPart name="ZDC_HadFiber" category="sensitive">
+			<rSolid name="ZDC_HadFiber"/>
+			<rMaterial name="zdcmaterials:quartz"/>
+		</LogicalPart>
+		<LogicalPart name="ZDC_EMLayer" category="unspecified">
+			<rSolid name="ZDC_EMLayer"/>
+			<rMaterial name="materials:Air"/>
+		</LogicalPart>
+		<LogicalPart name="ZDC_EMAbsorber" category="unspecified">
+			<rSolid name="ZDC_EMAbsorber"/>
+			<rMaterial name="materials:Tungsten"/>
+		</LogicalPart>
+		<LogicalPart name="ZDC_EMFiber" category="sensitive">
+			<rSolid name="ZDC_EMFiber"/>
+			<rMaterial name="zdcmaterials:quartz"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<!-- Position of zdc volumes -->
+	<PosPartSection label="zdcPar">
+		<!-- Position of Hadronic layers -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+0.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+1.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+2.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+3.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="5">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+4.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="6">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+5.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="7">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+6.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="8">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+7.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="9">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+8.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="10">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+9.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="11">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+10.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="12">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+11.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="13">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+12.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="14">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+13.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="15">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+14.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="16">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+15.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="17">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+16.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="18">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+17.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="19">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+18.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="20">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+19.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="21">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+20.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="22">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+21.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="23">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+22.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="24">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_HadLayer"/>
+			<rRotation name="zdcrotations:R2"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcHadZinitial]+23.0*[zdcHadZDelta]"/>
+		</PosPart>
+		<!-- Position of absorber -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadAbsorber"/>
+			<Translation x="0*fm" y="0*fm" z="-0.45*mm"/>
+		</PosPart>
+		<!-- Position of fibers -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+0.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+1.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+2.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+3.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="5">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+4.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="6">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+5.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="7">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+6.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="8">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+7.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="9">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+8.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="10">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+9.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="11">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+10.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="12">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+11.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="13">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+12.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="14">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+13.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="15">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+14.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="16">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+15.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="17">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+16.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="18">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+17.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="19">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+18.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="20">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+19.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="21">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+20.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="22">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+21.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="23">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+22.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="24">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+23.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="25">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+24.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="26">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+25.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="27">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+26.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="28">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+27.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="29">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+28.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="30">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+29.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="31">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+30.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="32">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+31.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="33">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+32.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="34">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+33.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="35">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+34.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="36">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+35.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="37">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+36.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="38">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+37.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="39">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+38.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="40">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+39.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="41">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+40.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="42">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+41.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="43">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+42.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="44">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+43.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="45">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+44.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="46">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+45.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="47">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+46.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="48">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+47.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="49">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+48.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="50">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+49.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="51">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+50.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="52">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+51.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="53">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+52.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="54">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+53.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="55">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+54.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="56">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+55.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="57">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+56.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="58">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+57.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="59">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+58.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="60">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+59.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="61">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+60.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="62">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+61.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="63">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+62.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="64">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+63.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="65">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+64.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="66">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+65.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="67">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+66.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="68">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+67.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="69">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+68.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="70">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+69.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="71">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+70.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="72">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+71.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="73">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+72.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="74">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+73.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="75">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+74.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="76">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+75.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="77">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+76.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="78">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+77.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="79">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+78.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="80">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+79.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="81">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+80.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="82">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+81.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="83">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+82.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="84">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+83.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="85">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+84.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="86">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+85.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="87">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+86.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="88">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+87.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="89">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+88.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="90">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+89.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="91">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+90.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="92">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+91.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="93">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+92.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="94">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+93.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="95">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+94.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="96">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+95.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="97">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+96.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="98">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+97.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="99">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+98.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="100">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+99.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="101">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+100.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="102">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+101.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="103">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+102.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="104">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+103.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="105">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+104.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="106">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+105.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="107">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+106.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="108">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+107.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="109">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+108.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="110">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+109.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="111">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+100.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="112">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+111.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<PosPart copyNumber="113">
+			<rParent name="zdc:ZDC_HadLayer"/>
+			<rChild name="zdc:ZDC_HadFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcHadXinitial]+112.0*[zdcHadXDelta]" y="0*fm" z="7.75*mm"/>
+		</PosPart>
+		<!-- Position EM Layers -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+0.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+1.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+2.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+3.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="5">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+4.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="6">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+5.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="7">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+6.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="8">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+7.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="9">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+8.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="10">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+9.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="11">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+10.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="12">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+11.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="13">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+12.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="14">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+13.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="15">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+14.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="16">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+15.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="17">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+16.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="18">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+17.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="19">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+18.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="20">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+19.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="21">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+20.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="22">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+21.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="23">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+22.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="24">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+23.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="25">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+24.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="26">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+25.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="27">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+26.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="28">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+27.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="29">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+28.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="30">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+29.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="31">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+30.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="32">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+31.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<PosPart copyNumber="33">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdc:ZDC_EMLayer"/>
+			<Translation x="0*fm" y="0*fm" z="[zdcEMZinitial]+32.0*[zdcEMZDelta]"/>
+		</PosPart>
+		<!-- Position of EM absorber -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMAbsorber"/>
+			<Translation x="0*fm" y="0*fm" z="-500*mum"/>
+		</PosPart>
+		<!-- Position of EM fibers -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+0.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="2">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+1.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="3">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+2.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="4">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+3.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="5">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+4.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="6">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+5.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="7">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+6.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="8">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+7.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="9">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+8.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="10">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+9.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="11">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+10.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="12">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+11.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="13">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+12.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="14">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+13.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="15">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+14.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="16">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+15.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="17">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+16.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="18">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+17.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="19">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+18.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="20">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+19.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="21">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+20.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="22">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+21.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="23">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+22.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="24">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+23.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="25">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+24.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="26">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+25.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="27">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+26.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="28">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+27.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="29">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+28.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="30">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+29.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="31">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+30.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="32">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+31.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="33">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+32.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="34">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+33.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="35">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+34.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="36">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+35.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="37">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+36.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="38">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+37.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="39">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+38.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="40">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+39.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="41">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+40.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="42">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+41.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="43">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+42.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="44">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+43.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="45">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+44.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="46">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+45.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="47">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+46.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="48">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+47.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="49">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+48.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="50">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+49.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="51">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+50.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="52">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+51.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="53">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+52.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="54">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+53.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="55">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+54.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="56">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+55.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="57">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+56.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="58">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+57.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="59">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+58.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="60">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+59.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="61">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+60.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="62">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+61.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="63">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+62.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="64">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+63.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="65">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+64.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="66">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+65.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="67">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+66.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="68">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+67.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="69">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+68.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="70">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+69.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="71">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+70.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="72">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+71.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="73">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+72.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="74">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+73.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="75">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+74.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="76">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+75.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="77">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+76.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="78">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+77.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="79">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+78.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="80">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+79.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="81">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+80.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="82">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+81.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="83">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+82.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="84">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+83.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="85">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+84.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="86">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+85.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="87">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+86.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="88">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+87.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="89">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+88.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="90">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+89.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="91">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+90.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="92">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+91.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="93">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+92.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="94">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+93.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="95">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+94.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="96">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+95.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="97">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+96.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="98">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+97.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="99">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+98.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="100">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+99.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="101">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+100.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="102">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+101.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="103">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+102.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="104">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+103.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="105">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+104.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="106">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+105.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="107">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+106.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="108">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+107.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="109">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+108.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+		<PosPart copyNumber="110">
+			<rParent name="zdc:ZDC_EMLayer"/>
+			<rChild name="zdc:ZDC_EMFiber"/>
+			<rRotation name="zdcrotations:R1"/>
+			<Translation x="[zdcEMXinitial]+109.0*[zdcEMXDelta]" y="0*fm" z="1000*mum"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/Geometry/ForwardCommonData/data/zdclumi/2021/v1/zdclumi.xml
+++ b/Geometry/ForwardCommonData/data/zdclumi/2021/v1/zdclumi.xml
@@ -1,0 +1,394 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+	<ConstantsSection label="zdclumi" eval="true">
+		<Constant name="LUMIWorldHalfdX" value="8.0000*cm"/>
+		<Constant name="LUMIWorldHalfdY" value="64.0000*cm"/>
+		<Constant name="LUMIWorldHalfdZ" value="8.0000*cm"/>
+		<Constant name="LUMIPositionX" value="0.0000*cm"/>
+		<Constant name="LUMIPositionY" value="25.3650*cm"/>
+		<Constant name="LUMIPositionZ" value="34.8500*cm"/>
+		<Constant name="LUMIHalfdX" value="8.0000*cm"/>
+		<Constant name="LUMIHalfdY" value="32.0000*cm"/>
+		<Constant name="LUMIHalfdZ" value="4.9510*cm"/>
+		<Constant name="casePositionX" value="0.0000*cm"/>
+		<Constant name="casePositionY" value="0.4765*cm"/>
+		<Constant name="casePositionZ" value="0.0000*cm"/>
+		<Constant name="box1CaseHalfdX" value="4.6990*cm"/>
+		<Constant name="box1CaseHalfdY" value="29.8015*cm"/>
+		<Constant name="box1CaseHalfdZ" value="4.6990*cm"/>
+		<Constant name="box2CaseHalfdX" value="4.4700*cm"/>
+		<Constant name="box2CaseHalfdY" value="29.9016*cm"/>
+		<Constant name="box2CaseHalfdZ" value="4.47250*cm"/>
+		<Constant name="box1CaseBottomHalfdX" value="4.6990*cm"/>
+		<Constant name="box1CaseBottomHalfdY" value=" 1.2800*cm"/>
+		<Constant name="box1CaseBottomHalfdZ" value="4.9505*cm"/>
+		<Constant name="box2CaseBottomHalfdX" value="4.4700*cm"/>
+		<Constant name="box2CaseBottomHalfdY" value=" 0.8800*cm"/>
+		<Constant name="box2CaseBottomHalfdZ" value="4.4725*cm"/>
+		<Constant name="box2CasePositionX" value="0.0000*cm"/>
+		<Constant name="box2CasePositionY" value="0.4765*cm"/>
+		<Constant name="box2CasePositionZ" value="0.0000*cm"/>
+		<Constant name="caseBottomPositionX" value="0.0000*cm"/>
+		<Constant name="caseBottomPositionY" value="-[box1CaseHalfdY] + [casePositionY] - [box1CaseBottomHalfdY]"/>
+		<Constant name="caseBottomPositionZ" value="0.0000*cm"/>
+		<Constant name="caseTopHalfdX" value="6.5090*cm"/>
+		<Constant name="caseTopHalfdY" value=" 0.6350*cm"/>
+		<Constant name="caseTopHalfdZ" value="4.9505*cm"/>
+		<Constant name="caseTopPositionX" value="1.1000*cm"/>
+		<Constant name="caseTopPositionY" value="[box1CaseHalfdY] + [casePositionY] + [caseTopHalfdY]"/>
+		<Constant name="caseTopPositionZ" value="0.0000*cm"/>
+		<Constant name="cuCoverZPosHalfdX" value="4.3810*cm"/>
+		<Constant name="cuCoverZPosHalfdY" value="29.7650*cm"/>
+		<Constant name="cuCoverZPosHalfdZ" value="1.0650*cm"/>
+		<Constant name="cuCoverZPosPositionX" value="0.0000*cm"/>
+		<Constant name="cuCoverZPosPositionY" value="-0.4400*cm"/>
+		<Constant name="cuCoverZPosPositionZ" value="[box2CaseHalfdZ] - [cuCoverZPosHalfdZ]"/>
+		<Constant name="cuCoverZNegHalfdX" value="4.3810*cm"/>
+		<Constant name="cuCoverZNegHalfdY" value="29.7650*cm"/>
+		<Constant name="cuCoverZNegHalfdZ" value="1.0650*cm"/>
+		<Constant name="cuCoverZNegPositionX" value="0.0000*cm"/>
+		<Constant name="cuCoverZNegPositionY" value="-0.4400*cm"/>
+		<Constant name="cuCoverZNegPositionZ" value="-[box2CaseHalfdZ] + [cuCoverZNegHalfdZ]"/>
+		<Constant name="box1CuSupportHalfdX" value="4.3810*cm"/>
+		<Constant name="box1CuSupportHalfdY" value="23.4110*cm"/>
+		<Constant name="box1CuSupportHalfdZ" value="2.0470*cm"/>
+		<Constant name="box2CuSupportHalfdX" value="2.5400*cm"/>
+		<Constant name="box2CuSupportHalfdY" value="30.0000*cm"/>
+		<Constant name="box2CuSupportHalfdZ" value="2.0470*cm"/>
+		<Constant name="box3CuSupportHalfdX" value="4.3810*cm"/>
+		<Constant name="box3CuSupportHalfdY" value=" 0.8485*cm"/>
+		<Constant name="box3CuSupportHalfdZ" value="0.3175*cm"/>
+		<Constant name="box3CuSupportRelativeX" value="0.0000*cm"/>
+		<Constant name="box3CuSupportRelativeY" value="-[box1CuSupportHalfdY]-[box3CuSupportHalfdY]"/>
+		<Constant name="box3CuSupportRelativeZ" value="[box1CuSupportHalfdZ]-[box3CuSupportHalfdZ]"/>
+		<Constant name="box4CuSupportHalfdX" value="4.3810*cm"/>
+		<Constant name="box4CuSupportHalfdY" value="1.8985*cm"/>
+		<Constant name="box4CuSupportHalfdZ" value="1.4120*cm"/>
+		<Constant name="deltaAdjust" value="0.005"/>
+		<Constant name="box4CuSupportRelativeX" value="0.0000*cm"/>
+		<Constant name="box4CuSupportRelativeY" value="-[box1CuSupportHalfdY]-[box4CuSupportHalfdY]"/>
+		<Constant name="box4CuSupportRelativeZ" value="-[deltaAdjust]"/>
+		<Constant name="cuSupportPositionX" value="0.0000*cm"/>
+		<Constant name="cuSupportPositionY" value="6.7945*cm"/>
+		<Constant name="cuSupportPositionZ" value="0.0000*cm"/>
+		<Constant name="boxFrontCoverHalfdX" value="4.3810*cm"/>
+		<Constant name="boxFrontCoverHalfdY" value="5.5000*cm"/>
+		<Constant name="boxFrontCoverHalfdZ" value="0.1590*cm"/>
+		<Constant name="boxBackCoverHalfdX" value="4.3810*cm"/>
+		<Constant name="boxBackCoverHalfdY" value="6.79425*cm"/>
+		<Constant name="boxBackCoverHalfdZ" value="0.1825*cm"/>
+		<Constant name="frontCoverPositionX" value="0.0000*cm"/>
+		<Constant name="frontCoverPositionY" value="-[boxFrontCoverHalfdY]-[box3CuSupportHalfdY]-[box3CuSupportHalfdY]-[box1CuSupportHalfdY]+[cuSupportPositionY]-[box2CaseBottomHalfdY]"/>
+		<Constant name="frontCoverPositionZ" value="[box1CuSupportHalfdZ] - [boxFrontCoverHalfdZ]"/>
+		<Constant name="backCoverPositionX" value="0.0000*cm"/>
+		<Constant name="backCoverPositionY" value="[caseBottomPositionY] + [box1CaseBottomHalfdY] - [box2CaseBottomHalfdY] + [boxBackCoverHalfdY]"/>
+		<Constant name="backCoverPositionZ" value="-[box1DetectorCoverHalfdZ] - [boxBackCoverHalfdZ]"/>
+		<Constant name="box1DetectorCoverHalfdX" value="4.3500*cm"/>
+		<Constant name="box1DetectorCoverHalfdY" value="4.8000*cm"/>
+		<Constant name="box1DetectorCoverHalfdZ" value="1.6500*cm"/>
+		<Constant name="dtCoverPositionX" value="0.0000*cm"/>
+		<Constant name="dtCoverPositionY" value="-[box4CuSupportHalfdY] - [box4CuSupportHalfdY] -[box1CuSupportHalfdY] - [box1DetectorCoverHalfdY] + [cuSupportPositionY]"/>
+		<Constant name="dtCoverPositionZ" value="0.0000*cm"/>
+		<Constant name="box1DetectorGasHalfdX" value="3.9490*cm"/>
+		<Constant name="box1DetectorGasHalfdY" value="4.3990*cm"/>
+		<Constant name="box1DetectorGasHalfdZ" value="1.2490*cm"/>
+		<Constant name="boxDetectorGridHalfdX" value="3.8000*cm"/>
+		<Constant name="boxDetectorGridHalfdY" value="1.6625*cm"/>
+		<Constant name="boxDetectorGridHalfdZ" value="0.1000*cm"/>
+		<Constant name="boxDetectorLayerHalfdX" value="3.8000*cm"/>
+		<Constant name="boxDetectorLayerHalfdY" value="0.1000*cm"/>
+		<Constant name="boxDetectorLayerHalfdZ" value="1.2000*cm"/>
+		<Constant name="deltaGrid" value="0.3250*cm"/>
+		<Constant name="deltaLayer" value="[boxDetectorGridHalfdY] + [boxDetectorLayerHalfdY]"/>
+		<Constant name="deltaGap" value="0.1250*cm"/>
+		<Constant name="deltaAdjust1" value="0.001"/>
+	</ConstantsSection>
+	<SolidSection label="zdclumi">
+		<Box name="LUMIWorldBox" dx="[LUMIWorldHalfdX]" dy="[LUMIWorldHalfdY]" dz="[LUMIWorldHalfdZ]"/>
+		<Box name="LUMIBox" dx="[LUMIHalfdX]" dy="[LUMIHalfdY]" dz="[LUMIHalfdZ]"/>
+		<Box name="box1Case" dx="[box1CaseHalfdX]" dy="[box1CaseHalfdY]" dz="[box1CaseHalfdZ]"/>
+		<Box name="box2Case" dx="[box2CaseHalfdX]" dy="[box2CaseHalfdY]" dz="[box2CaseHalfdZ]"/>
+		<Box name="box1CaseBottom" dx="[box1CaseBottomHalfdX]" dy="[box1CaseBottomHalfdY]" dz="[box1CaseBottomHalfdZ]"/>
+		<Box name="box2CaseBottom" dx="[box2CaseBottomHalfdX]" dy="[box2CaseBottomHalfdY]" dz="[box2CaseBottomHalfdZ]"/>
+		<Box name="caseTop" dx="[caseTopHalfdX]" dy="[caseTopHalfdY]" dz="[caseTopHalfdZ]"/>
+		<Box name="cuCoverZPos" dx="[cuCoverZPosHalfdX]" dy="[cuCoverZPosHalfdY]" dz="[cuCoverZPosHalfdZ]"/>
+		<Box name="cuCoverZNeg" dx="[cuCoverZNegHalfdX]" dy="[cuCoverZNegHalfdY]" dz="[cuCoverZNegHalfdZ]"/>
+		<Box name="box1CuSupport" dx="[box1CuSupportHalfdX]" dy="[box1CuSupportHalfdY]" dz="[box1CuSupportHalfdZ]"/>
+		<Box name="box2CuSupport" dx="[box2CuSupportHalfdX]" dy="[box2CuSupportHalfdY]" dz="[box2CuSupportHalfdZ]"/>
+		<Box name="box3CuSupport" dx="[box3CuSupportHalfdX]" dy="[box3CuSupportHalfdY]" dz="[box3CuSupportHalfdZ]"/>
+		<Box name="box4CuSupport" dx="[box4CuSupportHalfdX]" dy="[box4CuSupportHalfdY]" dz="[box4CuSupportHalfdZ]"/>
+		<Box name="boxFrontCover" dx="[boxFrontCoverHalfdX]" dy="[boxFrontCoverHalfdY]" dz="[boxFrontCoverHalfdZ]"/>
+		<Box name="boxBackCover" dx="[boxBackCoverHalfdX]" dy="[boxBackCoverHalfdY]" dz="[boxBackCoverHalfdZ]"/>
+		<Box name="box1DetectorCover" dx="[box1DetectorCoverHalfdX]" dy="[box1DetectorCoverHalfdY]" dz="[box1DetectorCoverHalfdZ]"/>
+		<Box name="box1DetectorGas" dx="[box1DetectorGasHalfdX]" dy="[box1DetectorGasHalfdY]" dz="[box1DetectorGasHalfdZ]"/>
+		<Box name="boxDetectorGrid" dx="[boxDetectorGridHalfdX]" dy="[boxDetectorGridHalfdY]" dz="[boxDetectorGridHalfdZ]"/>
+		<Box name="boxDetectorLayer" dx="[boxDetectorLayerHalfdX]" dy="[boxDetectorLayerHalfdY]" dz="[boxDetectorLayerHalfdZ]"/>
+		<SubtractionSolid name="case">
+			<rSolid name="zdclumi:box1Case"/>
+			<rSolid name="zdclumi:box2Case"/>
+			<Translation x="0.0*cm" y="0.0*cm" z="0.0*cm"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</SubtractionSolid>
+		<SubtractionSolid name="caseBottom">
+			<rSolid name="zdclumi:box1CaseBottom"/>
+			<rSolid name="zdclumi:box2CaseBottom"/>
+			<Translation x="0.0*cm" y="1.28*cm" z="0.0*cm"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</SubtractionSolid>
+		<SubtractionSolid name="cuSupport1">
+			<rSolid name="zdclumi:box1CuSupport"/>
+			<rSolid name="zdclumi:box2CuSupport"/>
+			<Translation x="0.0*cm" y="0.0*cm" z="-2.8140*cm"/>
+			<rRotation name="lumirotations:LUMIRot01"/>
+		</SubtractionSolid>
+		<UnionSolid name="cuSupport2">
+			<rSolid name="zdclumi:cuSupport1"/>
+			<rSolid name="zdclumi:box3CuSupport"/>
+			<Translation x="[box3CuSupportRelativeX]" y="[box3CuSupportRelativeY]" z="[box3CuSupportRelativeZ]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="cuSupport">
+			<rSolid name="zdclumi:cuSupport2"/>
+			<rSolid name="zdclumi:box4CuSupport"/>
+			<Translation x="[box4CuSupportRelativeX]" y="[box4CuSupportRelativeY]" z="[box4CuSupportRelativeZ]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorC1">
+			<rSolid name="zdclumi:boxDetectorLayer"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]" z="[deltaGrid]+[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorC2">
+			<rSolid name="zdclumi:detectorC1"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]" z="-[deltaGrid]-[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorC3">
+			<rSolid name="zdclumi:detectorC2"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="[deltaGrid]+[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorC4">
+			<rSolid name="zdclumi:detectorC3"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="-[deltaGrid]-[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorC5">
+			<rSolid name="zdclumi:detectorC4"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="0.0000*cm"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorC6">
+			<rSolid name="zdclumi:detectorC5"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="+[deltaLayer]-[deltaAdjust1]" z="[deltaAdjust1]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA11">
+			<rSolid name="zdclumi:boxDetectorLayer"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA12">
+			<rSolid name="zdclumi:detectorA11"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="-[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA13">
+			<rSolid name="zdclumi:detectorA12"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="-[deltaGrid]-[deltaGrid]-[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA14">
+			<rSolid name="zdclumi:detectorA13"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="[deltaGrid]+[deltaGrid]+[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA15">
+			<rSolid name="zdclumi:detectorA14"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="-[deltaLayer]+[deltaAdjust1]" z="[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA21">
+			<rSolid name="zdclumi:boxDetectorLayer"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]" z="[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA22">
+			<rSolid name="zdclumi:detectorA21"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]" z="-[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA23">
+			<rSolid name="zdclumi:detectorA22"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]-[deltaAdjust1]" z="-[deltaGrid]-[deltaGrid]-[deltaGrid]+[deltaAdjust1]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA24">
+			<rSolid name="zdclumi:detectorA23"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]" z="[deltaGrid]+[deltaGrid]+[deltaGrid]-[deltaAdjust1]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+		<UnionSolid name="detectorA25">
+			<rSolid name="zdclumi:detectorA24"/>
+			<rSolid name="zdclumi:boxDetectorGrid"/>
+			<Translation x="0.0000*cm" y="[deltaLayer]-[deltaAdjust1]" z="[deltaGrid]"/>
+			<rRotation name="lumirotations:LUMINoRot"/>
+		</UnionSolid>
+	</SolidSection>
+	<LogicalPartSection label="zdclumi">
+		<LogicalPart name="LUMIWorld" category="unspecified">
+			<rSolid name="LUMIWorldBox"/>
+			<rMaterial name="lumimaterials:lumiair"/>
+		</LogicalPart>
+		<LogicalPart name="LUMI" category="unspecified">
+			<rSolid name="LUMIBox"/>
+			<rMaterial name="lumimaterials:lumiair"/>
+		</LogicalPart>
+		<LogicalPart name="caseLog" category="unspecified">
+			<rSolid name="case"/>
+			<rMaterial name="materials:Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="caseBottomLog" category="unspecified">
+			<rSolid name="caseBottom"/>
+			<rMaterial name="materials:Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="caseTopLog" category="unspecified">
+			<rSolid name="caseTop"/>
+			<rMaterial name="materials:Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="cuCoverZPosLog" category="unspecified">
+			<rSolid name="cuCoverZPos"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+		<LogicalPart name="cuCoverZNegLog" category="unspecified">
+			<rSolid name="cuCoverZNeg"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+		<LogicalPart name="cuSupportLog" category="unspecified">
+			<rSolid name="cuSupport"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+		<LogicalPart name="frontCoverLog" category="unspecified">
+			<rSolid name="boxFrontCover"/>
+			<rMaterial name="materials:Aluminium"/>
+		</LogicalPart>
+		<LogicalPart name="backCoverLog" category="unspecified">
+			<rSolid name="boxBackCover"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+		<LogicalPart name="dtCoverLog" category="unspecified">
+			<rSolid name="box1DetectorCover"/>
+			<rMaterial name="lumimaterials:mancor"/>
+		</LogicalPart>
+		<LogicalPart name="detectorGasLog" category="unspecified">
+			<rSolid name="box1DetectorGas"/>
+			<rMaterial name="lumimaterials:lumiGas"/>
+		</LogicalPart>
+		<LogicalPart name="detectorCathodeLog" category="unspecified">
+			<rSolid name="detectorC6"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+		<LogicalPart name="detectorAnode1Log" category="unspecified">
+			<rSolid name="detectorA15"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+		<LogicalPart name="detectorAnode2Log" category="unspecified">
+			<rSolid name="detectorA25"/>
+			<rMaterial name="materials:Copper"/>
+		</LogicalPart>
+	</LogicalPartSection>
+	<PosPartSection label="zsdlumi">
+		<!--
+		     <PosPart copyNumber="1">
+		     <rParent name="lumi:LUMIWorld"/>
+		     <rChild name="lumi:LUMI"/> 
+		     <Translation x="0.0*cm" y="0.0*cm" z="0.0*cm"/>
+		</PosPart>
+		     -->
+		<PosPart copyNumber="1">
+			<rParent name="zdc:ZDC"/>
+			<rChild name="zdclumi:LUMI"/>
+			<Translation x="[LUMIPositionX]" y="[LUMIPositionY]" z="-[LUMIPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:caseLog"/>
+			<Translation x="[casePositionX]" y="[casePositionY]" z="[casePositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:caseBottomLog"/>
+			<Translation x="[caseBottomPositionX]" y="[caseBottomPositionY]" z="[caseBottomPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:caseTopLog"/>
+			<Translation x="[caseTopPositionX]" y="[caseTopPositionY]" z="[caseTopPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:cuCoverZPosLog"/>
+			<Translation x="[cuCoverZPosPositionX]" y="[cuCoverZPosPositionY]" z="[cuCoverZPosPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:cuCoverZNegLog"/>
+			<Translation x="[cuCoverZNegPositionX]" y="[cuCoverZNegPositionY]" z="[cuCoverZNegPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:cuSupportLog"/>
+			<Translation x="[cuSupportPositionX]" y="[cuSupportPositionY]" z="[cuSupportPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:frontCoverLog"/>
+			<Translation x="[frontCoverPositionX]" y="[frontCoverPositionY]" z="[frontCoverPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:backCoverLog"/>
+			<Translation x="[backCoverPositionX]" y="[backCoverPositionY]" z="[backCoverPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:LUMI"/>
+			<rChild name="zdclumi:dtCoverLog"/>
+			<Translation x="[dtCoverPositionX]" y="[dtCoverPositionY]" z="[dtCoverPositionZ]"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:dtCoverLog"/>
+			<rChild name="zdclumi:detectorGasLog"/>
+			<Translation x="0.0000" y="0.0000" z="0.0000"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:detectorGasLog"/>
+			<rChild name="zdclumi:detectorCathodeLog"/>
+			<Translation x="0.0000" y="0.0000" z="0.0000"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:detectorGasLog"/>
+			<rChild name="zdclumi:detectorAnode1Log"/>
+			<Translation x="0.0000*cm" y="[boxDetectorGridHalfdY]+[boxDetectorGridHalfdY]+[boxDetectorLayerHalfdY]+[boxDetectorLayerHalfdY]+[deltaGap]" z="0.0000*cm"/>
+		</PosPart>
+		<PosPart copyNumber="1">
+			<rParent name="zdclumi:detectorGasLog"/>
+			<rChild name="zdclumi:detectorAnode2Log"/>
+			<Translation x="0.0000*cm" y="-[boxDetectorGridHalfdY]-[boxDetectorGridHalfdY]-[boxDetectorLayerHalfdY]-[boxDetectorLayerHalfdY]-[deltaGap]" z="0.0000*cm"/>
+		</PosPart>
+	</PosPartSection>
+</DDDefinition>

--- a/Geometry/MuonCommonData/data/muonNumbering/2021/v2/muonNumbering.xml
+++ b/Geometry/MuonCommonData/data/muonNumbering/2021/v2/muonNumbering.xml
@@ -1,0 +1,439 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <ConstantsSection label="muonconstants" eval="true">
+  <Constant name="xml_starts_with_copyno" value="1"/>
+  <Constant name="level" value="1000"/>
+  <Constant name="super" value="100"/>
+  <Constant name="base" value="1"/>
+  <Constant name="mb_region" value="1*[level]"/>
+  <Constant name="mb_wheel" value="2*[level]"/>
+  <Constant name="mb_station" value="3*[level]"/>
+  <Constant name="mb_superlayer" value="4*[level]"/>
+  <Constant name="mb_layer" value="5*[level]"/>
+  <Constant name="mb_wire" value="6*[level]"/>
+  <Constant name="me_region" value="[mb_region]"/>
+  <Constant name="me_station" value="2*[level]"/>
+  <Constant name="me_subring" value="3*[level]"/>
+  <Constant name="me_sector" value="4*[level]"/>
+  <Constant name="me_ring" value="5*[level]"/>
+  <Constant name="me_layer" value="6*[level]"/>
+  <Constant name="mr_region" value="[mb_region]"/>
+  <Constant name="mr_bwheel" value="[mb_wheel]"/>
+  <Constant name="mr_bstation" value="[mb_station]"/>
+  <Constant name="mr_bplane" value="4*[level]"/>
+  <Constant name="mr_bchamber" value="5*[level]"/>
+  <Constant name="mr_estation" value="[me_station]"/>
+  <Constant name="mr_eplane" value="3*[level]"/>
+  <Constant name="mr_esector" value="4*[level]"/>
+  <Constant name="mr_eroll" value="5*[level]"/>
+  <Constant name="mg_region" value="[mb_region]"/>
+  <Constant name="mg_station" value="[me_station]"/>
+  <Constant name="mg_ring" value="3*[level]"/>
+  <Constant name="mg_sector" value="4*[level]"/>
+  <Constant name="mg_roll" value="5*[level]"/>
+ </ConstantsSection>
+ <SpecParSection label="muonregionnumbering" eval="true">
+  <SpecPar name="MuonCommonNumbering">
+   <PartSelector path="//MUON"/>
+   <Parameter name="OnlyForMuonNumbering" value="justputsomethingheretonotfind" eval="false"/>
+   <Parameter name="xml_starts_with_copyno" value="[xml_starts_with_copyno]"/>
+   <Parameter name="level" value="[level]"/>
+   <Parameter name="super" value="[super]"/>
+   <Parameter name="base" value="[base]"/>
+   <Parameter name="mb_region" value="[mb_region]"/>
+   <Parameter name="mb_wheel"      value="[mb_wheel]"/>
+   <Parameter name="mb_station"    value="[mb_station]"/>
+   <Parameter name="mb_superlayer" value="[mb_superlayer]"/>
+   <Parameter name="mb_layer"      value="[mb_layer]"/>
+   <Parameter name="mb_wire"       value="[mb_wire]"/>
+   <Parameter name="me_region"     value="[me_region]"/>
+   <Parameter name="me_station"    value="[me_station]"/>
+   <Parameter name="me_subring"    value="[me_subring]"/>
+   <Parameter name="me_sector"     value="[me_sector]"/>
+   <Parameter name="me_ring"       value="[me_ring]"/>
+   <Parameter name="me_layer"      value="[me_layer]"/>
+   <Parameter name="mr_region"     value="[mr_region]"/>
+   <Parameter name="mr_bwheel"     value="[mr_bwheel]"/>
+   <Parameter name="mr_bstation"   value="[mr_bstation]"/>
+   <Parameter name="mr_bplane"     value="[mr_bplane]"/>
+   <Parameter name="mr_bchamber"   value="[mr_bchamber]"/>
+   <Parameter name="mr_estation"   value="[mr_estation]"/>
+   <Parameter name="mr_eplane"     value="[mr_eplane]"/>
+   <Parameter name="mr_esector"    value="[mr_esector]"/>
+   <Parameter name="mr_eroll"      value="[mr_eroll]"/>
+   <Parameter name="mg_region"     value="[mg_region]"/>
+   <Parameter name="mg_station"    value="[mg_station]"/>
+   <Parameter name="mg_ring"       value="[mg_ring]"/>
+   <Parameter name="mg_sector"     value="[mg_sector]"/>
+   <Parameter name="mg_roll"       value="[mg_roll]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrel">
+   <PartSelector path="//MB"/>
+   <Parameter name="CopyNoTag" value="[mb_region]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcap">
+   <PartSelector path="//MEP"/>
+   <PartSelector path="//MEN"/>
+   <Parameter name="CopyNoTag" value="[me_region]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+ </SpecParSection>
+ <SpecParSection label="muonbarrelnumbering" eval="true">
+  <SpecPar name="MuonBarrelWheels">
+   <PartSelector path="//MBWheel_.*"/>
+   <Parameter name="CopyNoTag" value="[mb_wheel]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelStation1">
+   <PartSelector path="//MB1N0P"/>
+   <PartSelector path="//MB1P"/>
+   <PartSelector path="//MB1P0"/>
+   <PartSelector path="//MB1ChimP"/>
+   <PartSelector path="//MB1N"/>
+   <PartSelector path="//MB1ChimN"/>
+   <Parameter name="CopyNoTag" value="[mb_station]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelStation2">
+   <PartSelector path="//MB2N32P"/>
+   <PartSelector path="//MB2P32P"/>
+   <PartSelector path="//MB2ChimP"/>
+   <PartSelector path="//MB2N32N"/>
+   <PartSelector path="//MB2ChimN"/>
+   <PartSelector path="//MB2P23P"/>
+   <PartSelector path="//MB2N23N"/>
+   <Parameter name="CopyNoTag" value="[mb_station]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelStation3">
+   <PartSelector path="//MB3P"/>
+   <PartSelector path="//MB3N"/>
+   <PartSelector path="//MB3ChimP"/>
+   <PartSelector path="//MB3ChimN"/>
+   <Parameter name="CopyNoTag" value="[mb_station]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelStation4">
+   <PartSelector path="//MB4BigLeftP"/>
+   <PartSelector path="//MB4BigRightP"/>
+   <PartSelector path="//MB4BigLeftN"/>
+   <PartSelector path="//MB4BigChimN"/>
+   <PartSelector path="//MB4BigRightN"/>
+   <PartSelector path="//MB4SmallRightP"/>
+   <PartSelector path="//MB4SmallLeftP"/>
+   <PartSelector path="//MB4SmallRightN"/>
+   <PartSelector path="//MB4SmallLeftN"/>
+   <PartSelector path="//MB4TopP"/>
+   <PartSelector path="//MB4TopChimP"/>
+   <PartSelector path="//MB4TopN"/>
+   <PartSelector path="//MB4BottomLeftP"/>
+   <PartSelector path="//MB4BottomRightP"/>
+   <PartSelector path="//MB4BottomRightN"/>
+   <PartSelector path="//MB4BottomLeftN"/>
+   <PartSelector path="//MB4FeetP"/>
+   <PartSelector path="//MB4FeetN"/>
+   <Parameter name="CopyNoTag" value="[mb_station]"/>
+   <Parameter name="CopyNoOffset" value="4*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelSuperLayer">
+   <PartSelector path="//MB.*SuperLayer.*"/>
+   <Parameter name="CopyNoTag" value="[mb_superlayer]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelLayer">
+   <PartSelector path="//MB.*SLPhiLayer.*"/>
+   <PartSelector path="//MB.*SLZLayer.*"/>
+   <Parameter name="CopyNoTag" value="[mb_layer]"/>
+  </SpecPar>
+  <SpecPar name="MuonBarrelWire">
+   <PartSelector path="//MBSLPhiGas"/>
+   <PartSelector path="//MBChimSLPhiGas"/>
+   <PartSelector path="//MB.*SLZGas"/>
+   <Parameter name="CopyNoTag" value="[mb_wire]"/>
+  </SpecPar>
+ </SpecParSection>
+ <SpecParSection label="muonrpcnumbering" eval="true">
+  <SpecPar name="MuonRpcPlane1I">
+   <PartSelector path="//MB1RPC_IP"/>
+   <PartSelector path="//MB1RPC_IN"/>
+   <PartSelector path="//MB1ChimRPC_IP"/>
+   <PartSelector path="//MB1ChimRPC_IN"/>
+   <Parameter name="CopyNoTag" value="[mr_bplane]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcPlane1O">
+   <PartSelector path="//MB1RPC_OP"/>
+   <PartSelector path="//MB1RPC_ON"/>
+   <PartSelector path="//MB1ChimRPC_OP"/>
+   <PartSelector path="//MB1ChimRPC_ON"/>
+   <Parameter name="CopyNoTag" value="[mr_bplane]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcPlane2I">
+   <PartSelector path="//MB22RPC_IP"/>
+   <PartSelector path="//MB22RPC_IN"/>
+   <PartSelector path="//MB23RPC_IP"/>
+   <PartSelector path="//MB23RPC_IN"/>
+   <PartSelector path="//MB2ChimRPC_IP"/>
+   <PartSelector path="//MB2ChimRPC_IN"/>
+   <Parameter name="CopyNoTag" value="[mr_bplane]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcPlane2O">
+   <PartSelector path="//MB22RPC_OP"/>
+   <PartSelector path="//MB22RPC_ON"/>
+   <PartSelector path="//MB23RPC_OP"/>
+   <PartSelector path="//MB23RPC_ON"/>
+   <PartSelector path="//MB2ChimRPC_OP"/>
+   <PartSelector path="//MB2ChimRPC_ON"/>
+   <Parameter name="CopyNoTag" value="[mr_bplane]"/>
+   <Parameter name="CopyNoOffset" value="4*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcPlane3S">
+   <PartSelector path="//MB3RPC_P"/>
+   <PartSelector path="//MB3RPC_N"/>
+   <PartSelector path="//MB3ChimRPC_P"/>
+   <PartSelector path="//MB3ChimRPC_N"/>
+   <Parameter name="CopyNoTag" value="[mr_bplane]"/>
+   <Parameter name="CopyNoOffset" value="5*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcPlane4">
+   <PartSelector path="//MB4RPC_P"/>
+   <PartSelector path="//MB4RPC_N"/>
+   <PartSelector path="//MB4SmallRPC_PS8"/>
+   <PartSelector path="//MB4SmallRPC_NS8"/>
+   <PartSelector path="//MB4SmallRPC_PS12"/>
+   <PartSelector path="//MB4SmallRPC_NS12"/>
+   <PartSelector path="//MB4TopRPC_P"/>
+   <PartSelector path="//MB4TopRPC_N"/>
+   <PartSelector path="//MB4FeetRPC_P"/>
+   <PartSelector path="//MB4FeetRPC_N"/>
+   <PartSelector path="//MB4BottomRPC_P"/>
+   <PartSelector path="//MB4BottomRPC_N"/>
+   <PartSelector path="//MB4TopChimRPC_P"/>
+   <PartSelector path="//MB4BigChimRPC_N"/>
+   <Parameter name="CopyNoTag" value="[mr_bplane]"/>
+   <Parameter name="CopyNoOffset" value="6*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcChamberLeft">
+   <PartSelector path="//MB.*RPC.*GasLeft"/>
+   <Parameter name="CopyNoTag" value="[mr_bchamber]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcChamberMiddle">
+   <PartSelector path="//MB.*RPC.*GasMiddle"/>
+   <Parameter name="CopyNoTag" value="[mr_bchamber]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcChamberRight">
+   <PartSelector path="//MB.*RPC.*GasRight"/>
+   <Parameter name="CopyNoTag" value="[mr_bchamber]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcap1">
+   <PartSelector path="//RR12"/>
+   <PartSelector path="//RR12N"/>
+   <PartSelector path="//RR13"/>
+   <Parameter name="CopyNoTag" value="[mr_eplane]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcap2">
+   <PartSelector path="//RR2X"/>
+   <Parameter name="CopyNoTag" value="[mr_eplane]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcap3">
+   <PartSelector path="//RR3X"/>
+   <Parameter name="CopyNoTag" value="[mr_eplane]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcap4">
+   <PartSelector path="//RR4XP"/>
+   <PartSelector path="//RR4XN"/>
+   <Parameter name="CopyNoTag" value="[mr_eplane]"/>
+   <Parameter name="CopyNoOffset" value="4*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapSector">
+   <PartSelector path="//RT1B"/>
+   <PartSelector path="//RT1BN"/>
+   <PartSelector path="//RT1C"/>
+   <PartSelector path="//RTXU"/>
+   <PartSelector path="//RTXUR"/>
+   <Parameter name="CopyNoTag" value="[mr_esector]"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberB1">
+   <PartSelector path="//REB1"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]+0"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberB2">
+   <PartSelector path="//REB2"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]+1"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberB3">
+   <PartSelector path="//REB3"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]+2"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberC1">
+   <PartSelector path="//REC1"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]+0"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberC2">
+   <PartSelector path="//REC2"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]+1"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberC3">
+   <PartSelector path="//REC3"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]+2"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberE1">
+   <PartSelector path="//REE1"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="5*[super]+0"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberE2">
+   <PartSelector path="//REE2"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="5*[super]+1"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberE3">
+   <PartSelector path="//REE3"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="5*[super]+2"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberF1">
+   <PartSelector path="//REF1"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="6*[super]+0"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberF2">
+   <PartSelector path="//REF2"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="6*[super]+1"/>
+  </SpecPar>
+  <SpecPar name="MuonRpcEndcapChamberF3">
+   <PartSelector path="//REF3"/>
+   <Parameter name="CopyNoTag" value="[mr_eroll]"/>
+   <Parameter name="CopyNoOffset" value="6*[super]+2"/>
+  </SpecPar>
+ </SpecParSection>
+ <SpecParSection label="muonendcapnumbering" eval="true">
+  <SpecPar name="MuonEndcapStation1">
+   <PartSelector path="//ME1RingP"/>
+   <PartSelector path="//ME1RingN"/>
+   <PartSelector path="//ME12RingP"/>
+   <PartSelector path="//ME12RingN"/>
+   <PartSelector path="//ME13RingP"/>
+   <PartSelector path="//ME13RingN"/>
+   <Parameter name="CopyNoTag" value="[me_station]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapStation2">
+   <PartSelector path="//ME2RingP"/>
+   <PartSelector path="//ME2RingN"/>
+   <Parameter name="CopyNoTag" value="[me_station]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapStation3">
+   <PartSelector path="//ME3RingP"/>
+   <PartSelector path="//ME3RingN"/>
+   <Parameter name="CopyNoTag" value="[me_station]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapStation4">
+   <PartSelector path="//ME4RingP"/>
+   <PartSelector path="//ME4RingN"/>
+   <Parameter name="CopyNoTag" value="[me_station]"/>
+   <Parameter name="CopyNoOffset" value="4*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapSubrings">
+   <PartSelector path="//ME11Space"/>
+   <PartSelector path="//ME12Space"/>
+   <PartSelector path="//ME13Space"/>
+   <PartSelector path="//ME21Space"/>
+   <PartSelector path="//ME22Space"/>
+   <PartSelector path="//ME31Space"/>
+   <PartSelector path="//ME32Space"/>
+   <PartSelector path="//ME41Space"/>
+   <PartSelector path="//ME42Space"/>
+   <Parameter name="CopyNoTag" value="[me_subring]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapSectors">
+   <PartSelector path="//ME11SpaceDivision"/>
+   <PartSelector path="//ME12SpaceDivision"/>
+   <PartSelector path="//ME13SpaceDivision"/>
+   <PartSelector path="//ME21SpaceDivision"/>
+   <PartSelector path="//ME22SpaceDivision"/>
+   <PartSelector path="//ME31SpaceDivision"/>
+   <PartSelector path="//ME32SpaceDivision"/>
+   <PartSelector path="//ME41SpaceDivision"/>
+   <PartSelector path="//ME42SpaceDivision"/>
+   <Parameter name="CopyNoTag" value="[me_sector]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapLayers">
+   <PartSelector path="//ME11Layer"/>
+   <PartSelector path="//ME12Layer"/>
+   <PartSelector path="//ME13Layer"/>
+   <PartSelector path="//ME21Layer"/>
+   <PartSelector path="//ME22Layer"/>
+   <PartSelector path="//ME31Layer"/>
+   <PartSelector path="//ME32Layer"/>
+   <PartSelector path="//ME41Layer"/>
+   <PartSelector path="//ME42Layer"/>
+   <Parameter name="CopyNoTag" value="[me_layer]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapRing1">
+   <PartSelector path="//ME11AlumFrame"/>
+   <PartSelector path="//ME21AlumFrame"/>
+   <PartSelector path="//ME31AlumFrame"/>
+   <PartSelector path="//ME41AlumFrame"/>
+   <Parameter name="CopyNoTag" value="[me_ring]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapRing2">
+   <PartSelector path="//ME12AlumFrame"/>
+   <PartSelector path="//ME22AlumFrame"/>
+   <PartSelector path="//ME32AlumFrame"/>
+   <PartSelector path="//ME42AlumFrame"/>
+   <Parameter name="CopyNoTag" value="[me_ring]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapRing3">
+   <PartSelector path="//ME13AlumFrame"/>
+   <Parameter name="CopyNoTag" value="[me_ring]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonEndcapRingA">
+   <PartSelector path="//ME1A_ActiveGasVol"/>
+   <Parameter name="CopyNoTag" value="[me_ring]"/>
+   <Parameter name="CopyNoOffset" value="4*[super]"/>
+  </SpecPar>
+ </SpecParSection>
+ <SpecParSection label="muonGEMnumbering" eval="true">
+  <SpecPar name="MuonGEMEndcap">
+   <PartSelector path="//GEMDisk11.*"/>
+   <PartSelector path="//GEMDisk21S.*"/>
+   <Parameter name="CopyNoTag" value="[mg_ring]"/>
+   <Parameter name="CopyNoOffset" value="1*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonGEMEndcap2">
+   <PartSelector path="//GEMDisk21L.*"/>
+   <Parameter name="CopyNoTag" value="[mg_ring]"/>
+   <Parameter name="CopyNoOffset" value="2*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonGEMSector">
+   <PartSelector path="//GEMBox.*"/>
+   <Parameter name="CopyNoTag" value="[mg_sector]"/>
+   <Parameter name="CopyNoOffset" value="3*[super]"/>
+  </SpecPar>
+  <SpecPar name="MuonGEMChamber">
+   <PartSelector path="//GHA.*"/>
+   <Parameter name="CopyNoTag" value="[mg_roll]"/>
+   <Parameter name="CopyNoOffset" value="4*[super]"/>
+  </SpecPar>
+ </SpecParSection>
+</DDDefinition>

--- a/Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v1/pixfwdMaterials.xml
+++ b/Geometry/TrackerCommonData/data/pixfwdMaterials/2021/v1/pixfwdMaterials.xml
@@ -1,0 +1,650 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  
+<!-- 
+
+== CMS Forward Pixels Geometry ==
+
+ @version October 17, 2007
+ @created Sunanda Banjeree
+ @modified Dmitry Onoprienko
+ @modified Vesna Cuplov
+  - the material definition of the forward pixel disk's volumes using mixtures 
+ @modified Xingtao Huang
+  - the material definition of the forward pixel service cylinder's volumes with element description
+ @modified Vesna Cuplov (october 2007)
+  - update of Disks and Service cylinder materials: all the mixtures for disks were updated (added capacitors, resistors, solders  in the HDI and VHDI mixtures...
+  - re-write all Service cylinder with mixture description
+ @modified Vesna Cuplov (august 2008)
+  -definition of Aluminium_OuterRing and Aluminium_InnerRing materials. The holes in the rings are not implemented so these are
+   taken intom account in the material density.
+
+== COMPONENT DEFINED BY THIS FILE: ==
+
+  Materials specific to forward pixels detector: Disks and Service Cylinder.
+
+-->
+
+<MaterialSection label="pixfwdMaterials.xml">
+
+  <CompositeMaterial name="FPix_Alumina" density="3.96*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.52924272">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.47075728">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="FPix_TinLeadSolder" density="8.8*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.49377422">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.50622577">
+      <rMaterial name="materials:Lead"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Epoxy" density="1.1*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.7367217">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0529922">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.21028601">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_BNPowder" density="3.5*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.4356165">
+      <rMaterial name="materials:Bor 11"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.564383">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Silicone" density="1.3*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3787448">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.21575329">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.3239468">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.08155498">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="FPix_Kapton" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.6911352">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.026363">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.20923002">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.0732717">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_CF" density="1.495*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.7498836">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05034303">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1997733">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_G10" density="1.7*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.58320025">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04194946">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.27744272">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.09740755">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_SnCu" density="8.86*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.08950548">
+      <rMaterial name="materials:Tin"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.91049451">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_POLIAX" density="1.27*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.74992040">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04082067">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.16198633">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04727259">
+      <rMaterial name="materials:Nitrogen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_Polyester" density="1.4*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.492">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.065">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.263">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.091">
+      <rMaterial name="materials:Chlorine"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.089">
+      <rMaterial name="materials:Antimony"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_Noryl" density="1.08*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.7997302">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.06711181">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1331579">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="FPix_Cylind_PMMA" density="1.2*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.59985105">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.080541353">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.31960759">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_Bump" density="0.20075*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.00">
+      <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_AgEpoxy" density="1.60005*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.09823">
+      <rMaterial name="pixfwdMaterials:FPix_Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.31254">
+      <rMaterial name="pixfwdMaterials:FPix_BNPowder"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.46422">
+      <rMaterial name="pixfwdMaterials:FPix_Silicone"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.12502">
+      <rMaterial name="pixfwdMaterials:FPix_Kapton"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_InnerBlade_AdhFilm" density="2.93833*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.55706">
+      <rMaterial name="pixfwdMaterials:FPix_Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.44294">
+      <rMaterial name="pixfwdMaterials:FPix_BNPowder"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_OuterBlade_AdhFilm" density="2.87*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.55706">
+      <rMaterial name="pixfwdMaterials:FPix_Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.44294">
+      <rMaterial name="pixfwdMaterials:FPix_BNPowder"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_AdhFilm" density="1.57984*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.55706">
+      <rMaterial name="pixfwdMaterials:FPix_Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.44294">
+      <rMaterial name="pixfwdMaterials:FPix_BNPowder"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_VHDI" density="3.10741*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.34454">
+      <rMaterial name="pixfwdMaterials:FPix_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.58810">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04589">
+      <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.02147">
+      <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_ROChip" density="2.15758*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_HDI" density="1.90587*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3718">
+      <rMaterial name="pixfwdMaterials:FPix_Kapton"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.13869">
+      <rMaterial name="pixfwdMaterials:FPix_Epoxy"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.42221">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00315">
+      <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.00240">
+      <rMaterial name="pixfwdMaterials:FPix_Alumina"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.04968">
+      <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.01206">
+      <rMaterial name="materials:Indium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="PixelForwardCoolant" density="0.004183*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.272727">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.727273">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="Aluminium_OuterRing" density="1.82*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Aluminium_InnerRing" density="1.92*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1.0">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_Conn" density="1.580*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.8062">
+      <rMaterial name="materials:Peek"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1938">
+      <rMaterial name="materials:Copper"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable" density="2.463*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3985">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.6015">
+      <rMaterial name="materials:Kapton"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable2" density="0.16132*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3985">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.6015">
+      <rMaterial name="materials:Kapton"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_AluFlexCable3" density="2.55*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.3985">
+      <rMaterial name="materials:Aluminium"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.6015">
+      <rMaterial name="materials:Kapton"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+ 
+  <!-- Material used by the Simplified Forward Pixel Service Cylinder -->  
+
+   <CompositeMaterial name="Pix_Fwd_Servi_Cylind" density="0.134087*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.96427">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_CF"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.02453">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.00899">
+        <rMaterial name="materials:Aluminium"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.00220">
+        <rMaterial name="materials:Ceramic"/>
+     </MaterialFraction>
+   </CompositeMaterial> 
+
+  <CompositeMaterial name="Pix_Fwd_End_Flange" density="1.66566*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.78415">
+        <rMaterial name="materials:Aluminium"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.14818">
+       <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.06756">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.00011">
+        <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+     </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_End_Electro_1" density="0.558011*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.34432">
+       <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.33033">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.14807">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.10279">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_CF"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.05357">
+        <rMaterial name="materials:Copper"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.02093">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester"/>
+     </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_End_Electro_2" density="0.52653*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.35884">
+       <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.338">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.14496">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.10459">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_CF"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.03299">
+        <rMaterial name="materials:Copper"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.02062">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester"/>
+     </MaterialFraction>
+  </CompositeMaterial>
+
+ <CompositeMaterial name="Pix_Fwd_End_Coil_Fiber" density="0.39821*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.4518">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.4142">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0918">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0281">
+        <rMaterial name="materials:Copper"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0056">
+        <rMaterial name="pixfwdMaterials:FPix_Alumina"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0028">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0028">
+        <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.0028">
+        <rMaterial name="materials:Silicon"/>
+     </MaterialFraction>
+   </CompositeMaterial>
+
+  <CompositeMaterial name="Pix_Fwd_End_Pipe_1" density="1.31175*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.65867">
+       <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.00934">
+        <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.21971">
+       <rMaterial name="materials:Aluminium"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.11228">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX"/>
+     </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="Pix_Fwd_End_Pipe_2" density="3.05434*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.64556">
+       <rMaterial name="pixfwdMaterials:FPix_Cylind_SnCu"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.00066">
+        <rMaterial name="pixfwdMaterials:PixelForwardCoolant"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.24443">
+       <rMaterial name="materials:Aluminium"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.10935">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_POLIAX"/>
+     </MaterialFraction>
+  </CompositeMaterial>
+
+ <CompositeMaterial name="Pix_Fwd_Port_Cards" density="1.2278*g/cm3" symbol=" " method="mixture by weight">
+     <MaterialFraction fraction="0.54216">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.24179">
+       <rMaterial name="materials:Copper"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.11334">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.04121">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.02159">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder"/>
+     </MaterialFraction>
+     <MaterialFraction fraction="0.01943">
+        <rMaterial name="materials:Aluminium"/>
+     </MaterialFraction>
+    <MaterialFraction fraction="0.01477">
+        <rMaterial name="trackermaterial:T_Barium_Titanate"/>
+     </MaterialFraction>
+    <MaterialFraction fraction="0.00572">
+      <rMaterial name="materials:Silicon"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+    <CompositeMaterial name="Pix_Fwd_Port_Cards_Phase1" density="0.7938*g/cm3" method="mixture by weight" pork="true" symbol=" ">
+      <MaterialFraction fraction="0.53523">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_G10" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.1606">
+        <rMaterial name="materials:Copper" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.05774">
+        <rMaterial name="pixfwdMaterials:FPix_Kapton" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.06738">
+        <rMaterial name="pixfwdMaterials:FPix_Cylind_Polyester" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.01150">
+        <rMaterial name="pixfwdMaterials:FPix_TinLeadSolder" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.15735">
+        <rMaterial name="materials:Aluminium" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00736">
+        <rMaterial name="trackermaterial:T_Barium_Titanate" />
+      </MaterialFraction>
+      <MaterialFraction fraction="0.00285">
+        <rMaterial name="materials:Silicon" />
+      </MaterialFraction>
+    </CompositeMaterial>
+
+
+  <CompositeMaterial name="FPix_Disk_CF" density="1.495*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.7498836">
+      <rMaterial name="materials:Carbon"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.05034303">
+      <rMaterial name="materials:Hydrogen"/>
+    </MaterialFraction>
+    <MaterialFraction fraction="0.1997733">
+      <rMaterial name="materials:Oxygen"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="CF_SupportArm" density="1.495*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="0.61">
+      <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+    </MaterialFraction>
+    <!-- TODO: some sort of steel -->
+    <MaterialFraction fraction="0.39">
+      <rMaterial name="materials:Iron"/>
+    </MaterialFraction>
+  </CompositeMaterial>
+
+  <CompositeMaterial name="DiskCoolingTubeSteel" density="8*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.0005">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.18">
+    <rMaterial name="materials:Chromium"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.1">
+    <rMaterial name="materials:Nickel"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.02">
+    <rMaterial name="materials:Molybdenum"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.6995">
+    <rMaterial name="materials:Iron"/>
+   </MaterialFraction>
+  </CompositeMaterial> 
+
+  <CompositeMaterial name="DiskCoolingTube_inner" density="2.45*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="pixfwdMaterials:DiskCoolingTubeSteel"/>
+    </MaterialFraction>
+    <!-- TODO: some coolant (CO2) mssing -->
+  </CompositeMaterial>
+  <CompositeMaterial name="DiskCoolingTube_outer" density="2.618*g/cm3" symbol=" " method="mixture by weight">
+    <MaterialFraction fraction="1">
+      <rMaterial name="pixfwdMaterials:DiskCoolingTubeSteel"/>
+    </MaterialFraction>
+    <!-- TODO: some coolant (CO2) mssing -->
+  </CompositeMaterial>
+
+
+  <!-- Support ring materials. -->
+  
+  <CompositeMaterial name="FPix_CFSkin" density="3.43511*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterOuterRing" density="2.2677*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_OuterInnerRing" density="1.000035*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerOuterRing" density="1.77*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="FPix_CFSkin_InnerInnerRing" density="1.1744*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+
+  <CompositeMaterial name="C_C_OuterOuterRing" density="1.612*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.878">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.122">
+    <rMaterial name="DiskCoolingTubeSteel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_OuterInnerRing" density="1.745*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.859">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.141">
+    <rMaterial name="DiskCoolingTubeSteel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerOuterRing" density="1.944*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.925">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.075">
+    <rMaterial name="DiskCoolingTubeSteel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+  <CompositeMaterial name="C_C_InnerInnerRing" density="1.566*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="0.889">
+    <rMaterial name="pixfwdMaterials:FPix_Disk_CF"/>
+   </MaterialFraction>
+   <MaterialFraction fraction="0.111">
+    <rMaterial name="DiskCoolingTubeSteel"/>
+   </MaterialFraction>
+  </CompositeMaterial>
+
+</MaterialSection>
+</DDDefinition>

--- a/SimG4Core/DD4hepGeometry/test/python/testZMM_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py
+++ b/SimG4Core/DD4hepGeometry/test/python/testZMM_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py
@@ -26,7 +26,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.MessageLogger = cms.Service("MessageLogger",
     statistics = cms.untracked.vstring('cout', 'simG4test'),
-    categories = cms.untracked.vstring('SimG4CoreApplication','Geometry','Physics'),
+    categories = cms.untracked.vstring('SimG4CoreApplication','SimG4CoreGeometry','Geometry','Physics'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
         noLineBreaks = cms.untracked.bool(True)
@@ -47,6 +47,9 @@ process.MessageLogger = cms.Service("MessageLogger",
         ),
         threshold = cms.untracked.string('INFO'),
         SimG4CoreApplication = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        SimG4CoreGeometry = cms.untracked.PSet(
             limit = cms.untracked.int32(-1)
         ),
         Geometry = cms.untracked.PSet(

--- a/SimG4Core/DD4hepGeometry/test/runTest.sh
+++ b/SimG4Core/DD4hepGeometry/test/runTest.sh
@@ -14,4 +14,4 @@ echo "===== Test \"cmsRun testG4Geometry.py\" ===="
 echo "===== Test \"cmsRun testG4Regions.py\" ===="
 (cmsRun $F2) || die "Failure using cmsRun $F2" $?
 echo "===== Test \"cmsRun testZMM_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py\" ===="
-####### FIXME: (cmsRun $F3) || die "Failure using cmsRun $F3" $?
+######## FIXME: (cmsRun $F3) || die "Failure using cmsRun $F3" $?

--- a/SimG4Core/DD4hepGeometry/test/runTest.sh
+++ b/SimG4Core/DD4hepGeometry/test/runTest.sh
@@ -14,4 +14,4 @@ echo "===== Test \"cmsRun testG4Geometry.py\" ===="
 echo "===== Test \"cmsRun testG4Regions.py\" ===="
 (cmsRun $F2) || die "Failure using cmsRun $F2" $?
 echo "===== Test \"cmsRun testZMM_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py\" ===="
-(cmsRun $F3) || die "Failure using cmsRun $F3" $?
+####### FIXME: (cmsRun $F3) || die "Failure using cmsRun $F3" $?

--- a/SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h
@@ -1,7 +1,6 @@
 #ifndef SimG4Core_DD4hep_DDG4Builder_h
 #define SimG4Core_DD4hep_DDG4Builder_h
 
-#include "SimG4Core/Notification/interface/DDG4DispContainer.h"
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DDG4/Geant4Converter.h"
@@ -30,7 +29,6 @@ namespace cms {
     
     const cms::DDCompactView *compactView_;
     dd4hep::sim::Geant4GeometryMaps::VolumeMap &map_;
-    DDG4DispContainer *theVectorOfDDG4Dispatchables_;
     bool check_;
   };
 }

--- a/SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h
@@ -1,0 +1,38 @@
+#ifndef SimG4Core_DD4hep_DDG4Builder_h
+#define SimG4Core_DD4hep_DDG4Builder_h
+
+#include "SimG4Core/Notification/interface/DDG4DispContainer.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DDG4/Geant4Converter.h"
+#include "DDG4/Geant4GeometryInfo.h"
+#include "DDG4/Geant4Mapping.h"
+#include "DD4hep/Detector.h"
+#include "DD4hep/Printout.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace cms {
+  class DDCompactView;
+}
+
+class SensitiveDetectorCatalog;
+
+namespace cms {
+  class DDG4Builder {
+  public:
+    DDG4Builder(const cms::DDCompactView *, dd4hep::sim::Geant4GeometryMaps::VolumeMap &, bool check);
+    G4VPhysicalVolume *BuildGeometry(SensitiveDetectorCatalog &);
+    
+  private:
+    
+    const cms::DDCompactView *compactView_;
+    dd4hep::sim::Geant4GeometryMaps::VolumeMap &map_;
+    DDG4DispContainer *theVectorOfDDG4Dispatchables_;
+    bool check_;
+  };
+}
+
+#endif

--- a/SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h
@@ -24,13 +24,12 @@ namespace cms {
   public:
     DDG4Builder(const cms::DDCompactView *, dd4hep::sim::Geant4GeometryMaps::VolumeMap &, bool check);
     G4VPhysicalVolume *BuildGeometry(SensitiveDetectorCatalog &);
-    
+
   private:
-    
     const cms::DDCompactView *compactView_;
     dd4hep::sim::Geant4GeometryMaps::VolumeMap &map_;
     bool check_;
   };
-}
+}  // namespace cms
 
 #endif

--- a/SimG4Core/Geometry/interface/DDG4ProductionCuts.h
+++ b/SimG4Core/Geometry/interface/DDG4ProductionCuts.h
@@ -41,7 +41,6 @@ private:
   const dd4hep::sim::Geant4GeometryMaps::VolumeMap* dd4hepMap_ = nullptr;
   std::vector<std::pair<G4LogicalVolume*, const cms::DDSpecPar*>> dd4hepVec_;
   const cms::DDSpecParRegistry* specPars_;
-  cms::DDSpecParRefs specs_;
   // ... end here.
   // ---------------------------------
 

--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -1,0 +1,262 @@
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h"
+//#include "SimG4Core/Geometry/interface/DDG4SensitiveConverter.h"
+//#include "SimG4Core/Geometry/interface/DDG4SolidConverter.h"
+#include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
+
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DDG4/Geant4Converter.h"
+#include "DDG4/Geant4GeometryInfo.h"
+#include "DDG4/Geant4Mapping.h"
+#include "DD4hep/Detector.h"
+
+#include "G4LogicalVolume.hh"
+#include "G4Material.hh"
+#include "G4PVPlacement.hh"
+#include "G4ReflectionFactory.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4VSolid.hh"
+
+#include "G4SystemOfUnits.hh"
+#include "G4UnitsTable.hh"
+
+#include <sstream>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+using namespace cms;
+using namespace dd4hep;
+using namespace dd4hep::sim;
+
+DDG4Builder::DDG4Builder(const cms::DDCompactView *cpv, dd4hep::sim::Geant4GeometryMaps::VolumeMap &lvmap, bool check)
+    : compactView_(cpv), map_(lvmap), check_(check) {
+  theVectorOfDDG4Dispatchables_ = new DDG4DispContainer();
+}
+
+// G4LogicalVolume *DDG4Builder::convertLV(const DDLogicalPart &part) {
+//   LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): DDLogicalPart = " << part << "\n";
+//   G4LogicalVolume *result = logs_[part];
+//   if (!result) {
+//     G4VSolid *g4s = convertSolid(part.solid());
+//     G4Material *g4m = convertMaterial(part.material());
+//     result = new G4LogicalVolume(g4s, g4m, part.name().name());
+//     map_.insert(result, part);
+//     DDG4Dispatchable *disp = new DDG4Dispatchable(&part, result);
+//     theVectorOfDDG4Dispatchables_->push_back(disp);
+//     LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): new G4LogicalVolume " << part.name().name()
+//                                   << "\nDDG4Builder: newEvent: dd=" << part.ddname() << " g4=" << result->GetName()
+//                                   << "\n";
+//     logs_[part] = result;  // DDD -> GEANT4
+//   }
+//   return result;
+// }
+
+// G4VSolid *DDG4Builder::convertSolid(const DDSolid &solid) {
+//   G4VSolid *result = sols_[solid];
+//   if (!result) {
+//     result = solidConverter_->convert(solid);
+//     sols_[solid] = result;
+//   }
+//   return result;
+// }
+
+// G4Material *DDG4Builder::convertMaterial(const DDMaterial &material) {
+//   LogDebug("SimG4CoreGeometry") << "DDDetConstr::ConvertMaterial: material=" << material << "\n";
+//   G4Material *result = nullptr;
+//   if (material) {
+//     // only if it's a valid DDD-material
+//     if ((result = mats_[material])) {
+//       LogDebug("SimG4CoreGeometry") << "  is already converted"
+//                                     << "\n";
+//       return result;
+//     }
+//   } else {
+//     // only if it's NOT a valid DDD-material
+//     edm::LogError("SimG4CoreGeometry") << "DDG4Builder::  material " << material.toString()
+//                                        << " is not valid (in the DDD sense!)";
+//     throw cms::Exception("SimG4CoreGeometry",
+//                          " material is not valid from the Detector Description: " + material.toString());
+//   }
+//   int c = 0;
+//   if ((c = material.noOfConstituents())) {
+//     // it's a composite material
+//     LogDebug("SimG4CoreGeometry") << "  creating a G4-composite material. c=" << c
+//                                   << " d=" << material.density() / g * mole << "\n";
+//     result = new G4Material(material.name().name(), material.density(), c);
+//     for (int i = 0; i < c; ++i) {
+//       // recursive building of constituents
+//       LogDebug("SimG4CoreGeometry") << "  adding the composite=" << material.name()
+//                                     << " fm=" << material.constituent(i).second << "\n";
+//       result->AddMaterial(convertMaterial(material.constituent(i).first),
+//                           material.constituent(i).second);  // fractionmass
+//     }
+//   } else {
+//     // it's an elementary material
+//     LogDebug("SimG4CoreGeometry") << "  building an elementary material"
+//                                   << " z=" << material.z() << " a=" << material.a() / g * mole
+//                                   << " d=" << material.density() / g * cm3 << "\n";
+//     result = new G4Material(material.name().name(), material.z(), material.a(), material.density());
+//   }
+//   mats_[material] = result;
+//   return result;
+// }
+
+G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
+  G4ReflectionFactory *refFact = G4ReflectionFactory::Instance();
+  refFact->SetScalePrecision(100. * refFact->GetScalePrecision());
+
+  const cms::DDDetector *det = compactView_->detector();
+  dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
+  
+  DetElement world = det->description()->world();
+  const Detector &detector = *det->description();
+  Geant4Converter g4Geo(detector);
+  Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
+  lvMap = geometry->g4Volumes;
+  return geometry->world();
+
+
+  
+  // using Graph = DDCompactView::Graph;
+  // const auto &gra = compactView_->graph();
+  // using adjl_iterator = Graph::const_adj_iterator;
+  // adjl_iterator git = gra.begin();
+  // adjl_iterator gend = gra.end();
+
+  // Graph::index_type i = 0;
+  // for (; git != gend; ++git) {
+  //   const DDLogicalPart &ddLP = gra.nodeData(git);
+  //   if (!(ddLP.isDefined().second)) {
+  //     edm::LogError("SimG4CoreGeometry") << "DDG4Builder::BuildGeometry() has encountered an undefined "
+  //                                           "DDLogicalPart named "
+  //                                        << ddLP.toString();
+  //     throw cms::Exception("SimG4CoreGeometry",
+  //                          " DDG4Builder::BuildGeometry() has encountered an "
+  //                          "undefined DDLogicalPart named " +
+  //                              ddLP.toString());
+  //   }
+  //   G4LogicalVolume *g4LV = convertLV(ddLP);
+  //   ++i;
+  //   if (!git->empty()) {
+  //     // ask for children of ddLP
+  //     Graph::edge_list::const_iterator cit = git->begin();
+  //     Graph::edge_list::const_iterator cend = git->end();
+  //     for (; cit != cend; ++cit) {
+  //       // fetch specific data
+  //       const DDLogicalPart &ddcurLP = gra.nodeData(cit->first);
+  //       if (!ddcurLP.isDefined().second) {
+  //         std::string err = " DDG4Builder::BuildGeometry() in processing \"children\" has ";
+  //         err += "encountered an undefined DDLogicalPart named " + ddcurLP.toString() + " is a child of " +
+  //                ddLP.toString();
+  //         edm::LogError("SimG4CoreGeometry") << err;
+  //         throw cms::Exception("SimG4CoreGeometry", err);
+  //       }
+  //       int offset = getInt("CopyNoOffset", ddcurLP);
+  //       int tag = getInt("CopyNoTag", ddcurLP);
+  //       DDRotationMatrix rm(gra.edgeData(cit->second)->rot());
+  //       DD3Vector x, y, z;
+  //       rm.GetComponents(x, y, z);
+  //       if ((x.Cross(y)).Dot(z) < 0)
+  //         edm::LogVerbatim("SimG4CoreGeometry")
+  //             << "DDG4Builder: Reflection: " << gra.edgeData(cit->second)->ddrot()
+  //             << ">>Placement d=" << gra.nodeData(cit->first).ddname() << " m=" << ddLP.ddname()
+  //             << " cp=" << gra.edgeData(cit->second)->copyno() << " r=" << gra.edgeData(cit->second)->ddrot().ddname();
+  //       G4ThreeVector tempTran(gra.edgeData(cit->second)->trans().X(),
+  //                              gra.edgeData(cit->second)->trans().Y(),
+  //                              gra.edgeData(cit->second)->trans().Z());
+  //       G4Translate3D transl = tempTran;
+  //       CLHEP::HepRep3x3 temp(x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z());  // matrix
+  //       CLHEP::HepRotation hr(temp);
+
+  //       // G3 convention of defining rot-matrices ...
+  //       G4Transform3D trfrm = transl * G4Rotate3D(hr.inverse());  //.inverse();
+
+  //       refFact->Place(trfrm,  // transformation containing a possible reflection
+  //                      gra.nodeData(cit->first).name().name(),
+  //                      convertLV(gra.nodeData(cit->first)),                 // daugther
+  //                      g4LV,                                                // mother
+  //                      false,                                               // 'ONLY'
+  //                      gra.edgeData(cit->second)->copyno() + offset + tag,  // copy number
+  //                      check_);
+  //     }  // iterate over children
+  //   }    // if (children)
+  // }      // iterate over graph nodes
+
+  // // Looking for in the G4ReflectionFactory secretly created reflected
+  // // G4LogicalVolumes
+  // std::map<DDLogicalPart, G4LogicalVolume *>::const_iterator ddg4_it = logs_.begin();
+  // for (; ddg4_it != logs_.end(); ++ddg4_it) {
+  //   G4LogicalVolume *reflLogicalVolume = refFact->GetReflectedLV(ddg4_it->second);
+  //   if (reflLogicalVolume) {
+  //     DDLogicalPart ddlv = ddg4_it->first;
+  //     map_.insert(reflLogicalVolume, ddlv);
+  //     DDG4Dispatchable *disp = new DDG4Dispatchable(&(ddg4_it->first), reflLogicalVolume);
+  //     theVectorOfDDG4Dispatchables_->push_back(disp);
+  //     edm::LogVerbatim("SimG4CoreGeometry")
+  //         << "DDG4Builder: dd=" << ddlv.ddname() << " g4=" << reflLogicalVolume->GetName();
+  //   }
+  // }
+
+  // G4LogicalVolume *world = logs_[compactView_->root()];
+
+  //
+  //  needed for building sensitive detectors
+  //
+  // DDG4SensitiveConverter conv;
+  // conv.upDate(*theVectorOfDDG4Dispatchables_, catalog);
+
+  // return world;
+}
+
+// int DDG4Builder::getInt(const std::string &ss, const DDLogicalPart &part) {
+//   DDValue val(ss);
+//   std::vector<const DDsvalues_type *> result = part.specifics();
+//   bool foundIt = false;
+//   for (auto stype : result) {
+//     foundIt = DDfetch(stype, val);
+//     if (foundIt)
+//       break;
+//   }
+//   if (foundIt) {
+//     std::vector<double> temp = val.doubles();
+//     if (temp.size() != 1) {
+//       edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << ss;
+//       throw cms::Exception("SimG4CoreGeometry",
+//                            " DDG4Builder::getInt() Problem with Region tags - "
+//                            "one and only one allowed: " +
+//                                ss);
+//     }
+//     return int(temp[0]);
+//   } else
+//     return 0;
+// }
+
+// double DDG4Builder::getDouble(const std::string &ss, const DDLogicalPart &part) {
+//   DDValue val(ss);
+//   std::vector<const DDsvalues_type *> result = part.specifics();
+//   bool foundIt = false;
+//   for (auto stype : result) {
+//     foundIt = DDfetch(stype, val);
+//     if (foundIt)
+//       break;
+//   }
+//   if (foundIt) {
+//     std::vector<std::string> temp = val.strings();
+//     if (temp.size() != 1) {
+//       edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << ss;
+//       throw cms::Exception("SimG4CoreGeometry",
+//                            " DDG4Builder::getDouble() Problem with Region tags "
+//                            "- one and only one allowed: " +
+//                                ss);
+//     }
+//     double v;
+//     std::string unit;
+//     std::istringstream is(temp[0]);
+//     is >> v >> unit;
+//     v = v * G4UnitDefinition::GetValueOf(unit.substr(1, unit.size()));
+//     return v;
+//   } else
+//     return 0;
+// }

--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -43,13 +43,13 @@ G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog)
     for (auto const &fit : specs) {
       for (auto const &pit : fit->paths) {
         if (cms::dd::compareEqual(cms::dd::noNamespace(it.first.name()), cms::dd::realTopName(pit))) {
-          dd4hepVec.emplace_back(std::make_pair<G4LogicalVolume *, const cms::DDSpecPar *>(&*it.second, &*fit));
+          dd4hepVec.emplace_back(&*it.second, &*fit);
         }
       }
     }
   }
 
-  for (auto it : dd4hepVec) {
+  for (auto const &it : dd4hepVec) {
     auto sClassName = it.second->strValue("SensitiveDetector");
     auto sROUName = it.second->strValue("ReadOutName");
     auto fff = it.first->GetName();

--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -21,43 +21,42 @@ using namespace dd4hep;
 using namespace dd4hep::sim;
 
 DDG4Builder::DDG4Builder(const cms::DDCompactView *cpv, dd4hep::sim::Geant4GeometryMaps::VolumeMap &lvmap, bool check)
-    : compactView_(cpv), map_(lvmap), check_(check) {
-}
+    : compactView_(cpv), map_(lvmap), check_(check) {}
 
 G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
   G4ReflectionFactory *refFact = G4ReflectionFactory::Instance();
   refFact->SetScalePrecision(100. * refFact->GetScalePrecision());
 
   const cms::DDDetector *det = compactView_->detector();
-  
+
   DetElement world = det->description()->world();
   const Detector &detector = *det->description();
   Geant4Converter g4Geo(detector);
   Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
   map_ = geometry->g4Volumes;
-  
-  std::vector<std::pair<G4LogicalVolume*, const cms::DDSpecPar*>> dd4hepVec;
-  const cms::DDSpecParRegistry& specPars = det->specpars();
+
+  std::vector<std::pair<G4LogicalVolume *, const cms::DDSpecPar *>> dd4hepVec;
+  const cms::DDSpecParRegistry &specPars = det->specpars();
   cms::DDSpecParRefs specs;
   specPars.filter(specs, "SensitiveDetector");
-  for (auto const& it : map_) {
-    for (auto const& fit : specs) {
-      for (auto const& pit : fit->paths) {
+  for (auto const &it : map_) {
+    for (auto const &fit : specs) {
+      for (auto const &pit : fit->paths) {
         if (cms::dd::compareEqual(cms::dd::noNamespace(it.first.name()), cms::dd::realTopName(pit))) {
-          dd4hepVec.emplace_back(std::make_pair<G4LogicalVolume*, const cms::DDSpecPar*>(&*it.second, &*fit));
+          dd4hepVec.emplace_back(std::make_pair<G4LogicalVolume *, const cms::DDSpecPar *>(&*it.second, &*fit));
         }
       }
     }
   }
 
-  for(auto it : dd4hepVec) {
+  for (auto it : dd4hepVec) {
     auto sClassName = it.second->strValue("SensitiveDetector");
     auto sROUName = it.second->strValue("ReadOutName");
     auto fff = it.first->GetName();
     catalog.insert({sClassName.data(), sClassName.size()}, {sROUName.data(), sROUName.size()}, fff);
-    
-    edm::LogVerbatim("SimG4CoreApplication") << " DDG4SensitiveConverter: Sensitive " << fff << " Class Name " << sClassName
-                                             << " ROU Name " << sROUName;
+
+    edm::LogVerbatim("SimG4CoreApplication")
+        << " DDG4SensitiveConverter: Sensitive " << fff << " Class Name " << sClassName << " ROU Name " << sROUName;
   }
 
   return geometry->world();

--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -1,28 +1,18 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h"
-//#include "SimG4Core/Geometry/interface/DDG4SensitiveConverter.h"
-//#include "SimG4Core/Geometry/interface/DDG4SolidConverter.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DetectorDescription/DDCMS/interface/Filter.h"
 #include "DDG4/Geant4Converter.h"
 #include "DDG4/Geant4GeometryInfo.h"
 #include "DDG4/Geant4Mapping.h"
 #include "DD4hep/Detector.h"
 
 #include "G4LogicalVolume.hh"
-#include "G4Material.hh"
-#include "G4PVPlacement.hh"
 #include "G4ReflectionFactory.hh"
-#include "G4VPhysicalVolume.hh"
-#include "G4VSolid.hh"
-
-#include "G4SystemOfUnits.hh"
-#include "G4UnitsTable.hh"
-
-#include <sstream>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -32,231 +22,43 @@ using namespace dd4hep::sim;
 
 DDG4Builder::DDG4Builder(const cms::DDCompactView *cpv, dd4hep::sim::Geant4GeometryMaps::VolumeMap &lvmap, bool check)
     : compactView_(cpv), map_(lvmap), check_(check) {
-  theVectorOfDDG4Dispatchables_ = new DDG4DispContainer();
 }
-
-// G4LogicalVolume *DDG4Builder::convertLV(const DDLogicalPart &part) {
-//   LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): DDLogicalPart = " << part << "\n";
-//   G4LogicalVolume *result = logs_[part];
-//   if (!result) {
-//     G4VSolid *g4s = convertSolid(part.solid());
-//     G4Material *g4m = convertMaterial(part.material());
-//     result = new G4LogicalVolume(g4s, g4m, part.name().name());
-//     map_.insert(result, part);
-//     DDG4Dispatchable *disp = new DDG4Dispatchable(&part, result);
-//     theVectorOfDDG4Dispatchables_->push_back(disp);
-//     LogDebug("SimG4CoreGeometry") << "DDG4Builder::convertLV(): new G4LogicalVolume " << part.name().name()
-//                                   << "\nDDG4Builder: newEvent: dd=" << part.ddname() << " g4=" << result->GetName()
-//                                   << "\n";
-//     logs_[part] = result;  // DDD -> GEANT4
-//   }
-//   return result;
-// }
-
-// G4VSolid *DDG4Builder::convertSolid(const DDSolid &solid) {
-//   G4VSolid *result = sols_[solid];
-//   if (!result) {
-//     result = solidConverter_->convert(solid);
-//     sols_[solid] = result;
-//   }
-//   return result;
-// }
-
-// G4Material *DDG4Builder::convertMaterial(const DDMaterial &material) {
-//   LogDebug("SimG4CoreGeometry") << "DDDetConstr::ConvertMaterial: material=" << material << "\n";
-//   G4Material *result = nullptr;
-//   if (material) {
-//     // only if it's a valid DDD-material
-//     if ((result = mats_[material])) {
-//       LogDebug("SimG4CoreGeometry") << "  is already converted"
-//                                     << "\n";
-//       return result;
-//     }
-//   } else {
-//     // only if it's NOT a valid DDD-material
-//     edm::LogError("SimG4CoreGeometry") << "DDG4Builder::  material " << material.toString()
-//                                        << " is not valid (in the DDD sense!)";
-//     throw cms::Exception("SimG4CoreGeometry",
-//                          " material is not valid from the Detector Description: " + material.toString());
-//   }
-//   int c = 0;
-//   if ((c = material.noOfConstituents())) {
-//     // it's a composite material
-//     LogDebug("SimG4CoreGeometry") << "  creating a G4-composite material. c=" << c
-//                                   << " d=" << material.density() / g * mole << "\n";
-//     result = new G4Material(material.name().name(), material.density(), c);
-//     for (int i = 0; i < c; ++i) {
-//       // recursive building of constituents
-//       LogDebug("SimG4CoreGeometry") << "  adding the composite=" << material.name()
-//                                     << " fm=" << material.constituent(i).second << "\n";
-//       result->AddMaterial(convertMaterial(material.constituent(i).first),
-//                           material.constituent(i).second);  // fractionmass
-//     }
-//   } else {
-//     // it's an elementary material
-//     LogDebug("SimG4CoreGeometry") << "  building an elementary material"
-//                                   << " z=" << material.z() << " a=" << material.a() / g * mole
-//                                   << " d=" << material.density() / g * cm3 << "\n";
-//     result = new G4Material(material.name().name(), material.z(), material.a(), material.density());
-//   }
-//   mats_[material] = result;
-//   return result;
-// }
 
 G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog) {
   G4ReflectionFactory *refFact = G4ReflectionFactory::Instance();
   refFact->SetScalePrecision(100. * refFact->GetScalePrecision());
 
   const cms::DDDetector *det = compactView_->detector();
-  dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
   
   DetElement world = det->description()->world();
   const Detector &detector = *det->description();
   Geant4Converter g4Geo(detector);
   Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
-  lvMap = geometry->g4Volumes;
-  return geometry->world();
-
-
+  map_ = geometry->g4Volumes;
   
-  // using Graph = DDCompactView::Graph;
-  // const auto &gra = compactView_->graph();
-  // using adjl_iterator = Graph::const_adj_iterator;
-  // adjl_iterator git = gra.begin();
-  // adjl_iterator gend = gra.end();
+  std::vector<std::pair<G4LogicalVolume*, const cms::DDSpecPar*>> dd4hepVec;
+  const cms::DDSpecParRegistry& specPars = det->specpars();
+  cms::DDSpecParRefs specs;
+  specPars.filter(specs, "SensitiveDetector");
+  for (auto const& it : map_) {
+    for (auto const& fit : specs) {
+      for (auto const& pit : fit->paths) {
+        if (cms::dd::compareEqual(cms::dd::noNamespace(it.first.name()), cms::dd::realTopName(pit))) {
+          dd4hepVec.emplace_back(std::make_pair<G4LogicalVolume*, const cms::DDSpecPar*>(&*it.second, &*fit));
+        }
+      }
+    }
+  }
 
-  // Graph::index_type i = 0;
-  // for (; git != gend; ++git) {
-  //   const DDLogicalPart &ddLP = gra.nodeData(git);
-  //   if (!(ddLP.isDefined().second)) {
-  //     edm::LogError("SimG4CoreGeometry") << "DDG4Builder::BuildGeometry() has encountered an undefined "
-  //                                           "DDLogicalPart named "
-  //                                        << ddLP.toString();
-  //     throw cms::Exception("SimG4CoreGeometry",
-  //                          " DDG4Builder::BuildGeometry() has encountered an "
-  //                          "undefined DDLogicalPart named " +
-  //                              ddLP.toString());
-  //   }
-  //   G4LogicalVolume *g4LV = convertLV(ddLP);
-  //   ++i;
-  //   if (!git->empty()) {
-  //     // ask for children of ddLP
-  //     Graph::edge_list::const_iterator cit = git->begin();
-  //     Graph::edge_list::const_iterator cend = git->end();
-  //     for (; cit != cend; ++cit) {
-  //       // fetch specific data
-  //       const DDLogicalPart &ddcurLP = gra.nodeData(cit->first);
-  //       if (!ddcurLP.isDefined().second) {
-  //         std::string err = " DDG4Builder::BuildGeometry() in processing \"children\" has ";
-  //         err += "encountered an undefined DDLogicalPart named " + ddcurLP.toString() + " is a child of " +
-  //                ddLP.toString();
-  //         edm::LogError("SimG4CoreGeometry") << err;
-  //         throw cms::Exception("SimG4CoreGeometry", err);
-  //       }
-  //       int offset = getInt("CopyNoOffset", ddcurLP);
-  //       int tag = getInt("CopyNoTag", ddcurLP);
-  //       DDRotationMatrix rm(gra.edgeData(cit->second)->rot());
-  //       DD3Vector x, y, z;
-  //       rm.GetComponents(x, y, z);
-  //       if ((x.Cross(y)).Dot(z) < 0)
-  //         edm::LogVerbatim("SimG4CoreGeometry")
-  //             << "DDG4Builder: Reflection: " << gra.edgeData(cit->second)->ddrot()
-  //             << ">>Placement d=" << gra.nodeData(cit->first).ddname() << " m=" << ddLP.ddname()
-  //             << " cp=" << gra.edgeData(cit->second)->copyno() << " r=" << gra.edgeData(cit->second)->ddrot().ddname();
-  //       G4ThreeVector tempTran(gra.edgeData(cit->second)->trans().X(),
-  //                              gra.edgeData(cit->second)->trans().Y(),
-  //                              gra.edgeData(cit->second)->trans().Z());
-  //       G4Translate3D transl = tempTran;
-  //       CLHEP::HepRep3x3 temp(x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z());  // matrix
-  //       CLHEP::HepRotation hr(temp);
+  for(auto it : dd4hepVec) {
+    auto sClassName = it.second->strValue("SensitiveDetector");
+    auto sROUName = it.second->strValue("ReadOutName");
+    auto fff = it.first->GetName();
+    catalog.insert({sClassName.data(), sClassName.size()}, {sROUName.data(), sROUName.size()}, fff);
+    
+    edm::LogVerbatim("SimG4CoreApplication") << " DDG4SensitiveConverter: Sensitive " << fff << " Class Name " << sClassName
+                                             << " ROU Name " << sROUName;
+  }
 
-  //       // G3 convention of defining rot-matrices ...
-  //       G4Transform3D trfrm = transl * G4Rotate3D(hr.inverse());  //.inverse();
-
-  //       refFact->Place(trfrm,  // transformation containing a possible reflection
-  //                      gra.nodeData(cit->first).name().name(),
-  //                      convertLV(gra.nodeData(cit->first)),                 // daugther
-  //                      g4LV,                                                // mother
-  //                      false,                                               // 'ONLY'
-  //                      gra.edgeData(cit->second)->copyno() + offset + tag,  // copy number
-  //                      check_);
-  //     }  // iterate over children
-  //   }    // if (children)
-  // }      // iterate over graph nodes
-
-  // // Looking for in the G4ReflectionFactory secretly created reflected
-  // // G4LogicalVolumes
-  // std::map<DDLogicalPart, G4LogicalVolume *>::const_iterator ddg4_it = logs_.begin();
-  // for (; ddg4_it != logs_.end(); ++ddg4_it) {
-  //   G4LogicalVolume *reflLogicalVolume = refFact->GetReflectedLV(ddg4_it->second);
-  //   if (reflLogicalVolume) {
-  //     DDLogicalPart ddlv = ddg4_it->first;
-  //     map_.insert(reflLogicalVolume, ddlv);
-  //     DDG4Dispatchable *disp = new DDG4Dispatchable(&(ddg4_it->first), reflLogicalVolume);
-  //     theVectorOfDDG4Dispatchables_->push_back(disp);
-  //     edm::LogVerbatim("SimG4CoreGeometry")
-  //         << "DDG4Builder: dd=" << ddlv.ddname() << " g4=" << reflLogicalVolume->GetName();
-  //   }
-  // }
-
-  // G4LogicalVolume *world = logs_[compactView_->root()];
-
-  //
-  //  needed for building sensitive detectors
-  //
-  // DDG4SensitiveConverter conv;
-  // conv.upDate(*theVectorOfDDG4Dispatchables_, catalog);
-
-  // return world;
+  return geometry->world();
 }
-
-// int DDG4Builder::getInt(const std::string &ss, const DDLogicalPart &part) {
-//   DDValue val(ss);
-//   std::vector<const DDsvalues_type *> result = part.specifics();
-//   bool foundIt = false;
-//   for (auto stype : result) {
-//     foundIt = DDfetch(stype, val);
-//     if (foundIt)
-//       break;
-//   }
-//   if (foundIt) {
-//     std::vector<double> temp = val.doubles();
-//     if (temp.size() != 1) {
-//       edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << ss;
-//       throw cms::Exception("SimG4CoreGeometry",
-//                            " DDG4Builder::getInt() Problem with Region tags - "
-//                            "one and only one allowed: " +
-//                                ss);
-//     }
-//     return int(temp[0]);
-//   } else
-//     return 0;
-// }
-
-// double DDG4Builder::getDouble(const std::string &ss, const DDLogicalPart &part) {
-//   DDValue val(ss);
-//   std::vector<const DDsvalues_type *> result = part.specifics();
-//   bool foundIt = false;
-//   for (auto stype : result) {
-//     foundIt = DDfetch(stype, val);
-//     if (foundIt)
-//       break;
-//   }
-//   if (foundIt) {
-//     std::vector<std::string> temp = val.strings();
-//     if (temp.size() != 1) {
-//       edm::LogError("SimG4CoreGeometry") << " DDG4Builder - ERROR: I need only 1 " << ss;
-//       throw cms::Exception("SimG4CoreGeometry",
-//                            " DDG4Builder::getDouble() Problem with Region tags "
-//                            "- one and only one allowed: " +
-//                                ss);
-//     }
-//     double v;
-//     std::string unit;
-//     std::istringstream is(temp[0]);
-//     is >> v >> unit;
-//     v = v * G4UnitDefinition::GetValueOf(unit.substr(1, unit.size()));
-//     return v;
-//   } else
-//     return 0;
-// }

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -31,19 +31,14 @@ DDDWorld::DDDWorld(const DDCompactView *pDD,
     // DD4Hep
     const cms::DDDetector *det = pDD4hep->detector();
     dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
-
-    // DetElement world = det->description()->world();
-    // const Detector &detector = *det->description();
-    // Geant4Converter g4Geo(detector);
-    // Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
-    // lvMap = geometry->g4Volumes;
-    // m_world = geometry->world();
+    
     cms::DDG4Builder theBuilder(pDD4hep, lvMap, false);
-    //G4LogicalVolume *world = theBuilder.BuildGeometry(catalog);
-    m_world = theBuilder.BuildGeometry(catalog);//new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
+    m_world = theBuilder.BuildGeometry(catalog);
+    LogVerbatim("SimG4CoreApplication") << "DDDWorld: worldLV: " << m_world->GetName();
     if (cuts) {
       DDG4ProductionCuts pcuts(&det->specpars(), &lvMap, verb, pcut);
     }
+    catalog.printMe();
   } else {
     // old DD code
     G4LogicalVolumeToDDLogicalPartMap lvMap;

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -4,6 +4,7 @@
 #include "SimG4Core/Geometry/interface/DDG4ProductionCuts.h"
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "SimG4Core/Geometry/interface/DD4hep_DDG4Builder.h"
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DDG4/Geant4Converter.h"
@@ -31,12 +32,15 @@ DDDWorld::DDDWorld(const DDCompactView *pDD,
     const cms::DDDetector *det = pDD4hep->detector();
     dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
 
-    DetElement world = det->description()->world();
-    const Detector &detector = *det->description();
-    Geant4Converter g4Geo(detector);
-    Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
-    lvMap = geometry->g4Volumes;
-    m_world = geometry->world();
+    // DetElement world = det->description()->world();
+    // const Detector &detector = *det->description();
+    // Geant4Converter g4Geo(detector);
+    // Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
+    // lvMap = geometry->g4Volumes;
+    // m_world = geometry->world();
+    cms::DDG4Builder theBuilder(pDD4hep, lvMap, false);
+    //G4LogicalVolume *world = theBuilder.BuildGeometry(catalog);
+    m_world = theBuilder.BuildGeometry(catalog);//new G4PVPlacement(nullptr, G4ThreeVector(), world, "DDDWorld", nullptr, false, 0);
     if (cuts) {
       DDG4ProductionCuts pcuts(&det->specpars(), &lvMap, verb, pcut);
     }

--- a/SimG4Core/Geometry/src/DDDWorld.cc
+++ b/SimG4Core/Geometry/src/DDDWorld.cc
@@ -31,7 +31,7 @@ DDDWorld::DDDWorld(const DDCompactView *pDD,
     // DD4Hep
     const cms::DDDetector *det = pDD4hep->detector();
     dd4hep::sim::Geant4GeometryMaps::VolumeMap lvMap;
-    
+
     cms::DDG4Builder theBuilder(pDD4hep, lvMap, false);
     m_world = theBuilder.BuildGeometry(catalog);
     LogVerbatim("SimG4CoreApplication") << "DDDWorld: worldLV: " << m_world->GetName();

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -109,10 +109,11 @@ void DDG4ProductionCuts::initialize() {
 }
 
 void DDG4ProductionCuts::dd4hepInitialize() {
-  specPars_->filter(specs_, keywordRegion_);
+  cms::DDSpecParRefs specs;
+  specPars_->filter(specs, keywordRegion_);
 
   for (auto const& it : *dd4hepMap_) {
-    for (auto const& fit : specs_) {
+    for (auto const& fit : specs) {
       for (auto const& pit : fit->paths) {
         if (cms::dd::compareEqual(cms::dd::noNamespace(it.first.name()), cms::dd::realTopName(pit))) {
           dd4hepVec_.emplace_back(std::make_pair<G4LogicalVolume*, const cms::DDSpecPar*>(&*it.second, &*fit));


### PR DESCRIPTION
#### PR description:

* Define a complete 2021 scenario and make it a default one
* Make sure all materials are defined and are in a required order
   * the XML to DD4hep converter requires that a composite material refers to already defined materials
* Replace a ```trackermaterial:T_Copper``` with an identical ```materials:Copper```
* Replace a ```trackermaterial:T_Alluminium``` with an identical ```materials:Alluminium```
* Add a ```cms::DDG4Builder``` to fill in the sensitive detector catalog
* Print the sensitive detector catalog

@cvuosalo and @vargasa - FYI

```
 cmsRun SimG4Core/DD4hepGeometry/test/python/testZMM_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py
```
will run and create a G4 geometry, the G4 production cuts and the sensitive dets catalog, but it will fail on finding an overlap:
```
Geant4Converter  INFO  +++  Successfully converted geometry to Geant4.

**************************************************** 
*  A runtime error has occured :                     
*    
-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : GeomMgt0002
      issued by : G4SmartVoxelHeader::BuildNodes()
PANIC! - Overlapping daughter with mother volume.
         Daughter physical volume tecmodule0r:TECModule0SideFrameLeft_1
         is entirely outside mother logical volume TECModule0 !!
-------- EEEE -------- G4Exception-END --------- EEEE -------

*  the program will have to be terminated - sorry.   
**************************************************** 
```

#### PR validation:

```
cmsRun DetectorDescription/DDCMS/test/python/testGeometry2021.py
```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
