### PR TITLE
Fixing VID return value for HEEP Trk Iso: 11_0_X

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoCut.cc
@@ -44,5 +44,5 @@ CutApplicatorBase::result_type GsfEleTrkPtIsoCut::operator()(const reco::GsfElec
 
 double GsfEleTrkPtIsoCut::value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);
-  return ele->dr03TkSumPt();
+  return useHEEPIso_ ? ele->dr03TkSumPtHEEP() : ele->dr03TkSumPt();
 }


### PR DESCRIPTION
#### PR description:

Dear All, 

This PR fixes a bug which occurred when unifying the heep & non-HEEP track isolation VID cut. While the correct value is cut upon, the returned value is incorrect and this fixes it. 

Many thanks to @oglez (Oscar Gonzalez Lopez) for spotting and reporting the issue!

This bug has no impact on anything centrally run (we dont retrieve this value in any e/gamma workflow, its purely for users) so we expect zero changes. However our users may use this (and in fact do) so it needs to be fixed, also 10_6_X.

On code, there was the suggestion that the cut function should just use the result of the value function, on the face of it its a good idea however it means we have an extra dynamic cast + function call hence I kept it as is. 

Best,
Sam