### PR TITLE
Add SiStripApvSimulationParameters database object and record

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
@@ -55,8 +55,8 @@ SiStripApvSimulationParametersESSource::SiStripApvSimulationParametersESSource(c
 }
 
 void SiStripApvSimulationParametersESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-    const edm::IOVSyncValue& iov,
-    edm::ValidityInterval& iValidity) {
+                                                            const edm::IOVSyncValue& iov,
+                                                            edm::ValidityInterval& iValidity) {
   iValidity = edm::ValidityInterval{iov.beginOfTime(), iov.endOfTime()};
 }
 
@@ -111,7 +111,7 @@ SiStripApvSimulationParameters::LayerParameters SiStripApvSimulationParametersES
     unsigned int binInZ = int(apvBaseline.index()) / (nPUBins * baseline_nBins_);
     unsigned int binInPU = int(apvBaseline.index() - binInZ * (nPUBins)*baseline_nBins_) / baseline_nBins_;
 
-    layerParams.setBinContent(binInCurrentHistogram, binInPU+1, binInZ+1, apvBaseline.value());
+    layerParams.setBinContent(binInCurrentHistogram, binInPU + 1, binInZ + 1, apvBaseline.value());
   }
 
   return layerParams;
@@ -122,17 +122,17 @@ std::unique_ptr<SiStripApvSimulationParameters> SiStripApvSimulationParametersES
   auto apvSimParams =
       std::make_unique<SiStripApvSimulationParameters>(baselineFiles_TIB_.size(), baselineFiles_TOB_.size());
   for (unsigned int i{0}; i != baselineFiles_TIB_.size(); ++i) {
-    if ( ! apvSimParams->putTIB(i + 1, makeLayerParameters(baselineFiles_TIB_[i].fullPath())) ) {
-      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TIB layer " << (i+1);
+    if (!apvSimParams->putTIB(i + 1, makeLayerParameters(baselineFiles_TIB_[i].fullPath()))) {
+      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TIB layer " << (i + 1);
     } else {
-      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TIB layer " << (i+1);
+      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TIB layer " << (i + 1);
     }
   }
   for (unsigned int i{0}; i != baselineFiles_TOB_.size(); ++i) {
-    if ( ! apvSimParams->putTOB(i + 1, makeLayerParameters(baselineFiles_TOB_[i].fullPath())) ) {
-      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TOB layer " << (i+1);
+    if (!apvSimParams->putTOB(i + 1, makeLayerParameters(baselineFiles_TOB_[i].fullPath()))) {
+      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TOB layer " << (i + 1);
     } else {
-      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TOB layer " << (i+1);
+      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TOB layer " << (i + 1);
     }
   }
   return apvSimParams;

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
@@ -1,0 +1,142 @@
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
+#include <fstream>
+#include <boost/range/adaptor/indexed.hpp>
+
+class SiStripApvSimulationParametersESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  explicit SiStripApvSimulationParametersESSource(const edm::ParameterSet& conf);
+  ~SiStripApvSimulationParametersESSource() override {}
+
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue& iov,
+                      edm::ValidityInterval& iValidity) override;
+
+  std::unique_ptr<SiStripApvSimulationParameters> produce(const SiStripApvSimulationParametersRcd& record);
+
+private:
+  std::vector<edm::FileInPath> baselineFiles_TOB_;
+  std::vector<edm::FileInPath> baselineFiles_TIB_;
+  unsigned int baseline_nBins_;
+  float baseline_min_;
+  float baseline_max_;
+  std::vector<float> puBinEdges_;
+  std::vector<float> zBinEdges_;
+
+  SiStripApvSimulationParameters::LayerParameters makeLayerParameters(const std::string& apvBaselinesFileName) const;
+};
+
+SiStripApvSimulationParametersESSource::SiStripApvSimulationParametersESSource(const edm::ParameterSet& conf)
+    : baseline_nBins_(conf.getParameter<unsigned int>("apvBaselines_nBinsPerBaseline")),
+      baseline_min_(conf.getParameter<double>("apvBaselines_minBaseline")),
+      baseline_max_(conf.getParameter<double>("apvBaselines_maxBaseline")) {
+  setWhatProduced(this);
+  findingRecord<SiStripApvSimulationParametersRcd>();
+  for (const auto x : conf.getParameter<std::vector<double>>("apvBaselines_puBinEdges")) {
+    puBinEdges_.push_back(x);
+  }
+  for (const auto x : conf.getParameter<std::vector<double>>("apvBaselines_zBinEdges")) {
+    zBinEdges_.push_back(x);
+  }
+  baselineFiles_TIB_ = {conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib1"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib2"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib3"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib4")};
+  baselineFiles_TOB_ = {conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob1"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob2"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob3"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob4"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob5"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob6")};
+}
+
+void SiStripApvSimulationParametersESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+    const edm::IOVSyncValue& iov,
+    edm::ValidityInterval& iValidity) {
+  iValidity = edm::ValidityInterval{iov.beginOfTime(), iov.endOfTime()};
+}
+
+SiStripApvSimulationParameters::LayerParameters SiStripApvSimulationParametersESSource::makeLayerParameters(
+    const std::string& apvBaselinesFileName) const {
+  // Prepare histograms
+  unsigned int nZBins = zBinEdges_.size();
+  unsigned int nPUBins = puBinEdges_.size();
+
+  if (nPUBins == 0 || nZBins == 0 || baseline_nBins_ == 0) {
+    throw cms::Exception("MissingInput") << "The parameters for the APV simulation are not correctly configured\n";
+  }
+  std::vector<float> baselineBinEdges{};
+  const auto baseline_binWidth = (baseline_max_ - baseline_min_) / baseline_nBins_;
+  for (unsigned i{0}; i != baseline_nBins_; ++i) {
+    baselineBinEdges.push_back(baseline_min_ + i * baseline_binWidth);
+  }
+  baselineBinEdges.push_back(baseline_max_);
+
+  SiStripApvSimulationParameters::LayerParameters layerParams{baselineBinEdges, puBinEdges_, zBinEdges_};
+
+  // Read apv baselines from text files
+  std::vector<double> theAPVBaselines;
+  std::ifstream apvBaselineFile(apvBaselinesFileName.c_str());
+  if (!apvBaselineFile.good()) {
+    throw cms::Exception("FileError") << "Problem opening APV baselines file: " << apvBaselinesFileName;
+  }
+  std::string line;
+  while (std::getline(apvBaselineFile, line)) {
+    if (!line.empty()) {
+      std::istringstream lStr{line};
+      double value;
+      while (lStr >> value) {
+        theAPVBaselines.push_back(value);
+      }
+    }
+  }
+  if (theAPVBaselines.empty()) {
+    throw cms::Exception("WrongAPVBaselines")
+        << "Problem reading from APV baselines file " << apvBaselinesFileName << ": no values read in";
+  }
+
+  if (theAPVBaselines.size() != nZBins * nPUBins * baseline_nBins_) {
+    throw cms::Exception("WrongAPVBaselines") << "Problem reading from APV baselines file " << apvBaselinesFileName
+                                              << ": number of baselines read different to that expected i.e. nZBins * "
+                                                 "nPUBins * apvBaselines_nBinsPerBaseline_";
+  }
+
+  // Put baselines into histograms
+  for (auto const& apvBaseline : theAPVBaselines | boost::adaptors::indexed(0)) {
+    unsigned int binInCurrentHistogram = apvBaseline.index() % baseline_nBins_ + 1;
+    unsigned int binInZ = int(apvBaseline.index()) / (nPUBins * baseline_nBins_);
+    unsigned int binInPU = int(apvBaseline.index() - binInZ * (nPUBins)*baseline_nBins_) / baseline_nBins_;
+
+    layerParams.setBinContent(binInCurrentHistogram, binInPU+1, binInZ+1, apvBaseline.value());
+  }
+
+  return layerParams;
+}
+
+std::unique_ptr<SiStripApvSimulationParameters> SiStripApvSimulationParametersESSource::produce(
+    const SiStripApvSimulationParametersRcd& record) {
+  auto apvSimParams =
+      std::make_unique<SiStripApvSimulationParameters>(baselineFiles_TIB_.size(), baselineFiles_TOB_.size());
+  for (unsigned int i{0}; i != baselineFiles_TIB_.size(); ++i) {
+    if ( ! apvSimParams->putTIB(i + 1, makeLayerParameters(baselineFiles_TIB_[i].fullPath())) ) {
+      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TIB layer " << (i+1);
+    } else {
+      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TIB layer " << (i+1);
+    }
+  }
+  for (unsigned int i{0}; i != baselineFiles_TOB_.size(); ++i) {
+    if ( ! apvSimParams->putTOB(i + 1, makeLayerParameters(baselineFiles_TOB_[i].fullPath())) ) {
+      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TOB layer " << (i+1);
+    } else {
+      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TOB layer " << (i+1);
+    }
+  }
+  return apvSimParams;
+}
+
+#include "FWCore/Framework/interface/SourceFactory.h"
+DEFINE_FWK_EVENTSETUP_SOURCE(SiStripApvSimulationParametersESSource);

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
@@ -120,7 +120,7 @@ SiStripApvSimulationParameters::LayerParameters SiStripApvSimulationParametersES
 std::unique_ptr<SiStripApvSimulationParameters> SiStripApvSimulationParametersESSource::produce(
     const SiStripApvSimulationParametersRcd& record) {
   auto apvSimParams =
-      std::make_unique<SiStripApvSimulationParameters>(baselineFiles_TIB_.size(), baselineFiles_TOB_.size());
+      std::make_unique<SiStripApvSimulationParameters>(baselineFiles_TIB_.size(), baselineFiles_TOB_.size(), 0, 0);
   for (unsigned int i{0}; i != baselineFiles_TIB_.size(); ++i) {
     if (!apvSimParams->putTIB(i + 1, makeLayerParameters(baselineFiles_TIB_[i].fullPath()))) {
       throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TIB layer " << (i + 1);

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripApvSimulationParametersESProducer.cc
@@ -21,13 +21,18 @@ public:
 private:
   std::vector<edm::FileInPath> baselineFiles_TOB_;
   std::vector<edm::FileInPath> baselineFiles_TIB_;
+  std::vector<edm::FileInPath> baselineFiles_TID_;
+  std::vector<edm::FileInPath> baselineFiles_TEC_;
   unsigned int baseline_nBins_;
   float baseline_min_;
   float baseline_max_;
   std::vector<float> puBinEdges_;
   std::vector<float> zBinEdges_;
+  std::vector<float> rBinEdgesTID_;
+  std::vector<float> rBinEdgesTEC_;
 
-  SiStripApvSimulationParameters::LayerParameters makeLayerParameters(const std::string& apvBaselinesFileName) const;
+  SiStripApvSimulationParameters::LayerParameters makeLayerParameters(const std::string& apvBaselinesFileName,
+                                                                      const std::vector<float>& rzBinEdges) const;
 };
 
 SiStripApvSimulationParametersESSource::SiStripApvSimulationParametersESSource(const edm::ParameterSet& conf)
@@ -42,6 +47,12 @@ SiStripApvSimulationParametersESSource::SiStripApvSimulationParametersESSource(c
   for (const auto x : conf.getParameter<std::vector<double>>("apvBaselines_zBinEdges")) {
     zBinEdges_.push_back(x);
   }
+  for (const auto x : conf.getParameter<std::vector<double>>("apvBaselines_rBinEdges_TID")) {
+    rBinEdgesTID_.push_back(x);
+  }
+  for (const auto x : conf.getParameter<std::vector<double>>("apvBaselines_rBinEdges_TEC")) {
+    rBinEdgesTEC_.push_back(x);
+  }
   baselineFiles_TIB_ = {conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib1"),
                         conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib2"),
                         conf.getParameter<edm::FileInPath>("apvBaselinesFile_tib3"),
@@ -52,6 +63,18 @@ SiStripApvSimulationParametersESSource::SiStripApvSimulationParametersESSource(c
                         conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob4"),
                         conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob5"),
                         conf.getParameter<edm::FileInPath>("apvBaselinesFile_tob6")};
+  baselineFiles_TID_ = {conf.getParameter<edm::FileInPath>("apvBaselinesFile_tid1"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tid2"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tid3")};
+  baselineFiles_TEC_ = {conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec1"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec2"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec3"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec4"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec5"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec6"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec7"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec8"),
+                        conf.getParameter<edm::FileInPath>("apvBaselinesFile_tec9")};
 }
 
 void SiStripApvSimulationParametersESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
@@ -61,9 +84,9 @@ void SiStripApvSimulationParametersESSource::setIntervalFor(const edm::eventsetu
 }
 
 SiStripApvSimulationParameters::LayerParameters SiStripApvSimulationParametersESSource::makeLayerParameters(
-    const std::string& apvBaselinesFileName) const {
+    const std::string& apvBaselinesFileName, const std::vector<float>& rzBinEdges) const {
   // Prepare histograms
-  unsigned int nZBins = zBinEdges_.size();
+  unsigned int nZBins = rzBinEdges.size();
   unsigned int nPUBins = puBinEdges_.size();
 
   if (nPUBins == 0 || nZBins == 0 || baseline_nBins_ == 0) {
@@ -76,7 +99,7 @@ SiStripApvSimulationParameters::LayerParameters SiStripApvSimulationParametersES
   }
   baselineBinEdges.push_back(baseline_max_);
 
-  SiStripApvSimulationParameters::LayerParameters layerParams{baselineBinEdges, puBinEdges_, zBinEdges_};
+  SiStripApvSimulationParameters::LayerParameters layerParams{baselineBinEdges, puBinEdges_, rzBinEdges};
 
   // Read apv baselines from text files
   std::vector<double> theAPVBaselines;
@@ -119,20 +142,34 @@ SiStripApvSimulationParameters::LayerParameters SiStripApvSimulationParametersES
 
 std::unique_ptr<SiStripApvSimulationParameters> SiStripApvSimulationParametersESSource::produce(
     const SiStripApvSimulationParametersRcd& record) {
-  auto apvSimParams =
-      std::make_unique<SiStripApvSimulationParameters>(baselineFiles_TIB_.size(), baselineFiles_TOB_.size(), 0, 0);
+  auto apvSimParams = std::make_unique<SiStripApvSimulationParameters>(
+      baselineFiles_TIB_.size(), baselineFiles_TOB_.size(), baselineFiles_TID_.size(), baselineFiles_TEC_.size());
   for (unsigned int i{0}; i != baselineFiles_TIB_.size(); ++i) {
-    if (!apvSimParams->putTIB(i + 1, makeLayerParameters(baselineFiles_TIB_[i].fullPath()))) {
+    if (!apvSimParams->putTIB(i + 1, makeLayerParameters(baselineFiles_TIB_[i].fullPath(), zBinEdges_))) {
       throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TIB layer " << (i + 1);
     } else {
       LogDebug("SiStripApvSimulationParameters") << "Added parameters for TIB layer " << (i + 1);
     }
   }
   for (unsigned int i{0}; i != baselineFiles_TOB_.size(); ++i) {
-    if (!apvSimParams->putTOB(i + 1, makeLayerParameters(baselineFiles_TOB_[i].fullPath()))) {
+    if (!apvSimParams->putTOB(i + 1, makeLayerParameters(baselineFiles_TOB_[i].fullPath(), zBinEdges_))) {
       throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TOB layer " << (i + 1);
     } else {
       LogDebug("SiStripApvSimulationParameters") << "Added parameters for TOB layer " << (i + 1);
+    }
+  }
+  for (unsigned int i{0}; i != baselineFiles_TID_.size(); ++i) {
+    if (!apvSimParams->putTID(i + 1, makeLayerParameters(baselineFiles_TID_[i].fullPath(), rBinEdgesTID_))) {
+      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TID wheel " << (i + 1);
+    } else {
+      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TID wheel " << (i + 1);
+    }
+  }
+  for (unsigned int i{0}; i != baselineFiles_TEC_.size(); ++i) {
+    if (!apvSimParams->putTEC(i + 1, makeLayerParameters(baselineFiles_TEC_[i].fullPath(), rBinEdgesTEC_))) {
+      throw cms::Exception("SiStripApvSimulationParameters") << "Could not add parameters for TEC wheel " << (i + 1);
+    } else {
+      LogDebug("SiStripApvSimulationParameters") << "Added parameters for TEC wheel " << (i + 1);
     }
   }
   return apvSimParams;

--- a/CondCore/SiStripPlugins/plugins/plugin.cc
+++ b/CondCore/SiStripPlugins/plugins/plugin.cc
@@ -61,6 +61,16 @@ REGISTER_PLUGIN(SiStripSummaryRcd, SiStripSummary);
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 REGISTER_PLUGIN(SiStripConfObjectRcd, SiStripConfObject);
 
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
+namespace {
+  struct initializeApvSimulationParameters {
+    void operator()(SiStripApvSimulationParameters& param) { param.calculateIntegrals(); }
+  };
+}  // namespace
+REGISTER_PLUGIN_INIT(SiStripApvSimulationParametersRcd,
+                     SiStripApvSimulationParameters,
+                     initializeApvSimulationParameters);
+
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"
 namespace {
   struct initializeCabling {

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -250,6 +250,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(SiPixelQualityProbabilities);
   PAYLOAD_2XML_CLASS(SiPixelTemplateDBObject);
   PAYLOAD_2XML_CLASS(SiStripApvGain);
+  PAYLOAD_2XML_CLASS(SiStripApvSimulationParameters);
   PAYLOAD_2XML_CLASS(SiStripBackPlaneCorrection);
   PAYLOAD_2XML_CLASS(SiStripBadStrip);
   PAYLOAD_2XML_CLASS(SiStripConfObject);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -285,6 +285,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(SiPixelTemplateDBObject)
       FETCH_PAYLOAD_CASE(SiPixel2DTemplateDBObject)
       FETCH_PAYLOAD_CASE(SiStripApvGain)
+      FETCH_PAYLOAD_CASE(SiStripApvSimulationParameters)
       FETCH_PAYLOAD_CASE(SiStripBackPlaneCorrection)
       FETCH_PAYLOAD_CASE(SiStripBadStrip)
       FETCH_PAYLOAD_CASE(SiStripConfObject)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -311,6 +311,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(SiPixelTemplateDBObject)
         IMPORT_PAYLOAD_CASE(SiPixel2DTemplateDBObject)
         IMPORT_PAYLOAD_CASE(SiStripApvGain)
+        IMPORT_PAYLOAD_CASE(SiStripApvSimulationParameters)
         IMPORT_PAYLOAD_CASE(SiStripBadStrip)
         IMPORT_PAYLOAD_CASE(SiStripBackPlaneCorrection)
         IMPORT_PAYLOAD_CASE(SiStripConfObject)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -151,6 +151,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "CondFormats/SiStripObjects/interface/SiStripThreshold.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
 #include "CondFormats/CSCObjects/interface/CSCDBCrosstalk.h"
 #include "CondFormats/CSCObjects/interface/CSCDBL1TPParameters.h"
 #include "CondFormats/CastorObjects/interface/CastorChannelQuality.h"

--- a/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiStripCondDataRecords.h
@@ -55,6 +55,10 @@ class SiStripClusterThresholdRcd : public edm::eventsetup::EventSetupRecordImple
 /*Record for the configuration object*/
 class SiStripConfObjectRcd : public edm::eventsetup::EventSetupRecordImplementation<SiStripConfObjectRcd> {};
 
+/*Record for the APV simulation parameters*/
+class SiStripApvSimulationParametersRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<SiStripApvSimulationParametersRcd> {};
+
 /*Records for upgrade */
 class Phase2TrackerCablingRcd : public edm::eventsetup::EventSetupRecordImplementation<Phase2TrackerCablingRcd> {};
 

--- a/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
+++ b/CondFormats/DataRecord/src/SiStripCondDataRecords.cc
@@ -38,4 +38,6 @@ EVENTSETUP_RECORD_REG(SiStripClusterThresholdRcd);
 
 EVENTSETUP_RECORD_REG(SiStripConfObjectRcd);
 
+EVENTSETUP_RECORD_REG(SiStripApvSimulationParametersRcd);
+
 EVENTSETUP_RECORD_REG(Phase2TrackerCablingRcd);

--- a/CondFormats/PhysicsToolsObjects/interface/Histogram3D.icc
+++ b/CondFormats/PhysicsToolsObjects/interface/Histogram3D.icc
@@ -71,7 +71,7 @@ namespace PhysicsTools {
           binULimitsX(binULimitsX),
           binULimitsY(binULimitsY),
           binULimitsZ(binULimitsZ),
-          binValues((binULimitsY.size() + 1) * strideX * strideY),
+          binValues((binULimitsZ.size() + 1) * strideX * strideY),
           limitsX(AxisX_t(), AxisX_t()),
           limitsY(AxisY_t(), AxisY_t()),
           limitsZ(AxisZ_t(), AxisZ_t()),

--- a/CondFormats/SiStripObjects/BuildFile.xml
+++ b/CondFormats/SiStripObjects/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
+<use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="DataFormats/TrackerCommon"/>
 <use   name="DataFormats/SiStripCommon"/>
 <use   name="DataFormats/SiStripDetId"/>

--- a/CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h
+++ b/CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h
@@ -37,16 +37,16 @@ public:
   bool putTOB(layerid layer, const LayerParameters& params) { return putTOB(layer, LayerParameters(params)); }
   bool putTOB(layerid layer, LayerParameters&& params);
 
-  bool putTID(layerid ring, const LayerParameters& params) { return putTID(ring, LayerParameters(params)); }
-  bool putTID(layerid ring, LayerParameters&& params);
+  bool putTID(layerid wheel, const LayerParameters& params) { return putTID(wheel, LayerParameters(params)); }
+  bool putTID(layerid wheel, LayerParameters&& params);
 
-  bool putTEC(layerid ring, const LayerParameters& params) { return putTEC(ring, LayerParameters(params)); }
-  bool putTEC(layerid ring, LayerParameters&& params);
+  bool putTEC(layerid wheel, const LayerParameters& params) { return putTEC(wheel, LayerParameters(params)); }
+  bool putTEC(layerid wheel, LayerParameters&& params);
 
   const LayerParameters& getTIB(layerid layer) const { return m_barrelParam[layer - 1]; }
   const LayerParameters& getTOB(layerid layer) const { return m_barrelParam[m_nTIB + layer - 1]; }
-  const LayerParameters& getTID(layerid ring) const { return m_endcapParam[ring - 1]; }
-  const LayerParameters& getTEC(layerid ring) const { return m_endcapParam[m_nTID + ring - 1]; }
+  const LayerParameters& getTID(layerid wheel) const { return m_endcapParam[wheel - 1]; }
+  const LayerParameters& getTEC(layerid wheel) const { return m_endcapParam[m_nTID + wheel - 1]; }
 
   float sampleTIB(layerid layer, float z, float pu, CLHEP::HepRandomEngine* engine) const {
     return sampleBarrel(layer - 1, z, pu, engine);
@@ -54,11 +54,11 @@ public:
   float sampleTOB(layerid layer, float z, float pu, CLHEP::HepRandomEngine* engine) const {
     return sampleBarrel(m_nTIB + layer - 1, z, pu, engine);
   };
-  float sampleTID(layerid ring, float z, float pu, CLHEP::HepRandomEngine* engine) const {
-    return sampleEndcap(ring - 1, z, pu, engine);
+  float sampleTID(layerid wheel, float r, float pu, CLHEP::HepRandomEngine* engine) const {
+    return sampleEndcap(wheel - 1, r, pu, engine);
   }
-  float sampleTEC(layerid ring, float z, float pu, CLHEP::HepRandomEngine* engine) const {
-    return sampleEndcap(m_nTID + ring - 1, z, pu, engine);
+  float sampleTEC(layerid wheel, float r, float pu, CLHEP::HepRandomEngine* engine) const {
+    return sampleEndcap(m_nTID + wheel - 1, r, pu, engine);
   }
 
 private:
@@ -69,7 +69,7 @@ private:
   std::vector<PhysicsTools::Calibration::HistogramF2D> m_endcapParam_xInt;
 
   float sampleBarrel(layerid layerIdx, float z, float pu, CLHEP::HepRandomEngine* engine) const;
-  float sampleEndcap(layerid ringIdx, float z, float pu, CLHEP::HepRandomEngine* engine) const;
+  float sampleEndcap(layerid wheelIdx, float r, float pu, CLHEP::HepRandomEngine* engine) const;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h
+++ b/CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h
@@ -1,0 +1,57 @@
+#ifndef SiStripApvSimulationParameters_h
+#define SiStripApvSimulationParameters_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <vector>
+#include "CondFormats/PhysicsToolsObjects/interface/Histogram2D.h"
+#include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
+/**
+ * Stores a histogram binned in PU, z and baseline voltage, for every barrel layer of the strip tracker
+ */
+class SiStripApvSimulationParameters {
+public:
+  using layerid = unsigned int;
+  using LayerParameters = PhysicsTools::Calibration::HistogramF3D;
+
+  SiStripApvSimulationParameters(layerid nTIB, layerid nTOB) : m_nTIB(nTIB), m_nTOB(nTOB) {
+    m_barrelParam.resize(m_nTIB + m_nTOB);
+    m_barrelParam_xInt.resize(m_nTIB + m_nTOB);
+  }
+  SiStripApvSimulationParameters() {}
+  ~SiStripApvSimulationParameters() {}
+
+  void calculateIntegrals();  // make sure integrals have been calculated
+
+  bool putTIB(layerid layer, const LayerParameters& params) { return putTIB(layer, LayerParameters(params)); }
+  bool putTIB(layerid layer, LayerParameters&& params);
+
+  bool putTOB(layerid layer, const LayerParameters& params) { return putTOB(layer, LayerParameters(params)); }
+  bool putTOB(layerid layer, LayerParameters&& params);
+
+  const LayerParameters& getTIB(layerid layer) const { return m_barrelParam[layer - 1]; }
+  const LayerParameters& getTOB(layerid layer) const { return m_barrelParam[m_nTIB + layer - 1]; }
+
+  float sampleTIB(layerid layer, float z, float pu, CLHEP::HepRandomEngine* engine) const {
+    return sampleBarrel(layer - 1, z, pu, engine);
+  }
+  float sampleTOB(layerid layer, float z, float pu, CLHEP::HepRandomEngine* engine) const {
+    return sampleBarrel(m_nTIB + layer - 1, z, pu, engine);
+  };
+
+private:
+  layerid m_nTIB, m_nTOB;
+  std::vector<PhysicsTools::Calibration::HistogramF3D> m_barrelParam;
+  std::vector<PhysicsTools::Calibration::HistogramF2D> m_barrelParam_xInt;
+
+  float sampleBarrel(layerid layerIdx, float z, float pu, CLHEP::HepRandomEngine* engine) const;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h
+++ b/CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h
@@ -19,9 +19,12 @@ public:
   using layerid = unsigned int;
   using LayerParameters = PhysicsTools::Calibration::HistogramF3D;
 
-  SiStripApvSimulationParameters(layerid nTIB, layerid nTOB) : m_nTIB(nTIB), m_nTOB(nTOB) {
+  SiStripApvSimulationParameters(layerid nTIB, layerid nTOB, layerid nTID, layerid nTEC)
+      : m_nTIB(nTIB), m_nTOB(nTOB), m_nTID(nTID), m_nTEC(nTEC) {
     m_barrelParam.resize(m_nTIB + m_nTOB);
     m_barrelParam_xInt.resize(m_nTIB + m_nTOB);
+    m_endcapParam.resize(m_nTID + m_nTEC);
+    m_endcapParam_xInt.resize(m_nTID + m_nTEC);
   }
   SiStripApvSimulationParameters() {}
   ~SiStripApvSimulationParameters() {}
@@ -34,8 +37,16 @@ public:
   bool putTOB(layerid layer, const LayerParameters& params) { return putTOB(layer, LayerParameters(params)); }
   bool putTOB(layerid layer, LayerParameters&& params);
 
+  bool putTID(layerid ring, const LayerParameters& params) { return putTID(ring, LayerParameters(params)); }
+  bool putTID(layerid ring, LayerParameters&& params);
+
+  bool putTEC(layerid ring, const LayerParameters& params) { return putTEC(ring, LayerParameters(params)); }
+  bool putTEC(layerid ring, LayerParameters&& params);
+
   const LayerParameters& getTIB(layerid layer) const { return m_barrelParam[layer - 1]; }
   const LayerParameters& getTOB(layerid layer) const { return m_barrelParam[m_nTIB + layer - 1]; }
+  const LayerParameters& getTID(layerid ring) const { return m_endcapParam[ring - 1]; }
+  const LayerParameters& getTEC(layerid ring) const { return m_endcapParam[m_nTID + ring - 1]; }
 
   float sampleTIB(layerid layer, float z, float pu, CLHEP::HepRandomEngine* engine) const {
     return sampleBarrel(layer - 1, z, pu, engine);
@@ -43,13 +54,22 @@ public:
   float sampleTOB(layerid layer, float z, float pu, CLHEP::HepRandomEngine* engine) const {
     return sampleBarrel(m_nTIB + layer - 1, z, pu, engine);
   };
+  float sampleTID(layerid ring, float z, float pu, CLHEP::HepRandomEngine* engine) const {
+    return sampleEndcap(ring - 1, z, pu, engine);
+  }
+  float sampleTEC(layerid ring, float z, float pu, CLHEP::HepRandomEngine* engine) const {
+    return sampleEndcap(m_nTID + ring - 1, z, pu, engine);
+  }
 
 private:
-  layerid m_nTIB, m_nTOB;
+  layerid m_nTIB, m_nTOB, m_nTID, m_nTEC;
   std::vector<PhysicsTools::Calibration::HistogramF3D> m_barrelParam;
   std::vector<PhysicsTools::Calibration::HistogramF2D> m_barrelParam_xInt;
+  std::vector<PhysicsTools::Calibration::HistogramF3D> m_endcapParam;
+  std::vector<PhysicsTools::Calibration::HistogramF2D> m_endcapParam_xInt;
 
   float sampleBarrel(layerid layerIdx, float z, float pu, CLHEP::HepRandomEngine* engine) const;
+  float sampleEndcap(layerid ringIdx, float z, float pu, CLHEP::HepRandomEngine* engine) const;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
+++ b/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
@@ -45,6 +45,12 @@ void SiStripApvSimulationParameters::calculateIntegrals() {
       m_barrelParam_xInt[i] = calculateXInt(m_barrelParam[i]);
     }
   }
+  if (m_endcapParam.size() != m_endcapParam_xInt.size()) {
+    m_endcapParam_xInt.resize(m_endcapParam.size());
+    for (unsigned int i{0}; i != m_endcapParam.size(); ++i) {
+      m_endcapParam_xInt[i] = calculateXInt(m_endcapParam[i]);
+    }
+  }
 }
 
 bool SiStripApvSimulationParameters::putTIB(SiStripApvSimulationParameters::layerid layer,
@@ -71,6 +77,30 @@ bool SiStripApvSimulationParameters::putTOB(SiStripApvSimulationParameters::laye
   return true;
 }
 
+bool SiStripApvSimulationParameters::putTID(SiStripApvSimulationParameters::layerid ring,
+                                            SiStripApvSimulationParameters::LayerParameters&& params) {
+  if ((ring > m_nTID) || (ring < 1)) {
+    edm::LogError("SiStripApvSimulationParameters")
+        << "[" << __PRETTY_FUNCTION__ << "] ring index " << ring << " out of range [1," << m_nTID << "]";
+    return false;
+  }
+  m_endcapParam[ring - 1] = params;
+  m_endcapParam_xInt[ring - 1] = calculateXInt(params);
+  return true;
+}
+
+bool SiStripApvSimulationParameters::putTEC(SiStripApvSimulationParameters::layerid ring,
+                                            SiStripApvSimulationParameters::LayerParameters&& params) {
+  if ((ring > m_nTEC) || (ring < 1)) {
+    edm::LogError("SiStripApvSimulationParameters")
+        << "[" << __PRETTY_FUNCTION__ << "] ring index " << ring << " out of range [1," << m_nTEC << ")";
+    return false;
+  }
+  m_endcapParam[m_nTID + ring - 1] = params;
+  m_endcapParam_xInt[m_nTID + ring - 1] = calculateXInt(params);
+  return true;
+}
+
 float SiStripApvSimulationParameters::sampleBarrel(layerid layerIdx,
                                                    float z,
                                                    float pu,
@@ -82,6 +112,34 @@ float SiStripApvSimulationParameters::sampleBarrel(layerid layerIdx,
   const int ip = layerParam.findBinY(pu);
   const int iz = layerParam.findBinZ(z);
   const float norm = m_barrelParam_xInt[layerIdx].binContent(ip, iz);
+  const auto val = CLHEP::RandFlat::shoot(engine) * norm;
+  if (val < layerParam.binContent(0, ip, iz)) {  // underflow
+    return layerParam.rangeX().min;
+  } else if (norm - val < layerParam.binContent(layerParam.numberOfBinsX() + 1, ip, iz)) {  // overflow
+    return layerParam.rangeX().max;
+  } else {  // loop over bins, return center of our bin
+    float sum = layerParam.binContent(0, ip, iz);
+    for (int i{1}; i != layerParam.numberOfBinsX() + 1; ++i) {
+      sum += layerParam.binContent(i, ip, iz);
+      if (sum > val) {
+        return xBinPos(layerParam, i, (sum - val) / layerParam.binContent(i, ip, iz));
+      }
+    }
+  }
+  throw cms::Exception("LogicError") << "Problem drawing a random number from the distribution";
+}
+
+float SiStripApvSimulationParameters::sampleEndcap(layerid ringIdx,
+                                                   float z,
+                                                   float pu,
+                                                   CLHEP::HepRandomEngine* engine) const {
+  if (m_endcapParam.size() != m_endcapParam_xInt.size()) {
+    throw cms::Exception("LogicError") << "x-integrals of 3D histograms have not been calculated";
+  }
+  const auto layerParam = m_endcapParam[ringIdx];
+  const int ip = layerParam.findBinY(pu);
+  const int iz = layerParam.findBinZ(z);
+  const float norm = m_endcapParam_xInt[ringIdx].binContent(ip, iz);
   const auto val = CLHEP::RandFlat::shoot(engine) * norm;
   if (val < layerParam.binContent(0, ip, iz)) {  // underflow
     return layerParam.rangeX().min;

--- a/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
+++ b/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
@@ -1,0 +1,99 @@
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CLHEP/Random/RandFlat.h"
+
+namespace {
+  PhysicsTools::Calibration::HistogramF2D calculateXInt(const SiStripApvSimulationParameters::LayerParameters& params) {
+    auto hXInt = (
+        params.hasEquidistantBinsY() ?
+          ( params.hasEquidistantBinsZ() ?
+            PhysicsTools::Calibration::HistogramF2D(params.numberOfBinsY(), params.rangeY(), params.numberOfBinsZ(), params.rangeZ())
+          : PhysicsTools::Calibration::HistogramF2D(params.numberOfBinsY(), params.rangeY(), params.upperLimitsZ()) )
+        : ( params.hasEquidistantBinsZ() ?
+            PhysicsTools::Calibration::HistogramF2D(params.upperLimitsY(), params.numberOfBinsZ(), params.rangeZ())
+          : PhysicsTools::Calibration::HistogramF2D(params.upperLimitsY(), params.upperLimitsZ()) )
+        );
+    for (int i{0}; i != params.numberOfBinsY() + 2; ++i) {
+      for (int j{0}; j != params.numberOfBinsZ() + 2; ++j) {
+        float xInt = 0.;
+        for (int k{0}; k != params.numberOfBinsX() + 2; ++k) {
+          xInt += params.binContent(k, i, j);
+        }
+        hXInt.setBinContent(i, j, xInt);
+      }
+    }
+    return hXInt;
+  }
+
+  float xBinPos(const SiStripApvSimulationParameters::LayerParameters& hist, int iBin, float pos=0.5) {
+    // NOTE: does not work for under- and overflow bins (iBin = 0 and iBIn == hist.numberOfBinsX()+1)
+    if ( hist.hasEquidistantBinsX() ) {
+      const auto range = hist.rangeX();
+      const auto binWidth = (range.max-range.min)/hist.numberOfBinsX();
+      return range.min+(iBin-1+pos)*binWidth;
+    } else {
+      return (1.-pos)*hist.upperLimitsX()[iBin-1]+pos*hist.upperLimitsX()[iBin];
+    }
+  }
+}  // namespace
+
+void SiStripApvSimulationParameters::calculateIntegrals() {
+  if (m_barrelParam.size() != m_barrelParam_xInt.size()) {
+    m_barrelParam_xInt.resize(m_barrelParam.size());
+    for (unsigned int i{0}; i != m_barrelParam.size(); ++i) {
+      m_barrelParam_xInt[i] = calculateXInt(m_barrelParam[i]);
+    }
+  }
+}
+
+bool SiStripApvSimulationParameters::putTIB(SiStripApvSimulationParameters::layerid layer,
+                                            SiStripApvSimulationParameters::LayerParameters&& params) {
+  if ((layer > m_nTIB) || (layer < 1)) {
+    edm::LogError("SiStripApvSimulationParameters")
+        << "[" << __PRETTY_FUNCTION__ << "] layer index " << layer << " out of range [1," << m_nTIB << "]";
+    return false;
+  }
+  m_barrelParam[layer - 1] = params;
+  m_barrelParam_xInt[layer - 1] = calculateXInt(params);
+  return true;
+}
+
+bool SiStripApvSimulationParameters::putTOB(SiStripApvSimulationParameters::layerid layer,
+                                            SiStripApvSimulationParameters::LayerParameters&& params) {
+  if ((layer > m_nTOB) || (layer < 1)) {
+    edm::LogError("SiStripApvSimulationParameters") << "[" << __PRETTY_FUNCTION__ << "] layer index " << layer
+                                                    << " out of range [1," << m_nTOB << ")";
+    return false;
+  }
+  m_barrelParam[m_nTIB + layer - 1] = params;
+  m_barrelParam_xInt[m_nTIB + layer - 1] = calculateXInt(params);
+  return true;
+}
+
+float SiStripApvSimulationParameters::sampleBarrel(layerid layerIdx,
+                                                   float z,
+                                                   float pu,
+                                                   CLHEP::HepRandomEngine* engine) const {
+  if (m_barrelParam.size() != m_barrelParam_xInt.size()) {
+    throw cms::Exception("LogicError") << "x-integrals of 3D histograms have not been calculated";
+  }
+  const auto layerParam = m_barrelParam[layerIdx];
+  const int ip = layerParam.findBinY(pu);
+  const int iz = layerParam.findBinZ(z);
+  const float norm = m_barrelParam_xInt[layerIdx].binContent(ip, iz);
+  const auto val = CLHEP::RandFlat::shoot(engine) * norm;
+  if (val < layerParam.binContent(0, ip, iz)) {  // underflow
+    return layerParam.rangeX().min;
+  } else if (norm - val < layerParam.binContent(layerParam.numberOfBinsX() + 1, ip, iz)) { // overflow
+    return layerParam.rangeX().max;
+  } else {  // loop over bins, return center of our bin
+    float sum = layerParam.binContent(0, ip, iz);
+    for (int i{1}; i != layerParam.numberOfBinsX() + 1; ++i) {
+      sum += layerParam.binContent(i, ip, iz);
+      if (sum > val) {
+        return xBinPos(layerParam, i, (sum-val)/layerParam.binContent(i, ip, iz));
+      }
+    }
+  }
+  throw cms::Exception("LogicError") << "Problem drawing a random number from the distribution";
+}

--- a/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
+++ b/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
@@ -4,15 +4,16 @@
 
 namespace {
   PhysicsTools::Calibration::HistogramF2D calculateXInt(const SiStripApvSimulationParameters::LayerParameters& params) {
-    auto hXInt = (
-        params.hasEquidistantBinsY() ?
-          ( params.hasEquidistantBinsZ() ?
-            PhysicsTools::Calibration::HistogramF2D(params.numberOfBinsY(), params.rangeY(), params.numberOfBinsZ(), params.rangeZ())
-          : PhysicsTools::Calibration::HistogramF2D(params.numberOfBinsY(), params.rangeY(), params.upperLimitsZ()) )
-        : ( params.hasEquidistantBinsZ() ?
-            PhysicsTools::Calibration::HistogramF2D(params.upperLimitsY(), params.numberOfBinsZ(), params.rangeZ())
-          : PhysicsTools::Calibration::HistogramF2D(params.upperLimitsY(), params.upperLimitsZ()) )
-        );
+    auto hXInt = (params.hasEquidistantBinsY()
+                      ? (params.hasEquidistantBinsZ()
+                             ? PhysicsTools::Calibration::HistogramF2D(
+                                   params.numberOfBinsY(), params.rangeY(), params.numberOfBinsZ(), params.rangeZ())
+                             : PhysicsTools::Calibration::HistogramF2D(
+                                   params.numberOfBinsY(), params.rangeY(), params.upperLimitsZ()))
+                      : (params.hasEquidistantBinsZ()
+                             ? PhysicsTools::Calibration::HistogramF2D(
+                                   params.upperLimitsY(), params.numberOfBinsZ(), params.rangeZ())
+                             : PhysicsTools::Calibration::HistogramF2D(params.upperLimitsY(), params.upperLimitsZ())));
     for (int i{0}; i != params.numberOfBinsY() + 2; ++i) {
       for (int j{0}; j != params.numberOfBinsZ() + 2; ++j) {
         float xInt = 0.;
@@ -25,14 +26,14 @@ namespace {
     return hXInt;
   }
 
-  float xBinPos(const SiStripApvSimulationParameters::LayerParameters& hist, int iBin, float pos=0.5) {
+  float xBinPos(const SiStripApvSimulationParameters::LayerParameters& hist, int iBin, float pos = 0.5) {
     // NOTE: does not work for under- and overflow bins (iBin = 0 and iBIn == hist.numberOfBinsX()+1)
-    if ( hist.hasEquidistantBinsX() ) {
+    if (hist.hasEquidistantBinsX()) {
       const auto range = hist.rangeX();
-      const auto binWidth = (range.max-range.min)/hist.numberOfBinsX();
-      return range.min+(iBin-1+pos)*binWidth;
+      const auto binWidth = (range.max - range.min) / hist.numberOfBinsX();
+      return range.min + (iBin - 1 + pos) * binWidth;
     } else {
-      return (1.-pos)*hist.upperLimitsX()[iBin-1]+pos*hist.upperLimitsX()[iBin];
+      return (1. - pos) * hist.upperLimitsX()[iBin - 1] + pos * hist.upperLimitsX()[iBin];
     }
   }
 }  // namespace
@@ -61,8 +62,8 @@ bool SiStripApvSimulationParameters::putTIB(SiStripApvSimulationParameters::laye
 bool SiStripApvSimulationParameters::putTOB(SiStripApvSimulationParameters::layerid layer,
                                             SiStripApvSimulationParameters::LayerParameters&& params) {
   if ((layer > m_nTOB) || (layer < 1)) {
-    edm::LogError("SiStripApvSimulationParameters") << "[" << __PRETTY_FUNCTION__ << "] layer index " << layer
-                                                    << " out of range [1," << m_nTOB << ")";
+    edm::LogError("SiStripApvSimulationParameters")
+        << "[" << __PRETTY_FUNCTION__ << "] layer index " << layer << " out of range [1," << m_nTOB << ")";
     return false;
   }
   m_barrelParam[m_nTIB + layer - 1] = params;
@@ -84,14 +85,14 @@ float SiStripApvSimulationParameters::sampleBarrel(layerid layerIdx,
   const auto val = CLHEP::RandFlat::shoot(engine) * norm;
   if (val < layerParam.binContent(0, ip, iz)) {  // underflow
     return layerParam.rangeX().min;
-  } else if (norm - val < layerParam.binContent(layerParam.numberOfBinsX() + 1, ip, iz)) { // overflow
+  } else if (norm - val < layerParam.binContent(layerParam.numberOfBinsX() + 1, ip, iz)) {  // overflow
     return layerParam.rangeX().max;
   } else {  // loop over bins, return center of our bin
     float sum = layerParam.binContent(0, ip, iz);
     for (int i{1}; i != layerParam.numberOfBinsX() + 1; ++i) {
       sum += layerParam.binContent(i, ip, iz);
       if (sum > val) {
-        return xBinPos(layerParam, i, (sum-val)/layerParam.binContent(i, ip, iz));
+        return xBinPos(layerParam, i, (sum - val) / layerParam.binContent(i, ip, iz));
       }
     }
   }

--- a/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
+++ b/CondFormats/SiStripObjects/src/SiStripApvSimulationParameters.cc
@@ -77,27 +77,27 @@ bool SiStripApvSimulationParameters::putTOB(SiStripApvSimulationParameters::laye
   return true;
 }
 
-bool SiStripApvSimulationParameters::putTID(SiStripApvSimulationParameters::layerid ring,
+bool SiStripApvSimulationParameters::putTID(SiStripApvSimulationParameters::layerid wheel,
                                             SiStripApvSimulationParameters::LayerParameters&& params) {
-  if ((ring > m_nTID) || (ring < 1)) {
+  if ((wheel > m_nTID) || (wheel < 1)) {
     edm::LogError("SiStripApvSimulationParameters")
-        << "[" << __PRETTY_FUNCTION__ << "] ring index " << ring << " out of range [1," << m_nTID << "]";
+        << "[" << __PRETTY_FUNCTION__ << "] wheel index " << wheel << " out of range [1," << m_nTID << "]";
     return false;
   }
-  m_endcapParam[ring - 1] = params;
-  m_endcapParam_xInt[ring - 1] = calculateXInt(params);
+  m_endcapParam[wheel - 1] = params;
+  m_endcapParam_xInt[wheel - 1] = calculateXInt(params);
   return true;
 }
 
-bool SiStripApvSimulationParameters::putTEC(SiStripApvSimulationParameters::layerid ring,
+bool SiStripApvSimulationParameters::putTEC(SiStripApvSimulationParameters::layerid wheel,
                                             SiStripApvSimulationParameters::LayerParameters&& params) {
-  if ((ring > m_nTEC) || (ring < 1)) {
+  if ((wheel > m_nTEC) || (wheel < 1)) {
     edm::LogError("SiStripApvSimulationParameters")
-        << "[" << __PRETTY_FUNCTION__ << "] ring index " << ring << " out of range [1," << m_nTEC << ")";
+        << "[" << __PRETTY_FUNCTION__ << "] wheel index " << wheel << " out of range [1," << m_nTEC << ")";
     return false;
   }
-  m_endcapParam[m_nTID + ring - 1] = params;
-  m_endcapParam_xInt[m_nTID + ring - 1] = calculateXInt(params);
+  m_endcapParam[m_nTID + wheel - 1] = params;
+  m_endcapParam_xInt[m_nTID + wheel - 1] = calculateXInt(params);
   return true;
 }
 
@@ -129,28 +129,28 @@ float SiStripApvSimulationParameters::sampleBarrel(layerid layerIdx,
   throw cms::Exception("LogicError") << "Problem drawing a random number from the distribution";
 }
 
-float SiStripApvSimulationParameters::sampleEndcap(layerid ringIdx,
-                                                   float z,
+float SiStripApvSimulationParameters::sampleEndcap(layerid wheelIdx,
+                                                   float r,
                                                    float pu,
                                                    CLHEP::HepRandomEngine* engine) const {
   if (m_endcapParam.size() != m_endcapParam_xInt.size()) {
     throw cms::Exception("LogicError") << "x-integrals of 3D histograms have not been calculated";
   }
-  const auto layerParam = m_endcapParam[ringIdx];
+  const auto layerParam = m_endcapParam[wheelIdx];
   const int ip = layerParam.findBinY(pu);
-  const int iz = layerParam.findBinZ(z);
-  const float norm = m_endcapParam_xInt[ringIdx].binContent(ip, iz);
+  const int ir = layerParam.findBinZ(r);
+  const float norm = m_endcapParam_xInt[wheelIdx].binContent(ip, ir);
   const auto val = CLHEP::RandFlat::shoot(engine) * norm;
-  if (val < layerParam.binContent(0, ip, iz)) {  // underflow
+  if (val < layerParam.binContent(0, ip, ir)) {  // underflow
     return layerParam.rangeX().min;
-  } else if (norm - val < layerParam.binContent(layerParam.numberOfBinsX() + 1, ip, iz)) {  // overflow
+  } else if (norm - val < layerParam.binContent(layerParam.numberOfBinsX() + 1, ip, ir)) {  // overflow
     return layerParam.rangeX().max;
   } else {  // loop over bins, return center of our bin
-    float sum = layerParam.binContent(0, ip, iz);
+    float sum = layerParam.binContent(0, ip, ir);
     for (int i{1}; i != layerParam.numberOfBinsX() + 1; ++i) {
-      sum += layerParam.binContent(i, ip, iz);
+      sum += layerParam.binContent(i, ip, ir);
       if (sum > val) {
-        return xBinPos(layerParam, i, (sum - val) / layerParam.binContent(i, ip, iz));
+        return xBinPos(layerParam, i, (sum - val) / layerParam.binContent(i, ip, ir));
       }
     }
   }

--- a/CondFormats/SiStripObjects/src/T_EventSetup_SiStrip.cc
+++ b/CondFormats/SiStripObjects/src/T_EventSetup_SiStrip.cc
@@ -26,6 +26,8 @@ TYPELOOKUP_DATA_REG(SiStripSummary);
 TYPELOOKUP_DATA_REG(SiStripThreshold);
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 TYPELOOKUP_DATA_REG(SiStripConfObject);
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
+TYPELOOKUP_DATA_REG(SiStripApvSimulationParameters);
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerModule.h"
 TYPELOOKUP_DATA_REG(Phase2TrackerModule);
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"

--- a/CondFormats/SiStripObjects/src/classes_def.xml
+++ b/CondFormats/SiStripObjects/src/classes_def.xml
@@ -93,6 +93,10 @@
     <!-- <field name="values_" mapping="blob"/> -->
   </class>
 
+  <class name="SiStripApvSimulationParameters" class_version="0">
+    <field name="m_barrelParam_xInt" transient="true"/>
+  </class>
+
   <class name="Phase2TrackerModule" ClassVersion="11">
    <version ClassVersion="11" checksum="707066581"/>
     <version ClassVersion="10" checksum="2583259051"/>

--- a/CondFormats/SiStripObjects/src/classes_def.xml
+++ b/CondFormats/SiStripObjects/src/classes_def.xml
@@ -95,6 +95,7 @@
 
   <class name="SiStripApvSimulationParameters" class_version="0">
     <field name="m_barrelParam_xInt" transient="true"/>
+    <field name="m_endcapParam_xInt" transient="true"/>
   </class>
 
   <class name="Phase2TrackerModule" ClassVersion="11">

--- a/CondFormats/SiStripObjects/src/headers.h
+++ b/CondFormats/SiStripObjects/src/headers.h
@@ -13,5 +13,6 @@
 #include "CondFormats/SiStripObjects/interface/SiStripRunSummary.h"
 #include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerModule.h"
 #include "CondFormats/SiStripObjects/interface/Phase2TrackerCabling.h"

--- a/CondFormats/SiStripObjects/test/testSerializationSiStripObjects.cpp
+++ b/CondFormats/SiStripObjects/test/testSerializationSiStripObjects.cpp
@@ -5,6 +5,7 @@
 int main() {
   testSerialization<FedChannelConnection>();
   testSerialization<SiStripApvGain>();
+  testSerialization<SiStripApvSimulationParameters>();
   testSerialization<SiStripBackPlaneCorrection>();
   testSerialization<SiStripBadStrip>();
   testSerialization<SiStripBadStrip::DetRegistry>();

--- a/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
@@ -1,0 +1,37 @@
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
+#include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
+
+class SiStripApvSimulationParametersBuilder : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiStripApvSimulationParametersBuilder(const edm::ParameterSet& iConfig) {}
+  ~SiStripApvSimulationParametersBuilder() override {}
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+};
+
+void SiStripApvSimulationParametersBuilder::analyze(const edm::Event&, const edm::EventSetup& evtSetup) {
+  edm::ESHandle<SiStripApvSimulationParameters> objHandle;
+  evtSetup.get<SiStripApvSimulationParametersRcd>().get(objHandle);
+
+  // copy; DB service needs non-const pointer but does not take ownership
+  auto obj = std::make_unique<SiStripApvSimulationParameters>(*objHandle);
+
+  edm::Service<cond::service::PoolDBOutputService> mydbservice;
+  if (mydbservice.isAvailable()) {
+    if (mydbservice->isNewTagRequest("SiStripApvSimulationParametersRcd")) {
+      mydbservice->createNewIOV<SiStripApvSimulationParameters>(
+          obj.get(), mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripApvSimulationParametersRcd");
+    } else {
+      mydbservice->appendSinceTime<SiStripApvSimulationParameters>(obj.get(), mydbservice->currentTime(), "SiStripApvSimulationParametersRcd");
+    }
+  } else {
+    edm::LogError("SiStripApvSimulationParametersBuilder") << "Service is unavailable";
+  }
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiStripApvSimulationParametersBuilder);

--- a/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvSimulationParametersBuilder.cc
@@ -25,7 +25,8 @@ void SiStripApvSimulationParametersBuilder::analyze(const edm::Event&, const edm
       mydbservice->createNewIOV<SiStripApvSimulationParameters>(
           obj.get(), mydbservice->beginOfTime(), mydbservice->endOfTime(), "SiStripApvSimulationParametersRcd");
     } else {
-      mydbservice->appendSinceTime<SiStripApvSimulationParameters>(obj.get(), mydbservice->currentTime(), "SiStripApvSimulationParametersRcd");
+      mydbservice->appendSinceTime<SiStripApvSimulationParameters>(
+          obj.get(), mydbservice->currentTime(), "SiStripApvSimulationParametersRcd");
     }
   } else {
     edm::LogError("SiStripApvSimulationParametersBuilder") << "Service is unavailable";

--- a/CondTools/SiStrip/test/SiStripApvSimulationParametersBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvSimulationParametersBuilder_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ICALIB")
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(1),
+    firstRun = cms.untracked.uint32(1)
+)
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(2),
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:dbfile.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripApvSimulationParametersRcd'),
+        tag = cms.string('SiStripApvSimulationParameters_2016preVFP_v1')
+    ))
+)
+
+process.apvSimParam = cms.ESSource("SiStripApvSimulationParametersESSource",
+    apvBaselines_nBinsPerBaseline=cms.uint32(82),
+    apvBaselines_minBaseline=cms.double(0.),
+    apvBaselines_maxBaseline=cms.double(738.),
+    apvBaselines_puBinEdges=cms.vdouble(0.,  2.,  4.,  6.,  8., 10., 12., 14., 16., 18., 20., 22., 24., 26., 28., 30., 32., 34., 36., 38., 40., 42., 44., 46., 48., 50.),
+    apvBaselines_zBinEdges=cms.vdouble(0., 25., 50., 75.),
+    apvBaselinesFile_tib1=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TIB1_12us.txt"),
+    apvBaselinesFile_tib2=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TIB2_15us.txt"),
+    apvBaselinesFile_tib3=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TIB3_16us.txt"),
+    apvBaselinesFile_tib4=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TIB4_17us.txt"),
+    apvBaselinesFile_tob1=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TOB1_10us.txt"),
+    apvBaselinesFile_tob2=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TOB2_13us.txt"),
+    apvBaselinesFile_tob3=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TOB3_16us.txt"),
+    apvBaselinesFile_tob4=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TOB4_17us.txt"),
+    apvBaselinesFile_tob5=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TOB5_17us.txt"),
+    apvBaselinesFile_tob6=cms.FileInPath("SimTracker/SiStripDigitizer/data/APVBaselines_TOB6_18us.txt")
+    )
+process.prod = cms.EDAnalyzer("SiStripApvSimulationParametersBuilder")
+
+process.p = cms.Path(process.prod)


### PR DESCRIPTION
#### PR description:

This PR adds a new object and record to hold the APV simulation baseline distributions, as discussed in https://github.com/cms-sw/cmssw/pull/27823 .
It also adds an ESSource to create it from the existing ascii files, and an EDAnalyzer to add it to the database.
Thanks @mmusich and @EmyrClement for the help and feedback!

#### PR validation:

Compiles, unit tests (serialization) run, created an sqlite file with a payload, adapted the digitizer to use this database (or the product directly from the ESSource in the same job). Inspected the xml of the payload and tested histogram sampling code in a standalone example.