### PR TITLE
Bug fix for setRunNumberForEachLumi

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1466,8 +1466,9 @@ namespace edm {
 
   std::shared_ptr<RunAuxiliary> RootFile::readRunAuxiliary_() {
     if (runHelper_->fakeNewRun()) {
-      runHelper_->overrideRunNumber(savedRunAuxiliary_->id());
-      return savedRunAuxiliary();
+      auto runAuxiliary = std::make_shared<RunAuxiliary>(*savedRunAuxiliary());
+      runHelper_->overrideRunNumber(runAuxiliary->id());
+      return runAuxiliary;
     }
     assert(indexIntoFileIter_ != indexIntoFileEnd_);
     assert(indexIntoFileIter_.getEntryType() == IndexIntoFile::kRun);

--- a/IOPool/Input/test/RunPerLumiTest_cfg.py
+++ b/IOPool/Input/test/RunPerLumiTest_cfg.py
@@ -21,6 +21,11 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring('file:RunPerLumiTest.root')
 )
 
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('OutputRunPerLumiTest.root')
+)
+
 process.p = cms.Path(process.OtherThing*process.Analysis)
 
+process.e = cms.EndPath(process.output)
 


### PR DESCRIPTION
#### PR description:

The PoolSource configuration option setRunNumberForEachLumi had a bug that would cause an assert failure if there was an output module running (and possibly other problems because the wrong run number was being used at endRun). Probably no one was using this option before now because no one noticed the failure before and there is nothing in the repository referencing it other than a Framework unit test.

This bug should not affect anything if that option is not configured. The code fragment with the bug would not be executed.

#### PR validation:

I added an output module to the unit test so this failure will be detected in the IB if it recurs.
