### PR TITLE
renamed TopLHEFilter -> LHEJetFilter

### DIFF
--- a/GeneratorInterface/GenFilters/BuildFile.xml
+++ b/GeneratorInterface/GenFilters/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="fastjet"/>
 <use   name="boost"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>

--- a/GeneratorInterface/GenFilters/python/LHEJetFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/LHEJetFilter_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+LHEJetFilter = cms.EDFilter('LHEJetFilter',
+jetPtMin = cms.double(350.),
+jetR = cms.double(0.8),
+src = cms.InputTag('externalLHEProducer')
+)
+

--- a/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
@@ -20,58 +20,52 @@
 using namespace std;
 using namespace fastjet;
 
-class LHEJetFilter : public edm::EDFilter
-{
-	public:
-		explicit LHEJetFilter(const edm::ParameterSet&);
-		virtual ~LHEJetFilter() {}
+class LHEJetFilter : public edm::EDFilter {
+public:
+  explicit LHEJetFilter(const edm::ParameterSet&);
+  ~LHEJetFilter() override {}
 
-	private:
-		bool filter(edm::Event&, const edm::EventSetup&) override;
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
 
-		edm::EDGetTokenT<LHEEventProduct> tokenLHEEvent_; 
-		double jetPtMin_;
-		JetDefinition jetdef_;
+  edm::EDGetTokenT<LHEEventProduct> tokenLHEEvent_;
+  double jetPtMin_;
+  JetDefinition jetdef_;
 
-		vector<PseudoJet> jetconsts_;
-
-
+  vector<PseudoJet> jetconsts_;
 };
- 
+
 LHEJetFilter::LHEJetFilter(const edm::ParameterSet& params)
-	: tokenLHEEvent_(consumes<LHEEventProduct>(params.getParameter<edm::InputTag>("src"))),
-	jetPtMin_(params.getParameter<double>("jetPtMin")),
-	jetdef_(antikt_algorithm, params.getParameter<double>("jetR"))
-{
+    : tokenLHEEvent_(consumes<LHEEventProduct>(params.getParameter<edm::InputTag>("src"))),
+      jetPtMin_(params.getParameter<double>("jetPtMin")),
+      jetdef_(antikt_algorithm, params.getParameter<double>("jetR")) {}
 
+bool LHEJetFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
+  edm::Handle<LHEEventProduct> lheinfo;
+  evt.getByToken(tokenLHEEvent_, lheinfo);
+
+  if (!lheinfo.isValid()) {
+    return true;
+  }
+
+  jetconsts_.clear();
+  const lhef::HEPEUP& hepeup = lheinfo->hepeup();
+  for (size_t p = 0; p < hepeup.IDUP.size(); ++p) {
+    if (hepeup.ISTUP[p] == 1) {
+      const lhef::HEPEUP::FiveVector& mom = hepeup.PUP[p];
+      jetconsts_.emplace_back(mom[0], mom[1], mom[2], mom[3]);
+    }
+  }
+
+  ClusterSequence cs(jetconsts_, jetdef_);
+  vector<PseudoJet> jets = sorted_by_pt(cs.inclusive_jets());
+
+  if (jets.empty()) {
+    return false;
+  }
+
+  return jets[0].perp() > jetPtMin_;
 }
 
-bool LHEJetFilter::filter(edm::Event& evt, const edm::EventSetup& params)
-{
-	edm::Handle<LHEEventProduct> lheinfo;
-	evt.getByToken(tokenLHEEvent_, lheinfo);
-
-	if(!lheinfo.isValid()) {return true;}
-
-	jetconsts_.clear();
-	const lhef::HEPEUP& hepeup = lheinfo->hepeup();
-	for(size_t p = 0 ; p < hepeup.IDUP.size() ; ++p)
-	{
-		if(hepeup.ISTUP[p] == 1)
-		{
-			const lhef::HEPEUP::FiveVector& mom = hepeup.PUP[p];
-			jetconsts_.emplace_back(mom[0], mom[1], mom[2], mom[3]);
-		}
-
-	}
-
-	ClusterSequence cs(jetconsts_, jetdef_);
-	vector<PseudoJet> jets = sorted_by_pt(cs.inclusive_jets());
-
-	if(jets.size() == 0) {return false;}
-
-	return jets[0].perp() > jetPtMin_;
-}
- 
- // Define module as a plug-in
- DEFINE_FWK_MODULE(LHEJetFilter);
+// Define module as a plug-in
+DEFINE_FWK_MODULE(LHEJetFilter);

--- a/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
@@ -1,0 +1,77 @@
+#include <vector>
+
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/Selector.hh"
+
+using namespace std;
+using namespace fastjet;
+
+class LHEJetFilter : public edm::EDFilter
+{
+	public:
+		explicit LHEJetFilter(const edm::ParameterSet&);
+		virtual ~LHEJetFilter() {}
+
+	private:
+		bool filter(edm::Event&, const edm::EventSetup&) override;
+
+		edm::EDGetTokenT<LHEEventProduct> tokenLHEEvent_; 
+		double jetPtMin_;
+		JetDefinition jetdef_;
+
+		vector<PseudoJet> jetconsts_;
+
+
+};
+ 
+LHEJetFilter::LHEJetFilter(const edm::ParameterSet& params)
+	: tokenLHEEvent_(consumes<LHEEventProduct>(params.getParameter<edm::InputTag>("src"))),
+	jetPtMin_(params.getParameter<double>("jetPtMin")),
+	jetdef_(antikt_algorithm, params.getParameter<double>("jetR"))
+{
+
+}
+
+bool LHEJetFilter::filter(edm::Event& evt, const edm::EventSetup& params)
+{
+	edm::Handle<LHEEventProduct> lheinfo;
+	evt.getByToken(tokenLHEEvent_, lheinfo);
+
+	if(!lheinfo.isValid()) {return true;}
+
+	jetconsts_.clear();
+	const lhef::HEPEUP& hepeup = lheinfo->hepeup();
+	for(size_t p = 0 ; p < hepeup.IDUP.size() ; ++p)
+	{
+		if(hepeup.ISTUP[p] == 1)
+		{
+			const lhef::HEPEUP::FiveVector& mom = hepeup.PUP[p];
+			jetconsts_.emplace_back(mom[0], mom[1], mom[2], mom[3]);
+		}
+
+	}
+
+	ClusterSequence cs(jetconsts_, jetdef_);
+	vector<PseudoJet> jets = sorted_by_pt(cs.inclusive_jets());
+
+	if(jets.size() == 0) {return false;}
+
+	return jets[0].perp() > jetPtMin_;
+}
+ 
+ // Define module as a plug-in
+ DEFINE_FWK_MODULE(LHEJetFilter);

--- a/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
@@ -46,7 +46,8 @@ bool LHEJetFilter::filter(edm::StreamID strid, edm::Event& evt, const edm::Event
     return true;
   }
 
-  vector<PseudoJet> jetconsts(6);
+  vector<PseudoJet> jetconsts;
+  jetconsts.reserve(10);
   const lhef::HEPEUP& hepeup = lheinfo->hepeup();
   for (size_t p = 0; p < hepeup.IDUP.size(); ++p) {
     if (hepeup.ISTUP[p] == 1) {

--- a/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
+++ b/GeneratorInterface/GenFilters/src/LHEJetFilter.cc
@@ -1,6 +1,6 @@
 #include <vector>
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,19 +20,17 @@
 using namespace std;
 using namespace fastjet;
 
-class LHEJetFilter : public edm::EDFilter {
+class LHEJetFilter : public edm::global::EDFilter<> {
 public:
   explicit LHEJetFilter(const edm::ParameterSet&);
   ~LHEJetFilter() override {}
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID strid, edm::Event& evt, const edm::EventSetup& params) const override;
 
   edm::EDGetTokenT<LHEEventProduct> tokenLHEEvent_;
   double jetPtMin_;
   JetDefinition jetdef_;
-
-  vector<PseudoJet> jetconsts_;
 };
 
 LHEJetFilter::LHEJetFilter(const edm::ParameterSet& params)
@@ -40,7 +38,7 @@ LHEJetFilter::LHEJetFilter(const edm::ParameterSet& params)
       jetPtMin_(params.getParameter<double>("jetPtMin")),
       jetdef_(antikt_algorithm, params.getParameter<double>("jetR")) {}
 
-bool LHEJetFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
+bool LHEJetFilter::filter(edm::StreamID strid, edm::Event& evt, const edm::EventSetup& params) const {
   edm::Handle<LHEEventProduct> lheinfo;
   evt.getByToken(tokenLHEEvent_, lheinfo);
 
@@ -48,23 +46,19 @@ bool LHEJetFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
     return true;
   }
 
-  jetconsts_.clear();
+  vector<PseudoJet> jetconsts(6);
   const lhef::HEPEUP& hepeup = lheinfo->hepeup();
   for (size_t p = 0; p < hepeup.IDUP.size(); ++p) {
     if (hepeup.ISTUP[p] == 1) {
       const lhef::HEPEUP::FiveVector& mom = hepeup.PUP[p];
-      jetconsts_.emplace_back(mom[0], mom[1], mom[2], mom[3]);
+      jetconsts.emplace_back(mom[0], mom[1], mom[2], mom[3]);
     }
   }
 
-  ClusterSequence cs(jetconsts_, jetdef_);
-  vector<PseudoJet> jets = sorted_by_pt(cs.inclusive_jets());
+  ClusterSequence cs(jetconsts, jetdef_);
+  vector<PseudoJet> jets = cs.inclusive_jets(jetPtMin_);
 
-  if (jets.empty()) {
-    return false;
-  }
-
-  return jets[0].perp() > jetPtMin_;
+  return !jets.empty();
 }
 
 // Define module as a plug-in


### PR DESCRIPTION
#### PR description:

This is a filter acting on the LHE output. It clusters the final LHE particles using the anti-kt jet algorithm. A cut on the minimum pT > 350 GeV is selected. This filter is a loose pre-selection of the AK8-jet pT > 650 GeV filter at particle level used in the production of TT_AK8HT650* samples. The pre-filter selects at LHE level 99.8% of the events with a jet of pT > 650 GeV at particle level, while only 3% of the inclusive ttbar sample passes the filter. Therefore, the number of events that have to be showered before the filter decision is drastically reduced.

#### PR validation:

Tests have shown that this pre-filter reduces the the run time per event from ~1.3s to ~0.2s.
