### PR TITLE
Restore updated PPS association cuts for 2017

### DIFF
--- a/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoCTPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -30,13 +30,8 @@ def applyDefaultSettings(ctppsProtons):
 ctpps_2016.toModify(ctppsProtons, applyDefaultSettings) # applied for all Run2 years (2016, 2017 and 2018)
 
 def apply2017Settings(ctppsProtons):
-  ctppsProtons.association_cuts_45.xi_cut_value = 0.013
-  ctppsProtons.association_cuts_45.th_y_cut_apply = True
-  ctppsProtons.association_cuts_45.th_y_cut_value = 20E-6
-  ctppsProtons.association_cuts_56.xi_cut_value = 0.013
-  ctppsProtons.association_cuts_56.th_y_cut_apply = True
-  ctppsProtons.association_cuts_56.th_y_cut_value = 20E-6
-
+  ctppsProtons.association_cuts_45.xi_cut_value = 0.010
+  ctppsProtons.association_cuts_56.xi_cut_value = 0.015
 
 ctpps_2017.toModify(ctppsProtons, apply2017Settings)
 


### PR DESCRIPTION
#### PR description:

This reverts commit 41eca266b64be26a9a56f549c3808448a0c88b58 , restoring the optimised 2017 association cuts for PPS (present in master, reverted to the default in 10_6_X for backward compatibility).

As the 2017 production should likely be restarted for unrelated reasons this PR offers the possibility to get the best scenario also for 2017.

#### PR validation:

See #27440 