### PR TITLE
modifying filters to use with higgs samples

### DIFF
--- a/GeneratorInterface/Core/interface/EmbeddingHepMCFilter.h
+++ b/GeneratorInterface/Core/interface/EmbeddingHepMCFilter.h
@@ -14,7 +14,7 @@ private:
   const int muonPDGID_ = 13;
   const int electron_neutrino_PDGID_ = 12;
   const int electronPDGID_ = 11;
-  const int ZPDGID_ = 23;
+  int ZPDGID_ = 23;
 
   enum class TauDecayMode : int { Unfilled = -1, Muon = 0, Electron = 1, Hadronic = 2 };
 

--- a/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
+++ b/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
@@ -3,7 +3,8 @@
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/trim_all.hpp"
 
-EmbeddingHepMCFilter::EmbeddingHepMCFilter(const edm::ParameterSet &iConfig) {
+EmbeddingHepMCFilter::EmbeddingHepMCFilter(const edm::ParameterSet &iConfig)
+  : ZPDGID_(iConfig.getParameter<int>("BosonPDGID")) {
   // Defining standard decay channels
   ee.fill(TauDecayMode::Electron);
   ee.fill(TauDecayMode::Electron);
@@ -118,13 +119,16 @@ void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco
     // Asuming, that there are only the two tauons from the Z-boson.
     // This is the case for the simulated Z->tautau event constructed by EmbeddingLHEProducer.
     if (std::abs(particle->pdg_id()) == tauonPDGID_ && !decaymode_known) {
+      // use these bools to protect againt taus that aren't the last copy (which "decay" to a tau and a gamma)
+      bool isGamma = std::abs((*daughter)->pdg_id())==22;
+      bool isTau = std::abs((*daughter)->pdg_id())==15;
       if (std::abs((*daughter)->pdg_id()) == muonPDGID_) {
         DecayChannel_.fill(TauDecayMode::Muon);
         decaymode_known = true;
       } else if (std::abs((*daughter)->pdg_id()) == electronPDGID_) {
         DecayChannel_.fill(TauDecayMode::Electron);
         decaymode_known = true;
-      } else if (!neutrino) {
+      } else if (!neutrino && !isGamma && !isTau) {
         DecayChannel_.fill(TauDecayMode::Hadronic);
         decaymode_known = true;
       }

--- a/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
+++ b/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
@@ -4,7 +4,7 @@
 #include "boost/algorithm/string/trim_all.hpp"
 
 EmbeddingHepMCFilter::EmbeddingHepMCFilter(const edm::ParameterSet &iConfig)
-  : ZPDGID_(iConfig.getParameter<int>("BosonPDGID")) {
+    : ZPDGID_(iConfig.getParameter<int>("BosonPDGID")) {
   // Defining standard decay channels
   ee.fill(TauDecayMode::Electron);
   ee.fill(TauDecayMode::Electron);
@@ -120,8 +120,8 @@ void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco
     // This is the case for the simulated Z->tautau event constructed by EmbeddingLHEProducer.
     if (std::abs(particle->pdg_id()) == tauonPDGID_ && !decaymode_known) {
       // use these bools to protect againt taus that aren't the last copy (which "decay" to a tau and a gamma)
-      bool isGamma = std::abs((*daughter)->pdg_id())==22;
-      bool isTau = std::abs((*daughter)->pdg_id())==15;
+      bool isGamma = std::abs((*daughter)->pdg_id()) == 22;
+      bool isTau = std::abs((*daughter)->pdg_id()) == 15;
       if (std::abs((*daughter)->pdg_id()) == muonPDGID_) {
         DecayChannel_.fill(TauDecayMode::Muon);
         decaymode_known = true;

--- a/TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py
+++ b/TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py
@@ -19,7 +19,8 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
             MuHadCut = cms.string('Mu.Pt > 18 && Had.Pt > 25 && Mu.Eta < 2.1'),
             MuMuCut = cms.string('Mu1.Pt > 17 && Mu2.Pt > 8'),
             Final_States = cms.vstring('ElEl','ElHad','ElMu','HadHad','MuHad','MuMu')
-    )
+    ),
+    BosonPDGID = cms.int32(23)
   ),
   pythiaPylistVerbosity = cms.untracked.int32(0),
   filterEfficiency = cms.untracked.double(1.0),

--- a/TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py
+++ b/TauAnalysis/MCEmbeddingTools/python/EmbeddingPythia8Hadronizer_cfi.py
@@ -18,9 +18,9 @@ generator = cms.EDFilter("Pythia8HadronizerFilter",
             HadHadCut = cms.string('Had1.Pt > 35 && Had2.Pt > 30'),
             MuHadCut = cms.string('Mu.Pt > 18 && Had.Pt > 25 && Mu.Eta < 2.1'),
             MuMuCut = cms.string('Mu1.Pt > 17 && Mu2.Pt > 8'),
-            Final_States = cms.vstring('ElEl','ElHad','ElMu','HadHad','MuHad','MuMu')
+            Final_States = cms.vstring('ElEl','ElHad','ElMu','HadHad','MuHad','MuMu'),
+            BosonPDGID = cms.int32(23)
     ),
-    BosonPDGID = cms.int32(23)
   ),
   pythiaPylistVerbosity = cms.untracked.int32(0),
   filterEfficiency = cms.untracked.double(1.0),


### PR DESCRIPTION
#### PR description:
- Setting the boson PDGID under option so that the filter can be used for Higgs events
- Adding booleans to make sure the correct tau decay types are identified in cases where there are additional FSR photons

#### PR validation:

Checked that the code compiles and that the modifications work correctly by generating MC events privately using the filter

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
