### PR TITLE
Fix gcc9 warnings Alignment/MillePedeAlignmentAlgorithm

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
@@ -193,7 +193,7 @@ Alignable *PedeReader::setParameter(unsigned int paramLabel,
           userParams->sigma()[paramNum] = buf[3] / cmsToPede;
         covMat[paramNum][paramNum] = buf[3] * buf[3] / (cmsToPede * cmsToPede);
         [[fallthrough]];
-      case 3:             // difference to start value
+      case 3:  // difference to start value
         if (userParams)
           userParams->diffBefore()[paramNum] = buf[2] / cmsToPede;
         [[fallthrough]];
@@ -246,8 +246,8 @@ bool PedeReader::setCalibrationParameter(IntegratedCalibrationBase *calib,
   // FIXME: Should we attach MillePedeVariables to IntegratedCalibrationBase to store
   //        'other' results beyond value and error?
   switch (bufLength) {
-    case 5:                                        // buf[4]: global correlation - not treated yet FIXME // no break;
-    case 4:                                        // uncertainty
+    case 5:  // buf[4]: global correlation - not treated yet FIXME // no break;
+    case 4:  // uncertainty
       calib->setParameterError(paramNum, buf[3]);
       [[fallthrough]];
     case 3:  // buf[2]: difference to start value - not treated yet

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
@@ -186,17 +186,17 @@ Alignable *PedeReader::setParameter(unsigned int paramLabel,
     switch (bufLength) {
       case 5:  // global correlation
         if (userParams)
-          userParams->globalCor()[paramNum] = buf[4];  // no break
+          userParams->globalCor()[paramNum] = buf[4];
         [[fallthrough]];
       case 4:  // uncertainty
         if (userParams)
           userParams->sigma()[paramNum] = buf[3] / cmsToPede;
         covMat[paramNum][paramNum] = buf[3] * buf[3] / (cmsToPede * cmsToPede);
-        [[fallthrough]];  // no break;
+        [[fallthrough]];
       case 3:             // difference to start value
         if (userParams)
           userParams->diffBefore()[paramNum] = buf[2] / cmsToPede;
-        [[fallthrough]];  // no break
+        [[fallthrough]];
       case 2:
         params->setValid(true);
         parVec[paramNum] = buf[0] / cmsToPede * mySteerer.parameterSign();  // parameter
@@ -248,9 +248,9 @@ bool PedeReader::setCalibrationParameter(IntegratedCalibrationBase *calib,
   switch (bufLength) {
     case 5:                                        // buf[4]: global correlation - not treated yet FIXME // no break;
     case 4:                                        // uncertainty
-      calib->setParameterError(paramNum, buf[3]);  // no break;
+      calib->setParameterError(paramNum, buf[3]);
       [[fallthrough]];
-    case 3:  // buf[2]: difference to start value - not treated yet // no break;
+    case 3:  // buf[2]: difference to start value - not treated yet
     case 2:
       if (bufLength == 2 && buf[1] >= 0.) {  // buf[1]: pre-sigma, < 0 means fixed
         edm::LogWarning("Alignment") << "@SUB=PedeReader::setCalibrationParameter"

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeReader.cc
@@ -187,15 +187,16 @@ Alignable *PedeReader::setParameter(unsigned int paramLabel,
       case 5:  // global correlation
         if (userParams)
           userParams->globalCor()[paramNum] = buf[4];  // no break
-      case 4:                                          // uncertainty
+        [[fallthrough]];
+      case 4:  // uncertainty
         if (userParams)
           userParams->sigma()[paramNum] = buf[3] / cmsToPede;
         covMat[paramNum][paramNum] = buf[3] * buf[3] / (cmsToPede * cmsToPede);
-        // no break;
-      case 3:  // difference to start value
+        [[fallthrough]];  // no break;
+      case 3:             // difference to start value
         if (userParams)
           userParams->diffBefore()[paramNum] = buf[2] / cmsToPede;
-        // no break
+        [[fallthrough]];  // no break
       case 2:
         params->setValid(true);
         parVec[paramNum] = buf[0] / cmsToPede * mySteerer.parameterSign();  // parameter
@@ -248,7 +249,8 @@ bool PedeReader::setCalibrationParameter(IntegratedCalibrationBase *calib,
     case 5:                                        // buf[4]: global correlation - not treated yet FIXME // no break;
     case 4:                                        // uncertainty
       calib->setParameterError(paramNum, buf[3]);  // no break;
-    case 3:                                        // buf[2]: difference to start value - not treated yet // no break;
+      [[fallthrough]];
+    case 3:  // buf[2]: difference to start value - not treated yet // no break;
     case 2:
       if (bufLength == 2 && buf[1] >= 0.) {  // buf[1]: pre-sigma, < 0 means fixed
         edm::LogWarning("Alignment") << "@SUB=PedeReader::setCalibrationParameter"


### PR DESCRIPTION
#### PR description:

Fix gcc9 warnings in Alignment/MillePedeAlignmentAlgorithm

#### PR validation:

Builds and doesn't complain with warnings. Intentionally left the empty cases untouched (didn't remove them) since the author left comments for future filling of that cases