### PR TITLE
Update tracker alignment for 2021 realistic scenario

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,7 +66,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v9', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
#### PR description:

The global tag queues for the `phase1_2021_realistic` scenario had to be branched to support the different needs of the Run-3 LHCC studies and CMSSW development. This PR introduces an updated tracker alignment [1] and a purely technical payload [2]. It re-synchronizes `auto:phase1_2021_realistic` with the GT used for the Run-3 studies, `106X_mcRun3_2021_realistic_v3`.

It would be useful to have this PR merged to avoid spurious differences in comparison tests in future PRs that affect `phase1_2021_realistic` conditions, for example, the eventual 10_6_X backport of #27644.

GT diff with respect to current autoCond:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_v8/106X_upgrade2021_realistic_v9

GT diff with respect to GT for Run-3 studies:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun3_2021_realistic_v3/106X_upgrade2021_realistic_v9

The tag difference above corresponds to payloads that were introduced by PR #27203 and ignored for Run-3 scenarios in a subsequent commit to that PR.

[1] https://indico.cern.ch/event/831067/contributions/3485251/attachments/1871918/3080764/Run3Alignment_AlcaDB017_AdeWit.pdf 
[2] https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_v8/106X_upgrade2021_realistic_v9

#### PR validation:

Payload validation can be found in [1] and [2]. In addition, `runTheMatrix.py -l 11624.0` was executed as a technical test.

[1] https://indico.cern.ch/event/831067/contributions/3485251/attachments/1871918/3080764/Run3Alignment_AlcaDB017_AdeWit.pdf 
[2] https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_v8/106X_upgrade2021_realistic_v9

#### if this PR is a backport please specify the original PR:

This is not a backport per se but PR #27441 introduced into 11_0_X the tracker alignment payload used in this PR. But it introduced other changes as well; only the changes needed for consistency with existing 10_6_X workflows are used here.
