### PR TITLE
fix handling of intermediate lumi values in HCAL aging

### DIFF
--- a/CondFormats/HcalObjects/src/HBHEDarkening.cc
+++ b/CondFormats/HcalObjects/src/HBHEDarkening.cc
@@ -89,7 +89,7 @@ float HBHEDarkening::degradationYear(const LumiYear& year, float intlumi, int ie
   //determine if this is a partial year
   float intlumiToUse = year.intlumi_;
   if (intlumi < year.sumlumi_)
-    intlumiToUse = year.sumlumi_ - intlumi;
+    intlumiToUse = intlumi - (year.sumlumi_ - year.intlumi_);
 
   //calculate degradation
   return std::exp(-(intlumiToUse * doseToUse) / decayConst);


### PR DESCRIPTION
#### PR description:

The HCAL aging model specifies the expected integrated luminosity collected in future years (at a given average instantaneous luminosity). If the user requests a luminosity value that is accumulated in the middle of the year, the darkening must be evaluated using a partial luminosity value for the last year. This computation was done incorrectly, which manifested as larger-than-expected response correction factors (seen in https://indico.cern.ch/event/844333/contributions/3546577/attachments/1900343/3136629/Phase_2_conditions_update.pdf). The calculation has now been fixed and confirmed to be correct.

#### PR validation:

Ran the test analyzer [hbhedarkeninganalyzer_cfg.py](https://github.com/cms-sw/cmssw/blob/master/CalibCalorimetry/HcalPlugins/test/hbhedarkeninganalyzer_cfg.py) to check the output at various intermediate luminosity values.

attn: @abdoulline