### PR TITLE
Access best/second A/CLCT through public function in CSC TP emulator

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -71,10 +71,10 @@ public:
   void run(const std::vector<int> wire[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES]);
 
   /** Returns vector of ALCTs in the read-out time window, if any. */
-  std::vector<CSCALCTDigi> readoutALCTs();
+  std::vector<CSCALCTDigi> readoutALCTs() const;
 
   /** Returns vector of all found ALCTs, if any. */
-  std::vector<CSCALCTDigi> getALCTs();
+  std::vector<CSCALCTDigi> getALCTs() const;
 
   /** Return best/second best ALCTs */
   CSCALCTDigi getBestALCT(int bx) const;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -76,11 +76,16 @@ public:
   /** Returns vector of all found ALCTs, if any. */
   std::vector<CSCALCTDigi> getALCTs();
 
+  /** Return best/second best ALCTs */
+  CSCALCTDigi getBestALCT(int bx) const;
+  CSCALCTDigi getSecondALCT(int bx) const;
+
   /** Pre-defined patterns. */
   static const int pattern_envelope[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int pattern_mask_open[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
   static const int pattern_mask_r1[CSCConstants::NUM_ALCT_PATTERNS][CSCConstants::MAX_WIRES_IN_PATTERN];
 
+protected:
   /** Best LCTs in this chamber, as found by the processor.
       In old ALCT algorithms, up to two best ALCT per Level-1 accept window
       had been reported.
@@ -91,7 +96,6 @@ public:
   /** Second best LCTs in this chamber, as found by the processor. */
   CSCALCTDigi secondALCT[CSCConstants::MAX_ALCT_TBINS];
 
-protected:
   /** Access routines to wire digis. */
   bool getDigis(const CSCWireDigiCollection* wiredc);
   void getDigis(const CSCWireDigiCollection* wiredc, const CSCDetId& id);

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -73,6 +73,11 @@ public:
   /** Returns vector of all found CLCTs, if any. */
   std::vector<CSCCLCTDigi> getCLCTs() const;
 
+  /** get best/second best CLCT
+   * Note: CLCT has BX shifted */
+  CSCCLCTDigi getBestCLCT(int bx) const;
+  CSCCLCTDigi getSecondCLCT(int bx) const;
+
   std::vector<int> preTriggerBXs() const { return thePreTriggerBXs; }
 
   /** read out CLCTs in ME1a , ME1b */
@@ -80,13 +85,13 @@ public:
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1a() const;
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1b() const;
 
+protected:
   /** Best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
 
   /** Second best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi secondCLCT[CSCConstants::MAX_CLCT_TBINS];
 
-protected:
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
   void getDigis(const CSCComparatorDigiCollection* compdc, const CSCDetId& id);

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -85,6 +85,15 @@ public:
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1a() const;
   std::vector<CSCCLCTPreTriggerDigi> preTriggerDigisME1b() const;
 
+  /** Pre-defined patterns. */
+  // New set of halfstrip patterns for 2007 version of the algorithm.
+  // For the given pattern, set the unused parts of the pattern to 999.
+  // Pattern[i][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN] contains bend direction.
+  // Bend of 0 is right/straight and bend of 1 is left.
+  // Pattern[i][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN+1] contains pattern maximum width
+  static const int pattern2007_offset[CSCConstants::MAX_HALFSTRIPS_IN_PATTERN];
+  static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN + 2];
+
 protected:
   /** Best LCT in this chamber, as found by the processor. */
   CSCCLCTDigi bestCLCT[CSCConstants::MAX_CLCT_TBINS];
@@ -149,17 +158,6 @@ protected:
   /* does a given half-strip have a pre-trigger? */
   bool ispretrig[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
-public:
-  /** Pre-defined patterns. */
-  // New set of halfstrip patterns for 2007 version of the algorithm.
-  // For the given pattern, set the unused parts of the pattern to 999.
-  // Pattern[i][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN] contains bend direction.
-  // Bend of 0 is right/straight and bend of 1 is left.
-  // Pattern[i][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN+1] contains pattern maximum width
-  static const int pattern2007_offset[CSCConstants::MAX_HALFSTRIPS_IN_PATTERN];
-  static const int pattern2007[CSCConstants::NUM_CLCT_PATTERNS][CSCConstants::MAX_HALFSTRIPS_IN_PATTERN + 2];
-
-protected:
   // we use these next ones to address the various bits inside the array that's
   // used to make the cathode LCTs.
   enum CLCT_INDICES {

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -134,8 +134,8 @@ protected:
   // use this function when the best matching copads are not clear yet
   // the template is ALCT or CLCT
   template <class T>
-  void correlateLCTsGEM(
-      T& best, T& second, const GEMCoPadDigiIds& coPads, CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const;
+  void correlateLCTsGEM(const T& best, const T& second, const GEMCoPadDigiIds& coPads,
+                        CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const;
 
   // correlate ALCTs/CLCTs with their best matching GEM copads
   // the template is ALCT or CLCT
@@ -293,7 +293,7 @@ void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct, matches<T>& result
   int keyStrip = clct.getKeyStrip();
   //ME1A part, convert halfstrip from 128-223 to 0-95
   if (part == CSCPart::ME1A and keyStrip > CSCConstants::MAX_HALF_STRIP_ME1B)
-    keyStrip = keyStrip - CSCConstants::MAX_HALF_STRIP_ME1B - 1;
+    keyStrip = keyStrip -  CSCConstants::MAX_HALF_STRIP_ME1B -1;
   const int lowPad(mymap[keyStrip].first);
   const int highPad(mymap[keyStrip].second);
 
@@ -444,11 +444,15 @@ S CSCGEMMotherboard::bestMatchingPad(const CSCALCTDigi& alct1, const CSCCLCTDigi
 }
 
 template <class T>
-void CSCGEMMotherboard::correlateLCTsGEM(T& bestLCT,
-                                         T& secondLCT,
+void CSCGEMMotherboard::correlateLCTsGEM(const T& bLCT,
+                                         const T& sLCT,
                                          const GEMCoPadDigiIds& coPads,
                                          CSCCorrelatedLCTDigi& lct1,
                                          CSCCorrelatedLCTDigi& lct2) const {
+
+  T bestLCT = bLCT;
+  T secondLCT = sLCT;
+
   // Check which LCTs are valid
   bool bestValid = bestLCT.isValid();
   bool secondValid = secondLCT.isValid();
@@ -465,12 +469,12 @@ void CSCGEMMotherboard::correlateLCTsGEM(T& bestLCT,
   const GEMCoPadDigi& secondCoPad = bestMatchingPad<GEMCoPadDigi>(secondLCT, coPads);
 
   correlateLCTsGEM(bestLCT, secondLCT, bestCoPad, secondCoPad, lct1, lct2);
-}
+ }
 
-template <class T>
-void CSCGEMMotherboard::correlateLCTsGEM(const T& bestLCT,
-                                         const T& secondLCT,
-                                         const GEMCoPadDigi& bestCoPad,
+ template <class T>
+   void CSCGEMMotherboard::correlateLCTsGEM(const T& bestLCT,
+                                            const T& secondLCT,
+                                            const GEMCoPadDigi& bestCoPad,
                                          const GEMCoPadDigi& secondCoPad,
                                          CSCCorrelatedLCTDigi& lct1,
                                          CSCCorrelatedLCTDigi& lct2) const {

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -134,8 +134,11 @@ protected:
   // use this function when the best matching copads are not clear yet
   // the template is ALCT or CLCT
   template <class T>
-  void correlateLCTsGEM(const T& best, const T& second, const GEMCoPadDigiIds& coPads,
-                        CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2) const;
+  void correlateLCTsGEM(const T& best,
+                        const T& second,
+                        const GEMCoPadDigiIds& coPads,
+                        CSCCorrelatedLCTDigi& lct1,
+                        CSCCorrelatedLCTDigi& lct2) const;
 
   // correlate ALCTs/CLCTs with their best matching GEM copads
   // the template is ALCT or CLCT
@@ -293,7 +296,7 @@ void CSCGEMMotherboard::matchingPads(const CSCCLCTDigi& clct, matches<T>& result
   int keyStrip = clct.getKeyStrip();
   //ME1A part, convert halfstrip from 128-223 to 0-95
   if (part == CSCPart::ME1A and keyStrip > CSCConstants::MAX_HALF_STRIP_ME1B)
-    keyStrip = keyStrip -  CSCConstants::MAX_HALF_STRIP_ME1B -1;
+    keyStrip = keyStrip - CSCConstants::MAX_HALF_STRIP_ME1B - 1;
   const int lowPad(mymap[keyStrip].first);
   const int highPad(mymap[keyStrip].second);
 
@@ -449,7 +452,6 @@ void CSCGEMMotherboard::correlateLCTsGEM(const T& bLCT,
                                          const GEMCoPadDigiIds& coPads,
                                          CSCCorrelatedLCTDigi& lct1,
                                          CSCCorrelatedLCTDigi& lct2) const {
-
   T bestLCT = bLCT;
   T secondLCT = sLCT;
 
@@ -469,12 +471,12 @@ void CSCGEMMotherboard::correlateLCTsGEM(const T& bLCT,
   const GEMCoPadDigi& secondCoPad = bestMatchingPad<GEMCoPadDigi>(secondLCT, coPads);
 
   correlateLCTsGEM(bestLCT, secondLCT, bestCoPad, secondCoPad, lct1, lct2);
- }
+}
 
- template <class T>
-   void CSCGEMMotherboard::correlateLCTsGEM(const T& bestLCT,
-                                            const T& secondLCT,
-                                            const GEMCoPadDigi& bestCoPad,
+template <class T>
+void CSCGEMMotherboard::correlateLCTsGEM(const T& bestLCT,
+                                         const T& secondLCT,
+                                         const GEMCoPadDigi& bestCoPad,
                                          const GEMCoPadDigi& secondCoPad,
                                          CSCCorrelatedLCTDigi& lct1,
                                          CSCCorrelatedLCTDigi& lct2) const {

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -90,8 +90,9 @@ protected:
   /** Container for second correlated LCT. */
   CSCCorrelatedLCTDigi secondLCT[CSCConstants::MAX_LCT_TBINS];
 
-  // helper function to return ALCT with correct central BX
+  // helper function to return ALCT/CLCT with correct central BX
   CSCALCTDigi getBXShiftedALCT(const CSCALCTDigi&) const;
+  CSCCLCTDigi getBXShiftedCLCT(const CSCCLCTDigi&) const;
 
   /** Configuration parameters. */
   unsigned int mpc_block_me1a;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -1287,7 +1287,7 @@ void CSCAnodeLCTProcessor::dumpDigis(
 
 // Returns vector of read-out ALCTs, if any.  Starts with the vector of
 // all found ALCTs and selects the ones in the read-out time window.
-std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() {
+std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() const {
   std::vector<CSCALCTDigi> tmpV;
 
   // The number of LCT bins in the read-out is given by the
@@ -1361,7 +1361,7 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::readoutALCTs() {
 }
 
 // Returns vector of all found ALCTs, if any.  Used in ALCT-CLCT matching.
-std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() {
+std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() const {
   std::vector<CSCALCTDigi> tmpV;
   for (int bx = 0; bx < CSCConstants::MAX_ALCT_TBINS; bx++) {
     if (bestALCT[bx].isValid())

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -1372,6 +1372,18 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() {
   return tmpV;
 }
 
+CSCALCTDigi
+CSCAnodeLCTProcessor::getBestALCT(int bx) const
+{
+  return bestALCT[bx];
+}
+
+CSCALCTDigi
+CSCAnodeLCTProcessor::getSecondALCT(int bx) const
+{
+  return secondALCT[bx];
+}
+
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////Test Routines///////////////////////////////
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -1372,17 +1372,9 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() {
   return tmpV;
 }
 
-CSCALCTDigi
-CSCAnodeLCTProcessor::getBestALCT(int bx) const
-{
-  return bestALCT[bx];
-}
+CSCALCTDigi CSCAnodeLCTProcessor::getBestALCT(int bx) const { return bestALCT[bx]; }
 
-CSCALCTDigi
-CSCAnodeLCTProcessor::getSecondALCT(int bx) const
-{
-  return secondALCT[bx];
-}
+CSCALCTDigi CSCAnodeLCTProcessor::getSecondALCT(int bx) const { return secondALCT[bx]; }
 
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////Test Routines///////////////////////////////

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1257,14 +1257,6 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() const {
   return tmpV;
 }
 
-CSCCLCTDigi
-CSCCathodeLCTProcessor::getBestCLCT(int bx) const
-{
-  return bestCLCT[bx];
-}
+CSCCLCTDigi CSCCathodeLCTProcessor::getBestCLCT(int bx) const { return bestCLCT[bx]; }
 
-CSCCLCTDigi
-CSCCathodeLCTProcessor::getSecondCLCT(int bx) const
-{
-  return secondCLCT[bx];
-}
+CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const { return secondCLCT[bx]; }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1256,3 +1256,15 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() const {
   }
   return tmpV;
 }
+
+CSCCLCTDigi
+CSCCathodeLCTProcessor::getBestCLCT(int bx) const
+{
+  return bestCLCT[bx];
+}
+
+CSCCLCTDigi
+CSCCathodeLCTProcessor::getSecondCLCT(int bx) const
+{
+  return secondCLCT[bx];
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1257,6 +1257,19 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() const {
   return tmpV;
 }
 
-CSCCLCTDigi CSCCathodeLCTProcessor::getBestCLCT(int bx) const { return bestCLCT[bx]; }
+// shift the BX from 7 to 8
+// the unpacked real data CLCTs have central BX at bin 7
+// however in simulation the central BX  is bin 8
+// to make a proper comparison with ALCTs we need
+// CLCT and ALCT to have the central BX in the same bin
+CSCCLCTDigi CSCCathodeLCTProcessor::getBestCLCT(int bx) const {
+  CSCCLCTDigi lct = bestCLCT[bx];
+  lct.setBX(lct.getBX() + alctClctOffset_);
+  return lct;
+}
 
-CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const { return secondCLCT[bx]; }
+CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const {
+  CSCCLCTDigi lct = secondCLCT[bx];
+  lct.setBX(lct.getBX() + alctClctOffset_);
+  return lct;
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -120,7 +120,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     keyWG = alct.getKeyWG();
     bend = clct.getBend();
     thisLCT.setALCT(getBXShiftedALCT(alct));
-    thisLCT.setCLCT(clct);
+    thisLCT.setCLCT(getBXShiftedCLCT(clct));
     thisLCT.setGEM1(gem1);
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCTGEM);
   } else if (alct.isValid() and clct.isValid() and not gem1.isValid() and gem2.isValid()) {
@@ -131,7 +131,7 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     keyWG = alct.getKeyWG();
     bend = clct.getBend();
     thisLCT.setALCT(getBXShiftedALCT(alct));
-    thisLCT.setCLCT(clct);
+    thisLCT.setCLCT(getBXShiftedCLCT(clct));
     thisLCT.setGEM1(gem2.first());
     thisLCT.setGEM2(gem2.second());
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT2GEM);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -225,7 +225,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
           // find the best matching copad
           matches<GEMCoPadDigi> copads;
-          matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->getBestALCT(bx_alct), alctProc->getSecondALCT(bx_alct), copads);
+          matchingPads<CSCALCTDigi, GEMCoPadDigi>(
+              alctProc->getBestALCT(bx_alct), alctProc->getSecondALCT(bx_alct), copads);
 
           if (debug_matching)
             LogTrace("CSCGEMCMotherboardME11")

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -106,8 +106,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
   // ALCT-centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
     if (alctProc->getBestALCT(bx_alct).isValid()) {
-      const int bx_clct_start(bx_alct - match_trig_window_size / 2 - alctClctOffset_);
-      const int bx_clct_stop(bx_alct + match_trig_window_size / 2 - alctClctOffset_);
+      const int bx_clct_start(bx_alct - match_trig_window_size / 2);
+      const int bx_clct_stop(bx_alct + match_trig_window_size / 2);
       const int bx_copad_start(bx_alct - maxDeltaBXCoPad_);
       const int bx_copad_stop(bx_alct + maxDeltaBXCoPad_);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME11.cc
@@ -105,7 +105,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
   // ALCT-centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
-    if (alctProc->bestALCT[bx_alct].isValid()) {
+    if (alctProc->getBestALCT(bx_alct).isValid()) {
       const int bx_clct_start(bx_alct - match_trig_window_size / 2 - alctClctOffset_);
       const int bx_clct_stop(bx_alct + match_trig_window_size / 2 - alctClctOffset_);
       const int bx_copad_start(bx_alct - maxDeltaBXCoPad_);
@@ -116,8 +116,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
             << "========================================================================\n"
             << "ALCT-CLCT matching in ME1/1 chamber: " << cscId_ << "\n"
             << "------------------------------------------------------------------------\n"
-            << "+++ Best ALCT Details: " << alctProc->bestALCT[bx_alct] << "\n"
-            << "+++ Second ALCT Details: " << alctProc->secondALCT[bx_alct] << std::endl;
+            << "+++ Best ALCT Details: " << alctProc->getBestALCT(bx_alct) << "\n"
+            << "+++ Second ALCT Details: " << alctProc->getSecondALCT(bx_alct) << std::endl;
 
         printGEMTriggerPads(bx_clct_start, bx_clct_stop, CSCPart::ME11);
         printGEMTriggerCoPads(bx_clct_start, bx_clct_stop, CSCPart::ME11);
@@ -135,31 +135,31 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
           continue;
         if (drop_used_clcts and used_clct_mask[bx_clct])
           continue;
-        if (clctProc->bestCLCT[bx_clct].isValid()) {
-          const int quality(clctProc->bestCLCT[bx_clct].getQuality());
+        if (clctProc->getBestCLCT(bx_clct).isValid()) {
+          const int quality(clctProc->getBestCLCT(bx_clct).getQuality());
           if (debug_matching)
-            LogTrace("CSCGEMCMotherboardME11") << "++Valid ME1b CLCT: " << clctProc->bestCLCT[bx_clct] << std::endl;
+            LogTrace("CSCGEMCMotherboardME11") << "++Valid ME1b CLCT: " << clctProc->getBestCLCT(bx_clct) << std::endl;
 
           // pick the pad that corresponds
           matches<GEMPadDigi> mPads;
-          matchingPads<GEMPadDigi>(clctProc->bestCLCT[bx_clct],
-                                   clctProc->secondCLCT[bx_clct],
-                                   alctProc->bestALCT[bx_alct],
-                                   alctProc->secondALCT[bx_alct],
+          matchingPads<GEMPadDigi>(clctProc->getBestCLCT(bx_clct),
+                                   clctProc->getSecondCLCT(bx_clct),
+                                   alctProc->getBestALCT(bx_alct),
+                                   alctProc->getSecondALCT(bx_alct),
                                    mPads);
           matches<GEMCoPadDigi> mCoPads;
-          matchingPads<GEMCoPadDigi>(clctProc->bestCLCT[bx_clct],
-                                     clctProc->secondCLCT[bx_clct],
-                                     alctProc->bestALCT[bx_alct],
-                                     alctProc->secondALCT[bx_alct],
+          matchingPads<GEMCoPadDigi>(clctProc->getBestCLCT(bx_clct),
+                                     clctProc->getSecondCLCT(bx_clct),
+                                     alctProc->getBestALCT(bx_alct),
+                                     alctProc->getSecondALCT(bx_alct),
                                      mCoPads);
 
           // Low quality LCTs have at most 3 layers. Check if there is a matching GEM pad to keep the CLCT
           if (dropLowQualityCLCTsNoGEMs_ME1b_ and quality < 4 and hasPads) {
             int nFound(mPads.size());
             // these halfstrips (1,2,3,4) and (125,126,127,128) do not have matching GEM pads because GEM chambers are slightly wider than CSCs
-            const bool clctInEdge(clctProc->bestCLCT[bx_clct].getKeyStrip() < 5 or
-                                  clctProc->bestCLCT[bx_clct].getKeyStrip() > 124);
+            const bool clctInEdge(clctProc->getBestCLCT(bx_clct).getKeyStrip() < 5 or
+                                  clctProc->getBestCLCT(bx_clct).getKeyStrip() > 124);
             if (clctInEdge) {
               if (debug_matching)
                 LogTrace("CSCGEMCMotherboardME11")
@@ -182,10 +182,10 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
           //	    if (infoV > 1) LogTrace("CSCMotherboard")
           int mbx = bx_clct - bx_clct_start;
-          correlateLCTsGEM(alctProc->bestALCT[bx_alct],
-                           alctProc->secondALCT[bx_alct],
-                           clctProc->bestCLCT[bx_clct],
-                           clctProc->secondCLCT[bx_clct],
+          correlateLCTsGEM(alctProc->getBestALCT(bx_alct),
+                           alctProc->getSecondALCT(bx_alct),
+                           clctProc->getBestCLCT(bx_clct),
+                           clctProc->getSecondCLCT(bx_clct),
                            mPads,
                            mCoPads,
                            allLCTs(bx_alct, mbx, 0),
@@ -194,8 +194,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
             LogTrace("CSCGEMCMotherboardME11")
                 << "Successful ALCT-CLCT match in ME1b: bx_alct = " << bx_alct << "; match window: [" << bx_clct_start
                 << "; " << bx_clct_stop << "]; bx_clct = " << bx_clct << "\n"
-                << "+++ Best CLCT Details: " << clctProc->bestCLCT[bx_clct] << "\n"
-                << "+++ Second CLCT Details: " << clctProc->secondCLCT[bx_clct] << std::endl;
+                << "+++ Best CLCT Details: " << clctProc->getBestCLCT(bx_clct) << "\n"
+                << "+++ Second CLCT Details: " << clctProc->getSecondCLCT(bx_clct) << std::endl;
             if (allLCTs(bx_alct, mbx, 0).isValid())
               LogTrace("CSCGEMCMotherboardME11") << "LCT #1 " << allLCTs(bx_alct, mbx, 0) << std::endl;
             else
@@ -225,7 +225,7 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
 
           // find the best matching copad
           matches<GEMCoPadDigi> copads;
-          matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct], copads);
+          matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->getBestALCT(bx_alct), alctProc->getSecondALCT(bx_alct), copads);
 
           if (debug_matching)
             LogTrace("CSCGEMCMotherboardME11")
@@ -234,8 +234,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
             continue;
           }
 
-          CSCGEMMotherboard::correlateLCTsGEM(alctProc->bestALCT[bx_alct],
-                                              alctProc->secondALCT[bx_alct],
+          CSCGEMMotherboard::correlateLCTsGEM(alctProc->getBestALCT(bx_alct),
+                                              alctProc->getSecondALCT(bx_alct),
                                               copads,
                                               allLCTs(bx_alct, 0, 0),
                                               allLCTs(bx_alct, 0, 1));
@@ -301,14 +301,14 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
               continue;
             if (drop_used_clcts and used_clct_mask[bx_clct])
               continue;
-            if (clctProc->bestCLCT[bx_clct].isValid()) {
-              const int quality(clctProc->bestCLCT[bx_clct].getQuality());
+            if (clctProc->getBestCLCT(bx_clct).isValid()) {
+              const int quality(clctProc->getBestCLCT(bx_clct).getQuality());
               // only use high-Q stubs for the time being
               if (quality < 4)
                 continue;
               int mbx = bx_clct - bx_clct_start;
-              CSCGEMMotherboard::correlateLCTsGEM(clctProc->bestCLCT[bx_clct],
-                                                  clctProc->secondCLCT[bx_clct],
+              CSCGEMMotherboard::correlateLCTsGEM(clctProc->getBestCLCT(bx_clct),
+                                                  clctProc->getSecondCLCT(bx_clct),
                                                   coPads,
                                                   allLCTs(bx_alct, mbx, 0),
                                                   allLCTs(bx_alct, mbx, 1));
@@ -317,8 +317,8 @@ void CSCGEMMotherboardME11::run(const CSCWireDigiCollection* wiredc,
                 LogTrace("CSCGEMCMotherboardME11")
                     << "Successful GEM-CLCT match in ME1b: bx_alct = " << bx_alct << "; match window: ["
                     << bx_clct_start << "; " << bx_clct_stop << "]; bx_clct = " << bx_clct << "\n"
-                    << "+++ Best CLCT Details: " << clctProc->bestCLCT[bx_clct] << "\n"
-                    << "+++ Second CLCT Details: " << clctProc->secondCLCT[bx_clct] << std::endl;
+                    << "+++ Best CLCT Details: " << clctProc->getBestCLCT(bx_clct) << "\n"
+                    << "+++ Second CLCT Details: " << clctProc->getSecondCLCT(bx_clct) << std::endl;
               }
               if (allLCTs(bx_alct, mbx, 0).isValid()) {
                 used_clct_mask[bx_clct] += 1;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -91,8 +91,8 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
   // ALCT centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
     if (alctProc->getBestALCT(bx_alct).isValid()) {
-      const int bx_clct_start(bx_alct - match_trig_window_size / 2 - alctClctOffset_);
-      const int bx_clct_stop(bx_alct + match_trig_window_size / 2 - alctClctOffset_);
+      const int bx_clct_start(bx_alct - match_trig_window_size / 2);
+      const int bx_clct_stop(bx_alct + match_trig_window_size / 2);
       const int bx_copad_start(bx_alct - maxDeltaBXCoPad_);
       const int bx_copad_stop(bx_alct + maxDeltaBXCoPad_);
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -90,7 +90,7 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
 
   // ALCT centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
-    if (alctProc->bestALCT[bx_alct].isValid()) {
+    if (alctProc->getBestALCT(bx_alct).isValid()) {
       const int bx_clct_start(bx_alct - match_trig_window_size / 2 - alctClctOffset_);
       const int bx_clct_stop(bx_alct + match_trig_window_size / 2 - alctClctOffset_);
       const int bx_copad_start(bx_alct - maxDeltaBXCoPad_);
@@ -103,9 +103,9 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
         LogTrace("CSCGEMCMotherboardME21")
             << "------------------------------------------------------------------------" << std::endl;
         LogTrace("CSCGEMCMotherboardME21") << "+++ Best ALCT Details: ";
-        alctProc->bestALCT[bx_alct].print();
+        alctProc->getBestALCT(bx_alct).print();
         LogTrace("CSCGEMCMotherboardME21") << "+++ Second ALCT Details: ";
-        alctProc->secondALCT[bx_alct].print();
+        alctProc->getSecondALCT(bx_alct).print();
 
         printGEMTriggerPads(bx_clct_start, bx_clct_stop, CSCPart::ME21);
         printGEMTriggerCoPads(bx_clct_start, bx_clct_stop, CSCPart::ME21);
@@ -123,34 +123,34 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
           continue;
         if (drop_used_clcts and used_clct_mask[bx_clct])
           continue;
-        if (clctProc->bestCLCT[bx_clct].isValid()) {
+        if (clctProc->getBestCLCT(bx_clct).isValid()) {
           // clct quality
-          const int quality(clctProc->bestCLCT[bx_clct].getQuality());
+          const int quality(clctProc->getBestCLCT(bx_clct).getQuality());
           // low quality ALCT
-          const bool lowQualityALCT(alctProc->bestALCT[bx_alct].getQuality() == 0);
+          const bool lowQualityALCT(alctProc->getBestALCT(bx_alct).getQuality() == 0);
           // low quality ALCT or CLCT
           const bool lowQuality(quality < 4 or lowQualityALCT);
           if (debug_matching)
-            LogTrace("CSCGEMCMotherboardME21") << "++Valid ME21 CLCT: " << clctProc->bestCLCT[bx_clct] << std::endl;
+            LogTrace("CSCGEMCMotherboardME21") << "++Valid ME21 CLCT: " << clctProc->getBestCLCT(bx_clct) << std::endl;
 
           // pick the pad that corresponds
           matches<GEMPadDigi> mPads;
-          matchingPads<GEMPadDigi>(clctProc->bestCLCT[bx_clct],
-                                   clctProc->secondCLCT[bx_clct],
-                                   alctProc->bestALCT[bx_alct],
-                                   alctProc->secondALCT[bx_alct],
+          matchingPads<GEMPadDigi>(clctProc->getBestCLCT(bx_clct),
+                                   clctProc->getSecondCLCT(bx_clct),
+                                   alctProc->getBestALCT(bx_alct),
+                                   alctProc->getSecondALCT(bx_alct),
                                    mPads);
           matches<GEMCoPadDigi> mCoPads;
-          matchingPads<GEMCoPadDigi>(clctProc->bestCLCT[bx_clct],
-                                     clctProc->secondCLCT[bx_clct],
-                                     alctProc->bestALCT[bx_alct],
-                                     alctProc->secondALCT[bx_alct],
+          matchingPads<GEMCoPadDigi>(clctProc->getBestCLCT(bx_clct),
+                                     clctProc->getSecondCLCT(bx_clct),
+                                     alctProc->getBestALCT(bx_alct),
+                                     alctProc->getSecondALCT(bx_alct),
                                      mCoPads);
 
           if (dropLowQualityCLCTsNoGEMs_ and lowQuality and hasPads) {
             int nFound(mPads.size());
-            const bool clctInEdge(clctProc->bestCLCT[bx_clct].getKeyStrip() < 5 or
-                                  clctProc->bestCLCT[bx_clct].getKeyStrip() > 155);
+            const bool clctInEdge(clctProc->getBestCLCT(bx_clct).getKeyStrip() < 5 or
+                                  clctProc->getBestCLCT(bx_clct).getKeyStrip() > 155);
             if (clctInEdge) {
               if (debug_matching)
                 LogTrace("CSCGEMCMotherboardME21")
@@ -172,10 +172,10 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
           ++nSuccessFulMatches;
 
           int mbx = bx_clct - bx_clct_start;
-          correlateLCTsGEM(alctProc->bestALCT[bx_alct],
-                           alctProc->secondALCT[bx_alct],
-                           clctProc->bestCLCT[bx_clct],
-                           clctProc->secondCLCT[bx_clct],
+          correlateLCTsGEM(alctProc->getBestALCT(bx_alct),
+                           alctProc->getSecondALCT(bx_alct),
+                           clctProc->getBestCLCT(bx_clct),
+                           clctProc->getSecondCLCT(bx_clct),
                            mPads,
                            mCoPads,
                            allLCTs(bx_alct, mbx, 0),
@@ -186,9 +186,9 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
                 << "Successful ALCT-CLCT match in ME21: bx_alct = " << bx_alct << "; match window: [" << bx_clct_start
                 << "; " << bx_clct_stop << "]; bx_clct = " << bx_clct << std::endl;
             LogTrace("CSCGEMCMotherboardME21") << "+++ Best CLCT Details: ";
-            clctProc->bestCLCT[bx_clct].print();
+            clctProc->getBestCLCT(bx_clct).print();
             LogTrace("CSCGEMCMotherboardME21") << "+++ Second CLCT Details: ";
-            clctProc->secondCLCT[bx_clct].print();
+            clctProc->getSecondCLCT(bx_clct).print();
           }
           if (allLCTs(bx_alct, mbx, 0).isValid()) {
             used_clct_mask[bx_clct] += 1;
@@ -210,7 +210,7 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
 
           // find the best matching copad
           matches<GEMCoPadDigi> copads;
-          matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->bestALCT[bx_alct], alctProc->secondALCT[bx_alct], copads);
+          matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->getBestALCT(bx_alct), alctProc->getSecondALCT(bx_alct), copads);
 
           if (debug_matching)
             LogTrace("CSCGEMCMotherboardME21")
@@ -219,8 +219,8 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
             continue;
           }
 
-          CSCGEMMotherboard::correlateLCTsGEM(alctProc->bestALCT[bx_alct],
-                                              alctProc->secondALCT[bx_alct],
+          CSCGEMMotherboard::correlateLCTsGEM(alctProc->getBestALCT(bx_alct),
+                                              alctProc->getSecondALCT(bx_alct),
                                               copads,
                                               allLCTs(bx_alct, 0, 0),
                                               allLCTs(bx_alct, 0, 1));
@@ -288,18 +288,18 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
             continue;
           if (drop_used_clcts and used_clct_mask[bx_clct])
             continue;
-          if (clctProc->bestCLCT[bx_clct].isValid()) {
-            const int quality(clctProc->bestCLCT[bx_clct].getQuality());
+          if (clctProc->getBestCLCT(bx_clct).isValid()) {
+            const int quality(clctProc->getBestCLCT(bx_clct).getQuality());
             // only use high-Q stubs for the time being
             if (quality < 4)
               continue;
 
             ++nSuccessFulMatches;
 
-            int mbx = std::abs(clctProc->bestCLCT[bx_clct].getBX() - bx_alct);
+            int mbx = std::abs(clctProc->getBestCLCT(bx_clct).getBX() - bx_alct);
             int bx_gem = (coPads[0].second).bx(1) + CSCConstants::LCT_CENTRAL_BX;
-            CSCGEMMotherboard::correlateLCTsGEM(clctProc->bestCLCT[bx_clct],
-                                                clctProc->secondCLCT[bx_clct],
+            CSCGEMMotherboard::correlateLCTsGEM(clctProc->getBestCLCT(bx_clct),
+                                                clctProc->getSecondCLCT(bx_clct),
                                                 coPads,
                                                 allLCTs(bx_gem, mbx, 0),
                                                 allLCTs(bx_gem, mbx, 1));
@@ -310,9 +310,9 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
               //<< "; match window: [" << bx_clct_start << "; " << bx_clct_stop
               //<< "]; bx_clct = " << bx_clct << std::endl;
               LogTrace("CSCGEMCMotherboardME21") << "+++ Best CLCT Details: ";
-              clctProc->bestCLCT[bx_clct].print();
+              clctProc->getBestCLCT(bx_clct).print();
               LogTrace("CSCGEMCMotherboardME21") << "+++ Second CLCT Details: ";
-              clctProc->secondCLCT[bx_clct].print();
+              clctProc->getSecondCLCT(bx_clct).print();
             }
             if (allLCTs(bx_gem, mbx, 0).isValid()) {
               used_clct_mask[bx_gem] += 1;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboardME21.cc
@@ -210,7 +210,8 @@ void CSCGEMMotherboardME21::run(const CSCWireDigiCollection* wiredc,
 
           // find the best matching copad
           matches<GEMCoPadDigi> copads;
-          matchingPads<CSCALCTDigi, GEMCoPadDigi>(alctProc->getBestALCT(bx_alct), alctProc->getSecondALCT(bx_alct), copads);
+          matchingPads<CSCALCTDigi, GEMCoPadDigi>(
+              alctProc->getBestALCT(bx_alct), alctProc->getSecondALCT(bx_alct), copads);
 
           if (debug_matching)
             LogTrace("CSCGEMCMotherboardME21")

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -482,9 +482,9 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
   CSCCorrelatedLCTDigi thisLCT(
       trknmb, 1, quality, aLCT.getKeyWG(), cLCT.getKeyStrip(), pattern, cLCT.getBend(), bx, 0, 0, 0, theTrigChamber);
   thisLCT.setType(type);
-  // make sure to shift the ALCT BX from 8 to 3!
+  // make sure to shift the ALCT BX from 8 to 3 and the CLCT BX from 8 to 7!
   thisLCT.setALCT(getBXShiftedALCT(aLCT));
-  thisLCT.setCLCT(cLCT);
+  thisLCT.setCLCT(getBXShiftedCLCT(cLCT));
   return thisLCT;
 }
 
@@ -637,4 +637,10 @@ CSCALCTDigi CSCMotherboard::getBXShiftedALCT(const CSCALCTDigi& aLCT) const {
   CSCALCTDigi aLCT_shifted = aLCT;
   aLCT_shifted.setBX(aLCT_shifted.getBX() - (CSCConstants::LCT_CENTRAL_BX - tmb_l1a_window_size / 2));
   return aLCT_shifted;
+}
+
+CSCCLCTDigi CSCMotherboard::getBXShiftedCLCT(const CSCCLCTDigi& cLCT) const {
+  CSCCLCTDigi cLCT_shifted = cLCT;
+  cLCT_shifted.setBX(cLCT_shifted.getBX() - alctClctOffset_);
+  return cLCT_shifted;
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -154,7 +154,7 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
       // correlated LCT to be formed.  Decision on whether to reject
       // non-complete LCTs (and if yes of which type) is made further
       // upstream.
-      if (clctProc->bestCLCT[bx_clct].isValid()) {
+      if (clctProc->getBestCLCT(bx_clct).isValid()) {
         // Look for ALCTs within the match-time window.  The window is
         // centered at the CLCT bx; therefore, we make an assumption
         // that anode and cathode hits are perfectly synchronized.  This
@@ -173,14 +173,14 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
           // default: do not reuse ALCTs that were used with previous CLCTs
           if (drop_used_alcts && used_alct_mask[bx_alct])
             continue;
-          if (alctProc->bestALCT[bx_alct].isValid()) {
+          if (alctProc->getBestALCT(bx_alct).isValid()) {
             if (infoV > 1)
               LogTrace("CSCMotherboard") << "Successful CLCT-ALCT match: bx_clct = " << bx_clct << "; match window: ["
                                          << bx_alct_start << "; " << bx_alct_stop << "]; bx_alct = " << bx_alct;
-            correlateLCTs(alctProc->bestALCT[bx_alct],
-                          alctProc->secondALCT[bx_alct],
-                          clctProc->bestCLCT[bx_clct],
-                          clctProc->secondCLCT[bx_clct],
+            correlateLCTs(alctProc->getBestALCT(bx_alct),
+                          alctProc->getSecondALCT(bx_alct),
+                          clctProc->getBestCLCT(bx_clct),
+                          clctProc->getSecondCLCT(bx_clct),
                           CSCCorrelatedLCTDigi::CLCTALCT);
             used_alct_mask[bx_alct] += 1;
             is_matched = true;
@@ -193,12 +193,12 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
         if (!is_matched and clct_trig_enable) {
           if (infoV > 1)
             LogTrace("CSCMotherboard") << "Unsuccessful CLCT-ALCT match (CLCT only): bx_clct = " << bx_clct
-                                       << " first ALCT " << clctProc->bestCLCT[bx_clct] << "; match window: ["
+                                       << " first ALCT " << clctProc->getBestCLCT(bx_clct) << "; match window: ["
                                        << bx_alct_start << "; " << bx_alct_stop << "]";
-          correlateLCTs(alctProc->bestALCT[bx_clct],
-                        alctProc->secondALCT[bx_clct],
-                        clctProc->bestCLCT[bx_clct],
-                        clctProc->secondCLCT[bx_clct],
+          correlateLCTs(alctProc->getBestALCT(bx_clct),
+                        alctProc->getSecondALCT(bx_clct),
+                        clctProc->getBestCLCT(bx_clct),
+                        clctProc->getSecondCLCT(bx_clct),
                         CSCCorrelatedLCTDigi::CLCTONLY);
         }
       }
@@ -209,13 +209,13 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
       else {
         int bx_alct = bx_clct - match_trig_window_size / 2;
         if (bx_alct >= 0 && bx_alct > bx_alct_matched) {
-          if (alctProc->bestALCT[bx_alct].isValid() and alct_trig_enable) {
+          if (alctProc->getBestALCT(bx_alct).isValid() and alct_trig_enable) {
             if (infoV > 1)
               LogTrace("CSCMotherboard") << "Unsuccessful CLCT-ALCT match (ALCT only): bx_alct = " << bx_alct;
-            correlateLCTs(alctProc->bestALCT[bx_alct],
-                          alctProc->secondALCT[bx_alct],
-                          clctProc->bestCLCT[bx_clct],
-                          clctProc->secondCLCT[bx_clct],
+            correlateLCTs(alctProc->getBestALCT(bx_alct),
+                          alctProc->getSecondALCT(bx_alct),
+                          clctProc->getBestCLCT(bx_clct),
+                          clctProc->getSecondCLCT(bx_clct),
                           CSCCorrelatedLCTDigi::ALCTONLY);
           }
         }
@@ -234,7 +234,7 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
       // correlated LCT to be formed.  Decision on whether to reject
       // non-complete LCTs (and if yes of which type) is made further
       // upstream.
-      if (alctProc->bestALCT[bx_alct].isValid()) {
+      if (alctProc->getBestALCT(bx_alct).isValid()) {
         // Look for CLCTs within the match-time window.  The window is
         // centered at the ALCT bx; therefore, we make an assumption
         // that anode and cathode hits are perfectly synchronized.  This
@@ -253,14 +253,14 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
           // default: do not reuse CLCTs that were used with previous ALCTs
           if (drop_used_clcts && used_clct_mask[bx_clct])
             continue;
-          if (clctProc->bestCLCT[bx_clct].isValid()) {
+          if (clctProc->getBestCLCT(bx_clct).isValid()) {
             if (infoV > 1)
               LogTrace("CSCMotherboard") << "Successful ALCT-CLCT match: bx_alct = " << bx_alct << "; match window: ["
                                          << bx_clct_start << "; " << bx_clct_stop << "]; bx_clct = " << bx_clct;
-            correlateLCTs(alctProc->bestALCT[bx_alct],
-                          alctProc->secondALCT[bx_alct],
-                          clctProc->bestCLCT[bx_clct],
-                          clctProc->secondCLCT[bx_clct],
+            correlateLCTs(alctProc->getBestALCT(bx_alct),
+                          alctProc->getSecondALCT(bx_alct),
+                          clctProc->getBestCLCT(bx_clct),
+                          clctProc->getSecondCLCT(bx_clct),
                           CSCCorrelatedLCTDigi::ALCTCLCT);
             used_clct_mask[bx_clct] += 1;
             is_matched = true;
@@ -273,13 +273,13 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
         if (!is_matched) {
           if (infoV > 1)
             LogTrace("CSCMotherboard") << "Unsuccessful ALCT-CLCT match (ALCT only): bx_alct = " << bx_alct
-                                       << " first ALCT " << alctProc->bestALCT[bx_alct] << "; match window: ["
+                                       << " first ALCT " << alctProc->getBestALCT(bx_alct) << "; match window: ["
                                        << bx_clct_start << "; " << bx_clct_stop << "]";
           if (alct_trig_enable)
-            correlateLCTs(alctProc->bestALCT[bx_alct],
-                          alctProc->secondALCT[bx_alct],
-                          clctProc->bestCLCT[bx_alct],
-                          clctProc->secondCLCT[bx_alct],
+            correlateLCTs(alctProc->getBestALCT(bx_alct),
+                          alctProc->getSecondALCT(bx_alct),
+                          clctProc->getBestCLCT(bx_alct),
+                          clctProc->getSecondCLCT(bx_alct),
                           CSCCorrelatedLCTDigi::ALCTONLY);
         }
       }
@@ -290,13 +290,13 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
       else {
         int bx_clct = bx_alct - match_trig_window_size / 2;
         if (bx_clct >= 0 && bx_clct > bx_clct_matched) {
-          if (clctProc->bestCLCT[bx_clct].isValid() and clct_trig_enable) {
+          if (clctProc->getBestCLCT(bx_clct).isValid() and clct_trig_enable) {
             if (infoV > 1)
               LogTrace("CSCMotherboard") << "Unsuccessful ALCT-CLCT match (CLCT only): bx_clct = " << bx_clct;
-            correlateLCTs(alctProc->bestALCT[bx_alct],
-                          alctProc->secondALCT[bx_alct],
-                          clctProc->bestCLCT[bx_clct],
-                          clctProc->secondCLCT[bx_clct],
+            correlateLCTs(alctProc->getBestALCT(bx_alct),
+                          alctProc->getSecondALCT(bx_alct),
+                          clctProc->getBestCLCT(bx_clct),
+                          clctProc->getSecondCLCT(bx_clct),
                           CSCCorrelatedLCTDigi::CLCTONLY);
           }
         }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -164,8 +164,8 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
         // need to access "full BX" words, which are not readily
         // available.
         bool is_matched = false;
-        const int bx_alct_start = bx_clct - match_trig_window_size / 2 + alctClctOffset_;
-        const int bx_alct_stop = bx_clct + match_trig_window_size / 2 + alctClctOffset_;
+        const int bx_alct_start = bx_clct - match_trig_window_size / 2;
+        const int bx_alct_stop = bx_clct + match_trig_window_size / 2;
 
         for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
           if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS)
@@ -244,8 +244,8 @@ void CSCMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCComparato
         // need to access "full BX" words, which are not readily
         // available.
         bool is_matched = false;
-        const int bx_clct_start = bx_alct - match_trig_window_size / 2 - alctClctOffset_;
-        const int bx_clct_stop = bx_alct + match_trig_window_size / 2 - alctClctOffset_;
+        const int bx_clct_start = bx_alct - match_trig_window_size / 2;
+        const int bx_clct_stop = bx_alct + match_trig_window_size / 2;
 
         for (int bx_clct = bx_clct_start; bx_clct <= bx_clct_stop; bx_clct++) {
           if (bx_clct < 0 || bx_clct >= CSCConstants::MAX_CLCT_TBINS)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -74,7 +74,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
   // CLCT-centric CLCT-to-ALCT matching
   if (clct_to_alct) {
     for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS; bx_clct++) {
-      if (clctProc->bestCLCT[bx_clct].isValid()) {
+      if (clctProc->getBestCLCT(bx_clct).isValid()) {
         bool is_matched = false;
         const int bx_alct_start = bx_clct - match_trig_window_size / 2 + alctClctOffset_;
         const int bx_alct_stop = bx_clct + match_trig_window_size / 2 + alctClctOffset_;
@@ -83,16 +83,16 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
             continue;
           if (drop_used_alcts && used_alct_mask[bx_alct])
             continue;
-          if (alctProc->bestALCT[bx_alct].isValid()) {
+          if (alctProc->getBestALCT(bx_alct).isValid()) {
             if (infoV > 1)
               LogTrace("CSCMotherboardME11")
                   << "Successful CLCT-ALCT match in ME11: bx_clct = " << bx_clct << "; match window: [" << bx_alct_start
                   << "; " << bx_alct_stop << "]; bx_alct = " << bx_alct;
             int mbx = bx_alct_stop - bx_alct;
-            correlateLCTsME11(alctProc->bestALCT[bx_alct],
-                              alctProc->secondALCT[bx_alct],
-                              clctProc->bestCLCT[bx_clct],
-                              clctProc->secondCLCT[bx_clct],
+            correlateLCTsME11(alctProc->getBestALCT(bx_alct),
+                              alctProc->getSecondALCT(bx_alct),
+                              clctProc->getBestCLCT(bx_clct),
+                              clctProc->getSecondCLCT(bx_clct),
                               allLCTs(bx_alct, mbx, 0),
                               allLCTs(bx_alct, mbx, 1));
             if (allLCTs(bx_alct, mbx, 0).isValid()) {
@@ -106,7 +106,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
         if (!is_matched) {
           if (infoV > 1)
             LogTrace("CSCMotherboard") << "Unsuccessful ALCT-CLCT match (CLCT only): bx_clct = " << bx_clct
-                                       << " first CLCT " << clctProc->bestCLCT[bx_clct] << "; match window: ["
+                                       << " first CLCT " << clctProc->getBestCLCT(bx_clct) << "; match window: ["
                                        << bx_alct_start << "; " << bx_alct_stop << "]";
         }
       }
@@ -115,7 +115,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
     // ALCT-centric ALCT-to-CLCT matching
   } else {
     for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
-      if (alctProc->bestALCT[bx_alct].isValid()) {
+      if (alctProc->getBestALCT(bx_alct).isValid()) {
         const int bx_clct_start = bx_alct - match_trig_window_size / 2 - alctClctOffset_;
         const int bx_clct_stop = bx_alct + match_trig_window_size / 2 - alctClctOffset_;
 
@@ -126,16 +126,16 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
             continue;
           if (drop_used_clcts && used_clct_mask[bx_clct])
             continue;
-          if (clctProc->bestCLCT[bx_clct].isValid()) {
+          if (clctProc->getBestCLCT(bx_clct).isValid()) {
             if (infoV > 1)
               LogTrace("CSCMotherboardME11")
                   << "Successful ALCT-CLCT match in ME11: bx_alct = " << bx_alct << "; match window: [" << bx_clct_start
                   << "; " << bx_clct_stop << "]; bx_clct = " << bx_clct;
             int mbx = bx_clct - bx_clct_start;
-            correlateLCTsME11(alctProc->bestALCT[bx_alct],
-                              alctProc->secondALCT[bx_alct],
-                              clctProc->bestCLCT[bx_clct],
-                              clctProc->secondCLCT[bx_clct],
+            correlateLCTsME11(alctProc->getBestALCT(bx_alct),
+                              alctProc->getSecondALCT(bx_alct),
+                              clctProc->getBestCLCT(bx_clct),
+                              clctProc->getSecondCLCT(bx_clct),
                               allLCTs(bx_alct, mbx, 0),
                               allLCTs(bx_alct, mbx, 1));
             if (allLCTs(bx_alct, mbx, 0).isValid()) {
@@ -149,7 +149,7 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
         if (!is_matched) {
           if (infoV > 1)
             LogTrace("CSCMotherboard") << "Unsuccessful ALCT-CLCT match (ALCT only): bx_alct = " << bx_alct
-                                       << " first ALCT " << alctProc->bestALCT[bx_alct] << "; match window: ["
+                                       << " first ALCT " << alctProc->getBestALCT(bx_alct) << "; match window: ["
                                        << bx_clct_start << "; " << bx_clct_stop << "]";
         }
       }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -76,8 +76,8 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
     for (int bx_clct = 0; bx_clct < CSCConstants::MAX_CLCT_TBINS; bx_clct++) {
       if (clctProc->getBestCLCT(bx_clct).isValid()) {
         bool is_matched = false;
-        const int bx_alct_start = bx_clct - match_trig_window_size / 2 + alctClctOffset_;
-        const int bx_alct_stop = bx_clct + match_trig_window_size / 2 + alctClctOffset_;
+        const int bx_alct_start = bx_clct - match_trig_window_size / 2;
+        const int bx_alct_stop = bx_clct + match_trig_window_size / 2;
         for (int bx_alct = bx_alct_start; bx_alct <= bx_alct_stop; bx_alct++) {
           if (bx_alct < 0 || bx_alct >= CSCConstants::MAX_ALCT_TBINS)
             continue;
@@ -116,8 +116,8 @@ void CSCMotherboardME11::run(const CSCWireDigiCollection* wiredc, const CSCCompa
   } else {
     for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
       if (alctProc->getBestALCT(bx_alct).isValid()) {
-        const int bx_clct_start = bx_alct - match_trig_window_size / 2 - alctClctOffset_;
-        const int bx_clct_stop = bx_alct + match_trig_window_size / 2 - alctClctOffset_;
+        const int bx_clct_start = bx_alct - match_trig_window_size / 2;
+        const int bx_clct_stop = bx_alct + match_trig_window_size / 2;
 
         // matching in ME11
         bool is_matched = false;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -117,8 +117,8 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
   // ALCT centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
     if (alctProc->getBestALCT(bx_alct).isValid()) {
-      const int bx_clct_start(bx_alct - match_trig_window_size / 2 - alctClctOffset_);
-      const int bx_clct_stop(bx_alct + match_trig_window_size / 2 - alctClctOffset_);
+      const int bx_clct_start(bx_alct - match_trig_window_size / 2);
+      const int bx_clct_stop(bx_alct + match_trig_window_size / 2);
 
       if (debug_matching) {
         LogTrace("CSCUpgradeMotherboard")

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -116,7 +116,7 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
 
   // ALCT centric matching
   for (int bx_alct = 0; bx_alct < CSCConstants::MAX_ALCT_TBINS; bx_alct++) {
-    if (alctProc->bestALCT[bx_alct].isValid()) {
+    if (alctProc->getBestALCT(bx_alct).isValid()) {
       const int bx_clct_start(bx_alct - match_trig_window_size / 2 - alctClctOffset_);
       const int bx_clct_stop(bx_alct + match_trig_window_size / 2 - alctClctOffset_);
 
@@ -127,9 +127,9 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
         LogTrace("CSCUpgradeMotherboard")
             << "------------------------------------------------------------------------" << std::endl;
         LogTrace("CSCUpgradeMotherboard") << "+++ Best ALCT Details: ";
-        alctProc->bestALCT[bx_alct].print();
+        alctProc->getBestALCT(bx_alct).print();
         LogTrace("CSCUpgradeMotherboard") << "+++ Second ALCT Details: ";
-        alctProc->secondALCT[bx_alct].print();
+        alctProc->getSecondALCT(bx_alct).print();
 
         LogTrace("CSCUpgradeMotherboard")
             << "------------------------------------------------------------------------" << std::endl;
@@ -143,15 +143,15 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
           continue;
         if (drop_used_clcts and used_clct_mask[bx_clct])
           continue;
-        if (clctProc->bestCLCT[bx_clct].isValid()) {
+        if (clctProc->getBestCLCT(bx_clct).isValid()) {
           if (debug_matching)
-            LogTrace("CSCUpgradeMotherboard") << "++Valid ME21 CLCT: " << clctProc->bestCLCT[bx_clct] << std::endl;
+            LogTrace("CSCUpgradeMotherboard") << "++Valid ME21 CLCT: " << clctProc->getBestCLCT(bx_clct) << std::endl;
 
           int mbx = bx_clct - bx_clct_start;
-          CSCUpgradeMotherboard::correlateLCTs(alctProc->bestALCT[bx_alct],
-                                               alctProc->secondALCT[bx_alct],
-                                               clctProc->bestCLCT[bx_clct],
-                                               clctProc->secondCLCT[bx_clct],
+          CSCUpgradeMotherboard::correlateLCTs(alctProc->getBestALCT(bx_alct),
+                                               alctProc->getSecondALCT(bx_alct),
+                                               clctProc->getBestCLCT(bx_clct),
+                                               clctProc->getSecondCLCT(bx_clct),
                                                allLCTs(bx_alct, mbx, 0),
                                                allLCTs(bx_alct, mbx, 1));
           if (infoV > 1)
@@ -159,9 +159,9 @@ void CSCUpgradeMotherboard::run(const CSCWireDigiCollection* wiredc, const CSCCo
                 << "Successful ALCT-CLCT match in ME21: bx_alct = " << bx_alct << "; match window: [" << bx_clct_start
                 << "; " << bx_clct_stop << "]; bx_clct = " << bx_clct << std::endl;
           LogTrace("CSCUpgradeMotherboard") << "+++ Best CLCT Details: ";
-          clctProc->bestCLCT[bx_clct].print();
+          clctProc->getBestCLCT(bx_clct).print();
           LogTrace("CSCUpgradeMotherboard") << "+++ Second CLCT Details: ";
-          clctProc->secondCLCT[bx_clct].print();
+          clctProc->getSecondCLCT(bx_clct).print();
           if (allLCTs(bx_alct, mbx, 0).isValid()) {
             used_clct_mask[bx_clct] += 1;
             if (match_earliest_clct_only)


### PR DESCRIPTION
#### PR description:

This PR replaces the usage of public member variables (e.g. `bestALCT`) to public member functions (e.g. `getBestALCT()`) in CSC motherboard classes - an artifact of the legacy CSC TP emulator code. I largely relied on `sed` to make the (trivial) changes:
```
sed -i 's/->bestALCT\[/->getBestALCT(/g' *.cc
sed -i 's/->bestCLCT\[/->getBestCLCT(/g' *.cc
sed -i 's/->secondALCT\[/->getSecondALCT(/g' *.cc
sed -i 's/->secondCLCT\[/->getSecondCLCT(/g' *.cc
sed -i 's/(bx_alct\]/(bx_alct)/g' *.cc
sed -i 's/(bx_clct\]/(bx_clct)/g' *.cc
```

Update: upon further inspection, it appears that the CLCT BX shift in PR #24402 was incomplete. The public variables `bestCLCT` and `secondCLCT` would return CLCTs at central BX7. The new public functions `getBestCLCT()` and `getSecondCLCT()` return CLCTs with central BX8. However, the CLCT readout remains unchanged, i.e. it will produce produce the CLCT digi collection with a central BX of 7. Also, this change won't have an effect on the LCT reconstruction efficiency, since the ALCT-CLCT BX matching window is at least 3 to 7 BX wide.

#### PR validation:

I tested it with WF 22034.0

@tahuang1991 