### PR TITLE
Run3-sim43 Expand passive hits to contain PDG Id of track and store this in CaloSteppingAction

### DIFF
--- a/SimDataFormats/CaloHit/interface/PassiveHit.h
+++ b/SimDataFormats/CaloHit/interface/PassiveHit.h
@@ -8,9 +8,9 @@
 
 class PassiveHit {
 public:
-  PassiveHit(std::string vname, unsigned int id, float e = 0, float etot = 0, float t = 0, int it = 0)
-      : vname_(vname), id_(id), energy_(e), etotal_(etot), time_(t), it_(it) {}
-  PassiveHit() : vname_(""), id_(0), energy_(0), etotal_(0), time_(0), it_(0) {}
+  PassiveHit(std::string vname, unsigned int id, float e = 0, float etot = 0, float t = 0, int it = 0, int ip = 0)
+      : vname_(vname), id_(id), energy_(e), etotal_(etot), time_(t), it_(it), ip_(ip) {}
+  PassiveHit() : vname_(""), id_(0), energy_(0), etotal_(0), time_(0), it_(0), ip_(0) {}
 
   //Names
   static const char *name() { return "PassiveHit"; }
@@ -39,6 +39,10 @@ public:
   std::string vname() const { return vname_; }
   unsigned int id() const { return id_; }
 
+  //PDGId of the track causing the Hit
+  int pdgId() const { return ip_; }
+  void setPDGId(int ip) { ip_ = ip; }
+
   //Comparisons
   bool operator<(const PassiveHit &d) const { return energy_ < d.energy_; }
 
@@ -52,6 +56,7 @@ protected:
   float etotal_;
   float time_;
   int it_;
+  int ip_;
 };
 
 namespace edm {

--- a/SimDataFormats/CaloHit/src/classes_def.xml
+++ b/SimDataFormats/CaloHit/src/classes_def.xml
@@ -28,7 +28,8 @@
   <class name="edm::Wrapper<HFShowerLibraryEventInfo>" />
   <class name="edm::Wrapper<std::vector<HFShowerLibraryEventInfo> >"/>
   <typedef name="CastorShowerEvent::Point" />
-  <class name="PassiveHit" ClassVersion="12">
+  <class name="PassiveHit" ClassVersion="13">
+   <version ClassVersion="13" checksum="1735297430"/>
    <version ClassVersion="12" checksum="1168914655"/>
    <version ClassVersion="11" checksum="2866279991"/>
   </class>

--- a/SimG4CMS/Calo/interface/CaloSteppingAction.h
+++ b/SimG4CMS/Calo/interface/CaloSteppingAction.h
@@ -100,8 +100,9 @@ private:
   double birkCutEC_, birkC1HC_, birkC2HC_;
   double birkC3HC_;
   std::map<std::pair<int, CaloHitID>, CaloGVHit> hitMap_[nSD_];
-  typedef std::tuple<const G4LogicalVolume *, uint32_t, int> PassiveKey;
-  std::map<PassiveKey, std::array<double, 3> > store_;
+  typedef std::tuple<const G4LogicalVolume *, uint32_t, int, int> PassiveKey;
+  typedef std::tuple<int, double, double, double> PassiveData;
+  std::map<PassiveKey, PassiveData> store_;
 };
 
 #endif

--- a/SimG4CMS/Calo/interface/CaloSteppingAction.h
+++ b/SimG4CMS/Calo/interface/CaloSteppingAction.h
@@ -98,7 +98,7 @@ private:
   int allSteps_, count_, eventID_;
   double slopeLY_, birkC1EC_, birkSlopeEC_;
   double birkCutEC_, birkC1HC_, birkC2HC_;
-  double birkC3HC_;
+  double birkC3HC_, timeSliceUnit_;
   std::map<std::pair<int, CaloHitID>, CaloGVHit> hitMap_[nSD_];
   typedef std::tuple<const G4LogicalVolume *, uint32_t, int, int> PassiveKey;
   typedef std::tuple<int, double, double, double> PassiveData;

--- a/SimG4CMS/Calo/src/CaloSteppingAction.cc
+++ b/SimG4CMS/Calo/src/CaloSteppingAction.cc
@@ -116,7 +116,7 @@ void CaloSteppingAction::fillPassiveHits(edm::PassiveHitContainer& cc) {
                      std::get<3>(element.second),
                      std::get<1>(element.second),
                      std::get<2>(element.first),
-		     std::get<0>(element.second));
+                     std::get<0>(element.second));
       cc.emplace_back(hit);
     }
   }
@@ -307,8 +307,8 @@ void CaloSteppingAction::update(const G4Step* aStep) {
           store_[key] = std::make_tuple(pdg, time, energy, energy);
         } else {
           auto itr = store_.find(key);
-	  double e1 = std::get<2>(itr->second) + energy;
-	  double e2 = std::get<3>(itr->second) + energy;
+          double e1 = std::get<2>(itr->second) + energy;
+          double e2 = std::get<3>(itr->second) + energy;
           store_[key] = std::make_tuple(pdg, time, e1, e2);
         }
       } else {
@@ -316,8 +316,8 @@ void CaloSteppingAction::update(const G4Step* aStep) {
         if (itr == store_.end()) {
           store_[key] = std::make_tuple(pdg, time, energy, energy);
         } else {
-	  double e1 = std::get<2>(itr->second) + energy;
-	  double e2 = std::get<3>(itr->second) + energy;
+          double e1 = std::get<2>(itr->second) + energy;
+          double e2 = std::get<3>(itr->second) + energy;
           store_[key] = std::make_tuple(pdg, time, e1, e2);
         }
       }

--- a/SimG4CMS/Calo/src/CaloSteppingAction.cc
+++ b/SimG4CMS/Calo/src/CaloSteppingAction.cc
@@ -112,10 +112,11 @@ void CaloSteppingAction::fillPassiveHits(edm::PassiveHitContainer& cc) {
     if (it != mapLV_.end()) {
       PassiveHit hit(it->second,
                      std::get<1>(element.first),
-                     (element.second)[1],
-                     (element.second)[2],
-                     (element.second)[0],
-                     std::get<2>(element.first));
+                     std::get<2>(element.second),
+                     std::get<3>(element.second),
+                     std::get<1>(element.second),
+                     std::get<2>(element.first),
+		     std::get<0>(element.second));
       cc.emplace_back(hit);
     }
   }
@@ -271,12 +272,14 @@ void CaloSteppingAction::update(const G4Step* aStep) {
     double energy = aStep->GetTotalEnergyDeposit() / CLHEP::MeV;
     auto const touch = aStep->GetPreStepPoint()->GetTouchable();
     double time = aStep->GetTrack()->GetGlobalTime() / CLHEP::nanosecond;
+    int itime = static_cast<int>(1000.0 * time);
     int trackId = aStep->GetTrack()->GetTrackID();
+    int pdg = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("Step") << "CaloSteppingAction: Volume " << lv->GetName() << " History "
                              << touch->GetHistoryDepth() << " Pointers " << aStep->GetPostStepPoint() << ":"
                              << aStep->GetTrack()->GetNextVolume() << ":" << aStep->IsLastStepInVolume() << " E "
-                             << energy << " T " << time;
+                             << energy << " T " << time << ":" << itime << " PDG " << pdg;
 #endif
     uint32_t copy = 0;
     if (((aStep->GetPostStepPoint() == nullptr) || (aStep->GetTrack()->GetNextVolume() == nullptr)) &&
@@ -289,31 +292,33 @@ void CaloSteppingAction::update(const G4Step* aStep) {
                  : static_cast<uint32_t>(touch->GetReplicaNumber(0) + 1000 * touch->GetReplicaNumber(1));
     }
     if (it != mapLV_.end()) {
-      PassiveKey key(std::make_tuple(lv, copy, trackId));
+      PassiveKey key(std::make_tuple(lv, copy, trackId, itime));
       if (allSteps_ > 1) {
         bool flag(true);
         while (store_.find(key) != store_.end()) {
           copy += 1000000;
-          key = std::make_tuple(lv, copy, trackId);
+          key = std::make_tuple(lv, copy, trackId, itime);
           if (copy > 100000000) {
             flag = false;
             break;
           }
         }
         if (flag) {
-          store_[key] = {{time, energy, energy}};
+          store_[key] = std::make_tuple(pdg, time, energy, energy);
         } else {
           auto itr = store_.find(key);
-          (itr->second)[1] += energy;
-          (itr->second)[2] += energy;
+	  double e1 = std::get<2>(itr->second) + energy;
+	  double e2 = std::get<3>(itr->second) + energy;
+          store_[key] = std::make_tuple(pdg, time, e1, e2);
         }
       } else {
         auto itr = store_.find(key);
         if (itr == store_.end()) {
-          store_[key] = {{time, energy, energy}};
+          store_[key] = std::make_tuple(pdg, time, energy, energy);
         } else {
-          (itr->second)[1] += energy;
-          (itr->second)[2] += energy;
+	  double e1 = std::get<2>(itr->second) + energy;
+	  double e2 = std::get<3>(itr->second) + energy;
+          store_[key] = std::make_tuple(pdg, time, e1, e2);
         }
       }
     }

--- a/SimG4CMS/Calo/src/CaloSteppingAction.cc
+++ b/SimG4CMS/Calo/src/CaloSteppingAction.cc
@@ -44,6 +44,7 @@ CaloSteppingAction::CaloSteppingAction(const edm::ParameterSet& p) : count_(0) {
   birkC1HC_ = iC.getParameter<double>("BirkC1HC");
   birkC2HC_ = iC.getParameter<double>("BirkC2HC");
   birkC3HC_ = iC.getParameter<double>("BirkC3HC");
+  timeSliceUnit_ = iC.getUntrackedParameter<double>("TimeSliceUnit",1.0);
 
   edm::LogVerbatim("Step") << "CaloSteppingAction:: " << nameEBSD_.size() << " names for EB SD's";
   for (unsigned int k = 0; k < nameEBSD_.size(); ++k)
@@ -58,6 +59,7 @@ CaloSteppingAction::CaloSteppingAction(const edm::ParameterSet& p) : count_(0) {
                            << birkC1EC_ << ":" << birkSlopeEC_ << ":" << birkCutEC_;
   edm::LogVerbatim("Step") << "CaloSteppingAction::Constants for HCAL: Birk "
                            << "constants " << birkC1HC_ << ":" << birkC2HC_ << ":" << birkC3HC_;
+  edm::LogVerbatim("Step") << "CaloSteppingAction::Constant for time slice " << timeSliceUnit_;
   edm::LogVerbatim("Step") << "CaloSteppingAction:: " << nameHitC_.size() << " hit collections";
   for (unsigned int k = 0; k < nameHitC_.size(); ++k)
     edm::LogVerbatim("Step") << "[" << k << "] " << nameHitC_[k];
@@ -359,7 +361,7 @@ uint32_t CaloSteppingAction::getDetIDHC(int det, int lay, int depth, const math:
 }
 
 void CaloSteppingAction::fillHit(uint32_t id, double dE, double time, int primID, uint16_t depth, double em, int flag) {
-  CaloHitID currentID(id, time, primID, depth);
+  CaloHitID currentID(id, time, primID, depth, timeSliceUnit_);
   double edepEM = (em ? dE : 0);
   double edepHAD = (em ? 0 : dE);
   std::pair<int, CaloHitID> evID = std::make_pair(eventID_, currentID);

--- a/SimG4CMS/Calo/src/CaloSteppingAction.cc
+++ b/SimG4CMS/Calo/src/CaloSteppingAction.cc
@@ -44,7 +44,7 @@ CaloSteppingAction::CaloSteppingAction(const edm::ParameterSet& p) : count_(0) {
   birkC1HC_ = iC.getParameter<double>("BirkC1HC");
   birkC2HC_ = iC.getParameter<double>("BirkC2HC");
   birkC3HC_ = iC.getParameter<double>("BirkC3HC");
-  timeSliceUnit_ = iC.getUntrackedParameter<double>("TimeSliceUnit",1.0);
+  timeSliceUnit_ = iC.getUntrackedParameter<double>("TimeSliceUnit", 1.0);
 
   edm::LogVerbatim("Step") << "CaloSteppingAction:: " << nameEBSD_.size() << " names for EB SD's";
   for (unsigned int k = 0; k < nameEBSD_.size(); ++k)


### PR DESCRIPTION

#### PR description:

Expand the contents of PassiveHit class to contain PDG ID of the track causing the hit and this information is now saved in CaloSteppingAction class

#### PR validation:

Tested privately using the python script SimG4CMS/Calo/test/python/calostep_cfg.py

#### if this PR is a backport please specify the original PR:

Nothing special