### PR TITLE
Complete the implementation of RPC Digi Collection Merger started in PR #24613

### DIFF
--- a/Configuration/Eras/python/Modifier_run3_RPC_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_RPC_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_RPC =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -57,7 +57,7 @@ class Eras (object):
                            'peripheralPbPb', 'pA_2016',
                            'run2_HE_2017', 'stage2L1Trigger', 'stage2L1Trigger_2017',
                            'run2_HF_2017', 'run2_HCAL_2017', 'run2_HEPlan1_2017', 'run2_HB_2018','run2_HE_2018', 
-                           'run3_HB', 'run3_common',
+                           'run3_HB', 'run3_common', 'run3_RPC',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',
@@ -69,8 +69,7 @@ class Eras (object):
                            'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1',
                            'hcalHardcodeConditions', 'hcalSkipPacker',
                            'run2_HLTconditions_2016','run2_HLTconditions_2017','run2_HLTconditions_2018',
-                           'bParking',
-                           'run3_RPC']
+                           'bParking']
         internalUseModChains = ['run2_2017_noTrackingModifier']
 
         self.pythonCfgLines = {}

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -69,7 +69,8 @@ class Eras (object):
                            'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1',
                            'hcalHardcodeConditions', 'hcalSkipPacker',
                            'run2_HLTconditions_2016','run2_HLTconditions_2017','run2_HLTconditions_2018',
-                           'bParking']
+                           'bParking',
+                           'run3_RPC']
         internalUseModChains = ['run2_2017_noTrackingModifier']
 
         self.pythonCfgLines = {}

--- a/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
@@ -7,6 +7,9 @@ ecalDigis.DoRegional = False
 #False by default ecalDigis.DoRegional = False
 
 # RPC Merged Digis 
-muonRPCNewDigis.inputTagTwinMuxDigis = cms.InputTag('rpcTwinMuxRawToDigi')
-muonRPCNewDigis.inputTagOMTFDigis = cms.InputTag('omtfStage2Digis')
-muonRPCNewDigis.inputTagCPPFDigis = cms.InputTag('rpcCPPFRawToDigi')
+_muonRPCDigis = muonRPCDigis.copy()
+from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+_muonRPCDigis.inputTagTwinMuxDigis = cms.InputTag('rpcTwinMuxRawToDigi')
+_muonRPCDigis.inputTagOMTFDigis = cms.InputTag('omtfStage2Digis')
+_muonRPCDigis.inputTagCPPFDigis = cms.InputTag('rpcCPPFRawToDigi')
+run3_RPC.toReplaceWith(muonRPCDigis,_muonRPCDigis)

--- a/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
@@ -6,3 +6,7 @@ from Configuration.StandardSequences.RawToDigi_cff import *
 ecalDigis.DoRegional = False
 #False by default ecalDigis.DoRegional = False
 
+# RPC Merged Digis 
+muonRPCNewDigis.inputTagTwinMuxDigis = cms.InputTag('rpcTwinMuxRawToDigi')
+muonRPCNewDigis.inputTagOMTFDigis = cms.InputTag('omtfStage2Digis')
+muonRPCNewDigis.inputTagCPPFDigis = cms.InputTag('rpcCPPFRawToDigi')

--- a/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
@@ -7,9 +7,9 @@ ecalDigis.DoRegional = False
 #False by default ecalDigis.DoRegional = False
 
 # RPC Merged Digis 
-_muonRPCDigis = muonRPCDigis.copy()
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
-_muonRPCDigis.inputTagTwinMuxDigis = cms.InputTag('rpcTwinMuxRawToDigi')
-_muonRPCDigis.inputTagOMTFDigis = cms.InputTag('omtfStage2Digis')
-_muonRPCDigis.inputTagCPPFDigis = cms.InputTag('rpcCPPFRawToDigi')
-run3_RPC.toReplaceWith(muonRPCDigis,_muonRPCDigis)
+run3_RPC.toModify(muonRPCDigis,
+    inputTagTwinMuxDigis = 'rpcTwinMuxRawToDigi',
+    inputTagOMTFDigis = 'omtfStage2Digis',
+    inputTagCPPFDigis = 'rpcCPPFRawToDigi'
+)

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -24,11 +24,8 @@ muonCSCDigis = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone()
 import EventFilter.DTRawToDigi.dtunpacker_cfi
 muonDTDigis = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone()
 
-import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
-muonRPCDigis = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone()
-
-import EventFilter.RPCRawToDigi.rpcDigiMerger_cfi
-muonRPCNewDigis = EventFilter.RPCRawToDigi.rpcDigiMerger_cfi.rpcDigiMerger.clone()
+import EventFilter.RPCRawToDigi.RPCRawToDigi_cfi 
+muonRPCDigis = EventFilter.RPCRawToDigi.RPCRawToDigi_cfi.muonRPCDigis.clone()
 
 import EventFilter.GEMRawToDigi.muonGEMDigis_cfi
 muonGEMDigis = EventFilter.GEMRawToDigi.muonGEMDigis_cfi.muonGEMDigis.clone()
@@ -115,19 +112,6 @@ _hgcal_RawToDigiTask = RawToDigiTask.copy()
 _hgcal_RawToDigiTask.add(hgcalDigis)
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith(RawToDigiTask,_hgcal_RawToDigiTask)
-
-# RPC New Readout Validation
-from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-_rpc_NewReadoutVal_RawToDigiTask = RawToDigiTask.copy()
-_rpc_NewReadoutVal_RawToDigiTask_noTk = RawToDigiTask_noTk.copy()
-_rpc_NewReadoutVal_RawToDigiTask.add(muonRPCNewDigis)
-_rpc_NewReadoutVal_RawToDigiTask_noTk.add(muonRPCNewDigis)
-stage2L1Trigger_2017.toReplaceWith(RawToDigiTask, _rpc_NewReadoutVal_RawToDigiTask)
-stage2L1Trigger_2017.toReplaceWith(RawToDigiTask_noTk, _rpc_NewReadoutVal_RawToDigiTask)
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([muonRPCNewDigis]))
-fastSim.toReplaceWith(RawToDigiTask_noTk, RawToDigiTask_noTk.copyAndExclude([muonRPCNewDigis]))
 
 _hfnose_RawToDigiTask = RawToDigiTask.copy()
 _hfnose_RawToDigiTask.add(hfnoseDigis)

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
@@ -47,6 +47,7 @@ void RPCDigiMerger::fillDescriptions(edm::ConfigurationDescriptions& descs) {
   desc.add<edm::InputTag>("inputTagTwinMuxDigis", edm::InputTag("", ""));
   desc.add<edm::InputTag>("inputTagOMTFDigis", edm::InputTag("", ""));
   desc.add<edm::InputTag>("inputTagCPPFDigis", edm::InputTag("", ""));
+  desc.add<edm::InputTag>("InputLabel", edm::InputTag(" "));
   desc.add<int>("bxMinTwinMux", -2);
   desc.add<int>("bxMaxTwinMux", 2);
   desc.add<int>("bxMinOMTF", -3);

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
@@ -66,18 +66,11 @@ void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
 
   //Check if its Data
   if (not(cppf_token_.isUninitialized() && omtf_token_.isUninitialized() && twinMux_token_.isUninitialized())) {
-    // TwinMux
-    Handle<RPCDigiCollection> TwinMux_digis;
-    event.getByToken(twinMux_token_, TwinMux_digis);
-    // OMTF
-    Handle<RPCDigiCollection> OMTF_digis;
-    event.getByToken(omtf_token_, OMTF_digis);
-    // CPFF
-    Handle<RPCDigiCollection> CPPF_digis;
-    event.getByToken(cppf_token_, CPPF_digis);
     // loop over TwinMux digis
     // protection against empty InputTag to allow for Data/MC compatibility
     if (not twinMux_token_.isUninitialized()) {
+      Handle<RPCDigiCollection> TwinMux_digis;
+      event.getByToken(twinMux_token_, TwinMux_digis);
       for (const auto&& rpcdgIt : (*TwinMux_digis)) {
         // The layerId
         const RPCDetId& rpcId = rpcdgIt.first;
@@ -89,6 +82,8 @@ void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
     // loop over CPPF digis
     // protection against empty InputTag to allow for Data/MC compatibility
     if (not cppf_token_.isUninitialized()) {
+      Handle<RPCDigiCollection> CPPF_digis;
+      event.getByToken(cppf_token_, CPPF_digis);
       for (const auto&& rpcdgIt : (*CPPF_digis)) {
         // The layerId
         const RPCDetId& rpcId = rpcdgIt.first;
@@ -100,6 +95,8 @@ void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
     // loop over OMTF digis
     // protection against empty InputTag to allow for Data/MC compatibility
     if (not omtf_token_.isUninitialized()) {
+      Handle<RPCDigiCollection> OMTF_digis;
+      event.getByToken(omtf_token_, OMTF_digis);
       for (const auto& rpcdgIt : (*OMTF_digis)) {
         // The layerId
         const RPCDetId& rpcId = rpcdgIt.first;

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
@@ -17,20 +17,42 @@
 using namespace edm;
 using namespace std;
 
-RPCDigiMerger::RPCDigiMerger(edm::ParameterSet const& config) {
+RPCDigiMerger::RPCDigiMerger(edm::ParameterSet const& config)
+  : bx_minTwinMux_(config.getParameter<int>("bxMinTwinMux"))
+  , bx_maxTwinMux_(config.getParameter<int>("bxMaxTwinMux"))
+  , bx_minOMTF_(config.getParameter<int>("bxMinOMTF"))
+  , bx_maxOMTF_(config.getParameter<int>("bxMaxOMTF"))
+  , bx_minCPPF_(config.getParameter<int>("bxMinCPPF"))
+  , bx_maxCPPF_(config.getParameter<int>("bxMaxCPPF"))
+{
   produces<RPCDigiCollection>();
-  twinMux_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagTwinMuxDigis"));
-  omtf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagOMTFDigis"));
-  cppf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagCPPFDigis"));
+  simRPC_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagSimRPCDigis"));
+  // protection against empty InputTag to allow for Data/MC compatibility
+  if (not config.getParameter<edm::InputTag>("inputTagTwinMuxDigis").label().empty()) {
+      twinMux_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagTwinMuxDigis"));
+  } 
+  if (not config.getParameter<edm::InputTag>("inputTagOMTFDigis").label().empty()) {
+      omtf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagOMTFDigis"));
+  }
+  if (not config.getParameter<edm::InputTag>("inputTagCPPFDigis").label().empty()) {
+      cppf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagCPPFDigis"));
+  }
 }
 
 RPCDigiMerger::~RPCDigiMerger() {}
 
 void RPCDigiMerger::fillDescriptions(edm::ConfigurationDescriptions& descs) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("inputTagTwinMuxDigis", edm::InputTag("rpcTwinMuxRawToDigi", ""));
-  desc.add<edm::InputTag>("inputTagOMTFDigis", edm::InputTag("omtfStage2Digis", ""));
-  desc.add<edm::InputTag>("inputTagCPPFDigis", edm::InputTag("rpcCPPFRawToDigi", ""));
+  desc.add<edm::InputTag>("inputTagSimRPCDigis", edm::InputTag("simMuonRPCDigis", ""));
+  desc.add<edm::InputTag>("inputTagTwinMuxDigis", edm::InputTag("", ""));
+  desc.add<edm::InputTag>("inputTagOMTFDigis", edm::InputTag("", ""));
+  desc.add<edm::InputTag>("inputTagCPPFDigis", edm::InputTag("", ""));
+  desc.add<int>("bxMinTwinMux", -2);
+  desc.add<int>("bxMaxTwinMux", 2);
+  desc.add<int>("bxMinOMTF", -3);
+  desc.add<int>("bxMaxOMTF", 4);
+  desc.add<int>("bxMinCPPF", -2);
+  desc.add<int>("bxMaxCPPF", 2);
 
   descs.add("rpcDigiMerger", desc);
 }
@@ -39,53 +61,105 @@ void RPCDigiMerger::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
 
 void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
   // Get the digis
-  // TwinMux
-  Handle<RPCDigiCollection> TwinMux_digis;
-  event.getByToken(twinMux_token_, TwinMux_digis);
-  // OMTF
-  Handle<RPCDigiCollection> OMTF_digis;
-  event.getByToken(omtf_token_, OMTF_digis);
-  // CPFF
-  Handle<RPCDigiCollection> CPPF_digis;
-  event.getByToken(cppf_token_, CPPF_digis);
-
   // new RPCDigiCollection
   std::unique_ptr<RPCDigiCollection> rpc_digi_collection(new RPCDigiCollection());
 
-  // loop over TwinMux digis
-  for (const auto& rpcdgIt : (*TwinMux_digis)) {
-    // The layerId
-    const RPCDetId& rpcId = rpcdgIt.first;
-    // Get the iterators over the digis associated with this LayerId
-    const RPCDigiCollection::Range& range = rpcdgIt.second;
-
-    rpc_digi_collection->put(range, rpcId);
-  }
-
-  // loop over CPPF digis
-  for (const auto&& rpcdgIt : (*CPPF_digis)) {
-    // The layerId
-    const RPCDetId& rpcId = rpcdgIt.first;
-    // Get the iterators over the digis associated with this LayerId
-    const RPCDigiCollection::Range& range = rpcdgIt.second;
-
-    rpc_digi_collection->put(range, rpcId);
-  }
-
-  // loop over OMTF digis
-  for (const auto& rpcdgIt : (*OMTF_digis)) {
-    // The layerId
-    const RPCDetId& rpcId = rpcdgIt.first;
-    // Get the iterators over the digis associated with this LayerId
-    const RPCDigiCollection::Range& range = rpcdgIt.second;
-
-    // accepts only rings: RE-2_R3 ; RE-1_R3 ; RE+1_R3 ; RE+2_R3 ;
-    if (((rpcId.region() == -1 || rpcId.region() == 1) && (rpcId.ring() == 3) &&
-         (rpcId.station() == 1 || rpcId.station() == 2))) {
-      rpc_digi_collection->put(range, rpcId);
+  //Check if its Data
+  if (not ( cppf_token_.isUninitialized() && omtf_token_.isUninitialized() && twinMux_token_.isUninitialized())) {
+    // TwinMux
+    Handle<RPCDigiCollection> TwinMux_digis; 
+    event.getByToken(twinMux_token_,TwinMux_digis);
+    // OMTF
+    Handle<RPCDigiCollection> OMTF_digis; 
+    event.getByToken(omtf_token_,OMTF_digis);
+    // CPFF
+    Handle<RPCDigiCollection> CPPF_digis; 
+    event.getByToken(cppf_token_,CPPF_digis);
+    // loop over TwinMux digis
+    // protection against empty InputTag to allow for Data/MC compatibility
+    if (not twinMux_token_.isUninitialized()) {
+      for (const auto && rpcdgIt : (*TwinMux_digis) ) {
+        // The layerId
+        const RPCDetId& rpcId = rpcdgIt.first;
+        // Get the iterators over the digis associated with this LayerId
+        const RPCDigiCollection::Range& range = rpcdgIt.second;
+        rpc_digi_collection->put(range, rpcId);
+      }
+    }
+    // loop over CPPF digis
+    // protection against empty InputTag to allow for Data/MC compatibility
+    if (not cppf_token_.isUninitialized()) {
+      for (const auto && rpcdgIt : (*CPPF_digis) ) {
+        // The layerId
+        const RPCDetId& rpcId = rpcdgIt.first;
+        // Get the iterators over the digis associated with this LayerId
+        const RPCDigiCollection::Range& range = rpcdgIt.second;
+        rpc_digi_collection->put(range, rpcId);
+      }
+    }
+    // loop over OMTF digis
+    // protection against empty InputTag to allow for Data/MC compatibility
+    if (not omtf_token_.isUninitialized()) {
+      for (const auto & rpcdgIt : (*OMTF_digis) ) {
+        // The layerId
+        const RPCDetId& rpcId = rpcdgIt.first;
+        // Get the iterators over the digis associated with this LayerId
+        const RPCDigiCollection::Range& range = rpcdgIt.second;
+        // accepts only rings: RE-2_R3 ; RE-1_R3 ; RE+1_R3 ; RE+2_R3 ; 
+        if ( ((rpcId.region() == -1 || rpcId.region() == 1) && (rpcId.ring() == 3) && (rpcId.station() == 1 || rpcId.station() == 2)) )  {
+          rpc_digi_collection->put(range, rpcId);
+        }
+      }
     }
   }
+  else { //its MC
+    // SimRPCDigis collection
+    Handle<RPCDigiCollection> SimRPC_digis; 
+    event.getByToken(simRPC_token_,SimRPC_digis);
 
+    RPCDetId rpc_det_id;
+    std::vector<RPCDigi> local_rpc_digis;
+
+    // loop over SimRPC digis
+    for (const auto & rpc_digi : (*SimRPC_digis) ) {
+      // The layerId
+      const RPCDetId& rpcId = rpc_digi.first;
+      // Get the iterators over the digis associated with this LayerId
+      const RPCDigiCollection::Range& range = rpc_digi.second;
+
+      if(rpcId!= rpc_det_id ) {
+        if (!local_rpc_digis.empty()) {
+          rpc_digi_collection->put(RPCDigiCollection::Range(local_rpc_digis.begin(), local_rpc_digis.end()), rpc_det_id); 
+          local_rpc_digis.clear();
+        }
+        rpc_det_id = rpcId; 
+      }
+      for (std::vector<RPCDigi>::const_iterator  id = range.first; id != range.second; id++) {
+        const RPCDigi & dit = (*id);
+        //Barrel  
+        if (rpcId.region() == 0) {
+          //TwinMux 
+          if( dit.bx() >= bx_minTwinMux_  && dit.bx() <= bx_maxTwinMux_) {
+            local_rpc_digis.push_back(dit);
+          }
+        }
+        //EndCap
+        if(rpcId.region() == -1 || rpcId.region() == 1) {
+          //OMTF
+          if ( rpcId.ring() == 3 && (rpcId.station() == 1 || rpcId.station() == 2) && dit.bx() >= bx_minOMTF_ && dit.bx() <= bx_maxOMTF_ ) {
+            local_rpc_digis.push_back(dit);
+          }
+          //CPPF
+          if (((rpcId.ring() == 2) || (rpcId.ring() == 3  && (rpcId.station() == 3 || rpcId.station() == 4))) && ( dit.bx() >= bx_minCPPF_  && dit.bx() <= bx_maxCPPF_) )  {
+            local_rpc_digis.push_back(dit);
+          }
+        }
+      }  
+    }
+    if (!local_rpc_digis.empty()) {
+      rpc_digi_collection->put(RPCDigiCollection::Range(local_rpc_digis.begin(), local_rpc_digis.end()), rpc_det_id);
+    }  
+  }
   // "put" into the event
   event.put(std::move(rpc_digi_collection));
 }

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
@@ -18,24 +18,23 @@ using namespace edm;
 using namespace std;
 
 RPCDigiMerger::RPCDigiMerger(edm::ParameterSet const& config)
-  : bx_minTwinMux_(config.getParameter<int>("bxMinTwinMux"))
-  , bx_maxTwinMux_(config.getParameter<int>("bxMaxTwinMux"))
-  , bx_minOMTF_(config.getParameter<int>("bxMinOMTF"))
-  , bx_maxOMTF_(config.getParameter<int>("bxMaxOMTF"))
-  , bx_minCPPF_(config.getParameter<int>("bxMinCPPF"))
-  , bx_maxCPPF_(config.getParameter<int>("bxMaxCPPF"))
-{
+    : bx_minTwinMux_(config.getParameter<int>("bxMinTwinMux")),
+      bx_maxTwinMux_(config.getParameter<int>("bxMaxTwinMux")),
+      bx_minOMTF_(config.getParameter<int>("bxMinOMTF")),
+      bx_maxOMTF_(config.getParameter<int>("bxMaxOMTF")),
+      bx_minCPPF_(config.getParameter<int>("bxMinCPPF")),
+      bx_maxCPPF_(config.getParameter<int>("bxMaxCPPF")) {
   produces<RPCDigiCollection>();
   simRPC_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagSimRPCDigis"));
   // protection against empty InputTag to allow for Data/MC compatibility
   if (not config.getParameter<edm::InputTag>("inputTagTwinMuxDigis").label().empty()) {
-      twinMux_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagTwinMuxDigis"));
-  } 
+    twinMux_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagTwinMuxDigis"));
+  }
   if (not config.getParameter<edm::InputTag>("inputTagOMTFDigis").label().empty()) {
-      omtf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagOMTFDigis"));
+    omtf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagOMTFDigis"));
   }
   if (not config.getParameter<edm::InputTag>("inputTagCPPFDigis").label().empty()) {
-      cppf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagCPPFDigis"));
+    cppf_token_ = consumes<RPCDigiCollection>(config.getParameter<edm::InputTag>("inputTagCPPFDigis"));
   }
 }
 
@@ -66,20 +65,20 @@ void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
   std::unique_ptr<RPCDigiCollection> rpc_digi_collection(new RPCDigiCollection());
 
   //Check if its Data
-  if (not ( cppf_token_.isUninitialized() && omtf_token_.isUninitialized() && twinMux_token_.isUninitialized())) {
+  if (not(cppf_token_.isUninitialized() && omtf_token_.isUninitialized() && twinMux_token_.isUninitialized())) {
     // TwinMux
-    Handle<RPCDigiCollection> TwinMux_digis; 
-    event.getByToken(twinMux_token_,TwinMux_digis);
+    Handle<RPCDigiCollection> TwinMux_digis;
+    event.getByToken(twinMux_token_, TwinMux_digis);
     // OMTF
-    Handle<RPCDigiCollection> OMTF_digis; 
-    event.getByToken(omtf_token_,OMTF_digis);
+    Handle<RPCDigiCollection> OMTF_digis;
+    event.getByToken(omtf_token_, OMTF_digis);
     // CPFF
-    Handle<RPCDigiCollection> CPPF_digis; 
-    event.getByToken(cppf_token_,CPPF_digis);
+    Handle<RPCDigiCollection> CPPF_digis;
+    event.getByToken(cppf_token_, CPPF_digis);
     // loop over TwinMux digis
     // protection against empty InputTag to allow for Data/MC compatibility
     if (not twinMux_token_.isUninitialized()) {
-      for (const auto && rpcdgIt : (*TwinMux_digis) ) {
+      for (const auto&& rpcdgIt : (*TwinMux_digis)) {
         // The layerId
         const RPCDetId& rpcId = rpcdgIt.first;
         // Get the iterators over the digis associated with this LayerId
@@ -90,7 +89,7 @@ void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
     // loop over CPPF digis
     // protection against empty InputTag to allow for Data/MC compatibility
     if (not cppf_token_.isUninitialized()) {
-      for (const auto && rpcdgIt : (*CPPF_digis) ) {
+      for (const auto&& rpcdgIt : (*CPPF_digis)) {
         // The layerId
         const RPCDetId& rpcId = rpcdgIt.first;
         // Get the iterators over the digis associated with this LayerId
@@ -101,65 +100,68 @@ void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
     // loop over OMTF digis
     // protection against empty InputTag to allow for Data/MC compatibility
     if (not omtf_token_.isUninitialized()) {
-      for (const auto & rpcdgIt : (*OMTF_digis) ) {
+      for (const auto& rpcdgIt : (*OMTF_digis)) {
         // The layerId
         const RPCDetId& rpcId = rpcdgIt.first;
         // Get the iterators over the digis associated with this LayerId
         const RPCDigiCollection::Range& range = rpcdgIt.second;
-        // accepts only rings: RE-2_R3 ; RE-1_R3 ; RE+1_R3 ; RE+2_R3 ; 
-        if ( ((rpcId.region() == -1 || rpcId.region() == 1) && (rpcId.ring() == 3) && (rpcId.station() == 1 || rpcId.station() == 2)) )  {
+        // accepts only rings: RE-2_R3 ; RE-1_R3 ; RE+1_R3 ; RE+2_R3 ;
+        if (((rpcId.region() == -1 || rpcId.region() == 1) && (rpcId.ring() == 3) &&
+             (rpcId.station() == 1 || rpcId.station() == 2))) {
           rpc_digi_collection->put(range, rpcId);
         }
       }
     }
-  }
-  else { //its MC
+  } else {  //its MC
     // SimRPCDigis collection
-    Handle<RPCDigiCollection> SimRPC_digis; 
-    event.getByToken(simRPC_token_,SimRPC_digis);
+    Handle<RPCDigiCollection> SimRPC_digis;
+    event.getByToken(simRPC_token_, SimRPC_digis);
 
     RPCDetId rpc_det_id;
     std::vector<RPCDigi> local_rpc_digis;
 
     // loop over SimRPC digis
-    for (const auto & rpc_digi : (*SimRPC_digis) ) {
+    for (const auto& rpc_digi : (*SimRPC_digis)) {
       // The layerId
       const RPCDetId& rpcId = rpc_digi.first;
       // Get the iterators over the digis associated with this LayerId
       const RPCDigiCollection::Range& range = rpc_digi.second;
 
-      if(rpcId!= rpc_det_id ) {
+      if (rpcId != rpc_det_id) {
         if (!local_rpc_digis.empty()) {
-          rpc_digi_collection->put(RPCDigiCollection::Range(local_rpc_digis.begin(), local_rpc_digis.end()), rpc_det_id); 
+          rpc_digi_collection->put(RPCDigiCollection::Range(local_rpc_digis.begin(), local_rpc_digis.end()),
+                                   rpc_det_id);
           local_rpc_digis.clear();
         }
-        rpc_det_id = rpcId; 
+        rpc_det_id = rpcId;
       }
-      for (std::vector<RPCDigi>::const_iterator  id = range.first; id != range.second; id++) {
-        const RPCDigi & dit = (*id);
-        //Barrel  
+      for (std::vector<RPCDigi>::const_iterator id = range.first; id != range.second; id++) {
+        const RPCDigi& dit = (*id);
+        //Barrel
         if (rpcId.region() == 0) {
-          //TwinMux 
-          if( dit.bx() >= bx_minTwinMux_  && dit.bx() <= bx_maxTwinMux_) {
+          //TwinMux
+          if (dit.bx() >= bx_minTwinMux_ && dit.bx() <= bx_maxTwinMux_) {
             local_rpc_digis.push_back(dit);
           }
         }
         //EndCap
-        if(rpcId.region() == -1 || rpcId.region() == 1) {
+        if (rpcId.region() == -1 || rpcId.region() == 1) {
           //OMTF
-          if ( rpcId.ring() == 3 && (rpcId.station() == 1 || rpcId.station() == 2) && dit.bx() >= bx_minOMTF_ && dit.bx() <= bx_maxOMTF_ ) {
+          if (rpcId.ring() == 3 && (rpcId.station() == 1 || rpcId.station() == 2) && dit.bx() >= bx_minOMTF_ &&
+              dit.bx() <= bx_maxOMTF_) {
             local_rpc_digis.push_back(dit);
           }
           //CPPF
-          if (((rpcId.ring() == 2) || (rpcId.ring() == 3  && (rpcId.station() == 3 || rpcId.station() == 4))) && ( dit.bx() >= bx_minCPPF_  && dit.bx() <= bx_maxCPPF_) )  {
+          if (((rpcId.ring() == 2) || (rpcId.ring() == 3 && (rpcId.station() == 3 || rpcId.station() == 4))) &&
+              (dit.bx() >= bx_minCPPF_ && dit.bx() <= bx_maxCPPF_)) {
             local_rpc_digis.push_back(dit);
           }
         }
-      }  
+      }
     }
     if (!local_rpc_digis.empty()) {
       rpc_digi_collection->put(RPCDigiCollection::Range(local_rpc_digis.begin(), local_rpc_digis.end()), rpc_det_id);
-    }  
+    }
   }
   // "put" into the event
   event.put(std::move(rpc_digi_collection));

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.h
@@ -35,6 +35,11 @@ protected:
   edm::EDGetTokenT<RPCDigiCollection> twinMux_token_;
   edm::EDGetTokenT<RPCDigiCollection> omtf_token_;
   edm::EDGetTokenT<RPCDigiCollection> cppf_token_;
+  edm::EDGetTokenT<RPCDigiCollection> simRPC_token_;
+
+  int bx_minTwinMux_, bx_maxTwinMux_;
+  int bx_minOMTF_, bx_maxOMTF_;
+  int bx_minCPPF_, bx_maxCPPF_;  
 };
 
 #endif  // EventFilter_RPCRawToDigi_RPCDigiMerger_h

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.h
@@ -39,7 +39,7 @@ protected:
 
   int bx_minTwinMux_, bx_maxTwinMux_;
   int bx_minOMTF_, bx_maxOMTF_;
-  int bx_minCPPF_, bx_maxCPPF_;  
+  int bx_minCPPF_, bx_maxCPPF_;
 };
 
 #endif  // EventFilter_RPCRawToDigi_RPCDigiMerger_h

--- a/EventFilter/RPCRawToDigi/python/RPCRawToDigi_cfi.py
+++ b/EventFilter/RPCRawToDigi/python/RPCRawToDigi_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+import EventFilter.RPCRawToDigi.rpcUnpacker_cfi
+muonRPCDigis = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone()
+
+from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+from EventFilter.RPCRawToDigi.rpcDigiMerger_cfi import rpcDigiMerger 
+
+run3_RPC.toReplaceWith(muonRPCDigis,rpcDigiMerger)
+
+

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_cff.py
@@ -68,22 +68,3 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonlocalrecoTask , _run3_muonlocalrecoTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonlocalrecoTask , _phase2_muonlocalrecoTask )
-
-
-# RPC New Readout Validation
-from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask = muonlocalreco_with_2DSegmentsTask.copy()
-_rpc_NewReadoutVal_muonlocalrecoTask = muonlocalrecoTask.copy()
-_rpc_NewReadoutVal_muonlocalrecoT0SegTask = muonlocalrecoT0SegTask.copy()
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask.add(rpcNewRecHits)
-_rpc_NewReadoutVal_muonlocalrecoTask.add(rpcNewRecHits)
-_rpc_NewReadoutVal_muonlocalrecoT0SegTask.add(rpcNewRecHits)
-stage2L1Trigger_2017.toReplaceWith(muonlocalreco_with_2DSegmentsTask, _rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask)
-stage2L1Trigger_2017.toReplaceWith(muonlocalrecoTask, _rpc_NewReadoutVal_muonlocalrecoTask)
-stage2L1Trigger_2017.toReplaceWith(muonlocalrecoT0SegTask, _rpc_NewReadoutVal_muonlocalrecoT0SegTask)
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(muonlocalreco_with_2DSegmentsTask, muonlocalreco_with_2DSegmentsTask.copyAndExclude([rpcNewRecHits]))
-fastSim.toReplaceWith(muonlocalrecoTask, muonlocalrecoTask.copyAndExclude([rpcNewRecHits]))
-fastSim.toReplaceWith(muonlocalrecoT0SegTask, muonlocalrecoT0SegTask.copyAndExclude([rpcNewRecHits]))
-

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -60,16 +60,3 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonlocalrecoTask , _run3_muonlocalrecoTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonlocalrecoTask , _phase2_muonlocalrecoTask )
-
-# RPC New Readout Validation
-from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask = muonlocalreco_with_2DSegmentsTask.copy()
-_rpc_NewReadoutVal_muonlocalrecoTask = muonlocalrecoTask.copy()
-_rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask.add(rpcNewRecHits)
-_rpc_NewReadoutVal_muonlocalrecoTask.add(rpcNewRecHits)
-stage2L1Trigger_2017.toReplaceWith(muonlocalreco_with_2DSegmentsTask, _rpc_NewReadoutVal_muonlocalreco_with_2DSegmentsTask)
-stage2L1Trigger_2017.toReplaceWith(muonlocalrecoTask, _rpc_NewReadoutVal_muonlocalrecoTask)
-
-from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toReplaceWith(muonlocalreco_with_2DSegmentsTask, muonlocalreco_with_2DSegmentsTask.copyAndExclude([rpcNewRecHits]))
-fastSim.toReplaceWith(muonlocalrecoTask, muonlocalrecoTask.copyAndExclude([rpcNewRecHits]))

--- a/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
+++ b/RecoLocalMuon/RPCRecHit/python/rpcRecHits_cfi.py
@@ -13,18 +13,6 @@ rpcRecHits = cms.EDProducer("RPCRecHitProducer",
     deadvecfile = cms.FileInPath('RecoLocalMuon/RPCRecHit/data/RPCDeadVec.dat')
 )
 
-rpcNewRecHits = cms.EDProducer("RPCRecHitProducer",
-    recAlgoConfig = cms.PSet(
-
-    ),
-    recAlgo = cms.string('RPCRecHitStandardAlgo'),
-    rpcDigiLabel = cms.InputTag('muonRPCNewDigis'),
-    maskSource = cms.string('File'),
-    maskvecfile = cms.FileInPath('RecoLocalMuon/RPCRecHit/data/RPCMaskVec.dat'),
-    deadSource = cms.string('File'),
-    deadvecfile = cms.FileInPath('RecoLocalMuon/RPCRecHit/data/RPCDeadVec.dat')
-)
-
 #disabling DIGI2RAW,RAW2DIGI chain for Phase2
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(rpcRecHits, rpcDigiLabel = cms.InputTag('simMuonRPCDigis'))


### PR DESCRIPTION
#### PR description:

- Complete the implementation of RPC Digi Collection Merger started in PR #24613
- Replace the temporary muonRPCNewDigis and rpcNewRecHits modules implemented in #24613 to the "default" muonRPCDigis and rpcRecHits 

#### PR validation:
scram b runtests
scram b code-checks
scram b code-formats 

runTheMatrix.py -l limited -i all --ibeos
32 31 30 24 12 2 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

@ftorresd @mileva  @BrieucF @jhgoh 
