### PR TITLE
Fix gcc9 warning in PhysicsTools

### DIFF
--- a/PhysicsTools/IsolationUtils/src/ConeAreaFunction.cc
+++ b/PhysicsTools/IsolationUtils/src/ConeAreaFunction.cc
@@ -47,7 +47,8 @@ ConeAreaFunction::ConeAreaFunction() : ROOT::Math::ParamFunction<ROOT::Math::IPa
   integrator_ = new ROOT::Math::Integrator(*fTheta_);
 }
 
-ConeAreaFunction::ConeAreaFunction(const ConeAreaFunction& bluePrint) {
+ConeAreaFunction::ConeAreaFunction(const ConeAreaFunction& bluePrint)
+    : ROOT::Math::ParamFunction<ROOT::Math::IParametricGradFunctionOneDim>(bluePrint) {
   theta0_ = bluePrint.theta0_;
   phi0_ = bluePrint.phi0_;
 

--- a/PhysicsTools/IsolationUtils/src/IntegrandThetaFunction.cc
+++ b/PhysicsTools/IsolationUtils/src/IntegrandThetaFunction.cc
@@ -46,7 +46,8 @@ IntegrandThetaFunction::IntegrandThetaFunction()
   fPhi_ = new IntegralOverPhiFunction();
 }
 
-IntegrandThetaFunction::IntegrandThetaFunction(const IntegrandThetaFunction& bluePrint) {
+IntegrandThetaFunction::IntegrandThetaFunction(const IntegrandThetaFunction& bluePrint)
+    : ROOT::Math::ParamFunction<ROOT::Math::IParametricGradFunctionOneDim>(bluePrint) {
   theta0_ = bluePrint.theta0_;
   phi0_ = bluePrint.phi0_;
   alpha_ = bluePrint.alpha_;

--- a/PhysicsTools/RecoUtils/src/CandKinematicVertexFitter.cc
+++ b/PhysicsTools/RecoUtils/src/CandKinematicVertexFitter.cc
@@ -73,6 +73,7 @@ void CandKinematicVertexFitter::set(VertexCompositeCandidate &c) const {
             px *= scale;
             py *= scale;
             pz *= scale;
+            [[fallthrough]];
           default:
             double mass = (*particleIt)->currentState().mass();
             energy = sqrt(p * p + mass * mass);


### PR DESCRIPTION
#### PR description:

Fixes warnings in PhysicsTools for gcc9 

#### PR validation:

Builds without warnings. A break might work the same as the fallthrough here, its a single case . 