### PR TITLE
Fix simulation of the pixel bad components on the FED channel basis for PreMixing

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -280,6 +280,10 @@ void PreMixingSiPixelWorker::put(edm::Event& e,
   iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
   const TrackerTopology* tTopo = tTopoHand.product();
 
+  digitizer_.chooseScenario(ps,engine);
+
+  std::cout << "5: " << (digitizer_.GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
+
   for (const auto& iu : pDD->detUnits()) {
     if (iu->type().isTrackerPixel()) {
       edm::DetSet<PixelDigi> collector(iu->geographicalId().rawId());

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -94,6 +94,7 @@ PreMixingSiPixelWorker::PreMixingSiPixelWorker(const edm::ParameterSet& ps,
   PixelDigiPToken_ = iC.consumes<edm::DetSetVector<PixelDigi>>(pixeldigi_collectionPile_);
 
   producer.produces<edm::DetSetVector<PixelDigi>>(PixelDigiCollectionDM_);
+  producer.produces<PixelFEDChannelCollection>();
 
   // clear local storage for this event
   SiHitStorage_.clear();
@@ -280,7 +281,13 @@ void PreMixingSiPixelWorker::put(edm::Event& e,
   iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
   const TrackerTopology* tTopo = tTopoHand.product();
 
-  digitizer_.chooseScenario(ps,engine);
+  if(digitizer_.killBadFEDChannels()){
+    std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = digitizer_.chooseScenario(ps,engine);
+    if (PixelFEDChannelCollection_ == nullptr) {
+      throw cms::Exception("NullPointerError") << "PixelFEDChannelCollection not set in chooseScenario function.\n";
+    }
+    e.put(std::move(PixelFEDChannelCollection_));
+  }
 
   std::cout << "5: " << (digitizer_.GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
 

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -281,8 +281,8 @@ void PreMixingSiPixelWorker::put(edm::Event& e,
   iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
   const TrackerTopology* tTopo = tTopoHand.product();
 
-  if(digitizer_.killBadFEDChannels()){
-    std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = digitizer_.chooseScenario(ps,engine);
+  if (digitizer_.killBadFEDChannels()) {
+    std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = digitizer_.chooseScenario(ps, engine);
     if (PixelFEDChannelCollection_ == nullptr) {
       throw cms::Exception("NullPointerError") << "PixelFEDChannelCollection not set in chooseScenario function.\n";
     }

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -94,7 +94,7 @@ PreMixingSiPixelWorker::PreMixingSiPixelWorker(const edm::ParameterSet& ps,
   PixelDigiPToken_ = iC.consumes<edm::DetSetVector<PixelDigi>>(pixeldigi_collectionPile_);
 
   producer.produces<edm::DetSetVector<PixelDigi>>(PixelDigiCollectionDM_);
-  producer.produces<PixelFEDChannelCollection>();
+  producer.produces<PixelFEDChannelCollection>(PixelDigiCollectionDM_);
 
   // clear local storage for this event
   SiHitStorage_.clear();
@@ -286,10 +286,8 @@ void PreMixingSiPixelWorker::put(edm::Event& e,
     if (PixelFEDChannelCollection_ == nullptr) {
       throw cms::Exception("NullPointerError") << "PixelFEDChannelCollection not set in chooseScenario function.\n";
     }
-    e.put(std::move(PixelFEDChannelCollection_));
+    e.put(std::move(PixelFEDChannelCollection_), PixelDigiCollectionDM_);
   }
-
-  std::cout << "5: " << (digitizer_.GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
 
   for (const auto& iu : pDD->detUnits()) {
     if (iu->type().isTrackerPixel()) {

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -268,6 +268,9 @@ namespace cms {
     if (_pixeldigialgo->killBadFEDChannels()) {
       std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ =
           _pixeldigialgo->chooseScenario(PileupInfo_.get(), randomEngine_);
+
+      std::cout << __FILE__ << " " <<  __LINE__ << ": PixelFEDChannelCollection_: " << PixelFEDChannelCollection_.get() << std::endl;
+
       if (PixelFEDChannelCollection_ == nullptr) {
         throw cms::Exception("NullPointerError") << "PixelFEDChannelCollection not set in chooseScenario function.\n";
       }
@@ -281,8 +284,14 @@ namespace cms {
         edm::DetSet<PixelDigi> collector(iu->geographicalId().rawId());
         edm::DetSet<PixelDigiSimLink> linkcollector(iu->geographicalId().rawId());
 
+	std::cout << "3: " << (_pixeldigialgo->GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
+	
         _pixeldigialgo->digitize(
             dynamic_cast<const PixelGeomDetUnit*>(iu), collector.data, linkcollector.data, tTopo, randomEngine_);
+
+	std::cout << "4: " << (_pixeldigialgo->GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
+
+
         if (!collector.data.empty()) {
           theDigiVector.push_back(std::move(collector));
         }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -268,9 +268,6 @@ namespace cms {
     if (_pixeldigialgo->killBadFEDChannels()) {
       std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ =
           _pixeldigialgo->chooseScenario(PileupInfo_.get(), randomEngine_);
-
-      std::cout << __FILE__ << " " <<  __LINE__ << ": PixelFEDChannelCollection_: " << PixelFEDChannelCollection_.get() << std::endl;
-
       if (PixelFEDChannelCollection_ == nullptr) {
         throw cms::Exception("NullPointerError") << "PixelFEDChannelCollection not set in chooseScenario function.\n";
       }
@@ -284,14 +281,8 @@ namespace cms {
         edm::DetSet<PixelDigi> collector(iu->geographicalId().rawId());
         edm::DetSet<PixelDigiSimLink> linkcollector(iu->geographicalId().rawId());
 
-	std::cout << "3: " << (_pixeldigialgo->GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
-	
         _pixeldigialgo->digitize(
             dynamic_cast<const PixelGeomDetUnit*>(iu), collector.data, linkcollector.data, tTopo, randomEngine_);
-
-	std::cout << "4: " << (_pixeldigialgo->GetPixelFEDChannelCollection_ptr() != nullptr) << std::endl;
-
-
         if (!collector.data.empty()) {
           theDigiVector.push_back(std::move(collector));
         }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1779,9 +1779,6 @@ void SiPixelDigitizerAlgorithm::pixel_inefficiency(const PixelEfficiencies& eff,
   auto pIndexConverter = PixelIndices(numColumns, numRows);
 
   std::vector<int> badRocsFromFEDChannels(16, 0);
-
-  std::cout<< __FILE__ << " " << __LINE__ <<": " << eff.PixelFEDChannelCollection_.get() << std::endl;
-
   if (eff.PixelFEDChannelCollection_ != nullptr) {
     PixelFEDChannelCollection::const_iterator it = eff.PixelFEDChannelCollection_->find(detID);
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -895,6 +895,55 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(const std::vector<Pileup
 
 bool SiPixelDigitizerAlgorithm::killBadFEDChannels() const { return KillBadFEDChannels; }
 
+
+std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(const std::vector<PileupSummaryInfo>& ps ,CLHEP::HepRandomEngine* engine) 
+{
+  std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = nullptr;
+  pixelEfficiencies_.PixelFEDChannelCollection_ = nullptr;
+
+  std::vector<int> bunchCrossing;
+  std::vector<float> TrueInteractionList;
+
+  for (unsigned int i = 0; i < ps.size(); i++){
+    bunchCrossing.push_back(ps[i].getBunchCrossing());
+    TrueInteractionList.push_back(ps[i].getTrueNumInteractions());
+  }
+
+  int pui = 0, p = 0;
+  std::vector<int>::const_iterator pu;
+  std::vector<int>::const_iterator pu0 = bunchCrossing.end();
+
+  for (pu = bunchCrossing.begin(); pu != bunchCrossing.end(); ++pu) {
+    if (*pu == 0) {
+      pu0 = pu;
+      p = pui;
+    }
+    pui++;
+  }
+  
+  if (pu0 != bunchCrossing.end()) {
+    unsigned int PUBin = TrueInteractionList.at(p);  // case delta PU=1, fix me
+    const auto& theProbabilitiesPerScenario = scenarioProbabilityHandle->getProbabilities(PUBin);
+    std::vector<double> probabilities;
+    probabilities.reserve(theProbabilitiesPerScenario.size());
+    for (auto it = theProbabilitiesPerScenario.begin(); it != theProbabilitiesPerScenario.end(); it++) {
+      probabilities.push_back(it->second);
+    }
+
+    CLHEP::RandGeneral randGeneral(*engine, &(probabilities.front()), probabilities.size());
+    double x = randGeneral.shoot();
+    unsigned int index = x * probabilities.size() - 1;
+    const std::string& scenario = theProbabilitiesPerScenario.at(index).first;
+
+    PixelFEDChannelCollection_ = std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
+    pixelEfficiencies_.PixelFEDChannelCollection_ =
+      std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
+  }
+
+  return PixelFEDChannelCollection_;
+}
+
+
 std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(PileupMixingContent* puInfo,
                                                                                      CLHEP::HepRandomEngine* engine) {
   //Determine scenario to use for the current event based on pileup information
@@ -1730,6 +1779,9 @@ void SiPixelDigitizerAlgorithm::pixel_inefficiency(const PixelEfficiencies& eff,
   auto pIndexConverter = PixelIndices(numColumns, numRows);
 
   std::vector<int> badRocsFromFEDChannels(16, 0);
+
+  std::cout<< __FILE__ << " " << __LINE__ <<": " << eff.PixelFEDChannelCollection_.get() << std::endl;
+
   if (eff.PixelFEDChannelCollection_ != nullptr) {
     PixelFEDChannelCollection::const_iterator it = eff.PixelFEDChannelCollection_->find(detID);
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -895,16 +895,15 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(const std::vector<Pileup
 
 bool SiPixelDigitizerAlgorithm::killBadFEDChannels() const { return KillBadFEDChannels; }
 
-
-std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(const std::vector<PileupSummaryInfo>& ps ,CLHEP::HepRandomEngine* engine) 
-{
+std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(
+    const std::vector<PileupSummaryInfo>& ps, CLHEP::HepRandomEngine* engine) {
   std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = nullptr;
   pixelEfficiencies_.PixelFEDChannelCollection_ = nullptr;
 
   std::vector<int> bunchCrossing;
   std::vector<float> TrueInteractionList;
 
-  for (unsigned int i = 0; i < ps.size(); i++){
+  for (unsigned int i = 0; i < ps.size(); i++) {
     bunchCrossing.push_back(ps[i].getBunchCrossing());
     TrueInteractionList.push_back(ps[i].getTrueNumInteractions());
   }
@@ -920,7 +919,7 @@ std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScen
     }
     pui++;
   }
-  
+
   if (pu0 != bunchCrossing.end()) {
     unsigned int PUBin = TrueInteractionList.at(p);  // case delta PU=1, fix me
     const auto& theProbabilitiesPerScenario = scenarioProbabilityHandle->getProbabilities(PUBin);
@@ -937,12 +936,11 @@ std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScen
 
     PixelFEDChannelCollection_ = std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
     pixelEfficiencies_.PixelFEDChannelCollection_ =
-      std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
+        std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
   }
 
   return PixelFEDChannelCollection_;
 }
-
 
 std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(PileupMixingContent* puInfo,
                                                                                      CLHEP::HepRandomEngine* engine) {

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -77,16 +77,23 @@ public:
                 CLHEP::HepRandomEngine*);
   void calculateInstlumiFactor(PileupMixingContent* puInfo);
   void init_DynIneffDB(const edm::EventSetup&, const unsigned int&);
+  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine*);
+  
 
   // for premixing
   void calculateInstlumiFactor(const std::vector<PileupSummaryInfo>& ps,
                                int bunchSpacing);  // TODO: try to remove the duplication of logic...
   void setSimAccumulator(const std::map<uint32_t, std::map<int, int> >& signalMap);
+  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(const std::vector<PileupSummaryInfo>& ps ,CLHEP::HepRandomEngine* engine);
 
-  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine*);
   bool killBadFEDChannels() const;
   typedef std::unordered_map<std::string, PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
   const PixelFEDChannelCollectionMap* quality_map;
+
+  PixelFEDChannelCollection* GetPixelFEDChannelCollection_ptr(){
+    return pixelEfficiencies_.PixelFEDChannelCollection_.get();
+  }
+
 
 private:
   //Accessing Lorentz angle from DB:

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -78,12 +78,13 @@ public:
   void calculateInstlumiFactor(PileupMixingContent* puInfo);
   void init_DynIneffDB(const edm::EventSetup&, const unsigned int&);
   std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine*);
-  
+
   // for premixing
   void calculateInstlumiFactor(const std::vector<PileupSummaryInfo>& ps,
                                int bunchSpacing);  // TODO: try to remove the duplication of logic...
   void setSimAccumulator(const std::map<uint32_t, std::map<int, int> >& signalMap);
-  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(const std::vector<PileupSummaryInfo>& ps ,CLHEP::HepRandomEngine* engine);
+  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(const std::vector<PileupSummaryInfo>& ps,
+                                                            CLHEP::HepRandomEngine* engine);
 
   bool killBadFEDChannels() const;
   typedef std::unordered_map<std::string, PixelFEDChannelCollection> PixelFEDChannelCollectionMap;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -79,7 +79,6 @@ public:
   void init_DynIneffDB(const edm::EventSetup&, const unsigned int&);
   std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine*);
   
-
   // for premixing
   void calculateInstlumiFactor(const std::vector<PileupSummaryInfo>& ps,
                                int bunchSpacing);  // TODO: try to remove the duplication of logic...
@@ -89,11 +88,6 @@ public:
   bool killBadFEDChannels() const;
   typedef std::unordered_map<std::string, PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
   const PixelFEDChannelCollectionMap* quality_map;
-
-  PixelFEDChannelCollection* GetPixelFEDChannelCollection_ptr(){
-    return pixelEfficiencies_.PixelFEDChannelCollection_.get();
-  }
-
 
 private:
   //Accessing Lorentz angle from DB:


### PR DESCRIPTION
#### PR description:

During the CMSSW_11_0_0_pre5 validation it was noticed that the per-FED channel Pixel bad components handling (a.k.a. "stuck-TBM" simulation) introduced in PR https://github.com/cms-sw/cmssw/pull/25466,  was not working in the premixing case (cf. [valDB report](https://hypernews.cern.ch/HyperNews/CMS/get/relval/13837/3/1.html) ).
This PR fixes the premixing case.  

#### PR validation:
PR validation has been carried out by @tsusa by comparing the pixel valid hit occupancy maps in the baseline CMSSW_11_0_X branch for premixing with and without this PR and compared with classical mixing (tested earlier to work correctly).
I report here one example for BPix Layer 1:

![image](https://user-images.githubusercontent.com/5082376/64092106-a5412380-cd53-11e9-9d97-cb9305dc3868.png)

more information is contained in this [presentation](https://cernbox.cern.ch/index.php/s/V8XrBlPMsMbk8iv).

#### if this PR is a backport please specify the original PR:

This PR is not a backport.
cc:
@tsusa @veszpv @tvami 
