### PR TITLE
Fix gcc9 warnigns in EventFilter/CTPPSRawToDigi add 0 init values

### DIFF
--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -211,7 +211,7 @@ void CTPPSPixelDataFormatter::formatRawData(unsigned int lvl1_ID,
       const int pxid = 2 * (ROCSizeInX - rocPixelRow) + (rocPixelColumn % 2);
 
       unsigned int urocID = rocID;
-      PPSPixelIndex myTest = {rawId, urocID};
+      PPSPixelIndex myTest = {rawId, urocID, 0, 0, 0};
       // the range has always at most one element
       auto range = std::equal_range(iDdet2fed.begin(), iDdet2fed.end(), myTest, compare);
       if (range.first != range.second) {

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSTotemDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSTotemDataFormatter.cc
@@ -61,7 +61,7 @@ void CTPPSTotemDataFormatter::formatRawData(unsigned int lvl1_ID,
       mapIdCh[newrawId].push_back(channel);
     }
     for (auto &pId : mapIdCh) {
-      PPSStripIndex myTest = {pId.first};
+      PPSStripIndex myTest = {pId.first, 0, 0, 0, 0};
 
       // the range has always at most one element
       auto range = std::equal_range(iDdet2fed.begin(), iDdet2fed.end(), myTest, compare);


### PR DESCRIPTION
#### PR description:

Fix gcc9 warnings about missing initializers 
 
#### PR validation:

Builds without warnigns

