### PR TITLE
Update GEMPadDigi clustering procedure

### DIFF
--- a/SimMuon/GEMDigitizer/plugins/GEMPadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMPadDigiClusterProducer.cc
@@ -85,6 +85,8 @@ private:
    Further, a second step of cluster merging that is required in the full
    algorithm is avoided, which reduces latency by an additional bunch
    crossing and significantly reduces resource usage as well.
+
+   The sorting of the clusters favors lower eta partitions and lower pad numbers
   */
 
   void buildClusters(const GEMPadDigiCollection& pads, GEMPadDigiClusterContainer& out_clusters) const;
@@ -205,17 +207,17 @@ void GEMPadDigiClusterProducer::selectClusters(GEMPadDigiClusterContainer& proto
 
     // loop over all the optohybrids
     for (unsigned int iOH = 0; iOH < nOH; iOH++) {
-      // all clusters per combined eta partitions
+      // all clusters for a set of eta partitions
       GEMPadDigiClusterContainer temp_clusters;
 
-      // loop over the eta partitions for this optohybrid
-      for (unsigned iPart = iOH; iPart < nPartOH; iPart++) {
+      // loop over the 4 or 2 eta partitions for this optohybrid
+      for (unsigned iPart = 0; iPart < nPartOH; iPart++) {
         // get the clusters for this eta partition
-        const GEMDetId& partId = ch->etaPartition(iPart + nPartOH)->id();
+        const GEMDetId& partId = ch->etaPartition(iPart + iOH * nPartOH)->id();
         temp_clusters.emplace(partId, proto_clusters[partId]);
       }
 
-      // cluster selection: pick first maxClusters for now
+      // cluster selection: pick first maxClusters for now for each OH
       unsigned loopMax = std::min(maxClustersOH, unsigned(temp_clusters.size()));
       unsigned nClusters = 0;
       for (const auto& p : temp_clusters) {
@@ -232,4 +234,5 @@ void GEMPadDigiClusterProducer::selectClusters(GEMPadDigiClusterContainer& proto
 }
 
 DEFINE_FWK_MODULE(GEMPadDigiClusterProducer);
+
 #endif


### PR DESCRIPTION
#### PR description:

Update of the clustering procedure so it matches the implementation in the GEM optohybrid firmware. 

In the current version of the algorithm, cluster finding is segmented into two separate halves of the GE1/1 chambers. Thus, each one of the trigger fibers can transmit clusters only from the half of the chamber that it corresponds to. For GE2/1, there are four separate quarts of the GE2/1 chamber. 

This has the downside of being unable to transmit more than 4 clusters when they occur within that side of the chamber, so there will be a slightly higher rate of cluster overflow. For GE2/1 each OH can transmit up to 5 clusters.

*Note*: GE1/1 does not have 2 physical optohybrids. There is only one optohybrid per chamber, but the firmware sees two independent halves. So `nOHGE11_` really means the number of independent optohybrid sectors. On the other hand `nOHGE21_` is the actual number of optohybrids on the chamber. However, the emulator should match the firmware, despite this subtle difference.

#### PR validation:

I tested this pull request on a customized multi-muon gun. I simulated 10 events, each with 100 muons and 100 antimuons propagating between 1.55 < |eta| < 2.15 - to emulate high pileup conditions in the GE1/1 region. Print-outs (not included in the pull request) show

* Example GE1/1
```
Analyzing optohybrid 1
	Adding cluster to final collection Re -1 Ri 1 St 1 La 1 Ch 7 Ro 1   bx: 0 pads:  29
	Adding cluster to final collection Re -1 Ri 1 St 1 La 1 Ch 7 Ro 1   bx: 0 pads:  60
	Adding cluster to final collection Re -1 Ri 1 St 1 La 1 Ch 7 Ro 1   bx: 0 pads:  127
	Adding cluster to final collection Re -1 Ri 1 St 1 La 1 Ch 7 Ro 3   bx: 0 pads:  63 64
	Rejecting cluster  Re -1 Ri 1 St 1 La 1 Ch 7 Ro 3   bx: 0 pads:  70 71
Analyzing optohybrid 2
	Adding cluster to final collection Re -1 Ri 1 St 1 La 1 Ch 7 Ro 7   bx: 1 pads:  181
```
* Example GE2/1:
```
Analyzing optohybrid 1
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 2   bx: 0 pads:  207
Analyzing optohybrid 2
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 4   bx: 0 pads:  271 272
Analyzing optohybrid 3
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 5   bx: 0 pads:  61
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 5   bx: 0 pads:  119
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 5   bx: 0 pads:  123
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 5   bx: 0 pads:  244
	Adding cluster to final collection Re 1 Ri 1 St 2 La 1 Ch 11 Ro 5   bx: 0 pads:  262
	Rejecting cluster  Re 1 Ri 1 St 2 La 1 Ch 11 Ro 5   bx: 0 pads:  265 266 267 268
	Rejecting cluster  Re 1 Ri 1 St 2 La 1 Ch 11 Ro 6   bx: 0 pads:  346
	Rejecting cluster  Re 1 Ri 1 St 2 La 1 Ch 11 Ro 6   bx: 0 pads:  375
Analyzing optohybrid 4
```

Attention: @tahuang1991 @jiafulow @jshlee 