### PR TITLE
Fix GCC 9 shadowing compiler warnings in Core

### DIFF
--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -116,8 +116,8 @@ namespace edm {
       assert(i == map_.end());
       pairType& p = map_[id];
       p.first = collection_.size();
-      for (CI i = begin; i != end; ++i)
-        collection_.push_back(P::clone(*i));
+      for (CI ii = begin; ii != end; ++ii)
+        collection_.push_back(P::clone(*ii));
       p.second = collection_.size();
     }
     /// return number of contained object

--- a/DataFormats/Common/src/RefCoreStreamer.cc
+++ b/DataFormats/Common/src/RefCoreStreamer.cc
@@ -72,8 +72,8 @@ namespace edm {
       cl->AdoptStreamer(new RefCoreStreamer());
     }
     {
-      TClass* cl = TClass::GetClass("edm::RefCoreWithIndex");
-      TClassStreamer* st = cl->GetStreamer();
+      cl = TClass::GetClass("edm::RefCoreWithIndex");
+      st = cl->GetStreamer();
       if (st == nullptr) {
         cl->AdoptStreamer(new RefCoreWithIndexStreamer());
       }

--- a/DataFormats/Common/test/containermask_t.cppunit.cc
+++ b/DataFormats/Common/test/containermask_t.cppunit.cc
@@ -61,12 +61,12 @@ void testContainerMask::testVector() {
   CPPUNIT_ASSERT(!alternate[3]);
 
   {
-    std::vector<bool> alternate(3, false);
-    cMask.copyMaskTo(alternate);
-    CPPUNIT_ASSERT(alternate[0]);
-    CPPUNIT_ASSERT(!alternate[1]);
-    CPPUNIT_ASSERT(alternate[2]);
-    CPPUNIT_ASSERT(!alternate[3]);
+    std::vector<bool> alternate1(3, false);
+    cMask.copyMaskTo(alternate1);
+    CPPUNIT_ASSERT(alternate1[0]);
+    CPPUNIT_ASSERT(!alternate1[1]);
+    CPPUNIT_ASSERT(alternate1[2]);
+    CPPUNIT_ASSERT(!alternate1[3]);
   }
 }
 

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -334,44 +334,44 @@ void testPtr::getTest() {
 
   {
     typedef std::vector<IntValue2> SDCollection;
-    auto ptr = std::make_unique<SDCollection>();
+    auto ptr1 = std::make_unique<SDCollection>();
 
-    ptr->push_back(IntValue2(0));
-    ptr->back().value_ = 0;
-    ptr->push_back(IntValue2(1));
-    ptr->back().value_ = 1;
+    ptr1->push_back(IntValue2(0));
+    ptr1->back().value_ = 0;
+    ptr1->push_back(IntValue2(1));
+    ptr1->back().value_ = 1;
 
-    edm::Wrapper<SDCollection> wrapper(std::move(ptr));
-    TestGetter tester;
-    tester.hold_ = &wrapper;
+    edm::Wrapper<SDCollection> wrapper1(std::move(ptr1));
+    TestGetter tester1;
+    tester1.hold_ = &wrapper1;
 
-    ProductID const pid(1, 1);
+    ProductID const pid1(1, 1);
 
-    SDCollection const* wptr = dynamic_cast<SDCollection const*>(wrapper.product());
+    SDCollection const* wptr1 = dynamic_cast<SDCollection const*>(wrapper1.product());
 
-    OrphanHandle<SDCollection> handle(wptr, pid);
+    OrphanHandle<SDCollection> handle1(wptr1, pid1);
 
-    Ptr<IntValue> ref0(pid, 0, &tester);
-    CPPUNIT_ASSERT(!ref0.hasProductCache());
+    Ptr<IntValue> ref00(pid1, 0, &tester1);
+    CPPUNIT_ASSERT(!ref00.hasProductCache());
 
-    Ptr<IntValue> ref1(pid, 1, &tester);
+    Ptr<IntValue> ref11(pid1, 1, &tester1);
 
-    Ptr<IntValue> ref2(pid, 1, &tester);
+    Ptr<IntValue> ref22(pid1, 1, &tester1);
 
-    CPPUNIT_ASSERT(0 == ref0->value_);
-    CPPUNIT_ASSERT(ref0.hasProductCache());
-    CPPUNIT_ASSERT(1 == ref1->value_);
-    CPPUNIT_ASSERT(1 == ref2->value_);
-    CPPUNIT_ASSERT(1 == (*ref1).value_);
+    CPPUNIT_ASSERT(0 == ref00->value_);
+    CPPUNIT_ASSERT(ref00.hasProductCache());
+    CPPUNIT_ASSERT(1 == ref11->value_);
+    CPPUNIT_ASSERT(1 == ref22->value_);
+    CPPUNIT_ASSERT(1 == (*ref11).value_);
   }
 
   {
-    TestGetter tester;
-    tester.hold_ = nullptr;
-    ProductID const pid(1, 1);
+    TestGetter tester2;
+    tester2.hold_ = nullptr;
+    ProductID const pid2(1, 1);
 
-    Ptr<IntValue> ref0(pid, 0, &tester);
-    CPPUNIT_ASSERT_THROW((*ref0), cms::Exception);
-    CPPUNIT_ASSERT_THROW((ref0.operator->()), cms::Exception);
+    Ptr<IntValue> ref00(pid2, 0, &tester2);
+    CPPUNIT_ASSERT_THROW((*ref00), cms::Exception);
+    CPPUNIT_ASSERT_THROW((ref00.operator->()), cms::Exception);
   }
 }

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -230,50 +230,50 @@ void testRefToBaseProd::getTest() {
 
   {
     typedef std::vector<IntValue2> SDCollection;
-    auto ptr = std::make_unique<SDCollection>();
+    auto ptr1 = std::make_unique<SDCollection>();
 
-    ptr->push_back(IntValue2(0));
-    ptr->back().value_ = 0;
-    ptr->push_back(IntValue2(1));
-    ptr->back().value_ = 1;
+    ptr1->push_back(IntValue2(0));
+    ptr1->back().value_ = 0;
+    ptr1->push_back(IntValue2(1));
+    ptr1->back().value_ = 1;
 
-    edm::Wrapper<SDCollection> wrapper(std::move(ptr));
-    TestGetter tester;
-    tester.hold_ = &wrapper;
+    edm::Wrapper<SDCollection> wrapper1(std::move(ptr1));
+    TestGetter tester1;
+    tester1.hold_ = &wrapper1;
 
-    ProductID const pid(1, 1);
+    ProductID const pid1(1, 1);
 
-    SDCollection const* wptr = dynamic_cast<SDCollection const*>(wrapper.product());
+    SDCollection const* wptr1 = dynamic_cast<SDCollection const*>(wrapper1.product());
 
-    OrphanHandle<SDCollection> handle(wptr, pid);
+    OrphanHandle<SDCollection> handle1(wptr1, pid1);
 
     //NOTE: ROOT will touch the private variables directly and since the RefToBaseProd
     // has no constructor which takes RefCore, I have to play this dirty trick
     assert(sizeof(edm::RefCore) == sizeof(edm::RefToBaseProd<IntValue>));
 
-    RefCore core(pid, nullptr, &tester, false);
-    RefToBaseProd<IntValue>& prod = reinterpret_cast<RefToBaseProd<IntValue>&>(core);
+    RefCore core1(pid1, nullptr, &tester1, false);
+    RefToBaseProd<IntValue>& prod1 = reinterpret_cast<RefToBaseProd<IntValue>&>(core1);
 
-    CPPUNIT_ASSERT(!prod.hasCache());
+    CPPUNIT_ASSERT(!prod1.hasCache());
 
-    CPPUNIT_ASSERT(0 != prod.get());
-    CPPUNIT_ASSERT(prod.hasCache());
-    compareTo(prod, *wptr);
+    CPPUNIT_ASSERT(0 != prod1.get());
+    CPPUNIT_ASSERT(prod1.hasCache());
+    compareTo(prod1, *wptr1);
   }
 
   {
-    TestGetter tester;
-    tester.hold_ = nullptr;
-    ProductID const pid(1, 1);
+    TestGetter tester2;
+    tester2.hold_ = nullptr;
+    ProductID const pid2(1, 1);
 
     //NOTE: ROOT will touch the private variables directly and since the RefToBaseProd
     // has no constructor which takes RefCore, I have to play this dirty trick
     assert(sizeof(edm::RefCore) == sizeof(edm::RefToBaseProd<IntValue>));
 
-    RefCore core(pid, nullptr, &tester, false);
-    RefToBaseProd<IntValue>& prod = reinterpret_cast<RefToBaseProd<IntValue>&>(core);
+    RefCore core2(pid2, nullptr, &tester2, false);
+    RefToBaseProd<IntValue>& prod2 = reinterpret_cast<RefToBaseProd<IntValue>&>(core2);
 
-    CPPUNIT_ASSERT_THROW((*prod), cms::Exception);
-    CPPUNIT_ASSERT_THROW((prod.operator->()), cms::Exception);
+    CPPUNIT_ASSERT_THROW((*prod2), cms::Exception);
+    CPPUNIT_ASSERT_THROW((prod2.operator->()), cms::Exception);
   }
 }

--- a/DataFormats/Common/test/testOwnVector.cc
+++ b/DataFormats/Common/test/testOwnVector.cc
@@ -109,21 +109,21 @@ void testOwnVector::checkAll() {
   CPPUNIT_ASSERT(deleted[2]);
   CPPUNIT_ASSERT(deleted[3]);
   {
-    edm::OwnVector<test::a> v;
+    edm::OwnVector<test::a> v1;
     test::a* aa = new test::ClassB(2);
-    v.push_back(aa);
+    v1.push_back(aa);
     aa = new test::ClassB(1);
-    v.push_back(aa);
+    v1.push_back(aa);
     aa = new test::ClassB(3);
-    v.push_back(aa);
-    v.sort(test::ss());
+    v1.push_back(aa);
+    v1.sort(test::ss());
     std::cout << "OwnVector : dumping contents" << std::endl;
-    std::copy(v.begin(), v.end(), std::ostream_iterator<test::a>(std::cout, "\t"));
+    std::copy(v1.begin(), v1.end(), std::ostream_iterator<test::a>(std::cout, "\t"));
 
     edm::Ptr<test::a> ptr_v;
     unsigned long index(0);
-    void const* data = &v[0];
-    v.setPtr(typeid(test::a), index, data);
+    void const* data = &v1[0];
+    v1.setPtr(typeid(test::a), index, data);
     test::a const* data_a = static_cast<test::a const*>(data);
     test::ClassB const* data_b = dynamic_cast<test::ClassB const*>(data_a);
     CPPUNIT_ASSERT(data != 0);

--- a/DataFormats/Common/test/testValueMapNew.cc
+++ b/DataFormats/Common/test/testValueMapNew.cc
@@ -124,9 +124,9 @@ void testValueMapNew::test(const edm::ValueMap<int> &values) {
     CPPUNIT_ASSERT(i.id() == pids[idx]);
     CPPUNIT_ASSERT(i.size() == w[idx]->size());
     {
-      std::vector<int>::const_iterator b = i.begin(), e = i.end(), j;
-      for (j = b; j != e; ++j) {
-        size_t jdx = j - b;
+      std::vector<int>::const_iterator bb = i.begin(), ee = i.end(), j;
+      for (j = bb; j != ee; ++j) {
+        size_t jdx = j - bb;
         CPPUNIT_ASSERT(*j == (*w[idx])[jdx]);
         CPPUNIT_ASSERT(i[jdx] == (*w[idx])[jdx]);
       }

--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -228,15 +228,15 @@ namespace fwlite {
         //We do not already have this data as another key
 
         //create an instance of the object to be used as a buffer
-        edm::TypeWithDict type(iInfo);
-        if (!bool(type)) {
+        edm::TypeWithDict type1(iInfo);
+        if (!bool(type1)) {
           throw cms::Exception("UnknownType") << "No dictionary exists for type " << iInfo.name();
         }
 
-        edm::ObjectWithDict obj = edm::ObjectWithDict::byType(type);
+        edm::ObjectWithDict obj = edm::ObjectWithDict::byType(type1);
 
         if (obj.address() == nullptr) {
-          throw cms::Exception("ConstructionFailed") << "failed to construct an instance of " << type.name();
+          throw cms::Exception("ConstructionFailed") << "failed to construct an instance of " << type1.name();
         }
         auto newData = std::make_shared<internal::Data>();
         newData->branch_ = branch;
@@ -254,9 +254,9 @@ namespace fwlite {
         newProcess = new char[foundProcessLabel.size() + 1];
         std::strcpy(newProcess, foundProcessLabel.c_str());
         labels_.push_back(newProcess);
-        internal::DataKey newKey(edm::TypeID(iInfo), newModule, newProduct, newProcess);
+        internal::DataKey newKey1(edm::TypeID(iInfo), newModule, newProduct, newProcess);
 
-        data_.insert(std::make_pair(newKey, theData));
+        data_.insert(std::make_pair(newKey1, theData));
       }
     }
     return *(itFind->second);

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -111,9 +111,9 @@ namespace edm {
       readProvenance();
       auto ptr = readEntryInfoSet_.load();
       if (ptr) {
-        auto it = ptr->find(ei);
-        if (it != ptr->end()) {
-          return &*it;
+        auto itRead = ptr->find(ei);
+        if (itRead != ptr->end()) {
+          return &*itRead;
         }
       }
       if (nextRetriever_) {

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -376,8 +376,8 @@ namespace edm {
           }
 
           if (hasContainedType) {
-            auto iter = containedTypeToBaseTypesMap.find(containedTypeID);
-            if (iter == containedTypeToBaseTypesMap.end()) {
+            auto iter1 = containedTypeToBaseTypesMap.find(containedTypeID);
+            if (iter1 == containedTypeToBaseTypesMap.end()) {
               std::vector<TypeWithDict> baseTypes;
               if (!public_base_classes(missingDictionaries, containedTypeID, baseTypes)) {
                 branchNamesForMissing.emplace_back(desc.branchName());
@@ -388,9 +388,9 @@ namespace edm {
                 }
                 continue;
               }
-              iter = containedTypeToBaseTypesMap.insert(std::make_pair(containedTypeID, baseTypes)).first;
+              iter1 = containedTypeToBaseTypesMap.insert(std::make_pair(containedTypeID, baseTypes)).first;
             }
-            baseTypesOfContainedType = &iter->second;
+            baseTypesOfContainedType = &iter1->second;
           }
 
           // Do this after the dictionary checks of constituents so the list of branch names for missing types
@@ -398,9 +398,9 @@ namespace edm {
           containedTypeMap.emplace(typeID, containedTypeID);
         } else {
           if (hasContainedType) {
-            auto iter = containedTypeToBaseTypesMap.find(containedTypeID);
-            if (iter != containedTypeToBaseTypesMap.end()) {
-              baseTypesOfContainedType = &iter->second;
+            auto iter2 = containedTypeToBaseTypesMap.find(containedTypeID);
+            if (iter2 != containedTypeToBaseTypesMap.end()) {
+              baseTypesOfContainedType = &iter2->second;
             }
           }
         }

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -993,51 +993,51 @@ void TestIndexIntoFile3::testOverlappingLumis() {
   CPPUNIT_ASSERT(i == 16);
 
   {
-    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::numericalOrder);
-    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::numericalOrder);
-    int i = 0;
-    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst1 = indexIntoFile.begin(IndexIntoFile::numericalOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd1 = indexIntoFile.end(IndexIntoFile::numericalOrder);
+    int j = 0;
+    for (j = 0; iterFirst1 != iterFirstEnd1; ++iterFirst1, ++j) {
       //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
-      if (i == 0) {
-        check(iterFirst, kRun, 0, 2, 1, 0, 2);
+      if (j == 0) {
+        check(iterFirst1, kRun, 0, 2, 1, 0, 2);
 
-        iterFirst.getLumisInRun(lumis);
+        iterFirst1.getLumisInRun(lumis);
         std::vector<LuminosityBlockNumber_t> expected{102, 103, 104};
         CPPUNIT_ASSERT(lumis == expected);
-      } else if (i == 1)
-        check(iterFirst, kLumi, 0, 2, 1, 0, 2);
-      else if (i == 2)
-        check(iterFirst, kEvent, 0, 2, 1, 0, 2);
-      else if (i == 3)
-        check(iterFirst, kEvent, 0, 2, 1, 1, 2);
-      else if (i == 4)
-        check(iterFirst, kLumi, 0, 4, 3, 0, 4);
-      else if (i == 5)
-        check(iterFirst, kEvent, 0, 4, 3, 0, 4);
-      else if (i == 6)
-        check(iterFirst, kEvent, 0, 4, 3, 1, 4);
-      else if (i == 7)
-        check(iterFirst, kEvent, 0, 4, 3, 2, 4);
-      else if (i == 8)
-        check(iterFirst, kEvent, 0, 4, 3, 3, 4);
-      else if (i == 9)
-        check(iterFirst, kLumi, 0, 5, -1, 0, 0);
-      else if (i == 10)
-        check(iterFirst, kRun, 6, 8, -1, 0, 0);
-      else if (i == 11)
-        check(iterFirst, kRun, 7, 8, -1, 0, 0);
-      else if (i == 12)
-        check(iterFirst, kLumi, 7, 8, -1, 0, 0);
-      else if (i == 13)
-        check(iterFirst, kLumi, 7, 9, 9, 0, 1);
-      else if (i == 14)
-        check(iterFirst, kLumi, 7, 10, 9, 0, 1);
-      else if (i == 15)
-        check(iterFirst, kEvent, 7, 10, 9, 0, 1);
+      } else if (j == 1)
+        check(iterFirst1, kLumi, 0, 2, 1, 0, 2);
+      else if (j == 2)
+        check(iterFirst1, kEvent, 0, 2, 1, 0, 2);
+      else if (j == 3)
+        check(iterFirst1, kEvent, 0, 2, 1, 1, 2);
+      else if (j == 4)
+        check(iterFirst1, kLumi, 0, 4, 3, 0, 4);
+      else if (j == 5)
+        check(iterFirst1, kEvent, 0, 4, 3, 0, 4);
+      else if (j == 6)
+        check(iterFirst1, kEvent, 0, 4, 3, 1, 4);
+      else if (j == 7)
+        check(iterFirst1, kEvent, 0, 4, 3, 2, 4);
+      else if (j == 8)
+        check(iterFirst1, kEvent, 0, 4, 3, 3, 4);
+      else if (j == 9)
+        check(iterFirst1, kLumi, 0, 5, -1, 0, 0);
+      else if (j == 10)
+        check(iterFirst1, kRun, 6, 8, -1, 0, 0);
+      else if (j == 11)
+        check(iterFirst1, kRun, 7, 8, -1, 0, 0);
+      else if (j == 12)
+        check(iterFirst1, kLumi, 7, 8, -1, 0, 0);
+      else if (j == 13)
+        check(iterFirst1, kLumi, 7, 9, 9, 0, 1);
+      else if (j == 14)
+        check(iterFirst1, kLumi, 7, 10, 9, 0, 1);
+      else if (j == 15)
+        check(iterFirst1, kEvent, 7, 10, 9, 0, 1);
       else
         CPPUNIT_ASSERT(false);
     }
-    CPPUNIT_ASSERT(i == 16);
+    CPPUNIT_ASSERT(j == 16);
   }
 
   edm::IndexIntoFile::IndexIntoFileItr testIter = indexIntoFile.findPosition(11, 103, 7);
@@ -1050,103 +1050,103 @@ void TestIndexIntoFile3::testOverlappingLumis() {
   check(testIter, kLumi, 0, 5, -1, 0, 0);
 
   {
-    edm::IndexIntoFile::IndexIntoFileItr testIter = indexIntoFile.findPosition(11, 0, 7);
-    check(testIter, kRun, 0, 4, 3, 3, 4);
-    ++testIter;
-    check(testIter, kLumi, 0, 4, 3, 3, 4);
-    ++testIter;
-    check(testIter, kEvent, 0, 4, 3, 3, 4);
-    ++testIter;
-    check(testIter, kLumi, 0, 5, -1, 0, 0);
-    skipEventBackward(testIter);
-    check(testIter, kLumi, 0, 4, 3, 3, 4);
+    edm::IndexIntoFile::IndexIntoFileItr testIter1 = indexIntoFile.findPosition(11, 0, 7);
+    check(testIter1, kRun, 0, 4, 3, 3, 4);
+    ++testIter1;
+    check(testIter1, kLumi, 0, 4, 3, 3, 4);
+    ++testIter1;
+    check(testIter1, kEvent, 0, 4, 3, 3, 4);
+    ++testIter1;
+    check(testIter1, kLumi, 0, 5, -1, 0, 0);
+    skipEventBackward(testIter1);
+    check(testIter1, kLumi, 0, 4, 3, 3, 4);
   }
 
   {
-    edm::IndexIntoFile indexIntoFile;
-    indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0);  // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 101, 6, 1);  // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 101, 5, 2);  // Event
-                                                       //Dummy Lumi gets added
-    indexIntoFile.addEntry(fakePHID1, 11, 102, 5, 4);  // Event
-                                                       //Another dummy lumi gets added
-    indexIntoFile.addEntry(fakePHID1, 11, 101, 4, 3);  // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 101, 0, 0);  // Lumi
+    edm::IndexIntoFile indexIntoFile1;
+    indexIntoFile1.addEntry(fakePHID1, 11, 101, 7, 0);  // Event
+    indexIntoFile1.addEntry(fakePHID1, 11, 101, 6, 1);  // Event
+    indexIntoFile1.addEntry(fakePHID1, 11, 101, 5, 2);  // Event
+                                                        //Dummy Lumi gets added
+    indexIntoFile1.addEntry(fakePHID1, 11, 102, 5, 4);  // Event
+                                                        //Another dummy lumi gets added
+    indexIntoFile1.addEntry(fakePHID1, 11, 101, 4, 3);  // Event
+    indexIntoFile1.addEntry(fakePHID1, 11, 101, 0, 0);  // Lumi
 
-    indexIntoFile.addEntry(fakePHID1, 11, 102, 4, 5);  // Event
-    indexIntoFile.addEntry(fakePHID1, 11, 102, 0, 1);  // Lumi
-    indexIntoFile.addEntry(fakePHID1, 11, 0, 0, 0);    // Run
-    indexIntoFile.addEntry(fakePHID2, 11, 0, 0, 1);    // Run
-    indexIntoFile.addEntry(fakePHID2, 11, 101, 0, 2);  // Lumi
-    indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 3);  // Lumi
-    indexIntoFile.addEntry(fakePHID2, 11, 102, 4, 6);  // Event
-    indexIntoFile.addEntry(fakePHID2, 11, 102, 0, 4);  // Lumi
-    indexIntoFile.addEntry(fakePHID2, 11, 0, 0, 2);    // Run
-    indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+    indexIntoFile1.addEntry(fakePHID1, 11, 102, 4, 5);  // Event
+    indexIntoFile1.addEntry(fakePHID1, 11, 102, 0, 1);  // Lumi
+    indexIntoFile1.addEntry(fakePHID1, 11, 0, 0, 0);    // Run
+    indexIntoFile1.addEntry(fakePHID2, 11, 0, 0, 1);    // Run
+    indexIntoFile1.addEntry(fakePHID2, 11, 101, 0, 2);  // Lumi
+    indexIntoFile1.addEntry(fakePHID2, 11, 102, 0, 3);  // Lumi
+    indexIntoFile1.addEntry(fakePHID2, 11, 102, 4, 6);  // Event
+    indexIntoFile1.addEntry(fakePHID2, 11, 102, 0, 4);  // Lumi
+    indexIntoFile1.addEntry(fakePHID2, 11, 0, 0, 2);    // Run
+    indexIntoFile1.sortVector_Run_Or_Lumi_Entries();
 
-    edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
-    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd = indexIntoFile.end(IndexIntoFile::firstAppearanceOrder);
-    int i = 0;
-    for (i = 0; iterFirst != iterFirstEnd; ++iterFirst, ++i) {
-      if (i == 0) {
-        check(iterFirst, kRun, 0, 2, 1, 0, 3);
-        CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
-        CPPUNIT_ASSERT(iterFirst.size() == 10);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirst2 = indexIntoFile1.begin(IndexIntoFile::firstAppearanceOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterFirstEnd2 = indexIntoFile1.end(IndexIntoFile::firstAppearanceOrder);
+    int k = 0;
+    for (k = 0; iterFirst2 != iterFirstEnd2; ++iterFirst2, ++k) {
+      if (k == 0) {
+        check(iterFirst2, kRun, 0, 2, 1, 0, 3);
+        CPPUNIT_ASSERT(iterFirst2.indexIntoFile() == &indexIntoFile1);
+        CPPUNIT_ASSERT(iterFirst2.size() == 10);
 
-        iterFirst.getLumisInRun(lumis);
+        iterFirst2.getLumisInRun(lumis);
         std::vector<LuminosityBlockNumber_t> expected{101, 102};
         CPPUNIT_ASSERT(lumis == expected);
       }
       //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
-      else if (i == 1)
-        check(iterFirst, kLumi, 0, 2, 1, 0, 3);
-      else if (i == 2)
-        check(iterFirst, kEvent, 0, 2, 1, 0, 3);
-      else if (i == 3)
-        check(iterFirst, kEvent, 0, 2, 1, 1, 3);
-      else if (i == 4)
-        check(iterFirst, kEvent, 0, 2, 1, 2, 3);
-      else if (i == 5)
-        check(iterFirst, kEvent, 0, 2, 2, 0, 1);
-      else if (i == 6)
-        check(iterFirst, kLumi, 0, 4, 3, 0, 1);
-      else if (i == 7)
-        check(iterFirst, kEvent, 0, 4, 3, 0, 1);
-      else if (i == 8)
-        check(iterFirst, kEvent, 0, 4, 4, 0, 1);
-      else if (i == 9) {
-        check(iterFirst, kRun, 5, 7, -1, 0, 0);
+      else if (k == 1)
+        check(iterFirst2, kLumi, 0, 2, 1, 0, 3);
+      else if (k == 2)
+        check(iterFirst2, kEvent, 0, 2, 1, 0, 3);
+      else if (k == 3)
+        check(iterFirst2, kEvent, 0, 2, 1, 1, 3);
+      else if (k == 4)
+        check(iterFirst2, kEvent, 0, 2, 1, 2, 3);
+      else if (k == 5)
+        check(iterFirst2, kEvent, 0, 2, 2, 0, 1);
+      else if (k == 6)
+        check(iterFirst2, kLumi, 0, 4, 3, 0, 1);
+      else if (k == 7)
+        check(iterFirst2, kEvent, 0, 4, 3, 0, 1);
+      else if (k == 8)
+        check(iterFirst2, kEvent, 0, 4, 4, 0, 1);
+      else if (k == 9) {
+        check(iterFirst2, kRun, 5, 7, -1, 0, 0);
 
-        iterFirst.getLumisInRun(lumis);
+        iterFirst2.getLumisInRun(lumis);
         std::vector<LuminosityBlockNumber_t> expected{101, 102};
         CPPUNIT_ASSERT(lumis == expected);
-      } else if (i == 10)
-        check(iterFirst, kRun, 6, 7, -1, 0, 0);
-      else if (i == 11)
-        check(iterFirst, kLumi, 6, 7, -1, 0, 0);
-      else if (i == 12)
-        check(iterFirst, kLumi, 6, 8, 9, 0, 1);
-      else if (i == 13)
-        check(iterFirst, kLumi, 6, 9, 9, 0, 1);
-      else if (i == 14)
-        check(iterFirst, kEvent, 6, 9, 9, 0, 1);
+      } else if (k == 10)
+        check(iterFirst2, kRun, 6, 7, -1, 0, 0);
+      else if (k == 11)
+        check(iterFirst2, kLumi, 6, 7, -1, 0, 0);
+      else if (k == 12)
+        check(iterFirst2, kLumi, 6, 8, 9, 0, 1);
+      else if (k == 13)
+        check(iterFirst2, kLumi, 6, 9, 9, 0, 1);
+      else if (k == 14)
+        check(iterFirst2, kEvent, 6, 9, 9, 0, 1);
       else
         CPPUNIT_ASSERT(false);
 
-      if (i == 0)
-        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
-      if (i == 8)
-        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 0);
-      if (i == 10)
-        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisRun() == 6);
+      if (k == 0)
+        CPPUNIT_ASSERT(iterFirst2.firstEventEntryThisRun() == 0);
+      if (k == 8)
+        CPPUNIT_ASSERT(iterFirst2.firstEventEntryThisRun() == 0);
+      if (k == 10)
+        CPPUNIT_ASSERT(iterFirst2.firstEventEntryThisRun() == 6);
 
-      if (i == 0)
-        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 0);
-      if (i == 8)
-        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == 4);
-      if (i == 10)
-        CPPUNIT_ASSERT(iterFirst.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
+      if (k == 0)
+        CPPUNIT_ASSERT(iterFirst2.firstEventEntryThisLumi() == 0);
+      if (k == 8)
+        CPPUNIT_ASSERT(iterFirst2.firstEventEntryThisLumi() == 4);
+      if (k == 10)
+        CPPUNIT_ASSERT(iterFirst2.firstEventEntryThisLumi() == IndexIntoFile::invalidIndex);
     }
-    CPPUNIT_ASSERT(i == 15);
+    CPPUNIT_ASSERT(k == 15);
   }
 }

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -81,12 +81,12 @@ TEST_CASE("FileLocator", "[filelocator]") {
   SECTION("override") {
     edm::ServiceRegistry::Operate operate(tempToken);
 
-    std::string file_name("/src/FWCore/Catalog/test/override_catalog.xml");
-    std::string full_file_name = boost::filesystem::exists((CMSSW_BASE + file_name).c_str())
-                                     ? CMSSW_BASE + file_name
-                                     : CMSSW_RELEASE_BASE + file_name;
+    std::string file_name1("/src/FWCore/Catalog/test/override_catalog.xml");
+    std::string full_file_name1 = boost::filesystem::exists((CMSSW_BASE + file_name1).c_str())
+                                      ? CMSSW_BASE + file_name1
+                                      : CMSSW_RELEASE_BASE + file_name1;
 
-    edm::FileLocator fl(("trivialcatalog_file:" + full_file_name + "?protocol=override").c_str(), false);
+    edm::FileLocator fl(("trivialcatalog_file:" + full_file_name1 + "?protocol=override").c_str(), false);
 
     std::array<const char*, 8> lfn = {{"/store/group/bha/bho",
                                        "/bha/bho",

--- a/FWCore/Concurrency/src/SerialTaskQueue.cc
+++ b/FWCore/Concurrency/src/SerialTaskQueue.cc
@@ -78,7 +78,7 @@ SerialTaskQueue::TaskBase* SerialTaskQueue::pickNextTask() {
       //was a new entry added after we called 'try_pop' but before we did the clear?
       expect = false;
       if (not m_tasks.empty() and m_taskChosen.compare_exchange_strong(expect, true)) {
-        TaskBase* t = nullptr;
+        t = nullptr;
         if (m_tasks.try_pop(t)) {
           return t;
         }

--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -263,7 +263,7 @@ void LimitedTaskQueue_test::stressTest() {
             for (unsigned int i = 0; i < nTasks; ++i) {
               pWaitTask->increment_ref_count();
               queue.push([&count, pWaitTask, &nRunningTasks] {
-                std::shared_ptr<tbb::task> guard{pWaitTask, [](tbb::task* iTask) { iTask->decrement_ref_count(); }};
+                std::shared_ptr<tbb::task> guard1{pWaitTask, [](tbb::task* iTask) { iTask->decrement_ref_count(); }};
                 auto nrt = nRunningTasks++;
                 if (nrt >= kMax) {
                   std::cout << "ERROR " << nRunningTasks << " >= " << kMax << std::endl;

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -98,12 +98,12 @@ void WaitingTaskList_test::addThenDone() {
   called = false;
 
   {
-    std::exception_ptr excPtr;
+    std::exception_ptr excPtr1;
 
     auto waitTask = edm::make_empty_waiting_task();
     waitTask->set_ref_count(2);
 
-    auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr};
+    auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr1};
 
     waitList.add(t);
 
@@ -113,7 +113,7 @@ void WaitingTaskList_test::addThenDone() {
     waitList.doneWaiting(std::exception_ptr{});
     waitTask->wait_for_all();
     CPPUNIT_ASSERT(true == called);
-    CPPUNIT_ASSERT(bool(excPtr) == false);
+    CPPUNIT_ASSERT(bool(excPtr1) == false);
   }
 }
 
@@ -143,12 +143,12 @@ void WaitingTaskList_test::addThenDoneFailed() {
 
   edm::WaitingTaskList waitList;
   {
-    std::exception_ptr excPtr;
+    std::exception_ptr excPtr1;
 
     auto waitTask = edm::make_empty_waiting_task();
     waitTask->set_ref_count(2);
 
-    auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr};
+    auto t = new (waitTask->allocate_child()) TestCalledTask{called, excPtr1};
 
     waitList.add(t);
 
@@ -158,7 +158,7 @@ void WaitingTaskList_test::addThenDoneFailed() {
     waitList.doneWaiting(std::make_exception_ptr(std::string("failed")));
     waitTask->wait_for_all();
     CPPUNIT_ASSERT(true == called);
-    CPPUNIT_ASSERT(bool(excPtr) == true);
+    CPPUNIT_ASSERT(bool(excPtr1) == true);
   }
 }
 

--- a/FWCore/Framework/interface/GetterOfProducts.h
+++ b/FWCore/Framework/interface/GetterOfProducts.h
@@ -144,7 +144,6 @@ namespace edm {
       handles.clear();
       if (branchType_ == edm::InEvent) {
         handles.reserve(tokens_->size());
-        edm::Handle<T> handle;
         for (auto const& token : *tokens_) {
           if (auto handle = event.getHandle(token)) {
             handles.push_back(handle);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1114,7 +1114,7 @@ namespace edm {
                   if (looper_) {
                     try {
                       //make the services available
-                      ServiceRegistry::Operate operate(serviceToken_);
+                      ServiceRegistry::Operate operate1(serviceToken_);
                       looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
                     } catch (...) {
                       status.reset();
@@ -1129,10 +1129,10 @@ namespace edm {
                       streamQueues_[i].pause();
 
                       auto eventTask = edm::make_waiting_task(
-                          tbb::task::allocate_root(), [this, i, h = holder](std::exception_ptr const* iPtr) mutable {
-                            if (iPtr) {
+                          tbb::task::allocate_root(), [this, i, h = holder](std::exception_ptr const* iPtr1) mutable {
+                            if (iPtr1) {
                               WaitingTaskHolder tmp(h);
-                              tmp.doneWaiting(*iPtr);
+                              tmp.doneWaiting(*iPtr1);
                               streamEndLumiAsync(h, i, streamLumiStatus_[i]);
                             } else {
                               handleNextEventForStreamAsync(std::move(h), i);
@@ -1287,9 +1287,9 @@ namespace edm {
             try {
               ServiceRegistry::Operate operate(serviceToken_);
               if (looper_) {
-                auto& lp = *(status->lumiPrincipal());
+                auto& lp1 = *(status->lumiPrincipal());
                 EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
-                looper_->doEndLuminosityBlock(lp, es, &processContext_);
+                looper_->doEndLuminosityBlock(lp1, es, &processContext_);
               }
             } catch (...) {
               ptr = std::current_exception();
@@ -1708,7 +1708,7 @@ namespace edm {
         tbb::task::allocate_root(), [this, pep, iHolder, iStreamIndex](std::exception_ptr const* iPtr) mutable {
           //NOTE: If we have a looper we only have one Stream
           if (looper_) {
-            ServiceRegistry::Operate operate(serviceToken_);
+            ServiceRegistry::Operate operate1(serviceToken_);
             processEventWithLooper(*pep, iStreamIndex);
           }
 

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -90,8 +90,8 @@ namespace edm {
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
         activityRegistry->preModuleWriteRunSignal_(globalContext, mcc);
-        auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
-          activityRegistry->postModuleWriteRunSignal_(globalContext, mcc);
+        auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* activityRegistry1) {
+          activityRegistry1->postModuleWriteRunSignal_(globalContext, mcc);
         }));
         mod.doWriteRun(rp, &mcc, mergeableRunProductMetadata);
       } catch (...) {
@@ -123,8 +123,8 @@ namespace edm {
         ModuleCallingContext mcc(desc);
         ModuleContextSentry moduleContextSentry(&mcc, parentContext);
         activityRegistry->preModuleWriteLumiSignal_(globalContext, mcc);
-        auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* activityRegistry) {
-          activityRegistry->postModuleWriteLumiSignal_(globalContext, mcc);
+        auto sentry(make_sentry(activityRegistry, [&globalContext, &mcc](ActivityRegistry* activityRegistry1) {
+          activityRegistry1->postModuleWriteLumiSignal_(globalContext, mcc);
         }));
         mod.doWriteLuminosityBlock(lbp, &mcc);
       } catch (...) {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -236,9 +236,9 @@ namespace edm {
               } else {
                 bool productMadeAtEnd = false;
                 //Need to know if the product from this processes is added at end of transition
-                for (unsigned int i = 0; i < matchingHolders.size(); ++i) {
-                  if ((not ambiguous[i]) and ProductResolverIndexInvalid != matchingHolders[i] and
-                      productResolvers_[matchingHolders[i]]->branchDescription().availableOnlyAtEndTransition()) {
+                for (unsigned int j = 0; j < matchingHolders.size(); ++j) {
+                  if ((not ambiguous[j]) and ProductResolverIndexInvalid != matchingHolders[j] and
+                      productResolvers_[matchingHolders[j]]->branchDescription().availableOnlyAtEndTransition()) {
                     productMadeAtEnd = true;
                     break;
                   }
@@ -460,11 +460,11 @@ namespace edm {
       }
 
       for (auto iEnd = processHistoryPtr_->rend(); iter != iEnd; ++iter) {
-        auto nameIter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), iter->processName());
-        if (nameIter == lookupProcessNames.end()) {
+        auto nameIter1 = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), iter->processName());
+        if (nameIter1 == lookupProcessNames.end()) {
           continue;
         }
-        lookupProcessOrder_.at(k) = nameIter - lookupProcessNames.begin();
+        lookupProcessOrder_.at(k) = nameIter1 - lookupProcessNames.begin();
         ++k;
       }
       orderProcessHistoryID_ = processHistoryID_;

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -51,11 +51,11 @@ namespace edm {
     if (callResolver && presentStatus == ProductStatus::ResolveNotRun) {
       //if resolver fails because of exception or not setting product
       // make sure the status goes to failed
-      auto failedStatusSetter = [this](ProductStatus* presentStatus) {
+      auto failedStatusSetter = [this](ProductStatus* presentStatus1) {
         if (this->status() == ProductStatus::ResolveNotRun) {
           this->setFailedStatus();
         }
-        *presentStatus = this->status();
+        *presentStatus1 = this->status();
       };
       std::unique_ptr<ProductStatus, decltype(failedStatusSetter)> failedStatusGuard(&presentStatus,
                                                                                      failedStatusSetter);
@@ -252,7 +252,7 @@ namespace edm {
     if (m_prefetchRequested.compare_exchange_strong(expected, true)) {
       auto workToDo = [this, mcc, &principal, token]() {
         //need to make sure Service system is activated on the reading thread
-        ServiceRegistry::Operate guard(token);
+        ServiceRegistry::Operate guard1(token);
         try {
           resolveProductImpl<true>([this, &principal, mcc]() {
             if (principal.branchType() != InEvent) {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -322,18 +322,18 @@ namespace edm {
             it = inserted.first;
           }
 
-          for (auto const& item : preg.productList()) {
-            if (item.second.branchType() == prod.second.branchType() and
-                item.second.unwrappedTypeID().typeInfo() == prod.second.unwrappedTypeID().typeInfo() and
-                item.first.moduleLabel() == prod.second.switchAliasModuleLabel() and
-                item.first.productInstanceName() == prod.second.productInstanceName()) {
-              if (item.first.processName() != processName) {
+          for (auto const& item1 : preg.productList()) {
+            if (item1.second.branchType() == prod.second.branchType() and
+                item1.second.unwrappedTypeID().typeInfo() == prod.second.unwrappedTypeID().typeInfo() and
+                item1.first.moduleLabel() == prod.second.switchAliasModuleLabel() and
+                item1.first.productInstanceName() == prod.second.productInstanceName()) {
+              if (item1.first.processName() != processName) {
                 throw Exception(errors::LogicError)
                     << "Encountered a BranchDescription that is aliased-for by SwitchProducer, and whose processName "
-                    << item.first.processName() << " differs from current process " << processName
-                    << ". Module label is " << item.first.moduleLabel() << ".\nPlease contact a framework developer.";
+                    << item1.first.processName() << " differs from current process " << processName
+                    << ". Module label is " << item1.first.moduleLabel() << ".\nPlease contact a framework developer.";
               }
-              prod.second.setSwitchAliasForBranch(item.second);
+              prod.second.setSwitchAliasForBranch(item1.second);
               it->second.chosenBranches.push_back(prod.first);  // with moduleLabel of the Switch
             }
           }
@@ -392,8 +392,8 @@ namespace edm {
                           << "SwitchProducer does not support ROOT branch aliases. Got the following ROOT branch "
                              "aliases for SwitchProducer with label "
                           << switchLabel << " for case " << caseLabel << ":";
-                for (auto const& item : bd.branchAliases()) {
-                  ex << " " << item;
+                for (auto const& item2 : bd.branchAliases()) {
+                  ex << " " << item2;
                 }
                 throw ex;
               }

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -468,7 +468,7 @@ namespace edm {
           if (iExcept) {
             task.doneWaiting(*iExcept);
           } else {
-            ServiceRegistry::Operate operate(serviceToken_);
+            ServiceRegistry::Operate operate1(serviceToken_);
             for (auto& s : subProcesses_) {
               s.writeRunAsync(task, childPhID, runNumber, mergeableRunProductMetadata);
             }
@@ -547,7 +547,7 @@ namespace edm {
           if (iExcept) {
             task.doneWaiting(*iExcept);
           } else {
-            ServiceRegistry::Operate operate(serviceToken_);
+            ServiceRegistry::Operate operate1(serviceToken_);
             for (auto& s : subProcesses_) {
               s.writeLumiAsync(task, *l);
             }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -462,7 +462,7 @@ namespace edm {
                       sContext = m_context,
                       serviceToken = m_serviceToken]() {
               //Need to make the services available
-              ServiceRegistry::Operate guard(serviceToken);
+              ServiceRegistry::Operate guard1(serviceToken);
 
               //If needed, we pause the queue in begin transition and resume it
               // at the end transition. This guarantees that the module
@@ -560,7 +560,7 @@ namespace edm {
                         serviceToken = m_serviceToken,
                         holder = m_holder]() {
               //Need to make the services available
-              ServiceRegistry::Operate guard(serviceToken);
+              ServiceRegistry::Operate guard1(serviceToken);
 
               std::exception_ptr* ptr = nullptr;
               worker->runAcquireAfterAsyncPrefetch(ptr, principal, es, parentContext, holder);
@@ -951,8 +951,8 @@ namespace edm {
       if (auto queue = this->serializeRunModule()) {
         queue.push(toDo);
       } else {
-        auto task = make_functor_task(tbb::task::allocate_root(), toDo);
-        tbb::task::spawn(*task);
+        auto taskToDo = make_functor_task(tbb::task::allocate_root(), toDo);
+        tbb::task::spawn(*taskToDo);
       }
     }
   }

--- a/FWCore/Framework/src/throwIfImproperDependencies.cc
+++ b/FWCore/Framework/src/throwIfImproperDependencies.cc
@@ -394,8 +394,8 @@ namespace {
                 continue;
               }
               bool alreadyAdvanced = false;
-              for (auto index : pathIndicies) {
-                if (index == out) {
+              for (auto index1 : pathIndicies) {
+                if (index1 == out) {
                   //we must have skipped over the module so the earlier worry about the
                   // module being called on the path was wrong
                   auto toErase = it;
@@ -404,7 +404,7 @@ namespace {
                   pathToModulesWhichMustAppearLater.erase(toErase);
                   break;
                 }
-                if (index == moduleIDToCheck) {
+                if (index1 == moduleIDToCheck) {
                   //module still earlier on the path
                   break;
                 }
@@ -435,12 +435,12 @@ namespace {
                 //we left this path so we now need to see if the module 'out'
                 // is on this path ahead of the module 'in'
                 bool foundOut = false;
-                for (auto index : m_pathIndexToModuleIndexOrder[seenPath]) {
-                  if (index == out) {
+                for (auto index2 : m_pathIndexToModuleIndexOrder[seenPath]) {
+                  if (index2 == out) {
                     foundOut = true;
                     pathsToWatch.push_back(seenPath);
                   }
-                  if (index == lastOut) {
+                  if (index2 == lastOut) {
                     if (not foundOut) {
                       atLeastOnePathFailed = true;
                     }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -706,10 +706,10 @@ void testEvent::getByLabel() {
   CPPUNIT_ASSERT(h->value == 4);
 
   {
-    handle_t h;
+    handle_t h1;
     edm::EventBase* baseEvent = currentEvent_.get();
-    CPPUNIT_ASSERT(baseEvent->getByLabel(inputTag, h));
-    CPPUNIT_ASSERT(h->value == 200);
+    CPPUNIT_ASSERT(baseEvent->getByLabel(inputTag, h1));
+    CPPUNIT_ASSERT(h1->value == 200);
   }
 
   BasicHandle bh = principal_->getByLabel(

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -370,12 +370,12 @@ void testdependentrecord::timeAndRunTest() {
                                              edm::IOVSyncValue(edm::Timestamp(5ULL << 32)));
     dummyProvider2->setValidityInterval_forTesting(timeInterval);
 
-    const edm::ValidityInterval overlapInterval(runLumiInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    const edm::ValidityInterval overlapInterval5(runLumiInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
     dummyProvider1->initializeForNewSyncValue();
     dummyProvider2->initializeForNewSyncValue();
     CPPUNIT_ASSERT(
-        overlapInterval ==
+        overlapInterval5 ==
         finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 2, 12), edm::Timestamp(3ULL << 32))));
   }
 
@@ -389,12 +389,12 @@ void testdependentrecord::timeAndRunTest() {
                                              edm::IOVSyncValue(edm::Timestamp(10ULL << 32)));
     dummyProvider2->setValidityInterval_forTesting(timeInterval);
 
-    const edm::ValidityInterval overlapInterval(timeInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    const edm::ValidityInterval overlapInterval6(timeInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
     dummyProvider1->initializeForNewSyncValue();
     dummyProvider2->initializeForNewSyncValue();
     CPPUNIT_ASSERT(
-        overlapInterval ==
+        overlapInterval6 ==
         finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 4, 30), edm::Timestamp(8ULL << 32))));
   }
 
@@ -408,12 +408,12 @@ void testdependentrecord::timeAndRunTest() {
                                              edm::IOVSyncValue(edm::Timestamp(100ULL << 32)));
     dummyProvider2->setValidityInterval_forTesting(timeInterval);
 
-    const edm::ValidityInterval overlapInterval(runLumiInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    const edm::ValidityInterval overlapInterval7(runLumiInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
     dummyProvider1->initializeForNewSyncValue();
     dummyProvider2->initializeForNewSyncValue();
     CPPUNIT_ASSERT(
-        overlapInterval ==
+        overlapInterval7 ==
         finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 12, 50), edm::Timestamp(70ULL << 32))));
   }
 
@@ -427,12 +427,12 @@ void testdependentrecord::timeAndRunTest() {
                                              edm::IOVSyncValue(edm::Timestamp(500ULL << 32)));
     dummyProvider2->setValidityInterval_forTesting(timeInterval);
 
-    const edm::ValidityInterval overlapInterval(timeInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    const edm::ValidityInterval overlapInterval8(timeInterval.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
     dummyProvider1->initializeForNewSyncValue();
     dummyProvider2->initializeForNewSyncValue();
     CPPUNIT_ASSERT(
-        overlapInterval ==
+        overlapInterval8 ==
         finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(4, 12, 50), edm::Timestamp(400ULL << 32))));
   }
 
@@ -467,77 +467,74 @@ void testdependentrecord::timeAndRunTest() {
   {
     //check for bug which only happens the first time we synchronize
     // have the second one invalid
-    auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
+    auto dummyProvider3 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
 
-    const edm::EventID eID_1(1, 1, 1);
-    const edm::IOVSyncValue sync_1(eID_1);
-    const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 6)));
-    dummyProvider1->setValidityInterval_forTesting(definedInterval1);
+    const edm::EventID eID_2(1, 1, 1);
+    const edm::IOVSyncValue sync_3(eID_2);
+    const edm::ValidityInterval definedInterval6(sync_3, edm::IOVSyncValue(edm::EventID(1, 1, 6)));
+    dummyProvider3->setValidityInterval_forTesting(definedInterval6);
 
-    auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
+    auto dummyProvider4 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
 
-    dummyProvider2->setValidityInterval_forTesting(invalid);
+    dummyProvider4->setValidityInterval_forTesting(invalid);
 
-    const edm::ValidityInterval overlapInterval(definedInterval1.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    const edm::ValidityInterval overlapInterval9(definedInterval6.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
-    const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+    DependentRecordIntervalFinder finder1(depRecordKey);
+    finder1.addProviderWeAreDependentOn(dummyProvider3);
+    finder1.addProviderWeAreDependentOn(dummyProvider4);
 
-    DependentRecordIntervalFinder finder(depRecordKey);
-    finder.addProviderWeAreDependentOn(dummyProvider1);
-    finder.addProviderWeAreDependentOn(dummyProvider2);
+    CPPUNIT_ASSERT(overlapInterval9 ==
+                   finder1.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(1))));
 
-    CPPUNIT_ASSERT(overlapInterval ==
-                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(1))));
+    const edm::Timestamp time_2(2);
+    const edm::IOVSyncValue sync_4(time_2);
+    const edm::ValidityInterval definedInterval7(sync_4, edm::IOVSyncValue(edm::Timestamp(6)));
+    dummyProvider4->setValidityInterval_forTesting(definedInterval7);
 
-    const edm::Timestamp time_1(2);
-    const edm::IOVSyncValue sync_2(time_1);
-    const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::Timestamp(6)));
-    dummyProvider2->setValidityInterval_forTesting(definedInterval2);
+    const edm::ValidityInterval overlapInterval10(definedInterval7.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
-    const edm::ValidityInterval overlapInterval2(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    dummyProvider3->initializeForNewSyncValue();
+    dummyProvider4->initializeForNewSyncValue();
 
-    dummyProvider1->initializeForNewSyncValue();
-    dummyProvider2->initializeForNewSyncValue();
-    CPPUNIT_ASSERT(overlapInterval2 ==
-                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(3))));
+    CPPUNIT_ASSERT(overlapInterval10 ==
+                   finder1.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(3))));
   }
   {
     //check for bug which only happens the first time we synchronize
     // have the  first one invalid
+    auto dummyProvider5 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
 
-    auto dummyProvider1 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
+    dummyProvider5->setValidityInterval_forTesting(invalid);
 
-    dummyProvider1->setValidityInterval_forTesting(invalid);
+    auto dummyProvider6 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
 
-    auto dummyProvider2 = std::make_shared<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
+    const edm::Timestamp time_3(1);
+    const edm::IOVSyncValue sync_5(time_3);
+    const edm::ValidityInterval definedInterval8(sync_5, edm::IOVSyncValue(edm::Timestamp(6)));
+    dummyProvider6->setValidityInterval_forTesting(definedInterval8);
 
-    const edm::Timestamp time_1(1);
-    const edm::IOVSyncValue sync_2(time_1);
-    const edm::ValidityInterval definedInterval2(sync_2, edm::IOVSyncValue(edm::Timestamp(6)));
-    dummyProvider2->setValidityInterval_forTesting(definedInterval2);
+    const edm::ValidityInterval overlapInterval11(definedInterval8.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
-    const edm::ValidityInterval overlapInterval(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
+    DependentRecordIntervalFinder finder2(depRecordKey);
+    finder2.addProviderWeAreDependentOn(dummyProvider5);
+    finder2.addProviderWeAreDependentOn(dummyProvider6);
 
-    const EventSetupRecordKey depRecordKey = DepRecord::keyForClass();
+    CPPUNIT_ASSERT(overlapInterval11 ==
+                   finder2.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(3))));
 
-    DependentRecordIntervalFinder finder(depRecordKey);
-    finder.addProviderWeAreDependentOn(dummyProvider1);
-    finder.addProviderWeAreDependentOn(dummyProvider2);
+    const edm::EventID eID_3(1, 1, 5);
+    const edm::IOVSyncValue sync_6(eID_3);
+    const edm::ValidityInterval definedInterval9(sync_6, edm::IOVSyncValue(edm::EventID(1, 1, 10)));
+    dummyProvider5->setValidityInterval_forTesting(definedInterval9);
 
-    CPPUNIT_ASSERT(overlapInterval ==
-                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(3))));
+    const edm::ValidityInterval overlapInterval12(definedInterval8.first(), edm::IOVSyncValue::invalidIOVSyncValue());
 
-    const edm::EventID eID_1(1, 1, 5);
-    const edm::IOVSyncValue sync_1(eID_1);
-    const edm::ValidityInterval definedInterval1(sync_1, edm::IOVSyncValue(edm::EventID(1, 1, 10)));
-    dummyProvider1->setValidityInterval_forTesting(definedInterval1);
+    dummyProvider5->initializeForNewSyncValue();
+    dummyProvider6->initializeForNewSyncValue();
 
-    const edm::ValidityInterval overlapInterval2(definedInterval2.first(), edm::IOVSyncValue::invalidIOVSyncValue());
-
-    dummyProvider1->initializeForNewSyncValue();
-    dummyProvider2->initializeForNewSyncValue();
-    CPPUNIT_ASSERT(overlapInterval2 ==
-                   finder.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(4))));
+    CPPUNIT_ASSERT(overlapInterval12 ==
+                   finder2.findIntervalFor(depRecordKey, edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(4))));
   }
 
   edm::ParameterSet pset = createDummyPset();

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -187,15 +187,15 @@ void testGenericHandle::getbyLabelTest() {
 
   edm::GenericHandle h("edmtest::DummyProduct");
   try {
-    edm::ParameterSet dummyProcessPset;
-    dummyProcessPset.registerIt();
-    auto processConfiguration = std::make_shared<edm::ProcessConfiguration>();
-    processConfiguration->setParameterSetID(dummyProcessPset.id());
+    edm::ParameterSet dummyProcessPset1;
+    dummyProcessPset1.registerIt();
+    auto processConfiguration1 = std::make_shared<edm::ProcessConfiguration>();
+    processConfiguration1->setParameterSetID(dummyProcessPset1.id());
 
-    edm::ParameterSet pset;
-    pset.registerIt();
+    edm::ParameterSet pset1;
+    pset1.registerIt();
     edm::ModuleDescription modDesc(
-        pset.id(), "Blah", "blahs", processConfiguration.get(), edm::ModuleDescription::getUniqueID());
+        pset1.id(), "Blah", "blahs", processConfiguration1.get(), edm::ModuleDescription::getUniqueID());
     edm::Event event(ep, modDesc, nullptr);
 
     event.getByLabel(label, productInstanceName, h);

--- a/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
+++ b/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
@@ -121,10 +121,10 @@ void testintersectingiovrecordintervalfinder::intersectionTest() {
     std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
     dummyFinder2->setInterval(edm::ValidityInterval(sync_3, sync_5));
     finders.push_back(dummyFinder2);
-    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-    intFinder.swapFinders(finders);
+    IntersectingIOVRecordIntervalFinder intFinder1(dummyRecordKey);
+    intFinder1.swapFinders(finders);
 
-    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, sync_4) == intFinder.findIntervalFor(dummyRecordKey, sync_3));
+    CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, sync_4) == intFinder1.findIntervalFor(dummyRecordKey, sync_3));
   }
 
   {
@@ -144,13 +144,13 @@ void testintersectingiovrecordintervalfinder::intersectionTest() {
     std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
     dummyFinder2->setInterval(edm::ValidityInterval::invalidInterval());
     finders.push_back(dummyFinder2);
-    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-    intFinder.swapFinders(finders);
+    IntersectingIOVRecordIntervalFinder intFinder2(dummyRecordKey);
+    intFinder2.swapFinders(finders);
 
     CPPUNIT_ASSERT(edm::ValidityInterval::invalidInterval() == dummyFinder2->findIntervalFor(dummyRecordKey, sync_3));
 
     CPPUNIT_ASSERT(edm::ValidityInterval(sync_1, edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                   intFinder.findIntervalFor(dummyRecordKey, sync_3));
+                   intFinder2.findIntervalFor(dummyRecordKey, sync_3));
   }
 
   {
@@ -168,14 +168,14 @@ void testintersectingiovrecordintervalfinder::intersectionTest() {
     std::shared_ptr<DummyFinder> dummyFinder2 = std::make_shared<DummyFinder>();
     dummyFinder2->setInterval(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()));
     finders.push_back(dummyFinder2);
-    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-    intFinder.swapFinders(finders);
+    IntersectingIOVRecordIntervalFinder intFinder3(dummyRecordKey);
+    intFinder3.swapFinders(finders);
 
     CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
                    dummyFinder2->findIntervalFor(dummyRecordKey, sync_3));
 
     CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                   intFinder.findIntervalFor(dummyRecordKey, sync_3));
+                   intFinder3.findIntervalFor(dummyRecordKey, sync_3));
   }
 
   {
@@ -196,13 +196,13 @@ void testintersectingiovrecordintervalfinder::intersectionTest() {
     dummyFinder->setInterval(definedInterval);
     finders.push_back(dummyFinder);
 
-    IntersectingIOVRecordIntervalFinder intFinder(dummyRecordKey);
-    intFinder.swapFinders(finders);
+    IntersectingIOVRecordIntervalFinder intFinder4(dummyRecordKey);
+    intFinder4.swapFinders(finders);
 
     CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
                    dummyFinder2->findIntervalFor(dummyRecordKey, sync_3));
 
     CPPUNIT_ASSERT(edm::ValidityInterval(sync_3, edm::IOVSyncValue::invalidIOVSyncValue()) ==
-                   intFinder.findIntervalFor(dummyRecordKey, sync_3));
+                   intFinder4.findIntervalFor(dummyRecordKey, sync_3));
   }
 }

--- a/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
+++ b/FWCore/Framework/test/test_catch2notTP_MergeableRunProductMetadata.cc
@@ -168,8 +168,8 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
 
     REQUIRE(mergeableRunProductProcesses.size() == 2);
 
-    std::vector<std::string> expected{"AAPROD", "APROD"};
-    REQUIRE(mergeableRunProductProcesses.processesWithMergeableRunProducts() == expected);
+    std::vector<std::string> expected0{"AAPROD", "APROD"};
+    REQUIRE(mergeableRunProductProcesses.processesWithMergeableRunProducts() == expected0);
 
     std::vector<std::string> storedProcesses{"AAAPROD", "AAPROD", "APROD", "ZPROD"};
     edm::StoredMergeableRunProductMetadata storedMetadata(storedProcesses);
@@ -654,63 +654,63 @@ TEST_CASE("test MergeableRunProductMetadata", "[MergeableRunProductMetadata]") {
 
       // ---------------------------------------------------
 
-      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries =
+      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntry>& singleRunEntries1 =
           storedMetadataOutput.singleRunEntries();
-      REQUIRE(singleRunEntries.size() == 4);
-      REQUIRE(singleRunEntries[0].beginProcess() == 0);
-      REQUIRE(singleRunEntries[0].endProcess() == 0);
-      REQUIRE(singleRunEntries[1].beginProcess() == 0);
-      REQUIRE(singleRunEntries[1].endProcess() == 1);
-      REQUIRE(singleRunEntries[2].beginProcess() == 1);
-      REQUIRE(singleRunEntries[2].endProcess() == 3);
-      REQUIRE(singleRunEntries[3].beginProcess() == 3);
-      REQUIRE(singleRunEntries[3].endProcess() == 5);
+      REQUIRE(singleRunEntries1.size() == 4);
+      REQUIRE(singleRunEntries1[0].beginProcess() == 0);
+      REQUIRE(singleRunEntries1[0].endProcess() == 0);
+      REQUIRE(singleRunEntries1[1].beginProcess() == 0);
+      REQUIRE(singleRunEntries1[1].endProcess() == 1);
+      REQUIRE(singleRunEntries1[2].beginProcess() == 1);
+      REQUIRE(singleRunEntries1[2].endProcess() == 3);
+      REQUIRE(singleRunEntries1[3].beginProcess() == 3);
+      REQUIRE(singleRunEntries1[3].endProcess() == 5);
 
-      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses =
+      std::vector<edm::StoredMergeableRunProductMetadata::SingleRunEntryAndProcess>& singleRunEntryAndProcesses1 =
           storedMetadataOutput.singleRunEntryAndProcesses();
-      REQUIRE(singleRunEntryAndProcesses.size() == 5);
+      REQUIRE(singleRunEntryAndProcesses1.size() == 5);
 
-      REQUIRE(singleRunEntryAndProcesses[0].beginLumi() == 0);
-      REQUIRE(singleRunEntryAndProcesses[0].endLumi() == 0);
-      REQUIRE(singleRunEntryAndProcesses[0].process() == 2);
-      REQUIRE(!singleRunEntryAndProcesses[0].valid());
-      REQUIRE(singleRunEntryAndProcesses[0].useIndexIntoFile());
+      REQUIRE(singleRunEntryAndProcesses1[0].beginLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses1[0].endLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses1[0].process() == 2);
+      REQUIRE(!singleRunEntryAndProcesses1[0].valid());
+      REQUIRE(singleRunEntryAndProcesses1[0].useIndexIntoFile());
 
-      REQUIRE(singleRunEntryAndProcesses[1].beginLumi() == 0);
-      REQUIRE(singleRunEntryAndProcesses[1].endLumi() == 2);
-      REQUIRE(singleRunEntryAndProcesses[1].process() == 1);
-      REQUIRE(singleRunEntryAndProcesses[1].valid());
-      REQUIRE(!singleRunEntryAndProcesses[1].useIndexIntoFile());
+      REQUIRE(singleRunEntryAndProcesses1[1].beginLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses1[1].endLumi() == 2);
+      REQUIRE(singleRunEntryAndProcesses1[1].process() == 1);
+      REQUIRE(singleRunEntryAndProcesses1[1].valid());
+      REQUIRE(!singleRunEntryAndProcesses1[1].useIndexIntoFile());
 
-      REQUIRE(singleRunEntryAndProcesses[2].beginLumi() == 0);
-      REQUIRE(singleRunEntryAndProcesses[2].endLumi() == 2);
-      REQUIRE(singleRunEntryAndProcesses[2].process() == 2);
-      REQUIRE(!singleRunEntryAndProcesses[2].valid());
-      REQUIRE(!singleRunEntryAndProcesses[2].useIndexIntoFile());
+      REQUIRE(singleRunEntryAndProcesses1[2].beginLumi() == 0);
+      REQUIRE(singleRunEntryAndProcesses1[2].endLumi() == 2);
+      REQUIRE(singleRunEntryAndProcesses1[2].process() == 2);
+      REQUIRE(!singleRunEntryAndProcesses1[2].valid());
+      REQUIRE(!singleRunEntryAndProcesses1[2].useIndexIntoFile());
 
-      REQUIRE(singleRunEntryAndProcesses[3].beginLumi() == 2);
-      REQUIRE(singleRunEntryAndProcesses[3].endLumi() == 4);
-      REQUIRE(singleRunEntryAndProcesses[3].process() == 1);
-      REQUIRE(singleRunEntryAndProcesses[3].valid());
-      REQUIRE(!singleRunEntryAndProcesses[3].useIndexIntoFile());
+      REQUIRE(singleRunEntryAndProcesses1[3].beginLumi() == 2);
+      REQUIRE(singleRunEntryAndProcesses1[3].endLumi() == 4);
+      REQUIRE(singleRunEntryAndProcesses1[3].process() == 1);
+      REQUIRE(singleRunEntryAndProcesses1[3].valid());
+      REQUIRE(!singleRunEntryAndProcesses1[3].useIndexIntoFile());
 
-      REQUIRE(singleRunEntryAndProcesses[4].beginLumi() == 4);
-      REQUIRE(singleRunEntryAndProcesses[4].endLumi() == 9);
-      REQUIRE(singleRunEntryAndProcesses[4].process() == 2);
-      REQUIRE(!singleRunEntryAndProcesses[4].valid());
-      REQUIRE(!singleRunEntryAndProcesses[4].useIndexIntoFile());
+      REQUIRE(singleRunEntryAndProcesses1[4].beginLumi() == 4);
+      REQUIRE(singleRunEntryAndProcesses1[4].endLumi() == 9);
+      REQUIRE(singleRunEntryAndProcesses1[4].process() == 2);
+      REQUIRE(!singleRunEntryAndProcesses1[4].valid());
+      REQUIRE(!singleRunEntryAndProcesses1[4].useIndexIntoFile());
 
-      std::vector<edm::LuminosityBlockNumber_t>& lumis = storedMetadataOutput.lumis();
-      REQUIRE(lumis.size() == 9);
-      REQUIRE(lumis[0] == 1001);
-      REQUIRE(lumis[1] == 1003);
-      REQUIRE(lumis[2] == 1001);
-      REQUIRE(lumis[3] == 1003);
-      REQUIRE(lumis[4] == 1000);
-      REQUIRE(lumis[5] == 1001);
-      REQUIRE(lumis[6] == 1002);
-      REQUIRE(lumis[7] == 1003);
-      REQUIRE(lumis[8] == 1004);
+      std::vector<edm::LuminosityBlockNumber_t>& lumis1 = storedMetadataOutput.lumis();
+      REQUIRE(lumis1.size() == 9);
+      REQUIRE(lumis1[0] == 1001);
+      REQUIRE(lumis1[1] == 1003);
+      REQUIRE(lumis1[2] == 1001);
+      REQUIRE(lumis1[3] == 1003);
+      REQUIRE(lumis1[4] == 1000);
+      REQUIRE(lumis1[5] == 1001);
+      REQUIRE(lumis1[6] == 1002);
+      REQUIRE(lumis1[7] == 1003);
+      REQUIRE(lumis1[8] == 1004);
 
       REQUIRE(!storedMetadataOutput.allValidAndUseIndexIntoFile());
     }

--- a/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
+++ b/FWCore/Framework/test/throwIfImproperDependencies_t.cppunit.cc
@@ -294,18 +294,18 @@ void test_throwIfImproperDependencies::twoPathsNoCycleTest() {
           pathModules.push_back(moduleName[k]);
 
           std::vector<std::string> path2Modules;
-          for (unsigned int i = 0; i < 3; ++i) {
-            path2Modules.push_back(moduleName[i]);
-            for (unsigned int j = 0; j < 3; ++j) {
-              if (j == i) {
+          for (unsigned int ii = 0; ii < 3; ++ii) {
+            path2Modules.push_back(moduleName[ii]);
+            for (unsigned int jj = 0; jj < 3; ++jj) {
+              if (jj == ii) {
                 continue;
               }
-              path2Modules.push_back(moduleName[j]);
-              for (unsigned int k = 0; k < 3; ++k) {
-                if (j == k or i == k) {
+              path2Modules.push_back(moduleName[jj]);
+              for (unsigned int kk = 0; kk < 3; ++kk) {
+                if (jj == kk or ii == kk) {
                   continue;
                 }
-                path2Modules.push_back(moduleName[k]);
+                path2Modules.push_back(moduleName[kk]);
                 PathToModules paths;
                 paths["p1"] = pathModules;
                 paths["p2"] = path2Modules;

--- a/FWCore/Integration/test/OtherThingAnalyzer.cc
+++ b/FWCore/Integration/test/OtherThingAnalyzer.cc
@@ -208,18 +208,19 @@ namespace edmtest {
           throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze")
               << "VECTOR ITEM 1 " << i << " has incorrect value " << tcv1.a << '\n';
         }
-        for (edm::RefVector<ThingCollection>::iterator it = otherThing.refVec.begin(), itEnd = otherThing.refVec.end();
-             it != itEnd;
-             ++it) {
-          edm::Ref<ThingCollection> tcol = *it;
-          Thing const& ti = **it;
-          int const& xi = (*it)->a;
+        for (edm::RefVector<ThingCollection>::iterator it3 = otherThing.refVec.begin(),
+                                                       itEnd3 = otherThing.refVec.end();
+             it3 != itEnd3;
+             ++it3) {
+          edm::Ref<ThingCollection> tcol = *it3;
+          Thing const& ti = **it3;
+          int const& xi = (*it3)->a;
           if (xi != ti.a) {
             throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze")
                 << "iterator item " << ti.a << " " << xi << '\n';
-          } else if (it == otherThing.refVec.begin() && xi != i) {
+          } else if (it3 == otherThing.refVec.begin() && xi != i) {
             throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze") << "iterator item 0" << xi << '\n';
-          } else if (it != otherThing.refVec.begin() && xi != 19 - i) {
+          } else if (it3 != otherThing.refVec.begin() && xi != 19 - i) {
             throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze") << "iterator item 1" << xi << '\n';
           }
         }
@@ -285,18 +286,18 @@ namespace edmtest {
           throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze")
               << "VECTOR ITEM 1 " << i << " has incorrect value " << tcv1.a << '\n';
         }
-        for (edm::PtrVector<Thing>::const_iterator it = otherThing.ptrVec.begin(), itEnd = otherThing.ptrVec.end();
-             it != itEnd;
-             ++it) {
-          edm::Ptr<Thing> tcol = *it;
-          Thing const& ti = **it;
-          int const& xi = (*it)->a;
+        for (edm::PtrVector<Thing>::const_iterator it4 = otherThing.ptrVec.begin(), itEnd4 = otherThing.ptrVec.end();
+             it4 != itEnd4;
+             ++it4) {
+          edm::Ptr<Thing> tcol = *it4;
+          Thing const& ti = **it4;
+          int const& xi = (*it4)->a;
           if (xi != ti.a) {
             throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze")
                 << "iterator item " << ti.a << " " << xi << '\n';
-          } else if (it == otherThing.ptrVec.begin() && xi != i) {
+          } else if (it4 == otherThing.ptrVec.begin() && xi != i) {
             throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze") << "iterator item 0" << xi << '\n';
-          } else if (it != otherThing.ptrVec.begin() && xi != 19 - i) {
+          } else if (it4 != otherThing.ptrVec.begin() && xi != 19 - i) {
             throw cms::Exception("Inconsistent Data", "OtherThingAnalyzer::analyze") << "iterator item 1" << xi << '\n';
           }
         }

--- a/FWCore/Integration/test/ProcessHistory_t.cpp
+++ b/FWCore/Integration/test/ProcessHistory_t.cpp
@@ -167,27 +167,27 @@ int main() try {
     edm::ProcessHistory ph3;
     edm::ProcessHistory ph4;
 
-    edm::ParameterSet dummyPset;
-    dummyPset.registerIt();
-    edm::ParameterSetID psetID = dummyPset.id();
+    edm::ParameterSet dummyPset1;
+    dummyPset1.registerIt();
+    edm::ParameterSetID psetID1 = dummyPset1.id();
 
-    edm::ProcessConfiguration pc1(std::string("HLT"), psetID, std::string("CMSSW_5_1_40"), std::string(""));
-    edm::ProcessConfiguration pc1a(std::string("HLT"), psetID, std::string("CMSSW_5_1_40patch1"), std::string(""));
-    edm::ProcessConfiguration pc1b(std::string("HLT"), psetID, std::string("CMSSW_5_1_40patch2"), std::string(""));
-    edm::ProcessConfiguration pc2(std::string("HLT"), psetID, std::string("CMSSW_5_2_40"), std::string(""));
-    edm::ProcessConfiguration pc2a(std::string("HLT"), psetID, std::string("CMSSW_5_2_40patch1"), std::string(""));
-    edm::ProcessConfiguration pc2b(std::string("HLT"), psetID, std::string("CMSSW_5_2_40patch2"), std::string(""));
-    edm::ProcessConfiguration pc3(std::string("HLT"), psetID, std::string("CMSSW_5_3_40"), std::string(""));
-    edm::ProcessConfiguration pc4(std::string("HLT"), psetID, std::string("CMSSW_5_4_40"), std::string(""));
+    edm::ProcessConfiguration pcfg1(std::string("HLT"), psetID1, std::string("CMSSW_5_1_40"), std::string(""));
+    edm::ProcessConfiguration pcfg1a(std::string("HLT"), psetID1, std::string("CMSSW_5_1_40patch1"), std::string(""));
+    edm::ProcessConfiguration pcfg1b(std::string("HLT"), psetID1, std::string("CMSSW_5_1_40patch2"), std::string(""));
+    edm::ProcessConfiguration pcfg2(std::string("HLT"), psetID1, std::string("CMSSW_5_2_40"), std::string(""));
+    edm::ProcessConfiguration pcfg2a(std::string("HLT"), psetID1, std::string("CMSSW_5_2_40patch1"), std::string(""));
+    edm::ProcessConfiguration pcfg2b(std::string("HLT"), psetID1, std::string("CMSSW_5_2_40patch2"), std::string(""));
+    edm::ProcessConfiguration pcfg3(std::string("HLT"), psetID1, std::string("CMSSW_5_3_40"), std::string(""));
+    edm::ProcessConfiguration pcfg4(std::string("HLT"), psetID1, std::string("CMSSW_5_4_40"), std::string(""));
 
-    ph1.push_back(pc1);
-    ph1a.push_back(pc1a);
-    ph1b.push_back(pc1b);
-    ph2.push_back(pc2);
-    ph2a.push_back(pc2a);
-    ph2b.push_back(pc2b);
-    ph3.push_back(pc3);
-    ph4.push_back(pc4);
+    ph1.push_back(pcfg1);
+    ph1a.push_back(pcfg1a);
+    ph1b.push_back(pcfg1b);
+    ph2.push_back(pcfg2);
+    ph2a.push_back(pcfg2a);
+    ph2b.push_back(pcfg2b);
+    ph3.push_back(pcfg3);
+    ph4.push_back(pcfg4);
 
     edm::ProcessHistoryID phid1 = ph1.setProcessHistoryID();
     edm::ProcessHistoryID phid1a = ph1a.setProcessHistoryID();

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -176,19 +176,19 @@ namespace edm {
           continue;
         }
 
-        std::stringstream ss;
-        ss << dfh.section() << "." << dfh.counter();
-        std::string newSection = ss.str();
+        std::stringstream ss1;
+        ss1 << dfh.section() << "." << dfh.counter();
+        std::string newSection1 = ss1.str();
         printSpaces(os, indentation);
-        os << "Section " << newSection << "." << ++pluginCount << " " << info.name_ << " Plugin description:\n";
+        os << "Section " << newSection1 << "." << ++pluginCount << " " << info.name_ << " Plugin description:\n";
         if (!dfh.brief())
           os << "\n";
 
-        DocFormatHelper new_dfh(dfh);
-        new_dfh.init();
-        new_dfh.setSection(newSection);
+        DocFormatHelper new_dfh1(dfh);
+        new_dfh1.init();
+        new_dfh1.setSection(newSection1);
 
-        loadDescription(info.name_)->print(os, new_dfh);
+        loadDescription(info.name_)->print(os, new_dfh1);
 
         previousName = info.name_;
       }

--- a/FWCore/ParameterSet/src/ParameterDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterDescription.cc
@@ -417,9 +417,9 @@ namespace edm {
       result = s.str();
 
       if (result.size() > 15 && std::string::npos != result.find(".")) {
-        std::stringstream s;
-        s << std::setprecision(15) << value;
-        std::string resultLessPrecision = s.str();
+        std::stringstream s1;
+        s1 << std::setprecision(15) << value;
+        std::string resultLessPrecision = s1.str();
 
         if (resultLessPrecision.size() < result.size() - 2) {
           double test = std::strtod(resultLessPrecision.c_str(), nullptr);

--- a/FWCore/ParameterSet/src/ParameterSetConverter.cc
+++ b/FWCore/ParameterSet/src/ParameterSetConverter.cc
@@ -157,9 +157,9 @@ namespace edm {
       }
     }
     if (!doItAgain && !parameterSets_.empty()) {
-      for (StringWithIDList::iterator i = parameterSets_.begin(), iEnd = parameterSets_.end(); i != iEnd; ++i) {
+      for (StringWithIDList::iterator k = parameterSets_.begin(), kEnd = parameterSets_.end(); k != kEnd; ++k) {
         std::list<std::string> pieces;
-        split(std::back_inserter(pieces), i->first, '<', ';', '>');
+        split(std::back_inserter(pieces), k->first, '<', ';', '>');
         for (std::list<std::string>::iterator i = pieces.begin(), e = pieces.end(); i != e; ++i) {
           std::string removeName = i->substr(i->find('+'));
           if (removeName.size() >= 4) {

--- a/FWCore/ParameterSet/test/parameterSetDescription_t.cc
+++ b/FWCore/ParameterSet/test/parameterSetDescription_t.cc
@@ -1047,9 +1047,9 @@ namespace testParameterSetDescription {
       } catch (edm::Exception const&) { /* There should be an exception */
       }
 
-      std::vector<std::string> labels1;
-      labels1.push_back(std::string("vSetD"));
-      psetC.addParameter<std::vector<std::string>>("allowedLabelsC", labels1);
+      std::vector<std::string> labels2;
+      labels2.push_back(std::string("vSetD"));
+      psetC.addParameter<std::vector<std::string>>("allowedLabelsC", labels2);
 
       // Now vSetB should be an allowed parameter
       psetDesc14.validate(psetC);
@@ -1068,12 +1068,12 @@ namespace testParameterSetDescription {
       }
 
       // Now include "y" in the description and it should once again pass validation
-      edm::ParameterSetDescription psetDesc6;
-      edm::ParameterSetDescription psetDesc7;
-      psetDesc7.add<int>("y", 1);
+      edm::ParameterSetDescription psetDesc106;
+      edm::ParameterSetDescription psetDesc107;
+      psetDesc107.add<int>("y", 1);
 
-      psetDesc6.labelsFrom<std::vector<edm::ParameterSet>>("allowedLabelsC", psetDesc7);
-      psetDesc6.validate(psetC);
+      psetDesc106.labelsFrom<std::vector<edm::ParameterSet>>("allowedLabelsC", psetDesc107);
+      psetDesc106.validate(psetC);
 
       // A minor variation, repeat with a string argument
       edm::ParameterSetDescription psetDesc18;
@@ -1082,7 +1082,7 @@ namespace testParameterSetDescription {
       psetDesc18.labelsFrom<std::vector<edm::ParameterSet>>(std::string("allowedLabelsC"));
       psetDesc19.labelsFrom<std::vector<edm::ParameterSet>>(std::string("allowedLabelsC"),
                                                             edm::ParameterSetDescription());
-      psetDesc20.labelsFrom<std::vector<edm::ParameterSet>>(std::string("allowedLabelsC"), psetDesc7);
+      psetDesc20.labelsFrom<std::vector<edm::ParameterSet>>(std::string("allowedLabelsC"), psetDesc107);
       psetDesc18.validate(psetC);
       try {
         psetDesc19.validate(psetC);
@@ -1600,20 +1600,20 @@ int main(int, char**) try {
   testDescriptions.push_back(psetDesc);
   testDescriptions.push_back(psetDesc);
 
-  for (int i = 0; i < 3; ++i) {
+  for (int ii = 0; ii < 3; ++ii) {
     edm::ParameterSetDescription nestLevel2;
 
     // for the first test do not put a parameter in the description
     // so there will be an extra parameter in the ParameterSet and
     // validation should fail.
-    if (i > 0)
+    if (ii > 0)
       nestLevel2.add<int>("intLevel2a", 1);
 
     // for the next test validation should pass
 
     // For the last test add an extra required parameter in the
     // description that is not in the ParameterSet.
-    if (i == 2)
+    if (ii == 2)
       nestLevel2.add<int>("intLevel2extra", 11);
 
     nestLevel2.addUntracked<int>("intLevel2b", 1);
@@ -1626,7 +1626,7 @@ int main(int, char**) try {
     nestLevel1.add<int>("intLevel1a", 1);
     nestLevel1.add<edm::ParameterSetDescription>("nestLevel1b", nestLevel2);
 
-    testDescriptions[i].addVPSetUntracked("nestLevel0", nestLevel1);
+    testDescriptions[ii].addVPSetUntracked("nestLevel0", nestLevel1);
   }
 
   // Now run the validation and make sure we get the expected results

--- a/FWCore/PluginManager/test/cacheparser_t.cc
+++ b/FWCore/PluginManager/test/cacheparser_t.cc
@@ -93,10 +93,10 @@ void TestCacheParser::testReadWrite() {
     CPPUNIT_ASSERT(categoryToInfos.size() == readValues.size());
 
     {
-      std::stringstream s;
-      CacheParser::write(readValues, s);
-      std::cout << s.str() << std::endl;
-      CPPUNIT_ASSERT(match == s.str());
+      std::stringstream s1;
+      CacheParser::write(readValues, s1);
+      std::cout << s1.str() << std::endl;
+      CPPUNIT_ASSERT(match == s1.str());
     }
   }
 }

--- a/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
+++ b/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
@@ -94,9 +94,9 @@ void testServiceRegistry::externalServiceTest() {
       ps.addParameter("value", value);
       pss.push_back(ps);
 
-      edm::ServiceToken token(edm::ServiceRegistry::createSet(pss));
+      edm::ServiceToken token3(edm::ServiceRegistry::createSet(pss));
       edm::ServiceToken token2(
-          edm::ServiceRegistry::createContaining(std::move(dummyPtr), token, edm::serviceregistry::kOverlapIsError));
+          edm::ServiceRegistry::createContaining(std::move(dummyPtr), token3, edm::serviceregistry::kOverlapIsError));
 
       edm::ServiceRegistry::Operate operate(token2);
       edm::Service<testserviceregistry::DummyService> dummy;
@@ -130,9 +130,9 @@ void testServiceRegistry::externalServiceTest() {
       ps.addParameter("value", value);
       pss.push_back(ps);
 
-      edm::ServiceToken token(edm::ServiceRegistry::createSet(pss));
+      edm::ServiceToken token3(edm::ServiceRegistry::createSet(pss));
       edm::ServiceToken token2(
-          edm::ServiceRegistry::createContaining(std::move(dummyPtr), token, edm::serviceregistry::kOverlapIsError));
+          edm::ServiceRegistry::createContaining(std::move(dummyPtr), token3, edm::serviceregistry::kOverlapIsError));
 
       edm::ServiceRegistry::Operate operate(token2);
       edm::Service<testserviceregistry::DummyService> dummy;
@@ -264,8 +264,8 @@ void testServiceRegistry::threadTest() {
     edm::ParameterSet ps;
     std::string typeName("DummyService");
     ps.addParameter("@service_type", typeName);
-    int value = 1;
-    ps.addParameter("value", value);
+    int value1 = 1;
+    ps.addParameter("value", value1);
     pss.push_back(ps);
   }
   edm::ServiceToken token(edm::ServiceRegistry::createSet(pss));

--- a/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
+++ b/FWCore/ServiceRegistry/test/servicesmanager_t.cppunit.cc
@@ -147,16 +147,16 @@ void testServicesManager::legacyTest() {
 
   edm::AssertHandler ah;
 
-  std::vector<edm::ParameterSet> pss;
+  std::vector<edm::ParameterSet> pss1;
 
-  edm::ParameterSet ps;
-  std::string typeName("DummyService");
-  ps.addParameter("@service_type", typeName);
-  int value = 1;
-  ps.addParameter("value", value);
-  pss.push_back(ps);
+  edm::ParameterSet ps1;
+  std::string typeName1("DummyService");
+  ps1.addParameter("@service_type", typeName1);
+  int value1 = 1;
+  ps1.addParameter("value", value1);
+  pss1.push_back(ps1);
 
-  auto legacy = std::make_shared<ServicesManager>(pss);
+  auto legacy = std::make_shared<ServicesManager>(pss1);
   CPPUNIT_ASSERT(1 == legacy->get<TestService>().value());
 
   edm::ServiceToken legacyToken(legacy);

--- a/FWCore/Services/plugins/DependencyGraph.cc
+++ b/FWCore/Services/plugins/DependencyGraph.cc
@@ -291,11 +291,11 @@ void DependencyGraph::preBeginJob(PathsAndConsumesOfModulesBase const &pathsAndC
         if (not found) {
           edge_status = boost::add_edge(module->id(), previous->id(), m_graph);
           auto const &edge = edge_status.first;
-          auto &attributes = boost::get(boost::get(boost::edge_attribute, m_graph), edge);
-          attributes["style"] = "dashed";
+          auto &attributes1 = boost::get(boost::get(boost::edge_attribute, m_graph), edge);
+          attributes1["style"] = "dashed";
           // highlight the arrow between highlighted nodes
           if (highlighted(module->moduleLabel()) and highlighted(previous->moduleLabel()))
-            attributes["color"] = "darkgreen";
+            attributes1["color"] = "darkgreen";
         }
       }
       previous = module;
@@ -315,11 +315,11 @@ void DependencyGraph::preBeginJob(PathsAndConsumesOfModulesBase const &pathsAndC
         if (not found) {
           edge_status = boost::add_edge(module->id(), previous->id(), m_graph);
           auto const &edge = edge_status.first;
-          auto &attributes = boost::get(boost::get(boost::edge_attribute, m_graph), edge);
-          attributes["style"] = "dashed";
+          auto &attributes1 = boost::get(boost::get(boost::edge_attribute, m_graph), edge);
+          attributes1["style"] = "dashed";
           // highlight the arrow between highlighted nodes
           if (highlighted(module->moduleLabel()) and highlighted(previous->moduleLabel()))
-            attributes["color"] = "darkgreen";
+            attributes1["color"] = "darkgreen";
         }
       }
       previous = module;

--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -724,8 +724,8 @@ namespace edm {
       if (measurementUnderway_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
         std::shared_ptr<void> guard(
             nullptr, [this](void const*) { measurementUnderway_.store(false, std::memory_order_release); });
-        bool expected = false;
-        if (moduleMeasurementUnderway_.compare_exchange_strong(expected, true)) {
+        bool expected1 = false;
+        if (moduleMeasurementUnderway_.compare_exchange_strong(expected1, true)) {
           update();
           // changelog 2
           moduleEntryVsize_ = current_->vsize;
@@ -757,7 +757,7 @@ namespace edm {
               nullptr, [this](void const*) { moduleMeasurementUnderway_.store(false, std::memory_order_release); });
           bool expected = false;
           if (measurementUnderway_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-            std::shared_ptr<void> guard(
+            std::shared_ptr<void> guard1(
                 nullptr, [this](void const*) { measurementUnderway_.store(false, std::memory_order_release); });
             if (oncePerEventMode_) {
               update();

--- a/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
+++ b/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
@@ -10,7 +10,7 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
   if (dir) {
     dirString = dir;
   } else {
-    auto dir = getenv("CMSSW_BASE");
+    dir = getenv("CMSSW_BASE");
     if (dir) {
       dirString = dir;
       dirString += "/src/FWCore/Services/test";

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -275,13 +275,13 @@ void TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID,
   if (nStreams_ > 1) {
     {
       std::lock_guard<std::mutex> lock(write_mutex);
-      std::ostringstream ss;
+      std::ostringstream ss1;
       if (multiStreamReplay_) {
-        ss << "replay";
+        ss1 << "replay";
       }
-      ss << "testRandomServiceL" << event.eventAuxiliary().luminosityBlock() << "E" << event.eventAuxiliary().event()
-         << ".txt";
-      std::string filename = ss.str();
+      ss1 << "testRandomServiceL" << event.eventAuxiliary().luminosityBlock() << "E" << event.eventAuxiliary().event()
+          << ".txt";
+      std::string filename = ss1.str();
 
       std::ofstream outFile;
       outFile.open(filename.c_str(), std::ofstream::app);

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -262,7 +262,7 @@ namespace edm {
     bool found = rootFile()->readCurrentEvent(cache);
     if (!found) {
       rootFile()->setAtEventEntry(0);
-      bool found = rootFile()->readCurrentEvent(cache);
+      found = rootFile()->readCurrentEvent(cache);
       assert(found);
     }
     fileNameHash = lfnHash();
@@ -292,7 +292,7 @@ namespace edm {
       assert(found);
       int eventInLumi = CLHEP::RandFlat::shootInt(engine, eventsInLumi);
       for (int i = 0; i < eventInLumi; ++i) {
-        bool found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
+        found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
         assert(found);
       }
     }
@@ -302,7 +302,7 @@ namespace edm {
       found = rootFile()->readCurrentEvent(cache);
     }
     if (!found) {
-      bool found = rootFile()->setEntryAtItem(id.run(), id.luminosityBlock(), 0);
+      found = rootFile()->setEntryAtItem(id.run(), id.luminosityBlock(), 0);
       if (!found) {
         return false;
       }


### PR DESCRIPTION
#### PR description:

Fix GCC 9 shadowing compiler warnings in Core. This should not change behavior. Most of this is variable renaming. One unused variable deleted. A couple places the same variable could be reused instead of declaring a new one.

As far as I could tell no real bugs uncovered by this.

#### PR validation:

Existing tests should be adequate, there is no new functionality.

#### if this PR is a backport please specify the original PR:

Not a backport.
