### PR TITLE
Fix mix-up between the physical and the trigger chamber number in upgrade CSC motherboard

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/GEMCoPadProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/GEMCoPadProcessor.h
@@ -17,7 +17,7 @@
 class GEMCoPadProcessor {
 public:
   /** Normal constructor. */
-  GEMCoPadProcessor(unsigned endcap, unsigned station, unsigned chamber, const edm::ParameterSet& copad);
+  GEMCoPadProcessor(unsigned region, unsigned station, unsigned chamber, const edm::ParameterSet& copad);
 
   /** Default constructor. Used for testing. */
   GEMCoPadProcessor();
@@ -44,7 +44,7 @@ public:
 
 private:
   /** Chamber id (trigger-type labels). */
-  const int theEndcap;
+  const int theRegion;
   const int theStation;
   const int theChamber;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -18,7 +18,7 @@ CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
 
   const edm::ParameterSet coPadParams(station == 1 ? conf.getParameter<edm::ParameterSet>("copadParamGE11")
                                                    : conf.getParameter<edm::ParameterSet>("copadParamGE21"));
-  coPadProcessor.reset(new GEMCoPadProcessor(endcap, station, chamber, coPadParams));
+  coPadProcessor.reset(new GEMCoPadProcessor(theRegion, theStation, theChamber, coPadParams));
 
   maxDeltaPadL1_ = (theParity ? tmbParams_.getParameter<int>("maxDeltaPadL1Even")
                               : tmbParams_.getParameter<int>("maxDeltaPadL1Odd"));

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -27,7 +27,6 @@ GEMCoPadProcessor::GEMCoPadProcessor() : theRegion(1), theStation(1), theChamber
 void GEMCoPadProcessor::clear() { gemCoPadV.clear(); }
 
 std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads) {
-
   // Build coincidences
   for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
     const GEMDetId& id = (*det_range).first;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -8,8 +8,8 @@
 // Constructors --
 //----------------
 
-GEMCoPadProcessor::GEMCoPadProcessor(unsigned endcap, unsigned station, unsigned chamber, const edm::ParameterSet& copad)
-    : theEndcap(endcap), theStation(station), theChamber(chamber) {
+GEMCoPadProcessor::GEMCoPadProcessor(unsigned region, unsigned station, unsigned chamber, const edm::ParameterSet& copad)
+    : theRegion(region), theStation(station), theChamber(chamber) {
   // Verbosity level, set to 0 (no print) by default.
   infoV = copad.getParameter<unsigned int>("verbosity");
   maxDeltaPad_ = copad.getParameter<unsigned int>("maxDeltaPad");
@@ -17,7 +17,7 @@ GEMCoPadProcessor::GEMCoPadProcessor(unsigned endcap, unsigned station, unsigned
   maxDeltaBX_ = copad.getParameter<unsigned int>("maxDeltaBX");
 }
 
-GEMCoPadProcessor::GEMCoPadProcessor() : theEndcap(1), theStation(1), theChamber(1) {
+GEMCoPadProcessor::GEMCoPadProcessor() : theRegion(1), theStation(1), theChamber(1) {
   infoV = 0;
   maxDeltaPad_ = 0;
   maxDeltaRoll_ = 0;
@@ -27,14 +27,13 @@ GEMCoPadProcessor::GEMCoPadProcessor() : theEndcap(1), theStation(1), theChamber
 void GEMCoPadProcessor::clear() { gemCoPadV.clear(); }
 
 std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads) {
-  const int region((theEndcap == 1) ? 1 : -1);
 
   // Build coincidences
   for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
     const GEMDetId& id = (*det_range).first;
 
     // same chamber (no restriction on the roll number)
-    if (id.region() != region or id.station() != theStation or id.chamber() != theChamber)
+    if (id.region() != theRegion or id.station() != theStation or id.chamber() != theChamber)
       continue;
 
     // all coincidences detIDs will have layer=1


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in the initialization of the GEMCoPadProcessor. In the constructor of the base class `CSCGEMMotherboard` the variable `chamber` is used to reset the processor. This needs to be  `theChamber` instead which refers to the physical chamber number, not the trigger chamber number. Without the fix the upgrade motherboards do not produce coincidence pads.

#### PR validation:

I tested this fix with workflow 22034.0.

@tahuang1991