### PR TITLE
Add energy regression and particle identification to RecoHGCal/TICL (reopened)

### DIFF
--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -28,6 +28,30 @@ namespace ticl {
 
     edm::ProductID seedID;
     int seedIndex;
+
+    // regressed energy
+    float regressed_energy;
+
+    // types considered by the particle identification
+    enum ParticleType {
+      photon = 0,
+      electron,
+      muon,
+      neutral_pion,
+      charged_hadron,
+      neutral_hadron,
+      ambiguous,
+      unknown,
+    };
+
+    // trackster ID probabilities
+    std::array<float, 8> id_probabilities;
+
+    // convenience method to return the ID probability for a certain particle type
+    inline float id_probability(ParticleType type) {
+      // probabilities are stored in the same order as defined in the ParticleType enum
+      return id_probabilities[(int)type];
+    }
   };
 }  // namespace ticl
 #endif

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -48,7 +48,7 @@ namespace ticl {
     std::array<float, 8> id_probabilities;
 
     // convenience method to return the ID probability for a certain particle type
-    inline float id_probability(ParticleType type) {
+    inline float id_probability(ParticleType type) const {
       // probabilities are stored in the same order as defined in the ParticleType enum
       return id_probabilities[(int)type];
     }

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -33,7 +33,7 @@ namespace ticl {
     float regressed_energy;
 
     // types considered by the particle identification
-    enum ParticleType {
+    enum class ParticleType {
       photon = 0,
       electron,
       muon,

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,7 +1,9 @@
 
 <lcgdict>
-  <class name="ticl::Trackster" ClassVersion="4">
-   <version ClassVersion="4" checksum="2963413313"/>
+  <class name="ticl::Trackster" ClassVersion="5">
+    <version ClassVersion="5" checksum="1679804166"/>
+    <version ClassVersion="4" checksum="2963413313"/>
+    <version ClassVersion="3" checksum="3878166595"/>
   </class>
   <class name="std::vector<ticl::Trackster>" />
   <class name="edm::Wrapper<ticl::Trackster>" />

--- a/RecoHGCal/TICL/interface/GlobalCache.h
+++ b/RecoHGCal/TICL/interface/GlobalCache.h
@@ -7,15 +7,17 @@
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
 namespace ticl {
-  // base struct across ticl for objects hold in the edm::GlobalCache by plugins
-  struct CacheBase {
+  // base class across ticl for objects hold in the edm::GlobalCache by plugins
+  class CacheBase {
+  public:
     CacheBase(const edm::ParameterSet& params) {}
 
     virtual ~CacheBase() {}
   };
 
   // data structure hold by TrackstersProducer to store the TF graph for energy regression and ID
-  struct TrackstersCache : CacheBase {
+  class TrackstersCache : public CacheBase {
+  public:
     TrackstersCache(const edm::ParameterSet& params) : CacheBase(params), eidGraphDef(nullptr) {}
 
     ~TrackstersCache() override {}

--- a/RecoHGCal/TICL/interface/GlobalCache.h
+++ b/RecoHGCal/TICL/interface/GlobalCache.h
@@ -1,0 +1,27 @@
+// Definition of objects placed in the edm::GlobalCache.
+
+#ifndef RecoHGCal_TICL_GlobalCache_H__
+#define RecoHGCal_TICL_GlobalCache_H__
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+
+namespace ticl {
+  // base struct across ticl for objects hold in the edm::GlobalCache by plugins
+  struct CacheBase {
+    CacheBase(const edm::ParameterSet& params) {}
+
+    virtual ~CacheBase() {}
+  };
+
+  // data structure hold by TrackstersProducer to store the TF graph for energy regression and ID
+  struct TrackstersCache : CacheBase {
+    TrackstersCache(const edm::ParameterSet& params) : CacheBase(params), eidGraphDef(nullptr) {}
+
+    ~TrackstersCache() override {}
+
+    std::atomic<tensorflow::GraphDef*> eidGraphDef;
+  };
+}  // namespace ticl
+
+#endif  // RecoHGCal_TICL_GlobalCache_H__

--- a/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
@@ -13,6 +13,7 @@
 #include "DataFormats/HGCalReco/interface/TICLSeedingRegion.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoHGCal/TICL/interface/GlobalCache.h"
 
 namespace edm {
   class Event;
@@ -22,7 +23,7 @@ namespace edm {
 namespace ticl {
   class PatternRecognitionAlgoBase {
   public:
-    PatternRecognitionAlgoBase(const edm::ParameterSet& conf)
+    PatternRecognitionAlgoBase(const edm::ParameterSet& conf, const CacheBase* cache)
         : algo_verbosity_(conf.getParameter<int>("algo_verbosity")) {}
     virtual ~PatternRecognitionAlgoBase(){};
 

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="TrackingTools/Records"/>
 <use   name="Geometry/Records"/>
+<use   name="PhysicsTools/TensorFlow"/>
 
 <library   file="*.cc" name="RecoHGCalTICLPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -10,16 +10,29 @@
 
 using namespace ticl;
 
-PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf)
-    : PatternRecognitionAlgoBase(conf),
+PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf, const CacheBase *cache)
+    : PatternRecognitionAlgoBase(conf, cache),
       out_in_dfs_(conf.getParameter<bool>("out_in_dfs")),
-      max_out_in_hops_(conf.getParameter<int>("max_out_in_hops")) {
+      max_out_in_hops_(conf.getParameter<int>("max_out_in_hops")),
+      eidSession_(nullptr) {
   theGraph_ = std::make_unique<HGCGraph>();
   min_cos_theta_ = conf.getParameter<double>("min_cos_theta");
   min_cos_pointing_ = conf.getParameter<double>("min_cos_pointing");
   missing_layers_ = conf.getParameter<int>("missing_layers");
   min_clusters_per_ntuplet_ = conf.getParameter<int>("min_clusters_per_ntuplet");
   max_delta_time_ = conf.getParameter<double>("max_delta_time");
+  eidInputName_ = conf.getParameter<std::string>("eid_input_name");
+  eidOutputNameEnergy_ = conf.getParameter<std::string>("eid_output_name_energy");
+  eidOutputNameId_ = conf.getParameter<std::string>("eid_output_name_id");
+  eidMinClusterEnergy_ = conf.getParameter<double>("eid_min_cluster_energy");
+  eidNLayers_ = conf.getParameter<int>("eid_n_layers");
+  eidNClusters_ = conf.getParameter<int>("eid_n_clusters");
+
+  // mount the tensorflow graph onto the session when set
+  const TrackstersCache *trackstersCache = dynamic_cast<const TrackstersCache *>(cache);
+  if (trackstersCache->eidGraphDef != nullptr) {
+    eidSession_ = tensorflow::createSession(trackstersCache->eidGraphDef);
+  }
 }
 
 PatternRecognitionbyCA::~PatternRecognitionbyCA(){};
@@ -95,6 +108,153 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
       trackster.vertex_multiplicity[i] = layer_cluster_usage[trackster.vertices[i]];
       LogDebug("HGCPatterRecoByCA") << "LayerID: " << trackster.vertices[i]
                                     << " count: " << (int)trackster.vertex_multiplicity[i] << std::endl;
+    }
+  }
+
+  // energy regression and ID when a session is created
+  if (eidSession_ != nullptr) {
+    energyRegressionAndID(input.layerClusters, result);
+  }
+}
+
+void PatternRecognitionbyCA::energyRegressionAndID(const std::vector<reco::CaloCluster> &layerClusters,
+                                                   std::vector<Trackster> &tracksters) {
+  // Energy regression and particle identification strategy:
+  //
+  // 1. Set default values for regressed energy and particle id for each trackster.
+  // 2. Store indices of tracksters whose total sum of cluster energies is above the
+  //    eidMinClusterEnergy_ (GeV) treshold. Inference is not applied for soft tracksters.
+  // 3. When no trackster passes the selection, return.
+  // 4. Create input and output tensors. The batch dimension is determined by the number of
+  //    selected tracksters.
+  // 5. Fill input tensors with layer cluster features. Per layer, clusters are ordered descending
+  //    by energy. Given that tensor data is contiguous in memory, we can use pointer arithmetic to
+  //    fill values, even with batching.
+  // 6. Zero-fill features for empty clusters in each layer.
+  // 7. Batched inference.
+  // 8. Assign the regressed energy and id probabilities to each trackster.
+  //
+  // Indices used throughout this method:
+  // i -> batch / trackster
+  // j -> layer
+  // k -> cluster
+  // l -> feature
+
+  // set default values per trackster, determine if the cluster energy threshold is passed,
+  // and store indices of hard tracksters
+  std::vector<int> tracksterIndices;
+  for (int i = 0; i < (int)tracksters.size(); i++) {
+    // set default values (1)
+    tracksters[i].regressed_energy = 0.;
+    for (int p = 0; p < (int)tracksters[i].id_probabilities.size(); p++) {
+      tracksters[i].id_probabilities[p] = 0.;
+    }
+
+    // calculate the cluster energy sum (2)
+    // note: after the loop, sumClusterEnergy might be just above the threshold which is enough to
+    // decide whether to run inference for the trackster or not
+    float sumClusterEnergy = 0.;
+    for (int k = 0; k < (int)tracksters[i].vertices.size(); k++) {
+      sumClusterEnergy += (float)layerClusters[tracksters[i].vertices[k]].energy();
+      // there might be many clusters, so try to stop early
+      if (sumClusterEnergy >= eidMinClusterEnergy_) {
+        tracksterIndices.push_back(i);
+        break;
+      }
+    }
+  }
+
+  // do nothing when no trackster passes the selection (3)
+  int batchSize = (int)tracksterIndices.size();
+  if (batchSize == 0) {
+    return;
+  }
+
+  // create input and output tensors (4)
+  tensorflow::TensorShape shape({batchSize, eidNLayers_, eidNClusters_, eidNFeatures_});
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, shape);
+  tensorflow::NamedTensorList inputList = {{eidInputName_, input}};
+
+  std::vector<tensorflow::Tensor> outputs;
+  std::vector<std::string> outputNames;
+  if (!eidOutputNameEnergy_.empty()) {
+    outputNames.push_back(eidOutputNameEnergy_);
+  }
+  if (!eidOutputNameId_.empty()) {
+    outputNames.push_back(eidOutputNameId_);
+  }
+
+  // fill input tensor (5)
+  for (int i = 0; i < batchSize; i++) {
+    const Trackster &trackster = tracksters[tracksterIndices[i]];
+
+    // per layer, we only consider the first eidNClusters_ clusters in terms of energy, so in order
+    // to avoid creating large / nested structures to do the sorting for an unknown number of total
+    // clusters, create a sorted list of layer cluster indices to keep track of the filled clusters
+    std::vector<int> clusterIndices(trackster.vertices.size());
+    for (int k = 0; k < (int)trackster.vertices.size(); k++) {
+      clusterIndices[k] = k;
+    }
+    sort(clusterIndices.begin(), clusterIndices.end(), [&layerClusters, &trackster](const int &a, const int &b) {
+      return layerClusters[trackster.vertices[a]].energy() > layerClusters[trackster.vertices[b]].energy();
+    });
+
+    // keep track of the number of seen clusters per layer
+    std::vector<int> seenClusters(eidNLayers_);
+
+    // loop through clusters by descending energy
+    for (int k : clusterIndices) {
+      // get features per layer and cluster and store the values directly in the input tensor
+      const reco::CaloCluster &cluster = layerClusters[trackster.vertices[k]];
+      int j = rhtools_.getLayerWithOffset(cluster.hitsAndFractions()[0].first) - 1;
+      if (j < eidNLayers_ && seenClusters[j] < eidNClusters_) {
+        // get the pointer to the first feature value for the current batch, layer and cluster
+        float *features = &input.tensor<float, 4>()(i, j, seenClusters[j], 0);
+
+        // fill features
+        *(features++) = float(cluster.eta());
+        *(features++) = float(cluster.phi());
+        *features = float(cluster.energy());
+
+        // increment seen clusters
+        seenClusters[j]++;
+      }
+    }
+
+    // zero-fill features of empty clusters in each layer (6)
+    for (int j = 0; j < eidNLayers_; j++) {
+      for (int k = seenClusters[j]; k < eidNClusters_; k++) {
+        float *features = &input.tensor<float, 4>()(i, j, k, 0);
+        for (int l = 0; l < eidNFeatures_; l++, features++) {
+          *features = 0.f;
+        }
+      }
+    }
+  }
+
+  // run the inference (7)
+  tensorflow::run(eidSession_, inputList, outputNames, &outputs);
+
+  // store regressed energy per trackster (8)
+  if (!eidOutputNameEnergy_.empty()) {
+    // get the pointer to the energy tensor, dimension is batch x 1
+    float *energy = outputs[0].flat<float>().data();
+
+    for (int i : tracksterIndices) {
+      tracksters[i].regressed_energy = *(energy++);
+    }
+  }
+
+  // store id probabilities per trackster (8)
+  if (!eidOutputNameId_.empty()) {
+    // get the pointer to the id probability tensor, dimension is batch x id_probabilities.size()
+    int probsIdx = eidOutputNameEnergy_.empty() ? 0 : 1;
+    float *probs = outputs[probsIdx].flat<float>().data();
+
+    for (int i : tracksterIndices) {
+      for (int p = 0; p < (int)tracksters[i].id_probabilities.size(); p++) {
+        tracksters[i].id_probabilities[p] = *(probs++);
+      }
     }
   }
 }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -21,22 +21,22 @@ namespace ticl {
     void energyRegressionAndID(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& result);
 
   private:
-    hgcal::RecHitTools rhtools_;
-    std::unique_ptr<HGCGraph> theGraph_;
-    const bool out_in_dfs_ = false;
-    const unsigned int max_out_in_hops_ = 99999;
-    float min_cos_theta_;
-    float min_cos_pointing_;
-    int missing_layers_;
-    int min_clusters_per_ntuplet_;
-    float max_delta_time_;
-    std::string eidInputName_;
-    std::string eidOutputNameEnergy_;
-    std::string eidOutputNameId_;
-    float eidMinClusterEnergy_;
-    int eidNLayers_;
-    int eidNClusters_;
+    const std::unique_ptr<HGCGraph> theGraph_;
+    const bool out_in_dfs_;
+    const unsigned int max_out_in_hops_;
+    const float min_cos_theta_;
+    const float min_cos_pointing_;
+    const int missing_layers_;
+    const int min_clusters_per_ntuplet_;
+    const float max_delta_time_;
+    const std::string eidInputName_;
+    const std::string eidOutputNameEnergy_;
+    const std::string eidOutputNameId_;
+    const float eidMinClusterEnergy_;
+    const int eidNLayers_;
+    const int eidNClusters_;
 
+    hgcal::RecHitTools rhtools_;
     tensorflow::Session* eidSession_;
 
     static const int eidNFeatures_ = 3;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -30,13 +30,14 @@ namespace ticl {
     int missing_layers_;
     int min_clusters_per_ntuplet_;
     float max_delta_time_;
-    tensorflow::Session* eidSession_;
     std::string eidInputName_;
     std::string eidOutputNameEnergy_;
     std::string eidOutputNameId_;
     float eidMinClusterEnergy_;
     int eidNLayers_;
     int eidNClusters_;
+
+    tensorflow::Session* eidSession_;
 
     static const int eidNFeatures_ = 3;
   };

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -6,16 +6,19 @@
 #include <memory>  // unique_ptr
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
 class HGCGraph;
 
 namespace ticl {
   class PatternRecognitionbyCA final : public PatternRecognitionAlgoBase {
   public:
-    PatternRecognitionbyCA(const edm::ParameterSet& conf);
+    PatternRecognitionbyCA(const edm::ParameterSet& conf, const CacheBase* cache);
     ~PatternRecognitionbyCA() override;
 
     void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result) override;
+
+    void energyRegressionAndID(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& result);
 
   private:
     hgcal::RecHitTools rhtools_;
@@ -27,6 +30,15 @@ namespace ticl {
     int missing_layers_;
     int min_clusters_per_ntuplet_;
     float max_delta_time_;
+    tensorflow::Session* eidSession_;
+    std::string eidInputName_;
+    std::string eidOutputNameEnergy_;
+    std::string eidOutputNameId_;
+    float eidMinClusterEnergy_;
+    int eidNLayers_;
+    int eidNClusters_;
+
+    static const int eidNFeatures_ = 3;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
@@ -16,7 +16,8 @@ namespace edm {
 namespace ticl {
   class PatternRecognitionbyMultiClusters final : public PatternRecognitionAlgoBase {
   public:
-    PatternRecognitionbyMultiClusters(const edm::ParameterSet& conf) : PatternRecognitionAlgoBase(conf) {}
+    PatternRecognitionbyMultiClusters(const edm::ParameterSet& conf, const CacheBase* cache)
+        : PatternRecognitionAlgoBase(conf, cache) {}
     ~PatternRecognitionbyMultiClusters() override{};
 
     void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result) override;

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -21,18 +21,25 @@
 #include "DataFormats/HGCalReco/interface/TICLSeedingRegion.h"
 
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"
+#include "RecoHGCal/TICL/interface/GlobalCache.h"
 #include "PatternRecognitionbyCA.h"
 #include "PatternRecognitionbyMultiClusters.h"
 
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+
 using namespace ticl;
 
-class TrackstersProducer : public edm::stream::EDProducer<> {
+class TrackstersProducer : public edm::stream::EDProducer<edm::GlobalCache<TrackstersCache>> {
 public:
-  TrackstersProducer(const edm::ParameterSet&);
+  explicit TrackstersProducer(const edm::ParameterSet&, const TrackstersCache*);
   ~TrackstersProducer() override {}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // static methods for handling the global cache
+  static std::unique_ptr<TrackstersCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(TrackstersCache*);
 
 private:
   edm::EDGetTokenT<std::vector<reco::CaloCluster>> clusters_token_;
@@ -46,8 +53,29 @@ private:
 };
 DEFINE_FWK_MODULE(TrackstersProducer);
 
-TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps)
-    : myAlgo_(std::make_unique<PatternRecognitionbyCA>(ps)) {
+std::unique_ptr<TrackstersCache> TrackstersProducer::initializeGlobalCache(const edm::ParameterSet& params) {
+  // this method is supposed to create, initialize and return a TrackstersCache instance
+  std::unique_ptr<TrackstersCache> cache = std::make_unique<TrackstersCache>(params);
+
+  // load the graph def and save it
+  std::string graphPath = params.getParameter<std::string>("eid_graph_path");
+  if (!graphPath.empty()) {
+    graphPath = edm::FileInPath(graphPath).fullPath();
+    cache->eidGraphDef = tensorflow::loadGraphDef(graphPath);
+  }
+
+  return cache;
+}
+
+void TrackstersProducer::globalEndJob(TrackstersCache* cache) {
+  if (cache->eidGraphDef != nullptr) {
+    delete cache->eidGraphDef;
+    cache->eidGraphDef = nullptr;
+  }
+}
+
+TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps, const TrackstersCache* cache)
+    : myAlgo_(std::make_unique<PatternRecognitionbyCA>(ps, cache)) {
   clusters_token_ = consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"));
   filtered_layerclusters_mask_token_ = consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("filtered_mask"));
   original_layerclusters_mask_token_ = consumes<std::vector<float>>(ps.getParameter<edm::InputTag>("original_mask"));
@@ -76,6 +104,13 @@ void TrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<double>("max_delta_time", 0.09);
   desc.add<bool>("out_in_dfs", true);
   desc.add<int>("max_out_in_hops", 10);
+  desc.add<std::string>("eid_graph_path", "RecoHGCal/TICL/data/tf_models/energy_id_v0.pb");
+  desc.add<std::string>("eid_input_name", "input");
+  desc.add<std::string>("eid_output_name_energy", "output/regressed_energy");
+  desc.add<std::string>("eid_output_name_id", "output/id_probabilities");
+  desc.add<double>("eid_min_cluster_energy", 1.);
+  desc.add<int>("eid_n_layers", 50);
+  desc.add<int>("eid_n_clusters", 10);
   descriptions.add("trackstersProducer", desc);
 }
 

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -68,10 +68,8 @@ std::unique_ptr<TrackstersCache> TrackstersProducer::initializeGlobalCache(const
 }
 
 void TrackstersProducer::globalEndJob(TrackstersCache* cache) {
-  if (cache->eidGraphDef != nullptr) {
-    delete cache->eidGraphDef;
-    cache->eidGraphDef = nullptr;
-  }
+  delete cache->eidGraphDef;
+  cache->eidGraphDef = nullptr;
 }
 
 TrackstersProducer::TrackstersProducer(const edm::ParameterSet& ps, const TrackstersCache* cache)


### PR DESCRIPTION
#### PR description

This PR adds energy regression and particle identification for trackster objects to the TrackstersProducer of the RecoHGCal/TICL package. Both the regressed energy and ID probabilities for different types of particles are the outputs of a single neural network, stored as a TensorFlow model. The first version of this model is proposed in

cms-data/RecoHGCal-TICL#1.

This PR is a clean version of #27634. The changes since the last review comments can be found [here](https://github.com/riga/cmssw/compare/c75d2de...e9fb179).

#### Performance

Tested with workflow 20634.0 (`TTbar_14TeV_TuneCUETP8M1_2026D41PU` with 200 PU).

The CPU runtime for inference scales linearly with the batch size, i.e., the number of tracksters, as expected for the `no_threads` TensorFlow session. The average runtime per trackster is ~0.6 ms (see slope below). The time includes trackster selection, preprocessing and filling of input data, the actual inference, and handling of results (== `PatternRecognitionbyCA::energyRegressionAndID`).

![runtime](https://www.dropbox.com/s/hjivr1l4384lg9q/cpu_perf_27917.png?raw=1)

The memory consumption, obtained using the `SimpleMemoryCheck` with and without running the regression and ID, is 178 MB for a maximum batch size of ~750 tracksters.

To get an estimate of the memory used per event, I queried `VmRSS` of `/proc/self/status` ([link](https://stackoverflow.com/a/64166/2408501)) at the beginning and at the end of `PatternRecognitionbyCA::energyRegressionAndID`, and also before and after loading the graph and setting up the session.

- Load graph: + 3.6 MB
- Load session: +7.2 MB
- `energyRegressionAndID`:
![memory](https://www.dropbox.com/s/ukj4f2604islo7h/memory_27917.png?raw=1)
