### PR TITLE
Fix pixel fiducial volume selection for cosmics

### DIFF
--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -153,7 +153,7 @@ namespace {
 
       // find out whether track crosses pixel fiducial volume (for cosmic tracks)
       auto d0 = track.d0(), dz = track.dz();
-      if (std::abs(d0) < 15 && std::abs(dz) < 50)
+      if (std::abs(d0) < 16 && std::abs(dz) < 50)
         crossesPixVol = true;
 
       auto etatk = track.eta();


### PR DESCRIPTION
#### PR description:

Fix a tracker acceptance cut, used in cosmic to determine if a cosmic track is crossing the pixel volume. It was not updated to match the pixel phase 1 (was 15 cm, updated to 16). This is a minor change in the SiPixelPhase1Track code.

#### PR validation:

Compile and 

runTheMatrix.py -l limited -i all --ibeos

