### PR TITLE
Introduce Payload Inspector for SiPixel conditions

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -146,7 +146,7 @@ namespace SiPixelPI {
     gStyle->SetPalette(1);
 
     h->SetMarkerSize(0.7);
-    h->Draw("text");
+    h->Draw("colz");
 
     auto ltx = TLatex();
     ltx.SetTextFont(62);

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -407,5 +407,26 @@ namespace SiPixelPI {
     return result;
   }
 
+
+  /*--------------------------------------------------------------------*/
+  void makeNicePlotStyle(TH1* hist)
+  /*--------------------------------------------------------------------*/
+  {
+    hist->SetStats(kFALSE);
+    hist->SetLineWidth(2);
+    hist->GetXaxis()->CenterTitle(true);
+    hist->GetYaxis()->CenterTitle(true);
+    hist->GetXaxis()->SetTitleFont(42);
+    hist->GetYaxis()->SetTitleFont(42);
+    hist->GetXaxis()->SetTitleSize(0.05);
+    hist->GetYaxis()->SetTitleSize(0.05);
+    hist->GetXaxis()->SetTitleOffset(1.1);
+    hist->GetYaxis()->SetTitleOffset(1.3);
+    hist->GetXaxis()->SetLabelFont(42);
+    hist->GetYaxis()->SetLabelFont(42);
+    hist->GetYaxis()->SetLabelSize(.05);
+    hist->GetXaxis()->SetLabelSize(.05);
+  }
+
 };  // namespace SiPixelPI
 #endif

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -1,0 +1,283 @@
+#ifndef CONDCORE_SIPIXELPLUGINS_SIPIXELPAYLOADINSPECTORHELPER_H
+#define CONDCORE_SIPIXELPLUGINS_SIPIXELPAYLOADINSPECTORHELPER_H
+
+#include <vector>
+#include <numeric>
+#include <string>
+#include "TGraph.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TLatex.h"
+#include "TLine.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+#include "TPaveText.h"
+#include "TStyle.h"
+#include "TCanvas.h"
+
+namespace SiPixelPI {
+
+  //============================================================================                     
+  void draw_line(double x1, double x2, double y1, double y2, int width=2, int style=1, int color=1) {
+    TLine* l = new TLine(x1, y1, x2, y2);
+    l->SetBit(kCanDelete);
+    l->SetLineWidth(width);
+    l->SetLineStyle(style);
+    l->SetLineColor(color);
+    l->Draw();
+  }
+
+  //============================================================================                     
+  void dress_occup_plot(TCanvas& canv,TH2* h, int lay, int ring=0, int phase=0, bool half_shift = 1, bool mark_zero=1) {
+    
+    std::string s_title;
+    
+    if(lay>0){
+      canv.cd(lay);
+      s_title="Barrel Pixel Layer"+std::to_string(lay);
+    } else {
+      canv.cd(ring);
+      s_title="Forward Pixel Ring"+std::to_string(ring);
+    }
+      
+    gStyle->SetPadRightMargin(0.125);
+    gStyle->SetPalette(1);
+
+    h->Draw("zcol");
+
+    auto ltx = TLatex();
+    ltx.SetTextFont(62);
+    ltx.SetTextColor(1);
+    ltx.SetTextSize(0.06);
+    ltx.SetTextAlign(31);
+    ltx.DrawLatexNDC(1-gPad->GetRightMargin(),
+		     1-gPad->GetTopMargin()+0.01,(s_title).c_str());
+
+    // Draw Lines around modules
+    if (lay>0) {
+      std::vector<std::vector<int> > nladder = { { 10, 16, 22 }, { 6, 14, 22, 32 } };
+      int nlad = nladder[phase][lay-1];
+      for (int xsign=-1; xsign<=1; xsign+=2) for (int ysign=-1; ysign<=1; ysign+=2) {
+	  float xlow  = xsign * (half_shift*0.5 );
+	  float xhigh = xsign * (half_shift*0.5 + 4 );
+	  float ylow  = ysign * (half_shift*0.5 + (phase==0)*0.5 );
+	  float yhigh = ysign * (half_shift*0.5 - (phase==0)*0.5 + nlad);
+	  // Outside box
+	  draw_line(xlow,  xhigh,  ylow,  ylow, 1); // bottom
+	  draw_line(xlow,  xhigh, yhigh, yhigh, 1); // top
+	  draw_line(xlow,   xlow,  ylow, yhigh, 1); // left
+	  draw_line(xhigh, xhigh,  ylow, yhigh, 1); // right
+	  // Inner Horizontal lines
+	  for (int lad=1; lad<nlad; ++lad) {
+          float y = ysign * (lad + half_shift*0.5);
+          draw_line(xlow, xhigh,  y,  y, 1);
+	  }
+	  for (int lad=1; lad<=nlad; ++lad) if (!(phase==0&&(lad==1||lad==nlad))) {
+	      float y = ysign * (lad + half_shift*0.5 - 0.5);
+	      draw_line(xlow, xhigh,  y,  y, 1, 3);
+	    }
+	  // Inner Vertical lines
+	  for (int mod=1; mod<4; ++mod) {
+	    float x = xsign * (mod + half_shift*0.5);
+	    draw_line(x, x,  ylow,  yhigh, 1);
+	  }
+	  // Make a BOX around ROC 0
+	  // Phase 0 - ladder +1 is always non-flipped
+	  // Phase 1 - ladder +1 is always     flipped
+	  if (mark_zero) {
+	    for (int mod=1; mod<=4; ++mod) for (int lad=1; lad<=nlad; ++lad) {
+		bool flipped = ysign==1 ? lad%2==0 : lad%2==1;
+		if (phase==1)  flipped = !flipped;
+		int roc0_orientation = flipped ? -1 : 1;
+		if (xsign==-1) roc0_orientation *= -1;
+		if (ysign==-1) roc0_orientation *= -1;
+		float x1 = xsign * (mod+half_shift*0.5);
+		float x2 = xsign * (mod+half_shift*0.5 - 1./8);
+		float y1 = ysign * (lad+half_shift*0.5-0.5);
+		float y2 = ysign * (lad+half_shift*0.5-0.5 + roc0_orientation*1./2);
+		if (!(phase==0&&(lad==1||lad==nlad)&&xsign==-1)) {
+		  if (lay == 1 && xsign <= -1 ){
+		    float x1 = xsign * ((mod-1)+half_shift*0.5 );
+		    float x2 = xsign * ((mod-1)+half_shift*0.5 + 1./8);
+		    float y1 = ysign * (lad+half_shift*0.5-0.5 + roc0_orientation);
+		    float y2 = ysign * (lad+half_shift*0.5-0.5 + roc0_orientation*3./2);		    
+		    draw_line(x1, x2, y1, y1, 1);
+		    draw_line(x2, x2, y1, y2, 1);
+		  }
+		  else{
+		    draw_line(x1, x2, y1, y1, 1);
+		    //draw_line(x1, x2, y2, y2, 1);                                         
+		    //draw_line(x1, x1, y1, y2, 1);                                    
+		    draw_line(x2, x2, y1, y2, 1);
+		  }
+		}
+	      }
+	  }
+	}
+    } else {
+      // FPIX
+      for (int dsk=1, ndsk=2+(phase==1); dsk<=ndsk; ++dsk) {
+        for (int xsign=-1; xsign<=1; xsign+=2) for (int ysign=-1; ysign<=1; ysign+=2) {
+	    if (phase==0) {
+	      int first_roc = 3, nbin = 16;
+	      for (int bld=1, nbld=12; bld<=nbld; ++bld) {
+		// Horizontal lines
+		for (int plq=1, nplq=7; plq<=nplq; ++plq) {
+		  float xlow  = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1))/(float)nbin);
+		  float xhigh = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*(plq+1)-(plq==7))/(float)nbin);
+		  float ylow  = ysign * (half_shift*0.5 + (bld-0.5) - (2+plq/2)*0.1);
+		  float yhigh = ysign * (half_shift*0.5 + (bld-0.5) + (2+plq/2)*0.1);
+		  draw_line(xlow,  xhigh,   ylow,  ylow, 1); // bottom
+		  draw_line(xlow,  xhigh,  yhigh, yhigh, 1); // top
+		}
+		// Vertical lines
+		for (int plq=1, nplq=7+1; plq<=nplq; ++plq) {
+		  float x     = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1)-(plq==8))/(float)nbin);
+		  float ylow  = ysign * (half_shift*0.5 + (bld-0.5) - (2+(plq-(plq==8))/2)*0.1);
+		  float yhigh = ysign * (half_shift*0.5 + (bld-0.5) + (2+(plq-(plq==8))/2)*0.1);
+		  draw_line(x,  x,  ylow,  yhigh, 1);
+		}
+		// Panel 2 has dashed mid-plane
+		for (int plq=2, nplq=6; plq<=nplq; ++plq) if (plq%2==0) {
+		    float x     = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1)-(plq==8)+1)/(float)nbin);
+		    float ylow  = ysign * (half_shift*0.5 + (bld-0.5) - (2+(plq-(plq==8))/2)*0.1);
+		    float yhigh = ysign * (half_shift*0.5 + (bld-0.5) + (2+(plq-(plq==8))/2)*0.1);
+		    draw_line(x,  x,  ylow,  yhigh, 1, 2);
+		  }
+		// Make a BOX around ROC 0
+		for (int plq=1, nplq=7; plq<=nplq; ++plq) {
+		  float x1 = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1))/(float)nbin);
+		  float x2 = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1)+1)/(float)nbin);
+		  int sign = xsign * ysign * ((plq%2) ? 1 : -1);
+		  float y1 = ysign * (half_shift*0.5 + (bld-0.5) + sign *(2+plq/2)*0.1);
+		  float y2 = ysign * (half_shift*0.5 + (bld-0.5) + sign *(  plq/2)*0.1);
+		  //draw_line(x1, x2, y1, y1, 1);
+		  draw_line(x1, x2, y2, y2, 1);
+		  //draw_line(x1, x1, y1, y2, 1);
+		  draw_line(x2, x2, y1, y2, 1);
+		}
+	      }
+	    } else if (phase==1) {
+	      if (ring == 0) { // both
+		for (int ring=1; ring<=2; ++ring) for (int bld=1, nbld=5+ring*6; bld<=nbld; ++bld) {
+		    float scale = (ring==1) ? 1.5 : 1;
+		    Color_t p1_color = 1, p2_color = 1;
+		    // Horizontal lines
+		    // Panel 2 has dashed mid-plane
+		    float x1      = xsign * (half_shift*0.5 + dsk - 1 + (ring-1)*0.5);
+		    float x2      = xsign * (half_shift*0.5 + dsk - 1 +  ring   *0.5);
+		    int sign = ysign;
+		    float y1      = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.5);
+		    //float yp1_mid = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25);
+		    float y2      = ysign * (half_shift*0.5 - 0.5 + scale*bld);
+		    float yp2_mid = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.25);
+		    float y3      = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.5);
+		    draw_line(x1, x2, y1,      y1,      1, 1, p1_color);
+		    //draw_line(x1, x2, yp1_mid, yp1_mid, 1, 3);
+		    draw_line(x1, x2, y2,      y2,      1, 1, p1_color);
+		    draw_line(x1, x2, yp2_mid, yp2_mid, 1, 2);
+		    draw_line(x1, x2, y3,      y3,      1, 1, p2_color);
+		    // Vertical lines
+		    float x = xsign * (half_shift*0.5 + dsk - 1 + (ring-1)*0.5);
+		    draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
+		    draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
+		    if (ring==2) {
+		      //draw_line(x,  x,  y2,  y3, 1, 1, p1_color);
+		      x         = xsign * (half_shift*0.5 + dsk);
+		      draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
+		      draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
+		    }
+		    // Make a BOX around ROC 0
+		    x1          = xsign * (half_shift*0.5 + dsk - 1 + ring*0.5 - 1/16.);
+		    x2          = xsign * (half_shift*0.5 + dsk - 1 + ring*0.5);
+		    float y1_p1 = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25);
+		    float y2_p1 = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25 + xsign*ysign*0.25);
+		    draw_line(x1, x2, y1_p1, y1_p1, 1);
+		    //draw_line(x1, x2, y2_p1, y2_p1, 1);
+		    draw_line(x1, x1, y1_p1, y2_p1, 1);
+		    //draw_line(x2, x2, y1_p1, y2_p1, 1);
+		    float y1_p2 = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.25);
+		    float y2_p2 = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.25 - xsign*ysign*0.25);
+		    draw_line(x1, x2, y1_p2, y1_p2, 1);
+		    //draw_line(x1, x2, y2_p2, y2_p2, 1);
+		    draw_line(x1, x1, y1_p2, y2_p2, 1);
+		    //draw_line(x2, x2, y1_p2, y2_p2, 1);
+		  }
+	      } else { // only one ring, 1 or 2
+		for (int bld=1, nbld=5+ring*6; bld<=nbld; ++bld) {
+		  Color_t p1_color = 1, p2_color = 1;
+		  // Horizontal lines
+		  // Panel 2 has dashed mid-plane
+		  float x1      = xsign * (half_shift*0.5 + dsk - 1);
+		  float x2      = xsign * (half_shift*0.5 + dsk);
+		  int sign = ysign;
+		  float y1      = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.5);
+		  //float yp1_mid = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25);
+		  float y2      = ysign * (half_shift*0.5 - 0.5 + bld);
+		  float yp2_mid = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.25);
+		  float y3      = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.5);
+		  draw_line(x1, x2, y1,      y1,      1, 1, p1_color);
+		  //draw_line(x1, x2, yp1_mid, yp1_mid, 1, 3);
+		  draw_line(x1, x2, y2,      y2,      1, 1, p1_color);
+		  draw_line(x1, x2, yp2_mid, yp2_mid, 1, 2);
+		  draw_line(x1, x2, y3,      y3,      1, 1, p2_color);
+		  // Vertical lines
+		  float x = xsign * (half_shift*0.5 + dsk - 1);
+		  draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
+		  draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
+		  if (ring==2) {
+		    //draw_line(x,  x,  y2,  y3, 1, 1, p1_color);
+		    x         = xsign * (half_shift*0.5 + dsk);
+		    draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
+		    draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
+		  }
+		  // Make a BOX around ROC 0
+		  x1          = xsign * (half_shift*0.5 + dsk - 1/8.);
+		  x2          = xsign * (half_shift*0.5 + dsk);
+		  float y1_p1 = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25);
+		  float y2_p1 = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25 + xsign*ysign*0.25);
+		  draw_line(x1, x2, y1_p1, y1_p1, 1);
+		  //draw_line(x1, x2, y2_p1, y2_p1, 1);
+		  draw_line(x1, x1, y1_p1, y2_p1, 1);
+		  //draw_line(x2, x2, y1_p1, y2_p1, 1);
+		  float y1_p2 = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.25);
+		  float y2_p2 = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.25 - xsign*ysign*0.25);
+		  draw_line(x1, x2, y1_p2, y1_p2, 1);
+		  //draw_line(x1, x2, y2_p2, y2_p2, 1);
+		  draw_line(x1, x1, y1_p2, y2_p2, 1);
+		  //draw_line(x2, x2, y1_p2, y2_p2, 1);
+		}
+	      }
+	    }
+	  }
+      }
+      // Special shifted "rebin" for Phase 0
+      // Y axis should always have at least half-roc granularity because
+      // there are half-ROC size shifts implemented in the coordinates
+      // To remove this and show full ROC granularity
+      // We merge bin contents in each pair of bins corresponding to one ROC
+      // TODO: make sure this works for Profiles
+      if (phase==0&&h->GetNbinsY()==250&&h->GetNbinsX()==80) {
+        int nentries = h->GetEntries();
+        for (int binx = 1; binx<=80; ++binx) {
+          double sum = 0;
+          for (int biny = 1; biny<=250; ++biny) {
+            bool odd_nrocy = (binx-1<40) != (((binx-1)/4)%2);
+            if (biny%2==odd_nrocy) sum+= h->GetBinContent(binx, biny);
+            else {
+              sum+= h->GetBinContent(binx, biny);
+              if (sum) {
+                h->SetBinContent(binx, biny, sum);
+                h->SetBinContent(binx, biny-1, sum);
+              }
+              sum = 0;
+            }
+          }
+        }
+        h->SetEntries(nentries);
+      }
+    }
+  }
+};
+#endif
+

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -14,12 +14,20 @@
 #include "TPaveText.h"
 #include "TStyle.h"
 #include "TCanvas.h"
+#include "CondCore/CondDB/interface/Time.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 
 namespace SiPixelPI {
+
+  std::pair<unsigned int,unsigned int> unpack(cond::Time_t since){
+    auto kLowMask = 0XFFFFFFFF;
+    auto run  = (since >> 32);
+    auto lumi = (since & kLowMask);
+    return std::make_pair(run,lumi);
+  }
 
   //============================================================================                     
   // Taken from pixel naming classes

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -145,7 +145,8 @@ namespace SiPixelPI {
     gStyle->SetPadRightMargin(0.125);
     gStyle->SetPalette(1);
 
-    h->Draw("zcol");
+    h->SetMarkerSize(0.7);
+    h->Draw("text");
 
     auto ltx = TLatex();
     ltx.SetTextFont(62);

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -24,7 +24,7 @@
 namespace SiPixelPI {
 
   // size of the phase-0 pixel detID list
-  static const unsigned int phase0size = 1440 ;
+  static const unsigned int phase0size = 1440;
 
   std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {
     auto kLowMask = 0XFFFFFFFF;
@@ -433,21 +433,21 @@ namespace SiPixelPI {
   }
 
   enum regions {
-    BPixL1o,          //0  Barrel Pixel Layer 1 outer
-    BPixL1i,          //1  Barrel Pixel Layer 1 inner
-    BPixL2o,          //2  Barrel Pixel Layer 2 outer
-    BPixL2i,          //3  Barrel Pixel Layer 2 inner
-    BPixL3o,          //4  Barrel Pixel Layer 3 outer
-    BPixL3i,          //5  Barrel Pixel Layer 3 inner
-    BPixL4o,          //6  Barrel Pixel Layer 4 outer
-    BPixL4i,          //7  Barrel Pixel Layer 4 inner
-    FPixmL1,          //8  Forward Pixel Minus side Disk 1
-    FPixmL2,          //9  Forward Pixel Minus side Disk 2
-    FPixmL3,          //10 Forward Pixel Minus side Disk 3
-    FPixpL1,          //11 Forward Pixel Plus side Disk 1
-    FPixpL2,          //12 Forward Pixel Plus side Disk 2
-    FPixpL3,          //13 Forward Pixel Plus side Disk 3
-    NUM_OF_REGIONS    //14 -- default
+    BPixL1o,        //0  Barrel Pixel Layer 1 outer
+    BPixL1i,        //1  Barrel Pixel Layer 1 inner
+    BPixL2o,        //2  Barrel Pixel Layer 2 outer
+    BPixL2i,        //3  Barrel Pixel Layer 2 inner
+    BPixL3o,        //4  Barrel Pixel Layer 3 outer
+    BPixL3i,        //5  Barrel Pixel Layer 3 inner
+    BPixL4o,        //6  Barrel Pixel Layer 4 outer
+    BPixL4i,        //7  Barrel Pixel Layer 4 inner
+    FPixmL1,        //8  Forward Pixel Minus side Disk 1
+    FPixmL2,        //9  Forward Pixel Minus side Disk 2
+    FPixmL3,        //10 Forward Pixel Minus side Disk 3
+    FPixpL1,        //11 Forward Pixel Plus side Disk 1
+    FPixpL2,        //12 Forward Pixel Plus side Disk 2
+    FPixpL3,        //13 Forward Pixel Plus side Disk 3
+    NUM_OF_REGIONS  //14 -- default
   };
 
   /*--------------------------------------------------------------------*/
@@ -455,41 +455,41 @@ namespace SiPixelPI {
   /*--------------------------------------------------------------------*/
   {
     switch (e) {
-    case SiPixelPI::BPixL1o:
-      return "BPix L1/o";
-    case SiPixelPI::BPixL1i:
-      return "BPix L1/i";
-    case SiPixelPI::BPixL2o:
-      return "BPix L2/o";
-    case SiPixelPI::BPixL2i:
-      return "BPix L2/i";
-    case SiPixelPI::BPixL3o:
-      return "BPix L3/o";
-    case SiPixelPI::BPixL3i:
-      return "BPix L3/i";
-    case SiPixelPI::BPixL4o:
-      return "BPix L4/o";
-    case SiPixelPI::BPixL4i:
-      return "BPix L4/i";
-    case SiPixelPI::FPixmL1:
-      return "FPix- D1";
-    case SiPixelPI::FPixmL2:
-      return "FPix- D2";
-    case SiPixelPI::FPixmL3:
-      return "FPix- D3";
-    case SiPixelPI::FPixpL1:
-      return "FPix+ D1";
-    case SiPixelPI::FPixpL2:
-      return "FPix+ D2";
-    case SiPixelPI::FPixpL3:
-      return "FPix+ D3";
-    default:
-      edm::LogWarning("LogicError") << "Unknown partition: " << e;
-      return "";
+      case SiPixelPI::BPixL1o:
+        return "BPix L1/o";
+      case SiPixelPI::BPixL1i:
+        return "BPix L1/i";
+      case SiPixelPI::BPixL2o:
+        return "BPix L2/o";
+      case SiPixelPI::BPixL2i:
+        return "BPix L2/i";
+      case SiPixelPI::BPixL3o:
+        return "BPix L3/o";
+      case SiPixelPI::BPixL3i:
+        return "BPix L3/i";
+      case SiPixelPI::BPixL4o:
+        return "BPix L4/o";
+      case SiPixelPI::BPixL4i:
+        return "BPix L4/i";
+      case SiPixelPI::FPixmL1:
+        return "FPix- D1";
+      case SiPixelPI::FPixmL2:
+        return "FPix- D2";
+      case SiPixelPI::FPixmL3:
+        return "FPix- D3";
+      case SiPixelPI::FPixpL1:
+        return "FPix+ D1";
+      case SiPixelPI::FPixpL2:
+        return "FPix+ D2";
+      case SiPixelPI::FPixpL3:
+        return "FPix+ D3";
+      default:
+        edm::LogWarning("LogicError") << "Unknown partition: " << e;
+        return "";
     }
   }
 
- /*--------------------------------------------------------------------*/
+  /*--------------------------------------------------------------------*/
   bool isBPixOuterLadder(const DetId& detid, const TrackerTopology& tTopo, bool isPhase0)
   /*--------------------------------------------------------------------*/
   {

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -22,91 +22,101 @@
 
 namespace SiPixelPI {
 
-  std::pair<unsigned int,unsigned int> unpack(cond::Time_t since){
+  std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {
     auto kLowMask = 0XFFFFFFFF;
-    auto run  = (since >> 32);
+    auto run = (since >> 32);
     auto lumi = (since & kLowMask);
-    return std::make_pair(run,lumi);
+    return std::make_pair(run, lumi);
   }
 
-  //============================================================================                     
+  //============================================================================
   // Taken from pixel naming classes
   // BmO (-z-x) = 1, BmI (-z+x) = 2 , BpO (+z-x) = 3 , BpI (+z+x) = 4
-  int quadrant(const DetId& detid, const TrackerTopology* tTopo_,bool phase_) {
-    if(detid.subdetId() == PixelSubdetector::PixelBarrel){
-      return PixelBarrelName(detid,tTopo_, phase_).shell();
+  int quadrant(const DetId& detid, const TrackerTopology* tTopo_, bool phase_) {
+    if (detid.subdetId() == PixelSubdetector::PixelBarrel) {
+      return PixelBarrelName(detid, tTopo_, phase_).shell();
     } else {
-      return PixelEndcapName(detid,tTopo_, phase_).halfCylinder();
+      return PixelEndcapName(detid, tTopo_, phase_).halfCylinder();
     }
   }
 
-  //============================================================================               
+  //============================================================================
   // Online ladder convention taken from pixel naming class for barrel
   // Apply sign convention (- sign for BmO and BpO)
-  int signed_ladder(const DetId& detid, const TrackerTopology& tTopo_,bool phase_) {
-    if (detid.subdetId() != PixelSubdetector::PixelBarrel) return -9999;
+  int signed_ladder(const DetId& detid, const TrackerTopology& tTopo_, bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelBarrel)
+      return -9999;
     int signed_ladder = PixelBarrelName(detid, &tTopo_, phase_).ladderName();
-    if (quadrant(detid,&tTopo_,phase_)%2) signed_ladder *= -1;
+    if (quadrant(detid, &tTopo_, phase_) % 2)
+      signed_ladder *= -1;
     return signed_ladder;
   }
 
-  //============================================================================               
+  //============================================================================
   // Online mdoule convention taken from pixel naming class for barrel
   // Apply sign convention (- sign for BmO and BmI)
-  int signed_module(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {
-    if (detid.subdetId() != PixelSubdetector::PixelBarrel) return -9999;
+  int signed_module(const DetId& detid, const TrackerTopology& tTopo_, bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelBarrel)
+      return -9999;
     int signed_module = PixelBarrelName(detid, &tTopo_, phase_).moduleName();
-    if (quadrant(detid,&tTopo_,phase_)<3) signed_module *= -1;
+    if (quadrant(detid, &tTopo_, phase_) < 3)
+      signed_module *= -1;
     return signed_module;
   }
 
-  //============================================================================               
+  //============================================================================
   // Phase 0: Ring was not an existing convention
   //   but the 7 plaquettes were split by HV group
   //   --> Derive Ring 1/2 for them
   //   Panel 1 plq 1-2, Panel 2, plq 1   = Ring 1
   //   Panel 1 plq 3-4, Panel 2, plq 2-3 = Ring 2
   // Phase 1: Using pixel naming class for endcap
-  int ring(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {
-    if (detid.subdetId() != PixelSubdetector::PixelEndcap) return -9999;
+  int ring(const DetId& detid, const TrackerTopology& tTopo_, bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelEndcap)
+      return -9999;
     int ring = -9999;
-    if (phase_==0) {
-      ring = 1 + (tTopo_.pxfPanel(detid)+tTopo_.pxfModule(detid)>3);
-    } else if (phase_==1) {
-      ring = PixelEndcapName(detid,&tTopo_, phase_).ringName();
+    if (phase_ == 0) {
+      ring = 1 + (tTopo_.pxfPanel(detid) + tTopo_.pxfModule(detid) > 3);
+    } else if (phase_ == 1) {
+      ring = PixelEndcapName(detid, &tTopo_, phase_).ringName();
     }
     return ring;
   }
 
-  //============================================================================               
+  //============================================================================
   // Online blade convention taken from pixel naming class for endcap
   // Apply sign convention (- sign for BmO and BpO)
-  int signed_blade(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {
-    if (detid.subdetId() != PixelSubdetector::PixelEndcap) return -9999;
-    int signed_blade = PixelEndcapName(detid,&tTopo_, phase_).bladeName();
-    if (quadrant(detid,&tTopo_,phase_)%2) signed_blade *= -1;
+  int signed_blade(const DetId& detid, const TrackerTopology& tTopo_, bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelEndcap)
+      return -9999;
+    int signed_blade = PixelEndcapName(detid, &tTopo_, phase_).bladeName();
+    if (quadrant(detid, &tTopo_, phase_) % 2)
+      signed_blade *= -1;
     return signed_blade;
   }
 
-  //============================================================================               
-  int signed_blade_panel(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {
-    if (detid.subdetId() != PixelSubdetector::PixelEndcap) return -9999;
-    int signed_blade_panel = signed_blade(detid,tTopo_,phase_)+(tTopo_.pxfPanel(detid)-1);
+  //============================================================================
+  int signed_blade_panel(const DetId& detid, const TrackerTopology& tTopo_, bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelEndcap)
+      return -9999;
+    int signed_blade_panel = signed_blade(detid, tTopo_, phase_) + (tTopo_.pxfPanel(detid) - 1);
     return signed_blade_panel;
   }
 
-  //============================================================================               
+  //============================================================================
   // Online disk convention
   // Apply sign convention (- sign for BmO and BmI)
-  int signed_disk(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {
-    if (detid.subdetId() != PixelSubdetector::PixelEndcap) return -9999;
+  int signed_disk(const DetId& detid, const TrackerTopology& tTopo_, bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelEndcap)
+      return -9999;
     int signed_disk = tTopo_.pxfDisk(DetId(detid));
-    if (quadrant(detid,&tTopo_,phase_)<3) signed_disk *= -1;
+    if (quadrant(detid, &tTopo_, phase_) < 3)
+      signed_disk *= -1;
     return signed_disk;
   }
 
-  //============================================================================                     
-  void draw_line(double x1, double x2, double y1, double y2, int width=2, int style=1, int color=1) {
+  //============================================================================
+  void draw_line(double x1, double x2, double y1, double y2, int width = 2, int style = 1, int color = 1) {
     TLine* l = new TLine(x1, y1, x2, y2);
     l->SetBit(kCanDelete);
     l->SetLineWidth(width);
@@ -115,19 +125,19 @@ namespace SiPixelPI {
     l->Draw();
   }
 
-  //============================================================================                     
-  void dress_occup_plot(TCanvas& canv,TH2* h, int lay, int ring=0, int phase=0, bool half_shift = 1, bool mark_zero=1) {
-    
+  //============================================================================
+  void dress_occup_plot(
+      TCanvas& canv, TH2* h, int lay, int ring = 0, int phase = 0, bool half_shift = true, bool mark_zero = true) {
     std::string s_title;
-    
-    if(lay>0){
+
+    if (lay > 0) {
       canv.cd(lay);
-      s_title="Barrel Pixel Layer"+std::to_string(lay);
+      s_title = "Barrel Pixel Layer" + std::to_string(lay);
     } else {
       canv.cd(ring);
-      s_title="Forward Pixel Ring"+std::to_string(ring);
+      s_title = "Forward Pixel Ring" + std::to_string(ring);
     }
-      
+
     gStyle->SetPadRightMargin(0.125);
     gStyle->SetPalette(1);
 
@@ -138,206 +148,219 @@ namespace SiPixelPI {
     ltx.SetTextColor(1);
     ltx.SetTextSize(0.06);
     ltx.SetTextAlign(31);
-    ltx.DrawLatexNDC(1-gPad->GetRightMargin(),
-		     1-gPad->GetTopMargin()+0.01,(s_title).c_str());
+    ltx.DrawLatexNDC(1 - gPad->GetRightMargin(), 1 - gPad->GetTopMargin() + 0.01, (s_title).c_str());
 
     // Draw Lines around modules
-    if (lay>0) {
-      std::vector<std::vector<int> > nladder = { { 10, 16, 22 }, { 6, 14, 22, 32 } };
-      int nlad = nladder[phase][lay-1];
-      for (int xsign=-1; xsign<=1; xsign+=2) for (int ysign=-1; ysign<=1; ysign+=2) {
-	  float xlow  = xsign * (half_shift*0.5 );
-	  float xhigh = xsign * (half_shift*0.5 + 4 );
-	  float ylow  = ysign * (half_shift*0.5 + (phase==0)*0.5 );
-	  float yhigh = ysign * (half_shift*0.5 - (phase==0)*0.5 + nlad);
-	  // Outside box
-	  draw_line(xlow,  xhigh,  ylow,  ylow, 1); // bottom
-	  draw_line(xlow,  xhigh, yhigh, yhigh, 1); // top
-	  draw_line(xlow,   xlow,  ylow, yhigh, 1); // left
-	  draw_line(xhigh, xhigh,  ylow, yhigh, 1); // right
-	  // Inner Horizontal lines
-	  for (int lad=1; lad<nlad; ++lad) {
-          float y = ysign * (lad + half_shift*0.5);
-          draw_line(xlow, xhigh,  y,  y, 1);
-	  }
-	  for (int lad=1; lad<=nlad; ++lad) if (!(phase==0&&(lad==1||lad==nlad))) {
-	      float y = ysign * (lad + half_shift*0.5 - 0.5);
-	      draw_line(xlow, xhigh,  y,  y, 1, 3);
-	    }
-	  // Inner Vertical lines
-	  for (int mod=1; mod<4; ++mod) {
-	    float x = xsign * (mod + half_shift*0.5);
-	    draw_line(x, x,  ylow,  yhigh, 1);
-	  }
-	  // Make a BOX around ROC 0
-	  // Phase 0 - ladder +1 is always non-flipped
-	  // Phase 1 - ladder +1 is always     flipped
-	  if (mark_zero) {
-	    for (int mod=1; mod<=4; ++mod) for (int lad=1; lad<=nlad; ++lad) {
-		bool flipped = ysign==1 ? lad%2==0 : lad%2==1;
-		if (phase==1)  flipped = !flipped;
-		int roc0_orientation = flipped ? -1 : 1;
-		if (xsign==-1) roc0_orientation *= -1;
-		if (ysign==-1) roc0_orientation *= -1;
-		float x1 = xsign * (mod+half_shift*0.5);
-		float x2 = xsign * (mod+half_shift*0.5 - 1./8);
-		float y1 = ysign * (lad+half_shift*0.5-0.5);
-		float y2 = ysign * (lad+half_shift*0.5-0.5 + roc0_orientation*1./2);
-		if (!(phase==0&&(lad==1||lad==nlad)&&xsign==-1)) {
-		  if (lay == 1 && xsign <= -1 ){
-		    float x1 = xsign * ((mod-1)+half_shift*0.5 );
-		    float x2 = xsign * ((mod-1)+half_shift*0.5 + 1./8);
-		    float y1 = ysign * (lad+half_shift*0.5-0.5 + roc0_orientation);
-		    float y2 = ysign * (lad+half_shift*0.5-0.5 + roc0_orientation*3./2);		    
-		    draw_line(x1, x2, y1, y1, 1);
-		    draw_line(x2, x2, y1, y2, 1);
-		  }
-		  else{
-		    draw_line(x1, x2, y1, y1, 1);
-		    //draw_line(x1, x2, y2, y2, 1);                                         
-		    //draw_line(x1, x1, y1, y2, 1);                                    
-		    draw_line(x2, x2, y1, y2, 1);
-		  }
-		}
-	      }
-	  }
-	}
+    if (lay > 0) {
+      std::vector<std::vector<int> > nladder = {{10, 16, 22}, {6, 14, 22, 32}};
+      int nlad = nladder[phase][lay - 1];
+      for (int xsign = -1; xsign <= 1; xsign += 2)
+        for (int ysign = -1; ysign <= 1; ysign += 2) {
+          float xlow = xsign * (half_shift * 0.5);
+          float xhigh = xsign * (half_shift * 0.5 + 4);
+          float ylow = ysign * (half_shift * 0.5 + (phase == 0) * 0.5);
+          float yhigh = ysign * (half_shift * 0.5 - (phase == 0) * 0.5 + nlad);
+          // Outside box
+          draw_line(xlow, xhigh, ylow, ylow, 1);    // bottom
+          draw_line(xlow, xhigh, yhigh, yhigh, 1);  // top
+          draw_line(xlow, xlow, ylow, yhigh, 1);    // left
+          draw_line(xhigh, xhigh, ylow, yhigh, 1);  // right
+          // Inner Horizontal lines
+          for (int lad = 1; lad < nlad; ++lad) {
+            float y = ysign * (lad + half_shift * 0.5);
+            draw_line(xlow, xhigh, y, y, 1);
+          }
+          for (int lad = 1; lad <= nlad; ++lad)
+            if (!(phase == 0 && (lad == 1 || lad == nlad))) {
+              float y = ysign * (lad + half_shift * 0.5 - 0.5);
+              draw_line(xlow, xhigh, y, y, 1, 3);
+            }
+          // Inner Vertical lines
+          for (int mod = 1; mod < 4; ++mod) {
+            float x = xsign * (mod + half_shift * 0.5);
+            draw_line(x, x, ylow, yhigh, 1);
+          }
+          // Make a BOX around ROC 0
+          // Phase 0 - ladder +1 is always non-flipped
+          // Phase 1 - ladder +1 is always     flipped
+          if (mark_zero) {
+            for (int mod = 1; mod <= 4; ++mod)
+              for (int lad = 1; lad <= nlad; ++lad) {
+                bool flipped = ysign == 1 ? lad % 2 == 0 : lad % 2 == 1;
+                if (phase == 1)
+                  flipped = !flipped;
+                int roc0_orientation = flipped ? -1 : 1;
+                if (xsign == -1)
+                  roc0_orientation *= -1;
+                if (ysign == -1)
+                  roc0_orientation *= -1;
+                float x1 = xsign * (mod + half_shift * 0.5);
+                float x2 = xsign * (mod + half_shift * 0.5 - 1. / 8);
+                float y1 = ysign * (lad + half_shift * 0.5 - 0.5);
+                float y2 = ysign * (lad + half_shift * 0.5 - 0.5 + roc0_orientation * 1. / 2);
+                if (!(phase == 0 && (lad == 1 || lad == nlad) && xsign == -1)) {
+                  if (lay == 1 && xsign <= -1) {
+                    float x1 = xsign * ((mod - 1) + half_shift * 0.5);
+                    float x2 = xsign * ((mod - 1) + half_shift * 0.5 + 1. / 8);
+                    float y1 = ysign * (lad + half_shift * 0.5 - 0.5 + roc0_orientation);
+                    float y2 = ysign * (lad + half_shift * 0.5 - 0.5 + roc0_orientation * 3. / 2);
+                    draw_line(x1, x2, y1, y1, 1);
+                    draw_line(x2, x2, y1, y2, 1);
+                  } else {
+                    draw_line(x1, x2, y1, y1, 1);
+                    //draw_line(x1, x2, y2, y2, 1);
+                    //draw_line(x1, x1, y1, y2, 1);
+                    draw_line(x2, x2, y1, y2, 1);
+                  }
+                }
+              }
+          }
+        }
     } else {
       // FPIX
-      for (int dsk=1, ndsk=2+(phase==1); dsk<=ndsk; ++dsk) {
-        for (int xsign=-1; xsign<=1; xsign+=2) for (int ysign=-1; ysign<=1; ysign+=2) {
-	    if (phase==0) {
-	      int first_roc = 3, nbin = 16;
-	      for (int bld=1, nbld=12; bld<=nbld; ++bld) {
-		// Horizontal lines
-		for (int plq=1, nplq=7; plq<=nplq; ++plq) {
-		  float xlow  = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1))/(float)nbin);
-		  float xhigh = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*(plq+1)-(plq==7))/(float)nbin);
-		  float ylow  = ysign * (half_shift*0.5 + (bld-0.5) - (2+plq/2)*0.1);
-		  float yhigh = ysign * (half_shift*0.5 + (bld-0.5) + (2+plq/2)*0.1);
-		  draw_line(xlow,  xhigh,   ylow,  ylow, 1); // bottom
-		  draw_line(xlow,  xhigh,  yhigh, yhigh, 1); // top
-		}
-		// Vertical lines
-		for (int plq=1, nplq=7+1; plq<=nplq; ++plq) {
-		  float x     = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1)-(plq==8))/(float)nbin);
-		  float ylow  = ysign * (half_shift*0.5 + (bld-0.5) - (2+(plq-(plq==8))/2)*0.1);
-		  float yhigh = ysign * (half_shift*0.5 + (bld-0.5) + (2+(plq-(plq==8))/2)*0.1);
-		  draw_line(x,  x,  ylow,  yhigh, 1);
-		}
-		// Panel 2 has dashed mid-plane
-		for (int plq=2, nplq=6; plq<=nplq; ++plq) if (plq%2==0) {
-		    float x     = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1)-(plq==8)+1)/(float)nbin);
-		    float ylow  = ysign * (half_shift*0.5 + (bld-0.5) - (2+(plq-(plq==8))/2)*0.1);
-		    float yhigh = ysign * (half_shift*0.5 + (bld-0.5) + (2+(plq-(plq==8))/2)*0.1);
-		    draw_line(x,  x,  ylow,  yhigh, 1, 2);
-		  }
-		// Make a BOX around ROC 0
-		for (int plq=1, nplq=7; plq<=nplq; ++plq) {
-		  float x1 = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1))/(float)nbin);
-		  float x2 = xsign * (half_shift*0.5 + dsk - 1   + (first_roc-3+2*plq+(plq==1)+1)/(float)nbin);
-		  int sign = xsign * ysign * ((plq%2) ? 1 : -1);
-		  float y1 = ysign * (half_shift*0.5 + (bld-0.5) + sign *(2+plq/2)*0.1);
-		  float y2 = ysign * (half_shift*0.5 + (bld-0.5) + sign *(  plq/2)*0.1);
-		  //draw_line(x1, x2, y1, y1, 1);
-		  draw_line(x1, x2, y2, y2, 1);
-		  //draw_line(x1, x1, y1, y2, 1);
-		  draw_line(x2, x2, y1, y2, 1);
-		}
-	      }
-	    } else if (phase==1) {
-	      if (ring == 0) { // both
-		for (int ring=1; ring<=2; ++ring) for (int bld=1, nbld=5+ring*6; bld<=nbld; ++bld) {
-		    float scale = (ring==1) ? 1.5 : 1;
-		    Color_t p1_color = 1, p2_color = 1;
-		    // Horizontal lines
-		    // Panel 2 has dashed mid-plane
-		    float x1      = xsign * (half_shift*0.5 + dsk - 1 + (ring-1)*0.5);
-		    float x2      = xsign * (half_shift*0.5 + dsk - 1 +  ring   *0.5);
-		    int sign = ysign;
-		    float y1      = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.5);
-		    //float yp1_mid = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25);
-		    float y2      = ysign * (half_shift*0.5 - 0.5 + scale*bld);
-		    float yp2_mid = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.25);
-		    float y3      = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.5);
-		    draw_line(x1, x2, y1,      y1,      1, 1, p1_color);
-		    //draw_line(x1, x2, yp1_mid, yp1_mid, 1, 3);
-		    draw_line(x1, x2, y2,      y2,      1, 1, p1_color);
-		    draw_line(x1, x2, yp2_mid, yp2_mid, 1, 2);
-		    draw_line(x1, x2, y3,      y3,      1, 1, p2_color);
-		    // Vertical lines
-		    float x = xsign * (half_shift*0.5 + dsk - 1 + (ring-1)*0.5);
-		    draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
-		    draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
-		    if (ring==2) {
-		      //draw_line(x,  x,  y2,  y3, 1, 1, p1_color);
-		      x         = xsign * (half_shift*0.5 + dsk);
-		      draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
-		      draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
-		    }
-		    // Make a BOX around ROC 0
-		    x1          = xsign * (half_shift*0.5 + dsk - 1 + ring*0.5 - 1/16.);
-		    x2          = xsign * (half_shift*0.5 + dsk - 1 + ring*0.5);
-		    float y1_p1 = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25);
-		    float y2_p1 = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25 + xsign*ysign*0.25);
-		    draw_line(x1, x2, y1_p1, y1_p1, 1);
-		    //draw_line(x1, x2, y2_p1, y2_p1, 1);
-		    draw_line(x1, x1, y1_p1, y2_p1, 1);
-		    //draw_line(x2, x2, y1_p1, y2_p1, 1);
-		    float y1_p2 = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.25);
-		    float y2_p2 = ysign * (half_shift*0.5 - 0.5 + scale*bld - sign*0.25 - xsign*ysign*0.25);
-		    draw_line(x1, x2, y1_p2, y1_p2, 1);
-		    //draw_line(x1, x2, y2_p2, y2_p2, 1);
-		    draw_line(x1, x1, y1_p2, y2_p2, 1);
-		    //draw_line(x2, x2, y1_p2, y2_p2, 1);
-		  }
-	      } else { // only one ring, 1 or 2
-		for (int bld=1, nbld=5+ring*6; bld<=nbld; ++bld) {
-		  Color_t p1_color = 1, p2_color = 1;
-		  // Horizontal lines
-		  // Panel 2 has dashed mid-plane
-		  float x1      = xsign * (half_shift*0.5 + dsk - 1);
-		  float x2      = xsign * (half_shift*0.5 + dsk);
-		  int sign = ysign;
-		  float y1      = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.5);
-		  //float yp1_mid = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25);
-		  float y2      = ysign * (half_shift*0.5 - 0.5 + bld);
-		  float yp2_mid = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.25);
-		  float y3      = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.5);
-		  draw_line(x1, x2, y1,      y1,      1, 1, p1_color);
-		  //draw_line(x1, x2, yp1_mid, yp1_mid, 1, 3);
-		  draw_line(x1, x2, y2,      y2,      1, 1, p1_color);
-		  draw_line(x1, x2, yp2_mid, yp2_mid, 1, 2);
-		  draw_line(x1, x2, y3,      y3,      1, 1, p2_color);
-		  // Vertical lines
-		  float x = xsign * (half_shift*0.5 + dsk - 1);
-		  draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
-		  draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
-		  if (ring==2) {
-		    //draw_line(x,  x,  y2,  y3, 1, 1, p1_color);
-		    x         = xsign * (half_shift*0.5 + dsk);
-		    draw_line(x,  x,  y1,  y2, 1, 1, p1_color);
-		    draw_line(x,  x,  y2,  y3, 1, 1, p2_color);
-		  }
-		  // Make a BOX around ROC 0
-		  x1          = xsign * (half_shift*0.5 + dsk - 1/8.);
-		  x2          = xsign * (half_shift*0.5 + dsk);
-		  float y1_p1 = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25);
-		  float y2_p1 = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25 + xsign*ysign*0.25);
-		  draw_line(x1, x2, y1_p1, y1_p1, 1);
-		  //draw_line(x1, x2, y2_p1, y2_p1, 1);
-		  draw_line(x1, x1, y1_p1, y2_p1, 1);
-		  //draw_line(x2, x2, y1_p1, y2_p1, 1);
-		  float y1_p2 = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.25);
-		  float y2_p2 = ysign * (half_shift*0.5 - 0.5 + bld - sign*0.25 - xsign*ysign*0.25);
-		  draw_line(x1, x2, y1_p2, y1_p2, 1);
-		  //draw_line(x1, x2, y2_p2, y2_p2, 1);
-		  draw_line(x1, x1, y1_p2, y2_p2, 1);
-		  //draw_line(x2, x2, y1_p2, y2_p2, 1);
-		}
-	      }
-	    }
-	  }
+      for (int dsk = 1, ndsk = 2 + (phase == 1); dsk <= ndsk; ++dsk) {
+        for (int xsign = -1; xsign <= 1; xsign += 2)
+          for (int ysign = -1; ysign <= 1; ysign += 2) {
+            if (phase == 0) {
+              int first_roc = 3, nbin = 16;
+              for (int bld = 1, nbld = 12; bld <= nbld; ++bld) {
+                // Horizontal lines
+                for (int plq = 1, nplq = 7; plq <= nplq; ++plq) {
+                  float xlow =
+                      xsign * (half_shift * 0.5 + dsk - 1 + (first_roc - 3 + 2 * plq + (plq == 1)) / (float)nbin);
+                  float xhigh =
+                      xsign * (half_shift * 0.5 + dsk - 1 + (first_roc - 3 + 2 * (plq + 1) - (plq == 7)) / (float)nbin);
+                  float ylow = ysign * (half_shift * 0.5 + (bld - 0.5) - (2 + plq / 2) * 0.1);
+                  float yhigh = ysign * (half_shift * 0.5 + (bld - 0.5) + (2 + plq / 2) * 0.1);
+                  draw_line(xlow, xhigh, ylow, ylow, 1);    // bottom
+                  draw_line(xlow, xhigh, yhigh, yhigh, 1);  // top
+                }
+                // Vertical lines
+                for (int plq = 1, nplq = 7 + 1; plq <= nplq; ++plq) {
+                  float x = xsign * (half_shift * 0.5 + dsk - 1 +
+                                     (first_roc - 3 + 2 * plq + (plq == 1) - (plq == 8)) / (float)nbin);
+                  float ylow = ysign * (half_shift * 0.5 + (bld - 0.5) - (2 + (plq - (plq == 8)) / 2) * 0.1);
+                  float yhigh = ysign * (half_shift * 0.5 + (bld - 0.5) + (2 + (plq - (plq == 8)) / 2) * 0.1);
+                  draw_line(x, x, ylow, yhigh, 1);
+                }
+                // Panel 2 has dashed mid-plane
+                for (int plq = 2, nplq = 6; plq <= nplq; ++plq)
+                  if (plq % 2 == 0) {
+                    float x = xsign * (half_shift * 0.5 + dsk - 1 +
+                                       (first_roc - 3 + 2 * plq + (plq == 1) - (plq == 8) + 1) / (float)nbin);
+                    float ylow = ysign * (half_shift * 0.5 + (bld - 0.5) - (2 + (plq - (plq == 8)) / 2) * 0.1);
+                    float yhigh = ysign * (half_shift * 0.5 + (bld - 0.5) + (2 + (plq - (plq == 8)) / 2) * 0.1);
+                    draw_line(x, x, ylow, yhigh, 1, 2);
+                  }
+                // Make a BOX around ROC 0
+                for (int plq = 1, nplq = 7; plq <= nplq; ++plq) {
+                  float x1 =
+                      xsign * (half_shift * 0.5 + dsk - 1 + (first_roc - 3 + 2 * plq + (plq == 1)) / (float)nbin);
+                  float x2 =
+                      xsign * (half_shift * 0.5 + dsk - 1 + (first_roc - 3 + 2 * plq + (plq == 1) + 1) / (float)nbin);
+                  int sign = xsign * ysign * ((plq % 2) ? 1 : -1);
+                  float y1 = ysign * (half_shift * 0.5 + (bld - 0.5) + sign * (2 + plq / 2) * 0.1);
+                  float y2 = ysign * (half_shift * 0.5 + (bld - 0.5) + sign * (plq / 2) * 0.1);
+                  //draw_line(x1, x2, y1, y1, 1);
+                  draw_line(x1, x2, y2, y2, 1);
+                  //draw_line(x1, x1, y1, y2, 1);
+                  draw_line(x2, x2, y1, y2, 1);
+                }
+              }
+            } else if (phase == 1) {
+              if (ring == 0) {  // both
+                for (int ring = 1; ring <= 2; ++ring)
+                  for (int bld = 1, nbld = 5 + ring * 6; bld <= nbld; ++bld) {
+                    float scale = (ring == 1) ? 1.5 : 1;
+                    Color_t p1_color = 1, p2_color = 1;
+                    // Horizontal lines
+                    // Panel 2 has dashed mid-plane
+                    float x1 = xsign * (half_shift * 0.5 + dsk - 1 + (ring - 1) * 0.5);
+                    float x2 = xsign * (half_shift * 0.5 + dsk - 1 + ring * 0.5);
+                    int sign = ysign;
+                    float y1 = ysign * (half_shift * 0.5 - 0.5 + scale * bld + sign * 0.5);
+                    //float yp1_mid = ysign * (half_shift*0.5 - 0.5 + scale*bld + sign*0.25);
+                    float y2 = ysign * (half_shift * 0.5 - 0.5 + scale * bld);
+                    float yp2_mid = ysign * (half_shift * 0.5 - 0.5 + scale * bld - sign * 0.25);
+                    float y3 = ysign * (half_shift * 0.5 - 0.5 + scale * bld - sign * 0.5);
+                    draw_line(x1, x2, y1, y1, 1, 1, p1_color);
+                    //draw_line(x1, x2, yp1_mid, yp1_mid, 1, 3);
+                    draw_line(x1, x2, y2, y2, 1, 1, p1_color);
+                    draw_line(x1, x2, yp2_mid, yp2_mid, 1, 2);
+                    draw_line(x1, x2, y3, y3, 1, 1, p2_color);
+                    // Vertical lines
+                    float x = xsign * (half_shift * 0.5 + dsk - 1 + (ring - 1) * 0.5);
+                    draw_line(x, x, y1, y2, 1, 1, p1_color);
+                    draw_line(x, x, y2, y3, 1, 1, p2_color);
+                    if (ring == 2) {
+                      //draw_line(x,  x,  y2,  y3, 1, 1, p1_color);
+                      x = xsign * (half_shift * 0.5 + dsk);
+                      draw_line(x, x, y1, y2, 1, 1, p1_color);
+                      draw_line(x, x, y2, y3, 1, 1, p2_color);
+                    }
+                    // Make a BOX around ROC 0
+                    x1 = xsign * (half_shift * 0.5 + dsk - 1 + ring * 0.5 - 1 / 16.);
+                    x2 = xsign * (half_shift * 0.5 + dsk - 1 + ring * 0.5);
+                    float y1_p1 = ysign * (half_shift * 0.5 - 0.5 + scale * bld + sign * 0.25);
+                    float y2_p1 = ysign * (half_shift * 0.5 - 0.5 + scale * bld + sign * 0.25 + xsign * ysign * 0.25);
+                    draw_line(x1, x2, y1_p1, y1_p1, 1);
+                    //draw_line(x1, x2, y2_p1, y2_p1, 1);
+                    draw_line(x1, x1, y1_p1, y2_p1, 1);
+                    //draw_line(x2, x2, y1_p1, y2_p1, 1);
+                    float y1_p2 = ysign * (half_shift * 0.5 - 0.5 + scale * bld - sign * 0.25);
+                    float y2_p2 = ysign * (half_shift * 0.5 - 0.5 + scale * bld - sign * 0.25 - xsign * ysign * 0.25);
+                    draw_line(x1, x2, y1_p2, y1_p2, 1);
+                    //draw_line(x1, x2, y2_p2, y2_p2, 1);
+                    draw_line(x1, x1, y1_p2, y2_p2, 1);
+                    //draw_line(x2, x2, y1_p2, y2_p2, 1);
+                  }
+              } else {  // only one ring, 1 or 2
+                for (int bld = 1, nbld = 5 + ring * 6; bld <= nbld; ++bld) {
+                  Color_t p1_color = 1, p2_color = 1;
+                  // Horizontal lines
+                  // Panel 2 has dashed mid-plane
+                  float x1 = xsign * (half_shift * 0.5 + dsk - 1);
+                  float x2 = xsign * (half_shift * 0.5 + dsk);
+                  int sign = ysign;
+                  float y1 = ysign * (half_shift * 0.5 - 0.5 + bld + sign * 0.5);
+                  //float yp1_mid = ysign * (half_shift*0.5 - 0.5 + bld + sign*0.25);
+                  float y2 = ysign * (half_shift * 0.5 - 0.5 + bld);
+                  float yp2_mid = ysign * (half_shift * 0.5 - 0.5 + bld - sign * 0.25);
+                  float y3 = ysign * (half_shift * 0.5 - 0.5 + bld - sign * 0.5);
+                  draw_line(x1, x2, y1, y1, 1, 1, p1_color);
+                  //draw_line(x1, x2, yp1_mid, yp1_mid, 1, 3);
+                  draw_line(x1, x2, y2, y2, 1, 1, p1_color);
+                  draw_line(x1, x2, yp2_mid, yp2_mid, 1, 2);
+                  draw_line(x1, x2, y3, y3, 1, 1, p2_color);
+                  // Vertical lines
+                  float x = xsign * (half_shift * 0.5 + dsk - 1);
+                  draw_line(x, x, y1, y2, 1, 1, p1_color);
+                  draw_line(x, x, y2, y3, 1, 1, p2_color);
+                  if (ring == 2) {
+                    //draw_line(x,  x,  y2,  y3, 1, 1, p1_color);
+                    x = xsign * (half_shift * 0.5 + dsk);
+                    draw_line(x, x, y1, y2, 1, 1, p1_color);
+                    draw_line(x, x, y2, y3, 1, 1, p2_color);
+                  }
+                  // Make a BOX around ROC 0
+                  x1 = xsign * (half_shift * 0.5 + dsk - 1 / 8.);
+                  x2 = xsign * (half_shift * 0.5 + dsk);
+                  float y1_p1 = ysign * (half_shift * 0.5 - 0.5 + bld + sign * 0.25);
+                  float y2_p1 = ysign * (half_shift * 0.5 - 0.5 + bld + sign * 0.25 + xsign * ysign * 0.25);
+                  draw_line(x1, x2, y1_p1, y1_p1, 1);
+                  //draw_line(x1, x2, y2_p1, y2_p1, 1);
+                  draw_line(x1, x1, y1_p1, y2_p1, 1);
+                  //draw_line(x2, x2, y1_p1, y2_p1, 1);
+                  float y1_p2 = ysign * (half_shift * 0.5 - 0.5 + bld - sign * 0.25);
+                  float y2_p2 = ysign * (half_shift * 0.5 - 0.5 + bld - sign * 0.25 - xsign * ysign * 0.25);
+                  draw_line(x1, x2, y1_p2, y1_p2, 1);
+                  //draw_line(x1, x2, y2_p2, y2_p2, 1);
+                  draw_line(x1, x1, y1_p2, y2_p2, 1);
+                  //draw_line(x2, x2, y1_p2, y2_p2, 1);
+                }
+              }
+            }
+          }
       }
       // Special shifted "rebin" for Phase 0
       // Y axis should always have at least half-roc granularity because
@@ -345,18 +368,19 @@ namespace SiPixelPI {
       // To remove this and show full ROC granularity
       // We merge bin contents in each pair of bins corresponding to one ROC
       // TODO: make sure this works for Profiles
-      if (phase==0&&h->GetNbinsY()==250&&h->GetNbinsX()==80) {
+      if (phase == 0 && h->GetNbinsY() == 250 && h->GetNbinsX() == 80) {
         int nentries = h->GetEntries();
-        for (int binx = 1; binx<=80; ++binx) {
+        for (int binx = 1; binx <= 80; ++binx) {
           double sum = 0;
-          for (int biny = 1; biny<=250; ++biny) {
-            bool odd_nrocy = (binx-1<40) != (((binx-1)/4)%2);
-            if (biny%2==odd_nrocy) sum+= h->GetBinContent(binx, biny);
+          for (int biny = 1; biny <= 250; ++biny) {
+            bool odd_nrocy = (binx - 1 < 40) != (((binx - 1) / 4) % 2);
+            if (biny % 2 == odd_nrocy)
+              sum += h->GetBinContent(binx, biny);
             else {
-              sum+= h->GetBinContent(binx, biny);
+              sum += h->GetBinContent(binx, biny);
               if (sum) {
                 h->SetBinContent(binx, biny, sum);
-                h->SetBinContent(binx, biny-1, sum);
+                h->SetBinContent(binx, biny - 1, sum);
               }
               sum = 0;
             }
@@ -366,6 +390,22 @@ namespace SiPixelPI {
       }
     }
   }
-};
-#endif
 
+  /*--------------------------------------------------------------------*/
+  std::pair<float, float> getExtrema(TH1* h1, TH1* h2)
+  /*--------------------------------------------------------------------*/
+  {
+    float theMax(-9999.);
+    float theMin(9999.);
+    theMax = h1->GetMaximum() > h2->GetMaximum() ? h1->GetMaximum() : h2->GetMaximum();
+    theMin = h1->GetMinimum() < h2->GetMaximum() ? h1->GetMinimum() : h2->GetMinimum();
+
+    float add_min = theMin > 0. ? -0.05 : 0.05;
+    float add_max = theMax > 0. ? 0.05 : -0.05;
+
+    auto result = std::make_pair(theMin * (1 + add_min), theMax * (1 + add_max));
+    return result;
+  }
+
+};  // namespace SiPixelPI
+#endif

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -81,6 +81,13 @@ namespace SiPixelPI {
   }
 
   //============================================================================               
+  int signed_blade_panel(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {
+    if (detid.subdetId() != PixelSubdetector::PixelEndcap) return -9999;
+    int signed_blade_panel = signed_blade(detid,tTopo_,phase_)+(tTopo_.pxfPanel(detid)-1);
+    return signed_blade_panel;
+  }
+
+  //============================================================================               
   // Online disk convention
   // Apply sign convention (- sign for BmO and BmI)
   int signed_disk(const DetId& detid,const TrackerTopology& tTopo_,bool phase_) {

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -1,0 +1,6 @@
+<library file="SiPixelQuality_PayloadInspector.cc" name="SiPixelQuality_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -5,3 +5,11 @@
   <use   name="CalibTracker/StandaloneTrackerTopology"/>
   <use   name="boost_python"/>
 </library>
+
+<library file="SiPixelLorentzAngle_PayloadInspector.cc" name="SiPixelLorentzAngle_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="CalibTracker/StandaloneTrackerTopology"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/SiPixelPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiPixelPlugins/plugins/BuildFile.xml
@@ -2,5 +2,6 @@
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
+  <use   name="CalibTracker/StandaloneTrackerTopology"/>
   <use   name="boost_python"/>
 </library>

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -1,0 +1,62 @@
+/*!
+  \file SiPixelLorentzAngle_PayloadInspector
+  \Payload Inspector Plugin for SiPixel Lorentz angles
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2019/06/20 10:59:56 $
+*/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+
+#include <memory>
+#include <sstream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+#include "TGaxis.h"
+
+namespace {
+
+  /************************************************
+    1d histogram of SiPixelLorentzAngle of 1 IOV 
+  *************************************************/
+
+  // inherit from one of the predefined plot class: Histogram1D
+  class SiPixelLorentzAngleValue : public cond::payloadInspector::Histogram1D<SiPixelLorentzAngle> {
+  public:
+    SiPixelLorentzAngleValue()
+      : cond::payloadInspector::Histogram1D<SiPixelLorentzAngle>(
+								 "SiPixel LorentzAngle values", "SiPixel LorentzAngle values", 100, 0.0, 0.05) {
+      Base::setSingleIov(true);
+    }
+    
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
+      for (auto const &iov : iovs) {
+        std::shared_ptr<SiPixelLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));
+        if (payload.get()) {
+          std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
+	  
+          for (const auto &element : LAMap_) {
+            fillWithValue(element.second);
+          }
+        }  // payload
+      }    // iovs
+      return true;
+    }  // fill
+  }; 
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(SiPixelLorentzAngle) {
+  PAYLOAD_INSPECTOR_CLASS(SiPixelLorentzAngleValue);
+}

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -367,13 +367,13 @@ namespace {
       }
 
       SiPixelPI::makeNicePlotStyle(summaryFirst.get());//, kBlue);
-      summaryFirst->SetMarkerColor(kBlue);
+      summaryFirst->SetMarkerColor(kRed);
       summaryFirst->GetXaxis()->LabelsOption("v");
       summaryFirst->GetXaxis()->SetLabelSize(0.05);
       summaryFirst->GetYaxis()->SetTitleOffset(0.9);
 
       SiPixelPI::makeNicePlotStyle(summaryLast.get());//, kRed);
-      summaryLast->SetMarkerColor(kRed);
+      summaryLast->SetMarkerColor(kBlue);
       summaryLast->GetYaxis()->SetTitleOffset(0.9);
       summaryLast->GetXaxis()->LabelsOption("v");
       summaryLast->GetXaxis()->SetLabelSize(0.05);
@@ -385,8 +385,8 @@ namespace {
       canvas.SetRightMargin(0.02);
       canvas.Modified();
 
-      summaryFirst->SetFillColor(kBlue);
-      summaryLast->SetFillColor(kRed);
+      summaryFirst->SetFillColor(kRed);
+      summaryLast->SetFillColor(kBlue);
 
       summaryFirst->SetBarWidth(0.45);
       summaryFirst->SetBarOffset(0.1);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -75,8 +75,8 @@ namespace {
 
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
-      auto h1 = std::unique_ptr<TH1F>(
-          new TH1F("value", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
+      auto h1 = std::unique_ptr<TH1F>(new TH1F(
+          "value", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
       h1->SetStats(false);
 
       canvas.SetTopMargin(0.06);
@@ -102,7 +102,8 @@ namespace {
       canvas.Update();
 
       TLegend legend = TLegend(0.40, 0.88, 0.95, 0.94);
-      legend.SetHeader(("Payload hash: #bf{"+(std::get<1>(iov))+"}" ).c_str(), "C");  // option "C" allows to center the header
+      legend.SetHeader(("Payload hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
+                       "C");  // option "C" allows to center the header
       //legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
       legend.SetTextSize(0.025);
       legend.Draw("same");
@@ -113,8 +114,8 @@ namespace {
       ltx.SetTextSize(0.05);
       ltx.SetTextAlign(11);
       ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-		       1 - gPad->GetTopMargin() + 0.01,
-		       ("SiPixel Lorentz Angle IOV:" + std::to_string(std::get<0>(iov))).c_str());
+                       1 - gPad->GetTopMargin() + 0.01,
+                       ("SiPixel Lorentz Angle IOV:" + std::to_string(std::get<0>(iov))).c_str());
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
@@ -151,11 +152,19 @@ namespace {
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
       auto hfirst = std::unique_ptr<TH1F>(
-          new TH1F("value_first", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
+          new TH1F("value_first",
+                   "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules",
+                   50,
+                   0.051,
+                   0.15));
       hfirst->SetStats(false);
 
       auto hlast = std::unique_ptr<TH1F>(
-          new TH1F("value_last", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
+          new TH1F("value_last",
+                   "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules",
+                   50,
+                   0.051,
+                   0.15));
       hlast->SetStats(false);
 
       canvas.SetTopMargin(0.06);
@@ -200,8 +209,8 @@ namespace {
       //legend.SetHeader("#font[22]{SiPixel Lorentz Angle Comparison}", "C");  // option "C" allows to center the header
       //legend.AddEntry(hfirst.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "FL");
       //legend.AddEntry(hlast.get(),  ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "FL");
-      legend.AddEntry(hfirst.get(), ("payload: #color[2]{" + std::get<1>(firstiov)+"}").c_str(), "F");
-      legend.AddEntry(hlast.get(),  ("payload: #color[4]{" + std::get<1>(lastiov)+"}").c_str(), "F");
+      legend.AddEntry(hfirst.get(), ("payload: #color[2]{" + std::get<1>(firstiov) + "}").c_str(), "F");
+      legend.AddEntry(hlast.get(), ("payload: #color[4]{" + std::get<1>(lastiov) + "}").c_str(), "F");
       legend.SetTextSize(0.025);
       legend.Draw("same");
 
@@ -211,8 +220,10 @@ namespace {
       ltx.SetTextSize(0.05);
       ltx.SetTextAlign(11);
       ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-		       1 - gPad->GetTopMargin() + 0.01,
-		       ("SiPixel Lorentz Angle IOV: #color[2]{"+std::to_string(std::get<0>(firstiov)) + "} vs IOV: #color[4]{" + std::to_string(std::get<0>(lastiov))+"}").c_str());
+                       1 - gPad->GetTopMargin() + 0.01,
+                       ("SiPixel Lorentz Angle IOV: #color[2]{" + std::to_string(std::get<0>(firstiov)) +
+                        "} vs IOV: #color[4]{" + std::to_string(std::get<0>(lastiov)) + "}")
+                           .c_str());
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
@@ -237,22 +248,21 @@ namespace {
   class SiPixelLorentzAngleByRegionComparisonBase : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
   public:
     SiPixelLorentzAngleByRegionComparisonBase()
-      : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Comparison by Region") {}
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Comparison by Region") {}
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
-
       gStyle->SetPaintTextFormat(".3f");
 
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
 
       // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
         return std::get<0>(t1) < std::get<0>(t2);
       });
 
       auto firstiov = sorted_iovs.front();
       auto lastiov = sorted_iovs.back();
 
-      std::shared_ptr<SiPixelLorentzAngle> last_payload  = fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiPixelLorentzAngle> last_payload = fetchPayload(std::get<1>(lastiov));
       std::map<uint32_t, float> l_LAMap_ = last_payload->getLorentzAngles();
       std::shared_ptr<SiPixelLorentzAngle> first_payload = fetchPayload(std::get<1>(firstiov));
       std::map<uint32_t, float> f_LAMap_ = first_payload->getLorentzAngles();
@@ -262,8 +272,8 @@ namespace {
 
       TCanvas canvas("Comparison", "Comparison", 1600, 800);
 
-      std::map<SiPixelPI::regions, std::shared_ptr<TH1F> > FirstLA_spectraByRegion;
-      std::map<SiPixelPI::regions, std::shared_ptr<TH1F> > LastLA_spectraByRegion;
+      std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> FirstLA_spectraByRegion;
+      std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> LastLA_spectraByRegion;
       std::shared_ptr<TH1F> summaryFirst;
       std::shared_ptr<TH1F> summaryLast;
 
@@ -272,49 +282,44 @@ namespace {
         SiPixelPI::regions part = static_cast<SiPixelPI::regions>(r);
         std::string s_part = SiPixelPI::getStringFromRegionEnum(part);
 
-        FirstLA_spectraByRegion[part] =
-            std::make_shared<TH1F>(Form("hfirstLA_%s", s_part.c_str()),
-                                   Form(";%s #mu_{H} [1/T];n. of modules", s_part.c_str()),
-                                   1000,
-                                   0.,
-                                   1000.);
-        LastLA_spectraByRegion[part] =
-            std::make_shared<TH1F>(Form("hlastLA_%s", s_part.c_str()),
-                                   Form(";%s #mu_{H} [1/T];n. of modules", s_part.c_str()),
-                                   1000,
-                                   0.,
-                                   1000.);
+        FirstLA_spectraByRegion[part] = std::make_shared<TH1F>(Form("hfirstLA_%s", s_part.c_str()),
+                                                               Form(";%s #mu_{H} [1/T];n. of modules", s_part.c_str()),
+                                                               1000,
+                                                               0.,
+                                                               1000.);
+        LastLA_spectraByRegion[part] = std::make_shared<TH1F>(Form("hlastLA_%s", s_part.c_str()),
+                                                              Form(";%s #mu_{H} [1/T];n. of modules", s_part.c_str()),
+                                                              1000,
+                                                              0.,
+                                                              1000.);
       }
 
-      summaryFirst =
-          std::make_shared<TH1F>("first Summary",
-				 "Summary for #LT tan#theta_{L}/B #GT;;average LA #LT #mu_{H} #GT [1/T]",
-                                 FirstLA_spectraByRegion.size(),
-                                 0,
-                                 FirstLA_spectraByRegion.size());
-      summaryLast =
-	std::make_shared<TH1F>("last Summary",
-			       "Summary for #LT tan#theta_{L}/B #GT;;average LA #LT #mu_{H}  #GT [1/T]",
-			       LastLA_spectraByRegion.size(),
-			       0,
-			       LastLA_spectraByRegion.size());
+      summaryFirst = std::make_shared<TH1F>("first Summary",
+                                            "Summary for #LT tan#theta_{L}/B #GT;;average LA #LT #mu_{H} #GT [1/T]",
+                                            FirstLA_spectraByRegion.size(),
+                                            0,
+                                            FirstLA_spectraByRegion.size());
+      summaryLast = std::make_shared<TH1F>("last Summary",
+                                           "Summary for #LT tan#theta_{L}/B #GT;;average LA #LT #mu_{H}  #GT [1/T]",
+                                           LastLA_spectraByRegion.size(),
+                                           0,
+                                           LastLA_spectraByRegion.size());
 
-      const char* path_toTopologyXML = (f_LAMap_.size() == SiPixelPI::phase0size)
+      const char *path_toTopologyXML = (f_LAMap_.size() == SiPixelPI::phase0size)
                                            ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
                                            : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
       TrackerTopology f_tTopo =
-	StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
       bool isPhase0(false);
-      if (f_LAMap_.size() == SiPixelPI::phase0size){
-	isPhase0 = true;
+      if (f_LAMap_.size() == SiPixelPI::phase0size) {
+        isPhase0 = true;
       }
 
       // -------------------------------------------------------------------
       // loop on the first LA Map
       // -------------------------------------------------------------------
-      for (const auto& it : f_LAMap_) {
-
+      for (const auto &it : f_LAMap_) {
         if (DetId(it.first).det() != DetId::Tracker) {
           edm::LogWarning("SiPixelLorentzAngle_PayloadInspector")
               << "Encountered invalid Tracker DetId:" << it.first << " - terminating ";
@@ -336,15 +341,14 @@ namespace {
       TrackerTopology l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      if (l_LAMap_.size() == SiPixelPI::phase0size){
+      if (l_LAMap_.size() == SiPixelPI::phase0size) {
         isPhase0 = true;
       }
 
       // -------------------------------------------------------------------
       // loop on the second LA Map
       // -------------------------------------------------------------------
-      for (const auto& it : l_LAMap_) {
-
+      for (const auto &it : l_LAMap_) {
         if (DetId(it.first).det() != DetId::Tracker) {
           edm::LogWarning("SiPixelLorentzAngle_PayloadInspector")
               << "Encountered invalid Tracker DetId:" << it.first << " - terminating ";
@@ -381,13 +385,13 @@ namespace {
         bin++;
       }
 
-      SiPixelPI::makeNicePlotStyle(summaryFirst.get());//, kBlue);
+      SiPixelPI::makeNicePlotStyle(summaryFirst.get());  //, kBlue);
       summaryFirst->SetMarkerColor(kRed);
       summaryFirst->GetXaxis()->LabelsOption("v");
       summaryFirst->GetXaxis()->SetLabelSize(0.05);
       summaryFirst->GetYaxis()->SetTitleOffset(0.9);
 
-      SiPixelPI::makeNicePlotStyle(summaryLast.get());//, kRed);
+      SiPixelPI::makeNicePlotStyle(summaryLast.get());  //, kRed);
       summaryLast->SetMarkerColor(kBlue);
       summaryLast->GetYaxis()->SetTitleOffset(0.9);
       summaryLast->GetXaxis()->LabelsOption("v");
@@ -423,7 +427,7 @@ namespace {
       summaryLast->Draw("text60same");
 
       TLegend legend = TLegend(0.52, 0.80, 0.98, 0.9);
-      legend.SetHeader("#mu_{H} value comparison","C");  // option "C" allows to center the header
+      legend.SetHeader("#mu_{H} value comparison", "C");  // option "C" allows to center the header
       legend.AddEntry(
           summaryLast.get(),
           ("IOV: #scale[1.2]{" + std::to_string(std::get<0>(lastiov)) + "} | #color[4]{" + std::get<1>(lastiov) + "}")
@@ -437,7 +441,6 @@ namespace {
       legend.SetTextSize(0.025);
       legend.Draw("same");
 
-
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
       return true;
@@ -446,14 +449,15 @@ namespace {
 
   class SiPixelLorentzAngleByRegionComparisonSingleTag : public SiPixelLorentzAngleByRegionComparisonBase {
   public:
-    SiPixelLorentzAngleByRegionComparisonSingleTag() : SiPixelLorentzAngleByRegionComparisonBase() { setSingleIov(false); }
+    SiPixelLorentzAngleByRegionComparisonSingleTag() : SiPixelLorentzAngleByRegionComparisonBase() {
+      setSingleIov(false);
+    }
   };
 
   class SiPixelLorentzAngleByRegionComparisonTwoTags : public SiPixelLorentzAngleByRegionComparisonBase {
   public:
     SiPixelLorentzAngleByRegionComparisonTwoTags() : SiPixelLorentzAngleByRegionComparisonBase() { setTwoTags(true); }
   };
-
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -411,12 +411,12 @@ namespace {
       legend.SetHeader("#mu_{H} value comparison","C");  // option "C" allows to center the header
       legend.AddEntry(
           summaryLast.get(),
-          ("IOV: #scale[1.2]{" + std::to_string(std::get<0>(lastiov)) + "} | #color[2]{" + std::get<1>(lastiov) + "}")
+          ("IOV: #scale[1.2]{" + std::to_string(std::get<0>(lastiov)) + "} | #color[4]{" + std::get<1>(lastiov) + "}")
               .c_str(),
           "F");
       legend.AddEntry(
           summaryFirst.get(),
-          ("IOV: #scale[1.2]{" + std::to_string(std::get<0>(firstiov)) + "} | #color[4]{" + std::get<1>(firstiov) + "}")
+          ("IOV: #scale[1.2]{" + std::to_string(std::get<0>(firstiov)) + "} | #color[2]{" + std::get<1>(firstiov) + "}")
               .c_str(),
           "F");
       legend.SetTextSize(0.025);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -75,7 +75,7 @@ namespace {
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
       auto h1 = std::unique_ptr<TH1F>(
-          new TH1F("value", "SiPixel LA value;SiPixel Lorentz Angle [rad];# modules", 100, 0., 0.1));
+          new TH1F("value", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 100, 0., 0.15));
       h1->SetStats(false);
       canvas.SetBottomMargin(0.10);
       canvas.SetLeftMargin(0.12);
@@ -136,11 +136,11 @@ namespace {
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
       auto hfirst = std::unique_ptr<TH1F>(
-          new TH1F("value_first", "SiPixel LA value;SiPixel Lorentz Angle [rad];# modules", 50, 0., 0.1));
+          new TH1F("value_first", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0., 0.1));
       hfirst->SetStats(false);
 
       auto hlast = std::unique_ptr<TH1F>(
-          new TH1F("value_last", "SiPixel LA value;SiPixel Lorentz Angle [rad];# modules", 50, 0., 0.1));
+          new TH1F("value_last", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0., 0.1));
       hlast->SetStats(false);
 
       canvas.SetBottomMargin(0.10);
@@ -176,7 +176,7 @@ namespace {
       TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
       legend.SetHeader("SiPixel Lorentz Angle Comparison", "C");  // option "C" allows to center the header
       legend.AddEntry(hfirst.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "FL");
-      legend.AddEntry(hlast.get(), ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "FL");
+      legend.AddEntry(hlast.get(),  ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "FL");
       legend.SetTextSize(0.025);
       legend.Draw("same");
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -136,16 +136,17 @@ namespace {
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
       auto hfirst = std::unique_ptr<TH1F>(
-          new TH1F("value_first", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0., 0.1));
+          new TH1F("value_first", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.11));
       hfirst->SetStats(false);
 
       auto hlast = std::unique_ptr<TH1F>(
-          new TH1F("value_last", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0., 0.1));
+          new TH1F("value_last", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.11));
       hlast->SetStats(false);
 
-      canvas.SetBottomMargin(0.10);
+      canvas.SetTopMargin(0.06);
+      canvas.SetBottomMargin(0.12);
       canvas.SetLeftMargin(0.12);
-      canvas.SetRightMargin(0.03);
+      canvas.SetRightMargin(0.05);
       canvas.Modified();
 
       for (const auto &element : f_LAMap_) {
@@ -159,26 +160,44 @@ namespace {
       auto extrema = SiPixelPI::getExtrema(hfirst.get(), hlast.get());
       hfirst->GetYaxis()->SetRangeUser(extrema.first, extrema.second * 1.10);
 
+      hfirst->SetTitle("");
       hfirst->SetFillColor(kRed);
-      hfirst->SetMarkerStyle(20);
-      hfirst->SetMarkerSize(1);
+      hfirst->SetMarkerStyle(kFullCircle);
+      hfirst->SetMarkerSize(1.5);
+      hfirst->SetMarkerColor(kRed);
       hfirst->Draw("HIST");
       hfirst->Draw("Psame");
 
+      hlast->SetTitle("");
       hlast->SetFillColorAlpha(kBlue, 0.20);
-      hlast->SetMarkerStyle(20);
-      hlast->SetMarkerSize(1);
+      hlast->SetMarkerStyle(kOpenCircle);
+      hlast->SetMarkerSize(1.5);
+      hlast->SetMarkerColor(kBlue);
       hlast->Draw("HISTsame");
       hlast->Draw("Psame");
 
+      SiPixelPI::makeNicePlotStyle(hfirst.get());
+      SiPixelPI::makeNicePlotStyle(hlast.get());
+
       canvas.Update();
 
-      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
-      legend.SetHeader("SiPixel Lorentz Angle Comparison", "C");  // option "C" allows to center the header
-      legend.AddEntry(hfirst.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "FL");
-      legend.AddEntry(hlast.get(),  ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "FL");
+      TLegend legend = TLegend(0.32, 0.86, 0.95, 0.94);
+      //legend.SetHeader("#font[22]{SiPixel Lorentz Angle Comparison}", "C");  // option "C" allows to center the header
+      //legend.AddEntry(hfirst.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "FL");
+      //legend.AddEntry(hlast.get(),  ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "FL");
+      legend.AddEntry(hfirst.get(), ("payload: #color[2]{" + std::get<1>(firstiov)+"}").c_str(), "F");
+      legend.AddEntry(hlast.get(),  ("payload: #color[4]{" + std::get<1>(lastiov)+"}").c_str(), "F");
       legend.SetTextSize(0.025);
       legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      //ltx.SetTextColor(kBlue);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+		       1 - gPad->GetTopMargin() + 0.01,
+		       ("SiPixel Lorentz Angle IOV: #color[2]{"+std::to_string(std::get<0>(firstiov)) + "} vs IOV: #color[4]{" + std::to_string(std::get<0>(lastiov))+"}").c_str());
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -64,7 +64,7 @@ namespace {
   *************************************************/
   class SiPixelLorentzAngleValues : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
   public:
-    SiPixelLorentzAngleValues() : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle") {
+    SiPixelLorentzAngleValues() : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Values") {
       setSingleIov(true);
     }
 
@@ -76,17 +76,20 @@ namespace {
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
       auto h1 = std::unique_ptr<TH1F>(
-          new TH1F("value", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 100, 0., 0.15));
+          new TH1F("value", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
       h1->SetStats(false);
-      canvas.SetBottomMargin(0.10);
+
+      canvas.SetTopMargin(0.06);
+      canvas.SetBottomMargin(0.12);
       canvas.SetLeftMargin(0.12);
-      canvas.SetRightMargin(0.03);
+      canvas.SetRightMargin(0.05);
       canvas.Modified();
 
       for (const auto &element : LAMap_) {
         h1->Fill(element.second);
       }
 
+      h1->SetTitle("");
       h1->GetYaxis()->SetRangeUser(0., h1->GetMaximum() * 1.30);
       h1->SetFillColor(kRed);
       h1->SetMarkerStyle(20);
@@ -94,13 +97,24 @@ namespace {
       h1->Draw("HIST");
       h1->Draw("Psame");
 
+      SiPixelPI::makeNicePlotStyle(h1.get());
+
       canvas.Update();
 
-      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
-      legend.SetHeader((std::get<1>(iov)).c_str(), "C");  // option "C" allows to center the header
-      legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
+      TLegend legend = TLegend(0.40, 0.88, 0.95, 0.94);
+      legend.SetHeader(("Payload hash: #bf{"+(std::get<1>(iov))+"}" ).c_str(), "C");  // option "C" allows to center the header
+      //legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
       legend.SetTextSize(0.025);
       legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      //ltx.SetTextColor(kBlue);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+		       1 - gPad->GetTopMargin() + 0.01,
+		       ("SiPixel Lorentz Angle IOV:" + std::to_string(std::get<0>(iov))).c_str());
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
@@ -115,7 +129,7 @@ namespace {
   class SiPixelLorentzAngleValueComparisonBase : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
   public:
     SiPixelLorentzAngleValueComparisonBase()
-        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle") {}
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Values Comparison") {}
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
       TH1F::SetDefaultSumw2(true);
       std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
@@ -137,11 +151,11 @@ namespace {
       TCanvas canvas("Canv", "Canv", 1200, 1000);
       canvas.cd();
       auto hfirst = std::unique_ptr<TH1F>(
-          new TH1F("value_first", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.11));
+          new TH1F("value_first", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
       hfirst->SetStats(false);
 
       auto hlast = std::unique_ptr<TH1F>(
-          new TH1F("value_last", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.11));
+          new TH1F("value_last", "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules", 50, 0.051, 0.15));
       hlast->SetStats(false);
 
       canvas.SetTopMargin(0.06);
@@ -223,7 +237,7 @@ namespace {
   class SiPixelLorentzAngleByRegionComparisonBase : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
   public:
     SiPixelLorentzAngleByRegionComparisonBase()
-      : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle") {}
+      : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle Comparison by Region") {}
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
 
       gStyle->SetPaintTextFormat(".3f");
@@ -302,7 +316,7 @@ namespace {
       for (const auto& it : f_LAMap_) {
 
         if (DetId(it.first).det() != DetId::Tracker) {
-          edm::LogWarning("TrackerAlignmentErrorExtended_PayloadInspector")
+          edm::LogWarning("SiPixelLorentzAngle_PayloadInspector")
               << "Encountered invalid Tracker DetId:" << it.first << " - terminating ";
           return false;
         }
@@ -322,8 +336,9 @@ namespace {
       TrackerTopology l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      if (l_LAMap_.size() == SiPixelPI::phase0size)
+      if (l_LAMap_.size() == SiPixelPI::phase0size){
         isPhase0 = true;
+      }
 
       // -------------------------------------------------------------------
       // loop on the second LA Map
@@ -331,7 +346,7 @@ namespace {
       for (const auto& it : l_LAMap_) {
 
         if (DetId(it.first).det() != DetId::Tracker) {
-          edm::LogWarning("TrackerAlignmentErrorExtended_PayloadInspector")
+          edm::LogWarning("SiPixelLorentzAngle_PayloadInspector")
               << "Encountered invalid Tracker DetId:" << it.first << " - terminating ";
           return false;
         }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -11,12 +11,14 @@
 #include "CondCore/CondDB/interface/Time.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
 
 #include <memory>
 #include <sstream>
 
 // include ROOT
 #include "TH2F.h"
+#include "TH1F.h"
 #include "TLegend.h"
 #include "TCanvas.h"
 #include "TLine.h"
@@ -36,17 +38,17 @@ namespace {
   class SiPixelLorentzAngleValue : public cond::payloadInspector::Histogram1D<SiPixelLorentzAngle> {
   public:
     SiPixelLorentzAngleValue()
-      : cond::payloadInspector::Histogram1D<SiPixelLorentzAngle>(
-								 "SiPixel LorentzAngle values", "SiPixel LorentzAngle values", 100, 0.0, 0.05) {
+        : cond::payloadInspector::Histogram1D<SiPixelLorentzAngle>(
+              "SiPixel LorentzAngle values", "SiPixel LorentzAngle values", 100, 0.0, 0.1) {
       Base::setSingleIov(true);
     }
-    
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
       for (auto const &iov : iovs) {
         std::shared_ptr<SiPixelLorentzAngle> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
           std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
-	  
+
           for (const auto &element : LAMap_) {
             fillWithValue(element.second);
           }
@@ -54,9 +56,152 @@ namespace {
       }    // iovs
       return true;
     }  // fill
-  }; 
+  };
+
+  /************************************************
+    1d histogram of SiPixelLorentzAngle of 1 IOV 
+  *************************************************/
+  class SiPixelLorentzAngleValues : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
+  public:
+    SiPixelLorentzAngleValues() : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle") {
+      setSingleIov(true);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
+      auto iov = iovs.front();
+      std::shared_ptr<SiPixelLorentzAngle> payload = fetchPayload(std::get<1>(iov));
+      std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
+
+      TCanvas canvas("Canv", "Canv", 1200, 1000);
+      canvas.cd();
+      auto h1 = std::unique_ptr<TH1F>(
+          new TH1F("value", "SiPixel LA value;SiPixel Lorentz Angle [rad];# modules", 100, 0., 0.1));
+      h1->SetStats(false);
+      canvas.SetBottomMargin(0.10);
+      canvas.SetLeftMargin(0.12);
+      canvas.SetRightMargin(0.03);
+      canvas.Modified();
+
+      for (const auto &element : LAMap_) {
+        h1->Fill(element.second);
+      }
+
+      h1->GetYaxis()->SetRangeUser(0., h1->GetMaximum() * 1.30);
+      h1->SetFillColor(kRed);
+      h1->SetMarkerStyle(20);
+      h1->SetMarkerSize(1);
+      h1->Draw("HIST");
+      h1->Draw("Psame");
+
+      canvas.Update();
+
+      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
+      legend.SetHeader((std::get<1>(iov)).c_str(), "C");  // option "C" allows to center the header
+      legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
+      legend.SetTextSize(0.025);
+      legend.Draw("same");
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
+
+  /************************************************
+    1d histogram of SiPixelLorentzAngle of 1 IOV 
+  *************************************************/
+  class SiPixelLorentzAngleValueComparisonBase : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
+  public:
+    SiPixelLorentzAngleValueComparisonBase()
+        : cond::payloadInspector::PlotImage<SiPixelLorentzAngle>("SiPixelLorentzAngle") {}
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>> &iovs) override {
+      TH1F::SetDefaultSumw2(true);
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+      auto firstiov = sorted_iovs.front();
+      auto lastiov = sorted_iovs.back();
+
+      std::shared_ptr<SiPixelLorentzAngle> last_payload = fetchPayload(std::get<1>(lastiov));
+      std::map<uint32_t, float> l_LAMap_ = last_payload->getLorentzAngles();
+      std::shared_ptr<SiPixelLorentzAngle> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::map<uint32_t, float> f_LAMap_ = first_payload->getLorentzAngles();
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      TCanvas canvas("Canv", "Canv", 1200, 1000);
+      canvas.cd();
+      auto hfirst = std::unique_ptr<TH1F>(
+          new TH1F("value_first", "SiPixel LA value;SiPixel Lorentz Angle [rad];# modules", 50, 0., 0.1));
+      hfirst->SetStats(false);
+
+      auto hlast = std::unique_ptr<TH1F>(
+          new TH1F("value_last", "SiPixel LA value;SiPixel Lorentz Angle [rad];# modules", 50, 0., 0.1));
+      hlast->SetStats(false);
+
+      canvas.SetBottomMargin(0.10);
+      canvas.SetLeftMargin(0.12);
+      canvas.SetRightMargin(0.03);
+      canvas.Modified();
+
+      for (const auto &element : f_LAMap_) {
+        hfirst->Fill(element.second);
+      }
+
+      for (const auto &element : l_LAMap_) {
+        hlast->Fill(element.second);
+      }
+
+      auto extrema = SiPixelPI::getExtrema(hfirst.get(), hlast.get());
+      hfirst->GetYaxis()->SetRangeUser(extrema.first, extrema.second * 1.10);
+
+      hfirst->SetFillColor(kRed);
+      hfirst->SetMarkerStyle(20);
+      hfirst->SetMarkerSize(1);
+      hfirst->Draw("HIST");
+      hfirst->Draw("Psame");
+
+      hlast->SetFillColorAlpha(kBlue, 0.20);
+      hlast->SetMarkerStyle(20);
+      hlast->SetMarkerSize(1);
+      hlast->Draw("HISTsame");
+      hlast->Draw("Psame");
+
+      canvas.Update();
+
+      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
+      legend.SetHeader("SiPixel Lorentz Angle Comparison", "C");  // option "C" allows to center the header
+      legend.AddEntry(hfirst.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "FL");
+      legend.AddEntry(hlast.get(), ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "FL");
+      legend.SetTextSize(0.025);
+      legend.Draw("same");
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
+
+  class SiPixelLorentzAngleValueComparisonSingleTag : public SiPixelLorentzAngleValueComparisonBase {
+  public:
+    SiPixelLorentzAngleValueComparisonSingleTag() : SiPixelLorentzAngleValueComparisonBase() { setSingleIov(false); }
+  };
+
+  class SiPixelLorentzAngleValueComparisonTwoTags : public SiPixelLorentzAngleValueComparisonBase {
+  public:
+    SiPixelLorentzAngleValueComparisonTwoTags() : SiPixelLorentzAngleValueComparisonBase() { setTwoTags(true); }
+  };
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiPixelLorentzAngle) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelLorentzAngleValue);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelLorentzAngleValues);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelLorentzAngleValueComparisonSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelLorentzAngleValueComparisonTwoTags);
 }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -1,0 +1,153 @@
+/*!
+  \file SiPixelQulity_PayloadInspector
+  \Payload Inspector Plugin for SiPixelQuality
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2018/10/18 14:48:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT 
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+
+  /************************************************
+    test class
+  *************************************************/
+
+  class SiPixelQualityTest : public cond::payloadInspector::Histogram1D<SiPixelQuality> {
+    
+  public:
+    SiPixelQualityTest() : cond::payloadInspector::Histogram1D<SiPixelQuality>("SiPixelQuality test",
+									       "SiPixelQuality test", 10,0.0,10.0){
+      Base::setSingleIov( true );
+    }
+    
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      for ( auto const & iov: iovs) {
+	std::shared_ptr<SiPixelQuality> payload = Base::fetchPayload( std::get<1>(iov) );
+	if( payload.get() ){
+	 
+	  fillWithValue(1.);
+	 
+	  auto theDisabledModules = payload->getBadComponentList();
+	  for (const auto &mod : theDisabledModules){
+	    int BadRocCount(0);
+	    for (unsigned short n = 0; n < 16; n++){
+	      unsigned short mask = 1 << n;  // 1 << n = 2^{n} using bitwise shift
+	      if (mod.BadRocs & mask) BadRocCount++;
+	    }
+	    std::cout<<"detId:" <<  mod.DetID << " error type:" << mod.errorType << " BadRocs:"  << BadRocCount <<  std::endl;
+	  }
+	}// payload
+      }// iovs
+      return true;
+    }// fill
+  };
+  
+  /************************************************
+    summary class
+  *************************************************/
+
+  class SiPixelQualityBadRocsSummary : public cond::payloadInspector::PlotImage<SiPixelQuality> {
+
+  public:
+    SiPixelQualityBadRocsSummary() : cond::payloadInspector::PlotImage<SiPixelQuality>("SiPixel Quality Summary"){
+      setSingleIov( false );
+    }
+
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+
+      std::vector<std::tuple<cond::Time_t,cond::Hash> > sorted_iovs = iovs;
+
+      for(const auto &iov: iovs){
+	std::shared_ptr<SiPixelQuality> payload = fetchPayload( std::get<1>(iov) );
+	auto unpacked = unpack(std::get<0>(iov));
+
+	std::cout<<"======================= " << unpacked.first <<" : "<< unpacked.second  << std::endl;
+	auto theDisabledModules = payload->getBadComponentList();
+	  for (const auto &mod : theDisabledModules){
+	    std::cout<<"detId: " <<  mod.DetID << " |error type: " << mod.errorType << " |BadRocs: "  <<  mod.BadRocs <<  std::endl;
+	  }
+      }
+
+      //=========================
+      TCanvas canvas("Partion summary","partition summary",1200,1000);
+      canvas.cd();
+      canvas.SetBottomMargin(0.11);
+      canvas.SetLeftMargin(0.13);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+
+    }
+
+    std::pair<unsigned int,unsigned int> unpack(cond::Time_t since){
+      auto kLowMask = 0XFFFFFFFF;
+      auto run  = (since >> 32);
+      auto lumi = (since & kLowMask);
+      return std::make_pair(run,lumi);
+    }
+
+  };
+
+  /************************************************
+    time history class
+  *************************************************/
+
+  class SiPixelQualityBadRocsTimeHistory : public cond::payloadInspector::TimeHistoryPlot<SiPixelQuality,std::pair<double,double> > {
+    
+  public:
+    SiPixelQualityBadRocsTimeHistory() : cond::payloadInspector::TimeHistoryPlot<SiPixelQuality,std::pair<double,double> >("bad ROCs count vs time","bad ROCs count"){}
+
+    std::pair<double,double> getFromPayload(SiPixelQuality& payload ) override{
+      return std::make_pair(extractBadRocCount(payload),0.);
+    }
+
+    unsigned int extractBadRocCount(SiPixelQuality& payload){
+      unsigned int BadRocCount(0);
+      auto theDisabledModules = payload.getBadComponentList();
+      for (const auto &mod : theDisabledModules){
+	for (unsigned short n = 0; n < 16; n++){
+	  unsigned short mask = 1 << n;  // 1 << n = 2^{n} using bitwise shift
+	  if (mod.BadRocs & mask) BadRocCount++;
+	}
+      }
+      return BadRocCount;
+    }
+  };
+
+} // namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(SiPixelQuality){
+  PAYLOAD_INSPECTOR_CLASS(SiPixelQualityTest);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelQualityBadRocsSummary);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelQualityBadRocsTimeHistory);
+}

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -395,10 +395,13 @@ namespace {
 	    auto ring    =  SiPixelPI::ring(DetId(mod.DetID),m_trackerTopo,1);
 	    auto s_blade =  SiPixelPI::signed_blade(DetId(mod.DetID),m_trackerTopo,1); 
 	    auto s_disk  =  SiPixelPI::signed_disk(DetId(mod.DetID),m_trackerTopo,1);
+	    auto s_blade_panel = SiPixelPI::signed_blade_panel(DetId(mod.DetID),m_trackerTopo,1);
+	    auto panel =  m_trackerTopo.pxfPanel(mod.DetID);
 
-	    std::cout << "ring:" << ring << " blade: "<<s_blade<<" disk: "<<s_disk<<std::endl;
+	    std::cout << "ring:" << ring << " blade: "<<s_blade<<" panel: "<<panel
+		      << " disk: "<<s_disk<<std::endl;
 
-	    std::vector<std::pair<int,int> > rocsToMask = maskedForwardRocsToBins(ring,s_blade,s_disk);	   
+	    std::vector<std::pair<int,int> > rocsToMask = maskedForwardRocsToBins(ring,s_blade,panel,s_disk);	   
 	    for(const auto& bin : rocsToMask ){
 	     h_fpix_occ[ring-1]->SetBinContent(bin.first,bin.second,1);
 	    }
@@ -428,7 +431,7 @@ namespace {
     }
 
     // #============================================================================     
-    std::vector<std::pair<int,int> > maskedForwardRocsToBins(int ring, int blade, int disk){
+    std::vector<std::pair<int,int> > maskedForwardRocsToBins(int ring, int blade, int panel,int disk){
 
       std::vector<std::pair<int,int> > rocsToMask;
 
@@ -437,15 +440,16 @@ namespace {
       int nblade = nblade_list[ring-1];
       int nybins = nybins_list[ring-1];
 
-      int start_x = disk  > 0 ? ((disk+3)*8)+1        : ((3-(std::abs(disk)))*8)+1;
-      int start_y = blade > 0 ? ((blade+nblade)*4)+3  : ((nblade-(std::abs(blade)))*4)+3;
+      int start_x = disk  > 0 ? ((disk+3)*8)+1                : ((3-(std::abs(disk)))*8)+1;
+      //int start_y = blade > 0 ? ((blade+nblade)*4)-panel*2  : ((nblade-(std::abs(blade)))*4)-panel*2;
+      int start_y = blade > 0 ? (nybins/2)+(blade*4)-(panel*2)+3 : ((nybins/2)-(std::abs(blade)*4)-panel*2)+3;
 
       int end_x   = start_x+7;
       int end_y   = start_y+1;
 
+      std::cout <<"==================================================================" << std::endl;
       std::cout <<"disk:  " << disk  << " start_x:" << start_x << " end_x:" << end_x << std::endl;
       std::cout <<"blade: " << blade << " start_y:" << start_y << " end_y:" << end_y << std::endl;
-      std::cout <<"==================================================================" << std::endl;
 
       for(int bin_x=1;bin_x<=56;bin_x++){
 	for(int bin_y=1;bin_y<=nybins;bin_y++){

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -11,9 +11,12 @@
 #include "CondCore/Utilities/interface/PayloadInspectorModule.h"
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 
 // the data format of the condition to be inspected
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include <memory>
@@ -143,6 +146,195 @@ namespace {
     }
   };
 
+  /************************************************
+   occupancy style map
+  *************************************************/
+ 
+  class SiPixelQualityMap : public cond::payloadInspector::PlotImage<SiPixelQuality> {
+  public:
+    SiPixelQualityMap () : cond::payloadInspector::PlotImage<SiPixelQuality>("SiPixelQuality Map"),
+			   m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())}
+    {
+      setSingleIov( true );
+    }
+
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+      auto iov = iovs.front();
+      std::shared_ptr<SiPixelQuality> payload = fetchPayload( std::get<1>(iov));
+
+      static const int n_layers = 4;
+      int nlad_list[n_layers] = {6, 14, 22, 32};
+      int divide_roc = 1;
+
+      // ---------------------    BOOK HISTOGRAMS                                                                        
+      std::array<TH2D*,n_layers> h_bpix_occ;
+
+      for(unsigned int lay=1;lay<=4;lay++){
+	int nlad = nlad_list[lay-1];
+
+	std::string name = "occ_Layer_"+std::to_string(lay);
+	std::string title = "; Module # ; Ladder #";
+	h_bpix_occ[lay-1] = new TH2D(name.c_str(), title.c_str(),
+				     72*divide_roc,-4.5,4.5,
+				     (nlad*4+2)*divide_roc,-nlad-0.5,nlad+0.5);
+      }
+      
+      auto theDisabledModules = payload->getBadComponentList();
+      for (const auto &mod : theDisabledModules){
+	int coded_badRocs = mod.BadRocs;
+	if(payload->IsModuleBad(mod.DetID)){
+	  int subid = DetId(mod.DetID).subdetId();
+	  if(subid==PixelSubdetector::PixelBarrel){
+	    auto layer  = m_trackerTopo.pxbLayer(DetId(mod.DetID));
+	    auto ladder = m_trackerTopo.pxbLadder(DetId(mod.DetID));
+	    auto module = m_trackerTopo.pxbModule(DetId(mod.DetID));
+	    std::cout << layer << " " << ladder << " " << module << std::endl;
+
+	    std::vector<std::pair<int,int> > rocsToMask = maskedBarrelRocsToBins(layer,ladder,module);
+	    for(const auto& bin : rocsToMask ){
+	      h_bpix_occ[layer-1]->SetBinContent(bin.first,bin.second,1);
+	    }
+	  }
+	}
+	std::bitset<16> bad_rocs(coded_badRocs);	  
+      }
+   
+      gStyle->SetOptStat(0);
+      //=========================
+      TCanvas canvas("Summary","Summary",1200,1200);
+      canvas.Divide(2,2);
+      canvas.SetBottomMargin(0.11);
+      canvas.SetLeftMargin(0.13);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+  
+      for(unsigned int lay=1;lay<=4;lay++){
+	dress_occ_plot_bpix(canvas,h_bpix_occ[lay-1],lay);
+      }
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+
+    }
+
+    // #============================================================================     
+    std::vector<std::pair<int,int> > maskedBarrelRocsToBins(int layer, int ladder, int module){
+
+      std::vector<std::pair<int,int> > rocsToMask;
+
+      int nlad_list[4] = {6, 14, 22, 32};
+      int nlad = nlad_list[layer-1];
+
+      int start_x = module<=4 ? ((module-1)*8)+1 : ((module-1)*8)+9;
+      int start_y = ladder<nlad/2 ? ((ladder-1)*2)+1 : ((ladder-1)*2)+3 ;
+      int end_x   = start_y+8;
+      int end_y   = start_y+1;
+
+      for(int bin_x=1;bin_x<=72;bin_x++){
+	for(int bin_y=1;bin_y<= (nlad*4+2);bin_y++){
+	  if(bin_x >= start_x && bin_x<=end_x && bin_y >= start_y && bin_y <=end_y){
+	    rocsToMask.push_back(std::make_pair(bin_x,bin_y));
+	  }
+	}
+      }
+      
+      return rocsToMask;
+
+    }
+
+    // #============================================================================     
+    void dress_occ_plot_bpix(TCanvas& canv,TH2D *h,int lay){
+
+      canv.cd(lay);
+      gStyle->SetPadRightMargin(0.125);
+
+      h->Draw("zcol");
+      int phase      = 1;
+      int half_shift = 1;
+      unsigned int n_ladder[4] = {6, 14, 22, 32};
+      unsigned int n_lad = n_ladder[lay-1];
+
+      std::vector<TLine*> lines;
+      std::vector signs = {-1,1}; 
+
+      for(const auto x_sign : signs ){
+	for(const auto y_sign : signs ){
+	  float x_low  = x_sign * (half_shift*0.5);
+          float x_high = x_sign * (half_shift*0.5 + 4 );
+          float y_low  = y_sign * (half_shift*0.5);
+          float y_high = y_sign * (half_shift*0.5 + n_lad);
+	  //# Outside box                                  
+	  
+	  lines.push_back(draw_line(x_low,x_high,y_low,y_low,1));   // # bottom
+	  lines.push_back(draw_line(x_low,x_high,y_high,y_high,1)); // # top
+	  lines.push_back(draw_line(x_low,x_low,y_low,y_high,1));   // # left 
+	  lines.push_back(draw_line(x_high,x_high,y_low,y_high,1)); // # right
+
+	  //# Inner Horizontal lines                                        
+	  for(unsigned int lad=1;lad<n_lad;lad++){
+	    float y = y_sign * (lad + half_shift*0.5);
+	    lines.push_back(draw_line(x_low,x_high,y,y,1));
+	  }
+
+	  for(unsigned int lad=1;lad<n_lad+1;lad++){
+	    float y = y_sign * (lad + half_shift*0.5 - 0.5);
+	    lines.push_back(draw_line(x_low, x_high,y,y,1, 3));
+	  }
+	  
+	  //# Inner Vertical lines                                                                                             
+	  for(unsigned int mod=1;mod<=4;mod++){
+	    float x = x_sign * (mod + half_shift*0.5);
+	    lines.push_back(draw_line(x, x, y_low,  y_high, 1));  
+	  }
+          
+	  for(unsigned int mod=1;mod<=4;mod++){
+	    for(unsigned int lad=1;lad<n_lad+1;lad++){
+
+	      bool flipped = y_sign==1 ? lad%2==0 : lad%2==1;
+	      if (phase==1)  flipped = !flipped;
+	      int roc0_orientation = flipped ? -1 : 1;
+	      if (x_sign==-1) roc0_orientation *= -1;
+	      if (y_sign==-1) roc0_orientation *= -1;
+	      float x1 = x_sign * (mod+half_shift*0.5);
+	      float x2 = x_sign * (mod+half_shift*0.5 - 1./8);
+	      float y1 = y_sign * (lad+half_shift*0.5-0.5);
+	      float y2 = y_sign * (lad+half_shift*0.5-0.5 + roc0_orientation*1./2);
+
+	      lines.push_back(draw_line(x1, x2, y1, y1, 1));
+	      lines.push_back(draw_line(x2, x2, y1, y2, 1));
+	    }
+	  }
+	}
+      }
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextColor(1);
+      ltx.SetTextSize(0.06);
+      ltx.SetTextAlign(31);
+      ltx.DrawLatexNDC(1-gPad->GetRightMargin(),
+		       1-gPad->GetTopMargin()+0.01,("Layer"+std::to_string(lay)).c_str());
+      
+      for (auto& l : lines){
+	l->Draw("same");
+      }
+    }
+
+    //============================================================================                     
+    TLine* draw_line(float x1, float x2,float y1,float y2,int width=2,int style=1,int color=1){
+      
+      TLine* l = new TLine(x1, y1, x2, y2);
+      l->SetLineWidth(width);
+      l->SetLineStyle(style);
+      l->SetLineColor(color);
+      return l;
+    }
+
+  private:
+    TrackerTopology m_trackerTopo;
+  };
 } // namespace
 
 // Register the classes as boost python plugin
@@ -150,4 +342,5 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelQuality){
   PAYLOAD_INSPECTOR_CLASS(SiPixelQualityTest);
   PAYLOAD_INSPECTOR_CLASS(SiPixelQualityBadRocsSummary);
   PAYLOAD_INSPECTOR_CLASS(SiPixelQualityBadRocsTimeHistory);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelQualityMap);
 }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -222,7 +222,6 @@ namespace {
       canvas.Modified();
 
       for (unsigned int lay = 1; lay <= 4; lay++) {
-        //dress_occ_plot_bpix(canvas,h_bpix_occ[lay-1],lay);
         SiPixelPI::dress_occup_plot(canvas, h_bpix_occ[lay - 1], lay, 0, 1);
       }
 
@@ -272,97 +271,6 @@ namespace {
       }
 
       return rocsToMask;
-    }
-
-    // #============================================================================
-    void dress_occ_plot_bpix(TCanvas& canv, TH2D* h, int lay) {
-      canv.cd(lay);
-
-      gStyle->SetPadRightMargin(0.125);
-      gStyle->SetPalette(56);
-
-      h->Draw("zcol");
-
-      int phase = 1;
-      int half_shift = 1;
-      unsigned int n_ladder[4] = {6, 14, 22, 32};
-      unsigned int n_lad = n_ladder[lay - 1];
-
-      std::vector<TLine*> lines;
-      std::vector signs = {-1, 1};
-
-      for (const auto x_sign : signs) {
-        for (const auto y_sign : signs) {
-          float x_low = x_sign * (half_shift * 0.5);
-          float x_high = x_sign * (half_shift * 0.5 + 4);
-          float y_low = y_sign * (half_shift * 0.5);
-          float y_high = y_sign * (half_shift * 0.5 + n_lad);
-          //# Outside box
-
-          lines.push_back(draw_line(x_low, x_high, y_low, y_low, 1));    // # bottom
-          lines.push_back(draw_line(x_low, x_high, y_high, y_high, 1));  // # top
-          lines.push_back(draw_line(x_low, x_low, y_low, y_high, 1));    // # left
-          lines.push_back(draw_line(x_high, x_high, y_low, y_high, 1));  // # right
-
-          //# Inner Horizontal lines
-          for (unsigned int lad = 1; lad < n_lad; lad++) {
-            float y = y_sign * (lad + half_shift * 0.5);
-            lines.push_back(draw_line(x_low, x_high, y, y, 1));
-          }
-
-          for (unsigned int lad = 1; lad < n_lad + 1; lad++) {
-            float y = y_sign * (lad + half_shift * 0.5 - 0.5);
-            lines.push_back(draw_line(x_low, x_high, y, y, 1, 3));
-          }
-
-          //# Inner Vertical lines
-          for (unsigned int mod = 1; mod <= 4; mod++) {
-            float x = x_sign * (mod + half_shift * 0.5);
-            lines.push_back(draw_line(x, x, y_low, y_high, 1));
-          }
-
-          for (unsigned int mod = 1; mod <= 4; mod++) {
-            for (unsigned int lad = 1; lad < n_lad + 1; lad++) {
-              bool flipped = y_sign == 1 ? lad % 2 == 0 : lad % 2 == 1;
-              if (phase == 1)
-                flipped = !flipped;
-              int roc0_orientation = flipped ? -1 : 1;
-              if (x_sign == -1)
-                roc0_orientation *= -1;
-              if (y_sign == -1)
-                roc0_orientation *= -1;
-              float x1 = x_sign * (mod + half_shift * 0.5);
-              float x2 = x_sign * (mod + half_shift * 0.5 - 1. / 8);
-              float y1 = y_sign * (lad + half_shift * 0.5 - 0.5);
-              float y2 = y_sign * (lad + half_shift * 0.5 - 0.5 + roc0_orientation * 1. / 2);
-
-              lines.push_back(draw_line(x1, x2, y1, y1, 1));
-              lines.push_back(draw_line(x2, x2, y1, y2, 1));
-            }
-          }
-        }
-      }
-
-      auto ltx = TLatex();
-      ltx.SetTextFont(62);
-      ltx.SetTextColor(1);
-      ltx.SetTextSize(0.06);
-      ltx.SetTextAlign(31);
-      ltx.DrawLatexNDC(
-          1 - gPad->GetRightMargin(), 1 - gPad->GetTopMargin() + 0.01, ("Layer" + std::to_string(lay)).c_str());
-
-      for (auto& l : lines) {
-        l->Draw("same");
-      }
-    }
-
-    //============================================================================
-    TLine* draw_line(float x1, float x2, float y1, float y2, int width = 2, int style = 1, int color = 1) {
-      TLine* l = new TLine(x1, y1, x2, y2);
-      l->SetLineWidth(width);
-      l->SetLineStyle(style);
-      l->SetLineColor(color);
-      return l;
     }
 
   private:

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -38,7 +38,7 @@
 
 // #define MMDEBUG
 #ifdef MMDEBUG
-#include<iostream>
+#include <iostream>
 #define COUT std::cout << "MM "
 #else
 #define COUT edm::LogVerbatim("")
@@ -72,11 +72,10 @@ namespace {
               if (mod.BadRocs & mask)
                 BadRocCount++;
             }
-            COUT << "detId:" << mod.DetID << " error type:" << mod.errorType << " BadRocs:" << BadRocCount
-                      << std::endl;
+            COUT << "detId:" << mod.DetID << " error type:" << mod.errorType << " BadRocs:" << BadRocCount << std::endl;
           }
-        }// payload
-      }// iovs
+        }  // payload
+      }    // iovs
       return true;
     }  // fill
   };
@@ -102,7 +101,7 @@ namespace {
         auto theDisabledModules = payload->getBadComponentList();
         for (const auto& mod : theDisabledModules) {
           COUT << "detId: " << mod.DetID << " |error type: " << mod.errorType << " |BadRocs: " << mod.BadRocs
-                    << std::endl;
+               << std::endl;
         }
       }
 
@@ -192,34 +191,34 @@ namespace {
       auto theDisabledModules = payload->getBadComponentList();
       for (const auto& mod : theDisabledModules) {
         int coded_badRocs = mod.BadRocs;
-	int subid = DetId(mod.DetID).subdetId();
-	std::bitset<16> bad_rocs(coded_badRocs);
-	if (subid == PixelSubdetector::PixelBarrel) {
-	  auto layer = m_trackerTopo.pxbLayer(DetId(mod.DetID));
-	  auto s_ladder = SiPixelPI::signed_ladder(DetId(mod.DetID), m_trackerTopo, true);
-	  auto s_module = SiPixelPI::signed_module(DetId(mod.DetID), m_trackerTopo, true);
+        int subid = DetId(mod.DetID).subdetId();
+        std::bitset<16> bad_rocs(coded_badRocs);
+        if (subid == PixelSubdetector::PixelBarrel) {
+          auto layer = m_trackerTopo.pxbLayer(DetId(mod.DetID));
+          auto s_ladder = SiPixelPI::signed_ladder(DetId(mod.DetID), m_trackerTopo, true);
+          auto s_module = SiPixelPI::signed_module(DetId(mod.DetID), m_trackerTopo, true);
 
-	  bool isFlipped = SiPixelPI::isBPixOuterLadder(DetId(mod.DetID), m_trackerTopo,false);
-	  if((layer>1 && s_module<0)) isFlipped = !isFlipped;
+          bool isFlipped = SiPixelPI::isBPixOuterLadder(DetId(mod.DetID), m_trackerTopo, false);
+          if ((layer > 1 && s_module < 0))
+            isFlipped = !isFlipped;
 
-	  auto ladder = m_trackerTopo.pxbLadder(DetId(mod.DetID));
-	  auto module = m_trackerTopo.pxbModule(DetId(mod.DetID));
-	  COUT <<"layer:" << layer << " ladder:" << ladder << " module:" << module
-	       <<" signed ladder: "<< s_ladder
-	       <<" signed module: "<< s_module << std::endl;
+          auto ladder = m_trackerTopo.pxbLadder(DetId(mod.DetID));
+          auto module = m_trackerTopo.pxbModule(DetId(mod.DetID));
+          COUT << "layer:" << layer << " ladder:" << ladder << " module:" << module << " signed ladder: " << s_ladder
+               << " signed module: " << s_module << std::endl;
 
-	  if (payload->IsModuleBad(mod.DetID)) {
-	    auto rocsToMask = maskedBarrelRocsToBins(layer, s_ladder, s_module);
-	    for (const auto& bin : rocsToMask) {
-              h_bpix_occ[layer - 1]->SetBinContent(bin.first, bin.second,1);
-	    }
-	  } else {
-	    auto rocsToMask = maskedBarrelRocsToBins(layer, s_ladder, s_module,bad_rocs,isFlipped);
-	    for (const auto& bin : rocsToMask) {
-              h_bpix_occ[layer - 1]->SetBinContent(std::get<0>(bin),std::get<1>(bin),1);
-	    }
-	  }
-	}
+          if (payload->IsModuleBad(mod.DetID)) {
+            auto rocsToMask = maskedBarrelRocsToBins(layer, s_ladder, s_module);
+            for (const auto& bin : rocsToMask) {
+              h_bpix_occ[layer - 1]->SetBinContent(bin.first, bin.second, 1);
+            }
+          } else {
+            auto rocsToMask = maskedBarrelRocsToBins(layer, s_ladder, s_module, bad_rocs, isFlipped);
+            for (const auto& bin : rocsToMask) {
+              h_bpix_occ[layer - 1]->SetBinContent(std::get<0>(bin), std::get<1>(bin), 1);
+            }
+          }
+        }
       }
 
       gStyle->SetOptStat(0);
@@ -286,7 +285,8 @@ namespace {
     }
 
     // #============================================================================
-    std::vector<std::tuple<int, int, int> > maskedBarrelRocsToBins(int layer, int ladder, int module, std::bitset<16> bad_rocs, bool isFlipped) {
+    std::vector<std::tuple<int, int, int> > maskedBarrelRocsToBins(
+        int layer, int ladder, int module, std::bitset<16> bad_rocs, bool isFlipped) {
       std::vector<std::tuple<int, int, int> > rocsToMask;
 
       int nlad_list[4] = {6, 14, 22, 32};
@@ -295,70 +295,68 @@ namespace {
       int start_x = module > 0 ? ((module + 4) * 8) + 1 : ((4 - (std::abs(module))) * 8) + 1;
       int start_y = ladder > 0 ? ((ladder + nlad) * 2) + 1 : ((nlad - (std::abs(ladder))) * 2) + 1;
 
-      int roc0_x = ((layer==1) || (layer>1 && module>0)) ? start_x+7 : start_x;	     
-      int roc0_y = start_y-1;
+      int roc0_x = ((layer == 1) || (layer > 1 && module > 0)) ? start_x + 7 : start_x;
+      int roc0_y = start_y - 1;
 
       size_t idx = 0;
       while (idx < bad_rocs.size()) {
-	if(bad_rocs.test(idx)){
-	  
-	  //////////////////////////////////////////////////////////////////////////////////////
-	  //		                            |					      //
-	  // In BPix Layer1 and module>0 in L2,3,4  |   In BPix Layer 2,3,4 module > 0	      //
-	  //                                        |					      //
-	  // ROCs are ordered in the following      |   ROCs are ordered in the following     //
-	  // fashion for unplipped modules 	    |   fashion for unplipped modules         //
-	  //					    |  				              //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 8 |9  |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  //					    |  					      //
-	  // if the module is flipped the ordering  |   if the module is flipped the ordering //
-	  // is reveresed                           |   is reversed                           //
-	  //					    |                                         //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 8 | 9 |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  //////////////////////////////////////////////////////////////////////////////////////
+        if (bad_rocs.test(idx)) {
+          //////////////////////////////////////////////////////////////////////////////////////
+          //		                            |					      //
+          // In BPix Layer1 and module>0 in L2,3,4  |   In BPix Layer 2,3,4 module > 0	      //
+          //                                        |					      //
+          // ROCs are ordered in the following      |   ROCs are ordered in the following     //
+          // fashion for unplipped modules 	    |   fashion for unplipped modules         //
+          //					    |  				              //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 8 |9  |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          //					    |  					      //
+          // if the module is flipped the ordering  |   if the module is flipped the ordering //
+          // is reveresed                           |   is reversed                           //
+          //					    |                                         //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 8 | 9 |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          //////////////////////////////////////////////////////////////////////////////////////
 
-	  int roc_x(0),roc_y(0);
+          int roc_x(0), roc_y(0);
 
-	  if((layer==1) || (layer>1 && module>0)){
-	    if(!isFlipped){
-	      roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
-	      roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
-	    } else {
-	      roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
-	      roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
-	    }
-	  } else {
-	    if(!isFlipped){
-	      roc_x = idx<8 ? roc0_x+idx : (roc0_x+7)-(idx-8);
-	      roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
-	    } else {
-	      roc_x = idx<8 ? roc0_x+idx : (roc0_x+7)-(idx-8);
-	      roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
-	    }
-	  }
+          if ((layer == 1) || (layer > 1 && module > 0)) {
+            if (!isFlipped) {
+              roc_x = idx < 8 ? roc0_x - idx : (start_x - 8) + idx;
+              roc_y = idx < 8 ? roc0_y + 1 : roc0_y + 2;
+            } else {
+              roc_x = idx < 8 ? roc0_x - idx : (start_x - 8) + idx;
+              roc_y = idx < 8 ? roc0_y + 2 : roc0_y + 1;
+            }
+          } else {
+            if (!isFlipped) {
+              roc_x = idx < 8 ? roc0_x + idx : (roc0_x + 7) - (idx - 8);
+              roc_y = idx < 8 ? roc0_y + 1 : roc0_y + 2;
+            } else {
+              roc_x = idx < 8 ? roc0_x + idx : (roc0_x + 7) - (idx - 8);
+              roc_y = idx < 8 ? roc0_y + 2 : roc0_y + 1;
+            }
+          }
 
-	  COUT << bad_rocs << " : (idx)= " << idx << std::endl;
-	  COUT <<" layer:  " << layer << std::endl;
-	  COUT << "module: " << module << " roc_x:" << roc_x << std::endl;
-	  COUT << "ladder: " << ladder << " roc_y:" << roc_y << std::endl;
-	  COUT << "==================================================================" << std::endl;
+          COUT << bad_rocs << " : (idx)= " << idx << std::endl;
+          COUT << " layer:  " << layer << std::endl;
+          COUT << "module: " << module << " roc_x:" << roc_x << std::endl;
+          COUT << "ladder: " << ladder << " roc_y:" << roc_y << std::endl;
+          COUT << "==================================================================" << std::endl;
 
-	  rocsToMask.push_back(std::make_tuple(roc_x,roc_y,idx));
-
-	}	  
-	++idx;
+          rocsToMask.push_back(std::make_tuple(roc_x, roc_y, idx));
+        }
+        ++idx;
       }
       return rocsToMask;
     }
-    
+
   private:
     TrackerTopology m_trackerTopo;
   };
@@ -397,35 +395,34 @@ namespace {
       auto theDisabledModules = payload->getBadComponentList();
       for (const auto& mod : theDisabledModules) {
         int coded_badRocs = mod.BadRocs;
-	int subid = DetId(mod.DetID).subdetId();
-	std::bitset<16> bad_rocs(coded_badRocs);        
-	if (subid == PixelSubdetector::PixelEndcap) {
-	  auto ring = SiPixelPI::ring(DetId(mod.DetID), m_trackerTopo, true);
-	  auto s_blade = SiPixelPI::signed_blade(DetId(mod.DetID), m_trackerTopo, true);
-	  auto s_disk = SiPixelPI::signed_disk(DetId(mod.DetID), m_trackerTopo, true);
-	  auto s_blade_panel = SiPixelPI::signed_blade_panel(DetId(mod.DetID), m_trackerTopo, true);
-	  auto panel = m_trackerTopo.pxfPanel(mod.DetID);
+        int subid = DetId(mod.DetID).subdetId();
+        std::bitset<16> bad_rocs(coded_badRocs);
+        if (subid == PixelSubdetector::PixelEndcap) {
+          auto ring = SiPixelPI::ring(DetId(mod.DetID), m_trackerTopo, true);
+          auto s_blade = SiPixelPI::signed_blade(DetId(mod.DetID), m_trackerTopo, true);
+          auto s_disk = SiPixelPI::signed_disk(DetId(mod.DetID), m_trackerTopo, true);
+          auto s_blade_panel = SiPixelPI::signed_blade_panel(DetId(mod.DetID), m_trackerTopo, true);
+          auto panel = m_trackerTopo.pxfPanel(mod.DetID);
 
-	  //bool isFlipped = (s_disk > 0) ? (std::abs(s_blade)%2==0) : (std::abs(s_blade)%2==1);
-	  bool isFlipped = (s_disk > 0) ? (panel==1) : (panel==2);
+          //bool isFlipped = (s_disk > 0) ? (std::abs(s_blade)%2==0) : (std::abs(s_blade)%2==1);
+          bool isFlipped = (s_disk > 0) ? (panel == 1) : (panel == 2);
 
-	  COUT << "ring:" << ring << " blade: " << s_blade << " panel: " << panel << " signed blade/panel: " << s_blade_panel
-	       << " disk: " << s_disk << std::endl;
+          COUT << "ring:" << ring << " blade: " << s_blade << " panel: " << panel
+               << " signed blade/panel: " << s_blade_panel << " disk: " << s_disk << std::endl;
 
-	  if (payload->IsModuleBad(mod.DetID)) {
-	    auto rocsToMask = maskedForwardRocsToBins(ring, s_blade, panel, s_disk);
-	    for (const auto& bin : rocsToMask) {
-	      h_fpix_occ[ring - 1]->SetBinContent(bin.first, bin.second, 1);
-	    }
-	  } else {
-	    auto rocsToMask = maskedForwardRocsToBins(ring, s_blade, panel, s_disk,bad_rocs,isFlipped);
-	    for (const auto& bin : rocsToMask) {
-	      h_fpix_occ[ring - 1]->SetBinContent(std::get<0>(bin),std::get<1>(bin),1);
-	    }
-	  }
-	}// if it's endcap 
-      } // loop on disable moduels
-    
+          if (payload->IsModuleBad(mod.DetID)) {
+            auto rocsToMask = maskedForwardRocsToBins(ring, s_blade, panel, s_disk);
+            for (const auto& bin : rocsToMask) {
+              h_fpix_occ[ring - 1]->SetBinContent(bin.first, bin.second, 1);
+            }
+          } else {
+            auto rocsToMask = maskedForwardRocsToBins(ring, s_blade, panel, s_disk, bad_rocs, isFlipped);
+            for (const auto& bin : rocsToMask) {
+              h_fpix_occ[ring - 1]->SetBinContent(std::get<0>(bin), std::get<1>(bin), 1);
+            }
+          }
+        }  // if it's endcap
+      }    // loop on disable moduels
 
       gStyle->SetOptStat(0);
       //=========================
@@ -493,9 +490,9 @@ namespace {
       return rocsToMask;
     }
 
-    
     // #============================================================================
-    std::vector<std::tuple<int, int, int> >  maskedForwardRocsToBins(int ring, int blade, int panel, int disk, std::bitset<16> bad_rocs, bool isFlipped ) {
+    std::vector<std::tuple<int, int, int> > maskedForwardRocsToBins(
+        int ring, int blade, int panel, int disk, std::bitset<16> bad_rocs, bool isFlipped) {
       std::vector<std::tuple<int, int, int> > rocsToMask;
 
       //int nblade_list[2] = {11, 17};
@@ -508,69 +505,68 @@ namespace {
       int start_y = blade > 0 ? (nybins / 2) + (blade * 4) - (panel * 2) + 3
                               : ((nybins / 2) - (std::abs(blade) * 4) - panel * 2) + 3;
 
-      int roc0_x = disk>0 ? start_x+7 : start_x;	     
-      int roc0_y = start_y-1;
+      int roc0_x = disk > 0 ? start_x + 7 : start_x;
+      int roc0_y = start_y - 1;
 
       size_t idx = 0;
       while (idx < bad_rocs.size()) {
-	if(bad_rocs.test(idx)){
-	  
-	  int roc_x(0),roc_y(0);
+        if (bad_rocs.test(idx)) {
+          int roc_x(0), roc_y(0);
 
-	  //////////////////////////////////////////////////////////////////////////////////////
-	  //		                            |					      //
-	  // In FPix + (Disk 1,2,3)                 |   In FPix - (Disk -1,-2,-3)	      //
-	  //                                        |					      //
-	  // ROCs are ordered in the following      |   ROCs are ordered in the following     //
-	  // fashion for unplipped modules 	    |   fashion for unplipped modules         //
-	  //					    |  				              //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 8 |9  |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  //					    |  					      //
-	  // if the module is flipped the ordering  |   if the module is flipped the ordering //
-	  // is reveresed                           |   is reversed                           //
-	  //					    |                                         //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  // | 8 | 9 |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
-	  // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
-	  //////////////////////////////////////////////////////////////////////////////////////
+          //////////////////////////////////////////////////////////////////////////////////////
+          //		                            |					      //
+          // In FPix + (Disk 1,2,3)                 |   In FPix - (Disk -1,-2,-3)	      //
+          //                                        |					      //
+          // ROCs are ordered in the following      |   ROCs are ordered in the following     //
+          // fashion for unplipped modules 	    |   fashion for unplipped modules         //
+          //					    |  				              //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 8 |9  |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          //					    |  					      //
+          // if the module is flipped the ordering  |   if the module is flipped the ordering //
+          // is reveresed                           |   is reversed                           //
+          //					    |                                         //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |      |   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          // | 8 | 9 |10 |11 |12 |13 |14 |15 |      |   |15 |14 |13 |12 |11 |10 | 9 | 8 |     //
+          // +---+---+---+---+---+---+---+---+      |   +---+---+---+---+---+---+---+---+     //
+          //////////////////////////////////////////////////////////////////////////////////////
 
-	  if(disk>0){
-	    if(!isFlipped){
-	      roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
-	      roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
-	    } else {
-	      roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
-	      roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
-	    }
-	  } else {
-	    if(!isFlipped){
-	      roc_x = idx<8 ? roc0_x+idx : (roc0_x+7)-(idx-8);
-	      roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
-	    } else {
-	      roc_x = idx<8 ? roc0_x+idx : (roc0_x+7)-(idx-8);
-	      roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
-	    }
-	  }
+          if (disk > 0) {
+            if (!isFlipped) {
+              roc_x = idx < 8 ? roc0_x - idx : (start_x - 8) + idx;
+              roc_y = idx < 8 ? roc0_y + 1 : roc0_y + 2;
+            } else {
+              roc_x = idx < 8 ? roc0_x - idx : (start_x - 8) + idx;
+              roc_y = idx < 8 ? roc0_y + 2 : roc0_y + 1;
+            }
+          } else {
+            if (!isFlipped) {
+              roc_x = idx < 8 ? roc0_x + idx : (roc0_x + 7) - (idx - 8);
+              roc_y = idx < 8 ? roc0_y + 1 : roc0_y + 2;
+            } else {
+              roc_x = idx < 8 ? roc0_x + idx : (roc0_x + 7) - (idx - 8);
+              roc_y = idx < 8 ? roc0_y + 2 : roc0_y + 1;
+            }
+          }
 
-	  COUT << bad_rocs << " : (idx)= " << idx << std::endl;
-	  COUT << " panel: " << panel << " isFlipped: " << isFlipped << std::endl;
-	  COUT << " disk:  " << disk  << " roc_x:" << roc_x << std::endl;
-	  COUT << " blade: " << blade << " roc_y:" << roc_y << std::endl;
-	  COUT << "===============================" << std::endl;
+          COUT << bad_rocs << " : (idx)= " << idx << std::endl;
+          COUT << " panel: " << panel << " isFlipped: " << isFlipped << std::endl;
+          COUT << " disk:  " << disk << " roc_x:" << roc_x << std::endl;
+          COUT << " blade: " << blade << " roc_y:" << roc_y << std::endl;
+          COUT << "===============================" << std::endl;
 
-	  rocsToMask.push_back(std::make_tuple(roc_x,roc_y,idx));
-	}	  
-	++idx;
+          rocsToMask.push_back(std::make_tuple(roc_x, roc_y, idx));
+        }
+        ++idx;
       }
       return rocsToMask;
     }
-      
+
   private:
     TrackerTopology m_trackerTopo;
   };

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -198,6 +198,7 @@ namespace {
 	  auto s_module = SiPixelPI::signed_module(DetId(mod.DetID), m_trackerTopo, true);
 
 	  bool isFlipped = SiPixelPI::isBPixOuterLadder(DetId(mod.DetID), m_trackerTopo,false);
+	  if((layer>1 && s_module<0)) isFlipped = !isFlipped;
 
 	  //auto ladder = m_trackerTopo.pxbLadder(DetId(mod.DetID));
 	  //auto module = m_trackerTopo.pxbModule(DetId(mod.DetID));
@@ -290,7 +291,7 @@ namespace {
       int start_x = module > 0 ? ((module + 4) * 8) + 1 : ((4 - (std::abs(module))) * 8) + 1;
       int start_y = ladder > 0 ? ((ladder + nlad) * 2) + 1 : ((nlad - (std::abs(ladder))) * 2) + 1;
 
-      int roc0_x = start_x+7;	     
+      int roc0_x = ((layer==1) || (layer>1 && module>0)) ? start_x+7 : start_x;	     
       int roc0_y = start_y-1;
 
       size_t idx = 0;
@@ -319,14 +320,23 @@ namespace {
 	  
 	  int roc_x(0),roc_y(0);
 
-	  if(!isFlipped){
-	    roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
-	    roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
+	  if((layer==1) || (layer>1 && module>0)){
+	    if(!isFlipped){
+	      roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
+	      roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
+	    } else {
+	      roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
+	      roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
+	    }
 	  } else {
-	    roc_x = idx<8 ? roc0_x-idx : (start_x-8)+idx;
-	    roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
+	    if(!isFlipped){
+	      roc_x = idx<8 ? roc0_x+idx : (roc0_x+7)-(idx-8);
+	      roc_y = idx<8 ? roc0_y+1 : roc0_y+2;
+	    } else {
+	      roc_x = idx<8 ? roc0_x+idx : (roc0_x+7)-(idx-8);
+	      roc_y = idx<8 ? roc0_y+2 : roc0_y+1;
+	    }
 	  }
-
 	  /*
 	    std::cout << bad_rocs << " : (idx)= " << idx << std::endl;
 	    std::cout <<" layer:  " << layer << std::endl;

--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -220,6 +220,21 @@ namespace {
 	SiPixelPI::dress_occup_plot(canvas,h_bpix_occ[lay-1],lay,0,1);
       }
 
+
+      auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
+
+      for(unsigned int lay=1;lay<=4;lay++){
+      	canvas.cd(lay);
+	auto ltx = TLatex();
+	ltx.SetTextFont(62);
+	ltx.SetTextColor(kBlue);
+	ltx.SetTextSize(0.06);
+	ltx.SetTextAlign(11);
+	ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+			 1-gPad->GetTopMargin()+0.01,
+			 (std::to_string(unpacked.first)+","+std::to_string(unpacked.second)).c_str());
+      }
+
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
@@ -421,6 +436,20 @@ namespace {
   
       for(unsigned int ring=1;ring<=n_rings;ring++){
 	SiPixelPI::dress_occup_plot(canvas,h_fpix_occ[ring-1],0,ring,1);
+      }
+
+      auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
+
+      for(unsigned int ring=1;ring<=n_rings;ring++){
+	canvas.cd(ring);
+	auto ltx = TLatex();
+	ltx.SetTextFont(62);
+	ltx.SetTextColor(kBlue);
+	ltx.SetTextSize(0.06);
+	ltx.SetTextAlign(11);
+	ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+			 1-gPad->GetTopMargin()+0.01,
+			 (std::to_string(unpacked.first)+","+std::to_string(unpacked.second)).c_str());
       }
 
       std::string fileName(m_imageFileName);

--- a/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
@@ -9,17 +9,24 @@ eval `scram run -sh`;
 # Go back to original working directory
 cd $W_DIR;
 # Run get payload data script
+if [ -d $W_DIR/plots_LA ]; then
+    rm -fr $W_DIR/plots_LA
+fi
+
+mkdir $W_DIR/plots_LA
 
 getPayloadData.py \
-    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
-    --plot plot_SiPixelLorentzAngleValueComparisonTwoTags \
-    --tag SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr1300 \
-    --tagtwo SiPixelLorentzAngle_phase1_BoR3_HV350_Tr1300 \
-    --time_type Run \
-    --iovs '{"start_iov": "1", "end_iov": "1"}' \
-    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
-    --db Prod \
-    --test ;
+     --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+     --plot plot_SiPixelLorentzAngleValueComparisonTwoTags \
+     --tag SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr1300 \
+     --tagtwo SiPixelLorentzAngle_phase1_BoR3_HV350_Tr1300 \
+     --time_type Run \
+     --iovs '{"start_iov": "1", "end_iov": "1"}' \
+     --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+     --db Prod \
+     --test ;
+
+mv *.png  $W_DIR/plots_LA/comparisonByValuePhase1.png
 
 getPayloadData.py \
     --plugin pluginSiPixelLorentzAngle_PayloadInspector \
@@ -30,6 +37,8 @@ getPayloadData.py \
     --db Prod \
     --test ;
 
+mv *.png  $W_DIR/plots_LA/ByValuePhase1.png
+
 getPayloadData.py \
     --plugin pluginSiPixelLorentzAngle_PayloadInspector \
     --plot plot_SiPixelLorentzAngleValueComparisonTwoTags \
@@ -38,8 +47,10 @@ getPayloadData.py \
     --time_type Run \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
-    --db Prod
+    --db Prod \
     --test ;
+
+mv *.png  $W_DIR/plots_LA/comparisonByValuePhase0.png
 
 getPayloadData.py \
     --plugin pluginSiPixelLorentzAngle_PayloadInspector \
@@ -51,3 +62,6 @@ getPayloadData.py \
     --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test ;
+
+mv *.png  $W_DIR/plots_LA/comparisonByRegionPhase0.png
+

--- a/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+getPayloadData.py \
+    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+    --plot plot_SiPixelLorentzAngleValueComparisonTwoTags \
+    --tag SiPixelLorentzAngleSim_phase1_BoR3_HV350_Tr1300 \
+    --tagtwo SiPixelLorentzAngle_phase1_BoR3_HV350_Tr1300 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+getPayloadData.py \
+    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+    --plot plot_SiPixelLorentzAngleValues \
+    --tag SiPixelLorentzAngle_forWidth_phase1_mc_v1 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;                                  

--- a/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelLorentzAngle.sh
@@ -28,4 +28,26 @@ getPayloadData.py \
     --time_type Run \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
-    --test ;                                  
+    --test ;
+
+getPayloadData.py \
+    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+    --plot plot_SiPixelLorentzAngleValueComparisonTwoTags \
+    --tag SiPixelLorentzAngle_forWidth_v1_mc \
+    --tagtwo SiPixelLorentzAngle_2016_ultralegacymc_v2 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod
+    --test ;
+
+getPayloadData.py \
+    --plugin pluginSiPixelLorentzAngle_PayloadInspector \
+    --plot plot_SiPixelLorentzAngleByRegionComparisonTwoTags \
+    --tag SiPixelLorentzAngle_forWidth_v1_mc \
+    --tagtwo SiPixelLorentzAngle_2016_ultralegacymc_v2 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;

--- a/CondCore/SiPixelPlugins/test/testSiPixelQuality.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQuality.sh
@@ -43,3 +43,4 @@ getPayloadData.py \
     --iovs '{"start_iov": "1355878225674241", "end_iov": "1395228716040193"}' \
     --db Prod \
     --test;
+

--- a/CondCore/SiPixelPlugins/test/testSiPixelQuality.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQuality.sh
@@ -33,7 +33,9 @@ cd $W_DIR;
 
 #    --tag SiPixelQuality_byPCL_stuckTBM_v1 \
 #    --tag SiPixelQuality_byPCL_other_v1 \
-#     --tag SiPixelQuality_byPCL_prompt_v2 \
+#    --tag SiPixelQuality_byPCL_prompt_v2 \
+
+### to produce detailed list of bad ROCs for a whole year
 
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \

--- a/CondCore/SiPixelPlugins/test/testSiPixelQuality.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQuality.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+####################
+# Test SiPixelQuality
+####################
+# getPayloadData.py \
+#     --plugin pluginSiPixelQuality_PayloadInspector \
+#     --plot plot_SiPixelQualityTest \
+#     --tag SiPixelQuality_byPCL_prompt_v2 \
+#     --time_type Run \
+#     --iovs '{"start_iov": "1395142816694363", "end_iov": "1395142816694363"}' \
+#     --db Prod \
+#     --test;
+
+# getPayloadData.py \
+#     --plugin pluginSiPixelQuality_PayloadInspector \
+#     --plot plot_SiPixelQualityBadRocsTimeHistory \
+#     --tag SiPixelQuality_byPCL_prompt_v2 \
+#     --time_type Lumi \
+#     --iovs '{"start_iov": "1390615921164381", "end_iov": "1395142816694363"}' \
+#     --db Prod \
+#     --test;
+
+#    --tag SiPixelQuality_byPCL_stuckTBM_v1 \
+#    --tag SiPixelQuality_byPCL_other_v1 \
+#     --tag SiPixelQuality_byPCL_prompt_v2 \
+
+getPayloadData.py \
+    --plugin pluginSiPixelQuality_PayloadInspector \
+    --plot plot_SiPixelQualityBadRocsSummary \
+    --tag SiPixelQuality_byPCL_stuckTBM_v1 \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1355878225674241", "end_iov": "1395228716040193"}' \
+    --db Prod \
+    --test;

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -9,6 +9,7 @@ eval `scram run -sh`;
 # Go back to original working directory
 cd $W_DIR;
 # Run get payload data script
+rm -fr *.png
 
 #    --iovs '{"start_iov": "1407898869563565", "end_iov": "1407898869563565"}' \
 ####################
@@ -23,6 +24,8 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+mv *.png $HOME/www/display/CheckROCsBPix.png
+
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelFPixQualityMap \
@@ -32,3 +35,4 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+mv *.png $HOME/www/display/CheckROCsFPix.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -17,18 +17,18 @@ cd $W_DIR;
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelBPixQualityMap \
-    --tag SiPixelQuality_phase1_2018_permanentlyBad \
+    --tag  SiPixelQuality_byPCL_prompt_v2 \
     --time_type Lumi \
-    --iovs '{"start_iov": "1", "end_iov": "1"}' \
-    --db sqlite_file:SiPixelQuality_phase1_2018_permanentlyBad.db \
+    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
+    --db Prod \
     --test;
 
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelFPixQualityMap \
-    --tag SiPixelQuality_phase1_2018_permanentlyBad  \
+    --tag  SiPixelQuality_byPCL_prompt_v2 \
     --time_type Lumi \
-    --iovs '{"start_iov": "1", "end_iov": "1"}' \
-    --db sqlite_file:SiPixelQuality_phase1_2018_permanentlyBad.db \
+    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
+    --db Prod \
     --test;
 

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -14,14 +14,14 @@ cd $W_DIR;
 ####################
 # Test SiPixelQuality
 ####################
-# getPayloadData.py \
-#     --plugin pluginSiPixelQuality_PayloadInspector \
-#     --plot plot_SiPixelBPixQualityMap \
-#     --tag  SiPixelQuality_byPCL_prompt_v2 \
-#     --time_type Lumi \
-#     --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
-#     --db Prod \
-#     --test;
+getPayloadData.py \
+    --plugin pluginSiPixelQuality_PayloadInspector \
+    --plot plot_SiPixelBPixQualityMap \
+    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
+    --db Prod \
+    --test;
 
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -9,30 +9,55 @@ eval `scram run -sh`;
 # Go back to original working directory
 cd $W_DIR;
 # Run get payload data script
-rm -fr *.png
+if [ -d $W_DIR/plots_Quality ]; then
+    rm -fr $W_DIR/plots_Quality
+fi
 
-#    --iovs '{"start_iov": "1407898869563565", "end_iov": "1407898869563565"}' \
+mkdir $W_DIR/plots_Quality
+
 ####################
 # Test SiPixelQuality
 ####################
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelBPixQualityMap \
-    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --tag SiPixelQuality_phase1_2018_permanentlyBad \
     --time_type Lumi \
-    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test;
 
-mv *.png $HOME/www/display/CheckROCsBPix.png
+mv *.png $W_DIR/plots_Quality/SiPixelQuality_phase1_2018_permanentlyBad_BPix.png
 
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelFPixQualityMap \
-    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --tag SiPixelQuality_phase1_2018_permanentlyBad  \
     --time_type Lumi \
-    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test;
 
-mv *.png $HOME/www/display/CheckROCsFPix.png
+mv *.png $W_DIR/plots_Quality/SiPixelQuality_phase1_2018_permanentlyBad_FPix.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelQuality_PayloadInspector \
+    --plot plot_SiPixelBPixQualityMap \
+    --tag SiPixelQuality_forDigitizer_phase1_2018_permanentlyBad \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots_Quality/SiPixelQuality_forDigitizer_phase1_2018_permanentlyBad_BPix.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelQuality_PayloadInspector \
+    --plot plot_SiPixelFPixQualityMap \
+    --tag SiPixelQuality_forDigitizer_phase1_2018_permanentlyBad  \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots_Quality/SiPixelQuality_forDigitizer_phase1_2018_permanentlyBad_FPix.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+#    --iovs '{"start_iov": "1407898869563565", "end_iov": "1407898869563565"}' \
+####################
+# Test SiPixelQuality
+####################
+getPayloadData.py \
+    --plugin pluginSiPixelQuality_PayloadInspector \
+    --plot plot_SiPixelBPixQualityMap \
+    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1371189784084481", "end_iov": "1371189784084481"}' \
+    --db Prod \
+    --test;
+
+getPayloadData.py \
+    --plugin pluginSiPixelQuality_PayloadInspector \
+    --plot plot_SiPixelFPixQualityMap \
+    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1371189784084481", "end_iov": "1371189784084481"}' \
+    --db Prod \
+    --test;

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -17,17 +17,18 @@ cd $W_DIR;
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelBPixQualityMap \
-    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --tag SiPixelQuality_phase1_2018_permanentlyBad \
     --time_type Lumi \
-    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
-    --db Prod \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db sqlite_file:SiPixelQuality_phase1_2018_permanentlyBad.db \
     --test;
 
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelFPixQualityMap \
-    --tag  SiPixelQuality_byPCL_prompt_v2 \
+    --tag SiPixelQuality_phase1_2018_permanentlyBad  \
     --time_type Lumi \
-    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
-    --db Prod \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db sqlite_file:SiPixelQuality_phase1_2018_permanentlyBad.db \
     --test;
+

--- a/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelQualityMap.sh
@@ -14,20 +14,20 @@ cd $W_DIR;
 ####################
 # Test SiPixelQuality
 ####################
-getPayloadData.py \
-    --plugin pluginSiPixelQuality_PayloadInspector \
-    --plot plot_SiPixelBPixQualityMap \
-    --tag  SiPixelQuality_byPCL_prompt_v2 \
-    --time_type Lumi \
-    --iovs '{"start_iov": "1371189784084481", "end_iov": "1371189784084481"}' \
-    --db Prod \
-    --test;
+# getPayloadData.py \
+#     --plugin pluginSiPixelQuality_PayloadInspector \
+#     --plot plot_SiPixelBPixQualityMap \
+#     --tag  SiPixelQuality_byPCL_prompt_v2 \
+#     --time_type Lumi \
+#     --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
+#     --db Prod \
+#     --test;
 
 getPayloadData.py \
     --plugin pluginSiPixelQuality_PayloadInspector \
     --plot plot_SiPixelFPixQualityMap \
     --tag  SiPixelQuality_byPCL_prompt_v2 \
     --time_type Lumi \
-    --iovs '{"start_iov": "1371189784084481", "end_iov": "1371189784084481"}' \
+    --iovs '{"start_iov": "1390517136916505", "end_iov": "1390517136916505"}' \
     --db Prod \
     --test;


### PR DESCRIPTION
#### PR description:

This PR aims to introduce the first few classes for the inspection of SiPixel conditions, namely the `SiPixelLorentzAngle` and the `SiPixelQuality`. More classes for other conditions types will be added at a later time.  

#### PR validation:
The code has been privately tested using the scripts provided in the  `CondCore/SiPixelPlugins/test` directory.
In the particular case of the `SiPixelQuality` Bad ROC maps a dedicated validation has been done, by cross-checking the output of the payload inspector, with the content of the `MonitorElement`s used for monitoring the PCL output in the Phase-1 pixel DQM ( [example](https://tinyurl.com/yxd852hc) )
Example of output image to be displayed in [Conditions Browser](https://cms-conddb.cern.ch/cmsDbBrowser/payload_inspector/Prod) from one of the classes introduced here: 

![CheckROCsBPix](https://user-images.githubusercontent.com/5082376/62231220-e6948b00-b3c3-11e9-8198-e5d97cbb1dc2.png)

#### if this PR is a backport please specify the original PR:

This PR is not a backport.
cc:
@tvami @tsusa 