### PR TITLE
Fix gcc9 warning in HeavyFlavorAnalysis/RecoDecay

### DIFF
--- a/HeavyFlavorAnalysis/RecoDecay/src/BPHPlusMinusCandidate.cc
+++ b/HeavyFlavorAnalysis/RecoDecay/src/BPHPlusMinusCandidate.cc
@@ -73,6 +73,7 @@ void BPHPlusMinusCandidate::add(
                                           << "already containing same sign particle, add rejected";
         return;
       }
+      [[fallthrough]];
     case 0:
       addK(name, daug, searchList, mass, sigma);
   }


### PR DESCRIPTION
#### PR description:

Fixes a warning in HeavyFlavorAnalysis/RecoDecay

#### PR validation:

Builds without warning 
