### PR TITLE
Fixing VID return value for HEEP Trk Iso: 10_6_X 

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoCut.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/cuts/GsfEleTrkPtIsoCut.cc
@@ -58,5 +58,5 @@ operator()(const reco::GsfElectronPtr& cand) const{
 double GsfEleTrkPtIsoCut::
 value(const reco::CandidatePtr& cand) const {
   reco::GsfElectronPtr ele(cand);  
-  return ele->dr03TkSumPt();
+  return useHEEPIso_ ? ele->dr03TkSumPtHEEP() : ele->dr03TkSumPt();
 }


### PR DESCRIPTION
#### PR description:
Fixes the HEEP track isolation value returned by VID. No changes in any workflow or result is expected, its purely for analyse level


#### if this PR is a backport please specify the original PR:

Backport of : https://github.com/cms-sw/cmssw/pull/27944 (see for more details)

