### PR TITLE
Introduce changes in order to switch from LumiScalers to MetaData 

### DIFF
--- a/DQM/TrackingMonitor/BuildFile.xml
+++ b/DQM/TrackingMonitor/BuildFile.xml
@@ -6,6 +6,7 @@
 <use   name="CommonTools/TriggerUtils"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/Luminosity"/>
+<use   name="DataFormats/OnlineMetaData"/>
 <use   name="DataFormats/VertexReco"/> 
 <use   name="DataFormats/PatCandidates"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>

--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -26,6 +26,7 @@ Monitoring source for general quantities related to tracks.
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
 
 class BeamSpot;
 class TrackAnalyzer {
@@ -80,6 +81,7 @@ private:
   edm::EDGetTokenT<reco::VertexCollection> pvToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
   edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+  edm::EDGetTokenT<OnlineLuminosityRecord> metaDataToken_;
   float lumi_factor_per_bx_;
 
   edm::ParameterSet const* conf_;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -41,6 +41,7 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 
 #include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
 
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
@@ -102,6 +103,7 @@ private:
   edm::EDGetTokenT<reco::CandidateView> regionCandidateToken_;
 
   edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+  edm::EDGetTokenT<OnlineLuminosityRecord> metaDataToken_;
 
   edm::InputTag stripClusterInputTag_;
   edm::InputTag pixelClusterInputTag_;

--- a/DQM/TrackingMonitor/interface/V0Monitor.h
+++ b/DQM/TrackingMonitor/interface/V0Monitor.h
@@ -23,6 +23,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
 
 class GenericTriggerEventFlag;
 
@@ -77,6 +78,7 @@ private:
   edm::EDGetTokenT<reco::BeamSpot> bsToken_;
   edm::EDGetTokenT<reco::VertexCollection> pvToken_;
   edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+  edm::EDGetTokenT<OnlineLuminosityRecord> metaDataToken_;
 
   int pvNDOF_;
 

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -67,6 +67,7 @@ TrackMon = DQMEDAnalyzer('TrackingMonitor',
     pvNDOF                              = cms.int32(4),
     pixelCluster4lumi                   = cms.InputTag('siPixelClustersPreSplitting'),
     scal                                = cms.InputTag('scalersRawToDigi'),
+    metadata                            = cms.InputTag('onlineMetaDataDigis'),
     useBPixLayer1                       = cms.bool(False),
     minNumberOfPixelsPerCluster         = cms.int32(2), # from DQM/PixelLumi/python/PixelLumiDQM_cfi.py
     minPixelClusterCharge               = cms.double(15000.),

--- a/DQM/TrackingMonitor/python/V0Monitor_cfi.py
+++ b/DQM/TrackingMonitor/python/V0Monitor_cfi.py
@@ -7,6 +7,7 @@ v0Monitor = DQMEDAnalyzer('V0Monitor',
    beamSpot      = cms.InputTag('offlineBeamSpot'),
    primaryVertex = cms.InputTag('offlinePrimaryVertices'),
    lumiScalers   = cms.InputTag('scalersRawToDigi'),
+   metadata      = cms.InputTag('onlineMetaDataDigis'),
    pvNDOF = cms.int32(4),   
    genericTriggerEventPSet = cms.PSet(),
    histoPSet = cms.PSet(


### PR DESCRIPTION
#### PR description:

With the changes proposed here the TkDQM module which make use of SCAL information about luminosity will, by default, first check the availability of MetaData and only if this are not available use SCAL info. This changes will work only together with PR #27676 which introduce a customization of the RawToDigi sequence via era modifier. 

#### PR validation:

To test it a manual merge of PR #27676 is needed otherwise the code will use luminosity info from metadata also for run where metadata are not available (OnlineLuminosityRecord filled with all 0).
Manually tested on a run from 2017(no softFED1022) and one from 2018(with softFED1022).
1) 2017
cmsDriver.py step1 -s RAW2DIGI,L1Reco,RECO,DQM -n 100 --eventcontent DQM --datatier DQMIO --conditions 110X_dataRun2_v1 --filein /store/data/Run2018D/ZeroBias/RAW/v1/000/323/997/00000/DDE05469-39F3-0647-BC31-AA8247C0B6C1.root --data --no_exec --python_filename=runFirst2017.py --era Run2_2017
cmsRun runFirst2017.py

2) 2018
cmsDriver.py step1 -s RAW2DIGI,L1Reco,RECO,DQM -n 100 --eventcontent DQM --datatier DQMIO --conditions 110X_dataRun2_v1 --filein /store/data/Run2018D/ZeroBias/RAW/v1/000/323/997/00000/DDE05469-39F3-0647-BC31-AA8247C0B6C1.root --data --no_exec --python_filename=runFirst2018.py --era Run2_2018 
cmsRun runFirst2018.py


#### if this PR is a backport please specify the original PR:

is not a backport