### PR TITLE
Filtering on pixel and strip clusters

### DIFF
--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -26,3 +26,12 @@ pp_on_AA_2018.toModify(trackerClusterCheck,
                MaxNumberOfPixelClusters = 150000,
                MaxNumberOfCosmicClusters = 500000
                )
+
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+egamma_lowPt_exclusive.toModify(trackerClusterCheck,
+               doClusterCheck=True,
+               cut = "strip < 1000 && pixel < 300 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)",
+               MaxNumberOfPixelClusters = 300,
+               MaxNumberOfCosmicClusters = 1000
+               )
+

--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -30,7 +30,7 @@ pp_on_AA_2018.toModify(trackerClusterCheck,
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toModify(trackerClusterCheck,
                doClusterCheck=True,
-               cut = "strip < 1000 && pixel < 300 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)",
+               cut = "strip < 1000 && pixel < 300 ",
                MaxNumberOfPixelClusters = 300,
                MaxNumberOfCosmicClusters = 1000
                )


### PR DESCRIPTION
#### PR description:
@echapon @slava77 
This PR is submitted to filter out events with large activity in Pixel and Strip clusters for light by light analysis. The filtering reduces the timing of the reconstruction process by significant amount. The results has been presented in Reconstruction and Analysis Tools meeting. 

https://indico.cern.ch/event/841640/contributions/3534139/attachments/1896758/3129554/CMS_Reco_23rdAug_2019.pdf

