### PR TITLE
Run3-hcx217 Move remaining geometry parameters for SIM step to HcalSimulationParameters

### DIFF
--- a/CondFormats/GeometryObjects/interface/HcalSimulationParameters.h
+++ b/CondFormats/GeometryObjects/interface/HcalSimulationParameters.h
@@ -18,6 +18,14 @@ public:
   std::vector<int> pmtLeft_;
   std::vector<int> pmtFiberLeft_;
 
+  std::vector<int> hfLevels_;
+  std::vector<std::string> hfNames_;
+  std::vector<std::string> hfFibreNames_;
+  std::vector<std::string> hfPMTNames_;
+  std::vector<std::string> hfFibreStraightNames_;
+  std::vector<std::string> hfFibreConicalNames_;
+  std::vector<std::string> hcalMaterialNames_;
+
   COND_SERIALIZABLE;
 };
 

--- a/Geometry/HcalCommonData/interface/HcalSimParametersFromDD.h
+++ b/Geometry/HcalCommonData/interface/HcalSimParametersFromDD.h
@@ -5,6 +5,7 @@
 #include <string>
 
 class DDCompactView;
+class DDFilteredView;
 class HcalSimulationParameters;
 
 class HcalSimParametersFromDD {
@@ -15,6 +16,9 @@ public:
   bool build(const DDCompactView*, HcalSimulationParameters&);
 
 private:
+  void fillNameVector(const DDCompactView*, const std::string&, const std::string&, std::vector<std::string>&);
+  bool isItHF(const std::string&, const HcalSimulationParameters&);
+  std::vector<std::string> getNames(DDFilteredView& fv);
   std::vector<double> getDDDArray(const std::string& str, const DDsvalues_type& sv, int& nmin);
 };
 

--- a/Geometry/HcalCommonData/src/HcalSimParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalSimParametersFromDD.cc
@@ -164,13 +164,15 @@ bool HcalSimParametersFromDD::build(const DDCompactView* cpv, HcalSimulationPara
 #endif
   fillNameVector(cpv, attribute, "HFFibreBundleStraight", php.hfFibreStraightNames_);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreStraightNames_.size() << " names of HFFibreBundleStraight";
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreStraightNames_.size()
+                               << " names of HFFibreBundleStraight";
   for (unsigned int k = 0; k < php.hfFibreStraightNames_.size(); ++k)
     edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hfFibreStraightNames_[k];
 #endif
   fillNameVector(cpv, attribute, "HFFibreBundleConical", php.hfFibreConicalNames_);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreConicalNames_.size() << " names of FibreBundleConical";
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreConicalNames_.size()
+                               << " names of FibreBundleConical";
   for (unsigned int k = 0; k < php.hfFibreConicalNames_.size(); ++k)
     edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hfFibreConicalNames_[k];
 #endif
@@ -205,8 +207,10 @@ bool HcalSimParametersFromDD::build(const DDCompactView* cpv, HcalSimulationPara
   return true;
 }
 
-void HcalSimParametersFromDD::fillNameVector(const DDCompactView* cpv, const std::string& attribute, const std::string& value, std::vector<std::string>& lvnames) {
-
+void HcalSimParametersFromDD::fillNameVector(const DDCompactView* cpv,
+                                             const std::string& attribute,
+                                             const std::string& value,
+                                             std::vector<std::string>& lvnames) {
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0)};
   DDFilteredView fv(*cpv, filter);
   lvnames = getNames(fv);
@@ -214,16 +218,21 @@ void HcalSimParametersFromDD::fillNameVector(const DDCompactView* cpv, const std
 
 bool HcalSimParametersFromDD::isItHF(const std::string& name, const HcalSimulationParameters& php) {
   for (auto nam : php.hfNames_)
-    if (name == nam) return true;
+    if (name == nam)
+      return true;
   for (auto nam : php.hfFibreNames_)
-    if (name == nam) return true;
+    if (name == nam)
+      return true;
   for (auto nam : php.hfPMTNames_)
-    if (name == nam) return true;
+    if (name == nam)
+      return true;
   for (auto nam : php.hfFibreStraightNames_)
-    if (name == nam) return true;
+    if (name == nam)
+      return true;
   for (auto nam : php.hfFibreConicalNames_)
-    if (name == nam) return true;
-   
+    if (name == nam)
+      return true;
+
   return false;
 }
 

--- a/Geometry/HcalCommonData/src/HcalSimParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalSimParametersFromDD.cc
@@ -21,13 +21,42 @@ bool HcalSimParametersFromDD::build(const DDCompactView* cpv, HcalSimulationPara
   std::string value = "HF";
   DDSpecificsMatchesValueFilter filter1{DDValue(attribute, value, 0)};
   DDFilteredView fv1(*cpv, filter1);
-  bool dodet = fv1.firstChild();
 
+  // Names of sensitive volumes for HF
+  php.hfNames_ = getNames(fv1);
+  int nb(-1);
+#ifdef EDM_ML_DEBUG
+  nb = static_cast<int>(php.hfNames_.size());
+  std::stringstream ss0;
+  for (int it = 0; it < nb; it++) {
+    if (it / 10 * 10 == it) {
+      ss0 << "\n";
+    }
+    ss0 << " [" << it << "] " << php.hfNames_[it];
+  }
+  edm::LogVerbatim("HCalGeom") << "HFNames: " << nb << ": " << ss0.str();
+#endif
+
+  bool dodet = fv1.firstChild();
   if (dodet) {
     DDsvalues_type sv(fv1.mergedSpecifics());
 
+    // The level positions
+    nb = -1;
+    php.hfLevels_ = dbl_to_int(getDDDArray("Levels", sv, nb));
+#ifdef EDM_ML_DEBUG
+    std::stringstream ss0;
+    for (int it = 0; it < nb; it++) {
+      if (it / 10 * 10 == it) {
+        ss0 << "\n";
+      }
+      ss0 << " [" << it << "] " << php.hfLevels_[it];
+    }
+    edm::LogVerbatim("HCalGeom") << "HF Volume Levels: " << nb << " hfLevels: " << ss0.str();
+#endif
+
     // Attenuation length
-    int nb = -1;
+    nb = -1;
     php.attenuationLength_ = getDDDArray("attl", sv, nb);
 #ifdef EDM_ML_DEBUG
     std::stringstream ss1;
@@ -120,7 +149,102 @@ bool HcalSimParametersFromDD::build(const DDCompactView* cpv, HcalSimulationPara
     throw cms::Exception("HcalSimParametersFromDD") << "Not found " << value << " for " << attribute << " but needed.";
   }
 
+  //Names of special volumes (HFFibre, HFPMT, HFFibreBundles)
+  fillNameVector(cpv, attribute, "HFFibre", php.hfFibreNames_);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreNames_.size() << " names of HFFibre";
+  for (unsigned int k = 0; k < php.hfFibreNames_.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hfFibreNames_[k];
+#endif
+  fillNameVector(cpv, attribute, "HFPMT", php.hfPMTNames_);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfPMTNames_.size() << " names of HFPMT";
+  for (unsigned int k = 0; k < php.hfPMTNames_.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hfPMTNames_[k];
+#endif
+  fillNameVector(cpv, attribute, "HFFibreBundleStraight", php.hfFibreStraightNames_);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreStraightNames_.size() << " names of HFFibreBundleStraight";
+  for (unsigned int k = 0; k < php.hfFibreStraightNames_.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hfFibreStraightNames_[k];
+#endif
+  fillNameVector(cpv, attribute, "HFFibreBundleConical", php.hfFibreConicalNames_);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hfFibreConicalNames_.size() << " names of FibreBundleConical";
+  for (unsigned int k = 0; k < php.hfFibreConicalNames_.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hfFibreConicalNames_[k];
+#endif
+
+  // HCal materials
+  attribute = "OnlyForHcalSimNumbering";
+  DDSpecificsHasNamedValueFilter filter3{attribute};
+  DDFilteredView fv3(*cpv, filter3);
+  dodet = fv3.firstChild();
+
+  while (dodet) {
+    const DDLogicalPart& log = fv3.logicalPart();
+    if (!isItHF(log.name().name(), php)) {
+      bool notIn = true;
+      for (unsigned int i = 0; i < php.hcalMaterialNames_.size(); ++i) {
+        if (!strcmp(php.hcalMaterialNames_[i].c_str(), log.material().name().name().c_str())) {
+          notIn = false;
+          break;
+        }
+      }
+      if (notIn)
+        php.hcalMaterialNames_.push_back(log.material().name().name());
+    }
+    dodet = fv2.next();
+  }
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalSimParameters: " << php.hcalMaterialNames_.size() << " names of HCAL materials";
+  for (unsigned int k = 0; k < php.hcalMaterialNames_.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php.hcalMaterialNames_[k];
+#endif
+
   return true;
+}
+
+void HcalSimParametersFromDD::fillNameVector(const DDCompactView* cpv, const std::string& attribute, const std::string& value, std::vector<std::string>& lvnames) {
+
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0)};
+  DDFilteredView fv(*cpv, filter);
+  lvnames = getNames(fv);
+}
+
+bool HcalSimParametersFromDD::isItHF(const std::string& name, const HcalSimulationParameters& php) {
+  for (auto nam : php.hfNames_)
+    if (name == nam) return true;
+  for (auto nam : php.hfFibreNames_)
+    if (name == nam) return true;
+  for (auto nam : php.hfPMTNames_)
+    if (name == nam) return true;
+  for (auto nam : php.hfFibreStraightNames_)
+    if (name == nam) return true;
+  for (auto nam : php.hfFibreConicalNames_)
+    if (name == nam) return true;
+   
+  return false;
+}
+
+std::vector<std::string> HcalSimParametersFromDD::getNames(DDFilteredView& fv) {
+  std::vector<std::string> tmp;
+  bool dodet = fv.firstChild();
+  while (dodet) {
+    const DDLogicalPart& log = fv.logicalPart();
+    bool ok = true;
+
+    for (unsigned int i = 0; i < tmp.size(); ++i) {
+      if (!strcmp(tmp[i].c_str(), log.name().name().c_str())) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok)
+      tmp.push_back(log.name().name());
+    dodet = fv.next();
+  }
+  return tmp;
 }
 
 std::vector<double> HcalSimParametersFromDD::getDDDArray(const std::string& str, const DDsvalues_type& sv, int& nmin) {

--- a/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
+++ b/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
@@ -234,6 +234,29 @@ void HcalParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Ev
     for (const auto& it : parsim->pmtFiberLeft_)
       std::cout << it << ", ";
     std::cout << std::endl;
+
+    std::cout << "\nhfLevels_: ";
+    for (const auto& it : parsim->hfLevels_)
+      std::cout << it << ", ";
+    std::cout << "\nhfNames_: ";
+    for (const auto& it : parsim->hfNames_)
+      std::cout << it << ", ";
+    std::cout << "\nhfFibreNames_: ";
+    for (const auto& it : parsim->hfFibreNames_)
+      std::cout << it << ", ";
+    std::cout << "\nhfPMTNames_: ";
+    for (const auto& it : parsim->hfPMTNames_)
+      std::cout << it << ", ";
+    std::cout << "\nhfFibreStraightNames_: ";
+    for (const auto& it : parsim->hfFibreStraightNames_)
+      std::cout << it << ", ";
+    std::cout << "\nhfFibreConicalNames_: ";
+    for (const auto& it : parsim->hfFibreConicalNames_)
+      std::cout << it << ", ";
+    std::cout << "\nhcalMaterialNames_: ";
+    for (const auto& it : parsim->hcalMaterialNames_)
+      std::cout << it << ", ";
+    std::cout << std::endl;
   }
 }
 


### PR DESCRIPTION
#### PR description:

In the process of removing dependence of CompactView in the SIM step of HCAL, a few more variables are extracted and put in the object HcalSimulationParameters

#### PR validation:

Tested with standard runTheMatrix workflows

#### if this PR is a backport please specify the original PR:

Nothing special