### PR TITLE
fix SimProducers for MT

### DIFF
--- a/SimG4Core/Application/interface/OscarMTProducer.h
+++ b/SimG4Core/Application/interface/OscarMTProducer.h
@@ -35,7 +35,6 @@ public:
   void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  Producers m_producers;
   std::unique_ptr<RunManagerMTWorker> m_runManagerWorker;
 };
 

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -62,7 +62,7 @@ public:
   SimTrackManager* GetSimTrackManager();
   std::vector<SensitiveTkDetector*>& sensTkDetectors();
   std::vector<SensitiveCaloDetector*>& sensCaloDetectors();
-  std::vector<std::shared_ptr<SimProducer> > producers();
+  std::vector<std::shared_ptr<SimProducer> >& producers();
 
 private:
   void initializeTLS();

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -123,9 +123,9 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
   produces<edm::PCaloHitContainer>("HFNoseHits");
 
   //register any products
-  m_producers = m_runManagerWorker->producers();
+  auto& producers = m_runManagerWorker->producers();
 
-  for (Producers::iterator itProd = m_producers.begin(); itProd != m_producers.end(); ++itProd) {
+  for (Producers::iterator itProd = producers.begin(); itProd != producers.end(); ++itProd) {
     (*itProd)->registerProducts(*this);
   }
 }
@@ -207,7 +207,8 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     }
   }
 
-  for (auto& prod : m_producers) {
+  auto& producers = m_runManagerWorker->producers();
+  for (auto& prod : producers) {
     prod.get()->produce(e, es);
   }
   LogDebug("SimG4CoreApplication") << "Event is produced " << e.id() << " stream " << e.streamID()

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -420,7 +420,7 @@ std::vector<SensitiveCaloDetector*>& RunManagerMTWorker::sensCaloDetectors() {
   initializeTLS();
   return m_tls->sensCaloDets;
 }
-std::vector<std::shared_ptr<SimProducer> > RunManagerMTWorker::producers() {
+std::vector<std::shared_ptr<SimProducer> >& RunManagerMTWorker::producers() {
   initializeTLS();
   return m_tls->producers;
 }


### PR DESCRIPTION
#### PR description:

I observed data races when using a SimProducer in a multithreaded job.

The problem was that the vector of SimProducers was kept by OscarMTProducer as a member, outside the thread local context. It just kept trying to use the instance from thread 0 for all the threads.

#### PR validation:

Private testing with debug statements printing the thread counter and the SimProducer memory addresses, as well as tests on multiple threads and with helgrind.

attn: @makortel @Dr15Jones