### PR TITLE
Fix gcc9 warnings in RecoEgamma/EgammaElectronAlgos

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -456,7 +456,11 @@ GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event) 
                                                 eventSetupData_.caloGeom,
                                                 *endcapRecHits,
                                                 eventSetupData_.sevLevel.product(),
-                                                DetId::Ecal)};
+                                                DetId::Ecal),
+      .pfIsolationValues = {},
+      .edIsolationValues = {},
+      .originalCtfTracks = {},
+      .originalGsfTracks = {}};
 
   eventData.ecalBarrelIsol03.setUseNumCrystals(generalData_.isoCfg.useNumCrystals);
   eventData.ecalBarrelIsol03.setVetoClustered(generalData_.isoCfg.vetoClustered);


### PR DESCRIPTION
#### PR description:

Fixes gcc9 warnings in RecoEgamma/EgammaElectronAlgos

#### PR validation:

Builds without warnings. 
Added empty {} initializers since none were provided. 

