### PR TITLE
Bug fix for 2016-2017 HBHE negative energy filter

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45',
+    'run1_data'         :   '110X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45',
+    'run2_data'         :   '110X_dataRun2_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2019_08_03_03_55_32',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v4',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_Candidate_2019_08_02_16_55_52',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR fixes the misconfiguration of the HBHE noise filter in the 2016-2017 offline GT after migrating Mahi to use 8 samples rather than 10 [1].

This PR should be merged before PR #27644 so that the GT history in autoCond is consistent with that of the GT queues.

[1] https://indico.cern.ch/event/840252/#14-ultralegacy-2017-gt-fix-for

GT diffs:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_2017_2018_Candidate_2019_08_03_03_51_45/110X_dataRun2_v4  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_Candidate_2019_08_03_03_55_32/110X_dataRun2_relval_v4 

#### PR validation:

See [1] for details. A technical test was also performed: `runTheMatrix.py -l limited -i all --ibeos`

[1] https://indico.cern.ch/event/840252/#14-ultralegacy-2017-gt-fix-for

#### if this PR is a backport please specify the original PR:

This is not a backport.