### PR TITLE
Fix gcc9 warnings in GeneratorInterface

### DIFF
--- a/GeneratorInterface/Herwig6Interface/src/params.inc
+++ b/GeneratorInterface/Herwig6Interface/src/params.inc
@@ -60,12 +60,12 @@ enum ParamTypes { kInt, kDouble, kLogical };
 
 struct ConfigParam {
   const char *name;
-  void *ptr;
-  ParamTypes type;
+  void *ptr = nullptr;
+  ParamTypes type = {};
   struct {
     unsigned short size;
     unsigned short offset;
-  } dim[3];
+  } dim[3] = {};
 } static const configParams[] = {PARM_N0(kDouble, hw6202, DXRCYL),
                                  PARM_N0(kDouble, hw6202, DXRSPH),
                                  PARM_N0(kDouble, hw6202, DXZMAX),

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -133,6 +133,7 @@ namespace lhef {
         proc->addAccepted(eventWeight * matchWeight);
         procLumi->addAcceptedBr(eventWeight * brWeight * matchWeight);
         procLumi->addAccepted(eventWeight * matchWeight);
+        [[fallthrough]];
       case kKilled:
         proc->addKilled(eventWeight * matchWeight);
         procLumi->addKilled(eventWeight * matchWeight);
@@ -143,6 +144,7 @@ namespace lhef {
           proc->addNPassNeg();
           procLumi->addNPassNeg();
         }
+        [[fallthrough]];
       case kSelected:
         proc->addSelected(eventWeight);
         procLumi->addSelected(eventWeight);
@@ -153,6 +155,7 @@ namespace lhef {
           proc->addNTotalNeg();
           procLumi->addNTotalNeg();
         }
+        [[fallthrough]];
       case kTried:
         proc->addTried(eventWeight);
         procLumi->addTried(eventWeight);


### PR DESCRIPTION
#### PR description:

Fixes 6 compiler warnings in gcc 9 IB

#### PR validation:

Builds without warnings.
