### PR TITLE
HBHE cleanup and speedup

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -17,12 +17,10 @@ typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, Max
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
+typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxSVSize> PulseSampleMatrix;
 
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 typedef Eigen::LLT<PulseMatrix> PulseDecompLLT;
 typedef Eigen::LDLT<PulseMatrix> PulseDecompLDLT;
-
-typedef Eigen::Matrix<double, 1, 1> SingleMatrix;
-typedef Eigen::Matrix<double, 1, 1> SingleVector;
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -18,10 +18,9 @@ struct MahiNnlsWorkspace {
   unsigned int nPulseTot;
   unsigned int tsSize;
   unsigned int tsOffset;
-  unsigned int fullTSOffset;
   int bxOffset;
   int maxoffset;
-  double dt;
+  float dt;
 
   //holds active bunch crossings
   BXVector bxs;
@@ -33,11 +32,11 @@ struct MahiNnlsWorkspace {
   SampleVector noiseTerms;
 
   //holds flat pedestal uncertainty
-  SampleMatrix pedConstraint;
+  float pedVal;
 
   //holds full covariance matrix for a pulse shape
   //varied in time
-  std::array<FullSampleMatrix, MaxPVSize> pulseCovArray;
+  std::array<SampleMatrix, MaxPVSize> pulseCovArray;
 
   //holds matrix of pulse shape templates for each BX
   SamplePulseMatrix pulseMat;
@@ -121,8 +120,11 @@ public:
 
   void doFit(std::array<float, 3>& correctedOutput, const int nbx) const;
 
-  void setPulseShapeTemplate(const HcalPulseShapes::Shape& ps, const HcalTimeSlew* hcalTimeSlewDelay);
-  void resetPulseShapeTemplate(const HcalPulseShapes::Shape& ps);
+  void setPulseShapeTemplate(const HcalPulseShapes::Shape& ps,
+                             bool hasTimeInfo,
+                             const HcalTimeSlew* hcalTimeSlewDelay,
+                             unsigned int nSamples);
+  void resetPulseShapeTemplate(const HcalPulseShapes::Shape& ps, bool hasTimeInfo, unsigned int nSamples);
 
   typedef BXVector::Index Index;
   const HcalPulseShapes::Shape* currentPulseShape_ = nullptr;
@@ -150,9 +152,6 @@ private:
   mutable MahiNnlsWorkspace nnlsWork_;
 
   //hard coded in initializer
-  const unsigned int fullTSSize_;
-  const unsigned int fullTSofInterest_;
-
   static constexpr int pedestalBX_ = 100;
 
   // used to restrict returned time value to a 25 ns window centered

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFunctor.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFunctor.h
@@ -59,10 +59,10 @@ namespace FitterFuncs {
     void setinvertpedSig2(double x) { invertpedSig2_ = x; }
     void setinverttimeSig2(double x) { inverttimeSig2_ = x; }
 
-    inline void singlePulseShapeFuncMahi(const float *x) { return EvalPulse(x); };
-    inline double singlePulseShapeFunc(const double *x) { return EvalPulseM2(x, 3); };
-    inline double doublePulseShapeFunc(const double *x) { return EvalPulseM2(x, 5); };
-    inline double triplePulseShapeFunc(const double *x) { return EvalPulseM2(x, 7); };
+    inline void singlePulseShapeFuncMahi(const float *x) { return EvalPulse(x); }
+    inline double singlePulseShapeFunc(const double *x) { return EvalPulseM2(x, 3); }
+    inline double doublePulseShapeFunc(const double *x) { return EvalPulseM2(x, 5); }
+    inline double triplePulseShapeFunc(const double *x) { return EvalPulseM2(x, 7); }
 
     void getPulseShape(std::array<double, HcalConst::maxSamples> &fillPulseShape) { fillPulseShape = pulse_shape_; }
 
@@ -74,11 +74,11 @@ namespace FitterFuncs {
     std::vector<float> accVarLenIdxZEROVec, diffVarItvlIdxZEROVec;
     std::vector<float> accVarLenIdxMinusOneVec, diffVarItvlIdxMinusOneVec;
 
-    void funcShape(std::array<double, HcalConst::maxSamples> &ntmpbin, const float pulseTime, const double slew);
-    void funcShapeM2(std::array<double, HcalConst::maxSamples> &ntmpbin,
-                     const double pulseTime,
-                     const double pulseHeight,
-                     const double slew);
+    void funcShape(std::array<double, HcalConst::maxSamples> &ntmpbin,
+                   const double pulseTime,
+                   const double pulseHeight,
+                   const double slew,
+                   bool scalePulse);
     double psFit_x[HcalConst::maxSamples], psFit_y[HcalConst::maxSamples], psFit_erry[HcalConst::maxSamples],
         psFit_erry2[HcalConst::maxSamples], psFit_slew[HcalConst::maxSamples];
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFunctor.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFunctor.h
@@ -28,7 +28,7 @@ namespace FitterFuncs {
                       unsigned int nSamplesToFit);
     ~PulseShapeFunctor();
 
-    void EvalPulse(const double *pars);
+    void EvalPulse(const float *pars);
     double EvalPulseM2(const double *pars, const unsigned nPar);
 
     void setDefaultcntNANinfit() { cntNANinfit = 0; }
@@ -59,10 +59,10 @@ namespace FitterFuncs {
     void setinvertpedSig2(double x) { invertpedSig2_ = x; }
     void setinverttimeSig2(double x) { inverttimeSig2_ = x; }
 
-    void singlePulseShapeFuncMahi(const double *x);
-    double singlePulseShapeFunc(const double *x);
-    double doublePulseShapeFunc(const double *x);
-    double triplePulseShapeFunc(const double *x);
+    inline void singlePulseShapeFuncMahi(const float *x) { return EvalPulse(x); };
+    inline double singlePulseShapeFunc(const double *x) { return EvalPulseM2(x, 3); };
+    inline double doublePulseShapeFunc(const double *x) { return EvalPulseM2(x, 5); };
+    inline double triplePulseShapeFunc(const double *x) { return EvalPulseM2(x, 7); };
 
     void getPulseShape(std::array<double, HcalConst::maxSamples> &fillPulseShape) { fillPulseShape = pulse_shape_; }
 
@@ -74,10 +74,11 @@ namespace FitterFuncs {
     std::vector<float> accVarLenIdxZEROVec, diffVarItvlIdxZEROVec;
     std::vector<float> accVarLenIdxMinusOneVec, diffVarItvlIdxMinusOneVec;
 
-    void funcShape(std::array<double, HcalConst::maxSamples> &ntmpbin,
-                   const double pulseTime,
-                   const double pulseHeight,
-                   const double slew);
+    void funcShape(std::array<double, HcalConst::maxSamples> &ntmpbin, const float pulseTime, const double slew);
+    void funcShapeM2(std::array<double, HcalConst::maxSamples> &ntmpbin,
+                     const double pulseTime,
+                     const double pulseHeight,
+                     const double slew);
     double psFit_x[HcalConst::maxSamples], psFit_y[HcalConst::maxSamples], psFit_erry[HcalConst::maxSamples],
         psFit_erry2[HcalConst::maxSamples], psFit_slew[HcalConst::maxSamples];
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
@@ -85,10 +85,7 @@ protected:
                  int nSamplesToAdd);
 
   // "Method 0" rechit timing (original low-pileup QIE8 algorithm)
-  float m0Time(const HBHEChannelInfo& info,
-               double reconstructedCharge,
-               const HcalCalibrations& calibs,
-               int nSamplesToExamine) const;
+  float m0Time(const HBHEChannelInfo& info, double reconstructedCharge, int nSamplesToExamine) const;
 
 private:
   HcalPulseContainmentManager pulseCorr_;

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFunctor.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFunctor.cc
@@ -68,10 +68,10 @@ namespace FitterFuncs {
     nSamplesToFit_ = nSamplesToFit;
   }
 
-  void PulseShapeFunctor::funcShape(std::array<double, HcalConst::maxSamples> &ntmpbin,
-                                    const double pulseTime,
-                                    const double pulseHeight,
-                                    const double slew) {
+  void PulseShapeFunctor::funcShapeM2(std::array<double, HcalConst::maxSamples> &ntmpbin,
+                                      const double pulseTime,
+                                      const double pulseHeight,
+                                      const double slew) {
     // pulse shape components over a range of time 0 ns to 255 ns in 1 ns steps
     constexpr int ns_per_bx = HcalConst::nsPerBX;
     constexpr int num_ns = HcalConst::nsPerBX * HcalConst::maxSamples;
@@ -119,12 +119,57 @@ namespace FitterFuncs {
     return;
   }
 
+  void PulseShapeFunctor::funcShape(std::array<double, HcalConst::maxSamples> &ntmpbin,
+                                    const float pulseTime,
+                                    const double slew) {
+    // pulse shape components over a range of time 0 ns to 255 ns in 1 ns steps
+    constexpr int ns_per_bx = HcalConst::nsPerBX;
+    constexpr int num_ns = HcalConst::nsPerBX * HcalConst::maxSamples;
+    constexpr int num_bx = num_ns / ns_per_bx;
+    //Get the starting time
+    int i_start = (-HcalConst::iniTimeShift - pulseTime - slew > 0
+                       ? 0
+                       : (int)std::abs(-HcalConst::iniTimeShift - pulseTime - slew) + 1);
+    double offset_start = i_start - HcalConst::iniTimeShift - pulseTime -
+                          slew;  //-199-2*pars[0]-2.*slew (for pars[0] > 98.5) or just -98.5-pars[0]-slew;
+    // zeroing output binned pulse shape
+    ntmpbin.fill(0.0f);
+
+    if (edm::isNotFinite(offset_start)) {  //Check for nan
+      ++cntNANinfit;
+    } else {
+      if (offset_start == 1.0) {
+        offset_start = 0.;
+        i_start -= 1;
+      }  //Deal with boundary
+
+      const int bin_start = (int)offset_start;                                               //bin off to integer
+      const int bin_0_start = (offset_start < bin_start + 0.5 ? bin_start - 1 : bin_start);  //Round it
+      const int iTS_start = i_start / ns_per_bx;                                             //Time Slice for time shift
+      const int distTo25ns_start = HcalConst::nsPerBX - 1 - i_start % ns_per_bx;             //Delta ns
+      const double factor = offset_start - bin_0_start - 0.5;                                //Small correction?
+
+      //Build the new pulse
+      ntmpbin[iTS_start] =
+          (bin_0_start == -1
+               ?  // Initial bin (I'm assuming this is ok)
+               accVarLenIdxMinusOneVec[distTo25ns_start] + factor * diffVarItvlIdxMinusOneVec[distTo25ns_start]
+               : accVarLenIdxZEROVec[distTo25ns_start] + factor * diffVarItvlIdxZEROVec[distTo25ns_start]);
+      //Fill the rest of the bins
+      for (int iTS = iTS_start + 1; iTS < num_bx; ++iTS) {
+        int bin_idx = distTo25ns_start + 1 + (iTS - iTS_start - 1) * ns_per_bx + bin_0_start;
+        ntmpbin[iTS] = acc25nsVec[bin_idx] + factor * diff25nsItvlVec[bin_idx];
+      }
+    }
+
+    return;
+  }
+
   PulseShapeFunctor::~PulseShapeFunctor() {}
 
-  void PulseShapeFunctor::EvalPulse(const double *pars) {
+  void PulseShapeFunctor::EvalPulse(const float *pars) {
     int time = (pars[0] + timeShift_ - timeMean_) * HcalConst::invertnsPerBx;
-    funcShape(pulse_shape_, pars[0], pars[1], psFit_slew[time]);
-
+    funcShape(pulse_shape_, pars[0], psFit_slew[time]);
     return;
   }
 
@@ -148,7 +193,7 @@ namespace FitterFuncs {
     if (addPulseJitter_) {
       int time = (pars[0] + timeShift_ - timeMean_) * HcalConst::invertnsPerBx;
       //Interpolate the fit (Quickly)
-      funcShape(pulse_shape_, pars[0], pars[1], psFit_slew[time]);
+      funcShapeM2(pulse_shape_, pars[0], pars[1], psFit_slew[time]);
       for (j = 0; j < nSamplesToFit_; ++j) {
         psFit_erry2[j] += pulse_shape_[j] * pulse_shape_[j] * pulseJitter_;
         pulse_shape_sum_[j] = pulse_shape_[j] + pedestal;
@@ -157,7 +202,7 @@ namespace FitterFuncs {
       for (i = 1; i < parBy2; ++i) {
         time = (pars[i * 2] + timeShift_ - timeMean_) * HcalConst::invertnsPerBx;
         //Interpolate the fit (Quickly)
-        funcShape(pulse_shape_, pars[i * 2], pars[i * 2 + 1], psFit_slew[time]);
+        funcShapeM2(pulse_shape_, pars[i * 2], pars[i * 2 + 1], psFit_slew[time]);
         // add an uncertainty from the pulse (currently noise * pulse height =>Ecal uses full cov)
         /////
         for (j = 0; j < nSamplesToFit_; ++j) {
@@ -168,14 +213,14 @@ namespace FitterFuncs {
     } else {
       int time = (pars[0] + timeShift_ - timeMean_) * HcalConst::invertnsPerBx;
       //Interpolate the fit (Quickly)
-      funcShape(pulse_shape_, pars[0], pars[1], psFit_slew[time]);
+      funcShapeM2(pulse_shape_, pars[0], pars[1], psFit_slew[time]);
       for (j = 0; j < nSamplesToFit_; ++j)
         pulse_shape_sum_[j] = pulse_shape_[j] + pedestal;
 
       for (i = 1; i < parBy2; ++i) {
         time = (pars[i * 2] + timeShift_ - timeMean_) * HcalConst::invertnsPerBx;
         //Interpolate the fit (Quickly)
-        funcShape(pulse_shape_, pars[i * 2], pars[i * 2 + 1], psFit_slew[time]);
+        funcShapeM2(pulse_shape_, pars[i * 2], pars[i * 2 + 1], psFit_slew[time]);
         // add an uncertainty from the pulse (currently noise * pulse height =>Ecal uses full cov)
         for (j = 0; j < nSamplesToFit_; ++j)
           pulse_shape_sum_[j] += pulse_shape_[j];
@@ -201,13 +246,4 @@ namespace FitterFuncs {
     }
     return chisq;
   }
-
-  void PulseShapeFunctor::singlePulseShapeFuncMahi(const double *x) { return EvalPulse(x); }
-
-  double PulseShapeFunctor::singlePulseShapeFunc(const double *x) { return EvalPulseM2(x, 3); }
-
-  double PulseShapeFunctor::doublePulseShapeFunc(const double *x) { return EvalPulseM2(x, 5); }
-
-  double PulseShapeFunctor::triplePulseShapeFunc(const double *x) { return EvalPulseM2(x, 7); }
-
 }  // namespace FitterFuncs

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -71,7 +71,7 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
     const float phasens = params ? params->correctionPhaseNS() : phaseNS_;
     m0E = m0Energy(info, fc_ampl, applyContainment, phasens, nSamplesToAdd);
     m0E *= hbminusCorrectionFactor(channelId, m0E, isData);
-    m0t = m0Time(info, fc_ampl, calibs, nSamplesToAdd);
+    m0t = m0Time(info, fc_ampl, nSamplesToAdd);
   }
 
   // Run "Method 2"
@@ -104,7 +104,8 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
   const MahiFit* mahi = mahiOOTpuCorr_.get();
 
   if (mahi) {
-    mahiOOTpuCorr_->setPulseShapeTemplate(theHcalPulseShapes_.getShape(info.recoShape()), hcalTimeSlew_delay_);
+    mahiOOTpuCorr_->setPulseShapeTemplate(
+        theHcalPulseShapes_.getShape(info.recoShape()), info.hasTimeInfo(), hcalTimeSlew_delay_, info.nSamples());
     mahi->phase1Apply(info, m4E, m4T, m4UseTriple, m4chi2);
     m4E *= hbminusCorrectionFactor(channelId, m4E, isData);
   }
@@ -179,7 +180,6 @@ float SimpleHBHEPhase1Algo::m0Energy(const HBHEChannelInfo& info,
 
 float SimpleHBHEPhase1Algo::m0Time(const HBHEChannelInfo& info,
                                    const double fc_ampl,
-                                   const HcalCalibrations& calibs,
                                    const int nSamplesToExamine) const {
   float time = -9999.f;  // historic value
 

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -241,7 +241,8 @@ void MahiDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     const bool isRealData = true;
 
     const MahiFit* mahi = mahi_.get();
-    mahi_->setPulseShapeTemplate(theHcalPulseShapes_.getShape(hci.recoShape()), hcalTimeSlewDelay);
+    mahi_->setPulseShapeTemplate(
+        theHcalPulseShapes_.getShape(hci.recoShape()), hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples());
     MahiDebugInfo mdi;
     mahi->phase1Debug(hci, mdi);
 


### PR DESCRIPTION
This PR save 10% of the CPU speed in view of the Run3.
Changes are expected within numerical precision level in the E/ArrivalTime of recHits.
Pass clang formats checks.

Validation plots are here
[PR27726.pdf](http://dalfonso.web.cern.ch/dalfonso/HCAL/PR27726.pdf)

Main gain is in the updatePulseShape and updateCov functions of Mahi.
Below igprof report (test done on Run2018A_HLTPhysics run#316457 PU50 ).

ORIGINAL:
```
           13.4  .........      62.43 / 63.03        MahiFit::phase1Apply(HBHEChannelInfo const&, float&, float&, bool&, float&) const [45]
[46]       13.4      62.43       3.03 / 59.40      MahiFit::doFit(std::array<float, 3ul>&, int) const
            9.7  .........      45.45 / 45.45        MahiFit::minimize() const [47]
            1.7  .........       7.75 / 7.75         MahiFit::updatePulseShape(double, Eigen::Matrix<double, -1, 1, 0, 19, 1>&, Eigen::Matrix<double, -1, 1, 0, 19, 1>&, Eigen::Matrix<$
            1.3  .........       6.19 / 6.19         MahiFit::calculateArrivalTime() const [80]
            0.0  .........       0.00 / 0.89         _init [204]
            0.0  .........       0.00 / 0.12         _dl_runtime_resolve_xsave [757]

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
            9.7  .........      45.45 / 62.43        MahiFit::doFit(std::array<float, 3ul>&, int) const [46]
[47]        9.7      45.45       0.52 / 44.92      MahiFit::minimize() const
            4.2  .........      19.42 / 19.42        MahiFit::nnls() const [53]
            3.5  .........      16.26 / 16.26        MahiFit::updateCov() const [55]
            1.2  .........       5.54 / 5.54         MahiFit::onePulseMinimize() const [83]
            0.8  .........       3.63 / 3.63         MahiFit::calculateChiSq() const [94]
            0.0  .........       0.07 / 0.89         _init [204]
```

NEW

```
           11.0  .........      57.34 / 57.54        MahiFit::phase1Apply(HBHEChannelInfo const&, float&, float&, bool&, float&) const [45]
[46]       11.0      57.34       3.78 / 53.55      MahiFit::doFit(std::array<float, 3ul>&, int) const
            8.1  .........      42.62 / 42.62        MahiFit::minimize() const [47]
            1.1  .........       5.76 / 5.76         MahiFit::updatePulseShape(double, Eigen::Matrix<double, -1, 1, 0, 19, 1>&, Eigen::Matrix<double, -1, 1, 0, 19, 1>&, Eigen::Matrix<$
le, -1, -1, 0, 19, 19>&) const [78]
            1.0  .........       5.17 / 5.17         MahiFit::calculateArrivalTime() const [81]
            0.0  .........       0.00 / 0.79         _init [211]

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
            8.1  .........      42.62 / 57.34        MahiFit::doFit(std::array<float, 3ul>&, int) const [46]
[47]        8.1      42.62       0.32 / 42.29      MahiFit::minimize() const
            4.6  .........      24.09 / 24.09        MahiFit::nnls() const [48]
            2.1  .........      10.73 / 10.73        MahiFit::updateCov() const [60]
            0.9  .........       4.65 / 4.65         MahiFit::onePulseMinimize() const [85]
            0.5  .........       2.80 / 2.80         MahiFit::calculateChiSq() const [107]
            0.0  .........       0.02 / 0.79         _init [211]

```




