### PR TITLE
Updates to DT, PF hadron, HCAL, PPS and pixel calibrations for 2018 UL [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v17',
+    'run1_data'         :   '106X_dataRun2_2017_2018_Candidate_2019_08_05_17_19_13',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v17',
+    'run2_data'         :   '106X_dataRun2_2017_2018_Candidate_2019_08_05_17_19_13',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v16',
+    'run2_data_relval'  :   '106X_dataRun2_relval_Candidate_2019_08_05_17_36_16',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_Candidate_2019_08_05_17_40_11',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v10',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v10',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_Candidate_2019_08_05_17_44_43',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_Candidate_2019_08_05_17_49_31',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -54,11 +54,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_Candidate_2019_08_05_17_57_55',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_Candidate_2019_08_05_18_03_46',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode


### PR DESCRIPTION
#### PR description:

This is a backport of PR #27683. With this PR, 2018 collision GTs are up-to-date with the corresponding 11_0_X GTs:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45/106X_dataRun2_2017_2018_Candidate_2019_08_05_17_19_13 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_Candidate_2019_08_03_03_55_32/106X_dataRun2_relval_Candidate_2019_08_05_17_36_16 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_02_16_55_52/106X_dataRun2_PromptLike_HEfail_Candidate_2019_08_05_17_40_11 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_Candidate_2019_08_02_16_53_14/106X_dataRun2_PromptLike_Candidate_2019_08_05_17_44_43 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HI_Candidate_2019_08_02_16_55_18/106X_dataRun2_PromptLike_HI_Candidate_2019_08_05_17_49_31 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_Candidate_2019_08_03_11_37_17/106X_upgrade2018_realistic_Candidate_2019_08_05_17_57_55 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HEfail_Candidate_2019_08_03_11_39_50/106X_upgrade2018_realistic_HEfail_Candidate_2019_08_05_18_03_46 

The GT diffs with respect to the current 10_6_X autoCond are:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_2017_2018_Candidate_2019_08_05_17_19_13/106X_dataRun2_v17
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_Candidate_2019_08_05_17_36_16/106X_dataRun2_relval_v16
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_Candidate_2019_08_05_17_40_11/106X_dataRun2_PromptLike_HEfail_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_Candidate_2019_08_05_17_44_43/106X_dataRun2_PromptLike_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_Candidate_2019_08_05_17_49_31/106X_dataRun2_PromptLike_HI_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_Candidate_2019_08_05_17_57_55/106X_upgrade2018_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_Candidate_2019_08_05_18_03_46/106X_upgrade2018_realistic_HEfail_v6

This PR should be merged after #27605 so that clean PR comparison tests can be run on this PR. The merge conflict with #27605 will be resolved by preferring the changes in this PR. The backport of PR #27644 will also conflict this PR. Once either this PR or the backport of #27644 are merged, the GT candidates in the other PR will be converted to versioned GTs.

#### PR validation:

Validation as in PR #27683.

#### if this PR is a backport please specify the original PR:

Backport of #27683 
