### PR TITLE
Add an LHE-based mc relval with multiple lumi sections and concurrent lumi settings

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -625,6 +625,9 @@ workflows[1361.18] = ['', ['GluGluHToZZTo4L_M125_Pow_py8_Evt_13UP18','DIGIUP18',
 workflows[1362.18] = ['', ['VBFHToZZTo4Nu_M125_Pow_py8_Evt_13UP18','DIGIUP18','RECOUP18','HARVESTUP18']]
 workflows[1363.18] = ['', ['VBFHToBB_M125_Pow_py8_Evt_13UP18','DIGIUP18','RECOUP18','HARVESTUP18']]
 
+#2018 workflows starting from gridpacks LHE generation with multiple concurrent lumi sections
+workflows[1361.181] = ['', ['GluGluHToZZTo4L_M125_Pow_py8_Evt_13UP18ml','DIGIUP18ml','RECOUP18ml','HARVESTUP18']]
+
 # fullSim 13TeV normal workflows starting from pLHE
 workflows[1370] = ['', ['GluGluHToGG_M125_Pow_MINLO_NNLOPS_py8_13','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_2p_HToGG_M125_13','DIGIUP15','RECOUP15','HARVESTUP15']]
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1491,6 +1491,19 @@ steps['Upsilon4sBaBarExample_BpBm_Dstarpipi_D0Kpi_nonres_forSTEAM_13TeV_TuneCUET
 steps['LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1']=genvalid('LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1_cfi',step1GenDefaults)
 steps['BsToMuMu_forSTEAM_13TeV_TuneCUETP8M1']=genvalid('BsToMuMu_forSTEAM_13TeV_TuneCUETP8M1_cfi',step1GenDefaults)
 
+# Workflows for multiple concurrent lumi blocks
+
+step1LHEGenSimUp2018MultiLumi = merge ([{'--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"',
+                                         '--nStreams': 4,
+                                         '--nConcurrentLumis': 2,
+                                         },step1LHEGenSimUp2018Default])
+
+def lhegensim2018ml(fragment,howMuch):
+    global step1LHEGenSimUp2018MultiLumi
+    return merge([{'cfg':fragment},howMuch,step1LHEGenSimUp2018MultiLumi])
+
+steps['GluGluHToZZTo4L_M125_Pow_py8_Evt_13UP18ml']=lhegensim2018ml('Configuration/Generator/python/GGHZZ4L_JHUGen_Pow_NNPDF30_LHE_13TeV_cfi.py',Kby(9,50))
+
 
 # sometimes v1 won't be used - override it here - the dictionary key is gen fragment + '_' + geometry
 overrideFragments={'H125GGgluonfusion_13UP18INPUT':'2'}
@@ -1586,6 +1599,7 @@ steps['DIGIUP15_PU25']=merge([PU25,step2Upg2015Defaults])
 steps['DIGIUP15_PU50']=merge([PU50,step2Upg2015Defaults50ns])
 steps['DIGIUP17']=merge([step2Upg2017Defaults])
 steps['DIGIUP18']=merge([step2Upg2018Defaults])
+steps['DIGIUP18ml']=merge([{'--nStreams': 4,'--nConcurrentLumis': 2},step2Upg2018Defaults])
 steps['DIGIUP17PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2017','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2017Defaults])
 steps['DIGIUP18PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2018','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2018Defaults])
 steps['DIGIUP17_PU25']=merge([PU25UP17,step2Upg2017Defaults])
@@ -2120,6 +2134,7 @@ steps['RECOUP17']=merge([{'--conditions':'auto:phase1_2017_realistic','--era' : 
 steps['RECOUP17_PU25']=merge([PU25UP17,steps['RECOUP17']])
 
 steps['RECOUP18']=merge([{'--conditions':'auto:phase1_2018_realistic','--era' : 'Run2_2018','--geometry' : 'DB:Extended'},steps['RECOUP15']])
+steps['RECOUP18ml']=merge([{'--nStreams': 4,'--nConcurrentLumis': 2},steps['RECOUP18']])
 steps['RECOUP18_PU25']=merge([PU25UP18,steps['RECOUP18']])
 
 # for Run1 PPb data workflow

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4,6 +4,10 @@ from .MatrixUtil import *
 from Configuration.HLT.autoHLT import autoHLT
 from Configuration.AlCa.autoPCL import autoPCL
 
+concurrentLumis = {'--nStreams':         4,
+                   '--nConcurrentLumis': 2,
+                   }
+
 # step1 gensim: for run1
 step1Defaults = {'--relval'      : None, # need to be explicitly set
                  '-s'            : 'GEN,SIM',
@@ -1493,14 +1497,8 @@ steps['BsToMuMu_forSTEAM_13TeV_TuneCUETP8M1']=genvalid('BsToMuMu_forSTEAM_13TeV_
 
 # Workflows for multiple concurrent lumi blocks
 
-step1LHEGenSimUp2018MultiLumi = merge ([{'--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"',
-                                         '--nStreams': 4,
-                                         '--nConcurrentLumis': 2,
-                                         },step1LHEGenSimUp2018Default])
-
 def lhegensim2018ml(fragment,howMuch):
-    global step1LHEGenSimUp2018MultiLumi
-    return merge([{'cfg':fragment},howMuch,step1LHEGenSimUp2018MultiLumi])
+    return merge([{'cfg':fragment},howMuch,{'--customise_commands': '"process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(5)"'},concurrentLumis,step1LHEGenSimUp2018Default])
 
 steps['GluGluHToZZTo4L_M125_Pow_py8_Evt_13UP18ml']=lhegensim2018ml('Configuration/Generator/python/GGHZZ4L_JHUGen_Pow_NNPDF30_LHE_13TeV_cfi.py',Kby(9,50))
 
@@ -1599,7 +1597,7 @@ steps['DIGIUP15_PU25']=merge([PU25,step2Upg2015Defaults])
 steps['DIGIUP15_PU50']=merge([PU50,step2Upg2015Defaults50ns])
 steps['DIGIUP17']=merge([step2Upg2017Defaults])
 steps['DIGIUP18']=merge([step2Upg2018Defaults])
-steps['DIGIUP18ml']=merge([{'--nStreams': 4,'--nConcurrentLumis': 2},step2Upg2018Defaults])
+steps['DIGIUP18ml']=merge([concurrentLumis,step2Upg2018Defaults])
 steps['DIGIUP17PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2017','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2017Defaults])
 steps['DIGIUP18PROD1']=merge([{'-s':'DIGI,L1,DIGI2RAW,HLT:@relval2018','--eventcontent':'RAWSIM','--datatier':'GEN-SIM-RAW'},step2Upg2018Defaults])
 steps['DIGIUP17_PU25']=merge([PU25UP17,step2Upg2017Defaults])
@@ -2134,7 +2132,7 @@ steps['RECOUP17']=merge([{'--conditions':'auto:phase1_2017_realistic','--era' : 
 steps['RECOUP17_PU25']=merge([PU25UP17,steps['RECOUP17']])
 
 steps['RECOUP18']=merge([{'--conditions':'auto:phase1_2018_realistic','--era' : 'Run2_2018','--geometry' : 'DB:Extended'},steps['RECOUP15']])
-steps['RECOUP18ml']=merge([{'--nStreams': 4,'--nConcurrentLumis': 2},steps['RECOUP18']])
+steps['RECOUP18ml']=merge([concurrentLumis,steps['RECOUP18']])
 steps['RECOUP18_PU25']=merge([PU25UP18,steps['RECOUP18']])
 
 # for Run1 PPb data workflow


### PR DESCRIPTION
#### PR description:

This PR adds an LHE-based simulation relval workflow where 2 lumi sections are produced, and the concurrent luminosity block settings are activated. This is a first attempt to address the request by @Dr15Jones discussed in #26348 , and test the lumi section boundary crossing that is usual in production and that sometimes shows problems (see for instance #25708 ).

In order to test the boundary crossing from LHE_based input onwards, the workflow 1361.18 is modified by forcing the EmptySource to have 5 events per lumi section, and therefore forcing the standard 10 events sample to contain 2 lumi sections.

#### PR validation:

If ```--nThreads 4``` the new workflow 1361.181 has the new correct settings, for instance in step2 (DIGI):

```
%MSG-i ThreadStreamSetup:  (NoModuleName) 04-Sep-2019 16:12:47 CEST pre-events
setting # threads 4
setting # streams 4
%MSG
04-Sep-2019 16:12:53 CEST  Initiating request to open file file:step1.root
04-Sep-2019 16:12:54 CEST  Successfully opened file file:step1.root
%MSG-s ModulesSynchingOnLumis:  AfterModConstruction 04-Sep-2019 16:12:59 CEST  pre-events
The following modules require synchronizing on LuminosityBlock boundaries:
  HLTrigReport hltTrigReport
%MSG
Begin processing the 1st record. Run 1, Event 2, LumiSection 1 on stream 3 at 04-Sep-2019 16:13:05.814 CEST
Begin processing the 2nd record. Run 1, Event 3, LumiSection 1 on stream 0 at 04-Sep-2019 16:13:05.814 CEST
Begin processing the 3rd record. Run 1, Event 4, LumiSection 1 on stream 2 at 04-Sep-2019 16:13:05.814 CEST
Begin processing the 4th record. Run 1, Event 5, LumiSection 1 on stream 1 at 04-Sep-2019 16:13:05.814 CEST
DTTSPhi::addTracoT: preview not present in TRACO trigger or its code=0  trigger not added!
Begin processing the 5th record. Run 1, Event 1, LumiSection 1 on stream 1 at 04-Sep-2019 16:14:14.785 CEST
Begin processing the 6th record. Run 1, Event 9, LumiSection 2 on stream 3 at 04-Sep-2019 16:14:16.953 CEST
Begin processing the 7th record. Run 1, Event 7, LumiSection 2 on stream 0 at 04-Sep-2019 16:14:16.953 CEST
Begin processing the 8th record. Run 1, Event 6, LumiSection 2 on stream 2 at 04-Sep-2019 16:14:16.953 CEST
Begin processing the 9th record. Run 1, Event 8, LumiSection 2 on stream 1 at 04-Sep-2019 16:14:16.954 CEST
Begin processing the 10th record. Run 1, Event 10, LumiSection 2 on stream 0 at 04-Sep-2019 16:14:18.686 CEST
04-Sep-2019 16:14:20 CEST  Closed file file:step1.root
```
