### PR TITLE
DD4hep: Legacy DD Shape ID Support and Mapping

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
@@ -26,6 +26,7 @@
     <Include ref='Geometry/CMSCommonData/data/cms.xml'/>
     <Include ref='DetectorDescription/DDCMS/data/cmsMagneticField.xml'/>
     <Include ref='MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_1.xml'/>
+    <Include ref='MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_2.xml'/>
     <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
   </IncludeSection>
   

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -134,6 +134,9 @@ namespace cms {
 
     const DDSolidShape shape() const;
 
+    // Convert new DD4hep shape id to an old DD one
+    LegacySolidShape legacyShape(const cms::DDSolidShape shape) const;
+
     //! extract attribute value
     template <typename T>
     T get(const char*) const;

--- a/DetectorDescription/DDCMS/interface/DDShapes.h
+++ b/DetectorDescription/DDCMS/interface/DDShapes.h
@@ -2,9 +2,11 @@
 #define Detector_Description_DDCMS_DDShapes_h
 
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
-#include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
 
 namespace cms {
+
+  enum class DDSolidShape;
+  
   namespace dd {
 
     DDSolidShape getCurrentShape(const cms::DDFilteredView &fview);

--- a/DetectorDescription/DDCMS/interface/DDShapes.h
+++ b/DetectorDescription/DDCMS/interface/DDShapes.h
@@ -6,7 +6,7 @@
 namespace cms {
 
   enum class DDSolidShape;
-  
+
   namespace dd {
 
     DDSolidShape getCurrentShape(const cms::DDFilteredView &fview);

--- a/DetectorDescription/DDCMS/interface/DDSolidShapes.h
+++ b/DetectorDescription/DDCMS/interface/DDSolidShapes.h
@@ -57,7 +57,7 @@ namespace cms {
       }
       return std::begin(a)->value;
     }
-};  // namespace dd
+  };  // namespace dd
 
   enum class DDSolidShape {
     dd_not_init = 0,
@@ -101,28 +101,28 @@ namespace cms {
        {DDSolidShape::ddextrudedpolygon, "ExtrudedPolygon"}}};
 
   const std::array<const cms::dd::ValuePair<LegacySolidShape, cms::DDSolidShape>, 22> LegacySolidShapeMap{
-    {{LegacySolidShape::dd_not_init, cms::DDSolidShape::dd_not_init},
-     {LegacySolidShape::ddbox, cms::DDSolidShape::ddbox},
-     {LegacySolidShape::ddtubs, cms::DDSolidShape::ddtubs},
-     {LegacySolidShape::ddtrap, cms::DDSolidShape::ddtrap},
-     {LegacySolidShape::ddcons, cms::DDSolidShape::ddcons},
-     {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
-     {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
-     {LegacySolidShape::ddpolycone_rrz, cms::DDSolidShape::ddpolycone},
-     {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
-     {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
-     {LegacySolidShape::ddpolyhedra_rrz, cms::DDSolidShape::ddpolyhedra},
-     {LegacySolidShape::ddtorus, cms::DDSolidShape::ddtorus},
-     {LegacySolidShape::ddunion, cms::DDSolidShape::ddunion},
-     {LegacySolidShape::ddsubtraction, cms::DDSolidShape::ddsubtraction},
-     {LegacySolidShape::ddintersection, cms::DDSolidShape::ddintersection},
-     {LegacySolidShape::ddshapeless, cms::DDSolidShape::ddshapeless},
-     {LegacySolidShape::ddpseudotrap, cms::DDSolidShape::ddpseudotrap},
-     {LegacySolidShape::ddtrunctubs, cms::DDSolidShape::ddtrunctubs},
-     {LegacySolidShape::ddsphere, cms::DDSolidShape::ddsphere},
-     {LegacySolidShape::ddellipticaltube, cms::DDSolidShape::ddellipticaltube},
-     {LegacySolidShape::ddcuttubs, cms::DDSolidShape::ddcuttubs},
-     {LegacySolidShape::ddextrudedpolygon, cms::DDSolidShape::ddextrudedpolygon}}};
+      {{LegacySolidShape::dd_not_init, cms::DDSolidShape::dd_not_init},
+       {LegacySolidShape::ddbox, cms::DDSolidShape::ddbox},
+       {LegacySolidShape::ddtubs, cms::DDSolidShape::ddtubs},
+       {LegacySolidShape::ddtrap, cms::DDSolidShape::ddtrap},
+       {LegacySolidShape::ddcons, cms::DDSolidShape::ddcons},
+       {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
+       {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
+       {LegacySolidShape::ddpolycone_rrz, cms::DDSolidShape::ddpolycone},
+       {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
+       {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
+       {LegacySolidShape::ddpolyhedra_rrz, cms::DDSolidShape::ddpolyhedra},
+       {LegacySolidShape::ddtorus, cms::DDSolidShape::ddtorus},
+       {LegacySolidShape::ddunion, cms::DDSolidShape::ddunion},
+       {LegacySolidShape::ddsubtraction, cms::DDSolidShape::ddsubtraction},
+       {LegacySolidShape::ddintersection, cms::DDSolidShape::ddintersection},
+       {LegacySolidShape::ddshapeless, cms::DDSolidShape::ddshapeless},
+       {LegacySolidShape::ddpseudotrap, cms::DDSolidShape::ddpseudotrap},
+       {LegacySolidShape::ddtrunctubs, cms::DDSolidShape::ddtrunctubs},
+       {LegacySolidShape::ddsphere, cms::DDSolidShape::ddsphere},
+       {LegacySolidShape::ddellipticaltube, cms::DDSolidShape::ddellipticaltube},
+       {LegacySolidShape::ddcuttubs, cms::DDSolidShape::ddcuttubs},
+       {LegacySolidShape::ddextrudedpolygon, cms::DDSolidShape::ddextrudedpolygon}}};
 
 }  // namespace cms
 

--- a/DetectorDescription/DDCMS/interface/DDSolidShapes.h
+++ b/DetectorDescription/DDCMS/interface/DDSolidShapes.h
@@ -100,16 +100,14 @@ namespace cms {
        {DDSolidShape::ddcuttubs, "CutTube"},
        {DDSolidShape::ddextrudedpolygon, "ExtrudedPolygon"}}};
 
-  const std::array<const cms::dd::ValuePair<LegacySolidShape, cms::DDSolidShape>, 22> LegacySolidShapeMap{
+  const std::array<const cms::dd::ValuePair<LegacySolidShape, cms::DDSolidShape>, 20> LegacySolidShapeMap{
       {{LegacySolidShape::dd_not_init, cms::DDSolidShape::dd_not_init},
        {LegacySolidShape::ddbox, cms::DDSolidShape::ddbox},
        {LegacySolidShape::ddtubs, cms::DDSolidShape::ddtubs},
        {LegacySolidShape::ddtrap, cms::DDSolidShape::ddtrap},
        {LegacySolidShape::ddcons, cms::DDSolidShape::ddcons},
        {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
-       {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
        {LegacySolidShape::ddpolycone_rrz, cms::DDSolidShape::ddpolycone},
-       {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
        {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
        {LegacySolidShape::ddpolyhedra_rrz, cms::DDSolidShape::ddpolyhedra},
        {LegacySolidShape::ddtorus, cms::DDSolidShape::ddtorus},

--- a/DetectorDescription/DDCMS/interface/DDSolidShapes.h
+++ b/DetectorDescription/DDCMS/interface/DDSolidShapes.h
@@ -5,6 +5,10 @@
 #include <array>
 #include <algorithm>
 
+#include "DetectorDescription/Core/interface/DDSolidShapes.h"
+
+using LegacySolidShape = DDSolidShape;
+
 namespace cms {
 
   namespace dd {
@@ -13,6 +17,14 @@ namespace cms {
       using value_type = T;
       const T value;
       const char* const name;
+    };
+
+    template <class T, class U>
+    struct ValuePair {
+      using value_type = T;
+      using name_type = U;
+      const T value;
+      const U name;
     };
 
     template <class Mapping, class V>
@@ -35,7 +47,17 @@ namespace cms {
       }
       return std::begin(a)->value;
     }
-  };  // namespace dd
+
+    template <class Mapping, class N>
+    typename Mapping::value_type::value_type value(Mapping a, N name) {
+      auto pos = std::find_if(
+          std::begin(a), std::end(a), [&name](const typename Mapping::value_type& t) { return (t.name == name); });
+      if (pos != std::end(a)) {
+        return pos->value;
+      }
+      return std::begin(a)->value;
+    }
+};  // namespace dd
 
   enum class DDSolidShape {
     dd_not_init = 0,
@@ -77,6 +99,31 @@ namespace cms {
        {DDSolidShape::ddellipticaltube, "EllipticalTube"},
        {DDSolidShape::ddcuttubs, "CutTube"},
        {DDSolidShape::ddextrudedpolygon, "ExtrudedPolygon"}}};
+
+  const std::array<const cms::dd::ValuePair<LegacySolidShape, cms::DDSolidShape>, 22> LegacySolidShapeMap{
+    {{LegacySolidShape::dd_not_init, cms::DDSolidShape::dd_not_init},
+     {LegacySolidShape::ddbox, cms::DDSolidShape::ddbox},
+     {LegacySolidShape::ddtubs, cms::DDSolidShape::ddtubs},
+     {LegacySolidShape::ddtrap, cms::DDSolidShape::ddtrap},
+     {LegacySolidShape::ddcons, cms::DDSolidShape::ddcons},
+     {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
+     {LegacySolidShape::ddpolycone_rz, cms::DDSolidShape::ddpolycone},
+     {LegacySolidShape::ddpolycone_rrz, cms::DDSolidShape::ddpolycone},
+     {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
+     {LegacySolidShape::ddpolyhedra_rz, cms::DDSolidShape::ddpolyhedra},
+     {LegacySolidShape::ddpolyhedra_rrz, cms::DDSolidShape::ddpolyhedra},
+     {LegacySolidShape::ddtorus, cms::DDSolidShape::ddtorus},
+     {LegacySolidShape::ddunion, cms::DDSolidShape::ddunion},
+     {LegacySolidShape::ddsubtraction, cms::DDSolidShape::ddsubtraction},
+     {LegacySolidShape::ddintersection, cms::DDSolidShape::ddintersection},
+     {LegacySolidShape::ddshapeless, cms::DDSolidShape::ddshapeless},
+     {LegacySolidShape::ddpseudotrap, cms::DDSolidShape::ddpseudotrap},
+     {LegacySolidShape::ddtrunctubs, cms::DDSolidShape::ddtrunctubs},
+     {LegacySolidShape::ddsphere, cms::DDSolidShape::ddsphere},
+     {LegacySolidShape::ddellipticaltube, cms::DDSolidShape::ddellipticaltube},
+     {LegacySolidShape::ddcuttubs, cms::DDSolidShape::ddcuttubs},
+     {LegacySolidShape::ddextrudedpolygon, cms::DDSolidShape::ddextrudedpolygon}}};
+
 }  // namespace cms
 
 #endif

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -305,7 +305,7 @@ const std::vector<double> DDFilteredView::parameters() const {
 const cms::DDSolidShape DDFilteredView::shape() const {
   return cms::dd::value(cms::DDSolidShapeMap, node_->GetVolume()->GetShape()->GetTitle());
 }
-    
+
 LegacySolidShape DDFilteredView::legacyShape(const cms::DDSolidShape shape) const {
   return cms::dd::value(cms::LegacySolidShapeMap, shape);
 }

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -3,6 +3,7 @@
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DD4hep/Detector.h"
+#include "DD4hep/Shapes.h"
 #include <TGeoBBox.h>
 #include <TGeoBoolNode.h>
 #include <vector>
@@ -301,8 +302,12 @@ const std::vector<double> DDFilteredView::parameters() const {
   return currVol.solid().dimensions();
 }
 
-const DDSolidShape DDFilteredView::shape() const {
+const cms::DDSolidShape DDFilteredView::shape() const {
   return cms::dd::value(cms::DDSolidShapeMap, node_->GetVolume()->GetShape()->GetTitle());
+}
+    
+LegacySolidShape DDFilteredView::legacyShape(const cms::DDSolidShape shape) const {
+  return cms::dd::value(cms::LegacySolidShapeMap, shape);
 }
 
 template <>

--- a/DetectorDescription/DDCMS/src/DDShapes.cc
+++ b/DetectorDescription/DDCMS/src/DDShapes.cc
@@ -1,5 +1,6 @@
 #include "DetectorDescription/DDCMS/interface/DDAlgoArguments.h"
 #include "DetectorDescription/DDCMS/interface/DDShapes.h"
+#include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
 #include "DataFormats/GeometryVector/interface/Phi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -15,7 +16,7 @@ bool convFpToBool(T val) {
   return (static_cast<int>(val + 0.5) != 0);
 }
 
-DDSolidShape cms::dd::getCurrentShape(const DDFilteredView &fview) {
+cms::DDSolidShape cms::dd::getCurrentShape(const DDFilteredView &fview) {
   if (fview.isABox())
     return (DDSolidShape::ddbox);
 

--- a/DetectorDescription/DDCMS/test/BuildFile.xml
+++ b/DetectorDescription/DDCMS/test/BuildFile.xml
@@ -20,6 +20,9 @@
 <bin   name="testDD4hepDDSolidShapes" file="DDSolidShapes.cppunit.cc,testRunner.cpp">
   <use name="DetectorDescription/DDCMS"/>
 </bin>
+<bin   name="testDD4hepDDSolidLegacyShapes" file="DDSolidLegacyShapes.cppunit.cc,testRunner.cpp">
+  <use name="DetectorDescription/DDCMS"/>
+</bin>
 <bin file="dummyMain.cpp" name="DetectorDescriptionDDCMSTestDriver">
   <use   name="FWCore/Utilities"/>
   <flags   TEST_RUNNER_ARGS="/bin/bash DetectorDescription/DDCMS/test runTest.sh"/>

--- a/DetectorDescription/DDCMS/test/DDSolidLegacyShapes.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolidLegacyShapes.cppunit.cc
@@ -52,19 +52,19 @@ void testDDSolidLegacyShapes::checkDDSolidLegacyShapes() {
 
   LegacySolidShape legacyTrap = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtrap);
   CPPUNIT_ASSERT(legacyTrap == LegacySolidShape::ddtrap);
-  
+
   LegacySolidShape legacyCons = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddcons);
   CPPUNIT_ASSERT(legacyCons == LegacySolidShape::ddcons);
 
   LegacySolidShape legacyPcon = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpolycone);
   CPPUNIT_ASSERT(legacyPcon == LegacySolidShape::ddpolycone_rz);
-  
+
   LegacySolidShape legacyPolyhedra = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpolyhedra);
   CPPUNIT_ASSERT(legacyPolyhedra == LegacySolidShape::ddpolyhedra_rz);
-  
+
   LegacySolidShape legacyTorus = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtorus);
   CPPUNIT_ASSERT(legacyTorus == LegacySolidShape::ddtorus);
-  
+
   LegacySolidShape legacyUnion = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddunion);
   CPPUNIT_ASSERT(legacyUnion == LegacySolidShape::ddunion);
 
@@ -76,22 +76,23 @@ void testDDSolidLegacyShapes::checkDDSolidLegacyShapes() {
 
   LegacySolidShape legacyShapeless = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddshapeless);
   CPPUNIT_ASSERT(legacyShapeless == LegacySolidShape::ddshapeless);
-  
+
   LegacySolidShape legacyPseudotrap = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpseudotrap);
   CPPUNIT_ASSERT(legacyPseudotrap == LegacySolidShape::ddpseudotrap);
-  
+
   LegacySolidShape legacyTrunctubs = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtrunctubs);
   CPPUNIT_ASSERT(legacyTrunctubs == LegacySolidShape::ddtrunctubs);
-  
+
   LegacySolidShape legacySphere = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddsphere);
   CPPUNIT_ASSERT(legacySphere == LegacySolidShape::ddsphere);
-  
+
   LegacySolidShape legacyEllipticaltube = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddellipticaltube);
   CPPUNIT_ASSERT(legacyEllipticaltube == LegacySolidShape::ddellipticaltube);
-  
+
   LegacySolidShape legacyCuttubs = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddcuttubs);
   CPPUNIT_ASSERT(legacyCuttubs == LegacySolidShape::ddcuttubs);
-  
-  LegacySolidShape legacyExtrudedpolygon = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddextrudedpolygon);
+
+  LegacySolidShape legacyExtrudedpolygon =
+      cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddextrudedpolygon);
   CPPUNIT_ASSERT(legacyExtrudedpolygon == LegacySolidShape::ddextrudedpolygon);
 }

--- a/DetectorDescription/DDCMS/test/DDSolidLegacyShapes.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolidLegacyShapes.cppunit.cc
@@ -1,0 +1,97 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
+
+#include <iostream>
+
+#include "cppunit/TestAssert.h"
+#include "cppunit/TestFixture.h"
+
+using namespace cms;
+using namespace std;
+
+class testDDSolidLegacyShapes : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testDDSolidLegacyShapes);
+  CPPUNIT_TEST(checkDDSolidLegacyShapes);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() override;
+  void tearDown() override {}
+  void checkDDSolidLegacyShapes();
+
+private:
+  std::string solidName_;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testDDSolidLegacyShapes);
+
+void testDDSolidLegacyShapes::setUp() { solidName_ = "Trapezoid"; }
+
+void testDDSolidLegacyShapes::checkDDSolidLegacyShapes() {
+  cms::DDSolidShape shape = cms::dd::value(cms::DDSolidShapeMap, solidName_);
+  CPPUNIT_ASSERT(shape == cms::DDSolidShape::ddtrap);
+
+  std::string name = cms::dd::name(cms::DDSolidShapeMap, shape);
+  CPPUNIT_ASSERT(name == solidName_);
+
+  cms::DDSolidShape invalidShape = cms::dd::value(cms::DDSolidShapeMap, "Blah Blah Blah");
+  CPPUNIT_ASSERT(invalidShape == cms::DDSolidShape::dd_not_init);
+
+  std::string invalidName = cms::dd::name(cms::DDSolidShapeMap, invalidShape);
+  CPPUNIT_ASSERT(invalidName == std::string("Solid not initialized"));
+
+  LegacySolidShape invalidLegacyShape = cms::dd::value(cms::LegacySolidShapeMap, invalidShape);
+  CPPUNIT_ASSERT(invalidLegacyShape == LegacySolidShape::dd_not_init);
+
+  LegacySolidShape legacyBox = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddbox);
+  CPPUNIT_ASSERT(legacyBox == LegacySolidShape::ddbox);
+
+  LegacySolidShape legacyTubs = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtubs);
+  CPPUNIT_ASSERT(legacyTubs == LegacySolidShape::ddtubs);
+
+  LegacySolidShape legacyTrap = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtrap);
+  CPPUNIT_ASSERT(legacyTrap == LegacySolidShape::ddtrap);
+  
+  LegacySolidShape legacyCons = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddcons);
+  CPPUNIT_ASSERT(legacyCons == LegacySolidShape::ddcons);
+
+  LegacySolidShape legacyPcon = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpolycone);
+  CPPUNIT_ASSERT(legacyPcon == LegacySolidShape::ddpolycone_rz);
+  
+  LegacySolidShape legacyPolyhedra = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpolyhedra);
+  CPPUNIT_ASSERT(legacyPolyhedra == LegacySolidShape::ddpolyhedra_rz);
+  
+  LegacySolidShape legacyTorus = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtorus);
+  CPPUNIT_ASSERT(legacyTorus == LegacySolidShape::ddtorus);
+  
+  LegacySolidShape legacyUnion = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddunion);
+  CPPUNIT_ASSERT(legacyUnion == LegacySolidShape::ddunion);
+
+  LegacySolidShape legacySubtraction = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddsubtraction);
+  CPPUNIT_ASSERT(legacySubtraction == LegacySolidShape::ddsubtraction);
+
+  LegacySolidShape legacyIntersection = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddintersection);
+  CPPUNIT_ASSERT(legacyIntersection == LegacySolidShape::ddintersection);
+
+  LegacySolidShape legacyShapeless = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddshapeless);
+  CPPUNIT_ASSERT(legacyShapeless == LegacySolidShape::ddshapeless);
+  
+  LegacySolidShape legacyPseudotrap = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddpseudotrap);
+  CPPUNIT_ASSERT(legacyPseudotrap == LegacySolidShape::ddpseudotrap);
+  
+  LegacySolidShape legacyTrunctubs = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddtrunctubs);
+  CPPUNIT_ASSERT(legacyTrunctubs == LegacySolidShape::ddtrunctubs);
+  
+  LegacySolidShape legacySphere = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddsphere);
+  CPPUNIT_ASSERT(legacySphere == LegacySolidShape::ddsphere);
+  
+  LegacySolidShape legacyEllipticaltube = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddellipticaltube);
+  CPPUNIT_ASSERT(legacyEllipticaltube == LegacySolidShape::ddellipticaltube);
+  
+  LegacySolidShape legacyCuttubs = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddcuttubs);
+  CPPUNIT_ASSERT(legacyCuttubs == LegacySolidShape::ddcuttubs);
+  
+  LegacySolidShape legacyExtrudedpolygon = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddextrudedpolygon);
+  CPPUNIT_ASSERT(legacyExtrudedpolygon == LegacySolidShape::ddextrudedpolygon);
+}

--- a/DetectorDescription/DDCMS/test/DDSolidShapes.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolidShapes.cppunit.cc
@@ -29,14 +29,14 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testDDSolidShapes);
 void testDDSolidShapes::setUp() { solidName_ = "Trapezoid"; }
 
 void testDDSolidShapes::checkDDSolidShapes() {
-  DDSolidShape shape = cms::dd::value(cms::DDSolidShapeMap, solidName_);
-  CPPUNIT_ASSERT(shape == DDSolidShape::ddtrap);
+  cms::DDSolidShape shape = cms::dd::value(cms::DDSolidShapeMap, solidName_);
+  CPPUNIT_ASSERT(shape == cms::DDSolidShape::ddtrap);
 
   std::string name = cms::dd::name(cms::DDSolidShapeMap, shape);
   CPPUNIT_ASSERT(name == solidName_);
 
-  DDSolidShape invalidShape = cms::dd::value(cms::DDSolidShapeMap, "Blah Blah Blah");
-  CPPUNIT_ASSERT(invalidShape == DDSolidShape::dd_not_init);
+  cms::DDSolidShape invalidShape = cms::dd::value(cms::DDSolidShapeMap, "Blah Blah Blah");
+  CPPUNIT_ASSERT(invalidShape == cms::DDSolidShape::dd_not_init);
 
   std::string invalidName = cms::dd::name(cms::DDSolidShapeMap, invalidShape);
   CPPUNIT_ASSERT(invalidName == std::string("Solid not initialized"));


### PR DESCRIPTION
#### PR description:

* Add mapping between the old DD and the new DD4hep shape identifiers
* Add unit test to check the conversion
* Add a convenience ``` LegacySolidShape legacyShape(const cms::DDSolidShape shape) const``` function to request an old shape ID from the ```cms::DDFilteredView```

Example:
```
LegacySolidShape legacySphere = cms::dd::value(cms::LegacySolidShapeMap, cms::DDSolidShape::ddsphere);
```

#### PR validation:

Run unit test:
```
testDD4hepDDSolidLegacyShapes
```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
