### PR TITLE
Fix gcc9 warning in MuonAnalysis/MuonAssociators

### DIFF
--- a/MuonAnalysis/MuonAssociators/src/MatcherUsingTracksAlgorithm.cc
+++ b/MuonAnalysis/MuonAssociators/src/MatcherUsingTracksAlgorithm.cc
@@ -182,6 +182,7 @@ bool MatcherUsingTracksAlgorithm::match(const reco::Candidate &c1,
         }
       }
     }
+      [[fallthrough]];
     case ByPropagatingSrc: {
       FreeTrajectoryState start = startingState(c1, whichTrack1_, whichState1_);
       TrajectoryStateOnSurface target = targetState(c2, whichTrack2_, whichState2_);


### PR DESCRIPTION
#### PR description:

Fixes warning in MuonAnalysis/MuonAssociators

#### PR validation:

Builds without warning
