### PR TITLE
Add 2023 test workflow to the short PyRelVal matrix, add a protection for not defined workflows

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -22,6 +22,13 @@ def runSelected(opt):
     mrd = MatrixReader(opt)
     mrd.prepare(opt.useInput, opt.refRel, opt.fromScratch)
 
+    # test for wrong input workflows
+    if opt.testList:
+        definedWF = []
+        for dwf in mrd.workFlows: definedWF.append(dwf.numId)
+        for twf in opt.testList:
+            if twf not in definedWF: raise ValueError('Not defined workflow ', twf , ' requested')
+
     ret = 0
     if opt.show:
         mrd.show(opt.testList, opt.extended, opt.cafVeto)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -75,6 +75,7 @@ if __name__ == '__main__':
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
                      11634.0, #2021 ttbar
+                     12434.0, #2023 ttbar
                      20034.0, #2026D35 ttbar (MTD TDR baseline)
                      20434.0, #2026D41 ttbar (L1T TDR baseline)
                      21234.0, #2026D44 (exercise HF nose)


### PR DESCRIPTION
#### PR description:

This PR addresses two requests by @slava77 

- add a 2023 test workflow to the short PyReleaseValidation matrix https://github.com/cms-sw/cmssw/pull/27678#pullrequestreview-270461796

- raise an exception in case runTheMatrix.py is requested to run not defined workflows #27687

#### PR validation:

```
18:50 cmsdev25 1912> runTheMatrix.py -n -l limited
processing relval_standard
processing relval_highstats
processing relval_pileup
processing relval_generator
processing relval_extendedgen
processing relval_production
processing relval_ged
ignoring relval_upgrade from default matrix
processing relval_2017
processing relval_2026
ignoring relval_identity from default matrix
processing relval_machine
processing relval_unsch
processing relval_premix

found a total of  786  workflows:
      of which the following 34 were selected:
4.22   RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC 
4.53   RunPhoton2012B+HLTD+RECODR1reHLT+HARVESTDR1reHLT 
5.1    TTbarFS+HARVESTFS                   
7.3    CosmicsSPLoose_UP18+DIGICOS_UP18+RECOCOS_UP18+ALCACOS_UP18+HARVESTCOS_UP18 
8.0    BeamHalo+DIGICOS+RECOCOS+ALCABH+HARVESTCOS 
9.0    Higgs200ChargedTaus+DIGI+RECO+HARVEST 
25.0   TTbar+DIGI+RECOAlCaCalo+HARVEST+ALCATT 
135.4  ZEEFS_13+HARVESTUP15FS+MINIAODMCUP15FS 
136.731 RunSinglePh2016B+HLTDR2_2016+RECODR2_2016reHLT_skimSinglePh_HIPM+HARVESTDR2 
136.7611 RunJetHT2016E_reminiaod+REMINIAOD_data2016_HIPM+HARVESTDR2_REMINIAOD_data2016_HIPM 
136.788 RunSinglePh2017B+HLTDR2_2017+RECODR2_2017reHLT_skimSinglePh_Prompt+HARVEST2017 
136.8311 RunJetHT2017F_reminiaod+REMINIAOD_data2017+HARVEST2017_REMINIAOD_data2017 
136.85 RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM 
140.53 RunHI2011+RECOHID11+HARVESTDHI      
140.56 RunHI2018+RECOHID18+HARVESTDHI18    
158.0  HydjetQ_B12_5020GeV_2018_ppReco+DIGIHI2018PPRECO+RECOHI2018PPRECO+ALCARECOHI2018PPRECO+HARVESTHI2018PPRECO 
1306.0 SingleMuPt1_UP15+DIGIUP15+RECOUP15+HARVESTUP15 
1325.7 TTbar_13_94Xv2NanoAODINPUT+NANOEDMMC2017_94XMiniAODv2+HARVESTNANOAODMC2017_94XMiniAODv2 
1330.0 ZMM_13+DIGIUP15+RECOUP15_L1TMuDQM+HARVESTUP15_L1TMuDQM 
101.0  SingleElectronE120EHCAL             
25202.0 TTbar_13+DIGIUP15_PU25+RECOUP15_PU25+HARVESTUP15_PU25 
1000.0 RunMinBias2011A+TIER0+SKIMD+HARVESTDfst2+ALCASPLIT 
1001.0 RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVDSIPIXELCALRUN1+ALCAHARVD1+ALCAHARVD2+ALCAHARVD3+ALCAHARVD4+ALCAHARVD5 
10024.0 TTbar_13TeV_TuneCUETP8M1_2017_GenSimFull+DigiFull_2017+RecoFull_2017+HARVESTFull_2017+ALCAFull_2017 
10042.0 ZMM_13TeV_TuneCUETP8M1_2017_GenSimFull+DigiFull_2017+RecoFull_2017+HARVESTFull_2017+ALCAFull_2017 
10224.0 TTbar_13TeV_TuneCUETP8M1_2017PU_GenSimFull+DigiFullPU_2017PU+RecoFullPU_2017PU+HARVESTFullPU_2017PU 
10824.0 TTbar_13TeV_TuneCUETP8M1_2018_GenSimFull+DigiFull_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018 
11634.0 TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_2021+RecoFull_2021+HARVESTFull_2021+ALCAFull_2021 
12434.0 TTbar_14TeV_TuneCUETP8M1_2023_GenSimFull+DigiFull_2023+RecoFull_2023+HARVESTFull_2023+ALCAFull_2023 
20034.0 TTbar_14TeV_TuneCUETP8M1_2026D35_GenSimHLBeamSpotFull14+DigiFullTrigger_2026D35+RecoFullGlobal_2026D35+HARVESTFullGlobal_2026D35 
20434.0 TTbar_14TeV_TuneCUETP8M1_2026D41_GenSimHLBeamSpotFull14+DigiFullTrigger_2026D41+RecoFullGlobal_2026D41+HARVESTFullGlobal_2026D41 
21234.0 TTbar_14TeV_TuneCUETP8M1_2026D44_GenSimHLBeamSpotFull14+DigiFullTrigger_2026D44+RecoFullGlobal_2026D44+HARVESTFullGlobal_2026D44 
22034.0 TTbar_14TeV_TuneCUETP8M1_2026D46_GenSimHLBeamSpotFull14+DigiFullTrigger_2026D46+RecoFullGlobal_2026D46+HARVESTFullGlobal_2026D46 
250202.181 TTbar_13UP18+PREMIXUP18_PU25+DIGIPRMXLOCALUP18_PU25+RECOPRMXUP18_PU25+HARVESTUP18_PU25 

1 workflows with 1 steps
1 workflows with 2 steps
6 workflows with 3 steps
13 workflows with 4 steps
11 workflows with 5 steps
1 workflows with 6 steps
1 workflows with 9 steps

 -------------------------------------------------------------------------------- 

testListected items: [8, 9.0, 140.53, 12434.0, 140.56, 5.1, 25, 1306.0, 158.0, 1325.7, 10024.0, 21234.0, 136.788, 1330, 135.4, 4.22, 136.7611, 10042.0, 20034.0, 4.53, 10824.0, 7.3, 250202.181, 136.85, 20434.0, 101.0, 136.731, 1001, 22034.0, 10224.0, 1000, 11634.0, 25202.0, 136.8311]
```

```
18:50 cmsdev25 1913> runTheMatrix.py -n -l 1111111.88
processing relval_standard
processing relval_highstats
processing relval_pileup
processing relval_generator
processing relval_extendedgen
processing relval_production
processing relval_ged
ignoring relval_upgrade from default matrix
processing relval_2017
processing relval_2026
ignoring relval_identity from default matrix
processing relval_machine
processing relval_unsch
processing relval_premix
Traceback (most recent call last):
  File "/build/fabiocos/110X/update-relval/CMSSW_11_0_X_2019-08-06-2300/bin/slc7_amd64_gcc700/runTheMatrix.py", line 347, in <module>
    ret = runSelected(opt)
  File "/build/fabiocos/110X/update-relval/CMSSW_11_0_X_2019-08-06-2300/bin/slc7_amd64_gcc700/runTheMatrix.py", line 30, in runSelected
    if twf not in definedWF: raise ValueError('Not defined workflow ', twf , ' requested')
ValueError: ('Not defined workflow ', 1111111.88, ' requested')
```

Various input flag combinations have been tested (--dryRun,. --what upgrade, regular processing, etc...) , and python3 compilation passes.