### PR TITLE
Fix autoCondPhase2.py for python 3

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -1,3 +1,5 @@
+import six
+
 from Configuration.StandardSequences.CondDBESSource_cff import GlobalTag as essource
 connectionString = essource.connect.value()
 
@@ -71,7 +73,7 @@ for det in activeDets:
 
 # method called in autoAlCa
 def autoCondPhase2(autoCond):
-    for key,val in phase2GTs.iteritems():
+    for key,val in six.iteritems(phase2GTs):
         if len(val)==1 :
            autoCond[key] = ( autoCond[val[0]] )
         else:


### PR DESCRIPTION
#### PR description:

Python 3 dicts do not have iteritems method.

#### PR validation:

Using CMSSW_11_0_DEVEL_X_2019-08-18-2300 ran runTheMatrix.py -l 1.0 which now works (was failing in the IBs).