### PR TITLE
Fix 'allowed' configuration construct to deduce also later types than just the first one

### DIFF
--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1690,6 +1690,30 @@ if __name__ == "__main__":
             p2.aValue = PSet(i = int32(3))
             self.assertEqual(p2.aValue.i.value(),3)
 
+            p3 = PSet(aValue=required.allowed(int32,uint32))
+            p3.aValue = -42
+            self.assertEqual(p3.aValue.value(), -42)
+            p3 = PSet(aValue=required.allowed(int32,uint32))
+            self.assertRaises(RuntimeError, lambda: setattr(p3, "aValue", 42))
+
+            p3 = PSet(aValue=required.untracked.allowed(int32,uint32))
+            p3.aValue = -42
+            self.assertEqual(p3.aValue.value(), -42)
+            p3 = PSet(aValue=required.untracked.allowed(int32,uint32))
+            self.assertRaises(RuntimeError, lambda: setattr(p3, "aValue", 42))
+
+            p3 = PSet(aValue=optional.allowed(int32,uint32))
+            p3.aValue = -42
+            self.assertEqual(p3.aValue.value(), -42)
+            p3 = PSet(aValue=optional.allowed(int32,uint32))
+            self.assertRaises(RuntimeError, lambda: setattr(p3, "aValue", 42))
+
+            p3 = PSet(aValue=optional.untracked.allowed(int32,uint32))
+            p3.aValue = -42
+            self.assertEqual(p3.aValue.value(), -42)
+            p3 = PSet(aValue=optional.untracked.allowed(int32,uint32))
+            self.assertRaises(RuntimeError, lambda: setattr(p3, "aValue", 42))
+
         def testVPSet(self):
             p1 = VPSet(PSet(anInt = int32(1)), PSet(anInt=int32(2)))
             self.assertEqual(len(p1),2)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -129,8 +129,8 @@ class _AllowedParameterTypes(object):
                 if chosenType is not None:
                     raise RuntimeError("Ambiguous type conversion for 'allowed' parameter")
                 chosenType = t
-            if chosenType is None:
-                raise RuntimeError("Cannot convert "+str(value)+" to 'allowed' type")
+        if chosenType is None:
+            raise RuntimeError("Cannot convert "+str(value)+" to 'allowed' type")
         return chosenType(value)
 
 
@@ -1659,11 +1659,21 @@ if __name__ == "__main__":
             p1.aValue = 1
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.int32(1)\n)')
             self.assertRaises(ValueError,setattr(p1,'aValue',PSet()))
+            p1 = PSet(aValue = required.allowed(int32, string))
+            self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.required.allowed(cms.int32,cms.string)\n)')
+            p1.aValue = "foo"
+            self.assertEqual(p1.dumpPython(),"cms.PSet(\n    aValue = cms.string('foo')\n)")
+
             p1 = PSet(aValue = required.untracked.allowed(int32, string))
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.required.untracked.allowed(cms.int32,cms.string)\n)')
             p1.aValue = 1
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.untracked.int32(1)\n)')
             self.assertRaises(ValueError,setattr(p1,'aValue',PSet()))
+            p1 = PSet(aValue = required.untracked.allowed(int32, string))
+            self.assertEqual(p1.dumpPython(),'cms.PSet(\n    aValue = cms.required.untracked.allowed(cms.int32,cms.string)\n)')
+            p1.aValue = "foo"
+            self.assertEqual(p1.dumpPython(),"cms.PSet(\n    aValue = cms.untracked.string('foo')\n)")
+
             p2 = PSet(aValue=optional.allowed(int32,PSet))
             self.assertEqual(p2.dumpPython(),'cms.PSet(\n    aValue = cms.optional.allowed(cms.int32,cms.PSet)\n)')
             p2.aValue = 2
@@ -1671,6 +1681,7 @@ if __name__ == "__main__":
             p2 = PSet(aValue=optional.allowed(int32,PSet))
             p2.aValue = PSet(i = int32(3))
             self.assertEqual(p2.aValue.i.value(),3)
+
             p2 = PSet(aValue=optional.untracked.allowed(int32,PSet))
             self.assertEqual(p2.dumpPython(),'cms.PSet(\n    aValue = cms.optional.untracked.allowed(cms.int32,cms.PSet)\n)')
             p2.aValue = 2


### PR DESCRIPTION
#### PR description:

While working with something else I came to wonder the indentation level of
```python
            if chosenType is None:
                raise RuntimeError("Cannot convert "+str(value)+" to 'allowed' type")
```
in `_AllowedParameterTypes.__call__()`. It looked to me that the loop where the `if` is would execute exactly one iteration over the allowed types. Extending the unit tests to check also setting of one of the later types confirmed that this is indeed the case. This PR proposes to fix the problem by moving the check above to be done after the loop over types (which possibly was the intention).

In addition, I added tests to exercise the exception in ambiguous cases.

#### PR validation:

Framework unit tests run.