### PR TITLE
BTL validation update

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -13,7 +13,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'standardValidation' : ['prevalidation','validation','validationHarvesting'],
                    'standardValidationNoHLT' : ['prevalidationNoHLT','validationNoHLT','validationHarvestingNoHLT'],
                    'HGCalValidation' : ['', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
-                   'MTDValidation' : ['', 'globalValidationMTD', ''],
+                   'MTDValidation' : ['', 'globalValidationMTD', 'mtdValidationPostProcessor'],
                    'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],
                    'ecalValidation_phase2' : ['', 'validationECALPhase2', ''],
                  }

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -67,6 +67,7 @@ from Validation.MuonGEMDigis.PostProcessor_cff import *
 from Validation.MuonGEMRecHits.PostProcessor_cff import *
 from Validation.MuonME0Validation.PostProcessor_cff import *
 from Validation.HGCalValidation.HGCalPostProcessor_cff import *
+from Validation.MtdValidation.MtdPostProcessor_cff import *
 
 postValidation_common = cms.Sequence()
 

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -150,8 +150,10 @@ void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   }  // dataFrame loop
 
-  meNhits_[0]->Fill(n_digi_btl[0]);
-  meNhits_[1]->Fill(n_digi_btl[1]);
+  if (n_digi_btl[0] > 0)
+    meNhits_[0]->Fill(log10(n_digi_btl[0]));
+  if (n_digi_btl[1] > 0)
+    meNhits_[1]->Fill(log10(n_digi_btl[1]));
 }
 
 // ------------ method for histogram booking ------------
@@ -162,8 +164,8 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[0] = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);N_{DIGI}", 100, 0., 5000.);
-  meNhits_[1] = ibook.book1D("BtlNhitsR", "Number of BTL DIGI hits (R);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("BtlNhitsL", "Number of BTL DIGI hits (L);log_{10}(N_{DIGI})", 100, 0., 5.25);
+  meNhits_[1] = ibook.book1D("BtlNhitsR", "Number of BTL DIGI hits (R);log_{10}(N_{DIGI})", 100, 0., 5.25);
 
   meHitCharge_[0] = ibook.book1D("BtlHitChargeL", "BTL DIGI hits charge (L);Q_{DIGI} [ADC counts]", 100, 0., 1024.);
   meHitCharge_[1] = ibook.book1D("BtlHitChargeR", "BTL DIGI hits charge (R);Q_{DIGI} [ADC counts]", 100, 0., 1024.);

--- a/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlRecHitsValidation.cc
@@ -201,7 +201,8 @@ void BtlRecHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   }  // recHit loop
 
-  meNhits_->Fill(n_reco_btl);
+  if (n_reco_btl > 0)
+    meNhits_->Fill(log10(n_reco_btl));
 }
 
 // ------------ method for histogram booking ------------
@@ -212,7 +213,7 @@ void BtlRecHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_ = ibook.book1D("BtlNhits", "Number of BTL RECO hits;N_{RECO}", 100, 0., 5000.);
+  meNhits_ = ibook.book1D("BtlNhits", "Number of BTL RECO hits;log_{10}(N_{RECO})", 100, 0., 5.25);
 
   meHitEnergy_ = ibook.book1D("BtlHitEnergy", "BTL RECO hits energy;E_{RECO} [MeV]", 100, 0., 20.);
   meHitTime_ = ibook.book1D("BtlHitTime", "BTL RECO hits ToA;ToA_{RECO} [ns]", 100, 0., 25.);

--- a/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
@@ -23,7 +23,6 @@
 
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 
-
 class BtlSimHitsHarvester : public DQMEDHarvester {
 public:
   explicit BtlSimHitsHarvester(const edm::ParameterSet& iConfig);
@@ -32,28 +31,26 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+  void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
 private:
   const std::string folder_;
 
   // --- Histograms
   MonitorElement* meHitOccupancy_;
-
 };
 
 // ------------ constructor and destructor --------------
-BtlSimHitsHarvester::BtlSimHitsHarvester(const edm::ParameterSet &iConfig) 
-  : folder_(iConfig.getParameter<std::string>("folder")) {}
+BtlSimHitsHarvester::BtlSimHitsHarvester(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {}
 
 BtlSimHitsHarvester::~BtlSimHitsHarvester() {}
 
 // ------------ endjob tasks ----------------------------
-void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker &ibook, DQMStore::IGetter &igetter) {
-
+void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
-  MonitorElement* meBtlHitLogEnergy = igetter.get(folder_+"BtlHitLogEnergy");
-  MonitorElement* meNevents = igetter.get(folder_+"BtlNevents");
+  MonitorElement* meBtlHitLogEnergy = igetter.get(folder_ + "BtlHitLogEnergy");
+  MonitorElement* meNevents = igetter.get(folder_ + "BtlNevents");
 
   if (!meBtlHitLogEnergy || !meNevents) {
     edm::LogError("BtlSimHitsHarvester") << "Monitoring histograms not found!" << std::endl;
@@ -63,23 +60,22 @@ void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker &ibook, DQMStore::IGetter 
   // --- Get the number of BTL crystals and the number of processed events
   const float NBtlCrystals = BTLDetId::kCrystalsPerRODBarPhiFlat * BTLDetId::MAX_ROD;
   const float Nevents = meNevents->getEntries();
-  const float scale = (Nevents > 0 ? 1./(Nevents*NBtlCrystals) : 1.);
+  const float scale = (Nevents > 0 ? 1. / (Nevents * NBtlCrystals) : 1.);
 
   // --- Book the cumulative histogram
   ibook.cd(folder_);
-  meHitOccupancy_ = ibook.book1D(
-    "BtlHitOccupancy", "BTL cell occupancy vs hit energy;log_{10}(E_{SIM} [MeV]); Occupancy per event", 
-    meBtlHitLogEnergy->getNbinsX(),
-    meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
-    meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
+  meHitOccupancy_ = ibook.book1D("BtlHitOccupancy",
+                                 "BTL cell occupancy vs hit energy;log_{10}(E_{SIM} [MeV]); Occupancy per event",
+                                 meBtlHitLogEnergy->getNbinsX(),
+                                 meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
+                                 meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
 
   // --- Calculate the cumulative histogram
-  double bin_sum = meBtlHitLogEnergy->getBinContent(meBtlHitLogEnergy->getNbinsX()+1);
-  for (int ibin = meBtlHitLogEnergy->getNbinsX(); ibin>=1; --ibin) {
+  double bin_sum = meBtlHitLogEnergy->getBinContent(meBtlHitLogEnergy->getNbinsX() + 1);
+  for (int ibin = meBtlHitLogEnergy->getNbinsX(); ibin >= 1; --ibin) {
     bin_sum += meBtlHitLogEnergy->getBinContent(ibin);
     meHitOccupancy_->setBinContent(ibin, scale * bin_sum);
   }
-
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -89,7 +85,6 @@ void BtlSimHitsHarvester::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<std::string>("folder", "MTD/BTL/SimHits/");
 
   descriptions.add("btlSimHitsPostProcessor", desc);
-
 }
 
 DEFINE_FWK_MODULE(BtlSimHitsHarvester);

--- a/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
@@ -1,0 +1,95 @@
+// -*- C++ -*-
+//
+// Package:    Validation/MtdValidation
+// Class:      BtlSimHitsHarvester
+//
+/**\class BtlSimHitsHarvester BtlSimHitsHarvester.cc Validation/MtdValidation/plugins/BtlSimHitsHarvester.cc
+
+ Description: BTL SIM hits validation harvester
+
+ Implementation:
+     [Notes on implementation]
+*/
+
+#include <string>
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+
+class BtlSimHitsHarvester : public DQMEDHarvester {
+public:
+  explicit BtlSimHitsHarvester(const edm::ParameterSet& iConfig);
+  ~BtlSimHitsHarvester() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+
+private:
+  const std::string folder_;
+
+  // --- Histograms
+  MonitorElement* meHitOccupancy_;
+
+};
+
+// ------------ constructor and destructor --------------
+BtlSimHitsHarvester::BtlSimHitsHarvester(const edm::ParameterSet &iConfig) 
+  : folder_(iConfig.getParameter<std::string>("folder")) {}
+
+BtlSimHitsHarvester::~BtlSimHitsHarvester() {}
+
+// ------------ endjob tasks ----------------------------
+void BtlSimHitsHarvester::dqmEndJob(DQMStore::IBooker &ibook, DQMStore::IGetter &igetter) {
+
+  // --- Get the monitoring histograms
+  MonitorElement* meBtlHitLogEnergy = igetter.get(folder_+"BtlHitLogEnergy");
+  MonitorElement* meNevents = igetter.get(folder_+"BtlNevents");
+
+  if (!meBtlHitLogEnergy || !meNevents) {
+    edm::LogError("BtlSimHitsHarvester") << "Monitoring histograms not found!" << std::endl;
+    return;
+  }
+
+  // --- Get the number of BTL crystals and the number of processed events
+  const float NBtlCrystals = BTLDetId::kCrystalsPerRODBarPhiFlat * BTLDetId::MAX_ROD;
+  const float Nevents = meNevents->getEntries();
+  const float scale = (Nevents > 0 ? 1./(Nevents*NBtlCrystals) : 1.);
+
+  // --- Book the cumulative histogram
+  ibook.cd(folder_);
+  meHitOccupancy_ = ibook.book1D(
+    "BtlHitOccupancy", "BTL cell occupancy vs hit energy;log_{10}(E_{SIM} [MeV]); Occupancy per event", 
+    meBtlHitLogEnergy->getNbinsX(),
+    meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmin(),
+    meBtlHitLogEnergy->getTH1()->GetXaxis()->GetXmax());
+
+  // --- Calculate the cumulative histogram
+  double bin_sum = meBtlHitLogEnergy->getBinContent(meBtlHitLogEnergy->getNbinsX()+1);
+  for (int ibin = meBtlHitLogEnergy->getNbinsX(); ibin>=1; --ibin) {
+    bin_sum += meBtlHitLogEnergy->getBinContent(ibin);
+    meHitOccupancy_->setBinContent(ibin, scale * bin_sum);
+  }
+
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BtlSimHitsHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "MTD/BTL/SimHits/");
+
+  descriptions.add("btlSimHitsPostProcessor", desc);
+
+}
+
+DEFINE_FWK_MODULE(BtlSimHitsHarvester);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -155,7 +155,7 @@ void BtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   //  Histogram filling
   // ==============================================================================
 
-  if (m_btlHits.size() > 0)
+  if (!m_btlHits.empty())
     meNhits_->Fill(log10(m_btlHits.size()));
 
   for (auto const& hit : m_btlTrkPerCell)

--- a/Validation/MtdValidation/python/MtdPostProcessor_cff.py
+++ b/Validation/MtdValidation/python/MtdPostProcessor_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.MtdValidation.btlSimHitsPostProcessor_cfi import btlSimHitsPostProcessor
+
+mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor)


### PR DESCRIPTION
#### PR description:

This is a refinement of PR #27607. The cumulative histogram BtlHitOccupancy was calculated and filled in BtlSimHitsValidation::endLuminosityBlock at step 3 and resulted not mergeable in the case of multiple parallel jobs. A new harvester module (BtlSimHitsHarvester) has been introduced and now the cumulative histogram filling is properly done at the harvesting step.

In addition, to deal with the huge number of BTL SIM/DIGI/RECO hits in the case of high PU events, the histograms with the number of hits are filled with the logarithm of the number of hits.

#### PR validation:

The updated code has been compiled in the release CMSSW_11_0_X_2019-08-21-2300 and tested with the WF 20434 and the WF 20607 with PU200.

The total size of the MTD monitoring plots is now:
476.28 KiB MTD/ETL
234.96 KiB MTD/BTL