### PR TITLE
Explicitly use default c'tor in muon DetId copy c'tors

### DIFF
--- a/DataFormats/MuonDetId/src/DTLayerId.cc
+++ b/DataFormats/MuonDetId/src/DTLayerId.cc
@@ -19,7 +19,7 @@ DTLayerId::DTLayerId(uint32_t id) {
 }
 
 // Copy Constructor.
-DTLayerId::DTLayerId(const DTLayerId& layerId) {
+DTLayerId::DTLayerId(const DTLayerId& layerId) : DTSuperLayerId() {
   // The mask is required for proper slicing, i.e. if layerId is
   // actually a derived class.
   id_ = (layerId.rawId() & layerIdMask_);

--- a/DataFormats/MuonDetId/src/DTSuperLayerId.cc
+++ b/DataFormats/MuonDetId/src/DTSuperLayerId.cc
@@ -27,7 +27,7 @@ DTSuperLayerId::DTSuperLayerId(int wheel, int station, int sector, int superlaye
 }
 
 // Copy Constructor.
-DTSuperLayerId::DTSuperLayerId(const DTSuperLayerId& slId) {
+DTSuperLayerId::DTSuperLayerId(const DTSuperLayerId& slId) : DTChamberId() {
   // The mask is required for proper slicing, i.e. if slId is
   // actually a derived class.
   id_ = (slId.rawId() & slIdMask_);

--- a/DataFormats/MuonDetId/src/DTWireId.cc
+++ b/DataFormats/MuonDetId/src/DTWireId.cc
@@ -29,7 +29,7 @@ DTWireId::DTWireId(int wheel, int station, int sector, int superlayer, int layer
 }
 
 // Copy Constructor.
-DTWireId::DTWireId(const DTWireId& wireId) { id_ = wireId.rawId(); }
+DTWireId::DTWireId(const DTWireId& wireId) : DTLayerId() { id_ = wireId.rawId(); }
 
 // Constructor from a CamberId and SL, layer and wire numbers
 DTWireId::DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire) : DTLayerId(chId, superlayer, layer) {


### PR DESCRIPTION
#### PR description:

The gcc 9 compiler was warning that inheriting class copy constructors were not calling the base class copy constructors. The code was doing that on purpose. To make that clear, the code now explicitly calls the default constructor for the base class.

#### PR validation:

The code compiles using a gcc 9 IB.
This is a technical change (explicitly doing what the compiler was implicitly doing) and should not change results.