### PR TITLE
Fix gcc 9 warnings DQM/DTMonitorClient - Add fallthroughs to clear the warnings

### DIFF
--- a/DQM/DTMonitorClient/src/DTLocalTriggerLutTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerLutTest.cc
@@ -271,19 +271,17 @@ void DTLocalTriggerLutTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMS
           int phiNoData = 0;
           int phibNoData = 0;
           for (int stat = 1; stat <= 4; ++stat) {
-            switch (static_cast<int>(phiWhSummary->GetBinContent(sect, stat))) {
-              case 1:
-                phiNoData++;
-              case 2:
-              case 3:
-                phiErr++;
+            int res = static_cast<int>(phiWhSummary->GetBinContent(sect, stat));
+            if (res == 1) {
+              phiNoData++;
+            } else if (res == 3) {
+              phiErr++;
             }
-            switch (static_cast<int>(phibWhSummary->GetBinContent(sect, stat))) {
-              case 1:
-                phibNoData++;
-              case 2:
-              case 3:
-                phibErr++;
+            res = static_cast<int>(phibWhSummary->GetBinContent(sect, stat));
+            if (res == 1) {
+              phibNoData++;
+            } else if (res == 3) {
+              phibErr++;
             }
           }
           if (phiNoData == 4)

--- a/DQM/DTMonitorClient/src/DTLocalTriggerLutTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerLutTest.cc
@@ -271,17 +271,21 @@ void DTLocalTriggerLutTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMS
           int phiNoData = 0;
           int phibNoData = 0;
           for (int stat = 1; stat <= 4; ++stat) {
-            int res = static_cast<int>(phiWhSummary->GetBinContent(sect, stat));
-            if (res == 1) {
-              phiNoData++;
-            } else if (res == 3) {
-              phiErr++;
+            switch (static_cast<int>(phiWhSummary->GetBinContent(sect, stat))) {
+              case 1:
+                phiNoData++;
+                [[fallthrough]];
+              case 2:
+              case 3:
+                phiErr++;
             }
-            res = static_cast<int>(phibWhSummary->GetBinContent(sect, stat));
-            if (res == 1) {
-              phibNoData++;
-            } else if (res == 3) {
-              phibErr++;
+            switch (static_cast<int>(phibWhSummary->GetBinContent(sect, stat))) {
+              case 1:
+                phibNoData++;
+                [[fallthrough]];
+              case 2:
+              case 3:
+                phibErr++;
             }
           }
           if (phiNoData == 4)

--- a/DQM/DTMonitorClient/src/DTLocalTriggerTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerTest.cc
@@ -438,11 +438,11 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMStor
             int matchErr = 0;
             int matchNoData = 0;
             for (int stat = 1; stat <= 4; ++stat) {
-              switch (static_cast<int>(matchWhSummary->GetBinContent(sect, stat))) {
-                case 1:
-                  matchNoData++;
-                case 2:
-                  matchErr++;
+              int res = static_cast<int>(matchWhSummary->GetBinContent(sect, stat));
+              if (res == 1) {
+                matchNoData++;
+              } else if (res == 2) {
+                matchErr++;
               }
             }
             if (matchNoData == 4)
@@ -459,17 +459,17 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMStor
             int corrNoData = 0;
             int secondNoData = 0;
             for (int stat = 1; stat <= 4; ++stat) {
-              switch (static_cast<int>(corrWhSummaryIn->GetBinContent(sect, stat))) {
-                case 1:
-                  corrNoData++;
-                case 2:
-                  corrErr++;
+              int res = static_cast<int>(corrWhSummaryIn->GetBinContent(sect, stat));
+              if (res == 1) {
+                corrNoData++;
+              } else if (res == 2) {
+                corrErr++;
               }
-              switch (static_cast<int>(secondWhSummaryIn->GetBinContent(sect, stat))) {
-                case 1:
-                  secondNoData++;
-                case 2:
-                  secondErr++;
+              res = static_cast<int>(secondWhSummaryIn->GetBinContent(sect, stat));
+              if (res == 1) {
+                secondNoData++;
+              } else if (res == 2) {
+                secondErr++;
               }
             }
             if (corrNoData == 4)
@@ -488,17 +488,17 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMStor
             int corrNoData = 0;
             int secondNoData = 0;
             for (int stat = 1; stat <= 4; ++stat) {
-              switch (static_cast<int>(corrWhSummaryOut->GetBinContent(sect, stat))) {
-                case 1:
-                  corrNoData++;
-                case 2:
-                  corrErr++;
+              int res = static_cast<int>(corrWhSummaryOut->GetBinContent(sect, stat));
+              if (res == 1) {
+                corrNoData++;
+              } else if (res == 2) {
+                corrErr++;
               }
-              switch (static_cast<int>(secondWhSummaryOut->GetBinContent(sect, stat))) {
-                case 1:
-                  secondNoData++;
-                case 2:
-                  secondErr++;
+              res = static_cast<int>(secondWhSummaryOut->GetBinContent(sect, stat));
+              if (res == 1) {
+                secondNoData++;
+              } else if (res == 2) {
+                secondErr++;
               }
             }
             if (corrNoData == 4)

--- a/DQM/DTMonitorClient/src/DTLocalTriggerTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerTest.cc
@@ -438,11 +438,12 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMStor
             int matchErr = 0;
             int matchNoData = 0;
             for (int stat = 1; stat <= 4; ++stat) {
-              int res = static_cast<int>(matchWhSummary->GetBinContent(sect, stat));
-              if (res == 1) {
-                matchNoData++;
-              } else if (res == 2) {
-                matchErr++;
+              switch (static_cast<int>(matchWhSummary->GetBinContent(sect, stat))) {
+                case 1:
+                  matchNoData++;
+                  [[fallthrough]];
+                case 2:
+                  matchErr++;
               }
             }
             if (matchNoData == 4)
@@ -459,17 +460,19 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMStor
             int corrNoData = 0;
             int secondNoData = 0;
             for (int stat = 1; stat <= 4; ++stat) {
-              int res = static_cast<int>(corrWhSummaryIn->GetBinContent(sect, stat));
-              if (res == 1) {
-                corrNoData++;
-              } else if (res == 2) {
-                corrErr++;
+              switch (static_cast<int>(corrWhSummaryIn->GetBinContent(sect, stat))) {
+                case 1:
+                  corrNoData++;
+                  [[fallthrough]];
+                case 2:
+                  corrErr++;
               }
-              res = static_cast<int>(secondWhSummaryIn->GetBinContent(sect, stat));
-              if (res == 1) {
-                secondNoData++;
-              } else if (res == 2) {
-                secondErr++;
+              switch (static_cast<int>(secondWhSummaryIn->GetBinContent(sect, stat))) {
+                case 1:
+                  secondNoData++;
+                  [[fallthrough]];
+                case 2:
+                  secondErr++;
               }
             }
             if (corrNoData == 4)
@@ -488,17 +491,19 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker& ibooker, DQMStor
             int corrNoData = 0;
             int secondNoData = 0;
             for (int stat = 1; stat <= 4; ++stat) {
-              int res = static_cast<int>(corrWhSummaryOut->GetBinContent(sect, stat));
-              if (res == 1) {
-                corrNoData++;
-              } else if (res == 2) {
-                corrErr++;
+              switch (static_cast<int>(corrWhSummaryOut->GetBinContent(sect, stat))) {
+                case 1:
+                  corrNoData++;
+                  [[fallthrough]];
+                case 2:
+                  corrErr++;
               }
-              res = static_cast<int>(secondWhSummaryOut->GetBinContent(sect, stat));
-              if (res == 1) {
-                secondNoData++;
-              } else if (res == 2) {
-                secondErr++;
+              switch (static_cast<int>(secondWhSummaryOut->GetBinContent(sect, stat))) {
+                case 1:
+                  secondNoData++;
+                  [[fallthrough]];
+                case 2:
+                  secondErr++;
               }
             }
             if (corrNoData == 4)


### PR DESCRIPTION
#### PR description:

Fixes warnings in gcc9 
Substitutes switch statements with less than 5 cases with if conditions

#### PR validation:

Builds without warnings 