### PR TITLE
Removed use of L1Trigger/GlobalMuonTrigger from test

### DIFF
--- a/L1Trigger/GlobalMuonTrigger/test/BuildFile.xml
+++ b/L1Trigger/GlobalMuonTrigger/test/BuildFile.xml
@@ -14,7 +14,6 @@
 <use   name="CLHEP"/>
 <bin file="test_*.cc" name="L1TriggerGlobalMuonTriggerTest">
   <use name="catch2"/>
-  <use name="L1Trigger/GlobalMuonTrigger"/>
 </bin>
 <library   file="CruzetL1DTfilter.cc" name="CruzetL1DTfilter">
   <flags   EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

The test only needs the header so the lack of a shared library (since the package is plugin only) does not matter.

This gets rid of a 'non existent package' warning from scram.

#### PR validation:

The code compiles and the test run. No scram warnings anymore.