### PR TITLE
Exclude dark photon 3000022 tracking

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -497,7 +497,7 @@ bool Generator::particlePassesPrimaryCuts(const G4ThreeVector &p) const {
 
 bool Generator::isExotic(int pdgcode) const {
   int pdgid = std::abs(pdgcode);
-  return ((pdgid >= 1000000 && pdgid < 4000000) ||  // SUSY, R-hadron, and technicolor particles
+  return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                            // 4th generation lepton
           pdgid == 34 ||                            // W-prime
           pdgid == 37)                              // charged Higgs


### PR DESCRIPTION
Minor change to exclude Geant4 tracking of neutral dark photon 3000022 decaying (to muons) outside the CMS beam pipe.
The previous PR #27732 was not merged and now closed because of too many unnecessary changes.
@civanch Please review this new PR.
@qliphy For 2017 and 2018 central MC production, when we complete this PR, what CMSSW releases should we back port the fix to? Vladimir mentioned previously that he will back port the fix to CMSW_10_6_X (legacy for run-2), will that be good enough for the central MC production?
Adding more folks: FYI, @jalimena , @lowette , @mcitron, @dildick


