### PR TITLE
DQM: Remove empty labels from METAnalyzer

### DIFF
--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -327,10 +327,6 @@ void METAnalyzer::bookMonitorElement(std::string DirName,
         }
       }
     }
-    if (!hTriggerLabelsIsSet_)
-      for (int i = allTriggerNames_.size(); i < hTrigger->getNbinsX(); i++) {
-        hTrigger->setBinLabel(i + 1, "");
-      }
     hTriggerLabelsIsSet_ = true;
 
     hMEx = ibooker.book1D("MEx", "MEx", 200, -500, 500);


### PR DESCRIPTION
## PR description:

These seemed to cause trouble with merging in the latest ROOT verisons.
There is no easy way of achieving the same effect ("hiding" the unused
bins), but it should not hurt much to have them numbered.

Actually, I can't see the labels in DQMGUI at all, not sure if they get lost somewhere.

This hopefully fixes #27472. Thanks at @Dr15Jones for tracking down the issue!

#### PR validation:

Compiles and runs, should not change any values.
