### PR TITLE
Support concurrent LuminosityBlocks in HLTrigReport

### DIFF
--- a/HLTrigger/HLTanalyzers/plugins/HLTrigReport.cc
+++ b/HLTrigger/HLTanalyzers/plugins/HLTrigReport.cc
@@ -44,11 +44,8 @@ HLTrigReport::ReportEvery HLTrigReport::decode(const std::string& value) {
 //
 // constructors and destructor
 //
-HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig)
-    : hlTriggerResults_(iConfig.getParameter<edm::InputTag>("HLTriggerResults")),
-      hlTriggerResultsToken_(consumes<edm::TriggerResults>(hlTriggerResults_)),
-      configured_(false),
-      nEvents_(0),
+hltrigreport::Accumulate::Accumulate()
+    : nEvents_(0),
       nWasRun_(0),
       nAccept_(0),
       nErrors_(0),
@@ -58,22 +55,118 @@ HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig)
       hlAccept_(0),
       hlAccTot_(0),
       hlErrors_(0),
-      posL1s_(0),
-      posPre_(0),
+      hlAccTotDS_(0),
+      dsAccTotS_(0) {}
+
+hltrigreport::Accumulate::Accumulate(size_t numHLNames,
+                                     std::vector<std::vector<unsigned int> > const& hlIndex,
+                                     std::vector<std::vector<unsigned int> > const& dsIndex)
+    : nEvents_(0),
+      nWasRun_(0),
+      nAccept_(0),
+      nErrors_(0),
+      hlWasRun_(numHLNames),
+      hltL1s_(numHLNames),
+      hltPre_(numHLNames),
+      hlAccept_(numHLNames),
+      hlAccTot_(numHLNames),
+      hlErrors_(numHLNames),
+      hlAccTotDS_(hlIndex.size()),
+      hlAllTotDS_(hlIndex.size()),
+      dsAccTotS_(dsIndex.size()),
+      dsAllTotS_(dsIndex.size()) {
+  for (size_t ds = 0; ds < hlIndex.size(); ++ds) {
+    hlAccTotDS_[ds].resize(hlIndex[ds].size());
+  }
+
+  for (size_t s = 0; s < dsIndex.size(); ++s) {
+    dsAccTotS_[s].resize(dsIndex[s].size());
+  }
+}
+
+void hltrigreport::Accumulate::accumulate(hltrigreport::Accumulate const& iOther) {
+  nEvents_ += iOther.nEvents_;
+  nWasRun_ += iOther.nWasRun_;
+  nAccept_ += iOther.nAccept_;
+  nErrors_ += iOther.nErrors_;
+
+  auto vsum = [](auto& to, auto const& from) {
+    for (size_t i = 0; i < from.size(); ++i) {
+      to[i] += from[i];
+    }
+  };
+
+  assert(hlWasRun_.size() == iOther.hlWasRun_.size());
+  vsum(hlWasRun_, iOther.hlWasRun_);
+  vsum(hltL1s_, iOther.hltL1s_);
+  vsum(hltPre_, iOther.hltPre_);
+  vsum(hlAccept_, iOther.hlAccept_);
+  vsum(hlAccTot_, iOther.hlAccTot_);
+  vsum(hlErrors_, iOther.hlErrors_);
+
+  assert(hlAllTotDS_.size() == iOther.hlAllTotDS_.size());
+  vsum(hlAllTotDS_, iOther.hlAllTotDS_);
+  vsum(dsAllTotS_, iOther.dsAllTotS_);
+
+  auto vvsum = [](auto& to, auto const& from) {
+    for (size_t i = 0; i < from.size(); ++i) {
+      assert(from[i].size() == to[i].size());
+      for (size_t j = 0; j < from[i].size(); ++j) {
+        to[i][j] += from[i][j];
+      }
+    }
+  };
+
+  vvsum(hlAccTotDS_, iOther.hlAccTotDS_);
+  vvsum(dsAccTotS_, iOther.dsAccTotS_);
+}
+
+void hltrigreport::Accumulate::reset() {
+  nEvents_ = 0;
+  nWasRun_ = 0;
+  nAccept_ = 0;
+  nErrors_ = 0;
+
+  auto vreset = [](auto& to) { std::fill(to.begin(), to.end(), 0); };
+
+  vreset(hlWasRun_);
+  vreset(hltL1s_);
+  vreset(hltPre_);
+  vreset(hlAccept_);
+  vreset(hlAccTot_);
+  vreset(hlErrors_);
+
+  vreset(hlAllTotDS_);
+  vreset(dsAllTotS_);
+
+  auto vvreset = [&vreset](auto& to) {
+    for (auto& e : to) {
+      vreset(e);
+    }
+  };
+
+  vvreset(hlAccTotDS_);
+  vvreset(dsAccTotS_);
+}
+
+HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig)
+    : hlTriggerResults_(iConfig.getParameter<edm::InputTag>("HLTriggerResults")),
+      hlTriggerResultsToken_(consumes<edm::TriggerResults>(hlTriggerResults_)),
+      configured_(false),
       hlNames_(0),
       hlIndex_(0),
-      hlAccTotDS_(0),
+      posL1s_(0),
+      posPre_(0),
       datasetNames_(0),
       datasetContents_(0),
       isCustomDatasets_(false),
       dsIndex_(0),
-      dsAccTotS_(0),
       streamNames_(0),
       streamContents_(0),
       isCustomStreams_(false),
       refPath_("HLTriggerFinalPath"),
       refIndex_(0),
-      refRate_(100.0),
+      refRate_(iConfig.getUntrackedParameter<double>("ReferenceRate", 100.0)),
       reportBy_(decode(iConfig.getUntrackedParameter<std::string>("reportBy", "job"))),
       resetBy_(decode(iConfig.getUntrackedParameter<std::string>("resetBy", "never"))),
       serviceBy_(decode(iConfig.getUntrackedParameter<std::string>("serviceBy", "never"))),
@@ -99,7 +192,6 @@ HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig)
   }
 
   refPath_ = iConfig.getUntrackedParameter<std::string>("ReferencePath", "HLTriggerFinalPath");
-  refRate_ = iConfig.getUntrackedParameter<double>("ReferenceRate", 100.0);
   refIndex_ = 0;
 
   LogDebug("HLTrigReport") << "HL TiggerResults: " + hlTriggerResults_.encode()
@@ -135,153 +227,93 @@ void HLTrigReport::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 
 const std::vector<std::string>& HLTrigReport::datasetNames() const { return datasetNames_; }
 const std::vector<std::string>& HLTrigReport::streamNames() const { return streamNames_; }
-const std::vector<unsigned int>& HLTrigReport::datasetCounts() const { return hlAllTotDS_; }
-const std::vector<unsigned int>& HLTrigReport::streamCounts() const { return dsAllTotS_; }
 
-void HLTrigReport::reset(bool changed /* = false */) {
-  // reset global counters
-  nEvents_ = 0;
-  nWasRun_ = 0;
-  nAccept_ = 0;
-  nErrors_ = 0;
-
+void HLTrigReport::updateConfigCache() {
   // update trigger names
-  if (changed)
-    hlNames_ = hltConfig_.triggerNames();
+  hlNames_ = hltConfig_.triggerNames();
 
   const unsigned int n = hlNames_.size();
 
-  if (changed) {
-    // resize per-path counters
-    hlWasRun_.resize(n);
-    hltL1s_.resize(n);
-    hltPre_.resize(n);
-    hlAccept_.resize(n);
-    hlAccTot_.resize(n);
-    hlErrors_.resize(n);
-    // find the positions of seeding and prescaler modules
-    posL1s_.resize(n);
-    posPre_.resize(n);
-    for (unsigned int i = 0; i < n; ++i) {
-      posL1s_[i] = -1;
-      posPre_[i] = -1;
-      const std::vector<std::string>& moduleLabels(hltConfig_.moduleLabels(i));
-      for (unsigned int j = 0; j < moduleLabels.size(); ++j) {
-        const std::string& label = hltConfig_.moduleType(moduleLabels[j]);
-        if (label == "HLTLevel1GTSeed")
-          posL1s_[i] = j;
-        else if (label == "HLTPrescaler")
-          posPre_[i] = j;
-      }
+  // find the positions of seeding and prescaler modules
+  posL1s_.resize(n);
+  posPre_.resize(n);
+  for (unsigned int i = 0; i < n; ++i) {
+    posL1s_[i] = -1;
+    posPre_[i] = -1;
+    const std::vector<std::string>& moduleLabels(hltConfig_.moduleLabels(i));
+    for (unsigned int j = 0; j < moduleLabels.size(); ++j) {
+      const std::string& label = hltConfig_.moduleType(moduleLabels[j]);
+      if (label == "HLTLevel1GTSeed")
+        posL1s_[i] = j;
+      else if (label == "HLTPrescaler")
+        posPre_[i] = j;
     }
   }
 
-  // reset per-path counters
-  for (unsigned int i = 0; i < n; ++i) {
-    hlWasRun_[i] = 0;
-    hltL1s_[i] = 0;
-    hltPre_[i] = 0;
-    hlAccept_[i] = 0;
-    hlAccTot_[i] = 0;
-    hlErrors_[i] = 0;
-  }
-
   // if not overridden, reload the datasets and streams
-  if (changed and not isCustomDatasets_) {
+  if (not isCustomDatasets_) {
     datasetNames_ = hltConfig_.datasetNames();
     datasetContents_ = hltConfig_.datasetContents();
   }
-  if (changed and not isCustomStreams_) {
+  if (not isCustomStreams_) {
     streamNames_ = hltConfig_.streamNames();
     streamContents_ = hltConfig_.streamContents();
   }
 
-  if (changed) {
-    // fill the matrices of hlIndex_, hlAccTotDS_
-    hlIndex_.clear();
-    hlIndex_.resize(datasetNames_.size());
-    hlAccTotDS_.clear();
-    hlAllTotDS_.clear();
-    hlAccTotDS_.resize(datasetNames_.size());
-    hlAllTotDS_.resize(datasetNames_.size());
-    for (unsigned int ds = 0; ds < datasetNames_.size(); ds++) {
-      unsigned int size = datasetContents_[ds].size();
-      hlIndex_[ds].reserve(size);
-      hlAccTotDS_[ds].reserve(size);
-      hlAllTotDS_[ds] = 0;
-      for (unsigned int p = 0; p < size; ++p) {
-        unsigned int i = hltConfig_.triggerIndex(datasetContents_[ds][p]);
-        if (i < n) {
-          hlIndex_[ds].push_back(i);
-          hlAccTotDS_[ds].push_back(0);
-        }
+  // fill the matrices of hlIndex_, hlAccTotDS_
+  hlIndex_.clear();
+  hlIndex_.resize(datasetNames_.size());
+  for (unsigned int ds = 0; ds < datasetNames_.size(); ds++) {
+    unsigned int size = datasetContents_[ds].size();
+    hlIndex_[ds].reserve(size);
+    for (unsigned int p = 0; p < size; ++p) {
+      unsigned int i = hltConfig_.triggerIndex(datasetContents_[ds][p]);
+      if (i < n) {
+        hlIndex_[ds].push_back(i);
       }
-    }
-  } else {
-    // reset the matrix of hlAccTotDS_
-    for (unsigned int ds = 0; ds < datasetNames_.size(); ds++) {
-      hlAllTotDS_[ds] = 0;
-      for (unsigned int& i : hlAccTotDS_[ds])
-        i = 0;
     }
   }
 
-  if (changed) {
-    // fill the matrices of dsIndex_, dsAccTotS_
-    dsIndex_.clear();
-    dsIndex_.resize(streamNames_.size());
-    dsAccTotS_.clear();
-    dsAllTotS_.clear();
-    dsAccTotS_.resize(streamNames_.size());
-    dsAllTotS_.resize(streamNames_.size());
-    for (unsigned int s = 0; s < streamNames_.size(); ++s) {
-      unsigned int size = streamContents_[s].size();
-      dsIndex_.reserve(size);
-      dsAccTotS_.reserve(size);
-      dsAllTotS_[s] = 0;
-      for (unsigned int ds = 0; ds < size; ++ds) {
-        unsigned int i = 0;
-        for (; i < datasetNames_.size(); i++)
-          if (datasetNames_[i] == streamContents_[s][ds])
-            break;
-        // report only datasets that have at least one path otherwise crash
-        if (i < datasetNames_.size() and !hlIndex_[i].empty()) {
-          dsIndex_[s].push_back(i);
-          dsAccTotS_[s].push_back(0);
-        }
+  // fill the matrices of dsIndex_, dsAccTotS_
+  dsIndex_.clear();
+  dsIndex_.resize(streamNames_.size());
+  for (unsigned int s = 0; s < streamNames_.size(); ++s) {
+    unsigned int size = streamContents_[s].size();
+    dsIndex_.reserve(size);
+    for (unsigned int ds = 0; ds < size; ++ds) {
+      unsigned int i = 0;
+      for (; i < datasetNames_.size(); i++)
+        if (datasetNames_[i] == streamContents_[s][ds])
+          break;
+      // report only datasets that have at least one path otherwise crash
+      if (i < datasetNames_.size() and !hlIndex_[i].empty()) {
+        dsIndex_[s].push_back(i);
       }
-    }
-  } else {
-    // reset the matrix of dsAccTotS_
-    for (unsigned int s = 0; s < streamNames_.size(); ++s) {
-      dsAllTotS_[s] = 0;
-      for (unsigned int& i : dsAccTotS_[s])
-        i = 0;
     }
   }
 
   // if needed, update the reference path
-  if (changed) {
+  refIndex_ = hltConfig_.triggerIndex(refPath_);
+  if (refIndex_ >= n) {
+    refIndex_ = 0;
+    edm::LogWarning("HLTrigReport") << "Requested reference path '" + refPath_ + "' not in HLT menu. "
+                                    << "Using HLTriggerFinalPath instead.";
+    refPath_ = "HLTriggerFinalPath";
     refIndex_ = hltConfig_.triggerIndex(refPath_);
     if (refIndex_ >= n) {
       refIndex_ = 0;
       edm::LogWarning("HLTrigReport") << "Requested reference path '" + refPath_ + "' not in HLT menu. "
-                                      << "Using HLTriggerFinalPath instead.";
-      refPath_ = "HLTriggerFinalPath";
-      refIndex_ = hltConfig_.triggerIndex(refPath_);
-      if (refIndex_ >= n) {
-        refIndex_ = 0;
-        edm::LogWarning("HLTrigReport") << "Requested reference path '" + refPath_ + "' not in HLT menu. "
-                                        << "Using first path in table (index=0) instead.";
-      }
+                                      << "Using first path in table (index=0) instead.";
     }
   }
 
-  if (changed and serviceBy_ != NEVER and edm::Service<HLTrigReportService>()) {
+  if (serviceBy_ != NEVER and edm::Service<HLTrigReportService>()) {
     edm::Service<HLTrigReportService>()->setDatasetNames(datasetNames_);
     edm::Service<HLTrigReportService>()->setStreamNames(streamNames_);
   }
 }
+
+void HLTrigReport::reset() { accumulate_.reset(); }
 
 void HLTrigReport::beginJob() {
   if (resetBy_ == EVERY_JOB)
@@ -290,10 +322,9 @@ void HLTrigReport::beginJob() {
 
 void HLTrigReport::endJob() {
   if (reportBy_ == EVERY_JOB)
-    dumpReport("Summary for Job");
-  if (serviceBy_ == EVERY_JOB and edm::Service<HLTrigReportService>()) {
-    edm::Service<HLTrigReportService>()->setDatasetCounts(datasetCounts());
-    edm::Service<HLTrigReportService>()->setStreamCounts(streamCounts());
+    dumpReport(accumulate_, "Summary for Job");
+  if (serviceBy_ == EVERY_JOB) {
+    updateService(accumulate_);
   }
 }
 
@@ -302,32 +333,16 @@ void HLTrigReport::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
   if (hltConfig_.init(iRun, iSetup, hlTriggerResults_.process(), changed)) {
     configured_ = true;
     if (changed) {
-      dumpReport("Summary for this HLT table");
-      reset(true);
+      dumpReport(accumulate_, "Summary for this HLT table");
+      updateConfigCache();
+      accumulate_ = Accumulate(hlNames_.size(), hlIndex_, dsIndex_);
     }
   } else {
-    dumpReport("Summary for this HLT table");
+    dumpReport(accumulate_, "Summary for this HLT table");
     // cannot initialize the HLT menu - reset and clear all counters and tables
     configured_ = false;
-    nEvents_ = 0;
-    nWasRun_ = 0;
-    nAccept_ = 0;
-    nErrors_ = 0;
-    hlWasRun_.clear();
-    hltL1s_.clear();
-    hltPre_.clear();
-    hlAccept_.clear();
-    hlAccTot_.clear();
-    hlErrors_.clear();
-    posL1s_.clear();
-    posPre_.clear();
-    hlNames_.clear();
-    hlIndex_.clear();
-    hlAccTotDS_.clear();
-    hlAllTotDS_.clear();
-    dsIndex_.clear();
-    dsAccTotS_.clear();
-    dsAllTotS_.clear();
+
+    accumulate_ = hltrigreport::Accumulate();
   }
 
   if (resetBy_ == EVERY_RUN)
@@ -338,28 +353,53 @@ void HLTrigReport::endRun(edm::Run const& run, edm::EventSetup const& setup) {
   if (reportBy_ == EVERY_RUN) {
     std::stringstream stream;
     stream << "Summary for Run " << run.run();
-    dumpReport(stream.str());
+    dumpReport(accumulate_, stream.str());
   }
-  if (serviceBy_ == EVERY_RUN and edm::Service<HLTrigReportService>()) {
-    edm::Service<HLTrigReportService>()->setDatasetCounts(datasetCounts());
-    edm::Service<HLTrigReportService>()->setStreamCounts(streamCounts());
+  if (serviceBy_ == EVERY_RUN) {
+    updateService(accumulate_);
   }
 }
 
-void HLTrigReport::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
-  if (resetBy_ == EVERY_LUMI)
-    reset();
+std::shared_ptr<HLTrigReport::Accumulate> HLTrigReport::globalBeginLuminosityBlock(edm::LuminosityBlock const& lumi,
+                                                                                   edm::EventSetup const& setup) const {
+  if (useLumiCache()) {
+    if (not configured_) {
+      return std::make_shared<Accumulate>();
+    }
+    return std::make_shared<Accumulate>(hlNames_.size(), hlIndex_, dsIndex_);
+  }
+  return std::shared_ptr<Accumulate>();
 }
 
-void HLTrigReport::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
+void HLTrigReport::globalEndLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
+  if (not useLumiCache()) {
+    return;
+  }
+
+  if (resetBy_ == EVERY_LUMI and readAfterLumi()) {
+    //we will be reporting the last processed lumi
+    accumulate_ = std::move(*luminosityBlockCache(lumi.index()));
+  } else if (resetBy_ == NEVER or resetBy_ == EVERY_RUN or resetBy_ == EVERY_JOB or readAfterLumi()) {
+    //we need to add this lumi's info to the longer lived accumulation
+    accumulate_.accumulate(*luminosityBlockCache(lumi.index()));
+  }
+
   if (reportBy_ == EVERY_LUMI) {
     std::stringstream stream;
     stream << "Summary for Run " << lumi.run() << ", LumiSection " << lumi.luminosityBlock();
-    dumpReport(stream.str());
+    if (resetBy_ == EVERY_LUMI or resetBy_ == EVERY_EVENT) {
+      dumpReport(*luminosityBlockCache(lumi.index()), stream.str());
+    } else {
+      dumpReport(accumulate_, stream.str());
+    }
   }
-  if (serviceBy_ == EVERY_LUMI and edm::Service<HLTrigReportService>()) {
-    edm::Service<HLTrigReportService>()->setDatasetCounts(datasetCounts());
-    edm::Service<HLTrigReportService>()->setStreamCounts(streamCounts());
+
+  if (serviceBy_ == EVERY_LUMI) {
+    if (resetBy_ == EVERY_LUMI or resetBy_ == EVERY_EVENT) {
+      updateService(*luminosityBlockCache(lumi.index()));
+    } else {
+      updateService(accumulate_);
+    }
   }
 }
 
@@ -370,26 +410,30 @@ void HLTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   using namespace std;
   using namespace edm;
 
-  if (resetBy_ == EVERY_EVENT)
-    reset();
+  auto& accumulate = chooseAccumulate(iEvent.getLuminosityBlock().index());
+  if (resetBy_ == EVERY_EVENT) {
+    //NOTE if we have reportBy == lumi/run/job then we will report the last
+    // event in each lumi/run/job
+    accumulate.reset();
+  }
 
-  nEvents_++;
+  accumulate.nEvents_++;
 
   // get hold of TriggerResults
   Handle<TriggerResults> HLTR;
   iEvent.getByToken(hlTriggerResultsToken_, HLTR);
   if (HLTR.isValid()) {
     if (HLTR->wasrun())
-      nWasRun_++;
+      accumulate.nWasRun_++;
     const bool accept(HLTR->accept());
     LogDebug("HLTrigReport") << "HLT TriggerResults decision: " << accept;
     if (accept)
-      ++nAccept_;
+      ++accumulate.nAccept_;
     if (HLTR->error())
-      nErrors_++;
+      accumulate.nErrors_++;
   } else {
     LogDebug("HLTrigReport") << "HLT TriggerResults with label [" + hlTriggerResults_.encode() + "] not found!";
-    nErrors_++;
+    accumulate.nErrors_++;
     return;
   }
 
@@ -402,26 +446,26 @@ void HLTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   bool acceptedByPrevoiusPaths = false;
   for (unsigned int i = 0; i != n; ++i) {
     if (HLTR->wasrun(i))
-      hlWasRun_[i]++;
+      accumulate.hlWasRun_[i]++;
     if (HLTR->accept(i)) {
       acceptedByPrevoiusPaths = true;
-      hlAccept_[i]++;
+      accumulate.hlAccept_[i]++;
     }
     if (acceptedByPrevoiusPaths)
-      hlAccTot_[i]++;
+      accumulate.hlAccTot_[i]++;
     if (HLTR->error(i))
-      hlErrors_[i]++;
+      accumulate.hlErrors_[i]++;
     const int index(static_cast<int>(HLTR->index(i)));
     if (HLTR->accept(i)) {
       if (index >= posL1s_[i])
-        hltL1s_[i]++;
+        accumulate.hltL1s_[i]++;
       if (index >= posPre_[i])
-        hltPre_[i]++;
+        accumulate.hltPre_[i]++;
     } else {
       if (index > posL1s_[i])
-        hltL1s_[i]++;
+        accumulate.hltL1s_[i]++;
       if (index > posPre_[i])
-        hltPre_[i]++;
+        accumulate.hltPre_[i]++;
     }
   }
 
@@ -431,11 +475,11 @@ void HLTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     for (size_t p = 0; p < hlIndex_[ds].size(); ++p) {
       if (acceptedByDS[ds] or HLTR->accept(hlIndex_[ds][p])) {
         acceptedByDS[ds] = true;
-        hlAccTotDS_[ds][p]++;
+        accumulate.hlAccTotDS_[ds][p]++;
       }
     }
     if (acceptedByDS[ds])
-      hlAllTotDS_[ds]++;
+      accumulate.hlAllTotDS_[ds]++;
   }
 
   // calculate accumulation of accepted events by a dataset within a stream
@@ -444,33 +488,41 @@ void HLTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     for (size_t ds = 0; ds < dsIndex_[s].size(); ++ds) {
       if (acceptedByS or acceptedByDS[dsIndex_[s][ds]]) {
         acceptedByS = true;
-        dsAccTotS_[s][ds]++;
+        accumulate.dsAccTotS_[s][ds]++;
       }
     }
     if (acceptedByS)
-      dsAllTotS_[s]++;
+      accumulate.dsAllTotS_[s]++;
   }
 
   if (reportBy_ == EVERY_EVENT) {
     std::stringstream stream;
     stream << "Summary for Run " << iEvent.run() << ", LumiSection " << iEvent.luminosityBlock() << ", Event "
            << iEvent.id();
-    dumpReport(stream.str());
+    dumpReport(accumulate, stream.str());
   }
-  if (serviceBy_ == EVERY_EVENT and edm::Service<HLTrigReportService>()) {
-    edm::Service<HLTrigReportService>()->setDatasetCounts(datasetCounts());
-    edm::Service<HLTrigReportService>()->setStreamCounts(streamCounts());
+  if (serviceBy_ == EVERY_EVENT) {
+    updateService(accumulate);
   }
 }
 
-void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
+void HLTrigReport::updateService(Accumulate const& accumulate) const {
+  edm::Service<HLTrigReportService> s;
+  if (s) {
+    s->setDatasetCounts(accumulate.hlAllTotDS_);
+    s->setStreamCounts(accumulate.dsAllTotS_);
+  }
+}
+
+void HLTrigReport::dumpReport(hltrigreport::Accumulate const& accumulate,
+                              std::string const& header /* = std::string() */) const {
   // final printout of accumulated statistics
 
   using namespace std;
   using namespace edm;
   const unsigned int n(hlNames_.size());
 
-  if ((n == 0) and (nEvents_ == 0))
+  if ((n == 0) and (accumulate.nEvents_ == 0))
     return;
 
   LogVerbatim("HLTrigReport") << dec << endl;
@@ -479,14 +531,14 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
   if (not header.empty())
     LogVerbatim("HLTrigReport") << "HLT-Report " << header << endl;
   LogVerbatim("HLTrigReport") << "HLT-Report"
-                              << " Events total = " << nEvents_ << " wasrun = " << nWasRun_ << " passed = " << nAccept_
-                              << " errors = " << nErrors_ << endl;
+                              << " Events total = " << accumulate.nEvents_ << " wasrun = " << accumulate.nWasRun_
+                              << " passed = " << accumulate.nAccept_ << " errors = " << accumulate.nErrors_ << endl;
 
   // HLTConfigProvider not configured - cannot produce any detailed statistics
   if (not configured_)
     return;
 
-  double scale = hlAccept_[refIndex_] > 0 ? refRate_ / hlAccept_[refIndex_] : 0.;
+  double scale = accumulate.hlAccept_[refIndex_] > 0 ? refRate_ / accumulate.hlAccept_[refIndex_] : 0.;
   double alpha = 1 - (1.0 - .6854) / 2;  // for the Clopper-Pearson 68% CI
 
   LogVerbatim("HLTrigReport") << endl;
@@ -506,18 +558,19 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
 
   if (n > 0) {
     for (unsigned int i = 0; i != n; ++i) {
-      LogVerbatim("HLTrigReport") << "HLT-Report " << right << setw(7) << i << " " << right << setw(7) << hlWasRun_[i]
-                                  << " " << right << setw(7) << hltL1s_[i] << " " << right << setw(7) << hltPre_[i]
-                                  << " " << right << setw(7) << hlAccept_[i] << " " << right << setw(9) << fixed
-                                  << setprecision(5)
-                                  << static_cast<float>(100 * hlAccept_[i]) / static_cast<float>(max(hltPre_[i], 1u))
-                                  << " " << right << setw(7) << fixed << setprecision(1) << scale * hlAccept_[i] << " "
-                                  << right << setw(7) << fixed << setprecision(1)
-                                  << ((hlAccept_[refIndex_] - hlAccept_[i] > 0)
-                                          ? refRate_ * ROOT::Math::beta_quantile(
-                                                           alpha, hlAccept_[i] + 1, hlAccept_[refIndex_] - hlAccept_[i])
-                                          : 0)
-                                  << " " << right << setw(7) << hlErrors_[i] << " " << hlNames_[i] << endl;
+      LogVerbatim("HLTrigReport")
+          << "HLT-Report " << right << setw(7) << i << " " << right << setw(7) << accumulate.hlWasRun_[i] << " "
+          << right << setw(7) << accumulate.hltL1s_[i] << " " << right << setw(7) << accumulate.hltPre_[i] << " "
+          << right << setw(7) << accumulate.hlAccept_[i] << " " << right << setw(9) << fixed << setprecision(5)
+          << static_cast<float>(100 * accumulate.hlAccept_[i]) / static_cast<float>(max(accumulate.hltPre_[i], 1u))
+          << " " << right << setw(7) << fixed << setprecision(1) << scale * accumulate.hlAccept_[i] << " " << right
+          << setw(7) << fixed << setprecision(1)
+          << ((accumulate.hlAccept_[refIndex_] - accumulate.hlAccept_[i] > 0)
+                  ? refRate_ * ROOT::Math::beta_quantile(alpha,
+                                                         accumulate.hlAccept_[i] + 1,
+                                                         accumulate.hlAccept_[refIndex_] - accumulate.hlAccept_[i])
+                  : 0)
+          << " " << right << setw(7) << accumulate.hlErrors_[i] << " " << hlNames_[i] << endl;
     }
   }
 
@@ -541,16 +594,20 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
   if (n > 0) {
     for (unsigned int i = 0; i != n; ++i) {
       LogVerbatim("HLTrigRprtTt")
-          << "HLT-Report " << right << setw(7) << i << " " << right << setw(7) << hlWasRun_[i] << " " << right
-          << setw(7) << hltL1s_[i] << " " << right << setw(7) << hltPre_[i] << " " << right << setw(7) << hlAccept_[i]
-          << " " << right << setw(9) << fixed << setprecision(5)
-          << static_cast<float>(100 * hlAccept_[i]) / static_cast<float>(max(hltPre_[i], 1u)) << " " << right << setw(7)
-          << fixed << setprecision(1) << scale * hlAccept_[i] << " " << right << setw(7) << fixed << setprecision(1)
-          << ((hlAccept_[refIndex_] - hlAccept_[i] > 0)
-                  ? refRate_ * ROOT::Math::beta_quantile(alpha, hlAccept_[i] + 1, hlAccept_[refIndex_] - hlAccept_[i])
+          << "HLT-Report " << right << setw(7) << i << " " << right << setw(7) << accumulate.hlWasRun_[i] << " "
+          << right << setw(7) << accumulate.hltL1s_[i] << " " << right << setw(7) << accumulate.hltPre_[i] << " "
+          << right << setw(7) << accumulate.hlAccept_[i] << " " << right << setw(9) << fixed << setprecision(5)
+          << static_cast<float>(100 * accumulate.hlAccept_[i]) / static_cast<float>(max(accumulate.hltPre_[i], 1u))
+          << " " << right << setw(7) << fixed << setprecision(1) << scale * accumulate.hlAccept_[i] << " " << right
+          << setw(7) << fixed << setprecision(1)
+          << ((accumulate.hlAccept_[refIndex_] - accumulate.hlAccept_[i] > 0)
+                  ? refRate_ * ROOT::Math::beta_quantile(alpha,
+                                                         accumulate.hlAccept_[i] + 1,
+                                                         accumulate.hlAccept_[refIndex_] - accumulate.hlAccept_[i])
                   : 0)
-          << " " << right << setw(7) << hlAccTot_[i] << " " << right << setw(7) << fixed << setprecision(1)
-          << scale * hlAccTot_[i] << " " << right << setw(7) << hlErrors_[i] << " " << hlNames_[i] << endl;
+          << " " << right << setw(7) << accumulate.hlAccTot_[i] << " " << right << setw(7) << fixed << setprecision(1)
+          << scale * accumulate.hlAccTot_[i] << " " << right << setw(7) << accumulate.hlErrors_[i] << " " << hlNames_[i]
+          << endl;
     }
 
     // now for each dataset
@@ -558,7 +615,7 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
       LogVerbatim("HLTrigRprtPD") << endl;
       LogVerbatim("HLTrigRprtPD") << "HLT-Report "
                                   << "---------- Dataset Summary: " << datasetNames_[ds] << " ------------"
-                                  << hlAllTotDS_[ds] << endl;
+                                  << accumulate.hlAllTotDS_[ds] << endl;
       LogVerbatim("HLTrigRprtPD") << "HLT-Report " << right << setw(7) << "HLT #"
                                   << " " << right << setw(7) << "WasRun"
                                   << " " << right << setw(7) << "L1S"
@@ -573,24 +630,24 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
                                   << " "
                                   << "Name" << endl;
       for (size_t p = 0; p < hlIndex_[ds].size(); ++p) {
-        LogVerbatim("HLTrigRprtPD") << "HLT-Report " << right << setw(7) << p << " " << right << setw(7)
-                                    << hlWasRun_[hlIndex_[ds][p]] << " " << right << setw(7) << hltL1s_[hlIndex_[ds][p]]
-                                    << " " << right << setw(7) << hltPre_[hlIndex_[ds][p]] << " " << right << setw(7)
-                                    << hlAccept_[hlIndex_[ds][p]] << " " << right << setw(9) << fixed << setprecision(5)
-                                    << static_cast<float>(100 * hlAccept_[hlIndex_[ds][p]]) /
-                                           static_cast<float>(max(hltPre_[hlIndex_[ds][p]], 1u))
-                                    << " " << right << setw(7) << fixed << setprecision(1)
-                                    << scale * hlAccept_[hlIndex_[ds][p]] << " " << right << setw(7) << fixed
-                                    << setprecision(1)
-                                    << ((hlAccept_[refIndex_] - hlAccept_[hlIndex_[ds][p]] > 0)
-                                            ? refRate_ * ROOT::Math::beta_quantile(
-                                                             alpha,
-                                                             hlAccept_[hlIndex_[ds][p]] + 1,
-                                                             hlAccept_[refIndex_] - hlAccept_[hlIndex_[ds][p]])
-                                            : 0)
-                                    << " " << right << setw(7) << hlAccTotDS_[ds][p] << " " << right << setw(7) << fixed
-                                    << setprecision(1) << scale * hlAccTotDS_[ds][p] << " " << right << setw(7)
-                                    << hlErrors_[hlIndex_[ds][p]] << " " << hlNames_[hlIndex_[ds][p]] << endl;
+        LogVerbatim("HLTrigRprtPD")
+            << "HLT-Report " << right << setw(7) << p << " " << right << setw(7)
+            << accumulate.hlWasRun_[hlIndex_[ds][p]] << " " << right << setw(7) << accumulate.hltL1s_[hlIndex_[ds][p]]
+            << " " << right << setw(7) << accumulate.hltPre_[hlIndex_[ds][p]] << " " << right << setw(7)
+            << accumulate.hlAccept_[hlIndex_[ds][p]] << " " << right << setw(9) << fixed << setprecision(5)
+            << static_cast<float>(100 * accumulate.hlAccept_[hlIndex_[ds][p]]) /
+                   static_cast<float>(max(accumulate.hltPre_[hlIndex_[ds][p]], 1u))
+            << " " << right << setw(7) << fixed << setprecision(1) << scale * accumulate.hlAccept_[hlIndex_[ds][p]]
+            << " " << right << setw(7) << fixed << setprecision(1)
+            << ((accumulate.hlAccept_[refIndex_] - accumulate.hlAccept_[hlIndex_[ds][p]] > 0)
+                    ? refRate_ * ROOT::Math::beta_quantile(
+                                     alpha,
+                                     accumulate.hlAccept_[hlIndex_[ds][p]] + 1,
+                                     accumulate.hlAccept_[refIndex_] - accumulate.hlAccept_[hlIndex_[ds][p]])
+                    : 0)
+            << " " << right << setw(7) << accumulate.hlAccTotDS_[ds][p] << " " << right << setw(7) << fixed
+            << setprecision(1) << scale * accumulate.hlAccTotDS_[ds][p] << " " << right << setw(7)
+            << accumulate.hlErrors_[hlIndex_[ds][p]] << " " << hlNames_[hlIndex_[ds][p]] << endl;
       }
     }
 
@@ -599,7 +656,7 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
       LogVerbatim("HLTrigRprtST") << endl;
       LogVerbatim("HLTrigRprtST") << "HLT-Report "
                                   << "---------- Stream Summary: " << streamNames_[s] << " ------------"
-                                  << dsAllTotS_[s] << endl;
+                                  << accumulate.dsAllTotS_[s] << endl;
       LogVerbatim("HLTrigRprtST") << "HLT-Report " << right << setw(10) << "Dataset #"
                                   << " " << right << setw(10) << "Individual"
                                   << " " << right << setw(10) << "Total"
@@ -609,17 +666,17 @@ void HLTrigReport::dumpReport(std::string const& header /* = std::string() */) {
                                   << " "
                                   << "Name" << endl;
       for (size_t ds = 0; ds < dsIndex_[s].size(); ++ds) {
-        unsigned int acceptedDS = hlAccTotDS_[dsIndex_[s][ds]][hlIndex_[dsIndex_[s][ds]].size() - 1];
-        LogVerbatim("HLTrigRprtST") << "HLT-Report " << right << setw(10) << ds << " " << right << setw(10)
-                                    << acceptedDS << " " << right << setw(10) << dsAccTotS_[s][ds] << " " << right
-                                    << setw(10) << fixed << setprecision(1) << scale * acceptedDS << " " << right
-                                    << setw(10) << fixed << setprecision(1)
-                                    << ((hlAccept_[refIndex_] - acceptedDS > 0)
-                                            ? refRate_ * ROOT::Math::beta_quantile(
-                                                             alpha, acceptedDS + 1, hlAccept_[refIndex_] - acceptedDS)
-                                            : 0)
-                                    << " " << right << setw(10) << fixed << setprecision(1) << scale * dsAccTotS_[s][ds]
-                                    << " " << datasetNames_[dsIndex_[s][ds]] << endl;
+        unsigned int acceptedDS = accumulate.hlAccTotDS_[dsIndex_[s][ds]][hlIndex_[dsIndex_[s][ds]].size() - 1];
+        LogVerbatim("HLTrigRprtST")
+            << "HLT-Report " << right << setw(10) << ds << " " << right << setw(10) << acceptedDS << " " << right
+            << setw(10) << accumulate.dsAccTotS_[s][ds] << " " << right << setw(10) << fixed << setprecision(1)
+            << scale * acceptedDS << " " << right << setw(10) << fixed << setprecision(1)
+            << ((accumulate.hlAccept_[refIndex_] - acceptedDS > 0)
+                    ? refRate_ *
+                          ROOT::Math::beta_quantile(alpha, acceptedDS + 1, accumulate.hlAccept_[refIndex_] - acceptedDS)
+                    : 0)
+            << " " << right << setw(10) << fixed << setprecision(1) << scale * accumulate.dsAccTotS_[s][ds] << " "
+            << datasetNames_[dsIndex_[s][ds]] << endl;
       }
     }
 

--- a/HLTrigger/HLTanalyzers/plugins/HLTrigReport.h
+++ b/HLTrigger/HLTanalyzers/plugins/HLTrigReport.h
@@ -28,11 +28,46 @@
 // class declaration
 //
 
-class HLTrigReport : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+namespace hltrigreport {
+  struct Accumulate {
+    Accumulate();
+    Accumulate(size_t numHLNames,
+               std::vector<std::vector<unsigned int>> const& hlIndex,
+               std::vector<std::vector<unsigned int>> const& dsIndex);
+
+    unsigned int nEvents_;  // number of events processed
+    unsigned int nWasRun_;  // # where at least one HLT was run
+    unsigned int nAccept_;  // # of accepted events
+    unsigned int nErrors_;  // # where at least one HLT had error
+
+    std::vector<unsigned int> hlWasRun_;  // # where HLT[i] was run
+    std::vector<unsigned int> hltL1s_;    // # of events after L1 seed
+    std::vector<unsigned int> hltPre_;    // # of events after HLT prescale
+    std::vector<unsigned int> hlAccept_;  // # of events accepted by HLT[i]
+    std::vector<unsigned int> hlAccTot_;  // # of events accepted by HLT[0] OR ... OR HLT[i]
+    std::vector<unsigned int> hlErrors_;  // # of events with error in HLT[i]
+
+    std::vector<std::vector<unsigned int>>
+        hlAccTotDS_;  // hlAccTotDS_[ds][p] stores the # of accepted events by the 0-th to p-th paths in the ds-th dataset
+    std::vector<unsigned int> hlAllTotDS_;  // hlAllTotDS_[ds] stores the # of accepted events in the ds-th dataset
+    std::vector<std::vector<unsigned int>>
+        dsAccTotS_;  // dsAccTotS_[s][ds] stores the # of accepted events by the 0-th to ds-th dataset in the s-th stream
+    std::vector<unsigned int> dsAllTotS_;  // dsAllTotS_[s] stores the # of accepted events in the s-th stream
+
+    void accumulate(Accumulate const&);
+    void reset();
+  };
+
+}  // namespace hltrigreport
+
+class HLTrigReport
+    : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::LuminosityBlockCache<hltrigreport::Accumulate>> {
 private:
   enum ReportEvery { NEVER = 0, EVERY_EVENT = 1, EVERY_LUMI = 2, EVERY_RUN = 3, EVERY_JOB = 4 };
 
 public:
+  using Accumulate = hltrigreport::Accumulate;
+
   explicit HLTrigReport(const edm::ParameterSet&);
   ~HLTrigReport() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -45,66 +80,65 @@ public:
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override;
 
-  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  std::shared_ptr<Accumulate> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                         edm::EventSetup const&) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-
-  void reset(bool changed = false);  // reset all counters
 
   // names and event counts
   const std::vector<std::string>& streamNames() const;
   const std::vector<std::string>& datasetNames() const;
-  const std::vector<unsigned int>& streamCounts() const;
-  const std::vector<unsigned int>& datasetCounts() const;
 
 private:
-  void dumpReport(std::string const& header = std::string());
+  void reset();  // reset all counters
 
-  edm::InputTag hlTriggerResults_;  // Input tag for TriggerResults
-  edm::EDGetTokenT<edm::TriggerResults> hlTriggerResultsToken_;
+  hltrigreport::Accumulate& chooseAccumulate(edm::LuminosityBlockIndex index) {
+    if (useLumiCache()) {
+      return *luminosityBlockCache(index);
+    }
+    return accumulate_;
+  }
+  bool useLumiCache() const { return reportBy_ == EVERY_LUMI or serviceBy_ == EVERY_LUMI or resetBy_ == EVERY_LUMI; }
+  bool readAfterLumi() const {
+    return (reportBy_ == EVERY_RUN or reportBy_ == EVERY_JOB or serviceBy_ == EVERY_RUN or serviceBy_ == EVERY_JOB);
+  }
+
+  void updateConfigCache();
+
+  void dumpReport(hltrigreport::Accumulate const& accumulate, std::string const& header = std::string()) const;
+  void updateService(Accumulate const& accumulate) const;
+
+  const edm::InputTag hlTriggerResults_;  // Input tag for TriggerResults
+  const edm::EDGetTokenT<edm::TriggerResults> hlTriggerResultsToken_;
   bool configured_;  // is HLTConfigProvider configured ?
 
-  unsigned int nEvents_;  // number of events processed
-  unsigned int nWasRun_;  // # where at least one HLT was run
-  unsigned int nAccept_;  // # of accepted events
-  unsigned int nErrors_;  // # where at least one HLT had error
-
-  std::vector<unsigned int> hlWasRun_;  // # where HLT[i] was run
-  std::vector<unsigned int> hltL1s_;    // # of events after L1 seed
-  std::vector<unsigned int> hltPre_;    // # of events after HLT prescale
-  std::vector<unsigned int> hlAccept_;  // # of events accepted by HLT[i]
-  std::vector<unsigned int> hlAccTot_;  // # of events accepted by HLT[0] OR ... OR HLT[i]
-  std::vector<unsigned int> hlErrors_;  // # of events with error in HLT[i]
-
-  std::vector<int> posL1s_;           // pos # of last L1 seed
-  std::vector<int> posPre_;           // pos # of last HLT prescale
   std::vector<std::string> hlNames_;  // name of each HLT algorithm
 
-  std::vector<std::vector<unsigned int> >
+  std::vector<std::vector<unsigned int>>
       hlIndex_;  // hlIndex_[ds][p] stores the hlNames_ index of the p-th path of the ds-th dataset
-  std::vector<std::vector<unsigned int> >
-      hlAccTotDS_;  // hlAccTotDS_[ds][p] stores the # of accepted events by the 0-th to p-th paths in the ds-th dataset
-  std::vector<unsigned int> hlAllTotDS_;   // hlAllTotDS_[ds] stores the # of accepted events in the ds-th dataset
-  std::vector<std::string> datasetNames_;  // list of dataset names
-  std::vector<std::vector<std::string> > datasetContents_;  // list of path names for each dataset
+
+  std::vector<int> posL1s_;  // pos # of last L1 seed
+  std::vector<int> posPre_;  // pos # of last HLT prescale
+
+  std::vector<std::string> datasetNames_;                  // list of dataset names
+  std::vector<std::vector<std::string>> datasetContents_;  // list of path names for each dataset
   bool isCustomDatasets_;  // true if the user overwrote the dataset definitions of the provenance with the CustomDatasets parameter
-  std::vector<std::vector<unsigned int> >
+  std::vector<std::vector<unsigned int>>
       dsIndex_;  // dsIndex_[s][ds] stores the datasetNames_ index of the ds-th dataset of the s-th stream
-  std::vector<std::vector<unsigned int> >
-      dsAccTotS_;  // dsAccTotS_[s][ds] stores the # of accepted events by the 0-th to ds-th dataset in the s-th stream
-  std::vector<unsigned int> dsAllTotS_;   // dsAllTotS_[s] stores the # of accepted events in the s-th stream
-  std::vector<std::string> streamNames_;  // list of stream names
-  std::vector<std::vector<std::string> > streamContents_;  // list of dataset names for each stream
+  std::vector<std::string> streamNames_;                  // list of stream names
+  std::vector<std::vector<std::string>> streamContents_;  // list of dataset names for each stream
   bool isCustomStreams_;  // true if the user overwrote the stream definitions of the provenance with the CustomSterams parameter
   std::string refPath_;    // name of the reference path for rate calculation
   unsigned int refIndex_;  // index of the reference path for rate calculation
-  double refRate_;         // rate of the reference path, the rate of all other paths will be normalized to this
+  const double refRate_;   // rate of the reference path, the rate of all other paths will be normalized to this
 
   const ReportEvery reportBy_;   // dump report for every never/event/lumi/run/job
   const ReportEvery resetBy_;    // reset counters  every never/event/lumi/run/job
   const ReportEvery serviceBy_;  // call to service every never/event/lumi/run/job
   HLTConfigProvider hltConfig_;  // to get configuration for L1s/Pre
+
+  hltrigreport::Accumulate accumulate_;
 };
 
 #endif  //HLTrigReport_h

--- a/HLTrigger/HLTanalyzers/test/BuildFile.xml
+++ b/HLTrigger/HLTanalyzers/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <bin   file="TestHLTrigReport.cpp" name="TestHLTrigReport">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash HLTrigger/HLTanalyzers/test test_hltrigreport.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/HLTrigger/HLTanalyzers/test/TestHLTrigReport.cpp
+++ b/HLTrigger/HLTanalyzers/test/TestHLTrigReport.cpp
@@ -1,0 +1,3 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+
+RUNTEST()

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/event_event.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/event_event.log
@@ -1,0 +1,90 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 2
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       1       1       1       1 100.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 3
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 4
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 2
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 3
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 4
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 2
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/event_job.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/event_job.log
@@ -1,0 +1,9 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Job
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/event_lumi.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/event_lumi.log
@@ -1,0 +1,45 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       1       1       1       1 100.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/event_run.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/event_run.log
@@ -1,0 +1,27 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_event.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_event.log
@@ -1,0 +1,90 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       2       2       2       1  50.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 3
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 4
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 3
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 4
+HLT-Report Events total = 2 wasrun = 2 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_job.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_job.log
@@ -1,0 +1,9 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Job
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_lumi.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_lumi.log
@@ -1,0 +1,45 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       2       2       2       1  50.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2
+HLT-Report Events total = 2 wasrun = 2 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_run.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/lumi_run.log
@@ -1,0 +1,27 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2
+HLT-Report Events total = 2 wasrun = 2 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/never_event.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/never_event.log
@@ -1,0 +1,90 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       2       2       2       1  50.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 3
+HLT-Report Events total = 3 wasrun = 3 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       3       3       3       2  66.66666   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       3       3       3       1  33.33333    50.0    91.8       0 p1
+HLT-Report       2       3       3       3       1  33.33333    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 4
+HLT-Report Events total = 4 wasrun = 4 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       2  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000    50.0    91.8       0 p1
+HLT-Report       2       4       4       4       1  25.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 1
+HLT-Report Events total = 5 wasrun = 5 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       5       5       5       2  40.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       5       5       5       1  20.00000    50.0    91.8       0 p1
+HLT-Report       2       5       5       5       1  20.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 2
+HLT-Report Events total = 6 wasrun = 6 passed = 3 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       6       6       6       3  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       6       6       6       2  33.33333    66.7    94.5       0 p1
+HLT-Report       2       6       6       6       1  16.66667    33.3    74.9       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 3
+HLT-Report Events total = 7 wasrun = 7 passed = 3 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       7       7       7       3  42.85714   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       7       7       7       2  28.57143    66.7    94.5       0 p1
+HLT-Report       2       7       7       7       1  14.28571    33.3    74.9       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 4
+HLT-Report Events total = 8 wasrun = 8 passed = 3 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       8       8       8       3  37.50000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       8       8       8       2  25.00000    66.7    94.5       0 p1
+HLT-Report       2       8       8       8       1  12.50000    33.3    74.9       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 1
+HLT-Report Events total = 9 wasrun = 9 passed = 4 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       9       9       9       4  44.44444   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       9       9       9       3  33.33333    75.0    95.8       0 p1
+HLT-Report       2       9       9       9       1  11.11111    25.0    62.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 2
+HLT-Report Events total = 10 wasrun = 10 passed = 4 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0      10      10      10       4  40.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1      10      10      10       3  30.00000    75.0    95.8       0 p1
+HLT-Report       2      10      10      10       1  10.00000    25.0    62.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/never_job.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/never_job.log
@@ -1,0 +1,9 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Job
+HLT-Report Events total = 10 wasrun = 10 passed = 4 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0      10      10      10       4  40.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1      10      10      10       3  30.00000    75.0    95.8       0 p1
+HLT-Report       2      10      10      10       1  10.00000    25.0    62.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/never_lumi.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/never_lumi.log
@@ -1,0 +1,45 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       2       2       2       1  50.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2
+HLT-Report Events total = 4 wasrun = 4 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       2  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000    50.0    91.8       0 p1
+HLT-Report       2       4       4       4       1  25.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1
+HLT-Report Events total = 6 wasrun = 6 passed = 3 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       6       6       6       3  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       6       6       6       2  33.33333    66.7    94.5       0 p1
+HLT-Report       2       6       6       6       1  16.66667    33.3    74.9       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2
+HLT-Report Events total = 8 wasrun = 8 passed = 3 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       8       8       8       3  37.50000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       8       8       8       2  25.00000    66.7    94.5       0 p1
+HLT-Report       2       8       8       8       1  12.50000    33.3    74.9       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1
+HLT-Report Events total = 10 wasrun = 10 passed = 4 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0      10      10      10       4  40.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1      10      10      10       3  30.00000    75.0    95.8       0 p1
+HLT-Report       2      10      10      10       1  10.00000    25.0    62.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/never_run.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/never_run.log
@@ -1,0 +1,27 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1
+HLT-Report Events total = 4 wasrun = 4 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       2  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000    50.0    91.8       0 p1
+HLT-Report       2       4       4       4       1  25.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2
+HLT-Report Events total = 8 wasrun = 8 passed = 3 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       8       8       8       3  37.50000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       8       8       8       2  25.00000    66.7    94.5       0 p1
+HLT-Report       2       8       8       8       1  12.50000    33.3    74.9       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3
+HLT-Report Events total = 10 wasrun = 10 passed = 4 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0      10      10      10       4  40.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1      10      10      10       3  30.00000    75.0    95.8       0 p1
+HLT-Report       2      10      10      10       1  10.00000    25.0    62.0       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/run_event.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/run_event.log
@@ -1,0 +1,90 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1, Event run: 1 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       2       2       2       1  50.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 3
+HLT-Report Events total = 3 wasrun = 3 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       3       3       3       2  66.66666   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       3       3       3       1  33.33333    50.0    91.8       0 p1
+HLT-Report       2       3       3       3       1  33.33333    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2, Event run: 1 lumi: 2 event: 4
+HLT-Report Events total = 4 wasrun = 4 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       2  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000    50.0    91.8       0 p1
+HLT-Report       2       4       4       4       1  25.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 0 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       0   0.00000     0.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       0   0.00000     0.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1, Event run: 2 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 3
+HLT-Report Events total = 3 wasrun = 3 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       3       3       3       1  33.33333   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       3       3       3       1  33.33333   100.0     0.0       0 p1
+HLT-Report       2       3       3       3       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2, Event run: 2 lumi: 2 event: 4
+HLT-Report Events total = 4 wasrun = 4 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       1  25.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000   100.0     0.0       0 p1
+HLT-Report       2       4       4       4       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 1
+HLT-Report Events total = 1 wasrun = 1 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       1       1       1       1 100.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       1       1       1       1 100.00000   100.0     0.0       0 p1
+HLT-Report       2       1       1       1       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1, Event run: 3 lumi: 1 event: 2
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/run_job.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/run_job.log
@@ -1,0 +1,9 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Job
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/run_lumi.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/run_lumi.log
@@ -1,0 +1,45 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       0   0.00000     0.0    84.3       0 p1
+HLT-Report       2       2       2       2       1  50.00000   100.0     0.0       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1, LumiSection 2
+HLT-Report Events total = 4 wasrun = 4 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       2  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000    50.0    91.8       0 p1
+HLT-Report       2       4       4       4       1  25.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2, LumiSection 2
+HLT-Report Events total = 4 wasrun = 4 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       1  25.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000   100.0     0.0       0 p1
+HLT-Report       2       4       4       4       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3, LumiSection 1
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/comparison_logs/run_run.log
+++ b/HLTrigger/HLTanalyzers/test/comparison_logs/run_run.log
@@ -1,0 +1,27 @@
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 1
+HLT-Report Events total = 4 wasrun = 4 passed = 2 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       2  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000    50.0    91.8       0 p1
+HLT-Report       2       4       4       4       1  25.00000    50.0    91.8       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 2
+HLT-Report Events total = 4 wasrun = 4 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       4       4       4       1  25.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       4       4       4       1  25.00000   100.0     0.0       0 p1
+HLT-Report       2       4       4       4       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!
+HLT-Report ---------- Event  Summary ------------
+HLT-Report Summary for Run 3
+HLT-Report Events total = 2 wasrun = 2 passed = 1 errors = 0
+HLT-Report ---------- HLTrig Summary ------------
+HLT-Report   HLT #  WasRun     L1S     Pre     HLT   %L1sPre    Rate  RateHi  Errors Name
+HLT-Report       0       2       2       2       1  50.00000   100.0     0.0       0 HLTriggerFinalPath
+HLT-Report       1       2       2       2       1  50.00000   100.0     0.0       0 p1
+HLT-Report       2       2       2       2       0   0.00000     0.0    84.3       0 p2
+HLT-Report end!

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport.sh
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+function die { echo $1: status $2; exit $2; }
+
+pushd ${LOCAL_TMP_DIR}
+cp ${LOCAL_TEST_DIR}/test_hltrigreport_base_cfg.py .
+
+echo reset:event report:event
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_event_event.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/event_event.log || die 'failed running cmsRun test_hltrigreport_event_event.py' $?
+
+echo reset:event report:lumi
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_event_lumi.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/event_lumi.log || die 'failed running cmsRun test_hltrigreport_event_lumi.py' $?
+
+echo reset:event report:run
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_event_run.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/event_run.log || die 'failed running cmsRun test_hltrigreport_event_run.py' $?
+
+echo reset:event report:job
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_event_job.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/event_job.log || die 'failed running cmsRun test_hltrigreport_event_job.py' $?
+
+echo reset:lumi report:event
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_lumi_event.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/lumi_event.log || die 'failed running cmsRun test_hltrigreport_lumi_event.py' $?
+
+echo reset:lumi report:lumi
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_lumi_lumi.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/lumi_lumi.log || die 'failed running cmsRun test_hltrigreport_lumi_lumi.py' $?
+
+echo reset:lumi report:run
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_lumi_run.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/lumi_run.log || die 'failed running cmsRun test_hltrigreport_lumi_run.py' $?
+
+echo reset:lumi report:job
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_lumi_job.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/lumi_job.log || die 'failed running cmsRun test_hltrigreport_lumi_job.py' $?
+
+echo reset:run report:event
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_run_event.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/run_event.log || die 'failed running cmsRun test_hltrigreport_run_event.py' $?
+
+echo reset:run report:lumi
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_run_lumi.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/run_lumi.log || die 'failed running cmsRun test_hltrigreport_run_lumi.py' $?
+
+echo reset:run report:run
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_run_run.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/run_run.log || die 'failed running cmsRun test_hltrigreport_run_run.py' $?
+
+echo reset:run report:job
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_run_job.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/run_job.log || die 'failed running cmsRun test_hltrigreport_run_job.py' $?
+
+echo reset:never report:event
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_never_event.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/never_event.log || die 'failed running cmsRun test_hltrigreport_never_event.py' $?
+
+echo reset:never report:lumi
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_never_lumi.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/never_lumi.log || die 'failed running cmsRun test_hltrigreport_never_lumi.py' $?
+
+echo reset:never report:run
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_never_run.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/never_run.log || die 'failed running cmsRun test_hltrigreport_never_run.py' $?
+
+
+echo reset:never report:job
+(cmsRun ${LOCAL_TEST_DIR}/test_hltrigreport_never_job.py 2>&1) | grep 'HLT-Report' | diff - ${LOCAL_TEST_DIR}/comparison_logs/never_job.log || die 'failed running cmsRun test_hltrigreport_never_job.py' $?
+
+popd

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_base_cfg.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_base_cfg.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLT")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 999999999
+process.MessageLogger.categories.append('HLTrigReport')
+
+process.options.wantSummary = False
+
+process.source = cms.Source("EmptySource",
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(2),
+                            numberEventsInRun = cms.untracked.uint32(4))
+
+process.maxEvents.input = 10
+
+process.f1 = cms.EDFilter("Prescaler", 
+                          prescaleFactor = cms.int32(3), 
+                          prescaleOffset = cms.int32(0) )
+
+process.f2 = cms.EDFilter("Prescaler",
+                          prescaleFactor = cms.int32(5), 
+                          prescaleOffset = cms.int32(2) )
+
+process.f3 = cms.EDFilter("Prescaler",
+                          prescaleFactor = cms.int32(2), 
+                          prescaleOffset = cms.int32(1) )
+
+process.pathFilter =cms.EDFilter("PathStatusFilter", logicalExpression = cms.string("p1 or p2"))
+process.HLTriggerFinalPath = cms.Path(process.pathFilter)
+
+process.p1 = cms.Path(process.f1)
+process.p2 = cms.Path(process.f2+process.f3)
+
+process.load( "HLTrigger.HLTanalyzers.hlTrigReport_cfi" )
+process.hlTrigReport.HLTriggerResults   = cms.InputTag("TriggerResults", "", "HLT")
+process.hlTrigReport.ReferencePath      = cms.untracked.string( "HLTriggerFinalPath" )
+process.hlTrigReport.ReferenceRate      = cms.untracked.double( 100.0 )
+process.hlTrigReport.reportBy        = "lumi"
+
+process.report = cms.EndPath( process.hlTrigReport )
+
+

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_event.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_event.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "event"
+process.hlTrigReport.reportBy = "event"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_job.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_job.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "event"
+process.hlTrigReport.reportBy = "job"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_lumi.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_lumi.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "event"
+process.hlTrigReport.reportBy = "lumi"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_run.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_event_run.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "event"
+process.hlTrigReport.reportBy = "run"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_event.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_event.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "lumi"
+process.hlTrigReport.reportBy = "event"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_job.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_job.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "lumi"
+process.hlTrigReport.reportBy = "job"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_lumi.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_lumi.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "lumi"
+process.hlTrigReport.reportBy = "lumi"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_run.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_lumi_run.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "lumi"
+process.hlTrigReport.reportBy = "run"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_event.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_event.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "never"
+process.hlTrigReport.reportBy = "event"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_job.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_job.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "never"
+process.hlTrigReport.reportBy = "job"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_lumi.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_lumi.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "never"
+process.hlTrigReport.reportBy = "lumi"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_run.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_never_run.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "never"
+process.hlTrigReport.reportBy = "run"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_event.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_event.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "run"
+process.hlTrigReport.reportBy = "event"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_job.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_job.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "run"
+process.hlTrigReport.reportBy = "job"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_lumi.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_lumi.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "run"
+process.hlTrigReport.reportBy = "lumi"

--- a/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_run.py
+++ b/HLTrigger/HLTanalyzers/test/test_hltrigreport_run_run.py
@@ -1,0 +1,4 @@
+from test_hltrigreport_base_cfg import process
+
+process.hlTrigReport.resetBy = "run"
+process.hlTrigReport.reportBy = "run"


### PR DESCRIPTION
#### PR description:
Switched to using a LuminosityBlockCache to allow HLTrigReport to not be sensitive to the ordering of completion of a LuminosityBlock. This allows concurrent LuminosityBlocks to be processed properly.

Support for concurrent Runs would require further work.

Added unit tests to be sure the behavior remains the same.

This change is needed to allow workflows containing this module to be able to use concurrent LuminosityBlocks. This includes the new workflow which is testing such concurrency, 1631.181.
#### PR validation:

The new unit test passes.