### PR TITLE
Fix product labels for tokens in VolumeBasedMagneticFieldESProducer

### DIFF
--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.cc
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.cc
@@ -52,9 +52,9 @@ VolumeBasedMagneticFieldESProducer::VolumeBasedMagneticFieldESProducer(const edm
       conf_{iConfig, debug_},
       version_{iConfig.getParameter<std::string>("version")} {
   auto cc = setWhatProduced(this, iConfig.getUntrackedParameter<std::string>("label", ""));
-  cc.setConsumes(cpvToken_);
+  cc.setConsumes(cpvToken_, edm::ESInputTag{"", "magfield"});
   if (useParametrizedTrackerField_) {
-    cc.setConsumes(paramFieldToken_);
+    cc.setConsumes(paramFieldToken_, edm::ESInputTag{"", iConfig.getParameter<string>("paramLabel")});
   }
 }
 


### PR DESCRIPTION
#### PR description:

The PR #27412 that migrated VolumeBasedMagneticFieldESProducer to use ESGetToken introduced two bugs (thanks to @cvuosalo for reporting): the product labels for the `cpvToken_` and `paramFieldToken_` were left unset while the corresponding `get()` calls did have values before #27412. This PR adds the labels back (and is part of #26748).

#### PR validation:

Code compiles.