### PR TITLE
Put test in condition for arm and ppc

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -27,13 +27,13 @@
 <bin   file="testFrontier.cpp" name="testFrontier">
 </bin>
 
-<bin   file="testConnectionPool.cpp" name="testConnectionPool">
-  <use   name="CondFormats/RunInfo"/>
-</bin>
 <bin   file="testRunInfo.cpp" name="testRunInfo">
 </bin>
 <bin   file="testGroupSelection.cpp" name="testGroupSelection">
 </bin>
 <architecture name="slc.*_amd64_.*">
+<bin   file="testConnectionPool.cpp" name="testConnectionPool">
+  <use   name="CondFormats/RunInfo"/>
+</bin>
   <test name="condTestRegression" command="condTestRegression.py"/>
 </architecture>


### PR DESCRIPTION
#### PR description:

Add condition test to be run only for intel archs, oracle client not available for arm and ppc
Skips this failing test:
https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_ppc64le_gcc700/CMSSW_11_0_X_2019-08-07-2300/unitTestLogs/CondCore/CondDB#/488-488

#### PR validation:

Builds and runs without fails in the tests

