### PR TITLE
Minor technical fix for FastSim de/dx LLP

### DIFF
--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -192,6 +192,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
   // Check that the particle hasn't decayed
   if (myTrack.noEndVertex()) {
     // Simulate energy smearing for photon and electrons
+    float charge_ = (float)(myTrack.charge());
     if (pid == 11 || pid == 22) {
       if (myTrack.onEcal())
         EMShowerSimulation(myTrack, random);
@@ -204,7 +205,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
           reconstructHCAL(myTrack, random);
       }
     }  // electron or photon
-    else if (pid == 13 || pid == 1000024) {
+    else if (pid == 13 || pid == 1000024 || (pid>1000100 && pid<1999999 && fabs(charge_)>0.001)) {
       MuonMipSimulation(myTrack, random);
     }
     // Simulate energy smearing for hadrons (i.e., everything
@@ -454,7 +455,8 @@ void CalorimetryManager::reconstructHCAL(const FSimTrack& myTrack, RandomEngineA
   double EGen = myTrack.hcalEntrance().e();
   double emeas = 0.;
 
-  if (pid == 13 || pid == 1000024) {
+  float charge_ = (float)myTrack.charge();
+    if (pid == 13 || pid == 1000024 || (pid>1000100 && pid<1999999 && fabs(charge_)>0.001)) {
     emeas = myHDResponse_->responseHCAL(0, EGen, pathEta, 2, random);  // 2=muon
     if (debug_)
       LogInfo("FastCalorimetry") << "CalorimetryManager::reconstructHCAL - MUON !!!" << std::endl;
@@ -1205,7 +1207,7 @@ void CalorimetryManager::loadMuonSimTracks(edm::SimTrackContainer& muons) const 
   unsigned size = muons.size();
   for (unsigned i = 0; i < size; ++i) {
     int id = muons[i].trackId();
-    if (abs(muons[i].type()) != 13 && abs(muons[i].type()) != 1000024)
+    if (!(abs(muons[i].type()) == 13 || abs(muons[i].type()) == 1000024  || (abs(muons[i].type())>1000100 && abs(muons[i].type())<1999999) ))
       continue;
     // identify the corresponding muon in the local collection
 

--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -205,7 +205,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
           reconstructHCAL(myTrack, random);
       }
     }  // electron or photon
-    else if (pid == 13 || pid == 1000024 || (pid>1000100 && pid<1999999 && fabs(charge_)>0.001)) {
+    else if (pid == 13 || pid == 1000024 || (pid > 1000100 && pid < 1999999 && fabs(charge_) > 0.001)) {
       MuonMipSimulation(myTrack, random);
     }
     // Simulate energy smearing for hadrons (i.e., everything
@@ -456,7 +456,7 @@ void CalorimetryManager::reconstructHCAL(const FSimTrack& myTrack, RandomEngineA
   double emeas = 0.;
 
   float charge_ = (float)myTrack.charge();
-    if (pid == 13 || pid == 1000024 || (pid>1000100 && pid<1999999 && fabs(charge_)>0.001)) {
+  if (pid == 13 || pid == 1000024 || (pid > 1000100 && pid < 1999999 && fabs(charge_) > 0.001)) {
     emeas = myHDResponse_->responseHCAL(0, EGen, pathEta, 2, random);  // 2=muon
     if (debug_)
       LogInfo("FastCalorimetry") << "CalorimetryManager::reconstructHCAL - MUON !!!" << std::endl;
@@ -1207,7 +1207,8 @@ void CalorimetryManager::loadMuonSimTracks(edm::SimTrackContainer& muons) const 
   unsigned size = muons.size();
   for (unsigned i = 0; i < size; ++i) {
     int id = muons[i].trackId();
-    if (!(abs(muons[i].type()) == 13 || abs(muons[i].type()) == 1000024  || (abs(muons[i].type())>1000100 && abs(muons[i].type())<1999999) ))
+    if (!(abs(muons[i].type()) == 13 || abs(muons[i].type()) == 1000024 ||
+          (abs(muons[i].type()) > 1000100 && abs(muons[i].type()) < 1999999)))
       continue;
     // identify the corresponding muon in the local collection
 

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -247,9 +247,11 @@ void FastTrackDeDxProducer::processHit(const FastTrackerRecHit& recHit,
     return;
 
   auto const& thit = static_cast<BaseTrackerRecHit const&>(recHit);
-  if (!thit.isValid()) return;
+  if (!thit.isValid())
+    return;
   auto const& clus = thit.firstClusterRef();
-  if (!clus.isValid()) return;
+  if (!clus.isValid())
+    return;
 
   if (recHit.isPixel()) {
     if (!usePixel)

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -246,6 +246,11 @@ void FastTrackDeDxProducer::processHit(const FastTrackerRecHit& recHit,
   if (!recHit.isValid())
     return;
 
+  auto const& thit = static_cast<BaseTrackerRecHit const&>(recHit);
+  if (!thit.isValid()) return;
+  auto const& clus = thit.firstClusterRef();
+  if (!clus.isValid()) return;
+
   if (recHit.isPixel()) {
     if (!usePixel)
       return;


### PR DESCRIPTION
#27475 ## PR description:

This PR proposes adding safety statements for FastSim tracker hits that are not associated to a cluster to avoid a seg fault I saw when producing long-lived signal samples with pileup. Also, the treatment of muons and charginos in the muon system is now extended cover charged R-hadrons (pid>1000100 && pid<1999999).

#### PR validation:

I have produced signal files with PU mixing and now observe no segmentation fault.

#### if this PR is a backport please specify the original PR:

I did the recommended checks I did find a number of error messages when running
runTheMatrix.py -l limited -i all --ibeos. See below [1]

[1]
...
ERROR executing  cd 4.53_RunPhoton2012B+RunPhoton2012B+HLTD+RECODR1reHLT+HARVESTDR1reHLT; cmsDriver.py step2  --datatier FEVTDEBUGHLT --conditions auto:run1_hlt_Fake -s L1REPACK,HLT:@fake --process reHLT --data  --eventcontent FEVTDEBUGHLT -n 100  --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root  > step2_RunPhoton2012B+RunPhoton2012B+HLTD+RECODR1reHLT+HARVESTDR1reHLT.log  2>&1;  ret= 16896
ERROR executing  cd 7.3_CosmicsSPLoose_UP18+CosmicsSPLoose_UP18+DIGICOS_UP18+RECOCOS_UP18+ALCACOS_UP18+HARVESTCOS_UP18; cmsDriver.py UndergroundCosmicSPLooseMu_cfi.py  --conditions auto:phase1_2018_cosmics
...
