### PR TITLE
HBHE: bugfix for MAHI on issue of missing SOI+4 subtraction

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -275,8 +275,8 @@ void MahiFit::updatePulseShape(double itQ,
     pulseShape.coeffRef(iTS + nnlsWork_.maxoffset) = pulseN[iTS + delta];
     pulseDeriv.coeffRef(iTS + nnlsWork_.maxoffset) = (pulseM[iTS + delta] - pulseP[iTS + delta]) * invDt;
 
-    pulseM[iTS+delta] -= pulseN[iTS+delta];
-    pulseP[iTS+delta] -= pulseN[iTS+delta];
+    pulseM[iTS + delta] -= pulseN[iTS + delta];
+    pulseP[iTS + delta] -= pulseN[iTS + delta];
   }
 
   for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -275,8 +275,8 @@ void MahiFit::updatePulseShape(double itQ,
     pulseShape.coeffRef(iTS + nnlsWork_.maxoffset) = pulseN[iTS + delta];
     pulseDeriv.coeffRef(iTS + nnlsWork_.maxoffset) = (pulseM[iTS + delta] - pulseP[iTS + delta]) * invDt;
 
-    pulseM[iTS] -= pulseN[iTS];
-    pulseP[iTS] -= pulseN[iTS];
+    pulseM[iTS+delta] -= pulseN[iTS+delta];
+    pulseP[iTS+delta] -= pulseN[iTS+delta];
   }
 
   for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {


### PR DESCRIPTION
#### PR description:

This subtraction should goes from 0 to 9 for 10TS, and 1 to 8 for 8TS because of the presence of this "delta". While for the current code, without "delta" present in the index, it's actually going from 0 to 7, missing the last TS, which results in some weird behavior in the fitting for the +4BX. After this fix, this behavior's gone. 
Details can be viewed in slides: [https://indico.cern.ch/event/839463/contributions/3521507/attachments/1892056/3120549/Wired_Behavior_of_Mahi_at_4BX.pdf](https://indico.cern.ch/event/839463/contributions/3521507/attachments/1892056/3120549/Wired_Behavior_of_Mahi_at_4BX.pdf)
And the check of the impact on jets and MET are:  [https://indico.cern.ch/event/839463/contributions/3521507/attachments/1892056/3125214/20190812_Jae_NoMtg_4BXImpact.pdf](https://indico.cern.ch/event/839463/contributions/3521507/attachments/1892056/3125214/20190812_Jae_NoMtg_4BXImpact.pdf)

#### PR validation:

Basic tests are performed and all succeed.

