### PR TITLE
Update autoskim for egamma datasets

### DIFF
--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -7,7 +7,8 @@ autoSkim = {
  'MET' : 'HighMET+EXOMONOPOLE+LogError+LogErrorMonitor',
  'SingleElectron' : 'LogError+LogErrorMonitor',
  'SinglePhoton' : 'SinglePhotonJetPlusHOFilter+EXOMONOPOLE+LogError+LogErrorMonitor',
- 'DoubleEG' : 'ZElectron+LogError+LogErrorMonitor',
+ 'DoubleEG' : 'ZElectron+EXOMONOPOLE+LogError+LogErrorMonitor',
+ 'EGamma':'SinglePhotonJetPlusHOFilter+ZElectron+EXOMONOPOLE+LogError+LogErrorMonitor',
  'Tau' : 'LogError+LogErrorMonitor',
  'SingleMuon' : 'MuonPOGSkim+ZMu+MuTau+LogError+LogErrorMonitor',
  'DoubleMuon' : 'LogError+LogErrorMonitor',
@@ -25,6 +26,7 @@ autoSkim = {
  'ParkingBPH':'SkimBPark+LogError+LogErrorMonitor',
  
 }
+#2018 EGamma is a merged datasets of SingleElectron, SinglePhoton, DoubleEG
 
 autoSkimRunI = {
     'MinBias':'MuonTrack+BeamBkg+ValSkim+LogError+HSCPSD',


### PR DESCRIPTION
#### PR description:

This is to update the autoskim for EGamma datasets to match datasets we have in 2018 (EGamma = SinglePhoton, SingleElectron, DoubleEG)

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

backport of https://github.com/cms-sw/cmssw/pull/27746

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
