### PR TITLE
FixLumisPerJobSplittingFor2018

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -225,6 +225,8 @@ class MatrixInjector(object):
             wmsplit['RECODR2_2018reHLT_skimCharmonium_Prompt']=1
             wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_HEfail']=1
             wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_BadHcalMitig']=1
+            wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Prompt']=1
+            wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Prompt']=1
             wmsplit['RECODR2_2018reHLT_Offline']=1
             wmsplit['RECODR2_2018reHLT_skimSingleMu_Offline_Lumi']=1
             wmsplit['RECODR2_2018reHLT_skimDoubleEG_Offline']=1
@@ -236,6 +238,8 @@ class MatrixInjector(object):
             wmsplit['RECODR2_2018reHLT_skimCharmonium_Offline']=1
             wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_HEfail']=1
             wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_BadHcalMitig']=1
+            wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Offline']=1
             wmsplit['HLTDR2_50ns']=1
             wmsplit['HLTDR2_25ns']=1
             wmsplit['HLTDR2_2016']=1

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -225,6 +225,17 @@ class MatrixInjector(object):
             wmsplit['RECODR2_2018reHLT_skimCharmonium_Prompt']=1
             wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_HEfail']=1
             wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_BadHcalMitig']=1
+            wmsplit['RECODR2_2018reHLT_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimSingleMu_Offline_Lumi']=1
+            wmsplit['RECODR2_2018reHLT_skimDoubleEG_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimMET_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimMuOnia_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM']=1
+            wmsplit['RECODR2_2018reHLT_skimMuonEG_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimCharmonium_Offline']=1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_HEfail']=1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_BadHcalMitig']=1
             wmsplit['HLTDR2_50ns']=1
             wmsplit['HLTDR2_25ns']=1
             wmsplit['HLTDR2_2016']=1

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -227,6 +227,7 @@ class MatrixInjector(object):
             wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_BadHcalMitig']=1
             wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Prompt']=1
             wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Prompt']=1
+            wmsplit['RECODR2_2018reHLT_ZBPrompt']=1
             wmsplit['RECODR2_2018reHLT_Offline']=1
             wmsplit['RECODR2_2018reHLT_skimSingleMu_Offline_Lumi']=1
             wmsplit['RECODR2_2018reHLT_skimDoubleEG_Offline']=1
@@ -240,6 +241,7 @@ class MatrixInjector(object):
             wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_BadHcalMitig']=1
             wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Offline']=1
             wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Offline']=1
+            wmsplit['RECODR2_2018reHLT_ZBOffline']=1
             wmsplit['HLTDR2_50ns']=1
             wmsplit['HLTDR2_25ns']=1
             wmsplit['HLTDR2_2016']=1


### PR DESCRIPTION
#### PR description:
Fix LumisPerJobSplitting For 2018 which changed from Prompt to Offline in
https://github.com/cms-sw/cmssw/pull/26417/files

#### PR validation:
https://cmsweb.cern.ch/reqmgr2/fetch?rid=request-srimanob_RVCMSSW_11_0_0_pre5RunEGamma2018C__PHATTEST_RelVal_2018C_190831_214637_5994

#### if this PR is a backport please specify the original PR:
-

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
