### PR TITLE
Comments to parameters definition for HFStripFilter

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -356,15 +356,24 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(const edm::Param
 edm::ParameterSetDescription HFStripFilter::fillDescription() {
   edm::ParameterSetDescription desc;
 
-  desc.add<double>("stripThreshold", 40.0)->setComment(" threshold to include hits into strips");
-  desc.add<double>("maxThreshold", 100.0)->setComment(" threshold for seed hits in the strips (depth1 and depth2)");
-  desc.add<double>("timeMax", 6.0)->setComment(" seed hits should have time < timeMax");
-  desc.add<double>("maxStripTime", 10.0)->setComment(" maximum time for hits in the strips");
-  desc.add<double>("wedgeCut", 0.05)->setComment(" the possible level of energy leak into adjacent wedges");
-  desc.add<int>("seedHitIetaMax", 35)->setComment(" maximum possible Ieta value for seed hit");
-  desc.add<int>("gap", 2)->setComment(" maximum distance between hits in the strip (along Ieta direction)");
-  desc.add<int>("lstrips", 2)->setComment(" at least one of strips in depth1 or depth2 is not less than lstrips");
-  desc.addUntracked<int>("verboseLevel", 0)->setComment(" verboseLevel for debugging printouts, should be > 20 to get output");
+  desc.add<double>("stripThreshold", 40.0)
+       ->setComment(" threshold to include hits into strips");
+  desc.add<double>("maxThreshold", 100.0)
+       ->setComment(" threshold for seed hits in the strips (depth1 and depth2)");
+  desc.add<double>("timeMax", 6.0)
+       ->setComment(" seed hits should have time < timeMax");
+  desc.add<double>("maxStripTime", 10.0)
+       ->setComment(" maximum time for hits in the strips");
+  desc.add<double>("wedgeCut", 0.05)
+       ->setComment(" the possible level of energy leak into adjacent wedges");
+  desc.add<int>("seedHitIetaMax", 35)
+       ->setComment(" maximum possible Ieta value for seed hit");
+  desc.add<int>("gap", 2)
+       ->setComment(" maximum distance between hits in the strip (along Ieta direction)");
+  desc.add<int>("lstrips", 2)
+       ->setComment(" at least one of strips in depth1 or depth2 is not less than lstrips");
+  desc.addUntracked<int>("verboseLevel", 0)
+       ->setComment(" verboseLevel for debugging printouts, should be > 20 to get output");
 
   return desc;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -356,15 +356,15 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(const edm::Param
 edm::ParameterSetDescription HFStripFilter::fillDescription() {
   edm::ParameterSetDescription desc;
 
-  desc.add<double>("stripThreshold", 40.0);  // threshold to include hits into strips   
-  desc.add<double>("maxThreshold", 100.0);   // threshold for seed hits in the strips (depth1 and depth2)
-  desc.add<double>("timeMax", 6.0);          // seed hits should have time < timeMax
-  desc.add<double>("maxStripTime", 10.0);    // maximum time for hits in the strips
-  desc.add<double>("wedgeCut", 0.05);        // the possible level of energy leak into adjacent wedges
-  desc.add<int>("seedHitIetaMax", 35);       // maximum possible Ieta value for seed hit
-  desc.add<int>("gap", 2);                   // maximum distance between hits in the strip (along Ieta direction)
-  desc.add<int>("lstrips", 2);               // at least one of strips in depth1 or depth2 is not less than lstrips
-  desc.addUntracked<int>("verboseLevel", 0); // verboseLevel for debugging printouts, should be > 20 to get output
+  desc.add<double>("stripThreshold", 40.0);   // threshold to include hits into strips
+  desc.add<double>("maxThreshold", 100.0);    // threshold for seed hits in the strips (depth1 and depth2)
+  desc.add<double>("timeMax", 6.0);           // seed hits should have time < timeMax
+  desc.add<double>("maxStripTime", 10.0);     // maximum time for hits in the strips
+  desc.add<double>("wedgeCut", 0.05);         // the possible level of energy leak into adjacent wedges
+  desc.add<int>("seedHitIetaMax", 35);        // maximum possible Ieta value for seed hit
+  desc.add<int>("gap", 2);                    // maximum distance between hits in the strip (along Ieta direction)
+  desc.add<int>("lstrips", 2);                // at least one of strips in depth1 or depth2 is not less than lstrips
+  desc.addUntracked<int>("verboseLevel", 0);  // verboseLevel for debugging printouts, should be > 20 to get output
 
   return desc;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -356,15 +356,15 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(const edm::Param
 edm::ParameterSetDescription HFStripFilter::fillDescription() {
   edm::ParameterSetDescription desc;
 
-  desc.add<double>("stripThreshold", 40.0);   // threshold to include hits into strips
-  desc.add<double>("maxThreshold", 100.0);    // threshold for seed hits in the strips (depth1 and depth2)
-  desc.add<double>("timeMax", 6.0);           // seed hits should have time < timeMax
-  desc.add<double>("maxStripTime", 10.0);     // maximum time for hits in the strips
-  desc.add<double>("wedgeCut", 0.05);         // the possible level of energy leak into adjacent wedges
-  desc.add<int>("seedHitIetaMax", 35);        // maximum possible Ieta value for seed hit
-  desc.add<int>("gap", 2);                    // maximum distance between hits in the strip (along Ieta direction)
-  desc.add<int>("lstrips", 2);                // at least one of strips in depth1 or depth2 is not less than lstrips
-  desc.addUntracked<int>("verboseLevel", 0);  // verboseLevel for debugging printouts, should be > 20 to get output
+  desc.add<double>("stripThreshold", 40.0)->setComment(" threshold to include hits into strips");
+  desc.add<double>("maxThreshold", 100.0)->setComment(" threshold for seed hits in the strips (depth1 and depth2)");
+  desc.add<double>("timeMax", 6.0)->setComment(" seed hits should have time < timeMax");
+  desc.add<double>("maxStripTime", 10.0)->setComment(" maximum time for hits in the strips");
+  desc.add<double>("wedgeCut", 0.05)->setComment(" the possible level of energy leak into adjacent wedges");
+  desc.add<int>("seedHitIetaMax", 35)->setComment(" maximum possible Ieta value for seed hit");
+  desc.add<int>("gap", 2)->setComment(" maximum distance between hits in the strip (along Ieta direction)");
+  desc.add<int>("lstrips", 2)->setComment(" at least one of strips in depth1 or depth2 is not less than lstrips");
+  desc.addUntracked<int>("verboseLevel", 0)->setComment(" verboseLevel for debugging printouts, should be > 20 to get output");
 
   return desc;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -356,24 +356,16 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(const edm::Param
 edm::ParameterSetDescription HFStripFilter::fillDescription() {
   edm::ParameterSetDescription desc;
 
-  desc.add<double>("stripThreshold", 40.0)
-       ->setComment(" threshold to include hits into strips");
-  desc.add<double>("maxThreshold", 100.0)
-       ->setComment(" threshold for seed hits in the strips (depth1 and depth2)");
-  desc.add<double>("timeMax", 6.0)
-       ->setComment(" seed hits should have time < timeMax");
-  desc.add<double>("maxStripTime", 10.0)
-       ->setComment(" maximum time for hits in the strips");
-  desc.add<double>("wedgeCut", 0.05)
-       ->setComment(" the possible level of energy leak into adjacent wedges");
-  desc.add<int>("seedHitIetaMax", 35)
-       ->setComment(" maximum possible Ieta value for seed hit");
-  desc.add<int>("gap", 2)
-       ->setComment(" maximum distance between hits in the strip (along Ieta direction)");
-  desc.add<int>("lstrips", 2)
-       ->setComment(" at least one of strips in depth1 or depth2 is not less than lstrips");
+  desc.add<double>("stripThreshold", 40.0)->setComment(" threshold to include hits into strips");
+  desc.add<double>("maxThreshold", 100.0)->setComment(" threshold for seed hits in the strips (depth1 and depth2)");
+  desc.add<double>("timeMax", 6.0)->setComment(" seed hits should have time < timeMax");
+  desc.add<double>("maxStripTime", 10.0)->setComment(" maximum time for hits in the strips");
+  desc.add<double>("wedgeCut", 0.05)->setComment(" the possible level of energy leak into adjacent wedges");
+  desc.add<int>("seedHitIetaMax", 35)->setComment(" maximum possible Ieta value for seed hit");
+  desc.add<int>("gap", 2)->setComment(" maximum distance between hits in the strip (along Ieta direction)");
+  desc.add<int>("lstrips", 2)->setComment(" at least one of strips in depth1 or depth2 is not less than lstrips");
   desc.addUntracked<int>("verboseLevel", 0)
-       ->setComment(" verboseLevel for debugging printouts, should be > 20 to get output");
+      ->setComment(" verboseLevel for debugging printouts, should be > 20 to get output");
 
   return desc;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc
@@ -356,15 +356,15 @@ std::unique_ptr<HFStripFilter> HFStripFilter::parseParameterSet(const edm::Param
 edm::ParameterSetDescription HFStripFilter::fillDescription() {
   edm::ParameterSetDescription desc;
 
-  desc.add<double>("stripThreshold", 40.0);
-  desc.add<double>("maxThreshold", 100.0);
-  desc.add<double>("timeMax", 6.0);
-  desc.add<double>("maxStripTime", 10.0);
-  desc.add<double>("wedgeCut", 0.05);
-  desc.add<int>("seedHitIetaMax", 35);
-  desc.add<int>("gap", 2);
-  desc.add<int>("lstrips", 2);
-  desc.addUntracked<int>("verboseLevel", 0);
+  desc.add<double>("stripThreshold", 40.0);  // threshold to include hits into strips   
+  desc.add<double>("maxThreshold", 100.0);   // threshold for seed hits in the strips (depth1 and depth2)
+  desc.add<double>("timeMax", 6.0);          // seed hits should have time < timeMax
+  desc.add<double>("maxStripTime", 10.0);    // maximum time for hits in the strips
+  desc.add<double>("wedgeCut", 0.05);        // the possible level of energy leak into adjacent wedges
+  desc.add<int>("seedHitIetaMax", 35);       // maximum possible Ieta value for seed hit
+  desc.add<int>("gap", 2);                   // maximum distance between hits in the strip (along Ieta direction)
+  desc.add<int>("lstrips", 2);               // at least one of strips in depth1 or depth2 is not less than lstrips
+  desc.addUntracked<int>("verboseLevel", 0); // verboseLevel for debugging printouts, should be > 20 to get output
 
   return desc;
 }

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -201,16 +201,15 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     ),
 
     # Parameters for HFStripFilter.
-    # Please add some descriptions of their meaning.
     HFStripFilter = cms.PSet(
-        stripThreshold = cms.double(40.0),
-        maxThreshold = cms.double(100.0),
-        timeMax = cms.double(6.0),
-        maxStripTime = cms.double(10.0),
-        wedgeCut = cms.double(0.05),
-        seedHitIetaMax = cms.int32(35),
-        gap = cms.int32(2),
-        lstrips = cms.int32(2),
-        verboseLevel = cms.untracked.int32(10)
+        stripThreshold = cms.double(40.0),     # threshold to include hits into strips
+        maxThreshold = cms.double(100.0),      # threshold for seed hits in the strips (depth1 and depth2)
+        timeMax = cms.double(6.0),             # seed hits should have time < timeMax
+        maxStripTime = cms.double(10.0),       # maximum time for hits in the strips
+        wedgeCut = cms.double(0.05),           # the possible level of energy leak into adjacent wedges
+        seedHitIetaMax = cms.int32(35),        # maximum possible Ieta value for seed hit
+        gap = cms.int32(2),                    # maximum distance between hits in the strip (along Ieta direction)
+        lstrips = cms.int32(2),                # at least one of strips in depth1 or depth2 is not less than lstrips
+        verboseLevel = cms.untracked.int32(10) # verboseLevel for debugging printouts, should be > 20 to get output
     )
 )


### PR DESCRIPTION
#### PR description:

In this PR only comments were added to the definition of parameters for HFStripFilter in the
/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py and /RecoLocalCalo/HcalRecAlgos/src/HFStripFilter.cc.
The decision to add comments was made at the following meeting to make the meaning of parameters more clear:
https://indico.cern.ch/event/845652/contributions/3555228/attachments/1903523/3142982/HFStripFilter_Update_6Sep2019.pdf

#### PR validation:

After these changes the code was compiled and all functionality was checked one more time.
