### PR TITLE
Add support for ESInputTag to ParameterDescription

### DIFF
--- a/FWCore/Integration/test/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/test/ProducerWithPSetDesc.cc
@@ -284,6 +284,26 @@ namespace edmtest {
     assert(vInputTag[2] == inputTag3);
     assert(vInputTag[3] == inputTag4);
 
+    edm::ESInputTag esinputTag1("One", "Two");
+    assert(ps.getParameter<edm::ESInputTag>("esinputTagv1") == esinputTag1);
+    edm::ESInputTag esinputTag2("One", "");
+    assert(ps.getParameter<edm::ESInputTag>("esinputTagv2") == esinputTag2);
+    edm::ESInputTag esinputTag3("", "Two");
+    assert(ps.getParameter<edm::ESInputTag>("esinputTagv3") == esinputTag3);
+
+    std::vector<edm::ESInputTag> vESInputTag;
+    vESInputTag = ps.getParameter<std::vector<edm::ESInputTag>>("vESInputTagv1");
+    assert(vESInputTag.empty());
+    vESInputTag = ps.getParameter<std::vector<edm::ESInputTag>>("vESInputTagv2");
+    assert(vESInputTag[0] == esinputTag1);
+    vESInputTag = ps.getParameter<std::vector<edm::ESInputTag>>("vESInputTagv3");
+    assert(vESInputTag[0] == esinputTag1);
+    assert(vESInputTag[1] == esinputTag2);
+    vESInputTag = ps.getParameter<std::vector<edm::ESInputTag>>("vESInputTagv4");
+    assert(vESInputTag[0] == esinputTag1);
+    assert(vESInputTag[1] == esinputTag2);
+    assert(vESInputTag[2] == esinputTag3);
+
     // For purposes of the test, this just needs to point to any file
     // that exists.  I guess pointing to itself cannot ever fail ...
     edm::FileInPath fileInPath("FWCore/Integration/test/ProducerWithPSetDesc.cc");
@@ -653,6 +673,22 @@ namespace edmtest {
     iDesc.add<std::vector<edm::InputTag>>("vInputTagv4", vInputTag);
     vInputTag.push_back(inputTag4);
     iDesc.add<std::vector<edm::InputTag>>("vInputTagv5", vInputTag);
+
+    edm::ESInputTag esinputTag("One", "Two");
+    iDesc.add<edm::ESInputTag>("esinputTagv1", esinputTag);
+    edm::ESInputTag esinputTag2("One", "");
+    iDesc.add<edm::ESInputTag>("esinputTagv2", esinputTag2);
+    edm::ESInputTag esinputTag3("", "Two");
+    iDesc.add<edm::ESInputTag>("esinputTagv3", esinputTag3);
+
+    std::vector<edm::ESInputTag> vESInputTag;
+    iDesc.add<std::vector<edm::ESInputTag>>("vESInputTagv1", vESInputTag);
+    vESInputTag.push_back(esinputTag);
+    iDesc.add<std::vector<edm::ESInputTag>>("vESInputTagv2", vESInputTag);
+    vESInputTag.push_back(esinputTag2);
+    iDesc.add<std::vector<edm::ESInputTag>>("vESInputTagv3", vESInputTag);
+    vESInputTag.push_back(esinputTag3);
+    iDesc.add<std::vector<edm::ESInputTag>>("vESInputTagv4", vESInputTag);
 
     // For purposes of the test, this just needs to point to any file
     // that exists.  I guess pointing to itself cannot ever fail ...

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
@@ -146,6 +146,19 @@
       [1]: 'One:Two'
       [2]: 'One'
       [3]: 'One::Three'
+    esinputTagv1            ESInputTag                     'One:Two'
+    esinputTagv2            ESInputTag                     'One:'
+    esinputTagv3            ESInputTag                     ':Two'
+    vESInputTagv1           VESInputTag                    empty
+    vESInputTagv2           VESInputTag                    (vector size = 1)
+      [0]: 'One:Two'
+    vESInputTagv3           VESInputTag                    (vector size = 2)
+      [0]: 'One:Two'
+      [1]: 'One:'
+    vESInputTagv4           VESInputTag                    (vector size = 3)
+      [0]: 'One:Two'
+      [1]: 'One:'
+      [2]: ':Two'
     fileInPath              FileInPath                     'FWCore/Integration/test/ProducerWithPSetDesc.cc'
     Empty group description
     bar                     PSet                           see Section 1.1.2

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
@@ -165,6 +165,20 @@ testProducerWithPsetDesc = cms.EDProducer('ProducerWithPSetDesc',
     'One',
     'One::Three'
   ),
+  esinputTagv1 = cms.ESInputTag('One', 'Two'),
+  esinputTagv2 = cms.ESInputTag('One', ''),
+  esinputTagv3 = cms.ESInputTag('', 'Two'),
+  vESInputTagv1 = cms.VESInputTag(),
+  vESInputTagv2 = cms.VESInputTag('One:Two'),
+  vESInputTagv3 = cms.VESInputTag(
+    'One:Two',
+    'One:'
+  ),
+  vESInputTagv4 = cms.VESInputTag(
+    'One:Two',
+    'One:',
+    ':Two'
+  ),
   fileInPath = cms.FileInPath('FWCore/Integration/test/ProducerWithPSetDesc.cc'),
   bar = cms.PSet(
     Drinks = cms.uint32(5),

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
@@ -397,6 +397,40 @@ generated for each configuration with a module label.
                           [2]: 'One'
                           [3]: 'One::Three'
 
+    esinputTagv1
+                        type: ESInputTag 
+                        default: 'One:Two'
+
+    esinputTagv2
+                        type: ESInputTag 
+                        default: 'One:'
+
+    esinputTagv3
+                        type: ESInputTag 
+                        default: ':Two'
+
+    vESInputTagv1
+                        type: VESInputTag 
+                        default: empty
+
+    vESInputTagv2
+                        type: VESInputTag 
+                        default: (vector size = 1)
+                          [0]: 'One:Two'
+
+    vESInputTagv3
+                        type: VESInputTag 
+                        default: (vector size = 2)
+                          [0]: 'One:Two'
+                          [1]: 'One:'
+
+    vESInputTagv4
+                        type: VESInputTag 
+                        default: (vector size = 3)
+                          [0]: 'One:Two'
+                          [1]: 'One:'
+                          [2]: ':Two'
+
     fileInPath
                         type: FileInPath 
                         default: 'FWCore/Integration/test/ProducerWithPSetDesc.cc'

--- a/FWCore/ParameterSet/interface/ParameterDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterDescription.h
@@ -37,6 +37,7 @@ namespace edm {
   class LuminosityBlockRange;
   class EventRange;
   class InputTag;
+  class ESInputTag;
   class FileInPath;
   class DocFormatHelper;
 
@@ -73,6 +74,8 @@ namespace edm {
     void writeValue(std::ostream& os, int indentation, std::vector<EventRange> const& value_, ValueFormat format);
     void writeValue(std::ostream& os, int indentation, InputTag const& value_, ValueFormat format);
     void writeValue(std::ostream& os, int indentation, std::vector<InputTag> const& value_, ValueFormat format);
+    void writeValue(std::ostream& os, int indentation, ESInputTag const& value_, ValueFormat format);
+    void writeValue(std::ostream& os, int indentation, std::vector<ESInputTag> const& value_, ValueFormat format);
     void writeValue(std::ostream& os, int indentation, FileInPath const& value_, ValueFormat format);
 
     bool hasNestedContent(int const& value);
@@ -98,6 +101,8 @@ namespace edm {
     bool hasNestedContent(std::vector<EventRange> const& value);
     bool hasNestedContent(InputTag const& value);
     bool hasNestedContent(std::vector<InputTag> const& value);
+    bool hasNestedContent(ESInputTag const& value);
+    bool hasNestedContent(std::vector<ESInputTag> const& value);
     bool hasNestedContent(FileInPath const& value);
   }  // namespace writeParameterValue
 

--- a/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
@@ -50,6 +50,8 @@ namespace edm {
     k_VLuminosityBlockID = 'm',
     k_InputTag = 't',
     k_VInputTag = 'v',
+    k_ESInputTag = 'g',
+    k_VESInputTag = 'G',
     k_FileInPath = 'F',
     k_LuminosityBlockRange = 'A',
     k_VLuminosityBlockRange = 'a',

--- a/FWCore/ParameterSet/src/ParameterDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterDescription.cc
@@ -13,6 +13,7 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 
 #include <cassert>
 #include <cstdlib>
@@ -519,6 +520,15 @@ namespace edm {
     }
 
     template <>
+    void writeSingleValue<ESInputTag>(std::ostream& os, ESInputTag const& value, ValueFormat format) {
+      if (format == CFI) {
+        os << "'" << value.module() << "', '" << value.data() << "'";
+      } else {
+        os << "'" << value.module() << ":" << value.data() << "'";
+      }
+    }
+
+    template <>
     void writeSingleValue<FileInPath>(std::ostream& os, FileInPath const& value, ValueFormat) {
       os << "'" << value.relativePath() << "'";
     }
@@ -571,6 +581,11 @@ namespace edm {
         os << ":" << value.process();
       }
       os << "'";
+    }
+
+    template <>
+    void writeValueInVector<ESInputTag>(std::ostream& os, ESInputTag const& value, ValueFormat) {
+      os << "'" << value.module() << ":" << value.data() << "'";
     }
 
     template <typename T>
@@ -721,6 +736,14 @@ namespace edm {
       writeVector<InputTag>(os, indentation, value_, format);
     }
 
+    void writeValue(std::ostream& os, int, ESInputTag const& value_, ValueFormat format) {
+      writeValue<ESInputTag>(os, value_, format);
+    }
+
+    void writeValue(std::ostream& os, int indentation, std::vector<ESInputTag> const& value_, ValueFormat format) {
+      writeVector<ESInputTag>(os, indentation, value_, format);
+    }
+
     void writeValue(std::ostream& os, int, FileInPath const& value_, ValueFormat format) {
       writeValue<FileInPath>(os, value_, format);
     }
@@ -748,6 +771,8 @@ namespace edm {
     bool hasNestedContent(std::vector<EventRange> const& value) { return value.size() > 5U; }
     bool hasNestedContent(InputTag const&) { return false; }
     bool hasNestedContent(std::vector<InputTag> const& value) { return value.size() > 5U; }
+    bool hasNestedContent(ESInputTag const&) { return false; }
+    bool hasNestedContent(std::vector<ESInputTag> const& value) { return value.size() > 5U; }
     bool hasNestedContent(FileInPath const&) { return false; }
   }  // namespace writeParameterValue
 }  // namespace edm

--- a/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionNode.cc
@@ -26,6 +26,7 @@ namespace edm {
   class LuminosityBlockRange;
   class EventRange;
   class InputTag;
+  class ESInputTag;
   class FileInPath;
 
   TYPE_TO_ENUM(int, k_int32)
@@ -47,6 +48,8 @@ namespace edm {
   TYPE_TO_ENUM(std::vector<LuminosityBlockID>, k_VLuminosityBlockID)
   TYPE_TO_ENUM(InputTag, k_InputTag)
   TYPE_TO_ENUM(std::vector<InputTag>, k_VInputTag)
+  TYPE_TO_ENUM(ESInputTag, k_ESInputTag)
+  TYPE_TO_ENUM(std::vector<ESInputTag>, k_VESInputTag)
   TYPE_TO_ENUM(FileInPath, k_FileInPath)
   TYPE_TO_ENUM(LuminosityBlockRange, k_LuminosityBlockRange)
   TYPE_TO_ENUM(std::vector<LuminosityBlockRange>, k_VLuminosityBlockRange)
@@ -79,6 +82,8 @@ namespace edm {
       TYPE_TO_NAME(VLuminosityBlockID);
       TYPE_TO_NAME(InputTag);
       TYPE_TO_NAME(VInputTag);
+      TYPE_TO_NAME(ESInputTag);
+      TYPE_TO_NAME(VESInputTag);
       TYPE_TO_NAME(FileInPath);
       TYPE_TO_NAME(PSet);
       TYPE_TO_NAME(VPSet);

--- a/FWCore/ParameterSet/test/parameterSetDescription_t.cc
+++ b/FWCore/ParameterSet/test/parameterSetDescription_t.cc
@@ -1481,6 +1481,12 @@ int main(int, char**) try {
   assert(par->type() == edm::k_InputTag);
   assert(edm::parameterTypeEnumToString(par->type()) == std::string("InputTag"));
 
+  edm::ESInputTag k;
+  par = psetDesc.add<edm::ESInputTag>("esinput", k);
+  pset.addParameter<edm::ESInputTag>("esinput", k);
+  assert(par->type() == edm::k_ESInputTag);
+  assert(edm::parameterTypeEnumToString(par->type()) == std::string("ESInputTag"));
+
   std::vector<int> v1;
   par = psetDesc.add<std::vector<int>>("v1", v1);
   pset.addParameter<std::vector<int>>("v1", v1);
@@ -1534,6 +1540,12 @@ int main(int, char**) try {
   pset.addParameter<std::vector<edm::InputTag>>("v9", v9);
   assert(par->type() == edm::k_VInputTag);
   assert(edm::parameterTypeEnumToString(par->type()) == std::string("VInputTag"));
+
+  std::vector<edm::ESInputTag> v11;
+  par = psetDesc.add<std::vector<edm::ESInputTag>>("v11", v11);
+  pset.addParameter<std::vector<edm::ESInputTag>>("v11", v11);
+  assert(par->type() == edm::k_VESInputTag);
+  assert(edm::parameterTypeEnumToString(par->type()) == std::string("VESInputTag"));
 
   edm::ParameterSetDescription m;
   par = psetDesc.add<edm::ParameterSetDescription>("psetDesc", m);


### PR DESCRIPTION
#### PR description:

It was noticed in https://github.com/cms-sw/cmssw/issues/27660 that ESInputTag parameters can not be added in `fillDescriptions()`. This PR adds the support.

#### PR validation:

Code compiles and unit tests succeed.