### PR TITLE
Fix gcc9 warning GeneratorInterface/SherpaInterface

### DIFF
--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -104,6 +104,7 @@ namespace spu {
         switch (ret) {
           case Z_NEED_DICT:
             ret = Z_DATA_ERROR; /* and fall through */
+            [[fallthrough]];
           case Z_DATA_ERROR:
           case Z_MEM_ERROR:
             (void)inflateEnd(&strm);

--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -103,7 +103,7 @@ namespace spu {
         assert(ret != Z_STREAM_ERROR); /* state not clobbered */
         switch (ret) {
           case Z_NEED_DICT:
-            ret = Z_DATA_ERROR; /* and fall through */
+            ret = Z_DATA_ERROR;
             [[fallthrough]];
           case Z_DATA_ERROR:
           case Z_MEM_ERROR:


### PR DESCRIPTION
#### PR description:

Fixes a warning in GeneratorInterface
#### PR validation:

Builds without the warning
