### PR TITLE
python 3 fix for GlobalTag.py

### DIFF
--- a/Configuration/AlCa/python/GlobalTag.py
+++ b/Configuration/AlCa/python/GlobalTag.py
@@ -79,7 +79,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
                 for entry in autoKey[1:]:
                   entry = entry.split(',')
                   record     = entry[1]
-                  label      = len(entry) > 3 and entry[3] or None
+                  label      = len(entry) > 3 and entry[3] or ""
                   tag        = entry[0]
                   connection = len(entry) > 2 and entry[2] or None
                   snapshotTime = len(entry) > 4 and entry[4] or None
@@ -111,7 +111,7 @@ def GlobalTag(essource = None, globaltag = None, conditions = None):
             for entry in conditions.split('+'):
                 entry = entry.split(',')
                 record     = entry[1]
-                label      = len(entry) > 3 and entry[3] or None
+                label      = len(entry) > 3 and entry[3] or ""
                 tag        = entry[0]
                 connection = len(entry) > 2 and entry[2] or None
                 snapshotTime = len(entry) > 4 and entry[4] or None


### PR DESCRIPTION
#### PR description:

python 3 does not allow comparison of a string to a None. This was occuring in the call to sorted. Replacing the None with '' allows the comparison to function and the final results are the
same.


#### PR validation:

The code was tested in the CMSSW_11_0_DEVEL_X IB which uses python 3 using the configuration generated for the 20661.97 workflow (which was failing in the IB). The resultant configuration for the PoolDBESSource is the same as for the original python 2 case.