### PR TITLE
Added missing return statement in switch for SiStripPayloadInspectorHelper

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -330,7 +330,7 @@ namespace SiStripPI {
       case SiStripPI::TID3s:
         return std::make_pair(38, "TID D3 stereo");
       case SiStripPI::END_OF_REGIONS:
-        std::make_pair(-1, "undefined");
+        return std::make_pair(-1, "undefined");
       default:
         return std::make_pair(999, "should never be here");
     }


### PR DESCRIPTION
#### PR description:

gcc 9 gave a warning that the case statement was falling through to the next statement. Looking at the git history showed that before the routine was returning a std::pair it returned a string and for the case in question it returned the value "undefined". This change now matches the earlier behavior.

#### PR validation:

Tested compilation under a gcc 9 IB.

This change would only cause a results change if incorrect values are being passed to the routine which was modified.