### PR TITLE
apply postEra customization for HI 2018 data

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1851,6 +1851,7 @@ steps['RECOHID18']=merge([{ '--scenario':'pp',
                             '--datatier':'AOD,DQMIO',
                             '--eventcontent':'AOD,DQM',
                             '--era':'Run2_2018_pp_on_AA',
+			    '--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018_pp_on_AA',
                             '-n':'10'
                             },steps['RECOHID15']])
 


### PR DESCRIPTION
```RecoTLR.customisePostEra_``` should be present for all data reprocessing in order to match the settings used in the prompt reco.

I tested on 200 events in wf 140.56 and there were no differences. The effect is apparently small.

@abdoulline @jaehyeok 
