### PR TITLE
Ignore sanitize options when generating CondFormat serialzations

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -510,7 +510,7 @@ class SerializationCodeGenerator(object):
         return os.path.join(self.cmssw_base, self.split_path[0], self.split_path[1], self.split_path[2], *path)
 
     def cleanFlags(self, flagsIn):
-        flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune', '-fdebug-prefix-map', '-ax', '-wd')) ]
+        flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune', '-fdebug-prefix-map', '-ax', '-wd', '-fsanitize=')) ]
         blackList = ['--', '-fipa-pta', '-xSSE3', '-fno-crossjumping', '-fno-aggressive-loop-optimizations']
         return [x for x in flags if x not in blackList]
 


### PR DESCRIPTION
#### PR description:

The sanitize compiler options are not useful when all we need is the compiler to do C++ parsing, not code generation. Ignoring the option avoids problems when clang does not support the same options as gcc.

#### PR validation:

Using this pull request one can now generate serialization code using CMSSW_11_0_ASAN_X_2019-09-06-2300.