### PR TITLE
Select the unpacker to be run (between SCAL and MetaData) via Era modifier

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -17,7 +17,6 @@ from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+from Configuration.Eras.Modifier_run2_onlineMetaData_2018_cff import run2_onlineMetaData_2018
 
-Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017]),
-run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
-run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018)
+Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017]), run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018, run2_onlineMetaData_2018)

--- a/Configuration/Eras/python/Modifier_run2_onlineMetaData_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_onlineMetaData_2018_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_onlineMetaData_2018 =  cms.Modifier()
+

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -60,7 +60,6 @@ RawToDigiTask = cms.Task(L1TRawToDigiTask,
                          castorDigis,
                          scalersRawToDigi,
                          tcdsDigis,
-                         onlineMetaDataDigis,
                          )
 RawToDigi = cms.Sequence(RawToDigiTask)
 
@@ -80,6 +79,12 @@ muonCSCDigis.InputObjects = 'rawDataCollector'
 muonDTDigis.inputLabel = 'rawDataCollector'
 muonRPCDigis.InputLabel = 'rawDataCollector'
 castorDigis.InputLabel = 'rawDataCollector'
+
+#Add OnlineMetaData only from Run2_2018
+from Configuration.Eras.Modifier_run2_onlineMetaData_2018_cff import run2_onlineMetaData_2018
+RawToDigiTask2018=RawToDigiTask.copy()
+RawToDigiTask2018.add(onlineMetaDataDigis)
+run2_onlineMetaData_2018.toReplaceWith(RawToDigiTask, RawToDigiTask2018)
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([castorDigis]))


### PR DESCRIPTION
## PR description:

Actually both unpacker (for Scalers and MetaData) are inserted in the RawToDigi sequence. With the changes proposed here the OnlineMetaData unpacker is inserted only starting from Era Run2_2018 (when these data start to be available). After these changes all the MetaData/SCAL consumers can simply select the available Handle exploiting isValid method in order to preserve backward compatibility of the code.

(with the same approach Scalers unpacker could be removed starting from Run3, if needed)

#### PR validation:

Manually tested on a run from 2017(no softFED1022) and one from 2018(with softFED1022).
1) 2017
cmsDriver.py step1 -s RAW2DIGI,L1Reco,RECO,DQM -n 100 --eventcontent DQM --datatier DQMIO --conditions 110X_dataRun2_v1 --filein /store/data/Run2018D/ZeroBias/RAW/v1/000/323/997/00000/DDE05469-39F3-0647-BC31-AA8247C0B6C1.root --data --no_exec --python_filename=runFirst2017.py --era Run2_2017
cmsRun runFirst2017.py

2) 2018
cmsDriver.py step1 -s RAW2DIGI,L1Reco,RECO,DQM -n 100 --eventcontent DQM --datatier DQMIO --conditions 110X_dataRun2_v1 --filein /store/data/Run2018D/ZeroBias/RAW/v1/000/323/997/00000/DDE05469-39F3-0647-BC31-AA8247C0B6C1.root --data --no_exec --python_filename=runFirst2018.py --era Run2_2018 
cmsRun runFirst2018.py

#### if this PR is a backport please specify the original PR:

is not a backport 