### PR TITLE
Allow std::vector<std::unique_ptr<T>> be produced, and be read with edm::View<T>

### DIFF
--- a/DataFormats/Common/interface/GetProduct.h
+++ b/DataFormats/Common/interface/GetProduct.h
@@ -20,6 +20,9 @@
 
 // system include files
 
+#include <memory>
+#include <vector>
+
 // user include files
 
 // forward declarations
@@ -31,6 +34,14 @@ namespace edm {
       typedef typename COLLECTION::value_type element_type;
       typedef typename COLLECTION::const_iterator iter;
       static const element_type* address(const iter& i) { return &*i; }
+    };
+
+    // Specialize for vector<unique_ptr<T>>>
+    template <typename T, typename D, typename A>
+    struct GetProduct<std::vector<std::unique_ptr<T, D>, A> > {
+      using element_type = T;
+      using iter = typename std::vector<std::unique_ptr<T, D>, A>::const_iterator;
+      static const element_type* address(const iter& i) { return i->get(); }
     };
   }  // namespace detail
 }  // namespace edm

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -75,6 +75,16 @@ namespace edm {
       std::type_info const& operator()() { return typeid(T); }
     };
 
+    template <typename T, typename Deleter>
+    struct has_typedef_member_type<std::vector<std::unique_ptr<T, Deleter> > > {
+      static constexpr bool value = true;
+    };
+
+    template <typename T, typename Deleter>
+    struct getMemberType<std::vector<std::unique_ptr<T, Deleter> >, true> {
+      std::type_info const& operator()() { return typeid(T); }
+    };
+
     // bool isMergeable_() will return true if T::mergeProduct(T const&) is declared and false otherwise
     // bool mergeProduct_(WrapperBase const*) will merge products if T::mergeProduct(T const&) is defined
     // Definitions for the following struct and function templates are not needed; we only require the declarations.

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -7,6 +7,7 @@ WrapperDetail: Metafunction support for compile-time selection of code.
 
 ----------------------------------------------------------------------*/
 
+#include <memory>
 #include <typeinfo>
 #include <type_traits>
 #include <vector>

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -24,17 +24,20 @@ namespace edm {
       static std::string const refToBaseVector("edm::RefToBaseVector<");
       static std::string const ptrVector("edm::PtrVector<");
       static std::string const vectorPtr("std::vector<edm::Ptr<");
+      static std::string const vectorUniquePtr("std::vector<std::unique_ptr<");
       static std::string const associationMap("edm::AssociationMap<");
       static std::string const newDetSetVector("edmNew::DetSetVector<");
       static size_t const rvsize = refVector.size();
       static size_t const rtbvsize = refToBaseVector.size();
       static size_t const pvsize = ptrVector.size();
       static size_t const vpsize = vectorPtr.size();
+      static size_t const vupsize = vectorUniquePtr.size();
       static size_t const amsize = associationMap.size();
       static size_t const ndsize = newDetSetVector.size();
       bool mayBeRefVector = (className.substr(0, rvsize) == refVector) ||
                             (className.substr(0, rtbvsize) == refToBaseVector) ||
-                            (className.substr(0, pvsize) == ptrVector) || (className.substr(0, vpsize) == vectorPtr);
+                            (className.substr(0, pvsize) == ptrVector) || (className.substr(0, vpsize) == vectorPtr) ||
+                            (className.substr(0, vupsize) == vectorUniquePtr);
       // AssociationMap and edmNew::DetSetVector do not support View and
       // this function is used to get a contained type that can be accessed
       // using a View. So return the void type in these cases.

--- a/DataFormats/StdDictionaries/src/classes_def_vector.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_vector.xml
@@ -44,6 +44,7 @@
  <class name="std::vector<unsigned long long>"/>
  <class name="std::vector<unsigned short>"/>
  <class name="std::vector<const void*>" />
+ <class name="std::vector<std::unique_ptr<int> >" />
  <class name="std::vector<std::pair<int,std::bitset<6> > >" />
  <class name="std::pair<int,std::bitset<6>>"/>
 </lcgdict>

--- a/DataFormats/StdDictionaries/src/classes_vector.h
+++ b/DataFormats/StdDictionaries/src/classes_vector.h
@@ -6,3 +6,4 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <memory>

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -43,6 +43,8 @@ namespace edmtest {
     explicit IntProduct(int i = 0) : value(i) {}
     ~IntProduct() {}
 
+    bool operator==(IntProduct const& rhs) const { return value == rhs.value; }
+
     cms_int32_t value;
   };
 

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -78,6 +78,8 @@
  </ioread>
  <class name="edm::Wrapper<edmtest::DummyProduct>"/>
  <class name="edm::Wrapper<edmtest::IntProduct>"/>
+ <class name="std::vector<std::unique_ptr<edmtest::IntProduct>>"/>
+ <class name="edm::Wrapper<std::vector<std::unique_ptr<edmtest::IntProduct>>>"/>
  <class name="edm::Wrapper<edmtest::UInt64Product>"/>
  <class name="edm::Wrapper<edmtest::TransientIntProduct>" persistent="false"/>
  <class name="edm::Wrapper<edmtest::Int16_tProduct>"/>

--- a/DataFormats/WrappedStdDictionaries/src/classes_def.xml
+++ b/DataFormats/WrappedStdDictionaries/src/classes_def.xml
@@ -54,4 +54,5 @@
  <class name="edm::Wrapper<unsigned long long>"/>
  <class name="edm::Wrapper<unsigned short>"/>
  <class name="edm::Wrapper<std::vector<std::pair<int,std::bitset<6> > > >" />
+ <class name="edm::Wrapper<std::vector<std::unique_ptr<int>>>"/>
 </lcgdict>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -126,6 +126,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test CatchCmsExceptiontest.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegrationExistingDictionary">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestExistingDictionary.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="ProcessConfiguration_t.cpp">
     <use   name="FWCore/ParameterSet"/>
     <use   name="DataFormats/Provenance"/>
@@ -157,7 +161,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <lib   name="FWCoreIntegrationWaitingServer"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/ExistingDictionaryTestModules.cc
+++ b/FWCore/Integration/test/ExistingDictionaryTestModules.cc
@@ -1,0 +1,103 @@
+// The purpose of this EDProducer is to test the existence of
+// dictionaries for certain types, especially those from the standard
+// library.
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+
+#include <cassert>
+#include <memory>
+#include <vector>
+
+namespace edm {
+  class EventSetup;
+}
+
+namespace edmtest {
+  class ExistingDictionaryTestProducer : public edm::global::EDProducer<> {
+  public:
+    explicit ExistingDictionaryTestProducer(edm::ParameterSet const&)
+        : intToken_{produces<int>()},
+          vecUniqIntToken_{produces<std::vector<std::unique_ptr<int>>>()},
+          vecUniqIntProdToken_{produces<std::vector<std::unique_ptr<IntProduct>>>()} {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      descriptions.addDefault(desc);
+    }
+
+    void produce(edm::StreamID id, edm::Event& iEvent, edm::EventSetup const&) const override {
+      iEvent.emplace(intToken_, 1);
+
+      std::vector<std::unique_ptr<int>> foo;
+      foo.emplace_back(std::make_unique<int>(1));
+      iEvent.emplace(vecUniqIntToken_, std::move(foo));
+
+      std::vector<std::unique_ptr<IntProduct>> foo2;
+      foo2.emplace_back(std::make_unique<IntProduct>(1));
+      iEvent.emplace(vecUniqIntProdToken_, std::move(foo2));
+    }
+
+  private:
+    const edm::EDPutTokenT<int> intToken_;
+    const edm::EDPutTokenT<std::vector<std::unique_ptr<int>>> vecUniqIntToken_;
+    const edm::EDPutTokenT<std::vector<std::unique_ptr<IntProduct>>> vecUniqIntProdToken_;
+  };
+
+  class ExistingDictionaryTestAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit ExistingDictionaryTestAnalyzer(edm::ParameterSet const& iConfig)
+        : intToken_{consumes<int>(iConfig.getParameter<edm::InputTag>("src"))},
+          vecUniqIntToken_{consumes<std::vector<std::unique_ptr<int>>>(iConfig.getParameter<edm::InputTag>("src"))},
+          vecUniqIntProdToken_{
+              consumes<std::vector<std::unique_ptr<IntProduct>>>(iConfig.getParameter<edm::InputTag>("src"))},
+          testVecUniqInt_{iConfig.getParameter<bool>("testVecUniqInt")} {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("src", edm::InputTag{"prod"});
+      desc.add<bool>("testVecUniqInt", true);
+      descriptions.addDefault(desc);
+    }
+
+    void analyze(edm::StreamID id, edm::Event const& iEvent, edm::EventSetup const&) const override {
+      assert(iEvent.get(intToken_) == 1);
+
+      const auto& vecUniqInt = iEvent.get(vecUniqIntToken_);
+      assert(vecUniqInt.size() == 1);
+      for (const auto& elem : vecUniqInt) {
+        if (testVecUniqInt_) {
+          assert(elem.get() != nullptr);
+          assert(*elem == 1);
+        } else {
+          if (elem) {
+            edm::LogError("ExistingDictionaryTestAnalyzer")
+                << "I am now getting a valid pointer, please update the test";
+          }
+        }
+      }
+
+      const auto& vecUniqIntProd = iEvent.get(vecUniqIntProdToken_);
+      assert(vecUniqIntProd.size() == 1);
+      for (const auto& elem : vecUniqIntProd) {
+        assert(elem.get() != nullptr);
+        assert(elem->value == 1);
+      }
+    }
+
+  private:
+    const edm::EDGetTokenT<int> intToken_;
+    const edm::EDGetTokenT<std::vector<std::unique_ptr<int>>> vecUniqIntToken_;
+    const edm::EDGetTokenT<std::vector<std::unique_ptr<IntProduct>>> vecUniqIntProdToken_;
+    const bool testVecUniqInt_;
+  };
+}  // namespace edmtest
+
+using edmtest::ExistingDictionaryTestAnalyzer;
+using edmtest::ExistingDictionaryTestProducer;
+DEFINE_FWK_MODULE(ExistingDictionaryTestProducer);
+DEFINE_FWK_MODULE(ExistingDictionaryTestAnalyzer);

--- a/FWCore/Integration/test/ViewAnalyzer.cc
+++ b/FWCore/Integration/test/ViewAnalyzer.cc
@@ -434,10 +434,21 @@ namespace edmtest {
 }  // namespace edmtest
 
 namespace {
-  template <template <typename> typename Ptr, typename value_t>
+  template <typename PtrT>
+  struct ValueType {
+    using type = typename PtrT::element_type;
+  };
+
+  template <typename T>
+  struct ValueType<edm::Ptr<T>> {
+    using type = T;
+  };
+
+  template <typename Ptr>
   void testStdVectorPtrT(Event const& e, std::string const& moduleLabel) {
-    typedef std::vector<Ptr<value_t>> sequence_t;
-    typedef View<value_t> view_t;
+    using sequence_t = std::vector<Ptr>;
+    using value_t = typename ValueType<Ptr>::type;
+    using view_t = View<value_t>;
 
     Handle<sequence_t> hproduct;
     e.getByLabel(moduleLabel, hproduct);
@@ -476,12 +487,12 @@ namespace {
 
 namespace edmtest {
   void ViewAnalyzer::testStdVectorPtr(Event const& e, std::string const& moduleLabel) const {
-    testStdVectorPtrT<edm::Ptr, int>(e, moduleLabel);
+    testStdVectorPtrT<edm::Ptr<int>>(e, moduleLabel);
   }
 
   void ViewAnalyzer::testStdVectorUniquePtr(Event const& e, std::string const& moduleLabel) const {
-    testStdVectorPtrT<std::unique_ptr, int>(e, moduleLabel);
-    testStdVectorPtrT<std::unique_ptr, IntProduct>(e, moduleLabel);
+    testStdVectorPtrT<std::unique_ptr<int>>(e, moduleLabel);
+    testStdVectorPtrT<std::unique_ptr<IntProduct>>(e, moduleLabel);
   }
 
 }  // namespace edmtest

--- a/FWCore/Integration/test/ViewTest_cfg.py
+++ b/FWCore/Integration/test/ViewTest_cfg.py
@@ -58,6 +58,12 @@ process.intvecstdvecptr = cms.EDProducer("IntVecStdVectorPtrProducer",
                                       target = cms.InputTag('intvec')
                                       )
 
+process.intvecstdvecuniqptr = cms.EDProducer("UniqPtrIntVectorProducer",
+    count = cms.int32(9),
+    ivalue = cms.int32(11),
+    delta = cms.int32(1)
+)
+
 process.ovsimple = cms.EDProducer("OVSimpleProducer",
     size = cms.int32(7)
 )
@@ -87,5 +93,6 @@ process.p = cms.Path(process.simple +
                      process.intvecrefvec +
                      process.intvecreftbvec +
                      process.intvecptrvec +
-                     process.intvecstdvecptr)
+                     process.intvecstdvecptr +
+                     process.intvecstdvecuniqptr)
 process.e1 = cms.EndPath(process.testview)

--- a/FWCore/Integration/test/run_TestExistingDictionary.sh
+++ b/FWCore/Integration/test/run_TestExistingDictionary.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+test=testExistingDictionaryChecking
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  echo "*************************************************"
+  echo "Producer"
+  cmsRun ${LOCAL_TEST_DIR}/${test}_cfg.py || die "cmsRun ${test}_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "Consumer"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Read_cfg.py || die "cmsRun ${test}Read_cfg.py 1" $?
+
+popd
+

--- a/FWCore/Integration/test/testExistingDictionaryCheckingRead_cfg.py
+++ b/FWCore/Integration/test/testExistingDictionaryCheckingRead_cfg.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:testExistingDictionaryChecking.root")
+)
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.read = cms.EDAnalyzer("ExistingDictionaryTestAnalyzer",
+    src = cms.InputTag("prod"),
+    testVecUniqInt = cms.bool(False) # reading in plain vector<unique_ptr<int>> does not work yet
+)
+
+process.p = cms.Path(process.read)

--- a/FWCore/Integration/test/testExistingDictionaryChecking_cfg.py
+++ b/FWCore/Integration/test/testExistingDictionaryChecking_cfg.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.prod = cms.EDProducer("ExistingDictionaryTestProducer")
+process.read = cms.EDAnalyzer("ExistingDictionaryTestAnalyzer",
+                              src = cms.InputTag("prod")
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testExistingDictionaryChecking.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *_prod_*_*',
+    )
+)
+
+process.p = cms.Path(process.prod+process.read)
+process.ep = cms.EndPath(process.out)

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -126,7 +126,7 @@ namespace edm {
           regex const eMatch(std::string("(^[^<]*)<")+aMatch+">");
           result = regex_replace(result,eMatch,theSub+"$1");
        }
-       return result;
+       return removeAllSpaces(result);
     }
 
     std::string handleTemplateArguments(std::string const& iIn) {
@@ -138,7 +138,7 @@ namespace edm {
              smatch theMatch;
              if(regex_search(result,theMatch,reTemplateClass)) {
                 std::string templateClass = theMatch.str(1);
-                std::string friendlierName = removeAllSpaces(subFriendlyName(templateClass));
+                std::string friendlierName = subFriendlyName(templateClass);
                
                 //std::cout <<" t: "<<templateClass <<" f:"<<friendlierName<<std::endl;
                 result = regex_replace(result, regex(templateClass),friendlierName);

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -18,8 +18,8 @@
 
 namespace {
   constexpr bool debug = false;
-  std::string prefix; // used only if debug == true
-}
+  std::string prefix;  // used only if debug == true
+}  // namespace
 
 namespace edm {
   namespace friendlyname {
@@ -35,19 +35,13 @@ namespace edm {
     static std::regex const reUniquePtr("^std::unique_ptr");
     static std::string const emptyString("");
 
-    std::string handleNamespaces(std::string const& iIn) {
-       return std::regex_replace(iIn,reColons,emptyString);
-
-    }
+    std::string handleNamespaces(std::string const& iIn) { return std::regex_replace(iIn, reColons, emptyString); }
 
     std::string removeExtraSpaces(std::string const& iIn) {
-       return std::regex_replace(std::regex_replace(iIn,reBeginSpace,emptyString),
-                                    reEndSpace, emptyString);
+      return std::regex_replace(std::regex_replace(iIn, reBeginSpace, emptyString), reEndSpace, emptyString);
     }
 
-    std::string removeAllSpaces(std::string const& iIn) {
-      return std::regex_replace(iIn, reAllSpaces,emptyString);
-    }
+    std::string removeAllSpaces(std::string const& iIn) { return std::regex_replace(iIn, reAllSpaces, emptyString); }
     static std::regex const reWrapper("edm::Wrapper<(.*)>");
     static std::regex const reString("std::basic_string<char>");
     static std::regex const reString2("std::string");
@@ -62,7 +56,8 @@ namespace edm {
     static std::regex const reLong("long ");
     static std::regex const reVector("std::vector");
     static std::regex const reSharedPtr("std::shared_ptr");
-    static std::regex const reAIKR(", *edm::helper::AssociationIdenticalKeyReference"); //this is a default so can replaced with empty
+    static std::regex const reAIKR(
+        ", *edm::helper::AssociationIdenticalKeyReference");  //this is a default so can replaced with empty
     //force first argument to also be the argument to edm::ClonePolicy so that if OwnVector is within
     // a template it will not eat all the remaining '>'s
     static std::regex const reOwnVector("edm::OwnVector<(.*), *edm::ClonePolicy<\\1 *> >");
@@ -72,154 +67,173 @@ namespace edm {
     static std::regex const reOneToOne("edm::AssociationMap< *edm::OneToOne<(.*?),(.*?), *u[a-z]*> >");
     static std::regex const reOneToMany("edm::AssociationMap< *edm::OneToMany<(.*?),(.*?), *u[a-z]*> >");
     static std::regex const reOneToValue("edm::AssociationMap< *edm::OneToValue<(.*?),(.*?), *u[a-z]*> >");
-    static std::regex const reOneToManyWithQuality("edm::AssociationMap<edm::OneToManyWithQuality<(.*?), *(.*?), *(.*?), *u[a-z]*> >");
+    static std::regex const reOneToManyWithQuality(
+        "edm::AssociationMap<edm::OneToManyWithQuality<(.*?), *(.*?), *(.*?), *u[a-z]*> >");
     static std::regex const reToVector("edm::AssociationVector<(.*), *(.*), *edm::Ref.*,.*>");
     //NOTE: if the item within a clone policy is a template, this substitution will probably fail
     static std::regex const reToRangeMap("edm::RangeMap< *(.*), *(.*), *edm::ClonePolicy<([^>]*)> >");
     //NOTE: If container is a template with one argument which is its 'type' then can simplify name
-    static std::regex const reToRefs1("edm::RefVector< *(.*)< *(.*) *>, *\\2 *, *edm::refhelper::FindUsingAdvance< *\\1< *\\2 *> *, *\\2 *> *>");
-    static std::regex const reToRefs2("edm::RefVector< *(.*) *, *(.*) *, *edm::refhelper::FindUsingAdvance< *\\1, *\\2 *> *>");
-    static std::regex const reToRefsAssoc("edm::RefVector< *Association(.*) *, *edm::helper(.*), *Association(.*)::Find>");
-    
-    
+    static std::regex const reToRefs1(
+        "edm::RefVector< *(.*)< *(.*) *>, *\\2 *, *edm::refhelper::FindUsingAdvance< *\\1< *\\2 *> *, *\\2 *> *>");
+    static std::regex const reToRefs2(
+        "edm::RefVector< *(.*) *, *(.*) *, *edm::refhelper::FindUsingAdvance< *\\1, *\\2 *> *>");
+    static std::regex const reToRefsAssoc(
+        "edm::RefVector< *Association(.*) *, *edm::helper(.*), *Association(.*)::Find>");
+
     std::string standardRenames(std::string const& iIn) {
-       using std::regex_replace;
-       using std::regex;
-       std::string name = regex_replace(iIn, reWrapper, "$1");
-       name = regex_replace(name,rePointer,"ptr");
-       name = regex_replace(name,reArray,"As");
-       name = regex_replace(name,reAIKR,"");
-       name = regex_replace(name,reclangabi,"std::");
-       name = regex_replace(name,reCXX11,"std::");
-       name = regex_replace(name,reString,"String");
-       name = regex_replace(name,reString2,"String");
-       name = regex_replace(name,reString3,"String");
-       name = regex_replace(name,reSorted,"sSorted<$1>");
-       name = regex_replace(name,reULongLong,"ull");
-       name = regex_replace(name,reLongLong,"ll");
-       name = regex_replace(name,reUnsigned,"u");
-       name = regex_replace(name,reLong,"l");
-       name = regex_replace(name,reVector,"s");
-       name = regex_replace(name,reSharedPtr,"SharedPtr");
-       name = regex_replace(name,reOwnVector,"sOwned<$1>");
-       name = regex_replace(name,reToVector,"AssociationVector<$1,To,$2>");
-       name = regex_replace(name,reOneToOne,"Association<$1,ToOne,$2>");
-       name = regex_replace(name,reOneToMany,"Association<$1,ToMany,$2>");
-       name = regex_replace(name,reOneToValue,"Association<$1,ToValue,$2>");
-       name = regex_replace(name,reOneToManyWithQuality,"Association<$1,ToMany,$2,WithQuantity,$3>");
-       name = regex_replace(name,reToRangeMap,"RangeMap<$1,$2>");
-       name = regex_replace(name,reToRefs1,"Refs<$1<$2>>");
-       name = regex_replace(name,reToRefs2,"Refs<$1,$2>");
-       name = regex_replace(name,reToRefsAssoc,"Refs<Association$1>");
-       //std::cout <<"standardRenames '"<<name<<"'"<<std::endl;
-       return name;
+      using std::regex;
+      using std::regex_replace;
+      std::string name = regex_replace(iIn, reWrapper, "$1");
+      name = regex_replace(name, rePointer, "ptr");
+      name = regex_replace(name, reArray, "As");
+      name = regex_replace(name, reAIKR, "");
+      name = regex_replace(name, reclangabi, "std::");
+      name = regex_replace(name, reCXX11, "std::");
+      name = regex_replace(name, reString, "String");
+      name = regex_replace(name, reString2, "String");
+      name = regex_replace(name, reString3, "String");
+      name = regex_replace(name, reSorted, "sSorted<$1>");
+      name = regex_replace(name, reULongLong, "ull");
+      name = regex_replace(name, reLongLong, "ll");
+      name = regex_replace(name, reUnsigned, "u");
+      name = regex_replace(name, reLong, "l");
+      name = regex_replace(name, reVector, "s");
+      name = regex_replace(name, reSharedPtr, "SharedPtr");
+      name = regex_replace(name, reOwnVector, "sOwned<$1>");
+      name = regex_replace(name, reToVector, "AssociationVector<$1,To,$2>");
+      name = regex_replace(name, reOneToOne, "Association<$1,ToOne,$2>");
+      name = regex_replace(name, reOneToMany, "Association<$1,ToMany,$2>");
+      name = regex_replace(name, reOneToValue, "Association<$1,ToValue,$2>");
+      name = regex_replace(name, reOneToManyWithQuality, "Association<$1,ToMany,$2,WithQuantity,$3>");
+      name = regex_replace(name, reToRangeMap, "RangeMap<$1,$2>");
+      name = regex_replace(name, reToRefs1, "Refs<$1<$2>>");
+      name = regex_replace(name, reToRefs2, "Refs<$1,$2>");
+      name = regex_replace(name, reToRefsAssoc, "Refs<Association$1>");
+      //std::cout <<"standardRenames '"<<name<<"'"<<std::endl;
+      return name;
     }
 
     std::string handleTemplateArguments(std::string const&);
     std::string subFriendlyName(std::string const& iFullName) {
-       using namespace std;
-       std::string result = removeExtraSpaces(iFullName);
+      using namespace std;
+      std::string result = removeExtraSpaces(iFullName);
 
-       // temporarily remove leading const
-       std::string leadingConst;
-       if(std::string_view{result}.substr(0, 5) == "const") {
-         leadingConst = "const";
-         result = removeExtraSpaces(result.substr(5));
-       }
+      // temporarily remove leading const
+      std::string leadingConst;
+      if (std::string_view{result}.substr(0, 5) == "const") {
+        leadingConst = "const";
+        result = removeExtraSpaces(result.substr(5));
+      }
 
-       if constexpr (debug) { std::cout << prefix << "subFriendlyName iFullName " << iFullName << " result " << result << std::endl; }
-       // Handle unique_ptr, which may contain the deleter (but handle only std::default_delete)
-       {
-         auto result2 = regex_replace(result,reUniquePtrDeleter,"UniquePtr<$1>", std::regex_constants::format_first_only);
-         if (result2 == result) {
-           result2 = regex_replace(result,reUniquePtr,"UniquePtr", std::regex_constants::format_first_only);
-         }
-         result = std::move(result2);
-       }
-       // insert the leading const back if it was there
-       result = leadingConst+result;
-       if(smatch theMatch; regex_match(result,theMatch,reTemplateArgs)) {
-          //std::cout <<"found match \""<<theMatch.str(1) <<"\"" <<std::endl;
-          //static regex const templateClosing(">$");
-          //std::string aMatch = regex_replace(theMatch.str(1),templateClosing,"");
-          std::string aMatch = theMatch.str(1);
-          if constexpr (debug) { prefix += "  "; }
-          std::string theSub = handleTemplateArguments(aMatch);
-          if constexpr (debug) {
-            prefix.pop_back();
-            prefix.pop_back();
-            std::cout << prefix << " aMatch "<< aMatch <<" theSub " << theSub << std::endl;
-          }
-          regex const eMatch(std::string("(^[^<]*)<")+aMatch+">");
-          result = regex_replace(result,eMatch,theSub+"$1");
-       }
-       return removeAllSpaces(result);
+      if constexpr (debug) {
+        std::cout << prefix << "subFriendlyName iFullName " << iFullName << " result " << result << std::endl;
+      }
+      // Handle unique_ptr, which may contain the deleter (but handle only std::default_delete)
+      {
+        auto result2 =
+            regex_replace(result, reUniquePtrDeleter, "UniquePtr<$1>", std::regex_constants::format_first_only);
+        if (result2 == result) {
+          result2 = regex_replace(result, reUniquePtr, "UniquePtr", std::regex_constants::format_first_only);
+        }
+        result = std::move(result2);
+      }
+      // insert the leading const back if it was there
+      result = leadingConst + result;
+      if (smatch theMatch; regex_match(result, theMatch, reTemplateArgs)) {
+        //std::cout <<"found match \""<<theMatch.str(1) <<"\"" <<std::endl;
+        //static regex const templateClosing(">$");
+        //std::string aMatch = regex_replace(theMatch.str(1),templateClosing,"");
+        std::string aMatch = theMatch.str(1);
+        if constexpr (debug) {
+          prefix += "  ";
+        }
+        std::string theSub = handleTemplateArguments(aMatch);
+        if constexpr (debug) {
+          prefix.pop_back();
+          prefix.pop_back();
+          std::cout << prefix << " aMatch " << aMatch << " theSub " << theSub << std::endl;
+        }
+        regex const eMatch(std::string("(^[^<]*)<") + aMatch + ">");
+        result = regex_replace(result, eMatch, theSub + "$1");
+      }
+      return removeAllSpaces(result);
     }
 
     std::string handleTemplateArguments(std::string const& iIn) {
-       using namespace std;
-       std::string result = removeExtraSpaces(iIn);
-       if constexpr (debug) { std::cout << prefix << "handleTemplateArguments " << iIn << " removeExtraSpaces " << result << std::endl; }
+      using namespace std;
+      std::string result = removeExtraSpaces(iIn);
+      if constexpr (debug) {
+        std::cout << prefix << "handleTemplateArguments " << iIn << " removeExtraSpaces " << result << std::endl;
+      }
 
-       // Trick to have every full class name to end with comma to
-       // avoid treating the end as a special case
-       result += ",";
+      // Trick to have every full class name to end with comma to
+      // avoid treating the end as a special case
+      result += ",";
 
-       std::string result2;
-       result2.reserve(iIn.size());
-       unsigned int openTemplate = 0;
-       bool hadTemplate = false;
-       size_t begin = 0;
-       for(size_t i=0, size=result.size(); i<size; ++i) {
-         if(result[i] == '<') {
-           ++openTemplate;
-           hadTemplate = true;
-           continue;
-         }
-         else if(result[i] == '>') {
-           --openTemplate;
-         }
-         if((result[i] == ',') and openTemplate == 0) {
-           std::string templateClass = result.substr(begin, i-begin);
-           if constexpr (debug) { std::cout << prefix << " templateClass " << templateClass << std::endl; }
-           if(hadTemplate) {
-             if constexpr (debug) { prefix += "  "; }
-             std::string friendlierName = subFriendlyName(templateClass);
-             if constexpr (debug) {
-               prefix.pop_back();
-               prefix.pop_back();
-               std::cout << prefix << " friendlierName " << friendlierName << std::endl;
-             }
-             result2 += friendlierName;
-           }
-           else {
-             result2 += templateClass;
-           }
-           if constexpr(debug) { std::cout << prefix << " result2 " << result2 << std::endl; }
-           // reset counters
-           hadTemplate = false;
-           begin = i+1;
-         }
-       }
+      std::string result2;
+      result2.reserve(iIn.size());
+      unsigned int openTemplate = 0;
+      bool hadTemplate = false;
+      size_t begin = 0;
+      for (size_t i = 0, size = result.size(); i < size; ++i) {
+        if (result[i] == '<') {
+          ++openTemplate;
+          hadTemplate = true;
+          continue;
+        } else if (result[i] == '>') {
+          --openTemplate;
+        }
+        if ((result[i] == ',') and openTemplate == 0) {
+          std::string templateClass = result.substr(begin, i - begin);
+          if constexpr (debug) {
+            std::cout << prefix << " templateClass " << templateClass << std::endl;
+          }
+          if (hadTemplate) {
+            if constexpr (debug) {
+              prefix += "  ";
+            }
+            std::string friendlierName = subFriendlyName(templateClass);
+            if constexpr (debug) {
+              prefix.pop_back();
+              prefix.pop_back();
+              std::cout << prefix << " friendlierName " << friendlierName << std::endl;
+            }
+            result2 += friendlierName;
+          } else {
+            result2 += templateClass;
+          }
+          if constexpr (debug) {
+            std::cout << prefix << " result2 " << result2 << std::endl;
+          }
+          // reset counters
+          hadTemplate = false;
+          begin = i + 1;
+        }
+      }
 
-       result = regex_replace(result2,reComma,"");
-       if constexpr(debug) { std::cout << prefix << " reComma " << result << std::endl; }
-       return result;
+      result = regex_replace(result2, reComma, "");
+      if constexpr (debug) {
+        std::cout << prefix << " reComma " << result << std::endl;
+      }
+      return result;
     }
     std::string friendlyName(std::string const& iFullName) {
       if constexpr (debug) {
         std::cout << "\nfriendlyName for " << iFullName << std::endl;
         prefix = " ";
-        }
-       typedef tbb::concurrent_unordered_map<std::string, std::string> Map;
-       static Map s_fillToFriendlyName;
-       auto itFound = s_fillToFriendlyName.find(iFullName);
-       if(s_fillToFriendlyName.end()==itFound) {
-          itFound = s_fillToFriendlyName.insert(Map::value_type(iFullName, handleNamespaces(subFriendlyName(standardRenames(iFullName))))).first;
-       }
-       if constexpr (debug) { std::cout << "result " << itFound->second << std::endl; }
-       return itFound->second;
+      }
+      typedef tbb::concurrent_unordered_map<std::string, std::string> Map;
+      static Map s_fillToFriendlyName;
+      auto itFound = s_fillToFriendlyName.find(iFullName);
+      if (s_fillToFriendlyName.end() == itFound) {
+        itFound = s_fillToFriendlyName
+                      .insert(Map::value_type(iFullName, handleNamespaces(subFriendlyName(standardRenames(iFullName)))))
+                      .first;
+      }
+      if constexpr (debug) {
+        std::cout << "result " << itFound->second << std::endl;
+      }
+      return itFound->second;
     }
-  }
-} // namespace edm
-
+  }  // namespace friendlyname
+}  // namespace edm

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -33,6 +33,7 @@ void testfriendlyName::test() {
   typedef std::pair<std::string, std::string> Values;
   std::map<std::string, std::string> classToFriendly;
   classToFriendly.insert(Values("Foo", "Foo"));
+  classToFriendly.insert(Values("const Foo", "constFoo"));
   classToFriendly.insert(Values("bar::Foo", "barFoo"));
   classToFriendly.insert(Values("std::vector<Foo>", "Foos"));
   classToFriendly.insert(Values("std::vector<bar::Foo>", "barFoos"));
@@ -49,7 +50,10 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("std::__cxx11::vector<std::__cxx11::basic_string<char>>", "Strings"));
   classToFriendly.insert(Values("std::unique_ptr<Foo>", "FooUniquePtr"));
   classToFriendly.insert(Values("std::unique_ptr<bar::Foo>", "barFooUniquePtr"));
+  classToFriendly.insert(Values("std::unique_ptr<const Foo>", "constFooUniquePtr"));
+  classToFriendly.insert(Values("const std::unique_ptr<Foo>", "FooconstUniquePtr"));
   classToFriendly.insert(Values("std::vector<std::unique_ptr<bar::Foo>>", "barFooUniquePtrs"));
+  classToFriendly.insert(Values("std::vector<std::unique_ptr<const Foo>>", "constFooUniquePtrs"));
   classToFriendly.insert(Values("V<A,B>", "ABV"));
   classToFriendly.insert(Values("edm::ExtCollection<std::vector<reco::SuperCluster>,reco::SuperClusterRefProds>",
                                 "recoSuperClustersrecoSuperClusterRefProdsedmExtCollection"));

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -52,8 +52,29 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("std::unique_ptr<bar::Foo>", "barFooUniquePtr"));
   classToFriendly.insert(Values("std::unique_ptr<const Foo>", "constFooUniquePtr"));
   classToFriendly.insert(Values("const std::unique_ptr<Foo>", "FooconstUniquePtr"));
+  classToFriendly.insert(Values("std::unique_ptr<Foo,std::default_delete<Foo>>", "FooUniquePtr"));
+  classToFriendly.insert(Values("std::unique_ptr<const Foo, std::default_delete<const Foo>>", "constFooUniquePtr"));
+  classToFriendly.insert(
+      Values("std::unique_ptr<std::unique_ptr<Bar,std::default_delete<Bar>>,std::default_delete<std::unique_ptr<Bar,"
+             "std::default_delete<Bar>>>>",
+             "BarUniquePtrUniquePtr"));
   classToFriendly.insert(Values("std::vector<std::unique_ptr<bar::Foo>>", "barFooUniquePtrs"));
+  classToFriendly.insert(
+      Values("std::vector<std::unique_ptr<bar::Foo, std::default_delete<bar::Foo>>>", "barFooUniquePtrs"));
   classToFriendly.insert(Values("std::vector<std::unique_ptr<const Foo>>", "constFooUniquePtrs"));
+  classToFriendly.insert(
+      Values("std::unique_ptr<std::vector<std::unique_ptr<bar::Foo>>>", "barFooUniquePtrsUniquePtr"));
+  classToFriendly.insert(
+      Values("std::unique_ptr<std::vector<std::unique_ptr<bar::Foo>>, "
+             "std::default_delete<std::vector<std::unique_ptr<bar::Foo>>>>",
+             "barFooUniquePtrsUniquePtr"));
+  classToFriendly.insert(
+      Values("std::unique_ptr<std::vector<std::unique_ptr<bar::Foo, std::default_delete<bar::Foo>>>>",
+             "barFooUniquePtrsUniquePtr"));
+  classToFriendly.insert(
+      Values("std::unique_ptr<std::vector<std::unique_ptr<bar::Foo, std::default_delete<bar::Foo>>>, "
+             "std::default_delete<std::vector<std::unique_ptr<bar::Foo, std::default_delete<bar::Foo>>>>>",
+             "barFooUniquePtrsUniquePtr"));
   classToFriendly.insert(Values("V<A,B>", "ABV"));
   classToFriendly.insert(Values("edm::ExtCollection<std::vector<reco::SuperCluster>,reco::SuperClusterRefProds>",
                                 "recoSuperClustersrecoSuperClusterRefProdsedmExtCollection"));


### PR DESCRIPTION
#### PR description:

Fixes #27277. The complaint on missing dictionary for `std::unique_ptr<T>` came from the support code for `edm::View<T>`. The minimal fix was to specialize the `edm::detail::getMemberType` for `std::vector<std::unique_ptr<T>>`. That alone allows the `std::vector<std::unique_ptr<T>>` be produced by an EDProducer, and written to a file. Reading such a product from a file appears to currently work only if `T` has a dictionary, i.e. it does not work e.g. for fundamental types.

After that it was natural to complete the support for `edm::View`, i.e. with this PR `edm::View<T>` can be used to read `std::vector<std::unique_ptr<T>>`.

In addition the "friendly name" transformation is improved to ignore the `std::default_delete<T>` from the full type name of `std::unique_ptr1` (among some other improvements in the parsing).

#### PR validation:

Code compiles, unit tests run.