### PR TITLE
HGCal - Minimum Cluster size for Pattern Recognition

### DIFF
--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
@@ -1,8 +1,8 @@
-// Author: Marco Rovere - marco.rovere@cern.ch
+// Authors: Marco Rovere - marco.rovere@cern.ch, Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 11/2018
 
-#ifndef RecoHGCal_TICL_ClusterFilterByAlgoOrSize_H__
-#define RecoHGCal_TICL_ClusterFilterByAlgoOrSize_H__
+#ifndef RecoHGCal_TICL_ClusterFilterByAlgoAndSize_H__
+#define RecoHGCal_TICL_ClusterFilterByAlgoAndSize_H__
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "ClusterFilterBase.h"
@@ -12,21 +12,23 @@
 
 // Filter clusters that belong to a specific algorithm
 namespace ticl {
-  class ClusterFilterByAlgoOrSize final : public ClusterFilterBase {
+  class ClusterFilterByAlgoAndSize final : public ClusterFilterBase {
   public:
-    ClusterFilterByAlgoOrSize(const edm::ParameterSet& ps)
+    ClusterFilterByAlgoAndSize(const edm::ParameterSet& ps)
         : ClusterFilterBase(ps),
           algo_number_(ps.getParameter<int>("algo_number")),
+          min_cluster_size_(ps.getParameter<int>("min_cluster_size")),
           max_cluster_size_(ps.getParameter<int>("max_cluster_size")) {}
-    ~ClusterFilterByAlgoOrSize() override{};
+    ~ClusterFilterByAlgoAndSize() override{};
 
     std::unique_ptr<HgcalClusterFilterMask> filter(const std::vector<reco::CaloCluster>& layerClusters,
                                                    const HgcalClusterFilterMask& availableLayerClusters,
                                                    std::vector<float>& layerClustersMask) const override {
       auto filteredLayerClusters = std::make_unique<HgcalClusterFilterMask>();
       for (auto const& cl : availableLayerClusters) {
-        if (layerClusters[cl.first].algo() == algo_number_ ||
-            layerClusters[cl.first].hitsAndFractions().size() <= max_cluster_size_) {
+        if (layerClusters[cl.first].algo() == algo_number_ and
+            layerClusters[cl.first].hitsAndFractions().size() <= max_cluster_size_ and
+            layerClusters[cl.first].hitsAndFractions().size() >= min_cluster_size_) {
           filteredLayerClusters->emplace_back(cl);
         } else {
           layerClustersMask[cl.first] = 0.;
@@ -37,6 +39,7 @@ namespace ticl {
 
   private:
     int algo_number_;
+    unsigned int min_cluster_size_;
     unsigned int max_cluster_size_;
   };
 }  // namespace ticl

--- a/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
@@ -53,8 +53,9 @@ void FilteredLayerClustersProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<edm::InputTag>("HGCLayerClusters", edm::InputTag("hgcalLayerClusters"));
   desc.add<edm::InputTag>("LayerClustersInputMask", edm::InputTag("hgcalLayerClusters", "InitialLayerClustersMask"));
   desc.add<std::string>("iteration_label", "iterationLabelGoesHere");
-  desc.add<std::string>("clusterFilter", "ClusterFilterByAlgo");
+  desc.add<std::string>("clusterFilter", "ClusterFilterByAlgoAndSize");
   desc.add<int>("algo_number", 9);
+  desc.add<int>("min_cluster_size", 0);
   desc.add<int>("max_cluster_size", 9999);
   descriptions.add("filteredLayerClustersProducer", desc);
 }

--- a/RecoHGCal/TICL/plugins/filters.cc
+++ b/RecoHGCal/TICL/plugins/filters.cc
@@ -5,11 +5,11 @@
 #include "ClusterFilterFactory.h"
 
 #include "ClusterFilterByAlgo.h"
-#include "ClusterFilterByAlgoOrSize.h"
+#include "ClusterFilterByAlgoAndSize.h"
 #include "ClusterFilterBySize.h"
 
 using namespace ticl;
 
 DEFINE_EDM_PLUGIN(ClusterFilterFactory, ClusterFilterByAlgo, "ClusterFilterByAlgo");
-DEFINE_EDM_PLUGIN(ClusterFilterFactory, ClusterFilterByAlgoOrSize, "ClusterFilterByAlgoOrSize");
+DEFINE_EDM_PLUGIN(ClusterFilterFactory, ClusterFilterByAlgoAndSize, "ClusterFilterByAlgoAndSize");
 DEFINE_EDM_PLUGIN(ClusterFilterFactory, ClusterFilterBySize, "ClusterFilterBySize");

--- a/RecoHGCal/TICL/python/ticl_iterations.py
+++ b/RecoHGCal/TICL/python/ticl_iterations.py
@@ -43,6 +43,8 @@ def TICL_iterations_withReco(process):
   )
 
   process.FilteredLayerClusters = filteredLayerClustersProducer.clone(
+      clusterFilter = "ClusterFilterByAlgoAndSize",
+      min_cluster_size = 2,
       algo_number = 8,
       iteration_label = "algo8",
       LayerClustersInputMask = "TrackstersMIP"
@@ -98,6 +100,8 @@ def TICL_iterations(process):
   )
 
   process.FilteredLayerClusters = filteredLayerClustersProducer.clone(
+      clusterFilter = "ClusterFilterByAlgoAndSize",
+      min_cluster_size = 2,
       algo_number = 8,
       iteration_label = "algo8"
   )


### PR DESCRIPTION
#### PR description:

This PR is introducing a new filter on the minimum layer clusters size that a hgcalLayerCluster requires in order to be passed to the next step of the Pattern Recognition in TICL. This is useful to make PR more robust against single cell inefficiency and to remove duplicate tracksters.
#### PR validation:

This PR was tested with 20490.0_SingleGammaPt25Eta1p7_2p7 checking that the number of hgcalLayerClusters fed to the pattern recognition is halved, and that the number of duplicate tracksters is decreased. 
Another PR will be made in order to make the Pattern Recognition by CA more robust as well.

@rovere @cseez @amartelli fyi 