### PR TITLE
More verbose error if plugin could not be loaded due to missing shared library

### DIFF
--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -5,7 +5,6 @@
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 int main(int argc, char** argv) {

--- a/CondCore/CondDB/test/testConditionDatabase_0.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_0.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //

--- a/CondCore/CondDB/test/testConditionDatabase_1.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_1.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //

--- a/CondCore/CondDB/test/testConditionDatabase_2.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_2.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //

--- a/CondCore/CondDB/test/testConnectionPool.cpp
+++ b/CondCore/CondDB/test/testConnectionPool.cpp
@@ -1,7 +1,6 @@
 //Framework includes
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //Module includes

--- a/CondCore/CondDB/test/testFrontier.cpp
+++ b/CondCore/CondDB/test/testFrontier.cpp
@@ -1,6 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //

--- a/CondCore/CondDB/test/testGroupSelection.cpp
+++ b/CondCore/CondDB/test/testGroupSelection.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //

--- a/CondCore/CondDB/test/testPayloadProxy.cpp
+++ b/CondCore/CondDB/test/testPayloadProxy.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "CondCore/CondDB/interface/PayloadProxy.h"

--- a/CondCore/CondDB/test/testReadWritePayloads.cpp
+++ b/CondCore/CondDB/test/testReadWritePayloads.cpp
@@ -1,9 +1,6 @@
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //

--- a/CondCore/CondDB/test/testRunInfo.cpp
+++ b/CondCore/CondDB/test/testRunInfo.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 //

--- a/CondCore/CondDB/test/testTempWrapper_0.cpp
+++ b/CondCore/CondDB/test/testTempWrapper_0.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/CondDB.h"
 //

--- a/CondCore/CondDB/test/testTempWrapper_0.cpp
+++ b/CondCore/CondDB/test/testTempWrapper_0.cpp
@@ -10,84 +10,89 @@
 
 using namespace cond::db;
 
-int main (int argc, char** argv)
-{
+int main(int argc, char** argv) {
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
 
   std::string connectionString0("oracle://cms_orcon_adg/CMS_COND_31X_RUN_INFO");
   std::string connectionString1("oracle://cms_orcoff_prep/CMS_CONDITIONS");
   std::string gtConnectionStr("oracle://cms_orcon_adg/CMS_COND_31X_GLOBALTAG");
-  try{
-
+  try {
     Session session;
     //session.configuration().setMessageVerbosity( coral::Debug );
     size_t i = 0;
     IOVProxy reader;
-    std::cout <<"# Connecting with db in "<<connectionString0<<std::endl;
-    session.open( connectionString0, true );
-    session.transaction().start( true );
-    std::string tag0(  "runinfo_31X_hlt" );  
-    reader = session.readIov( tag0, true );
-    std::cout <<"Tag "<<reader.tag()<<" timeType:"<<cond::time::timeTypeName(reader.timeType())<<" size:"<<reader.size()<<
-      " type:"<<reader.payloadObjectType()<<" endOfValidity:"<<reader.endOfValidity()<<" lastValidatedTime:"<<reader.lastValidatedTime()<<std::endl;
+    std::cout << "# Connecting with db in " << connectionString0 << std::endl;
+    session.open(connectionString0, true);
+    session.transaction().start(true);
+    std::string tag0("runinfo_31X_hlt");
+    reader = session.readIov(tag0, true);
+    std::cout << "Tag " << reader.tag() << " timeType:" << cond::time::timeTypeName(reader.timeType())
+              << " size:" << reader.size() << " type:" << reader.payloadObjectType()
+              << " endOfValidity:" << reader.endOfValidity() << " lastValidatedTime:" << reader.lastValidatedTime()
+              << std::endl;
 
-    for( auto iov: reader ){
+    for (auto iov : reader) {
       i++;
-      std::cout <<"#Since "<<iov.since<<" Till "<<iov.till<<" PID "<<iov.payloadId<<std::endl;
-      if( i == 20 ) break;
+      std::cout << "#Since " << iov.since << " Till " << iov.till << " PID " << iov.payloadId << std::endl;
+      if (i == 20)
+        break;
     }
     session.transaction().commit();
     session.close();
 
-    std::cout <<"# Connecting with db in "<<connectionString1<<std::endl;
-    session.open( connectionString1, true );
-    session.transaction().start( true );    
-    reader = session.readIov( tag0, true );
+    std::cout << "# Connecting with db in " << connectionString1 << std::endl;
+    session.open(connectionString1, true);
+    session.transaction().start(true);
+    reader = session.readIov(tag0, true);
     i = 0;
-    std::cout <<"Tag "<<reader.tag()<<" timeType:"<<cond::time::timeTypeName(reader.timeType())<<" size:"<<reader.size()<<
-      " type:"<<reader.payloadObjectType()<<" endOfValidity:"<<reader.endOfValidity()<<" lastValidatedTime:"<<reader.lastValidatedTime()<<std::endl;
+    std::cout << "Tag " << reader.tag() << " timeType:" << cond::time::timeTypeName(reader.timeType())
+              << " size:" << reader.size() << " type:" << reader.payloadObjectType()
+              << " endOfValidity:" << reader.endOfValidity() << " lastValidatedTime:" << reader.lastValidatedTime()
+              << std::endl;
 
-    for( auto iov: reader ){
+    for (auto iov : reader) {
       i++;
-      std::cout <<"#Since "<<iov.since<<" Till "<<iov.till<<" PID "<<iov.payloadId<<std::endl;
-      if( i == 20 ) break;
+      std::cout << "#Since " << iov.since << " Till " << iov.till << " PID " << iov.payloadId << std::endl;
+      if (i == 20)
+        break;
     }
     session.transaction().commit();
     session.close();
 
-    std::cout <<"# Connecting with db in "<<gtConnectionStr<<std::endl;
-    session.open( gtConnectionStr, true );
-    session.transaction().start( true );
-    GTProxy gtReader = session.readGlobalTag( "FT_R_53_V6" );
+    std::cout << "# Connecting with db in " << gtConnectionStr << std::endl;
+    session.open(gtConnectionStr, true);
+    session.transaction().start(true);
+    GTProxy gtReader = session.readGlobalTag("FT_R_53_V6");
     i = 0;
-    for( auto t: gtReader ){
+    for (auto t : gtReader) {
       i++;
-      std::cout <<"#Tag "<<t.tagName()<<" Record "<<t.recordName()<<" Label "<<t.recordLabel()<<std::endl;
-      if( i==20 ) break;
+      std::cout << "#Tag " << t.tagName() << " Record " << t.recordName() << " Label " << t.recordLabel() << std::endl;
+      if (i == 20)
+        break;
     }
     session.transaction().commit();
     session.close();
 
-    std::cout <<"# Connecting with db in "<<connectionString1<<std::endl;
-    session.open( connectionString1, true );
-    session.transaction().start( true );
-    gtReader = session.readGlobalTag( "FT_R_53_V6" );
+    std::cout << "# Connecting with db in " << connectionString1 << std::endl;
+    session.open(connectionString1, true);
+    session.transaction().start(true);
+    gtReader = session.readGlobalTag("FT_R_53_V6");
     i = 0;
-    for( auto t: gtReader ){
+    for (auto t : gtReader) {
       i++;
-      std::cout <<"#Tag "<<t.tagName()<<" Record "<<t.recordName()<<" Label "<<t.recordLabel()<<std::endl;
-      if( i==20 ) break;
+      std::cout << "#Tag " << t.tagName() << " Record " << t.recordName() << " Label " << t.recordLabel() << std::endl;
+      if (i == 20)
+        break;
     }
     session.transaction().commit();
     session.close();
-    
-  } catch (const std::exception& e){
+
+  } catch (const std::exception& e) {
     std::cout << "ERROR: " << e.what() << std::endl;
     return -1;
-  } catch (...){
+  } catch (...) {
     std::cout << "UNEXPECTED FAILURE." << std::endl;
     return -1;
   }
 }
-

--- a/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.cpp
+++ b/CondCore/RunInfoPlugins/test/testRunInfoPayloadInspector.cpp
@@ -5,7 +5,6 @@
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 int main(int argc, char** argv) {

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -10,7 +10,6 @@
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 int main(int argc, char** argv) {

--- a/CondCore/Utilities/src/Utilities.cc
+++ b/CondCore/Utilities/src/Utilities.cc
@@ -5,10 +5,6 @@
 
 //local includes
 #include "CondCore/Utilities/interface/Utilities.h"
-#include "FWCore/PluginManager/interface/PluginManager.h"
-#include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include <boost/foreach.hpp>
 #include <fstream>
 #include <iostream>
 

--- a/CondCore/Utilities/test/testBasicPayload.cpp
+++ b/CondCore/Utilities/test/testBasicPayload.cpp
@@ -1,8 +1,5 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 //
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "CondFormats/Common/interface/BasicPayload.h"

--- a/CondCore/Utilities/test/testPngHistograms.cpp
+++ b/CondCore/Utilities/test/testPngHistograms.cpp
@@ -5,7 +5,6 @@
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 int main(int argc, char** argv) {

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -245,7 +245,12 @@ namespace edmplugin {
           //TEMPORARY: to avoid possible deadlocks from ROOT, we must
           // take the lock ourselves
           R__LOCKGUARD2(gInterpreterMutex);
-          ptr.reset(new SharedLibrary(p));
+          try {
+            ptr = std::make_shared<SharedLibrary>(p);
+          } catch (cms::Exception const& e) {
+            throw cms::Exception("PluginLoadError")
+                << "could not load plugin " << iPlugin << " because " << e.message();
+          }
         }
         loadables_[p] = ptr;
         justLoaded_(*ptr);
@@ -281,7 +286,12 @@ namespace edmplugin {
           //TEMPORARY: to avoid possible deadlocks from ROOT, we must
           // take the lock ourselves
           R__LOCKGUARD(gInterpreterMutex);
-          ptr.reset(new SharedLibrary(p));
+          try {
+            ptr = std::make_shared<SharedLibrary>(p);
+          } catch (cms::Exception const& e) {
+            throw cms::Exception("PluginLoadError")
+                << "could not load plugin " << iPlugin << " because " << e.message();
+          }
         }
         loadables_[p] = ptr;
         justLoaded_(*ptr);

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -247,9 +247,9 @@ namespace edmplugin {
           R__LOCKGUARD2(gInterpreterMutex);
           try {
             ptr = std::make_shared<SharedLibrary>(p);
-          } catch (cms::Exception const& e) {
-            throw cms::Exception("PluginLoadError")
-                << "could not load plugin " << iPlugin << " because " << e.message();
+          } catch (cms::Exception& e) {
+            e.addContext("While attempting to load plugin " + iPlugin);
+            throw;
           }
         }
         loadables_[p] = ptr;
@@ -288,9 +288,9 @@ namespace edmplugin {
           R__LOCKGUARD(gInterpreterMutex);
           try {
             ptr = std::make_shared<SharedLibrary>(p);
-          } catch (cms::Exception const& e) {
-            throw cms::Exception("PluginLoadError")
-                << "could not load plugin " << iPlugin << " because " << e.message();
+          } catch (cms::Exception& e) {
+            e.addContext("While attempting to load plugin " + iPlugin);
+            throw;
           }
         }
         loadables_[p] = ptr;


### PR DESCRIPTION
#### PR description:

The error message that you get if you delete plugin that is in the realease in your work area, and then try to use that plugin, is not very informative. The way this is handled is by referring to "poisoned" libraries in the work area, which actually don't exist. So you get some error like this:

```
----- Begin Fatal Exception 04-Sep-2019 13:39:04 CEST-----------------------
An exception of category 'PluginLibraryLoadError' occurred while
   [0] Constructing the EventProcessor
Exception Message:
unable to load /scratch/rembser/cmssw/dev/CMSSW_11_0_X_2019-09-02-2300/lib/slc7_amd64_gcc700/poisoned/plugin-poisoned-RecoEgammaElectronIdentificationPlugins.so because /scratch/rembser/cmssw/dev/CMSSW_11_0_X_2019-09-02-2300/lib/slc7_amd64_gcc700/poisoned/plugin-poisoned-RecoEgammaElectronIdentificationPlugins.so: cannot open shared object file: No such file or directory
----- End Fatal Exception -------------------------------------------------
```

However, it would be great (in particular to catch mistakes in cleanup PRs) if the message told you the name of the plugin it tried to load in the first place. I propose to add this information as a context to the exception (thanks @Dr15Jones for the implementation idea). The error message would look like this then:

```
----- Begin Fatal Exception 04-Sep-2019 13:39:04 CEST-----------------------
An exception of category 'PluginLibraryLoadError' occurred while
   [0] Constructing the EventProcessor
   [1] While attempting to load plugin ElectronMVANtuplizer
Exception Message:
unable to load /scratch/rembser/cmssw/dev/CMSSW_11_0_X_2019-09-02-2300/lib/slc7_amd64_gcc700/poisoned/plugin-poisoned-RecoEgammaElectronIdentificationPlugins.so because /scratch/rembser/cmssw/dev/CMSSW_11_0_X_2019-09-02-2300/lib/slc7_amd64_gcc700/poisoned/plugin-poisoned-RecoEgammaElectronIdentificationPlugins.so: cannot open shared object file: No such file or directory
----- End Fatal Exception -------------------------------------------------
```

We talked a bit about this already a little bit in PR https://github.com/cms-sw/cmssw/pull/27522 (in particular https://github.com/cms-sw/cmssw/pull/27522#issuecomment-516534785).

While investigating how to do that I "git grepped" for "SharedLibrary" and therefore found by chance many places where `SharedLibrary.h` is included but not used. We could also remove these as a little side effect of this PR.

#### PR validation:

CMSSW compiles, local matrix tests pass.

#### if this PR is a backport please specify the original PR:

No backport intended.
