### PR TITLE
Fix friendly class name for nested types of class templates

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -183,7 +183,15 @@ namespace edm {
         } else if (result[i] == '>') {
           --openTemplate;
         }
-        if ((result[i] == ',') and openTemplate == 0) {
+        // If we are not within the template arguments of a class template
+        // - encountering comma means that we are within a template
+        //   argument of some other class template, and we've reached
+        //   a point when we should translate the argument class name
+        // - encountering colon, but only if the class name so far
+        //   itself was a template, we've reached a point when we
+        //   should translate the class name
+        if (const bool hasComma = result[i] == ',', hasColon = hadTemplate and result[i] == ':';
+            openTemplate == 0 and (hasComma or hasColon)) {
           std::string templateClass = result.substr(begin, i - begin);
           if constexpr (debug) {
             std::cout << prefix << " templateClass " << templateClass << std::endl;
@@ -208,6 +216,11 @@ namespace edm {
           // reset counters
           hadTemplate = false;
           begin = i + 1;
+          // With colon we need to eat the second colon as well
+          if (hasColon) {
+            assert(result[begin] == ':');
+            ++begin;
+          }
         }
       }
 

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -164,6 +164,11 @@ void testfriendlyName::test() {
              "unsigned int> >::Find>",
              "recoBasicClustersToOnerecoClusterShapesAssociationRefs"));
   classToFriendly.insert(
+      Values("edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiPixelCluster>,SiPixelCluster,edmNew::DetSetVector<"
+             "SiPixelCluster>::FindForDetSetVector> >",
+             "SiPixelClusteredmNewDetSetVectorSiPixelClusterSiPixelClusteredmNewDetSetVectorFindForDetSetVectoredmRefed"
+             "mNewDetSetVector"));
+  classToFriendly.insert(
       Values("std::vector<std::pair<const pat::Muon *, TLorentzVector>>", "constpatMuonptrTLorentzVectorstdpairs"));
   classToFriendly.insert(Values("int[]", "intAs"));
   classToFriendly.insert(Values("foo<int[]>", "intAsfoo"));


### PR DESCRIPTION
#### PR description:

The previous update in the logic (#27861) missed the case that for `Class<T>::Nested` the parsing in `handleTemplateArguments()` should stop at the first colon and pass `Class<T>` to `subFriendlyName()` (because `reTemplateArgs` expects the name to end with `>`).

Rather than messing with `reTemplateArgs`, the problem is fixed by recognizing the colon after a class template as a break point in the parsing, and remove the second colon as well.

#### PR validation:

Unit tests runs, previously failing workflow 4.23 runs.