### PR TITLE
Provide fillDescriptions for Pixel CPE classes

### DIFF
--- a/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
@@ -15,7 +15,6 @@ hltESPDummyDetLayerGeometry = DummyDetLayerGeometry.clone(
 ##     make sure they are not already defined somewhereelse in the final configuration
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import templates
 hltESPPixelCPETemplateReco = templates.clone(
-  DoCosmics = cms.bool( False ),
   LoadTemplatesFromDB = cms.bool( True ),
   ComponentName = cms.string( "hltESPPixelCPETemplateReco" ),
   Alpha2Order = cms.bool( True ),
@@ -36,7 +35,6 @@ hltESPPixelCPEGeneric = PixelCPEGenericESProducer.clone(
   size_cutX = cms.double( 3.0 ),
   inflate_all_errors_no_trk_angle = cms.bool( False ),
   IrradiationBiasCorrection = cms.bool( False ),
-  TanLorentzAnglePerTesla = cms.double( 0.106 ),
   inflate_errors = cms.bool( False ),
   eff_charge_cut_lowX = cms.double( 0.0 ),
   eff_charge_cut_highY = cms.double( 1.0 ),
@@ -44,7 +42,6 @@ hltESPPixelCPEGeneric = PixelCPEGenericESProducer.clone(
   EdgeClusterErrorY = cms.double( 85.0 ),
   ComponentName = cms.string( "hltESPPixelCPEGeneric" ),
   eff_charge_cut_lowY = cms.double( 0.0 ),
-  PixelErrorParametrization = cms.string( "NOTcmsim" ),
   Alpha2Order = cms.bool( True )
 )
 

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -64,7 +64,6 @@ HLTSiStripMonitorCluster.TH1NClusStrip = cms.PSet(
         xmin = cms.double(-0.5)
     )
 hltESPPixelCPETemplateReco = cms.ESProducer( "PixelCPETemplateRecoESProducer",
-  DoCosmics = cms.bool( False ),
   LoadTemplatesFromDB = cms.bool( True ),
   ComponentName = cms.string( "hltESPPixelCPETemplateReco" ),
   Alpha2Order = cms.bool( True ),
@@ -84,7 +83,6 @@ hltESPPixelCPEGeneric = cms.ESProducer( "PixelCPEGenericESProducer",
   size_cutX = cms.double( 3.0 ),
   inflate_all_errors_no_trk_angle = cms.bool( False ),
   IrradiationBiasCorrection = cms.bool( False ),
-  TanLorentzAnglePerTesla = cms.double( 0.106 ),
   inflate_errors = cms.bool( False ),
   eff_charge_cut_lowX = cms.double( 0.0 ),
   eff_charge_cut_highY = cms.double( 1.0 ),
@@ -92,7 +90,6 @@ hltESPPixelCPEGeneric = cms.ESProducer( "PixelCPEGenericESProducer",
   EdgeClusterErrorY = cms.double( 85.0 ),
   ComponentName = cms.string( "hltESPPixelCPEGeneric" ),
   eff_charge_cut_lowY = cms.double( 0.0 ),
-  PixelErrorParametrization = cms.string( "NOTcmsim" ),
   Alpha2Order = cms.bool( True )
 )
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -46,11 +46,23 @@ def customiseFor2017DtUnpacking(process):
 
     return process
 
+def customiseFor27694(process) :
+
+    for producer in esproducers_by_type(process, "PixelCPETemplateRecoESProducer"):
+        if hasattr(producer, "DoCosmics"): del producer.DoCosmics
+
+    for producer in esproducers_by_type(process, "PixelCPEGenericESProducer"):
+        if hasattr(producer, "TanLorentzAnglePerTesla"): del producer.TanLorentzAnglePerTesla
+        if hasattr(producer, "PixelErrorParametrization"): del producer.PixelErrorParametrization
+
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customiseFor27694(process)
 
     return process

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -27,6 +27,7 @@
 
 //--- For the configuration:
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
@@ -127,6 +128,8 @@ public:
                const SiPixelLorentzAngle* lorentzAngleWidth,
                int flag = 0  // flag=0 for generic, =1 for templates
   );                         // NEW
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
   //--------------------------------------------------------------------------
   // Allow the magnetic field to be set/updated later.

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -61,6 +61,8 @@ public:
 
   ~PixelCPEClusterRepair() override;
 
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
+
 private:
   ClusterParam *createClusterParam(const SiPixelCluster &cl) const override;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -86,6 +86,8 @@ public:
 
   ~PixelCPEGeneric() override { ; }
 
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
+
 private:
   ClusterParam *createClusterParam(const SiPixelCluster &cl) const override;
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -60,6 +60,8 @@ public:
 
   ~PixelCPETemplateReco() override;
 
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
+
 private:
   ClusterParam *createClusterParam(const SiPixelCluster &cl) const override;
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -71,6 +71,9 @@ void PixelCPEClusterRepairESProducer::fillDescriptions(edm::ConfigurationDescrip
 
   // from PixelCPEClusterRepair
   PixelCPEClusterRepair::fillPSetDescription(desc);
+
+  // specific to PixelCPEClusterRepairESProducer
+  desc.add<bool>("DoLorentz", true);
   descriptions.add("_templates2_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -71,8 +71,7 @@ void PixelCPEClusterRepairESProducer::fillDescriptions(edm::ConfigurationDescrip
 
   // from PixelCPEClusterRepair
   PixelCPEClusterRepair::fillPSetDescription(desc);
-
-  descriptions.add("templates2", desc);
+  descriptions.add("_templates2_default", desc);
 }
 
 std::unique_ptr<PixelClusterParameterEstimator> PixelCPEClusterRepairESProducer::produce(

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -64,23 +64,14 @@ PixelCPEClusterRepairESProducer::~PixelCPEClusterRepairESProducer() {}
 void PixelCPEClusterRepairESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // templates2
   edm::ParameterSetDescription desc;
-  desc.add<bool>("DoLorentz", true);
-  desc.add<bool>("DoCosmics", false);
-  desc.add<bool>("LoadTemplatesFromDB", true);
-  desc.add<bool>("RunDamagedClusters", false);
   desc.add<std::string>("ComponentName", "PixelCPEClusterRepair");
-  desc.add<double>("MinChargeRatio", 0.8);
-  desc.add<double>("MaxSizeMismatchInY", 0.3);
-  desc.add<bool>("Alpha2Order", true);
-  desc.add<std::vector<std::string>>("Recommend2D",
-                                     {
-                                         "PXB 2",
-                                         "PXB 3",
-                                         "PXB 4",
-                                     });
-  desc.add<int>("ClusterProbComputationFlag", 0);
-  desc.add<int>("speed", -2);
-  desc.add<bool>("UseClusterSplitter", false);
+
+  // from PixelCPEBase
+  PixelCPEBase::fillPSetDescription(desc);
+
+  // from PixelCPEClusterRepair
+  PixelCPEClusterRepair::fillPSetDescription(desc);
+
   descriptions.add("templates2", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -109,6 +109,7 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<std::string>("ComponentName", "PixelCPEGeneric");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag(""));
   desc.add<bool>("useLAAlignmentOffsets", false);
+  desc.add<bool>("DoLorentz", false);
   descriptions.add("_generic_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -114,7 +114,7 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.addOptional<double>("TanLorentzAnglePerTesla");
   desc.addOptional<std::string>("PixelErrorParametrization");
 
-  descriptions.add("PixelCPEGenericESProducer", desc);
+  descriptions.add("_generic_default", desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEGenericESProducer);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -109,11 +109,6 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<std::string>("ComponentName", "PixelCPEGeneric");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag(""));
   desc.add<bool>("useLAAlignmentOffsets", false);
-
-  // vestigial (present in certain HLT menus)
-  desc.addOptional<double>("TanLorentzAnglePerTesla");
-  desc.addOptional<std::string>("PixelErrorParametrization");
-
   descriptions.add("_generic_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -56,7 +56,7 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p)
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(magfieldToken_, edm::ESInputTag(magname))
+  c.setConsumes(magfieldToken_, magname)
       .setConsumes(pDDToken_)
       .setConsumes(hTTToken_)
       .setConsumes(lorentzAngleToken_, edm::ESInputTag("", laLabel));

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -112,7 +112,7 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
 
   // vestigial (present in certain HLT menus)
   desc.addOptional<double>("TanLorentzAnglePerTesla");
-  desc.addOptional<std::string>("PixelErrorParametrization", "NOTcmsim");
+  desc.addOptional<std::string>("PixelErrorParametrization");
 
   descriptions.add("PixelCPEGenericESProducer", desc);
 }

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -23,6 +23,7 @@ class PixelCPEGenericESProducer : public edm::ESProducer {
 public:
   PixelCPEGenericESProducer(const edm::ParameterSet& p);
   std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
@@ -42,23 +43,20 @@ using namespace edm;
 PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   // Use LA-width from DB. If both (upper and this) are false LA-width is calcuated from LA-offset
-  useLAWidthFromDB_ = p.existsAs<bool>("useLAWidthFromDB") ? p.getParameter<bool>("useLAWidthFromDB") : false;
+  useLAWidthFromDB_ = p.getParameter<bool>("useLAWidthFromDB");
   // Use Alignment LA-offset
-  const bool useLAAlignmentOffsets =
-      p.existsAs<bool>("useLAAlignmentOffsets") ? p.getParameter<bool>("useLAAlignmentOffsets") : false;
+  const bool useLAAlignmentOffsets = p.getParameter<bool>("useLAAlignmentOffsets");
   char const* laLabel = "";  // standard LA, from calibration, label=""
   if (useLAAlignmentOffsets) {
     laLabel = "fromAlignment";
   }
 
-  auto magname = p.existsAs<edm::ESInputTag>("MagneticFieldRecord")
-                     ? p.getParameter<edm::ESInputTag>("MagneticFieldRecord")
-                     : edm::ESInputTag("");
+  auto magname = p.getParameter<edm::ESInputTag>("MagneticFieldRecord");
   UseErrorsFromTemplates_ = p.getParameter<bool>("UseErrorsFromTemplates");
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(magfieldToken_, magname)
+  c.setConsumes(magfieldToken_, edm::ESInputTag(magname))
       .setConsumes(pDDToken_)
       .setConsumes(hTTToken_)
       .setConsumes(lorentzAngleToken_, edm::ESInputTag("", laLabel));
@@ -96,6 +94,27 @@ std::unique_ptr<PixelClusterParameterEstimator> PixelCPEGenericESProducer::produ
                                            &iRecord.get(lorentzAngleToken_),
                                            genErrorDBObjectProduct,
                                            lorentzAngleWidthProduct);
+}
+
+void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  // from PixelCPEBase
+  PixelCPEBase::fillPSetDescription(desc);
+
+  // from PixelCPEGeneric
+  PixelCPEGeneric::fillPSetDescription(desc);
+
+  // specific to PixelCPEGenericESProducer
+  desc.add<std::string>("ComponentName", "PixelCPEGeneric");
+  desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag(""));
+  desc.add<bool>("useLAAlignmentOffsets", false);
+
+  // vestigial (present in certain HLT menus)
+  desc.addOptional<double>("TanLorentzAnglePerTesla", 0.106);
+  desc.addOptional<std::string>("PixelErrorParametrization", "NOTcmsim");
+
+  descriptions.add("PixelCPEGenericESProducer", desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEGenericESProducer);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -111,7 +111,7 @@ void PixelCPEGenericESProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<bool>("useLAAlignmentOffsets", false);
 
   // vestigial (present in certain HLT menus)
-  desc.addOptional<double>("TanLorentzAnglePerTesla", 0.106);
+  desc.addOptional<double>("TanLorentzAnglePerTesla");
   desc.addOptional<std::string>("PixelErrorParametrization", "NOTcmsim");
 
   descriptions.add("PixelCPEGenericESProducer", desc);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -78,6 +78,7 @@ void PixelCPETemplateRecoESProducer::fillDescriptions(edm::ConfigurationDescript
 
   // specific to PixelCPETemplateRecoESProducer
   desc.add<std::string>("ComponentName", "PixelCPETemplateReco");
+  desc.add<bool>("DoLorentz", true);
   descriptions.add("_templates_default", desc);
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -78,7 +78,7 @@ void PixelCPETemplateRecoESProducer::fillDescriptions(edm::ConfigurationDescript
 
   // specific to PixelCPETemplateRecoESProducer
   desc.add<std::string>("ComponentName", "PixelCPETemplateReco");
-  descriptions.add("templates", desc);
+  descriptions.add("_templates_default", desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPETemplateRecoESProducer);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -20,6 +20,7 @@ class PixelCPETemplateRecoESProducer : public edm::ESProducer {
 public:
   PixelCPETemplateRecoESProducer(const edm::ParameterSet& p);
   std::unique_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
@@ -38,7 +39,7 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
   std::string myname = p.getParameter<std::string>("ComponentName");
 
   //DoLorentz_ = p.getParameter<bool>("DoLorentz"); // True when LA from alignment is used
-  DoLorentz_ = p.existsAs<bool>("DoLorentz") ? p.getParameter<bool>("DoLorentz") : false;
+  DoLorentz_ = p.getParameter<bool>("DoLorentz");
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
@@ -64,6 +65,20 @@ std::unique_ptr<PixelClusterParameterEstimator> PixelCPETemplateRecoESProducer::
                                                 iRecord.get(hTTToken_),
                                                 lorentzAngleProduct,
                                                 &iRecord.get(templateDBobjectToken_));
+}
+
+void PixelCPETemplateRecoESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  // from PixelCPEBase
+  PixelCPEBase::fillPSetDescription(desc);
+
+  // from PixelCPETemplateReco
+  PixelCPETemplateReco::fillPSetDescription(desc);
+
+  // specific to PixelCPETemplateRecoESProducer
+  desc.add<std::string>("ComponentName", "PixelCPETemplateReco");
+  descriptions.add("templates", desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPETemplateRecoESProducer);

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -1,33 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-templates2 = cms.ESProducer("PixelCPEClusterRepairESProducer",
-    ComponentName = cms.string('PixelCPEClusterRepair'),
-    speed = cms.int32(-2),
-    #PixelErrorParametrization = cms.string('NOTcmsim'),
-    Alpha2Order = cms.bool(True),
-    UseClusterSplitter = cms.bool(False),
-
-    # parameters to select which clusters we believe are truncated from dead double columns
-    # Be careful modifying these!
-    MaxSizeMismatchInY = cms.double(0.3),
-    MinChargeRatio = cms.double(0.8),
-    
-    # layers to run on: (only PXB 2,PXB 3,PXB 4 for now)
-    Recommend2D = cms.vstring("PXB 2","PXB 3","PXB 4"),
-
-    # to run on damaged clusterss or not (default=no)
-    RunDamagedClusters = cms.bool(False),
-
-    # petar, for clusterProbability() from TTRHs
-    ClusterProbComputationFlag = cms.int32(0),
-
-    # The flag to regulate if the LA offset is taken from Alignment 
-    # True in Run II for offline RECO
-    DoLorentz = cms.bool(True),
- 
-    LoadTemplatesFromDB = cms.bool(True)
-
-)
+from RecoLocalTracker.SiPixelRecHits._templates2_default_cfi import _templates2_default
+templates2 = _templates2_default.clone()
 
 # This customization will be removed once we get the templates for phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -20,8 +20,7 @@ templates2 = cms.ESProducer("PixelCPEClusterRepairESProducer",
 
     # petar, for clusterProbability() from TTRHs
     ClusterProbComputationFlag = cms.int32(0),
-    # gavril
-    DoCosmics = cms.bool(False), 
+
     # The flag to regulate if the LA offset is taken from Alignment 
     # True in Run II for offline RECO
     DoLorentz = cms.bool(True),

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -1,63 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-PixelCPEGenericESProducer = cms.ESProducer("PixelCPEGenericESProducer",
-
-    ComponentName = cms.string('PixelCPEGeneric'),
-    Alpha2Order = cms.bool(True),
-    PixelErrorParametrization = cms.string('NOTcmsim'),
-
-    # Allows cuts to be optimized
-    eff_charge_cut_lowX = cms.double(0.0),
-    eff_charge_cut_lowY = cms.double(0.0),
-    eff_charge_cut_highX = cms.double(1.0),
-    eff_charge_cut_highY = cms.double(1.0),
-    size_cutX = cms.double(3.0),
-    size_cutY = cms.double(3.0),
-
-    # Edge cluster errors in microns (determined by looking at residual RMS) 
-    EdgeClusterErrorX = cms.double( 50.0 ),                                      
-    EdgeClusterErrorY = cms.double( 85.0 ),                                                     
-
-    # ggiurgiu@jhu.edu
-    inflate_errors = cms.bool(False),
-    inflate_all_errors_no_trk_angle = cms.bool(False),
-
-    # Can use errors predicted by the template code
-    # If UseErrorsFromTemplates is False, must also set
-    # TruncatePixelCharge, IrradiationBiasCorrection, DoCosmics and LoadTemplatesFromDB to be False                                        
-    UseErrorsFromTemplates = cms.bool(True),
-
-    # When set True this gives a slight improvement in resolution at no cost 
-    TruncatePixelCharge = cms.bool(True),
-
-    # Turn this ON later
-    IrradiationBiasCorrection = cms.bool(False),                                       
-
-    # When set to True we use templates with extended angular acceptance   
-    DoCosmics = cms.bool(False),                                      
-
-    LoadTemplatesFromDB = cms.bool(True),                                       
-
-    # petar, for clusterProbability() from TTRHs
-    ClusterProbComputationFlag = cms.int32(0),
-
-    # new parameters added in 1/14, dk
-    # LA defined by hand, FOR TESTING ONLY, not for production   
-    # 0.0 means that the offset is taken from DB        
-    #lAOffset = cms..double(0.0),
-    #lAWidthBPix = cms.double(0.0),
-    #lAWidthFPix = cms.double(0.0),
-
-    # Flag to select the source of LA-Width
-    # Normal = True, use LA from DB
-    useLAWidthFromDB = cms.bool(True),                             
-    # if lAWith=0 and useLAWidthFromDB=false than width is calculated from lAOffset.         
-    # Use the LA-Offsets from Alignment instead of our calibration
-    useLAAlignmentOffsets = cms.bool(False),                             
-                                           
-    #MagneticFieldRecord: e.g. "" or "ParabolicMF"
-    MagneticFieldRecord = cms.ESInputTag(""),
-)
+from RecoLocalTracker.SiPixelRecHits._generic_default_cfi import _generic_default
+PixelCPEGenericESProducer = _generic_default.clone()
 
 # This customizes the Run3 Pixel CPE generic reconstruction in order to activate the IrradiationBiasCorrection
 # because of the expected resolution loss due to radiation damage

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiPixelRecHits._templates_default_cfi import _templates_default
 templates = _templates_default.clone()
-templates.DoLorentz = True
 
 # This customization will be removed once we get the templates for phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -1,22 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-templates = cms.ESProducer("PixelCPETemplateRecoESProducer",
-    ComponentName = cms.string('PixelCPETemplateReco'),
-    speed = cms.int32(-2),
-    #PixelErrorParametrization = cms.string('NOTcmsim'),
-    Alpha2Order = cms.bool(True),
-    UseClusterSplitter = cms.bool(False),
-
-    # petar, for clusterProbability() from TTRHs
-    ClusterProbComputationFlag = cms.int32(0),
-
-    # The flag to regulate if the LA offset is taken from Alignment 
-    # True in Run II for offline RECO
-    DoLorentz = cms.bool(True),
- 
-    LoadTemplatesFromDB = cms.bool(True)
-
-)
+from RecoLocalTracker.SiPixelRecHits._templates_default_cfi import _templates_default
+templates = _templates_default.clone()
+templates.DoLorentz = True
 
 # This customization will be removed once we get the templates for phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -9,8 +9,7 @@ templates = cms.ESProducer("PixelCPETemplateRecoESProducer",
 
     # petar, for clusterProbability() from TTRHs
     ClusterProbComputationFlag = cms.int32(0),
-    # gavril
-    DoCosmics = cms.bool(False), 
+
     # The flag to regulate if the LA offset is taken from Alignment 
     # True in Run II for offline RECO
     DoLorentz = cms.bool(True),

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -466,9 +466,8 @@ void PixelCPEBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("LoadTemplatesFromDB", true);
   desc.add<bool>("Alpha2Order", true);
   desc.add<int>("ClusterProbComputationFlag", 0);
-  desc.add<bool>("useLAWidthFromDB", false);
+  desc.add<bool>("useLAWidthFromDB", true);
   desc.add<double>("lAOffset", 0.0);
   desc.add<double>("lAWidthBPix", 0.0);
   desc.add<double>("lAWidthFPix", 0.0);
-  desc.add<bool>("DoLorentz", false);
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -85,7 +85,7 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const& conf,
 
   // Use LA-width from DB.
   // If both (this and from config) are false LA-width is calcuated from LA-offset
-  useLAWidthFromDB_ = conf.existsAs<bool>("useLAWidthFromDB") ? conf.getParameter<bool>("useLAWidthFromDB") : false;
+  useLAWidthFromDB_ = conf.getParameter<bool>("useLAWidthFromDB");
 
   // Use Alignment LA-offset in generic
   // (Experimental; leave commented out)
@@ -93,15 +93,9 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const& conf,
   //conf.getParameter<bool>("useLAAlignmentOffsets"):false;
 
   // Used only for testing
-  lAOffset_ = conf.existsAs<double>("lAOffset") ?  // fixed LA value
-                  conf.getParameter<double>("lAOffset")
-                                                : 0.0;
-  lAWidthBPix_ = conf.existsAs<double>("lAWidthBPix") ?  // fixed LA width
-                     conf.getParameter<double>("lAWidthBPix")
-                                                      : 0.0;
-  lAWidthFPix_ = conf.existsAs<double>("lAWidthFPix") ?  // fixed LA width
-                     conf.getParameter<double>("lAWidthFPix")
-                                                      : 0.0;
+  lAOffset_ = conf.getParameter<double>("lAOffset");
+  lAWidthBPix_ = conf.getParameter<double>("lAWidthBPix");
+  lAWidthFPix_ = conf.getParameter<double>("lAWidthFPix");
 
   // Use LA-offset from config, for testing only
   if (lAOffset_ > 0.0)
@@ -112,7 +106,7 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const& conf,
 
   // For Templates only
   // Compute the Lorentz shifts for this detector element for templates (from Alignment)
-  DoLorentz_ = conf.existsAs<bool>("DoLorentz") ? conf.getParameter<bool>("DoLorentz") : false;
+  DoLorentz_ = conf.getParameter<bool>("DoLorentz");
 
   LogDebug("PixelCPEBase") << " LA constants - " << lAOffset_ << " " << lAWidthBPix_ << " " << lAWidthFPix_
                            << endl;  //dk
@@ -466,4 +460,15 @@ SiPixelRecHitQuality::QualWordType PixelCPEBase::rawQualityWord(ClusterParam& th
   SiPixelRecHitQuality::thePacking.setHasFilledProb(theClusterParam.hasFilledProb_, qualWord);
 
   return qualWord;
+}
+
+void PixelCPEBase::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("LoadTemplatesFromDB", true);
+  desc.add<bool>("Alpha2Order", true);
+  desc.add<int>("ClusterProbComputationFlag", 0);
+  desc.add<bool>("useLAWidthFromDB", false);
+  desc.add<double>("lAOffset", 0.0);
+  desc.add<double>("lAWidthBPix", 0.0);
+  desc.add<double>("lAWidthFPix", 0.0);
+  desc.add<bool>("DoLorentz", false);
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -100,7 +100,7 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const& conf,
   // can be:
   //     XYX (XYZ = PXB, PXE)
   //     XYZ n (XYZ as above, n = layer, wheel or disk = 1 .. 6 ;)
-  std::vector<std::string> str_recommend2D = conf.getParameter<std::vector<std::string> >("Recommend2D");
+  std::vector<std::string> str_recommend2D = conf.getParameter<std::vector<std::string>>("Recommend2D");
   recommend2D_.reserve(str_recommend2D.size());
   for (auto& str : str_recommend2D) {
     recommend2D_.push_back(str);
@@ -336,7 +336,7 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
   float locBx = theDetParam.bx;
   //
   const bool deadpix = false;
-  std::vector<std::pair<int, int> > zeropix;
+  std::vector<std::pair<int, int>> zeropix;
   int nypix = 0, nxpix = 0;
   //
   theClusterParam.ierr = PixelTempReco1D(ID,
@@ -718,3 +718,15 @@ PixelCPEClusterRepair::Rule::Rule(const std::string& str) {
     layer_ = 0;
   }
 }  //end Rule::Rule
+
+void PixelCPEClusterRepair::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<int>("barrelTemplateID", 0);
+  desc.add<int>("forwardTemplateID", 0);
+  desc.add<int>("directoryWithTemplates", 0);
+  desc.add<int>("speed", -2);
+  desc.add<bool>("UseClusterSplitter", false);
+  desc.add<double>("MaxSizeMismatchInY", 0.3);
+  desc.add<double>("MinChargeRatio", 0.8);
+  desc.add<std::vector<std::string>>("Recommend2D", {"PXB 2", "PXB 3", "PXB 4"});
+  desc.add<bool>("RunDamagedClusters", false);
+}

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -59,7 +59,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
 
   // no clear what upgrade means, is it phase1, phase2? Probably delete.
   isUpgrade_ = false;
-  if (conf.exists("Upgrade") && conf.getParameter<bool>("Upgrade"))
+  if (conf.getParameter<bool>("Upgrade"))
     isUpgrade_ = true;
 
   // Select the position error source
@@ -120,7 +120,7 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
     yerr_endcap_ = {0.00289, 0.00025};
     yerr_endcap_def_ = 0.00180;
 
-    if (conf.exists("SmallPitch") && conf.getParameter<bool>("SmallPitch")) {
+    if (conf.getParameter<bool>("SmallPitch")) {
       xerr_barrel_l1_ = {0.00104, 0.000691, 0.00122};
       xerr_barrel_l1_def_ = 0.00321;
       yerr_barrel_l1_ = {0.00199, 0.00136, 0.0015, 0.00153, 0.00152, 0.00171, 0.00154, 0.00157, 0.00154};
@@ -743,4 +743,23 @@ LocalError PixelCPEGeneric::localError(DetParam const& theDetParam, ClusterParam
   auto yerr_sq = yerr * yerr;
 
   return LocalError(xerr_sq, 0, yerr_sq);
+}
+
+void PixelCPEGeneric::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<double>("eff_charge_cut_highX", 1.0);
+  desc.add<double>("eff_charge_cut_highY", 1.0);
+  desc.add<double>("eff_charge_cut_lowX", 0.0);
+  desc.add<double>("eff_charge_cut_lowY", 0.0);
+  desc.add<double>("size_cutX", 3.0);
+  desc.add<double>("size_cutY", 3.0);
+  desc.add<double>("EdgeClusterErrorX", 50.0);
+  desc.add<double>("EdgeClusterErrorY", 85.0);
+  desc.add<bool>("inflate_errors", false);
+  desc.add<bool>("inflate_all_errors_no_trk_angle", false);
+  desc.add<bool>("UseErrorsFromTemplates", true);
+  desc.add<bool>("TruncatePixelCharge", true);
+  desc.add<bool>("IrradiationBiasCorrection", false);
+  desc.add<bool>("DoCosmics", false);
+  desc.add<bool>("Upgrade", false);
+  desc.add<bool>("SmallPitch", false);
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -550,7 +550,4 @@ void PixelCPETemplateReco::fillPSetDescription(edm::ParameterSetDescription& des
   desc.add<int>("directoryWithTemplates", 0);
   desc.add<int>("speed", -2);
   desc.add<bool>("UseClusterSplitter", false);
-
-  // needed because it's in the HLT configuration
-  desc.addOptional<bool>("DoCosmics", false);
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -543,3 +543,14 @@ LocalError PixelCPETemplateReco::localError(DetParam const& theDetParam, Cluster
 
   return LocalError(xerr * xerr, 0, yerr * yerr);
 }
+
+void PixelCPETemplateReco::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<int>("barrelTemplateID", 0);
+  desc.add<int>("forwardTemplateID", 0);
+  desc.add<int>("directoryWithTemplates", 0);
+  desc.add<int>("speed", -2);
+  desc.add<bool>("UseClusterSplitter", false);
+
+  // needed because it's in the HLT configuration
+  desc.addOptional<bool>("DoCosmics", false);
+}


### PR DESCRIPTION
#### PR description:
This PR provides `fillDescriptions` methods for PixelCPE classes as requested in issue https://github.com/cms-sw/cmssw/issues/27660. 
The `fillPSetDescription` method is used when useful to recycle configuration from the helper classes. 
As a result, all occurences of  `existsAs` in `RecoLocalTracker/SiPixelRecHits` are removed.
The parameter `DoCosmics` (unused) is removed from the configuration files of `PixelCPEClusterRepair` and `PixelCPETemplateReco` though is maintained in the  `fillDescriptions` as it happens to be in existing HLT configuration files.

#### PR validation:
It passes standard tests performed with `addOnTests` and
```
runTheMatrix.py -s -j 8 -t 4 --ibeos
```
#### if this PR is a backport please specify the original PR:
This PR is not a backport.
cc:
@tsusa @pmaksim1 @cmantill @OzAmram @tvami 
