### PR TITLE
Fix copy constructor for TRecHit1DMomConstraint

### DIFF
--- a/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TRecHit1DMomConstraint.h
@@ -76,8 +76,7 @@ private:
                          const Surface* surface)
       : charge_(charge), mom_(mom), err_(err), surface_(surface) {}
 
-  TRecHit1DMomConstraint(const TRecHit1DMomConstraint& other)
-      : charge_(other.charge()), mom_(other.mom()), err_(other.err()), surface_((other.surface())) {}
+  TRecHit1DMomConstraint(const TRecHit1DMomConstraint& other) = default;
 
   TRecHit1DMomConstraint* clone() const override { return new TRecHit1DMomConstraint(*this); }
 };


### PR DESCRIPTION
#### PR description:

The gcc 9 compiler complained that the base class copy constructor was not being called. As the code was doing the same work as the default compiler written copy constructor, switched to using `= default`.

#### PR validation:

Tested compilation using a gcc 9 IB.
The change is technical and should not affect results unless the results were dependent on an incorrect copy constructor.