### PR TITLE
Exclude dark photon 3000022 tracking for CMSSW_10_6_X

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -497,10 +497,10 @@ bool Generator::particlePassesPrimaryCuts(const G4ThreeVector &p) const {
 
 bool Generator::isExotic(int pdgcode) const {
   int pdgid = std::abs(pdgcode);
-  return ((pdgid >= 1000000 && pdgid < 4000000) ||  // SUSY, R-hadron, and technicolor particles
-          pdgid == 17 ||                            // 4th generation lepton
-          pdgid == 34 ||                            // W-prime
-          pdgid == 37)                              // charged Higgs
+  return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
+          pdgid == 17 ||                                                // 4th generation lepton
+          pdgid == 34 ||                                                // W-prime
+          pdgid == 37)                                                  // charged Higgs
              ? true
              : false;
 }


### PR DESCRIPTION
Minor change to exclude Geant4 tracking of neutral dark photon 3000022 decaying (to muons) outside the CMS beam pipe.
cf. #27768: back port to 10_6_X, @civanch