### PR TITLE
Fix expression evaluator unit test

### DIFF
--- a/CommonTools/Utils/src/ExpressionEvaluator.cc
+++ b/CommonTools/Utils/src/ExpressionEvaluator.cc
@@ -28,9 +28,9 @@ namespace {
     return n1;
   }
 
-  void remove(std::string const& name) {
-    std::string sfile = "/tmp/" + name + ".cc";
-    std::string ofile = "/tmp/" + name + ".so";
+  void remove(std::string const& name, std::string const& tmpDir="/tmp") {
+    std::string sfile = tmpDir + "/" + name + ".cc";
+    std::string ofile = tmpDir + "/" + name + ".so";
 
     std::string rm = "rm -f ";
     rm += sfile + ' ' + ofile;
@@ -55,12 +55,12 @@ namespace reco {
     pch += "/src/precompile.h";
     std::string quote("\"");
 
-    std::string sfile = "/tmp/" + m_name + ".cc";
-    std::string ofile = "/tmp/" + m_name + ".so";
-
     auto arch = edm::getEnvironmentVariable("SCRAM_ARCH");
     auto baseDir = edm::getEnvironmentVariable("CMSSW_BASE");
     auto relDir = edm::getEnvironmentVariable("CMSSW_RELEASE_BASE");
+
+    std::string sfile = baseDir + "/tmp/" + m_name + ".cc";
+    std::string ofile = baseDir + "/tmp/" + m_name + ".so";
 
     std::string incDir = "/include/" + arch + "/";
     std::string cxxf;
@@ -144,16 +144,16 @@ namespace reco {
 
     void* dl = dlopen(ofile.c_str(), RTLD_LAZY);
     if (!dl) {
-      remove(m_name);
+      remove(m_name, baseDir+"/tmp");
       throw cms::Exception("ExpressionEvaluator",
                            std::string("compilation/linking failed\n") + cpp + ss + "dlerror " + dlerror());
       return;
     }
 
     m_expr = dlsym(dl, factory.c_str());
-    remove(m_name);
+    remove(m_name, baseDir+"/tmp");
   }
 
-  ExpressionEvaluator::~ExpressionEvaluator() { remove(m_name); }
+  ExpressionEvaluator::~ExpressionEvaluator() { remove(m_name, edm::getEnvironmentVariable("CMSSW_BASE")+"/tmp"); }
 
 }  // namespace reco

--- a/CommonTools/Utils/src/ExpressionEvaluator.cc
+++ b/CommonTools/Utils/src/ExpressionEvaluator.cc
@@ -28,7 +28,7 @@ namespace {
     return n1;
   }
 
-  void remove(std::string const& name, std::string const& tmpDir="/tmp") {
+  void remove(std::string const& name, std::string const& tmpDir = "/tmp") {
     std::string sfile = tmpDir + "/" + name + ".cc";
     std::string ofile = tmpDir + "/" + name + ".so";
 
@@ -144,16 +144,16 @@ namespace reco {
 
     void* dl = dlopen(ofile.c_str(), RTLD_LAZY);
     if (!dl) {
-      remove(m_name, baseDir+"/tmp");
+      remove(m_name, baseDir + "/tmp");
       throw cms::Exception("ExpressionEvaluator",
                            std::string("compilation/linking failed\n") + cpp + ss + "dlerror " + dlerror());
       return;
     }
 
     m_expr = dlsym(dl, factory.c_str());
-    remove(m_name, baseDir+"/tmp");
+    remove(m_name, baseDir + "/tmp");
   }
 
-  ExpressionEvaluator::~ExpressionEvaluator() { remove(m_name, edm::getEnvironmentVariable("CMSSW_BASE")+"/tmp"); }
+  ExpressionEvaluator::~ExpressionEvaluator() { remove(m_name, edm::getEnvironmentVariable("CMSSW_BASE") + "/tmp"); }
 
 }  // namespace reco

--- a/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
+++ b/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
@@ -61,7 +61,7 @@ int main() {
   }
 
   try {
-    std::string cut = "bool operator()(int i, int j) override { return i<10&& j<5; }";
+    std::string cut = "bool operator()(int i, int j) const override { return i<10&& j<5; }";
     auto const& mcut =
         *reco_expressionEvaluator("CommonTools/Utils", SINGLE_ARG(reco::genericExpression<bool, int, int>), cut);
     std::cout << mcut(2, 7) << ' ' << mcut(3, 4) << std::endl;


### PR DESCRIPTION
Added missing 'const' to match the `reco::genericExpression::operator()` signatures. This should fix ExpressionEvaluatorUnitTest.
use CMSSW_BASE/tmp to create tmp `VI_*` files