### PR TITLE
ME0TriggerPseudoBuilder  mistook GEM strip pitch unit as radiu and this commit is to fix it

### DIFF
--- a/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
@@ -106,7 +106,7 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
   float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
   GlobalPoint gp_digi = etapart->toGlobal(etapart->centreOfStrip(centreOfStrip));
 
-  float strippitch_rad = strippitch/gp.perp(); //unit in rad
+  float strippitch_rad = strippitch / gp.perp(); //unit in rad
 
   int idphi = static_cast<int>(fabs(dphi) / (strippitch_rad * dphiresolution_));
   const int max_idphi = 512;

--- a/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
@@ -106,7 +106,9 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
   float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
   GlobalPoint gp_digi = etapart->toGlobal(etapart->centreOfStrip(centreOfStrip));
 
-  int idphi = static_cast<int>(fabs(dphi) / (strippitch * dphiresolution_));
+  float strippitch_rad = strippitch/gp.perp(); //unit in rad
+
+  int idphi = static_cast<int>(fabs(dphi) / (strippitch_rad * dphiresolution_));
   const int max_idphi = 512;
   if (idphi >= max_idphi) {
     LogTrace("L1ME0Trigger") << " ME0 segment dphi " << dphi << " and int type: " << idphi
@@ -125,7 +127,7 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
                              << "\t strip(float) " << strip << " (int) " << istrip << " phiposition " << phiposition
                              << " resolution (in term of strip) " << phi_resolution << " \n"
                              << "\t deltaphi(float) " << dphi << " (int) " << idphi << " resolution "
-                             << strippitch * dphiresolution_ << " bend " << bend << " \n"
+                             << strippitch_rad * dphiresolution_ << " bend " << bend << " \n"
                              << "\t global point eta " << gp.eta() << " phi " << gp.phi() << " trigger digi eta "
                              << gp_digi.eta() << " phi " << gp_digi.phi() << " \n"
                              << "\t time (ns, float) " << time << " BX " << BX << " \n";

--- a/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
@@ -20,11 +20,13 @@ ME0TriggerPseudoBuilder::~ME0TriggerPseudoBuilder() {}
 void ME0TriggerPseudoBuilder::build(const ME0SegmentCollection* me0Segments, ME0TriggerDigiCollection& oc_trig) {
   if (info_ > 2)
     dumpAllME0Segments(*me0Segments);
+
   for (int endc = 0; endc < static_cast<int>(trig_me0s::MAX_ENDCAPS); endc++) {
     for (int cham = 0; cham < static_cast<int>(trig_me0s::MAX_CHAMBERS); cham++) {
       // 0th layer means whole chamber.
+      // chamber counts from 1 to 18 in ME0ID
       const int region(endc == 0 ? -1 : 1);
-      ME0DetId detid(region, 0, cham, 0);
+      ME0DetId detid(region, 0, cham + 1, 0);
 
       const auto& drange = me0Segments->get(detid);
       std::vector<ME0TriggerDigi> trigV;

--- a/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
@@ -68,7 +68,7 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
   }
   if (rolls.size() > 2 or rolls.empty())
     LogTrace("L1ME0Trigger") << " ME0 segment is crossing " << rolls.size() << " roll !!! \n";
-  assert(rolls.size() <= 2);
+  //assert(rolls.size() <= 2);   // we did found very few ME0 segments crossing 3 rolls!!! this cut is applied offline
   if (rolls.empty())
     return ME0TriggerDigi();
   if (rolls[0] < 1)

--- a/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
@@ -106,7 +106,7 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
   float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
   GlobalPoint gp_digi = etapart->toGlobal(etapart->centreOfStrip(centreOfStrip));
 
-  float strippitch_rad = strippitch / gp.perp(); //unit in rad
+  float strippitch_rad = strippitch / gp.perp();  //unit in rad
 
   int idphi = static_cast<int>(fabs(dphi) / (strippitch_rad * dphiresolution_));
   const int max_idphi = 512;

--- a/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc
@@ -87,9 +87,12 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
     return ME0TriggerDigi();
   }
 
+  //globalpoint from ME0 segment
+  GlobalPoint gp = me0_g->idToDet(segment.me0DetId())->surface().toGlobal(segment.localPosition());
   const ME0EtaPartition* etapart = keylayer->etaPartition(rolls[0]);
-  float strippitch = etapart->localPitch(segment.localPosition());
-  float strip = etapart->strip(segment.localPosition());
+  LocalPoint segment_lp = etapart->surface().toLocal(gp);  // convert segment gp into lp in etapartition coordinate
+  float strippitch = etapart->localPitch(segment_lp);
+  float strip = etapart->strip(segment_lp);
   int totstrip = etapart->nstrips();
   int istrip = static_cast<int>(strip);
   int phiposition = istrip;
@@ -100,8 +103,6 @@ ME0TriggerDigi ME0TriggerPseudoBuilder::segmentConversion(const ME0Segment segme
   int phiposition2 = (static_cast<int>((strip - phiposition) / phi_resolution) & 1);  // half-strip resolution
   phiposition = (phiposition << 1) | phiposition2;
 
-  //globalpoint from ME0 segment
-  GlobalPoint gp = me0_g->idToDet(segment.me0DetId())->surface().toGlobal(segment.localPosition());
   //gloablpoint from ME0 trigger digi
   float centreOfStrip = istrip + 0.25 + phiposition2 * 0.5;
   GlobalPoint gp_digi = etapart->toGlobal(etapart->centreOfStrip(centreOfStrip));


### PR DESCRIPTION
#### PR description:
pitch() from GEM geometry returns the strip pitch in cm and was supposed to be converted into radius before it is compared with deltaphi. JiaFu found this bug and  this PR is to fix this bug in  L1Trigger/ME0Trigger/src/ME0TriggerPseudoBuilder.cc

This PR is independent from Sven's previous PR to update Me0 trigger built from GEM trigger pads.   This PR is to fix a old bug in  ME0 pseudo-triggers  which is actually used by EMTF .
<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

#### PR validation:
I ran test with step 20034.0 and everything seems right .   
Summary from test 20034.0:
1 1 1 1 tests passed, 0 0 0 0 failed
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->


FYI: @jshlee @dildick  @rekovic @jiafulow 