### PR TITLE
Explicitly define move related ReferenceCounted methods

### DIFF
--- a/DataFormats/GeometrySurface/interface/ReferenceCounted.h
+++ b/DataFormats/GeometrySurface/interface/ReferenceCounted.h
@@ -30,8 +30,8 @@ class BasicReferenceCounted {
 public:
   BasicReferenceCounted() : referenceCount_(0) {}
   BasicReferenceCounted(const BasicReferenceCounted& /* iRHS */) : referenceCount_(0) {}
-  BasicReferenceCounted(BasicReferenceCounted&&) = default;
-  BasicReferenceCounted& operator=(BasicReferenceCounted&&) = default;
+  BasicReferenceCounted(BasicReferenceCounted&&) : referenceCount_(0) {}
+  BasicReferenceCounted& operator=(BasicReferenceCounted&&) { return *this; }
 
   BasicReferenceCounted& operator=(const BasicReferenceCounted&) { return *this; }
 


### PR DESCRIPTION
#### PR description:

The clang compiler warned that the '= default' version were not begin generated by the compiler. Fixed via explicit versions.

#### PR validation:

Compiled using CMSSW_11_0_CLANG_X_2019-09-09-2300 and the clang compiler warnings are gone.