### PR TITLE
Run3-TB42 Correct numbering for AHCal so that |row|/|column| can exceed 10

### DIFF
--- a/Geometry/HGCalCommonData/plugins/DDAHcalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/DDAHcalModuleAlgo.cc
@@ -182,11 +182,11 @@ void DDAHcalModuleAlgo::positionSensitive(DDLogicalPart& glog, DDCompactView& cp
       if (nr != 0 && nc != 0) {
         DDTranslation tran(xpos, ypos, 0.0);
         DDRotation rotation;
-        int copy = inr * 10 + inc;
+        int copy = inr * 100 + inc;
         if (nc < 0)
-          copy += 100;
+          copy += 10000;
         if (nr < 0)
-          copy += 1000;
+          copy += 100000;
         DDName name = DDName(DDSplit(tile).first, DDSplit(tile).second);
         cpv.position(name, glog.ddname(), copy, tran, rotation);
 #ifdef EDM_ML_DEBUG

--- a/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
+++ b/SimG4CMS/HGCalTestBeam/plugins/AHCalSD.cc
@@ -88,10 +88,10 @@ uint32_t AHCalSD::setDetUnitId(const G4Step* aStep) {
   const G4VTouchable* touch = preStepPoint->GetTouchable();
 
   int depth = (touch->GetReplicaNumber(1));
-  int incol = ((touch->GetReplicaNumber(0)) % 10);
-  int inrow = ((touch->GetReplicaNumber(0)) / 10) % 10;
-  int jncol = ((touch->GetReplicaNumber(0)) / 100) % 10;
-  int jnrow = ((touch->GetReplicaNumber(0)) / 1000) % 10;
+  int incol = ((touch->GetReplicaNumber(0)) % 100);
+  int inrow = ((touch->GetReplicaNumber(0)) / 100) % 100;
+  int jncol = ((touch->GetReplicaNumber(0)) / 10000) % 10;
+  int jnrow = ((touch->GetReplicaNumber(0)) / 100000) % 10;
   int col = (jncol == 0) ? incol : -incol;
   int row = (jnrow == 0) ? inrow : -inrow;
   uint32_t index = AHCalDetId(row, col, depth).rawId();


### PR DESCRIPTION
#### PR description:

The earlier code was restricting row-column number for AHCal cell to be within -9 to +9. In fact it has to be between -12 to +12. The code is corrected to allow that

#### PR validation:

Tested with scripts for TestBeam simulation

#### if this PR is a backport please specify the original PR:

Nothing special