### PR TITLE
Run3-sim45 Remove reference to G4DataQuestionaire

### DIFF
--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -11,12 +11,10 @@
 #include "G4HadronElasticPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 #include "G4SystemOfUnits.hh"
 
 CustomPhysics::CustomPhysics(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool tracking = p.getParameter<bool>("TrackingCut");

--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -15,7 +15,6 @@
 #include "G4SystemOfUnits.hh"
 
 CustomPhysics::CustomPhysics(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool tracking = p.getParameter<bool>("TrackingCut");
   bool ssPhys = p.getUntrackedParameter<bool>("ExoticaPhysicsSS", false);

--- a/SimG4Core/GFlash/plugins/GFlash.cc
+++ b/SimG4Core/GFlash/plugins/GFlash.cc
@@ -16,7 +16,6 @@
 #include <string>
 
 GFlash::GFlash(const edm::ParameterSet &p) : PhysicsList(p), thePar(p.getParameter<edm::ParameterSet>("GFlash")) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/GFlash/plugins/GFlash.cc
+++ b/SimG4Core/GFlash/plugins/GFlash.cc
@@ -11,13 +11,11 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4StoppingPhysics.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "SimGeneral/GFlash/interface/GflashHistogram.h"
 
 #include <string>
 
 GFlash::GFlash(const edm::ParameterSet &p) : PhysicsList(p), thePar(p.getParameter<edm::ParameterSet>("GFlash")) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTF_BIC.hh"
 
 FTFCMS_BIC::FTFCMS_BIC(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTF_BIC.hh"
 
 FTFCMS_BIC::FTFCMS_BIC(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
@@ -11,10 +11,7 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
-
 FTFPCMS_BERT_ATL_EMM::FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
@@ -12,7 +12,6 @@
 #include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT_ATL_EMM::FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
@@ -11,10 +11,7 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
-
 FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
@@ -12,7 +12,6 @@
 #include "G4HadronicProcessStore.hh"
 
 FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
@@ -15,7 +15,6 @@
 #include "G4HadronPhysicsFTFP_BERT_HP.hh"
 
 FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
@@ -12,11 +12,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT_HP.hh"
 
 FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.cc
@@ -15,7 +15,6 @@
 #include "G4HadronPhysicsFTFP_BERT_HP.hh"
 
 FTFPCMS_BERT_HP_EMM::FTFPCMS_BERT_HP_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.cc
@@ -12,11 +12,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT_HP.hh"
 
 FTFPCMS_BERT_HP_EMM::FTFPCMS_BERT_HP_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
@@ -12,11 +12,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
@@ -15,7 +15,6 @@
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
 FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsINCLXX.hh"
 
 FTFPCMS_INCLXX_EMM::FTFPCMS_INCLXX_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsINCLXX.hh"
 
 FTFPCMS_INCLXX_EMM::FTFPCMS_INCLXX_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.cc
@@ -12,11 +12,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsINCLXX.hh"
 
 FTFPCMS_INCLXX_HP_EMM::FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.cc
@@ -15,7 +15,6 @@
 #include "G4HadronPhysicsINCLXX.hh"
 
 FTFPCMS_INCLXX_HP_EMM::FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
+++ b/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
@@ -7,14 +7,12 @@
 #include "G4StoppingPhysics.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronInelasticQBBC.hh"
 #include "G4HadronElasticPhysicsXS.hh"
 #include "G4IonPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
 
 QBBCCMS::QBBCCMS(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
+++ b/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
@@ -13,7 +13,6 @@
 #include "G4NeutronTrackingCut.hh"
 
 QBBCCMS::QBBCCMS(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
 QGSPCMS_BERT::QGSPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
 QGSPCMS_BERT::QGSPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
 QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
 QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
 QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
 QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT_HP.hh"
 
 QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_BERT_HP.hh"
 
 QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.cc
@@ -13,7 +13,6 @@
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMZ::QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
-
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.cc
@@ -10,11 +10,9 @@
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
 
-#include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
 QGSPCMS_FTFP_BERT_EMZ::QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
-  G4DataQuestionaire it(photon);
 
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);


### PR DESCRIPTION
#### PR description:

This reference is not needed in current Geant4 version used and the sequence G4DataQuestionaire.hh will be dropped in future Geant4 versions

#### PR validation:

Tested with the standard matrix

#### if this PR is a backport please specify the original PR:

Nothing special