### PR TITLE
Update DTDigi so that it can be accomodate Phase2 TDC units.

### DIFF
--- a/DataFormats/DTDigi/interface/DTDigi.h
+++ b/DataFormats/DTDigi/interface/DTDigi.h
@@ -4,8 +4,8 @@
 /** \class DTDigi
  *
  * Digi for Drift Tubes.
- * It can be initialized/set with a time in ns or a TDC count in 25/32 ns 
- * units.
+ * It can be initialized/set with a time in ns or a TDC count in 
+ * the specified base (ie number of counts/BX)
  *  
  *
  * \author N. Amapane, G. Cerminara, M. Pelliccioni - INFN Torino
@@ -21,12 +21,12 @@ public:
   
   /// Construct from the wire#, the TDC counts and the digi number.
   /// number should identify uniquely multiple digis in the same cell.
-  explicit DTDigi (int wire, int nTDC, int number=0);
-
+  explicit DTDigi (int wire, int nTDC, int number=0, int base=32);
+  
   // Construct from the wire#, the time (ns) and the digi number.
-  // time is converted in TDC counts (1 TDC = 25./32. ns)
+  // time is converted in TDC counts (1 TDC = 25./base. ns)
   // number should identify uniquely multiple digis in the same cell.
-  explicit DTDigi (int wire, double tdrift, int number=0);
+  explicit DTDigi (int wire, double tdrift, int number=0, int base=32);
 
   // Construct from channel and counts.
   //  explicit DTDigi (ChannelType channel, int nTDC);
@@ -50,13 +50,13 @@ public:
   double time() const;
 
   /// Get raw TDC count
-  uint32_t countsTDC() const;
+  int32_t countsTDC() const;
 
-  /// Set with a time in ns
-  void setTime(double time);  
+  /// Get the TDC unit value in ns
+  double tdcUnit() const;
 
-  /// Set with a TDC count
-  void setCountsTDC (int nTDC);
+  /// Get the TDC base (counts per BX)
+  int tdcBase() const;
 
   /// Print content of digi
   void print() const;
@@ -67,14 +67,11 @@ private:
   // The value of one TDC count in ns
   static const double reso;
 
-  // Masks&shifts for the channel identifier
-//   static const uint32_t wire_mask   = 0xffff0000;
-//   static const uint32_t number_mask = 0xffff;
-//   static const uint32_t wire_offset = 16;
-
+  int32_t theCounts;  // TDC count, in units given by 1/theTDCBase
   uint16_t theWire;   // channel number
-  uint32_t theCounts; // TDC count, up to 20 bits actually used
-  uint16_t theNumber; // counter for digis in the same cell
+  uint8_t theNumber;  // counter for digis in the same cell
+  uint8_t theTDCBase; // TDC base (counts per BX; 32 in Ph1 or 30 in Ph2)
+
 };
 
 #include<iostream>

--- a/DataFormats/DTDigi/src/DTDigi.cc
+++ b/DataFormats/DTDigi/src/DTDigi.cc
@@ -6,42 +6,40 @@
 
 
 #include <DataFormats/DTDigi/interface/DTDigi.h>
-
+#include <FWCore/Utilities/interface/Exception.h>
 
 using namespace std;
 
 
-const double DTDigi::reso =  25./32.; //ns
-
-
-DTDigi::DTDigi (int wire, int nTDC, int number) : 
-  theWire(wire),
+DTDigi::DTDigi (int wire, int nTDC, int number, int base) : 
   theCounts(nTDC),
-  theNumber(number)
-{}
-
-
-DTDigi::DTDigi (int wire, double tdrift, int number): 
   theWire(wire),
-  theCounts(static_cast<int>(tdrift/reso)),
-  theNumber(number)
-{}
+  theNumber(number),
+  theTDCBase(base)
+{
+  if (number>255 || number <0 || !(base==30 || base==32)) {
+    throw cms::Exception("BadConfig") << "DTDigi ctor: invalid parameters: number: " << number << " base: " << base << endl;
+  }
+}
 
 
-// DTDigi::DTDigi (ChannelType channel, int nTDC):
-//   theWire(0),
-//   theCounts(nTDC),
-//   theNumber(0)
-// {
-//   theNumber = channel&number_mask;
-//   theWire   = (channel&wire_mask)>>wire_offset;
-// }
+DTDigi::DTDigi (int wire, double tdrift, int number, int base): 
+  theCounts(static_cast<int>(tdrift/25.*base)),
+  theWire(wire),
+  theNumber(number),
+  theTDCBase(base)
+{
+  if (number>255 || number <0 || !(base==30 || base==32)) {
+    throw cms::Exception("BadConfig") << "DTDigi ctor: invalid parameters: number: " << number << " base: " << base << endl;
+  }
+}
 
 
 DTDigi::DTDigi ():
-  theWire(0),
   theCounts(0), 
-  theNumber(0)
+  theWire(0),
+  theNumber(0),
+  theTDCBase(32)
 {}
 
 
@@ -54,34 +52,17 @@ DTDigi::operator == (const DTDigi& digi) const {
   return true;
 }
 
-// Getters
-// DTDigi::ChannelType
-// DTDigi::channel() const {
-//   return  (theNumber & number_mask) | (theWire<<wire_offset)&wire_mask;
-// }
+double DTDigi::time() const { return theCounts*25./theTDCBase; }
 
-double DTDigi::time() const { return theCounts*reso; }
-
-uint32_t DTDigi::countsTDC() const { return theCounts; }
+int32_t DTDigi::countsTDC() const { return theCounts; }
 
 int DTDigi::wire() const { return theWire; }
 
 int DTDigi::number() const { return theNumber; }
 
-// Setters
+double DTDigi::tdcUnit() const { return 25./theTDCBase; }
 
-void DTDigi::setTime(double time){
-  theCounts = static_cast<int>(time/reso);
-}
-
-void DTDigi::setCountsTDC (int nTDC) {
-  if (nTDC<0) cout << "WARNING: DTDigi::setCountsTDC: negative TDC count not supported "
-		   << nTDC << endl;
-  theCounts = nTDC;
-}
-
-
-// Debug
+int DTDigi::tdcBase() const { return theTDCBase; }
 
 void
 DTDigi::print() const {

--- a/DataFormats/DTDigi/src/classes_def.xml
+++ b/DataFormats/DTDigi/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-<class name="DTDigi" ClassVersion="10">
+<class name="DTDigi" ClassVersion="11">
+ <version ClassVersion="11" checksum="1984707097"/>
  <version ClassVersion="10" checksum="942813146"/>
 </class>
 <class name="std::vector<DTDigi>"/>

--- a/DataFormats/DTDigi/test/testDTDigis.cpp
+++ b/DataFormats/DTDigi/test/testDTDigis.cpp
@@ -74,7 +74,7 @@ void testDTDigis::testDigiCollectionPut(){
 	 ++digiIt){
 
       CPPUNIT_ASSERT((*digiIt).wire()==1+i);
-      CPPUNIT_ASSERT((*digiIt).countsTDC()==(unsigned)5+i);
+      CPPUNIT_ASSERT((*digiIt).countsTDC()==5+i);
       CPPUNIT_ASSERT((*digiIt).number()==100+i);
       i++;
       
@@ -133,7 +133,7 @@ void testDTDigis::testDigiCollectionInsert(){
 void testDTDigis::testTime2TDCConversion(){
   float time=243;
   float reso=25./32.;
-  unsigned int tdc=int(time/reso);
+  int tdc=int(time/reso);
   int pos=2;
   int wire=1;
 

--- a/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
+++ b/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
@@ -10,12 +10,13 @@ public:
 
   // Construct from the wire number and the digi number (this identifies
   // uniquely multiple digis on the same wire), the TDC counts, the SimTrack Id and the EncodedEvent Id.
-  explicit DTDigiSimLink(int wireNr, int digiNr, int nTDC, unsigned int trackId, EncodedEventId evId);
+  // Base is related to the tdc unit (32 = Phase 1; 30 = Phase 2)
+  explicit DTDigiSimLink(int wireNr, int digiNr, int nTDC, unsigned int trackId, EncodedEventId evId, int base = 32);
 
   // Construct from the wire number and the digi number (this identifies
   // uniquely multiple digis on the same wire), the time (ns), the SimTrack Id and the EncodedEvent Id.
   // time is converted in TDC counts (1 TDC = 25./32. ns)
-  explicit DTDigiSimLink(int wireNr, int digiNr, double tdrift, unsigned int trackId, EncodedEventId evId);
+  explicit DTDigiSimLink(int wireNr, int digiNr, double tdrift, unsigned int trackId, EncodedEventId evId, int base = 32);
 
   // Default constructor.
   DTDigiSimLink();
@@ -53,8 +54,9 @@ private:
 
 private:
   uint16_t theWire;        // wire number
-  uint16_t theDigiNumber;  // digi number on the wire
-  uint32_t theCounts;      // TDC count, up to 20 bits actually used
+  uint8_t theDigiNumber;   // counter for digis in the same cell
+  uint8_t theTDCBase;      // TDC base (counts per BX; 32 in Ph1 or 30 in Ph2)
+  int32_t theCounts;       // TDC count, in units given by 1/theTDCBase
   uint32_t theSimTrackId;  // identifier of the SimTrack that produced the digi
   EncodedEventId theEventId;
 };

--- a/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
+++ b/SimDataFormats/DigiSimLinks/src/DTDigiSimLink.cc
@@ -1,19 +1,19 @@
 #include <SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h>
 
 using namespace std;
-const double DTDigiSimLink::reso = 25. / 32.;  //ns
 
-DTDigiSimLink::DTDigiSimLink(int wireNr, int digiNr, int nTDC, unsigned int trackId, EncodedEventId evId)
-    : theWire(wireNr), theDigiNumber(digiNr), theCounts(nTDC), theSimTrackId(trackId), theEventId(evId) {}
+DTDigiSimLink::DTDigiSimLink(int wireNr, int digiNr, int nTDC, unsigned int trackId, EncodedEventId evId, int base)
+  : theWire(wireNr), theDigiNumber(digiNr), theTDCBase(base), theCounts(nTDC), theSimTrackId(trackId), theEventId(evId) {}
 
-DTDigiSimLink::DTDigiSimLink(int wireNr, int digiNr, double tdrift, unsigned int trackId, EncodedEventId evId)
+DTDigiSimLink::DTDigiSimLink(int wireNr, int digiNr, double tdrift, unsigned int trackId, EncodedEventId evId, int base)
     : theWire(wireNr),
       theDigiNumber(digiNr),
-      theCounts(static_cast<int>(tdrift / reso)),
+      theTDCBase(base),
+      theCounts(static_cast<int>(tdrift * base/25.)),
       theSimTrackId(trackId),
       theEventId(evId) {}
 
-DTDigiSimLink::DTDigiSimLink() : theWire(0), theDigiNumber(0), theCounts(0), theSimTrackId(0), theEventId(0) {}
+DTDigiSimLink::DTDigiSimLink() : theWire(0), theDigiNumber(0), theTDCBase(32), theCounts(0), theSimTrackId(0), theEventId(0) {}
 
 DTDigiSimLink::ChannelType DTDigiSimLink::channel() const {
   ChannelPacking result;
@@ -29,7 +29,7 @@ int DTDigiSimLink::number() const { return theDigiNumber; }
 
 uint32_t DTDigiSimLink::countsTDC() const { return theCounts; }
 
-double DTDigiSimLink::time() const { return theCounts * reso; }
+double DTDigiSimLink::time() const { return theCounts * 25./theTDCBase; }
 
 unsigned int DTDigiSimLink::SimTrackId() const { return theSimTrackId; }
 

--- a/SimDataFormats/DigiSimLinks/src/classes_def.xml
+++ b/SimDataFormats/DigiSimLinks/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-<class name="DTDigiSimLink" ClassVersion="10">
+<class name="DTDigiSimLink" ClassVersion="11">
+ <version ClassVersion="11" checksum="780875960"/>
  <version ClassVersion="10" checksum="1414990067"/>
 </class>
 <class name="std::vector<DTDigiSimLink>"/>

--- a/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
+++ b/SimMuon/DTDigitizer/python/muonDTDigis_cfi.py
@@ -33,7 +33,10 @@ simMuonDTDigis = cms.EDProducer("DTDigitizer",
     IdealModel = cms.bool(False),
     LinksTimeWindow = cms.double(10.0),
     onlyMuHits = cms.bool(False),
-    GeometryType = cms.string('idealForDigi')                          
+    GeometryType = cms.string('idealForDigi'),
+    # Option to write digis in phase2 units (25/30. ns, if True)  
+    # instead than in phase 1 units (25/32.ns )
+    phase2Digis = cms.bool(False)
 )
 
 

--- a/SimMuon/DTDigitizer/src/DTDigitizer.cc
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.cc
@@ -95,6 +95,11 @@ DTDigitizer::DTDigitizer(const ParameterSet &conf_)
   // it uses a constant drift velocity and doesn't set any external delay
   IdealModel = conf_.getParameter<bool>("IdealModel");
 
+  // Flag to specify that we want digis in phase-2 units (25./30. ns) 
+  // instead that the old units (25./32.)
+  if (conf_.getParameter<bool>("phase2Digis")) base = 30;
+  else base = 32;
+
   // Constant drift velocity needed by the above flag
   if (IdealModel)
     theConstVDrift = conf_.getParameter<double>("IdealModelConstantDriftVelocity");  // 55 um/ns
@@ -518,12 +523,12 @@ void DTDigitizer::storeDigis(DTWireId &wireId,
       // Note that digi is constructed with a float value (in ns)
       int wireN = wireId.wire();
       digiN++;
-      digi = DTDigi(wireN, time, digiN);
+      digi = DTDigi(wireN, time, digiN, base);
 
       // Add association between THIS digi and the corresponding SimTrack
       unsigned int SimTrackId = (*hit).first->trackId();
       EncodedEventId evId = (*hit).first->eventId();
-      DTDigiSimLink digisimLink(wireN, digiN, time, SimTrackId, evId);
+      DTDigiSimLink digisimLink(wireN, digiN, time, SimTrackId, evId, base);
 
       if (debug) {
         LogPrint("DTDigitizer") << endl << "---- DTDigitizer ----" << endl;
@@ -534,20 +539,16 @@ void DTDigitizer::storeDigis(DTWireId &wireId,
       }
 
       //************ 7D ***************
-      if (digi.countsTDC() < pow(2., 16)) {
-        DTLayerId layerID = wireId.layerId();  // taking the layer in which reside the wire
-        output.insertDigi(layerID, digi);      // ordering Digis by layer
-        outputLinks.insertDigi(layerID, digisimLink);
-        wakeTime = time + deadTime;
-        resolTime = time + LinksTimeWindow;
-      } else {
-        digiN--;
-      }
+      DTLayerId layerID = wireId.layerId();  // taking the layer of the wire 
+      output.insertDigi(layerID, digi);      // ordering Digis by layer
+      outputLinks.insertDigi(layerID, digisimLink);
+      wakeTime = time + deadTime;
+      resolTime = time + LinksTimeWindow;
     } else if (MultipleLinks && time < resolTime) {
       int wireN = wireId.wire();
       unsigned int SimTrackId = (*hit).first->trackId();
       EncodedEventId evId = (*hit).first->eventId();
-      DTDigiSimLink digisimLink(wireN, digiN, time, SimTrackId, evId);
+      DTDigiSimLink digisimLink(wireN, digiN, time, SimTrackId, evId, base);
       DTLayerId layerID = wireId.layerId();
       outputLinks.insertDigi(layerID, digisimLink);
 

--- a/SimMuon/DTDigitizer/src/DTDigitizer.h
+++ b/SimMuon/DTDigitizer/src/DTDigitizer.h
@@ -108,6 +108,7 @@ private:
   bool debug;
   bool interpolate;
   bool onlyMuHits;
+  int base; 
 
   std::string syncName;
   std::unique_ptr<DTDigiSyncBase> theSync;


### PR DESCRIPTION
#### PR description:
Update DTDigi to be able to accomodate the different TDC unit of Phase2 readout (in addition to the current unit, which remains the default).

DTDigiSimLink updated accordingly. Also added an option to create digis in the new units in the simulation (switched off by default).

There is NO change in the default behaviour of any class.

This update was requested by DT DPG (@fcavallo @battibass ). For more details:
https://indico.cern.ch/event/839945/#sc-4-10-dt-digi-format-for-tdc

#### PR validation:
Tested comparing comparing of raw2digi before and after the change with both phase-1 and phase-2 digis.

Note: the correspondig PR for 11_X is #27890.