### PR TITLE
Bug fix for 2016-2017 HBHE negative energy filter [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v18',
+    'run1_data'         :   '106X_dataRun2_v20',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v18',
+    'run2_data'         :   '106X_dataRun2_v20',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v17',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v19',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This is a backport of PR #27733

GT diffs:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v18/106X_dataRun2_v20
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v17/106X_dataRun2_relval_v19

#### PR validation:

See PR #27733 description for details. In addition, `runTheMatrix.py -l limited -i all --ibeos` was run as a technical test.

#### if this PR is a backport please specify the original PR:

This is a backport of PR #27733
