### PR TITLE
Updates to DT, PF hadron, HCAL, PPS and pixel calibrations for 2018 UL

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,11 +56,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_03_04_00_02',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_03_11_37_17',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_03_04_03_44',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_03_11_39_50',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v2',
+    'run1_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_02_16_26_41',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v2',
+    'run2_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_02_16_26_41',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_02_16_31_52',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v1',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_02_16_55_52',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v1',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_Candidate_2019_08_02_16_53_14',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_Candidate_2019_08_02_16_55_18',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -56,11 +56,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_02_16_44_50',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v1',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_02_16_45_22',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_02_16_26_41',
+    'run1_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_02_16_26_41',
+    'run2_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_02_16_31_52',
+    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_03_03_55_32',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_02_16_55_52',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -56,11 +56,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_02_16_44_50',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2019_08_03_04_00_02',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_02_16_45_22',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_Candidate_2019_08_03_04_03_44',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode


### PR DESCRIPTION
#### PR description:

This PR updates most of the conditions for the 2018 UL that are not dependent on the tracker alignment. For 2018 data, this includes the DT, PF hadron, HCAL, PPS and pixel calibrations. For 2018 MC, only the PF hadron calibration and pixel bad components are updated. ECAL conditions are not included because the ECAL intercalibration is not ready.

GT candidates are used rather than versioned GTs because it is not clear whether this PR or #27644 would be merged first and I would like to avoid the confusion of out-of-order GT versions.

For data, only 2018 IOVs are modified. Consequently, only 2018 data and MC should be affected by this PR.

GT diffs (data):
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v2/110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v2/110X_dataRun2_relval_Candidate_2019_08_03_03_55_32
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HEfail_v1/110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_02_16_55_52
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_v1/110X_dataRun2_PromptLike_Candidate_2019_08_02_16_53_14
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HI_v1/110X_dataRun2_PromptLike_HI_Candidate_2019_08_02_16_55_18

GT diffs (MC):

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_v1/110X_upgrade2018_realistic_Candidate_2019_08_03_11_37_17
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HEfail_v1/110X_upgrade2018_realistic_HEfail_Candidate_2019_08_03_11_39_50

#### PR validation:

The payload validation has been described in sign-off talks at AlCa meetings:

DT: https://indico.cern.ch/event/832785/contributions/3489416/attachments/1876295/3097194/20190626_DTCalib_AlCaDBmeeting_SGhosh_v2.pdf
PF hadron: https://indico.cern.ch/event/834090/contributions/3495432/attachments/1880854/3098893/PFHadronCalibration_Alca_DB_15_July_2019.pdf 
HCAL: https://indico.cern.ch/event/832785/contributions/3489397/attachments/1876358/3089810/Hcal_UL_2016_2018_July8_v1.pdf
PPS: https://indico.cern.ch/event/835589/#27-pps-calibration-sign-off-fo
Pixel: https://indico.cern.ch/event/834561/#25-tracker-sign-off-for-2018-u , https://indico.cern.ch/event/835589/contributions/3513525/attachments/1887574/3112176/20190729_AlCaDB_UL18FollowUp.pdf 

In addition, a technical validation of the autoCond modifications has been performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This is not a backport, though a 10_6_X backport will be needed.