### PR TITLE
[PPS] Removed static_cast in diamond raw-to-digi unpacker

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -21,9 +21,7 @@
 **/
 class DiamondVFATFrame {
 public:
-  DiamondVFATFrame(const VFATFrame::word* inputData = nullptr) {
-    std::copy_n(inputData, 9, data_.begin());
-  }
+  DiamondVFATFrame(const VFATFrame::word* inputData = nullptr) { std::copy_n(inputData, 9, data_.begin()); }
   ~DiamondVFATFrame() = default;
 
   /// get timing information for leading single edge
@@ -45,10 +43,8 @@ public:
 
 private:
   /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
-  uint32_t correctTime(uint32_t& time) const {
-    return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;
-  }
-  std::array<VFATFrame::word,9> data_;
+  uint32_t correctTime(uint32_t& time) const { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
+  std::array<VFATFrame::word, 9> data_;
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -1,8 +1,9 @@
 /****************************************************************************
 *
-* This is a part of the TOTEM offline software.
+* This is a part of the PPS offline software.
 * Authors:
 *   Seyed Mohsen Etesami (setesami@cern.ch)
+*   Laurent Forthomme
 *   Nicola Minafra
 *
 ****************************************************************************/
@@ -16,34 +17,39 @@
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
 
-/** 
+/**
  * This class intended to handle the timing infromation of diamond VFAT frame
 **/
-class DiamondVFATFrame : public VFATFrame {
+class DiamondVFATFrame {
 public:
-  DiamondVFATFrame(const word* inputData = nullptr) {}
-  ~DiamondVFATFrame() override {}
+  DiamondVFATFrame(const VFATFrame::word* inputData = nullptr) {
+    std::copy_n(inputData, 9, data_.begin());
+  }
+  ~DiamondVFATFrame() = default;
 
-  /// get timing infromation
+  /// get timing information for leading single edge
   uint32_t getLeadingEdgeTime() const {
-    uint32_t time = ((data[7] & 0x1f) << 16) + data[8];
-    time = (time & 0xFFE7FFFF) << 2 |
-           (time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
-    return time;
+    uint32_t time = ((data_[7] & 0x1f) << 16) + data_[8];
+    return correctTime(time);
   }
-
+  /// get timing information for trailing single edge
   uint32_t getTrailingEdgeTime() const {
-    uint32_t time = ((data[5] & 0x1f) << 16) + data[6];
-    time = (time & 0xFFE7FFFF) << 2 |
-           (time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
-    return time;
+    uint32_t time = ((data_[5] & 0x1f) << 16) + data_[6];
+    return correctTime(time);
   }
+  /// retrieve the threshold voltage for this channel
+  uint32_t getThresholdVoltage() const { return ((data_[3] & 0x7ff) << 16) + data_[4]; }
+  /// flag stating whether the HPTDC channel encountered multiple hits
+  VFATFrame::word getMultihit() const { return data_[2] & 0x01; }
+  /// retrieve the list of error/status flags for the HPTDC when the frame was recorded
+  VFATFrame::word getHptdcErrorFlag() const { return data_[1] & 0xFFFF; }
 
-  uint32_t getThresholdVoltage() const { return ((data[3] & 0x7ff) << 16) + data[4]; }
-
-  VFATFrame::word getMultihit() const { return data[2] & 0x01; }
-
-  VFATFrame::word getHptdcErrorFlag() const { return data[1] & 0xFFFF; }
+private:
+  /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
+  uint32_t correctTime(uint32_t& time) const {
+    return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;
+  }
+  std::array<VFATFrame::word,9> data_;
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -13,38 +13,38 @@
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
 
-#include <array>
 #include <cstdint>
 
 /**
- * This class intended to handle the timing infromation of diamond VFAT frame
+ * Utilitary namespace to retrieve timing/status information from diamond VFAT frame
 **/
-class DiamondVFATFrame {
-public:
-  DiamondVFATFrame(const VFATFrame::word* inputData = nullptr) { std::copy_n(inputData, 9, data_.begin()); }
-  ~DiamondVFATFrame() = default;
+namespace ppsdiamondvfat
+{
+  /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
+  uint32_t correctTime(const uint32_t& time) { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
 
-  /// get timing information for leading single edge
-  uint32_t getLeadingEdgeTime() const {
-    uint32_t time = ((data_[7] & 0x1f) << 16) + data_[8];
+  /// get timing information for single leading edge
+  uint32_t getLeadingEdgeTime(const VFATFrame& frame) {
+    uint32_t time = ((frame.getData()[7] & 0x1f) << 16) + frame.getData()[8];
     return correctTime(time);
   }
-  /// get timing information for trailing single edge
-  uint32_t getTrailingEdgeTime() const {
-    uint32_t time = ((data_[5] & 0x1f) << 16) + data_[6];
+  /// get timing information for single trailing edge
+  uint32_t getTrailingEdgeTime(const VFATFrame& frame) {
+    uint32_t time = ((frame.getData()[5] & 0x1f) << 16) + frame.getData()[6];
     return correctTime(time);
   }
   /// retrieve the threshold voltage for this channel
-  uint32_t getThresholdVoltage() const { return ((data_[3] & 0x7ff) << 16) + data_[4]; }
+  uint32_t getThresholdVoltage(const VFATFrame& frame) {
+    return ((frame.getData()[3] & 0x7ff) << 16) + frame.getData()[4];
+  }
   /// flag stating whether the HPTDC channel encountered multiple hits
-  VFATFrame::word getMultihit() const { return data_[2] & 0x01; }
+  VFATFrame::word getMultihit(const VFATFrame& frame) {
+    return frame.getData()[2] & 0x01;
+  }
   /// retrieve the list of error/status flags for the HPTDC when the frame was recorded
-  VFATFrame::word getHptdcErrorFlag() const { return data_[1] & 0xFFFF; }
-
-private:
-  /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
-  uint32_t correctTime(uint32_t& time) const { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
-  std::array<VFATFrame::word, 9> data_;
-};
+  VFATFrame::word getHptdcErrorFlag(const VFATFrame& frame) {
+    return frame.getData()[1] & 0xFFFF;
+  }
+}
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -18,7 +18,7 @@
 /**
  * Utilitary namespace to retrieve timing/status information from diamond VFAT frame
 **/
-namespace ppsdiamondvfat {
+namespace pps::diamond::vfat {
   /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
   inline uint32_t correctTime(const uint32_t& time) { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
 

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -18,8 +18,7 @@
 /**
  * Utilitary namespace to retrieve timing/status information from diamond VFAT frame
 **/
-namespace ppsdiamondvfat
-{
+namespace ppsdiamondvfat {
   /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
   inline uint32_t correctTime(const uint32_t& time) { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
 
@@ -38,13 +37,9 @@ namespace ppsdiamondvfat
     return ((frame.getData()[3] & 0x7ff) << 16) + frame.getData()[4];
   }
   /// flag stating whether the HPTDC channel encountered multiple hits
-  inline VFATFrame::word getMultihit(const VFATFrame& frame) {
-    return frame.getData()[2] & 0x01;
-  }
+  inline VFATFrame::word getMultihit(const VFATFrame& frame) { return frame.getData()[2] & 0x01; }
   /// retrieve the list of error/status flags for the HPTDC when the frame was recorded
-  inline VFATFrame::word getHptdcErrorFlag(const VFATFrame& frame) {
-    return frame.getData()[1] & 0xFFFF;
-  }
-}
+  inline VFATFrame::word getHptdcErrorFlag(const VFATFrame& frame) { return frame.getData()[1] & 0xFFFF; }
+}  // namespace ppsdiamondvfat
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -11,11 +11,10 @@
 #ifndef EventFilter_CTPPSRawToDigi_DiamondVFATFrame
 #define EventFilter_CTPPSRawToDigi_DiamondVFATFrame
 
-#include <vector>
-#include <cstddef>
-#include <cstdint>
-
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
+
+#include <array>
+#include <cstdint>
 
 /**
  * This class intended to handle the timing infromation of diamond VFAT frame

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -21,28 +21,28 @@
 namespace ppsdiamondvfat
 {
   /// Account for MSB/LSB "HW feature" reversal in HPTDC interpolation bits
-  uint32_t correctTime(const uint32_t& time) { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
+  inline uint32_t correctTime(const uint32_t& time) { return (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19; }
 
   /// get timing information for single leading edge
-  uint32_t getLeadingEdgeTime(const VFATFrame& frame) {
+  inline uint32_t getLeadingEdgeTime(const VFATFrame& frame) {
     uint32_t time = ((frame.getData()[7] & 0x1f) << 16) + frame.getData()[8];
     return correctTime(time);
   }
   /// get timing information for single trailing edge
-  uint32_t getTrailingEdgeTime(const VFATFrame& frame) {
+  inline uint32_t getTrailingEdgeTime(const VFATFrame& frame) {
     uint32_t time = ((frame.getData()[5] & 0x1f) << 16) + frame.getData()[6];
     return correctTime(time);
   }
   /// retrieve the threshold voltage for this channel
-  uint32_t getThresholdVoltage(const VFATFrame& frame) {
+  inline uint32_t getThresholdVoltage(const VFATFrame& frame) {
     return ((frame.getData()[3] & 0x7ff) << 16) + frame.getData()[4];
   }
   /// flag stating whether the HPTDC channel encountered multiple hits
-  VFATFrame::word getMultihit(const VFATFrame& frame) {
+  inline VFATFrame::word getMultihit(const VFATFrame& frame) {
     return frame.getData()[2] & 0x01;
   }
   /// retrieve the list of error/status flags for the HPTDC when the frame was recorded
-  VFATFrame::word getHptdcErrorFlag(const VFATFrame& frame) {
+  inline VFATFrame::word getHptdcErrorFlag(const VFATFrame& frame) {
     return frame.getData()[1] & 0xFFFF;
   }
 }

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -40,6 +40,6 @@ namespace pps::diamond::vfat {
   inline VFATFrame::word getMultihit(const VFATFrame& frame) { return frame.getData()[2] & 0x01; }
   /// retrieve the list of error/status flags for the HPTDC when the frame was recorded
   inline VFATFrame::word getHptdcErrorFlag(const VFATFrame& frame) { return frame.getData()[1] & 0xFFFF; }
-}  // namespace ppsdiamondvfat
+}  // namespace pps::diamond::vfat
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/ElectronicIndex.h
+++ b/EventFilter/CTPPSRawToDigi/interface/ElectronicIndex.h
@@ -1,13 +1,13 @@
 #ifndef EventFilter_CTPPSRawToDigi_ElectronicIndex_H
 #define EventFilter_CTPPSRawToDigi_ElectronicIndex_H
 
-namespace ctppspixelobjects {
+namespace pps::pixel {
   struct ElectronicIndex {
     int link;
     int roc;
     int dcol;
     int pxid;
   };
-}  // namespace ctppspixelobjects
+}  // namespace pps::pixel
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -18,7 +18,7 @@
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h"
 #include "EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h"
 
-namespace ctpps {
+namespace pps {
   /// \brief Collection of code for unpacking of TOTEM raw-data.
   class RawDataUnpacker {
   public:
@@ -74,6 +74,6 @@ namespace ctpps {
   private:
     unsigned char verbosity;
   };
-}  // namespace ctpps
+}  // namespace pps
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -52,7 +52,7 @@ private:
 
   edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-  ctpps::RawDataUnpacker rawDataUnpacker;
+  pps::RawDataUnpacker rawDataUnpacker;
   RawToDigiConverter rawToDigiConverter;
 
   template <typename DigiType>

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -219,7 +219,7 @@ void CTPPSPixelDataFormatter::formatRawData(unsigned int lvl1_ID,
         nlink = iDdet2fed.at(i).fedch;
         nroc = iDdet2fed.at(i).rocch + 1;
 
-        ctppspixelobjects::ElectronicIndex cabling = {nlink, nroc, dcol, pxid};
+        pps::pixel::ElectronicIndex cabling = {nlink, nroc, dcol, pxid};
 
         cms_uint32_t word = (cabling.link << m_LINK_shift) | (cabling.roc << m_ROC_shift) |
                             (cabling.dcol << m_DCOL_shift) | (cabling.pxid << m_PXID_shift) | (it.adc() << m_ADC_shift);

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -13,7 +13,7 @@
 
 using namespace std;
 using namespace edm;
-using namespace ctpps;
+using namespace pps;
 
 RawDataUnpacker::RawDataUnpacker(const edm::ParameterSet &iConfig)
     : verbosity(iConfig.getUntrackedParameter<unsigned int>("verbosity", 0)) {}

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -250,7 +250,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
     CTPPSDiamondDetId detId(record.info->symbolicID.symbolicID);
 
     if (record.status.isOK()) {
-      const VFATFrame* fr = record.frame;
+      const VFATFrame *fr = record.frame;
       const DiamondVFATFrame diamondframe(fr->getData());
 
       // update Event Counter in status

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -250,7 +250,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
     CTPPSDiamondDetId detId(record.info->symbolicID.symbolicID);
 
     if (record.status.isOK()) {
-      const VFATFrame *fr = record.frame;
+      const VFATFrame* fr = record.frame;
       const DiamondVFATFrame *diamondframe = static_cast<const DiamondVFATFrame *>(fr);
 
       // update Event Counter in status
@@ -263,6 +263,24 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
                                             diamondframe->getThresholdVoltage(),
                                             diamondframe->getMultihit(),
                                             diamondframe->getHptdcErrorFlag()));
+      std::cout << "before "
+        << diamondframe->getLeadingEdgeTime() << "\t"
+        << diamondframe->getTrailingEdgeTime() << "\t"
+        << diamondframe->getThresholdVoltage() << "\t"
+        << diamondframe->getMultihit() << "\t"
+        << diamondframe->getHptdcErrorFlag() << "\n";
+      uint32_t le_time = ((fr->getData()[7] & 0x1f) << 16) + fr->getData()[8];
+      le_time = (le_time & 0xFFE7FFFF) << 2 | (le_time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
+      uint32_t te_time = ((fr->getData()[5] & 0x1f) << 16) + fr->getData()[6];
+      te_time = (te_time & 0xFFE7FFFF) << 2 | (te_time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
+      uint32_t thres_volt = ((fr->getData()[3] & 0x7ff) << 16) + fr->getData()[4];
+      VFATFrame::word multi_hit = fr->getData()[2] & 0x01, hptdc_err = fr->getData()[1] & 0xFFFF;
+      std::cout << "after "
+        << le_time << "\t"
+        << te_time << "\t"
+        << thres_volt << "\t"
+        << multi_hit << "\t"
+        << hptdc_err << "\n";
     }
 
     // save status

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -255,11 +255,11 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.emplace_back(ppsdiamondvfat::getLeadingEdgeTime(*record.frame),
-                              ppsdiamondvfat::getTrailingEdgeTime(*record.frame),
-                              ppsdiamondvfat::getThresholdVoltage(*record.frame),
-                              ppsdiamondvfat::getMultihit(*record.frame),
-                              ppsdiamondvfat::getHptdcErrorFlag(*record.frame));
+      digiDetSet.emplace_back(pps::diamond::vfat::getLeadingEdgeTime(*record.frame),
+                              pps::diamond::vfat::getTrailingEdgeTime(*record.frame),
+                              pps::diamond::vfat::getThresholdVoltage(*record.frame),
+                              pps::diamond::vfat::getMultihit(*record.frame),
+                              pps::diamond::vfat::getHptdcErrorFlag(*record.frame));
     }
 
     // save status

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -250,19 +250,16 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
     CTPPSDiamondDetId detId(record.info->symbolicID.symbolicID);
 
     if (record.status.isOK()) {
-      const VFATFrame *fr = record.frame;
-      const DiamondVFATFrame diamondframe(fr->getData());
-
       // update Event Counter in status
-      record.status.setEC(fr->getEC() & 0xFF);
+      record.status.setEC(record.frame->getEC() & 0xFF);
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.emplace_back(diamondframe.getLeadingEdgeTime(),
-                              diamondframe.getTrailingEdgeTime(),
-                              diamondframe.getThresholdVoltage(),
-                              diamondframe.getMultihit(),
-                              diamondframe.getHptdcErrorFlag());
+      digiDetSet.emplace_back(ppsdiamondvfat::getLeadingEdgeTime(*record.frame),
+                              ppsdiamondvfat::getTrailingEdgeTime(*record.frame),
+                              ppsdiamondvfat::getThresholdVoltage(*record.frame),
+                              ppsdiamondvfat::getMultihit(*record.frame),
+                              ppsdiamondvfat::getHptdcErrorFlag(*record.frame));
     }
 
     // save status

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -254,7 +254,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
       const DiamondVFATFrame diamondframe(fr->getData());
 
       // update Event Counter in status
-      record.status.setEC(record.frame->getEC() & 0xFF);
+      record.status.setEC(fr->getEC() & 0xFF);
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
@@ -263,24 +263,6 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
                                             diamondframe.getThresholdVoltage(),
                                             diamondframe.getMultihit(),
                                             diamondframe.getHptdcErrorFlag()));
-      std::cout << "before "
-        << diamondframe.getLeadingEdgeTime() << "\t"
-        << diamondframe.getTrailingEdgeTime() << "\t"
-        << diamondframe.getThresholdVoltage() << "\t"
-        << diamondframe.getMultihit() << "\t"
-        << diamondframe.getHptdcErrorFlag() << "\n";
-      uint32_t le_time = ((fr->getData()[7] & 0x1f) << 16) + fr->getData()[8];
-      le_time = (le_time & 0xFFE7FFFF) << 2 | (le_time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
-      uint32_t te_time = ((fr->getData()[5] & 0x1f) << 16) + fr->getData()[6];
-      te_time = (te_time & 0xFFE7FFFF) << 2 | (te_time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
-      uint32_t thres_volt = ((fr->getData()[3] & 0x7ff) << 16) + fr->getData()[4];
-      VFATFrame::word multi_hit = fr->getData()[2] & 0x01, hptdc_err = fr->getData()[1] & 0xFFFF;
-      std::cout << "after "
-        << le_time << "\t"
-        << te_time << "\t"
-        << thres_volt << "\t"
-        << multi_hit << "\t"
-        << hptdc_err << "\n";
     }
 
     // save status

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -258,11 +258,11 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe.getLeadingEdgeTime(),
-                                            diamondframe.getTrailingEdgeTime(),
-                                            diamondframe.getThresholdVoltage(),
-                                            diamondframe.getMultihit(),
-                                            diamondframe.getHptdcErrorFlag()));
+      digiDetSet.emplace_back(diamondframe.getLeadingEdgeTime(),
+                              diamondframe.getTrailingEdgeTime(),
+                              diamondframe.getThresholdVoltage(),
+                              diamondframe.getMultihit(),
+                              diamondframe.getHptdcErrorFlag());
     }
 
     // save status

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -251,24 +251,24 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
 
     if (record.status.isOK()) {
       const VFATFrame* fr = record.frame;
-      const DiamondVFATFrame *diamondframe = static_cast<const DiamondVFATFrame *>(fr);
+      const DiamondVFATFrame diamondframe(fr->getData());
 
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe->getLeadingEdgeTime(),
-                                            diamondframe->getTrailingEdgeTime(),
-                                            diamondframe->getThresholdVoltage(),
-                                            diamondframe->getMultihit(),
-                                            diamondframe->getHptdcErrorFlag()));
+      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe.getLeadingEdgeTime(),
+                                            diamondframe.getTrailingEdgeTime(),
+                                            diamondframe.getThresholdVoltage(),
+                                            diamondframe.getMultihit(),
+                                            diamondframe.getHptdcErrorFlag()));
       std::cout << "before "
-        << diamondframe->getLeadingEdgeTime() << "\t"
-        << diamondframe->getTrailingEdgeTime() << "\t"
-        << diamondframe->getThresholdVoltage() << "\t"
-        << diamondframe->getMultihit() << "\t"
-        << diamondframe->getHptdcErrorFlag() << "\n";
+        << diamondframe.getLeadingEdgeTime() << "\t"
+        << diamondframe.getTrailingEdgeTime() << "\t"
+        << diamondframe.getThresholdVoltage() << "\t"
+        << diamondframe.getMultihit() << "\t"
+        << diamondframe.getHptdcErrorFlag() << "\n";
       uint32_t le_time = ((fr->getData()[7] & 0x1f) << 16) + fr->getData()[8];
       le_time = (le_time & 0xFFE7FFFF) << 2 | (le_time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
       uint32_t te_time = ((fr->getData()[5] & 0x1f) << 16) + fr->getData()[6];

--- a/EventFilter/CTPPSRawToDigi/test/TotemVFATFrameAnalyzer.cc
+++ b/EventFilter/CTPPSRawToDigi/test/TotemVFATFrameAnalyzer.cc
@@ -35,7 +35,7 @@ private:
 
   edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-  ctpps::RawDataUnpacker rawDataUnpacker;
+  pps::RawDataUnpacker rawDataUnpacker;
 
   template <typename DigiType>
   void run(edm::Event &, const edm::EventSetup &);


### PR DESCRIPTION
#### PR description:

This PR replaces a `static_cast` of plain TOTEM-like VFAT frames into `DiamondVFATFrame` by simple free-function accessors, following the prescription in #27860.

Also, new `pps` namespace (with nested sub-spaces) is introduced in this package to gradually replace the various `ctpps...` scopes found here and there.

#### PR validation:

Code compiles and runs successfully over a few backed up `t0streamer` streams. Produces exactly the same output as for the baseline.

#### if this PR is a backport please specify the original PR: N/A

Before submitting your pull requests, make sure you followed this checklist:
- [X] verify that the PR is really intended for the chosen branch
- [X] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [X] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
