### PR TITLE
Disabled PCA inputs for deepTau v2 (backport to 10_2_X)

### DIFF
--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -907,9 +907,13 @@ private:
         get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau.tauID("neutralIsoPtSumdR03") / tau.tauID("neutralIsoPtSum"));
         get(dnn::photonPtSumOutsideSignalCone) = getValueNorm(tau.tauID("photonPtSumOutsideSignalConedR03"), 1.731f, 6.846f);
         get(dnn::puCorrPtSum) = getValueNorm(tau.tauID("puCorrPtSum"), 22.38f, 16.34f);
-        get(dnn::tau_dxy_pca_x) = 0; // getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
-        get(dnn::tau_dxy_pca_y) = 0; // getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
-        get(dnn::tau_dxy_pca_z) = 0; // getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
+        // The global PCA coordinates were used as inputs during the NN training, but it was decided to disable
+        // them for the inference, because modeling of dxy_PCA in MC poorly describes the data, and x and y coordinates
+        // in data results outside of the expected 5 std. dev. input validity range. On the other hand,
+        // these coordinates are strongly era-dependent. Kept as comment to document what NN expects.
+        get(dnn::tau_dxy_pca_x) = 0;  // getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
+        get(dnn::tau_dxy_pca_y) = 0;  // getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
+        get(dnn::tau_dxy_pca_z) = 0;  // getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
 
         const bool tau_dxy_valid = std::isnormal(tau.dxy()) && tau.dxy() > - 10 && std::isnormal(tau.dxy_error())
             && tau.dxy_error() > 0;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -577,6 +577,7 @@ public:
         desc.add<bool>("mem_mapped", false);
         desc.add<unsigned>("version", 2);
         desc.add<int>("debug_level", 0);
+        desc.add<bool>("disable_dxy_pca", false);
 
         edm::ParameterSetDescription descWP;
         descWP.add<std::string>("VVVLoose", "0");
@@ -601,7 +602,8 @@ public:
         muons_token_(consumes<MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))),
         rho_token_(consumes<double>(cfg.getParameter<edm::InputTag>("rho"))),
         version(cfg.getParameter<unsigned>("version")),
-        debug_level(cfg.getParameter<int>("debug_level"))
+        debug_level(cfg.getParameter<int>("debug_level")),
+        disable_dxy_pca_(cfg.getParameter<bool>("disable_dxy_pca"))
     {
         if(version == 1) {
             input_layer_ = cache_->getGraph().node(0).name();
@@ -911,9 +913,15 @@ private:
         // them for the inference, because modeling of dxy_PCA in MC poorly describes the data, and x and y coordinates
         // in data results outside of the expected 5 std. dev. input validity range. On the other hand,
         // these coordinates are strongly era-dependent. Kept as comment to document what NN expects.
-        get(dnn::tau_dxy_pca_x) = 0;  // getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
-        get(dnn::tau_dxy_pca_y) = 0;  // getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
-        get(dnn::tau_dxy_pca_z) = 0;  // getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
+	if (!disable_dxy_pca_) {
+	  get(dnn::tau_dxy_pca_x) = getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
+	  get(dnn::tau_dxy_pca_y) = getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
+	  get(dnn::tau_dxy_pca_z) = getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
+	} else {
+	  get(dnn::tau_dxy_pca_x) = 0;
+	  get(dnn::tau_dxy_pca_y) = 0;
+	  get(dnn::tau_dxy_pca_z) = 0;
+	}
 
         const bool tau_dxy_valid = std::isnormal(tau.dxy()) && tau.dxy() > - 10 && std::isnormal(tau.dxy_error())
             && tau.dxy_error() > 0;
@@ -1691,6 +1699,7 @@ private:
     std::string input_layer_, output_layer_;
     const unsigned version;
     const int debug_level;
+    const bool disable_dxy_pca_;
     std::shared_ptr<tensorflow::Tensor> tauBlockTensor_;
     std::array<std::shared_ptr<tensorflow::Tensor>, 2> eGammaTensor_, muonTensor_, hadronsTensor_,
                                                        convTensor_, zeroOutputTensor_;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -907,9 +907,9 @@ private:
         get(dnn::neutralIsoPtSumdR03_over_dR05) = getValue(tau.tauID("neutralIsoPtSumdR03") / tau.tauID("neutralIsoPtSum"));
         get(dnn::photonPtSumOutsideSignalCone) = getValueNorm(tau.tauID("photonPtSumOutsideSignalConedR03"), 1.731f, 6.846f);
         get(dnn::puCorrPtSum) = getValueNorm(tau.tauID("puCorrPtSum"), 22.38f, 16.34f);
-        get(dnn::tau_dxy_pca_x) = getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
-        get(dnn::tau_dxy_pca_y) = getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
-        get(dnn::tau_dxy_pca_z) = getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
+        get(dnn::tau_dxy_pca_x) = 0; // getValueNorm(tau.dxy_PCA().x(), -0.0241f, 0.0074f);
+        get(dnn::tau_dxy_pca_y) = 0; // getValueNorm(tau.dxy_PCA().y(),0.0675f, 0.0128f);
+        get(dnn::tau_dxy_pca_z) = 0; // getValueNorm(tau.dxy_PCA().z(), 0.7973f, 3.456f);
 
         const bool tau_dxy_valid = std::isnormal(tau.dxy()) && tau.dxy() > - 10 && std::isnormal(tau.dxy_error())
             && tau.dxy_error() > 0;

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -7,12 +7,14 @@ class TauIDEmbedder(object):
     """class to rerun the tau seq and acces trainings from the database"""
     availableDiscriminators = [
         "2017v1", "2017v2", "newDM2017v2", "dR0p32017v2", "2016v1", "newDM2016v1",
-        "deepTau2017v1", "deepTau2017v2", "DPFTau_2016_v0", "DPFTau_2016_v1", "againstEle2018"
+        "deepTau2017v1", "deepTau2017v2", "deepTau2017v2p1",
+        "DPFTau_2016_v0", "DPFTau_2016_v1",
+        "againstEle2018"
     ]
 
     def __init__(self, process, cms, debug = False,
                  updatedTauName = "slimmedTausNewID",
-                 toKeep =  ["deepTau2017v2"],
+                 toKeep =  ["deepTau2017v2p1"],
                  tauIdDiscrMVA_trainings_run2_2017 = { 'tauIdMVAIsoDBoldDMwLT2017' : "tauIdMVAIsoDBoldDMwLT2017", },
                  tauIdDiscrMVA_WPs_run2_2017 = {
                     'tauIdMVAIsoDBoldDMwLT2017' : {
@@ -716,6 +718,63 @@ class TauIDEmbedder(object):
 
             self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v2)
             self.process.rerunMvaIsolationSequence += self.process.deepTau2017v2
+
+        if "deepTau2017v2p1" in self.toKeep:
+            if self.debug: print "Adding DeepTau IDs"
+
+            workingPoints_ = {
+                "e": {
+                    "VVVLoose": 0.0630386,
+                    "VVLoose": 0.1686942,
+                    "VLoose": 0.3628130,
+                    "Loose": 0.6815435,
+                    "Medium": 0.8847544,
+                    "Tight": 0.9675541,
+                    "VTight": 0.9859251,
+                    "VVTight": 0.9928449,
+                },
+                "mu": {
+                    "VLoose": 0.1058354,
+                    "Loose": 0.2158633,
+                    "Medium": 0.5551894,
+                    "Tight": 0.8754835,
+                },
+                "jet": {
+                    "VVVLoose": 0.2599605,
+                    "VVLoose": 0.4249705,
+                    "VLoose": 0.5983682,
+                    "Loose": 0.7848675,
+                    "Medium": 0.8834768,
+                    "Tight": 0.9308689,
+                    "VTight": 0.9573137,
+                    "VVTight": 0.9733927,
+                },
+            }
+
+            file_names = [
+                'core:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_core.pb',
+                'inner:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_inner.pb',
+                'outer:RecoTauTag/TrainingFiles/data/DeepTauId/deepTau_2017v2p6_e6_outer.pb',
+            ]
+            self.process.deepTau2017v2p1 = self.cms.EDProducer("DeepTauId",
+                electrons                = self.cms.InputTag('slimmedElectrons'),
+                muons                    = self.cms.InputTag('slimmedMuons'),
+                taus                     = self.cms.InputTag('slimmedTaus'),
+                pfcands                  = self.cms.InputTag('packedPFCandidates'),
+                vertices                 = self.cms.InputTag('offlineSlimmedPrimaryVertices'),
+                rho                      = self.cms.InputTag('fixedGridRhoAll'),
+                graph_file               = self.cms.vstring(file_names),
+                mem_mapped               = self.cms.bool(True),
+                version                  = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
+                debug_level              = self.cms.int32(0),
+                disable_dxy_pca          = self.cms.bool(True)
+
+            )
+
+            self.processDeepProducer('deepTau2017v2p1', tauIDSources, workingPoints_)
+
+            self.process.rerunMvaIsolationTask.add(self.process.deepTau2017v2p1)
+            self.process.rerunMvaIsolationSequence += self.process.deepTau2017v2p1
 
         if "DPFTau_2016_v0" in self.toKeep:
             if self.debug: print "Adding DPFTau isolation (v0)"

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -650,7 +650,9 @@ class TauIDEmbedder(object):
                 rho                    = self.cms.InputTag('fixedGridRhoAll'),
                 graph_file             = self.cms.vstring(file_names),
                 mem_mapped             = self.cms.bool(False),
-                version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1])
+                version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
+                debug_level            = self.cms.int32(0),
+                disable_dxy_pca        = self.cms.bool(False)
             )
 
             self.processDeepProducer('deepTau2017v1', tauIDSources, workingPoints_)
@@ -705,7 +707,8 @@ class TauIDEmbedder(object):
                 graph_file             = self.cms.vstring(file_names),
                 mem_mapped             = self.cms.bool(True),
                 version                = self.cms.uint32(self.getDeepTauVersion(file_names[0])[1]),
-                debug_level            = self.cms.int32(0)
+                debug_level            = self.cms.int32(0),
+                disable_dxy_pca        = self.cms.bool(False)
 
             )
 

--- a/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
+++ b/RecoTauTag/RecoTau/test/runDeepTauIDsOnMiniAOD.py
@@ -34,7 +34,7 @@ tauIdEmbedder = tauIdConfig.TauIDEmbedder(process, cms, debug = False,
                     updatedTauName = updatedTauName,
                     toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2",
                                # "deepTau2017v1",
-                               "deepTau2017v2",
+                               "deepTau2017v2p1",
                                # "DPFTau_2016_v0",
                                # "DPFTau_2016_v1",
                                "againstEle2018"


### PR DESCRIPTION
#### PR description:

Problems have been detected with dxy_PCA input variables to DeepTauID which are inconsistent between data and MC. This PR sets input values to 0 and disables the variables this way.
Issue and fix were discussed in https://indico.cern.ch/event/842796/contributions/3541592/attachments/1897386/3130770/2019-08-26_DeepTau_ID_2017v2_DY_MC_vs_Embedded_and_bug_in_definition_of_PCA_variables.pdf (see slide 7 in particular)

Backport to 10_2_X for legacy analyses intended.

#### PR validation:

compiles

#### if this PR is a backport please specify the original PR:

#27878 
