### PR TITLE
Explicitly removed methods implicitly ignored by compiler in FWCore/Framework

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -39,9 +39,9 @@ namespace edm {
   class ConsumesCollector {
   public:
     ConsumesCollector() = delete;
-    ConsumesCollector(ConsumesCollector const&) = default;
+    ConsumesCollector(ConsumesCollector const&) = delete;
     ConsumesCollector(ConsumesCollector&&) = default;
-    ConsumesCollector& operator=(ConsumesCollector const&) = default;
+    ConsumesCollector& operator=(ConsumesCollector const&) = delete;
     ConsumesCollector& operator=(ConsumesCollector&&) = default;
 
     // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -44,9 +44,9 @@ namespace edm {
   class ESConsumesCollector {
   public:
     ESConsumesCollector() = delete;
-    ESConsumesCollector(ESConsumesCollector const&) = default;
+    ESConsumesCollector(ESConsumesCollector const&) = delete;
     ESConsumesCollector(ESConsumesCollector&&) = default;
-    ESConsumesCollector& operator=(ESConsumesCollector const&) = default;
+    ESConsumesCollector& operator=(ESConsumesCollector const&) = delete;
     ESConsumesCollector& operator=(ESConsumesCollector&&) = default;
 
     // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -61,7 +61,7 @@ namespace edm {
     SubProcess(SubProcess const&) = delete;             // Disallow copying
     SubProcess& operator=(SubProcess const&) = delete;  // Disallow copying
     SubProcess(SubProcess&&) = default;                 // Allow Moving
-    SubProcess& operator=(SubProcess&&) = default;      // Allow moving
+    SubProcess& operator=(SubProcess&&) = delete;       // Move not supported by PrincipalCache
 
     //From OutputModule
     void selectProducts(ProductRegistry const& preg,

--- a/FWCore/Framework/src/EarlyDeleteHelper.h
+++ b/FWCore/Framework/src/EarlyDeleteHelper.h
@@ -43,7 +43,7 @@ namespace edm {
                       unsigned int* iEndIndexItr,
                       std::vector<BranchToCount>* iBranchCounts);
     EarlyDeleteHelper(const EarlyDeleteHelper&);
-    EarlyDeleteHelper& operator=(const EarlyDeleteHelper&) = default;
+    EarlyDeleteHelper& operator=(const EarlyDeleteHelper&) = delete;
     //virtual ~EarlyDeleteHelper();
 
     // ---------- const member functions ---------------------


### PR DESCRIPTION
#### PR description:

Although we had asked the compiler explicitly to create default versions
of functions, it was implicitly deleting them. Now we explicitly
request them to be deleted to match what the compiler was doing.

This fixes new clang warnings.

#### PR validation:

Compiled FWCore/Framework under CMSSW_11_0_CLANG_X_2019-09-03-2300. The only remaining clang warnings come from CppUnit external package.