### PR TITLE
Core support for concurrent IOVs in CondDBESSource

### DIFF
--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -69,6 +69,8 @@ namespace edm {
 
       void setProviderDescription(ComponentDescription const* iDesc) { description_ = iDesc; }
 
+      virtual void initializeForNewIOV() {}
+
     protected:
       /**This is the function which does the real work of getting the data if it is not
           already cached.  The returning 'void const*' must point to an instance of the class

--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -160,8 +160,11 @@ namespace edm {
         dataProxyContainer_.fillRecordsNotAllowingConcurrentIOVs(recordsNotAllowingConcurrentIOVs);
       }
 
+      virtual void initConcurrentIOVs(EventSetupRecordKey const& key, unsigned int nConcurrentIOVs) {}
+
       void createKeyedProxies(EventSetupRecordKey const& key, unsigned int nConcurrentIOVs) {
         dataProxyContainer_.createKeyedProxies(key, nConcurrentIOVs);
+        initConcurrentIOVs(key, nConcurrentIOVs);
       }
 
       const ComponentDescription& description() const { return description_; }

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -122,7 +122,7 @@ namespace edm {
       void clearProxies();
 
       ///Set the cache identifier and validity interval when starting a new IOV
-      void initializeForNewIOV(unsigned long long iCacheIdentifier, ValidityInterval const&);
+      void initializeForNewIOV(unsigned long long iCacheIdentifier, ValidityInterval const&, bool hasFinder);
 
       /**Set the validity interval in a thread safe way. This is used when the
          IOV is already in use and the end of the IOV needs to be updated but

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -122,6 +122,10 @@ namespace edm {
       void clearProxies();
 
       ///Set the cache identifier and validity interval when starting a new IOV
+      ///In addition, also notify the DataProxy's a new IOV is starting.
+      ///(As a performance optimization, we only notify the DataProxy's if hasFinder
+      ///is true. At the current time, the CondDBESSource DataProxy's are the only
+      ///ones who need to know about this and they always have finders).
       void initializeForNewIOV(unsigned long long iCacheIdentifier, ValidityInterval const&, bool hasFinder);
 
       /**Set the validity interval in a thread safe way. This is used when the

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -18,11 +18,11 @@
 #include "FWCore/Framework/interface/ComponentDescription.h"
 #include "FWCore/Framework/interface/MakeDataException.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/src/ESGlobalMutex.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 namespace edm {
   namespace eventsetup {
-    static std::recursive_mutex s_esGlobalMutex;
 
     static const ComponentDescription* dummyDescription() {
       static ComponentDescription s_desc;
@@ -97,7 +97,7 @@ namespace edm {
                                EventSetupImpl const* iEventSetupImpl) const {
       if (!cacheIsValid()) {
         ESSignalSentry signalSentry(iRecord, iKey, providerDescription(), activityRegistry);
-        std::lock_guard<std::recursive_mutex> guard(s_esGlobalMutex);
+        std::lock_guard<std::recursive_mutex> guard(esGlobalMutex());
         signalSentry.sendPostLockSignal();
         if (!cacheIsValid()) {
           cache_ = const_cast<DataProxy*>(this)->getImpl(iRecord, iKey, iEventSetupImpl);

--- a/FWCore/Framework/src/ESGlobalMutex.cc
+++ b/FWCore/Framework/src/ESGlobalMutex.cc
@@ -1,0 +1,9 @@
+#include "FWCore/Framework/src/ESGlobalMutex.h"
+
+namespace edm {
+
+  static std::recursive_mutex s_esGlobalMutex;
+
+  std::recursive_mutex& esGlobalMutex() { return s_esGlobalMutex; }
+
+}  // namespace edm

--- a/FWCore/Framework/src/ESGlobalMutex.h
+++ b/FWCore/Framework/src/ESGlobalMutex.h
@@ -1,0 +1,34 @@
+#ifndef FWCore_Framework_ESGlobalMutex_h
+#define FWCore_Framework_ESGlobalMutex_h
+
+// -*- C++ -*-
+//
+// Package:     Framework
+//
+/**
+Description: This should only be used by the parts of the Framework
+supporting the EventSetup system.  It is used in the functions:
+
+    edm::eventsetup::DataProxy::get
+    edm::EventSetupRecordIntervalFinder::findIntervalFor
+
+This protects activity that can't be safely run concurrently.
+For example, database transactions in CondDBESSource (aka
+PoolDBESSource).
+
+The current intent is that the existence of this mutex is temporary.
+In the future, the need for it will be replaced by use of things like
+WaitingTaskLists and WaitingTaskHolders used in such a way that this
+can be handled in a lock-free manner.
+*/
+// Author: W. David Dagenhart
+// Created: 9 August 2019
+
+#include <mutex>
+
+namespace edm {
+
+  std::recursive_mutex& esGlobalMutex();
+
+}  // namespace edm
+#endif  // FWCore_Framework_ESGlobalMutex_h

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1064,15 +1064,19 @@ namespace edm {
     }
 
     // We must be careful with the status object here and in code this function calls. IF we want
-    // endRun to be called, then the status object must be destroyed before the things waiting on
+    // endRun to be called, then we must call resetResources before the things waiting on
     // iHolder are allowed to proceed. Otherwise, there will be race condition (possibly causing
-    // endRun to be called much later than it should be, because it is holding iRunResource).
+    // endRun to be called much later than it should be, because status is holding iRunResource).
+    // Note that this must be done explicitly. Relying on the destructor does not work well
+    // because the LimitedTaskQueue for the lumiWork holds the shared_ptr in each of its internal
+    // queues, plus it is difficult to guarantee the destructor is called  before iHolder gets
+    // destroyed inside this function and lumiWork.
     auto status =
         std::make_shared<LuminosityBlockProcessingStatus>(this, preallocations_.numberOfStreams(), iRunResource);
 
     auto lumiWork = [this, iHolder, status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
       if (iHolder.taskHasFailed()) {
-        status.reset();
+        status->resetResources();
         return;
       }
 
@@ -1105,7 +1109,7 @@ namespace edm {
           auto beginStreamsTask = make_waiting_task(
               tbb::task::allocate_root(), [this, holder = iHolder, status, ts](std::exception_ptr const* iPtr) mutable {
                 if (iPtr) {
-                  status.reset();
+                  status->resetResources();
                   holder.doneWaiting(*iPtr);
                 } else {
                   status->globalBeginDidSucceed();
@@ -1117,7 +1121,7 @@ namespace edm {
                       ServiceRegistry::Operate operate(serviceToken_);
                       looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
                     } catch (...) {
-                      status.reset();
+                      status->resetResources();
                       holder.doneWaiting(std::current_exception());
                       return;
                     }
@@ -1152,10 +1156,8 @@ namespace edm {
                                                          &status->eventSetupImpls(),
                                                          serviceToken_,
                                                          subProcesses_);
-                      status.reset();
                     });
                   }
-                  status.reset();
                 }
               });  // beginStreamTask
 
@@ -1174,9 +1176,8 @@ namespace edm {
                                                serviceToken_,
                                                subProcesses_);
           }
-          status.reset();
         } catch (...) {
-          status.reset();
+          status->resetResources();
           iHolder.doneWaiting(std::current_exception());
         }
       });  // task in sourceResourcesAcquirer
@@ -1207,10 +1208,8 @@ namespace edm {
           // lumi is done and no longer needs its EventSetup IOVs.
           espController_->eventSetupForInstance(
               iSync, queueLumiWorkTaskHolder, status->endIOVWaitingTasks(), status->eventSetupImpls());
-          status.reset();
           sentry.completedSuccessfully();
         } catch (...) {
-          status.reset();
           queueLumiWorkTaskHolder.doneWaiting(std::current_exception());
         }
         queueWhichWaitsForIOVsToFinish_.pause();
@@ -1319,9 +1318,10 @@ namespace edm {
           }
 
           try {
-            // This call to status.reset() must occur before iTask is destroyed.
+            // This call to status.resetResources() must occur before iTask is destroyed.
             // Otherwise there will be a data race which could result in endRun
             // being delayed until it is too late to successfully call it.
+            status->resetResources();
             status.reset();
           } catch (...) {
             if (not ptr) {
@@ -1380,8 +1380,6 @@ namespace edm {
                                       //are we the last one?
                                       if (status->streamFinishedLumi()) {
                                         globalEndLumiAsync(iTask, std::move(status));
-                                      } else {
-                                        status.reset();
                                       }
                                     });
 
@@ -1409,7 +1407,6 @@ namespace edm {
                                        subProcesses_,
                                        cleaningUpAfterException);
     }
-    iLumiStatus.reset();
   }
 
   void EventProcessor::endUnfinishedLumi() {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -430,6 +430,7 @@ namespace edm {
       nConcurrentLumis = 1;
       nConcurrentRuns = 1;
     }
+    espController_->initialize(nStreams, nConcurrentLumis);
 
     preallocations_ = PreallocationConfiguration{nThreads, nStreams, nConcurrentLumis, nConcurrentRuns};
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -430,7 +430,7 @@ namespace edm {
       nConcurrentLumis = 1;
       nConcurrentRuns = 1;
     }
-    espController_->initialize(nStreams, nConcurrentLumis);
+    espController_->setMaxConcurrentIOVs(nStreams, nConcurrentLumis);
 
     preallocations_ = PreallocationConfiguration{nThreads, nStreams, nConcurrentLumis, nConcurrentRuns};
 

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -242,7 +242,8 @@ namespace edm {
 
           EventSetupRecordProvider* recProvider = tryToGetRecordProvider(key);
           if (recProvider == nullptr) {
-            unsigned int nConcurrentIOVs = numberOfConcurrentIOVs.numberOfConcurrentIOVs(key);
+            bool printInfoMsg = true;
+            unsigned int nConcurrentIOVs = numberOfConcurrentIOVs.numberOfConcurrentIOVs(key, printInfoMsg);
 
             //create a provider for this record
             insert(key, std::make_unique<EventSetupRecordProvider>(key, activityRegistry_, nConcurrentIOVs));
@@ -273,6 +274,8 @@ namespace edm {
 
           EventSetupRecordProvider* recProvider = tryToGetRecordProvider(key);
           if (recProvider == nullptr) {
+            bool printInfoMsg = true;
+            nConcurrentIOVs = numberOfConcurrentIOVs.numberOfConcurrentIOVs(key, printInfoMsg);
             //create a provider for this record
             insert(key, std::make_unique<EventSetupRecordProvider>(key, activityRegistry_, nConcurrentIOVs));
             recProvider = tryToGetRecordProvider(key);

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -71,9 +71,15 @@ namespace edm {
     }
 
     void EventSetupRecordImpl::initializeForNewIOV(unsigned long long iCacheIdentifier,
-                                                   ValidityInterval const& iValidityInterval) {
+                                                   ValidityInterval const& iValidityInterval,
+                                                   bool hasFinder) {
       cacheIdentifier_ = iCacheIdentifier;
       validity_ = iValidityInterval;
+      if (hasFinder) {
+        for (auto& dataProxy : proxies_) {
+          dataProxy->initializeForNewIOV();
+        }
+      }
     }
 
     void EventSetupRecordImpl::setSafely(const ValidityInterval& iInterval) const {

--- a/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
@@ -11,8 +11,10 @@
 //
 
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/src/ESGlobalMutex.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include <cassert>
+#include <mutex>
 
 using namespace edm::eventsetup;
 namespace edm {
@@ -25,7 +27,10 @@ namespace edm {
     assert(itFound != intervals_.end());
     if (!itFound->second.validFor(iInstance)) {
       if
-        LIKELY(iInstance != IOVSyncValue::invalidIOVSyncValue()) { setIntervalFor(iKey, iInstance, itFound->second); }
+        LIKELY(iInstance != IOVSyncValue::invalidIOVSyncValue()) {
+          std::lock_guard<std::recursive_mutex> guard(esGlobalMutex());
+          setIntervalFor(iKey, iInstance, itFound->second);
+        }
       else {
         itFound->second = ValidityInterval::invalidInterval();
       }

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -138,7 +138,8 @@ namespace edm {
     void EventSetupRecordProvider::initializeForNewIOV(unsigned int iovIndex, unsigned long long cacheIdentifier) {
       EventSetupRecordImpl* impl = &recordImpls_[iovIndex];
       recordImpl_ = impl;
-      impl->initializeForNewIOV(cacheIdentifier, validityInterval_);
+      bool hasFinder = finder_.get() != nullptr;
+      impl->initializeForNewIOV(cacheIdentifier, validityInterval_, hasFinder);
       eventSetupImpl_->addRecordImpl(*recordImpl_);
     }
 

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -52,6 +52,10 @@ namespace edm {
       return returnValue;
     }
 
+    void EventSetupsController::initialize(unsigned int nStreams, unsigned int nConcurrentLumis) {
+      numberOfConcurrentIOVs_.initialize(nStreams, nConcurrentLumis);
+    }
+
     void EventSetupsController::finishConfiguration() {
       if (mustFinishConfiguration_) {
         for (auto& eventSetupProvider : providers_) {

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -46,20 +46,20 @@ namespace edm {
       // EventSetupsController and in the EventSetupProvider
       fillEventSetupProvider(*this, *returnValue, iPSet);
 
-      numberOfConcurrentIOVs_.initialize(eventSetupPset);
+      numberOfConcurrentIOVs_.readConfigurationParameters(eventSetupPset);
 
       providers_.push_back(returnValue);
       return returnValue;
     }
 
-    void EventSetupsController::initialize(unsigned int nStreams, unsigned int nConcurrentLumis) {
-      numberOfConcurrentIOVs_.initialize(nStreams, nConcurrentLumis);
+    void EventSetupsController::setMaxConcurrentIOVs(unsigned int nStreams, unsigned int nConcurrentLumis) {
+      numberOfConcurrentIOVs_.setMaxConcurrentIOVs(nStreams, nConcurrentLumis);
     }
 
     void EventSetupsController::finishConfiguration() {
       if (mustFinishConfiguration_) {
         for (auto& eventSetupProvider : providers_) {
-          numberOfConcurrentIOVs_.initialize(*eventSetupProvider);
+          numberOfConcurrentIOVs_.fillRecordsNotAllowingConcurrentIOVs(*eventSetupProvider);
         }
 
         for (auto& eventSetupProvider : providers_) {

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -87,7 +87,7 @@ namespace edm {
                                                        ActivityRegistry*,
                                                        ParameterSet const* eventSetupPset = nullptr);
 
-      void initialize(unsigned int nStreams, unsigned int nConcurrentLumis);
+      void setMaxConcurrentIOVs(unsigned int nStreams, unsigned int nConcurrentLumis);
 
       // Pass in an IOVSyncValue to let the EventSetup system know which run and lumi
       // need to be processed and prepare IOVs for it (also could be a time or only a run).

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -87,6 +87,8 @@ namespace edm {
                                                        ActivityRegistry*,
                                                        ParameterSet const* eventSetupPset = nullptr);
 
+      void initialize(unsigned int nStreams, unsigned int nConcurrentLumis);
+
       // Pass in an IOVSyncValue to let the EventSetup system know which run and lumi
       // need to be processed and prepare IOVs for it (also could be a time or only a run).
       // Pass in a WaitingTaskHolder that allows the EventSetup to communicate when all

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
@@ -17,6 +17,15 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 
 namespace edm {
+  void LuminosityBlockProcessingStatus::resetResources() {
+    endIOVWaitingTasks_.doneWaiting(std::exception_ptr{});
+    for (auto& iter : eventSetupImpls_) {
+      iter.reset();
+    }
+    resumeGlobalLumiQueue();
+    run_.reset();
+  }
+
   void LuminosityBlockProcessingStatus::setEndTime() {
     if (2 != endTimeSetStatus_) {
       //not already set

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -57,6 +57,8 @@ namespace edm {
       globalLumiQueueResumer_.resume();
     }
 
+    void resetResources();
+
     EventSetupImpl const& eventSetupImpl(unsigned subProcessIndex) const {
       return *eventSetupImpls_.at(subProcessIndex);
     }

--- a/FWCore/Framework/src/NumberOfConcurrentIOVs.cc
+++ b/FWCore/Framework/src/NumberOfConcurrentIOVs.cc
@@ -35,6 +35,13 @@ namespace edm {
       }
     }
 
+    void NumberOfConcurrentIOVs::initialize(unsigned int nStreams, unsigned int nConcurrentLumis) {
+      maxConcurrentIOVs_ = nStreams;
+      if (maxConcurrentIOVs_ > nConcurrentLumis) {
+        maxConcurrentIOVs_ = nConcurrentLumis;
+      }
+    }
+
     void NumberOfConcurrentIOVs::initialize(EventSetupProvider const& eventSetupProvider) {
       eventSetupProvider.fillRecordsNotAllowingConcurrentIOVs(recordsNotAllowingConcurrentIOVs_);
     }
@@ -46,12 +53,12 @@ namespace edm {
                                    std::make_pair(eventSetupKey, 0u),
                                    [](auto const& left, auto const& right) { return left.first < right.first; });
       if (iter != forceNumberOfConcurrentIOVs_.end() && iter->first == eventSetupKey) {
-        return iter->second;
+        return std::min(iter->second, maxConcurrentIOVs_);
       }
       if (recordsNotAllowingConcurrentIOVs_.find(eventSetupKey) != recordsNotAllowingConcurrentIOVs_.end()) {
         return 1;
       }
-      return numberConcurrentIOVs_;
+      return std::min(numberConcurrentIOVs_, maxConcurrentIOVs_);
     }
 
     void NumberOfConcurrentIOVs::clear() {

--- a/FWCore/Framework/src/NumberOfConcurrentIOVs.h
+++ b/FWCore/Framework/src/NumberOfConcurrentIOVs.h
@@ -38,6 +38,8 @@ namespace edm {
 
       void initialize(ParameterSet const* eventSetupPset);
 
+      void initialize(unsigned int nStreams, unsigned int nConcurrentLumis);
+
       void initialize(EventSetupProvider const&);
 
       unsigned int numberOfConcurrentIOVs(EventSetupRecordKey const&) const;
@@ -71,6 +73,8 @@ namespace edm {
       // any subset of records. Values in this container override both of the
       // above data members.
       std::vector<std::pair<EventSetupRecordKey, unsigned int>> forceNumberOfConcurrentIOVs_;
+
+      unsigned int maxConcurrentIOVs_ = 1;
     };
 
   }  // namespace eventsetup

--- a/FWCore/Framework/src/NumberOfConcurrentIOVs.h
+++ b/FWCore/Framework/src/NumberOfConcurrentIOVs.h
@@ -36,13 +36,15 @@ namespace edm {
     public:
       NumberOfConcurrentIOVs();
 
-      void initialize(ParameterSet const* eventSetupPset);
+      void readConfigurationParameters(ParameterSet const* eventSetupPset);
 
-      void initialize(unsigned int nStreams, unsigned int nConcurrentLumis);
+      // Can't have more concurrent IOVs than streams or concurrent lumis
+      void setMaxConcurrentIOVs(unsigned int nStreams, unsigned int nConcurrentLumis);
 
-      void initialize(EventSetupProvider const&);
+      // This depends on bool's hard coded in the EventSetupRecord C++ classes
+      void fillRecordsNotAllowingConcurrentIOVs(EventSetupProvider const&);
 
-      unsigned int numberOfConcurrentIOVs(EventSetupRecordKey const&) const;
+      unsigned int numberOfConcurrentIOVs(EventSetupRecordKey const&, bool printInfoMsg = false) const;
 
       void clear();
 

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -126,10 +126,6 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test CatchCmsExceptiontest.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
-  <bin   file="TestIntegration.cpp" name="TestIntegrationExistingDictionary">
-    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestExistingDictionary.sh"/>
-    <use   name="FWCore/Utilities"/>
-  </bin>
   <bin   file="ProcessConfiguration_t.cpp">
     <use   name="FWCore/ParameterSet"/>
     <use   name="DataFormats/Provenance"/>
@@ -161,7 +157,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <lib   name="FWCoreIntegrationWaitingServer"/>
     <use   name="FWCore/Framework"/>
@@ -268,7 +264,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ConcurrentIOVESSource.cc,ConcurrentIOVESProducer.cc,ConcurrentIOVAnalyzer.cc,GadgetRcd.cc,IOVTestInfo.cc,RunLumiESAnalyzer.cc,RunLumiESSource.cc" name="ConcurrentIOVESSource">
+  <library   file="ConcurrentIOVESSource.cc,ConcurrentIOVESProducer.cc,ConcurrentIOVAnalyzer.cc,GadgetRcd.cc,IOVTestInfo.cc,RunLumiESAnalyzer.cc,RunLumiESSource.cc,TestESSource.cc" name="ConcurrentIOVESSource">
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/Integration"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -126,6 +126,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test CatchCmsExceptiontest.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegrationExistingDictionary">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_TestExistingDictionary.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="ProcessConfiguration_t.cpp">
     <use   name="FWCore/ParameterSet"/>
     <use   name="DataFormats/Provenance"/>
@@ -157,7 +161,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <lib   name="FWCoreIntegrationWaitingServer"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/TestESSource.cc
+++ b/FWCore/Integration/test/TestESSource.cc
@@ -1,0 +1,233 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     TestESSource
+//
+// Implementation:
+//     ESSource used for tests of Framework support for
+//     ESSources and ESProducers. This is primarily focused
+//     on the infrastructure used by CondDBESSource.
+//
+// Original Author:  W. David Dagenhart
+//         Created:  15 August 2019
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/Framework/interface/DataProxy.h"
+#include "FWCore/Framework/interface/DataProxyProvider.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Integration/interface/ESTestRecords.h"
+#include "FWCore/Integration/test/IOVTestInfo.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <atomic>
+#include <cmath>
+#include <limits>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace edmtest {
+
+  class TestESSource;
+
+  class TestESSourceTestProxy : public edm::eventsetup::DataProxy {
+  public:
+    TestESSourceTestProxy(TestESSource* testESSource) : testESSource_(testESSource) {}
+
+  private:
+    void const* getImpl(edm::eventsetup::EventSetupRecordImpl const&,
+                        edm::eventsetup::DataKey const&,
+                        edm::EventSetupImpl const*) override;
+    void invalidateCache() override {}
+    void initializeForNewIOV() override;
+
+    IOVTestInfo iovTestInfo_;
+    TestESSource* testESSource_;
+  };
+
+  class TestESSource : public edm::eventsetup::DataProxyProvider, public edm::EventSetupRecordIntervalFinder {
+  public:
+    using EventSetupRecordKey = edm::eventsetup::EventSetupRecordKey;
+    explicit TestESSource(edm::ParameterSet const&);
+    ~TestESSource();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    void busyWait(char const* msg) const;
+
+    std::atomic<unsigned int> count_;
+    std::atomic<unsigned int> count1_;
+    std::atomic<unsigned int> count2_;
+
+  private:
+    bool isConcurrentFinder() const override { return true; }
+    void setIntervalFor(EventSetupRecordKey const&, edm::IOVSyncValue const&, edm::ValidityInterval&) override;
+    KeyedProxiesVector registerProxies(EventSetupRecordKey const&, unsigned int iovIndex) override;
+    void initConcurrentIOVs(EventSetupRecordKey const&, unsigned int nConcurrentIOVs) override;
+
+    std::set<edm::IOVSyncValue> setOfIOV_;
+    const unsigned int iterations_;
+    const double pi_;
+    bool checkIOVInitialization_;
+    unsigned int expectedNumberOfConcurrentIOVs_;
+    unsigned int nConcurrentIOVs_ = 0;
+  };
+
+  void const* TestESSourceTestProxy::getImpl(edm::eventsetup::EventSetupRecordImpl const& iRecord,
+                                             edm::eventsetup::DataKey const& iKey,
+                                             edm::EventSetupImpl const* iEventSetupImpl) {
+    ++testESSource_->count_;
+    if (testESSource_->count_.load() > 1) {
+      throw cms::Exception("TestFailure") << "TestESSourceTestProxy::getImpl,"
+                                          << " functions in mutex should not run concurrently";
+    }
+    testESSource_->busyWait("getImpl");
+    ESTestRecordI record;
+    record.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl);
+
+    edm::ValidityInterval iov = record.validityInterval();
+    edm::LogAbsolute("TestESSoureTestProxy")
+        << "TestESSoureTestProxy::getImpl startIOV = " << iov.first().luminosityBlockNumber()
+        << " endIOV = " << iov.last().luminosityBlockNumber() << " IOV index = " << record.iovIndex()
+        << " cache identifier = " << record.cacheIdentifier();
+
+    iovTestInfo_.iovStartLumi_ = iov.first().luminosityBlockNumber();
+    iovTestInfo_.iovEndLumi_ = iov.last().luminosityBlockNumber();
+    iovTestInfo_.iovIndex_ = record.iovIndex();
+    iovTestInfo_.cacheIdentifier_ = record.cacheIdentifier();
+
+    --testESSource_->count_;
+    return &iovTestInfo_;
+  }
+
+  void TestESSourceTestProxy::initializeForNewIOV() {
+    edm::LogAbsolute("TestESSourceTestProxy::initializeForNewIOV") << "TestESSourceTestProxy::initializeForNewIOV";
+    ++testESSource_->count2_;
+  }
+
+  TestESSource::TestESSource(edm::ParameterSet const& pset)
+      : count_(0),
+        count1_(0),
+        count2_(0),
+        iterations_(pset.getParameter<unsigned int>("iterations")),
+        pi_(std::acos(-1)),
+        checkIOVInitialization_(pset.getParameter<bool>("checkIOVInitialization")),
+        expectedNumberOfConcurrentIOVs_(pset.getParameter<unsigned int>("expectedNumberOfConcurrentIOVs")) {
+    std::vector<unsigned int> temp(pset.getParameter<std::vector<unsigned int>>("firstValidLumis"));
+    for (auto val : temp) {
+      setOfIOV_.insert(edm::IOVSyncValue(edm::EventID(1, val, 0)));
+    }
+
+    findingRecord<ESTestRecordI>();
+    usingRecord<ESTestRecordI>();
+  }
+
+  TestESSource::~TestESSource() {}
+
+  void TestESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    std::vector<unsigned int> emptyVector;
+    desc.add<unsigned int>("iterations", 10 * 1000 * 1000);
+    desc.add<bool>("checkIOVInitialization", false);
+    desc.add<unsigned int>("expectedNumberOfConcurrentIOVs", 0);
+    desc.add<std::vector<unsigned int>>("firstValidLumis", emptyVector);
+    descriptions.addDefault(desc);
+  }
+
+  void TestESSource::setIntervalFor(EventSetupRecordKey const&,
+                                    edm::IOVSyncValue const& syncValue,
+                                    edm::ValidityInterval& iov) {
+    if (checkIOVInitialization_) {
+      // Note that this check should pass with the specific configuration where I enable
+      // the check, but in general it does not have to be true. The counts are offset
+      // by 1 because the beginRun IOV is invalid (no IOV initialization).
+      if (count1_ > 0 && count2_ + 1 != count1_) {
+        throw cms::Exception("TestFailure") << "TestESSource::setIntervalFor,"
+                                            << " unexpected number of IOV initializations";
+      }
+    }
+    ++count_;
+    ++count1_;
+    if (count_.load() > 1) {
+      throw cms::Exception("TestFailure") << "TestESSource::setIntervalFor,"
+                                          << " functions in mutex should not run concurrently";
+    }
+    busyWait("setIntervalFor");
+    iov = edm::ValidityInterval::invalidInterval();
+
+    if (setOfIOV_.empty()) {
+      --count_;
+      return;
+    }
+
+    std::pair<std::set<edm::IOVSyncValue>::iterator, std::set<edm::IOVSyncValue>::iterator> itFound =
+        setOfIOV_.equal_range(syncValue);
+
+    if (itFound.first == itFound.second) {
+      if (itFound.first == setOfIOV_.begin()) {
+        //request is before first valid interval, so fail
+        --count_;
+        return;
+      }
+      //go back one step
+      --itFound.first;
+    }
+
+    edm::IOVSyncValue endOfInterval = edm::IOVSyncValue::endOfTime();
+    if (itFound.second != setOfIOV_.end()) {
+      endOfInterval = edm::IOVSyncValue(
+          edm::EventID(1, itFound.second->eventID().luminosityBlock() - 1, edm::EventID::maxEventNumber()));
+    }
+    iov = edm::ValidityInterval(*(itFound.first), endOfInterval);
+    --count_;
+  }
+
+  edm::eventsetup::DataProxyProvider::KeyedProxiesVector TestESSource::registerProxies(EventSetupRecordKey const&,
+                                                                                       unsigned int iovIndex) {
+    if (expectedNumberOfConcurrentIOVs_ != 0 && nConcurrentIOVs_ != expectedNumberOfConcurrentIOVs_) {
+      throw cms::Exception("TestFailure") << "TestESSource::registerProxies,"
+                                          << " unexpected number of concurrent IOVs";
+    }
+    KeyedProxiesVector keyedProxiesVector;
+
+    edm::eventsetup::DataKey dataKey(edm::eventsetup::DataKey::makeTypeTag<IOVTestInfo>(), edm::eventsetup::IdTags(""));
+    keyedProxiesVector.emplace_back(dataKey, std::make_shared<TestESSourceTestProxy>(this));
+
+    return keyedProxiesVector;
+  }
+
+  void TestESSource::initConcurrentIOVs(EventSetupRecordKey const& key, unsigned int nConcurrentIOVs) {
+    edm::LogAbsolute("TestESSource::initConcurrentIOVs")
+        << "Start TestESSource::initConcurrentIOVs " << nConcurrentIOVs << " " << key.name();
+    if (EventSetupRecordKey::makeKey<ESTestRecordI>() != key) {
+      throw cms::Exception("TestFailure") << "TestESSource::initConcurrentIOVs,"
+                                          << " unexpected EventSetupRecordKey";
+    }
+    if (expectedNumberOfConcurrentIOVs_ != 0 && nConcurrentIOVs != expectedNumberOfConcurrentIOVs_) {
+      throw cms::Exception("TestFailure") << "TestESSource::initConcurrentIOVs,"
+                                          << " unexpected number of concurrent IOVs";
+    }
+    nConcurrentIOVs_ = nConcurrentIOVs;
+  }
+
+  void TestESSource::busyWait(char const* msg) const {
+    edm::LogAbsolute("TestESSource::busyWait") << "Start TestESSource::busyWait " << msg;
+    double sum = 0.;
+    const double stepSize = pi_ / iterations_;
+    for (unsigned int i = 0; i < iterations_; ++i) {
+      sum += stepSize * cos(i * stepSize);
+    }
+    edm::LogAbsolute("TestESSource::busyWait") << "Stop TestESSource::busyWait " << msg << " " << sum;
+  }
+}  // namespace edmtest
+using namespace edmtest;
+DEFINE_FWK_EVENTSETUP_SOURCE(TestESSource);

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -27,4 +27,7 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsForce_cfg.py || die '
 echo testEventSetupRunLumi_cfg
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/testEventSetupRunLumi_cfg.py || die 'Failed in testEventSetupRunLumi_cfg.py' $?
 
+echo testConcurrentIOVsESSource_cfg.py
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsESSource_cfg.py || die 'Failed in testConcurrentIOVsESSource_cfg.py' $?
+
 popd

--- a/FWCore/Integration/test/testConcurrentIOVsESSource_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsESSource_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(100)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(8)
+)
+
+process.options = dict(
+    numberOfThreads = 4,
+    numberOfStreams = 4,
+    numberOfConcurrentRuns = 1,
+    numberOfConcurrentLuminosityBlocks = 4,
+    eventSetup = dict(
+        numberOfConcurrentIOVs = 2
+    )
+)
+
+process.testESSource = cms.ESSource("TestESSource",
+    firstValidLumis = cms.vuint32(1, 4, 6, 7, 8, 9),
+    iterations = cms.uint32(10*1000*1000),
+    checkIOVInitialization = cms.bool(True),
+    expectedNumberOfConcurrentIOVs = cms.uint32(2)
+)
+
+process.concurrentIOVESProducer = cms.ESProducer("ConcurrentIOVESProducer")
+
+process.test = cms.EDAnalyzer("ConcurrentIOVAnalyzer",
+                              checkExpectedValues = cms.untracked.bool(False)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test)


### PR DESCRIPTION
#### PR description:

Add to Core support needed for CondDBESSource so that
it can be upgraded for concurrent IOVs. These are requirements
I found as I actually implemented the code to migrate CondDBESSource
to support concurrent IOVs. They are in addition to the changes recently
merged with PR #26592. There are 6 separate commits, each a separate
feature. The first 3 will only be needed by CondDBESSource. The second
two are extra checks for pathological cases, useful in general. The last a
new unit test.

1. Notify a DataProxy when a new IOV actually begins.
2. During job initialization explicitly inform how many concurrent
IOVs will be allowed for each record.
3. Include setIntervalFor calls in the global mutex already used for
DataProxy calls producing data.
4. More carefully reset resources in the LuminosityBlockProcessingStatus
object.
5. Don't allow the number of concurrent IOVs to be greater than the number
of streams or concurrent lumis.
6. Add a new unit test for concurrent IOVs particularly covering new features
listed above.

Note the PR migrating CondDBESSource is ready and I intend to submit
it immediately after this PR is merged.

#### PR validation:

New unit test. Note that until the future PR implementing concurrentIOVs
for CondDBESSource is submitted, this should not cause any noticeable
change in behavior.

#### if this PR is a backport please specify the original PR:

Not a backport.
