### PR TITLE
DD4hep: Strip off Residual Namespace while Calculating the History

### DIFF
--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -258,11 +258,11 @@ void DDFilteredView::down() {
 }
 
 void DDFilteredView::up() {
-  if (it_.empty() || currentFilter_ == nullptr)
-    return;
-  it_.pop_back();
-  if (currentFilter_->up)
-    currentFilter_ = currentFilter_->up;
+  if (it_.size() > 1 && currentFilter_ != nullptr) {
+    it_.pop_back();
+    if (currentFilter_->up)
+      currentFilter_ = currentFilter_->up;
+  }
 }
 
 bool DDFilteredView::accept(std::string_view name) {
@@ -352,7 +352,8 @@ bool DDFilteredView::addPath(Node* const node) {
   for (int nit = level; nit > 0; --nit) {
     for_each(begin(registry_->specpars), end(registry_->specpars), [&](auto const& i) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
-        return (compareEqual(it_.back().GetNode(nit)->GetVolume()->GetName(), *begin(split(realTopName(j), "/"))) &&
+        return (compareEqual(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()),
+                             *begin(split(realTopName(j), "/"))) &&
                 (i.second.hasValue("CopyNoTag") || i.second.hasValue("CopyNoOffset")));
       });
       if (k != end(i.second.paths)) {


### PR DESCRIPTION
#### PR description:

* Some of the algorithms rely on the volumes with namespaces defined. This is taken into an account when the history is calculated.
* Navigate *up* the tree to the top volume

#### PR validation:

unit tests and relval tests

#### if this PR is a backport please specify the original PR:

no backport is needed
