### PR TITLE
DD4hep: Tracker overlaps on pixel forward blades

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
@@ -400,7 +400,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     ns.addVolumeNS(inactive);
     ypos = inactivePos - 0.5 * activeHeight;
 
-    active.placeVolume(inactive, 1, dd4hep::Transform3D(ns.rotation(standardRot), dd4hep::Position(0., ypos, 0.)));
+    active.placeVolume(inactive, 1, dd4hep::Position(0., ypos, 0.));
   }
   //Pitch Adapter
   name = idName + "PA";


### PR DESCRIPTION
#### PR description:

Addresses overlaps on `PixFwdBlades` and fixes rotation in inactive piece in `TEC`

#### PR validation:

`master`

![masterd](https://user-images.githubusercontent.com/16821717/63025097-cdeaa180-bea8-11e9-8f33-124baf157f95.png)

`master + thisPr`

![thisPrd](https://user-images.githubusercontent.com/16821717/63025142-de9b1780-bea8-11e9-9b0a-b1d40bf7b39d.png)

`Reference`

![referenced](https://user-images.githubusercontent.com/16821717/63025162-e65abc00-bea8-11e9-9b40-b6d7735291db.png)

Check https://github.com/cms-sw/cmssw/pull/27689 for validation instructions

`Path: /Tracker_2/PixelForwardZplus_1/pixfwdDisks:PixelForwardDiskZplus_1`