### PR TITLE
First attempt to fix DQM GUI urls in RelMon

### DIFF
--- a/Utilities/RelMon/python/directories2html.py
+++ b/Utilities/RelMon/python/directories2html.py
@@ -258,7 +258,7 @@ def get_summary_section(directory,matrix_page=True):
   html= '<div class="span-6">'+\
         '<h3>Summary</h3>'
   html+=get_dir_stats(directory)
-  html+='<a href="%s/%s">To the DQM GUI...</a>' %(server,base_url)
+  html+='<a href="%s/%s/start?runnr=%s;dataset=/%s/%s/DQMIO;sampletype=offline_data;filter=all;referencepos=on-side;referenceshow=all;referencenorm=True;referenceobj1=other:%s:/%s/%s/DQMIO:;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;focus=;zoom=no;">To the DQM GUI...</a>' %(server,base_url,meta.run1,meta.sample1,meta.release1,meta.run2,meta.sample2,meta.release2)
   html+='</div>'
         
   html+='<div class="span-7 colborder">'+\

--- a/Utilities/RelMon/python/web/templates/directory_summary.html
+++ b/Utilities/RelMon/python/web/templates/directory_summary.html
@@ -22,7 +22,7 @@
             <li><span class="caps">Null: {{ null }}% ({{ nulls }})</span></li>
             <li><span class="caps">Fail: {{ fail }}% ({{ fails }})</span></li>
         </ul>
-        <a href="http://cmsweb.cern.ch/dqm/relval">To the DQM GUI...</a>
+        <a href="http://cmsweb.cern.ch/dqm/relval/start?runnr={{run1}};dataset=/{{sample1}}/{{release1}}/DQMIO;sampletype=offline_data;filter=all;referencepos=on-side;referenceshow=all;referencenorm=True;referenceobj1=other:{{run2}}:/{{sample2}}/{{release2}}/DQMIO:;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;focus=;zoom=no;">To the DQM GUI...</a>
     </div>
     <div class="span-5 colborder">
         <img class="top right" src="https://chart.googleapis.com/chart?cht=p3&amp;chco=00FF00|FFFF00|FF0000&amp;chs=200x200&amp;chd=t:{{ success }},{{ null }},{{ fail }}">

--- a/Utilities/RelMon/python/web/templates/release_summary.html
+++ b/Utilities/RelMon/python/web/templates/release_summary.html
@@ -74,7 +74,7 @@
             <li><span class="caps">Null: {{ null }}% ({{ nulls }})</span></li>
             <li><span class="caps">Fail: {{ fail }}% ({{ fails }})</span></li>
         </ul>
-        <a href="http://cmsweb.cern.ch/dqm/relval">To the DQM GUI...</a>
+         <a href="http://cmsweb.cern.ch/dqm/relval/start?runnr={{run1}};dataset=/{{sample1}}/{{release1}}/DQMIO;sampletype=offline_data;filter=all;referencepos=on-side;referenceshow=all;referencenorm=True;referenceobj1=other:{{run2}}:/{{sample2}}/{{release2}}/DQMIO:;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;focus=;zoom=no;">To the DQM GUI...</a>
     </div>
     <div class="span-5 colborder">
         <img class="top right" src="https://chart.googleapis.com/chart?cht=p3&amp;chco=00FF00|FFFF00|FF0000&amp;chs=200x200&amp;chd=t:{{ success }},{{ null }},{{ fail }}">


### PR DESCRIPTION
#### PR description:

This PR tries to fix issue https://github.com/cms-sw/cmssw/issues/27800
Links points to root Everything workspace instead of dedicated folder to simplify

#### PR validation:

Tested locally

#### if this PR is a backport please specify the original PR:

No backport