### PR TITLE
Geant4 parameters for tracking in field

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -103,13 +103,13 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
                     MinStep = cms.double(0.1),      ## in mm
                     DeltaIntersectionAndOneStep = cms.untracked.double(-1.0),
                     DeltaIntersection = cms.double(0.0001),## in mm
-                    MaxStep = cms.double(100000.),         ## in cm
+                    MaxStep = cms.double(150.),            ## in cm
                     MinimumEpsilonStep = cms.untracked.double(1e-05), ## in mm
-                    EnergyThSimple = cms.double(0.002),               ## in GeV
+                    EnergyThSimple = cms.double(0.015),               ## in GeV
                     DeltaChordSimple = cms.double(0.1),    ## in mm
                     DeltaOneStepSimple = cms.double(0.1),  ## in mm
                     DeltaIntersectionSimple = cms.double(0.01),       ## in mm
-                    MaxStepSimple = cms.double(100000.),   ## in cm
+                    MaxStepSimple = cms.double(50.),       ## in cm
                 )
             )
         ),


### PR DESCRIPTION
#### PR description:
For a long time non-optimal parameters for Geant4 tracking in field were used in order do not change simulation histories and not redo full validation for UL. In this PR few CMS/G4 magnetic field parameters are change, that will provoke many differences in regression. The CPU effects is expected to be minor, number of warnings from Geant4 tracking in field should be reduced dramatically. This seems to be useful for deployment of the coming Geant4 10.6.

#### PR validation:
private


#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
