### PR TITLE
Minor improvement to edmPluginHelp output

### DIFF
--- a/FWCore/Integration/test/unit_test_outputs/testDescriptionComments_doc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testDescriptionComments_doc.txt
@@ -11,7 +11,7 @@ configurations. The label below is used when generating the cfi file.
 
     mightGet
                         type: untracked vstring optional
-                        default: none (do not write to cfi)
+                        default: none
                         List contains the branch names for the EDProducts which 
                         might be requested by the module.
                         The format for identifying the EDProduct is the same as 
@@ -85,12 +85,12 @@ configurations. The label below is used when generating the cfi file.
 
         y1
                         type: double 
-                        default: none (do not write to cfi)
+                        default: none
                         test3
 
         y2
                         type: double 
-                        default: none (do not write to cfi)
+                        default: none
                         test4
 
     Section 1.1.1.2 nested1 PSet description:

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
@@ -5,8 +5,8 @@
     p_int_untracked         untracked int32                -2147483647
     p_int_opt               int32                 optional 0
     p_int_optuntracked      untracked int32       optional 7
-    p_int_opt_nd            int32                 optional none (do not write to cfi)
-    p_int_optuntracked_nd   untracked int32       optional none (do not write to cfi)
+    p_int_opt_nd            int32                 optional none
+    p_int_optuntracked_nd   untracked int32       optional none
     vint1                   vint32                         empty
     vint2                   vint32                         (vector size = 1)
       [0]: 2147483647
@@ -186,7 +186,7 @@
     noDefaultPset4          PSet                           see Section 1.1.21
     plugin                  PSet                           see Section 1.1.22
     plugin1                 PSet                           see Section 1.1.23
-    mightGet                untracked vstring     optional none (do not write to cfi)
+    mightGet                untracked vstring     optional none
     Section 1.1.1 vuint5 default contents: (vector size = 6)
         [0]: 4294967295
         [1]: 0
@@ -217,8 +217,8 @@
         uDrinks    untracked uint32          5
         oDrinks    uint32           optional 5
         ouDrinks   untracked uint32 optional 5
-        ndoDrinks  uint32           optional none (do not write to cfi)
-        ndouDrinks untracked uint32 optional none (do not write to cfi)
+        ndoDrinks  uint32           optional none
+        ndouDrinks untracked uint32 optional none
     Section 1.1.6 test104 VPSet description:
         All elements will be validated using the PSet description in Section 1.1.6.1.
         The default VPSet has 1 element.
@@ -228,8 +228,8 @@
         uDrinks    untracked uint32          5
         oDrinks    uint32           optional 5
         ouDrinks   untracked uint32 optional 5
-        ndoDrinks  uint32           optional none (do not write to cfi)
-        ndouDrinks untracked uint32 optional none (do not write to cfi)
+        ndoDrinks  uint32           optional none
+        ndouDrinks untracked uint32 optional none
     Section 1.1.6.2 PSet description of default VPSet element [0]
         Description is empty
     Section 1.1.7 test105 VPSet description:
@@ -240,8 +240,8 @@
         uDrinks    untracked uint32          5
         oDrinks    uint32           optional 5
         ouDrinks   untracked uint32 optional 5
-        ndoDrinks  uint32           optional none (do not write to cfi)
-        ndouDrinks untracked uint32 optional none (do not write to cfi)
+        ndoDrinks  uint32           optional none
+        ndouDrinks untracked uint32 optional none
     Section 1.1.8 AND group description:
     This optional AND group requires all or none of the following to be in the PSet
         testA string  'fooA'
@@ -326,8 +326,8 @@
         uDrinks          untracked uint32          5
         oDrinks          uint32           optional 5
         ouDrinks         untracked uint32 optional 5
-        ndoDrinks        uint32           optional none (do not write to cfi)
-        ndouDrinks       untracked uint32 optional none (do not write to cfi)
+        ndoDrinks        uint32           optional none
+        ndouDrinks       untracked uint32 optional none
         testDeeplyNested PSet                      see Section 1.1.11.1.1
         anotherVPSet     VPSet                     see Section 1.1.11.1.2
     Section 1.1.11.1.1 testDeeplyNested PSet description:
@@ -503,8 +503,8 @@
         uDrinks    untracked uint32          5
         oDrinks    uint32           optional 5
         ouDrinks   untracked uint32 optional 5
-        ndoDrinks  uint32           optional none (do not write to cfi)
-        ndouDrinks untracked uint32 optional none (do not write to cfi)
+        ndoDrinks  uint32           optional none
+        ndouDrinks untracked uint32 optional none
     Section 1.1.16 orPset PSet description:
         OR group: see Section 1.1.16.1
         OR group: see Section 1.1.16.2
@@ -536,8 +536,8 @@
         uDrinks    untracked uint32          5
         oDrinks    uint32           optional 5
         ouDrinks   untracked uint32 optional 5
-        ndoDrinks  uint32           optional none (do not write to cfi)
-        ndouDrinks untracked uint32 optional none (do not write to cfi)
+        ndoDrinks  uint32           optional none
+        ndouDrinks untracked uint32 optional none
     Section 1.1.17 andPset PSet description:
         AND group: see Section 1.1.17.1
         AND group: see Section 1.1.17.2
@@ -635,55 +635,55 @@
         oDrinks   uint32           optional 5
         ouDrinks  untracked uint32 optional 5
     Section 1.1.20 noDefaultPset3 PSet description:
-        noDefault1  int32                 optional none (do not write to cfi)
-        noDefault2  vint32                optional none (do not write to cfi)
-        noDefault3  uint32                optional none (do not write to cfi)
-        noDefault4  vuint32               optional none (do not write to cfi)
-        noDefault5  int64                 optional none (do not write to cfi)
-        noDefault6  vint64                optional none (do not write to cfi)
-        noDefault7  uint64                optional none (do not write to cfi)
-        noDefault8  vuint64               optional none (do not write to cfi)
-        noDefault9  double                optional none (do not write to cfi)
-        noDefault10 vdouble               optional none (do not write to cfi)
-        noDefault11 bool                  optional none (do not write to cfi)
-        noDefault12 string                optional none (do not write to cfi)
-        noDefault13 vstring               optional none (do not write to cfi)
-        noDefault14 EventID               optional none (do not write to cfi)
-        noDefault15 VEventID              optional none (do not write to cfi)
-        noDefault16 LuminosityBlockID     optional none (do not write to cfi)
-        noDefault17 VLuminosityBlockID    optional none (do not write to cfi)
-        noDefault18 InputTag              optional none (do not write to cfi)
-        noDefault19 VInputTag             optional none (do not write to cfi)
-        noDefault20 FileInPath            optional none (do not write to cfi)
-        noDefault21 LuminosityBlockRange  optional none (do not write to cfi)
-        noDefault22 VLuminosityBlockRange optional none (do not write to cfi)
-        noDefault23 EventRange            optional none (do not write to cfi)
-        noDefault24 VEventRange           optional none (do not write to cfi)
+        noDefault1  int32                 optional none
+        noDefault2  vint32                optional none
+        noDefault3  uint32                optional none
+        noDefault4  vuint32               optional none
+        noDefault5  int64                 optional none
+        noDefault6  vint64                optional none
+        noDefault7  uint64                optional none
+        noDefault8  vuint64               optional none
+        noDefault9  double                optional none
+        noDefault10 vdouble               optional none
+        noDefault11 bool                  optional none
+        noDefault12 string                optional none
+        noDefault13 vstring               optional none
+        noDefault14 EventID               optional none
+        noDefault15 VEventID              optional none
+        noDefault16 LuminosityBlockID     optional none
+        noDefault17 VLuminosityBlockID    optional none
+        noDefault18 InputTag              optional none
+        noDefault19 VInputTag             optional none
+        noDefault20 FileInPath            optional none
+        noDefault21 LuminosityBlockRange  optional none
+        noDefault22 VLuminosityBlockRange optional none
+        noDefault23 EventRange            optional none
+        noDefault24 VEventRange           optional none
     Section 1.1.21 noDefaultPset4 PSet description:
-        noDefault1  untracked int32                 optional none (do not write to cfi)
-        noDefault2  untracked vint32                optional none (do not write to cfi)
-        noDefault3  untracked uint32                optional none (do not write to cfi)
-        noDefault4  untracked vuint32               optional none (do not write to cfi)
-        noDefault5  untracked int64                 optional none (do not write to cfi)
-        noDefault6  untracked vint64                optional none (do not write to cfi)
-        noDefault7  untracked uint64                optional none (do not write to cfi)
-        noDefault8  untracked vuint64               optional none (do not write to cfi)
-        noDefault9  untracked double                optional none (do not write to cfi)
-        noDefault10 untracked vdouble               optional none (do not write to cfi)
-        noDefault11 untracked bool                  optional none (do not write to cfi)
-        noDefault12 untracked string                optional none (do not write to cfi)
-        noDefault13 untracked vstring               optional none (do not write to cfi)
-        noDefault14 untracked EventID               optional none (do not write to cfi)
-        noDefault15 untracked VEventID              optional none (do not write to cfi)
-        noDefault16 untracked LuminosityBlockID     optional none (do not write to cfi)
-        noDefault17 untracked VLuminosityBlockID    optional none (do not write to cfi)
-        noDefault18 untracked InputTag              optional none (do not write to cfi)
-        noDefault19 untracked VInputTag             optional none (do not write to cfi)
-        noDefault20 untracked FileInPath            optional none (do not write to cfi)
-        noDefault21 untracked LuminosityBlockRange  optional none (do not write to cfi)
-        noDefault22 untracked VLuminosityBlockRange optional none (do not write to cfi)
-        noDefault23 untracked EventRange            optional none (do not write to cfi)
-        noDefault24 untracked VEventRange           optional none (do not write to cfi)
+        noDefault1  untracked int32                 optional none
+        noDefault2  untracked vint32                optional none
+        noDefault3  untracked uint32                optional none
+        noDefault4  untracked vuint32               optional none
+        noDefault5  untracked int64                 optional none
+        noDefault6  untracked vint64                optional none
+        noDefault7  untracked uint64                optional none
+        noDefault8  untracked vuint64               optional none
+        noDefault9  untracked double                optional none
+        noDefault10 untracked vdouble               optional none
+        noDefault11 untracked bool                  optional none
+        noDefault12 untracked string                optional none
+        noDefault13 untracked vstring               optional none
+        noDefault14 untracked EventID               optional none
+        noDefault15 untracked VEventID              optional none
+        noDefault16 untracked LuminosityBlockID     optional none
+        noDefault17 untracked VLuminosityBlockID    optional none
+        noDefault18 untracked InputTag              optional none
+        noDefault19 untracked VInputTag             optional none
+        noDefault20 untracked FileInPath            optional none
+        noDefault21 untracked LuminosityBlockRange  optional none
+        noDefault22 untracked VLuminosityBlockRange optional none
+        noDefault23 untracked EventRange            optional none
+        noDefault24 untracked VEventRange           optional none
     Section 1.1.22 plugin PSet description:
         Section 1.1.22.1 PluginDescriptoredmtestAnotherIntFactory Plugins description:
         Section 1.1.22.1.1 edmtestAnotherOneMaker Plugin description:
@@ -694,70 +694,70 @@
     Section 1.1.23 plugin1 PSet description:
         Section 1.1.23.1 PluginDescriptoredmtestAnotherIntFactory Plugins description:
         Section 1.1.23.1.1 edmtestAnotherOneMaker Plugin description:
-        type string  none (do not write to cfi)
+        type string  none
         Section 1.1.23.1.2 edmtestAnotherValueMaker Plugin description:
         value int32   5
-        type  string  none (do not write to cfi)
+        type  string  none
   1.2 testLabel1
     Description allows anything. If the configured PSet contains illegal parameters,
     then validation will ignore them instead of throwing an exception.
     p_int          int32                      1
     noDefaultPset1 PSet                       see Section 1.2.1
     noDefaultPset2 PSet                       see Section 1.2.2
-    mightGet       untracked vstring optional none (do not write to cfi)
+    mightGet       untracked vstring optional none
     Section 1.2.1 noDefaultPset1 PSet description:
-        noDefault1  int32                  none (do not write to cfi)
-        noDefault2  vint32                 none (do not write to cfi)
-        noDefault3  uint32                 none (do not write to cfi)
-        noDefault4  vuint32                none (do not write to cfi)
-        noDefault5  int64                  none (do not write to cfi)
-        noDefault6  vint64                 none (do not write to cfi)
-        noDefault7  uint64                 none (do not write to cfi)
-        noDefault8  vuint64                none (do not write to cfi)
-        noDefault9  double                 none (do not write to cfi)
-        noDefault10 vdouble                none (do not write to cfi)
-        noDefault11 bool                   none (do not write to cfi)
-        noDefault12 string                 none (do not write to cfi)
-        noDefault13 vstring                none (do not write to cfi)
-        noDefault14 EventID                none (do not write to cfi)
-        noDefault15 VEventID               none (do not write to cfi)
-        noDefault16 LuminosityBlockID      none (do not write to cfi)
-        noDefault17 VLuminosityBlockID     none (do not write to cfi)
-        noDefault18 InputTag               none (do not write to cfi)
-        noDefault19 VInputTag              none (do not write to cfi)
-        noDefault20 FileInPath             none (do not write to cfi)
-        noDefault21 LuminosityBlockRange   none (do not write to cfi)
-        noDefault22 VLuminosityBlockRange  none (do not write to cfi)
-        noDefault23 EventRange             none (do not write to cfi)
-        noDefault24 VEventRange            none (do not write to cfi)
+        noDefault1  int32                  none
+        noDefault2  vint32                 none
+        noDefault3  uint32                 none
+        noDefault4  vuint32                none
+        noDefault5  int64                  none
+        noDefault6  vint64                 none
+        noDefault7  uint64                 none
+        noDefault8  vuint64                none
+        noDefault9  double                 none
+        noDefault10 vdouble                none
+        noDefault11 bool                   none
+        noDefault12 string                 none
+        noDefault13 vstring                none
+        noDefault14 EventID                none
+        noDefault15 VEventID               none
+        noDefault16 LuminosityBlockID      none
+        noDefault17 VLuminosityBlockID     none
+        noDefault18 InputTag               none
+        noDefault19 VInputTag              none
+        noDefault20 FileInPath             none
+        noDefault21 LuminosityBlockRange   none
+        noDefault22 VLuminosityBlockRange  none
+        noDefault23 EventRange             none
+        noDefault24 VEventRange            none
     Section 1.2.2 noDefaultPset2 PSet description:
-        noDefault1  untracked int32                  none (do not write to cfi)
-        noDefault2  untracked vint32                 none (do not write to cfi)
-        noDefault3  untracked uint32                 none (do not write to cfi)
-        noDefault4  untracked vuint32                none (do not write to cfi)
-        noDefault5  untracked int64                  none (do not write to cfi)
-        noDefault6  untracked vint64                 none (do not write to cfi)
-        noDefault7  untracked uint64                 none (do not write to cfi)
-        noDefault8  untracked vuint64                none (do not write to cfi)
-        noDefault9  untracked double                 none (do not write to cfi)
-        noDefault10 untracked vdouble                none (do not write to cfi)
-        noDefault11 untracked bool                   none (do not write to cfi)
-        noDefault12 untracked string                 none (do not write to cfi)
-        noDefault13 untracked vstring                none (do not write to cfi)
-        noDefault14 untracked EventID                none (do not write to cfi)
-        noDefault15 untracked VEventID               none (do not write to cfi)
-        noDefault16 untracked LuminosityBlockID      none (do not write to cfi)
-        noDefault17 untracked VLuminosityBlockID     none (do not write to cfi)
-        noDefault18 untracked InputTag               none (do not write to cfi)
-        noDefault19 untracked VInputTag              none (do not write to cfi)
-        noDefault20 untracked FileInPath             none (do not write to cfi)
-        noDefault21 untracked LuminosityBlockRange   none (do not write to cfi)
-        noDefault22 untracked VLuminosityBlockRange  none (do not write to cfi)
-        noDefault23 untracked EventRange             none (do not write to cfi)
-        noDefault24 untracked VEventRange            none (do not write to cfi)
+        noDefault1  untracked int32                  none
+        noDefault2  untracked vint32                 none
+        noDefault3  untracked uint32                 none
+        noDefault4  untracked vuint32                none
+        noDefault5  untracked int64                  none
+        noDefault6  untracked vint64                 none
+        noDefault7  untracked uint64                 none
+        noDefault8  untracked vuint64                none
+        noDefault9  untracked double                 none
+        noDefault10 untracked vdouble                none
+        noDefault11 untracked bool                   none
+        noDefault12 untracked string                 none
+        noDefault13 untracked vstring                none
+        noDefault14 untracked EventID                none
+        noDefault15 untracked VEventID               none
+        noDefault16 untracked LuminosityBlockID      none
+        noDefault17 untracked VLuminosityBlockID     none
+        noDefault18 untracked InputTag               none
+        noDefault19 untracked VInputTag              none
+        noDefault20 untracked FileInPath             none
+        noDefault21 untracked LuminosityBlockRange   none
+        noDefault22 untracked VLuminosityBlockRange  none
+        noDefault23 untracked EventRange             none
+        noDefault24 untracked VEventRange            none
   1.3 producerWithPSetDesc
     p_int    int32                      3
-    mightGet untracked vstring optional none (do not write to cfi)
+    mightGet untracked vstring optional none
   1.4 description without a module label
     p_int    int32                      2
-    mightGet untracked vstring optional none (do not write to cfi)
+    mightGet untracked vstring optional none

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
@@ -39,11 +39,11 @@ generated for each configuration with a module label.
 
     p_int_opt_nd
                         type: int32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     p_int_optuntracked_nd
                         type: untracked int32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     vint1
                         type: vint32 
@@ -539,7 +539,7 @@ generated for each configuration with a module label.
 
     mightGet
                         type: untracked vstring optional
-                        default: none (do not write to cfi)
+                        default: none
                         List contains the branch names for the EDProducts which 
                         might be requested by the module.
                         The format for identifying the EDProduct is the same as 
@@ -623,11 +623,11 @@ generated for each configuration with a module label.
 
         ndoDrinks
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         ndouDrinks
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.6 test104 VPSet description:
         All elements will be validated using the PSet description in Section 1.1.6.1.
@@ -654,11 +654,11 @@ generated for each configuration with a module label.
 
         ndoDrinks
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         ndouDrinks
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.6.2 PSet description of default VPSet element [0]
 
@@ -688,11 +688,11 @@ generated for each configuration with a module label.
 
         ndoDrinks
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         ndouDrinks
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.8 AND group description:
     This optional AND group requires all or none of the following to be in the PSet
@@ -922,11 +922,11 @@ generated for each configuration with a module label.
 
         ndoDrinks
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         ndouDrinks
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         testDeeplyNested
                         type: PSet 
@@ -1422,11 +1422,11 @@ generated for each configuration with a module label.
 
         ndoDrinks
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         ndouDrinks
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.16 orPset PSet description:
 
@@ -1523,11 +1523,11 @@ generated for each configuration with a module label.
 
         ndoDrinks
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         ndouDrinks
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.17 andPset PSet description:
 
@@ -1800,197 +1800,197 @@ generated for each configuration with a module label.
 
         noDefault1
                         type: int32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault2
                         type: vint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault3
                         type: uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault4
                         type: vuint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault5
                         type: int64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault6
                         type: vint64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault7
                         type: uint64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault8
                         type: vuint64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault9
                         type: double optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault10
                         type: vdouble optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault11
                         type: bool optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault12
                         type: string optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault13
                         type: vstring optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault14
                         type: EventID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault15
                         type: VEventID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault16
                         type: LuminosityBlockID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault17
                         type: VLuminosityBlockID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault18
                         type: InputTag optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault19
                         type: VInputTag optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault20
                         type: FileInPath optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault21
                         type: LuminosityBlockRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault22
                         type: VLuminosityBlockRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault23
                         type: EventRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault24
                         type: VEventRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.21 noDefaultPset4 PSet description:
 
         noDefault1
                         type: untracked int32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault2
                         type: untracked vint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault3
                         type: untracked uint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault4
                         type: untracked vuint32 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault5
                         type: untracked int64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault6
                         type: untracked vint64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault7
                         type: untracked uint64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault8
                         type: untracked vuint64 optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault9
                         type: untracked double optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault10
                         type: untracked vdouble optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault11
                         type: untracked bool optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault12
                         type: untracked string optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault13
                         type: untracked vstring optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault14
                         type: untracked EventID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault15
                         type: untracked VEventID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault16
                         type: untracked LuminosityBlockID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault17
                         type: untracked VLuminosityBlockID optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault18
                         type: untracked InputTag optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault19
                         type: untracked VInputTag optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault20
                         type: untracked FileInPath optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault21
                         type: untracked LuminosityBlockRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault22
                         type: untracked VLuminosityBlockRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault23
                         type: untracked EventRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault24
                         type: untracked VEventRange optional
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.1.22 plugin PSet description:
 
@@ -2020,7 +2020,7 @@ generated for each configuration with a module label.
 
         type
                         type: string 
-                        default: none (do not write to cfi)
+                        default: none
 
         Section 1.1.23.1.2 edmtestAnotherValueMaker Plugin description:
 
@@ -2030,7 +2030,7 @@ generated for each configuration with a module label.
 
         type
                         type: string 
-                        default: none (do not write to cfi)
+                        default: none
 
   1.2 module label: testLabel1
   A comment for a ParameterSetDescription
@@ -2052,7 +2052,7 @@ generated for each configuration with a module label.
 
     mightGet
                         type: untracked vstring optional
-                        default: none (do not write to cfi)
+                        default: none
                         List contains the branch names for the EDProducts which 
                         might be requested by the module.
                         The format for identifying the EDProduct is the same as 
@@ -2064,197 +2064,197 @@ generated for each configuration with a module label.
 
         noDefault1
                         type: int32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault2
                         type: vint32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault3
                         type: uint32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault4
                         type: vuint32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault5
                         type: int64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault6
                         type: vint64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault7
                         type: uint64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault8
                         type: vuint64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault9
                         type: double 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault10
                         type: vdouble 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault11
                         type: bool 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault12
                         type: string 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault13
                         type: vstring 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault14
                         type: EventID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault15
                         type: VEventID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault16
                         type: LuminosityBlockID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault17
                         type: VLuminosityBlockID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault18
                         type: InputTag 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault19
                         type: VInputTag 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault20
                         type: FileInPath 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault21
                         type: LuminosityBlockRange 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault22
                         type: VLuminosityBlockRange 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault23
                         type: EventRange 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault24
                         type: VEventRange 
-                        default: none (do not write to cfi)
+                        default: none
 
     Section 1.2.2 noDefaultPset2 PSet description:
 
         noDefault1
                         type: untracked int32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault2
                         type: untracked vint32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault3
                         type: untracked uint32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault4
                         type: untracked vuint32 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault5
                         type: untracked int64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault6
                         type: untracked vint64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault7
                         type: untracked uint64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault8
                         type: untracked vuint64 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault9
                         type: untracked double 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault10
                         type: untracked vdouble 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault11
                         type: untracked bool 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault12
                         type: untracked string 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault13
                         type: untracked vstring 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault14
                         type: untracked EventID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault15
                         type: untracked VEventID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault16
                         type: untracked LuminosityBlockID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault17
                         type: untracked VLuminosityBlockID 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault18
                         type: untracked InputTag 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault19
                         type: untracked VInputTag 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault20
                         type: untracked FileInPath 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault21
                         type: untracked LuminosityBlockRange 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault22
                         type: untracked VLuminosityBlockRange 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault23
                         type: untracked EventRange 
-                        default: none (do not write to cfi)
+                        default: none
 
         noDefault24
                         type: untracked VEventRange 
-                        default: none (do not write to cfi)
+                        default: none
 
   1.3 module label: producerWithPSetDesc
 
@@ -2264,7 +2264,7 @@ generated for each configuration with a module label.
 
     mightGet
                         type: untracked vstring optional
-                        default: none (do not write to cfi)
+                        default: none
                         List contains the branch names for the EDProducts which 
                         might be requested by the module.
                         The format for identifying the EDProduct is the same as 
@@ -2280,7 +2280,7 @@ generated for each configuration with a module label.
 
     mightGet
                         type: untracked vstring optional
-                        default: none (do not write to cfi)
+                        default: none
                         List contains the branch names for the EDProducts which 
                         might be requested by the module.
                         The format for identifying the EDProduct is the same as 

--- a/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
@@ -225,8 +225,10 @@ namespace edm {
           writeDoc_(os, dfh.startColumn2());
         }
       }
-    } else {
+    } else if (!writeToCfi) {
       os << "none (do not write to cfi)";
+    } else {
+      os << "none";
     }
     os << "\n";
   }


### PR DESCRIPTION
#### PR description:

Remove commment "do not write to cfi" when parameters with no
defaults are being written to cfi with new required or optional
Python types.

#### PR validation:

Changed reference files in existing unit tests. Should have no effect on anything other than the output of the edmPluginHelp utility executable.
