### PR TITLE
[10.6.X] Fix simulation of the pixel bad components on the FED channel basis for PreMixing

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -826,8 +826,55 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(const std::vector<Pileup
 
 bool SiPixelDigitizerAlgorithm::killBadFEDChannels() const {return KillBadFEDChannels;}
 
-std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine *engine){
-  
+std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(
+    const std::vector<PileupSummaryInfo>& ps, CLHEP::HepRandomEngine* engine) {
+  std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = nullptr;
+  pixelEfficiencies_.PixelFEDChannelCollection_ = nullptr;
+
+  std::vector<int> bunchCrossing;
+  std::vector<float> TrueInteractionList;
+
+  for (unsigned int i = 0; i < ps.size(); i++) {
+    bunchCrossing.push_back(ps[i].getBunchCrossing());
+    TrueInteractionList.push_back(ps[i].getTrueNumInteractions());
+  }
+
+  int pui = 0, p = 0;
+  std::vector<int>::const_iterator pu;
+  std::vector<int>::const_iterator pu0 = bunchCrossing.end();
+
+  for (pu = bunchCrossing.begin(); pu != bunchCrossing.end(); ++pu) {
+    if (*pu == 0) {
+      pu0 = pu;
+      p = pui;
+    }
+    pui++;
+  }
+
+  if (pu0 != bunchCrossing.end()) {
+    unsigned int PUBin = TrueInteractionList.at(p);  // case delta PU=1, fix me
+    const auto& theProbabilitiesPerScenario = scenarioProbabilityHandle->getProbabilities(PUBin);
+    std::vector<double> probabilities;
+    probabilities.reserve(theProbabilitiesPerScenario.size());
+    for (auto it = theProbabilitiesPerScenario.begin(); it != theProbabilitiesPerScenario.end(); it++) {
+      probabilities.push_back(it->second);
+    }
+
+    CLHEP::RandGeneral randGeneral(*engine, &(probabilities.front()), probabilities.size());
+    double x = randGeneral.shoot();
+    unsigned int index = x * probabilities.size() - 1;
+    const std::string& scenario = theProbabilitiesPerScenario.at(index).first;
+
+    PixelFEDChannelCollection_ = std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
+    pixelEfficiencies_.PixelFEDChannelCollection_ =
+        std::make_unique<PixelFEDChannelCollection>(quality_map->at(scenario));
+  }
+
+  return PixelFEDChannelCollection_;
+}
+
+std::unique_ptr<PixelFEDChannelCollection> SiPixelDigitizerAlgorithm::chooseScenario(PileupMixingContent* puInfo,
+                                                                                     CLHEP::HepRandomEngine* engine) {
   //Determine scenario to use for the current event based on pileup information
 
   std::unique_ptr<PixelFEDChannelCollection> PixelFEDChannelCollection_ = nullptr;      

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h
@@ -80,12 +80,15 @@ class SiPixelDigitizerAlgorithm  {
                 CLHEP::HepRandomEngine*);
   void calculateInstlumiFactor(PileupMixingContent* puInfo);
   void init_DynIneffDB(const edm::EventSetup&, const unsigned int&);
+  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine*);
 
   // for premixing
   void calculateInstlumiFactor(const std::vector<PileupSummaryInfo> &ps, int bunchSpacing); // TODO: try to remove the duplication of logic...
   void setSimAccumulator(const std::map<uint32_t, std::map<int, int> >& signalMap);
-  
-  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(PileupMixingContent* puInfo, CLHEP::HepRandomEngine *);
+
+  std::unique_ptr<PixelFEDChannelCollection> chooseScenario(const std::vector<PileupSummaryInfo>& ps,
+                                                            CLHEP::HepRandomEngine* engine);
+
   bool killBadFEDChannels() const;
   typedef std::unordered_map<std::string,PixelFEDChannelCollection> PixelFEDChannelCollectionMap;
   const PixelFEDChannelCollectionMap* quality_map;


### PR DESCRIPTION
backport of #27912

#### PR description:

During the CMSSW_11_0_0_pre5 validation it was noticed that the per-FED channel Pixel bad components handling (a.k.a. "stuck-TBM" simulation) introduced in PR https://github.com/cms-sw/cmssw/pull/25466,  was not working in the premixing case (cf. [valDB report](https://hypernews.cern.ch/HyperNews/CMS/get/relval/13837/3/1.html) ).
This PR fixes the premixing case.  

#### PR validation:
PR validation has been carried out by @tsusa by comparing the pixel valid hit occupancy maps in the baseline CMSSW_11_0_X branch for premixing with and without this PR and compared with classical mixing (tested earlier to work correctly).
I report here one example for BPix Layer 1:

![image](https://user-images.githubusercontent.com/5082376/64092106-a5412380-cd53-11e9-9d97-cb9305dc3868.png)

more information is contained in this [presentation](https://cernbox.cern.ch/index.php/s/V8XrBlPMsMbk8iv).

#### if this PR is a backport please specify the original PR:

backport of #27912

cc:
@tsusa @veszpv @tvami 
