### PR TITLE
move away from boost shared_ptrs

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -132,7 +132,7 @@ void AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
     edm::ESHandle<PTrackerParameters> ptp;
     iSetup.get<PTrackerParametersRcd>().get(ptp);
     TrackerGeomBuilderFromGeometricDet trackerBuilder;
-    boost::shared_ptr<TrackerGeometry> theTracker(trackerBuilder.build(&(*theGeometricDet), *ptp, tTopo));
+    std::shared_ptr<TrackerGeometry> theTracker(trackerBuilder.build(&(*theGeometricDet), *ptp, tTopo));
 
     edm::ESHandle<MuonDDDConstants> mdc;
     iSetup.get<MuonNumberingRecord>().get(mdc);

--- a/Alignment/MuonAlignment/test/TestRotation.cpp
+++ b/Alignment/MuonAlignment/test/TestRotation.cpp
@@ -96,8 +96,8 @@ void TestRotation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   DTGeometryBuilderFromDDD  DTGeometryBuilder;
   CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
-  theDTGeometry   = boost::shared_ptr<DTGeometry>( DTGeometryBuilder.build( &(*cpv) ) );
-  theCSCGeometry  = boost::shared_ptr<CSCGeometry>( CSCGeometryBuilder.build( &(*cpv) ) );
+  theDTGeometry   = std::shared_ptr<DTGeometry>( DTGeometryBuilder.build( &(*cpv) ) );
+  theCSCGeometry  = std::shared_ptr<CSCGeometry>( CSCGeometryBuilder.build( &(*cpv) ) );
 
   AlignableMuon* theAlignableMuon = new AlignableMuon( &(*theDTGeometry) , &(*theCSCGeometry) );
 */

--- a/Alignment/MuonAlignment/test/TestTranslation.cpp
+++ b/Alignment/MuonAlignment/test/TestTranslation.cpp
@@ -98,8 +98,8 @@ void TestTranslation::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   DTGeometryBuilderFromDDD  DTGeometryBuilder;
   CSCGeometryBuilderFromDDD CSCGeometryBuilder;
 
-  theDTGeometry   = boost::shared_ptr<DTGeometry>( DTGeometryBuilder.build( &(*cpv) ) );
-  theCSCGeometry  = boost::shared_ptr<CSCGeometry>( CSCGeometryBuilder.build( &(*cpv) ) );
+  theDTGeometry   = std::shared_ptr<DTGeometry>( DTGeometryBuilder.build( &(*cpv) ) );
+  theCSCGeometry  = std::shared_ptr<CSCGeometry>( CSCGeometryBuilder.build( &(*cpv) ) );
 
   AlignableMuon* theAlignableMuon = new AlignableMuon( &(*theDTGeometry) , &(*theCSCGeometry) );
 */

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcalEmap.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcalEmap.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <cstring>
 #include <fstream>
-#include <boost/shared_ptr.hpp>
+
 
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 

--- a/CalibCalorimetry/HcalTPGAlgos/interface/HcalEmap.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/HcalEmap.h
@@ -27,7 +27,6 @@
 #include <cstring>
 #include <fstream>
 
-
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 class HcalEmap {

--- a/CalibCalorimetry/HcalTPGAlgos/interface/XMLDOMBlock.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/XMLDOMBlock.h
@@ -18,7 +18,7 @@
 //         Created:  Thu Sep 27 01:46:46 CEST 2007
 //
 
-#include <boost/shared_ptr.hpp>
+
 #include <string>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/sax/HandlerBase.hpp>

--- a/CalibCalorimetry/HcalTPGAlgos/interface/XMLDOMBlock.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/XMLDOMBlock.h
@@ -18,7 +18,6 @@
 //         Created:  Thu Sep 27 01:46:46 CEST 2007
 //
 
-
 #include <string>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/sax/HandlerBase.hpp>

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -1,7 +1,6 @@
 #ifndef CALIBFORMATS_CALOTPG_CALOTPGTRANSCODER_H
 #define CALIBFORMATS_CALOTPG_CALOTPGTRANSCODER_H 1
 
-
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h"

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -1,11 +1,12 @@
 #ifndef CALIBFORMATS_CALOTPG_CALOTPGTRANSCODER_H
 #define CALIBFORMATS_CALOTPG_CALOTPGTRANSCODER_H 1
 
-#include <boost/shared_ptr.hpp>
+
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h"
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h"
+#include <memory>
 
 class HcalTPGCompressor;
 class EcalTPGCompressor;
@@ -52,12 +53,12 @@ public:
 
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& version, const int& compressedValue) const = 0;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const = 0;
-  boost::shared_ptr<const HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
-  boost::shared_ptr<const EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }
+  std::shared_ptr<const HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
+  std::shared_ptr<const EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }
 
 private:
-  boost::shared_ptr<const HcalTPGCompressor> hccompress_;
-  boost::shared_ptr<const EcalTPGCompressor> eccompress_;
+  std::shared_ptr<const HcalTPGCompressor> hccompress_;
+  std::shared_ptr<const EcalTPGCompressor> eccompress_;
 };
 
 #endif

--- a/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
@@ -1,7 +1,6 @@
 #ifndef SiStripQualityHistos_H
 #define SiStripQualityHistos_H
 
-
 #include <ext/hash_map>
 #include "TH1F.h"
 

--- a/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
@@ -1,11 +1,11 @@
 #ifndef SiStripQualityHistos_H
 #define SiStripQualityHistos_H
 
-#include "boost/shared_ptr.hpp"
+
 #include <ext/hash_map>
 #include "TH1F.h"
 
 namespace SiStrip {
-  typedef __gnu_cxx::hash_map<unsigned int, boost::shared_ptr<TH1F> > QualityHistosMap;
+  typedef __gnu_cxx::hash_map<unsigned int, std::shared_ptr<TH1F> > QualityHistosMap;
 }
 #endif

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -2,15 +2,16 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <sstream>
 
 //Insert here the include to the algos
@@ -129,7 +130,7 @@ void SiStripQualityHotStripIdentifier::bookHistos() {
     SiStrip::QualityHistosMap::iterator ref = ClusterPositionHistoMap.find(it->first);
     if (ref == ClusterPositionHistoMap.end()) {
       ClusterPositionHistoMap[it->first] =
-          std::shared_ptr<TH1F>(new TH1F(hname, hname, it->second.nApvs * 128, -0.5, it->second.nApvs * 128 - 0.5));
+          std::make_shared<TH1F>(hname, hname, it->second.nApvs * 128, -0.5, it->second.nApvs * 128 - 0.5);
     } else
       edm::LogError("SiStripQualityHotStripIdentifier")
           << " [SiStripQualityHotStripIdentifier::bookHistos] DetId " << it->first

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -129,7 +129,7 @@ void SiStripQualityHotStripIdentifier::bookHistos() {
     SiStrip::QualityHistosMap::iterator ref = ClusterPositionHistoMap.find(it->first);
     if (ref == ClusterPositionHistoMap.end()) {
       ClusterPositionHistoMap[it->first] =
-          boost::shared_ptr<TH1F>(new TH1F(hname, hname, it->second.nApvs * 128, -0.5, it->second.nApvs * 128 - 0.5));
+          std::shared_ptr<TH1F>(new TH1F(hname, hname, it->second.nApvs * 128, -0.5, it->second.nApvs * 128 - 0.5));
     } else
       edm::LogError("SiStripQualityHotStripIdentifier")
           << " [SiStripQualityHotStripIdentifier::bookHistos] DetId " << it->first

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -644,7 +644,7 @@ void IsoTrig::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
                                  << mybxlumi;
   if (!triggerResults.isValid()) {
     edm::LogWarning("IsoTrack") << "Error! Can't get the product triggerResults";
-    //      boost::shared_ptr<cms::Exception> const & error = triggerResults.whyFailed();
+    //      std::shared_ptr<cms::Exception> const & error = triggerResults.whyFailed();
     //      edm::LogWarning(error->category()) << error->what();
   } else {
     std::vector<std::string> modules;

--- a/CaloOnlineTools/HcalOnlineDb/interface/LMap.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/LMap.h
@@ -10,9 +10,7 @@
  Description: interface to the HCAL logical map
 
  Usage:
-    #include <boost/boost::shared_ptr.hpp>
-
-    boost::shared_ptr<LMap> the_map(new LMap);
+    std::shared_ptr<LMap> the_map(new LMap);
     the_map -> read( "your-accessor-string", "optional map type" );
 
 */
@@ -25,7 +23,7 @@
 #include <vector>
 #include <cstring>
 #include <fstream>
-#include <boost/shared_ptr.hpp>
+
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
@@ -77,7 +75,7 @@ public:
 
 private:
   class impl;
-  boost::shared_ptr<impl> p_impl;
+  std::shared_ptr<impl> p_impl;
 };
 
 class EMap {
@@ -135,7 +133,7 @@ public:
   int test_read(std::string accessor, std::string type = "HBEF");
 
 private:
-  boost::shared_ptr<LMap> _lmap;
+  std::shared_ptr<LMap> _lmap;
 };
 
 class EMap_test {

--- a/CaloOnlineTools/HcalOnlineDb/interface/LMap.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/LMap.h
@@ -24,7 +24,6 @@
 #include <cstring>
 #include <fstream>
 
-
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"

--- a/CommonTools/Utils/src/BinarySelector.h
+++ b/CommonTools/Utils/src/BinarySelector.h
@@ -13,21 +13,21 @@
 #include "CommonTools/Utils/src/SelectorBase.h"
 #include "CommonTools/Utils/src/ExpressionBase.h"
 #include "CommonTools/Utils/src/ComparisonBase.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace reco {
   namespace parser {
     struct BinarySelector : public SelectorBase {
-      BinarySelector(boost::shared_ptr<ExpressionBase> lhs,
-                     boost::shared_ptr<ComparisonBase> cmp,
-                     boost::shared_ptr<ExpressionBase> rhs)
+      BinarySelector(std::shared_ptr<ExpressionBase> lhs,
+                     std::shared_ptr<ComparisonBase> cmp,
+                     std::shared_ptr<ExpressionBase> rhs)
           : lhs_(lhs), cmp_(cmp), rhs_(rhs) {}
       bool operator()(const edm::ObjectWithDict& o) const override {
         return cmp_->compare(lhs_->value(o), rhs_->value(o));
       }
-      boost::shared_ptr<ExpressionBase> lhs_;
-      boost::shared_ptr<ComparisonBase> cmp_;
-      boost::shared_ptr<ExpressionBase> rhs_;
+      std::shared_ptr<ExpressionBase> lhs_;
+      std::shared_ptr<ComparisonBase> cmp_;
+      std::shared_ptr<ExpressionBase> rhs_;
     };
   }  // namespace parser
 }  // namespace reco

--- a/CommonTools/Utils/src/BinarySelector.h
+++ b/CommonTools/Utils/src/BinarySelector.h
@@ -14,7 +14,6 @@
 #include "CommonTools/Utils/src/ExpressionBase.h"
 #include "CommonTools/Utils/src/ComparisonBase.h"
 
-
 namespace reco {
   namespace parser {
     struct BinarySelector : public SelectorBase {

--- a/CommonTools/Utils/src/BinarySelectorSetter.h
+++ b/CommonTools/Utils/src/BinarySelectorSetter.h
@@ -16,7 +16,6 @@
 #include "CommonTools/Utils/src/BinarySelector.h"
 #include "CommonTools/Utils/interface/Exception.h"
 
-
 namespace reco {
   namespace parser {
     class BinarySelectorSetter {

--- a/CommonTools/Utils/src/BinarySelectorSetter.h
+++ b/CommonTools/Utils/src/BinarySelectorSetter.h
@@ -15,7 +15,7 @@
 #include "CommonTools/Utils/src/ExpressionStack.h"
 #include "CommonTools/Utils/src/BinarySelector.h"
 #include "CommonTools/Utils/interface/Exception.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace reco {
   namespace parser {
@@ -30,11 +30,11 @@ namespace reco {
         if (cmpStack_.empty())
           throw Exception(begin) << "Grammar error: empty comparator stack. Please contact developer."
                                  << "\"";
-        boost::shared_ptr<ExpressionBase> rhs = expStack_.back();
+        std::shared_ptr<ExpressionBase> rhs = expStack_.back();
         expStack_.pop_back();
-        boost::shared_ptr<ExpressionBase> lhs = expStack_.back();
+        std::shared_ptr<ExpressionBase> lhs = expStack_.back();
         expStack_.pop_back();
-        boost::shared_ptr<ComparisonBase> comp = cmpStack_.back();
+        std::shared_ptr<ComparisonBase> comp = cmpStack_.back();
         cmpStack_.pop_back();
 #ifdef BOOST_SPIRIT_DEBUG
         BOOST_SPIRIT_DEBUG_OUT << "pushing binary selector" << std::endl;

--- a/CommonTools/Utils/src/ComparisonSetter.h
+++ b/CommonTools/Utils/src/ComparisonSetter.h
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <string>
 #endif
+#include <memory>
 
 namespace reco {
   namespace parser {
@@ -33,7 +34,7 @@ namespace reco {
 #ifdef BOOST_SPIRIT_DEBUG
         BOOST_SPIRIT_DEBUG_OUT << "pushing comparison: " << cmp_out<CompT>::value << std::endl;
 #endif
-        stack_.push_back(boost::shared_ptr<ComparisonBase>(new Comparison<CompT>()));
+        stack_.push_back(std::shared_ptr<ComparisonBase>(new Comparison<CompT>()));
       }
 
     private:

--- a/CommonTools/Utils/src/ComparisonStack.h
+++ b/CommonTools/Utils/src/ComparisonStack.h
@@ -10,13 +10,14 @@
  * \version $Revision: 1.2 $
  *
  */
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
+#include <memory>
 
 namespace reco {
   namespace parser {
     struct ComparisonBase;
-    typedef std::vector<boost::shared_ptr<ComparisonBase> > ComparisonStack;
+    typedef std::vector<std::shared_ptr<ComparisonBase> > ComparisonStack;
   }  // namespace parser
 }  // namespace reco
 

--- a/CommonTools/Utils/src/ExpressionBase.h
+++ b/CommonTools/Utils/src/ExpressionBase.h
@@ -8,8 +8,9 @@
  *         adapted by Luca Lista, INFN
  *
  */
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
+#include <memory>
 
 namespace edm {
   class ObjectWithDict;
@@ -21,7 +22,7 @@ namespace reco {
       virtual ~ExpressionBase() {}
       virtual double value(const edm::ObjectWithDict&) const = 0;
     };
-    typedef boost::shared_ptr<ExpressionBase> ExpressionPtr;
+    typedef std::shared_ptr<ExpressionBase> ExpressionPtr;
   }  // namespace parser
 }  // namespace reco
 

--- a/CommonTools/Utils/src/ExpressionPtr.h
+++ b/CommonTools/Utils/src/ExpressionPtr.h
@@ -9,12 +9,13 @@
  * \version $Revision: 1.2 $
  *
  */
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 
 namespace reco {
   namespace parser {
     struct ExpressionBase;
-    typedef boost::shared_ptr<ExpressionBase> ExpressionPtr;
+    typedef std::shared_ptr<ExpressionBase> ExpressionPtr;
   }  // namespace parser
 }  // namespace reco
 

--- a/CommonTools/Utils/src/ExpressionSelectorSetter.h
+++ b/CommonTools/Utils/src/ExpressionSelectorSetter.h
@@ -16,7 +16,7 @@
 #include "CommonTools/Utils/src/ExpressionNumber.h"
 #include "CommonTools/Utils/src/Comparison.h"
 #include "CommonTools/Utils/interface/Exception.h"
-#include <boost/shared_ptr.hpp>
+
 #include <functional>
 
 namespace reco {
@@ -30,10 +30,10 @@ namespace reco {
         if (expStack_.empty())
           throw Exception(begin) << "Grammar error: empty expression stack. Please contact developer."
                                  << "\"";
-        boost::shared_ptr<ExpressionBase> rhs = expStack_.back();
+        std::shared_ptr<ExpressionBase> rhs = expStack_.back();
         expStack_.pop_back();
-        boost::shared_ptr<ExpressionBase> lhs(new ExpressionNumber(0.0));
-        boost::shared_ptr<ComparisonBase> comp(new Comparison<std::not_equal_to<double> >());
+        std::shared_ptr<ExpressionBase> lhs(new ExpressionNumber(0.0));
+        std::shared_ptr<ComparisonBase> comp(new Comparison<std::not_equal_to<double> >());
 #ifdef BOOST_SPIRIT_DEBUG
         BOOST_SPIRIT_DEBUG_OUT << "pushing expression selector" << std::endl;
 #endif

--- a/CommonTools/Utils/src/ExpressionStack.h
+++ b/CommonTools/Utils/src/ExpressionStack.h
@@ -10,14 +10,15 @@
  * \version $Revision: 1.2 $
  *
  */
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
+#include <memory>
 
 namespace reco {
   namespace parser {
     struct ExpressionBase;
 
-    typedef std::vector<boost::shared_ptr<ExpressionBase> > ExpressionStack;
+    typedef std::vector<std::shared_ptr<ExpressionBase> > ExpressionStack;
   }  // namespace parser
 }  // namespace reco
 

--- a/CommonTools/Utils/src/ExpressionVarSetter.cc
+++ b/CommonTools/Utils/src/ExpressionVarSetter.cc
@@ -28,13 +28,13 @@ void ExpressionVarSetter::push(const char *begin, const char *end) const {
                            << methStack_.back().returnTypeName() << "\" which is not convertible to double.";
   }
 
-  exprStack_.push_back(boost::shared_ptr<ExpressionBase>(new ExpressionVar(methStack_, retType)));
+  exprStack_.push_back(std::shared_ptr<ExpressionBase>(new ExpressionVar(methStack_, retType)));
   methStack_.clear();
   typeStack_.resize(1);
 }
 
 void ExpressionVarSetter::lazyPush(const char *begin, const char *end) const {
-  exprStack_.push_back(boost::shared_ptr<ExpressionBase>(new ExpressionLazyVar(lazyMethStack_)));
+  exprStack_.push_back(std::shared_ptr<ExpressionBase>(new ExpressionLazyVar(lazyMethStack_)));
   lazyMethStack_.clear();
   typeStack_.resize(1);
 }

--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -8,7 +8,6 @@
 #include "FWCore/Reflection/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-
 #include <boost/utility.hpp>
 
 #include <map>

--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -8,7 +8,7 @@
 #include "FWCore/Reflection/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
-#include <boost/shared_ptr.hpp>
+
 #include <boost/utility.hpp>
 
 #include <map>

--- a/CommonTools/Utils/src/SelectorPtr.h
+++ b/CommonTools/Utils/src/SelectorPtr.h
@@ -10,12 +10,13 @@
  * \version $Revision: 1.2 $
  *
  */
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 
 namespace reco {
   namespace parser {
     class SelectorBase;
-    typedef boost::shared_ptr<SelectorBase> SelectorPtr;
+    typedef std::shared_ptr<SelectorBase> SelectorPtr;
   }  // namespace parser
 }  // namespace reco
 

--- a/CommonTools/Utils/src/TrinarySelector.h
+++ b/CommonTools/Utils/src/TrinarySelector.h
@@ -14,7 +14,6 @@
 #include "CommonTools/Utils/src/ExpressionBase.h"
 #include "CommonTools/Utils/src/ComparisonBase.h"
 
-
 namespace reco {
   namespace parser {
     struct TrinarySelector : public SelectorBase {

--- a/CommonTools/Utils/src/TrinarySelector.h
+++ b/CommonTools/Utils/src/TrinarySelector.h
@@ -13,25 +13,25 @@
 #include "CommonTools/Utils/src/SelectorBase.h"
 #include "CommonTools/Utils/src/ExpressionBase.h"
 #include "CommonTools/Utils/src/ComparisonBase.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace reco {
   namespace parser {
     struct TrinarySelector : public SelectorBase {
-      TrinarySelector(boost::shared_ptr<ExpressionBase> lhs,
-                      boost::shared_ptr<ComparisonBase> cmp1,
-                      boost::shared_ptr<ExpressionBase> mid,
-                      boost::shared_ptr<ComparisonBase> cmp2,
-                      boost::shared_ptr<ExpressionBase> rhs)
+      TrinarySelector(std::shared_ptr<ExpressionBase> lhs,
+                      std::shared_ptr<ComparisonBase> cmp1,
+                      std::shared_ptr<ExpressionBase> mid,
+                      std::shared_ptr<ComparisonBase> cmp2,
+                      std::shared_ptr<ExpressionBase> rhs)
           : lhs_(lhs), cmp1_(cmp1), mid_(mid), cmp2_(cmp2), rhs_(rhs) {}
       bool operator()(const edm::ObjectWithDict& o) const override {
         return cmp1_->compare(lhs_->value(o), mid_->value(o)) && cmp2_->compare(mid_->value(o), rhs_->value(o));
       }
-      boost::shared_ptr<ExpressionBase> lhs_;
-      boost::shared_ptr<ComparisonBase> cmp1_;
-      boost::shared_ptr<ExpressionBase> mid_;
-      boost::shared_ptr<ComparisonBase> cmp2_;
-      boost::shared_ptr<ExpressionBase> rhs_;
+      std::shared_ptr<ExpressionBase> lhs_;
+      std::shared_ptr<ComparisonBase> cmp1_;
+      std::shared_ptr<ExpressionBase> mid_;
+      std::shared_ptr<ComparisonBase> cmp2_;
+      std::shared_ptr<ExpressionBase> rhs_;
     };
   }  // namespace parser
 }  // namespace reco

--- a/CommonTools/Utils/src/TrinarySelectorSetter.h
+++ b/CommonTools/Utils/src/TrinarySelectorSetter.h
@@ -15,7 +15,6 @@
 #include "CommonTools/Utils/src/ExpressionStack.h"
 #include "CommonTools/Utils/src/TrinarySelector.h"
 
-
 namespace reco {
   namespace parser {
     class TrinarySelectorSetter {

--- a/CommonTools/Utils/src/TrinarySelectorSetter.h
+++ b/CommonTools/Utils/src/TrinarySelectorSetter.h
@@ -14,7 +14,7 @@
 #include "CommonTools/Utils/src/ComparisonStack.h"
 #include "CommonTools/Utils/src/ExpressionStack.h"
 #include "CommonTools/Utils/src/TrinarySelector.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace reco {
   namespace parser {
@@ -24,15 +24,15 @@ namespace reco {
           : selStack_(selStack), cmpStack_(cmpStack), expStack_(expStack) {}
 
       void operator()(const char*, const char*) const {
-        boost::shared_ptr<ExpressionBase> rhs = expStack_.back();
+        std::shared_ptr<ExpressionBase> rhs = expStack_.back();
         expStack_.pop_back();
-        boost::shared_ptr<ExpressionBase> mid = expStack_.back();
+        std::shared_ptr<ExpressionBase> mid = expStack_.back();
         expStack_.pop_back();
-        boost::shared_ptr<ExpressionBase> lhs = expStack_.back();
+        std::shared_ptr<ExpressionBase> lhs = expStack_.back();
         expStack_.pop_back();
-        boost::shared_ptr<ComparisonBase> comp2 = cmpStack_.back();
+        std::shared_ptr<ComparisonBase> comp2 = cmpStack_.back();
         cmpStack_.pop_back();
-        boost::shared_ptr<ComparisonBase> comp1 = cmpStack_.back();
+        std::shared_ptr<ComparisonBase> comp1 = cmpStack_.back();
         cmpStack_.pop_back();
 #ifdef BOOST_SPIRIT_DEBUG
         BOOST_SPIRIT_DEBUG_OUT << "pushing trinary selector" << std::endl;

--- a/CondCore/DBOutputService/test/stubs/MyDataAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/MyDataAnalyzer.cc
@@ -88,7 +88,7 @@ void MyDataAnalyzer::endJob() {
     //example for instantiate object by token
     cond::DbSession pooldb=mydbservice->session();
     pooldb.transaction().start(true);
-    boost::shared_ptr<Pedestals> myinstance = pooldb.getTypedObject<Pedestals>( taginfo.lastPayloadToken);
+    std::shared_ptr<Pedestals> myinstance = pooldb.getTypedObject<Pedestals>( taginfo.lastPayloadToken);
     std::cout<<"size of items "<<myinstance->m_pedestals.size()<<std::endl;
     pooldb.transaction().commit();    
     **/

--- a/CondCore/ESSources/test/testWriteCondData.cpp
+++ b/CondCore/ESSources/test/testWriteCondData.cpp
@@ -9,8 +9,8 @@
 #include "FWCore/PluginManager/interface/standard.h"
 #include <iostream>
 
-int main(){
-  try{
+int main() {
+  try {
     // for runnumber
     cond::TimeType timetype = cond::runnumber;
     cond::Time_t globalTill = cond::timeTypeSpecs[timetype].endValue;
@@ -18,85 +18,85 @@ int main(){
     edmplugin::PluginManager::configure(edmplugin::standard::config());
 
     cond::DbConnection connection;
-    connection.configuration().setMessageLevel( coral::Error );
+    connection.configuration().setMessageLevel(coral::Error);
     connection.configuration().setAuthenticationPath(".");
     connection.configure();
     cond::DbSession session = connection.createSession();
-    session.open( "sqlite_file:test.db" );
+    session.open("sqlite_file:test.db");
 
-    cond::IOVEditor ioveditor( session );
+    cond::IOVEditor ioveditor(session);
     session.transaction().start(false);
-    std::cout<<"globalTill value "<<globalTill<<std::endl;
-    ioveditor.create(timetype,globalTill);
-    for(unsigned int i=0; i<3; ++i){ //inserting 3 payloads
-      std::shared_ptr<Pedestals> myped( new Pedestals );
-      for(int ichannel=1; ichannel<=5; ++ichannel){
+    std::cout << "globalTill value " << globalTill << std::endl;
+    ioveditor.create(timetype, globalTill);
+    for (unsigned int i = 0; i < 3; ++i) {  //inserting 3 payloads
+      std::shared_ptr<Pedestals> myped(new Pedestals);
+      for (int ichannel = 1; ichannel <= 5; ++ichannel) {
         Pedestals::Item item;
-        item.m_mean=1.11*ichannel+i;
-        item.m_variance=1.12*ichannel+i*2;
+        item.m_mean = 1.11 * ichannel + i;
+        item.m_variance = 1.12 * ichannel + i * 2;
         myped->m_pedestals.push_back(item);
       }
-      std::string payloadToken = session.storeObject(myped.get(),"PedestalsRcd");
-      ioveditor.append(cond::Time_t(2+2*i),payloadToken);
+      std::string payloadToken = session.storeObject(myped.get(), "PedestalsRcd");
+      ioveditor.append(cond::Time_t(2 + 2 * i), payloadToken);
     }
     //last one
-    std::shared_ptr<Pedestals> myped( new Pedestals );
-    for(int ichannel=1; ichannel<=5; ++ichannel){
+    std::shared_ptr<Pedestals> myped(new Pedestals);
+    for (int ichannel = 1; ichannel <= 5; ++ichannel) {
       Pedestals::Item item;
-      item.m_mean=3.11*ichannel;
-      item.m_variance=5.12*ichannel;
+      item.m_mean = 3.11 * ichannel;
+      item.m_variance = 5.12 * ichannel;
       myped->m_pedestals.push_back(item);
     }
-    std::string payloadToken = session.storeObject(myped.get(),"PedestalsRcd");
-    ioveditor.append(9001,payloadToken);
-    std::string iovtoken=ioveditor.token();
-    std::cout<<"iov token "<<iovtoken<<std::endl;
+    std::string payloadToken = session.storeObject(myped.get(), "PedestalsRcd");
+    ioveditor.append(9001, payloadToken);
+    std::string iovtoken = ioveditor.token();
+    std::cout << "iov token " << iovtoken << std::endl;
     session.transaction().commit();
     //pooldb.disconnect();
     session.transaction().start(false);
     ioveditor.create(timetype, globalTill);
-    std::shared_ptr<Pedestals> p( new Pedestals );
-    for(int ichannel=1; ichannel<=2; ++ichannel){
+    std::shared_ptr<Pedestals> p(new Pedestals);
+    for (int ichannel = 1; ichannel <= 2; ++ichannel) {
       Pedestals::Item item;
-      item.m_mean=4.11*ichannel;
-      item.m_variance=5.82*ichannel;
+      item.m_mean = 4.11 * ichannel;
+      item.m_variance = 5.82 * ichannel;
       p->m_pedestals.push_back(item);
     }
-    std::string payloadToken2 = session.storeObject(p.get(),"PedestalsRcd");
-    ioveditor.append(90001,payloadToken2);
-    std::string pediovtoken=ioveditor.token();
-    std::cout<<"iov token "<<pediovtoken<<std::endl;
+    std::string payloadToken2 = session.storeObject(p.get(), "PedestalsRcd");
+    ioveditor.append(90001, payloadToken2);
+    std::string pediovtoken = ioveditor.token();
+    std::cout << "iov token " << pediovtoken << std::endl;
     session.transaction().commit();
     //
     ///I write different pedestals in another record
     //
-    cond::IOVEditor anotherioveditor( session );
+    cond::IOVEditor anotherioveditor(session);
     session.transaction().start(false);
-    anotherioveditor.create(timetype,globalTill);
-    for(unsigned int i=0; i<2; ++i){ //inserting 2 payloads to another Rcd
-      std::shared_ptr<Pedestals> myped( new Pedestals );
-      for(int ichannel=1; ichannel<=3; ++ichannel){
+    anotherioveditor.create(timetype, globalTill);
+    for (unsigned int i = 0; i < 2; ++i) {  //inserting 2 payloads to another Rcd
+      std::shared_ptr<Pedestals> myped(new Pedestals);
+      for (int ichannel = 1; ichannel <= 3; ++ichannel) {
         Pedestals::Item item;
-        item.m_mean=1.11*ichannel+i;
-        item.m_variance=1.12*ichannel+i*2;
+        item.m_mean = 1.11 * ichannel + i;
+        item.m_variance = 1.12 * ichannel + i * 2;
         myped->m_pedestals.push_back(item);
       }
-      std::string payloadToken = session.storeObject(myped.get(),"anotherPedestalsRcd");
-      anotherioveditor.append(cond::Time_t(2+2*i),payloadToken);
+      std::string payloadToken = session.storeObject(myped.get(), "anotherPedestalsRcd");
+      anotherioveditor.append(cond::Time_t(2 + 2 * i), payloadToken);
     }
-    std::string anotheriovtoken=anotherioveditor.token();
-    std::cout<<"anotheriovtoken "<<anotheriovtoken<<std::endl;
+    std::string anotheriovtoken = anotherioveditor.token();
+    std::cout << "anotheriovtoken " << anotheriovtoken << std::endl;
     session.transaction().commit();
-    
+
     cond::MetaData metadata(session);
     session.transaction().start(false);
-    metadata.addMapping("mytest",iovtoken,cond::runnumber);
-    metadata.addMapping("pedtag",pediovtoken,cond::runnumber);
-    metadata.addMapping("anothermytest",anotheriovtoken,cond::runnumber);
+    metadata.addMapping("mytest", iovtoken, cond::runnumber);
+    metadata.addMapping("pedtag", pediovtoken, cond::runnumber);
+    metadata.addMapping("anothermytest", anotheriovtoken, cond::runnumber);
     session.transaction().commit();
-  }catch(const cond::Exception& er){
-    std::cout<<"error "<<er.what()<<std::endl;
-  }catch(const std::exception& er){
-    std::cout<<"std error "<<er.what()<<std::endl;
+  } catch (const cond::Exception& er) {
+    std::cout << "error " << er.what() << std::endl;
+  } catch (const std::exception& er) {
+    std::cout << "std error " << er.what() << std::endl;
   }
 }

--- a/CondCore/ESSources/test/testWriteCondData.cpp
+++ b/CondCore/ESSources/test/testWriteCondData.cpp
@@ -29,7 +29,7 @@ int main(){
     std::cout<<"globalTill value "<<globalTill<<std::endl;
     ioveditor.create(timetype,globalTill);
     for(unsigned int i=0; i<3; ++i){ //inserting 3 payloads
-      boost::shared_ptr<Pedestals> myped( new Pedestals );
+      std::shared_ptr<Pedestals> myped( new Pedestals );
       for(int ichannel=1; ichannel<=5; ++ichannel){
         Pedestals::Item item;
         item.m_mean=1.11*ichannel+i;
@@ -40,7 +40,7 @@ int main(){
       ioveditor.append(cond::Time_t(2+2*i),payloadToken);
     }
     //last one
-    boost::shared_ptr<Pedestals> myped( new Pedestals );
+    std::shared_ptr<Pedestals> myped( new Pedestals );
     for(int ichannel=1; ichannel<=5; ++ichannel){
       Pedestals::Item item;
       item.m_mean=3.11*ichannel;
@@ -55,7 +55,7 @@ int main(){
     //pooldb.disconnect();
     session.transaction().start(false);
     ioveditor.create(timetype, globalTill);
-    boost::shared_ptr<Pedestals> p( new Pedestals );
+    std::shared_ptr<Pedestals> p( new Pedestals );
     for(int ichannel=1; ichannel<=2; ++ichannel){
       Pedestals::Item item;
       item.m_mean=4.11*ichannel;
@@ -74,7 +74,7 @@ int main(){
     session.transaction().start(false);
     anotherioveditor.create(timetype,globalTill);
     for(unsigned int i=0; i<2; ++i){ //inserting 2 payloads to another Rcd
-      boost::shared_ptr<Pedestals> myped( new Pedestals );
+      std::shared_ptr<Pedestals> myped( new Pedestals );
       for(int ichannel=1; ichannel<=3; ++ichannel){
         Pedestals::Item item;
         item.m_mean=1.11*ichannel+i;

--- a/CondCore/ESSources/test/writeBasicData.cpp
+++ b/CondCore/ESSources/test/writeBasicData.cpp
@@ -9,100 +9,100 @@
 #include "FWCore/PluginManager/interface/standard.h"
 #include <iostream>
 
-int main(){
-  try{
+int main() {
+  try {
     // for runnumber
     cond::TimeType timetype = cond::runnumber;
     cond::Time_t globalTill = cond::timeTypeSpecs[timetype].endValue;
     edmplugin::PluginManager::Config config;
     edmplugin::PluginManager::configure(edmplugin::standard::config());
-    
+
     cond::DbConnection connection;
-    connection.configuration().setMessageLevel( coral::Error );
+    connection.configuration().setMessageLevel(coral::Error);
     connection.configure();
     cond::DbSession session = connection.createSession();
-    session.open( "sqlite_file:mytest.db" );
+    session.open("sqlite_file:mytest.db");
 
-    cond::IOVEditor ioveditor( session );
+    cond::IOVEditor ioveditor(session);
     session.transaction().start(false);
-    ioveditor.create(timetype,globalTill);
+    ioveditor.create(timetype, globalTill);
     std::string mytestiovtoken;
-    for(unsigned int i=0; i<3; ++i){ //inserting 3 payloads
-      std::shared_ptr<Pedestals> myped( new Pedestals );
-      for(int ichannel=1; ichannel<=5; ++ichannel){
+    for (unsigned int i = 0; i < 3; ++i) {  //inserting 3 payloads
+      std::shared_ptr<Pedestals> myped(new Pedestals);
+      for (int ichannel = 1; ichannel <= 5; ++ichannel) {
         Pedestals::Item item;
-        item.m_mean=1.11*ichannel+i;
-        item.m_variance=1.12*ichannel+i*2;
+        item.m_mean = 1.11 * ichannel + i;
+        item.m_variance = 1.12 * ichannel + i * 2;
         myped->m_pedestals.push_back(item);
       }
-      
-      std::string payloadToken = session.storeObject(myped.get(),"PedestalsRcd");
-      ioveditor.append(cond::Time_t(2+2*i),payloadToken);
+
+      std::string payloadToken = session.storeObject(myped.get(), "PedestalsRcd");
+      ioveditor.append(cond::Time_t(2 + 2 * i), payloadToken);
     }
     //last one
-    std::shared_ptr<Pedestals> myped( new Pedestals );
-    for(int ichannel=1; ichannel<=5; ++ichannel){
+    std::shared_ptr<Pedestals> myped(new Pedestals);
+    for (int ichannel = 1; ichannel <= 5; ++ichannel) {
       Pedestals::Item item;
-      item.m_mean=3.11*ichannel;
-      item.m_variance=5.12*ichannel;
+      item.m_mean = 3.11 * ichannel;
+      item.m_variance = 5.12 * ichannel;
       myped->m_pedestals.push_back(item);
     }
-    std::string payloadToken = session.storeObject(myped.get(),"PedestalsRcd");
-    ioveditor.append(9001,payloadToken);
-    mytestiovtoken=ioveditor.token();
-    std::cout<<"mytest iov token "<<mytestiovtoken<<std::endl;
+    std::string payloadToken = session.storeObject(myped.get(), "PedestalsRcd");
+    ioveditor.append(9001, payloadToken);
+    mytestiovtoken = ioveditor.token();
+    std::cout << "mytest iov token " << mytestiovtoken << std::endl;
     session.transaction().commit();
-    
+
     std::string mypedestalsiovtoken;
-    cond::IOVEditor ioveditor2( session );
+    cond::IOVEditor ioveditor2(session);
     session.transaction().start(false);
-    ioveditor2.create(timetype,globalTill);
-    for(unsigned int i=0; i<2; ++i){ //inserting 3 payloads
-      std::shared_ptr<Pedestals> myped( new Pedestals );
-      for(int ichannel=1; ichannel<=5; ++ichannel){
+    ioveditor2.create(timetype, globalTill);
+    for (unsigned int i = 0; i < 2; ++i) {  //inserting 3 payloads
+      std::shared_ptr<Pedestals> myped(new Pedestals);
+      for (int ichannel = 1; ichannel <= 5; ++ichannel) {
         Pedestals::Item item;
-        item.m_mean=1.11*ichannel+i;
-        item.m_variance=1.12*ichannel+i*2;
+        item.m_mean = 1.11 * ichannel + i;
+        item.m_variance = 1.12 * ichannel + i * 2;
         myped->m_pedestals.push_back(item);
       }
-      std::string payloadToken = session.storeObject(myped.get(),"PedestalsRcd");
-      ioveditor2.append(cond::Time_t(5+2*i),payloadToken);
+      std::string payloadToken = session.storeObject(myped.get(), "PedestalsRcd");
+      ioveditor2.append(cond::Time_t(5 + 2 * i), payloadToken);
     }
-    mypedestalsiovtoken=ioveditor2.token();
-    std::cout<<"mytest iov token "<<mypedestalsiovtoken<<std::endl;
+    mypedestalsiovtoken = ioveditor2.token();
+    std::cout << "mytest iov token " << mypedestalsiovtoken << std::endl;
     session.transaction().commit();
 
     //
     ///I write different pedestals in another record
     //
     std::string anothermytestiovtoken;
-    cond::IOVEditor anotherioveditor( session );
+    cond::IOVEditor anotherioveditor(session);
     session.transaction().start(false);
-    anotherioveditor.create(timetype,globalTill);
-    for(unsigned int i=0; i<2; ++i){ //inserting 2 payloads to another Rcd
-      std::shared_ptr<Pedestals> myped( new Pedestals );
-      for(int ichannel=1; ichannel<=3; ++ichannel){
+    anotherioveditor.create(timetype, globalTill);
+    for (unsigned int i = 0; i < 2; ++i) {  //inserting 2 payloads to another Rcd
+      std::shared_ptr<Pedestals> myped(new Pedestals);
+      for (int ichannel = 1; ichannel <= 3; ++ichannel) {
         Pedestals::Item item;
-        item.m_mean=1.11*ichannel+i;
-        item.m_variance=1.12*ichannel+i*2;
+        item.m_mean = 1.11 * ichannel + i;
+        item.m_variance = 1.12 * ichannel + i * 2;
         myped->m_pedestals.push_back(item);
       }
-      std::string payloadToken = session.storeObject(myped.get(),"anotherPedestalsRcd");
-      anotherioveditor.append(cond::Time_t(2+2*i),payloadToken);
+      std::string payloadToken = session.storeObject(myped.get(), "anotherPedestalsRcd");
+      anotherioveditor.append(cond::Time_t(2 + 2 * i), payloadToken);
     }
-    anothermytestiovtoken=anotherioveditor.token();
+    anothermytestiovtoken = anotherioveditor.token();
     session.transaction().commit();
-    std::cout<<"anothermytest iov token "<<anothermytestiovtoken<<std::endl;
-    
-    cond::MetaData metadata( session );
+    std::cout << "anothermytest iov token " << anothermytestiovtoken << std::endl;
+
+    cond::MetaData metadata(session);
     session.transaction().start(false);
-    metadata.addMapping("mytest",mytestiovtoken);
-    metadata.addMapping("mypedestals",mypedestalsiovtoken);
-    metadata.addMapping("anothermytest",anothermytestiovtoken);
+    metadata.addMapping("mytest", mytestiovtoken);
+    metadata.addMapping("mypedestals", mypedestalsiovtoken);
+    metadata.addMapping("anothermytest", anothermytestiovtoken);
     session.transaction().commit();
-  }catch(const cond::Exception& er){
-    std::cout<<"error "<<er.what()<<std::endl;
-  }catch(const std::exception& er){
-    std::cout<<"std error "<<er.what()<<std::endl;
+  } catch (const cond::Exception& er) {
+    std::cout << "error " << er.what() << std::endl;
+  } catch (const std::exception& er) {
+    std::cout << "std error " << er.what() << std::endl;
   }
 }

--- a/CondCore/ESSources/test/writeBasicData.cpp
+++ b/CondCore/ESSources/test/writeBasicData.cpp
@@ -28,7 +28,7 @@ int main(){
     ioveditor.create(timetype,globalTill);
     std::string mytestiovtoken;
     for(unsigned int i=0; i<3; ++i){ //inserting 3 payloads
-      boost::shared_ptr<Pedestals> myped( new Pedestals );
+      std::shared_ptr<Pedestals> myped( new Pedestals );
       for(int ichannel=1; ichannel<=5; ++ichannel){
         Pedestals::Item item;
         item.m_mean=1.11*ichannel+i;
@@ -40,7 +40,7 @@ int main(){
       ioveditor.append(cond::Time_t(2+2*i),payloadToken);
     }
     //last one
-    boost::shared_ptr<Pedestals> myped( new Pedestals );
+    std::shared_ptr<Pedestals> myped( new Pedestals );
     for(int ichannel=1; ichannel<=5; ++ichannel){
       Pedestals::Item item;
       item.m_mean=3.11*ichannel;
@@ -58,7 +58,7 @@ int main(){
     session.transaction().start(false);
     ioveditor2.create(timetype,globalTill);
     for(unsigned int i=0; i<2; ++i){ //inserting 3 payloads
-      boost::shared_ptr<Pedestals> myped( new Pedestals );
+      std::shared_ptr<Pedestals> myped( new Pedestals );
       for(int ichannel=1; ichannel<=5; ++ichannel){
         Pedestals::Item item;
         item.m_mean=1.11*ichannel+i;
@@ -80,7 +80,7 @@ int main(){
     session.transaction().start(false);
     anotherioveditor.create(timetype,globalTill);
     for(unsigned int i=0; i<2; ++i){ //inserting 2 payloads to another Rcd
-      boost::shared_ptr<Pedestals> myped( new Pedestals );
+      std::shared_ptr<Pedestals> myped( new Pedestals );
       for(int ichannel=1; ichannel<=3; ++ichannel){
         Pedestals::Item item;
         item.m_mean=1.11*ichannel+i;

--- a/CondCore/ESSources/test/writeExtraData.cpp
+++ b/CondCore/ESSources/test/writeExtraData.cpp
@@ -27,7 +27,7 @@ int main(){
     ioveditor.create(timetype,globalTill);
     std::string mytestiovtoken;
     for(unsigned int i=0; i<3; ++i){ //inserting 3 payloads
-      boost::shared_ptr<Pedestals> myped( new Pedestals );
+      std::shared_ptr<Pedestals> myped( new Pedestals );
       for(int ichannel=1; ichannel<=5; ++ichannel){
         Pedestals::Item item;
         item.m_mean=1.11*ichannel+i;

--- a/CondCore/ESSources/test/writeExtraData.cpp
+++ b/CondCore/ESSources/test/writeExtraData.cpp
@@ -9,42 +9,42 @@
 #include "FWCore/PluginManager/interface/standard.h"
 #include <iostream>
 
-int main(){
-  try{
+int main() {
+  try {
     // for runnumber
     cond::TimeType timetype = cond::runnumber;
     cond::Time_t globalTill = cond::timeTypeSpecs[timetype].endValue;
     edmplugin::PluginManager::Config config;
     edmplugin::PluginManager::configure(edmplugin::standard::config());
-    
+
     cond::DbConnection connection;
-    connection.configuration().setMessageLevel( coral::Error );
+    connection.configuration().setMessageLevel(coral::Error);
     connection.configure();
     cond::DbSession session = connection.createSession();
-    session.open( "sqlite_file:extradata.db" );
-    cond::IOVEditor ioveditor( session );
+    session.open("sqlite_file:extradata.db");
+    cond::IOVEditor ioveditor(session);
     session.transaction().start(false);
-    ioveditor.create(timetype,globalTill);
+    ioveditor.create(timetype, globalTill);
     std::string mytestiovtoken;
-    for(unsigned int i=0; i<3; ++i){ //inserting 3 payloads
-      std::shared_ptr<Pedestals> myped( new Pedestals );
-      for(int ichannel=1; ichannel<=5; ++ichannel){
+    for (unsigned int i = 0; i < 3; ++i) {  //inserting 3 payloads
+      std::shared_ptr<Pedestals> myped(new Pedestals);
+      for (int ichannel = 1; ichannel <= 5; ++ichannel) {
         Pedestals::Item item;
-        item.m_mean=1.11*ichannel+i;
-        item.m_variance=1.12*ichannel+i*2;
+        item.m_mean = 1.11 * ichannel + i;
+        item.m_variance = 1.12 * ichannel + i * 2;
         myped->m_pedestals.push_back(item);
       }
-      std::string payloadToken = session.storeObject(myped.get(),"anotherPedestalsRcd");
-      std::cout<<"payloadToken "<<payloadToken<<std::endl;
-      ioveditor.append(cond::Time_t(2+2*i),payloadToken);
+      std::string payloadToken = session.storeObject(myped.get(), "anotherPedestalsRcd");
+      std::cout << "payloadToken " << payloadToken << std::endl;
+      ioveditor.append(cond::Time_t(2 + 2 * i), payloadToken);
     }
-    std::string mytoken=ioveditor.token();
+    std::string mytoken = ioveditor.token();
     cond::MetaData metadata(session);
-    metadata.addMapping("anothertag",mytoken,cond::runnumber);
+    metadata.addMapping("anothertag", mytoken, cond::runnumber);
     session.transaction().commit();
-  }catch(const cond::Exception& er){
-    std::cout<<"error "<<er.what()<<std::endl;
-  }catch(const std::exception& er){
-    std::cout<<"std error "<<er.what()<<std::endl;
+  } catch (const cond::Exception& er) {
+    std::cout << "error " << er.what() << std::endl;
+  } catch (const std::exception& er) {
+    std::cout << "std error " << er.what() << std::endl;
   }
 }

--- a/CondCore/Utilities/bin/conddb_test_gt_load.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_load.cpp
@@ -145,7 +145,7 @@ namespace cond {
 
     Session m_session;
     IOVProxy m_iov;
-    boost::shared_ptr<pimpl> m_data;
+    std::shared_ptr<pimpl> m_data;
   };
 
   class TestGTLoad : public cond::Utilities {

--- a/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
@@ -77,7 +77,7 @@ namespace cond {
 
     Session m_session;
     IOVProxy m_iov;
-    boost::shared_ptr<pimpl> m_data;
+    std::shared_ptr<pimpl> m_data;
 
     Binary m_buffer;
     Binary m_streamerInfo;

--- a/CondFormats/HcalObjects/interface/HFPhase1PMTData.h
+++ b/CondFormats/HcalObjects/interface/HFPhase1PMTData.h
@@ -26,7 +26,7 @@ public:
     ASYMM_MAX,    // Maximum allowed asymmetry
     N_PMT_CUTS
   };
-  typedef boost::array<boost::shared_ptr<AbsHcalFunctor>, N_PMT_CUTS> Cuts;
+  typedef boost::array<std::shared_ptr<AbsHcalFunctor>, N_PMT_CUTS> Cuts;
 
   // Dummy constructor, to be used for deserialization only
   inline HFPhase1PMTData() : minCharge0_(0.0), minCharge1_(0.0), minChargeAsymm_(0.0) {}

--- a/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
@@ -36,7 +36,7 @@ public:
     {
         StoredArray st;
         for (unsigned i=0; i<N; ++i)
-            st[i] = boost::shared_ptr<Item>(arr[i].release());
+            st[i] = std::shared_ptr<Item>(arr[i].release());
         data_.push_back(st);
     }
 
@@ -81,7 +81,7 @@ public:
         {return !(*this == r);}
 
 private:
-    typedef boost::array<boost::shared_ptr<Item>,N> StoredArray;
+    typedef boost::array<std::shared_ptr<Item>,N> StoredArray;
     std::vector<StoredArray> data_;
 
     friend class boost::serialization::access;

--- a/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
@@ -22,86 +22,79 @@
 // an inheritance hierarchy by their base pointers.
 // The pointee objects are owned by this collection.
 //
-template<typename Item, unsigned N>
-class HcalItemArrayColl
-{
+template <typename Item, unsigned N>
+class HcalItemArrayColl {
 public:
-    typedef Item value_type;
-    typedef std::array<std::unique_ptr<Item>,N> InputArray;
-    static constexpr unsigned arraySize() {return N;}
+  typedef Item value_type;
+  typedef std::array<std::unique_ptr<Item>, N> InputArray;
+  static constexpr unsigned arraySize() { return N; }
 
-    // The following method adds a new array of pointers to the collection.
-    // This class will take ownership of the pointee objects.
-    void push_back(InputArray& arr)
-    {
-        StoredArray st;
-        for (unsigned i=0; i<N; ++i)
-            st[i] = std::shared_ptr<Item>(arr[i].release());
-        data_.push_back(st);
-    }
+  // The following method adds a new array of pointers to the collection.
+  // This class will take ownership of the pointee objects.
+  void push_back(InputArray& arr) {
+    StoredArray st;
+    for (unsigned i = 0; i < N; ++i)
+      st[i] = std::shared_ptr<Item>(arr[i].release());
+    data_.push_back(st);
+  }
 
-    // Other modifiers
-    inline void clear() {data_.clear();}
-    inline void reserve(const unsigned n) {data_.reserve(n);}
+  // Other modifiers
+  inline void clear() { data_.clear(); }
+  inline void reserve(const unsigned n) { data_.reserve(n); }
 
-    // Some inspectors
-    inline std::size_t size() const {return data_.size();}
-    inline bool empty() const {return data_.empty();}
+  // Some inspectors
+  inline std::size_t size() const { return data_.size(); }
+  inline bool empty() const { return data_.empty(); }
 
-    // The following function returns nullptr if
-    // one of the argument indices is out of range
-    inline const Item* get(const unsigned itemIndex,
-                           const unsigned arrayIndex) const
-    {
-        if (itemIndex < data_.size() && arrayIndex < N)
-            return data_[itemIndex][arrayIndex].get();
-        else
-            return nullptr;
-    }
+  // The following function returns nullptr if
+  // one of the argument indices is out of range
+  inline const Item* get(const unsigned itemIndex, const unsigned arrayIndex) const {
+    if (itemIndex < data_.size() && arrayIndex < N)
+      return data_[itemIndex][arrayIndex].get();
+    else
+      return nullptr;
+  }
 
-    // The following function throws an exception if
-    // one of the argument indices is out of range
-    inline Item& at(const unsigned itemIndex, const unsigned arrayIndex) const
-        {return *data_.at(itemIndex).at(arrayIndex);}
+  // The following function throws an exception if
+  // one of the argument indices is out of range
+  inline Item& at(const unsigned itemIndex, const unsigned arrayIndex) const {
+    return *data_.at(itemIndex).at(arrayIndex);
+  }
 
-    // Deep comparison for equality is useful for testing serialization
-    bool operator==(const HcalItemArrayColl& r) const
-    {
-        const std::size_t sz = data_.size();
-        if (sz != r.data_.size())
-            return false;
-        for (std::size_t i=0; i<sz; ++i)
-            for (unsigned j=0; j<N; ++j)
-                if (!(*data_[i][j] == *r.data_[i][j]))
-                    return false;
-        return true;
-    }
+  // Deep comparison for equality is useful for testing serialization
+  bool operator==(const HcalItemArrayColl& r) const {
+    const std::size_t sz = data_.size();
+    if (sz != r.data_.size())
+      return false;
+    for (std::size_t i = 0; i < sz; ++i)
+      for (unsigned j = 0; j < N; ++j)
+        if (!(*data_[i][j] == *r.data_[i][j]))
+          return false;
+    return true;
+  }
 
-    inline bool operator!=(const HcalItemArrayColl& r) const
-        {return !(*this == r);}
+  inline bool operator!=(const HcalItemArrayColl& r) const { return !(*this == r); }
 
 private:
-    typedef boost::array<std::shared_ptr<Item>,N> StoredArray;
-    std::vector<StoredArray> data_;
+  typedef boost::array<std::shared_ptr<Item>, N> StoredArray;
+  std::vector<StoredArray> data_;
 
-    friend class boost::serialization::access;
+  friend class boost::serialization::access;
 
-    template<class Archive>
-    inline void serialize(Archive & ar, unsigned /* version */)
-    {
-        ar & data_;
-    }
+  template <class Archive>
+  inline void serialize(Archive& ar, unsigned /* version */) {
+    ar& data_;
+  }
 };
 
 // boost serialization version number for this template
 namespace boost {
-    namespace serialization {
-        template<typename Item, unsigned N>
-        struct version<HcalItemArrayColl<Item,N> >
-        {
-            BOOST_STATIC_CONSTANT(int, value = 1);
-        };
-    }
-}
+  namespace serialization {
+    template <typename Item, unsigned N>
+    struct version<HcalItemArrayColl<Item, N> > {
+      BOOST_STATIC_CONSTANT(int, value = 1);
+    };
+  }  // namespace serialization
+}  // namespace boost
 
-#endif // CondFormats_HcalObjects_HcalItemArrayColl_h
+#endif  // CondFormats_HcalObjects_HcalItemArrayColl_h

--- a/CondFormats/HcalObjects/interface/HcalItemArrayCollById.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayCollById.h
@@ -69,7 +69,7 @@ public:
     inline void setDefault(InputArray& arr)
     {
         for (unsigned i=0; i<N; ++i)
-            default_[i] = boost::shared_ptr<Item>(arr[i].release());
+            default_[i] = std::shared_ptr<Item>(arr[i].release());
     }
 
     // Size of the internal collection, not counting the default
@@ -143,7 +143,7 @@ protected:
     }
 
 private:
-    typedef boost::array<boost::shared_ptr<Item>,N> StoredArray;
+    typedef boost::array<std::shared_ptr<Item>,N> StoredArray;
 
     HcalItemArrayColl<Item,N> coll_;
     HcalIndexLookup lookup_;

--- a/CondFormats/HcalObjects/interface/HcalItemArrayCollById.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayCollById.h
@@ -23,151 +23,139 @@
 // is owned by this collection. Its ownership will also become
 // shared if a copy of this collection is made.
 //
-template<typename Item, unsigned N>
-class HcalItemArrayCollById : public AbsHcalAlgoData
-{
+template <typename Item, unsigned N>
+class HcalItemArrayCollById : public AbsHcalAlgoData {
 public:
-    typedef Item value_type;
-    typedef typename HcalItemArrayColl<Item,N>::InputArray InputArray;
-    static constexpr unsigned arraySize() {return N;}
+  typedef Item value_type;
+  typedef typename HcalItemArrayColl<Item, N>::InputArray InputArray;
+  static constexpr unsigned arraySize() { return N; }
 
-    // Dummy constructor. To be used for deserialization only.
-    inline HcalItemArrayCollById()
-        : transformCode_(HcalDetIdTransform::N_TRANSFORMS) {}
+  // Dummy constructor. To be used for deserialization only.
+  inline HcalItemArrayCollById() : transformCode_(HcalDetIdTransform::N_TRANSFORMS) {}
 
-    // Normal constructor
-    HcalItemArrayCollById(const HcalItemArrayColl<Item,N>& coll,
-                          const HcalIndexLookup& indexLookupTable,
-                          const unsigned detIdTransformCode,
-                          InputArray& defaultFunctors)
-        : coll_(coll),
-          lookup_(indexLookupTable),
-          transformCode_(detIdTransformCode)
-    {
-        // Check that the lookup table is valid for this application
-        if (lookup_.hasDuplicateIds())
-            throw cms::Exception("In HcalItemArrayCollById constructor:"
-                                 " invalid lookup table");
+  // Normal constructor
+  HcalItemArrayCollById(const HcalItemArrayColl<Item, N>& coll,
+                        const HcalIndexLookup& indexLookupTable,
+                        const unsigned detIdTransformCode,
+                        InputArray& defaultFunctors)
+      : coll_(coll), lookup_(indexLookupTable), transformCode_(detIdTransformCode) {
+    // Check that the lookup table is valid for this application
+    if (lookup_.hasDuplicateIds())
+      throw cms::Exception(
+          "In HcalItemArrayCollById constructor:"
+          " invalid lookup table");
 
-        // Check that the lookup table is consistent with the size
-        // of the collection
-        const unsigned maxIndex = lookup_.largestIndex();
-        if (maxIndex != HcalIndexLookup::InvalidIndex &&
-            maxIndex >= coll_.size())
-            throw cms::Exception("In HcalItemArrayCollById constructor:"
-                         " collection and lookup table are inconsistent");
+    // Check that the lookup table is consistent with the size
+    // of the collection
+    const unsigned maxIndex = lookup_.largestIndex();
+    if (maxIndex != HcalIndexLookup::InvalidIndex && maxIndex >= coll_.size())
+      throw cms::Exception(
+          "In HcalItemArrayCollById constructor:"
+          " collection and lookup table are inconsistent");
 
-        HcalDetIdTransform::validateCode(transformCode_);
-        
-        // Take care of the default array
-        setDefault(defaultFunctors);
-    }
+    HcalDetIdTransform::validateCode(transformCode_);
 
-    inline virtual ~HcalItemArrayCollById() {}
+    // Take care of the default array
+    setDefault(defaultFunctors);
+  }
 
-    // Modifier for the default array of items
-    inline void setDefault(InputArray& arr)
-    {
-        for (unsigned i=0; i<N; ++i)
-            default_[i] = std::shared_ptr<Item>(arr[i].release());
-    }
+  inline virtual ~HcalItemArrayCollById() {}
 
-    // Size of the internal collection, not counting the default
-    inline std::size_t size() const {return coll_.size();}
+  // Modifier for the default array of items
+  inline void setDefault(InputArray& arr) {
+    for (unsigned i = 0; i < N; ++i)
+      default_[i] = std::shared_ptr<Item>(arr[i].release());
+  }
 
-    // Look up the index into the collection by detector id
-    inline unsigned getIndex(const HcalDetId& id) const
-        {return lookup_.find(HcalDetIdTransform::transform(id, transformCode_));}
+  // Size of the internal collection, not counting the default
+  inline std::size_t size() const { return coll_.size(); }
 
-    // Item lookup by its index and array index. If item lookup
-    // by index fails and the array index is not out of bounds,
-    // default item is returned.
-    inline const Item* getByIndex(const unsigned itemIndex,
-                                  const unsigned arrayIndex) const
-    {
-        const Item* f = coll_.get(itemIndex, arrayIndex);
-        if (f == nullptr && arrayIndex < N)
-            f = default_[arrayIndex].get();
-        return f;
-    }
+  // Look up the index into the collection by detector id
+  inline unsigned getIndex(const HcalDetId& id) const {
+    return lookup_.find(HcalDetIdTransform::transform(id, transformCode_));
+  }
 
-    // The following method will return nullptr if
-    // there is no corresponding default
-    inline const Item* getDefault(const unsigned arrayIndex) const
-    {
-        if (arrayIndex < N) return default_[arrayIndex].get();
-        else return nullptr;
-    }
+  // Item lookup by its index and array index. If item lookup
+  // by index fails and the array index is not out of bounds,
+  // default item is returned.
+  inline const Item* getByIndex(const unsigned itemIndex, const unsigned arrayIndex) const {
+    const Item* f = coll_.get(itemIndex, arrayIndex);
+    if (f == nullptr && arrayIndex < N)
+      f = default_[arrayIndex].get();
+    return f;
+  }
 
-    // Convenience function for getting what we need by id.
-    // Note that, if you are simply cycling over array indices,
-    // it will be more efficient to retrieve the item index
-    // first and then use "getByIndex" method.
-    inline const Item* get(const HcalDetId& id,
-                           const unsigned arrayIndex) const
-        {return getByIndex(getIndex(id), arrayIndex);}
+  // The following method will return nullptr if
+  // there is no corresponding default
+  inline const Item* getDefault(const unsigned arrayIndex) const {
+    if (arrayIndex < N)
+      return default_[arrayIndex].get();
+    else
+      return nullptr;
+  }
 
-    // Similar comment applies here if you are just cycling over array indices
-    inline const Item& at(const HcalDetId& id,
-                          const unsigned arrayIndex) const
-    {
-        const Item* f = getByIndex(getIndex(id), arrayIndex);
-        if (f == nullptr) throw cms::Exception(
-            "In HcalItemArrayCollById::at: invalid detector id");
-        return *f;
-    }
+  // Convenience function for getting what we need by id.
+  // Note that, if you are simply cycling over array indices,
+  // it will be more efficient to retrieve the item index
+  // first and then use "getByIndex" method.
+  inline const Item* get(const HcalDetId& id, const unsigned arrayIndex) const {
+    return getByIndex(getIndex(id), arrayIndex);
+  }
+
+  // Similar comment applies here if you are just cycling over array indices
+  inline const Item& at(const HcalDetId& id, const unsigned arrayIndex) const {
+    const Item* f = getByIndex(getIndex(id), arrayIndex);
+    if (f == nullptr)
+      throw cms::Exception("In HcalItemArrayCollById::at: invalid detector id");
+    return *f;
+  }
 
 protected:
-    virtual bool isEqual(const AbsHcalAlgoData& other) const override
-    {
-        const HcalItemArrayCollById& r =
-            static_cast<const HcalItemArrayCollById&>(other);
-        if (coll_ != r.coll_)
-            return false;
-        if (lookup_ != r.lookup_)
-            return false;
-        if (transformCode_ != r.transformCode_)
-            return false;
-        for (unsigned j=0; j<N; ++j)
-        {
-            // The default may or may not be there
-            const bool ld = default_[j].get();
-            const bool rd = r.default_[j].get();
-            if (ld != rd)
-                return false;
-            if (ld)
-                if (!(*default_[j] == *r.default_[j]))
-                    return false;
-        }
-        return true;
+  virtual bool isEqual(const AbsHcalAlgoData& other) const override {
+    const HcalItemArrayCollById& r = static_cast<const HcalItemArrayCollById&>(other);
+    if (coll_ != r.coll_)
+      return false;
+    if (lookup_ != r.lookup_)
+      return false;
+    if (transformCode_ != r.transformCode_)
+      return false;
+    for (unsigned j = 0; j < N; ++j) {
+      // The default may or may not be there
+      const bool ld = default_[j].get();
+      const bool rd = r.default_[j].get();
+      if (ld != rd)
+        return false;
+      if (ld)
+        if (!(*default_[j] == *r.default_[j]))
+          return false;
     }
+    return true;
+  }
 
 private:
-    typedef boost::array<std::shared_ptr<Item>,N> StoredArray;
+  typedef boost::array<std::shared_ptr<Item>, N> StoredArray;
 
-    HcalItemArrayColl<Item,N> coll_;
-    HcalIndexLookup lookup_;
-    StoredArray default_;
-    uint32_t transformCode_;
+  HcalItemArrayColl<Item, N> coll_;
+  HcalIndexLookup lookup_;
+  StoredArray default_;
+  uint32_t transformCode_;
 
-    friend class boost::serialization::access;
+  friend class boost::serialization::access;
 
-    template<class Archive>
-    inline void serialize(Archive & ar, unsigned /* version */)
-    {
-        ar & coll_ & lookup_ & default_ & transformCode_;
-    }
+  template <class Archive>
+  inline void serialize(Archive& ar, unsigned /* version */) {
+    ar& coll_& lookup_& default_& transformCode_;
+  }
 };
 
 // boost serialization version number for this template
 namespace boost {
-    namespace serialization {
-        template<typename Item, unsigned N>
-        struct version<HcalItemArrayCollById<Item,N> >
-        {
-            BOOST_STATIC_CONSTANT(int, value = 1);
-        };
-    }
-}
+  namespace serialization {
+    template <typename Item, unsigned N>
+    struct version<HcalItemArrayCollById<Item, N> > {
+      BOOST_STATIC_CONSTANT(int, value = 1);
+    };
+  }  // namespace serialization
+}  // namespace boost
 
-#endif // CondFormats_HcalObjects_HcalItemArrayCollById_h
+#endif  // CondFormats_HcalObjects_HcalItemArrayCollById_h

--- a/CondFormats/HcalObjects/interface/HcalItemColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemColl.h
@@ -22,7 +22,7 @@ public:
   typedef Item value_type;
 
   // The following method adds a new item to the collection
-  inline void push_back(std::unique_ptr<Item> ptr) { data_.push_back(boost::shared_ptr<Item>(ptr.release())); }
+  inline void push_back(std::unique_ptr<Item> ptr) { data_.push_back(std::shared_ptr<Item>(ptr.release())); }
 
   // Other modifiers
   inline void clear() { data_.clear(); }
@@ -57,7 +57,7 @@ public:
   inline bool operator!=(const HcalItemColl& r) const { return !(*this == r); }
 
 private:
-  std::vector<boost::shared_ptr<Item> > data_;
+  std::vector<std::shared_ptr<Item> > data_;
 
   friend class boost::serialization::access;
 

--- a/CondFormats/HcalObjects/interface/HcalItemCollById.h
+++ b/CondFormats/HcalObjects/interface/HcalItemCollById.h
@@ -57,7 +57,7 @@ public:
   inline ~HcalItemCollById() override {}
 
   // Modifier for the default item
-  inline void setDefault(std::unique_ptr<Item> f) { default_ = boost::shared_ptr<Item>(f.release()); }
+  inline void setDefault(std::unique_ptr<Item> f) { default_ = std::shared_ptr<Item>(f.release()); }
 
   // Size of the internal collection, not counting the default
   inline std::size_t size() const { return coll_.size(); }
@@ -117,7 +117,7 @@ protected:
 private:
   HcalItemColl<Item> coll_;
   HcalIndexLookup lookup_;
-  boost::shared_ptr<Item> default_;
+  std::shared_ptr<Item> default_;
   uint32_t transformCode_;
 
   friend class boost::serialization::access;

--- a/CondFormats/HcalObjects/interface/HcalLinearCompositionFunctor.h
+++ b/CondFormats/HcalObjects/interface/HcalLinearCompositionFunctor.h
@@ -20,7 +20,7 @@ public:
   inline HcalLinearCompositionFunctor() : a_(0.0), b_(0.0) {}
 
   // Normal constructor
-  HcalLinearCompositionFunctor(boost::shared_ptr<AbsHcalFunctor> p, double a, double b);
+  HcalLinearCompositionFunctor(std::shared_ptr<AbsHcalFunctor> p, double a, double b);
 
   inline ~HcalLinearCompositionFunctor() override {}
 
@@ -39,7 +39,7 @@ protected:
   }
 
 private:
-  boost::shared_ptr<AbsHcalFunctor> other_;
+  std::shared_ptr<AbsHcalFunctor> other_;
   double a_;
   double b_;
 

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h
@@ -10,7 +10,7 @@
 
 class OOTPileupCorrectionColl {
 public:
-  inline void add(const std::string& name, const std::string& category, boost::shared_ptr<AbsOOTPileupCorrection> ptr) {
+  inline void add(const std::string& name, const std::string& category, std::shared_ptr<AbsOOTPileupCorrection> ptr) {
     data_[category][name] = ptr;
   }
 
@@ -18,7 +18,7 @@ public:
 
   inline bool empty() const { return data_.empty(); }
 
-  boost::shared_ptr<AbsOOTPileupCorrection> get(const std::string& name, const std::string& category) const;
+  std::shared_ptr<AbsOOTPileupCorrection> get(const std::string& name, const std::string& category) const;
 
   bool exists(const std::string& name, const std::string& category) const;
 
@@ -27,7 +27,7 @@ public:
   inline bool operator!=(const OOTPileupCorrectionColl& r) const { return !(*this == r); }
 
 private:
-  typedef std::map<std::string, boost::shared_ptr<AbsOOTPileupCorrection> > PtrMap;
+  typedef std::map<std::string, std::shared_ptr<AbsOOTPileupCorrection> > PtrMap;
   typedef std::map<std::string, PtrMap> DataMap;
   DataMap data_;
 

--- a/CondFormats/HcalObjects/src/HcalLinearCompositionFunctor.cc
+++ b/CondFormats/HcalObjects/src/HcalLinearCompositionFunctor.cc
@@ -2,7 +2,7 @@
 
 #include "CondFormats/HcalObjects/interface/HcalLinearCompositionFunctor.h"
 
-HcalLinearCompositionFunctor::HcalLinearCompositionFunctor(boost::shared_ptr<AbsHcalFunctor> p,
+HcalLinearCompositionFunctor::HcalLinearCompositionFunctor(std::shared_ptr<AbsHcalFunctor> p,
                                                            const double ia,
                                                            const double ib)
     : other_(p), a_(ia), b_(ib) {

--- a/CondFormats/HcalObjects/src/OOTPileupCorrectionColl.cc
+++ b/CondFormats/HcalObjects/src/OOTPileupCorrectionColl.cc
@@ -10,7 +10,7 @@ bool OOTPileupCorrectionColl::exists(const std::string& name, const std::string&
     return !(dit->second.find(name) == dit->second.end());
 }
 
-boost::shared_ptr<AbsOOTPileupCorrection> OOTPileupCorrectionColl::get(const std::string& name,
+std::shared_ptr<AbsOOTPileupCorrection> OOTPileupCorrectionColl::get(const std::string& name,
                                                                        const std::string& category) const {
   DataMap::const_iterator dit = data_.find(category);
   if (dit == data_.end())

--- a/CondFormats/HcalObjects/src/OOTPileupCorrectionColl.cc
+++ b/CondFormats/HcalObjects/src/OOTPileupCorrectionColl.cc
@@ -11,7 +11,7 @@ bool OOTPileupCorrectionColl::exists(const std::string& name, const std::string&
 }
 
 std::shared_ptr<AbsOOTPileupCorrection> OOTPileupCorrectionColl::get(const std::string& name,
-                                                                       const std::string& category) const {
+                                                                     const std::string& category) const {
   DataMap::const_iterator dit = data_.find(category);
   if (dit == data_.end())
     throw cms::Exception("In OOTPileupCorrectionColl::get: unknown category");

--- a/CondFormats/HcalObjects/test/testHcalPayloadIO.cc
+++ b/CondFormats/HcalObjects/test/testHcalPayloadIO.cc
@@ -56,7 +56,7 @@ try{
     session.createDatabase();
     unsigned int iw;
     for (iw = 0; iw < nobjects; ++iw )   {
-      boost::shared_ptr<Payload> payload(new Payload);
+      std::shared_ptr<Payload> payload(new Payload);
       std::string pToken = session.storeObject(payload.get(),className);
       payTok.push_back(pToken);
     }
@@ -78,7 +78,7 @@ try{
     
     unsigned int ir;
     for (ir = 0; ir < payTok.size(); ++ir )   {
-      boost::shared_ptr<Payload> payload = session.getTypedObject<Payload>(payTok[ir]);
+      std::shared_ptr<Payload> payload = session.getTypedObject<Payload>(payTok[ir]);
       Payload const & p = *payload;
     }
 

--- a/CondFormats/HcalObjects/test/testHcalPayloadIO.cc
+++ b/CondFormats/HcalObjects/test/testHcalPayloadIO.cc
@@ -16,7 +16,6 @@
 
 #include <vector>
 
-
 #ifdef ALLCLASSES
 #include "CondFormats/THEPACKAGE/src/classes.h"
 #else
@@ -25,84 +24,73 @@
 
 typedef THECLASS Payload;
 
+int main(int argc, char**) {
+  try {
+    // this is the correct container name following cms rules (container name = C++ type name)
+    //  std::string className = cond::classNameForTypeId(typeid(THECLASS));
 
+    // for this test we use the class name THECLASS as typed by the user including space, typedefs etc
+    // this makes further mapping query easier at script level....
+    std::string className("THECLASS");
 
-int main(int argc, char** ) {
-try{
+    edmplugin::PluginManager::Config config;
+    edmplugin::PluginManager::configure(edmplugin::standard::config());
 
-  // this is the correct container name following cms rules (container name = C++ type name) 
-  //  std::string className = cond::classNameForTypeId(typeid(THECLASS));
+    unsigned int nobjects = 10;
+    std::vector<std::string> payTok;
 
-  // for this test we use the class name THECLASS as typed by the user including space, typedefs etc
-  // this makes further mapping query easier at script level....
-  std::string className("THECLASS");
-  
-  edmplugin::PluginManager::Config config;
-  edmplugin::PluginManager::configure(edmplugin::standard::config());
+    //write....
+    {
+      cond::DbConnection conn;
+      conn.configure(cond::CmsDefaults);
+      cond::DbSession session = conn.createSession();
+      session.open("sqlite_file:test.db", false);
 
-  unsigned int nobjects=10;
-  std::vector<std::string> payTok;
+      cond::DbScopedTransaction tr(session);
+      tr.start(false);
+      session.createDatabase();
+      unsigned int iw;
+      for (iw = 0; iw < nobjects; ++iw) {
+        std::shared_ptr<Payload> payload(new Payload);
+        std::string pToken = session.storeObject(payload.get(), className);
+        payTok.push_back(pToken);
+      }
 
-
-  //write....
-  {
-    cond::DbConnection conn;
-    conn.configure( cond::CmsDefaults );
-    cond::DbSession session = conn.createSession();
-    session.open("sqlite_file:test.db",false);
-    
-    cond::DbScopedTransaction tr(session);
-    tr.start(false);
-    session.createDatabase();
-    unsigned int iw;
-    for (iw = 0; iw < nobjects; ++iw )   {
-      std::shared_ptr<Payload> payload(new Payload);
-      std::string pToken = session.storeObject(payload.get(),className);
-      payTok.push_back(pToken);
-    }
-    
-    tr.commit();
-    if (payTok.size()!=nobjects)
-      throw std::string("not all object written!");
- 
-  }
-
-  //read....
-  {
-    cond::DbConnection conn;
-    conn.configure( cond::CmsDefaults );
-    cond::DbSession session = conn.createSession();
-    session.open("sqlite_file:test.db");
-    cond::DbScopedTransaction tr(session);
-    tr.start(true);
-    
-    unsigned int ir;
-    for (ir = 0; ir < payTok.size(); ++ir )   {
-      std::shared_ptr<Payload> payload = session.getTypedObject<Payload>(payTok[ir]);
-      Payload const & p = *payload;
+      tr.commit();
+      if (payTok.size() != nobjects)
+        throw std::string("not all object written!");
     }
 
-    if (ir!=nobjects)
-      throw std::string("not all object read!");
- 
-    tr.commit();
-    
-  }
- 
+    //read....
+    {
+      cond::DbConnection conn;
+      conn.configure(cond::CmsDefaults);
+      cond::DbSession session = conn.createSession();
+      session.open("sqlite_file:test.db");
+      cond::DbScopedTransaction tr(session);
+      tr.start(true);
 
+      unsigned int ir;
+      for (ir = 0; ir < payTok.size(); ++ir) {
+        std::shared_ptr<Payload> payload = session.getTypedObject<Payload>(payTok[ir]);
+        Payload const& p = *payload;
+      }
 
-  //read 
+      if (ir != nobjects)
+        throw std::string("not all object read!");
 
+      tr.commit();
+    }
 
+    //read
 
- } catch (const std::exception& e){
-  std::cout << "ERROR: " << e.what() << std::endl;
+  } catch (const std::exception& e) {
+    std::cout << "ERROR: " << e.what() << std::endl;
     throw;
- } catch (const std::string& e){
-  std::cout << "ERROR: " << e << std::endl;
-  throw;
- }
+  } catch (const std::string& e) {
+    std::cout << "ERROR: " << e << std::endl;
+    throw;
+  }
 
   return 0;
 }
-

--- a/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+
 #include "TFormula.h"
 
 #include "CondFormats/PhysicsToolsObjects/interface/BinningPointByMap.h"
@@ -65,7 +65,7 @@ protected:
 
   bool isOk(const BinningPointByMap& p, unsigned int&) const;
 
-  const boost::shared_ptr<TFormula>& getFormula(PerformanceResult::ResultType, const BinningPointByMap&) const;
+  const std::shared_ptr<TFormula>& getFormula(PerformanceResult::ResultType, const BinningPointByMap&) const;
 
   //
   // now this is a vector, since we can have different rectangular regions in the same object
@@ -82,7 +82,7 @@ protected:
   //
 
   // the compiled functions
-  std::vector<std::vector<boost::shared_ptr<TFormula> > > compiledFormulas_ COND_TRANSIENT;
+  std::vector<std::vector<std::shared_ptr<TFormula> > > compiledFormulas_ COND_TRANSIENT;
   ;
 
   COND_SERIALIZABLE;

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
@@ -28,7 +28,7 @@ void PerformancePayloadFromBinnedTFormula::initialize() {
 }
 
 const std::shared_ptr<TFormula>& PerformancePayloadFromBinnedTFormula::getFormula(PerformanceResult::ResultType r,
-                                                                                    const BinningPointByMap& p) const {
+                                                                                  const BinningPointByMap& p) const {
   //
   // chooses the correct rectangular region
   //

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
@@ -14,12 +14,12 @@ using namespace std;
 void PerformancePayloadFromBinnedTFormula::initialize() {
   boost::uuids::random_generator gen;
   for (unsigned int t = 0; t < pls.size(); ++t) {
-    std::vector<boost::shared_ptr<TFormula> > temp;
+    std::vector<std::shared_ptr<TFormula> > temp;
     for (unsigned int i = 0; i < (pls[t].formulas()).size(); ++i) {
       boost::uuids::uuid uniqueFormulaId = gen();
       const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
       PhysicsTFormulaPayload tmp = pls[t];
-      boost::shared_ptr<TFormula> tt(new TFormula(formulaUniqueName.c_str(), tmp.formulas()[i].c_str()));
+      std::shared_ptr<TFormula> tt(new TFormula(formulaUniqueName.c_str(), tmp.formulas()[i].c_str()));
       tt->Compile();
       temp.push_back(tt);
     }
@@ -27,7 +27,7 @@ void PerformancePayloadFromBinnedTFormula::initialize() {
   }
 }
 
-const boost::shared_ptr<TFormula>& PerformancePayloadFromBinnedTFormula::getFormula(PerformanceResult::ResultType r,
+const std::shared_ptr<TFormula>& PerformancePayloadFromBinnedTFormula::getFormula(PerformanceResult::ResultType r,
                                                                                     const BinningPointByMap& p) const {
   //
   // chooses the correct rectangular region
@@ -57,7 +57,7 @@ float PerformancePayloadFromBinnedTFormula::getResult(PerformanceResult::ResultT
   //  TFormula * formula = compiledFormulas_[resultPos(r)];
   //
 
-  const boost::shared_ptr<TFormula>& formula = getFormula(r, p);
+  const std::shared_ptr<TFormula>& formula = getFormula(r, p);
 
   // prepare the vector to pass, order counts!!!
   //
@@ -128,7 +128,7 @@ void PerformancePayloadFromBinnedTFormula::printFormula(PerformanceResult::Resul
   }
 
   // nice, what to do here???
-  const boost::shared_ptr<TFormula>& formula = getFormula(res, point);
+  const std::shared_ptr<TFormula>& formula = getFormula(res, point);
   unsigned int whichone;
   isOk(point, whichone);
   cout << "-- Formula: " << formula->GetExpFormula("p") << endl;

--- a/CondFormats/RPCObjects/interface/L1RPCConeBuilder.h
+++ b/CondFormats/RPCObjects/interface/L1RPCConeBuilder.h
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include "CondFormats/L1TObjects/interface/L1RPCConeDefinition.h"
 #include <memory>
+#include <boost/serialization/shared_ptr.hpp>
 
 class L1RPCConeBuilder {
 public:

--- a/CondFormats/Serialization/interface/Equal.h
+++ b/CondFormats/Serialization/interface/Equal.h
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <cmath>
 
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 namespace cond {

--- a/CondFormats/Serialization/interface/Equal.h
+++ b/CondFormats/Serialization/interface/Equal.h
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <cmath>
 
-#include <boost/shared_ptr.hpp>
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
@@ -126,7 +125,6 @@ namespace cond {
 
     equal_pointer(std::unique_ptr);
     equal_pointer(std::shared_ptr);
-    equal_pointer(boost::shared_ptr);
 #undef equal_pointer
 
     template <typename T, std::size_t N>

--- a/CondFormats/Serialization/interface/Serializable.h
+++ b/CondFormats/Serialization/interface/Serializable.h
@@ -19,8 +19,8 @@
 #include <boost/serialization/set.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/bitset.hpp>
-#include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/utility.hpp>
 
 // We cannot include Equal.h here since it is C++11
 namespace cond {

--- a/CondFormats/Serialization/test/testSerializationEqual.cpp
+++ b/CondFormats/Serialization/test/testSerializationEqual.cpp
@@ -222,7 +222,7 @@ int main() {
   si2.reset();
   sin.reset();
 
-  boost::shared_ptr<int> bsi1(pi1, deleter), bs2i1(pi1, deleter), bsi1b(pi1b, deleter), bsi2(pi2, deleter),
+  std::shared_ptr<int> bsi1(pi1, deleter), bs2i1(pi1, deleter), bsi1b(pi1b, deleter), bsi2(pi2, deleter),
       bsin(pin, deleter);
   same(bsi1, bsi1);
   same(bsi1, bs2i1);  // diff object, same addr (may happen since it is a shared_ptr)

--- a/CondTools/Hcal/test/make_HFPhase1PMTParams_dummy.cc
+++ b/CondTools/Hcal/test/make_HFPhase1PMTParams_dummy.cc
@@ -9,8 +9,8 @@ std::unique_ptr<HFPhase1PMTParams> make_HFPhase1PMTParams_dummy() {
   // Create "all pass" HFPhase1PMTData configuration
   HFPhase1PMTData::Cuts cuts;
 
-  cuts[HFPhase1PMTData::T_0_MIN] = boost::shared_ptr<AbsHcalFunctor>(new HcalConstFunctor(-FLT_MAX));
-  cuts[HFPhase1PMTData::T_0_MAX] = boost::shared_ptr<AbsHcalFunctor>(new HcalConstFunctor(FLT_MAX));
+  cuts[HFPhase1PMTData::T_0_MIN] = std::shared_ptr<AbsHcalFunctor>(new HcalConstFunctor(-FLT_MAX));
+  cuts[HFPhase1PMTData::T_0_MAX] = std::shared_ptr<AbsHcalFunctor>(new HcalConstFunctor(FLT_MAX));
   cuts[HFPhase1PMTData::T_1_MIN] = cuts[HFPhase1PMTData::T_0_MIN];
   cuts[HFPhase1PMTData::T_1_MAX] = cuts[HFPhase1PMTData::T_0_MAX];
   cuts[HFPhase1PMTData::ASYMM_MIN] = cuts[HFPhase1PMTData::T_0_MIN];

--- a/CondTools/Hcal/test/make_HFPhase1PMTParams_test.cc
+++ b/CondTools/Hcal/test/make_HFPhase1PMTParams_test.cc
@@ -64,15 +64,13 @@ std::unique_ptr<HFPhase1PMTParams> make_HFPhase1PMTParams_test() {
   pts.clear();
   pts.push_back(P(5.0 * minChargeAsymm, 2.0));
   pts.push_back(P(10.0 * minChargeAsymm, 1.0));
-  cuts[HFPhase1PMTData::ASYMM_MAX] =
-      std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::ASYMM_MAX] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 
 #ifdef BAD_BOOST_VERSION
   pts.clear();
   pts.push_back(P(5.0 * minChargeAsymm, -2.0));
   pts.push_back(P(10.0 * minChargeAsymm, -1.0));
-  cuts[HFPhase1PMTData::ASYMM_MIN] =
-      std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::ASYMM_MIN] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 #else
   cuts[HFPhase1PMTData::ASYMM_MIN] =
       std::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::ASYMM_MAX], -1.0, 0.0));
@@ -92,8 +90,7 @@ std::unique_ptr<HFPhase1PMTParams> make_HFPhase1PMTParams_test() {
   pts.clear();
   pts.push_back(P(5.0 * minChargeAsymm, -2.0 + 1.0));
   pts.push_back(P(10.0 * minChargeAsymm, -1.0 + 1.0));
-  cuts[HFPhase1PMTData::ASYMM_MIN] =
-      std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::ASYMM_MIN] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 #else
   cuts[HFPhase1PMTData::ASYMM_MIN] =
       std::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::ASYMM_MAX], -1.0, 1.0));

--- a/CondTools/Hcal/test/make_HFPhase1PMTParams_test.cc
+++ b/CondTools/Hcal/test/make_HFPhase1PMTParams_test.cc
@@ -31,23 +31,23 @@ std::unique_ptr<HFPhase1PMTParams> make_HFPhase1PMTParams_test() {
   pts.push_back(P(minCharge0, 10.0));
   pts.push_back(P(10.0 * minCharge0, 12.0));
   pts.push_back(P(20.0 * minCharge0, 13.0));
-  cuts[HFPhase1PMTData::T_0_MIN] = boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::T_0_MIN] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 
   pts.clear();
   pts.push_back(P(minCharge0, 20.0));
   pts.push_back(P(10.0 * minCharge0, 18.0));
   pts.push_back(P(20.0 * minCharge0, 17.0));
-  cuts[HFPhase1PMTData::T_0_MAX] = boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::T_0_MAX] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 
 #ifdef BAD_BOOST_VERSION
   pts.clear();
   pts.push_back(P(minCharge0, 10.0 - 2.0));
   pts.push_back(P(10.0 * minCharge0, 12.0 - 2.0));
   pts.push_back(P(20.0 * minCharge0, 13.0 - 2.0));
-  cuts[HFPhase1PMTData::T_1_MIN] = boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::T_1_MIN] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 #else
   cuts[HFPhase1PMTData::T_1_MIN] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::T_0_MIN], 1.0, -2.0));
+      std::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::T_0_MIN], 1.0, -2.0));
 #endif
 
 #ifdef BAD_BOOST_VERSION
@@ -55,27 +55,27 @@ std::unique_ptr<HFPhase1PMTParams> make_HFPhase1PMTParams_test() {
   pts.push_back(P(minCharge0, 20.0 + 2.0));
   pts.push_back(P(10.0 * minCharge0, 18.0 + 2.0));
   pts.push_back(P(20.0 * minCharge0, 17.0 + 2.0));
-  cuts[HFPhase1PMTData::T_1_MAX] = boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+  cuts[HFPhase1PMTData::T_1_MAX] = std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 #else
   cuts[HFPhase1PMTData::T_1_MAX] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::T_0_MAX], 1.0, 2.0));
+      std::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::T_0_MAX], 1.0, 2.0));
 #endif
 
   pts.clear();
   pts.push_back(P(5.0 * minChargeAsymm, 2.0));
   pts.push_back(P(10.0 * minChargeAsymm, 1.0));
   cuts[HFPhase1PMTData::ASYMM_MAX] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+      std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 
 #ifdef BAD_BOOST_VERSION
   pts.clear();
   pts.push_back(P(5.0 * minChargeAsymm, -2.0));
   pts.push_back(P(10.0 * minChargeAsymm, -1.0));
   cuts[HFPhase1PMTData::ASYMM_MIN] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+      std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 #else
   cuts[HFPhase1PMTData::ASYMM_MIN] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::ASYMM_MAX], -1.0, 0.0));
+      std::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::ASYMM_MAX], -1.0, 0.0));
 #endif
 
   std::unique_ptr<HFPhase1PMTData> defaultItem(new HFPhase1PMTData(cuts, minCharge0, minCharge1, minChargeAsymm));
@@ -93,10 +93,10 @@ std::unique_ptr<HFPhase1PMTParams> make_HFPhase1PMTParams_test() {
   pts.push_back(P(5.0 * minChargeAsymm, -2.0 + 1.0));
   pts.push_back(P(10.0 * minChargeAsymm, -1.0 + 1.0));
   cuts[HFPhase1PMTData::ASYMM_MIN] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
+      std::shared_ptr<AbsHcalFunctor>(new HcalPiecewiseLinearFunctor(pts, false, false));
 #else
   cuts[HFPhase1PMTData::ASYMM_MIN] =
-      boost::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::ASYMM_MAX], -1.0, 1.0));
+      std::shared_ptr<AbsHcalFunctor>(new HcalLinearCompositionFunctor(cuts[HFPhase1PMTData::ASYMM_MAX], -1.0, 1.0));
 #endif
 
   std::unique_ptr<HFPhase1PMTData> firstItem(new HFPhase1PMTData(cuts, minCharge0, minCharge1, minChargeAsymm));

--- a/CondTools/Hcal/test/readme_HFPhase1PMTParams.txt
+++ b/CondTools/Hcal/test/readme_HFPhase1PMTParams.txt
@@ -254,7 +254,7 @@ HFPhase1PMTData(const Cuts& cutShapes, const float charge0,
 The constructor arguments are:
 
 cutShapes -- An array of cut shapes. "Cuts" is actually a typedef:
-             typedef boost::array<boost::shared_ptr<AbsHcalFunctor>,6> Cuts.
+             typedef boost::array<std::shared_ptr<AbsHcalFunctor>,6> Cuts.
              AbsHcalFunctor is a base class for functors which define
              an arbitrary univariate function. In this case, the functors
              describe the dependence of the cut value on the collected

--- a/CondTools/L1Trigger/interface/OMDSReader.h
+++ b/CondTools/L1Trigger/interface/OMDSReader.h
@@ -203,7 +203,7 @@ namespace l1t {
     coral::ITable& table = schema.tableHandle(tableName);
 
     // Pointer is deleted automatically at end of function.
-    boost::shared_ptr<coral::IQuery> query(table.newQuery());
+    std::shared_ptr<coral::IQuery> query(table.newQuery());
 
     // Construct query
     std::vector<std::string>::const_iterator it = columnNames.begin();

--- a/CondTools/L1Trigger/src/OMDSReader.cc
+++ b/CondTools/L1Trigger/src/OMDSReader.cc
@@ -84,7 +84,7 @@ namespace l1t {
     coral::ITable& table = schema.tableHandle(tableName);
 
     // Pointer is deleted automatically at end of function.
-    boost::shared_ptr<coral::IQuery> query(table.newQuery());
+    std::shared_ptr<coral::IQuery> query(table.newQuery());
 
     // Construct query
     std::vector<std::string>::const_iterator it = columnNames.begin();

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Cache.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Cache.h
@@ -27,8 +27,6 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include "boost/tuple/tuple.hpp"
 
-
-
 #include "CSCDQM_Logger.h"
 #include "CSCDQM_HistoDef.h"
 #include "CSCDQM_MonitorObject.h"

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Cache.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Cache.h
@@ -27,7 +27,7 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include "boost/tuple/tuple.hpp"
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "CSCDQM_Logger.h"
 #include "CSCDQM_HistoDef.h"

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.h
@@ -29,8 +29,6 @@
 #include <xercesc/dom/DOMNodeList.hpp>
 #include <xercesc/dom/DOMElement.hpp>
 
-
-
 #include "CSCDQM_Exception.h"
 #include "CSCDQM_Logger.h"
 #include "CSCDQM_Utility.h"

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.h
@@ -29,7 +29,7 @@
 #include <xercesc/dom/DOMNodeList.hpp>
 #include <xercesc/dom/DOMElement.hpp>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "CSCDQM_Exception.h"
 #include "CSCDQM_Logger.h"

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Configuration.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Configuration.h
@@ -44,7 +44,7 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 
-#include <boost/shared_ptr.hpp>
+
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Configuration.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Configuration.h
@@ -44,7 +44,6 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 
-
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "boost/cstdint.hpp"
-#include "boost/shared_ptr.hpp"
+
 #include <set>
 #include <map>
 #include <memory>
@@ -59,10 +59,10 @@ namespace sistrip {
       std::vector<uint32_t> outputTotalEventCounters_;
       std::vector<uint32_t> outputL1ACounters_;
       std::vector<uint32_t> outputAPVAddresses_;
-      boost::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputScopeDigisVector_;
-      boost::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputPayloadDigisVector_;
-      boost::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputReorderedDigisVector_;
-      boost::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputVirginRawDigisVector_;
+      std::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputScopeDigisVector_;
+      std::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputPayloadDigisVector_;
+      std::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputReorderedDigisVector_;
+      std::shared_ptr<std::vector<edm::DetSet<SiStripRawDigi> > > outputVirginRawDigisVector_;
       std::set<uint16_t> alreadyMergedFeds_;
     };
 
@@ -118,7 +118,7 @@ namespace sistrip {
       Counters* p;
       bool deleteP;
     };
-    typedef boost::shared_ptr<CountersWrapper> CountersPtr;
+    typedef std::shared_ptr<CountersWrapper> CountersPtr;
 
     //source for spy events
     typedef edm::VectorInputSource Source;

--- a/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
@@ -325,6 +325,6 @@ void SiStripQualityHotStripIdentifierRoot::bookHistos() {
     LogDebug("SiStripQualityHotStripIdentifierRoot")
         << " [SiStripQualityHotStripIdentifierRoot::bookHistos] detid " << detid << std::endl;
 
-    ClusterPositionHistoMap[detid] = boost::shared_ptr<TH1F>(new TH1F(*(*iter)->getTH1F()));
+    ClusterPositionHistoMap[detid] = std::shared_ptr<TH1F>(new TH1F(*(*iter)->getTH1F()));
   }
 }

--- a/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
+++ b/DQMOffline/CalibTracker/plugins/SiStripQualityHotStripIdentifierRoot.cc
@@ -9,8 +9,9 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <sstream>
 
 #include "TH1F.h"
@@ -325,6 +326,6 @@ void SiStripQualityHotStripIdentifierRoot::bookHistos() {
     LogDebug("SiStripQualityHotStripIdentifierRoot")
         << " [SiStripQualityHotStripIdentifierRoot::bookHistos] detid " << detid << std::endl;
 
-    ClusterPositionHistoMap[detid] = std::shared_ptr<TH1F>(new TH1F(*(*iter)->getTH1F()));
+    ClusterPositionHistoMap[detid] = std::make_shared<TH1F>(*(*iter)->getTH1F());
   }
 }

--- a/DQMServices/Components/test/DummyBookFillDQMStore.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStore.cc
@@ -150,8 +150,8 @@ private:
   void fillerDispose();
 
   // ----------member data ---------------------------
-  std::vector<boost::shared_ptr<FillerBase>> m_runFillers;
-  std::vector<boost::shared_ptr<FillerBase>> m_lumiFillers;
+  std::vector<std::shared_ptr<FillerBase>> m_runFillers;
+  std::vector<std::shared_ptr<FillerBase>> m_lumiFillers;
   std::string folder_;
   bool m_fillRuns;
   bool m_fillLumis;
@@ -207,10 +207,10 @@ void DummyBookFillDQMStore::bookHistograms() {
     for (; it != ite; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_runFillers.push_back(boost::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, false)));
+          m_runFillers.push_back(std::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, false)));
           break;
         case 2:
-          m_runFillers.push_back(boost::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, false)));
+          m_runFillers.push_back(std::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, false)));
           break;
       }
     }
@@ -221,10 +221,10 @@ void DummyBookFillDQMStore::bookHistograms() {
     for (auto it = elements_.begin(), itEnd = elements_.end(); it != itEnd; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_lumiFillers.push_back(boost::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, true)));
+          m_lumiFillers.push_back(std::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, true)));
           break;
         case 2:
-          m_lumiFillers.push_back(boost::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, true)));
+          m_lumiFillers.push_back(std::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, true)));
           break;
       }
     }

--- a/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
@@ -150,8 +150,8 @@ private:
   void fillerDispose();
 
   // ----------member data ---------------------------
-  std::vector<boost::shared_ptr<FillerBase>> m_runFillers;
-  std::vector<boost::shared_ptr<FillerBase>> m_lumiFillers;
+  std::vector<std::shared_ptr<FillerBase>> m_runFillers;
+  std::vector<std::shared_ptr<FillerBase>> m_lumiFillers;
   std::string folder_;
   bool m_fillRuns;
   bool m_fillLumis;
@@ -201,10 +201,10 @@ void DummyBookFillDQMStoreMultiThread::bookHistograms(DQMStore::IBooker& iBooker
     for (; it != ite; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_runFillers.push_back(boost::shared_ptr<FillerBase>(new TH1FFiller(*it, iBooker, false)));
+          m_runFillers.push_back(std::shared_ptr<FillerBase>(new TH1FFiller(*it, iBooker, false)));
           break;
         case 2:
-          m_runFillers.push_back(boost::shared_ptr<FillerBase>(new TH2FFiller(*it, iBooker, false)));
+          m_runFillers.push_back(std::shared_ptr<FillerBase>(new TH2FFiller(*it, iBooker, false)));
           break;
       }
     }
@@ -215,10 +215,10 @@ void DummyBookFillDQMStoreMultiThread::bookHistograms(DQMStore::IBooker& iBooker
     for (auto it = elements_.begin(), itEnd = elements_.end(); it != itEnd; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_lumiFillers.push_back(boost::shared_ptr<FillerBase>(new TH1FFiller(*it, iBooker, true)));
+          m_lumiFillers.push_back(std::shared_ptr<FillerBase>(new TH1FFiller(*it, iBooker, true)));
           break;
         case 2:
-          m_lumiFillers.push_back(boost::shared_ptr<FillerBase>(new TH2FFiller(*it, iBooker, true)));
+          m_lumiFillers.push_back(std::shared_ptr<FillerBase>(new TH2FFiller(*it, iBooker, true)));
           break;
       }
     }

--- a/DQMServices/Components/test/DummyHarvestingClient.cc
+++ b/DQMServices/Components/test/DummyHarvestingClient.cc
@@ -194,7 +194,7 @@ private:
 
   void bookHistograms();
   // ----------member data ---------------------------
-  std::vector<boost::shared_ptr<CumulatorBase> > m_lumiCumulators;
+  std::vector<std::shared_ptr<CumulatorBase> > m_lumiCumulators;
   bool m_cumulateRuns;
   bool m_cumulateLumis;
   bool book_at_constructor_;
@@ -234,10 +234,10 @@ DummyHarvestingClient::DummyHarvestingClient(const edm::ParameterSet& iConfig)
     for (; it != ite; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_lumiCumulators.push_back(boost::shared_ptr<CumulatorBase>(new TH1FCumulator(*it, *dstore, folder, true)));
+          m_lumiCumulators.push_back(std::shared_ptr<CumulatorBase>(new TH1FCumulator(*it, *dstore, folder, true)));
           break;
         case 2:
-          m_lumiCumulators.push_back(boost::shared_ptr<CumulatorBase>(new TH2FCumulator(*it, *dstore, folder, true)));
+          m_lumiCumulators.push_back(std::shared_ptr<CumulatorBase>(new TH2FCumulator(*it, *dstore, folder, true)));
           break;
       }
     }

--- a/DQMServices/Components/test/DummyTestReadDQMStore.cc
+++ b/DQMServices/Components/test/DummyTestReadDQMStore.cc
@@ -173,8 +173,8 @@ private:
   void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
-  std::vector<boost::shared_ptr<ReaderBase> > m_runReaders;
-  std::vector<boost::shared_ptr<ReaderBase> > m_lumiReaders;
+  std::vector<std::shared_ptr<ReaderBase> > m_runReaders;
+  std::vector<std::shared_ptr<ReaderBase> > m_lumiReaders;
   std::string folder_;
   unsigned int runToCheck_;
   using PSets = std::vector<edm::ParameterSet>;
@@ -246,10 +246,10 @@ void DummyTestReadDQMStore::beginRun(edm::Run const& iRun, edm::EventSetup const
   for (auto it = runElements.begin(), itEnd = runElements.end(); it != itEnd; ++it) {
     switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
       case 1:
-        m_runReaders.push_back(boost::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, folder_, false)));
+        m_runReaders.push_back(std::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, folder_, false)));
         break;
       case 2:
-        m_runReaders.push_back(boost::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, folder_, false)));
+        m_runReaders.push_back(std::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, folder_, false)));
         break;
     }
   }
@@ -257,10 +257,10 @@ void DummyTestReadDQMStore::beginRun(edm::Run const& iRun, edm::EventSetup const
   for (auto it = lumiElements.begin(), itEnd = lumiElements.end(); it != itEnd; ++it) {
     switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
       case 1:
-        m_lumiReaders.push_back(boost::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, folder_, true)));
+        m_lumiReaders.push_back(std::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, folder_, true)));
         break;
       case 2:
-        m_lumiReaders.push_back(boost::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, folder_, true)));
+        m_lumiReaders.push_back(std::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, folder_, true)));
         break;
     }
   }
@@ -282,7 +282,7 @@ void DummyTestReadDQMStore::endRun(edm::Run const& iRun, edm::EventSetup const&)
 
 // ------------ method called when starting to processes a luminosity block  ------------
 void DummyTestReadDQMStore::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-  //   for(std::vector<boost::shared_ptr<ReaderBase> >::iterator it = m_lumiReaders.begin(), itEnd = m_lumiReaders.end();
+  //   for(std::vector<std::shared_ptr<ReaderBase> >::iterator it = m_lumiReaders.begin(), itEnd = m_lumiReaders.end();
   //   it != itEnd;
   //   ++it) {
   //     (*it)->reset();

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -17,7 +17,7 @@
 #include <map>
 #include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+
 #include <boost/filesystem.hpp>
 #include "TFile.h"
 #include "TTree.h"
@@ -211,7 +211,7 @@ private:
   std::string m_fileName;
   std::string m_logicalFileName;
   std::unique_ptr<TFile> m_file;
-  std::vector<boost::shared_ptr<TreeHelperBase> > m_treeHelpers;
+  std::vector<std::shared_ptr<TreeHelperBase> > m_treeHelpers;
 
   unsigned int m_run;
   unsigned int m_lumi;
@@ -282,7 +282,7 @@ DQMRootOutputModule::DQMRootOutputModule(edm::ParameterSet const& pset)
       m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
       m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
       m_file(nullptr),
-      m_treeHelpers(kNIndicies, boost::shared_ptr<TreeHelperBase>()),
+      m_treeHelpers(kNIndicies, std::shared_ptr<TreeHelperBase>()),
       m_presentHistoryIndex(0),
       m_filterOnRun(pset.getUntrackedParameter<unsigned int>("filterOnRun")),
       m_enableMultiThread(false),
@@ -351,13 +351,13 @@ void DQMRootOutputModule::openFile(edm::FileBlock const&) {
   m_indicesTree->SetDirectory(m_file.get());
 
   unsigned int i = 0;
-  for (std::vector<boost::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
+  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
                                                                  itEnd = m_treeHelpers.end();
        it != itEnd;
        ++it, ++i) {
     //std::cout <<"making "<<kTypeNames[i]<<std::endl;
     TTree* tree = new TTree(kTypeNames[i], kTypeNames[i]);
-    *it = boost::shared_ptr<TreeHelperBase>(makeHelper(i, tree, m_fullNameBufferPtr));
+    *it = std::shared_ptr<TreeHelperBase>(makeHelper(i, tree, m_fullNameBufferPtr));
     tree->SetDirectory(m_file.get());  //TFile takes ownership
   }
 
@@ -411,7 +411,7 @@ void DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput con
   //Now store the relationship between run/lumi and indices in the other TTrees
   bool storedLumiIndex = false;
   unsigned int typeIndex = 0;
-  for (std::vector<boost::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
+  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
                                                                  itEnd = m_treeHelpers.end();
        it != itEnd;
        ++it, ++typeIndex) {
@@ -468,7 +468,7 @@ void DQMRootOutputModule::writeRun(edm::RunForOutput const& iRun) {
 
   //Now store the relationship between run/lumi and indices in the other TTrees
   unsigned int typeIndex = 0;
-  for (std::vector<boost::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
+  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
                                                                  itEnd = m_treeHelpers.end();
        it != itEnd;
        ++it, ++typeIndex) {

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -351,8 +351,7 @@ void DQMRootOutputModule::openFile(edm::FileBlock const&) {
   m_indicesTree->SetDirectory(m_file.get());
 
   unsigned int i = 0;
-  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
-                                                                 itEnd = m_treeHelpers.end();
+  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(), itEnd = m_treeHelpers.end();
        it != itEnd;
        ++it, ++i) {
     //std::cout <<"making "<<kTypeNames[i]<<std::endl;
@@ -411,8 +410,7 @@ void DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput con
   //Now store the relationship between run/lumi and indices in the other TTrees
   bool storedLumiIndex = false;
   unsigned int typeIndex = 0;
-  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
-                                                                 itEnd = m_treeHelpers.end();
+  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(), itEnd = m_treeHelpers.end();
        it != itEnd;
        ++it, ++typeIndex) {
     if ((*it)->wasFilled()) {
@@ -468,8 +466,7 @@ void DQMRootOutputModule::writeRun(edm::RunForOutput const& iRun) {
 
   //Now store the relationship between run/lumi and indices in the other TTrees
   unsigned int typeIndex = 0;
-  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(),
-                                                                 itEnd = m_treeHelpers.end();
+  for (std::vector<std::shared_ptr<TreeHelperBase> >::iterator it = m_treeHelpers.begin(), itEnd = m_treeHelpers.end();
        it != itEnd;
        ++it, ++typeIndex) {
     if ((*it)->wasFilled()) {

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -385,7 +385,7 @@ private:
   std::vector<RunLumiToRange> m_runlumiToRange;
   std::unique_ptr<TFile> m_file;
   std::vector<TTree*> m_trees;
-  std::vector<boost::shared_ptr<TreeReaderBase> > m_treeReaders;
+  std::vector<std::shared_ptr<TreeReaderBase> > m_treeReaders;
 
   std::list<unsigned int> m_orderedIndices;
   edm::ProcessHistoryID m_lastSeenReducedPHID;
@@ -440,7 +440,7 @@ DQMRootSource::DQMRootSource(edm::ParameterSet const& iPSet, const edm::InputSou
       m_fileIndex(0),
       m_presentlyOpenFileIndex(0),
       m_trees(kNIndicies, static_cast<TTree*>(nullptr)),
-      m_treeReaders(kNIndicies, boost::shared_ptr<TreeReaderBase>()),
+      m_treeReaders(kNIndicies, std::shared_ptr<TreeReaderBase>()),
       m_lastSeenReducedPHID(),
       m_lastSeenRun(0),
       m_lastSeenReducedPHID2(),
@@ -671,7 +671,7 @@ void DQMRootSource::readElements() {
       ++m_presentIndexItr;
 
     if (runLumiRange.m_type != kNoTypesStored) {
-      boost::shared_ptr<TreeReaderBase> reader = m_treeReaders[runLumiRange.m_type];
+      std::shared_ptr<TreeReaderBase> reader = m_treeReaders[runLumiRange.m_type];
       ULong64_t index = runLumiRange.m_firstIndex;
       ULong64_t endIndex = runLumiRange.m_lastIndex + 1;
       for (; index != endIndex; ++index) {

--- a/DQMServices/FwkIO/test/DummyFillDQMStore.cc
+++ b/DQMServices/FwkIO/test/DummyFillDQMStore.cc
@@ -134,8 +134,8 @@ private:
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
   // ----------member data ---------------------------
-  std::vector<boost::shared_ptr<FillerBase> > m_runFillers;
-  std::vector<boost::shared_ptr<FillerBase> > m_lumiFillers;
+  std::vector<std::shared_ptr<FillerBase> > m_runFillers;
+  std::vector<std::shared_ptr<FillerBase> > m_lumiFillers;
   bool m_fillRuns;
   bool m_fillLumis;
 };
@@ -163,10 +163,10 @@ DummyFillDQMStore::DummyFillDQMStore(const edm::ParameterSet& iConfig)
     for (PSets::const_iterator it = elements.begin(), itEnd = elements.end(); it != itEnd; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_runFillers.push_back(boost::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, false)));
+          m_runFillers.push_back(std::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, false)));
           break;
         case 2:
-          m_runFillers.push_back(boost::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, false)));
+          m_runFillers.push_back(std::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, false)));
           break;
       }
     }
@@ -177,10 +177,10 @@ DummyFillDQMStore::DummyFillDQMStore(const edm::ParameterSet& iConfig)
     for (PSets::const_iterator it = elements.begin(), itEnd = elements.end(); it != itEnd; ++it) {
       switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
         case 1:
-          m_lumiFillers.push_back(boost::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, true)));
+          m_lumiFillers.push_back(std::shared_ptr<FillerBase>(new TH1FFiller(*it, *dstore, true)));
           break;
         case 2:
-          m_lumiFillers.push_back(boost::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, true)));
+          m_lumiFillers.push_back(std::shared_ptr<FillerBase>(new TH2FFiller(*it, *dstore, true)));
           break;
       }
     }
@@ -228,7 +228,7 @@ void DummyFillDQMStore::beginRun(edm::Run const&, edm::EventSetup const&) {}
 
 // ------------ method called when ending the processing of a run  ------------
 void DummyFillDQMStore::endRun(edm::Run const&, edm::EventSetup const&) {
-  for (std::vector<boost::shared_ptr<FillerBase> >::iterator it = m_runFillers.begin(), itEnd = m_runFillers.end();
+  for (std::vector<std::shared_ptr<FillerBase> >::iterator it = m_runFillers.begin(), itEnd = m_runFillers.end();
        it != itEnd;
        ++it) {
     (*it)->fill();
@@ -237,7 +237,7 @@ void DummyFillDQMStore::endRun(edm::Run const&, edm::EventSetup const&) {
 
 // ------------ method called when starting to processes a luminosity block  ------------
 void DummyFillDQMStore::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-  for (std::vector<boost::shared_ptr<FillerBase> >::iterator it = m_lumiFillers.begin(), itEnd = m_lumiFillers.end();
+  for (std::vector<std::shared_ptr<FillerBase> >::iterator it = m_lumiFillers.begin(), itEnd = m_lumiFillers.end();
        it != itEnd;
        ++it) {
     (*it)->reset();
@@ -246,7 +246,7 @@ void DummyFillDQMStore::beginLuminosityBlock(edm::LuminosityBlock const&, edm::E
 
 // ------------ method called when ending the processing of a luminosity block  ------------
 void DummyFillDQMStore::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-  for (std::vector<boost::shared_ptr<FillerBase> >::iterator it = m_lumiFillers.begin(), itEnd = m_lumiFillers.end();
+  for (std::vector<std::shared_ptr<FillerBase> >::iterator it = m_lumiFillers.begin(), itEnd = m_lumiFillers.end();
        it != itEnd;
        ++it) {
     (*it)->fill();

--- a/DQMServices/FwkIO/test/DummyReadDQMStore.cc
+++ b/DQMServices/FwkIO/test/DummyReadDQMStore.cc
@@ -168,8 +168,8 @@ private:
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
   // ----------member data ---------------------------
-  std::vector<boost::shared_ptr<ReaderBase> > m_runReaders;
-  std::vector<boost::shared_ptr<ReaderBase> > m_lumiReaders;
+  std::vector<std::shared_ptr<ReaderBase> > m_runReaders;
+  std::vector<std::shared_ptr<ReaderBase> > m_lumiReaders;
 };
 
 //
@@ -192,10 +192,10 @@ DummyReadDQMStore::DummyReadDQMStore(const edm::ParameterSet& iConfig) {
   for (PSets::const_iterator it = runElements.begin(), itEnd = runElements.end(); it != itEnd; ++it) {
     switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
       case 1:
-        m_runReaders.push_back(boost::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, false)));
+        m_runReaders.push_back(std::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, false)));
         break;
       case 2:
-        m_runReaders.push_back(boost::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, false)));
+        m_runReaders.push_back(std::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, false)));
         break;
     }
   }
@@ -205,10 +205,10 @@ DummyReadDQMStore::DummyReadDQMStore(const edm::ParameterSet& iConfig) {
   for (PSets::const_iterator it = lumiElements.begin(), itEnd = lumiElements.end(); it != itEnd; ++it) {
     switch (it->getUntrackedParameter<unsigned int>("type", 1)) {
       case 1:
-        m_lumiReaders.push_back(boost::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, true)));
+        m_lumiReaders.push_back(std::shared_ptr<ReaderBase>(new TH1FReader(*it, *dstore, true)));
         break;
       case 2:
-        m_lumiReaders.push_back(boost::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, true)));
+        m_lumiReaders.push_back(std::shared_ptr<ReaderBase>(new TH2FReader(*it, *dstore, true)));
         break;
     }
   }
@@ -255,7 +255,7 @@ void DummyReadDQMStore::beginRun(edm::Run const&, edm::EventSetup const&) {}
 
 // ------------ method called when ending the processing of a run  ------------
 void DummyReadDQMStore::endRun(edm::Run const&, edm::EventSetup const&) {
-  for (std::vector<boost::shared_ptr<ReaderBase> >::iterator it = m_runReaders.begin(), itEnd = m_runReaders.end();
+  for (std::vector<std::shared_ptr<ReaderBase> >::iterator it = m_runReaders.begin(), itEnd = m_runReaders.end();
        it != itEnd;
        ++it) {
     (*it)->read();
@@ -267,7 +267,7 @@ void DummyReadDQMStore::beginLuminosityBlock(edm::LuminosityBlock const&, edm::E
 
 // ------------ method called when ending the processing of a luminosity block  ------------
 void DummyReadDQMStore::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-  for (std::vector<boost::shared_ptr<ReaderBase> >::iterator it = m_lumiReaders.begin(), itEnd = m_lumiReaders.end();
+  for (std::vector<std::shared_ptr<ReaderBase> >::iterator it = m_lumiReaders.begin(), itEnd = m_lumiReaders.end();
        it != itEnd;
        ++it) {
     (*it)->read();

--- a/DQMServices/StreamerIO/plugins/TriggerSelector.h
+++ b/DQMServices/StreamerIO/plugins/TriggerSelector.h
@@ -7,7 +7,7 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Framework/interface/EventSelector.h"
 
-#include "boost/shared_ptr.hpp"
+
 
 #include <vector>
 #include <string>
@@ -127,12 +127,12 @@ namespace dqmservices {
       int trigBit_;
     };
 
-    boost::shared_ptr<TreeElement> masterElement_;
+    std::shared_ptr<TreeElement> masterElement_;
 
     // keep a copy of initialization string
     std::string expression_;
 
-    boost::shared_ptr<edm::EventSelector> eventSelector_;
+    std::shared_ptr<edm::EventSelector> eventSelector_;
     bool useOld_;
 
     static const bool debug_ = false;

--- a/DQMServices/StreamerIO/plugins/TriggerSelector.h
+++ b/DQMServices/StreamerIO/plugins/TriggerSelector.h
@@ -7,8 +7,6 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Framework/interface/EventSelector.h"
 
-
-
 #include <vector>
 #include <string>
 

--- a/DataFormats/GeometrySurface/test/referencecounted_t.cpp
+++ b/DataFormats/GeometrySurface/test/referencecounted_t.cpp
@@ -2,7 +2,7 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-//#include "boost/intrusive_ptr.hpp"
+//
 
 #include "DataFormats/GeometrySurface/interface/ReferenceCounted.h"
 

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include <boost/regex.hpp>
-#include <boost/shared_ptr.hpp>
+
 #include <typeinfo>
 #include <iostream>
 #include <type_traits>
@@ -27,7 +27,7 @@ namespace pat {
       virtual bool operator()(const CandRefType &cand, const std::string &role) const = 0;
     };
     // smart pointer to the filter
-    typedef boost::shared_ptr<const ParticleFilter> ParticleFilterPtr;
+    typedef std::shared_ptr<const ParticleFilter> ParticleFilterPtr;
   }  // namespace eventhypothesis
   // the class
   class EventHypothesis {

--- a/DetectorDescription/Parser/test/testmat.cpp
+++ b/DetectorDescription/Parser/test/testmat.cpp
@@ -14,7 +14,6 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Presence.h"
-#include "boost/smart_ptr/shared_ptr.hpp"
 
 int main(int argc, char* argv[]) {
   // Copied from example stand-alone program in Message Logger July 18, 2007
@@ -29,9 +28,9 @@ int main(int argc, char* argv[]) {
     //     In particular, the job hangs as soon as the output buffer fills up.
     //     That's because, without the message service, there is no mechanism for
     //     emptying the buffers.
-    boost::shared_ptr<edm::Presence> theMessageServicePresence;
+    std::shared_ptr<edm::Presence> theMessageServicePresence;
     theMessageServicePresence =
-        boost::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->makePresence("MessageServicePresence").release());
+        std::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->makePresence("MessageServicePresence").release());
 
     // C.  Manufacture a configuration and establish it.
     std::string config =

--- a/DetectorDescription/RegressionTest/test/testDDCompactView.cpp
+++ b/DetectorDescription/RegressionTest/test/testDDCompactView.cpp
@@ -18,7 +18,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Presence.h"
-#include "boost/smart_ptr/shared_ptr.hpp"
+
 
 int main(int argc, char* argv[]) {
   // Copied from example stand-alone program in Message Logger July 18, 2007
@@ -33,9 +33,9 @@ int main(int argc, char* argv[]) {
     //     In particular, the job hangs as soon as the output buffer fills up.
     //     That's because, without the message service, there is no mechanism for
     //     emptying the buffers.
-    boost::shared_ptr<edm::Presence> theMessageServicePresence;
+    std::shared_ptr<edm::Presence> theMessageServicePresence;
     theMessageServicePresence =
-        boost::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->makePresence("MessageServicePresence").release());
+        std::shared_ptr<edm::Presence>(edm::PresenceFactory::get()->makePresence("MessageServicePresence").release());
 
     // C.  Manufacture a configuration and establish it.
     std::string config =

--- a/DetectorDescription/RegressionTest/test/testDDCompactView.cpp
+++ b/DetectorDescription/RegressionTest/test/testDDCompactView.cpp
@@ -19,7 +19,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Presence.h"
 
-
 int main(int argc, char* argv[]) {
   // Copied from example stand-alone program in Message Logger July 18, 2007
   std::string const kProgramName = argv[0];

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassFit.cpp
@@ -19,7 +19,7 @@
 #include "TCanvas.h"
 #include "TROOT.h"
 //#include "TStyle.h"
-#include <boost/shared_ptr.hpp>
+
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <algorithm> 

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassFit.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <exception>
 #include <iterator>
 #include <string>
@@ -32,98 +32,87 @@ using namespace boost;
 namespace po = boost::program_options;
 
 // A helper function to simplify the main part.
-template<class T>
-ostream& operator<<(ostream& os, const vector<T>& v) {
-  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " ")); 
+template <class T>
+ostream &operator<<(ostream &os, const vector<T> &v) {
+  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " "));
   return os;
 }
 
 typedef funct::GaussIntegrator IntegratorConv;
 
-int main(int ac, char *av[]) { 
+int main(int ac, char *av[]) {
   try {
     double fMin, fMax;
     string ext;
     po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help", "produce help message")
-      ("include-path,I", po::value< vector<string> >(), 
-       "include path")
-      ("input-file", po::value< vector<string> >(), "input file")
-      ("min,m", po::value<double>(&fMin)->default_value(80), "minimum value for fit range")
-      ("max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")
-      ("breitwigner", "fit to a breit-wigner")
-      ("gauss", "fit to a gaussian")
-      ("bwinter", "fit to the breit-wigner plus interference term")
-      ("bwintgam", "fit to the breit-wigner plus interference term and gamma propagator")
-      ("convbwg", "fit to the convolution between a breit-wigner and a gaussian")
-      ("convbwinterg", 
-       "fit to the convolution between a breit-wigner plus interference term and a gaussian")
-      ("convbwintgamg", 
-       "fit to the convolution of a breit-wigner plus interference term and gamma propagator and a gaussian")
-      ("convbw2gf", 
-       "fit to the convolution between a breit-wigner and a linear combination of fixed gaussians")
-      ("convbwf2g", 
-       "fit to the convolution between a fixed breit-wigner and a linear combination of gaussians")
-      ("convbwint2gf", 
-       "fit to the convolution between the breit-wigner plus interference term and a linear combination of fixed gaussians")
-      ("convbwintf2g", 
-       "fit to the convolution between the fixed breit-wigner plus interference term and a linear combination of gaussians")
-      ("convbwintgam2gf", 
-       "fit to the convolution of the breit-wigner plus interference term and gamma propagator with a linear combination of fixed gaussians")
-      ("convbwintgamf2g", 
-       "fit to the convolution of the fixed breit-wigner plus interference term and gamma propagator with a linear combination of gaussians")
-      ("output-file,O", po::value<string>(&ext)->default_value(".ps"), 
-       "output file format")
-      ;
-    
+    desc.add_options()("help", "produce help message")("include-path,I", po::value<vector<string> >(), "include path")(
+        "input-file", po::value<vector<string> >(), "input file")(
+        "min,m", po::value<double>(&fMin)->default_value(80), "minimum value for fit range")(
+        "max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")(
+        "breitwigner", "fit to a breit-wigner")("gauss", "fit to a gaussian")(
+        "bwinter", "fit to the breit-wigner plus interference term")(
+        "bwintgam", "fit to the breit-wigner plus interference term and gamma propagator")(
+        "convbwg", "fit to the convolution between a breit-wigner and a gaussian")(
+        "convbwinterg", "fit to the convolution between a breit-wigner plus interference term and a gaussian")(
+        "convbwintgamg",
+        "fit to the convolution of a breit-wigner plus interference term and gamma propagator and a gaussian")(
+        "convbw2gf", "fit to the convolution between a breit-wigner and a linear combination of fixed gaussians")(
+        "convbwf2g", "fit to the convolution between a fixed breit-wigner and a linear combination of gaussians")(
+        "convbwint2gf",
+        "fit to the convolution between the breit-wigner plus interference term and a linear combination of fixed "
+        "gaussians")("convbwintf2g",
+                     "fit to the convolution between the fixed breit-wigner plus interference term and a linear "
+                     "combination of gaussians")("convbwintgam2gf",
+                                                 "fit to the convolution of the breit-wigner plus interference term "
+                                                 "and gamma propagator with a linear combination of fixed gaussians")(
+        "convbwintgamf2g",
+        "fit to the convolution of the fixed breit-wigner plus interference term and gamma propagator with a linear "
+        "combination of gaussians")(
+        "output-file,O", po::value<string>(&ext)->default_value(".ps"), "output file format");
+
     po::positional_options_description p;
     p.add("input-file", -1);
-    
+
     po::variables_map vm;
-    po::store(po::command_line_parser(ac, av).
-	      options(desc).positional(p).run(), vm);
+    po::store(po::command_line_parser(ac, av).options(desc).positional(p).run(), vm);
     po::notify(vm);
-    
+
     if (vm.count("help")) {
       cout << "Usage: options_description [options]\n";
       cout << desc;
       return 0;
     }
-    
+
     if (vm.count("include-path")) {
-      cout << "Include paths are: " 
-	   << vm["include-path"].as< vector<string> >() << "\n";
+      cout << "Include paths are: " << vm["include-path"].as<vector<string> >() << "\n";
     }
-    
+
     vector<string> v_file;
-    vector<TH1D*> v_ZMassHistos;
+    vector<TH1D *> v_ZMassHistos;
     vector<string> v_eps;
-    
+
     if (vm.count("input-file")) {
-      cout << "Input files are: " 
-	   << vm["input-file"].as< vector<string> >() << "\n";
-      v_file = vm["input-file"].as< vector<string> >();
-      for(vector<string>::const_iterator it = v_file.begin(); 
-	  it != v_file.end(); ++it) { 
-	TFile * root_file = new TFile(it->c_str(),"read");
-	TDirectory *Histos = (TDirectory*) root_file->GetDirectory("ZHisto");
-	TDirectory *RecoHistos = (TDirectory*) Histos->GetDirectory("ZRecoHisto");
-	TH1D * zMass = (TH1D*) RecoHistos->Get("ZMass");
-	zMass->Rebin(4); //remember...
-	zMass->GetXaxis()->SetTitle("#mu #mu invariant mass (GeV/c^{2})");
-	v_ZMassHistos.push_back(zMass);
-	gROOT->SetStyle("Plain");
-	//gStyle->SetOptFit(1111);
-	string f_string = *it;
-	replace(f_string.begin(), f_string.end(), '.', '_');
-	string eps_string = f_string + ext;
-	v_eps.push_back(eps_string);
-	cout << ">>> histogram loaded\n";
+      cout << "Input files are: " << vm["input-file"].as<vector<string> >() << "\n";
+      v_file = vm["input-file"].as<vector<string> >();
+      for (vector<string>::const_iterator it = v_file.begin(); it != v_file.end(); ++it) {
+        TFile *root_file = new TFile(it->c_str(), "read");
+        TDirectory *Histos = (TDirectory *)root_file->GetDirectory("ZHisto");
+        TDirectory *RecoHistos = (TDirectory *)Histos->GetDirectory("ZRecoHisto");
+        TH1D *zMass = (TH1D *)RecoHistos->Get("ZMass");
+        zMass->Rebin(4);  //remember...
+        zMass->GetXaxis()->SetTitle("#mu #mu invariant mass (GeV/c^{2})");
+        v_ZMassHistos.push_back(zMass);
+        gROOT->SetStyle("Plain");
+        //gStyle->SetOptFit(1111);
+        string f_string = *it;
+        replace(f_string.begin(), f_string.end(), '.', '_');
+        string eps_string = f_string + ext;
+        v_eps.push_back(eps_string);
+        cout << ">>> histogram loaded\n";
       }
       cout << v_file.size() << ", " << v_ZMassHistos.size() << ", " << v_eps.size() << endl;
-      cout <<">>> Input files loaded\n";
-    } 	
+      cout << ">>> Input files loaded\n";
+    }
 
     IntegratorConv integratorConv(1.e-5);
 
@@ -136,8 +125,8 @@ int main(int ac, char *av[]) {
     //Parameters for fits with gaussians
     funct::Parameter yield("Yield", 482000);
     funct::Parameter alpha("Alpha", 0.771);
-    funct::Parameter mean("Mean", 0); //0.229
-    funct::Parameter sigma1("Sigma 1", 1.027); 
+    funct::Parameter mean("Mean", 0);  //0.229
+    funct::Parameter sigma1("Sigma 1", 1.027);
     funct::Parameter sigma2("Sigma 2", 2.94);
     funct::Constant c_yield(yield), c_alpha(alpha);
     funct::Number _1(1);
@@ -145,854 +134,906 @@ int main(int ac, char *av[]) {
     if (vm.count("breitwigner")) {
       cout << "Fitting histograms in input file to a Breit-Wigner\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass << endl; 
-      cout << gamma << endl; 
-      for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	cout << ">>> load histogram\n";
-	TH1D * zMass = v_ZMassHistos[i];
-	cout << ">>> histogram loaded\n";
-	funct::BreitWigner bw(mass, gamma);
-	funct::Constant c_yield(yield);
-	typedef funct::Product<funct::Constant, funct::BreitWigner>::type FitFunction;
-	FitFunction f = c_yield * bw;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mass, gamma);
-	fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str());
-	fun.SetLineColor(kRed);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassFitBW_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassFitBW_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        cout << ">>> load histogram\n";
+        TH1D *zMass = v_ZMassHistos[i];
+        cout << ">>> histogram loaded\n";
+        funct::BreitWigner bw(mass, gamma);
+        funct::Constant c_yield(yield);
+        typedef funct::Product<funct::Constant, funct::BreitWigner>::type FitFunction;
+        FitFunction f = c_yield * bw;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mass, gamma);
+        fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitBW_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitBW_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
-    if (vm.count("gauss")) {
-      cout << "Fitting histograms in input files to a Gaussian\n"; 
-      cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mean << endl; 
-      cout << sigma1 << endl;
-      for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassHistos[i]; 
-	funct::Gaussian gaus(mean, sigma1);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
-	FitFunction f = c * gaus;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mean, 0.001, 80, 100);
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma1);
-	fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma1.name().c_str());
-	fun.SetLineColor(kRed);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassFitG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassFitG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
-      }
-    }
-    
-    if (vm.count("bwinter")) {
-	  cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl;
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Constant c(yield);
-	    typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	    FitFunction f = c * zls;
-	    cout << "set functions" << endl;
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.fixParameter(f_gamma.name());
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	    fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-	                    f_gamma.name().c_str(), f_int.name().c_str());
-	    fun.SetLineColor(kRed); 
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitBwIn_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitBwIn_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("bwint"))
-	{
-	  cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and gamma propagator\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl;
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Constant c(yield);
-	    typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	    FitFunction f = c * zls;
-	    cout << "set functions" << endl;
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	    fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-	                    f_gamma.name().c_str(), f_int.name().c_str());
-	    fun.SetLineColor(kRed); 
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitBwInGam_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitBwInGam_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("bwintgam"))
-	{
-	  cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and gamma propagator\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Constant c(yield);
-	    typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	    FitFunction f = c * zls;
-	    cout << "set functions" << endl;
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	    fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-	                    f_gamma.name().c_str(), f_int.name().c_str());
-	    fun.SetLineColor(kRed); 
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitBwInGam_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitBwInGam_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("convbwg")) {
-	  cout << "Fitting histograms in input files to the convolution between a Breit Wigner and a Gaussian\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::BreitWigner bw(mass, gamma);
-	    funct::Gaussian gauss(mean, sigma1);
-	    double range = 3 * sigma1.value();
-	    funct::Convolution<funct::BreitWigner, funct::Gaussian, IntegratorConv>::type cbg(bw, gauss, -range , range, integratorConv);
-	    funct::Constant c(yield);
-	    typedef funct::Product<funct::Constant, funct::Convolution<funct::BreitWigner, funct::Gaussian, IntegratorConv>::type >::type FitFunction;
-	    FitFunction f = c * cbg;
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    minuit.fixParameter(mean.name());
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwG_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwG_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("convbwinterg"))
-	{
-	  cout << "Fitting histograms in input files to the convolution between the Breit-Wigner plus Z/photon interference and a Gaussian\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Gaussian gauss(mean, sigma1);
-	    double range = 3 * sigma1.value();
-	    funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type czg(zls, gauss, -range , range, integratorConv);
-	    funct::Constant c(yield);
-	    typedef funct::Product<funct::Constant, funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type >::type FitFunction;
-	    FitFunction f = c * czg;
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.fixParameter(f_gamma.name());
-	    minuit.addParameter( f_int, .0001, -1000000, 1000000);
-	    minuit.addParameter( mean, 0.001, -0.5, 0.5);
-	    minuit.fixParameter(mean.name());
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			    f_gamma.name().c_str(), f_int.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwInG_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwInG_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      if (vm.count("convbwintgamg"))
-	{
-	  cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and photon propagator with a Gaussian\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Gaussian gauss(mean, sigma1);
-	    double range = 3 * sigma1.value();
-	    funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type czg(zls, gauss, -range , range, integratorConv);
-	    funct::Constant c(yield);
-	    typedef funct::Product<funct::Constant, funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type >::type FitFunction;
-	    FitFunction f = c * czg;
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 10000000);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    minuit.fixParameter(mean.name());
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			    f_gamma.name().c_str(), f_int.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str());
-	    fun.SetLineColor(kRed);
-	    fun.SetNpx(100000);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwInGaG_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwInGaG_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("convbw2gf"))
-	{ 
-	  cout << "Fitting histograms in input files to the convolution between the Z Breit-Wigner and a linear combination of fixed Gaussians\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << alpha << endl; 
-	  cout << mass << endl; 
-	  cout << gamma << endl; 
-	  cout << mean << endl; 
-	  cout << sigma1 << endl; 
-	  cout << sigma2 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::BreitWigner bw(mass, gamma);
-	    funct::Gaussian gaus1(mean, sigma1);
-	    funct::Gaussian gaus2(mean, sigma2);
-	    typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	    typedef funct::Product<funct::Difference<funct::Number,funct::Constant>::type, funct::Gaussian>::type G2;
-	    typedef funct::Product<funct::Constant,funct::Sum<G1, G2>::type >::type GaussComb;
-	    GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	    typedef funct::Convolution<funct::BreitWigner, GaussComb, IntegratorConv>::type FitFunction;
-	    double range = 3 * max(sigma1.value(), sigma2.value());
-	    FitFunction f(bw, gc, -range , range, 1000);
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    //minuit.fixParameter(0);
-	    minuit.addParameter(alpha, 0.1, -1., 1.);
-	    //minuit.fixParameter(1);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    //minuit.fixParameter(2);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    //minuit.fixParameter(3);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    minuit.fixParameter(mean.name());
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    //minuit.fixParameter(5);
-	    minuit.addParameter(sigma2, 0.1, -5., 5.); 
-	    //minuit.fixParameter(6);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(alpha.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    pars.push_back(sigma2.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			    mass.name().c_str(), gamma.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwGGf_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwGGf_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("convbwf2g"))
-	{ 
-	  cout << "Fitting histograms in input files to the convolution between the fixed Z Breit-Wigner and a linear combination of Gaussians\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << alpha << endl; 
-	  cout << mass  << endl; 
-	  cout << gamma << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl; 
-	  cout << sigma2 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::BreitWigner bw(mass, gamma);
-	    funct::Gaussian gaus1(mean, sigma1);
-	    funct::Gaussian gaus2(mean, sigma2);
-	    typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	    typedef funct::Product<funct::Difference<funct::Number,funct::Constant>::type, funct::Gaussian>::type G2;
-	    typedef funct::Product<funct::Constant,funct::Sum<G1, G2>::type >::type GaussComb;
-	    GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	    typedef funct::Convolution<funct::BreitWigner, GaussComb, IntegratorConv>::type FitFunction;
-	    double range = 3 * max(sigma1.value(), sigma2.value());
-	    FitFunction f(bw, gc, -range , range, 1000);
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    //minuit.fixParameter(0);
-	    minuit.addParameter(alpha, 0.1, -1., 1.);
-	    //minuit.fixParameter(1);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.fixParameter(mass.name());
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.fixParameter(gamma.name());
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    //minuit.fixParameter(4);
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    //minuit.fixParameter(5);
-	    minuit.addParameter(sigma2, 0.1, -10., 10.); 
-	    //minuit.fixParameter(6);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(alpha.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    pars.push_back(sigma2.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			    mass.name().c_str(), gamma.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwfGG_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwfGG_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("convbwint2gf")) 
-	{ 
-	  cout << "Fitting histograms in input files to the convolution between the Breit-Wigner plus Z/photon interference and a linear combination of fixed Gaussians\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << alpha << endl; 
-	  cout << mass  << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int  << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl; 
-	  cout << sigma2 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Gaussian gaus1(mean, sigma1);
-	    funct::Gaussian gaus2(mean, sigma2);
-	    typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	    typedef funct::Product<funct::Difference<funct::Number,funct::Constant>::type, funct::Gaussian>::type G2;
-	    typedef funct::Product<funct::Constant,funct::Sum<G1, G2>::type >::type GaussComb;
-	    GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	    typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
-	    double range = 3 * max(sigma1.value(), sigma2.value());
-	    FitFunction f(zls, gc, -range , range, integratorConv);
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    //minuit.fixParameter(0);
-	    minuit.addParameter(alpha, 0.1, -1., 1.);
-	    //minuit.fixParameter(1);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    //minuit.fixParameter(2);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    //minuit.fixParameter(3);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.fixParameter(f_gamma.name());
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    //minuit.fixParameter(5);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    minuit.fixParameter(mean.name());
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    //minuit.fixParameter(7);
-	    minuit.addParameter(sigma2, 0.1, -5., 5.);
-	    //minuit.fixParameter(8);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(alpha.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    pars.push_back(sigma2.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			    mass.name().c_str(), gamma.name().c_str(), 
-			    f_gamma.name().c_str(), f_int.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwInGGf_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwInGGf_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
 
-      if(vm.count("convbwintf2g"))
-	{ 
-	  cout << "Fitting histograms in input files to the convolution between the fixed Breit-Wigner plus Z/photon interference and a linear combination of Gaussians\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << alpha << endl; 
-	  cout << mass  << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl; 
-	  cout << sigma2 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Gaussian gaus1(mean, sigma1);
-	    funct::Gaussian gaus2(mean, sigma2);
-	    typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	    typedef funct::Product<funct::Difference<funct::Number,funct::Constant>::type, funct::Gaussian>::type G2;
-	    typedef funct::Product<funct::Constant,funct::Sum<G1, G2>::type >::type GaussComb;
-	    GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	    typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
-	    double range = 3 * max(sigma1.value(), sigma2.value());
-	    FitFunction f(zls, gc, -range , range, integratorConv);
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    //minuit.fixParameter(0);
-	    minuit.addParameter(alpha, 0.1, -1., 1.);
-	    //minuit.fixParameter(1);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.fixParameter(mass.name());
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.fixParameter(gamma.name());
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    minuit.fixParameter(f_gamma.name());
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    //minuit.fixParameter(5);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    //minuit.fixParameter(6);
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    //minuit.fixParameter(7);
-	    minuit.addParameter(sigma2, 0.1, -10., 10.);
-	    //minuit.fixParameter(8);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(alpha.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    pars.push_back(sigma2.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			    mass.name().c_str(), gamma.name().c_str(), 
-			    f_gamma.name().c_str(), f_int.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwInfGG_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwInfGG_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if (vm.count("convbwintgam2gf")) 
-	{ 
-	  cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and photon propagator with a linear combination of fixed Gaussians\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << alpha << endl; 
-	  cout << mass  << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int  << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl; 
-	  cout << sigma2 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i];
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Gaussian gaus1(mean, sigma1);
-	    funct::Gaussian gaus2(mean, sigma2);
-	    typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	    typedef funct::Product<funct::Difference<funct::Number,funct::Constant>::type, funct::Gaussian>::type G2;
-	    typedef funct::Product<funct::Constant,funct::Sum<G1, G2>::type >::type GaussComb;
-	    GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	    typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
-	    double range = 3 * max(sigma1.value(), sigma2.value());
-	    FitFunction f(zls, gc, -range , range, integratorConv);
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 10000000);
-	    //minuit.fixParameter(0);
-	    minuit.addParameter(alpha, 0.1, -1., 1.);
-	    //minuit.fixParameter(1);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    //minuit.fixParameter(2);
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    //minuit.fixParameter(3);
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    //minuit.fixParameter(4);
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    //minuit.fixParameter(5);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    minuit.fixParameter(mean.name());
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    //	    minuit.fixParameter(7);
-	    minuit.addParameter(sigma2, 0.1, -5., 5.);
-	    //	    minuit.fixParameter(8);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(alpha.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    pars.push_back(sigma2.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			    mass.name().c_str(), gamma.name().c_str(), 
-			    f_gamma.name().c_str(), f_int.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwInGaGGf_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwInGaGGf_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      if(vm.count("convbwintgamf2g"))
-	{ 
-	  cout << "Fitting histograms in input files to the convolution of the fixed Breit-Wigner plus Z/photon interference and photon propagator with a linear combination of Gaussians\n";
-	  cout << ">>> set pars: " << endl;
-	  cout << yield << endl; 
-	  cout << alpha << endl; 
-	  cout << mass  << endl; 
-	  cout << gamma << endl; 
-	  cout << f_gamma << endl; 
-	  cout << f_int << endl; 
-	  cout << mean  << endl; 
-	  cout << sigma1 << endl; 
-	  cout << sigma2 << endl;
-	  for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	    TH1D * zMass = v_ZMassHistos[i]; 
-	    funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	    funct::Gaussian gaus1(mean, sigma1);
-	    funct::Gaussian gaus2(mean, sigma2);
-	    typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	    typedef funct::Product<funct::Difference<funct::Number,funct::Constant>::type, funct::Gaussian>::type G2;
-	    typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type >::type GaussComb;
-	    GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	    typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
-	    double range = 3 * max(sigma1.value(), sigma2.value());
-	    FitFunction f(zls, gc, -range , range, integratorConv);
-	    cout << "set functions" << endl;
-	    typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	    ChiSquared chi2(f, zMass, fMin, fMax);
-	    int fullBins = chi2.numberOfBins();
-	    cout << "N. deg. of freedom: " << fullBins << endl;
-	    fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	    minuit.addParameter(yield, 10, 100, 100000);
-	    //minuit.fixParameter(0);
-	    minuit.addParameter(alpha, 0.1, -1., 1.);
-	    //minuit.fixParameter(1);
-	    minuit.addParameter(mass, .1, 70., 110);
-	    minuit.fixParameter(mass.name());
-	    minuit.addParameter(gamma, 1, 1, 10);
-	    minuit.fixParameter(gamma.name());
-	    minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	    //minuit.fixParameter(4);
-	    minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	    //minuit.fixParameter(5);
-	    minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	    //minuit.fixParameter(6);
-	    minuit.addParameter(sigma1, 0.1, -5., 5.);
-	    //minuit.fixParameter(7);
-	    minuit.addParameter(sigma2, 0.1, -10., 10.);
-	    //minuit.fixParameter(8);
-	    minuit.minimize();
-	    minuit.printFitResults();
-	    vector<shared_ptr<double> > pars;
-	    pars.push_back(yield.ptr());
-	    pars.push_back(alpha.ptr());
-	    pars.push_back(mass.ptr());
-	    pars.push_back(gamma.ptr());
-	    pars.push_back(f_gamma.ptr());
-	    pars.push_back(f_int.ptr());
-	    pars.push_back(mean.ptr());
-	    pars.push_back(sigma1.ptr());
-	    pars.push_back(sigma2.ptr());
-	    TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	    fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			    mass.name().c_str(), gamma.name().c_str(), 
-			    f_gamma.name().c_str(), f_int.name().c_str(), 
-			    mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	    fun.SetLineColor(kRed);
-	    TCanvas *canvas = new TCanvas("canvas");
-	    zMass->Draw("e");
-	    fun.Draw("same");
-	    string epsFilename = "ZMassFitCoBwInGafGG_" + v_eps[i];
-	    canvas->SaveAs(epsFilename.c_str());
-	    canvas->SetLogy();
-	    string epsLogFilename = "ZMassFitCoBwInGafGG_Log_" + v_eps[i];
-	    canvas->SaveAs(epsLogFilename.c_str());
-	  }
-	}
-      
-      cout << "It works!\n";
-  }
-  catch(std::exception& e) {
+    if (vm.count("gauss")) {
+      cout << "Fitting histograms in input files to a Gaussian\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::Gaussian gaus(mean, sigma1);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
+        FitFunction f = c * gaus;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mean, 0.001, 80, 100);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma1);
+        fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("bwinter")) {
+      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.fixParameter(f_gamma.name());
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitBwIn_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitBwIn_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("bwint")) {
+      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and gamma "
+              "propagator\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitBwInGam_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitBwInGam_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("bwintgam")) {
+      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and gamma "
+              "propagator\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitBwInGam_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitBwInGam_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwg")) {
+      cout << "Fitting histograms in input files to the convolution between a Breit Wigner and a Gaussian\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::BreitWigner bw(mass, gamma);
+        funct::Gaussian gauss(mean, sigma1);
+        double range = 3 * sigma1.value();
+        funct::Convolution<funct::BreitWigner, funct::Gaussian, IntegratorConv>::type cbg(
+            bw, gauss, -range, range, integratorConv);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant,
+                               funct::Convolution<funct::BreitWigner, funct::Gaussian, IntegratorConv>::type>::type
+            FitFunction;
+        FitFunction f = c * cbg;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(
+            yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), mean.name().c_str(), sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwinterg")) {
+      cout << "Fitting histograms in input files to the convolution between the Breit-Wigner plus Z/photon "
+              "interference and a Gaussian\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gauss(mean, sigma1);
+        double range = 3 * sigma1.value();
+        funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type czg(
+            zls, gauss, -range, range, integratorConv);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant,
+                               funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type>::type
+            FitFunction;
+        FitFunction f = c * czg;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.fixParameter(f_gamma.name());
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+    if (vm.count("convbwintgamg")) {
+      cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and "
+              "photon propagator with a Gaussian\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gauss(mean, sigma1);
+        double range = 3 * sigma1.value();
+        funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type czg(
+            zls, gauss, -range, range, integratorConv);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant,
+                               funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type>::type
+            FitFunction;
+        FitFunction f = c * czg;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        fun.SetNpx(100000);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInGaG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInGaG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbw2gf")) {
+      cout << "Fitting histograms in input files to the convolution between the Z Breit-Wigner and a linear "
+              "combination of fixed Gaussians\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::BreitWigner bw(mass, gamma);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::BreitWigner, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(bw, gc, -range, range, 1000);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        //minuit.fixParameter(0);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        //minuit.fixParameter(1);
+        minuit.addParameter(mass, .1, 70., 110);
+        //minuit.fixParameter(2);
+        minuit.addParameter(gamma, 1, 1, 10);
+        //minuit.fixParameter(3);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        //minuit.fixParameter(5);
+        minuit.addParameter(sigma2, 0.1, -5., 5.);
+        //minuit.fixParameter(6);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwGGf_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwGGf_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwf2g")) {
+      cout << "Fitting histograms in input files to the convolution between the fixed Z Breit-Wigner and a linear "
+              "combination of Gaussians\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::BreitWigner bw(mass, gamma);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::BreitWigner, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(bw, gc, -range, range, 1000);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        //minuit.fixParameter(0);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        //minuit.fixParameter(1);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.fixParameter(mass.name());
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.fixParameter(gamma.name());
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        //minuit.fixParameter(4);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        //minuit.fixParameter(5);
+        minuit.addParameter(sigma2, 0.1, -10., 10.);
+        //minuit.fixParameter(6);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwfGG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwfGG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwint2gf")) {
+      cout << "Fitting histograms in input files to the convolution between the Breit-Wigner plus Z/photon "
+              "interference and a linear combination of fixed Gaussians\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(zls, gc, -range, range, integratorConv);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        //minuit.fixParameter(0);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        //minuit.fixParameter(1);
+        minuit.addParameter(mass, .1, 70., 110);
+        //minuit.fixParameter(2);
+        minuit.addParameter(gamma, 1, 1, 10);
+        //minuit.fixParameter(3);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.fixParameter(f_gamma.name());
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        //minuit.fixParameter(5);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        //minuit.fixParameter(7);
+        minuit.addParameter(sigma2, 0.1, -5., 5.);
+        //minuit.fixParameter(8);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInGGf_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInGGf_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwintf2g")) {
+      cout << "Fitting histograms in input files to the convolution between the fixed Breit-Wigner plus Z/photon "
+              "interference and a linear combination of Gaussians\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(zls, gc, -range, range, integratorConv);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        //minuit.fixParameter(0);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        //minuit.fixParameter(1);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.fixParameter(mass.name());
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.fixParameter(gamma.name());
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.fixParameter(f_gamma.name());
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        //minuit.fixParameter(5);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        //minuit.fixParameter(6);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        //minuit.fixParameter(7);
+        minuit.addParameter(sigma2, 0.1, -10., 10.);
+        //minuit.fixParameter(8);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInfGG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInfGG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwintgam2gf")) {
+      cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and "
+              "photon propagator with a linear combination of fixed Gaussians\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(zls, gc, -range, range, integratorConv);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        //minuit.fixParameter(0);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        //minuit.fixParameter(1);
+        minuit.addParameter(mass, .1, 70., 110);
+        //minuit.fixParameter(2);
+        minuit.addParameter(gamma, 1, 1, 10);
+        //minuit.fixParameter(3);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        //minuit.fixParameter(4);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        //minuit.fixParameter(5);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        //	    minuit.fixParameter(7);
+        minuit.addParameter(sigma2, 0.1, -5., 5.);
+        //	    minuit.fixParameter(8);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInGaGGf_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInGaGGf_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("convbwintgamf2g")) {
+      cout << "Fitting histograms in input files to the convolution of the fixed Breit-Wigner plus Z/photon "
+              "interference and photon propagator with a linear combination of Gaussians\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(zls, gc, -range, range, integratorConv);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        //minuit.fixParameter(0);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        //minuit.fixParameter(1);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.fixParameter(mass.name());
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.fixParameter(gamma.name());
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        //minuit.fixParameter(4);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        //minuit.fixParameter(5);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        //minuit.fixParameter(6);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        //minuit.fixParameter(7);
+        minuit.addParameter(sigma2, 0.1, -10., 10.);
+        //minuit.fixParameter(8);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInGafGG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInGafGG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    cout << "It works!\n";
+  } catch (std::exception &e) {
     cerr << "error: " << e.what() << "\n";
     return 1;
-  }
-  catch(...) {
+  } catch (...) {
     cerr << "Exception of unknown type!\n";
   }
   return 0;

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassHSFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassHSFit.cpp
@@ -19,7 +19,7 @@
 #include "TMath.h"
 #include "TCanvas.h"
 #include "TROOT.h"
-#include <boost/shared_ptr.hpp>
+
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <algorithm> 

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassHSFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassHSFit.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <exception>
 #include <iterator>
 #include <string>
@@ -34,80 +34,72 @@ using namespace std;
 typedef funct::GaussIntegrator IntegratorConv;
 
 // A helper function to simplify the main part.
-template<class T>
-ostream& operator<<(ostream& os, const vector<T>& v) {
-  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " ")); 
+template <class T>
+ostream &operator<<(ostream &os, const vector<T> &v) {
+  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " "));
   return os;
 }
 
-int main(int ac, char *av[]) { 
+int main(int ac, char *av[]) {
   try {
     double fMin, fMax;
     string ext;
     po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help", "produce help message")
-      ("include-path,I", po::value< vector<string> >(), 
-       "include path")
-      ("input-file", po::value< vector<string> >(), "input file")
-      ("min,m", po::value<double>(&fMin)->default_value(60), "minimum value for fit range")
-      ("max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")
-      ("convbwintgamg", 
-       "fit to the convolution of a breit-wigner plus interference term and gamma propagator and a gaussian")
-      ("convexpbwintgamg", 
-       "fit to the convolution of the product between an exponential and a breit-wigner plus interference term and gamma propagator with a gaussian")
-      ("convbwintgam2gf", 
-       "fit to the convolution of the breit-wigner plus interference term and gamma propagator with a linear combination of fixed gaussians")
-      ("output-file,O", po::value<string>(&ext)->default_value(".ps"), 
-       "output file format")
-      ;
-    
+    desc.add_options()("help", "produce help message")("include-path,I", po::value<vector<string> >(), "include path")(
+        "input-file", po::value<vector<string> >(), "input file")(
+        "min,m", po::value<double>(&fMin)->default_value(60), "minimum value for fit range")(
+        "max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")(
+        "convbwintgamg",
+        "fit to the convolution of a breit-wigner plus interference term and gamma propagator and a gaussian")(
+        "convexpbwintgamg",
+        "fit to the convolution of the product between an exponential and a breit-wigner plus interference term and "
+        "gamma propagator with a gaussian")("convbwintgam2gf",
+                                            "fit to the convolution of the breit-wigner plus interference term and "
+                                            "gamma propagator with a linear combination of fixed gaussians")(
+        "output-file,O", po::value<string>(&ext)->default_value(".ps"), "output file format");
+
     po::positional_options_description p;
     p.add("input-file", -1);
-    
+
     po::variables_map vm;
-    po::store(po::command_line_parser(ac, av).
-	    options(desc).positional(p).run(), vm);
+    po::store(po::command_line_parser(ac, av).options(desc).positional(p).run(), vm);
     po::notify(vm);
-    
+
     if (vm.count("help")) {
       cout << "Usage: options_description [options]\n";
       cout << desc;
       return 0;
-      }
-    
-    if (vm.count("include-path")) {
-      cout << "Include paths are: " 
-	   << vm["include-path"].as< vector<string> >() << "\n";
     }
-    
+
+    if (vm.count("include-path")) {
+      cout << "Include paths are: " << vm["include-path"].as<vector<string> >() << "\n";
+    }
+
     vector<string> v_file;
-    vector<TH1D*> v_ZMassHistos;
+    vector<TH1D *> v_ZMassHistos;
     vector<string> v_eps;
-    
-    if (vm.count("input-file"))	{
-      cout << "Input files are: " 
-	   << vm["input-file"].as< vector<string> >() << "\n";
-      v_file = vm["input-file"].as< vector<string> >();
-      for(vector<string>::const_iterator it = v_file.begin(); 
-	  it != v_file.end(); ++it) { 
-	TFile * root_file = new TFile(it->c_str(),"read");
-	TDirectory *Histos = (TDirectory*) root_file->GetDirectory("ZHisto");
-	TDirectory *RecoHistos = (TDirectory*) Histos->GetDirectory("ZRecoHisto");
-	TH1D * zMass = (TH1D*) RecoHistos->Get("ZMass");
-	zMass->Rebin(4); //remember...
-	zMass->GetXaxis()->SetTitle("#mu #mu invariant mass (GeV/c^{2})");
-	v_ZMassHistos.push_back(zMass);
-	gROOT->SetStyle("Plain");
-	//gStyle->SetOptFit(1111);
-	string f_string = *it;
-	replace(f_string.begin(), f_string.end(), '.', '_');
-	string eps_string = f_string + ext;
-	v_eps.push_back(eps_string);
-	cout << ">>> histogram loaded\n";
+
+    if (vm.count("input-file")) {
+      cout << "Input files are: " << vm["input-file"].as<vector<string> >() << "\n";
+      v_file = vm["input-file"].as<vector<string> >();
+      for (vector<string>::const_iterator it = v_file.begin(); it != v_file.end(); ++it) {
+        TFile *root_file = new TFile(it->c_str(), "read");
+        TDirectory *Histos = (TDirectory *)root_file->GetDirectory("ZHisto");
+        TDirectory *RecoHistos = (TDirectory *)Histos->GetDirectory("ZRecoHisto");
+        TH1D *zMass = (TH1D *)RecoHistos->Get("ZMass");
+        zMass->Rebin(4);  //remember...
+        zMass->GetXaxis()->SetTitle("#mu #mu invariant mass (GeV/c^{2})");
+        v_ZMassHistos.push_back(zMass);
+        gROOT->SetStyle("Plain");
+        //gStyle->SetOptFit(1111);
+        string f_string = *it;
+        replace(f_string.begin(), f_string.end(), '.', '_');
+        string eps_string = f_string + ext;
+        v_eps.push_back(eps_string);
+        cout << ">>> histogram loaded\n";
       }
       cout << v_file.size() << ", " << v_ZMassHistos.size() << ", " << v_eps.size() << endl;
-      cout <<">>> Input files loaded\n";
+      cout << ">>> Input files loaded\n";
     }
 
     IntegratorConv integratorConv(1.e-5);
@@ -119,226 +111,242 @@ int main(int ac, char *av[]) {
     funct::Parameter f_int("Interference factor", -0.00197);
     //Parameters for fits with gaussians
     funct::Parameter yield("Yield", 283000);
-    funct::Parameter alpha("Alpha", 0.771); //the first gaussian is narrow
-    funct::Parameter mean("Mean", 0); //0.229
-    funct::Parameter sigma1("Sigma 1", 0.76); 
+    funct::Parameter alpha("Alpha", 0.771);  //the first gaussian is narrow
+    funct::Parameter mean("Mean", 0);        //0.229
+    funct::Parameter sigma1("Sigma 1", 0.76);
     funct::Parameter sigma2("Sigma 2", 2.94);
     //Parameter for exponential
     funct::Parameter lambda("Lambda", 0);
-    
+
     if (vm.count("convbwintgamg")) {
-      cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and photon propagator with a Gaussian\n";
+      cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and "
+              "photon propagator with a Gaussian\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass  << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int << endl; 
-      cout << mean  << endl; 
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
       cout << sigma1 << endl;
-      for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassHistos[i]; 
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Gaussian gauss(mean, sigma1);
-	double range = 3 * sigma1.value();
-	funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type 
-	  czg(zls, gauss, -range , range, integratorConv);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, 
-	  funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type >::type FitFunction;
-	FitFunction f = c * czg;
-	cout << "set functions" << endl;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	minuit.fixParameter(mean.name());
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	pars.push_back(mean.ptr());
-	pars.push_back(sigma1.ptr());
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str(), 
-			mean.name().c_str(), sigma1.name().c_str());
-	fun.SetLineColor(kRed);
-	fun.SetNpx(100000);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMassFitCoBwInGaG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassFitCoBwInGaG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gauss(mean, sigma1);
+        double range = 3 * sigma1.value();
+        funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type czg(
+            zls, gauss, -range, range, integratorConv);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant,
+                               funct::Convolution<funct::ZLineShape, funct::Gaussian, IntegratorConv>::type>::type
+            FitFunction;
+        FitFunction f = c * czg;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        fun.SetNpx(100000);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInGaG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInGaG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("convexpbwintgamg")) {
-      cout << "Fitting histograms in input files to the convolution of the product between an exponential and a breit-wigner plus interference term and gamma propagator with a gaussian" 
-	   << endl;
+      cout << "Fitting histograms in input files to the convolution of the product between an exponential and a "
+              "breit-wigner plus interference term and gamma propagator with a gaussian"
+           << endl;
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
+      cout << yield << endl;
       cout << lambda << endl;
-      cout << mass << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int  << endl; 
-      cout << mean  << endl; 
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
       cout << sigma1 << endl;
-      for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassHistos[i]; 
-	funct::Exponential expo(lambda);
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Gaussian gauss(mean, sigma1);
-	typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
-	ExpZLS expz = expo * zls;
-	double range = 3 * sigma1.value();
-	funct::Convolution<ExpZLS, funct::Gaussian, IntegratorConv>::type cezg(expz, gauss, -range , range, integratorConv);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::Convolution<ExpZLS, funct::Gaussian, IntegratorConv>::type >::type FitFunction;
-	FitFunction f = c * cezg;
-	cout << "set functions" << endl;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(lambda, 0.1, -100, 100);
-	minuit.fixParameter(lambda.name());
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	minuit.fixParameter(mean.name());
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	minuit.releaseParameter(lambda.name());
-	minuit.minimize();
-	minuit.printFitResults();
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(lambda.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	pars.push_back(mean.ptr());
-	pars.push_back(sigma1.ptr());
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	fun.SetParNames(yield.name().c_str(), lambda.name().c_str(),
-			mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str(), 
-			mean.name().c_str(), sigma1.name().c_str());
-	fun.SetLineColor(kRed);
-	fun.SetNpx(100000);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMassFitCoExBwInGaG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassFitCoExBwInGaG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::Exponential expo(lambda);
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gauss(mean, sigma1);
+        typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
+        ExpZLS expz = expo * zls;
+        double range = 3 * sigma1.value();
+        funct::Convolution<ExpZLS, funct::Gaussian, IntegratorConv>::type cezg(
+            expz, gauss, -range, range, integratorConv);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::Convolution<ExpZLS, funct::Gaussian, IntegratorConv>::type>::type
+            FitFunction;
+        FitFunction f = c * cezg;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(lambda, 0.1, -100, 100);
+        minuit.fixParameter(lambda.name());
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        minuit.releaseParameter(lambda.name());
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(lambda.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        lambda.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        fun.SetNpx(100000);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoExBwInGaG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoExBwInGaG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
-    if (vm.count("convbwintgam2gf")) { 
-      cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and photon propagator with a linear combination of fixed Gaussians\n";
+
+    if (vm.count("convbwintgam2gf")) {
+      cout << "Fitting histograms in input files to the convolution of the Breit-Wigner plus Z/photon interference and "
+              "photon propagator with a linear combination of fixed Gaussians\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << alpha << endl; 
-      cout << mass  << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int  << endl; 
-      cout << mean  << endl; 
-      cout << sigma1 << endl; 
+      cout << yield << endl;
+      cout << alpha << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma1 << endl;
       cout << sigma2 << endl;
-      for(unsigned int i = 0; i < v_ZMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassHistos[i];
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Gaussian gaus1(mean, sigma1);
-	funct::Gaussian gaus2(mean, sigma2);
-	funct::Number _1(1);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, 
-	  funct::Gaussian>::type G2;
-	typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
-	funct::Constant c_alpha(alpha), c_yield(yield);
-	GaussComb gc = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
-	double range = 3 * max(sigma1.value(), sigma2.value());
-	FitFunction f(zls, gc, -range , range, integratorConv);
-	cout << "set functions" << endl;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(alpha, 0.1, -1., 1.);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.addParameter(mean, 0.001, -0.5, 0.5);
-	minuit.fixParameter(mean.name());
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.addParameter(sigma2, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(alpha.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	pars.push_back(mean.ptr());
-	pars.push_back(sigma1.ptr());
-	pars.push_back(sigma2.ptr());
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str(), 
-			mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	fun.SetLineColor(kRed);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMassFitCoBwInGaGGf_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassFitCoBwInGaGGf_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      for (unsigned int i = 0; i < v_ZMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        funct::Number _1(1);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type GaussComb;
+        funct::Constant c_alpha(alpha), c_yield(yield);
+        GaussComb gc = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef funct::Convolution<funct::ZLineShape, GaussComb, IntegratorConv>::type FitFunction;
+        double range = 3 * max(sigma1.value(), sigma2.value());
+        FitFunction f(zls, gc, -range, range, integratorConv);
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.addParameter(mean, 0.001, -0.5, 0.5);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.addParameter(sigma2, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassFitCoBwInGaGGf_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassFitCoBwInGaGGf_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     cout << "It works!\n";
-  }
-  catch(std::exception& e) {
+  } catch (std::exception &e) {
     cerr << "error: " << e.what() << "\n";
     return 1;
-  }
-  catch(...) {
+  } catch (...) {
     cerr << "Exception of unknown type!\n";
   }
   return 0;

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassMCFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassMCFit.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <iterator>
 #include <string>
 #include <vector>
@@ -28,81 +28,70 @@ namespace po = boost::program_options;
 using namespace std;
 
 // A helper function to simplify the main part.
-template<class T>
-ostream& operator<<(ostream& os, const vector<T>& v) {
-  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " ")); 
+template <class T>
+ostream &operator<<(ostream &os, const vector<T> &v) {
+  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " "));
   return os;
 }
 
-int main(int ac, char *av[]) { 
+int main(int ac, char *av[]) {
   try {
     double fMin, fMax;
     string ext;
     po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help", "produce help message")
-      ("include-path,I", po::value< vector<string> >(), 
-       "include path")
-      ("input-file", po::value< vector<string> >(), "input file")
-      ("min,m", po::value<double>(&fMin)->default_value(80), "minimum value for fit range")
-      ("max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")
-      ("breitwigner", "fit to a breit-wigner")
-      ("gauss", "fit to a gaussian")
-      ("bwinter", "fit to a breit-wigner plus Z/photon interference term")
-      ("bwintgam", 
-       "fit to a breit-wigner plus Z/photon interference term and photon propagator")
-      ("expbwintgam", 
-       "fit to the product of an exponential with a breit-wigner plus Z/photon interference term and photon propagator")
-      ("output-file,O", po::value<string>(&ext)->default_value(".ps"), 
-       "output file format")
-      ;
-    
+    desc.add_options()("help", "produce help message")("include-path,I", po::value<vector<string> >(), "include path")(
+        "input-file", po::value<vector<string> >(), "input file")(
+        "min,m", po::value<double>(&fMin)->default_value(80), "minimum value for fit range")(
+        "max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")(
+        "breitwigner", "fit to a breit-wigner")("gauss", "fit to a gaussian")(
+        "bwinter", "fit to a breit-wigner plus Z/photon interference term")(
+        "bwintgam", "fit to a breit-wigner plus Z/photon interference term and photon propagator")(
+        "expbwintgam",
+        "fit to the product of an exponential with a breit-wigner plus Z/photon interference term and photon "
+        "propagator")("output-file,O", po::value<string>(&ext)->default_value(".ps"), "output file format");
+
     po::positional_options_description p;
     p.add("input-file", -1);
-    
+
     po::variables_map vm;
-    po::store(po::command_line_parser(ac, av).
-	      options(desc).positional(p).run(), vm);
+    po::store(po::command_line_parser(ac, av).options(desc).positional(p).run(), vm);
     po::notify(vm);
-    
+
     if (vm.count("help")) {
       cout << "Usage: options_description [options]\n";
       cout << desc;
       return 0;
     }
-    
+
     if (vm.count("include-path")) {
-      cout << "Include paths are: " 
-	   << vm["include-path"].as< vector<string> >() << "\n";
+      cout << "Include paths are: " << vm["include-path"].as<vector<string> >() << "\n";
     }
-    
+
     vector<string> v_file;
-    vector<TH1D*> v_ZMCMassHistos;
+    vector<TH1D *> v_ZMCMassHistos;
     vector<string> v_eps;
-    
+
     if (vm.count("input-file")) {
-      cout << "Input files are: " 
-	   << vm["input-file"].as< vector<string> >() << "\n";
-      v_file = vm["input-file"].as< vector<string> >();
-      for(vector<string>::const_iterator it = v_file.begin(); 
-	  it != v_file.end(); ++it) { 
-	TFile * root_file = new TFile(it->c_str(),"read");
-	TDirectory *Histos = (TDirectory*) root_file->GetDirectory("ZHisto");
-	TDirectory *MCHistos = (TDirectory*) Histos->GetDirectory("ZMCHisto");
-	TH1D * zMass = (TH1D*) MCHistos->Get("ZMCMass"); 
-	zMass->Rebin(4); //remember...
-	zMass->GetXaxis()->SetTitle("Mass (GeV/c^{2})");
-	v_ZMCMassHistos.push_back(zMass);
-	gROOT->SetStyle("Plain");
-	string f_string = *it;
-	replace(f_string.begin(), f_string.end(), '.', '_');
-	string eps_string = f_string + ext;
-	v_eps.push_back(eps_string);
-	cout << ">>> histogram loaded\n";
+      cout << "Input files are: " << vm["input-file"].as<vector<string> >() << "\n";
+      v_file = vm["input-file"].as<vector<string> >();
+      for (vector<string>::const_iterator it = v_file.begin(); it != v_file.end(); ++it) {
+        TFile *root_file = new TFile(it->c_str(), "read");
+        TDirectory *Histos = (TDirectory *)root_file->GetDirectory("ZHisto");
+        TDirectory *MCHistos = (TDirectory *)Histos->GetDirectory("ZMCHisto");
+        TH1D *zMass = (TH1D *)MCHistos->Get("ZMCMass");
+        zMass->Rebin(4);  //remember...
+        zMass->GetXaxis()->SetTitle("Mass (GeV/c^{2})");
+        v_ZMCMassHistos.push_back(zMass);
+        gROOT->SetStyle("Plain");
+        string f_string = *it;
+        replace(f_string.begin(), f_string.end(), '.', '_');
+        string eps_string = f_string + ext;
+        v_eps.push_back(eps_string);
+        cout << ">>> histogram loaded\n";
       }
       cout << v_file.size() << ", " << v_ZMCMassHistos.size() << ", " << v_eps.size() << endl;
-      cout <<">>> Input files loaded\n";
-    } 
+      cout << ">>> Input files loaded\n";
+    }
     //PDG values for Z mass and width
     funct::Parameter mass("Mass", 91.1876);
     funct::Parameter gamma("Gamma", 2.4952);
@@ -115,242 +104,251 @@ int main(int ac, char *av[]) {
     funct::Parameter sigma("Sigma", 1.);
     //Parameters for fit with an exponential
     funct::Parameter lambda("Lambda", 0);
-      
+
     if (vm.count("breitwigner")) {
       cout << "Fitting histograms in input file to a Breit-Wigner\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass  << endl; 
-      cout << gamma << endl; 
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	cout << ">>> load histogram\n";
-	TH1D * zMass = v_ZMCMassHistos[i];
-	cout << ">>> histogram loaded\n";
-	funct::BreitWigner bw(mass, gamma);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::BreitWigner>::type FitFunction;
-	FitFunction f = c * bw;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mass, gamma);
-	fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str());
-	fun.SetLineColor(kRed);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassMCFitBW_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassMCFitBW_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        cout << ">>> load histogram\n";
+        TH1D *zMass = v_ZMCMassHistos[i];
+        cout << ">>> histogram loaded\n";
+        funct::BreitWigner bw(mass, gamma);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::BreitWigner>::type FitFunction;
+        FitFunction f = c * bw;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mass, gamma);
+        fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassMCFitBW_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassMCFitBW_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("gauss")) {
-      cout << "Fitting histograms in input files to a Gaussian\n"; 
+      cout << "Fitting histograms in input files to a Gaussian\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mean  << endl; 
+      cout << yield << endl;
+      cout << mean << endl;
       cout << sigma << endl;
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMCMassHistos[i]; 
-	funct::Gaussian gaus(mean, sigma);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
-	FitFunction f = c * gaus;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mean, 0.001, 80, 100);
-	minuit.addParameter(sigma, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma);
-	fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma.name().c_str());
-	fun.SetLineColor(kRed);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassMCFitG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassMCFitG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::Gaussian gaus(mean, sigma);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
+        FitFunction f = c * gaus;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mean, 0.001, 80, 100);
+        minuit.addParameter(sigma, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma);
+        fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassMCFitG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassMCFitG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("bwinter")) {
       cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass  << endl; 
-	cout << gamma << endl; 
-	cout << f_gamma << endl; 
-	cout << f_int  << endl; 
-	for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	  TH1D * zMass = v_ZMCMassHistos[i]; 
-	  funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	  funct::Constant c(yield);
-	  typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	  FitFunction f = c * zls;
-	  cout << "set functions" << endl;
-	  vector<shared_ptr<double> > pars;
-	  pars.push_back(yield.ptr());
-	  pars.push_back(mass.ptr());
-	  pars.push_back(gamma.ptr());
-	  pars.push_back(f_gamma.ptr());
-	  pars.push_back(f_int.ptr());
-	  typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	  ChiSquared chi2(f, zMass, fMin, fMax);
-	  int fullBins = chi2.numberOfBins();
-	  cout << "N. deg. of freedom: " << fullBins << endl;
-	  fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	  minuit.addParameter(yield, 10, 100, 100000);
-	  minuit.addParameter(mass, .1, 70., 110);
-	  minuit.addParameter(gamma, 1, 1, 10);
-	  minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	  minuit.fixParameter(f_gamma.name());
-	  minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	  minuit.minimize();
-	  minuit.printFitResults();
-	  TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	  fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			  f_gamma.name().c_str(), f_int.name().c_str());
-	  fun.SetLineColor(kRed); 
-	  TCanvas *canvas = new TCanvas("canvas");
-	  zMass->Draw("e");
-	  fun.Draw("same");
-	  string epsFilename = "ZMassMCFitBwIn_" + v_eps[i];
-	  canvas->SaveAs(epsFilename.c_str());
-	  canvas->SetLogy();
-	  string epsLogFilename = "ZMassMCFitBwIn_Log_" + v_eps[i];
-	  canvas->SaveAs(epsLogFilename.c_str());
-	}
-    }
-    
-    if (vm.count("bwintgam"))	{
-      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and photon propagator\n";
-      cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int  << endl; 
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMCMassHistos[i]; 
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	FitFunction f = c * zls;
-	cout << "set functions" << endl;
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 1000000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	fun.SetNpx(100000);
-	fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str());
-	fun.SetLineColor(kRed); 
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMassMCFitBwInGa_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassMCFitBwInGa_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.fixParameter(f_gamma.name());
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassMCFitBwIn_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassMCFitBwIn_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
-    if (vm.count("expbwintgam"))	{
-      cout << "Fitting histograms in input files to the product of an exponential with the Breit-Wigner plus Z/photon interference term and photon propagator\n";
+
+    if (vm.count("bwintgam")) {
+      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and photon "
+              "propagator\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 1000000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetNpx(100000);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassMCFitBwInGa_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassMCFitBwInGa_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
+      }
+    }
+
+    if (vm.count("expbwintgam")) {
+      cout << "Fitting histograms in input files to the product of an exponential with the Breit-Wigner plus Z/photon "
+              "interference term and photon propagator\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
       cout << lambda << endl;
-      cout << mass << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int << endl; 
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMCMassHistos[i]; 
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Exponential expo(lambda);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
-	ExpZLS expz = expo * zls;
-	typedef funct::Product<funct::Constant, ExpZLS>::type FitFunction;
-	FitFunction f = c * expz;
-	cout << "set functions" << endl;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(lambda, 0.1, -100, 100);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.minimize();
-	minuit.printFitResults();
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(lambda.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	fun.SetNpx(100000);
-	fun.SetParNames(yield.name().c_str(), lambda.name().c_str(), 
-			mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str());
-	fun.SetLineColor(kRed); 
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMassMCFitExpBwInGa_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassMCFitExpBwInGa_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Exponential expo(lambda);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
+        ExpZLS expz = expo * zls;
+        typedef funct::Product<funct::Constant, ExpZLS>::type FitFunction;
+        FitFunction f = c * expz;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(lambda, 0.1, -100, 100);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(lambda.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetNpx(100000);
+        fun.SetParNames(yield.name().c_str(),
+                        lambda.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassMCFitExpBwInGa_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassMCFitExpBwInGa_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     cout << "It works!\n";
-  }
-  catch(std::exception& e) {
+  } catch (std::exception &e) {
     cerr << "error: " << e.what() << "\n";
     return 1;
-  }
-  catch(...) {
+  } catch (...) {
     cerr << "Exception of unknown type!\n";
   }
   return 0;

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassMCFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassMCFit.cpp
@@ -16,7 +16,7 @@
 #include "TCanvas.h"
 #include "TROOT.h"
 #include "TMath.h"
-#include <boost/shared_ptr.hpp>
+
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <algorithm> 

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassResFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassResFit.cpp
@@ -22,82 +22,72 @@ using namespace boost;
 namespace po = boost::program_options;
 
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <iterator>
 #include <string>
 #include <vector>
 using namespace std;
 
 // A helper function to simplify the main part.
-template<class T>
-ostream& operator<<(ostream& os, const vector<T>& v) {
-  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " ")); 
+template <class T>
+ostream &operator<<(ostream &os, const vector<T> &v) {
+  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " "));
   return os;
 }
 
-int main(int ac, char *av[]) { 
+int main(int ac, char *av[]) {
   try {
     double fMin, fMax;
     string ext;
     po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help", "produce help message")
-      ("include-path,I", po::value< vector<string> >(), 
-       "include path")
-      ("input-file", po::value< vector<string> >(), "input file")
-      ("min,m", po::value<double>(&fMin)->default_value(-20), "minimum value for fit range")
-      ("max,M", po::value<double>(&fMax)->default_value(20), "maximum value for fit range")
-      ("gauss", "fit to a gaussian")
-      ("2gauss", "fit to a linear combination of two gaussians")
-      ("3gauss", "fit to a linear combination of three gaussians")
-      ("output-file,O", po::value<string>(&ext)->default_value(".ps"), 
-       "output file format")
-      ;
-    
+    desc.add_options()("help", "produce help message")("include-path,I", po::value<vector<string> >(), "include path")(
+        "input-file", po::value<vector<string> >(), "input file")(
+        "min,m", po::value<double>(&fMin)->default_value(-20), "minimum value for fit range")(
+        "max,M", po::value<double>(&fMax)->default_value(20), "maximum value for fit range")(
+        "gauss", "fit to a gaussian")("2gauss", "fit to a linear combination of two gaussians")(
+        "3gauss", "fit to a linear combination of three gaussians")(
+        "output-file,O", po::value<string>(&ext)->default_value(".ps"), "output file format");
+
     po::positional_options_description p;
     p.add("input-file", -1);
-    
+
     po::variables_map vm;
-    po::store(po::command_line_parser(ac, av).
-	      options(desc).positional(p).run(), vm);
+    po::store(po::command_line_parser(ac, av).options(desc).positional(p).run(), vm);
     po::notify(vm);
-    
+
     if (vm.count("help")) {
       cout << "Usage: options_description [options]\n";
       cout << desc;
       return 0;
     }
-    
+
     if (vm.count("include-path")) {
-      cout << "Include paths are: " 
-	   << vm["include-path"].as< vector<string> >() << "\n";
+      cout << "Include paths are: " << vm["include-path"].as<vector<string> >() << "\n";
     }
-    
+
     vector<string> v_file;
-    vector<TH1D*> v_ZMassResHistos;
+    vector<TH1D *> v_ZMassResHistos;
     vector<string> v_eps;
-    
+
     if (vm.count("input-file")) {
-      cout << "Input files are: " 
-	   << vm["input-file"].as< vector<string> >() << "\n";
-      v_file = vm["input-file"].as< vector<string> >();
-      for(vector<string>::const_iterator it = v_file.begin(); 
-	  it != v_file.end(); ++it) { 
-	TFile * root_file = new TFile(it->c_str(),"read");
-	TDirectory *Histos = (TDirectory*) root_file->GetDirectory("ZHisto");
-	TDirectory *RecoHistos = (TDirectory*) Histos->GetDirectory("ZResolutionHisto");
-	TH1D * zMass = (TH1D*) RecoHistos->Get("ZToMuMuRecoMassResolution");
-	zMass->GetXaxis()->SetTitle("Mass (GeV/c^{2})"); 
-	v_ZMassResHistos.push_back(zMass);
-	gROOT->SetStyle("Plain");
-	string f_string = *it;
-	replace(f_string.begin(), f_string.end(), '.', '_');
-	    string eps_string = f_string + ext;
-	    v_eps.push_back(eps_string);
-	    cout << ">>> histogram loaded\n";
+      cout << "Input files are: " << vm["input-file"].as<vector<string> >() << "\n";
+      v_file = vm["input-file"].as<vector<string> >();
+      for (vector<string>::const_iterator it = v_file.begin(); it != v_file.end(); ++it) {
+        TFile *root_file = new TFile(it->c_str(), "read");
+        TDirectory *Histos = (TDirectory *)root_file->GetDirectory("ZHisto");
+        TDirectory *RecoHistos = (TDirectory *)Histos->GetDirectory("ZResolutionHisto");
+        TH1D *zMass = (TH1D *)RecoHistos->Get("ZToMuMuRecoMassResolution");
+        zMass->GetXaxis()->SetTitle("Mass (GeV/c^{2})");
+        v_ZMassResHistos.push_back(zMass);
+        gROOT->SetStyle("Plain");
+        string f_string = *it;
+        replace(f_string.begin(), f_string.end(), '.', '_');
+        string eps_string = f_string + ext;
+        v_eps.push_back(eps_string);
+        cout << ">>> histogram loaded\n";
       }
       cout << v_file.size() << ", " << v_ZMassResHistos.size() << ", " << v_eps.size() << endl;
-      cout <<">>> Input files loaded\n";
+      cout << ">>> Input files loaded\n";
     }
     //Parameters for fit
     funct::Parameter yield("Yield", 10000);
@@ -111,173 +101,180 @@ int main(int ac, char *av[]) {
     funct::Parameter sigma3("Sigma 3", 9.);
 
     if (vm.count("gauss")) {
-      cout << "Fitting histograms in input files to a Gaussian\n"; 
+      cout << "Fitting histograms in input files to a Gaussian\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mean  << endl; 
+      cout << yield << endl;
+      cout << mean << endl;
       cout << sigma1 << endl;
-      for(unsigned int i = 0; i < v_ZMassResHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassResHistos[i]; 
-	zMass->Rebin(4); //remember...
-	funct::Gaussian gaus(mean, sigma1);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
-	FitFunction f = c * gaus;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(mean, 0.001, -1., 1.);
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma1);
-	fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma1.name().c_str());
-	fun.SetLineColor(kRed);
-	fun.SetNpx(1000);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassResFitG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassResFitG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      for (unsigned int i = 0; i < v_ZMassResHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassResHistos[i];
+        zMass->Rebin(4);  //remember...
+        funct::Gaussian gaus(mean, sigma1);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
+        FitFunction f = c * gaus;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(mean, 0.001, -1., 1.);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma1);
+        fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma1.name().c_str());
+        fun.SetLineColor(kRed);
+        fun.SetNpx(1000);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassResFitG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassResFitG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("2gauss")) {
-      cout << "Fitting histograms in input files to a linear combination of two Gaussians\n"; 
+      cout << "Fitting histograms in input files to a linear combination of two Gaussians\n";
       cout << "set pars: " << endl;
       cout << yield << endl;
       cout << alpha << endl;
-      cout << mean  << endl; 
-      cout << mean2 << endl; 
-      cout << sigma1 << endl; 
-      cout << sigma2 << endl; 
-      for(unsigned int i = 0; i < v_ZMassResHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassResHistos[i]; 
-	zMass->Rebin(4); //remember...
-	funct::Gaussian gaus1(mean, sigma1);
-	funct::Gaussian gaus2(mean, sigma2);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
-	typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type FitFunction;
-	funct::Number _1(1);
-	funct::Constant c_alpha(alpha), c_yield(yield);
-	FitFunction f = c_yield*(c_alpha*gaus1 + (_1 - c_alpha)*gaus2);
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(alpha, 0.1, -1., 1.);
-	minuit.addParameter(mean, 0.001, -1., 1.);
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.addParameter(sigma2, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(alpha.ptr());
-	pars.push_back(mean.ptr());
-	pars.push_back(sigma1.ptr());
-	pars.push_back(sigma2.ptr());
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	fun.SetParNames(yield.name().c_str(), alpha.name().c_str(),
-			mean.name().c_str(), sigma1.name().c_str(), sigma2.name().c_str());
-	fun.SetLineColor(kRed);
-	fun.SetNpx(1000);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassResFitGG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassResFitGG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << mean << endl;
+      cout << mean2 << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      for (unsigned int i = 0; i < v_ZMassResHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassResHistos[i];
+        zMass->Rebin(4);  //remember...
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean, sigma2);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Product<funct::Difference<funct::Number, funct::Constant>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<G1, G2>::type>::type FitFunction;
+        funct::Number _1(1);
+        funct::Constant c_alpha(alpha), c_yield(yield);
+        FitFunction f = c_yield * (c_alpha * gaus1 + (_1 - c_alpha) * gaus2);
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        minuit.addParameter(mean, 0.001, -1., 1.);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.addParameter(sigma2, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mean.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str());
+        fun.SetLineColor(kRed);
+        fun.SetNpx(1000);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassResFitGG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassResFitGG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("3gauss")) {
       cout << "Fitting histograms in input files to a linear combination of three Gaussians\n";
       cout << "set pars: " << endl;
       cout << yield << endl;
       cout << alpha << endl;
-      cout << beta  << endl;
-      cout << mean  << endl; 
-      cout << mean2 << endl; 
-      cout << mean3 << endl; 
-      cout << sigma1 << endl; 
-      cout << sigma2 << endl; 
-      cout << sigma3 << endl; 
-      for(unsigned int i = 0; i < v_ZMassResHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMassResHistos[i]; 
-	zMass->Rebin(4); //remember...
-	funct::Gaussian gaus1(mean, sigma1);
-	funct::Gaussian gaus2(mean2, sigma2);
-	funct::Gaussian gaus3(mean3, sigma3);
-	funct::Constant a(alpha), b(beta), c(yield);
-	funct::Number _1(1);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
-	typedef funct::Sum<G1, G1>::type SumG1;
-	typedef funct::Sum<funct::Constant, funct::Constant>::type ConstSum;
-	typedef funct::Product<funct::Difference<funct::Number, ConstSum>::type, funct::Gaussian>::type G2;
-	typedef funct::Product<funct::Constant, funct::Sum<SumG1, G2>::type>::type FitFunction;
-	FitFunction f = c*(a*gaus1 + b*gaus2 + (_1 - (a+b))*gaus3);
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 10000000);
-	minuit.addParameter(alpha, 0.1, -1., 1.);
-	minuit.addParameter(beta, 0.1, -1., 1.);
-	minuit.addParameter(mean, 0.001, -1., 1.);
-	minuit.addParameter(mean2, 0.001, -1., 1.);
-	minuit.addParameter(mean3, 0.001, -1., 1.);
-	minuit.addParameter(sigma1, 0.1, -5., 5.);
-	minuit.addParameter(sigma2, 0.1, -5., 5.);
-	minuit.addParameter(sigma3, 0.1, -20., 20.);
-	minuit.minimize();
-	minuit.printFitResults();
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(alpha.ptr());
-	pars.push_back(beta.ptr());
-	pars.push_back(mean.ptr());
-	pars.push_back(mean2.ptr());
-	pars.push_back(mean3.ptr());
-	pars.push_back(sigma1.ptr());
-	pars.push_back(sigma2.ptr());
-	pars.push_back(sigma3.ptr());
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), beta.name().c_str(), 
-			mean.name().c_str(), mean2.name().c_str(), mean3.name().c_str(), 
-			sigma1.name().c_str(), sigma2.name().c_str(), sigma3.name().c_str());
-	fun.SetLineColor(kRed);
-	//fun.SetNpx(100000);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMassResFitGGG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMassResFitGGG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << beta << endl;
+      cout << mean << endl;
+      cout << mean2 << endl;
+      cout << mean3 << endl;
+      cout << sigma1 << endl;
+      cout << sigma2 << endl;
+      cout << sigma3 << endl;
+      for (unsigned int i = 0; i < v_ZMassResHistos.size(); ++i) {
+        TH1D *zMass = v_ZMassResHistos[i];
+        zMass->Rebin(4);  //remember...
+        funct::Gaussian gaus1(mean, sigma1);
+        funct::Gaussian gaus2(mean2, sigma2);
+        funct::Gaussian gaus3(mean3, sigma3);
+        funct::Constant a(alpha), b(beta), c(yield);
+        funct::Number _1(1);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type G1;
+        typedef funct::Sum<G1, G1>::type SumG1;
+        typedef funct::Sum<funct::Constant, funct::Constant>::type ConstSum;
+        typedef funct::Product<funct::Difference<funct::Number, ConstSum>::type, funct::Gaussian>::type G2;
+        typedef funct::Product<funct::Constant, funct::Sum<SumG1, G2>::type>::type FitFunction;
+        FitFunction f = c * (a * gaus1 + b * gaus2 + (_1 - (a + b)) * gaus3);
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(alpha, 0.1, -1., 1.);
+        minuit.addParameter(beta, 0.1, -1., 1.);
+        minuit.addParameter(mean, 0.001, -1., 1.);
+        minuit.addParameter(mean2, 0.001, -1., 1.);
+        minuit.addParameter(mean3, 0.001, -1., 1.);
+        minuit.addParameter(sigma1, 0.1, -5., 5.);
+        minuit.addParameter(sigma2, 0.1, -5., 5.);
+        minuit.addParameter(sigma3, 0.1, -20., 20.);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(beta.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(mean2.ptr());
+        pars.push_back(mean3.ptr());
+        pars.push_back(sigma1.ptr());
+        pars.push_back(sigma2.ptr());
+        pars.push_back(sigma3.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        beta.name().c_str(),
+                        mean.name().c_str(),
+                        mean2.name().c_str(),
+                        mean3.name().c_str(),
+                        sigma1.name().c_str(),
+                        sigma2.name().c_str(),
+                        sigma3.name().c_str());
+        fun.SetLineColor(kRed);
+        //fun.SetNpx(100000);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMassResFitGGG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMassResFitGGG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
     cout << "It works!\n";
-  }
-  catch(std::exception& e) {
+  } catch (std::exception &e) {
     cerr << "error: " << e.what() << "\n";
     return 1;
-  }
-  catch(...) {
+  } catch (...) {
     cerr << "Exception of unknown type!\n";
   }
-  return 0;  
+  return 0;
 }

--- a/ElectroWeakAnalysis/ZMuMu/bin/zMassResFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zMassResFit.cpp
@@ -16,7 +16,7 @@
 #include "TCanvas.h"
 #include "TROOT.h"
 #include "TMath.h"
-#include <boost/shared_ptr.hpp>
+
 #include <boost/program_options.hpp>
 using namespace boost;
 namespace po = boost::program_options;

--- a/ElectroWeakAnalysis/ZMuMu/bin/zToMuMuMassMCFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zToMuMuMassMCFit.cpp
@@ -18,7 +18,7 @@
 #include "TMath.h"
 #include "TCanvas.h"
 #include "TROOT.h"
-#include <boost/shared_ptr.hpp>
+
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <algorithm> 

--- a/ElectroWeakAnalysis/ZMuMu/bin/zToMuMuMassMCFit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zToMuMuMassMCFit.cpp
@@ -21,413 +21,417 @@
 
 #include <boost/program_options.hpp>
 #include <iostream>
-#include <algorithm> 
+#include <algorithm>
 #include <iterator>
 #include <string>
 #include <vector>
-using namespace boost;	
+using namespace boost;
 namespace po = boost::program_options;
 using namespace std;
 
 // A helper function to simplify the main part.
-template<class T>
-ostream& operator<<(ostream& os, const vector<T>& v) {
-  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " ")); 
+template <class T>
+ostream &operator<<(ostream &os, const vector<T> &v) {
+  copy(v.begin(), v.end(), ostream_iterator<T>(cout, " "));
   return os;
 }
 
-int main(int ac, char *av[]) { 
+int main(int ac, char *av[]) {
   try {
     double fMin, fMax;
     string ext;
     po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help", "produce help message")
-      ("include-path,I", po::value< vector<string> >(), 
-       "include path")
-      ("input-file", po::value< vector<string> >(), "input file")
-      ("min,m", po::value<double>(&fMin)->default_value(80), "minimum value for fit range")
-      ("max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")
-      ("breitwigner", "fit to a breit-wigner")
-      ("gauss", "fit to a gaussian")
-      ("bwinter", "fit to a breit-wigner plus Z/photon interference term")
-      ("bwintgam", 
-       "fit to a breit-wigner plus Z/photon interference term and photon propagator")
-      ("expbwintgam", 
-       "fit to the product of an exponential with a breit-wigner plus Z/photon interference term and photon propagator")
-      ("weipolexpbwintgam", 
-       "fit to the product of a weighted polynomial and an exponential with a breit-wigner plus Z/photon interference term and photon propagator")
-      ("output-file,O", po::value<string>(&ext)->default_value(".ps"), 
-       "output file format")
-      ;
-    
+    desc.add_options()("help", "produce help message")("include-path,I", po::value<vector<string> >(), "include path")(
+        "input-file", po::value<vector<string> >(), "input file")(
+        "min,m", po::value<double>(&fMin)->default_value(80), "minimum value for fit range")(
+        "max,M", po::value<double>(&fMax)->default_value(120), "maximum value for fit range")(
+        "breitwigner", "fit to a breit-wigner")("gauss", "fit to a gaussian")(
+        "bwinter", "fit to a breit-wigner plus Z/photon interference term")(
+        "bwintgam", "fit to a breit-wigner plus Z/photon interference term and photon propagator")(
+        "expbwintgam",
+        "fit to the product of an exponential with a breit-wigner plus Z/photon interference term and photon "
+        "propagator")("weipolexpbwintgam",
+                      "fit to the product of a weighted polynomial and an exponential with a breit-wigner plus "
+                      "Z/photon interference term and photon propagator")(
+        "output-file,O", po::value<string>(&ext)->default_value(".ps"), "output file format");
+
     po::positional_options_description p;
     p.add("input-file", -1);
-    
+
     po::variables_map vm;
-    po::store(po::command_line_parser(ac, av).
-	      options(desc).positional(p).run(), vm);
+    po::store(po::command_line_parser(ac, av).options(desc).positional(p).run(), vm);
     po::notify(vm);
-    
+
     if (vm.count("help")) {
       cout << "Usage: options_description [options]\n";
       cout << desc;
       return 0;
     }
-    
+
     if (vm.count("include-path")) {
-      cout << "Include paths are: " 
-	   << vm["include-path"].as< vector<string> >() << "\n";
+      cout << "Include paths are: " << vm["include-path"].as<vector<string> >() << "\n";
     }
-    
+
     vector<string> v_file;
-    vector<TH1D*> v_ZMCMassHistos;
+    vector<TH1D *> v_ZMCMassHistos;
     vector<string> v_eps;
-    
+
     if (vm.count("input-file")) {
-      cout << "Input files are: " 
-	   << vm["input-file"].as< vector<string> >() << "\n";
-      v_file = vm["input-file"].as< vector<string> >();
-      for(vector<string>::const_iterator it = v_file.begin(); 
-	  it != v_file.end(); ++it) { 
-	TFile * root_file = new TFile(it->c_str(),"read");
-	TDirectory *Histos = (TDirectory*) root_file->GetDirectory("ZHisto");
-	TDirectory *MCHistos = (TDirectory*) Histos->GetDirectory("ZMCHisto");
-	TH1D * zMass = (TH1D*) MCHistos->Get("MuMuMCMass"); //for Z status 3 use "ZMCMass"
-	zMass->Rebin(4); //remember...
-	zMass->GetXaxis()->SetTitle("Mass (GeV/c^{2})");
-	v_ZMCMassHistos.push_back(zMass);
-	gROOT->SetStyle("Plain");
-	string f_string = *it;
-	replace(f_string.begin(), f_string.end(), '.', '_');
-	string eps_string = f_string + ext;
-	v_eps.push_back(eps_string);
-	cout << ">>> histogram loaded\n";
+      cout << "Input files are: " << vm["input-file"].as<vector<string> >() << "\n";
+      v_file = vm["input-file"].as<vector<string> >();
+      for (vector<string>::const_iterator it = v_file.begin(); it != v_file.end(); ++it) {
+        TFile *root_file = new TFile(it->c_str(), "read");
+        TDirectory *Histos = (TDirectory *)root_file->GetDirectory("ZHisto");
+        TDirectory *MCHistos = (TDirectory *)Histos->GetDirectory("ZMCHisto");
+        TH1D *zMass = (TH1D *)MCHistos->Get("MuMuMCMass");  //for Z status 3 use "ZMCMass"
+        zMass->Rebin(4);                                    //remember...
+        zMass->GetXaxis()->SetTitle("Mass (GeV/c^{2})");
+        v_ZMCMassHistos.push_back(zMass);
+        gROOT->SetStyle("Plain");
+        string f_string = *it;
+        replace(f_string.begin(), f_string.end(), '.', '_');
+        string eps_string = f_string + ext;
+        v_eps.push_back(eps_string);
+        cout << ">>> histogram loaded\n";
       }
       cout << v_file.size() << ", " << v_ZMCMassHistos.size() << ", " << v_eps.size() << endl;
-      cout <<">>> Input files loaded\n";
-    } 
+      cout << ">>> Input files loaded\n";
+    }
     //Values for Z mass and width
-    funct::Parameter mass("Mass", 91.092); //91.1876
-    funct::Parameter gamma("Gamma", 2.980); //2.4952
+    funct::Parameter mass("Mass", 91.092);   //91.1876
+    funct::Parameter gamma("Gamma", 2.980);  //2.4952
     //funct::Parameters for Z Line Shape
-    funct::Parameter f_gamma("Photon factor", 0.85); //0
-    funct::Parameter f_int("Interference factor", -0.00142); //0.001
-    funct::Parameter yield("Yield", 482000); //1000
+    funct::Parameter f_gamma("Photon factor", 0.85);          //0
+    funct::Parameter f_int("Interference factor", -0.00142);  //0.001
+    funct::Parameter yield("Yield", 482000);                  //1000
     //funct::Parameters for fits with one gaussian
     funct::Parameter mean("Mean", 91.1876);
     funct::Parameter sigma("Sigma", 10.);
     //funct::Parameters for fit with an exponential
-    funct::Parameter lambda("Lambda", -0.0054); //-0.001
+    funct::Parameter lambda("Lambda", -0.0054);  //-0.001
     //funct::Parameters for fit with a weighted polynomial
     funct::Parameter alpha("Alpha", 0.1);
-      
+
     if (vm.count("breitwigner")) {
       cout << "Fitting histograms in input file to a Breit-Wigner\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass  << endl; 
-      cout << gamma << endl; 
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	cout << ">>> load histogram\n";
-	TH1D * zMass = v_ZMCMassHistos[i];
-	cout << ">>> histogram loaded\n";
-	funct::BreitWigner bw(mass, gamma);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::BreitWigner>::type FitFunction;
-	FitFunction f = c * bw;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.minimize();
-	minuit.printFitResults();
-	root::plot("ZMuMuMassMCFitBW.eps", *zMass, f, fMin, fMax, yield, mass, gamma);
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        cout << ">>> load histogram\n";
+        TH1D *zMass = v_ZMCMassHistos[i];
+        cout << ">>> histogram loaded\n";
+        funct::BreitWigner bw(mass, gamma);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::BreitWigner>::type FitFunction;
+        FitFunction f = c * bw;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.minimize();
+        minuit.printFitResults();
+        root::plot("ZMuMuMassMCFitBW.eps", *zMass, f, fMin, fMax, yield, mass, gamma);
       }
     }
-    
+
     if (vm.count("gauss")) {
-      cout << "Fitting histograms in input files to a Gaussian\n"; 
+      cout << "Fitting histograms in input files to a Gaussian\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mean  << endl; 
+      cout << yield << endl;
+      cout << mean << endl;
       cout << sigma << endl;
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMCMassHistos[i]; 
-	funct::Gaussian gaus(mean, sigma);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
-	FitFunction f = c * gaus;
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mean, 0.001, 80, 100);
-	minuit.addParameter(sigma, 0.1, -5., 5.);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma);
-	fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma.name().c_str());
-	fun.SetLineColor(kRed);
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");	
-	string epsFilename = "ZMuMuMassMCFitG_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMuMuMassMCFitG_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::Gaussian gaus(mean, sigma);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::Gaussian>::type FitFunction;
+        FitFunction f = c * gaus;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mean, 0.001, 80, 100);
+        minuit.addParameter(sigma, 0.1, -5., 5.);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, yield, mean, sigma);
+        fun.SetParNames(yield.name().c_str(), mean.name().c_str(), sigma.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMuMuMassMCFitG_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMuMuMassMCFitG_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("bwinter")) {
       cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass  << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int  << endl; 
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMCMassHistos[i]; 
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	FitFunction f = c * zls;
-	cout << "set functions" << endl;
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 100000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.fixParameter(f_gamma.name());
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str());
-	fun.SetLineColor(kRed); 
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMuMuMassMCFitBwIn_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMuMuMassMCFitBwIn_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 100000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.fixParameter(f_gamma.name());
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMuMuMassMCFitBwIn_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMuMuMassMCFitBwIn_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
-    if (vm.count("bwintgam"))	{
-      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and photon propagator\n";
+
+    if (vm.count("bwintgam")) {
+      cout << "Fitting histograms in input files to the Breit-Wigner plus Z/photon interference term and photon "
+              "propagator\n";
       cout << ">>> set pars: " << endl;
-      cout << yield << endl; 
-      cout << mass  << endl; 
-      cout << gamma << endl; 
-      cout << f_gamma << endl; 
-      cout << f_int << endl; 
-      for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	TH1D * zMass = v_ZMCMassHistos[i]; 
-	funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	funct::Constant c(yield);
-	typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
-	FitFunction f = c * zls;
-	cout << "set functions" << endl;
-	vector<shared_ptr<double> > pars;
-	pars.push_back(yield.ptr());
-	pars.push_back(mass.ptr());
-	pars.push_back(gamma.ptr());
-	pars.push_back(f_gamma.ptr());
-	pars.push_back(f_int.ptr());
-	typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	ChiSquared chi2(f, zMass, fMin, fMax);
-	int fullBins = chi2.numberOfBins();
-	cout << "N. deg. of freedom: " << fullBins << endl;
-	fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	minuit.addParameter(yield, 10, 100, 1000000);
-	minuit.addParameter(mass, .1, 70., 110);
-	minuit.addParameter(gamma, 1, 1, 10);
-	minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	minuit.minimize();
-	minuit.printFitResults();
-	TF1 fun = root::tf1("fun", f, fMin, fMax, pars); 
-	fun.SetParNames(yield.name().c_str(), mass.name().c_str(), gamma.name().c_str(), 
-			f_gamma.name().c_str(), f_int.name().c_str());
-	fun.SetLineColor(kRed); 
-	TCanvas *canvas = new TCanvas("canvas");
-	zMass->Draw("e");
-	fun.Draw("same");
-	string epsFilename = "ZMuMuMassMCFitBwInGa_" + v_eps[i];
-	canvas->SaveAs(epsFilename.c_str());
-	canvas->SetLogy();
-	string epsLogFilename = "ZMuMuMassMCFitBwInGa_Log_" + v_eps[i];
-	canvas->SaveAs(epsLogFilename.c_str());
+      cout << yield << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::ZLineShape>::type FitFunction;
+        FitFunction f = c * zls;
+        cout << "set functions" << endl;
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 1000000);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetParNames(yield.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMuMuMassMCFitBwInGa_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMuMuMassMCFitBwInGa_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
     }
-    
+
     if (vm.count("expbwintgam")) {
-	cout << "Fitting histograms in input files to the product of an exponential with the Breit-Wigner plus Z/photon interference term and photon propagator\n";
-	cout << ">>> set pars: " << endl;
-	cout << yield  << endl; 
-	cout << lambda << endl;
-	cout << mass << endl; 
-	cout << gamma  << endl; 
-	cout << f_gamma << endl; 
-	cout << f_int << endl; 
-	for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	  TH1D * zMass = v_ZMCMassHistos[i]; 
-	  funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	  funct::Exponential expo(lambda);
-	  funct::Constant c(yield);
-	  typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
-	  ExpZLS expz = expo * zls;
-	  typedef funct::Product<funct::Constant, ExpZLS>::type FitFunction;
-	  FitFunction f = c * expz;
-	  cout << "set functions" << endl;
-	  typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	  ChiSquared chi2(f, zMass, fMin, fMax);
-	  int fullBins = chi2.numberOfBins();
-	  cout << "N. deg. of freedom: " << fullBins << endl;
-	  fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	  minuit.addParameter(yield, 10, 100, 10000000);
-	  minuit.addParameter(lambda, 0.1, -1., 0);
-	  minuit.addParameter(mass, .1, 70., 110);
-	  minuit.addParameter(gamma, 1, 1, 10);
-	  minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	  minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	  minuit.minimize();
-	  minuit.printFitResults();
-	  vector<shared_ptr<double> > pars;
-	  pars.push_back(yield.ptr());
-	  pars.push_back(lambda.ptr());
-	  pars.push_back(mass.ptr());
-	  pars.push_back(gamma.ptr());
-	  pars.push_back(f_gamma.ptr());
-	  pars.push_back(f_int.ptr());
-	  TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	  fun.SetNpx(100000);
-	  fun.SetParNames(yield.name().c_str(), lambda.name().c_str(), 
-			  mass.name().c_str(), gamma.name().c_str(), 
-			  f_gamma.name().c_str(), f_int.name().c_str());
-	  fun.SetLineColor(kRed); 
-	  TCanvas *canvas = new TCanvas("canvas");
-	  zMass->Draw("e");
-	  fun.Draw("same");
-	  string epsFilename = "ZMuMuMassMCFitExpBwInGa_" + v_eps[i];
-	  canvas->SaveAs(epsFilename.c_str());
-	  canvas->SetLogy();
-	  string epsLogFilename = "ZMuMuMassMCFitExpBwInGa_Log_" + v_eps[i];
-	  canvas->SaveAs(epsLogFilename.c_str());
-	  }
+      cout << "Fitting histograms in input files to the product of an exponential with the Breit-Wigner plus Z/photon "
+              "interference term and photon propagator\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << lambda << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Exponential expo(lambda);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
+        ExpZLS expz = expo * zls;
+        typedef funct::Product<funct::Constant, ExpZLS>::type FitFunction;
+        FitFunction f = c * expz;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(lambda, 0.1, -1., 0);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(lambda.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetNpx(100000);
+        fun.SetParNames(yield.name().c_str(),
+                        lambda.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMuMuMassMCFitExpBwInGa_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMuMuMassMCFitExpBwInGa_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
-      
-      if (vm.count("weipolexpbwintgam")) {
-	cout << "Fitting histograms in input files to the product of a weighted polynomial and an exponential with the Breit-Wigner plus Z/photon interference term and photon propagator\n";
-	cout << ">>> set pars: " << endl;
-	cout << yield << endl; 
-	cout << lambda << endl;
-	cout << mass  << endl; 
-	cout << gamma << endl; 
-	cout << f_gamma << endl; 
-	cout << f_int  << endl; 
-	cout << mean  << endl; 
-	cout << sigma << endl; 
-	cout << alpha << endl;
-	for(unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) { 
-	  TH1D * zMass = v_ZMCMassHistos[i]; 
-	  funct::Constant a(alpha);
-	  funct::Identity id;
-	  funct::Gaussian gaus(mean, sigma);
-	  funct::Number _1(1.);
-	  funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
-	  funct::Exponential expo(lambda);
-	  funct::Constant c(yield);
-	  typedef funct::Product<funct::Constant, funct::Identity>::type Pol1;
-	  Pol1 pol = a * id;
-	  typedef funct::Product<Pol1, funct::Gaussian>::type PolGau;
-	  PolGau poga = pol * gaus;
-	  typedef funct::Sum<funct::Number, PolGau>::type SumPG;
-	  SumPG spg = _1 + poga;
-	  typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
-	  ExpZLS expz = expo * zls;
-	  typedef funct::Product<SumPG, ExpZLS>::type SumPGExpZ;
-	  SumPGExpZ spgexpz = spg * expz;
-	  typedef funct::Product<funct::Constant, SumPGExpZ>::type FitFunction;
-	  FitFunction f = c * spgexpz;
-	  cout << "set functions" << endl;
-	  typedef fit::HistoChiSquare<FitFunction> ChiSquared;
-	  ChiSquared chi2(f, zMass, fMin, fMax);
-	  int fullBins = chi2.numberOfBins();
-	  cout << "N. deg. of freedom: " << fullBins << endl;
-	  fit::RootMinuit<ChiSquared> minuit(chi2, true);
-	  minuit.addParameter(yield, 10, 100, 10000000);
-	  minuit.addParameter(alpha, 0.1, -100, 100);
-	  minuit.addParameter(mean, 10, 70, 110);
-	  minuit.fixParameter(mean.name());
-	  minuit.addParameter(sigma, 0.1, -100, 100);
-	  minuit.addParameter(lambda, 0.1, -100, 100);
-	  minuit.addParameter(mass, .1, 70., 110);
-	  minuit.addParameter(gamma, 1, 1, 10);
-	  minuit.addParameter(f_gamma, 0.1, -100, 1000);
-	  minuit.addParameter(f_int, .0001, -1000000, 1000000);
-	  minuit.minimize();
-	  minuit.printFitResults();
-	  vector<shared_ptr<double> > pars;
-	  pars.push_back(yield.ptr());
-	  pars.push_back(alpha.ptr());
-	  pars.push_back(mean.ptr());
-	  pars.push_back(sigma.ptr());
-	  pars.push_back(lambda.ptr());
-	  pars.push_back(mass.ptr());
-	  pars.push_back(gamma.ptr());
-	  pars.push_back(f_gamma.ptr());
-	  pars.push_back(f_int.ptr());
-	  TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
-	  fun.SetNpx(100000);
-	  fun.SetParNames(yield.name().c_str(), alpha.name().c_str(), 
-			  mean.name().c_str(), sigma.name().c_str(), 
-			  lambda.name().c_str(), 
-			  mass.name().c_str(), gamma.name().c_str(), 
-			  f_gamma.name().c_str(), f_int.name().c_str());
-	  fun.SetLineColor(kRed); 
-	  fun.SetLineWidth(1); 
-	  fun.SetLineStyle(kDashed); 
-	  TCanvas *canvas = new TCanvas("canvas");
-	  zMass->Draw("e");
-	  fun.Draw("same");
-	  string epsFilename = "ZMuMuMassMCFitWeiPolExpBwInGa_" + v_eps[i];
-	  canvas->SaveAs(epsFilename.c_str());
-	  canvas->SetLogy();
-	  string epsLogFilename = "ZMuMuMassMCFitWeiPolExpBwInGa_Log_" + v_eps[i];
-	  canvas->SaveAs(epsLogFilename.c_str());
-	}
+    }
+
+    if (vm.count("weipolexpbwintgam")) {
+      cout << "Fitting histograms in input files to the product of a weighted polynomial and an exponential with the "
+              "Breit-Wigner plus Z/photon interference term and photon propagator\n";
+      cout << ">>> set pars: " << endl;
+      cout << yield << endl;
+      cout << lambda << endl;
+      cout << mass << endl;
+      cout << gamma << endl;
+      cout << f_gamma << endl;
+      cout << f_int << endl;
+      cout << mean << endl;
+      cout << sigma << endl;
+      cout << alpha << endl;
+      for (unsigned int i = 0; i < v_ZMCMassHistos.size(); ++i) {
+        TH1D *zMass = v_ZMCMassHistos[i];
+        funct::Constant a(alpha);
+        funct::Identity id;
+        funct::Gaussian gaus(mean, sigma);
+        funct::Number _1(1.);
+        funct::ZLineShape zls(mass, gamma, f_gamma, f_int);
+        funct::Exponential expo(lambda);
+        funct::Constant c(yield);
+        typedef funct::Product<funct::Constant, funct::Identity>::type Pol1;
+        Pol1 pol = a * id;
+        typedef funct::Product<Pol1, funct::Gaussian>::type PolGau;
+        PolGau poga = pol * gaus;
+        typedef funct::Sum<funct::Number, PolGau>::type SumPG;
+        SumPG spg = _1 + poga;
+        typedef funct::Product<funct::Exponential, funct::ZLineShape>::type ExpZLS;
+        ExpZLS expz = expo * zls;
+        typedef funct::Product<SumPG, ExpZLS>::type SumPGExpZ;
+        SumPGExpZ spgexpz = spg * expz;
+        typedef funct::Product<funct::Constant, SumPGExpZ>::type FitFunction;
+        FitFunction f = c * spgexpz;
+        cout << "set functions" << endl;
+        typedef fit::HistoChiSquare<FitFunction> ChiSquared;
+        ChiSquared chi2(f, zMass, fMin, fMax);
+        int fullBins = chi2.numberOfBins();
+        cout << "N. deg. of freedom: " << fullBins << endl;
+        fit::RootMinuit<ChiSquared> minuit(chi2, true);
+        minuit.addParameter(yield, 10, 100, 10000000);
+        minuit.addParameter(alpha, 0.1, -100, 100);
+        minuit.addParameter(mean, 10, 70, 110);
+        minuit.fixParameter(mean.name());
+        minuit.addParameter(sigma, 0.1, -100, 100);
+        minuit.addParameter(lambda, 0.1, -100, 100);
+        minuit.addParameter(mass, .1, 70., 110);
+        minuit.addParameter(gamma, 1, 1, 10);
+        minuit.addParameter(f_gamma, 0.1, -100, 1000);
+        minuit.addParameter(f_int, .0001, -1000000, 1000000);
+        minuit.minimize();
+        minuit.printFitResults();
+        vector<shared_ptr<double> > pars;
+        pars.push_back(yield.ptr());
+        pars.push_back(alpha.ptr());
+        pars.push_back(mean.ptr());
+        pars.push_back(sigma.ptr());
+        pars.push_back(lambda.ptr());
+        pars.push_back(mass.ptr());
+        pars.push_back(gamma.ptr());
+        pars.push_back(f_gamma.ptr());
+        pars.push_back(f_int.ptr());
+        TF1 fun = root::tf1("fun", f, fMin, fMax, pars);
+        fun.SetNpx(100000);
+        fun.SetParNames(yield.name().c_str(),
+                        alpha.name().c_str(),
+                        mean.name().c_str(),
+                        sigma.name().c_str(),
+                        lambda.name().c_str(),
+                        mass.name().c_str(),
+                        gamma.name().c_str(),
+                        f_gamma.name().c_str(),
+                        f_int.name().c_str());
+        fun.SetLineColor(kRed);
+        fun.SetLineWidth(1);
+        fun.SetLineStyle(kDashed);
+        TCanvas *canvas = new TCanvas("canvas");
+        zMass->Draw("e");
+        fun.Draw("same");
+        string epsFilename = "ZMuMuMassMCFitWeiPolExpBwInGa_" + v_eps[i];
+        canvas->SaveAs(epsFilename.c_str());
+        canvas->SetLogy();
+        string epsLogFilename = "ZMuMuMassMCFitWeiPolExpBwInGa_Log_" + v_eps[i];
+        canvas->SaveAs(epsLogFilename.c_str());
       }
-      
-      cout << "It works!\n";
-  }
-  catch(std::exception& e) {
+    }
+
+    cout << "It works!\n";
+  } catch (std::exception &e) {
     cerr << "error: " << e.what() << "\n";
     return 1;
-  }
-  catch(...) {
+  } catch (...) {
     cerr << "Exception of unknown type!\n";
   }
   return 0;

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData.h
@@ -1,9 +1,10 @@
 #ifndef CSCAnodeData_h
 #define CSCAnodeData_h
 #include <vector>
+#include <memory>
 #include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeDataFormat.h"
-#include <boost/shared_ptr.hpp>
+
 
 class CSCALCTHeader;
 
@@ -27,7 +28,7 @@ public:
   static bool selfTest();
 
 private:
-  boost::shared_ptr<CSCAnodeDataFormat> theData;
+  std::shared_ptr<CSCAnodeDataFormat> theData;
   int firmwareVersion;
 };
 

--- a/EventFilter/CSCRawToDigi/interface/CSCAnodeData.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCAnodeData.h
@@ -5,7 +5,6 @@
 #include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCAnodeDataFormat.h"
 
-
 class CSCALCTHeader;
 
 class CSCAnodeData {

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -5,13 +5,14 @@
 
 #include <iosfwd>
 #include <vector>
+#include <memory>
 #include "DataFormats/CSCDigi/interface/CSCTMBStatusDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include <boost/shared_ptr.hpp>
+
 #ifndef LOCAL_UNPACK
 #include <atomic>
 #endif
@@ -112,7 +113,7 @@ private:
   static std::atomic<bool> debug;
 #endif
 
-  boost::shared_ptr<CSCVTMBHeaderFormat> theHeaderFormat;
+  std::shared_ptr<CSCVTMBHeaderFormat> theHeaderFormat;
   int theFirmwareVersion;
 };
 

--- a/EventFilter/CSCRawToDigi/src/CSCAnodeData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCAnodeData.cc
@@ -8,9 +8,9 @@
 CSCAnodeData::CSCAnodeData(const CSCALCTHeader &header)  ///for digi->raw packing
     : firmwareVersion(header.alctFirmwareVersion()) {
   if (firmwareVersion == 2006) {
-    theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2006(header));
+    theData = std::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2006(header));
   } else {
-    theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2007(header));
+    theData = std::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2007(header));
   }
 }
 
@@ -18,9 +18,9 @@ CSCAnodeData::CSCAnodeData(const CSCALCTHeader &header)  ///for digi->raw packin
 CSCAnodeData::CSCAnodeData(const CSCALCTHeader &header, const unsigned short *buf)
     : firmwareVersion(header.alctFirmwareVersion()) {
   if (firmwareVersion == 2006) {
-    theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2006(header, buf));
+    theData = std::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2006(header, buf));
   } else {
-    theData = boost::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2007(header, buf));
+    theData = std::shared_ptr<CSCAnodeDataFormat>(new CSCAnodeData2007(header, buf));
   }
 }
 

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -20,9 +20,9 @@ std::atomic<bool> CSCTMBHeader::debug{false};
 CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
     : theHeaderFormat(), theFirmwareVersion(firmwareVersion) {
   if (firmwareVersion == 2013) {
-    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
+    theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
   } else if (firmwareVersion == 2006) {
-    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006());
+    theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006());
   } else if (firmwareVersion == 2007) {
     /* Checks for TMB2007 firmware revisions ranges to detect data format
        * rev.0x50c3 - first revision with changed format 
@@ -33,12 +33,12 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
       // if (firmwareRevision >= 0x7a76) // First OTMB firmware revision with 2013 format
       /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
       if ((firmwareRevision >= 0x6000) || (firmwareRevision < 0x42D5)) {
-        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
+        theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
       } else {
-        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3());
+        theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3());
       }
     } else {
-      theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007());
+      theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007());
     }
   } else {
     edm::LogError("CSCTMBHeader|CSCRawToDigi") << "failed to determine TMB firmware version!!";
@@ -53,7 +53,7 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
   ///first determine the format
   if (buf[0] == 0xDB0C) {
     theFirmwareVersion = 2007;
-    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007(buf));
+    theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007(buf));
     /* Checks for TMB2007 firmware revisions ranges to detect data format
        * rev.0x50c3 - first revision with changed format 
        * rev.0x42D5 - oldest known from 06/21/2007
@@ -64,15 +64,15 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
       /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
       if ((theHeaderFormat->firmwareRevision() >= 0x6000) || (theHeaderFormat->firmwareRevision() < 0x42D5)) {
         theFirmwareVersion = 2013;
-        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013(buf));
+        theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013(buf));
       } else {
-        theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3(buf));
+        theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2007_rev0x50c3(buf));
       }
     }
 
   } else if (buf[0] == 0x6B0C) {
     theFirmwareVersion = 2006;
-    theHeaderFormat = boost::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006(buf));
+    theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2006(buf));
   } else {
     edm::LogError("CSCTMBHeader|CSCRawToDigi") << "failed to determine TMB firmware version!!";
   }

--- a/EventFilter/Utilities/plugins/EvFBuildingThrottle.h
+++ b/EventFilter/Utilities/plugins/EvFBuildingThrottle.h
@@ -93,7 +93,7 @@ namespace evf {
     void start() {
       assert(!m_thread);
       token_ = edm::ServiceRegistry::instance().presentToken();
-      m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&EvFBuildingThrottle::dowork, this)));
+      m_thread = std::shared_ptr<boost::thread>(new boost::thread(boost::bind(&EvFBuildingThrottle::dowork, this)));
       std::cout << "throttle thread started - throttle on " << whatToThrottleOn_ << std::endl;
     }
     void stop() {
@@ -105,7 +105,7 @@ namespace evf {
     double highWaterMark_;
     double lowWaterMark_;
     std::atomic<bool> m_stoprequest;
-    boost::shared_ptr<boost::thread> m_thread;
+    std::shared_ptr<boost::thread> m_thread;
     boost::mutex lock_;
     std::string baseDir_;
     Directory whatToThrottleOn_;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -63,7 +63,7 @@ namespace evf {
     jsoncollector::StringJ transferDestination_;
     jsoncollector::StringJ mergeType_;
     jsoncollector::IntJ hltErrorEvents_;
-    boost::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
+    std::shared_ptr<jsoncollector::FastMonitor> jsonMonitor_;
     evf::FastMonitoringService* fms_;
     jsoncollector::DataPointDefinition outJsonDef_;
     unsigned char* outBuf_ = nullptr;

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
@@ -10,8 +10,6 @@
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 
-
-
 #include <iostream>
 #include <vector>
 #include <memory>

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
@@ -10,7 +10,7 @@
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 
-#include "boost/shared_ptr.hpp"
+
 
 #include <iostream>
 #include <vector>
@@ -43,8 +43,8 @@ namespace evf {
     uint32 get_adler32() const { return stream_writer_events_->adler32(); }
 
   private:
-    boost::shared_ptr<StreamerOutputFile> stream_writer_preamble_;
-    boost::shared_ptr<StreamerOutputFile> stream_writer_events_;
+    std::shared_ptr<StreamerOutputFile> stream_writer_preamble_;
+    std::shared_ptr<StreamerOutputFile> stream_writer_events_;
     uint32 preamble_adler32_ = 1;
   };
 }  // namespace evf

--- a/GeneratorInterface/Core/interface/FortranCallback.h
+++ b/GeneratorInterface/Core/interface/FortranCallback.h
@@ -1,7 +1,7 @@
 #ifndef gen_FortranCallback_h
 #define gen_FortranCallback_h
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "SimDataFormats/GeneratorProducts/interface/LHECommonBlocks.h"
 

--- a/GeneratorInterface/Core/interface/FortranCallback.h
+++ b/GeneratorInterface/Core/interface/FortranCallback.h
@@ -1,8 +1,6 @@
 #ifndef gen_FortranCallback_h
 #define gen_FortranCallback_h
 
-
-
 #include "SimDataFormats/GeneratorProducts/interface/LHECommonBlocks.h"
 
 #include "GeneratorInterface/LHEInterface/interface/LHERunInfo.h"

--- a/GeneratorInterface/ExhumeInterface/interface/ExhumeHadronizer.h
+++ b/GeneratorInterface/ExhumeInterface/interface/ExhumeHadronizer.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 

--- a/GeneratorInterface/ExhumeInterface/interface/ExhumeHadronizer.h
+++ b/GeneratorInterface/ExhumeInterface/interface/ExhumeHadronizer.h
@@ -5,8 +5,6 @@
 #include <string>
 #include <vector>
 
-
-
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"

--- a/GeneratorInterface/Herwig6Interface/plugins/Herwig6Hadronizer.cc
+++ b/GeneratorInterface/Herwig6Interface/plugins/Herwig6Hadronizer.cc
@@ -5,7 +5,7 @@
 #include <memory>
 #include <map>
 #include <set>
-#include <boost/shared_ptr.hpp>
+
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <HepMC/GenEvent.h>

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -8,8 +8,6 @@ Marco A. Harrendorf
 #include <memory>
 #include <string>
 
-
-
 #include <HepMC/GenEvent.h>
 #include <HepMC/PdfInfo.h>
 #include <HepMC/IO_BaseClass.h>

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -8,7 +8,7 @@ Marco A. Harrendorf
 #include <memory>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include <HepMC/GenEvent.h>
 #include <HepMC/PdfInfo.h>
@@ -70,7 +70,7 @@ protected:
   void createInputFile(const edm::ParameterSet &params);
 
 private:
-  boost::shared_ptr<ThePEG::RandomEngineGlue::Proxy> randomEngineGlueProxy_;
+  std::shared_ptr<ThePEG::RandomEngineGlue::Proxy> randomEngineGlueProxy_;
 
   const std::string dataLocation_;
   const std::string generator_;

--- a/GeneratorInterface/Herwig7Interface/interface/Proxy.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Proxy.h
@@ -1,7 +1,7 @@
 #ifndef GeneratorInterface_Herwig7Interface_Proxy_h
 #define GeneratorInterface_Herwig7Interface_Proxy_h
+#include <memory>
 
-#include <boost/shared_ptr.hpp>
 
 namespace ThePEG {
 
@@ -28,8 +28,8 @@ namespace ThePEG {
 
     ProxyBase(ProxyID id);
 
-    static boost::shared_ptr<ProxyBase> create(ctor_t ctor);
-    static boost::shared_ptr<ProxyBase> find(ProxyID id);
+    static std::shared_ptr<ProxyBase> create(ctor_t ctor);
+    static std::shared_ptr<ProxyBase> find(ProxyID id);
 
     // not allowed and not implemented
     ProxyBase(const ProxyBase &orig) = delete;
@@ -43,10 +43,10 @@ namespace ThePEG {
   public:
     typedef Proxy Base;
 
-    static inline boost::shared_ptr<T> create() {
-      return boost::static_pointer_cast<T>(ProxyBase::create(&Proxy::ctor));
+    static inline std::shared_ptr<T> create() {
+      return std::static_pointer_cast<T>(ProxyBase::create(&Proxy::ctor));
     }
-    static inline boost::shared_ptr<T> find(ProxyID id) { return boost::dynamic_pointer_cast<T>(ProxyBase::find(id)); }
+    static inline std::shared_ptr<T> find(ProxyID id) { return std::dynamic_pointer_cast<T>(ProxyBase::find(id)); }
 
   protected:
     inline Proxy(ProxyID id) : ProxyBase(id) {}

--- a/GeneratorInterface/Herwig7Interface/interface/Proxy.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Proxy.h
@@ -2,7 +2,6 @@
 #define GeneratorInterface_Herwig7Interface_Proxy_h
 #include <memory>
 
-
 namespace ThePEG {
 
   // forward declarations
@@ -43,9 +42,7 @@ namespace ThePEG {
   public:
     typedef Proxy Base;
 
-    static inline std::shared_ptr<T> create() {
-      return std::static_pointer_cast<T>(ProxyBase::create(&Proxy::ctor));
-    }
+    static inline std::shared_ptr<T> create() { return std::static_pointer_cast<T>(ProxyBase::create(&Proxy::ctor)); }
     static inline std::shared_ptr<T> find(ProxyID id) { return std::dynamic_pointer_cast<T>(ProxyBase::find(id)); }
 
   protected:

--- a/GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h
+++ b/GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include <ThePEG/Interface/ClassDocumentation.h>
 #include <ThePEG/Interface/InterfacedBase.h>

--- a/GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h
+++ b/GeneratorInterface/Herwig7Interface/interface/RandomEngineGlue.h
@@ -3,8 +3,6 @@
 
 #include <string>
 
-
-
 #include <ThePEG/Interface/ClassDocumentation.h>
 #include <ThePEG/Interface/InterfacedBase.h>
 #include <ThePEG/Interface/Parameter.h>

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -14,7 +14,7 @@
 
 #include <algorithm>
 
-#include <boost/shared_ptr.hpp>
+
 #include <boost/filesystem.hpp>
 
 #include <HepMC/GenEvent.h>

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 
-
 #include <boost/filesystem.hpp>
 
 #include <HepMC/GenEvent.h>

--- a/GeneratorInterface/Herwig7Interface/src/Proxy.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Proxy.cc
@@ -1,8 +1,6 @@
 #include <map>
 
 #include <boost/thread.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 
 #include "GeneratorInterface/Herwig7Interface/interface/Proxy.h"
 
@@ -10,7 +8,7 @@ using namespace ThePEG;
 
 static boost::mutex mutex;
 
-typedef std::map<ProxyBase::ProxyID, boost::weak_ptr<ProxyBase> > ProxyMap;
+typedef std::map<ProxyBase::ProxyID, std::weak_ptr<ProxyBase> > ProxyMap;
 
 static ProxyMap *getProxyMapInstance() {
   static struct Sentinel {
@@ -36,12 +34,12 @@ ProxyBase::~ProxyBase() {
     map->erase(id);
 }
 
-boost::shared_ptr<ProxyBase> ProxyBase::create(ctor_t ctor) {
+std::shared_ptr<ProxyBase> ProxyBase::create(ctor_t ctor) {
   static ProxyBase::ProxyID nextProxyID = 0;
 
   boost::mutex::scoped_lock scoped_lock(mutex);
 
-  boost::shared_ptr<ProxyBase> proxy(ctor(++nextProxyID));
+  std::shared_ptr<ProxyBase> proxy(ctor(++nextProxyID));
 
   ProxyMap *map = getProxyMapInstance();
   if (map)
@@ -50,16 +48,16 @@ boost::shared_ptr<ProxyBase> ProxyBase::create(ctor_t ctor) {
   return proxy;
 }
 
-boost::shared_ptr<ProxyBase> ProxyBase::find(ProxyID id) {
+std::shared_ptr<ProxyBase> ProxyBase::find(ProxyID id) {
   boost::mutex::scoped_lock scoped_lock(mutex);
 
   ProxyMap *map = getProxyMapInstance();
   if (!map)
-    return boost::shared_ptr<ProxyBase>();
+    return std::shared_ptr<ProxyBase>();
 
   ProxyMap::const_iterator pos = map->find(id);
   if (pos == map->end())
-    return boost::shared_ptr<ProxyBase>();
+    return std::shared_ptr<ProxyBase>();
 
-  return boost::shared_ptr<ProxyBase>(pos->second);
+  return std::shared_ptr<ProxyBase>(pos->second);
 }

--- a/GeneratorInterface/Herwig7Interface/src/RandomEngineGlue.cc
+++ b/GeneratorInterface/Herwig7Interface/src/RandomEngineGlue.cc
@@ -43,7 +43,7 @@ void RandomEngineGlue::setSeed(long seed) {
 void RandomEngineGlue::doinit() noexcept(false) {
   RandomGenerator::doinit();
 
-  boost::shared_ptr<Proxy> proxy = Proxy::find(proxyID);
+  std::shared_ptr<Proxy> proxy = Proxy::find(proxyID);
   if (!proxy)
     throw InitException();
 

--- a/GeneratorInterface/LHEInterface/interface/LHEProxy.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEProxy.h
@@ -1,7 +1,7 @@
 #ifndef GeneratorInterface_LHEInterface_LHEProxy_h
 #define GeneratorInterface_LHEInterface_LHEProxy_h
 
-#include <boost/shared_ptr.hpp>
+
 
 namespace lhef {
 
@@ -15,16 +15,16 @@ namespace lhef {
 
     ~LHEProxy();
 
-    const boost::shared_ptr<LHERunInfo> &getRunInfo() const { return runInfo; }
-    const boost::shared_ptr<LHEEvent> &getEvent() const { return event; }
+    const std::shared_ptr<LHERunInfo> &getRunInfo() const { return runInfo; }
+    const std::shared_ptr<LHEEvent> &getEvent() const { return event; }
 
-    boost::shared_ptr<LHERunInfo> releaseRunInfo() {
-      boost::shared_ptr<LHERunInfo> result(runInfo);
+    std::shared_ptr<LHERunInfo> releaseRunInfo() {
+      std::shared_ptr<LHERunInfo> result(runInfo);
       runInfo.reset();
       return result;
     }
-    boost::shared_ptr<LHEEvent> releaseEvent() {
-      boost::shared_ptr<LHEEvent> result(event);
+    std::shared_ptr<LHEEvent> releaseEvent() {
+      std::shared_ptr<LHEEvent> result(event);
       event.reset();
       return result;
     }
@@ -32,13 +32,13 @@ namespace lhef {
     void clearRunInfo() { runInfo.reset(); }
     void clearEvent() { event.reset(); }
 
-    void loadRunInfo(const boost::shared_ptr<LHERunInfo> &runInfo) { this->runInfo = runInfo; }
-    void loadEvent(const boost::shared_ptr<LHEEvent> &event) { this->event = event; }
+    void loadRunInfo(const std::shared_ptr<LHERunInfo> &runInfo) { this->runInfo = runInfo; }
+    void loadEvent(const std::shared_ptr<LHEEvent> &event) { this->event = event; }
 
     ProxyID getID() const { return id; }
 
-    static boost::shared_ptr<LHEProxy> create();
-    static boost::shared_ptr<LHEProxy> find(ProxyID id);
+    static std::shared_ptr<LHEProxy> create();
+    static std::shared_ptr<LHEProxy> find(ProxyID id);
 
   private:
     LHEProxy(ProxyID id);
@@ -49,8 +49,8 @@ namespace lhef {
 
     const ProxyID id;
 
-    boost::shared_ptr<LHERunInfo> runInfo;
-    boost::shared_ptr<LHEEvent> event;
+    std::shared_ptr<LHERunInfo> runInfo;
+    std::shared_ptr<LHEEvent> event;
   };
 
 }  // namespace lhef

--- a/GeneratorInterface/LHEInterface/interface/LHEProxy.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEProxy.h
@@ -1,8 +1,6 @@
 #ifndef GeneratorInterface_LHEInterface_LHEProxy_h
 #define GeneratorInterface_LHEInterface_LHEProxy_h
 
-
-
 namespace lhef {
 
   // forward declarations

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -30,7 +30,7 @@ Implementation:
 #include <sys/resource.h>
 
 #include "boost/bind.hpp"
-#include "boost/shared_ptr.hpp"
+
 #include "boost/ptr_container/ptr_deque.hpp"
 
 // user include files

--- a/GeneratorInterface/LHEInterface/plugins/LHE2HepMCConverter.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHE2HepMCConverter.cc
@@ -19,7 +19,7 @@
 // system include files
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
+
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -60,7 +60,7 @@ private:
   edm::InputTag _lheRunSrcTag;
   const LHERunInfoProduct* _lheRunSrc;
 
-  //      boost::shared_ptr<lhef::LHERunInfo> lheRunInfo_;
+  //      std::shared_ptr<lhef::LHERunInfo> lheRunInfo_;
 };
 
 //

--- a/GeneratorInterface/LHEInterface/plugins/LHE2HepMCConverter.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHE2HepMCConverter.cc
@@ -19,8 +19,6 @@
 // system include files
 #include <memory>
 
-
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"

--- a/GeneratorInterface/LHEInterface/plugins/LHEFilter.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEFilter.cc
@@ -2,7 +2,7 @@
 #include <string>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "HepMC/GenEvent.h"
 #include "HepMC/SimpleVector.h"

--- a/GeneratorInterface/LHEInterface/plugins/LHEFilter.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEFilter.cc
@@ -2,8 +2,6 @@
 #include <string>
 #include <memory>
 
-
-
 #include "HepMC/GenEvent.h"
 #include "HepMC/SimpleVector.h"
 

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -5,7 +5,7 @@
 
 #include <deque>
 
-#include <boost/shared_ptr.hpp>
+
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.h"
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -5,7 +5,6 @@
 
 #include <deque>
 
-
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.h"
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"

--- a/GeneratorInterface/LHEInterface/src/LHEProxy.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEProxy.cc
@@ -1,8 +1,6 @@
 #include <map>
 
 #include <boost/thread.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 
 #include "GeneratorInterface/LHEInterface/interface/LHEProxy.h"
 
@@ -10,7 +8,7 @@ using namespace lhef;
 
 static boost::mutex mutex;
 
-typedef std::map<LHEProxy::ProxyID, boost::weak_ptr<LHEProxy> > ProxyMap;
+typedef std::map<LHEProxy::ProxyID, std::weak_ptr<LHEProxy> > ProxyMap;
 
 static ProxyMap *getProxyMapInstance() {
   static struct Sentinel {
@@ -36,12 +34,12 @@ LHEProxy::~LHEProxy() {
     map->erase(id);
 }
 
-boost::shared_ptr<LHEProxy> LHEProxy::create() {
+std::shared_ptr<LHEProxy> LHEProxy::create() {
   static LHEProxy::ProxyID nextProxyID = 0;
 
   boost::mutex::scoped_lock scoped_lock(mutex);
 
-  boost::shared_ptr<LHEProxy> proxy(new LHEProxy(++nextProxyID));
+  std::shared_ptr<LHEProxy> proxy(new LHEProxy(++nextProxyID));
 
   ProxyMap *map = getProxyMapInstance();
   if (map)
@@ -50,16 +48,16 @@ boost::shared_ptr<LHEProxy> LHEProxy::create() {
   return proxy;
 }
 
-boost::shared_ptr<LHEProxy> LHEProxy::find(ProxyID id) {
+std::shared_ptr<LHEProxy> LHEProxy::find(ProxyID id) {
   boost::mutex::scoped_lock scoped_lock(mutex);
 
   ProxyMap *map = getProxyMapInstance();
   if (!map)
-    return boost::shared_ptr<LHEProxy>();
+    return std::shared_ptr<LHEProxy>();
 
   ProxyMap::const_iterator pos = map->find(id);
   if (pos == map->end())
-    return boost::shared_ptr<LHEProxy>();
+    return std::shared_ptr<LHEProxy>();
 
-  return boost::shared_ptr<LHEProxy>(pos->second);
+  return std::shared_ptr<LHEProxy>(pos->second);
 }

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.h
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.h
@@ -3,8 +3,6 @@
 
 #include <memory>
 
-
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Sources/interface/ProducerSourceFromFiles.h"

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.h
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -72,8 +72,8 @@ private:
 
   std::unique_ptr<std::ifstream> reader;
 
-  boost::shared_ptr<lhef::LHERunInfo> runInfo;
-  boost::shared_ptr<lhef::LHEEvent> event;
+  std::shared_ptr<lhef::LHERunInfo> runInfo;
+  std::shared_ptr<lhef::LHEEvent> event;
 };
 
 #endif  // GeneratorInterface_MCatNLOInterface_MCatNLOSource_h

--- a/GeneratorInterface/PartonShowerVeto/interface/JetMatching.h
+++ b/GeneratorInterface/PartonShowerVeto/interface/JetMatching.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <set>
 
-#include <boost/shared_ptr.hpp>
+
 
 // #include <HepMC/GenEvent.h>
 // #include <HepMC/SimpleVector.h>

--- a/GeneratorInterface/PartonShowerVeto/interface/JetMatching.h
+++ b/GeneratorInterface/PartonShowerVeto/interface/JetMatching.h
@@ -6,8 +6,6 @@
 #include <string>
 #include <set>
 
-
-
 // #include <HepMC/GenEvent.h>
 // #include <HepMC/SimpleVector.h>
 

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatching.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatching.cc
@@ -1,8 +1,6 @@
 #include <string>
 #include <memory>
 
-
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatching.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatching.cc
@@ -1,7 +1,7 @@
 #include <string>
 #include <memory>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
@@ -7,7 +7,7 @@
 #include "GeneratorInterface/LHEInterface/interface/LHERunInfo.h"
 #include "GeneratorInterface/LHEInterface/interface/LHEEvent.h"
 
-#include <boost/shared_ptr.hpp>
+
 #include <boost/algorithm/string/trim.hpp>
 
 namespace gen {

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMGFastJet.cc
@@ -7,7 +7,6 @@
 #include "GeneratorInterface/LHEInterface/interface/LHERunInfo.h"
 #include "GeneratorInterface/LHEInterface/interface/LHEEvent.h"
 
-
 #include <boost/algorithm/string/trim.hpp>
 
 namespace gen {

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
@@ -10,7 +10,7 @@
 #include <map>
 #include <set>
 
-#include <boost/shared_ptr.hpp>
+
 #include <boost/algorithm/string/trim.hpp>
 
 // #include <HepMC/GenEvent.h>
@@ -255,7 +255,7 @@ namespace gen {
   }
 
   //void JetMatchingMadgraph::beforeHadronisation(
-  //				const boost::shared_ptr<lhef::LHEEvent> &event)
+  //				const std::shared_ptr<lhef::LHEEvent> &event)
 
   void JetMatchingMadgraph::beforeHadronisation(const lhef::LHEEvent *event) {
     if (!runInitialized)

--- a/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/PartonShowerVeto/src/JetMatchingMadgraph.cc
@@ -10,7 +10,6 @@
 #include <map>
 #include <set>
 
-
 #include <boost/algorithm/string/trim.hpp>
 
 // #include <HepMC/GenEvent.h>

--- a/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
+++ b/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
@@ -8,7 +8,7 @@
 #include <map>
 #include <set>
 
-#include <boost/shared_ptr.hpp>
+
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 

--- a/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
+++ b/GeneratorInterface/PomwigInterface/src/PomwigHadronizer.cc
@@ -8,7 +8,6 @@
 #include <map>
 #include <set>
 
-
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.h
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.h
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.h
@@ -10,8 +10,6 @@
 #include <string>
 #include <vector>
 
-
-
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"

--- a/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
@@ -13,8 +13,6 @@
 #include <string>
 #include <vector>
 
-
-
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"

--- a/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
@@ -6,8 +6,6 @@
 #include <memory>
 #include <cassert>
 
-
-
 #include "HepMC/GenEvent.h"
 #include "HepMC/GenParticle.h"
 

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <cassert>
 
-#include "boost/shared_ptr.hpp"
+
 
 #include "HepMC/GenEvent.h"
 #include "HepMC/GenParticle.h"
@@ -23,10 +23,10 @@ class LHAupLesHouches : public Pythia8::LHAup {
 public:
   LHAupLesHouches() : setScalesFromLHEF_(false), fEvAttributes(nullptr) { ; }
 
-  //void loadRunInfo(const boost::shared_ptr<lhef::LHERunInfo> &runInfo)
+  //void loadRunInfo(const std::shared_ptr<lhef::LHERunInfo> &runInfo)
   void loadRunInfo(lhef::LHERunInfo* runInfo) { this->runInfo = runInfo; }
 
-  //void loadEvent(const boost::shared_ptr<lhef::LHEEvent> &event)
+  //void loadEvent(const std::shared_ptr<lhef::LHEEvent> &event)
   void loadEvent(lhef::LHEEvent* event) { this->event = event; }
 
   void setScalesFromLHEF(bool b) { setScalesFromLHEF_ = b; }
@@ -40,9 +40,9 @@ private:
   bool setInit() override;
   bool setEvent(int idProcIn) override;
 
-  //boost::shared_ptr<lhef::LHERunInfo> runInfo;
+  //std::shared_ptr<lhef::LHERunInfo> runInfo;
   lhef::LHERunInfo* runInfo;
-  //boost::shared_ptr<lhef::LHEEvent>	event;
+  //std::shared_ptr<lhef::LHEEvent>	event;
   lhef::LHEEvent* event;
 
   // Flag to set particle production scales or not.

--- a/Geometry/CSCGeometry/interface/CSCLayer.h
+++ b/Geometry/CSCGeometry/interface/CSCLayer.h
@@ -18,8 +18,8 @@
 #include <DataFormats/GeometryVector/interface/GlobalPoint.h>
 #include <DataFormats/GeometrySurface/interface/BoundPlane.h>
 
-//#include <boost/shared_ptr.hpp>
-//typedef boost::shared_ptr<CSCChamber> Pointer2Chamber;
+//>
+//typedef std::shared_ptr<CSCChamber> Pointer2Chamber;
 
 class CSCLayer : public GeomDetUnit {
 public:

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -1,4 +1,4 @@
-#include <boost/shared_ptr.hpp>
+
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/IOMC/ParticleGuns/interface/BaseFlatGunProducer.h
+++ b/IOMC/ParticleGuns/interface/BaseFlatGunProducer.h
@@ -20,7 +20,7 @@
 #include "FWCore/Framework/interface/Run.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 
 namespace edm {
 

--- a/IOMC/ParticleGuns/interface/BaseFlatGunProducer.h
+++ b/IOMC/ParticleGuns/interface/BaseFlatGunProducer.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 
-
 namespace edm {
 
   class BaseFlatGunProducer : public one::EDProducer<one::WatchRuns, EndRunProducer> {

--- a/IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h
+++ b/IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h
@@ -20,7 +20,7 @@
 #include "FWCore/Framework/interface/Run.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 
 namespace edm {
 

--- a/IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h
+++ b/IOMC/ParticleGuns/interface/BaseRandomtXiGunProducer.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 
-
 namespace edm {
 
   class BaseRandomtXiGunProducer : public one::EDProducer<one::WatchRuns, EndRunProducer> {

--- a/IOMC/ParticleGuns/interface/FlatBaseThetaGunProducer.h
+++ b/IOMC/ParticleGuns/interface/FlatBaseThetaGunProducer.h
@@ -15,7 +15,7 @@
 #include "FWCore/Framework/interface/Run.h"
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 
 namespace edm {
 

--- a/IOMC/ParticleGuns/interface/FlatBaseThetaGunProducer.h
+++ b/IOMC/ParticleGuns/interface/FlatBaseThetaGunProducer.h
@@ -16,7 +16,6 @@
 
 #include <memory>
 
-
 namespace edm {
 
   class FlatBaseThetaGunProducer : public one::EDProducer<one::WatchRuns, EndRunProducer> {

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
@@ -22,7 +22,6 @@
 
 #include <memory>
 
-
 #include "Alignment/Geners/interface/CompressedIO.hh"
 #include "Alignment/Geners/interface/StringArchive.hh"
 #include "Alignment/Geners/interface/Reference.hh"

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
@@ -21,7 +21,7 @@
 #include <utility>
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 
 #include "Alignment/Geners/interface/CompressedIO.hh"
 #include "Alignment/Geners/interface/StringArchive.hh"
@@ -40,7 +40,7 @@
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableRcd.h"
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequence.h"
 
-typedef boost::shared_ptr<npstat::StorableMultivariateFunctor> StorableFunctorPtr;
+typedef std::shared_ptr<npstat::StorableMultivariateFunctor> StorableFunctorPtr;
 
 static void insertLUTItem(FFTJetLookupTableSequence& seq,
                           StorableFunctorPtr fptr,

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequence.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequence.h
@@ -2,11 +2,11 @@
 #define JetMETCorrections_FFTJetObjects_FFTJetLookupTableSequence_h
 
 #include <string>
-#include "boost/shared_ptr.hpp"
+
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetDict.h"
 #include "JetMETCorrections/InterpolationTables/interface/StorableMultivariateFunctor.h"
 
-typedef FFTJetDict<std::string, FFTJetDict<std::string, boost::shared_ptr<npstat::StorableMultivariateFunctor> > >
+typedef FFTJetDict<std::string, FFTJetDict<std::string, std::shared_ptr<npstat::StorableMultivariateFunctor> > >
     FFTJetLookupTableSequence;
 
 #endif  // JetMETCorrections_FFTJetObjects_FFTJetLookupTableSequence_h

--- a/JetMETCorrections/Modules/plugins/FactorizedJetCorrectorDemo.cc
+++ b/JetMETCorrections/Modules/plugins/FactorizedJetCorrectorDemo.cc
@@ -90,7 +90,7 @@ void FactorizedJetCorrectorDemo::analyze(const edm::Event& iEvent, const edm::Ev
     params.push_back(ip);
   }
 
-  boost::shared_ptr<FactorizedJetCorrector> corrector(new FactorizedJetCorrector(params));
+  std::shared_ptr<FactorizedJetCorrector> corrector(new FactorizedJetCorrector(params));
 
   double jec, rawPt, corPt, eta;
   TLorentzVector P4;

--- a/JetMETCorrections/Objects/interface/ChainedJetCorrector.h
+++ b/JetMETCorrections/Objects/interface/ChainedJetCorrector.h
@@ -6,7 +6,7 @@
 #ifndef ChainedJetCorrector_h
 #define ChainedJetCorrector_h
 
-#include "boost/shared_ptr.hpp"
+
 #include <vector>
 
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"

--- a/JetMETCorrections/Objects/interface/ChainedJetCorrector.h
+++ b/JetMETCorrections/Objects/interface/ChainedJetCorrector.h
@@ -6,7 +6,6 @@
 #ifndef ChainedJetCorrector_h
 #define ChainedJetCorrector_h
 
-
 #include <vector>
 
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctJet.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctJet.h
@@ -20,8 +20,6 @@
  *  Move this to DataFormats/L1GlobalCaloTrigger if possible
  */
 
-
-
 class L1GctJetCand;
 class L1GctJetEtCalibrationLut;
 

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctJet.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctJet.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <vector>
 #include <ostream>
+#include <memory>
 
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h"
 
@@ -19,7 +20,7 @@
  *  Move this to DataFormats/L1GlobalCaloTrigger if possible
  */
 
-#include "boost/shared_ptr.hpp"
+
 
 class L1GctJetCand;
 class L1GctJetEtCalibrationLut;
@@ -30,7 +31,7 @@ public:
   enum numberOfBits { kRawsumBitWidth = 10, kRawsumMaxValue = (1 << kRawsumBitWidth) - 1 };
 
   //Typedefs
-  typedef boost::shared_ptr<L1GctJetEtCalibrationLut> lutPtr;
+  typedef std::shared_ptr<L1GctJetEtCalibrationLut> lutPtr;
 
   //Constructors/destructors
   L1GctJet(const uint16_t rawsum = 0,

--- a/L1Trigger/GlobalCaloTrigger/test/produceTrivialCalibrationLut.h
+++ b/L1Trigger/GlobalCaloTrigger/test/produceTrivialCalibrationLut.h
@@ -3,7 +3,6 @@
 #include <vector>
 #include <memory>
 
-
 class L1GctJetFinderParams;
 
 class produceTrivialCalibrationLut {

--- a/L1Trigger/GlobalCaloTrigger/test/produceTrivialCalibrationLut.h
+++ b/L1Trigger/GlobalCaloTrigger/test/produceTrivialCalibrationLut.h
@@ -1,15 +1,15 @@
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GctJetEtCalibrationLut.h"
 
 #include <vector>
+#include <memory>
 
-#include "boost/shared_ptr.hpp"
 
 class L1GctJetFinderParams;
 
 class produceTrivialCalibrationLut {
 public:
   //Typedefs
-  typedef boost::shared_ptr<L1GctJetEtCalibrationLut> lutPtr;
+  typedef std::shared_ptr<L1GctJetEtCalibrationLut> lutPtr;
   typedef std::vector<lutPtr> lutPtrVector;
 
   produceTrivialCalibrationLut();

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondLegacyToStage2.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondLegacyToStage2.cc
@@ -8,7 +8,7 @@
 /// \revised: V. Rekovic
 
 // system include files
-#include <boost/shared_ptr.hpp>
+
 
 // user include files
 
@@ -58,9 +58,9 @@ private:
 
   // ----------member data ---------------------------
   //unsigned long long m_paramsCacheId; // Cache-ID from current parameters, to check if needs to be updated.
-  //boost::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
-  //boost::shared_ptr<const FirmwareVersion> m_fwv;
-  //boost::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
+  //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
+  //std::shared_ptr<const FirmwareVersion> m_fwv;
+  //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
 
   // BX parameters
   int bxFirst_;

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondLegacyToStage2.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondLegacyToStage2.cc
@@ -9,7 +9,6 @@
 
 // system include files
 
-
 // user include files
 
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -8,7 +8,7 @@
 ///
 
 // system include files
-#include <boost/shared_ptr.hpp>
+
 
 // user include files
 
@@ -57,9 +57,9 @@ private:
 
   // ----------member data ---------------------------
   // unsigned long long m_paramsCacheId; // Cache-ID from current parameters, to check if needs to be updated.
-  //boost::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
-  //boost::shared_ptr<const FirmwareVersion> m_fwv;
-  //boost::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
+  //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
+  //std::shared_ptr<const FirmwareVersion> m_fwv;
+  //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
 
   // BX parameters
   int bxFirst_;

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -9,7 +9,6 @@
 
 // system include files
 
-
 // user include files
 
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h
@@ -4,7 +4,6 @@
 // system include files
 #include <memory>
 
-
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h
@@ -3,7 +3,7 @@
 
 // system include files
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1Trigger/RPCTrigger/interface/RPCTriggerBoard.h
+++ b/L1Trigger/RPCTrigger/interface/RPCTriggerBoard.h
@@ -41,7 +41,7 @@ private:
   L1RpcTBMuonsVec m_PacsMuonsVec;
 
   //typedef std::vector<RPCPac*> PACsVec; // PACs in single tower
-  typedef std::vector<boost::shared_ptr<RPCPac> > PACsVec;  // PACs in single tower
+  typedef std::vector<std::shared_ptr<RPCPac> > PACsVec;  // PACs in single tower
   typedef std::map<int, PACsVec> PACsAll;                   // Holds pacs for all towers covered by tb
 
   PACsAll m_pacs;

--- a/L1Trigger/RPCTrigger/interface/RPCTriggerBoard.h
+++ b/L1Trigger/RPCTrigger/interface/RPCTriggerBoard.h
@@ -42,7 +42,7 @@ private:
 
   //typedef std::vector<RPCPac*> PACsVec; // PACs in single tower
   typedef std::vector<std::shared_ptr<RPCPac> > PACsVec;  // PACs in single tower
-  typedef std::map<int, PACsVec> PACsAll;                   // Holds pacs for all towers covered by tb
+  typedef std::map<int, PACsVec> PACsAll;                 // Holds pacs for all towers covered by tb
 
   PACsAll m_pacs;
 };

--- a/L1Trigger/RPCTrigger/src/RPCTriggerBoard.cc
+++ b/L1Trigger/RPCTrigger/src/RPCTriggerBoard.cc
@@ -36,7 +36,7 @@ RPCTriggerBoard::RPCTriggerBoard(RPCTriggerConfiguration* triggerConfig, int tbN
 
       // one trigger crate covers one logsector:
       //RPCPac *pac = new RPCPac(pacData, tower, tcNum, logSegment);
-      boost::shared_ptr<RPCPac> pac(new RPCPac(pacData, tower, tcNum, logSegment));
+      std::shared_ptr<RPCPac> pac(new RPCPac(pacData, tower, tcNum, logSegment));
 
       m_pacs[tower].push_back(pac);
     }

--- a/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
@@ -26,7 +26,7 @@ public:
 void L1KeyListWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TriggerKeyListExt> handle1;
   evSetup.get<L1TriggerKeyListExtRcd>().get(handle1);
-  boost::shared_ptr<L1TriggerKeyListExt> ptr1(new L1TriggerKeyListExt(*(handle1.product())));
+  std::shared_ptr<L1TriggerKeyListExt> ptr1(new L1TriggerKeyListExt(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
@@ -26,7 +26,7 @@ public:
 void L1KeyWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TriggerKeyExt> handle1;
   evSetup.get<L1TriggerKeyExtRcd>().get(handle1);
-  boost::shared_ptr<L1TriggerKeyExt> ptr1(new L1TriggerKeyExt(*(handle1.product())));
+  std::shared_ptr<L1TriggerKeyExt> ptr1(new L1TriggerKeyExt(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
@@ -29,7 +29,7 @@ public:
 void L1MenuViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TUtmTriggerMenu> handle1;
   evSetup.get<L1TUtmTriggerMenuRcd>().get(handle1);
-  boost::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
+  std::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
 
   cout << "L1TUtmTriggerMenu: " << endl;
   cout << " name: " << ptr1->getName() << endl;

--- a/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
@@ -36,7 +36,7 @@ void L1MenuWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSe
   else
     evSetup.get<L1TUtmTriggerMenuRcd>().get(handle1);
 
-  boost::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
+  std::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
@@ -106,7 +106,7 @@ void L1TCaloParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetu
   else
     evSetup.get<L1TCaloParamsRcd>().get(handle1);
 
-  boost::shared_ptr<l1t::CaloParams> ptr(new l1t::CaloParams(*(handle1.product())));
+  std::shared_ptr<l1t::CaloParams> ptr(new l1t::CaloParams(*(handle1.product())));
 
   l1t::CaloParamsHelper* ptr1 = nullptr;
   ptr1 = (l1t::CaloParamsHelper*)(&(*ptr));

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsWriter.cc
@@ -36,7 +36,7 @@ void L1TCaloStage2ParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   else
     evSetup.get<L1TCaloParamsRcd>().get(handle1);
 
-  boost::shared_ptr<l1t::CaloParams> ptr1(new l1t::CaloParams(*(handle1.product())));
+  std::shared_ptr<l1t::CaloParams> ptr1(new l1t::CaloParams(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
@@ -60,7 +60,7 @@ std::string L1TGlobalPrescalesVetosViewer::hash(void* buf, size_t len) const {
 void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TGlobalPrescalesVetos> handle1;
   evSetup.get<L1TGlobalPrescalesVetosRcd>().get(handle1);
-  boost::shared_ptr<L1TGlobalPrescalesVetos> ptr(new L1TGlobalPrescalesVetos(*(handle1.product())));
+  std::shared_ptr<L1TGlobalPrescalesVetos> ptr(new L1TGlobalPrescalesVetos(*(handle1.product())));
 
   edm::LogInfo("") << "L1TGlobalPrescalesVetosViewer:";
 

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosWriter.cc
@@ -36,7 +36,7 @@ void L1TGlobalPrescalesVetosWriter::analyze(const edm::Event& iEvent, const edm:
   else
     evSetup.get<L1TGlobalPrescalesVetosRcd>().get(handle1);
 
-  boost::shared_ptr<L1TGlobalPrescalesVetos> ptr1(new L1TGlobalPrescalesVetos(*(handle1.product())));
+  std::shared_ptr<L1TGlobalPrescalesVetos> ptr1(new L1TGlobalPrescalesVetos(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
@@ -61,7 +61,7 @@ std::string L1TMuonBarrelParamsViewer::hash(void *buf, size_t len) const {
 void L1TMuonBarrelParamsViewer::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
   edm::ESHandle<L1TMuonBarrelParams> handle1;
   evSetup.get<L1TMuonBarrelParamsRcd>().get(handle1);
-  boost::shared_ptr<L1TMuonBarrelParams> ptr(new L1TMuonBarrelParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonBarrelParams> ptr(new L1TMuonBarrelParams(*(handle1.product())));
 
   L1TMuonBarrelParamsHelper *ptr1 = (L1TMuonBarrelParamsHelper *)ptr.get();
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsWriter.cc
@@ -36,7 +36,7 @@ void L1TMuonBarrelParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   else
     evSetup.get<L1TMuonBarrelParamsRcd>().get(handle1);
 
-  boost::shared_ptr<L1TMuonBarrelParams> ptr1(new L1TMuonBarrelParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonBarrelParams> ptr1(new L1TMuonBarrelParams(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapForestWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapForestWriter.cc
@@ -37,7 +37,7 @@ void L1TMuonEndCapForestWriter::analyze(const edm::Event& iEvent, const edm::Eve
   //    else
   evSetup.get<L1TMuonEndCapForestRcd>().get(handle1);
 
-  boost::shared_ptr<L1TMuonEndCapForest> ptr1(new L1TMuonEndCapForest(*(handle1.product())));
+  std::shared_ptr<L1TMuonEndCapForest> ptr1(new L1TMuonEndCapForest(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsViewer.cc
@@ -32,7 +32,7 @@ void L1TMuonEndCapParamsViewer::analyze(const edm::Event& iEvent, const edm::Eve
   edm::ESHandle<L1TMuonEndCapParams> handle1;
   evSetup.get<L1TMuonEndCapParamsRcd>().get(handle1);
   //    evSetup.get<L1TMuonEndCapParamsRcd>().get( handle1 ) ;
-  boost::shared_ptr<L1TMuonEndCapParams> ptr1(new L1TMuonEndCapParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonEndCapParams> ptr1(new L1TMuonEndCapParams(*(handle1.product())));
 
   cout << "L1TMuonEndCapParams: " << endl;
   cout << " PtAssignVersion_ = " << ptr1->PtAssignVersion_ << endl;
@@ -44,7 +44,7 @@ void L1TMuonEndCapParamsViewer::analyze(const edm::Event& iEvent, const edm::Eve
 
   ///    edm::ESHandle<L1TMuonEndCapForest> handle2;
   ///    evSetup.get<L1TMuonEndCapForestRcd>().get( handle2 ) ;
-  ///    boost::shared_ptr<L1TMuonEndCapForest> ptr2(new L1TMuonEndCapForest(*(handle2.product ())));
+  ///    std::shared_ptr<L1TMuonEndCapForest> ptr2(new L1TMuonEndCapForest(*(handle2.product ())));
   ///
   ///    cout<<"L1TMuonEndCapForest: "<<endl;
   ///    l1t::ForestHelper fhelp( ptr2.get() );

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsWriter.cc
@@ -37,7 +37,7 @@ void L1TMuonEndCapParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   else
     evSetup.get<L1TMuonEndCapParamsRcd>().get(handle1);
 
-  boost::shared_ptr<L1TMuonEndCapParams> ptr1(new L1TMuonEndCapParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonEndCapParams> ptr1(new L1TMuonEndCapParams(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
@@ -78,7 +78,7 @@ void L1TMuonGlobalParamsViewer::analyze(const edm::Event& iEvent, const edm::Eve
   // Pull the config from the ES
   edm::ESHandle<L1TMuonGlobalParams> handle1;
   evSetup.get<L1TMuonGlobalParamsRcd>().get(handle1);
-  boost::shared_ptr<L1TMuonGlobalParams> ptr1(new L1TMuonGlobalParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonGlobalParams> ptr1(new L1TMuonGlobalParams(*(handle1.product())));
 
   //    cout<<"Some fields in L1TMuonGlobalParams: "<<endl;
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
@@ -36,7 +36,7 @@ void L1TMuonGlobalParamsWriter::analyze(const edm::Event& iEvent, const edm::Eve
   else
     evSetup.get<L1TMuonGlobalParamsRcd>().get(handle1);
 
-  boost::shared_ptr<L1TMuonGlobalParams> ptr1(new L1TMuonGlobalParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonGlobalParams> ptr1(new L1TMuonGlobalParams(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
@@ -63,7 +63,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
   // Pull the config from the ES
   edm::ESHandle<L1TMuonOverlapParams> handle1;
   evSetup.get<L1TMuonOverlapParamsRcd>().get(handle1);
-  boost::shared_ptr<L1TMuonOverlapParams> ptr1(new L1TMuonOverlapParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonOverlapParams> ptr1(new L1TMuonOverlapParams(*(handle1.product())));
 
   cout << "Some fields in L1TMuonOverlapParamsParams: " << endl;
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsWriter.cc
@@ -26,7 +26,7 @@ public:
 void L1TMuonOverlapParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TMuonOverlapParams> handle1;
   evSetup.get<L1TMuonOverlapParamsRcd>().get(handle1);
-  boost::shared_ptr<L1TMuonOverlapParams> ptr1(new L1TMuonOverlapParams(*(handle1.product())));
+  std::shared_ptr<L1TMuonOverlapParams> ptr1(new L1TMuonOverlapParams(*(handle1.product())));
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {

--- a/L1TriggerConfig/Utilities/src/L1TriggerKeyExtViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TriggerKeyExtViewer.cc
@@ -27,7 +27,7 @@ using namespace std;
 void L1TriggerKeyExtViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TriggerKeyExt> handle1;
   evSetup.get<L1TriggerKeyExtRcd>().get(label, handle1);
-  boost::shared_ptr<L1TriggerKeyExt> ptr1(new L1TriggerKeyExt(*(handle1.product())));
+  std::shared_ptr<L1TriggerKeyExt> ptr1(new L1TriggerKeyExt(*(handle1.product())));
 
   cout << "L1TriggerKeyExt: parent key = " << ptr1->tscKey() << endl;
 

--- a/L1TriggerConfig/Utilities/src/L1TriggerKeyListExtViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TriggerKeyListExtViewer.cc
@@ -23,7 +23,7 @@ using namespace std;
 void L1TriggerKeyListExtReader::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TriggerKeyListExt> handle1;
   evSetup.get<L1TriggerKeyListExtRcd>().get(handle1);
-  boost::shared_ptr<L1TriggerKeyListExt> ptr1(new L1TriggerKeyListExt(*(handle1.product())));
+  std::shared_ptr<L1TriggerKeyListExt> ptr1(new L1TriggerKeyListExt(*(handle1.product())));
 
   const L1TriggerKeyListExt::KeyToToken& allKeysTokens = ptr1->tscKeyToTokenMap();
   for (auto& keyToken : allKeysTokens)

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/DBReader.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/DBReader.h
@@ -3,7 +3,7 @@
 
 // system include files
 //#include <memory>
-#include <boost/shared_ptr.hpp>
+
 #include <iostream>
 #include <vector>
 
@@ -55,8 +55,8 @@ private:
   //  uint32_t printdebug_;
   std::string type_;
   //std::unique_ptr<BaseFunction> corrector_;
-  boost::shared_ptr<MomentumScaleCorrector> corrector_;
-  boost::shared_ptr<ResolutionFunction> resolution_;
-  boost::shared_ptr<BackgroundFunction> background_;
+  std::shared_ptr<MomentumScaleCorrector> corrector_;
+  std::shared_ptr<ResolutionFunction> resolution_;
+  std::shared_ptr<BackgroundFunction> background_;
 };
 #endif

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonProducer.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonProducer.cc
@@ -63,7 +63,7 @@ private:
   edm::ESHandle<MuScleFitDBobject> dbObject_;
   std::string dbObjectLabel_;
   unsigned long long dbObjectCacheId_;
-  boost::shared_ptr<MomentumScaleCorrector> corrector_;
+  std::shared_ptr<MomentumScaleCorrector> corrector_;
 };
 
 MuScleFitMuonProducer::MuScleFitMuonProducer(const edm::ParameterSet& iConfig)

--- a/OnlineDB/CSCCondDB/src/CSCChamberIndexValues.cc
+++ b/OnlineDB/CSCCondDB/src/CSCChamberIndexValues.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCChamberIndex.h"

--- a/OnlineDB/CSCCondDB/src/CSCChamberMapValues.cc
+++ b/OnlineDB/CSCCondDB/src/CSCChamberMapValues.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCChamberMap.h"

--- a/OnlineDB/CSCCondDB/src/CSCChamberTimeCorrectionsValues.cc
+++ b/OnlineDB/CSCCondDB/src/CSCChamberTimeCorrectionsValues.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCChamberTimeCorrections.h"

--- a/OnlineDB/CSCCondDB/src/CSCCrateMapValues.cc
+++ b/OnlineDB/CSCCondDB/src/CSCCrateMapValues.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCCrateMap.h"

--- a/OnlineDB/CSCCondDB/src/CSCDDUMapValues.cc
+++ b/OnlineDB/CSCCondDB/src/CSCDDUMapValues.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 #include <fstream>
 
 #include "CondFormats/CSCObjects/interface/CSCDDUMap.h"

--- a/PhysicsTools/FWLite/src/classes_def.xml
+++ b/PhysicsTools/FWLite/src/classes_def.xml
@@ -2,19 +2,24 @@
   <selection>
     <class name="reco::parser::ExpressionBase" persistent="false" />
     <class name="reco::parser::SelectorBase" persistent="false" />
+<!--
     <class name="reco::parser::ExpressionPtr" persistent="false" />
     <class name="reco::parser::SelectorPtr" persistent="false" />
     <class name="reco::parser::ExpressionPtrs" persistent="false" />
     <class name="reco::parser::SelectorPtrs" persistent="false" />
+-->
     <class name="helper::Parser" persistent="false" />
     <class name="helper::ScannerBase" persistent="false" />
   </selection>
+<!--
   <exclusion>
-    <class name="boost::shared_ptr<reco::parser::ExpressionBase>">
+    <class name="std::shared_ptr<reco::parser::ExpressionBase>">
       <method name="[]" />
     </class>
-    <class name="boost::shared_ptr<reco::parser::SelectorBase>">
+    <class name="std::shared_ptr<reco::parser::SelectorBase>">
       <method name="[]" />
     </class>
   </exclusion>
+-->
+
 </lcgdict>

--- a/PhysicsTools/FWLite/src/classes_def.xml
+++ b/PhysicsTools/FWLite/src/classes_def.xml
@@ -2,24 +2,8 @@
   <selection>
     <class name="reco::parser::ExpressionBase" persistent="false" />
     <class name="reco::parser::SelectorBase" persistent="false" />
-<!--
-    <class name="reco::parser::ExpressionPtr" persistent="false" />
-    <class name="reco::parser::SelectorPtr" persistent="false" />
-    <class name="reco::parser::ExpressionPtrs" persistent="false" />
-    <class name="reco::parser::SelectorPtrs" persistent="false" />
--->
     <class name="helper::Parser" persistent="false" />
     <class name="helper::ScannerBase" persistent="false" />
   </selection>
-<!--
-  <exclusion>
-    <class name="std::shared_ptr<reco::parser::ExpressionBase>">
-      <method name="[]" />
-    </class>
-    <class name="std::shared_ptr<reco::parser::SelectorBase>">
-      <method name="[]" />
-    </class>
-  </exclusion>
--->
 
 </lcgdict>

--- a/PhysicsTools/Heppy/interface/ReclusterJets.h
+++ b/PhysicsTools/Heppy/interface/ReclusterJets.h
@@ -8,7 +8,6 @@
 #include <TMath.h>
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-
 #include <fastjet/internal/base.hh>
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/JetDefinition.hh"

--- a/PhysicsTools/Heppy/interface/ReclusterJets.h
+++ b/PhysicsTools/Heppy/interface/ReclusterJets.h
@@ -8,7 +8,7 @@
 #include <TMath.h>
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-#include <boost/shared_ptr.hpp>
+
 #include <fastjet/internal/base.hh>
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/JetDefinition.hh"
@@ -55,7 +55,7 @@ namespace heppy {
     double rparam_;
 
     /// fastjet outputs
-    typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+    typedef std::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
     ClusterSequencePtr fjClusterSeq_;
     std::vector<fastjet::PseudoJet> inclusiveJets_;
     std::vector<fastjet::PseudoJet> exclusiveJets_;

--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -69,7 +69,7 @@
 //
 // constants, enums and typedefs
 //
-typedef boost::shared_ptr<BasePartonSelector> PartonSelectorPtr;
+typedef std::shared_ptr<BasePartonSelector> PartonSelectorPtr;
 
 //
 // class declaration

--- a/PhysicsTools/NanoAOD/plugins/FilterValueMapWrapper.h
+++ b/PhysicsTools/NanoAOD/plugins/FilterValueMapWrapper.h
@@ -10,7 +10,7 @@
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace edm {
 
@@ -23,7 +23,7 @@ namespace edm {
 
     /// default contructor. Declares the output (type "C") and the filter (of type T, operates on C::value_type)
     FilterValueMapWrapper(const edm::ParameterSet& cfg) : src_(consumes<C>(cfg.getParameter<edm::InputTag>("src"))) {
-      filter_ = boost::shared_ptr<T>(new T(cfg.getParameter<edm::ParameterSet>("filterParams")));
+      filter_ = std::shared_ptr<T>(new T(cfg.getParameter<edm::ParameterSet>("filterParams")));
       produces<edm::ValueMap<int>>();
     }
     /// default destructor
@@ -51,7 +51,7 @@ namespace edm {
     /// InputTag of the input source
     edm::EDGetTokenT<C> src_;
     /// shared pointer to analysis class of type BasicAnalyzer
-    boost::shared_ptr<T> filter_;
+    std::shared_ptr<T> filter_;
   };
 
 }  // namespace edm

--- a/PhysicsTools/NanoAOD/plugins/FilterValueMapWrapper.h
+++ b/PhysicsTools/NanoAOD/plugins/FilterValueMapWrapper.h
@@ -11,7 +11,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 namespace edm {
 
   template <class T, class C>

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
@@ -1,5 +1,7 @@
 #include "PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h"
 
+#include <memory>
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
@@ -103,8 +105,7 @@ void TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& 
       edm::ESHandle<JetCorrectorParametersCollection> jecParameters;
       es.get<JetCorrectionsRecord>().get(payload, jecParameters);
 
-      correctorMapping[payload] =
-          FactorizedJetCorrectorPtr(new FactorizedJetCorrector(params(*jecParameters, levels_)));
+      correctorMapping[payload] = std::make_shared<FactorizedJetCorrector>(params(*jecParameters, levels_));
     }
     FactorizedJetCorrectorPtr& corrector = correctorMapping[payload];
 

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.cc
@@ -51,7 +51,7 @@ std::vector<JetCorrectorParameters> TauJetCorrFactorsProducer::params(
 }
 
 float TauJetCorrFactorsProducer::evaluate(edm::View<reco::BaseTau>::const_iterator& tauJet,
-                                          boost::shared_ptr<FactorizedJetCorrector>& corrector,
+                                          std::shared_ptr<FactorizedJetCorrector>& corrector,
                                           int corrLevel) {
   corrector->setJetEta(tauJet->eta());
   corrector->setJetPt(tauJet->pt());
@@ -64,7 +64,7 @@ void TauJetCorrFactorsProducer::produce(edm::Event& evt, const edm::EventSetup& 
   edm::Handle<edm::View<reco::BaseTau> > tauJets;
   evt.getByToken(srcToken_, tauJets);
 
-  typedef boost::shared_ptr<FactorizedJetCorrector> FactorizedJetCorrectorPtr;
+  typedef std::shared_ptr<FactorizedJetCorrector> FactorizedJetCorrectorPtr;
   std::map<std::string, FactorizedJetCorrectorPtr> correctorMapping;
 
   // fill the tauJetCorrFactors

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
@@ -28,8 +28,6 @@
 #include "DataFormats/PatCandidates/interface/TauJetCorrFactors.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-
-
 #include <map>
 #include <string>
 

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
@@ -28,7 +28,7 @@
 #include "DataFormats/PatCandidates/interface/TauJetCorrFactors.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-#include <boost/shared_ptr.hpp>
+
 
 #include <map>
 #include <string>
@@ -55,7 +55,7 @@ namespace pat {
                                                const std::vector<std::string>&) const;
 
     /// evaluate jet correction factor up to a given level
-    float evaluate(edm::View<reco::BaseTau>::const_iterator&, boost::shared_ptr<FactorizedJetCorrector>&, int);
+    float evaluate(edm::View<reco::BaseTau>::const_iterator&, std::shared_ptr<FactorizedJetCorrector>&, int);
 
   private:
     /// python label of this TauJetCorrFactorsProducer module

--- a/PhysicsTools/PatUtils/interface/StringParserTools.h
+++ b/PhysicsTools/PatUtils/interface/StringParserTools.h
@@ -1,7 +1,7 @@
 #ifndef PhysicsTools_PatUtils_interface_StringParserTools_h
 #define PhysicsTools_PatUtils_interface_StringParserTools_h
 
-#include <boost/shared_ptr.hpp>
+
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
@@ -23,28 +23,28 @@ public:
 
 private:
   std::string expr_;
-  boost::shared_ptr<StringObjectFunction<reco::Candidate> > candFunc_;
+  std::shared_ptr<StringObjectFunction<reco::Candidate> > candFunc_;
 
-  boost::shared_ptr<StringObjectFunction<pat::Electron> > eleFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::Muon> > muFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::Tau> > tauFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::Photon> > gamFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::Jet> > jetFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::MET> > metFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::GenericParticle> > gpFunc_;
-  boost::shared_ptr<StringObjectFunction<pat::PFParticle> > pfFunc_;
+  std::shared_ptr<StringObjectFunction<pat::Electron> > eleFunc_;
+  std::shared_ptr<StringObjectFunction<pat::Muon> > muFunc_;
+  std::shared_ptr<StringObjectFunction<pat::Tau> > tauFunc_;
+  std::shared_ptr<StringObjectFunction<pat::Photon> > gamFunc_;
+  std::shared_ptr<StringObjectFunction<pat::Jet> > jetFunc_;
+  std::shared_ptr<StringObjectFunction<pat::MET> > metFunc_;
+  std::shared_ptr<StringObjectFunction<pat::GenericParticle> > gpFunc_;
+  std::shared_ptr<StringObjectFunction<pat::PFParticle> > pfFunc_;
 
   template <typename Obj>
-  boost::shared_ptr<StringObjectFunction<Obj> > tryGet(const std::string &str) {
+  std::shared_ptr<StringObjectFunction<Obj> > tryGet(const std::string &str) {
     try {
-      return boost::shared_ptr<StringObjectFunction<Obj> >(new StringObjectFunction<Obj>(str));
+      return std::shared_ptr<StringObjectFunction<Obj> >(new StringObjectFunction<Obj>(str));
     } catch (cms::Exception const &) {
-      return boost::shared_ptr<StringObjectFunction<Obj> >();
+      return std::shared_ptr<StringObjectFunction<Obj> >();
     }
   }
 
   template <typename Obj>
-  double tryEval(const reco::Candidate &c, const boost::shared_ptr<StringObjectFunction<Obj> > &func) const {
+  double tryEval(const reco::Candidate &c, const std::shared_ptr<StringObjectFunction<Obj> > &func) const {
     if (func.get())
       return (*func)(static_cast<const Obj &>(c));
     else
@@ -66,28 +66,28 @@ public:
 
 private:
   std::string expr_;
-  boost::shared_ptr<StringCutObjectSelector<reco::Candidate> > candFunc_;
+  std::shared_ptr<StringCutObjectSelector<reco::Candidate> > candFunc_;
 
-  boost::shared_ptr<StringCutObjectSelector<pat::Electron> > eleFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::Muon> > muFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::Tau> > tauFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::Photon> > gamFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::Jet> > jetFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::MET> > metFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::GenericParticle> > gpFunc_;
-  boost::shared_ptr<StringCutObjectSelector<pat::PFParticle> > pfFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::Electron> > eleFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::Muon> > muFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::Tau> > tauFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::Photon> > gamFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::Jet> > jetFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::MET> > metFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::GenericParticle> > gpFunc_;
+  std::shared_ptr<StringCutObjectSelector<pat::PFParticle> > pfFunc_;
 
   template <typename Obj>
-  boost::shared_ptr<StringCutObjectSelector<Obj> > tryGet(const std::string &str) {
+  std::shared_ptr<StringCutObjectSelector<Obj> > tryGet(const std::string &str) {
     try {
-      return boost::shared_ptr<StringCutObjectSelector<Obj> >(new StringCutObjectSelector<Obj>(str));
+      return std::shared_ptr<StringCutObjectSelector<Obj> >(new StringCutObjectSelector<Obj>(str));
     } catch (cms::Exception const &) {
-      return boost::shared_ptr<StringCutObjectSelector<Obj> >();
+      return std::shared_ptr<StringCutObjectSelector<Obj> >();
     }
   }
 
   template <typename Obj>
-  bool tryEval(const reco::Candidate &c, const boost::shared_ptr<StringCutObjectSelector<Obj> > &func) const {
+  bool tryEval(const reco::Candidate &c, const std::shared_ptr<StringCutObjectSelector<Obj> > &func) const {
     if (func.get())
       return (*func)(static_cast<const Obj &>(c));
     else

--- a/PhysicsTools/PatUtils/interface/StringParserTools.h
+++ b/PhysicsTools/PatUtils/interface/StringParserTools.h
@@ -1,7 +1,6 @@
 #ifndef PhysicsTools_PatUtils_interface_StringParserTools_h
 #define PhysicsTools_PatUtils_interface_StringParserTools_h
 
-
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 

--- a/PhysicsTools/RecoUtils/interface/CandKinematicVertexFitter.h
+++ b/PhysicsTools/RecoUtils/interface/CandKinematicVertexFitter.h
@@ -16,7 +16,6 @@
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include <vector>
 
-
 class MagneticField;
 namespace reco {
   class VertexCompositeCandidate;

--- a/PhysicsTools/RecoUtils/interface/CandKinematicVertexFitter.h
+++ b/PhysicsTools/RecoUtils/interface/CandKinematicVertexFitter.h
@@ -15,7 +15,7 @@
 #include "RecoVertex/KinematicFitPrimitives/interface/KinematicParticleFactoryFromTransientTrack.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include <vector>
-#include "boost/shared_ptr.hpp"
+
 
 class MagneticField;
 namespace reco {
@@ -58,7 +58,7 @@ private:
   /// covariance matrix (3x3)
   mutable CovarianceMatrix cov_;
   /// fitters used for recursive calls
-  boost::shared_ptr<std::vector<CandKinematicVertexFitter> > fitters_;
+  std::shared_ptr<std::vector<CandKinematicVertexFitter> > fitters_;
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/bin/testSelection_wplusjets.C
+++ b/PhysicsTools/SelectorUtils/bin/testSelection_wplusjets.C
@@ -12,7 +12,7 @@
 
 #include <iostream>
 #include <cmath>      //necessary for absolute function fabs()
-#include <boost/shared_ptr.hpp>
+
 #include <boost/lexical_cast.hpp>
 
 //Root includes

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -22,8 +22,8 @@
 #else
 
 #define CINT_GUARD(CODE)
-#include <boost/shared_ptr.hpp>
-#define SHARED_PTR(T) boost::shared_ptr<T>
+
+#define SHARED_PTR(T) std::shared_ptr<T>
 
 #endif
 

--- a/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
@@ -1,8 +1,6 @@
 #ifndef PhysicsTools_UtilAlgos_interface_EDAnalyzerWrapper_h
 #define PhysicsTools_UtilAlgos_interface_EDAnalyzerWrapper_h
 
-
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
@@ -1,7 +1,7 @@
 #ifndef PhysicsTools_UtilAlgos_interface_EDAnalyzerWrapper_h
 #define PhysicsTools_UtilAlgos_interface_EDAnalyzerWrapper_h
 
-#include <boost/shared_ptr.hpp>
+
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -58,7 +58,7 @@ namespace edm {
 
   protected:
     /// shared pointer to analysis class of type BasicAnalyzer
-    boost::shared_ptr<T> analyzer_;
+    std::shared_ptr<T> analyzer_;
   };
 
   /// default contructor
@@ -67,7 +67,7 @@ namespace edm {
     // defined TFileService
     edm::Service<TFileService> fileService;
     // create analysis class of type BasicAnalyzer
-    analyzer_ = boost::shared_ptr<T>(new T(cfg, fileService->tFileDirectory(), consumesCollector()));
+    analyzer_ = std::shared_ptr<T>(new T(cfg, fileService->tFileDirectory(), consumesCollector()));
   }
 
 }  // namespace edm

--- a/PhysicsTools/UtilAlgos/interface/EDFilterObjectWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDFilterObjectWrapper.h
@@ -40,7 +40,7 @@
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace edm {
 
@@ -53,7 +53,7 @@ namespace edm {
 
     /// default contructor. Declares the output (type "C") and the filter (of type T, operates on C::value_type)
     FilterObjectWrapper(const edm::ParameterSet& cfg) : src_(consumes<C>(cfg.getParameter<edm::InputTag>("src"))) {
-      filter_ = boost::shared_ptr<T>(new T(cfg.getParameter<edm::ParameterSet>("filterParams")));
+      filter_ = std::shared_ptr<T>(new T(cfg.getParameter<edm::ParameterSet>("filterParams")));
       if (cfg.exists("filter")) {
         doFilter_ = cfg.getParameter<bool>("filter");
       } else {
@@ -89,7 +89,7 @@ namespace edm {
     /// InputTag of the input source
     edm::EDGetTokenT<C> src_;
     /// shared pointer to analysis class of type BasicAnalyzer
-    boost::shared_ptr<T> filter_;
+    std::shared_ptr<T> filter_;
     /// whether or not to filter based on size
     bool doFilter_;
   };

--- a/PhysicsTools/UtilAlgos/interface/EDFilterObjectWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDFilterObjectWrapper.h
@@ -41,7 +41,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 namespace edm {
 
   template <class T, class C>

--- a/PhysicsTools/UtilAlgos/interface/EDFilterWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDFilterWrapper.h
@@ -37,7 +37,7 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Framework/interface/Event.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace edm {
 
@@ -45,7 +45,7 @@ namespace edm {
   class FilterWrapper : public edm::global::EDFilter<> {
   public:
     /// default contructor
-    FilterWrapper(const edm::ParameterSet& cfg) { filter_ = boost::shared_ptr<T>(new T(cfg, consumesCollector())); }
+    FilterWrapper(const edm::ParameterSet& cfg) { filter_ = std::shared_ptr<T>(new T(cfg, consumesCollector())); }
     /// default destructor
     ~FilterWrapper() override {}
     /// everything which has to be done during the event loop. NOTE: We can't use the eventSetup in FWLite so ignore it
@@ -57,7 +57,7 @@ namespace edm {
 
   protected:
     /// shared pointer to analysis class of type BasicAnalyzer
-    boost::shared_ptr<T> filter_;
+    std::shared_ptr<T> filter_;
   };
 
 }  // namespace edm

--- a/PhysicsTools/UtilAlgos/interface/EDFilterWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDFilterWrapper.h
@@ -38,7 +38,6 @@
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Framework/interface/Event.h"
 
-
 namespace edm {
 
   template <class T>

--- a/PhysicsTools/UtilAlgos/interface/FWLiteAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/FWLiteAnalyzerWrapper.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <boost/shared_ptr.hpp>
+
 
 #include <TFile.h>
 #include <TSystem.h>
@@ -124,7 +124,7 @@ namespace fwlite {
     /// TFileService for histogram management
     fwlite::TFileService fileService_;
     /// derived class of type BasicAnalyzer
-    boost::shared_ptr<T> analyzer_;
+    std::shared_ptr<T> analyzer_;
   };
 
   /// default contructor
@@ -139,11 +139,11 @@ namespace fwlite {
     const edm::ParameterSet& ana = cfg.getParameter<edm::ParameterSet>(analyzerName.c_str());
     if (directory.empty()) {
       // create analysis class of type BasicAnalyzer
-      analyzer_ = boost::shared_ptr<T>(new T(ana, fileService_));
+      analyzer_ = std::shared_ptr<T>(new T(ana, fileService_));
     } else {
       // create a directory in the file if directory string is non empty
       TFileDirectory dir = fileService_.mkdir(directory);
-      analyzer_ = boost::shared_ptr<T>(new T(ana, dir));
+      analyzer_ = std::shared_ptr<T>(new T(ana, dir));
     }
   }
 

--- a/PhysicsTools/UtilAlgos/interface/FWLiteAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/FWLiteAnalyzerWrapper.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <iostream>
 
-
 #include <TFile.h>
 #include <TSystem.h>
 

--- a/PhysicsTools/UtilAlgos/interface/FWLiteFilterWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/FWLiteFilterWrapper.h
@@ -6,8 +6,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-
 /**
   \class    FWLiteFilterWrapper FWLiteFilterWrapper.h "PhysicsTools/UtilAlgos/interface/FWLiteFilterWrapper.h"
   \brief    Implements a wrapper around an FWLite-friendly selector to "convert" it into a full EDFilter
@@ -19,41 +17,32 @@
   \version  $Id: FWLiteFilterWrapper.h,v 1.2 2010/10/14 09:53:48 snaumann Exp $
 */
 
-
-
 namespace edm {
 
-template<class T>
-class FWLiteFilterWrapper : public EDFilter {
+  template <class T>
+  class FWLiteFilterWrapper : public EDFilter {
+  public:
+    /// Pass the parameters to filter_
+    FWLiteFilterWrapper(const edm::ParameterSet& pset) {
+      edm::LogWarning("FWLiteFilterWrapper") << "Please Note: THIS FILE HAS BEEN DEPRECATED. IT HAS BEEN MOVED TO \n"
+                                             << "PhysicsTools/UtilsAlgos/interface/EDFilterWrapper.h";
 
- public:
+      filter_ = std::shared_ptr<T>(new T(pset));
+    }
 
-  /// Pass the parameters to filter_
- FWLiteFilterWrapper(const edm::ParameterSet& pset)
-  {
-    edm::LogWarning( "FWLiteFilterWrapper" )
-      << "Please Note: THIS FILE HAS BEEN DEPRECATED. IT HAS BEEN MOVED TO \n"
-      << "PhysicsTools/UtilsAlgos/interface/EDFilterWrapper.h";
+    /// Destructor does nothing
+    virtual ~FWLiteFilterWrapper() {}
 
-    filter_  = std::shared_ptr<T>( new T(pset) );
-  }
+    /// Pass the event to the filter. NOTE! We can't use the eventSetup in FWLite so ignore it.
+    virtual bool filter(edm::Event& event, const edm::EventSetup& eventSetup) {
+      edm::EventBase& ev = event;
+      return (*filter_)(ev);
+    }
 
-  /// Destructor does nothing
-  virtual ~FWLiteFilterWrapper() {}
- 
+  protected:
+    std::shared_ptr<T> filter_;
+  };
 
-  /// Pass the event to the filter. NOTE! We can't use the eventSetup in FWLite so ignore it.
-  virtual bool filter( edm::Event & event, const edm::EventSetup& eventSetup)
-  {
-    edm::EventBase & ev = event;
-    return (*filter_)(ev);
-  }
-
-
- protected:
-  std::shared_ptr<T> filter_;
-};
-
-}
+}  // namespace edm
 
 #endif

--- a/PhysicsTools/UtilAlgos/interface/FWLiteFilterWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/FWLiteFilterWrapper.h
@@ -6,7 +6,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <boost/shared_ptr.hpp>
+
 
 /**
   \class    FWLiteFilterWrapper FWLiteFilterWrapper.h "PhysicsTools/UtilAlgos/interface/FWLiteFilterWrapper.h"
@@ -35,7 +35,7 @@ class FWLiteFilterWrapper : public EDFilter {
       << "Please Note: THIS FILE HAS BEEN DEPRECATED. IT HAS BEEN MOVED TO \n"
       << "PhysicsTools/UtilsAlgos/interface/EDFilterWrapper.h";
 
-    filter_  = boost::shared_ptr<T>( new T(pset) );
+    filter_  = std::shared_ptr<T>( new T(pset) );
   }
 
   /// Destructor does nothing
@@ -51,7 +51,7 @@ class FWLiteFilterWrapper : public EDFilter {
 
 
  protected:
-  boost::shared_ptr<T> filter_;
+  std::shared_ptr<T> filter_;
 };
 
 }

--- a/PhysicsTools/Utilities/interface/BreitWigner.h
+++ b/PhysicsTools/Utilities/interface/BreitWigner.h
@@ -1,7 +1,7 @@
 #ifndef PhysicsTools_Utilities_ZMuMu_BreitWigner_h
 #define PhysicsTools_Utilities_ZMuMu_BreitWigner_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
-#include <boost/shared_ptr.hpp>
+
 #include <cmath>
 
 namespace funct {
@@ -9,7 +9,7 @@ namespace funct {
 
   struct BreitWigner {
     BreitWigner(const Parameter& m, const Parameter& g) : mass(m.ptr()), width(g.ptr()) {}
-    BreitWigner(boost::shared_ptr<double> m, boost::shared_ptr<double> g) : mass(m), width(g) {}
+    BreitWigner(std::shared_ptr<double> m, std::shared_ptr<double> g) : mass(m), width(g) {}
     BreitWigner(double m, double g) : mass(new double(m)), width(new double(g)) {}
     double operator()(double x) const {
       double m2 = *mass * (*mass);
@@ -24,7 +24,7 @@ namespace funct {
       }
       return lineShape;
     }
-    boost::shared_ptr<double> mass, width;
+    std::shared_ptr<double> mass, width;
   };
 
 }  // namespace funct

--- a/PhysicsTools/Utilities/interface/Exponential.h
+++ b/PhysicsTools/Utilities/interface/Exponential.h
@@ -1,17 +1,17 @@
 #ifndef PhysicsTools_Utilities_Exponential_h
 #define PhysicsTools_Utilities_Exponential_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
-#include <boost/shared_ptr.hpp>
+
 #include <cmath>
 
 namespace funct {
 
   struct Exponential {
     Exponential(const Parameter& l) : lambda(l.ptr()) {}
-    Exponential(boost::shared_ptr<double> l) : lambda(l) {}
+    Exponential(std::shared_ptr<double> l) : lambda(l) {}
     Exponential(double l) : lambda(new double(l)) {}
     double operator()(double x) const { return std::exp((*lambda) * x); }
-    boost::shared_ptr<double> lambda;
+    std::shared_ptr<double> lambda;
   };
 
 }  // namespace funct

--- a/PhysicsTools/Utilities/interface/FunctClone.h
+++ b/PhysicsTools/Utilities/interface/FunctClone.h
@@ -1,6 +1,6 @@
 #ifndef PhysicsTools_Utilities_FunctClone_h
 #define PhysicsTools_Utilities_FunctClone_h
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
 #include <algorithm>
 
@@ -37,7 +37,7 @@ namespace funct {
       clear();
       value_ = (*f_)(x);
     }
-    const boost::shared_ptr<F> f_;
+    const std::shared_ptr<F> f_;
     mutable double value_;
     mutable std::vector<bool> toBeUpdated_;
   };

--- a/PhysicsTools/Utilities/interface/GammaZInterference.h
+++ b/PhysicsTools/Utilities/interface/GammaZInterference.h
@@ -1,7 +1,7 @@
 #ifndef PhysicsTools_Utilities_GammaZInterference_h
 #define PhysicsTools_Utilities_GammaZInterference_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
-#include <boost/shared_ptr.hpp>
+
 #include <cmath>
 
 namespace funct {
@@ -9,7 +9,7 @@ namespace funct {
   struct GammaZInterference {
     GammaZInterference(const Parameter& m, const Parameter& g): 
       mass(m.ptr()), width(g.ptr()) { }
-    GammaZInterference(boost::shared_ptr<double> m, boost::shared_ptr<double> g): 
+    GammaZInterference(std::shared_ptr<double> m, std::shared_ptr<double> g): 
       mass(m), width(g) {}
     double operator()(double x) const { 
       double m2 = *mass * (*mass); 
@@ -24,7 +24,7 @@ namespace funct {
       }
       return interference;
     }
-    boost::shared_ptr<double> mass, width;
+    std::shared_ptr<double> mass, width;
   };
 
 }

--- a/PhysicsTools/Utilities/interface/GammaZInterference.h
+++ b/PhysicsTools/Utilities/interface/GammaZInterference.h
@@ -7,26 +7,24 @@
 namespace funct {
 
   struct GammaZInterference {
-    GammaZInterference(const Parameter& m, const Parameter& g): 
-      mass(m.ptr()), width(g.ptr()) { }
-    GammaZInterference(std::shared_ptr<double> m, std::shared_ptr<double> g): 
-      mass(m), width(g) {}
-    double operator()(double x) const { 
-      double m2 = *mass * (*mass); 
+    GammaZInterference(const Parameter& m, const Parameter& g) : mass(m.ptr()), width(g.ptr()) {}
+    GammaZInterference(std::shared_ptr<double> m, std::shared_ptr<double> g) : mass(m), width(g) {}
+    double operator()(double x) const {
+      double m2 = *mass * (*mass);
       double g2 = *width * (*width);
-      double g2OverM2 = g2/m2; 
-      double s = x*x;
+      double g2OverM2 = g2 / m2;
+      double s = x * x;
       double deltaS = s - m2;
       double interference = 0;
-      if (fabs(deltaS/m2)<16) {
-	double prop = deltaS*deltaS + s*s*g2OverM2;
-	interference =  5*(*mass)*deltaS/prop;
+      if (fabs(deltaS / m2) < 16) {
+        double prop = deltaS * deltaS + s * s * g2OverM2;
+        interference = 5 * (*mass) * deltaS / prop;
       }
       return interference;
     }
     std::shared_ptr<double> mass, width;
   };
 
-}
+}  // namespace funct
 
 #endif

--- a/PhysicsTools/Utilities/interface/Gaussian.h
+++ b/PhysicsTools/Utilities/interface/Gaussian.h
@@ -1,7 +1,7 @@
 #ifndef PhysicsTools_Utilities_Gaussian_h
 #define PhysicsTools_Utilities_Gaussian_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
-#include <boost/shared_ptr.hpp>
+
 #include <cmath>
 
 namespace funct {
@@ -10,7 +10,7 @@ namespace funct {
 
   struct Gaussian {
     Gaussian(const Parameter& m, const Parameter& s) : mean(m.ptr()), sigma(s.ptr()) {}
-    Gaussian(boost::shared_ptr<double> m, boost::shared_ptr<double> s) : mean(m), sigma(s) {}
+    Gaussian(std::shared_ptr<double> m, std::shared_ptr<double> s) : mean(m), sigma(s) {}
     Gaussian(double m, double s) : mean(new double(m)), sigma(new double(s)) {}
     double operator()(double x) const {
       double z = (x - *mean) / *sigma;
@@ -18,7 +18,7 @@ namespace funct {
         return 0;
       return oneOverSqrtTwoPi / *sigma * exp(-z * z / 2);
     }
-    boost::shared_ptr<double> mean, sigma;
+    std::shared_ptr<double> mean, sigma;
   };
 
 }  // namespace funct

--- a/PhysicsTools/Utilities/interface/Lumi3DReWeighting.h
+++ b/PhysicsTools/Utilities/interface/Lumi3DReWeighting.h
@@ -18,7 +18,7 @@
 #include "TFile.h"
 #include <cmath>
 #include <string>
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
 
 namespace edm {
@@ -59,14 +59,14 @@ namespace edm {
     std::string GenHistName_;
     std::string DataHistName_;
     std::string weightFileName_;
-    boost::shared_ptr<TFile> generatedFile_;
-    boost::shared_ptr<TFile> dataFile_;
-    boost::shared_ptr<TH1> weights_;
+    std::shared_ptr<TFile> generatedFile_;
+    std::shared_ptr<TFile> dataFile_;
+    std::shared_ptr<TH1> weights_;
 
     //keep copies of normalized distributions:
 
-    boost::shared_ptr<TH1> MC_distr_;
-    boost::shared_ptr<TH1> Data_distr_;
+    std::shared_ptr<TH1> MC_distr_;
+    std::shared_ptr<TH1> Data_distr_;
 
     double Weight3D_[50][50][50];
   };

--- a/PhysicsTools/Utilities/interface/LumiReWeighting.h
+++ b/PhysicsTools/Utilities/interface/LumiReWeighting.h
@@ -18,7 +18,7 @@
 #include "TFile.h"
 #include <cmath>
 #include <string>
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -130,14 +130,14 @@ namespace edm {
     std::string GenHistName_;
     std::string DataHistName_;
     edm::InputTag pileupSumInfoTag_;
-    boost::shared_ptr<TFile> generatedFile_;
-    boost::shared_ptr<TFile> dataFile_;
-    boost::shared_ptr<TH1> weights_;
+    std::shared_ptr<TFile> generatedFile_;
+    std::shared_ptr<TFile> dataFile_;
+    std::shared_ptr<TH1> weights_;
 
     //keep copies of normalized distributions:
 
-    boost::shared_ptr<TH1> MC_distr_;
-    boost::shared_ptr<TH1> Data_distr_;
+    std::shared_ptr<TH1> MC_distr_;
+    std::shared_ptr<TH1> Data_distr_;
 
     int OldLumiSection_;
     bool FirstWarning_;

--- a/PhysicsTools/Utilities/interface/Parameter.h
+++ b/PhysicsTools/Utilities/interface/Parameter.h
@@ -1,7 +1,7 @@
 #ifndef PhysicsTools_Parameter_h
 #define PhysicsTools_Parameter_h
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <ostream>
 
 namespace funct {
@@ -15,8 +15,8 @@ namespace funct {
     operator double() const { return value(); }
     double operator()(double) const { return *value_; }
     double operator()(double, double) const { return *value_; }
-    boost::shared_ptr<double> ptr() const { return value_; }
-    operator boost::shared_ptr<double>() const { return value_; }
+    std::shared_ptr<double> ptr() const { return value_; }
+    operator std::shared_ptr<double>() const { return value_; }
     Parameter& operator=(double value) {
       *value_ = value;
       return *this;
@@ -24,7 +24,7 @@ namespace funct {
 
   private:
     std::string name_;
-    boost::shared_ptr<double> value_;
+    std::shared_ptr<double> value_;
   };
 
   inline std::ostream& operator<<(std::ostream& cout, const funct::Parameter& p) {

--- a/PhysicsTools/Utilities/interface/Polynomial.h
+++ b/PhysicsTools/Utilities/interface/Polynomial.h
@@ -17,7 +17,7 @@ namespace funct {
   };
 
   template <unsigned int n>
-  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c->get() + 1) {}
+  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
   template <unsigned int n>
   Polynomial<n>::Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
 
@@ -48,7 +48,7 @@ namespace funct {
   template <>
   class Polynomial<1> {
   public:
-    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c->get() + 1) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
     Polynomial(const double *c) : c0_(new double(*c)), poly_(c + 1) {}
     Polynomial(std::shared_ptr<double> c0, std::shared_ptr<double> c1) : c0_(c0), poly_(c1) {}
@@ -64,7 +64,7 @@ namespace funct {
   template <>
   class Polynomial<2> {
   public:
-    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c->get() + 1) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
     Polynomial(const double *c) : c0_(new double(*c)), poly_(c + 1) {}
     Polynomial(std::shared_ptr<double> c0, std::shared_ptr<double> c1, std::shared_ptr<double> c2)

--- a/PhysicsTools/Utilities/interface/Polynomial.h
+++ b/PhysicsTools/Utilities/interface/Polynomial.h
@@ -2,7 +2,6 @@
 #define PhysicsTools_Utilities_Polynomial_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
 
-
 namespace funct {
   template <unsigned int n>
   class Polynomial {

--- a/PhysicsTools/Utilities/interface/Polynomial.h
+++ b/PhysicsTools/Utilities/interface/Polynomial.h
@@ -17,7 +17,7 @@ namespace funct {
   };
 
   template <unsigned int n>
-  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(c), poly_(c->get() + 1) {}
+  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c->get() + 1) {}
   template <unsigned int n>
   Polynomial<n>::Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
 

--- a/PhysicsTools/Utilities/interface/Polynomial.h
+++ b/PhysicsTools/Utilities/interface/Polynomial.h
@@ -1,24 +1,24 @@
 #ifndef PhysicsTools_Utilities_Polynomial_h
 #define PhysicsTools_Utilities_Polynomial_h
 #include "PhysicsTools/Utilities/interface/Parameter.h"
-#include "boost/shared_ptr.hpp"
+
 
 namespace funct {
   template <unsigned int n>
   class Polynomial {
   public:
     Polynomial(const double *c);
-    Polynomial(const boost::shared_ptr<double> *c);
+    Polynomial(const std::shared_ptr<double> *c);
     Polynomial(const Parameter *p);
     double operator()(double x) const;
 
   private:
-    boost::shared_ptr<double> c0_;
+    std::shared_ptr<double> c0_;
     Polynomial<n - 1> poly_;
   };
 
   template <unsigned int n>
-  Polynomial<n>::Polynomial(const boost::shared_ptr<double> *c) : c0_(c), poly_(c + 1) {}
+  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(c), poly_(c + 1) {}
   template <unsigned int n>
   Polynomial<n>::Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
 
@@ -33,49 +33,49 @@ namespace funct {
   template <>
   class Polynomial<0> {
   public:
-    Polynomial(const boost::shared_ptr<double> *c) : c0_(*c) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()) {}
     Polynomial(const double *c) : c0_(new double(*c)) {}
-    Polynomial(boost::shared_ptr<double> c0) : c0_(c0) {}
+    Polynomial(std::shared_ptr<double> c0) : c0_(c0) {}
     Polynomial(const Parameter &c0) : c0_(c0.ptr()) {}
     Polynomial(double c0) : c0_(new double(c0)) {}
     double operator()(double x) const { return *c0_; }
     double operator()() const { return *c0_; }
 
   private:
-    boost::shared_ptr<double> c0_;
+    std::shared_ptr<double> c0_;
   };
 
   template <>
   class Polynomial<1> {
   public:
-    Polynomial(const boost::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
     Polynomial(const double *c) : c0_(new double(*c)), poly_(c + 1) {}
-    Polynomial(boost::shared_ptr<double> c0, boost::shared_ptr<double> c1) : c0_(c0), poly_(c1) {}
+    Polynomial(std::shared_ptr<double> c0, std::shared_ptr<double> c1) : c0_(c0), poly_(c1) {}
     Polynomial(const Parameter &c0, const Parameter &c1) : c0_(c0.ptr()), poly_(c1.ptr()) {}
     Polynomial(double c0, double c1) : c0_(new double(c0)), poly_(c1) {}
     double operator()(double x) const { return *c0_ + x * poly_(x); }
 
   private:
-    boost::shared_ptr<double> c0_;
+    std::shared_ptr<double> c0_;
     Polynomial<0> poly_;
   };
 
   template <>
   class Polynomial<2> {
   public:
-    Polynomial(const boost::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
     Polynomial(const double *c) : c0_(new double(*c)), poly_(c + 1) {}
-    Polynomial(boost::shared_ptr<double> c0, boost::shared_ptr<double> c1, boost::shared_ptr<double> c2)
+    Polynomial(std::shared_ptr<double> c0, std::shared_ptr<double> c1, std::shared_ptr<double> c2)
         : c0_(c0), poly_(c1, c2) {}
     Polynomial(const Parameter &c0, const Parameter &c1, const Parameter &c2) : c0_(c0.ptr()), poly_(c1, c2) {}
     Polynomial(double c0, double c1, double c2) : c0_(new double(c0)), poly_(c1, c2) {}
     double operator()(double x) const { return *c0_ + x * poly_(x); }
 
   private:
-    boost::shared_ptr<double> c0_;
+    std::shared_ptr<double> c0_;
     Polynomial<1> poly_;
   };
 }  // namespace funct

--- a/PhysicsTools/Utilities/interface/Polynomial.h
+++ b/PhysicsTools/Utilities/interface/Polynomial.h
@@ -17,7 +17,7 @@ namespace funct {
   };
 
   template <unsigned int n>
-  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(c), poly_(c + 1) {}
+  Polynomial<n>::Polynomial(const std::shared_ptr<double> *c) : c0_(c), poly_(c->get() + 1) {}
   template <unsigned int n>
   Polynomial<n>::Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
 
@@ -48,7 +48,7 @@ namespace funct {
   template <>
   class Polynomial<1> {
   public:
-    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c->get() + 1) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
     Polynomial(const double *c) : c0_(new double(*c)), poly_(c + 1) {}
     Polynomial(std::shared_ptr<double> c0, std::shared_ptr<double> c1) : c0_(c0), poly_(c1) {}
@@ -64,7 +64,7 @@ namespace funct {
   template <>
   class Polynomial<2> {
   public:
-    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c + 1) {}
+    Polynomial(const std::shared_ptr<double> *c) : c0_(*c), poly_(c->get() + 1) {}
     Polynomial(const Parameter *c) : c0_(c->ptr()), poly_(c + 1) {}
     Polynomial(const double *c) : c0_(new double(*c)), poly_(c + 1) {}
     Polynomial(std::shared_ptr<double> c0, std::shared_ptr<double> c1, std::shared_ptr<double> c2)

--- a/PhysicsTools/Utilities/interface/RooFitFunction.h
+++ b/PhysicsTools/Utilities/interface/RooFitFunction.h
@@ -16,7 +16,7 @@ namespace root {
     RooFitFunction(const RooFitFunction<X, Expr>& other, const char* name = 0)
         : RooAbsReal(other, name), e_(other.e_), x_(X::name(), this, other.x_) {
       std::cout << ">>> making new RooFitFunction" << std::endl;
-      std::vector<std::pair<boost::shared_ptr<double>, RooRealProxy> >::const_iterator i = other.pars_.begin(),
+      std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = other.pars_.begin(),
                                                                                        end = other.pars_.end();
       for (; i != end; ++i) {
         std::cout << ">>> adding par to RooFitFunction" << std::endl;
@@ -66,10 +66,10 @@ namespace root {
   private:
     Expr e_;
     RooRealProxy x_;
-    std::vector<std::pair<boost::shared_ptr<double>, RooRealProxy> > pars_;
+    std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> > pars_;
     Double_t evaluate() const {
       X::set(x_);
-      std::vector<std::pair<boost::shared_ptr<double>, RooRealProxy> >::const_iterator i = pars_.begin(),
+      std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = pars_.begin(),
                                                                                        end = pars_.end();
       for (; i != end; ++i)
         *(i->first) = i->second;

--- a/PhysicsTools/Utilities/interface/RooFitFunction.h
+++ b/PhysicsTools/Utilities/interface/RooFitFunction.h
@@ -17,7 +17,7 @@ namespace root {
         : RooAbsReal(other, name), e_(other.e_), x_(X::name(), this, other.x_) {
       std::cout << ">>> making new RooFitFunction" << std::endl;
       std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = other.pars_.begin(),
-                                                                                       end = other.pars_.end();
+                                                                                     end = other.pars_.end();
       for (; i != end; ++i) {
         std::cout << ">>> adding par to RooFitFunction" << std::endl;
         pars_.push_back(std::make_pair(i->first, RooRealProxy(i->second.GetName(), this, i->second)));
@@ -70,7 +70,7 @@ namespace root {
     Double_t evaluate() const {
       X::set(x_);
       std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = pars_.begin(),
-                                                                                       end = pars_.end();
+                                                                                     end = pars_.end();
       for (; i != end; ++i)
         *(i->first) = i->second;
       return e_();

--- a/PhysicsTools/Utilities/interface/RootFunctionAdapter.h
+++ b/PhysicsTools/Utilities/interface/RootFunctionAdapter.h
@@ -1,7 +1,7 @@
 #ifndef PhysicTools_Utilities_RootFunctionAdapter_h
 #define PhysicTools_Utilities_RootFunctionAdapter_h
 #include <vector>
-#include <boost/shared_ptr.hpp>
+
 #include "PhysicsTools/Utilities/interface/RootVarsAdapter.h"
 
 namespace root {
@@ -11,7 +11,7 @@ namespace root {
     struct RootFunctionAdapter {
       RootFunctionAdapter() : f_(0) {}
       RootFunctionAdapter(F& f) : f_(&f) {}
-      void addParameter(const boost::shared_ptr<double>& par) { pars_.push_back(par); }
+      void addParameter(const std::shared_ptr<double>& par) { pars_.push_back(par); }
       void setParameters(const double* pars) {
         for (size_t i = 0; i < pars_.size(); ++i) {
           *pars_[i] = pars[i];
@@ -22,7 +22,7 @@ namespace root {
 
     private:
       F* f_;
-      std::vector<boost::shared_ptr<double> > pars_;
+      std::vector<std::shared_ptr<double> > pars_;
     };
 
   }  // namespace helper

--- a/PhysicsTools/Utilities/interface/RootFunctionHelper.h
+++ b/PhysicsTools/Utilities/interface/RootFunctionHelper.h
@@ -18,7 +18,7 @@ namespace root {
         adapter_ = RootFunctionAdapter<F, args>(f);
         return &fun_;
       }
-      static void addParameter(const boost::shared_ptr<double> &par) { adapter_.addParameter(par); }
+      static void addParameter(const std::shared_ptr<double> &par) { adapter_.addParameter(par); }
 
     private:
       static double fun_(const double *x, const double *par) {

--- a/PhysicsTools/Utilities/interface/RootMinuit.h
+++ b/PhysicsTools/Utilities/interface/RootMinuit.h
@@ -10,7 +10,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "TMinuit.h"
 #include "Math/SMatrix.h"
-#include <boost/shared_ptr.hpp>
+
 #include <vector>
 #include <string>
 #include <memory>
@@ -23,7 +23,7 @@ namespace fit {
     RootMinuit(const Function &f, bool verbose = false) : initialized_(false), minValue_(0), verbose_(verbose) {
       f_ = f;
     }
-    void addParameter(const std::string &name, boost::shared_ptr<double> val, double err, double min, double max) {
+    void addParameter(const std::string &name, std::shared_ptr<double> val, double err, double min, double max) {
       if (initialized_)
         throw edm::Exception(edm::errors::Configuration)
             << "RootMinuit: can't add parameter " << name << " after minuit initialization\n";
@@ -185,8 +185,8 @@ namespace fit {
     bool initialized_;
     double minValue_;
     std::unique_ptr<TMinuit> minuit_;
-    std::vector<boost::shared_ptr<double> > pars_;
-    static std::vector<boost::shared_ptr<double> > *fPars_;
+    std::vector<std::shared_ptr<double> > pars_;
+    static std::vector<std::shared_ptr<double> > *fPars_;
     bool verbose_;
     static Function f_;
     static void fcn_(int &, double *, double &f, double *par, int) {
@@ -242,7 +242,7 @@ namespace fit {
   Function RootMinuit<Function>::f_;
 
   template <class Function>
-  std::vector<boost::shared_ptr<double> > *RootMinuit<Function>::fPars_ = 0;
+  std::vector<std::shared_ptr<double> > *RootMinuit<Function>::fPars_ = 0;
 }  // namespace fit
 
 #endif

--- a/PhysicsTools/Utilities/interface/ZLineShape.h
+++ b/PhysicsTools/Utilities/interface/ZLineShape.h
@@ -4,7 +4,7 @@
 #include "PhysicsTools/Utilities/interface/GammaPropagator.h"
 #include "PhysicsTools/Utilities/interface/GammaZInterference.h"
 #include "PhysicsTools/Utilities/interface/Parameter.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace funct {
   class ZLineShape {
@@ -13,14 +13,14 @@ namespace funct {
 	       const Parameter& Ng, const Parameter& Ni): 
       Ngamma(Ng.ptr()), Nint(Ni.ptr()), 
       bw_(m, g), gp_(), gzi_(m, g) {}
-    ZLineShape(boost::shared_ptr<double> m, boost::shared_ptr<double> g, 
-	       boost::shared_ptr<double> Ng, boost::shared_ptr<double> Ni): 
+    ZLineShape(std::shared_ptr<double> m, std::shared_ptr<double> g, 
+	       std::shared_ptr<double> Ng, std::shared_ptr<double> Ni): 
       Ngamma(Ng), Nint(Ni), 
       bw_(m, g), gp_(), gzi_(m, g) {}
     double operator()(double x) const {
       return (1.0 - *Nint - *Ngamma) * bw_(x) + *Ngamma * gp_(x) + *Nint * gzi_(x);
     }
-    boost::shared_ptr<double> Ngamma, Nint; 
+    std::shared_ptr<double> Ngamma, Nint; 
   private:
     BreitWigner bw_;
     GammaPropagator gp_;

--- a/PhysicsTools/Utilities/interface/ZLineShape.h
+++ b/PhysicsTools/Utilities/interface/ZLineShape.h
@@ -5,29 +5,25 @@
 #include "PhysicsTools/Utilities/interface/GammaZInterference.h"
 #include "PhysicsTools/Utilities/interface/Parameter.h"
 
-
 namespace funct {
   class ZLineShape {
   public:
-    ZLineShape(const Parameter& m, const Parameter& g, 
-	       const Parameter& Ng, const Parameter& Ni): 
-      Ngamma(Ng.ptr()), Nint(Ni.ptr()), 
-      bw_(m, g), gp_(), gzi_(m, g) {}
-    ZLineShape(std::shared_ptr<double> m, std::shared_ptr<double> g, 
-	       std::shared_ptr<double> Ng, std::shared_ptr<double> Ni): 
-      Ngamma(Ng), Nint(Ni), 
-      bw_(m, g), gp_(), gzi_(m, g) {}
-    double operator()(double x) const {
-      return (1.0 - *Nint - *Ngamma) * bw_(x) + *Ngamma * gp_(x) + *Nint * gzi_(x);
-    }
-    std::shared_ptr<double> Ngamma, Nint; 
+    ZLineShape(const Parameter& m, const Parameter& g, const Parameter& Ng, const Parameter& Ni)
+        : Ngamma(Ng.ptr()), Nint(Ni.ptr()), bw_(m, g), gp_(), gzi_(m, g) {}
+    ZLineShape(std::shared_ptr<double> m,
+               std::shared_ptr<double> g,
+               std::shared_ptr<double> Ng,
+               std::shared_ptr<double> Ni)
+        : Ngamma(Ng), Nint(Ni), bw_(m, g), gp_(), gzi_(m, g) {}
+    double operator()(double x) const { return (1.0 - *Nint - *Ngamma) * bw_(x) + *Ngamma * gp_(x) + *Nint * gzi_(x); }
+    std::shared_ptr<double> Ngamma, Nint;
+
   private:
     BreitWigner bw_;
     GammaPropagator gp_;
     GammaZInterference gzi_;
   };
 
-}
+}  // namespace funct
 
 #endif
-

--- a/PhysicsTools/Utilities/interface/rootFunction.h
+++ b/PhysicsTools/Utilities/interface/rootFunction.h
@@ -904,10 +904,10 @@ namespace root {
 
   template <unsigned int args, typename Tag, typename F>
   typename helper::RootFunctionHelper<F, args, Tag>::root_function function_t(
-      F& f, const std::vector<boost::shared_ptr<double> >& pars) {
+      F& f, const std::vector<std::shared_ptr<double> >& pars) {
     typename helper::RootFunctionHelper<F, args, Tag>::root_function fun =
         helper::RootFunctionHelper<F, args, Tag>::fun(f);
-    std::vector<boost::shared_ptr<double> >::const_iterator i, b = pars.begin(), e = pars.end();
+    std::vector<std::shared_ptr<double> >::const_iterator i, b = pars.begin(), e = pars.end();
     for (i = b; i != e; ++i)
       helper::RootFunctionHelper<F, args, Tag>::addParameter(*i);
     return fun;
@@ -915,7 +915,7 @@ namespace root {
 
   template <unsigned int args, typename F>
   typename helper::RootFunctionHelper<F, args>::root_function function(
-      F& f, const std::vector<boost::shared_ptr<double> >& pars) {
+      F& f, const std::vector<std::shared_ptr<double> >& pars) {
     return function_t<args, helper::null_t>(f, pars);
   }
 

--- a/PhysicsTools/Utilities/interface/rootPlot.h
+++ b/PhysicsTools/Utilities/interface/rootPlot.h
@@ -673,7 +673,7 @@ namespace root {
             F& f,
             double min,
             double max,
-            const std::vector<boost::shared_ptr<double> >& p,
+            const std::vector<std::shared_ptr<double> >& p,
             Color_t lineColor = kRed,
             Width_t lineWidth = 1,
             Style_t lineStyle = kDashed,

--- a/PhysicsTools/Utilities/interface/rootTf1.h
+++ b/PhysicsTools/Utilities/interface/rootTf1.h
@@ -1227,7 +1227,7 @@ namespace root {
   }
 
   template <typename Tag, typename F>
-  TF1 tf1_t(const char* name, F& f, double min, double max, const std::vector<boost::shared_ptr<double> >& p) {
+  TF1 tf1_t(const char* name, F& f, double min, double max, const std::vector<std::shared_ptr<double> >& p) {
     TF1 fun(name, root::function_t<1, Tag>(f, p), min, max, p.size());
     for (size_t i = 0; i < p.size(); ++i)
       fun.SetParameter(i, *p[i]);
@@ -1235,7 +1235,7 @@ namespace root {
   }
 
   template <typename F>
-  TF1 tf1(const char* name, F& f, double min, double max, const std::vector<boost::shared_ptr<double> >& p) {
+  TF1 tf1(const char* name, F& f, double min, double max, const std::vector<std::shared_ptr<double> >& p) {
     return tf1_t<helper::null_t>(name, f, min, max, p);
   }
 

--- a/PhysicsTools/Utilities/src/Lumi3DReWeighting.cc
+++ b/PhysicsTools/Utilities/src/Lumi3DReWeighting.cc
@@ -16,16 +16,17 @@
   \author Salvatore Rappoccio, modified by Mike Hildreth
   
 */
+#include "TFile.h"
+#include "TH1.h"
+#include "TH3.h"
 #include "TRandom1.h"
 #include "TRandom2.h"
 #include "TRandom3.h"
 #include "TStopwatch.h"
-#include "TH1.h"
-#include "TH3.h"
-#include "TFile.h"
-#include <iostream>
-#include <string>
 #include <algorithm>
+#include <iostream>
+#include <memory>
+#include <string>
 
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "PhysicsTools/Utilities/interface/Lumi3DReWeighting.h"
@@ -46,8 +47,8 @@ Lumi3DReWeighting::Lumi3DReWeighting(std::string generatedFile,
       GenHistName_(GenHistName),
       DataHistName_(DataHistName),
       weightFileName_(WeightOutputFile) {
-  generatedFile_ = std::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
-  dataFile_ = std::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
+  generatedFile_ = std::make_shared<TFile>(generatedFileName_.c_str());  //MC distribution
+  dataFile_ = std::make_shared<TFile>(dataFileName_.c_str());            //Data distribution
 
   std::shared_ptr<TH1> Data_temp =
       std::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
@@ -166,8 +167,8 @@ void Lumi3DReWeighting::weight3D_set(std::string generatedFile,
   std::cout << " seting values: " << generatedFileName_ << " " << dataFileName_ << " " << GenHistName_ << " "
             << DataHistName_ << std::endl;
 
-  generatedFile_ = std::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
-  dataFile_ = std::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
+  generatedFile_ = std::make_shared<TFile>(generatedFileName_.c_str());  //MC distribution
+  dataFile_ = std::make_shared<TFile>(dataFileName_.c_str());            //Data distribution
 
   std::shared_ptr<TH1> Data_temp =
       std::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));

--- a/PhysicsTools/Utilities/src/Lumi3DReWeighting.cc
+++ b/PhysicsTools/Utilities/src/Lumi3DReWeighting.cc
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <string>
 #include <algorithm>
-#include <boost/shared_ptr.hpp>
+
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "PhysicsTools/Utilities/interface/Lumi3DReWeighting.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -46,17 +46,17 @@ Lumi3DReWeighting::Lumi3DReWeighting(std::string generatedFile,
       GenHistName_(GenHistName),
       DataHistName_(DataHistName),
       weightFileName_(WeightOutputFile) {
-  generatedFile_ = boost::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
-  dataFile_ = boost::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
+  generatedFile_ = std::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
+  dataFile_ = std::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
 
-  boost::shared_ptr<TH1> Data_temp =
-      boost::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
+  std::shared_ptr<TH1> Data_temp =
+      std::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
 
-  boost::shared_ptr<TH1> MC_temp =
-      boost::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
+  std::shared_ptr<TH1> MC_temp =
+      std::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
 
-  MC_distr_ = boost::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
-  Data_distr_ = boost::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
+  MC_distr_ = std::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
+  Data_distr_ = std::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
 
   // MC * data/MC = data, so the weights are data/MC:
 
@@ -77,11 +77,11 @@ Lumi3DReWeighting::Lumi3DReWeighting(const std::vector<float> &MC_distr,
 
   Int_t NMCBins = MC_distr.size();
 
-  MC_distr_ = boost::shared_ptr<TH1>(new TH1F("MC_distr", "MC dist", NMCBins, 0., float(NMCBins)));
+  MC_distr_ = std::shared_ptr<TH1>(new TH1F("MC_distr", "MC dist", NMCBins, 0., float(NMCBins)));
 
   Int_t NDBins = Lumi_distr.size();
 
-  Data_distr_ = boost::shared_ptr<TH1>(new TH1F("Data_distr", "Data dist", NDBins, 0., float(NDBins)));
+  Data_distr_ = std::shared_ptr<TH1>(new TH1F("Data_distr", "Data dist", NDBins, 0., float(NDBins)));
 
   for (int ibin = 1; ibin < NMCBins + 1; ++ibin) {
     MC_distr_->SetBinContent(ibin, MC_distr[ibin - 1]);
@@ -166,17 +166,17 @@ void Lumi3DReWeighting::weight3D_set(std::string generatedFile,
   std::cout << " seting values: " << generatedFileName_ << " " << dataFileName_ << " " << GenHistName_ << " "
             << DataHistName_ << std::endl;
 
-  generatedFile_ = boost::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
-  dataFile_ = boost::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
+  generatedFile_ = std::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
+  dataFile_ = std::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
 
-  boost::shared_ptr<TH1> Data_temp =
-      boost::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
+  std::shared_ptr<TH1> Data_temp =
+      std::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
 
-  boost::shared_ptr<TH1> MC_temp =
-      boost::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
+  std::shared_ptr<TH1> MC_temp =
+      std::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
 
-  MC_distr_ = boost::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
-  Data_distr_ = boost::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
+  MC_distr_ = std::shared_ptr<TH1>((static_cast<TH1 *>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
+  Data_distr_ = std::shared_ptr<TH1>((static_cast<TH1 *>(dataFile_->Get(DataHistName_.c_str())->Clone())));
 
   // MC * data/MC = data, so the weights are data/MC:
 

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -16,15 +16,16 @@
   \author Salvatore Rappoccio, modified by Mike Hildreth
   
 */
+#include "TFile.h"
+#include "TH1.h"
 #include "TRandom1.h"
 #include "TRandom2.h"
 #include "TRandom3.h"
 #include "TStopwatch.h"
-#include "TH1.h"
-#include "TFile.h"
-#include <iostream>
-#include <string>
 #include <algorithm>
+#include <iostream>
+#include <memory>
+#include <string>
 
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "PhysicsTools/Utilities/interface/LumiReWeighting.h"
@@ -45,8 +46,8 @@ LumiReWeighting::LumiReWeighting(std::string generatedFile,
       GenHistName_(GenHistName),
       DataHistName_(DataHistName),
       pileupSumInfoTag_(PileupSumInfoInputTag) {
-  generatedFile_ = std::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
-  dataFile_ = std::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
+  generatedFile_ = std::make_shared<TFile>(generatedFileName_.c_str());  //MC distribution
+  dataFile_ = std::make_shared<TFile>(dataFileName_.c_str());            //Data distribution
 
   Data_distr_ = std::shared_ptr<TH1>((static_cast<TH1*>(dataFile_->Get(DataHistName_.c_str())->Clone())));
   MC_distr_ = std::shared_ptr<TH1>((static_cast<TH1*>(generatedFile_->Get(GenHistName_.c_str())->Clone())));

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <string>
 #include <algorithm>
-#include <boost/shared_ptr.hpp>
+
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "PhysicsTools/Utilities/interface/LumiReWeighting.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -45,11 +45,11 @@ LumiReWeighting::LumiReWeighting(std::string generatedFile,
       GenHistName_(GenHistName),
       DataHistName_(DataHistName),
       pileupSumInfoTag_(PileupSumInfoInputTag) {
-  generatedFile_ = boost::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
-  dataFile_ = boost::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
+  generatedFile_ = std::shared_ptr<TFile>(new TFile(generatedFileName_.c_str()));  //MC distribution
+  dataFile_ = std::shared_ptr<TFile>(new TFile(dataFileName_.c_str()));            //Data distribution
 
-  Data_distr_ = boost::shared_ptr<TH1>((static_cast<TH1*>(dataFile_->Get(DataHistName_.c_str())->Clone())));
-  MC_distr_ = boost::shared_ptr<TH1>((static_cast<TH1*>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
+  Data_distr_ = std::shared_ptr<TH1>((static_cast<TH1*>(dataFile_->Get(DataHistName_.c_str())->Clone())));
+  MC_distr_ = std::shared_ptr<TH1>((static_cast<TH1*>(generatedFile_->Get(GenHistName_.c_str())->Clone())));
 
   // MC * data/MC = data, so the weights are data/MC:
 
@@ -58,7 +58,7 @@ LumiReWeighting::LumiReWeighting(std::string generatedFile,
   Data_distr_->Scale(1.0 / Data_distr_->Integral());
   MC_distr_->Scale(1.0 / MC_distr_->Integral());
 
-  weights_ = boost::shared_ptr<TH1>(static_cast<TH1*>(Data_distr_->Clone()));
+  weights_ = std::shared_ptr<TH1>(static_cast<TH1*>(Data_distr_->Clone()));
 
   weights_->SetName("lumiWeights");
 
@@ -97,10 +97,10 @@ LumiReWeighting::LumiReWeighting(const std::vector<float>& MC_distr,
 
   Int_t NBins = MC_distr.size();
 
-  MC_distr_ = boost::shared_ptr<TH1>(new TH1F("MC_distr", "MC dist", NBins, -0.5, float(NBins) - 0.5));
-  Data_distr_ = boost::shared_ptr<TH1>(new TH1F("Data_distr", "Data dist", NBins, -0.5, float(NBins) - 0.5));
+  MC_distr_ = std::shared_ptr<TH1>(new TH1F("MC_distr", "MC dist", NBins, -0.5, float(NBins) - 0.5));
+  Data_distr_ = std::shared_ptr<TH1>(new TH1F("Data_distr", "Data dist", NBins, -0.5, float(NBins) - 0.5));
 
-  weights_ = boost::shared_ptr<TH1>(new TH1F("luminumer", "luminumer", NBins, -0.5, float(NBins) - 0.5));
+  weights_ = std::shared_ptr<TH1>(new TH1F("luminumer", "luminumer", NBins, -0.5, float(NBins) - 0.5));
   TH1* den = new TH1F("lumidenom", "lumidenom", NBins, -0.5, float(NBins) - 0.5);
 
   for (int ibin = 1; ibin < NBins + 1; ++ibin) {

--- a/PhysicsTools/Utilities/test/testExpressionFit.cpp
+++ b/PhysicsTools/Utilities/test/testExpressionFit.cpp
@@ -10,7 +10,7 @@
 #include "TF1.h"
 #include "TCanvas.h"
 #include "TROOT.h"
-#include <boost/shared_ptr.hpp>
+
 #include <iostream>
 #include "PhysicsTools/Utilities/interface/Operations.h"
 

--- a/PhysicsTools/Utilities/test/testParameter.cc
+++ b/PhysicsTools/Utilities/test/testParameter.cc
@@ -23,7 +23,7 @@ void testParameter::checkAll() {
   CPPUNIT_ASSERT(a.value() == aVal);
   double av = a;
   CPPUNIT_ASSERT(av == aVal);
-  boost::shared_ptr<double> ap = a;
+  std::shared_ptr<double> ap = a;
   CPPUNIT_ASSERT(*ap == aVal);
   aVal = 234;
   a = aVal;

--- a/PhysicsTools/Utilities/test/testZMassFit.cpp
+++ b/PhysicsTools/Utilities/test/testZMassFit.cpp
@@ -11,7 +11,7 @@
 #include "TF1.h"
 #include "TCanvas.h"
 #include "TROOT.h"
-#include <boost/shared_ptr.hpp>
+
 #include <iostream>
 #include "PhysicsTools/Utilities/interface/Operations.h"
 //using namespace std;

--- a/PhysicsTools/Utilities/test/testZMassFitExtLikelihood.cpp
+++ b/PhysicsTools/Utilities/test/testZMassFitExtLikelihood.cpp
@@ -10,7 +10,7 @@
 #include "TF1.h"
 #include "TCanvas.h"
 #include "TROOT.h"
-#include <boost/shared_ptr.hpp>
+
 #include <iostream>
 #include "PhysicsTools/Utilities/interface/Operations.h"
 //using namespace std;

--- a/PhysicsTools/Utilities/test/testZMassFitLikelihood.cpp
+++ b/PhysicsTools/Utilities/test/testZMassFitLikelihood.cpp
@@ -10,7 +10,7 @@
 #include "TF1.h"
 #include "TCanvas.h"
 #include "TROOT.h"
-#include <boost/shared_ptr.hpp>
+
 #include <iostream>
 #include "PhysicsTools/Utilities/interface/Operations.h"
 //using namespace std;

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -1,11 +1,12 @@
-#include <functional>
 #include <algorithm>
-#include <iterator>
 #include <cstddef>
+#include <functional>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <map>
-#include <set>
 
 #include <boost/iterator/transform_iterator.hpp>
 
@@ -276,11 +277,11 @@ TemplatedSecondaryVertexProducer<IPTI, VTX>::TemplatedSecondaryVertexProducer(co
 
     // set jet algorithm
     if (jetAlgorithm == "Kt")
-      fjJetDefinition = JetDefPtr(new fastjet::JetDefinition(fastjet::kt_algorithm, rParam));
+      fjJetDefinition = std::make_shared<fastjet::JetDefinition>(fastjet::kt_algorithm, rParam);
     else if (jetAlgorithm == "CambridgeAachen")
-      fjJetDefinition = JetDefPtr(new fastjet::JetDefinition(fastjet::cambridge_algorithm, rParam));
+      fjJetDefinition = std::make_shared<fastjet::JetDefinition>(fastjet::cambridge_algorithm, rParam);
     else if (jetAlgorithm == "AntiKt")
-      fjJetDefinition = JetDefPtr(new fastjet::JetDefinition(fastjet::antikt_algorithm, rParam));
+      fjJetDefinition = std::make_shared<fastjet::JetDefinition>(fastjet::antikt_algorithm, rParam);
     else
       throw cms::Exception("InvalidJetAlgorithm") << "Jet clustering algorithm is invalid: " << jetAlgorithm
                                                   << ", use CambridgeAachen | Kt | AntiKt" << std::endl;
@@ -412,7 +413,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
     }
 
     // define jet clustering sequence
-    fjClusterSeq = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs, *fjJetDefinition));
+    fjClusterSeq = std::make_shared<fastjet::ClusterSequence>(fjInputs, *fjJetDefinition);
     // recluster jet constituents and inserted "ghosts"
     std::vector<fastjet::PseudoJet> inclusiveJets = fastjet::sorted_by_pt(fjClusterSeq->inclusive_jets(jetPtMin));
 

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -59,8 +59,8 @@
 //
 // constants, enums and typedefs
 //
-typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
-typedef boost::shared_ptr<fastjet::JetDefinition> JetDefPtr;
+typedef std::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+typedef std::shared_ptr<fastjet::JetDefinition> JetDefPtr;
 
 using namespace reco;
 

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
@@ -198,9 +198,9 @@ std::unique_ptr<reco::FFTJetPileupSummary> FFTJetPileupEstimator::calibrateFromD
                                                                                   const edm::EventSetup& iSetup) const {
   edm::ESHandle<FFTJetLookupTableSequence> h;
   StaticFFTJetLookupTableSequenceLoader::instance().load(iSetup, calibTableRecord, h);
-  boost::shared_ptr<npstat::StorableMultivariateFunctor> uz = (*h)[calibTableCategory][uncertaintyZonesName];
-  boost::shared_ptr<npstat::StorableMultivariateFunctor> cc = (*h)[calibTableCategory][calibrationCurveName];
-  boost::shared_ptr<npstat::StorableMultivariateFunctor> uc = (*h)[calibTableCategory][uncertaintyCurveName];
+  std::shared_ptr<npstat::StorableMultivariateFunctor> uz = (*h)[calibTableCategory][uncertaintyZonesName];
+  std::shared_ptr<npstat::StorableMultivariateFunctor> cc = (*h)[calibTableCategory][calibrationCurveName];
+  std::shared_ptr<npstat::StorableMultivariateFunctor> uc = (*h)[calibTableCategory][uncertaintyCurveName];
 
   const double pileupRho = ptToDensityFactor * (*cc)(&curve, 1U);
   const double rhoUncert = ptToDensityFactor * (*uc)(&curve, 1U);

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
@@ -327,7 +327,7 @@ void FFTJetPileupProcessor::endJob() {}
 void FFTJetPileupProcessor::loadFlatteningFactors(const edm::EventSetup& iSetup) {
   edm::ESHandle<FFTJetLookupTableSequence> h;
   StaticFFTJetLookupTableSequenceLoader::instance().load(iSetup, flatteningTableRecord, h);
-  boost::shared_ptr<npstat::StorableMultivariateFunctor> f = (*h)[flatteningTableCategory][flatteningTableName];
+  std::shared_ptr<npstat::StorableMultivariateFunctor> f = (*h)[flatteningTableCategory][flatteningTableName];
 
   // Fill out the table of flattening factors as a function of eta
   const unsigned nEta = energyFlow->nEta();

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -949,7 +949,7 @@ void FFTJetProducer::determinePileupDensityFromDB(const edm::Event& iEvent,
                                                   std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& density) {
   edm::ESHandle<FFTJetLookupTableSequence> h;
   StaticFFTJetLookupTableSequenceLoader::instance().load(iSetup, pileupTableRecord, h);
-  boost::shared_ptr<npstat::StorableMultivariateFunctor> f = (*h)[pileupTableCategory][pileupTableName];
+  std::shared_ptr<npstat::StorableMultivariateFunctor> f = (*h)[pileupTableCategory][pileupTableName];
 
   edm::Handle<reco::FFTJetPileupSummary> summary;
   iEvent.getByToken(input_pusummary_token_, summary);

--- a/RecoJets/JetAlgorithms/interface/CATopJetAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/CATopJetAlgorithm.h
@@ -17,7 +17,7 @@
 #include <TMath.h>
 #include <iostream>
 
-#include "boost/shared_ptr.hpp"
+
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
@@ -80,7 +80,7 @@ public:
   /// Find the ProtoJets from the collection of input Candidates.
   void run(const std::vector<fastjet::PseudoJet>& cell_particles,
            std::vector<fastjet::PseudoJet>& hardjetsOutput,
-           boost::shared_ptr<fastjet::ClusterSequence>& fjClusterSeq);
+           std::shared_ptr<fastjet::ClusterSequence>& fjClusterSeq);
 
 private:
   edm::InputTag mSrc_;    //<! calo tower input source

--- a/RecoJets/JetAlgorithms/interface/CATopJetAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/CATopJetAlgorithm.h
@@ -17,8 +17,6 @@
 #include <TMath.h>
 #include <iostream>
 
-
-
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDefs.h"

--- a/RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+
 
 #include "RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -19,9 +19,9 @@ public:
                   unsigned int subjets,
                   double zcut,
                   double rcut_factor,
-                  boost::shared_ptr<fastjet::JetDefinition> fjJetDefinition,
+                  std::shared_ptr<fastjet::JetDefinition> fjJetDefinition,
                   bool doAreaFastjet,
-                  boost::shared_ptr<fastjet::GhostedAreaSpec> fjActiveArea,
+                  std::shared_ptr<fastjet::GhostedAreaSpec> fjActiveArea,
                   double voronoiRfact)
       : ptMin_(ptMin),
         nSubjets_(subjets),
@@ -45,9 +45,9 @@ private:
   int nSubjets_;        //<! number of subjets to produce.
   double zcut_;         //<! zcut parameter (see arXiv:0903.5081). Only relevant if pruning is enabled.
   double rcut_factor_;  //<! r-cut factor (see arXiv:0903.5081).
-  boost::shared_ptr<fastjet::JetDefinition> fjJetDefinition_;  //<! jet definition to use
+  std::shared_ptr<fastjet::JetDefinition> fjJetDefinition_;  //<! jet definition to use
   bool doAreaFastjet_;                                         //<! whether or not to use the fastjet area
-  boost::shared_ptr<fastjet::GhostedAreaSpec> fjActiveArea_;   //<! fastjet area spec
+  std::shared_ptr<fastjet::GhostedAreaSpec> fjActiveArea_;   //<! fastjet area spec
   double voronoiRfact_;                                        //<! fastjet voronoi area R factor
 };
 

--- a/RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h
@@ -3,8 +3,6 @@
 
 #include <vector>
 
-
-
 #include "RecoJets/JetAlgorithms/interface/CompoundPseudoJet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "RecoJets/JetAlgorithms/interface/FastPrunePlugin.hh"
@@ -46,9 +44,9 @@ private:
   double zcut_;         //<! zcut parameter (see arXiv:0903.5081). Only relevant if pruning is enabled.
   double rcut_factor_;  //<! r-cut factor (see arXiv:0903.5081).
   std::shared_ptr<fastjet::JetDefinition> fjJetDefinition_;  //<! jet definition to use
-  bool doAreaFastjet_;                                         //<! whether or not to use the fastjet area
+  bool doAreaFastjet_;                                       //<! whether or not to use the fastjet area
   std::shared_ptr<fastjet::GhostedAreaSpec> fjActiveArea_;   //<! fastjet area spec
-  double voronoiRfact_;                                        //<! fastjet voronoi area R factor
+  double voronoiRfact_;                                      //<! fastjet voronoi area R factor
 };
 
 #endif

--- a/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CATopJetAlgorithm.cc
@@ -17,7 +17,7 @@ using namespace edm;
 //  ------------------
 void CATopJetAlgorithm::run(const vector<fastjet::PseudoJet>& cell_particles,
                             vector<fastjet::PseudoJet>& hardjetsOutput,
-                            boost::shared_ptr<fastjet::ClusterSequence>& fjClusterSeq) {
+                            std::shared_ptr<fastjet::ClusterSequence>& fjClusterSeq) {
   if (verbose_)
     cout << "Welcome to CATopSubJetAlgorithm::run" << endl;
 
@@ -74,13 +74,13 @@ void CATopJetAlgorithm::run(const vector<fastjet::PseudoJet>& cell_particles,
 
   //cluster the jets with the jet definition jetDef:
   // run algorithm
-  // boost::shared_ptr<fastjet::ClusterSequence> fjClusterSeq;
+  // std::shared_ptr<fastjet::ClusterSequence> fjClusterSeq;
   // if ( !doAreaFastjet_ ) {
-  //   fjClusterSeq = boost::shared_ptr<fastjet::ClusterSequence>( new fastjet::ClusterSequence( cell_particles, jetDef ) );
+  //   fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>( new fastjet::ClusterSequence( cell_particles, jetDef ) );
   // } else if (voronoiRfact_ <= 0) {
-  //   fjClusterSeq = boost::shared_ptr<fastjet::ClusterSequence>( new fastjet::ClusterSequenceArea( cell_particles, jetDef , *fjActiveArea_ ) );
+  //   fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>( new fastjet::ClusterSequenceArea( cell_particles, jetDef , *fjActiveArea_ ) );
   // } else {
-  //   fjClusterSeq = boost::shared_ptr<fastjet::ClusterSequence>( new fastjet::ClusterSequenceVoronoiArea( cell_particles, jetDef , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+  //   fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>( new fastjet::ClusterSequenceVoronoiArea( cell_particles, jetDef , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
   // }
 
   if (verbose_)

--- a/RecoJets/JetAlgorithms/src/SubJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/SubJetAlgorithm.cc
@@ -3,7 +3,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "fastjet/ClusterSequenceArea.hh"
 
-#include "boost/shared_ptr.hpp"
+
 
 using namespace std;
 using namespace edm;
@@ -22,14 +22,14 @@ void SubJetAlgorithm::run(const vector<fastjet::PseudoJet>& cell_particles, vect
 
   // cluster the jets with the jet definition jetDef:
   // run algorithm
-  boost::shared_ptr<fastjet::ClusterSequence> fjClusterSeq;
+  std::shared_ptr<fastjet::ClusterSequence> fjClusterSeq;
   if (!doAreaFastjet_) {
-    fjClusterSeq = boost::shared_ptr<fastjet::ClusterSequence>(new fastjet::ClusterSequence(cell_particles, pjetdef));
+    fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>(new fastjet::ClusterSequence(cell_particles, pjetdef));
   } else if (voronoiRfact_ <= 0) {
-    fjClusterSeq = boost::shared_ptr<fastjet::ClusterSequence>(
+    fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>(
         new fastjet::ClusterSequenceActiveArea(cell_particles, pjetdef, *fjActiveArea_));
   } else {
-    fjClusterSeq = boost::shared_ptr<fastjet::ClusterSequence>(
+    fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>(
         new fastjet::ClusterSequenceVoronoiArea(cell_particles, pjetdef, fastjet::VoronoiAreaSpec(voronoiRfact_)));
   }
 

--- a/RecoJets/JetAlgorithms/src/SubJetAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/SubJetAlgorithm.cc
@@ -1,9 +1,9 @@
+#include <memory>
+
 #include "RecoJets/JetAlgorithms/interface/SubJetAlgorithm.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "fastjet/ClusterSequenceArea.hh"
-
-
 
 using namespace std;
 using namespace edm;
@@ -24,7 +24,7 @@ void SubJetAlgorithm::run(const vector<fastjet::PseudoJet>& cell_particles, vect
   // run algorithm
   std::shared_ptr<fastjet::ClusterSequence> fjClusterSeq;
   if (!doAreaFastjet_) {
-    fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>(new fastjet::ClusterSequence(cell_particles, pjetdef));
+    fjClusterSeq = std::make_shared<fastjet::ClusterSequence>(cell_particles, pjetdef);
   } else if (voronoiRfact_ <= 0) {
     fjClusterSeq = std::shared_ptr<fastjet::ClusterSequence>(
         new fastjet::ClusterSequenceActiveArea(cell_particles, pjetdef, *fjActiveArea_));

--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -2,7 +2,7 @@
 #define __PUSubtractor__
 
 #include <vector>
-#include "boost/shared_ptr.hpp"
+
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/ClusterSequenceArea.hh"
@@ -22,10 +22,10 @@
 
 class PileUpSubtractor {
 public:
-  typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
-  typedef boost::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
-  typedef boost::shared_ptr<fastjet::RangeDefinition> RangeDefPtr;
-  typedef boost::shared_ptr<fastjet::JetDefinition> JetDefPtr;
+  typedef std::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+  typedef std::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
+  typedef std::shared_ptr<fastjet::RangeDefinition> RangeDefPtr;
+  typedef std::shared_ptr<fastjet::JetDefinition> JetDefPtr;
 
   PileUpSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
   virtual ~PileUpSubtractor() { ; }

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -55,7 +55,7 @@ public:
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   // typedefs
-  typedef boost::shared_ptr<DynamicRfilt> DynamicRfiltPtr;
+  typedef std::shared_ptr<DynamicRfilt> DynamicRfiltPtr;
 
 protected:
   //

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -206,9 +206,9 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
     if (puSubtractorName_.empty()) {
       LogWarning("VirtualJetProducer")
           << "Pile Up correction on; however, pile up type is not specified. Using default... \n";
-      subtractor_ = boost::shared_ptr<PileUpSubtractor>(new PileUpSubtractor(iConfig, consumesCollector()));
+      subtractor_ = std::shared_ptr<PileUpSubtractor>(new PileUpSubtractor(iConfig, consumesCollector()));
     } else
-      subtractor_ = boost::shared_ptr<PileUpSubtractor>(
+      subtractor_ = std::shared_ptr<PileUpSubtractor>(
           PileUpSubtractorFactory::get()->create(puSubtractorName_, iConfig, consumesCollector()));
   }
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -169,32 +169,32 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
   // - fastjet PU subtraction parameters (not yet considered)
   //
   if (jetAlgorithm_ == "Kt")
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::kt_algorithm, rParam_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(fastjet::kt_algorithm, rParam_);
 
   else if (jetAlgorithm_ == "CambridgeAachen")
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::cambridge_algorithm, rParam_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(fastjet::cambridge_algorithm, rParam_);
 
   else if (jetAlgorithm_ == "AntiKt")
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::antikt_algorithm, rParam_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(fastjet::antikt_algorithm, rParam_);
 
   else if (jetAlgorithm_ == "GeneralizedKt")
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(fastjet::genkt_algorithm, rParam_, -2));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(fastjet::genkt_algorithm, rParam_, -2);
 
   else if (jetAlgorithm_ == "SISCone") {
     fjPlugin_ = PluginPtr(new fastjet::SISConePlugin(rParam_, 0.75, 0, 0.0, false, fastjet::SISConePlugin::SM_pttilde));
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(&*fjPlugin_);
 
   } else if (jetAlgorithm_ == "IterativeCone") {
     fjPlugin_ = PluginPtr(new fastjet::CMSIterativeConePlugin(rParam_, 1.0));
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(&*fjPlugin_);
 
   } else if (jetAlgorithm_ == "CDFMidPoint") {
     fjPlugin_ = PluginPtr(new fastjet::CDFMidPointPlugin(rParam_, 0.75));
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(&*fjPlugin_);
 
   } else if (jetAlgorithm_ == "ATLASCone") {
     fjPlugin_ = PluginPtr(new fastjet::ATLASConePlugin(rParam_));
-    fjJetDefinition_ = JetDefPtr(new fastjet::JetDefinition(&*fjPlugin_));
+    fjJetDefinition_ = std::make_shared<fastjet::JetDefinition>(&*fjPlugin_);
 
   } else {
     throw cms::Exception("Invalid jetAlgorithm") << "Jet algorithm for VirtualJetProducer is invalid, Abort!\n";
@@ -206,7 +206,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
     if (puSubtractorName_.empty()) {
       LogWarning("VirtualJetProducer")
           << "Pile Up correction on; however, pile up type is not specified. Using default... \n";
-      subtractor_ = std::shared_ptr<PileUpSubtractor>(new PileUpSubtractor(iConfig, consumesCollector()));
+      subtractor_ = std::make_shared<PileUpSubtractor>(iConfig, consumesCollector());
     } else
       subtractor_ = std::shared_ptr<PileUpSubtractor>(
           PileUpSubtractorFactory::get()->create(puSubtractorName_, iConfig, consumesCollector()));
@@ -220,16 +220,16 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 
   if (doAreaFastjet_ || doRhoFastjet_) {
     if (voronoiRfact_ <= 0) {
-      fjActiveArea_ = ActiveAreaSpecPtr(new fastjet::GhostedAreaSpec(ghostEtaMax_, activeAreaRepeats_, ghostArea_));
+      fjActiveArea_ = std::make_shared<fastjet::GhostedAreaSpec>(ghostEtaMax_, activeAreaRepeats_, ghostArea_);
 
       if (!useExplicitGhosts_) {
-        fjAreaDefinition_ = AreaDefinitionPtr(new fastjet::AreaDefinition(fastjet::active_area, *fjActiveArea_));
+        fjAreaDefinition_ = std::make_shared<fastjet::AreaDefinition>(fastjet::active_area, *fjActiveArea_);
       } else {
         fjAreaDefinition_ =
-            AreaDefinitionPtr(new fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, *fjActiveArea_));
+            std::make_shared<fastjet::AreaDefinition>(fastjet::active_area_explicit_ghosts, *fjActiveArea_);
       }
     }
-    fjSelector_ = SelectorPtr(new fastjet::Selector(fastjet::SelectorAbsRapMax(rhoEtaMax_)));
+    fjSelector_ = std::make_shared<fastjet::Selector>(fastjet::SelectorAbsRapMax(rhoEtaMax_));
   }
 
   if ((doFastJetNonUniform_) && (puCenters_.empty()))

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -32,7 +32,6 @@
 #include <memory>
 #include <vector>
 
-
 class dso_hidden VirtualJetProducer : public edm::stream::EDProducer<> {
 protected:
   //

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -31,7 +31,7 @@
 
 #include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+
 
 class dso_hidden VirtualJetProducer : public edm::stream::EDProducer<> {
 protected:
@@ -71,12 +71,12 @@ public:
   static void fillDescriptionsFromVirtualJetProducer(edm::ParameterSetDescription& desc);
 
   // typedefs
-  typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
-  typedef boost::shared_ptr<fastjet::JetDefinition::Plugin> PluginPtr;
-  typedef boost::shared_ptr<fastjet::JetDefinition> JetDefPtr;
-  typedef boost::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
-  typedef boost::shared_ptr<fastjet::AreaDefinition> AreaDefinitionPtr;
-  typedef boost::shared_ptr<fastjet::Selector> SelectorPtr;
+  typedef std::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+  typedef std::shared_ptr<fastjet::JetDefinition::Plugin> PluginPtr;
+  typedef std::shared_ptr<fastjet::JetDefinition> JetDefPtr;
+  typedef std::shared_ptr<fastjet::GhostedAreaSpec> ActiveAreaSpecPtr;
+  typedef std::shared_ptr<fastjet::AreaDefinition> AreaDefinitionPtr;
+  typedef std::shared_ptr<fastjet::Selector> SelectorPtr;
 
   //
   // member functions
@@ -200,7 +200,7 @@ protected:
   std::string jetCollInstanceName_;  // instance name for output jet collection
   bool writeCompound_;               // write compound jets (i.e. jets of jets)
   bool writeJetsWithConst_;          // write jets with constituents
-  boost::shared_ptr<PileUpSubtractor> subtractor_;
+  std::shared_ptr<PileUpSubtractor> subtractor_;
 
   bool useDeterministicSeed_;  // If desired, use a deterministic seed to fastjet
   unsigned int minSeed_;       // minimum seed to use, useful for MC generation

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -2,7 +2,7 @@
 #define HCALSIMPLERECALGO_H 1
 
 #include <memory>
-#include "boost/shared_ptr.hpp"
+
 
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
@@ -50,8 +50,8 @@ public:
   void setLeakCorrection();
 
   // set OOT pileup corrections
-  void setHFPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr);
-  void setHOPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr);
+  void setHFPileupCorrection(std::shared_ptr<AbsOOTPileupCorrection> corr);
+  void setHOPileupCorrection(std::shared_ptr<AbsOOTPileupCorrection> corr);
 
   // Set bunch crossing information.
   // This object will not manage the pointer.
@@ -80,9 +80,9 @@ private:
   int pileupCleaningID_;
   const BunchXParameter* bunchCrossingInfo_;
   unsigned lenBunchCrossingInfo_;
-  boost::shared_ptr<AbsOOTPileupCorrection> hbhePileupCorr_;
-  boost::shared_ptr<AbsOOTPileupCorrection> hfPileupCorr_;
-  boost::shared_ptr<AbsOOTPileupCorrection> hoPileupCorr_;
+  std::shared_ptr<AbsOOTPileupCorrection> hbhePileupCorr_;
+  std::shared_ptr<AbsOOTPileupCorrection> hfPileupCorr_;
+  std::shared_ptr<AbsOOTPileupCorrection> hoPileupCorr_;
 
   HcalPulseShapes theHcalPulseShapes_;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -3,7 +3,6 @@
 
 #include <memory>
 
-
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HODataFrame.h"

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -51,9 +51,9 @@ void HcalSimpleRecAlgo::setRecoParams(
 
 void HcalSimpleRecAlgo::setLeakCorrection() { setLeakCorrection_ = true; }
 
-void HcalSimpleRecAlgo::setHFPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr) { hfPileupCorr_ = corr; }
+void HcalSimpleRecAlgo::setHFPileupCorrection(std::shared_ptr<AbsOOTPileupCorrection> corr) { hfPileupCorr_ = corr; }
 
-void HcalSimpleRecAlgo::setHOPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr) { hoPileupCorr_ = corr; }
+void HcalSimpleRecAlgo::setHOPileupCorrection(std::shared_ptr<AbsOOTPileupCorrection> corr) { hoPileupCorr_ = corr; }
 
 void HcalSimpleRecAlgo::setBXInfo(const BunchXParameter* info, const unsigned lenInfo) {
   bunchCrossingInfo_ = info;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -48,7 +48,7 @@ public:
   void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(boost::shared_ptr<AbsOOTPileupCorrection>);
+  typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(std::shared_ptr<AbsOOTPileupCorrection>);
 
   HcalSimpleRecAlgo reco_;
   HcalADCSaturationFlag* saturationFlagSetter_;

--- a/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
@@ -20,7 +20,7 @@
 #include "TH2D.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/shared_ptr.hpp"
+
 #include <string>
 
 class MuonCaloCompatibility {

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -32,7 +32,6 @@
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-
 #include <vector>
 
 namespace reco {

--- a/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauConstructor.h
@@ -32,7 +32,7 @@
 #include "DataFormats/TauReco/interface/RecoTauPiZero.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-#include "boost/shared_ptr.hpp"
+
 #include <vector>
 
 namespace reco {
@@ -129,7 +129,7 @@ namespace reco {
     private:
       typedef std::pair<Region, ParticleType> CollectionKey;
       typedef std::map<CollectionKey, std::vector<CandidatePtr>*> CollectionMap;
-      typedef boost::shared_ptr<std::vector<CandidatePtr> > SortedListPtr;
+      typedef std::shared_ptr<std::vector<CandidatePtr> > SortedListPtr;
       typedef std::map<CollectionKey, SortedListPtr> SortedCollectionMap;
 
       bool copyGammas_;

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -142,7 +142,7 @@ protected:
   /** Called at end of track building, to see if track should be kept */
   bool qualityFilter(const TempTrajectory& traj, bool inOut = false) const;
 
-  void addToResult(boost::shared_ptr<const TrajectorySeed> const& seed,
+  void addToResult(std::shared_ptr<const TrajectorySeed> const& seed,
                    TempTrajectory& traj,
                    TrajectoryContainer& result,
                    bool inOut = false) const;

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -77,7 +77,7 @@ protected:
   unsigned int limitedCandidates(const TrajectorySeed& seed,
                                  TempTrajectory& startingTraj,
                                  TrajectoryContainer& result) const;
-  unsigned int limitedCandidates(const boost::shared_ptr<const TrajectorySeed>& sharedSeed,
+  unsigned int limitedCandidates(const std::shared_ptr<const TrajectorySeed>& sharedSeed,
                                  TempTrajectoryContainer& candidates,
                                  TrajectoryContainer& result) const;
 

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc
@@ -206,7 +206,7 @@ void GroupedCkfTrajectoryBuilder::rebuildTrajectories(TempTrajectory const& star
   TrajectoryContainer final;
 
   // better the seed to be always the same...
-  boost::shared_ptr<const TrajectorySeed> sharedSeed;
+  std::shared_ptr<const TrajectorySeed> sharedSeed;
   if (result.empty())
     sharedSeed.reset(new TrajectorySeed(seed));
   else
@@ -263,7 +263,7 @@ TempTrajectory GroupedCkfTrajectoryBuilder::buildTrajectories(const TrajectorySe
   FastTrajectoryCleaner cleaner(theFoundHitBonus, theLostHitPenalty);
   cleaner.clean(work_);
 
-  boost::shared_ptr<const TrajectorySeed> pseed(new TrajectorySeed(seed));
+  std::shared_ptr<const TrajectorySeed> pseed(new TrajectorySeed(seed));
   for (auto const& it : work_)
     if (it.isValid()) {
       result.push_back(it.toTrajectory());

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -143,7 +143,7 @@ bool BaseCkfTrajectoryBuilder::qualityFilter(const TempTrajectory& traj, bool in
   }
 }
 
-void BaseCkfTrajectoryBuilder::addToResult(boost::shared_ptr<const TrajectorySeed> const& seed,
+void BaseCkfTrajectoryBuilder::addToResult(std::shared_ptr<const TrajectorySeed> const& seed,
                                            TempTrajectory& tmptraj,
                                            TrajectoryContainer& result,
                                            bool inOut) const {

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -436,7 +436,7 @@ namespace cms {
             PTrajectoryStateOnDet&& state = trajectoryStateTransform::persistentState(initState, initId);
             TrajectorySeed::recHitContainer hits;
             hits.push_back(it->lastMeasurement().recHit()->hit()->clone());
-            boost::shared_ptr<const TrajectorySeed> seed(new TrajectorySeed(state, std::move(hits), direction));
+            std::shared_ptr<const TrajectorySeed> seed(new TrajectorySeed(state, std::move(hits), direction));
             // 3) make a trajectory
             Trajectory trajectory(seed, direction);
             trajectory.setNLoops(it->nLoops());

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -171,11 +171,11 @@ unsigned int CkfTrajectoryBuilder::limitedCandidates(const TrajectorySeed& seed,
                                                      TrajectoryContainer& result) const {
   TempTrajectoryContainer candidates;
   candidates.push_back(startingTraj);
-  boost::shared_ptr<const TrajectorySeed> sharedSeed(new TrajectorySeed(seed));
+  std::shared_ptr<const TrajectorySeed> sharedSeed(new TrajectorySeed(seed));
   return limitedCandidates(sharedSeed, candidates, result);
 }
 
-unsigned int CkfTrajectoryBuilder::limitedCandidates(const boost::shared_ptr<const TrajectorySeed>& sharedSeed,
+unsigned int CkfTrajectoryBuilder::limitedCandidates(const std::shared_ptr<const TrajectorySeed>& sharedSeed,
                                                      TempTrajectoryContainer& candidates,
                                                      TrajectoryContainer& result) const {
   unsigned int nIter = 1;

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearInteractionFinder.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearInteractionFinder.h
@@ -38,8 +38,6 @@
 
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 
-
-
 class NuclearInteractionFinder {
 private:
   typedef TrajectoryStateOnSurface TSOS;

--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearInteractionFinder.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearInteractionFinder.h
@@ -38,7 +38,7 @@
 
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 
-#include <boost/shared_ptr.hpp>
+
 
 class NuclearInteractionFinder {
 private:

--- a/RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h
@@ -14,7 +14,7 @@
 
 #include "RecoTracker/NuclearSeedGenerator/interface/TangentHelix.h"
 
-#include <boost/shared_ptr.hpp>
+
 
 class FreeTrajectoryState;
 
@@ -79,11 +79,11 @@ private:
   ConstRecHitPointer innerHit_; /**< Pointer to the hit of the inner TM */
   ConstRecHitPointer outerHit_; /**< Pointer to the outer hit */
 
-  boost::shared_ptr<TSOS> updatedTSOS_; /**< Final TSOS */
+  std::shared_ptr<TSOS> updatedTSOS_; /**< Final TSOS */
 
-  boost::shared_ptr<TSOS> initialTSOS_; /**< Initial TSOS used as input */
+  std::shared_ptr<TSOS> initialTSOS_; /**< Initial TSOS used as input */
 
-  boost::shared_ptr<FreeTrajectoryState> freeTS_; /**< Initial FreeTrajectoryState */
+  std::shared_ptr<FreeTrajectoryState> freeTS_; /**< Initial FreeTrajectoryState */
 
   PTrajectoryStateOnDet pTraj; /**< the final persistent TSOS */
 

--- a/RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h
@@ -14,8 +14,6 @@
 
 #include "RecoTracker/NuclearSeedGenerator/interface/TangentHelix.h"
 
-
-
 class FreeTrajectoryState;
 
 class SeedFromNuclearInteraction {

--- a/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
@@ -14,9 +14,9 @@ SeedFromNuclearInteraction::SeedFromNuclearInteraction(const Propagator* prop,
                                                        const edm::ParameterSet& iConfig)
     : ptMin(iConfig.getParameter<double>("ptMin")), thePropagator(prop), theTrackerGeom(geom) {
   isValid_ = true;
-  initialTSOS_ = boost::shared_ptr<TrajectoryStateOnSurface>(new TrajectoryStateOnSurface());
-  updatedTSOS_ = boost::shared_ptr<TrajectoryStateOnSurface>(new TrajectoryStateOnSurface());
-  freeTS_ = boost::shared_ptr<FreeTrajectoryState>(new FreeTrajectoryState());
+  initialTSOS_ = std::shared_ptr<TrajectoryStateOnSurface>(new TrajectoryStateOnSurface());
+  updatedTSOS_ = std::shared_ptr<TrajectoryStateOnSurface>(new TrajectoryStateOnSurface());
+  freeTS_ = std::shared_ptr<FreeTrajectoryState>(new FreeTrajectoryState());
 }
 
 //----------------------------------------------------------------------

--- a/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -14,9 +16,9 @@ SeedFromNuclearInteraction::SeedFromNuclearInteraction(const Propagator* prop,
                                                        const edm::ParameterSet& iConfig)
     : ptMin(iConfig.getParameter<double>("ptMin")), thePropagator(prop), theTrackerGeom(geom) {
   isValid_ = true;
-  initialTSOS_ = std::shared_ptr<TrajectoryStateOnSurface>(new TrajectoryStateOnSurface());
-  updatedTSOS_ = std::shared_ptr<TrajectoryStateOnSurface>(new TrajectoryStateOnSurface());
-  freeTS_ = std::shared_ptr<FreeTrajectoryState>(new FreeTrajectoryState());
+  initialTSOS_ = std::make_shared<TrajectoryStateOnSurface>();
+  updatedTSOS_ = std::make_shared<TrajectoryStateOnSurface>();
+  freeTS_ = std::make_shared<FreeTrajectoryState>();
 }
 
 //----------------------------------------------------------------------

--- a/RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h
@@ -5,7 +5,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
-#include <boost/shared_ptr.hpp>
+
 
 namespace reco {
   class Track;

--- a/RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedFromProtoTrack.h
@@ -6,7 +6,6 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 
-
 namespace reco {
   class Track;
 }

--- a/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
@@ -3,7 +3,6 @@
 #include "RecoVertex/GaussianSumVertexFit/interface/BasicMultiVertexState.h"
 #include "TrackingTools/GsfTools/interface/SingleGaussianState.h"
 
-
 namespace GaussianStateConversions {
 
   MultiGaussianState<3> multiGaussianStateFromVertex(const VertexState aState) {

--- a/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
@@ -2,7 +2,7 @@
 
 #include "RecoVertex/GaussianSumVertexFit/interface/BasicMultiVertexState.h"
 #include "TrackingTools/GsfTools/interface/SingleGaussianState.h"
-#include "boost/shared_ptr.hpp"
+
 
 namespace GaussianStateConversions {
 

--- a/SimRomanPot/SimFP420/interface/DigitizerFP420.h
+++ b/SimRomanPot/SimFP420/interface/DigitizerFP420.h
@@ -2,7 +2,7 @@
 #define DigitizerFP420_h
 
 ///////////////////////////////////////////////////////////////////////
-#include "boost/shared_ptr.hpp"
+
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/SimRomanPot/SimFP420/interface/DigitizerFP420.h
+++ b/SimRomanPot/SimFP420/interface/DigitizerFP420.h
@@ -3,7 +3,6 @@
 
 ///////////////////////////////////////////////////////////////////////
 
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/TrackingTools/GsfTracking/interface/MultiTrajectoryStateMerger.h
+++ b/TrackingTools/GsfTracking/interface/MultiTrajectoryStateMerger.h
@@ -4,7 +4,7 @@
 #include "TrackingTools/GsfTools/interface/MultiGaussianStateMerger.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-#include "boost/shared_ptr.hpp"
+
 
 class TrajectoryStateOnSurface;
 

--- a/TrackingTools/GsfTracking/interface/MultiTrajectoryStateMerger.h
+++ b/TrackingTools/GsfTracking/interface/MultiTrajectoryStateMerger.h
@@ -4,8 +4,6 @@
 #include "TrackingTools/GsfTools/interface/MultiGaussianStateMerger.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-
-
 class TrajectoryStateOnSurface;
 
 /** Merging of MultiTrajectoryStates - uses MultiGaussianStateMergers

--- a/TrackingTools/PatternTools/interface/Trajectory.h
+++ b/TrackingTools/PatternTools/interface/Trajectory.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include <algorithm>
 #include <limits>
-#include <boost/shared_ptr.hpp>
+
 
 /** A class for detailed particle trajectory representation.
  *  It is used during trajectory building to "grow" a trajectory.
@@ -68,7 +68,7 @@ public:
    *  No check is made in the push method that measurements are
    *  added in the correct direction.
    */
-  Trajectory(const boost::shared_ptr<const TrajectorySeed>& seed, PropagationDirection dir)
+  Trajectory(const std::shared_ptr<const TrajectorySeed>& seed, PropagationDirection dir)
       : theSeed(seed), theDirection(dir), theDirectionValidity(true), theValid(true) {}
 
   /** Constructor of an empty trajectory with defined direction.
@@ -313,8 +313,8 @@ public:
   /// It doesn't reverse the forward and backward predicted states within each trajectory measurement
   void reverse();
 
-  const boost::shared_ptr<const TrajectorySeed>& sharedSeed() const { return theSeed; }
-  void setSharedSeed(const boost::shared_ptr<const TrajectorySeed>& seed) { theSeed = seed; }
+  const std::shared_ptr<const TrajectorySeed>& sharedSeed() const { return theSeed; }
+  void setSharedSeed(const std::shared_ptr<const TrajectorySeed>& seed) { theSeed = seed; }
 
   /// accessor to the delta phi angle betweem the directions of the two measurements on the last
   /// two layers crossed by the trajectory
@@ -342,7 +342,7 @@ private:
   bool badForCCC(const TrajectoryMeasurement& tm);
   void updateBadForCCC(float ccc_threshold);
 
-  boost::shared_ptr<const TrajectorySeed> theSeed;
+  std::shared_ptr<const TrajectorySeed> theSeed;
   edm::RefToBase<TrajectorySeed> seedRef_;
 
   DataContainer theData;

--- a/TrackingTools/PatternTools/interface/Trajectory.h
+++ b/TrackingTools/PatternTools/interface/Trajectory.h
@@ -13,7 +13,6 @@
 #include <algorithm>
 #include <limits>
 
-
 /** A class for detailed particle trajectory representation.
  *  It is used during trajectory building to "grow" a trajectory.
  *  The trajectory is represented as an ordered sequence of 

--- a/TrackingTools/PatternTools/interface/TrajectoryMeasurement.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryMeasurement.h
@@ -2,7 +2,7 @@
 #define _TRACKER_TRAJECTORYMEASUREMENT_H_
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "boost/intrusive_ptr.hpp"
+
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include <algorithm>
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"

--- a/TrackingTools/PatternTools/src/Trajectory.cc
+++ b/TrackingTools/PatternTools/src/Trajectory.cc
@@ -3,7 +3,7 @@
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
-#include "boost/intrusive_ptr.hpp"
+
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/TrackingTools/PatternTools/src/TransverseImpactPointExtrapolator.cc
+++ b/TrackingTools/PatternTools/src/TransverseImpactPointExtrapolator.cc
@@ -1,7 +1,7 @@
 #include "TrackingTools/PatternTools/interface/TransverseImpactPointExtrapolator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/GeometrySurface/interface/Surface.h"
-#include "boost/intrusive_ptr.hpp"
+
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"

--- a/TrackingTools/PatternTools/src/classes.h
+++ b/TrackingTools/PatternTools/src/classes.h
@@ -14,7 +14,7 @@
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
-#include "boost/intrusive_ptr.hpp"
+
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/Common/interface/AssociationMap.h"

--- a/TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h
+++ b/TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h
@@ -5,7 +5,6 @@
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 #include <memory>
 
-
 /** Class providing access to the covariance matrix of a set of relevant parameters of a trajectory
  *  in a local, Cartesian frame. The errors provided are: <BR> <BR>
  *  

--- a/TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h
+++ b/TrackingTools/TrajectoryParametrization/interface/LocalTrajectoryError.h
@@ -3,8 +3,8 @@
 
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+#include <memory>
 
-#include <boost/shared_ptr.hpp>
 
 /** Class providing access to the covariance matrix of a set of relevant parameters of a trajectory
  *  in a local, Cartesian frame. The errors provided are: <BR> <BR>
@@ -85,7 +85,7 @@ public:
 
 private:
   AlgebraicSymMatrix55 theCovarianceMatrix;
-  mutable boost::shared_ptr<AlgebraicSymMatrix55> theWeightMatrixPtr;
+  mutable std::shared_ptr<AlgebraicSymMatrix55> theWeightMatrixPtr;
 };
 
 #endif

--- a/TrackingTools/TrajectoryState/src/classes.h
+++ b/TrackingTools/TrajectoryState/src/classes.h
@@ -12,7 +12,7 @@
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
-#include "boost/intrusive_ptr.hpp"
+
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/Common/interface/AssociationMap.h"


### PR DESCRIPTION
#### PR description:

Removes boost::shared_ptr from cmssw code in favor of std::shared_ptr.

#### PR validation:

compiles and should run (it did during development, but last PR not explicitly checked

known unknown is the change to PhyscisTools/FWLite/src/classes_def.xml due to

Error: Class shared_ptr<reco::parser::ExpressionBase> has been selected but currently the support for its I/O is not yet available. Note that shared_ptr<reco::parser::ExpressionBase>, even if not selected, will be available for interpreted code.
Error: Class shared_ptr<reco::parser::SelectorBase> has been selected but currently the support for its I/O is not yet available. Note that shared_ptr<reco::parser::SelectorBase>, even if not selected, will be available for interpreted code.

which i've not found a better solution for. The unit tests of PhysicsTools/FWLite do pass after my change, but other unit tests may be interesting.