### PR TITLE
Fix gcc9 warnings L1Trigger/GlobalCaloTrigger

### DIFF
--- a/L1Trigger/GlobalCaloTrigger/src/L1GctRegion.cc
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctRegion.cc
@@ -44,7 +44,7 @@ L1GctRegion::L1GctRegion(const unsigned et,
                          const unsigned iphi,
                          const int16_t bx)
     : L1CaloRegion(L1CaloRegion::makeGctJetRegion(
-          ((overFlow || et > kGctRegionMaxValue) ? kGctRegionMaxValue : (et & kGctRegionMaxValue)),
+          ((overFlow || et > kGctRegionMaxValue) ? (unsigned)kGctRegionMaxValue : (unsigned)(et & kGctRegionMaxValue)),
           (overFlow || et > kGctRegionMaxValue),
           fineGrain,
           ieta,

--- a/L1Trigger/GlobalCaloTrigger/test/testElectronSorter.cpp
+++ b/L1Trigger/GlobalCaloTrigger/test/testElectronSorter.cpp
@@ -305,6 +305,7 @@ void convertToGct(EmInputCandVec candidates) {
         } else {
           eta = 5;
         }
+        [[fallthrough]];
       case 3:
         phi = 0;
         if (region == 0) {
@@ -320,6 +321,7 @@ void convertToGct(EmInputCandVec candidates) {
         } else {
           eta = 3;
         }
+        [[fallthrough]];
       case 5:
         phi = 0;
         if (region == 0) {


### PR DESCRIPTION
#### PR description:

Fix warnings in L1Trigger/GlobalCaloTrigger

#### PR validation:

Builds without warnings. Added [[fallthrough]] for every "missing" break. 
