### PR TITLE
improve protection for not defined workflows

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -27,7 +27,7 @@ def runSelected(opt):
         definedSet = set([dwf.numId for dwf in mrd.workFlows])
         testSet = set(opt.testList)
         undefSet = testSet - definedSet
-        if len(undefSet)>0: raise ValueError('Undefined workflows: '+str(undefSet))
+        if len(undefSet)>0: raise ValueError('Undefined workflows: '+', '.join(map(str,list(undefSet))))
 
     ret = 0
     if opt.show:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -24,10 +24,10 @@ def runSelected(opt):
 
     # test for wrong input workflows
     if opt.testList:
-        definedWF = []
-        for dwf in mrd.workFlows: definedWF.append(dwf.numId)
-        for twf in opt.testList:
-            if twf not in definedWF: raise ValueError('Not defined workflow ', twf , ' requested')
+        definedSet = set([dwf.numId for dwf in mrd.workFlows])
+        testSet = set(opt.testList)
+        undefSet = testSet - definedSet
+        if len(undefSet)>0: raise ValueError('Undefined workflows: '+str(undefSet))
 
     ret = 0
     if opt.show:


### PR DESCRIPTION
#### PR description:

Following up on my own suggestion in https://github.com/cms-sw/cmssw/pull/27713#discussion_r315266650

#### PR validation:

Tested runTheMatrix.py with both known and unknown WF numbers, saw expected behavior.
