### PR TITLE
Only track charged exotic particles outside CMS beam pipe for abs(pdg id) from 1000000 to 4000000

### DIFF
--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -33,8 +33,7 @@ public:
 
 private:
   bool particlePassesPrimaryCuts(const G4ThreeVector &p) const;
-  bool isExotic(int pdgcode) const;
-  bool isExoticNonDetectable(int pdgcode) const;
+  bool isChargedExotic(int pdgcode) const;
   bool IsInTheFilterList(int pdgcode) const;
   void particleAssignDaughters(G4PrimaryParticle *p, HepMC::GenParticle *hp, double length);
   void setGenId(G4PrimaryParticle *p, int id) const { p->SetUserInformation(new GenParticleInfo(id)); }

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -145,7 +145,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
       // propagated by GEANT
       int status = (*pitr)->status();
       int pdg = (*pitr)->pdg_id();
-      if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
+      if (status > 3 && isChargedExotic(pdg)) {
         // In Pythia 8, there are many status codes besides 1, 2, 3.
         // By setting the status to 2 for exotic particles, they will be
         // checked: if its decay vertex is outside the beampipe, it will be
@@ -216,7 +216,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
         if ((!pdgFilterSel && isInTheList) || (pdgFilterSel && !isInTheList)) {
           edm::LogVerbatim("SimG4CoreGenerator")
               << " Skiped GenParticle barcode= " << (*pitr)->barcode() << " PDGid= " << pdg << " status= " << status
-              << " isExotic: " << isExotic(pdg) << " isExoticNotDet: " << isExoticNonDetectable(pdg)
+              << " isChargedExotic: " << isChargedExotic(pdg)
               << " isInTheList: " << isInTheList << " hasDecayVertex: " << hasDecayVertex;
           continue;
         }
@@ -224,11 +224,11 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
 
       edm::LogVerbatim("SimG4CoreGenerator")
           << "Generator: pdg= " << pdg << " status= " << status << " hasPreDefinedDecay: " << hasDecayVertex
-          << " isExotic: " << isExotic(pdg) << " isExoticNotDet: " << isExoticNonDetectable(pdg)
+          << " isChargedExotic: " << isChargedExotic(pdg) 
           << " isInTheList: " << IsInTheFilterList(pdg) << "\n         (x,y,z,t): (" << x1 << "," << y1 << "," << z1
           << "," << t1 << ")";
 
-      if (status > 3 && isExotic(pdg) && (!(isExoticNonDetectable(pdg)))) {
+      if (status > 3 && isChargedExotic(pdg)) {
         status = hasDecayVertex ? 2 : 1;
       }
 
@@ -495,21 +495,14 @@ bool Generator::particlePassesPrimaryCuts(const G4ThreeVector &p) const {
   return flag;
 }
 
-bool Generator::isExotic(int pdgcode) const {
-  int pdgid = std::abs(pdgcode);
-  return ((pdgid >= 1000000 && pdgid < 4000000) ||  // SUSY, R-hadron, and technicolor particles
-          pdgid == 17 ||                            // 4th generation lepton
-          pdgid == 34 ||                            // W-prime
-          pdgid == 37)                              // charged Higgs
-             ? true
-             : false;
-}
-
-bool Generator::isExoticNonDetectable(int pdgcode) const {
+bool Generator::isChargedExotic(int pdgcode) const {
   int pdgid = std::abs(pdgcode);
   HepPDT::ParticleID pid(pdgcode);
   int charge = pid.threeCharge();
-  return ((charge == 0) && (pdgid >= 1000000 && pdgid < 1000040))  // SUSY
+  return (charge != 0 && ((pdgid >= 1000000 && pdgid < 4000000) ||  // SUSY, R-hadron, and technicolor particles
+          pdgid == 17 ||                            // 4th generation lepton
+          pdgid == 34 ||                            // W-prime
+          pdgid == 37))                             // charged Higgs
              ? true
              : false;
 }


### PR DESCRIPTION
This is to address the issue described in: https://hypernews.cern.ch/HyperNews/CMS/get/simDevelopment/1904.html

The original two functions 'isExotic' and 'isExoticNonDetectable' are now merged into one function 'isChargedExotic'.

Note: Ideally the absolute pdg id upper limit 4000000 could be extended to 9999999 (the largest number in 7-digit, base 10, following PDG MC particle numbering scheme convention) since some other groups might want to track charged exotic particles with pdg id beyond 4000000 in the future. Here I didn't extend it since our neutral signal particle 3000022 is covered by the current upper limit 4000000. But I'll let @civanch comment more.

This PR should be ported to all releases since CMSSW_8_1_X because that's when PR #16366 starts to add the tracking of long lived exotic particles (from my understanding what they really wanted in PR #16366 is to track 'charged' exotic particles, but they didn't specify charge!=0 back then and that caused an issue for our dark photon 3000022). We also need this PR #27732 for 2017 and 2018 central MC sample production. 