### PR TITLE
Restore fix for the segmentation violation in Phase2 workflow with darkening

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -501,7 +501,7 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs(const 
   //set depth segmentation for HB/HE recalib - only happens once
   if ((he_recalibration && !setHEdsegm) || (hb_recalibration && !setHBdsegm)) {
     std::vector<std::vector<int>> m_segmentation;
-    int maxEta = topo->lastHBHERing();
+    int maxEta = std::max(topo->lastHERing(),topo->lastHBRing());
     m_segmentation.resize(maxEta);
     for (int i = 0; i < maxEta; i++) {
       topo->getDepthSegmentation(i + 1, m_segmentation[i]);

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -501,7 +501,7 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs(const 
   //set depth segmentation for HB/HE recalib - only happens once
   if ((he_recalibration && !setHEdsegm) || (hb_recalibration && !setHBdsegm)) {
     std::vector<std::vector<int>> m_segmentation;
-    int maxEta = std::max(topo->lastHERing(),topo->lastHBRing());
+    int maxEta = std::max(topo->lastHERing(), topo->lastHBRing());
     m_segmentation.resize(maxEta);
     for (int i = 0; i < maxEta; i++) {
       topo->getDepthSegmentation(i + 1, m_segmentation[i]);


### PR DESCRIPTION
#### PR description:

This PR restores the fix in #26964 then undone in #26966 as discussed by @deguio and @bsunanda.

#### PR validation:

The same fix was already integrated in CMSSW in May, and code compiles.
