### PR TITLE
DD4hep: Tracker overlaps on OuterCylinder

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDTECCoolAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECCoolAlgo.cc
@@ -20,15 +20,15 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   vector<string> coolInsert = args.value<vector<string> >("CoolInsert");
   Volume mother = ns.volume(args.parentName());
 
-  LogDebug("TECGeom") << "debug: Parent " << mother.name() << " NameSpace " << ns.name() << " at radial Position "
-                      << rPosition;
+  LogDebug("TECGeom") << "DDTECCoolAlgo debug: Parent " << mother.name() << " NameSpace " << ns.name()
+                      << " at radial Position " << rPosition;
   if (phiPosition.size() == coolInsert.size()) {
     for (int i = 0; i < (int)(phiPosition.size()); i++) {
-      LogDebug("TECGeom") << "debug: Insert[" << i << "]: " << coolInsert.at(i) << " at Phi "
+      LogDebug("TECGeom") << "DDTECCoolAlgo debug: Insert[" << i << "]: " << coolInsert.at(i) << " at Phi "
                           << convertRadToDeg(phiPosition.at(i));
     }
   } else {
-    LogDebug("TECGeom") << "ERROR: Number of inserts does not match the numer of PhiPositions!";
+    LogDebug("TECGeom") << "DDTECCoolAlgo ERROR: Number of inserts does not match the numer of PhiPositions!";
   }
 
   int copyNo = startCopyNo;
@@ -41,11 +41,11 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     // place inserts
     Position tran(xpos, ypos, 0.0);
     mother.placeVolume(child, copyNo, tran);
-    LogDebug("TECGeom") << "test " << child.name() << "[" << copyNo << "] positioned in " << mother.name() << " at "
-                        << tran << " phi " << convertRadToDeg(phiPosition.at(i)) << " r " << rPosition;
+    LogDebug("TECGeom") << "DDTECCoolAlgo test " << child.name() << "[" << copyNo << "] positioned in " << mother.name()
+                        << " at " << tran << " phi " << convertRadToDeg(phiPosition.at(i)) << " r " << rPosition;
     copyNo++;
   }
-  LogDebug("TECGeom") << "Finished....";
+  LogDebug("TECGeom") << "DDTECCoolAlgo Finished....";
   return 1;
 }
 

--- a/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
@@ -56,7 +56,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   double sideFrameRWidthLow = isStereo ? args.value<double>("SideFrameRWidthLow")
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
   double sideFrameRHeight = resizeH * args.value<double>("SideFrameRHeight");  //             Height
-  double sideFrameRtheta = args.value<double>("SideFrameRtheta");    //              angle of the trapezoid shift
+  double sideFrameRtheta = args.value<double>("SideFrameRtheta");  //              angle of the trapezoid shift
   vector<double> siFrSuppBoxWidth = args.value<vector<double> >("SiFrSuppBoxWidth");    //    Supp.Box Width
   vector<double> siFrSuppBoxHeight = args.value<vector<double> >("SiFrSuppBoxHeight");  //            Height
   vector<double> siFrSuppBoxYPos = args.value<vector<double> >(

--- a/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTECModuleAlgo.cc
@@ -52,11 +52,10 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
   double sideFrameLHeight = resizeH * args.value<double>("SideFrameLHeight");  //             Height
   double sideFrameLtheta = args.value<double>("SideFrameLtheta");  //              angle of the trapezoid shift
-  double sideFrameRWidth =
-      resizeH * args.value<double>("SideFrameRWidth");  //    Right    Width (for stereo modules upper one)
+  double sideFrameRWidth = args.value<double>("SideFrameRWidth");  //    Right    Width (for stereo modules upper one)
   double sideFrameRWidthLow = isStereo ? args.value<double>("SideFrameRWidthLow")
                                        : 0e0;  //           Width (only for stereo modules: lower Width)
-  double sideFrameRHeight = args.value<double>("SideFrameRHeight");  //             Height
+  double sideFrameRHeight = resizeH * args.value<double>("SideFrameRHeight");  //             Height
   double sideFrameRtheta = args.value<double>("SideFrameRtheta");    //              angle of the trapezoid shift
   vector<double> siFrSuppBoxWidth = args.value<vector<double> >("SiFrSuppBoxWidth");    //    Supp.Box Width
   vector<double> siFrSuppBoxHeight = args.value<vector<double> >("SiFrSuppBoxHeight");  //            Height

--- a/DetectorDescription/DDCMS/plugins/DDTrackerAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTrackerAngular.cc
@@ -30,12 +30,12 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     delta = rangeAngle / double(n - 1);
   }
 
-  edm::LogVerbatim("TrackerGeom") << "debug: Parameters for positioning:: n " << n << " Start, Range, Delta "
-                                  << convertRadToDeg(startAngle) << " " << convertRadToDeg(rangeAngle) << " "
-                                  << convertRadToDeg(delta) << " Radius " << radius << " Centre " << center[0] << ", "
-                                  << center[1] << ", " << center[2];
-  edm::LogVerbatim("TrackerGeom") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace "
-                                  << ns.name();
+  edm::LogVerbatim("TrackerGeom") << "DDTrackerAngular debug: Parameters for positioning:: n " << n
+                                  << " Start, Range, Delta " << convertRadToDeg(startAngle) << " "
+                                  << convertRadToDeg(rangeAngle) << " " << convertRadToDeg(delta) << " Radius "
+                                  << radius << " Centre " << center[0] << ", " << center[1] << ", " << center[2];
+  edm::LogVerbatim("TrackerGeom") << "DDTrackerAngular debug: Parent " << mother.name() << "\tChild " << child.name()
+                                  << " NameSpace " << ns.name();
 
   double theta = 90._deg;
   int copy = startCopyNo;
@@ -52,7 +52,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
       if (irot != ctxt.rotations.end()) {
         rotation = ns.rotation(ns.prepend(rotstr));
       } else {
-        edm::LogVerbatim("TrackerGeom") << "Creating a new "
+        edm::LogVerbatim("TrackerGeom") << "DDTrackerAngular Creating a new "
                                         << "rotation: " << rotstr << "\t90., " << convertRadToDeg(phix) << ", 90.,"
                                         << convertRadToDeg(phiy) << ", 0, 0";
         RotationZYX rot;
@@ -65,8 +65,8 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     double zpos = center[2];
     Position tran(xpos, ypos, zpos);
     mother.placeVolume(child, copy, Transform3D(rotation, tran));
-    edm::LogVerbatim("TrackerGeom") << "test " << child.name() << " number " << copy << " positioned in "
-                                    << mother.name() << " at " << tran << " with " << rotation;
+    edm::LogVerbatim("TrackerGeom") << "DDTrackerAngular test " << child.name() << " number " << copy
+                                    << " positioned in " << mother.name() << " at " << tran << " with " << rotation;
     copy += incrCopyNo;
     phi += delta;
   }

--- a/DetectorDescription/DDCMS/plugins/DDTrackerLinear.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTrackerLinear.cc
@@ -21,7 +21,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   Volume mother = ns.volume(args.parentName());
   Volume child = ns.volume(args.value<string>("ChildName"));
 
-  LogDebug("TrackerGeom") << "+++ Executing Algorithm. rParent:" << mother.name();
+  LogDebug("TrackerGeom") << "DDTrackerLinear +++ Executing Algorithm. rParent:" << mother.name();
   LogDebug("TrackerGeom") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace "
                           << ns.name() << "\tNumber " << number << "\tAxis (theta/phi) " << theta / dd4hep::deg << ", "
                           << phi / dd4hep::deg << "\t(Offset/Delta) " << offset << ", " << delta << "\tCentre "

--- a/DetectorDescription/DDCMS/plugins/DDTrackerLinear.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTrackerLinear.cc
@@ -29,19 +29,17 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
 
   Position direction(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
   Position base(centre[0], centre[1], centre[2]);
-  RotationZYX rot;
-  if (!rotMat.empty()) {
-    rot = ns.rotation(rotMat);
-  }
+
+  Rotation3D rot = ns.rotation(rotMat);
+
   for (int i = 0, ci = startcn; i < number; i++, ci += incrcn) {
     Position tran = base + (offset + double(i) * delta) * direction;
-    // Copy number ???
-    /* PlacedVolume pv = */ rotMat.empty() ? mother.placeVolume(child, ci, Transform3D(rot, tran))
-                                           : mother.placeVolume(child, ci, tran);
+    mother.placeVolume(child, ci, Transform3D(rot, tran));
+
     LogDebug("TrackerGeom") << child.name() << " number " << ci << " positioned in " << mother.name() << " at " << tran
                             << " with " << rot;
   }
-  return 1;
+  return cms::s_executed;
 }
 
 // first argument is the type from the xml file

--- a/DetectorDescription/DDCMS/plugins/DDTrackerLinear.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTrackerLinear.cc
@@ -30,7 +30,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   Position direction(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
   Position base(centre[0], centre[1], centre[2]);
 
-  Rotation3D rot = ns.rotation(rotMat);
+  const Rotation3D& rot = ns.rotation(rotMat);
 
   for (int i = 0, ci = startcn; i < number; i++, ci += incrcn) {
     Position tran = base + (offset + double(i) * delta) * direction;


### PR DESCRIPTION
#### PR description:

Addresses overlaps on `TrackerOuterCylinder` and fix position of `TEC...SideFrameRight` 

#### PR validation:

`master`

![Screenshot from 2019-08-16 13-51-47](https://user-images.githubusercontent.com/16821717/63166073-978a5f00-c02d-11e9-8a8c-fabed6ac8f4f.png)

`master + thisPr`

![Screenshot from 2019-08-16 13-48-21](https://user-images.githubusercontent.com/16821717/63166081-a07b3080-c02d-11e9-8fd9-ecbce4a02ee7.png)

For validation instructions check: https://github.com/cms-sw/cmssw/pull/27761

`PATH: /Tracker_2/TrackerOuterCylinder_1`