### PR TITLE
Data and MC global tags for 2018 UL [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,11 +54,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v7',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v21',
+    'run1_data'         :   '106X_dataRun2_v22',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v21',
+    'run2_data'         :   '106X_dataRun2_v22',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v20',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v21',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v10',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,10 +30,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '106X_dataRun2_relval_v21',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v10',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v11',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v11',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v11',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v12',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v12',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR, a backport of PR #27923, introduces global tags for the 2018 ultra-legacy reprocessing. See the description of PR #27923 for details. 

The GT diffs with respect to the previous 10_6_X autoCond GTs are as follows:

**Offline**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v21/106X_dataRun2_v22
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v20/106X_dataRun2_relval_v21

**Prompt-like**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_v10/106X_dataRun2_PromptLike_HEfail_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_v11/106X_dataRun2_PromptLike_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_v11/106X_dataRun2_PromptLike_HI_v12

**2018 MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v7/106X_upgrade2018_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v7/106X_upgrade2018_realistic_HEfail_v8

With these changes, the tag content of the modified GTs are consistent with those in the master branch:

**Offline**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v6/106X_dataRun2_v22
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v6/106X_dataRun2_relval_v21

**Prompt-like**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HEfail_v5/106X_dataRun2_PromptLike_HEfail_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_v5/106X_dataRun2_PromptLike_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HI_v5/106X_dataRun2_PromptLike_HI_v12

**2018 MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_v4/106X_upgrade2018_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HEfail_v4/106X_upgrade2018_realistic_HEfail_v8

#### PR validation:

For physics validation, please see description in PR #27923. Also, as a technical test, ran `runTheMatrix.py -l limited -i all --ibeos`.

#### if this PR is a backport please specify the original PR:

Backport of PR #27923.