### PR TITLE
HCAL DQMOffline: adding rechits spectra with enabled cleaning   

### DIFF
--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -180,6 +180,7 @@ private:
 
   // energy of rechits
   MonitorElement *meRecHitsEnergyHB;
+  MonitorElement *meRecHitsCleanedEnergyHB;
   MonitorElement *meRecHitsEnergyHBM0;
   MonitorElement *meRecHitsEnergyHBM3;
   MonitorElement *meRecHitsEnergyM2vM0HB;
@@ -188,6 +189,7 @@ private:
   MonitorElement *meRecHitsM2Chi2HB;
 
   MonitorElement *meRecHitsEnergyHE;
+  MonitorElement *meRecHitsCleanedEnergyHE;
   MonitorElement *meRecHitsEnergyHEM0;
   MonitorElement *meRecHitsEnergyHEM3;
   std::vector<MonitorElement *> meRecHitsEnergyHEP17;
@@ -199,8 +201,10 @@ private:
   MonitorElement *meRecHitsM2Chi2HE;
 
   MonitorElement *meRecHitsEnergyHO;
+  MonitorElement *meRecHitsCleanedEnergyHO;
 
   MonitorElement *meRecHitsEnergyHF;
+  MonitorElement *meRecHitsCleanedEnergyHF;
 
   MonitorElement *meTE_Low_HB;
   MonitorElement *meTE_HB;
@@ -288,6 +292,7 @@ private:
   std::vector<double> cz;
   std::vector<uint32_t> cstwd;
   std::vector<uint32_t> cauxstwd;
+  std::vector<int> csevlev;
 
   // counter
   int nevtot;

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -896,7 +896,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 1 && (subdet_ == 1 || subdet_ == 5)) {
         meTimeHB->Fill(t);
         meRecHitsEnergyHB->Fill(en);
-        if(sevlev <= 9) meRecHitsCleanedEnergyHB->Fill(en);
+        if (sevlev <= 9) 
+	  meRecHitsCleanedEnergyHB->Fill(en);
 
         meRecHitsEnergyHBM0->Fill(enM0);
         meRecHitsEnergyHBM3->Fill(enM3);
@@ -919,8 +920,9 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
         meTimeHE->Fill(t);
         if (!isHEP17) {
           meRecHitsEnergyHE->Fill(en);
-	  if(sevlev <= 9) meRecHitsCleanedEnergyHE->Fill(en);
-
+	  if (sevlev <= 9) 
+	    meRecHitsCleanedEnergyHE->Fill(en);
+	  
           meRecHitsEnergyHEM0->Fill(enM0);
           meRecHitsEnergyHEM3->Fill(enM3);
         } else {
@@ -947,7 +949,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 4 && (subdet_ == 4 || subdet_ == 5)) {
         meTimeHF->Fill(t);
         meRecHitsEnergyHF->Fill(en);
-        if(sevlev <= 9) meRecHitsCleanedEnergyHF->Fill(en);
+        if (sevlev <= 9) 
+	  meRecHitsCleanedEnergyHF->Fill(en);
 
         meTE_Low_HF->Fill(en, t);
         meTE_HF->Fill(en, t);
@@ -957,7 +960,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 3 && (subdet_ == 3 || subdet_ == 5)) {
         meTimeHO->Fill(t);
         meRecHitsEnergyHO->Fill(en);
-        if(sevlev <= 9) meRecHitsCleanedEnergyHO->Fill(en);
+        if (sevlev <= 9) 
+	  meRecHitsCleanedEnergyHO->Fill(en);
 
         meTE_HO->Fill(en, t);
         meTE_High_HO->Fill(en, t);
@@ -1028,7 +1032,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
         int stwd = j->flags();
         int auxstwd = j->aux();
 
-        int severityLevel = hcalSevLvl((CaloRecHit *)&*j);   
+        int severityLevel = hcalSevLvl((CaloRecHit *)&*j);
         if (cell.subdet() == HcalBarrel) {
           hcalHBSevLvlVec.push_back(severityLevel);
         } else if (cell.subdet() == HcalEndcap) {
@@ -1050,7 +1054,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
           cz.push_back(zc);
           cstwd.push_back(stwd);
           cauxstwd.push_back(auxstwd);
-          csevlev.push_back(severityLevel); 
+          csevlev.push_back(severityLevel);
         }
       }
     }
@@ -1098,7 +1102,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
           cz.push_back(zc);
           cstwd.push_back(stwd);
           cauxstwd.push_back(auxstwd);
-          csevlev.push_back(severityLevel); 
+          csevlev.push_back(severityLevel);
         }
       }
     }
@@ -1146,7 +1150,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
           cz.push_back(zc);
           cstwd.push_back(stwd);
           cauxstwd.push_back(auxstwd);
-          csevlev.push_back(severityLevel); 
+          csevlev.push_back(severityLevel);
         }
       }
     }

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -363,6 +363,9 @@ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HB");
     meRecHitsEnergyHB = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
 
+    sprintf(histo, "HcalRecHitTask_cleaned_energy_of_rechits_HB");
+    meRecHitsCleanedEnergyHB = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
+
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_M0_HB");
     meRecHitsEnergyHBM0 = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
 
@@ -416,6 +419,9 @@ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
 
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HE");
     meRecHitsEnergyHE = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
+
+    sprintf(histo, "HcalRecHitTask_cleaned_energy_of_rechits_HE");
+    meRecHitsCleanedEnergyHE = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
 
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_M0_HE");
     meRecHitsEnergyHEM0 = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
@@ -486,6 +492,9 @@ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HO");
     meRecHitsEnergyHO = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
 
+    sprintf(histo, "HcalRecHitTask_cleaned_energy_of_rechits_HO");
+    meRecHitsCleanedEnergyHO = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
+
     sprintf(histo, "HcalRecHitTask_timing_HO");
     meTimeHO = ibooker.book1DD(histo, histo, 70, -48., 92.);
 
@@ -512,6 +521,9 @@ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
 
     sprintf(histo, "HcalRecHitTask_energy_of_rechits_HF");
     meRecHitsEnergyHF = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
+
+    sprintf(histo, "HcalRecHitTask_cleaned_energy_of_rechits_HF");
+    meRecHitsCleanedEnergyHF = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
 
     sprintf(histo, "HcalRecHitTask_timing_HF");
     meTimeHF = ibooker.book1DD(histo, histo, 70, -48., 92.);
@@ -860,6 +872,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
         chi2_log10 = log10(chi2);
       double t = ctime[i];
       double depth = cdepth[i];
+      int sevlev = csevlev[i];
 
       bool isHEP17 = (sub == 2) && (iphi >= 63) && (iphi <= 66) && (ieta > 0) && (hep17_);
 
@@ -883,6 +896,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 1 && (subdet_ == 1 || subdet_ == 5)) {
         meTimeHB->Fill(t);
         meRecHitsEnergyHB->Fill(en);
+        if(sevlev >= 9) meRecHitsCleanedEnergyHB->Fill(en);
+
         meRecHitsEnergyHBM0->Fill(enM0);
         meRecHitsEnergyHBM3->Fill(enM3);
 
@@ -904,6 +919,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
         meTimeHE->Fill(t);
         if (!isHEP17) {
           meRecHitsEnergyHE->Fill(en);
+	  if(sevlev >= 9) meRecHitsCleanedEnergyHE->Fill(en);
+
           meRecHitsEnergyHEM0->Fill(enM0);
           meRecHitsEnergyHEM3->Fill(enM3);
         } else {
@@ -930,6 +947,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 4 && (subdet_ == 4 || subdet_ == 5)) {
         meTimeHF->Fill(t);
         meRecHitsEnergyHF->Fill(en);
+        if(sevlev >= 9) meRecHitsCleanedEnergyHF->Fill(en);
 
         meTE_Low_HF->Fill(en, t);
         meTE_HF->Fill(en, t);
@@ -939,6 +957,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 3 && (subdet_ == 3 || subdet_ == 5)) {
         meTimeHO->Fill(t);
         meRecHitsEnergyHO->Fill(en);
+        if(sevlev >= 9) meRecHitsCleanedEnergyHO->Fill(en);
 
         meTE_HO->Fill(en, t);
         meTE_High_HO->Fill(en, t);
@@ -981,6 +1000,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
   cz.clear();
   cstwd.clear();
   cauxstwd.clear();
+  csevlev.clear();
   hcalHBSevLvlVec.clear();
   hcalHESevLvlVec.clear();
   hcalHFSevLvlVec.clear();
@@ -1008,7 +1028,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
         int stwd = j->flags();
         int auxstwd = j->aux();
 
-        int severityLevel = hcalSevLvl((CaloRecHit *)&*j);
+        int severityLevel = hcalSevLvl((CaloRecHit *)&*j);   
         if (cell.subdet() == HcalBarrel) {
           hcalHBSevLvlVec.push_back(severityLevel);
         } else if (cell.subdet() == HcalEndcap) {
@@ -1030,6 +1050,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
           cz.push_back(zc);
           cstwd.push_back(stwd);
           cauxstwd.push_back(auxstwd);
+          csevlev.push_back(severityLevel); 
         }
       }
     }
@@ -1077,6 +1098,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
           cz.push_back(zc);
           cstwd.push_back(stwd);
           cauxstwd.push_back(auxstwd);
+          csevlev.push_back(severityLevel); 
         }
       }
     }
@@ -1124,6 +1146,7 @@ void HcalRecHitsAnalyzer::fillRecHitsTmp(int subdet_, edm::Event const &ev) {
           cz.push_back(zc);
           cstwd.push_back(stwd);
           cauxstwd.push_back(auxstwd);
+          csevlev.push_back(severityLevel); 
         }
       }
     }

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -896,7 +896,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 1 && (subdet_ == 1 || subdet_ == 5)) {
         meTimeHB->Fill(t);
         meRecHitsEnergyHB->Fill(en);
-        if(sevlev >= 9) meRecHitsCleanedEnergyHB->Fill(en);
+        if(sevlev <= 9) meRecHitsCleanedEnergyHB->Fill(en);
 
         meRecHitsEnergyHBM0->Fill(enM0);
         meRecHitsEnergyHBM3->Fill(enM3);
@@ -919,7 +919,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
         meTimeHE->Fill(t);
         if (!isHEP17) {
           meRecHitsEnergyHE->Fill(en);
-	  if(sevlev >= 9) meRecHitsCleanedEnergyHE->Fill(en);
+	  if(sevlev <= 9) meRecHitsCleanedEnergyHE->Fill(en);
 
           meRecHitsEnergyHEM0->Fill(enM0);
           meRecHitsEnergyHEM3->Fill(enM3);
@@ -947,7 +947,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 4 && (subdet_ == 4 || subdet_ == 5)) {
         meTimeHF->Fill(t);
         meRecHitsEnergyHF->Fill(en);
-        if(sevlev >= 9) meRecHitsCleanedEnergyHF->Fill(en);
+        if(sevlev <= 9) meRecHitsCleanedEnergyHF->Fill(en);
 
         meTE_Low_HF->Fill(en, t);
         meTE_HF->Fill(en, t);
@@ -957,7 +957,7 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 3 && (subdet_ == 3 || subdet_ == 5)) {
         meTimeHO->Fill(t);
         meRecHitsEnergyHO->Fill(en);
-        if(sevlev >= 9) meRecHitsCleanedEnergyHO->Fill(en);
+        if(sevlev <= 9) meRecHitsCleanedEnergyHO->Fill(en);
 
         meTE_HO->Fill(en, t);
         meTE_High_HO->Fill(en, t);

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -896,8 +896,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 1 && (subdet_ == 1 || subdet_ == 5)) {
         meTimeHB->Fill(t);
         meRecHitsEnergyHB->Fill(en);
-        if (sevlev <= 9) 
-	  meRecHitsCleanedEnergyHB->Fill(en);
+        if (sevlev <= 9)
+          meRecHitsCleanedEnergyHB->Fill(en);
 
         meRecHitsEnergyHBM0->Fill(enM0);
         meRecHitsEnergyHBM3->Fill(enM3);
@@ -920,9 +920,9 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
         meTimeHE->Fill(t);
         if (!isHEP17) {
           meRecHitsEnergyHE->Fill(en);
-	  if (sevlev <= 9) 
-	    meRecHitsCleanedEnergyHE->Fill(en);
-	  
+          if (sevlev <= 9)
+            meRecHitsCleanedEnergyHE->Fill(en);
+
           meRecHitsEnergyHEM0->Fill(enM0);
           meRecHitsEnergyHEM3->Fill(enM3);
         } else {
@@ -949,8 +949,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 4 && (subdet_ == 4 || subdet_ == 5)) {
         meTimeHF->Fill(t);
         meRecHitsEnergyHF->Fill(en);
-        if (sevlev <= 9) 
-	  meRecHitsCleanedEnergyHF->Fill(en);
+        if (sevlev <= 9)
+          meRecHitsCleanedEnergyHF->Fill(en);
 
         meTE_Low_HF->Fill(en, t);
         meTE_HF->Fill(en, t);
@@ -960,8 +960,8 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
       if (sub == 3 && (subdet_ == 3 || subdet_ == 5)) {
         meTimeHO->Fill(t);
         meRecHitsEnergyHO->Fill(en);
-        if (sevlev <= 9) 
-	  meRecHitsCleanedEnergyHO->Fill(en);
+        if (sevlev <= 9)
+          meRecHitsCleanedEnergyHO->Fill(en);
 
         meTE_HO->Fill(en, t);
         meTE_High_HO->Fill(en, t);


### PR DESCRIPTION
#### PR description:

Additional 4 HB/HE/HO/HF rechits energy spectra with noise cleaning applied.
To explicitly assess the effect of cleaning at the level of HCAL RecHits,  as in CaloTowers plots (with the cleaning applied) it may not be well visible...     

#### PR validation:

runTheMatris is OK in 11_0_0_pre5

#### if this PR is a backport please specify the original PR:

no backport is needed

