### PR TITLE
Fix gcc 9 warnings in L1Trigger/L1TCalorimeter

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/L1GObject.h
+++ b/L1Trigger/L1TCalorimeter/interface/L1GObject.h
@@ -55,7 +55,7 @@ public:
     return (etBits);
   }
 
-  L1GObject(const L1GObject& t) {
+  L1GObject(const L1GObject& t) : reco::LeafCandidate::LeafCandidate() {
     myName = t.myName;
     myPhi = t.myPhi;
     myEta = t.myEta;


### PR DESCRIPTION
#### PR description:

Fixes this warnings:
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_11_0_X_2019-08-18-0000/L1Trigger/L1TCalorimeter

#### PR validation:

It builds and doesn't have the warnings. I used the default empty LeafCandidate constructor 
since it doesn't add anything to the functionality but removes the warnings.
