### PR TITLE
Properly veto HGCal superclusters from entering regular PFBlocks - phase2 scenarios

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GSFTrackImporter.cc
@@ -48,7 +48,8 @@ void GSFTrackImporter::importToBlock(const edm::Event& e, BlockElementImporterBa
         reco::SuperClusterRef scref = seedref->caloCluster().castTo<reco::SuperClusterRef>();
         if (scref.isNonnull()) {
           // explicitly veto HGCal super clusters
-          if (scref->seed()->seed().det() == DetId::Forward)
+          if (scref->seed()->seed().det() == DetId::HGCalEE || scref->seed()->seed().det() == DetId::HGCalHSi ||
+              scref->seed()->seed().det() == DetId::HGCalHSc || scref->seed()->seed().det() == DetId::Forward)
             continue;
           PFBlockElementSCEqual myEqual(scref);
           auto sc_elem = std::find_if(elems.begin(), SCs_end, myEqual);


### PR DESCRIPTION
#### PR description:

Fix vetoes of superclusters from HGCAL going into PFBlocks. As we set up the PF workflow now, we are keeping the endcap HGCAL part separate from the barrel and HF sections, and we don't want superclusters going into regular PFBlocks, but this vetoes was not implemented properly, causing many LogError messages.

This should also address issues reported here:
https://github.com/cms-sw/cmssw/issues/22582

#### PR validation:

Compiles. Also made sure the superclusters from HGCAL are properly removed from PFBlocks in a phase2 matrix test 20434.0 (ttbar D41), while retaining superclusters from barrel.

#### if this PR is a backport please specify the original PR:

Not backport.

@bendavid @guitargeek @jpata @Sam-Harper (cannot find github name of newer egamma leaders...)