### PR TITLE
DD4Hep: Tracker overlaps TEC

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
@@ -43,14 +43,16 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   double topFrame2LHeight = isStereo ? args.value<double>("TopFrame2LHeight") : 0e0;  //             left  height
   double topFrame2RHeight = isStereo ? args.value<double>("TopFrame2RHeight") : 0e0;  //             right height
   double topFrameZ = args.value<double>("TopFrameZ");                                 //              z-positions
+
+  double resizeH = 0.96;
   string sideFrameMat = args.value<string>("SideFrameMaterial");                      //Side frame    material
   double sideFrameThick = args.value<double>("SideFrameThick");                       //              thickness
   double sideFrameLWidth = args.value<double>("SideFrameLWidth");  //    Left     Width (for stereo modules upper one)
   double sideFrameLWidthLow = isStereo ? args.value<double>("SideFrameLWidthLow")
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
-  double sideFrameLHeight = args.value<double>("SideFrameLHeight");  //             Height
+  double sideFrameLHeight = resizeH * args.value<double>("SideFrameLHeight");  //             Height
   double sideFrameLtheta = args.value<double>("SideFrameLtheta");    //              angle of the trapezoid shift
-  double sideFrameRWidth = args.value<double>("SideFrameRWidth");    //    Right    Width (for stereo modules upper one)
+  double sideFrameRWidth = resizeH * args.value<double>("SideFrameRWidth");    //    Right    Width (for stereo modules upper one)
   double sideFrameRWidthLow = isStereo ? args.value<double>("SideFrameRWidthLow")
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
   double sideFrameRHeight = args.value<double>("SideFrameRHeight");  //             Height

--- a/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
@@ -45,14 +45,15 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   double topFrameZ = args.value<double>("TopFrameZ");                                 //              z-positions
 
   double resizeH = 0.96;
-  string sideFrameMat = args.value<string>("SideFrameMaterial");                      //Side frame    material
-  double sideFrameThick = args.value<double>("SideFrameThick");                       //              thickness
+  string sideFrameMat = args.value<string>("SideFrameMaterial");   //Side frame    material
+  double sideFrameThick = args.value<double>("SideFrameThick");    //              thickness
   double sideFrameLWidth = args.value<double>("SideFrameLWidth");  //    Left     Width (for stereo modules upper one)
   double sideFrameLWidthLow = isStereo ? args.value<double>("SideFrameLWidthLow")
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
   double sideFrameLHeight = resizeH * args.value<double>("SideFrameLHeight");  //             Height
-  double sideFrameLtheta = args.value<double>("SideFrameLtheta");    //              angle of the trapezoid shift
-  double sideFrameRWidth = resizeH * args.value<double>("SideFrameRWidth");    //    Right    Width (for stereo modules upper one)
+  double sideFrameLtheta = args.value<double>("SideFrameLtheta");  //              angle of the trapezoid shift
+  double sideFrameRWidth =
+      resizeH * args.value<double>("SideFrameRWidth");  //    Right    Width (for stereo modules upper one)
   double sideFrameRWidthLow = isStereo ? args.value<double>("SideFrameRWidthLow")
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
   double sideFrameRHeight = args.value<double>("SideFrameRHeight");  //             Height
@@ -219,12 +220,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
            dz * cos(detTilt + fabs(thet)) / cos(fabs(thet)) + bl2 * sin(detTilt) - 0.1_mm;
   }
   //position
-  mother.placeVolume(sideFrameLeft, isStereo? 2 : 1,
-                     dd4hep::Transform3D(ns.rotation(waferRot),
-                                         dd4hep::Position( zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos,
-                                                           ypos)));
-
-
+  mother.placeVolume(
+      sideFrameLeft,
+      isStereo ? 2 : 1,
+      dd4hep::Transform3D(ns.rotation(waferRot),
+                          dd4hep::Position(zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos, ypos)));
 
   //right Frame
   name = idName + "SideFrameRight";
@@ -256,10 +256,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
            dz * cos(detTilt - fabs(thet)) / cos(fabs(thet)) - bl2 * sin(detTilt) - 0.1_mm;
   }
   //position it
-  mother.placeVolume(sideFrameRight, isStereo? 2 : 1,
-                     dd4hep::Transform3D(ns.rotation(waferRot),
-                                         dd4hep::Position( zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos,
-                                                           ypos)));
+  mother.placeVolume(
+      sideFrameRight,
+      isStereo ? 2 : 1,
+      dd4hep::Transform3D(ns.rotation(waferRot),
+                          dd4hep::Position(zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos, ypos)));
   //Supplies Box(es)
   matter = ns.material(siFrSuppBoxMat);
   for (int i = 0; i < (int)(siFrSuppBoxWidth.size()); i++) {
@@ -297,10 +298,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
              siFrSuppBoxYPos[i] - sin(detTilt) * sideFrameRWidth;
     }
     //position it;
-    mother.placeVolume(siFrSuppBox, isStereo? 2 : 1,
-                       dd4hep::Transform3D(ns.rotation(waferRot),
-                                           dd4hep::Position( zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos,
-                                                             ypos)));
+    mother.placeVolume(siFrSuppBox,
+                       isStereo ? 2 : 1,
+                       dd4hep::Transform3D(
+                           ns.rotation(waferRot),
+                           dd4hep::Position(zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos, ypos)));
   }
 
   //The Hybrid
@@ -320,10 +322,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   if (isRing6)
     zpos *= -1;
   //position it
-  mother.placeVolume(hybrid, isStereo? 2 : 1,
-                     dd4hep::Transform3D(ns.rotation(standardRot),
-                                         dd4hep::Position( zpos + rPos, isStereo ?  rPos * sin(posCorrectionPhi) : 0.,
-                                                           ypos)));
+  mother.placeVolume(
+      hybrid,
+      isStereo ? 2 : 1,
+      dd4hep::Transform3D(ns.rotation(standardRot),
+                          dd4hep::Position(zpos + rPos, isStereo ? rPos * sin(posCorrectionPhi) : 0., ypos)));
 
   // Wafer
   name = idName + tag + "Wafer";
@@ -343,11 +346,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   if (isRing6)
     zpos *= -1;
 
-  mother.placeVolume(wafer, isStereo? 2 : 1,
-                     dd4hep::Transform3D(ns.rotation(waferRot),
-                                         dd4hep::Position(zpos + rPos, isStereo ? rPos * sin(posCorrectionPhi) : 0.,
-                                                           ypos)));
-
+  mother.placeVolume(
+      wafer,
+      isStereo ? 2 : 1,
+      dd4hep::Transform3D(ns.rotation(waferRot),
+                          dd4hep::Position(zpos + rPos, isStereo ? rPos * sin(posCorrectionPhi) : 0., ypos)));
 
   // Active
   name = idName + tag + "Active";
@@ -368,8 +371,8 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   Volume active(name, solid, ns.material(activeMat));
   ns.addVolumeNS(active);
 
-  wafer.placeVolume(active, 1, dd4hep::Transform3D(ns.rotation(activeRot),
-                                                   dd4hep::Position( 0., -0.5*backplaneThick, 0.))); 
+  wafer.placeVolume(
+      active, 1, dd4hep::Transform3D(ns.rotation(activeRot), dd4hep::Position(0., -0.5 * backplaneThick, 0.)));
 
   //inactive part in rings > 3
   if (ringNo > 3) {
@@ -397,9 +400,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     ns.addVolumeNS(inactive);
     ypos = inactivePos - 0.5 * activeHeight;
 
-    active.placeVolume(inactive, 1, dd4hep::Transform3D(ns.rotation(standardRot),
-                                                        dd4hep::Position(0., ypos, 0.)));
-
+    active.placeVolume(inactive, 1, dd4hep::Transform3D(ns.rotation(standardRot), dd4hep::Position(0., ypos, 0.)));
   }
   //Pitch Adapter
   name = idName + "PA";
@@ -433,14 +434,12 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
 
   Volume pa(name, solid, ns.material(pitchMat));
   if (isStereo)
-    mother.placeVolume(pa, 2,
+    mother.placeVolume(pa,
+                       2,
                        dd4hep::Transform3D(ns.rotation(pitchRot),
-                                           dd4hep::Position( zpos + rPos, xpos + rPos * sin(posCorrectionPhi),
-                                                             ypos)));
+                                           dd4hep::Position(zpos + rPos, xpos + rPos * sin(posCorrectionPhi), ypos)));
   else
-    mother.placeVolume(pa, 1,
-                     dd4hep::Transform3D(ns.rotation(standardRot),
-                                         dd4hep::Position( zpos + rPos, xpos, ypos)));
+    mother.placeVolume(pa, 1, dd4hep::Transform3D(ns.rotation(standardRot), dd4hep::Position(zpos + rPos, xpos, ypos)));
 
   //Top of the frame
   name = idName + "TopFrame";
@@ -484,20 +483,19 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     zpos *= -1;
   }
 
-
-
-  mother.placeVolume(topFrame, isStereo? 2 : 1,
-                     dd4hep::Transform3D(ns.rotation(standardRot),
-                                         dd4hep::Position( zpos + rPos, isStereo ? rPos * sin(posCorrectionPhi) : 0.,
-                                                           ypos)));
+  mother.placeVolume(
+      topFrame,
+      isStereo ? 2 : 1,
+      dd4hep::Transform3D(ns.rotation(standardRot),
+                          dd4hep::Position(zpos + rPos, isStereo ? rPos * sin(posCorrectionPhi) : 0., ypos)));
   if (isStereo) {
     //create
     Volume topFrame2(name, solid, ns.material(topFrameMat));
     zpos -= 0.5 * (topFrameHeight + 0.5 * (topFrame2LHeight + topFrame2RHeight));
-    mother.placeVolume(topFrame2, 2,
-                       dd4hep::Transform3D(ns.rotation(pitchRot),
-                                           dd4hep::Position( zpos + rPos, rPos * sin(posCorrectionPhi),
-                                                             ypos)));
+    mother.placeVolume(
+        topFrame2,
+        2,
+        dd4hep::Transform3D(ns.rotation(pitchRot), dd4hep::Position(zpos + rPos, rPos * sin(posCorrectionPhi), ypos)));
   }
 
   //Si - Reencorcement
@@ -528,11 +526,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
       zpos -= topFrame2RHeight + sin(fabs(detTilt)) * 0.5 * topFrame2Width;
     }
 
-
-    mother.placeVolume(siReenforce, isStereo? 2 : 1,
-                       dd4hep::Transform3D(ns.rotation(waferRot),
-                                           dd4hep::Position( zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos,
-                                                             ypos)));
+    mother.placeVolume(siReenforce,
+                       isStereo ? 2 : 1,
+                       dd4hep::Transform3D(
+                           ns.rotation(waferRot),
+                           dd4hep::Position(zpos + rPos, isStereo ? xpos + rPos * sin(posCorrectionPhi) : xpos, ypos)));
   }
 
   //Bridge


### PR DESCRIPTION
#### PR description:

This PR addresses overlaps on tracker endcap modules

#### PR validation:

master:

![master](https://user-images.githubusercontent.com/16821717/62455419-95471b80-b776-11e9-8aa9-1be506e7f5b7.png)

master + thisPr:

![thisPr](https://user-images.githubusercontent.com/16821717/62455396-882a2c80-b776-11e9-8857-3f7e346473f9.png)

```
cmsRun DetectorDescription/DDCMS/test/python/testTracker2021Geometry.py >Tracker2021.Log
./cmsShow -c simGeo.fwc --sim-geom-file cmsDD4HepGeom.root --tgeo-name=CMS
```


Reference:

![Reference](https://user-images.githubusercontent.com/16821717/62455405-8e200d80-b776-11e9-95c1-ffa0d0ccdb08.png)

```
cmsRun $CMSSW_RELEASE_BASE/src/Fireworks/Geometry/python/dumpSimGeometry_cfg.py tag=2021
 ./cmsShow -c simGeo.fwc --sim-geom-file cmsSimGeom-2021.root --tgeo-name=cmsGeo
```

#### Note:
Path:

```
/tracker:Tracker_1/tec:TEC_1/tec:TECWheels_1/tecwheela:TECWheelA_0/tecpetal0f:TECPetalCont0F_1/tecring0f:TECRing0F_1/tecmodule0:TECModule0_1
```

Some shapes:

```
*** Shape tecmodule0s:TECModule0SideFrameLeft_shape_0x7fad33bb0300: TGeoArb8 ***
    point #0 : x=   -0.65466 y=   -0.03820 z=   -4.59840
    point #1 : x=   -0.65466 y=    0.03820 z=   -4.59840
    point #2 : x=    1.47534 y=    0.03820 z=   -4.59840
    point #3 : x=    1.47534 y=   -0.03820 z=   -4.59840
    point #4 : x=   -0.98534 y=   -0.03820 z=    4.59840
    point #5 : x=   -0.98534 y=    0.03820 z=    4.59840
    point #6 : x=    0.16466 y=    0.03820 z=    4.59840
    point #7 : x=    0.16466 y=   -0.03820 z=    4.59840
 Bounding box:
*** Shape tecmodule0s:TECModule0SideFrameLeft_shape_0x7fad33bb0300: TGeoBBox ***
    dX =     1.23034
    dY =     0.03820
    dZ =     4.59840
    origin: x=    0.24500 y=    0.00000 z=    0.00000
*** Shape tecmodule0s:TECModule0SideFrameLeft: TGeoArb8 ***
    point #0 : x=   -0.65466 y=   -0.03820 z=   -4.59840
    point #1 : x=   -0.65466 y=    0.03820 z=   -4.59840
    point #2 : x=    1.47534 y=    0.03820 z=   -4.59840
    point #3 : x=    1.47534 y=   -0.03820 z=   -4.59840
    point #4 : x=   -0.98534 y=   -0.03820 z=    4.59840
    point #5 : x=   -0.98534 y=    0.03820 z=    4.59840
    point #6 : x=    0.16466 y=    0.03820 z=    4.59840
    point #7 : x=    0.16466 y=   -0.03820 z=    4.59840
 Bounding box:
*** Shape tecmodule0s:TECModule0SideFrameLeft: TGeoBBox ***
    dX =     1.23034
    dY =     0.03820
    dZ =     4.59840
    origin: x=    0.24500 y=    0.00000 z=    0.00000
*** Shape tecmodule0r:TECModule0RphiWafer: TGeoArb8 ***
    point #0 : x=   -3.23050 y=   -0.01600 z=   -4.36180
    point #1 : x=   -3.23050 y=    0.01600 z=   -4.36180
    point #2 : x=    3.23050 y=    0.01600 z=   -4.36180
    point #3 : x=    3.23050 y=   -0.01600 z=   -4.36180
    point #4 : x=   -4.39570 y=   -0.01600 z=    4.36180
    point #5 : x=   -4.39570 y=    0.01600 z=    4.36180
    point #6 : x=    4.39570 y=    0.01600 z=    4.36180
    point #7 : x=    4.39570 y=   -0.01600 z=    4.36180
 Bounding box:
*** Shape tecmodule0r:TECModule0RphiWafer: TGeoBBox ***
    dX =     4.39570
    dY =     0.01600
    dZ =     4.36180
    origin: x=    0.00000 y=    0.00000 z=    0.00000
*** Shape tecmodule0r:TECModule0RphiWafer_shape_0x7fad33a75b80: TGeoArb8 ***
    point #0 : x=   -3.23050 y=   -0.01600 z=   -4.36180
    point #1 : x=   -3.23050 y=    0.01600 z=   -4.36180
    point #2 : x=    3.23050 y=    0.01600 z=   -4.36180
    point #3 : x=    3.23050 y=   -0.01600 z=   -4.36180
    point #4 : x=   -4.39570 y=   -0.01600 z=    4.36180
    point #5 : x=   -4.39570 y=    0.01600 z=    4.36180
    point #6 : x=    4.39570 y=    0.01600 z=    4.36180
    point #7 : x=    4.39570 y=   -0.01600 z=    4.36180
 Bounding box:
*** Shape tecmodule0r:TECModule0RphiWafer_shape_0x7fad33a75b80: TGeoBBox ***
    dX =     4.39570
    dY =     0.01600
    dZ =     4.36180
    origin: x=    0.00000 y=    0.00000 z=    0.00000
```
