### PR TITLE
Allow for ME0 triggers to be produced from pads directly

### DIFF
--- a/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
+++ b/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
@@ -57,13 +57,13 @@ private:
 template <class T>
 void ME0TriggerBuilder::build(const T* me0Pads, ME0TriggerDigiCollection& oc_trig) {
   for (int endc = 0; endc < 2; endc++) {
-    for (int cham = 0; cham < 18; cham++) {
+    for (int cham = ME0DetId::minChamberId; cham < ME0DetId::maxChamberId; cham++) {
       ME0Motherboard* tmb = tmb_[endc][cham].get();
       tmb->setME0Geometry(me0_g);
 
       // 0th layer means whole chamber.
       const int region(endc == 0 ? -1 : 1);
-      ME0DetId detid(region, 0, cham, 0);
+      ME0DetId detid(region, 0, cham + 1, 0);
 
       // Run processors only if chamber exists in geometry.
       if (tmb == nullptr || me0_g->chamber(detid) == nullptr)

--- a/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
+++ b/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
@@ -71,7 +71,7 @@ void ME0TriggerBuilder::build(const T* me0Pads, ME0TriggerDigiCollection& oc_tri
 
       tmb->run(me0Pads);
 
-      std::vector<ME0TriggerDigi> trigV = tmb->readoutTriggers();
+      const std::vector<ME0TriggerDigi>& trigV = tmb->readoutTriggers();
 
       if (!trigV.empty()) {
         LogTrace("L1ME0Trigger") << "ME0TriggerBuilder got results in " << detid << std::endl

--- a/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
+++ b/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
@@ -11,29 +11,32 @@
 
 #include "DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-class ME0Motherboard;
-class ME0Geometry;
+#include "L1Trigger/ME0Trigger/interface/ME0Motherboard.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class ME0TriggerBuilder {
 public:
   /** Configure the algorithm via constructor.
-   *  Receives ParameterSet percolated down from 
+   *  Receives ParameterSet percolated down from
    *  EDProducer which owns this Builder.
    */
   explicit ME0TriggerBuilder(const edm::ParameterSet&);
 
   ~ME0TriggerBuilder();
 
-  /** Build Triggers from clusters in each chamber and fill them into output collections. */
-  void build(const ME0PadDigiClusterCollection* me0Pads, ME0TriggerDigiCollection& oc_trig);
+  /** Build Triggers from pads or clusters in each chamber and fill them into output collections. */
+  template<class T>
+  void build(const T* me0Pads, ME0TriggerDigiCollection& oc_trig);
 
   /** set geometry for the matching needs */
   void setME0Geometry(const ME0Geometry* g) { me0_g = g; }
 
-  /** Max values of trigger labels for all ME0s; 
-   *  used to construct TMB processors. 
+  /** Max values of trigger labels for all ME0s;
+   *  used to construct TMB processors.
    */
   enum trig_me0s { MAX_ENDCAPS = 2, MAX_CHAMBERS = 18 };
 
@@ -50,5 +53,34 @@ private:
   /** Pointers to TMB processors for all possible chambers. */
   std::unique_ptr<ME0Motherboard> tmb_[MAX_ENDCAPS][MAX_CHAMBERS];
 };
+
+template<class T>
+void ME0TriggerBuilder::build(const T* me0Pads, ME0TriggerDigiCollection& oc_trig) {
+  for (int endc = 0; endc < 2; endc++) {
+    for (int cham = 0; cham < 18; cham++) {
+      ME0Motherboard* tmb = tmb_[endc][cham].get();
+      tmb->setME0Geometry(me0_g);
+
+      // 0th layer means whole chamber.
+      const int region(endc == 0 ? -1 : 1);
+      ME0DetId detid(region, 0, cham, 0);
+
+      // Run processors only if chamber exists in geometry.
+      if (tmb == nullptr || me0_g->chamber(detid) == nullptr)
+        continue;
+
+      tmb->run(me0Pads);
+
+      std::vector<ME0TriggerDigi> trigV = tmb->readoutTriggers();
+
+      if (!trigV.empty()) {
+        LogTrace("L1ME0Trigger") << "ME0TriggerBuilder got results in " << detid << std::endl
+                                 << "Put " << trigV.size() << " Trigger digi" << ((trigV.size() > 1) ? "s " : " ")
+                                 << "in collection\n";
+        oc_trig.put(std::make_pair(trigV.begin(), trigV.end()), detid);
+      }
+    }
+  }
+}
 
 #endif

--- a/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
+++ b/L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h
@@ -29,7 +29,7 @@ public:
   ~ME0TriggerBuilder();
 
   /** Build Triggers from pads or clusters in each chamber and fill them into output collections. */
-  template<class T>
+  template <class T>
   void build(const T* me0Pads, ME0TriggerDigiCollection& oc_trig);
 
   /** set geometry for the matching needs */
@@ -54,7 +54,7 @@ private:
   std::unique_ptr<ME0Motherboard> tmb_[MAX_ENDCAPS][MAX_CHAMBERS];
 };
 
-template<class T>
+template <class T>
 void ME0TriggerBuilder::build(const T* me0Pads, ME0TriggerDigiCollection& oc_trig) {
   for (int endc = 0; endc < 2; endc++) {
     for (int cham = 0; cham < 18; cham++) {

--- a/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.cc
+++ b/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.cc
@@ -8,8 +8,10 @@
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 
 ME0TriggerProducer::ME0TriggerProducer(const edm::ParameterSet& conf) {
-  me0PadDigiClusterProducer_ = conf.getParameter<edm::InputTag>("ME0PadDigiClusterProducer");
-  me0_pad_token_ = consumes<ME0PadDigiClusterCollection>(me0PadDigiClusterProducer_);
+  me0PadDigiClusters_ = conf.getParameter<edm::InputTag>("ME0PadDigiClusterProducer");
+  me0_pad_cluster_token_ = consumes<ME0PadDigiClusterCollection>(me0PadDigiClusters_);
+  me0_pad_token_ = consumes<ME0PadDigiCollection>(me0PadDigis_);
+  useClusters_ = conf.getParameter<bool>("useClusters");
   config_ = conf;
 
   // register what this produces
@@ -23,8 +25,12 @@ void ME0TriggerProducer::produce(edm::StreamID, edm::Event& ev, const edm::Event
   setup.get<MuonGeometryRecord>().get(h_me0);
 
   edm::Handle<ME0PadDigiClusterCollection> me0PadDigiClusters;
-  ev.getByToken(me0_pad_token_, me0PadDigiClusters);
-  const ME0PadDigiClusterCollection* me0Pads = me0PadDigiClusters.product();
+  ev.getByToken(me0_pad_cluster_token_, me0PadDigiClusters);
+  const ME0PadDigiClusterCollection* me0PadClusters = me0PadDigiClusters.product();
+
+  edm::Handle<ME0PadDigiCollection> me0PadDigis;
+  ev.getByToken(me0_pad_token_, me0PadDigis);
+  const ME0PadDigiCollection* me0Pads = me0PadDigis.product();
 
   // Create empty collection
   std::unique_ptr<ME0TriggerDigiCollection> oc_trig(new ME0TriggerDigiCollection);
@@ -34,7 +40,8 @@ void ME0TriggerProducer::produce(edm::StreamID, edm::Event& ev, const edm::Event
 
   // Fill output collections if valid input collection is available.
   if (me0PadDigiClusters.isValid()) {
-    trigBuilder->build(me0Pads, *oc_trig);
+    if (useClusters_) trigBuilder->build<ME0PadDigiClusterCollection>(me0PadClusters, *oc_trig);
+    else              trigBuilder->build<ME0PadDigiCollection>(me0Pads, *oc_trig);
   }
 
   // Put collections in event.

--- a/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.cc
+++ b/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.cc
@@ -40,8 +40,10 @@ void ME0TriggerProducer::produce(edm::StreamID, edm::Event& ev, const edm::Event
 
   // Fill output collections if valid input collection is available.
   if (me0PadDigiClusters.isValid()) {
-    if (useClusters_) trigBuilder->build<ME0PadDigiClusterCollection>(me0PadClusters, *oc_trig);
-    else              trigBuilder->build<ME0PadDigiCollection>(me0Pads, *oc_trig);
+    if (useClusters_)
+      trigBuilder->build<ME0PadDigiClusterCollection>(me0PadClusters, *oc_trig);
+    else
+      trigBuilder->build<ME0PadDigiCollection>(me0Pads, *oc_trig);
   }
 
   // Put collections in event.

--- a/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.h
+++ b/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.h
@@ -11,6 +11,7 @@
  */
 
 #include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -29,9 +30,12 @@ public:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
-  edm::InputTag me0PadDigiClusterProducer_;
-  edm::EDGetTokenT<ME0PadDigiClusterCollection> me0_pad_token_;
+  edm::InputTag me0PadDigiClusters_;
+  edm::InputTag me0PadDigis_;
+  edm::EDGetTokenT<ME0PadDigiClusterCollection> me0_pad_cluster_token_;
+  edm::EDGetTokenT<ME0PadDigiCollection> me0_pad_token_;
   edm::ParameterSet config_;
+  bool useClusters_;
 };
 
 #endif

--- a/L1Trigger/ME0Trigger/python/me0TriggerDigis_cfi.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerDigis_cfi.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 me0TriggerDigis = cms.EDProducer("ME0TriggerProducer",
-    ME0PadDigiClusterProducer = cms.InputTag("simMuonME0PadDigiClusters"),
+    ME0PadDigiClusters = cms.InputTag("simMuonME0PadDigiClusters"),
+    ME0PadDigis = cms.InputTag("simMuonME0PadDigis"),
+    useClusters = cms.bool(False),
     tmbParam = cms.PSet()
 )

--- a/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
@@ -3,14 +3,8 @@
 ME0TriggerBuilder::ME0TriggerBuilder(const edm::ParameterSet& conf) {
   config_ = conf;
 
-  for (int endc = 0; endc < 2; endc++) {
-    for (int cham = 0; cham < 18; cham++) {
-      if ((endc <= 0 || endc > MAX_ENDCAPS) || (cham <= 0 || cham > MAX_CHAMBERS)) {
-        edm::LogError("L1ME0TPEmulatorSetupError")
-            << "+++ trying to instantiate TMB of illegal ME0 id ["
-            << " endcap = " << endc << " chamber = " << cham << "]; skipping it... +++\n";
-        continue;
-      }
+  for (int endc = 0; endc < MAX_ENDCAPS; endc++) {
+    for (int cham = 0; cham < MAX_CHAMBERS; cham++) {
       tmb_[endc][cham].reset(new ME0Motherboard(endc, cham, config_));
     }
   }

--- a/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
@@ -1,8 +1,4 @@
 #include "L1Trigger/ME0Trigger/interface/ME0TriggerBuilder.h"
-#include "L1Trigger/ME0Trigger/interface/ME0Motherboard.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 
 ME0TriggerBuilder::ME0TriggerBuilder(const edm::ParameterSet& conf) {
   config_ = conf;
@@ -21,31 +17,3 @@ ME0TriggerBuilder::ME0TriggerBuilder(const edm::ParameterSet& conf) {
 }
 
 ME0TriggerBuilder::~ME0TriggerBuilder() {}
-
-void ME0TriggerBuilder::build(const ME0PadDigiClusterCollection* me0Pads, ME0TriggerDigiCollection& oc_trig) {
-  for (int endc = 0; endc < 2; endc++) {
-    for (int cham = 0; cham < 18; cham++) {
-      ME0Motherboard* tmb = tmb_[endc][cham].get();
-      tmb->setME0Geometry(me0_g);
-
-      // 0th layer means whole chamber.
-      const int region(endc == 0 ? -1 : 1);
-      ME0DetId detid(region, 0, cham, 0);
-
-      // Run processors only if chamber exists in geometry.
-      if (tmb == nullptr || me0_g->chamber(detid) == nullptr)
-        continue;
-
-      tmb->run(me0Pads);
-
-      std::vector<ME0TriggerDigi> trigV = tmb->readoutTriggers();
-
-      if (!trigV.empty()) {
-        LogTrace("L1ME0Trigger") << "ME0TriggerBuilder got results in " << detid << std::endl
-                                 << "Put " << trigV.size() << " Trigger digi" << ((trigV.size() > 1) ? "s " : " ")
-                                 << "in collection\n";
-        oc_trig.put(std::make_pair(trigV.begin(), trigV.end()), detid);
-      }
-    }
-  }
-}


### PR DESCRIPTION
#### PR description:

Recent hardware developments by the GEM group argue for an FPGA-less ME0 front-end electronics design. This means that trigger pad clusters will not be produced in the L1-trigger chain during Phase-2. This is the currently the case in the simulation though. In Phase-2, ME0 triggers will be constructed out of trigger pads directly. This PR updates the simulation accordingly. More details can be found in this presentation: https://indico.cern.ch/event/831338/contributions/3482241/attachments/1869796/3079349/Change-ME0-001_CMS_Black.pdf. 

I added a flag in the configuration to choose the input (pad or pad cluster). Other modifications include additional member data and a function that was templated. 

#### PR validation:

I ran the workflow 20034.0 successfully.  

There should be no change in the performance as ME0 pseudo-triggers are still the actual objects that are used in the L1T Muon chain.

FYI: @jshlee @tahuang1991 @rekovic 