### PR TITLE
DD4hep: Tracker overlaps on PixelForwardDiskRings

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDCutTubsFromPoints.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCutTubsFromPoints.cc
@@ -166,13 +166,10 @@ static long algorithm(dd4hep::Detector& /* description */,
       n_y_t /= norm;
       n_z_t /= norm;
 
-      // the cuttubs wants a delta phi
-      double dphi = phi2 - phi1;
-
-      auto seg = dd4hep::CutTube(r_min, r_max, dz, phi1, dphi, n_x_l, n_y_l, n_z_l, n_x_t, n_y_t, n_z_t);
+      auto seg = dd4hep::CutTube(r_min, r_max, dz, phi1, phi2, n_x_l, n_y_l, n_z_l, n_x_t, n_y_t, n_z_t);
 
       edm::LogVerbatim("TrackerGeom") << "DDCutTubsFromPoints: CutTube(" << r_min << "," << r_max << "," << dz << ","
-                                      << phi1 << "," << dphi << "," << n_x_l << "," << n_y_l << "," << n_z_l << ","
+                                      << phi1 << "," << phi2 << "," << n_x_l << "," << n_y_l << "," << n_z_l << ","
                                       << n_x_t << "," << n_y_t << "," << n_z_t << ")";
 
       segments.emplace_back(seg);

--- a/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDefinitions2Objects.cc
@@ -1334,7 +1334,7 @@ void Converter<DDLCutTubs>::operator()(xml_h element) const {
            rmax,
            startPhi,
            deltaPhi);
-  ns.addSolid(nam, CutTube(rmin, rmax, dz, startPhi, deltaPhi, lx, ly, lz, tx, ty, tz));
+  ns.addSolid(nam, CutTube(rmin, rmax, dz, startPhi, startPhi + deltaPhi, lx, ly, lz, tx, ty, tz));
 }
 
 /// Converter for <TruncTubs/> tags


### PR DESCRIPTION
#### PR description:

Addresses overlaps on Tracker `PixFwdDisk*Rings`

#### PR validation:

`master`

![masterA](https://user-images.githubusercontent.com/16821717/62770728-e703e480-ba9b-11e9-96ab-897c13d4eecc.png)


`master + thisPr`

![thisPRa](https://user-images.githubusercontent.com/16821717/62770748-f71bc400-ba9b-11e9-9f4e-a5eaeeda7a03.png)


`Reference`

![referenceA](https://user-images.githubusercontent.com/16821717/62770759-fedb6880-ba9b-11e9-9ec7-604d72c6b4f6.png)

For validation instructions check: https://github.com/cms-sw/cmssw/pull/27689#issue-304227763

```
PATH:
/Tracker_2/PixelForwardZminus_1/pixfwdDisks:PixelForwardDiskZminus_1
```