### PR TITLE
Ad-hoc fix of Relvals TaskName more than 50 characters

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -450,6 +450,19 @@ class MatrixInjector(object):
                             if primary in o:
                                 #print "found",primary,"procuced by",om,"of",t_input['TaskName']
                                 t_second['InputTask'] = t_input['TaskName']
+				#ad-hoc fix due to restriction in TaskName of 50 characters
+				if (len(t_input['TaskName'])>50):
+				    t_input['TaskName'] = t_input['TaskName'].replace('_TuneCUETP8M1','')
+				    t_input['TaskName'] = t_input['TaskName'].replace('_TuneCP5','')
+				    t_input['TaskName'] = t_input['TaskName'].replace('_forSTEAM','')
+				if (len(t_input['TaskName'])>50):
+				    t_input['TaskName'] = t_input['TaskName'].replace('pythia8','')
+                                    t_input['TaskName'] = t_input['TaskName'].replace('_powhegEmissionVeto','')
+                                    t_input['TaskName'] = t_input['TaskName'].replace('_aMCatNLO','')
+                                if (len(t_input['TaskName'])>50):
+                                    t_input['TaskName'] = t_input['TaskName'].replace('GenSimFull','GS')
+                                    t_input['TaskName'] = t_input['TaskName'].replace('GammaGamma','GG')
+                                    t_input['TaskName'] = t_input['TaskName'].replace('Bottom','B')
                                 t_second['InputFromOutputModule'] = om
                                 #print 't_second',pprint.pformat(t_second)
                                 if t_second['TaskName'].startswith('HARVEST'):

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -449,13 +449,13 @@ class MatrixInjector(object):
                         for (om,o) in t_input['nowmIO'].items():
                             if primary in o:
                                 #print "found",primary,"procuced by",om,"of",t_input['TaskName']
-                                t_second['InputTask'] = t_input['TaskName']
 				#ad-hoc fix due to restriction in TaskName of 50 characters
 				if (len(t_input['TaskName'])>50):
 				     if (t_input['TaskName'].find('GenSim') != -1):
-                                        t_input['TaskName'] = 'GenSim'
+                                        t_input['TaskName'] = 'GenSimFull'
                                      if (t_input['TaskName'].find('Hadronizer') != -1):
-                                        t_input['TaskName'] = 'Hadronizer'
+                                        t_input['TaskName'] = 'HadronizerFull'
+				t_second['InputTask'] = t_input['TaskName']
                                 t_second['InputFromOutputModule'] = om
                                 #print 't_second',pprint.pformat(t_second)
                                 if t_second['TaskName'].startswith('HARVEST'):

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -452,17 +452,10 @@ class MatrixInjector(object):
                                 t_second['InputTask'] = t_input['TaskName']
 				#ad-hoc fix due to restriction in TaskName of 50 characters
 				if (len(t_input['TaskName'])>50):
-				    t_input['TaskName'] = t_input['TaskName'].replace('_TuneCUETP8M1','')
-				    t_input['TaskName'] = t_input['TaskName'].replace('_TuneCP5','')
-				    t_input['TaskName'] = t_input['TaskName'].replace('_forSTEAM','')
-				if (len(t_input['TaskName'])>50):
-				    t_input['TaskName'] = t_input['TaskName'].replace('pythia8','')
-                                    t_input['TaskName'] = t_input['TaskName'].replace('_powhegEmissionVeto','')
-                                    t_input['TaskName'] = t_input['TaskName'].replace('_aMCatNLO','')
-                                if (len(t_input['TaskName'])>50):
-                                    t_input['TaskName'] = t_input['TaskName'].replace('GenSimFull','GS')
-                                    t_input['TaskName'] = t_input['TaskName'].replace('GammaGamma','GG')
-                                    t_input['TaskName'] = t_input['TaskName'].replace('Bottom','B')
+				     if (t_input['TaskName'].find('GenSim') != -1):
+                                        t_input['TaskName'] = 'GenSim'
+                                     if (t_input['TaskName'].find('Hadronizer') != -1):
+                                        t_input['TaskName'] = 'Hadronizer'
                                 t_second['InputFromOutputModule'] = om
                                 #print 't_second',pprint.pformat(t_second)
                                 if t_second['TaskName'].startswith('HARVEST'):


### PR DESCRIPTION
#### PR description:

This PR aims to fix the restriction of TaskName added by WMCore in (https://github.com/dmwm/WMCore/commit/e15eee0763e86eadc5f38423d01f3542dbf0f6b6) for RelVals injection. Mainly due to GEN fragment convention. The solution is to check if the TaskName is greater than 50 characters and

- rename TaskName and InputTask to "GenSimFull" or "HadronizerFull"

#### PR validation:

Local test is done with one of the longest TaskName "DisplacedSUSY_stopToBottom_M_300_1000mm_TuneCUETP8M1_13TeV_pythia8_2018_GenSimFull"

`runTheMatrix.py --what upgrade -l 10884.0`

https://cmsweb.cern.ch/reqmgr2/fetch?rid=request-chayanit_RVCMSSW_11_0_0_pre5DisplacedSUSY_stopToBottom_M_300_1000mm_13_190820_164120_6223

The TaskName and InputTask is reduced to GenSimFull for this case