### PR TITLE
Data and MC global tags for 2018 UL

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,10 +30,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '110X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v4',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v4',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v4',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_v2',
+    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '110X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v5',
+    'run1_data'         :   '110X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v5',
+    'run2_data'         :   '110X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,11 +56,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,10 +30,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '110X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v3',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v4',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v3',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v3',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v4',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR includes global tags for the 2018 ultra-legacy reprocessing that are intended to be final. An unrelated change to the Run 3 prompt GT is included; this change is purely technical and will not affect any workflow.

**Offline GT**
Complete set of conditions for 2018UL. Includes updates to beamspot [1-2], tracker alignment [3-5], muon alignment [6-7], ECAL calibrations [8] and a fix for pixel conditions for a single fill with modified HV settings [9].

Diffs:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v5/110X_dataRun2_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v5/110X_dataRun2_relval_v6

[1] https://indico.cern.ch/event/840920/#35-ul-2018-sign-off-of-beamspo
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4213/1/1/1.html
[3] https://indico.cern.ch/event/837619/#10-ul-2018-tracker-alignment-s 
[4] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4205.html
[5] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4205/1/1.html
[6] https://indico.cern.ch/event/839963/#33-global-position-record-for 
[7] https://indico.cern.ch/event/840920/#34-ul-2018-sign-off-for-muon-a
[8] https://indico.cern.ch/event/840920/#38-ecal-sign-off-for-ultra-leg
[9] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4197.html



**Prompt-like GTs**

Updated PPS conditions for consistency with 2018 UL. The prompt-like GTs are updated as well because the PPS diamond was introduced after the completion of 2018 prompt reco. A payload is needed to avoid crashes in prompt-like workflows and so we have chosen to use payloads consistent with the offline GT.

Diffs: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HEfail_v3/110X_dataRun2_PromptLike_HEfail_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_v3/110X_dataRun2_PromptLike_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HI_v3/110X_dataRun2_PromptLike_HI_v5

**2018 MC**
Complete set of conditions for 2018UL. Updated tracker alignment scenario and APEs [1]

[1] https://indico.cern.ch/event/840920/#36-ul-2018-sign-off-for-mc-tra

Diffs:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_v3/110X_upgrade2018_realistic_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HEfail_v3/110X_upgrade2018_realistic_HEfail_v4

**Run 3 prompt**
Change to EcalADCToGeVConstantRcd tag populated by O2O [1]

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4191.html

Diff:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun3_Prompt_v2/106X_dataRun3_Prompt_v3 


#### PR validation:

For physics validation, please see above. Also, as a technical test, ran `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

Not a backport but will be backported to 10_6_X
