### PR TITLE
[TkDQM] Update of SiStripMonitorTrack : ES access put outside tracks loop

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -48,7 +48,6 @@
 #include "CalibTracker/Records/interface/SiStripGainRcd.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
-
 //******** Single include for the TkMap *************/
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
 //***************************************************/
@@ -172,15 +171,14 @@ private:
   float iOrbitSec, iLumisection;
 
   std::string topFolderName_;
-  
-  
-  const TrackerTopology* tTopo_ ;
-  edm::ESWatcher<TrackerTopologyRcd> watchertTopo_ ;
-  
-  const SiStripGain* stripGain_ ;
+
+  const TrackerTopology* tTopo_;
+  edm::ESWatcher<TrackerTopologyRcd> watchertTopo_;
+
+  const SiStripGain* stripGain_;
   edm::ESWatcher<SiStripGainRcd> watcherStripGain_;
-  
-  const SiStripQuality* stripQuality_ ;
+
+  const SiStripQuality* stripQuality_;
 
   //******* TkHistoMaps*/
   std::unique_ptr<TkHistoMap> tkhisto_StoNCorrOnTrack, tkhisto_NumOnTrack, tkhisto_NumOffTrack;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -43,6 +43,12 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+
+
 //******** Single include for the TkMap *************/
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
 //***************************************************/
@@ -166,6 +172,15 @@ private:
   float iOrbitSec, iLumisection;
 
   std::string topFolderName_;
+  
+  
+  const TrackerTopology* tTopo_ ;
+  edm::ESWatcher<TrackerTopologyRcd> watchertTopo_ ;
+  
+  const SiStripGain* stripGain_ ;
+  edm::ESWatcher<SiStripGainRcd> watcherStripGain_;
+  
+  const SiStripQuality* stripQuality_ ;
 
   //******* TkHistoMaps*/
   std::unique_ptr<TkHistoMap> tkhisto_StoNCorrOnTrack, tkhisto_NumOnTrack, tkhisto_NumOffTrack;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -78,7 +78,16 @@ void SiStripMonitorTrack::dqmBeginRun(const edm::Run& run, const edm::EventSetup
   LogDebug("SiStripMonitorTrack") << "[SiStripMonitorTrack::beginRun] There are " << tkgeom_->detUnits().size()
                                   << " detectors instantiated in the geometry" << std::endl;
   es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
-
+  
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  es.get<TrackerTopologyRcd>().get(tTopoHandle);
+  tTopo_ = tTopoHandle.product();
+    
+  edm::ESHandle<SiStripGain> gainHandle;
+  es.get<SiStripGainRcd>().get(gainHandle);
+  stripGain_ = gainHandle.product();
+  
+  
   // Initialize the GenericTriggerEventFlag
   if (genTriggerEventFlag_->on())
     genTriggerEventFlag_->initRun(run, es);
@@ -121,6 +130,25 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
     iSubDet->second.totNClustersOffTrack = 0;
   }
 
+  if (watchertTopo_.check(es) ) {
+    edm::ESHandle<TrackerTopology> tTopoHandle;
+    es.get<TrackerTopologyRcd>().get(tTopoHandle);
+    tTopo_ = tTopoHandle.product();
+  }
+
+  
+  if (watcherStripGain_.check(es) ) {
+    edm::ESHandle<SiStripGain> gainHandle;
+    es.get<SiStripGainRcd>().get(gainHandle);
+    stripGain_ = gainHandle.product();   
+  }
+  
+  
+  edm::ESHandle<SiStripQuality> qualityHandle;
+  es.get<SiStripQualityRcd>().get("", qualityHandle);
+  stripQuality_ = qualityHandle.product();
+  
+  
   //Perform track study
   trackStudy(e, es);
 
@@ -1222,22 +1250,6 @@ void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit,
       << tkgeom_->idToDet(tkrecHit->geographicalId())->surface().toGlobal(tkrecHit->localPosition())
       << "\n\t\tRecHit trackLocal vector " << LV.x() << " " << LV.y() << " " << LV.z() << std::endl;
 
-  // FIXME: MOVE ALL THE EV AND ES ACCESS OUTSIDE THE LOOP!!!!
-
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
-  // Getting SiStrip Gain settings
-  edm::ESHandle<SiStripGain> gainHandle;
-  es.get<SiStripGainRcd>().get(gainHandle);
-  const SiStripGain* const stripGain = gainHandle.product();
-
-  edm::ESHandle<SiStripQuality> qualityHandle;
-  es.get<SiStripQualityRcd>().get("", qualityHandle);
-  const SiStripQuality* stripQuality = qualityHandle.product();
-
   //Get SiStripCluster from SiStripRecHit
   if (tkrecHit != nullptr && tkrecHit->isValid()) {
     const DetId detid = tkrecHit->geographicalId();
@@ -1259,16 +1271,16 @@ void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit,
     const SiStripCluster* SiStripCluster_ = &*(tkrecHit->cluster());
     SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_, es, detid);
 
-    const Det2MEs MEs = findMEs(tTopo, detid);
+    const Det2MEs MEs = findMEs(tTopo_, detid);
     if (clusterInfos(&SiStripClusterInfo_,
                      detid,
                      OnTrack,
                      track_ok,
                      LV,
                      MEs,
-                     tTopo,
-                     stripGain,
-                     stripQuality,
+                     tTopo_,
+                     stripGain_,
+                     stripQuality_,
                      digilist,
                      clust_Pos1,
                      clust_Pos2)) {

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -78,16 +78,15 @@ void SiStripMonitorTrack::dqmBeginRun(const edm::Run& run, const edm::EventSetup
   LogDebug("SiStripMonitorTrack") << "[SiStripMonitorTrack::beginRun] There are " << tkgeom_->detUnits().size()
                                   << " detectors instantiated in the geometry" << std::endl;
   es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
-  
+
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
   tTopo_ = tTopoHandle.product();
-    
+
   edm::ESHandle<SiStripGain> gainHandle;
   es.get<SiStripGainRcd>().get(gainHandle);
   stripGain_ = gainHandle.product();
-  
-  
+
   // Initialize the GenericTriggerEventFlag
   if (genTriggerEventFlag_->on())
     genTriggerEventFlag_->initRun(run, es);
@@ -130,25 +129,22 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
     iSubDet->second.totNClustersOffTrack = 0;
   }
 
-  if (watchertTopo_.check(es) ) {
+  if (watchertTopo_.check(es)) {
     edm::ESHandle<TrackerTopology> tTopoHandle;
     es.get<TrackerTopologyRcd>().get(tTopoHandle);
     tTopo_ = tTopoHandle.product();
   }
 
-  
-  if (watcherStripGain_.check(es) ) {
+  if (watcherStripGain_.check(es)) {
     edm::ESHandle<SiStripGain> gainHandle;
     es.get<SiStripGainRcd>().get(gainHandle);
-    stripGain_ = gainHandle.product();   
+    stripGain_ = gainHandle.product();
   }
-  
-  
+
   edm::ESHandle<SiStripQuality> qualityHandle;
   es.get<SiStripQualityRcd>().get("", qualityHandle);
   stripQuality_ = qualityHandle.product();
-  
-  
+
   //Perform track study
   trackStudy(e, es);
 


### PR DESCRIPTION
#### PR description:

Some conditions (TrackerTopology, SiStripGain, SiStripQuality) were retrieved from ES in a loop on tracks. With this PR,  SiStripQuality is now retrieved for every event, while ESWatchers are used for  TrackerTopology and SiStripGain.

#### PR validation:

Compilation
runTheMatrix.py -l 10024 
runTheMatrix.py -l limited -i all --ibeos