### PR TITLE
revert SignalPropagationSpeed at GEMDigiProducer

### DIFF
--- a/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
@@ -85,7 +85,7 @@ void GEMDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<std::string>("inputCollection", "g4SimHitsMuonGEMHits");
   desc.add<std::string>("mixLabel", "mix");
 
-  desc.add<double>("signalPropagationSpeed", 6.6);
+  desc.add<double>("signalPropagationSpeed", 0.66);
   desc.add<double>("timeResolution", 5.);
   desc.add<double>("timeJitter", 1.0);
   desc.add<double>("averageShapingTime", 50.0);

--- a/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
@@ -105,7 +105,7 @@ int GEMSignalModel::getSimHitBx(const PSimHit* simhit, CLHEP::HepRandomEngine* e
   const float distanceFromEdge(halfStripLength - simHitPos.y());
 
   // signal propagation speed in material in [cm/ns]
-  double signalPropagationSpeedTrue = signalPropagationSpeed_ * cspeed;
+  double signalPropagationSpeedTrue = signalPropagationSpeed_ * geant_units::operators::convertMmToCm(cspeed);
 
   // average time for the signal to propagate from the SimHit to the top of a strip
   const float averagePropagationTime(distanceFromEdge / signalPropagationSpeedTrue);

--- a/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
@@ -23,7 +23,7 @@ GEMSignalModel::GEMSignalModel(const edm::ParameterSet& config)
       digitizeOnlyMuons_(config.getParameter<bool>("digitizeOnlyMuons")),
       resolutionX_(config.getParameter<double>("resolutionX")),
       muonPdgId(13),
-      cspeed(CLHEP::c_light),
+      cspeed(geant_units::operators::convertMmToCm(CLHEP::c_light)),
       momConvFact(1000.),
       elecMomCut1(1.96e-03),
       elecMomCut2(10.e-03),
@@ -98,14 +98,14 @@ int GEMSignalModel::getSimHitBx(const PSimHit* simhit, CLHEP::HepRandomEngine* e
   const GlobalPoint& globMiddleRol = roll->toGlobal(middleOfRoll);
   double muRadius = sqrt(globMiddleRol.x() * globMiddleRol.x() + globMiddleRol.y() * globMiddleRol.y() +
                          globMiddleRol.z() * globMiddleRol.z());
-  double timeCalibrationOffset_ = geant_units::operators::convertCmToMm(muRadius) / cspeed;  //[ns]
+  double timeCalibrationOffset_ = muRadius / cspeed;  //[ns]
 
   const TrapezoidalStripTopology* top(dynamic_cast<const TrapezoidalStripTopology*>(&(roll->topology())));
   const float halfStripLength(0.5 * top->stripLength());
   const float distanceFromEdge(halfStripLength - simHitPos.y());
 
   // signal propagation speed in material in [cm/ns]
-  double signalPropagationSpeedTrue = signalPropagationSpeed_ * geant_units::operators::convertMmToCm(cspeed);
+  double signalPropagationSpeedTrue = signalPropagationSpeed_ * cspeed;
 
   // average time for the signal to propagate from the SimHit to the top of a strip
   const float averagePropagationTime(distanceFromEdge / signalPropagationSpeedTrue);


### PR DESCRIPTION
#### PR description:

This PR is minor revert of the PR #27445.
For consistency with the comment line, the value of signalPropagationSpeed at GEMDigiProducer has reverted to the old version. And `cspeed` is converted to mm/ns to cm/ns for it. @kpedro88 