### PR TITLE
functionality to avoid creating (empty) DQM outputs for invalid HLT paths

### DIFF
--- a/CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h
+++ b/CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h
@@ -108,6 +108,8 @@ public:
   void initRun(const edm::Run& run, const edm::EventSetup& setup);     // To be called from beginRun() methods
   bool accept(const edm::Event& event, const edm::EventSetup& setup);  // To be called from analyze/filter() methods
 
+  bool allHLTPathsAreValid() const;
+
 private:
   GenericTriggerEventFlag(const edm::ParameterSet& config, edm::ConsumesCollector& iC, bool stage1Valid);
   // Private methods

--- a/DQMOffline/Trigger/plugins/TopMonitor.h
+++ b/DQMOffline/Trigger/plugins/TopMonitor.h
@@ -76,21 +76,20 @@ protected:
 
 private:
   std::string folderName_;
-  std::string histoSuffix_;
+
+  const bool requireValidHLTPaths_;
+  bool hltPathsAreValid_;
 
   edm::EDGetTokenT<reco::PFMETCollection> metToken_;
   edm::EDGetTokenT<reco::PFJetCollection> jetToken_;
   edm::EDGetTokenT<edm::View<reco::GsfElectron> > eleToken_;
-  edm::EDGetTokenT<edm::ValueMap<bool> > elecIDToken_;  //ATHER
+  edm::EDGetTokenT<edm::ValueMap<bool> > elecIDToken_;
   edm::EDGetTokenT<reco::MuonCollection> muoToken_;
   edm::EDGetTokenT<reco::PhotonCollection> phoToken_;
-  // Marina
   edm::EDGetTokenT<reco::JetTagCollection> jetTagToken_;
   edm::EDGetTokenT<reco::JetTagCollection> jetbbTagToken_;
-  //Suvankar
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
 
-  //Suvankar
   struct PVcut {
     double dxy;
     double dz;
@@ -103,9 +102,7 @@ private:
   MEbinning eta_binning_;
   MEbinning HT_binning_;
   MEbinning DR_binning_;
-  // Marina
   MEbinning csv_binning_;
-  //george
   MEbinning invMass_mumu_binning_;
   MEbinning MHT_binning_;
 
@@ -117,7 +114,6 @@ private:
   std::vector<double> jetEta_variable_binning_;
   std::vector<double> muEta_variable_binning_;
   std::vector<double> eleEta_variable_binning_;
-  //george
   std::vector<double> invMass_mumu_variable_binning_;
   std::vector<double> MHT_variable_binning_;
 
@@ -140,9 +136,7 @@ private:
   ObjME jetVsLS_;
   ObjME muVsLS_;
   ObjME eleVsLS_;
-  //Menglei
   ObjME phoVsLS_;
-  // Marina
   ObjME bjetVsLS_;
   ObjME htVsLS_;
 
@@ -151,9 +145,7 @@ private:
   ObjME jetMulti_;
   ObjME eleMulti_;
   ObjME muMulti_;
-  //Menglei
   ObjME phoMulti_;
-  // Marina
   ObjME bjetMulti_;
 
   ObjME elePt_jetPt_;
@@ -165,16 +157,13 @@ private:
   ObjME mu1Eta_mu2Eta_;
   ObjME elePt_muPt_;
   ObjME eleEta_muEta_;
-  //george
   ObjME invMass_mumu_;
   ObjME eventMHT_;
   ObjME invMass_mumu_variableBinning_;
   ObjME eventMHT_variableBinning_;
-  //Menglei
   ObjME muPt_phoPt_;
   ObjME muEta_phoEta_;
 
-  //BTV
   ObjME DeltaR_jet_Mu_;
 
   ObjME eventHT_;
@@ -196,7 +185,6 @@ private:
   std::vector<ObjME> phoEta_;
   std::vector<ObjME> phoPt_;
 
-  // Marina
   std::vector<ObjME> bjetPhi_;
   std::vector<ObjME> bjetEta_;
   std::vector<ObjME> bjetPt_;
@@ -204,26 +192,26 @@ private:
   std::vector<ObjME> muPt_variableBinning_;
   std::vector<ObjME> elePt_variableBinning_;
   std::vector<ObjME> jetPt_variableBinning_;
-  // Marina
   std::vector<ObjME> bjetPt_variableBinning_;
 
   std::vector<ObjME> muEta_variableBinning_;
   std::vector<ObjME> eleEta_variableBinning_;
   std::vector<ObjME> jetEta_variableBinning_;
-  // Marina
   std::vector<ObjME> bjetEta_variableBinning_;
 
-  //2D distributions
+  // 2D distributions
   std::vector<ObjME> jetPtEta_;
   std::vector<ObjME> jetEtaPhi_;
+
   std::vector<ObjME> elePtEta_;
   std::vector<ObjME> eleEtaPhi_;
+
   std::vector<ObjME> muPtEta_;
   std::vector<ObjME> muEtaPhi_;
-  //Menglei
+
   std::vector<ObjME> phoPtEta_;
   std::vector<ObjME> phoEtaPhi_;
-  // Marina
+
   std::vector<ObjME> bjetPtEta_;
   std::vector<ObjME> bjetEtaPhi_;
   std::vector<ObjME> bjetCSVHT_;
@@ -238,10 +226,10 @@ private:
   StringCutObjectSelector<reco::Photon, true> phoSelection_;
   StringCutObjectSelector<reco::PFJet, true> HTdefinition_;
 
-  //Suvankar
   StringCutObjectSelector<reco::Vertex, true> vtxSelection_;
 
   StringCutObjectSelector<reco::Jet, true> bjetSelection_;
+
   unsigned int njets_;
   unsigned int nelectrons_;
   unsigned int nmuons_;
@@ -250,17 +238,14 @@ private:
   double bJetMuDeltaRmax_;
   double bJetDeltaEtaMax_;
   double HTcut_;
-  // Marina
   unsigned int nbjets_;
   double workingpoint_;
   std::string btagalgoName_;
-  //Suvankar
   PVcut lepPVcuts_;
   bool usePVcuts_;
 
   bool applyMETcut_ = false;
 
-  //george
   double invMassUppercut_;
   double invMassLowercut_;
   bool opsign_;
@@ -270,10 +255,8 @@ private:
   int sign;
   bool invMassCutInAllMuPairs_;
 
-  //Menglei
   bool enablePhotonPlot_;
 
-  //Mateusz
   bool enableMETplot_;
 };
 


### PR DESCRIPTION
#### PR description:

This PR includes one possible way to avoid creating empty plots in the HLT offline-DQM
when a module is configured with HLT paths that are not present in the menu.

Implementation: added a method to the `GenericTriggerEventFlag` class in `CommonTools/TriggerUtils`,
and added a switch named `requireValidHLTPaths` in the `TopMonitor` plugin, as an example of how this could be used.

No differences expected in the comparisons (the `requireValidHLTPaths` switch added to `TopMonitor` is currently set to `False`).

#### PR validation:

Tested the changes locally and the code behaves as expected (for example: if the switch is turned on and the HLT path is not a valid one, the corresponding DQM outputs are not produced).

`runTheMatrix.py`: workflows 250202.171 and 250202.181 ran successfully.