### PR TITLE
Move SimG4CMS/PPS dependency to geant4core only

### DIFF
--- a/SimG4CMS/PPS/BuildFile.xml
+++ b/SimG4CMS/PPS/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/CTPPSDetId"/>
 <use   name="SimG4Core/SensitiveDetector"/>
 <use   name="SimDataFormats/SimHitMaker"/>
-<use   name="geant4"/>
+<use   name="geant4core"/>
 
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
#### PR description:

Follow-up of #27673 : the BuildFile.xml of SimG4CMS/PPS does not need to depend on the while geant4, but geant4core is enough as for the other similar packages.

#### PR validation:

Code compiles without issues.