### PR TITLE
MTV phase2 high eta

### DIFF
--- a/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
+++ b/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
@@ -18,15 +18,38 @@ public:
                             double lip,
                             bool chargedOnly,
                             int status,
-                            const std::vector<int>& pdgId = std::vector<int>())
+                            const std::vector<int>& pdgId = std::vector<int>(),
+                            bool invertRapidityCut = false,
+                            double minPhi = -3.2,
+                            double maxPhi = 3.2)
       : ptMin_(ptMin),
         minRapidity_(minRapidity),
         maxRapidity_(maxRapidity),
+        meanPhi_((minPhi + maxPhi) / 2.),
+        rangePhi_((maxPhi - minPhi) / 2.),
         tip_(tip),
         lip_(lip),
         chargedOnly_(chargedOnly),
         status_(status),
-        pdgId_(pdgId) {}
+        pdgId_(pdgId),
+        invertRapidityCut_(invertRapidityCut) {
+    if (minPhi >= maxPhi) {
+      throw cms::Exception("Configuration")
+          << "GenParticleCustomSelector: minPhi (" << minPhi << ") must be smaller than maxPhi (" << maxPhi
+          << "). The range is constructed from minPhi to maxPhi around their "
+             "average.";
+    }
+    if (minPhi >= M_PI) {
+      throw cms::Exception("Configuration") << "GenParticleCustomSelector: minPhi (" << minPhi
+                                            << ") must be smaller than PI. The range is constructed from minPhi "
+                                               "to maxPhi around their average.";
+    }
+    if (maxPhi <= -M_PI) {
+      throw cms::Exception("Configuration") << "GenParticleCustomSelector: maxPhi (" << maxPhi
+                                            << ") must be larger than -PI. The range is constructed from minPhi "
+                                               "to maxPhi around their average.";
+    }
+  }
 
   /// Operator() performs the selection: e.g. if (tPSelector(tp)) {...}
   bool operator()(const reco::GenParticle& tp) const {
@@ -42,19 +65,38 @@ public:
           testId = true;
       }
 
-    return (tp.pt() >= ptMin_ && tp.eta() >= minRapidity_ && tp.eta() <= maxRapidity_ &&
-            sqrt(tp.vertex().perp2()) <= tip_ && fabs(tp.vertex().z()) <= lip_ && tp.status() == status_ && testId);
+    auto etaOk = [&](const reco::GenParticle& p) -> bool {
+      float eta = p.eta();
+      if (!invertRapidityCut_)
+        return (eta >= minRapidity_) & (eta <= maxRapidity_);
+      else
+        return (!(eta >= minRapidity_) & !(eta <= maxRapidity_));
+    };
+    auto phiOk = [&](const reco::GenParticle& p) {
+      float dphi = deltaPhi(atan2f(p.py(), p.px()), meanPhi_);
+      return dphi >= -rangePhi_ && dphi <= rangePhi_;
+    };
+    auto ptOk = [&](const reco::GenParticle& p) {
+      double pt = tp.pt();
+      return pt >= ptMin_;
+    };
+
+    return (ptOk(tp) && etaOk(tp) && phiOk(tp) && sqrt(tp.vertex().perp2()) <= tip_ && fabs(tp.vertex().z()) <= lip_ &&
+            tp.status() == status_ && testId);
   }
 
 private:
   double ptMin_;
   double minRapidity_;
   double maxRapidity_;
+  float meanPhi_;
+  float rangePhi_;
   double tip_;
   double lip_;
   bool chargedOnly_;
   int status_;
   std::vector<int> pdgId_;
+  bool invertRapidityCut_;
 };
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -77,7 +119,10 @@ namespace reco {
                                          cfg.getParameter<double>("lip"),
                                          cfg.getParameter<bool>("chargedOnly"),
                                          cfg.getParameter<int>("status"),
-                                         cfg.getParameter<std::vector<int> >("pdgId"));
+                                         cfg.getParameter<std::vector<int> >("pdgId"),
+                                         cfg.getParameter<bool>("invertRapidityCut"),
+                                         cfg.getParameter<double>("minPhi"),
+                                         cfg.getParameter<double>("maxPhi"));
       }
     };
 

--- a/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
+++ b/CommonTools/CandAlgos/interface/GenParticleCustomSelector.h
@@ -68,16 +68,16 @@ public:
     auto etaOk = [&](const reco::GenParticle& p) -> bool {
       float eta = p.eta();
       if (!invertRapidityCut_)
-        return (eta >= minRapidity_) & (eta <= maxRapidity_);
+        return (eta >= minRapidity_) && (eta <= maxRapidity_);
       else
-        return (!(eta >= minRapidity_) & !(eta <= maxRapidity_));
+        return (eta < minRapidity_ || eta > maxRapidity_);
     };
     auto phiOk = [&](const reco::GenParticle& p) {
       float dphi = deltaPhi(atan2f(p.py(), p.px()), meanPhi_);
       return dphi >= -rangePhi_ && dphi <= rangePhi_;
     };
     auto ptOk = [&](const reco::GenParticle& p) {
-      double pt = tp.pt();
+      double pt = p.pt();
       return pt >= ptMin_;
     };
 

--- a/CommonTools/CandAlgos/python/genParticleCustomSelector_cfi.py
+++ b/CommonTools/CandAlgos/python/genParticleCustomSelector_cfi.py
@@ -10,6 +10,9 @@ genParticleCustomSelector = cms.EDFilter("GenParticleCustomSelector",
     lip = cms.double(30.0),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.4),
+    minPhi = cms.double(-3.2),
+    maxPhi = cms.double( 3.2),
+    invertRapidityCut = cms.bool(False)
 )
 
 

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -29,7 +29,8 @@ public:
         minPixelHit_(cfg.getParameter<int>("minPixelHit")),
         minLayer_(cfg.getParameter<int>("minLayer")),
         min3DLayer_(cfg.getParameter<int>("min3DLayer")),
-        usePV_(false) {
+        usePV_(false),
+        invertRapidityCut_(cfg.getParameter<bool>("invertRapidityCut")) {
     const auto minPhi = cfg.getParameter<double>("minPhi");
     const auto maxPhi = cfg.getParameter<double>("maxPhi");
     if (minPhi >= maxPhi) {
@@ -114,14 +115,21 @@ public:
 
     const auto dphi = deltaPhi(t.phi(), meanPhi_);
 
+    auto etaOk = [&](const reco::Track& p) -> bool {
+      float eta = p.eta();
+      if (!invertRapidityCut_)
+        return (eta >= minRapidity_) & (eta <= maxRapidity_);
+      else
+        return (!(eta >= minRapidity_) & !(eta <= maxRapidity_));
+    };
+
     return ((algo_ok & quality_ok) && t.hitPattern().numberOfValidHits() >= minHit_ &&
             t.hitPattern().numberOfValidPixelHits() >= minPixelHit_ &&
             t.hitPattern().trackerLayersWithMeasurement() >= minLayer_ &&
             t.hitPattern().pixelLayersWithMeasurement() + t.hitPattern().numberOfValidStripLayersWithMonoAndStereo() >=
                 min3DLayer_ &&
-            fabs(t.pt()) >= ptMin_ && t.eta() >= minRapidity_ && t.eta() <= maxRapidity_ && dphi >= -rangePhi_ &&
-            dphi <= rangePhi_ && fabs(t.dxy(vertex)) <= tip_ && fabs(t.dsz(vertex)) <= lip_ &&
-            t.normalizedChi2() <= maxChi2_);
+            fabs(t.pt()) >= ptMin_ && etaOk(t) && dphi >= -rangePhi_ && dphi <= rangePhi_ &&
+            fabs(t.dxy(vertex)) <= tip_ && fabs(t.dsz(vertex)) <= lip_ && t.normalizedChi2() <= maxChi2_);
   }
 
 private:
@@ -138,6 +146,7 @@ private:
   int minLayer_;
   int min3DLayer_;
   bool usePV_;
+  bool invertRapidityCut_;
 
   edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -118,9 +118,9 @@ public:
     auto etaOk = [&](const reco::Track& p) -> bool {
       float eta = p.eta();
       if (!invertRapidityCut_)
-        return (eta >= minRapidity_) & (eta <= maxRapidity_);
+        return (eta >= minRapidity_) && (eta <= maxRapidity_);
       else
-        return (!(eta >= minRapidity_) & !(eta <= maxRapidity_));
+        return (eta < minRapidity_ || eta > maxRapidity_);
     };
 
     return ((algo_ok & quality_ok) && t.hitPattern().numberOfValidHits() >= minHit_ &&

--- a/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
@@ -20,5 +20,6 @@ recoTrackSelectorPSet = cms.PSet(
     minPixelHit = cms.int32(0),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     usePV = cms.bool(False),
-    vertexTag = cms.InputTag('offlinePrimaryVertices')
+    vertexTag = cms.InputTag('offlinePrimaryVertices'),
+    invertRapidityCut = cms.bool(False)
 )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -17,6 +17,17 @@ from HLTrigger.Configuration.common import *
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+def customiseFor27653(process):
+   """ PR27653 : RecoTrackRefSelector has new parameter: invertRapidityCut
+                 default value (for back compatibility) : cms.bool(False)
+   """
+   for prod in producers_by_type(process,"RecoTrackRefSelector"):
+      if not hasattr(prod,"invertRapidityCut"):
+         setattr(prod,"invertRapidityCut",cms.bool(False))
+#      for p in prod.parameterNames_():
+#         print p
+   return process
+
 def customiseFor2017DtUnpacking(process):
     """Adapt the HLT to run the legacy DT unpacking
     for pre2018 data/MC workflows as the default"""
@@ -52,5 +63,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseFor27653(process)
 
     return process

--- a/PhysicsTools/RecoAlgos/python/trackingParticleSelector_cfi.py
+++ b/PhysicsTools/RecoAlgos/python/trackingParticleSelector_cfi.py
@@ -1,22 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-trackingParticleSelector = cms.EDFilter("TrackingParticleSelector",
-    src = cms.InputTag("mix","MergedTrackTruth"),
-    chargedOnly = cms.bool(True),
-    stableOnly = cms.bool(False),
-    pdgId = cms.vint32(),
-    tip = cms.double(3.5),
-    signalOnly = cms.bool(True),
-    intimeOnly = cms.bool(False),
-    minRapidity = cms.double(-2.4),
-    lip = cms.double(30.0),
-    ptMin = cms.double(0.9),
-    ptMax = cms.double(1e100),
-    maxRapidity = cms.double(2.4),
-    minHit = cms.int32(0),
-    minPhi = cms.double(-3.2),
-    maxPhi = cms.double(3.2),
-)
+import SimTracker.Common.trackingParticleSelector_cfi
+trackingParticleSelector = SimTracker.Common.trackingParticleSelector_cfi.trackingParticleSelector.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(trackingParticleSelector, src = "mixData:MergedTrackTruth")

--- a/SimTracker/Common/interface/TrackingParticleSelector.h
+++ b/SimTracker/Common/interface/TrackingParticleSelector.h
@@ -106,9 +106,9 @@ public:
     auto etaOk = [&](const TrackingParticle &p) -> bool {
       float eta = etaFromXYZ(p.px(), p.py(), p.pz());
       if (!invertRapidityCut_)
-        return (eta >= minRapidity_) & (eta <= maxRapidity_);
+        return (eta >= minRapidity_) && (eta <= maxRapidity_);
       else
-        return (!(eta >= minRapidity_) & !(eta <= maxRapidity_));
+        return (eta < minRapidity_ || eta > maxRapidity_);
     };
     auto phiOk = [&](const TrackingParticle &p) {
       float dphi = deltaPhi(atan2f(p.py(), p.px()), meanPhi_);

--- a/SimTracker/Common/interface/TrackingParticleSelector.h
+++ b/SimTracker/Common/interface/TrackingParticleSelector.h
@@ -28,6 +28,7 @@ public:
                            bool chargedOnly,
                            bool stableOnly,
                            const std::vector<int> &pdgId = std::vector<int>(),
+                           bool invertRapidityCut = false,
                            double minPhi = -3.2,
                            double maxPhi = 3.2)
       : ptMin2_(ptMin * ptMin),
@@ -43,7 +44,8 @@ public:
         intimeOnly_(intimeOnly),
         chargedOnly_(chargedOnly),
         stableOnly_(stableOnly),
-        pdgId_(pdgId) {
+        pdgId_(pdgId),
+        invertRapidityCut_(invertRapidityCut) {
     if (minPhi >= maxPhi) {
       throw cms::Exception("Configuration")
           << "TrackingParticleSelector: minPhi (" << minPhi << ") must be smaller than maxPhi (" << maxPhi
@@ -103,7 +105,10 @@ public:
 
     auto etaOk = [&](const TrackingParticle &p) -> bool {
       float eta = etaFromXYZ(p.px(), p.py(), p.pz());
-      return (eta >= minRapidity_) & (eta <= maxRapidity_);
+      if (!invertRapidityCut_)
+        return (eta >= minRapidity_) & (eta <= maxRapidity_);
+      else
+        return (!(eta >= minRapidity_) & !(eta <= maxRapidity_));
     };
     auto phiOk = [&](const TrackingParticle &p) {
       float dphi = deltaPhi(atan2f(p.py(), p.px()), meanPhi_);
@@ -134,6 +139,7 @@ private:
   bool chargedOnly_;
   bool stableOnly_;
   std::vector<int> pdgId_;
+  bool invertRapidityCut_;
 };
 
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
@@ -161,6 +167,7 @@ namespace reco {
                                         cfg.getParameter<bool>("chargedOnly"),
                                         cfg.getParameter<bool>("stableOnly"),
                                         cfg.getParameter<std::vector<int>>("pdgId"),
+                                        cfg.getParameter<bool>("invertRapidityCut"),
                                         cfg.getParameter<double>("minPhi"),
                                         cfg.getParameter<double>("maxPhi"));
       }

--- a/SimTracker/Common/python/trackingParticleSelector_cfi.py
+++ b/SimTracker/Common/python/trackingParticleSelector_cfi.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-trackingParticleRefSelector = cms.EDFilter("TrackingParticleRefSelector",
+trackingParticleSelector = cms.EDFilter("TrackingParticleSelector",
     src = cms.InputTag("mix","MergedTrackTruth"),
     chargedOnly = cms.bool(True),
+    stableOnly = cms.bool(False),
     pdgId = cms.vint32(),
     tip = cms.double(3.5),
     signalOnly = cms.bool(True),
     intimeOnly = cms.bool(False),
-    stableOnly = cms.bool(False),
     minRapidity = cms.double(-2.4),
     lip = cms.double(30.0),
     ptMin = cms.double(0.9),
@@ -18,6 +18,3 @@ trackingParticleRefSelector = cms.EDFilter("TrackingParticleRefSelector",
     maxPhi = cms.double(3.2),
     invertRapidityCut = cms.bool(False)
 )
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(trackingParticleRefSelector, src = "mixData:MergedTrackTruth")

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -142,8 +142,9 @@ struct MTVHistoProducerAlgoForTrackerHistograms {
   std::vector<ConcurrentMonitorElement> h_assochi2, h_assochi2_prob;
 
   //chi2 and # lost hits vs eta: to be used with doProfileX
-  std::vector<ConcurrentMonitorElement> chi2_vs_eta, nlosthits_vs_eta;
-  std::vector<ConcurrentMonitorElement> assoc_chi2_vs_eta, assoc_chi2prob_vs_eta;
+  std::vector<ConcurrentMonitorElement> chi2_vs_eta, chi2_vs_pt, nlosthits_vs_eta;
+  std::vector<ConcurrentMonitorElement> assoc_chi2_vs_eta, assoc_chi2_vs_pt, assoc_chi2prob_vs_eta,
+      assoc_chi2prob_vs_pt;
 
   //resolution of track params: to be used with fitslicesytool
   std::vector<ConcurrentMonitorElement> dxyres_vs_eta, ptres_vs_eta, dzres_vs_eta, phires_vs_eta, cotThetares_vs_eta;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -166,7 +166,8 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset)
                                         pset.getParameter<bool>("intimeOnlyTP"),
                                         pset.getParameter<bool>("chargedOnlyTP"),
                                         pset.getParameter<bool>("stableOnlyTP"),
-                                        pset.getParameter<std::vector<int>>("pdgIdTP"));
+                                        pset.getParameter<std::vector<int>>("pdgIdTP"),
+                                        pset.getParameter<bool>("invertRapidityCutTP"));
 
   cosmictpSelector = CosmicTrackingParticleSelector(pset.getParameter<double>("ptMinTP"),
                                                     pset.getParameter<double>("minRapidityTP"),
@@ -189,7 +190,8 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset)
                                           psetVsPhi.getParameter<bool>("intimeOnly"),
                                           psetVsPhi.getParameter<bool>("chargedOnly"),
                                           psetVsPhi.getParameter<bool>("stableOnly"),
-                                          psetVsPhi.getParameter<std::vector<int>>("pdgId"));
+                                          psetVsPhi.getParameter<std::vector<int>>("pdgId"),
+                                          psetVsPhi.getParameter<bool>("invertRapidityCut"));
 
   dRTrackSelector = MTVHistoProducerAlgoForTracker::makeRecoTrackSelectorFromTPSelectorParameters(psetVsPhi);
 

--- a/Validation/RecoTrack/python/GenParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/GenParticleSelectionsForEfficiency_cff.py
@@ -23,7 +23,10 @@ generalGpSelectorBlock = cms.PSet(
     minRapidity = cms.double(-2.5),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
-    tip = cms.double(3.5)
+    tip = cms.double(3.5),
+    invertRapidityCut = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2)
 )
 
 
@@ -35,7 +38,10 @@ GpSelectorForEfficiencyVsEtaBlock = cms.PSet(
     minRapidity = cms.double(-2.5),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
-    tip = cms.double(3.5)
+    tip = cms.double(3.5),
+    invertRapidityCut = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2)
 )
 
 GpSelectorForEfficiencyVsPhiBlock = cms.PSet(
@@ -46,7 +52,10 @@ GpSelectorForEfficiencyVsPhiBlock = cms.PSet(
     minRapidity = cms.double(-2.5),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
-    tip = cms.double(3.5)
+    tip = cms.double(3.5),
+    invertRapidityCut = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2)
 )
 
 GpSelectorForEfficiencyVsPtBlock = cms.PSet(
@@ -58,6 +67,9 @@ GpSelectorForEfficiencyVsPtBlock = cms.PSet(
     ptMin = cms.double(0.050),
     tip = cms.double(3.5),
     lip = cms.double(30.0),
+    invertRapidityCut = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2)
 )
 
 GpSelectorForEfficiencyVsVTXRBlock = cms.PSet(
@@ -68,7 +80,10 @@ GpSelectorForEfficiencyVsVTXRBlock = cms.PSet(
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
     lip = cms.double(30.0),
-    tip = cms.double(30.0)
+    tip = cms.double(30.0),
+    invertRapidityCut = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2)
 )
 
 GpSelectorForEfficiencyVsVTXZBlock = cms.PSet(
@@ -79,7 +94,10 @@ GpSelectorForEfficiencyVsVTXZBlock = cms.PSet(
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
     lip = cms.double(35.0),
-    tip = cms.double(3.5)
+    tip = cms.double(3.5),
+    invertRapidityCut = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2)
 )
 
 def _modifyForPhase1(pset):

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -15,13 +15,8 @@ def _addNoFlow(module):
         if not tmp[ind-1] in _noflowSeen:
             module.noFlowDists.append(tmp[ind-1])
 
-listOfDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*")
-
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(listOfDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"]))
-
 postProcessorTrack = DQMEDHarvester("DQMGenericClient",
-    subDirs = listOfDirs,
+    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -248,14 +243,9 @@ postProcessorTrack = DQMEDHarvester("DQMGenericClient",
 )
 _addNoFlow(postProcessorTrack)
 
-listOfDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*")
-
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(listOfDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"]))
-
 postProcessorTrack2D = DQMEDHarvester("DQMGenericClient",
     makeGlobalEffienciesPlot = cms.untracked.bool(False),
-    subDirs = listOfDirs,
+    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
     efficiency = cms.vstring(
     "efficPtvseta 'Efficiency in p_{T}-#eta plane' num_assoc(simToReco)_pTvseta num_simul_pTvseta",
     "duplicatesRate_Ptvseta 'Duplicates Rate in (p_{T}-#eta) plane' num_duplicate_pTvseta num_reco_pTvseta",
@@ -296,13 +286,8 @@ postProcessorTrackNrecVsNsim2D = DQMEDHarvester("DQMGenericClient",
 _addNoFlow(postProcessorTrackNrecVsNsim2D)
 
 
-listOfDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackTPPtLess09", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackBuilding", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron")
-
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(listOfDirs.extend(["Tracking/TrackTPEtaGreater2p7"]))
-
 postProcessorTrackSummary = DQMEDHarvester("DQMGenericClient",
-    subDirs = listOfDirs,
+    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackTPPtLess09", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackBuilding", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",
@@ -320,6 +305,15 @@ postProcessorTrackSequence = cms.Sequence(
     postProcessorTrackNrecVsNsim+
     postProcessorTrackSummary
 )
+
+postProcessorTrackPhase2 = postProcessorTrack.clone()
+postProcessorTrackPhase2.subDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"])
+postProcessorTrackSummaryPhase2 = postProcessorTrackSummary.clone()
+postProcessorTrackSummaryPhase2.subDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"])
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(postProcessorTrack,postProcessorTrackPhase2)
+phase2_tracker.toReplaceWith(postProcessorTrackSummary,postProcessorTrackSummaryPhase2)
 
 postProcessorTrackTrackingOnly = postProcessorTrack.clone()
 postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -15,8 +15,13 @@ def _addNoFlow(module):
         if not tmp[ind-1] in _noflowSeen:
             module.noFlowDists.append(tmp[ind-1])
 
+listOfDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*")
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(listOfDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"]))
+
 postProcessorTrack = DQMEDHarvester("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
+    subDirs = listOfDirs,
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -243,9 +248,14 @@ postProcessorTrack = DQMEDHarvester("DQMGenericClient",
 )
 _addNoFlow(postProcessorTrack)
 
+listOfDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*")
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(listOfDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"]))
+
 postProcessorTrack2D = DQMEDHarvester("DQMGenericClient",
     makeGlobalEffienciesPlot = cms.untracked.bool(False),
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
+    subDirs = listOfDirs,
     efficiency = cms.vstring(
     "efficPtvseta 'Efficiency in p_{T}-#eta plane' num_assoc(simToReco)_pTvseta num_simul_pTvseta",
     "duplicatesRate_Ptvseta 'Duplicates Rate in (p_{T}-#eta) plane' num_duplicate_pTvseta num_reco_pTvseta",
@@ -285,8 +295,14 @@ postProcessorTrackNrecVsNsim2D = DQMEDHarvester("DQMGenericClient",
 )
 _addNoFlow(postProcessorTrackNrecVsNsim2D)
 
+
+listOfDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackTPPtLess09", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackBuilding", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron")
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(listOfDirs.extend(["Tracking/TrackTPEtaGreater2p7"]))
+
 postProcessorTrackSummary = DQMEDHarvester("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackTPPtLess09", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackBuilding", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron"),
+    subDirs = listOfDirs,
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -410,8 +410,6 @@ trackValidatorTPEtaGreater2p7 = trackValidator.clone(
     label = [x for x in trackValidator.label.value() if ("Pt09" not in x) and ("BtvLike" not in x) and ("AK4PFJets" not in x)],
     dodEdxPlots = False,
 #    doPVAssociationPlots = False,
-#    doSimPlots = False,
-    doResolutionPlotsForLabels = ["disabled"],
     minRapidityTP = -2.7,
     maxRapidityTP = 2.7,
     invertRapidityCutTP = True,
@@ -430,7 +428,7 @@ trackValidatorTPEtaGreater2p7 = trackValidator.clone(
     ),
     doSimPlots = False,       # same as in trackValidator, no need to repeat here
     doRecoTrackPlots = False, # fake rates are same as in trackValidator, no need to repeat here
-#    doResolutionPlotsForLabels = ["disabled"] # resolutions are same as in trackValidator, no need to repeat here
+    doResolutionPlotsForLabels = ["disabled"] # resolutions are same as in trackValidator, no need to repeat here
 )
 
 

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -9,7 +9,8 @@ from Validation.RecoTrack.trajectorySeedTracks_cfi import trajectorySeedTracks a
 from SimTracker.TrackAssociation.LhcParametersDefinerForTP_cfi import *
 from SimTracker.TrackAssociation.CosmicParametersDefinerForTP_cfi import *
 from Validation.RecoTrack.PostProcessorTracker_cfi import *
-from . import cutsRecoTracks_cfi
+import Validation.RecoTrack.cutsRecoTracks_cfi as cutsRecoTracks_cfi
+#from . import cutsRecoTracks_cfi
 
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
@@ -403,6 +404,36 @@ trackValidatorTPPtLess09 = trackValidator.clone(
     doResolutionPlotsForLabels = ["disabled"], # resolutions are same as in trackValidator, no need to repeat here
 )
 
+# for high-eta (phase2 : |eta| > 2.7)
+trackValidatorTPEtaGreater2p7 = trackValidator.clone(
+    dirName = "Tracking/TrackTPEtaGreater2p7/",
+    label = [x for x in trackValidator.label.value() if ("Pt09" not in x) and ("BtvLike" not in x) and ("AK4PFJets" not in x)],
+    dodEdxPlots = False,
+#    doPVAssociationPlots = False,
+#    doSimPlots = False,
+    doResolutionPlotsForLabels = ["disabled"],
+    minRapidityTP = -2.7,
+    maxRapidityTP = 2.7,
+    invertRapidityCutTP = True,
+#    ptMaxTP = 0.9, # set maximum pT globally
+    histoProducerAlgoBlock = dict(
+        TpSelectorForEfficiencyVsPt   = dict(ptMin=0.005,minRapidity=-2.7,maxRapidity=2.7,invertRapidityCut=True), # enough to set min pT here
+        TpSelectorForEfficiencyVsEta  = dict(ptMin=0.005,minRapidity=-2.7,maxRapidity=2.7,invertRapidityCut=True), # enough to set min pT here
+        TpSelectorForEfficiencyVsPhi  = dict(ptMin=0.005,minRapidity=-2.7,maxRapidity=2.7,invertRapidityCut=True),
+        TpSelectorForEfficiencyVsVTXR = dict(ptMin=0.005,minRapidity=-2.7,maxRapidity=2.7,invertRapidityCut=True),
+        TpSelectorForEfficiencyVsVTXZ = dict(ptMin=0.005,minRapidity=-2.7,maxRapidity=2.7,invertRapidityCut=True),
+        generalTpSelector             = dict(ptMin=0.005,minRapidity=-2.7,maxRapidity=2.7,invertRapidityCut=True),
+#        minEta  = -4.5,
+#        maxEta  =  4.5,
+#        nintEta = 90,
+        #    minPt  = 0.01,
+    ),
+    doSimPlots = False,       # same as in trackValidator, no need to repeat here
+    doRecoTrackPlots = False, # fake rates are same as in trackValidator, no need to repeat here
+#    doResolutionPlotsForLabels = ["disabled"] # resolutions are same as in trackValidator, no need to repeat here
+)
+
+
 # For efficiency of signal TPs vs. signal tracks, and fake rate of
 # signal tracks vs. signal TPs
 trackValidatorFromPV = trackValidator.clone(
@@ -596,6 +627,14 @@ tracksValidation = cms.Sequence(
     trackValidatorGsfTracks,
     tracksPreValidation
 )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+#tracksValidationPhase2 = cms.Sequence(tracksValidation+trackValidatorTPEtaGreater2p7) # it does not work
+tracksValidationPhase2 = tracksValidation.copy()
+tracksValidationPhase2+=trackValidatorTPEtaGreater2p7
+phase2_tracker.toReplaceWith(tracksValidation, tracksValidationPhase2)
+
+
 fastSim.toReplaceWith(tracksValidation, tracksValidation.copyAndExclude([
     trackValidatorBuildingPreSplitting,
     trackValidatorConversion,
@@ -653,7 +692,6 @@ trackValidatorFromPVAllTPStandalone = trackValidatorFromPVAllTP.clone(
 trackValidatorAllTPEfficStandalone = trackValidatorAllTPEffic.clone(
     label = [ x for x in trackValidator.label.value() if x not in ["cutsRecoTracksBtvLike", "cutsRecoTracksAK4PFJets"] and "Pt09" not in x],
     cores = "highPtJets"
-
 )
 
 trackValidatorConversionStandalone = trackValidatorConversion.clone(

--- a/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
@@ -12,7 +12,10 @@ TrackingParticleSelectionForEfficiency = cms.PSet(
     ptMinTP = cms.double(0.005),
     ptMaxTP = cms.double(1e100),
     maxRapidityTP = cms.double(2.5),
-    tipTP = cms.double(60)
+    tipTP = cms.double(60),
+    invertRapidityCutTP = cms.bool(False),
+    maxPhi = cms.double(3.2),
+    minPhi = cms.double(-3.2),
 )
 
 def _modifyForPhase1(pset):

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -15,6 +15,7 @@ generalTpSelectorBlock = cms.PSet(
     tip = cms.double(3.5),
     minPhi = cms.double(-3.2),
     maxPhi = cms.double(3.2),
+    invertRapidityCut = cms.bool(False)
 )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -371,7 +371,9 @@ _tuning = PlotGroup("tuning", [
     Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})"),
     Plot("chi2mean", title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymin=[0, 0.5], ymax=[2, 2.5, 3, 5],
          fallback={"name": "chi2_vs_eta", "profileX": True}),
-    Plot("ptres_vs_eta_Mean", scale=100, title="", xtitle="TP #eta (PCA to beamline)", ytitle="< #delta p_{T} / p_{T} > (%)", ymin=_minResidualPt, ymax=_maxResidualPt)
+    Plot("ptres_vs_eta_Mean", scale=100, title="", xtitle="TP #eta (PCA to beamline)", ytitle="< #delta p_{T} / p_{T} > (%)", ymin=_minResidualPt, ymax=_maxResidualPt),
+    Plot("chi2mean_vs_pt", title="", xtitle="p_{T}", ytitle="< #chi^{2} / ndf >", ymin=[0, 0.5], ymax=[2, 2.5, 3, 5], xlog=True, fallback={"name": "chi2_vs_pt", "profileX": True}),
+    Plot("ptres_vs_pt_Mean", title="", xtitle="p_{T}", ytitle="< #delta p_{T}/p_{T} > (%)", scale=100, ymin=_minResidualPt, ymax=_maxResidualPt,xlog=True)
 ])
 _common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -10, "xmax": 10, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025], "ratioUncertainty": False}
 _pulls = PlotGroup("pulls", [

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -385,7 +385,9 @@ std::unique_ptr<RecoTrackSelectorBase> MTVHistoProducerAlgoForTracker::makeRecoT
   psetTrack.addParameter("algorithm", std::vector<std::string>{});
   psetTrack.addParameter("originalAlgorithm", std::vector<std::string>{});
   psetTrack.addParameter("algorithmMaskContains", std::vector<std::string>{});
-
+  psetTrack.addParameter("invertRapidityCut", false);
+  psetTrack.addParameter("minPhi", -3.2);
+  psetTrack.addParameter("maxPhi", 3.2);
   return std::make_unique<RecoTrackSelectorBase>(psetTrack);
 }
 

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -1099,11 +1099,17 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::ConcurrentBooker& 
       ibook.bookProfile("chi2mean", "mean #chi^{2} vs #eta", nintEta, minEta, maxEta, 200, 0, 20, " "));
   histograms.chi2_vs_phi.push_back(
       ibook.bookProfile("chi2mean_vs_phi", "mean #chi^{2} vs #phi", nintPhi, minPhi, maxPhi, 200, 0, 20, " "));
+  histograms.chi2_vs_pt.push_back(
+      makeProfileIfLogX(ibook, useLogPt, "chi2mean_vs_pt", "mean #chi^{2} vs p_{T}", nintPt, minPt, maxPt, 0, 20));
 
   histograms.assoc_chi2_vs_eta.push_back(
       ibook.bookProfile("assoc_chi2mean", "mean #chi^{2} vs #eta", nintEta, minEta, maxEta, 200, 0., 20., " "));
   histograms.assoc_chi2prob_vs_eta.push_back(ibook.bookProfile(
       "assoc_chi2prob_vs_eta", "mean #chi^{2} probability vs #eta", nintEta, minEta, maxEta, 100, 0., 1., " "));
+  histograms.assoc_chi2_vs_pt.push_back(makeProfileIfLogX(
+      ibook, useLogPt, "assoc_chi2mean_vs_pt", "mean #chi^{2} vs p_{T}", nintPt, minPt, maxPt, 0., 20.));
+  histograms.assoc_chi2prob_vs_pt.push_back(makeProfileIfLogX(
+      ibook, useLogPt, "assoc_chi2prob_vs_pt", "mean #chi^{2} probability vs p_{T}", nintPt, minPt, maxPt, 0., 20.));
 
   histograms.nhits_vs_eta.push_back(
       ibook.bookProfile("hits_eta", "mean hits vs eta", nintEta, minEta, maxEta, nintHit, minHit, maxHit, " "));
@@ -2045,6 +2051,8 @@ void MTVHistoProducerAlgoForTracker::fill_generic_recoTrack_histos(const Histogr
       histograms.h_assoc2chi2prob[count].fill(chi2prob);
       histograms.assoc_chi2_vs_eta[count].fill(eta, chi2);
       histograms.assoc_chi2prob_vs_eta[count].fill(eta, chi2prob);
+      histograms.assoc_chi2_vs_pt[count].fill(pt, chi2);
+      histograms.assoc_chi2prob_vs_pt[count].fill(pt, chi2prob);
       histograms.h_assoc2vertpos[count].fill(vertxy);
       histograms.h_assoc2zpos[count].fill(vertz);
       histograms.h_assoc2dr[count].fill(dR);
@@ -2215,6 +2223,8 @@ void MTVHistoProducerAlgoForTracker::fill_simAssociated_recoTrack_histos(const H
   const auto eta = getEta(track.eta());
   histograms.chi2_vs_eta[count].fill(eta, track.normalizedChi2());
   histograms.nhits_vs_eta[count].fill(eta, track.numberOfValidHits());
+  const auto pt = getPt(sqrt(track.momentum().perp2()));
+  histograms.chi2_vs_pt[count].fill(pt, track.normalizedChi2());
   const auto pxbHits = track.hitPattern().numberOfValidPixelBarrelHits();
   const auto pxfHits = track.hitPattern().numberOfValidPixelEndcapHits();
   const auto tibHits = track.hitPattern().numberOfValidStripTIBHits();


### PR DESCRIPTION
#### PR description:
as discussed w/ the TK Phase2 Simulation group (@emiglior @pieterdavid) 
the current selection based on the pT of the tracking particle used in the MTV
distorts the momentum spectrum of tracks, because of the Phase2 acceptance is upto |eta| = 4
(a track w/ pT=0.9 GeV at eta = 0.1 has p= 0.9045 GeV, while at eta=3 has p=9.0609 GeV)
therefore, it is useful to add an extra category in the MTV for the Phase2 workflow
meant to validate the tracks at high eta 
and given the tracker phase2 geometry we define it as |eta| > 2.7

the current selector for tracking particles, gen particles and tracks
is designed for applying the selection on the pseudo-rapidity, 
but it expects it to be w/in the min and max values

in this PR 
- an extra boolean parameter is added, 
  in order to handle the switch of the selection from inside a given range to outside
- the possibility of selecting a range in phi is added (when missing)
- the extra category `trackValidatorTPEtaGreater2p7` is added to `Validation/RecoTrack/python/TrackValidation_cff.py`


#### PR validation:
runTheMatrix.py -w upgrade -l 20424.1
runTheMatrix.py -l limited -i all --ibeos