### PR TITLE
Update the ADG database host names used by ConfDB

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -27,15 +27,15 @@ class OfflineConverter:
 
     databases = {}
     databases['v1'] = {}
-    databases['v1']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',      '-d', 'cms_cond.cern.ch',      '-u', 'cms_hltdev_reader', '-s', 'convertme!' )
+    databases['v1']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hltdev_reader', '-s', 'convertme!' )
     databases['v1']['hltdev']  = databases['v1']['offline']     # for backwards compatibility
-    databases['v1']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',        '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_r',         '-s', 'convertme!' )
-    databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',      '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'convertme!' )
+    databases['v1']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_r',         '-s', 'convertme!' )
+    databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'convertme!' )
     databases['v1']['orcoff']  = databases['v1']['adg']         # for backwards compatibility
     databases['v2'] = {}
-    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',      '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
-    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',        '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
-    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonradg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
+    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
+    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
+    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
 
 
     @staticmethod

--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -27,15 +27,15 @@ class OfflineConverter:
 
     databases = {}
     databases['v1'] = {}
-    databases['v1']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hltdev_reader', '-s', 'convertme!' )
+    databases['v1']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hltdev_reader', '-s', 'ConvertMe!' )
     databases['v1']['hltdev']  = databases['v1']['offline']     # for backwards compatibility
-    databases['v1']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_r',         '-s', 'convertme!' )
-    databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'convertme!' )
+    databases['v1']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_r',         '-s', 'ConvertMe!' )
+    databases['v1']['adg']     = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gui_r',     '-s', 'ConvertMe!' )
     databases['v1']['orcoff']  = databases['v1']['adg']         # for backwards compatibility
     databases['v2'] = {}
-    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
-    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
-    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'convertme!' )
+    databases['v2']['offline'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch',        '-d', 'cms_cond.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'ConvertMe!' )
+    databases['v2']['online']  = ( '-t', 'oracle', '-h', 'cmsonr1-s.cms',          '-d', 'cms_rcms.cern.ch',      '-u', 'cms_hlt_gdr_r',     '-s', 'ConvertMe!' )
+    databases['v2']['adg']     = ( '-t', 'oracle', '-h', 'cmsonr1-adg1-s.cern.ch', '-d', 'cms_orcon_adg.cern.ch', '-u', 'cms_hlt_gdr_r',     '-s', 'ConvertMe!' )
 
 
     @staticmethod


### PR DESCRIPTION
#### PR description:

This PR updates the database host names used by the ConfDB offline converter to access the ADG copy of the online database.

There are no changes to any CMSSW-specific code.

#### PR validation:

The sample command
```
hltConfigFromDB --v2 --adg --configName /cdaq/physics/Run2018/2e34/v3.6.1/HLT/V2 > hlt.py
```
fails without this PR, and succeeds with it.
