### PR TITLE
Provide initial values for all struct members in SiStripDcsInfo

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
@@ -36,12 +36,12 @@ SiStripDcsInfo::SiStripDcsInfo(edm::ParameterSet const& pSet) {
 void SiStripDcsInfo::beginJob() {
   // Since SubDetMEs is a struct, using the brace initialization will
   // zero-initialize all members that are not specified in the call.
-  SubDetMEsMap.emplace("TIB", SubDetMEs{"TIB"});
-  SubDetMEsMap.emplace("TOB", SubDetMEs{"TOB"});
-  SubDetMEsMap.emplace("TECB", SubDetMEs{"TEC/MINUS"});
-  SubDetMEsMap.emplace("TECF", SubDetMEs{"TEC/PLUS"});
-  SubDetMEsMap.emplace("TIDB", SubDetMEs{"TID/MINUS"});
-  SubDetMEsMap.emplace("TIDF", SubDetMEs{"TID/PLUS"});
+  SubDetMEsMap.emplace("TIB", SubDetMEs{"TIB", nullptr, 0, {}, {}});
+  SubDetMEsMap.emplace("TOB", SubDetMEs{"TOB", nullptr, 0, {}, {}});
+  SubDetMEsMap.emplace("TECB", SubDetMEs{"TEC/MINUS", nullptr, 0, {}, {}});
+  SubDetMEsMap.emplace("TECF", SubDetMEs{"TEC/PLUS", nullptr, 0, {}, {}});
+  SubDetMEsMap.emplace("TIDB", SubDetMEs{"TID/MINUS", nullptr, 0, {}, {}});
+  SubDetMEsMap.emplace("TIDF", SubDetMEs{"TID/PLUS", nullptr, 0, {}, {}});
 }
 //
 // -- Begin Run


### PR DESCRIPTION
#### PR description:

This fixes a gcc 9 warning about missing-field-initializers.

#### PR validation:

Tested using an gcc 9 IB.
This change is technical and should not change any results unless those results are dependent upon uninitialized values.