### PR TITLE
Fix warnings for gcc9 in DQM

### DIFF
--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -621,6 +621,7 @@ namespace ecaldqm {
             break;
           }
         }
+          [[fallthrough]];
         case kTriggerTower: {
           // EB-03 DCC 12 TCC 18 TT 3
           EcalTriggerElectronicsId teid(_rawId);

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1435,6 +1435,7 @@ void TrackAnalyzer::fillHistosForEfficiencyFromHitPatter(const reco::Track& trac
           case 2:
             if (!useInac)
               break;
+            [[fallthrough]];
           case 1:
             hits_total_[Key(hp.getSubStructure(pattern), hp.getSubSubStructure(pattern), mon)]->Fill(monitoring);
             break;

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -592,7 +592,7 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
           case 1:
 
             tnp_ = true;  // already filled hists for tnp method
-
+            [[fallthrough]];
           case 2:
 
             if ((Jpsi_) && (!Upsilon_))


### PR DESCRIPTION
#### PR description:

Fix gcc9 warnings in DQM packages

#### PR validation:

Builds without warnings. One of this cases might by an actual bug with break at non appropriate place. This PR doesn't change it's behavior
