### PR TITLE
[HGCal] Validation: Increase the score for matching Layerclusters and CaloParticles

### DIFF
--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -12,8 +12,8 @@ using namespace std;
 
 //Parameters for the score cut. Later, this will become part of the
 //configuration parameter for the HGCAL associator.
-const double ScoreCutLCtoCP_ = 0.01;
-const double ScoreCutCPtoLC_ = 0.01;
+const double ScoreCutLCtoCP_ = 0.1;
+const double ScoreCutCPtoLC_ = 0.1;
 const double ScoreCutMCLtoCP_ = 0.2;
 const double ScoreCutCPtoMCL_ = 0.2;
 


### PR DESCRIPTION
#### PR description:
LayerClusters and Caloparticles are matched if the validation score [0] is lower than a threshold. 
With this PR we increase that threshold from 0.01 to 0.1 which is, by looking at the distributions of the scores a more appropriate value. 

It would be nice to have this before 11_0_0 is closed.

[0][http://hgcal.web.cern.ch/hgcal/Validation/LayerClusterValidation/](http://hgcal.web.cern.ch/hgcal/Validation/LayerClusterValidation/)

