### PR TITLE
HGCAL: 1st version of hadronic reconstruction 

### DIFF
--- a/RecoHGCal/TICL/plugins/ClusterFilterBase.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterBase.h
@@ -27,7 +27,6 @@ namespace ticl {
                                                            const HgcalClusterFilterMask& mask,
                                                            std::vector<float>& layerClustersMask,
                                                            hgcal::RecHitTools& rhtools) const = 0;
-
   };
 }  // namespace ticl
 

--- a/RecoHGCal/TICL/plugins/ClusterFilterBase.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterBase.h
@@ -5,6 +5,7 @@
 #define RecoHGCal_TICL_ClusterFilterBase_H__
 
 #include "DataFormats/HGCalReco/interface/Common.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 #include <memory>
 #include <vector>
@@ -24,7 +25,9 @@ namespace ticl {
 
     virtual std::unique_ptr<HgcalClusterFilterMask> filter(const std::vector<reco::CaloCluster>& layerClusters,
                                                            const HgcalClusterFilterMask& mask,
-                                                           std::vector<float>& layerClustersMask) const = 0;
+                                                           std::vector<float>& layerClustersMask,
+                                                           hgcal::RecHitTools& rhtools) const = 0;
+
   };
 }  // namespace ticl
 

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgo.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgo.h
@@ -20,7 +20,8 @@ namespace ticl {
 
     std::unique_ptr<HgcalClusterFilterMask> filter(const std::vector<reco::CaloCluster>& layerClusters,
                                                    const HgcalClusterFilterMask& availableLayerClusters,
-                                                   std::vector<float>& layerClustersMask) const override {
+                                                   std::vector<float>& layerClustersMask,
+                                                   hgcal::RecHitTools& rhtools) const override {
       auto filteredLayerClusters = std::make_unique<HgcalClusterFilterMask>();
       for (auto const& cl : availableLayerClusters) {
         if (layerClusters[cl.first].algo() == algo_number_) {

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
@@ -28,10 +28,9 @@ namespace ticl {
       auto filteredLayerClusters = std::make_unique<HgcalClusterFilterMask>();
       for (auto const& cl : availableLayerClusters) {
         auto& layerCluster = layerClusters[cl.first];
-        if (layerCluster.algo() == algo_number_ and
-            layerCluster.hitsAndFractions().size() <= max_cluster_size_ and
-            (layerCluster.hitsAndFractions().size() >= min_cluster_size_ or 
-            (!(rhtools.isSilicon(layerCluster.hitsAndFractions()[0].first) ) )))  {
+        if (layerCluster.algo() == algo_number_ and layerCluster.hitsAndFractions().size() <= max_cluster_size_ and
+            (layerCluster.hitsAndFractions().size() >= min_cluster_size_ or
+             (!(rhtools.isSilicon(layerCluster.hitsAndFractions()[0].first))))) {
           filteredLayerClusters->emplace_back(cl);
         } else {
           layerClustersMask[cl.first] = 0.;

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
@@ -27,7 +27,7 @@ namespace ticl {
                                                    hgcal::RecHitTools& rhtools) const override {
       auto filteredLayerClusters = std::make_unique<HgcalClusterFilterMask>();
       for (auto const& cl : availableLayerClusters) {
-        auto& layerCluster = layerClusters[cl.first];
+        auto const& layerCluster = layerClusters[cl.first];
         if (layerCluster.algo() == algo_number_ and layerCluster.hitsAndFractions().size() <= max_cluster_size_ and
             (layerCluster.hitsAndFractions().size() >= min_cluster_size_ or
              (!(rhtools.isSilicon(layerCluster.hitsAndFractions()[0].first))))) {

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
@@ -23,12 +23,15 @@ namespace ticl {
 
     std::unique_ptr<HgcalClusterFilterMask> filter(const std::vector<reco::CaloCluster>& layerClusters,
                                                    const HgcalClusterFilterMask& availableLayerClusters,
-                                                   std::vector<float>& layerClustersMask) const override {
+                                                   std::vector<float>& layerClustersMask,
+                                                   hgcal::RecHitTools& rhtools) const override {
       auto filteredLayerClusters = std::make_unique<HgcalClusterFilterMask>();
       for (auto const& cl : availableLayerClusters) {
-        if (layerClusters[cl.first].algo() == algo_number_ and
-            layerClusters[cl.first].hitsAndFractions().size() <= max_cluster_size_ and
-            layerClusters[cl.first].hitsAndFractions().size() >= min_cluster_size_) {
+        auto& layerCluster = layerClusters[cl.first];
+        if (layerCluster.algo() == algo_number_ and
+            layerCluster.hitsAndFractions().size() <= max_cluster_size_ and
+            (layerCluster.hitsAndFractions().size() >= min_cluster_size_ or 
+            (!(rhtools.isSilicon(layerCluster.hitsAndFractions()[0].first) ) )))  {
           filteredLayerClusters->emplace_back(cl);
         } else {
           layerClustersMask[cl.first] = 0.;

--- a/RecoHGCal/TICL/plugins/ClusterFilterBySize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterBySize.h
@@ -20,7 +20,8 @@ namespace ticl {
 
     std::unique_ptr<HgcalClusterFilterMask> filter(const std::vector<reco::CaloCluster>& layerClusters,
                                                    const HgcalClusterFilterMask& availableLayerClusters,
-                                                   std::vector<float>& layerClustersMask) const override {
+                                                   std::vector<float>& layerClustersMask,
+                                                   hgcal::RecHitTools& rhtools) const override {
       auto filteredLayerClusters = std::make_unique<HgcalClusterFilterMask>();
       for (auto const& cl : availableLayerClusters) {
         if (layerClusters[cl.first].hitsAndFractions().size() <= max_cluster_size_) {

--- a/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
@@ -12,6 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 #include "ClusterFilterFactory.h"
 #include "ClusterFilterBase.h"
@@ -23,7 +24,7 @@ public:
   FilteredLayerClustersProducer(const edm::ParameterSet&);
   ~FilteredLayerClustersProducer() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  void beginRun(edm::Run const &, edm::EventSetup const &) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -32,6 +33,8 @@ private:
   std::string clusterFilter_;
   std::string iteration_label_;
   std::unique_ptr<const ticl::ClusterFilterBase> theFilter_;
+  hgcal::RecHitTools rhtools_;
+
 };
 
 DEFINE_FWK_MODULE(FilteredLayerClustersProducer);
@@ -42,10 +45,11 @@ FilteredLayerClustersProducer::FilteredLayerClustersProducer(const edm::Paramete
   clusterFilter_ = ps.getParameter<std::string>("clusterFilter");
   theFilter_ = ClusterFilterFactory::get()->create(clusterFilter_, ps);
   iteration_label_ = ps.getParameter<std::string>("iteration_label");
-
   produces<ticl::HgcalClusterFilterMask>(iteration_label_);
   produces<std::vector<float>>(iteration_label_);
 }
+
+void FilteredLayerClustersProducer::beginRun(edm::Run const &, edm::EventSetup const &es) { rhtools_.getEventSetup(es); }
 
 void FilteredLayerClustersProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // hgcalMultiClusters
@@ -82,7 +86,7 @@ void FilteredLayerClustersProducer::produce(edm::Event& evt, const edm::EventSet
 
   std::unique_ptr<ticl::HgcalClusterFilterMask> filteredLayerClusters;
   if (theFilter_) {
-    filteredLayerClusters = theFilter_->filter(layerClusters, *availableLayerClusters, *layerClustersMask);
+    filteredLayerClusters = theFilter_->filter(layerClusters, *availableLayerClusters, *layerClustersMask, rhtools_);
   } else {
     filteredLayerClusters = std::move(availableLayerClusters);
   }

--- a/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
+++ b/RecoHGCal/TICL/plugins/FilteredLayerClustersProducer.cc
@@ -24,7 +24,7 @@ public:
   FilteredLayerClustersProducer(const edm::ParameterSet&);
   ~FilteredLayerClustersProducer() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void beginRun(edm::Run const &, edm::EventSetup const &) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -34,7 +34,6 @@ private:
   std::string iteration_label_;
   std::unique_ptr<const ticl::ClusterFilterBase> theFilter_;
   hgcal::RecHitTools rhtools_;
-
 };
 
 DEFINE_FWK_MODULE(FilteredLayerClustersProducer);
@@ -49,7 +48,7 @@ FilteredLayerClustersProducer::FilteredLayerClustersProducer(const edm::Paramete
   produces<std::vector<float>>(iteration_label_);
 }
 
-void FilteredLayerClustersProducer::beginRun(edm::Run const &, edm::EventSetup const &es) { rhtools_.getEventSetup(es); }
+void FilteredLayerClustersProducer::beginRun(edm::Run const&, edm::EventSetup const& es) { rhtools_.getEventSetup(es); }
 
 void FilteredLayerClustersProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // hgcalMultiClusters

--- a/RecoHGCal/TICL/plugins/HGCDoublet.cc
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.cc
@@ -110,18 +110,25 @@ int HGCDoublet::areAligned(double xi,
   return (cosTheta > minCosTheta) && (cosTheta_pointing > minCosPointing);
 }
 
-void HGCDoublet::findNtuplets(std::vector<HGCDoublet> &allDoublets, HGCntuplet &tmpNtuplet, int seedIndex, const bool outInDFS, const unsigned int outInHops, const unsigned int maxOutInHops, std::vector<std::pair<unsigned int, unsigned int > >& outInToVisit) {
+void HGCDoublet::findNtuplets(std::vector<HGCDoublet> &allDoublets,
+                              HGCntuplet &tmpNtuplet,
+                              int seedIndex,
+                              const bool outInDFS,
+                              const unsigned int outInHops,
+                              const unsigned int maxOutInHops,
+                              std::vector<std::pair<unsigned int, unsigned int> > &outInToVisit) {
   if (!alreadyVisited_ && seedIndex == seedIndex_) {
     alreadyVisited_ = true;
     tmpNtuplet.push_back(theDoubletId_);
     unsigned int numberOfOuterNeighbors = outerNeighbors_.size();
     for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
-      allDoublets[outerNeighbors_[i]].findNtuplets(allDoublets, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
+      allDoublets[outerNeighbors_[i]].findNtuplets(
+          allDoublets, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
     }
     if (outInDFS && outInHops < maxOutInHops) {
       unsigned int numberOfInnerNeighbors = innerNeighbors_.size();
       for (unsigned int i = 0; i < numberOfInnerNeighbors; ++i) {
-        outInToVisit.emplace_back(innerNeighbors_[i], outInHops+1); 
+        outInToVisit.emplace_back(innerNeighbors_[i], outInHops + 1);
       }
     }
   }

--- a/RecoHGCal/TICL/plugins/HGCDoublet.cc
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.cc
@@ -127,7 +127,7 @@ void HGCDoublet::findNtuplets(std::vector<HGCDoublet> &allDoublets,
     }
     if (outInDFS && outInHops < maxOutInHops) {
       for (auto inN : innerNeighbors_) {
-	outInToVisit.emplace_back(inN, outInHops + 1);
+        outInToVisit.emplace_back(inN, outInHops + 1);
       }
     }
   }

--- a/RecoHGCal/TICL/plugins/HGCDoublet.cc
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.cc
@@ -126,9 +126,8 @@ void HGCDoublet::findNtuplets(std::vector<HGCDoublet> &allDoublets,
           allDoublets, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
     }
     if (outInDFS && outInHops < maxOutInHops) {
-      unsigned int numberOfInnerNeighbors = innerNeighbors_.size();
-      for (unsigned int i = 0; i < numberOfInnerNeighbors; ++i) {
-        outInToVisit.emplace_back(innerNeighbors_[i], outInHops + 1);
+      for (auto inN : innerNeighbors_) {
+	outInToVisit.emplace_back(inN, outInHops + 1);
       }
     }
   }

--- a/RecoHGCal/TICL/plugins/HGCDoublet.cc
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.cc
@@ -110,13 +110,19 @@ int HGCDoublet::areAligned(double xi,
   return (cosTheta > minCosTheta) && (cosTheta_pointing > minCosPointing);
 }
 
-void HGCDoublet::findNtuplets(std::vector<HGCDoublet> &allDoublets, HGCntuplet &tmpNtuplet, int seedIndex) {
+void HGCDoublet::findNtuplets(std::vector<HGCDoublet> &allDoublets, HGCntuplet &tmpNtuplet, int seedIndex, const bool outInDFS, const unsigned int outInHops, const unsigned int maxOutInHops, std::vector<std::pair<unsigned int, unsigned int > >& outInToVisit) {
   if (!alreadyVisited_ && seedIndex == seedIndex_) {
     alreadyVisited_ = true;
     tmpNtuplet.push_back(theDoubletId_);
     unsigned int numberOfOuterNeighbors = outerNeighbors_.size();
     for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
-      allDoublets[outerNeighbors_[i]].findNtuplets(allDoublets, tmpNtuplet, seedIndex);
+      allDoublets[outerNeighbors_[i]].findNtuplets(allDoublets, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
+    }
+    if (outInDFS && outInHops < maxOutInHops) {
+      unsigned int numberOfInnerNeighbors = innerNeighbors_.size();
+      for (unsigned int i = 0; i < numberOfInnerNeighbors; ++i) {
+        outInToVisit.emplace_back(innerNeighbors_[i], outInHops+1); 
+      }
     }
   }
 }

--- a/RecoHGCal/TICL/plugins/HGCDoublet.h
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.h
@@ -79,8 +79,10 @@ public:
                  const GlobalVector &refDir,
                  bool debug = false) const;
 
-  void findNtuplets(std::vector<HGCDoublet> &allDoublets, HGCntuplet &tmpNtuplet, int seedIndex);
+  void findNtuplets(std::vector<HGCDoublet> &allDoublets, HGCntuplet &tmpNtuplet, int seedIndex, const bool outInDFS, const unsigned int outInHops, const unsigned int maxOutInHops, std::vector<std::pair<unsigned int, unsigned int > >& outInToVisit);
 
+  void setVisited(bool visited) { alreadyVisited_ = visited; }
+  
 private:
   const std::vector<reco::CaloCluster> *layerClusters_;
   std::vector<int> outerNeighbors_;

--- a/RecoHGCal/TICL/plugins/HGCDoublet.h
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.h
@@ -79,10 +79,16 @@ public:
                  const GlobalVector &refDir,
                  bool debug = false) const;
 
-  void findNtuplets(std::vector<HGCDoublet> &allDoublets, HGCntuplet &tmpNtuplet, int seedIndex, const bool outInDFS, const unsigned int outInHops, const unsigned int maxOutInHops, std::vector<std::pair<unsigned int, unsigned int > >& outInToVisit);
+  void findNtuplets(std::vector<HGCDoublet> &allDoublets,
+                    HGCntuplet &tmpNtuplet,
+                    int seedIndex,
+                    const bool outInDFS,
+                    const unsigned int outInHops,
+                    const unsigned int maxOutInHops,
+                    std::vector<std::pair<unsigned int, unsigned int> > &outInToVisit);
 
   void setVisited(bool visited) { alreadyVisited_ = visited; }
-  
+
 private:
   const std::vector<reco::CaloCluster> *layerClusters_;
   std::vector<int> outerNeighbors_;

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -54,7 +54,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
         auto const &outerLayerHisto = histo[currentOuterLayerId];
         auto const &innerLayerHisto = histo[currentInnerLayerId];
 
-        for (int oeta = startEtaBin; oeta < endEtaBin; ++oeta) {
+        for (int oeta = startEtaBin; oeta < endEtaBin + 1; ++oeta) {
           auto offset = oeta * nPhiBins;
           for (int ophi_it = startPhiBin; ophi_it < endPhiBin; ++ophi_it) {
             int ophi = ((ophi_it % nPhiBins + nPhiBins) % nPhiBins);

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -136,13 +136,23 @@ bool HGCGraph::areTimeCompatible(int innerIdx,
 //also return a vector of seedIndex for the reconstructed tracksters
 void HGCGraph::findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,
                             std::vector<int> &seedIndices,
-                            const unsigned int minClustersPerNtuplet) {
+                            const unsigned int minClustersPerNtuplet, 
+                            const bool outInDFS, unsigned int maxOutInHops) {
   HGCDoublet::HGCntuplet tmpNtuplet;
   tmpNtuplet.reserve(minClustersPerNtuplet);
+  std::vector<std::pair<unsigned int, unsigned int > > outInToVisit;
   for (auto rootDoublet : theRootDoublets_) {
     tmpNtuplet.clear();
+    outInToVisit.clear();
     int seedIndex = allDoublets_[rootDoublet].seedIndex();
-    allDoublets_[rootDoublet].findNtuplets(allDoublets_, tmpNtuplet, seedIndex);
+    int outInHops = 0; 
+    allDoublets_[rootDoublet].findNtuplets(allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
+    while(!outInToVisit.empty())
+    {
+      allDoublets_[outInToVisit.back().first].findNtuplets(allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInToVisit.back().second, maxOutInHops, outInToVisit);
+      outInToVisit.pop_back();
+    }
+    
     if (tmpNtuplet.size() > minClustersPerNtuplet) {
       foundNtuplets.push_back(tmpNtuplet);
       seedIndices.push_back(seedIndex);

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -42,7 +42,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
       int entryEtaBin = firstLayerHisto.etaBin(r.origin.eta());
       int entryPhiBin = firstLayerHisto.phiBin(r.origin.phi());
       startEtaBin = std::max(entryEtaBin - deltaIEta, 0);
-      endEtaBin = std::min(entryEtaBin + deltaIEta, nEtaBins);
+      endEtaBin = std::min(entryEtaBin + deltaIEta + 1, nEtaBins);
       startPhiBin = entryPhiBin - deltaIPhi;
       endPhiBin = entryPhiBin + deltaIPhi;
     }
@@ -54,7 +54,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
         auto const &outerLayerHisto = histo[currentOuterLayerId];
         auto const &innerLayerHisto = histo[currentInnerLayerId];
 
-        for (int oeta = startEtaBin; oeta < endEtaBin + 1; ++oeta) {
+        for (int oeta = startEtaBin; oeta < endEtaBin; ++oeta) {
           auto offset = oeta * nPhiBins;
           for (int ophi_it = startPhiBin; ophi_it < endPhiBin; ++ophi_it) {
             int ophi = ((ophi_it % nPhiBins + nPhiBins) % nPhiBins);
@@ -63,9 +63,9 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
               if (mask[outerClusterId] == 0.)
                 continue;
               const auto etaRangeMin = std::max(0, oeta - deltaIEta);
-              const auto etaRangeMax = std::min(oeta + deltaIEta, nEtaBins);
+              const auto etaRangeMax = std::min(oeta + deltaIEta + 1, nEtaBins);
 
-              for (int ieta = etaRangeMin; ieta < etaRangeMax + 1; ++ieta) {
+              for (int ieta = etaRangeMin; ieta < etaRangeMax; ++ieta) {
                 // wrap phi bin
                 for (int phiRange = 0; phiRange < 2 * deltaIPhi + 1; ++phiRange) {
                   // The first wrapping is to take into account the

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -136,23 +136,25 @@ bool HGCGraph::areTimeCompatible(int innerIdx,
 //also return a vector of seedIndex for the reconstructed tracksters
 void HGCGraph::findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,
                             std::vector<int> &seedIndices,
-                            const unsigned int minClustersPerNtuplet, 
-                            const bool outInDFS, unsigned int maxOutInHops) {
+                            const unsigned int minClustersPerNtuplet,
+                            const bool outInDFS,
+                            unsigned int maxOutInHops) {
   HGCDoublet::HGCntuplet tmpNtuplet;
   tmpNtuplet.reserve(minClustersPerNtuplet);
-  std::vector<std::pair<unsigned int, unsigned int > > outInToVisit;
+  std::vector<std::pair<unsigned int, unsigned int> > outInToVisit;
   for (auto rootDoublet : theRootDoublets_) {
     tmpNtuplet.clear();
     outInToVisit.clear();
     int seedIndex = allDoublets_[rootDoublet].seedIndex();
-    int outInHops = 0; 
-    allDoublets_[rootDoublet].findNtuplets(allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
-    while(!outInToVisit.empty())
-    {
-      allDoublets_[outInToVisit.back().first].findNtuplets(allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInToVisit.back().second, maxOutInHops, outInToVisit);
+    int outInHops = 0;
+    allDoublets_[rootDoublet].findNtuplets(
+        allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
+    while (!outInToVisit.empty()) {
+      allDoublets_[outInToVisit.back().first].findNtuplets(
+          allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInToVisit.back().second, maxOutInHops, outInToVisit);
       outInToVisit.pop_back();
     }
-    
+
     if (tmpNtuplet.size() > minClustersPerNtuplet) {
       foundNtuplets.push_back(tmpNtuplet);
       seedIndices.push_back(seedIndex);

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -65,7 +65,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
               const auto etaRangeMin = std::max(0, oeta - deltaIEta);
               const auto etaRangeMax = std::min(oeta + deltaIEta, nEtaBins);
 
-	      for (int ieta = etaRangeMin; ieta < etaRangeMax+1; ++ieta) {
+              for (int ieta = etaRangeMin; ieta < etaRangeMax + 1; ++ieta) {
                 // wrap phi bin
                 for (int phiRange = 0; phiRange < 2 * deltaIPhi + 1; ++phiRange) {
                   // The first wrapping is to take into account the

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -65,7 +65,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
               const auto etaRangeMin = std::max(0, oeta - deltaIEta);
               const auto etaRangeMax = std::min(oeta + deltaIEta, nEtaBins);
 
-              for (int ieta = etaRangeMin; ieta < etaRangeMax; ++ieta) {
+	      for (int ieta = etaRangeMin; ieta < etaRangeMax+1; ++ieta) {
                 // wrap phi bin
                 for (int phiRange = 0; phiRange < 2 * deltaIPhi + 1; ++phiRange) {
                   // The first wrapping is to take into account the

--- a/RecoHGCal/TICL/plugins/HGCGraph.h
+++ b/RecoHGCal/TICL/plugins/HGCGraph.h
@@ -33,8 +33,9 @@ public:
   std::vector<HGCDoublet> &getAllDoublets() { return allDoublets_; }
   void findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,
                     std::vector<int> &seedIndices,
-                    const unsigned int minClustersPerNtuplet, 
-                    const bool outInDFS, const unsigned int maxOutInHops);
+                    const unsigned int minClustersPerNtuplet,
+                    const bool outInDFS,
+                    const unsigned int maxOutInHops);
   void clear() {
     allDoublets_.clear();
     theRootDoublets_.clear();

--- a/RecoHGCal/TICL/plugins/HGCGraph.h
+++ b/RecoHGCal/TICL/plugins/HGCGraph.h
@@ -33,7 +33,8 @@ public:
   std::vector<HGCDoublet> &getAllDoublets() { return allDoublets_; }
   void findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNtuplets,
                     std::vector<int> &seedIndices,
-                    const unsigned int minClustersPerNtuplet);
+                    const unsigned int minClustersPerNtuplet, 
+                    const bool outInDFS, const unsigned int maxOutInHops);
   void clear() {
     allDoublets_.clear();
     theRootDoublets_.clear();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -10,11 +10,10 @@
 
 using namespace ticl;
 
-PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf) : 
-  PatternRecognitionAlgoBase(conf), 
-  out_in_dfs_(conf.getParameter<bool>("out_in_dfs")),
-  max_out_in_hops_(conf.getParameter<int>("max_out_in_hops"))
-  {
+PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf)
+    : PatternRecognitionAlgoBase(conf),
+      out_in_dfs_(conf.getParameter<bool>("out_in_dfs")),
+      max_out_in_hops_(conf.getParameter<int>("max_out_in_hops")) {
   theGraph_ = std::make_unique<HGCGraph>();
   min_cos_theta_ = conf.getParameter<double>("min_cos_theta");
   min_cos_pointing_ = conf.getParameter<double>("min_cos_pointing");

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -10,7 +10,11 @@
 
 using namespace ticl;
 
-PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf) : PatternRecognitionAlgoBase(conf) {
+PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf) : 
+  PatternRecognitionAlgoBase(conf), 
+  out_in_dfs_(conf.getParameter<bool>("out_in_dfs")),
+  max_out_in_hops_(conf.getParameter<int>("max_out_in_hops"))
+  {
   theGraph_ = std::make_unique<HGCGraph>();
   min_cos_theta_ = conf.getParameter<double>("min_cos_theta");
   min_cos_pointing_ = conf.getParameter<double>("min_cos_pointing");
@@ -48,7 +52,7 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
                                     rhtools_.lastLayerFH(),
                                     max_delta_time_);
 
-  theGraph_->findNtuplets(foundNtuplets, seedIndices, min_clusters_per_ntuplet_);
+  theGraph_->findNtuplets(foundNtuplets, seedIndices, min_clusters_per_ntuplet_, out_in_dfs_, max_out_in_hops_);
   //#ifdef FP_DEBUG
   const auto &doublets = theGraph_->getAllDoublets();
   int tracksterId = 0;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -20,7 +20,7 @@ namespace ticl {
   private:
     hgcal::RecHitTools rhtools_;
     std::unique_ptr<HGCGraph> theGraph_;
-    const bool out_in_dfs_=false;
+    const bool out_in_dfs_ = false;
     const unsigned int max_out_in_hops_ = 99999;
     float min_cos_theta_;
     float min_cos_pointing_;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -20,6 +20,8 @@ namespace ticl {
   private:
     hgcal::RecHitTools rhtools_;
     std::unique_ptr<HGCGraph> theGraph_;
+    const bool out_in_dfs_=false;
+    const unsigned int max_out_in_hops_ = 99999;
     float min_cos_theta_;
     float min_cos_pointing_;
     int missing_layers_;

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -74,6 +74,8 @@ void TrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<int>("missing_layers", 0);
   desc.add<int>("min_clusters_per_ntuplet", 10);
   desc.add<double>("max_delta_time", 0.09);
+  desc.add<bool>("out_in_dfs", true);
+  desc.add<int>("max_out_in_hops", 10);
   descriptions.add("trackstersProducer", desc);
 }
 

--- a/RecoHGCal/TICL/python/ticl_iterations.py
+++ b/RecoHGCal/TICL/python/ticl_iterations.py
@@ -159,7 +159,7 @@ def TICL_iterations(process):
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 3,
       min_clusters_per_ntuplet = 15,
-      min_cos_theta = 0.985, # ~10 degrees
+      min_cos_theta = 0.99, # ~10 degrees
   )
 
   process.multiClustersFromTrackstersMIP = multiClustersFromTrackstersProducer.clone(
@@ -181,7 +181,7 @@ def TICL_iterations(process):
       missing_layers = 2,
       min_clusters_per_ntuplet = 15,
       min_cos_theta = 0.94, # ~20 degrees
-      min_cos_pointing = 0.7,
+      min_cos_pointing = 0.7
   )
 
   process.multiClustersFromTracksters = multiClustersFromTrackstersProducer.clone(

--- a/RecoHGCal/TICL/python/ticl_iterations.py
+++ b/RecoHGCal/TICL/python/ticl_iterations.py
@@ -39,9 +39,7 @@ def TICL_iterations_withReco(process):
     missing_layers = 3,
     min_clusters_per_ntuplet = 5,
     min_cos_theta = 0.99, # ~10 degrees                                              
-    min_cos_pointing = 0.9,
-    out_in_dfs = True, 
-    max_out_in_hops = 10,
+    min_cos_pointing = 0.9
   )
 
   process.multiClustersFromTrackstersTrk = multiClustersFromTrackstersProducer.clone(
@@ -91,9 +89,7 @@ def TICL_iterations_withReco(process):
       missing_layers = 2,
       min_clusters_per_ntuplet = 10,
       min_cos_theta = 0.94, # ~20 degrees
-      min_cos_pointing = 0.7,
-      out_in_dfs = True,
-      max_out_in_hops = 10,
+      min_cos_pointing = 0.7
   )
 
   process.multiClustersFromTrackstersEM = multiClustersFromTrackstersProducer.clone(
@@ -106,10 +102,8 @@ def TICL_iterations_withReco(process):
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 2,
       min_clusters_per_ntuplet = 10,
-      min_cos_theta = 0.8, # ~20 degrees
-      min_cos_pointing = 0.7,
-      out_in_dfs = True,
-      max_out_in_hops = 10,
+      min_cos_theta = 0.8, 
+      min_cos_pointing = 0.7
   )
 
   process.multiClustersFromTrackstersHAD = multiClustersFromTrackstersProducer.clone(

--- a/RecoHGCal/TICL/python/ticl_iterations.py
+++ b/RecoHGCal/TICL/python/ticl_iterations.py
@@ -39,7 +39,9 @@ def TICL_iterations_withReco(process):
     missing_layers = 3,
     min_clusters_per_ntuplet = 5,
     min_cos_theta = 0.99, # ~10 degrees                                              
-    min_cos_pointing = 0.9
+    min_cos_pointing = 0.9,
+    out_in_dfs = True, 
+    max_out_in_hops = 10,
   )
 
   process.multiClustersFromTrackstersTrk = multiClustersFromTrackstersProducer.clone(
@@ -65,7 +67,8 @@ def TICL_iterations_withReco(process):
       missing_layers = 3,
       min_clusters_per_ntuplet = 15,
       min_cos_theta = 0.99, # ~10 degrees
-      min_cos_pointing = 0.9
+      min_cos_pointing = 0.9,
+      out_in_dfs = False,
   )
 
   process.multiClustersFromTrackstersMIP = multiClustersFromTrackstersProducer.clone(
@@ -81,18 +84,36 @@ def TICL_iterations_withReco(process):
       LayerClustersInputMask = "trackstersMIP"
   )
 
-  process.tracksters = trackstersProducer.clone(
+  process.trackstersEM = trackstersProducer.clone(
       original_mask = "trackstersMIP",
       filtered_mask = cms.InputTag("filteredLayerClusters", "algo8"),
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 2,
-      min_clusters_per_ntuplet = 15,
+      min_clusters_per_ntuplet = 10,
       min_cos_theta = 0.94, # ~20 degrees
-      min_cos_pointing = 0.7
+      min_cos_pointing = 0.7,
+      out_in_dfs = True,
+      max_out_in_hops = 10,
   )
 
-  process.multiClustersFromTracksters = multiClustersFromTrackstersProducer.clone(
-      Tracksters = "tracksters"
+  process.multiClustersFromTrackstersEM = multiClustersFromTrackstersProducer.clone(
+      Tracksters = "trackstersEM"
+  )
+
+
+  process.trackstersHAD = trackstersProducer.clone(
+      filtered_mask = cms.InputTag("filteredLayerClusters", "algo8"),
+      seeding_regions = "ticlSeedingGlobal",
+      missing_layers = 2,
+      min_clusters_per_ntuplet = 10,
+      min_cos_theta = 0.8, # ~20 degrees
+      min_cos_pointing = 0.7,
+      out_in_dfs = True,
+      max_out_in_hops = 10,
+  )
+
+  process.multiClustersFromTrackstersHAD = multiClustersFromTrackstersProducer.clone(
+      Tracksters = "trackstersHAD"
   )
 
   process.hgcalMultiClusters = hgcalMultiClusters
@@ -107,8 +128,10 @@ def TICL_iterations_withReco(process):
       process.trackstersMIP,
       process.multiClustersFromTrackstersMIP,
       process.filteredLayerClusters,
-      process.tracksters,
-      process.multiClustersFromTracksters)
+      process.trackstersEM,
+      process.multiClustersFromTrackstersEM,
+      process.trackstersHAD,
+      process.multiClustersFromTrackstersHAD)
   process.schedule.associate(process.TICL_Task)
   return process
 
@@ -136,7 +159,7 @@ def TICL_iterations(process):
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 3,
       min_clusters_per_ntuplet = 15,
-      min_cos_theta = 0.99 # ~10 degrees
+      min_cos_theta = 0.985, # ~10 degrees
   )
 
   process.multiClustersFromTrackstersMIP = multiClustersFromTrackstersProducer.clone(
@@ -158,7 +181,7 @@ def TICL_iterations(process):
       missing_layers = 2,
       min_clusters_per_ntuplet = 15,
       min_cos_theta = 0.94, # ~20 degrees
-      min_cos_pointing = 0.7
+      min_cos_pointing = 0.7,
   )
 
   process.multiClustersFromTracksters = multiClustersFromTrackstersProducer.clone(


### PR DESCRIPTION
#### PR description:
- add the first version of the hadronic shower reconstruction. NB. Parameters need further tuning [work in progress]
- Introduce the "Out-In" step for the Trackster creation. Currently enabled by default for both EM and HAD reconstruction. Compatibility angles between Layer clusters can be tuned separately for the "In-Out" and "Out-In" steps. 
- Use at least 2 cells to form a Layer cluster in the Silicon part [more robust against noise, less combinatorial background]. For the Scintillator part the requirement is relaxed to 1 cell

#### PR validation:
First validation of the changes can be found in the following links:
- Aug 12: https://indico.cern.ch/event/838150/contributions/3526956/attachments/1892407/3121242/lg-hgccmg-hgchadreco-20190812.pdf
- Aug 19: https://indico.cern.ch/event/842095/contributions/3534224/attachments/1894454/3125220/lg-hgccmg-hgchadreco-20190819.pdf

