### PR TITLE
remove GENREFLEX_ARGS flag

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/Common"/>

--- a/CondFormats/Alignment/BuildFile.xml
+++ b/CondFormats/Alignment/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="DataFormats/CLHEP"/>

--- a/CondFormats/BTauObjects/BuildFile.xml
+++ b/CondFormats/BTauObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/MessageLogger"/>

--- a/CondFormats/BeamSpotObjects/BuildFile.xml
+++ b/CondFormats/BeamSpotObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Utilities"/>

--- a/CondFormats/CSCObjects/BuildFile.xml
+++ b/CondFormats/CSCObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/CondFormats/Calibration/BuildFile.xml
+++ b/CondFormats/Calibration/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Utilities"/>

--- a/CondFormats/CastorObjects/BuildFile.xml
+++ b/CondFormats/CastorObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="FWCore/Utilities"/>

--- a/CondFormats/Common/BuildFile.xml
+++ b/CondFormats/Common/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="boost"/>
 <use   name="CondFormats/Serialization"/>

--- a/CondFormats/DQMObjects/BuildFile.xml
+++ b/CondFormats/DQMObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Serialization"/>

--- a/CondFormats/DTObjects/BuildFile.xml
+++ b/CondFormats/DTObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="DataFormats/MuonDetId"/>

--- a/CondFormats/EcalCorrections/BuildFile.xml
+++ b/CondFormats/EcalCorrections/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="DataFormats/EcalDetId"/>

--- a/CondFormats/GEMObjects/BuildFile.xml
+++ b/CondFormats/GEMObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/MessageLogger"/>

--- a/CondFormats/GeometryObjects/BuildFile.xml
+++ b/CondFormats/GeometryObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>

--- a/CondFormats/HIObjects/BuildFile.xml
+++ b/CondFormats/HIObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Framework"/>

--- a/CondFormats/HLTObjects/BuildFile.xml
+++ b/CondFormats/HLTObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>

--- a/CondFormats/HcalObjects/BuildFile.xml
+++ b/CondFormats/HcalObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <ifrelease name="_UBSAN_">
   <flags   REM_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
 </ifrelease>

--- a/CondFormats/L1TObjects/BuildFile.xml
+++ b/CondFormats/L1TObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="boost"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>

--- a/CondFormats/Luminosity/BuildFile.xml
+++ b/CondFormats/Luminosity/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>

--- a/CondFormats/MFObjects/BuildFile.xml
+++ b/CondFormats/MFObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="CondFormats/Common"/>
 <use   name="FWCore/Utilities"/>

--- a/CondFormats/OptAlignObjects/BuildFile.xml
+++ b/CondFormats/OptAlignObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="DataFormats/Common"/>

--- a/CondFormats/PCLConfig/BuildFile.xml
+++ b/CondFormats/PCLConfig/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags GENREFLEX_ARGS="--"/>
 <use name="CondFormats/Common"/>
 <!-- // comment out
 <use name="FWCore/ParameterSet"/>

--- a/CondFormats/RPCObjects/BuildFile.xml
+++ b/CondFormats/RPCObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/MessageLogger"/>

--- a/CondFormats/RecoMuonObjects/BuildFile.xml
+++ b/CondFormats/RecoMuonObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>

--- a/CondFormats/RunInfo/BuildFile.xml
+++ b/CondFormats/RunInfo/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Utilities"/>

--- a/CondFormats/SiPhase2TrackerObjects/BuildFile.xml
+++ b/CondFormats/SiPhase2TrackerObjects/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/DetId"/>
 <use name="rootrflx"/>
-<flags GENREFLEX_ARGS="--"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="CalibFormats/SiPixelObjects"/>

--- a/DPGAnalysis/SiStripTools/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="root"/>
 
 <use   name="FWCore/MessageLogger"/>


### PR DESCRIPTION
#### PR description:

Cleanup `GENREFLEX_ARGS="--"`  flag from BuildFiles. It was only dropping the `--deep` flag for genreflex. As `--deep` is not supported by genreflex/rootcling any more ( https://github.com/cms-sw/cmsdist/commit/b9f88fe8fbf0ed2969ae95387a7900b3078a749c ) , we propose to cleanup our BuildFiles too.

#### PR validation:

local compilation was successful
