### PR TITLE
Premix option c, with 2 tags, ECAL, 11_0_X

### DIFF
--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h
@@ -17,8 +17,11 @@
 
 // class EcalLaserDbRecordMC : public edm::eventsetup::EventSetupRecordMCImplementation<EcalLaserDbRecordMC> {};
 
-class EcalLaserDbRecordMC : public edm::eventsetup::DependentRecordImplementation <EcalLaserDbRecordMC,  
-  boost::mpl::vector<EcalLaserAlphasRcd, EcalLaserAPDPNRatiosRefRcd, EcalLaserAPDPNRatiosMCRcd, EcalLinearCorrectionsRcd> > {}; 
+class EcalLaserDbRecordMC
+    : public edm::eventsetup::DependentRecordImplementation<EcalLaserDbRecordMC,
+                                                            boost::mpl::vector<EcalLaserAlphasRcd,
+                                                                               EcalLaserAPDPNRatiosRefRcd,
+                                                                               EcalLaserAPDPNRatiosMCRcd,
+                                                                               EcalLinearCorrectionsRcd> > {};
 
 #endif /* ECALLASERCORRECTION_ECALLASERDBRECORDMC_H */
-

--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h
@@ -1,0 +1,24 @@
+//
+// Toyoko Orimoto (Caltech), 10 July 2007
+// Andrea Massironi, 3 Aug 2019
+//
+
+#ifndef ECALLASERCORRECTION_ECALLASERDBRECORDMC_H
+#define ECALLASERCORRECTION_ECALLASERDBRECORDMC_H
+
+#include "boost/mpl/vector.hpp"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+// #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+#include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h"
+#include "CondFormats/DataRecord/interface/EcalLinearCorrectionsRcd.h"
+
+// class EcalLaserDbRecordMC : public edm::eventsetup::EventSetupRecordMCImplementation<EcalLaserDbRecordMC> {};
+
+class EcalLaserDbRecordMC : public edm::eventsetup::DependentRecordImplementation <EcalLaserDbRecordMC,  
+  boost::mpl::vector<EcalLaserAlphasRcd, EcalLaserAPDPNRatiosRefRcd, EcalLaserAPDPNRatiosMCRcd, EcalLinearCorrectionsRcd> > {}; 
+
+#endif /* ECALLASERCORRECTION_ECALLASERDBRECORDMC_H */
+

--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h
@@ -1,0 +1,53 @@
+//
+// Toyoko Orimoto (Caltech), 10 July 2007
+//
+
+#ifndef EcalLaserDbServiceMC_h
+#define EcalLaserDbServiceMC_h
+
+#include <memory>
+#include <tbb/concurrent_unordered_set.h>
+
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h"
+#include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
+
+
+class EcalLaserDbServiceMC {
+ public:
+  EcalLaserDbServiceMC ();
+
+  const EcalLaserAlphas* getAlphas () const;
+  const EcalLaserAPDPNRatiosRef* getAPDPNRatiosRef () const;
+  const EcalLaserAPDPNRatiosMC* getAPDPNRatiosMC () const;
+  const EcalLinearCorrections* getLinearCorrections () const;
+  float getLaserCorrection (DetId const & xid, edm::Timestamp const & iTime) const;
+
+  void setAlphaData (const EcalLaserAlphas* fItem) {mAlphas_ = fItem;}
+  void setAPDPNRefData (const EcalLaserAPDPNRatiosRef* fItem) {mAPDPNRatiosRef_ = fItem;}
+  void setAPDPNData (const EcalLaserAPDPNRatiosMC* fItem) {mAPDPNRatiosMC_ = fItem;}
+  void setLinearCorrectionsData (const EcalLinearCorrections* fItem) {mLinearCorrections_ = fItem;}
+
+ private:
+
+  const EcalLaserAlphas* mAlphas_;
+  const EcalLaserAPDPNRatiosRef* mAPDPNRatiosRef_;
+  const EcalLaserAPDPNRatiosMC* mAPDPNRatiosMC_;  
+  const EcalLinearCorrections* mLinearCorrections_;  
+
+  typedef tbb::concurrent_unordered_set<uint32_t> ErrorMapT;
+  mutable ErrorMapT channelsWithInvalidCorrection_;
+
+};
+
+#endif

--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <tbb/concurrent_unordered_set.h>
 
-
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
@@ -22,32 +21,29 @@
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h"
 #include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
 
-
 class EcalLaserDbServiceMC {
- public:
-  EcalLaserDbServiceMC ();
+public:
+  EcalLaserDbServiceMC();
 
-  const EcalLaserAlphas* getAlphas () const;
-  const EcalLaserAPDPNRatiosRef* getAPDPNRatiosRef () const;
-  const EcalLaserAPDPNRatiosMC* getAPDPNRatiosMC () const;
-  const EcalLinearCorrections* getLinearCorrections () const;
-  float getLaserCorrection (DetId const & xid, edm::Timestamp const & iTime) const;
+  const EcalLaserAlphas* getAlphas() const;
+  const EcalLaserAPDPNRatiosRef* getAPDPNRatiosRef() const;
+  const EcalLaserAPDPNRatiosMC* getAPDPNRatiosMC() const;
+  const EcalLinearCorrections* getLinearCorrections() const;
+  float getLaserCorrection(DetId const& xid, edm::Timestamp const& iTime) const;
 
-  void setAlphaData (const EcalLaserAlphas* fItem) {mAlphas_ = fItem;}
-  void setAPDPNRefData (const EcalLaserAPDPNRatiosRef* fItem) {mAPDPNRatiosRef_ = fItem;}
-  void setAPDPNData (const EcalLaserAPDPNRatiosMC* fItem) {mAPDPNRatiosMC_ = fItem;}
-  void setLinearCorrectionsData (const EcalLinearCorrections* fItem) {mLinearCorrections_ = fItem;}
+  void setAlphaData(const EcalLaserAlphas* fItem) { mAlphas_ = fItem; }
+  void setAPDPNRefData(const EcalLaserAPDPNRatiosRef* fItem) { mAPDPNRatiosRef_ = fItem; }
+  void setAPDPNData(const EcalLaserAPDPNRatiosMC* fItem) { mAPDPNRatiosMC_ = fItem; }
+  void setLinearCorrectionsData(const EcalLinearCorrections* fItem) { mLinearCorrections_ = fItem; }
 
- private:
-
+private:
   const EcalLaserAlphas* mAlphas_;
   const EcalLaserAPDPNRatiosRef* mAPDPNRatiosRef_;
-  const EcalLaserAPDPNRatiosMC* mAPDPNRatiosMC_;  
-  const EcalLinearCorrections* mLinearCorrections_;  
+  const EcalLaserAPDPNRatiosMC* mAPDPNRatiosMC_;
+  const EcalLinearCorrections* mLinearCorrections_;
 
   typedef tbb::concurrent_unordered_set<uint32_t> ErrorMapT;
   mutable ErrorMapT channelsWithInvalidCorrection_;
-
 };
 
 #endif

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
@@ -106,3 +106,5 @@ void EcalLaserCorrectionServiceMC::setupLinear(const EcalLinearCorrectionsRcd& f
   fRecord.get (item);
   service.setLinearCorrectionsData (item.product ());
 }
+
+DEFINE_FWK_EVENTSETUP_MODULE(EcalLaserCorrectionServiceMC);

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
@@ -14,16 +14,11 @@
 
 #include "CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h"
 
-EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC(const edm::ParameterSet& fConfig)
-    : ESProducer()
-{
-
+EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC(const edm::ParameterSet& fConfig) : ESProducer() {
   setWhatProduced(this);
-
 }
 
-EcalLaserCorrectionServiceMC::~EcalLaserCorrectionServiceMC() {
-}
+EcalLaserCorrectionServiceMC::~EcalLaserCorrectionServiceMC() {}
 
 //
 // member functions

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
@@ -1,0 +1,108 @@
+//
+// Toyoko Orimoto (Caltech), 10 July 2007
+// Andrea Massironi, 3 Aug 2019
+// 
+
+// system include files
+#include <iostream>
+#include <fstream>
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h"
+
+#include "CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h"
+
+
+EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC( const edm::ParameterSet& fConfig)
+  : ESProducer()
+    //    mDumpRequest (),
+    //    mDumpStream(0)
+{
+  //the following line is needed to tell the framework what
+  // data is being produced
+  //  setWhatProduced (this, (dependsOn (&EcalLaserCorrectionServiceMC::apdpnCallback)));
+
+  setWhatProduced (this);
+
+  //now do what ever other initialization is needed
+
+  //  mDumpRequest = fConfig.getUntrackedParameter <std::vector <std::string> > ("dump", std::vector<std::string>());
+  //  if (!mDumpRequest.empty()) {
+  //    std::string otputFile = fConfig.getUntrackedParameter <std::string> ("file", "");
+  //    mDumpStream = otputFile.empty () ? &std::cout : new std::ofstream (otputFile.c_str());
+  //  }
+}
+
+
+EcalLaserCorrectionServiceMC::~EcalLaserCorrectionServiceMC()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+  //  if (mDumpStream != &std::cout) delete mDumpStream;
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+std::shared_ptr<EcalLaserDbServiceMC> EcalLaserCorrectionServiceMC::produce( const EcalLaserDbRecordMC& record)
+{
+  auto host = holder_.makeOrGet([]() {
+    return new HostType;
+  });
+
+  host->ifRecordChanges<EcalLinearCorrectionsRcd>(record,
+                                                  [this,h=host.get()](auto const& rec) {
+    setupLinear(rec, *h);
+  });
+
+  host->ifRecordChanges<EcalLaserAPDPNRatiosMCRcd>(record,
+                                                 [this,h=host.get()](auto const& rec) {
+    setupApdpn(rec, *h);
+  });
+
+  host->ifRecordChanges<EcalLaserAPDPNRatiosRefRcd>(record,
+                                                    [this,h=host.get()](auto const& rec) {
+    setupApdpnRef(rec, *h);
+  });
+
+  host->ifRecordChanges<EcalLaserAlphasRcd>(record,
+                                            [this,h=host.get()](auto const& rec) {
+    setupAlpha(rec, *h);
+  });
+
+  return host; // automatically converts to std::shared_ptr<EcalLaserDbServiceMC>
+}
+
+void EcalLaserCorrectionServiceMC::setupAlpha(const EcalLaserAlphasRcd& fRecord,
+                                            EcalLaserDbServiceMC& service) {
+  edm::ESHandle <EcalLaserAlphas> item;
+  fRecord.get (item);
+  service.setAlphaData (item.product ());
+}
+
+void EcalLaserCorrectionServiceMC::setupApdpnRef(const EcalLaserAPDPNRatiosRefRcd& fRecord,
+                                               EcalLaserDbServiceMC& service) {
+  edm::ESHandle <EcalLaserAPDPNRatiosRef> item;
+  fRecord.get (item);
+  service.setAPDPNRefData (item.product ());
+}
+
+void EcalLaserCorrectionServiceMC::setupApdpn(const EcalLaserAPDPNRatiosMCRcd& fRecord,
+                                            EcalLaserDbServiceMC& service) {
+  edm::ESHandle <EcalLaserAPDPNRatiosMC> item;
+  fRecord.get (item);
+  service.setAPDPNData (item.product ());
+}
+
+void EcalLaserCorrectionServiceMC::setupLinear(const EcalLinearCorrectionsRcd& fRecord,
+                                             EcalLaserDbServiceMC& service) {
+  edm::ESHandle <EcalLinearCorrections> item;
+  fRecord.get (item);
+  service.setLinearCorrectionsData (item.product ());
+}

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
@@ -1,7 +1,7 @@
 //
 // Toyoko Orimoto (Caltech), 10 July 2007
 // Andrea Massironi, 3 Aug 2019
-// 
+//
 
 // system include files
 #include <iostream>
@@ -14,17 +14,16 @@
 
 #include "CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h"
 
-
-EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC( const edm::ParameterSet& fConfig)
-  : ESProducer()
-    //    mDumpRequest (),
-    //    mDumpStream(0)
+EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC(const edm::ParameterSet& fConfig)
+    : ESProducer()
+//    mDumpRequest (),
+//    mDumpStream(0)
 {
   //the following line is needed to tell the framework what
   // data is being produced
   //  setWhatProduced (this, (dependsOn (&EcalLaserCorrectionServiceMC::apdpnCallback)));
 
-  setWhatProduced (this);
+  setWhatProduced(this);
 
   //now do what ever other initialization is needed
 
@@ -35,76 +34,57 @@ EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC( const edm::Parameter
   //  }
 }
 
-
-EcalLaserCorrectionServiceMC::~EcalLaserCorrectionServiceMC()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+EcalLaserCorrectionServiceMC::~EcalLaserCorrectionServiceMC() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
   //  if (mDumpStream != &std::cout) delete mDumpStream;
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-std::shared_ptr<EcalLaserDbServiceMC> EcalLaserCorrectionServiceMC::produce( const EcalLaserDbRecordMC& record)
-{
-  auto host = holder_.makeOrGet([]() {
-    return new HostType;
-  });
+std::shared_ptr<EcalLaserDbServiceMC> EcalLaserCorrectionServiceMC::produce(const EcalLaserDbRecordMC& record) {
+  auto host = holder_.makeOrGet([]() { return new HostType; });
 
   host->ifRecordChanges<EcalLinearCorrectionsRcd>(record,
-                                                  [this,h=host.get()](auto const& rec) {
-    setupLinear(rec, *h);
-  });
+                                                  [this, h = host.get()](auto const& rec) { setupLinear(rec, *h); });
 
   host->ifRecordChanges<EcalLaserAPDPNRatiosMCRcd>(record,
-                                                 [this,h=host.get()](auto const& rec) {
-    setupApdpn(rec, *h);
-  });
+                                                   [this, h = host.get()](auto const& rec) { setupApdpn(rec, *h); });
 
-  host->ifRecordChanges<EcalLaserAPDPNRatiosRefRcd>(record,
-                                                    [this,h=host.get()](auto const& rec) {
-    setupApdpnRef(rec, *h);
-  });
+  host->ifRecordChanges<EcalLaserAPDPNRatiosRefRcd>(
+      record, [this, h = host.get()](auto const& rec) { setupApdpnRef(rec, *h); });
 
-  host->ifRecordChanges<EcalLaserAlphasRcd>(record,
-                                            [this,h=host.get()](auto const& rec) {
-    setupAlpha(rec, *h);
-  });
+  host->ifRecordChanges<EcalLaserAlphasRcd>(record, [this, h = host.get()](auto const& rec) { setupAlpha(rec, *h); });
 
-  return host; // automatically converts to std::shared_ptr<EcalLaserDbServiceMC>
+  return host;  // automatically converts to std::shared_ptr<EcalLaserDbServiceMC>
 }
 
-void EcalLaserCorrectionServiceMC::setupAlpha(const EcalLaserAlphasRcd& fRecord,
-                                            EcalLaserDbServiceMC& service) {
-  edm::ESHandle <EcalLaserAlphas> item;
-  fRecord.get (item);
-  service.setAlphaData (item.product ());
+void EcalLaserCorrectionServiceMC::setupAlpha(const EcalLaserAlphasRcd& fRecord, EcalLaserDbServiceMC& service) {
+  edm::ESHandle<EcalLaserAlphas> item;
+  fRecord.get(item);
+  service.setAlphaData(item.product());
 }
 
 void EcalLaserCorrectionServiceMC::setupApdpnRef(const EcalLaserAPDPNRatiosRefRcd& fRecord,
-                                               EcalLaserDbServiceMC& service) {
-  edm::ESHandle <EcalLaserAPDPNRatiosRef> item;
-  fRecord.get (item);
-  service.setAPDPNRefData (item.product ());
+                                                 EcalLaserDbServiceMC& service) {
+  edm::ESHandle<EcalLaserAPDPNRatiosRef> item;
+  fRecord.get(item);
+  service.setAPDPNRefData(item.product());
 }
 
-void EcalLaserCorrectionServiceMC::setupApdpn(const EcalLaserAPDPNRatiosMCRcd& fRecord,
-                                            EcalLaserDbServiceMC& service) {
-  edm::ESHandle <EcalLaserAPDPNRatiosMC> item;
-  fRecord.get (item);
-  service.setAPDPNData (item.product ());
+void EcalLaserCorrectionServiceMC::setupApdpn(const EcalLaserAPDPNRatiosMCRcd& fRecord, EcalLaserDbServiceMC& service) {
+  edm::ESHandle<EcalLaserAPDPNRatiosMC> item;
+  fRecord.get(item);
+  service.setAPDPNData(item.product());
 }
 
-void EcalLaserCorrectionServiceMC::setupLinear(const EcalLinearCorrectionsRcd& fRecord,
-                                             EcalLaserDbServiceMC& service) {
-  edm::ESHandle <EcalLinearCorrections> item;
-  fRecord.get (item);
-  service.setLinearCorrectionsData (item.product ());
+void EcalLaserCorrectionServiceMC::setupLinear(const EcalLinearCorrectionsRcd& fRecord, EcalLaserDbServiceMC& service) {
+  edm::ESHandle<EcalLinearCorrections> item;
+  fRecord.get(item);
+  service.setLinearCorrectionsData(item.product());
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(EcalLaserCorrectionServiceMC);

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
@@ -16,28 +16,13 @@
 
 EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC(const edm::ParameterSet& fConfig)
     : ESProducer()
-//    mDumpRequest (),
-//    mDumpStream(0)
 {
-  //the following line is needed to tell the framework what
-  // data is being produced
-  //  setWhatProduced (this, (dependsOn (&EcalLaserCorrectionServiceMC::apdpnCallback)));
 
   setWhatProduced(this);
 
-  //now do what ever other initialization is needed
-
-  //  mDumpRequest = fConfig.getUntrackedParameter <std::vector <std::string> > ("dump", std::vector<std::string>());
-  //  if (!mDumpRequest.empty()) {
-  //    std::string otputFile = fConfig.getUntrackedParameter <std::string> ("file", "");
-  //    mDumpStream = otputFile.empty () ? &std::cout : new std::ofstream (otputFile.c_str());
-  //  }
 }
 
 EcalLaserCorrectionServiceMC::~EcalLaserCorrectionServiceMC() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-  //  if (mDumpStream != &std::cout) delete mDumpStream;
 }
 
 //

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
@@ -42,6 +42,4 @@ private:
   // ----------member data ---------------------------
   edm::ReusableObjectHolder<HostType> holder_;
 
-  //  std::vector<std::string> mDumpRequest;
-  //  std::ostream* mDumpStream;
 };

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
@@ -1,0 +1,53 @@
+//
+// Toyoko Orimoto (Caltech), 10 July 2007
+// Andrea Massironi, 3 Aug 2019
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+
+class EcalLaserDbServiceMC;
+class EcalLaserDbRecordMC;
+
+#include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h"
+#include "CondFormats/DataRecord/interface/EcalLinearCorrectionsRcd.h"
+
+
+class EcalLaserCorrectionServiceMC : public edm::ESProducer {
+public:
+  EcalLaserCorrectionServiceMC( const edm::ParameterSet& );
+  ~EcalLaserCorrectionServiceMC() override;
+  
+  std::shared_ptr<EcalLaserDbServiceMC> produce( const EcalLaserDbRecordMC& );
+
+private:
+
+  using HostType = edm::ESProductHost<EcalLaserDbServiceMC,
+                                      EcalLaserAlphasRcd,
+                                      EcalLaserAPDPNRatiosRefRcd,
+                                      EcalLaserAPDPNRatiosMCRcd,
+                                      EcalLinearCorrectionsRcd>;
+
+  void setupAlpha(const EcalLaserAlphasRcd& fRecord,
+                  EcalLaserDbServiceMC& service);
+  void setupApdpnRef(const EcalLaserAPDPNRatiosRefRcd& fRecord,
+                     EcalLaserDbServiceMC& service);
+  void setupApdpn(const EcalLaserAPDPNRatiosMCRcd& fRecord,
+                  EcalLaserDbServiceMC& service);
+  void setupLinear(const EcalLinearCorrectionsRcd& fRecord,
+                   EcalLaserDbServiceMC& service);
+
+  // ----------member data ---------------------------
+  edm::ReusableObjectHolder<HostType> holder_;
+
+  //  std::vector<std::string> mDumpRequest;
+  //  std::ostream* mDumpStream;
+};

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
@@ -20,30 +20,24 @@ class EcalLaserDbRecordMC;
 #include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h"
 #include "CondFormats/DataRecord/interface/EcalLinearCorrectionsRcd.h"
 
-
 class EcalLaserCorrectionServiceMC : public edm::ESProducer {
 public:
-  EcalLaserCorrectionServiceMC( const edm::ParameterSet& );
+  EcalLaserCorrectionServiceMC(const edm::ParameterSet&);
   ~EcalLaserCorrectionServiceMC() override;
-  
-  std::shared_ptr<EcalLaserDbServiceMC> produce( const EcalLaserDbRecordMC& );
+
+  std::shared_ptr<EcalLaserDbServiceMC> produce(const EcalLaserDbRecordMC&);
 
 private:
-
   using HostType = edm::ESProductHost<EcalLaserDbServiceMC,
                                       EcalLaserAlphasRcd,
                                       EcalLaserAPDPNRatiosRefRcd,
                                       EcalLaserAPDPNRatiosMCRcd,
                                       EcalLinearCorrectionsRcd>;
 
-  void setupAlpha(const EcalLaserAlphasRcd& fRecord,
-                  EcalLaserDbServiceMC& service);
-  void setupApdpnRef(const EcalLaserAPDPNRatiosRefRcd& fRecord,
-                     EcalLaserDbServiceMC& service);
-  void setupApdpn(const EcalLaserAPDPNRatiosMCRcd& fRecord,
-                  EcalLaserDbServiceMC& service);
-  void setupLinear(const EcalLinearCorrectionsRcd& fRecord,
-                   EcalLaserDbServiceMC& service);
+  void setupAlpha(const EcalLaserAlphasRcd& fRecord, EcalLaserDbServiceMC& service);
+  void setupApdpnRef(const EcalLaserAPDPNRatiosRefRcd& fRecord, EcalLaserDbServiceMC& service);
+  void setupApdpn(const EcalLaserAPDPNRatiosMCRcd& fRecord, EcalLaserDbServiceMC& service);
+  void setupLinear(const EcalLinearCorrectionsRcd& fRecord, EcalLaserDbServiceMC& service);
 
   // ----------member data ---------------------------
   edm::ReusableObjectHolder<HostType> holder_;

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.h
@@ -41,5 +41,4 @@ private:
 
   // ----------member data ---------------------------
   edm::ReusableObjectHolder<HostType> holder_;
-
 };

--- a/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbRecordMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbRecordMC.cc
@@ -1,0 +1,5 @@
+
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalLaserDbRecordMC);

--- a/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbServiceMC.cc
@@ -8,49 +8,30 @@
 #include "CalibCalorimetry/EcalLaserAnalyzer/interface/MEEEGeom.h"
 // #include "CalibCalorimetry/EcalLaserAnalyzer/interface/ME.h"
 
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 
-EcalLaserDbServiceMC::EcalLaserDbServiceMC () 
-  : 
-  mAlphas_ (nullptr),
-  mAPDPNRatiosRef_ (nullptr),
-  mAPDPNRatiosMC_ (nullptr),
-  mLinearCorrections_ (nullptr)
- {}
+EcalLaserDbServiceMC::EcalLaserDbServiceMC()
+    : mAlphas_(nullptr), mAPDPNRatiosRef_(nullptr), mAPDPNRatiosMC_(nullptr), mLinearCorrections_(nullptr) {}
 
+const EcalLaserAlphas* EcalLaserDbServiceMC::getAlphas() const { return mAlphas_; }
 
+const EcalLaserAPDPNRatiosRef* EcalLaserDbServiceMC::getAPDPNRatiosRef() const { return mAPDPNRatiosRef_; }
 
-const EcalLaserAlphas* EcalLaserDbServiceMC::getAlphas () const {
-  return mAlphas_;
-}
+const EcalLaserAPDPNRatiosMC* EcalLaserDbServiceMC::getAPDPNRatiosMC() const { return mAPDPNRatiosMC_; }
 
-const EcalLaserAPDPNRatiosRef* EcalLaserDbServiceMC::getAPDPNRatiosRef () const {
-  return mAPDPNRatiosRef_;
-}
+const EcalLinearCorrections* EcalLaserDbServiceMC::getLinearCorrections() const { return mLinearCorrections_; }
 
-const EcalLaserAPDPNRatiosMC* EcalLaserDbServiceMC::getAPDPNRatiosMC () const {
-  return mAPDPNRatiosMC_;
-}
-
-const EcalLinearCorrections* EcalLaserDbServiceMC::getLinearCorrections () const {
-  return mLinearCorrections_;
-}
-
-
-
-float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestamp const & iTime) const {
-  
+float EcalLaserDbServiceMC::getLaserCorrection(DetId const& xid, edm::Timestamp const& iTime) const {
   float correctionFactor = 1.0;
 
-  const EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap& laserRatiosMap =  mAPDPNRatiosMC_->getLaserMap();
-  const EcalLaserAPDPNRatiosMC::EcalLaserTimeStampMap& laserTimeMap =  mAPDPNRatiosMC_->getTimeMap();
-  const EcalLaserAPDPNRatiosRefMap& laserRefMap =  mAPDPNRatiosRef_->getMap();
-  const EcalLaserAlphaMap& laserAlphaMap =  mAlphas_->getMap();
-  const EcalLinearCorrections::EcalValueMap& linearValueMap =  mLinearCorrections_->getValueMap();
-  const EcalLinearCorrections::EcalTimeMap& linearTimeMap =  mLinearCorrections_->getTimeMap();
+  const EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap& laserRatiosMap = mAPDPNRatiosMC_->getLaserMap();
+  const EcalLaserAPDPNRatiosMC::EcalLaserTimeStampMap& laserTimeMap = mAPDPNRatiosMC_->getTimeMap();
+  const EcalLaserAPDPNRatiosRefMap& laserRefMap = mAPDPNRatiosRef_->getMap();
+  const EcalLaserAlphaMap& laserAlphaMap = mAlphas_->getMap();
+  const EcalLinearCorrections::EcalValueMap& linearValueMap = mLinearCorrections_->getValueMap();
+  const EcalLinearCorrections::EcalTimeMap& linearTimeMap = mLinearCorrections_->getTimeMap();
 
   EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair apdpnpair;
   EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp timestamp;
@@ -59,30 +40,27 @@ float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestam
   EcalLinearCorrections::Values linValues;
   EcalLinearCorrections::Times linTimes;
 
-  if (xid.det()==DetId::Ecal) {
-
+  if (xid.det() == DetId::Ecal) {
   } else {
-
     edm::LogError("EcalLaserDbServiceMC") << " DetId is NOT in ECAL" << endl;
     return correctionFactor;
-  } 
-
+  }
 
   int iLM;
   int xind;
-  bool isBarrel=true;
-  if (xid.subdetId()==EcalBarrel) {
-    EBDetId ebid( xid.rawId() );
+  bool isBarrel = true;
+  if (xid.subdetId() == EcalBarrel) {
+    EBDetId ebid(xid.rawId());
     xind = ebid.hashedIndex();
     iLM = MEEBGeom::lmr(ebid.ieta(), ebid.iphi());
-  } else if (xid.subdetId()==EcalEndcap) {
-    isBarrel=false;
-    EEDetId eeid( xid.rawId() );  
+  } else if (xid.subdetId() == EcalEndcap) {
+    isBarrel = false;
+    EEDetId eeid(xid.rawId());
     xind = eeid.hashedIndex();
     // SuperCrystal coordinates
-    MEEEGeom::SuperCrysCoord iX = (eeid.ix()-1)/5 + 1;
-    MEEEGeom::SuperCrysCoord iY = (eeid.iy()-1)/5 + 1;    
-    iLM = MEEEGeom::lmr(iX, iY, eeid.zside());    
+    MEEEGeom::SuperCrysCoord iX = (eeid.ix() - 1) / 5 + 1;
+    MEEEGeom::SuperCrysCoord iY = (eeid.iy() - 1) / 5 + 1;
+    iLM = MEEEGeom::lmr(iX, iY, eeid.zside());
   } else {
     edm::LogError("EcalLaserDbServiceMC") << " DetId is NOT in ECAL Barrel or Endcap" << endl;
     return correctionFactor;
@@ -91,20 +69,19 @@ float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestam
 
   // get alpha, apd/pn ref, apd/pn pairs and timestamps for interpolation
 
-
 #ifdef VERIFY_LASER
   EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap::const_iterator itratio = laserRatiosMap.find(xid);
   if (itratio != laserRatiosMap.end()) {
     apdpnpair = (*itratio);
   } else {
-    edm::LogError("EcalLaserDbServiceMC") << "error with laserRatiosMap!" << endl;     
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserRatiosMap!" << endl;
     return correctionFactor;
   }
 
-  if (iLM-1< (int)laserTimeMap.size()) {
-    timestamp = laserTimeMap[iLM-1];  
+  if (iLM - 1 < (int)laserTimeMap.size()) {
+    timestamp = laserTimeMap[iLM - 1];
   } else {
-    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;     
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;
     return correctionFactor;
   }
 
@@ -112,73 +89,70 @@ float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestam
   if (itlin != linearValueMap.end()) {
     linValues = (*itlin);
   } else {
-    edm::LogError("EcalLaserDbServiceMC") << "error with linearValueMap!" << endl;     
+    edm::LogError("EcalLaserDbServiceMC") << "error with linearValueMap!" << endl;
     return correctionFactor;
   }
 
-  if (iLM-1< (int)linearTimeMap.size()) {
-    linTimes = linearTimeMap[iLM-1];  
+  if (iLM - 1 < (int)linearTimeMap.size()) {
+    linTimes = linearTimeMap[iLM - 1];
   } else {
-    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;     
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;
     return correctionFactor;
   }
 
   EcalLaserAPDPNRatiosRefMap::const_iterator itref = laserRefMap.find(xid);
-  if ( itref != laserRefMap.end() ) {
+  if (itref != laserRefMap.end()) {
     apdpnref = (*itref);
-  } else { 
-    edm::LogError("EcalLaserDbServiceMC") << "error with laserRefMap!" << endl;     
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserRefMap!" << endl;
     return correctionFactor;
   }
 
   EcalLaserAlphaMap::const_iterator italpha = laserAlphaMap.find(xid);
-  if ( italpha != laserAlphaMap.end() ) {
+  if (italpha != laserAlphaMap.end()) {
     alpha = (*italpha);
   } else {
-    edm::LogError("EcalLaserDbServiceMC") << "error with laserAlphaMap!" << endl;     
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserAlphaMap!" << endl;
     return correctionFactor;
   }
 
 #else
-    
+
   // waiting for templated lambdas
-  auto getCond =[=](EcalFloatCondObjectContainer const & cond)->float {
+  auto getCond = [=](EcalFloatCondObjectContainer const& cond) -> float {
     return isBarrel ? cond.barrel(xind) : cond.endcap(xind);
   };
 
-  auto getPair =[=](EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap const & cond)->EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair {
+  auto getPair =
+      [=](EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap const& cond) -> EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair {
     return isBarrel ? cond.barrel(xind) : cond.endcap(xind);
   };
 
-  auto getLinear =[=](EcalLinearCorrections::EcalValueMap const & cond)->EcalLinearCorrections::Values {
+  auto getLinear = [=](EcalLinearCorrections::EcalValueMap const& cond) -> EcalLinearCorrections::Values {
     return isBarrel ? cond.barrel(xind) : cond.endcap(xind);
   };
-
 
   apdpnpair = getPair(laserRatiosMap);
   linValues = getLinear(linearValueMap);
-  apdpnref  = getCond(laserRefMap);
-  alpha     = getCond(laserAlphaMap);
+  apdpnref = getCond(laserRefMap);
+  alpha = getCond(laserAlphaMap);
 
-  if (iLM-1< (int)laserTimeMap.size()) {
-    timestamp = laserTimeMap[iLM-1];
+  if (iLM - 1 < (int)laserTimeMap.size()) {
+    timestamp = laserTimeMap[iLM - 1];
   } else {
     edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;
     return correctionFactor;
   }
 
-  if (iLM-1< (int)linearTimeMap.size()) {
-    linTimes = linearTimeMap[iLM-1];
+  if (iLM - 1 < (int)linearTimeMap.size()) {
+    linTimes = linearTimeMap[iLM - 1];
   } else {
     edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;
     return correctionFactor;
   }
-
 
 #endif
 
-
-  
   // should implement some default in case of error...
 
   // should do some quality checks first
@@ -186,7 +160,7 @@ float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestam
 
   // we will need to treat time differently...
   // is time in DB same format as in MC?  probably not...
-  
+
   // interpolation
 
   edm::TimeValue_t t = iTime.value();
@@ -195,92 +169,82 @@ float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestam
   long long lt_i = 0, lt_f = 0;
   float lp_i = 0, lp_f = 0;
 
-  if ( t >= timestamp.t1.value() && t < timestamp.t2.value() ) {
-          t_i = timestamp.t1.value();
-          t_f = timestamp.t2.value();
-          p_i = apdpnpair.p1;
-          p_f = apdpnpair.p2;
-  } else if ( t >= timestamp.t2.value() && t <= timestamp.t3.value() ) {
-          t_i = timestamp.t2.value();
-          t_f = timestamp.t3.value();
-          p_i = apdpnpair.p2;
-          p_f = apdpnpair.p3;
-  } else if ( t < timestamp.t1.value() ) {
-          t_i = timestamp.t1.value();
-          t_f = timestamp.t2.value();
-          p_i = apdpnpair.p1;
-          p_f = apdpnpair.p2;
+  if (t >= timestamp.t1.value() && t < timestamp.t2.value()) {
+    t_i = timestamp.t1.value();
+    t_f = timestamp.t2.value();
+    p_i = apdpnpair.p1;
+    p_f = apdpnpair.p2;
+  } else if (t >= timestamp.t2.value() && t <= timestamp.t3.value()) {
+    t_i = timestamp.t2.value();
+    t_f = timestamp.t3.value();
+    p_i = apdpnpair.p2;
+    p_f = apdpnpair.p3;
+  } else if (t < timestamp.t1.value()) {
+    t_i = timestamp.t1.value();
+    t_f = timestamp.t2.value();
+    p_i = apdpnpair.p1;
+    p_f = apdpnpair.p2;
 
-  } else if ( t > timestamp.t3.value() ) {
-          t_i = timestamp.t2.value();
-          t_f = timestamp.t3.value();
-          p_i = apdpnpair.p2;
-          p_f = apdpnpair.p3;
-
+  } else if (t > timestamp.t3.value()) {
+    t_i = timestamp.t2.value();
+    t_f = timestamp.t3.value();
+    p_i = apdpnpair.p2;
+    p_f = apdpnpair.p3;
   }
 
-  if ( t >= linTimes.t1.value() && t < linTimes.t2.value() ) {
-          lt_i = linTimes.t1.value();
-          lt_f = linTimes.t2.value();
-          lp_i = linValues.p1;
-          lp_f = linValues.p2;
-  } else if ( t >= linTimes.t2.value() && t <= linTimes.t3.value() ) {
-          lt_i = linTimes.t2.value();
-          lt_f = linTimes.t3.value();
-          lp_i = linValues.p2;
-          lp_f = linValues.p3;
-  } else if ( t < linTimes.t1.value() ) {
-          lt_i = linTimes.t1.value();
-          lt_f = linTimes.t2.value();
-          lp_i = linValues.p1;
-          lp_f = linValues.p2;
+  if (t >= linTimes.t1.value() && t < linTimes.t2.value()) {
+    lt_i = linTimes.t1.value();
+    lt_f = linTimes.t2.value();
+    lp_i = linValues.p1;
+    lp_f = linValues.p2;
+  } else if (t >= linTimes.t2.value() && t <= linTimes.t3.value()) {
+    lt_i = linTimes.t2.value();
+    lt_f = linTimes.t3.value();
+    lp_i = linValues.p2;
+    lp_f = linValues.p3;
+  } else if (t < linTimes.t1.value()) {
+    lt_i = linTimes.t1.value();
+    lt_f = linTimes.t2.value();
+    lp_i = linValues.p1;
+    lp_f = linValues.p2;
 
-  } else if ( t > linTimes.t3.value() ) {
-          lt_i = linTimes.t2.value();
-          lt_f = linTimes.t3.value();
-          lp_i = linValues.p2;
-          lp_f = linValues.p3;
-
+  } else if (t > linTimes.t3.value()) {
+    lt_i = linTimes.t2.value();
+    lt_f = linTimes.t3.value();
+    lp_i = linValues.p2;
+    lp_f = linValues.p3;
   }
 
-  if ( apdpnref != 0 && (t_i - t_f) != 0 && (lt_i - lt_f) != 0) {
-    long long tt = t; // never subtract two unsigned!
-    float interpolatedLaserResponse = p_i/apdpnref + float(tt-t_i)*(p_f-p_i)/(apdpnref*float(t_f-t_i)); 
-    float interpolatedLinearResponse = lp_i/apdpnref + float(tt-lt_i)*(lp_f-lp_i)/(apdpnref*float(lt_f-lt_i)); // FIXED BY FC
-    
-    if(interpolatedLinearResponse >2.f || interpolatedLinearResponse <0.1f) 
-		interpolatedLinearResponse=1.f;
-    if ( interpolatedLaserResponse <= 0. ) {
+  if (apdpnref != 0 && (t_i - t_f) != 0 && (lt_i - lt_f) != 0) {
+    long long tt = t;  // never subtract two unsigned!
+    float interpolatedLaserResponse = p_i / apdpnref + float(tt - t_i) * (p_f - p_i) / (apdpnref * float(t_f - t_i));
+    float interpolatedLinearResponse =
+        lp_i / apdpnref + float(tt - lt_i) * (lp_f - lp_i) / (apdpnref * float(lt_f - lt_i));  // FIXED BY FC
 
-		// print message only if it is the first time we see < 0
-        // on this detid
-		if(channelsWithInvalidCorrection_.insert(xid.rawId()).second) {
-			edm::LogError("EcalLaserDbServiceMC")
-				<< "Interpolated Laser correction <0 for detid "<<xid.rawId(); 
+    if (interpolatedLinearResponse > 2.f || interpolatedLinearResponse < 0.1f)
+      interpolatedLinearResponse = 1.f;
+    if (interpolatedLaserResponse <= 0.) {
+      // print message only if it is the first time we see < 0
+      // on this detid
+      if (channelsWithInvalidCorrection_.insert(xid.rawId()).second) {
+        edm::LogError("EcalLaserDbServiceMC") << "Interpolated Laser correction <0 for detid " << xid.rawId();
+      }
 
-		}
-	
-		return correctionFactor;	
+      return correctionFactor;
 
     } else {
-
       float interpolatedTransparencyResponse = interpolatedLaserResponse / interpolatedLinearResponse;
 
-      correctionFactor =  1.f/( std::pow(interpolatedTransparencyResponse,alpha) *interpolatedLinearResponse  );
-      
+      correctionFactor = 1.f / (std::pow(interpolatedTransparencyResponse, alpha) * interpolatedLinearResponse);
     }
-    
+
   } else {
-    edm::LogError("EcalLaserDbServiceMC") 
-            << "apdpnref (" << apdpnref << ") "
-            << "or t_i-t_f (" << (t_i - t_f) << " is zero!";
+    edm::LogError("EcalLaserDbServiceMC") << "apdpnref (" << apdpnref << ") "
+                                          << "or t_i-t_f (" << (t_i - t_f) << " is zero!";
     return correctionFactor;
   }
-  
+
   return correctionFactor;
 }
-
-
-
 
 TYPELOOKUP_DATA_REG(EcalLaserDbServiceMC);

--- a/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/src/EcalLaserDbServiceMC.cc
@@ -1,0 +1,286 @@
+#include <iostream>
+
+#include "FWCore/Utilities/interface/typelookup.h"
+
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h"
+
+#include "CalibCalorimetry/EcalLaserAnalyzer/interface/MEEBGeom.h"
+#include "CalibCalorimetry/EcalLaserAnalyzer/interface/MEEEGeom.h"
+// #include "CalibCalorimetry/EcalLaserAnalyzer/interface/ME.h"
+
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+using namespace std;
+
+EcalLaserDbServiceMC::EcalLaserDbServiceMC () 
+  : 
+  mAlphas_ (nullptr),
+  mAPDPNRatiosRef_ (nullptr),
+  mAPDPNRatiosMC_ (nullptr),
+  mLinearCorrections_ (nullptr)
+ {}
+
+
+
+const EcalLaserAlphas* EcalLaserDbServiceMC::getAlphas () const {
+  return mAlphas_;
+}
+
+const EcalLaserAPDPNRatiosRef* EcalLaserDbServiceMC::getAPDPNRatiosRef () const {
+  return mAPDPNRatiosRef_;
+}
+
+const EcalLaserAPDPNRatiosMC* EcalLaserDbServiceMC::getAPDPNRatiosMC () const {
+  return mAPDPNRatiosMC_;
+}
+
+const EcalLinearCorrections* EcalLaserDbServiceMC::getLinearCorrections () const {
+  return mLinearCorrections_;
+}
+
+
+
+float EcalLaserDbServiceMC::getLaserCorrection (DetId const & xid, edm::Timestamp const & iTime) const {
+  
+  float correctionFactor = 1.0;
+
+  const EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap& laserRatiosMap =  mAPDPNRatiosMC_->getLaserMap();
+  const EcalLaserAPDPNRatiosMC::EcalLaserTimeStampMap& laserTimeMap =  mAPDPNRatiosMC_->getTimeMap();
+  const EcalLaserAPDPNRatiosRefMap& laserRefMap =  mAPDPNRatiosRef_->getMap();
+  const EcalLaserAlphaMap& laserAlphaMap =  mAlphas_->getMap();
+  const EcalLinearCorrections::EcalValueMap& linearValueMap =  mLinearCorrections_->getValueMap();
+  const EcalLinearCorrections::EcalTimeMap& linearTimeMap =  mLinearCorrections_->getTimeMap();
+
+  EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair apdpnpair;
+  EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp timestamp;
+  EcalLaserAPDPNref apdpnref;
+  EcalLaserAlpha alpha;
+  EcalLinearCorrections::Values linValues;
+  EcalLinearCorrections::Times linTimes;
+
+  if (xid.det()==DetId::Ecal) {
+
+  } else {
+
+    edm::LogError("EcalLaserDbServiceMC") << " DetId is NOT in ECAL" << endl;
+    return correctionFactor;
+  } 
+
+
+  int iLM;
+  int xind;
+  bool isBarrel=true;
+  if (xid.subdetId()==EcalBarrel) {
+    EBDetId ebid( xid.rawId() );
+    xind = ebid.hashedIndex();
+    iLM = MEEBGeom::lmr(ebid.ieta(), ebid.iphi());
+  } else if (xid.subdetId()==EcalEndcap) {
+    isBarrel=false;
+    EEDetId eeid( xid.rawId() );  
+    xind = eeid.hashedIndex();
+    // SuperCrystal coordinates
+    MEEEGeom::SuperCrysCoord iX = (eeid.ix()-1)/5 + 1;
+    MEEEGeom::SuperCrysCoord iY = (eeid.iy()-1)/5 + 1;    
+    iLM = MEEEGeom::lmr(iX, iY, eeid.zside());    
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << " DetId is NOT in ECAL Barrel or Endcap" << endl;
+    return correctionFactor;
+  }
+  //  std::cout << " LM num ====> " << iLM << endl;
+
+  // get alpha, apd/pn ref, apd/pn pairs and timestamps for interpolation
+
+
+#ifdef VERIFY_LASER
+  EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap::const_iterator itratio = laserRatiosMap.find(xid);
+  if (itratio != laserRatiosMap.end()) {
+    apdpnpair = (*itratio);
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserRatiosMap!" << endl;     
+    return correctionFactor;
+  }
+
+  if (iLM-1< (int)laserTimeMap.size()) {
+    timestamp = laserTimeMap[iLM-1];  
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;     
+    return correctionFactor;
+  }
+
+  EcalLinearCorrections::EcalValueMap::const_iterator itlin = linearValueMap.find(xid);
+  if (itlin != linearValueMap.end()) {
+    linValues = (*itlin);
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with linearValueMap!" << endl;     
+    return correctionFactor;
+  }
+
+  if (iLM-1< (int)linearTimeMap.size()) {
+    linTimes = linearTimeMap[iLM-1];  
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;     
+    return correctionFactor;
+  }
+
+  EcalLaserAPDPNRatiosRefMap::const_iterator itref = laserRefMap.find(xid);
+  if ( itref != laserRefMap.end() ) {
+    apdpnref = (*itref);
+  } else { 
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserRefMap!" << endl;     
+    return correctionFactor;
+  }
+
+  EcalLaserAlphaMap::const_iterator italpha = laserAlphaMap.find(xid);
+  if ( italpha != laserAlphaMap.end() ) {
+    alpha = (*italpha);
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserAlphaMap!" << endl;     
+    return correctionFactor;
+  }
+
+#else
+    
+  // waiting for templated lambdas
+  auto getCond =[=](EcalFloatCondObjectContainer const & cond)->float {
+    return isBarrel ? cond.barrel(xind) : cond.endcap(xind);
+  };
+
+  auto getPair =[=](EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap const & cond)->EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair {
+    return isBarrel ? cond.barrel(xind) : cond.endcap(xind);
+  };
+
+  auto getLinear =[=](EcalLinearCorrections::EcalValueMap const & cond)->EcalLinearCorrections::Values {
+    return isBarrel ? cond.barrel(xind) : cond.endcap(xind);
+  };
+
+
+  apdpnpair = getPair(laserRatiosMap);
+  linValues = getLinear(linearValueMap);
+  apdpnref  = getCond(laserRefMap);
+  alpha     = getCond(laserAlphaMap);
+
+  if (iLM-1< (int)laserTimeMap.size()) {
+    timestamp = laserTimeMap[iLM-1];
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;
+    return correctionFactor;
+  }
+
+  if (iLM-1< (int)linearTimeMap.size()) {
+    linTimes = linearTimeMap[iLM-1];
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") << "error with laserTimeMap!" << endl;
+    return correctionFactor;
+  }
+
+
+#endif
+
+
+  
+  // should implement some default in case of error...
+
+  // should do some quality checks first
+  // ...
+
+  // we will need to treat time differently...
+  // is time in DB same format as in MC?  probably not...
+  
+  // interpolation
+
+  edm::TimeValue_t t = iTime.value();
+  long long t_i = 0, t_f = 0;
+  float p_i = 0, p_f = 0;
+  long long lt_i = 0, lt_f = 0;
+  float lp_i = 0, lp_f = 0;
+
+  if ( t >= timestamp.t1.value() && t < timestamp.t2.value() ) {
+          t_i = timestamp.t1.value();
+          t_f = timestamp.t2.value();
+          p_i = apdpnpair.p1;
+          p_f = apdpnpair.p2;
+  } else if ( t >= timestamp.t2.value() && t <= timestamp.t3.value() ) {
+          t_i = timestamp.t2.value();
+          t_f = timestamp.t3.value();
+          p_i = apdpnpair.p2;
+          p_f = apdpnpair.p3;
+  } else if ( t < timestamp.t1.value() ) {
+          t_i = timestamp.t1.value();
+          t_f = timestamp.t2.value();
+          p_i = apdpnpair.p1;
+          p_f = apdpnpair.p2;
+
+  } else if ( t > timestamp.t3.value() ) {
+          t_i = timestamp.t2.value();
+          t_f = timestamp.t3.value();
+          p_i = apdpnpair.p2;
+          p_f = apdpnpair.p3;
+
+  }
+
+  if ( t >= linTimes.t1.value() && t < linTimes.t2.value() ) {
+          lt_i = linTimes.t1.value();
+          lt_f = linTimes.t2.value();
+          lp_i = linValues.p1;
+          lp_f = linValues.p2;
+  } else if ( t >= linTimes.t2.value() && t <= linTimes.t3.value() ) {
+          lt_i = linTimes.t2.value();
+          lt_f = linTimes.t3.value();
+          lp_i = linValues.p2;
+          lp_f = linValues.p3;
+  } else if ( t < linTimes.t1.value() ) {
+          lt_i = linTimes.t1.value();
+          lt_f = linTimes.t2.value();
+          lp_i = linValues.p1;
+          lp_f = linValues.p2;
+
+  } else if ( t > linTimes.t3.value() ) {
+          lt_i = linTimes.t2.value();
+          lt_f = linTimes.t3.value();
+          lp_i = linValues.p2;
+          lp_f = linValues.p3;
+
+  }
+
+  if ( apdpnref != 0 && (t_i - t_f) != 0 && (lt_i - lt_f) != 0) {
+    long long tt = t; // never subtract two unsigned!
+    float interpolatedLaserResponse = p_i/apdpnref + float(tt-t_i)*(p_f-p_i)/(apdpnref*float(t_f-t_i)); 
+    float interpolatedLinearResponse = lp_i/apdpnref + float(tt-lt_i)*(lp_f-lp_i)/(apdpnref*float(lt_f-lt_i)); // FIXED BY FC
+    
+    if(interpolatedLinearResponse >2.f || interpolatedLinearResponse <0.1f) 
+		interpolatedLinearResponse=1.f;
+    if ( interpolatedLaserResponse <= 0. ) {
+
+		// print message only if it is the first time we see < 0
+        // on this detid
+		if(channelsWithInvalidCorrection_.insert(xid.rawId()).second) {
+			edm::LogError("EcalLaserDbServiceMC")
+				<< "Interpolated Laser correction <0 for detid "<<xid.rawId(); 
+
+		}
+	
+		return correctionFactor;	
+
+    } else {
+
+      float interpolatedTransparencyResponse = interpolatedLaserResponse / interpolatedLinearResponse;
+
+      correctionFactor =  1.f/( std::pow(interpolatedTransparencyResponse,alpha) *interpolatedLinearResponse  );
+      
+    }
+    
+  } else {
+    edm::LogError("EcalLaserDbServiceMC") 
+            << "apdpnref (" << apdpnref << ") "
+            << "or t_i-t_f (" << (t_i - t_f) << " is zero!";
+    return correctionFactor;
+  }
+  
+  return correctionFactor;
+}
+
+
+
+
+TYPELOOKUP_DATA_REG(EcalLaserDbServiceMC);

--- a/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserDbMCAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserDbMCAnalyzer.cc
@@ -1,0 +1,149 @@
+//
+// Toyoko Orimoto (Caltech), 10 July 2007
+//
+
+
+// system include files
+#include <memory>
+//#include <time.h>
+#include <string>
+#include <map>
+#include <iostream>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h"
+
+#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMCRef.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMCMC.h"
+#include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
+
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+
+
+using namespace std;
+
+
+class EcalLaserDbAnalyzer : public edm::EDAnalyzer {
+        public:
+                explicit EcalLaserDbAnalyzer( const edm::ParameterSet& );
+                ~EcalLaserDbAnalyzer ();
+
+
+                virtual void analyze( const edm::Event&, const edm::EventSetup& );
+        private:
+
+                // ----------member data ---------------------------
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+EcalLaserDbAnalyzer::EcalLaserDbAnalyzer( const edm::ParameterSet& iConfig )
+{
+
+}
+
+
+EcalLaserDbAnalyzer::~EcalLaserDbAnalyzer()
+{
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+        void
+EcalLaserDbAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+
+        // get record from offline DB
+        edm::ESHandle<EcalLaserDbServiceMC> pSetup;
+        iSetup.get<EcalLaserDbRecordMC>().get( pSetup );
+        std::cout << "EcalLaserDbAnalyzer::analyze-> got EcalLaserDbRecordMC: " << std::endl;
+
+
+        EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair apdpnpair;
+        const EcalLaserAPDPNRatiosMC* myapdpn =  pSetup->getAPDPNRatios();
+        const EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap& laserRatiosMap =  myapdpn->getLaserMap();
+
+        //   EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp timestamp;
+        //   const EcalLaserAPDPNRatiosMC::EcalLaserTimeStampMap& laserTimeMap =  myapdpn->getTimeMap();
+
+        EcalLaserAPDPNref apdpnref;
+        const EcalLaserAPDPNRatiosMCRef* myapdpnref =  pSetup->getAPDPNRatiosRef();
+        const EcalLaserAPDPNRatiosMCRefMap& laserRefMap =  myapdpnref->getMap();
+
+        EcalLaserAlpha alpha;
+        const EcalLaserAlphas* myalpha =  pSetup->getAlphas();
+        const EcalLaserAlphaMap& laserAlphaMap =  myalpha->getMap();
+
+        EcalLinearCorrections::Values linValues;
+        const EcalLinearCorrections* mylinear = pSetup->getLinearCorrections();
+        const EcalLinearCorrections::EcalValueMap& linearValueMap =  mylinear->getValueMap();
+
+        for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
+                if(ieta==0) continue;
+                for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
+                        EBDetId ebdetid(ieta,iphi);
+
+                        std::cout << ebdetid << " " << ebdetid.ietaSM() << " " << ebdetid.iphiSM() << std::endl;
+
+                        EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap::const_iterator itratio = laserRatiosMap.find( ebdetid );
+                        if (itratio != laserRatiosMap.end()) {
+                                apdpnpair = (*itratio);
+                                std::cout << " APDPN pair = " << apdpnpair.p1 << " , " << apdpnpair.p2 << " , " << apdpnpair.p3 << std::endl;
+                        } else {
+                                edm::LogError("EcalLaserDbServiceMC") << "error with laserRatiosMap!" << endl;
+                        }
+
+                        EcalLinearCorrections::EcalValueMap::const_iterator itlin = linearValueMap.find( ebdetid );
+                        if (itlin != linearValueMap.end()) {
+                                linValues = (*itlin);
+                                std::cout << " APDPN pair = " << linValues.p1 << " , " << linValues.p2 << " , " << linValues.p3 << std::endl;
+                        } else {
+                                edm::LogError("EcalLaserDbServiceMC") << "error with linearValuesMap!" << endl;
+                        }
+
+                        EcalLaserAPDPNRatiosMCRefMap::const_iterator itref = laserRefMap.find( ebdetid );
+                        if ( itref != laserRefMap.end() ) {
+                                apdpnref = (*itref);
+                                std::cout << " APDPN ref = " << apdpnref << std::endl;
+                        } else {
+                                edm::LogError("EcalLaserDbServiceMC") << "error with laserRefMap!" << endl;
+                        }
+
+                        EcalLaserAlphaMap::const_iterator italpha = laserAlphaMap.find( ebdetid );
+                        if ( italpha != laserAlphaMap.end() ) {
+                                alpha = (*italpha);
+                                std::cout << " ALPHA = " << alpha << std::endl;
+                        } else {
+                                edm::LogError("EcalLaserDbServiceMC") << "error with laserAlphaMap!" << endl;
+                        }
+                }
+        }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EcalLaserDbAnalyzer);

--- a/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserDbMCAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserDbMCAnalyzer.cc
@@ -2,7 +2,6 @@
 // Toyoko Orimoto (Caltech), 10 July 2007
 //
 
-
 // system include files
 #include <memory>
 //#include <time.h>
@@ -15,7 +14,6 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -30,20 +28,17 @@
 
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 
-
 using namespace std;
 
-
 class EcalLaserDbAnalyzer : public edm::EDAnalyzer {
-        public:
-                explicit EcalLaserDbAnalyzer( const edm::ParameterSet& );
-                ~EcalLaserDbAnalyzer ();
+public:
+  explicit EcalLaserDbAnalyzer(const edm::ParameterSet&);
+  ~EcalLaserDbAnalyzer();
 
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-                virtual void analyze( const edm::Event&, const edm::EventSetup& );
-        private:
-
-                // ----------member data ---------------------------
+private:
+  // ----------member data ---------------------------
 };
 
 //
@@ -57,92 +52,81 @@ class EcalLaserDbAnalyzer : public edm::EDAnalyzer {
 //
 // constructors and destructor
 //
-EcalLaserDbAnalyzer::EcalLaserDbAnalyzer( const edm::ParameterSet& iConfig )
-{
+EcalLaserDbAnalyzer::EcalLaserDbAnalyzer(const edm::ParameterSet& iConfig) {}
 
-}
-
-
-EcalLaserDbAnalyzer::~EcalLaserDbAnalyzer()
-{
-
-}
-
+EcalLaserDbAnalyzer::~EcalLaserDbAnalyzer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-        void
-EcalLaserDbAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void EcalLaserDbAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // get record from offline DB
+  edm::ESHandle<EcalLaserDbServiceMC> pSetup;
+  iSetup.get<EcalLaserDbRecordMC>().get(pSetup);
+  std::cout << "EcalLaserDbAnalyzer::analyze-> got EcalLaserDbRecordMC: " << std::endl;
 
-        // get record from offline DB
-        edm::ESHandle<EcalLaserDbServiceMC> pSetup;
-        iSetup.get<EcalLaserDbRecordMC>().get( pSetup );
-        std::cout << "EcalLaserDbAnalyzer::analyze-> got EcalLaserDbRecordMC: " << std::endl;
+  EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair apdpnpair;
+  const EcalLaserAPDPNRatiosMC* myapdpn = pSetup->getAPDPNRatios();
+  const EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap& laserRatiosMap = myapdpn->getLaserMap();
 
+  //   EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp timestamp;
+  //   const EcalLaserAPDPNRatiosMC::EcalLaserTimeStampMap& laserTimeMap =  myapdpn->getTimeMap();
 
-        EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair apdpnpair;
-        const EcalLaserAPDPNRatiosMC* myapdpn =  pSetup->getAPDPNRatios();
-        const EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap& laserRatiosMap =  myapdpn->getLaserMap();
+  EcalLaserAPDPNref apdpnref;
+  const EcalLaserAPDPNRatiosMCRef* myapdpnref = pSetup->getAPDPNRatiosRef();
+  const EcalLaserAPDPNRatiosMCRefMap& laserRefMap = myapdpnref->getMap();
 
-        //   EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp timestamp;
-        //   const EcalLaserAPDPNRatiosMC::EcalLaserTimeStampMap& laserTimeMap =  myapdpn->getTimeMap();
+  EcalLaserAlpha alpha;
+  const EcalLaserAlphas* myalpha = pSetup->getAlphas();
+  const EcalLaserAlphaMap& laserAlphaMap = myalpha->getMap();
 
-        EcalLaserAPDPNref apdpnref;
-        const EcalLaserAPDPNRatiosMCRef* myapdpnref =  pSetup->getAPDPNRatiosRef();
-        const EcalLaserAPDPNRatiosMCRefMap& laserRefMap =  myapdpnref->getMap();
+  EcalLinearCorrections::Values linValues;
+  const EcalLinearCorrections* mylinear = pSetup->getLinearCorrections();
+  const EcalLinearCorrections::EcalValueMap& linearValueMap = mylinear->getValueMap();
 
-        EcalLaserAlpha alpha;
-        const EcalLaserAlphas* myalpha =  pSetup->getAlphas();
-        const EcalLaserAlphaMap& laserAlphaMap =  myalpha->getMap();
+  for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
+    if (ieta == 0)
+      continue;
+    for (int iphi = EBDetId::MIN_IPHI; iphi <= EBDetId::MAX_IPHI; ++iphi) {
+      EBDetId ebdetid(ieta, iphi);
 
-        EcalLinearCorrections::Values linValues;
-        const EcalLinearCorrections* mylinear = pSetup->getLinearCorrections();
-        const EcalLinearCorrections::EcalValueMap& linearValueMap =  mylinear->getValueMap();
+      std::cout << ebdetid << " " << ebdetid.ietaSM() << " " << ebdetid.iphiSM() << std::endl;
 
-        for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
-                if(ieta==0) continue;
-                for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
-                        EBDetId ebdetid(ieta,iphi);
+      EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap::const_iterator itratio = laserRatiosMap.find(ebdetid);
+      if (itratio != laserRatiosMap.end()) {
+        apdpnpair = (*itratio);
+        std::cout << " APDPN pair = " << apdpnpair.p1 << " , " << apdpnpair.p2 << " , " << apdpnpair.p3 << std::endl;
+      } else {
+        edm::LogError("EcalLaserDbServiceMC") << "error with laserRatiosMap!" << endl;
+      }
 
-                        std::cout << ebdetid << " " << ebdetid.ietaSM() << " " << ebdetid.iphiSM() << std::endl;
+      EcalLinearCorrections::EcalValueMap::const_iterator itlin = linearValueMap.find(ebdetid);
+      if (itlin != linearValueMap.end()) {
+        linValues = (*itlin);
+        std::cout << " APDPN pair = " << linValues.p1 << " , " << linValues.p2 << " , " << linValues.p3 << std::endl;
+      } else {
+        edm::LogError("EcalLaserDbServiceMC") << "error with linearValuesMap!" << endl;
+      }
 
-                        EcalLaserAPDPNRatiosMC::EcalLaserAPDPNRatiosMap::const_iterator itratio = laserRatiosMap.find( ebdetid );
-                        if (itratio != laserRatiosMap.end()) {
-                                apdpnpair = (*itratio);
-                                std::cout << " APDPN pair = " << apdpnpair.p1 << " , " << apdpnpair.p2 << " , " << apdpnpair.p3 << std::endl;
-                        } else {
-                                edm::LogError("EcalLaserDbServiceMC") << "error with laserRatiosMap!" << endl;
-                        }
+      EcalLaserAPDPNRatiosMCRefMap::const_iterator itref = laserRefMap.find(ebdetid);
+      if (itref != laserRefMap.end()) {
+        apdpnref = (*itref);
+        std::cout << " APDPN ref = " << apdpnref << std::endl;
+      } else {
+        edm::LogError("EcalLaserDbServiceMC") << "error with laserRefMap!" << endl;
+      }
 
-                        EcalLinearCorrections::EcalValueMap::const_iterator itlin = linearValueMap.find( ebdetid );
-                        if (itlin != linearValueMap.end()) {
-                                linValues = (*itlin);
-                                std::cout << " APDPN pair = " << linValues.p1 << " , " << linValues.p2 << " , " << linValues.p3 << std::endl;
-                        } else {
-                                edm::LogError("EcalLaserDbServiceMC") << "error with linearValuesMap!" << endl;
-                        }
-
-                        EcalLaserAPDPNRatiosMCRefMap::const_iterator itref = laserRefMap.find( ebdetid );
-                        if ( itref != laserRefMap.end() ) {
-                                apdpnref = (*itref);
-                                std::cout << " APDPN ref = " << apdpnref << std::endl;
-                        } else {
-                                edm::LogError("EcalLaserDbServiceMC") << "error with laserRefMap!" << endl;
-                        }
-
-                        EcalLaserAlphaMap::const_iterator italpha = laserAlphaMap.find( ebdetid );
-                        if ( italpha != laserAlphaMap.end() ) {
-                                alpha = (*italpha);
-                                std::cout << " ALPHA = " << alpha << std::endl;
-                        } else {
-                                edm::LogError("EcalLaserDbServiceMC") << "error with laserAlphaMap!" << endl;
-                        }
-                }
-        }
+      EcalLaserAlphaMap::const_iterator italpha = laserAlphaMap.find(ebdetid);
+      if (italpha != laserAlphaMap.end()) {
+        alpha = (*italpha);
+        std::cout << " ALPHA = " << alpha << std::endl;
+      } else {
+        edm::LogError("EcalLaserDbServiceMC") << "error with laserAlphaMap!" << endl;
+      }
+    }
+  }
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserTestAnalyzerMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserTestAnalyzerMC.cc
@@ -2,7 +2,6 @@
 // Toyoko Orimoto (Caltech), 10 July 2007
 //
 
-
 // system include files
 #include <memory>
 //#include <time.h>
@@ -17,37 +16,32 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h"
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h"
 
-
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 
-
 using namespace std;
 //using namespace oracle::occi;
 
-
 class EcalLaserTestAnalyzer : public edm::EDAnalyzer {
 public:
-  explicit EcalLaserTestAnalyzer( const edm::ParameterSet& );
-  ~EcalLaserTestAnalyzer ();
+  explicit EcalLaserTestAnalyzer(const edm::ParameterSet&);
+  ~EcalLaserTestAnalyzer();
 
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   //  std::string m_timetype;
   //  std::map<std::string, unsigned long long> m_cacheIDs;
   //  std::map<std::string, std::string> m_records;
   //  unsigned long m_firstRun ;
   //  unsigned long m_lastRun ;
-
 
   // ----------member data ---------------------------
 };
@@ -63,167 +57,150 @@ private:
 //
 // constructors and destructor
 //
-EcalLaserTestAnalyzer::EcalLaserTestAnalyzer( const edm::ParameterSet& iConfig )
-  //:
-  //  m_timetype(iConfig.getParameter<std::string>("timetype")),
-  //  m_cacheIDs(),
-  //  m_records()
+EcalLaserTestAnalyzer::EcalLaserTestAnalyzer(const edm::ParameterSet& iConfig)
+//:
+//  m_timetype(iConfig.getParameter<std::string>("timetype")),
+//  m_cacheIDs(),
+//  m_records()
 {
   //   std::cout << "EcalLaserTestAnalyzer::EcalLaserTestAnalyzer->... construct me!" << std::endl;
-   //now do what ever initialization is needed
+  //now do what ever initialization is needed
 
-//    std::string container;
-//    std::string tag;
-//    std::string record;
-  
-//    //   m_firstRun=(unsigned long)atoi( iConfig.getParameter<std::string>("firstRun").c_str());
-//    //   m_lastRun=(unsigned long)atoi( iConfig.getParameter<std::string>("lastRun").c_str());
-  
-//    typedef std::vector< edm::ParameterSet > Parameters;
-//    Parameters toGet = iConfig.getParameter<Parameters>("toGet");
-//    for(Parameters::iterator i = toGet.begin(); i != toGet.end(); ++i) {
-//      container = i->getParameter<std::string>("container");
-//      record = i->getParameter<std::string>("record");
-//      m_cacheIDs.insert( std::make_pair(container, 0) );
-//      m_records.insert( std::make_pair(container, record) );
+  //    std::string container;
+  //    std::string tag;
+  //    std::string record;
 
-//    } 
+  //    //   m_firstRun=(unsigned long)atoi( iConfig.getParameter<std::string>("firstRun").c_str());
+  //    //   m_lastRun=(unsigned long)atoi( iConfig.getParameter<std::string>("lastRun").c_str());
 
+  //    typedef std::vector< edm::ParameterSet > Parameters;
+  //    Parameters toGet = iConfig.getParameter<Parameters>("toGet");
+  //    for(Parameters::iterator i = toGet.begin(); i != toGet.end(); ++i) {
+  //      container = i->getParameter<std::string>("container");
+  //      record = i->getParameter<std::string>("record");
+  //      m_cacheIDs.insert( std::make_pair(container, 0) );
+  //      m_records.insert( std::make_pair(container, record) );
+
+  //    }
 }
 
-
-EcalLaserTestAnalyzer::~EcalLaserTestAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+EcalLaserTestAnalyzer::~EcalLaserTestAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-EcalLaserTestAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-
+void EcalLaserTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //   using namespace edm;
 
   // get record from offline DB
   edm::ESHandle<EcalLaserDbServiceMC> pSetup;
-  iSetup.get<EcalLaserDbRecordMC>().get( pSetup );
+  iSetup.get<EcalLaserDbRecordMC>().get(pSetup);
   std::cout << "EcalLaserTestAnalyzer::analyze-> got EcalLaserDbRecordMC: " << std::endl;
   //  pSetup->setVerbosity(true);
 
-//   int ieta = 83;
-//   int iphi = 168;
-//   EBDetId testid(ieta,iphi);
-//   edm::Timestamp testtime(2222);
-  
+  //   int ieta = 83;
+  //   int iphi = 168;
+  //   EBDetId testid(ieta,iphi);
+  //   edm::Timestamp testtime(2222);
 
-//   edm::ESHandle< EcalElectronicsMapping > ecalmapping;
-//   iSetup.get< EcalMappingRcd >().get(ecalmapping);
-//   const EcalElectronicsMapping* TheMapping = ecalmapping.product();
-// //   int dccid = TheMapping-> DCCid(testid);
-// //   int tccid = TheMapping-> TCCid(testid);
+  //   edm::ESHandle< EcalElectronicsMapping > ecalmapping;
+  //   iSetup.get< EcalMappingRcd >().get(ecalmapping);
+  //   const EcalElectronicsMapping* TheMapping = ecalmapping.product();
+  // //   int dccid = TheMapping-> DCCid(testid);
+  // //   int tccid = TheMapping-> TCCid(testid);
 
-// //   std::cout << std::endl 
-// // 	    << "TESTID: " << testid << " " 
-// // 	    << testid.ietaSM() << " " << testid.iphiSM() << " "
-// // 	    << testid.rawId() << " " 
-// // 	    << dccid << " " << tccid 
-// // 	    << std::endl;
+  // //   std::cout << std::endl
+  // // 	    << "TESTID: " << testid << " "
+  // // 	    << testid.ietaSM() << " " << testid.iphiSM() << " "
+  // // 	    << testid.rawId() << " "
+  // // 	    << dccid << " " << tccid
+  // // 	    << std::endl;
 
-
-//   float blah = pSetup->getLaserCorrection(testid, testtime);
-//   std::cout << " EcalLaserTestAnalyzer: " << blah << std::endl; 
+  //   float blah = pSetup->getLaserCorrection(testid, testtime);
+  //   std::cout << " EcalLaserTestAnalyzer: " << blah << std::endl;
 
   std::cout << "---> FIRST ECAL BARREL " << endl;
-  
-  // ECAL Barrel
-  for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
-    if(ieta==0) continue;
-    for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
-      try
- 	{
-	  
-	  EBDetId testid(ieta,iphi);
-	  //	  edm::Timestamp testtime(12000);
 
-	  // 	  int dccid = TheMapping-> DCCid(testid);
-	  // 	  int tccid = TheMapping-> TCCid(testid);
-	  
-	  // 	  EcalElectronicsId myid = TheMapping->getElectronicsId(testid);
-	  // 	  EcalTriggerElectronicsId mytid = TheMapping->getTriggerElectronicsId(testid);
-	  
- 	  std::cout << std::endl 
- 		    << "CRYSTAL EB: " << testid << " " 
-	    // 		    << testid.ietaSM() << " " << testid.iphiSM() << " : "
-	    // 		    << testid.rawId() << " : " << myid << " " << myid.rawId() << " : "
-	    // 	  	    << dccid << " " << tccid 
- 	  	    << std::endl;
-	  //	  std::cout << testid << std::endl;
-	  
-	  float blah = pSetup->getLaserCorrection(testid, iEvent.time());
-	  std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl; 
-	  
- 	}
-      catch (...)
-	{
-	}
+  // ECAL Barrel
+  for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
+    if (ieta == 0)
+      continue;
+    for (int iphi = EBDetId::MIN_IPHI; iphi <= EBDetId::MAX_IPHI; ++iphi) {
+      try {
+        EBDetId testid(ieta, iphi);
+        //	  edm::Timestamp testtime(12000);
+
+        // 	  int dccid = TheMapping-> DCCid(testid);
+        // 	  int tccid = TheMapping-> TCCid(testid);
+
+        // 	  EcalElectronicsId myid = TheMapping->getElectronicsId(testid);
+        // 	  EcalTriggerElectronicsId mytid = TheMapping->getTriggerElectronicsId(testid);
+
+        std::cout << std::endl
+                  << "CRYSTAL EB: " << testid
+                  << " "
+                  // 		    << testid.ietaSM() << " " << testid.iphiSM() << " : "
+                  // 		    << testid.rawId() << " : " << myid << " " << myid.rawId() << " : "
+                  // 	  	    << dccid << " " << tccid
+                  << std::endl;
+        //	  std::cout << testid << std::endl;
+
+        float blah = pSetup->getLaserCorrection(testid, iEvent.time());
+        std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl;
+
+      } catch (...) {
+      }
     }
   }
-  
+
   std::cout << "---> NOW ECAL ENDCAP " << endl;
-  
+
   //   ECAL Endcap
-  for(int iX=EEDetId::IX_MIN; iX<=EEDetId::IX_MAX ;++iX) {
-    for(int iY=EEDetId::IY_MIN; iY<=EEDetId::IY_MAX; ++iY) {
+  for (int iX = EEDetId::IX_MIN; iX <= EEDetId::IX_MAX; ++iX) {
+    for (int iY = EEDetId::IY_MIN; iY <= EEDetId::IY_MAX; ++iY) {
       // make an EEDetId since we need EEDetId::rawId() to be used as the key for the pedestals
-      try 
-	{
-	  
-	  // +Z side
- 	  EEDetId testidpos(iX,iY,1);
-	  // 	  edm::Timestamp testtime(12000);
-	  //	  std::cout << " EcalLaserTestAnalyzer: " << testidpos << " " << testidpos.isc() << endl;
-	  
-	  // 	  // test of elec mapping
-	  // 	  EcalElectronicsId myidpos = TheMapping->getElectronicsId(testidpos);
- 	  std::cout << std::endl 
- 		    << "CRYSTAL EE+: " << testidpos << " " << testidpos.isc() << " "
-	    // 		    << testidpos.rawId() << " : " << myidpos << " " << myidpos.rawId() << " : "
-	    // 		    << myidpos.dccId()
- 	  	    << std::endl;
-	  // 	  //
-	  
- 	  float blah = pSetup->getLaserCorrection(testidpos, iEvent.time());
-	  std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " <<  blah << std::endl; 
-	  
-	  // -Z side
-	  EEDetId testidneg(iX,iY,-1);
-	  //	  std::cout << " EcalLaserTestAnalyzer: " << testidneg << " " << testidneg.isc() << endl;
-	  
-	  // 	  EcalElectronicsId myidneg = TheMapping->getElectronicsId(testidneg);
- 	  std::cout << std::endl 
- 		    << "CRYSTAL EE-: " << testidneg << " " << testidneg.isc() << " "
-	    // 		    << testidneg.rawId() << " : " << myidneg << " " << myidneg.rawId() << " : "
-	    // 		    << myidneg.dccId()
- 	  	    << std::endl;
-	  
-	  blah = pSetup->getLaserCorrection(testidneg, iEvent.time());
-	  std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl; 
-	}
-      catch (...)
-	{
-	}
+      try {
+        // +Z side
+        EEDetId testidpos(iX, iY, 1);
+        // 	  edm::Timestamp testtime(12000);
+        //	  std::cout << " EcalLaserTestAnalyzer: " << testidpos << " " << testidpos.isc() << endl;
+
+        // 	  // test of elec mapping
+        // 	  EcalElectronicsId myidpos = TheMapping->getElectronicsId(testidpos);
+        std::cout << std::endl
+                  << "CRYSTAL EE+: " << testidpos << " " << testidpos.isc()
+                  << " "
+                  // 		    << testidpos.rawId() << " : " << myidpos << " " << myidpos.rawId() << " : "
+                  // 		    << myidpos.dccId()
+                  << std::endl;
+        // 	  //
+
+        float blah = pSetup->getLaserCorrection(testidpos, iEvent.time());
+        std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl;
+
+        // -Z side
+        EEDetId testidneg(iX, iY, -1);
+        //	  std::cout << " EcalLaserTestAnalyzer: " << testidneg << " " << testidneg.isc() << endl;
+
+        // 	  EcalElectronicsId myidneg = TheMapping->getElectronicsId(testidneg);
+        std::cout << std::endl
+                  << "CRYSTAL EE-: " << testidneg << " " << testidneg.isc()
+                  << " "
+                  // 		    << testidneg.rawId() << " : " << myidneg << " " << myidneg.rawId() << " : "
+                  // 		    << myidneg.dccId()
+                  << std::endl;
+
+        blah = pSetup->getLaserCorrection(testidneg, iEvent.time());
+        std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl;
+      } catch (...) {
+      }
     }
   }
-  
-  
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserTestAnalyzerMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/test/EcalLaserTestAnalyzerMC.cc
@@ -1,0 +1,230 @@
+//
+// Toyoko Orimoto (Caltech), 10 July 2007
+//
+
+
+// system include files
+#include <memory>
+//#include <time.h>
+#include <string>
+#include <map>
+#include <iostream>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbServiceMC.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecordMC.h"
+
+
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+
+
+using namespace std;
+//using namespace oracle::occi;
+
+
+class EcalLaserTestAnalyzer : public edm::EDAnalyzer {
+public:
+  explicit EcalLaserTestAnalyzer( const edm::ParameterSet& );
+  ~EcalLaserTestAnalyzer ();
+
+  
+  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+private:
+  //  std::string m_timetype;
+  //  std::map<std::string, unsigned long long> m_cacheIDs;
+  //  std::map<std::string, std::string> m_records;
+  //  unsigned long m_firstRun ;
+  //  unsigned long m_lastRun ;
+
+
+  // ----------member data ---------------------------
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+EcalLaserTestAnalyzer::EcalLaserTestAnalyzer( const edm::ParameterSet& iConfig )
+  //:
+  //  m_timetype(iConfig.getParameter<std::string>("timetype")),
+  //  m_cacheIDs(),
+  //  m_records()
+{
+  //   std::cout << "EcalLaserTestAnalyzer::EcalLaserTestAnalyzer->... construct me!" << std::endl;
+   //now do what ever initialization is needed
+
+//    std::string container;
+//    std::string tag;
+//    std::string record;
+  
+//    //   m_firstRun=(unsigned long)atoi( iConfig.getParameter<std::string>("firstRun").c_str());
+//    //   m_lastRun=(unsigned long)atoi( iConfig.getParameter<std::string>("lastRun").c_str());
+  
+//    typedef std::vector< edm::ParameterSet > Parameters;
+//    Parameters toGet = iConfig.getParameter<Parameters>("toGet");
+//    for(Parameters::iterator i = toGet.begin(); i != toGet.end(); ++i) {
+//      container = i->getParameter<std::string>("container");
+//      record = i->getParameter<std::string>("record");
+//      m_cacheIDs.insert( std::make_pair(container, 0) );
+//      m_records.insert( std::make_pair(container, record) );
+
+//    } 
+
+}
+
+
+EcalLaserTestAnalyzer::~EcalLaserTestAnalyzer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+EcalLaserTestAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+
+  //   using namespace edm;
+
+  // get record from offline DB
+  edm::ESHandle<EcalLaserDbServiceMC> pSetup;
+  iSetup.get<EcalLaserDbRecordMC>().get( pSetup );
+  std::cout << "EcalLaserTestAnalyzer::analyze-> got EcalLaserDbRecordMC: " << std::endl;
+  //  pSetup->setVerbosity(true);
+
+//   int ieta = 83;
+//   int iphi = 168;
+//   EBDetId testid(ieta,iphi);
+//   edm::Timestamp testtime(2222);
+  
+
+//   edm::ESHandle< EcalElectronicsMapping > ecalmapping;
+//   iSetup.get< EcalMappingRcd >().get(ecalmapping);
+//   const EcalElectronicsMapping* TheMapping = ecalmapping.product();
+// //   int dccid = TheMapping-> DCCid(testid);
+// //   int tccid = TheMapping-> TCCid(testid);
+
+// //   std::cout << std::endl 
+// // 	    << "TESTID: " << testid << " " 
+// // 	    << testid.ietaSM() << " " << testid.iphiSM() << " "
+// // 	    << testid.rawId() << " " 
+// // 	    << dccid << " " << tccid 
+// // 	    << std::endl;
+
+
+//   float blah = pSetup->getLaserCorrection(testid, testtime);
+//   std::cout << " EcalLaserTestAnalyzer: " << blah << std::endl; 
+
+  std::cout << "---> FIRST ECAL BARREL " << endl;
+  
+  // ECAL Barrel
+  for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
+    if(ieta==0) continue;
+    for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
+      try
+ 	{
+	  
+	  EBDetId testid(ieta,iphi);
+	  //	  edm::Timestamp testtime(12000);
+
+	  // 	  int dccid = TheMapping-> DCCid(testid);
+	  // 	  int tccid = TheMapping-> TCCid(testid);
+	  
+	  // 	  EcalElectronicsId myid = TheMapping->getElectronicsId(testid);
+	  // 	  EcalTriggerElectronicsId mytid = TheMapping->getTriggerElectronicsId(testid);
+	  
+ 	  std::cout << std::endl 
+ 		    << "CRYSTAL EB: " << testid << " " 
+	    // 		    << testid.ietaSM() << " " << testid.iphiSM() << " : "
+	    // 		    << testid.rawId() << " : " << myid << " " << myid.rawId() << " : "
+	    // 	  	    << dccid << " " << tccid 
+ 	  	    << std::endl;
+	  //	  std::cout << testid << std::endl;
+	  
+	  float blah = pSetup->getLaserCorrection(testid, iEvent.time());
+	  std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl; 
+	  
+ 	}
+      catch (...)
+	{
+	}
+    }
+  }
+  
+  std::cout << "---> NOW ECAL ENDCAP " << endl;
+  
+  //   ECAL Endcap
+  for(int iX=EEDetId::IX_MIN; iX<=EEDetId::IX_MAX ;++iX) {
+    for(int iY=EEDetId::IY_MIN; iY<=EEDetId::IY_MAX; ++iY) {
+      // make an EEDetId since we need EEDetId::rawId() to be used as the key for the pedestals
+      try 
+	{
+	  
+	  // +Z side
+ 	  EEDetId testidpos(iX,iY,1);
+	  // 	  edm::Timestamp testtime(12000);
+	  //	  std::cout << " EcalLaserTestAnalyzer: " << testidpos << " " << testidpos.isc() << endl;
+	  
+	  // 	  // test of elec mapping
+	  // 	  EcalElectronicsId myidpos = TheMapping->getElectronicsId(testidpos);
+ 	  std::cout << std::endl 
+ 		    << "CRYSTAL EE+: " << testidpos << " " << testidpos.isc() << " "
+	    // 		    << testidpos.rawId() << " : " << myidpos << " " << myidpos.rawId() << " : "
+	    // 		    << myidpos.dccId()
+ 	  	    << std::endl;
+	  // 	  //
+	  
+ 	  float blah = pSetup->getLaserCorrection(testidpos, iEvent.time());
+	  std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " <<  blah << std::endl; 
+	  
+	  // -Z side
+	  EEDetId testidneg(iX,iY,-1);
+	  //	  std::cout << " EcalLaserTestAnalyzer: " << testidneg << " " << testidneg.isc() << endl;
+	  
+	  // 	  EcalElectronicsId myidneg = TheMapping->getElectronicsId(testidneg);
+ 	  std::cout << std::endl 
+ 		    << "CRYSTAL EE-: " << testidneg << " " << testidneg.isc() << " "
+	    // 		    << testidneg.rawId() << " : " << myidneg << " " << myidneg.rawId() << " : "
+	    // 		    << myidneg.dccId()
+ 	  	    << std::endl;
+	  
+	  blah = pSetup->getLaserCorrection(testidneg, iEvent.time());
+	  std::cout << " EcalLaserTestAnalyzer: " << iEvent.time().value() << " " << blah << std::endl; 
+	}
+      catch (...)
+	{
+	}
+    }
+  }
+  
+  
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EcalLaserTestAnalyzer);

--- a/CondCore/EcalPlugins/src/plugin.cc
+++ b/CondCore/EcalPlugins/src/plugin.cc
@@ -175,7 +175,7 @@ REGISTER_PLUGIN(EcalIntercalibErrorsRcd, EcalCondObjectContainer<float>);
 REGISTER_PLUGIN(EcalADCToGeVConstantRcd, EcalADCToGeVConstant);
 REGISTER_PLUGIN(EcalLaserAlphasRcd, EcalCondObjectContainer<float>);
 REGISTER_PLUGIN(EcalLaserAPDPNRatiosRcd, EcalLaserAPDPNRatios);
-REGISTER_PLUGIN(EcalLaserAPDPNRatiosMCRcd,EcalLaserAPDPNRatiosMC);
+REGISTER_PLUGIN(EcalLaserAPDPNRatiosMCRcd, EcalLaserAPDPNRatiosMC);
 REGISTER_PLUGIN(EcalLaserAPDPNRatiosRefRcd, EcalCondObjectContainer<float>);
 REGISTER_PLUGIN(EcalChannelStatusRcd, EcalCondObjectContainer<EcalChannelStatusCode>);
 REGISTER_PLUGIN(EcalPFRecHitThresholdsRcd, EcalCondObjectContainer<float>);

--- a/CondCore/EcalPlugins/src/plugin.cc
+++ b/CondCore/EcalPlugins/src/plugin.cc
@@ -59,6 +59,9 @@
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
 
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h"
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h"
+
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 
@@ -172,6 +175,7 @@ REGISTER_PLUGIN(EcalIntercalibErrorsRcd, EcalCondObjectContainer<float>);
 REGISTER_PLUGIN(EcalADCToGeVConstantRcd, EcalADCToGeVConstant);
 REGISTER_PLUGIN(EcalLaserAlphasRcd, EcalCondObjectContainer<float>);
 REGISTER_PLUGIN(EcalLaserAPDPNRatiosRcd, EcalLaserAPDPNRatios);
+REGISTER_PLUGIN(EcalLaserAPDPNRatiosMCRcd,EcalLaserAPDPNRatiosMC);
 REGISTER_PLUGIN(EcalLaserAPDPNRatiosRefRcd, EcalCondObjectContainer<float>);
 REGISTER_PLUGIN(EcalChannelStatusRcd, EcalCondObjectContainer<EcalChannelStatusCode>);
 REGISTER_PLUGIN(EcalPFRecHitThresholdsRcd, EcalCondObjectContainer<float>);

--- a/CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h
+++ b/CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h
@@ -1,0 +1,26 @@
+#ifndef DataRecord_EcalLaserAPDPNRatiosMCRcd_h
+#define DataRecord_EcalLaserAPDPNRatiosMCRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     EcalLaserAPDPNRatiosMCRcd
+// 
+/**\class EcalLaserAPDPNRatiosMCRcd EcalLaserAPDPNRatiosMCRcd.h CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h
+
+ Description: <one line class summary>
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      
+// Created:     Fri Jun  1 12:30:43 CEST 2007
+// $Id$
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class EcalLaserAPDPNRatiosMCRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalLaserAPDPNRatiosMCRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h
+++ b/CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h
@@ -4,7 +4,7 @@
 //
 // Package:     DataRecord
 // Class  :     EcalLaserAPDPNRatiosMCRcd
-// 
+//
 /**\class EcalLaserAPDPNRatiosMCRcd EcalLaserAPDPNRatiosMCRcd.h CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h
 
  Description: <one line class summary>
@@ -14,7 +14,7 @@
 
 */
 //
-// Author:      
+// Author:
 // Created:     Fri Jun  1 12:30:43 CEST 2007
 // $Id$
 //

--- a/CondFormats/DataRecord/src/EcalLaserAPDPNRatiosMCRcd.cc
+++ b/CondFormats/DataRecord/src/EcalLaserAPDPNRatiosMCRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     EcalLaserAPDPNRatiosMCRcd
+// 
+// Implementation:
+//     <Notes on implementation>
+//
+// Author:      
+// Created:     Fri Jun  1 12:30:43 CEST 2007
+// $Id$
+
+#include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosMCRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalLaserAPDPNRatiosMCRcd);

--- a/CondFormats/DataRecord/src/EcalLaserAPDPNRatiosMCRcd.cc
+++ b/CondFormats/DataRecord/src/EcalLaserAPDPNRatiosMCRcd.cc
@@ -2,11 +2,11 @@
 //
 // Package:     DataRecord
 // Class  :     EcalLaserAPDPNRatiosMCRcd
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Fri Jun  1 12:30:43 CEST 2007
 // $Id$
 

--- a/CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h
+++ b/CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h
@@ -1,5 +1,5 @@
-#ifndef CondFormats_EcalObjects_EcalLaserAPDPNRatiosMC_H 
-#define CondFormats_EcalObjects_EcalLaserAPDPNRatiosMC_H 
+#ifndef CondFormats_EcalObjects_EcalLaserAPDPNRatiosMC_H
+#define CondFormats_EcalObjects_EcalLaserAPDPNRatiosMC_H
 /**
  *Author: Vladlen Timciuc, Caltech
  * Created: 10 July 2007
@@ -12,42 +12,41 @@
 #include <vector>
 
 class EcalLaserAPDPNRatiosMC {
- public:
-  struct EcalLaserAPDPNpair{
+public:
+  struct EcalLaserAPDPNpair {
     EcalLaserAPDPNpair() : p1(0), p2(0), p3(0) {}
     float p1;
     float p2;
     float p3;
-  
-  COND_SERIALIZABLE;
-};
-  struct EcalLaserTimeStamp{
+
+    COND_SERIALIZABLE;
+  };
+  struct EcalLaserTimeStamp {
     EcalLaserTimeStamp() : t1(), t2(), t3() {}
     edm::Timestamp t1;
     edm::Timestamp t2;
     edm::Timestamp t3;
-  
-  COND_SERIALIZABLE;
-};
-  
+
+    COND_SERIALIZABLE;
+  };
+
   typedef EcalCondObjectContainer<EcalLaserAPDPNpair> EcalLaserAPDPNRatiosMap;
   typedef std::vector<EcalLaserTimeStamp> EcalLaserTimeStampMap;
 
-  EcalLaserAPDPNRatiosMC() : time_map(92) {}; // FIXME
-  ~EcalLaserAPDPNRatiosMC() {};
-   
-  void  setValue(uint32_t rawId, const EcalLaserAPDPNpair& value) { laser_map[rawId] = value; };
-  const EcalLaserAPDPNRatiosMap& getLaserMap() const { return laser_map; }
-  
-  void setTime(int hashedIndex, const EcalLaserTimeStamp& value) { time_map[hashedIndex] = value; };
-  const EcalLaserTimeStampMap& getTimeMap() const { return time_map; }  
+  EcalLaserAPDPNRatiosMC() : time_map(92){};  // FIXME
+  ~EcalLaserAPDPNRatiosMC(){};
 
- private:
+  void setValue(uint32_t rawId, const EcalLaserAPDPNpair& value) { laser_map[rawId] = value; };
+  const EcalLaserAPDPNRatiosMap& getLaserMap() const { return laser_map; }
+
+  void setTime(int hashedIndex, const EcalLaserTimeStamp& value) { time_map[hashedIndex] = value; };
+  const EcalLaserTimeStampMap& getTimeMap() const { return time_map; }
+
+private:
   EcalLaserAPDPNRatiosMap laser_map;
   EcalLaserTimeStampMap time_map;
-   
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h
+++ b/CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h
@@ -1,0 +1,53 @@
+#ifndef CondFormats_EcalObjects_EcalLaserAPDPNRatiosMC_H 
+#define CondFormats_EcalObjects_EcalLaserAPDPNRatiosMC_H 
+/**
+ *Author: Vladlen Timciuc, Caltech
+ * Created: 10 July 2007
+ * $Id: EcalLaserAPDPNRatiosMC.h,v 1.5 2007/09/27 09:42:55 ferriff Exp $
+ **/
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include <vector>
+
+class EcalLaserAPDPNRatiosMC {
+ public:
+  struct EcalLaserAPDPNpair{
+    EcalLaserAPDPNpair() : p1(0), p2(0), p3(0) {}
+    float p1;
+    float p2;
+    float p3;
+  
+  COND_SERIALIZABLE;
+};
+  struct EcalLaserTimeStamp{
+    EcalLaserTimeStamp() : t1(), t2(), t3() {}
+    edm::Timestamp t1;
+    edm::Timestamp t2;
+    edm::Timestamp t3;
+  
+  COND_SERIALIZABLE;
+};
+  
+  typedef EcalCondObjectContainer<EcalLaserAPDPNpair> EcalLaserAPDPNRatiosMap;
+  typedef std::vector<EcalLaserTimeStamp> EcalLaserTimeStampMap;
+
+  EcalLaserAPDPNRatiosMC() : time_map(92) {}; // FIXME
+  ~EcalLaserAPDPNRatiosMC() {};
+   
+  void  setValue(uint32_t rawId, const EcalLaserAPDPNpair& value) { laser_map[rawId] = value; };
+  const EcalLaserAPDPNRatiosMap& getLaserMap() const { return laser_map; }
+  
+  void setTime(int hashedIndex, const EcalLaserTimeStamp& value) { time_map[hashedIndex] = value; };
+  const EcalLaserTimeStampMap& getTimeMap() const { return time_map; }  
+
+ private:
+  EcalLaserAPDPNRatiosMap laser_map;
+  EcalLaserTimeStampMap time_map;
+   
+
+ COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/EcalObjects/src/T_EventSetup_EcalLaserAPDPNRatiosMC.cc
+++ b/CondFormats/EcalObjects/src/T_EventSetup_EcalLaserAPDPNRatiosMC.cc
@@ -1,0 +1,5 @@
+// user include files
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(EcalLaserAPDPNRatiosMC);

--- a/CondFormats/EcalObjects/src/classes.h
+++ b/CondFormats/EcalObjects/src/classes.h
@@ -129,10 +129,10 @@ namespace CondFormats_EcalObjects {
     EcalLaserAPDPNRatiosMC laser_mc_map;
     std::vector<EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_pair_map;
     std::vector<EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp> laser_mc_time_map;
-    EcalContainer<EEDetId,EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_ec_eeDetId_pair;
-    EcalContainer<EBDetId,EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_ec_ebDetId_pair;
+    EcalContainer<EEDetId, EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_ec_eeDetId_pair;
+    EcalContainer<EBDetId, EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_ec_ebDetId_pair;
     EcalCondObjectContainer<EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_map_dm;
-    
+
     EcalTimeDependentCorrections correction_map;
     std::vector<EcalTimeDependentCorrections::Values> value_map;
     std::vector<EcalTimeDependentCorrections::Times> time_map;

--- a/CondFormats/EcalObjects/src/classes.h
+++ b/CondFormats/EcalObjects/src/classes.h
@@ -34,6 +34,7 @@
 #include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeDependentCorrections.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
+#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosMC.h"
 #include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h"
@@ -125,6 +126,13 @@ namespace CondFormats_EcalObjects {
     EcalContainer<EBDetId, EcalLaserAPDPNRatios::EcalLaserAPDPNpair> laser_ec_ebDetId_pair;
     EcalCondObjectContainer<EcalLaserAPDPNRatios::EcalLaserAPDPNpair> laser_map_dm;
 
+    EcalLaserAPDPNRatiosMC laser_mc_map;
+    std::vector<EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_pair_map;
+    std::vector<EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp> laser_mc_time_map;
+    EcalContainer<EEDetId,EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_ec_eeDetId_pair;
+    EcalContainer<EBDetId,EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_ec_ebDetId_pair;
+    EcalCondObjectContainer<EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair> laser_mc_map_dm;
+    
     EcalTimeDependentCorrections correction_map;
     std::vector<EcalTimeDependentCorrections::Values> value_map;
     std::vector<EcalTimeDependentCorrections::Times> time_map;

--- a/CondFormats/EcalObjects/src/classes_def.xml
+++ b/CondFormats/EcalObjects/src/classes_def.xml
@@ -152,6 +152,22 @@
 </class>
 
 <!-- base class -->
+<class name="EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair"/>
+<class name="EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp"/>
+<class name="EcalLaserAPDPNRatiosMC">
+   <field name="laser_map" mapping="blob" />
+</class>
+<!-- templates for EcalCondObjectContainer having the class as template parameter -->
+<class name="std::vector<EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair>"/>
+<class name="std::vector<EcalLaserAPDPNRatiosMC::EcalLaserTimeStamp>"/>
+<class name="EcalContainer<EEDetId,EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair>"/>
+<class name="EcalContainer<EBDetId,EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair>"/>
+<class name="EcalCondObjectContainer<EcalLaserAPDPNRatiosMC::EcalLaserAPDPNpair>">
+   <field name = "eb_" mapping = "blob"/>
+   <field name = "ee_" mapping = "blob"/>
+</class>
+
+<!-- base class -->
 <class name="EcalTimeDependentCorrections::Values"/>
 <class name="EcalTimeDependentCorrections::Times"/>
 <class name="EcalTimeDependentCorrections">

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -93,10 +93,13 @@ public:
     m_maxEneEB = (agc->getEBValue()) * theDefaultGains[1] * MAXADC * m_EBs25notCont;
     m_maxEneEE = (agc->getEEValue()) * theDefaultGains[1] * MAXADC * m_EEs25notCont;
 
+ 
+    //----
     // Ecal LaserCorrection Constants for laser correction ratio
     edm::ESHandle<EcalLaserDbService> laser;
     eventSetup->get<EcalLaserDbRecord>().get(laser);
-//     const edm::TimeValue_t eventTimeValue = event.time().value();
+    const edm::TimeValue_t eventTimeValue = theEvent->time().value();
+    m_iTime = eventTimeValue;
     m_lasercals = laser.product();
 
     edm::ESHandle<EcalLaserDbService> laser_prime;
@@ -104,8 +107,10 @@ public:
     //     const edm::TimeValue_t eventTimeValue = event.time().value();
     m_lasercals_prime = laser_prime.product();
     
-//     m_EBResponse->setEventTime(eventTimeValue);
-    
+    //clear the laser cache for each event time
+    CalibCache().swap(m_valueLCCache_LC);
+    //----
+
     
     eventSetup->get<EcalIntercalibConstantsMCRcd>().get(pIcal);
     ical = pIcal.product();
@@ -224,7 +229,8 @@ private:
     
 //     return 1.0;
     
-    int m_iTime = 0; //---- FIXME
+//     const edm::TimeValue_t m_iTime = event.time().value();
+//     int m_iTime = 0; //---- FIXME
     const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
     return (m_lasercals->getLaserCorrection(detId, evtTimeStamp));
     
@@ -234,11 +240,11 @@ private:
   //---- FIXME
   double findLaserConstant_LC_prime(const DetId& detId) const {
     
-    return 1.0;
+//     return 1.0;
     
-    int m_iTime = 0; //---- FIXME
-    const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
-    //   return (m_lasercals_prime->getLaserCorrection(detId, evtTimeStamp));
+    int temp_iTime = 0; //---- Correct to set the time to 0 --> the "LC'" is the first IOV of the tag MC to be used
+    const edm::Timestamp& evtTimeStamp = edm::Timestamp(temp_iTime);
+    return (m_lasercals_prime->getLaserCorrection(detId, evtTimeStamp));
     
   }
   

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -79,16 +79,11 @@ public:
     m_peToABarrel = peToABarrel;
     m_peToAEndcap = peToAEndcap;
     
-    
-//     std::cout << " ---> EcalSignalGenerator() : EcalBaseSignalGenerator() " << std::endl;
-    
   }
 
   ~EcalSignalGenerator() override {}
 
   void initializeEvent(const edm::Event* event, const edm::EventSetup* eventSetup) {
-    
-//     std::cout << " ---> EcalSignalGenerator() : initializeEvent() " << std::endl;
     
     theEvent = event;
     eventSetup->get<EcalGainRatiosRcd>().get(grHandle);  // find the gains
@@ -109,6 +104,10 @@ public:
     eventSetup->get<EcalLaserDbRecord>().get(laser);
     
 //     const edm::TimeValue_t eventTimeValue = theEvent->time().value();
+    //
+    // FIXME: is this workaround of using "run" really needed or "time" can be used in MC generation as well?
+    //        check with generation experts
+    //
     const edm::TimeValue_t eventTimeValue = theEvent->run(); 
     //---- NB: this is a trick. Since the time dependent MC 
     //         will be based on "run" (and lumisection)
@@ -122,7 +121,6 @@ public:
     
     
     m_lasercals = laser.product();
-//     std::cout << " ---> EcalSignalGenerator() : initializeEvent() :: eventTimeValue = " << eventTimeValue << std::endl;
 
     //
     // the "prime" is exactly the same as the usual laser service, BUT
@@ -136,9 +134,9 @@ public:
     m_lasercals_prime = laser_prime.product();
     
     //clear the laser cache for each event time
-//     CalibCache().swap(m_valueLCCache_LC);   -> strange way to clear a collection ... why was it like this?
-//     http://www.cplusplus.com/reference/unordered_map/unordered_map/clear/
-//     http://www.cplusplus.com/reference/unordered_map/unordered_map/swap/
+    //     CalibCache().swap(m_valueLCCache_LC);   -> strange way to clear a collection ... why was it like this?
+    //     http://www.cplusplus.com/reference/unordered_map/unordered_map/clear/
+    //     http://www.cplusplus.com/reference/unordered_map/unordered_map/swap/
     m_valueLCCache_LC.clear();
     m_valueLCCache_LC_prime.clear(); //--- also the "prime" ... yes
     //----
@@ -164,14 +162,10 @@ public:
     else
       ESMIPToGeV = esMipToGeV->getESValueHigh();
     
-//     std::cout << " ---> EcalSignalGenerator() : initializeEvent() [end] " << std::endl;
-    
   }
 
   /// some users use EventPrincipals, not Events.  We support both
   void initializeEvent(const edm::EventPrincipal* eventPrincipal, const edm::EventSetup* eventSetup) {
-
-//     std::cout << " ---> EcalSignalGenerator() : initializeEvent() [second version]" << std::endl;
 
     theEventPrincipal = eventPrincipal;
     eventSetup->get<EcalGainRatiosRcd>().get(grHandle);  // find the gains
@@ -191,6 +185,10 @@ public:
     edm::TimeValue_t eventTimeValue;
     if (theEventPrincipal) {
 //       eventTimeValue = theEventPrincipal->time().value();
+      //
+      // FIXME: is this workaround of using "run" really needed or "time" can be used in MC generation as well?
+      //        check with generation experts
+      //
       eventTimeValue = theEventPrincipal->run();
       //---- NB: this is a trick. Since the time dependent MC 
       //         will be based on "run" (and lumisection)
@@ -237,8 +235,6 @@ public:
       ESMIPToGeV = esMipToGeV->getESValueLow();
     else
       ESMIPToGeV = esMipToGeV->getESValueHigh();
-    
-//     std::cout << " ---> EcalSignalGenerator() : initializeEvent() [end] " << std::endl;
     
   }
 
@@ -305,13 +301,8 @@ private:
   //---- LC that depends with time
   double findLaserConstant_LC(const DetId& detId) const {
     
-//     return 1.0;
-    
 //     const edm::TimeValue_t m_iTime = event.time().value();
     const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
-    
-//     std::cout << " findLaserConstant_LC::evtTimeStamp = " << evtTimeStamp << std::endl;
-    
     return (m_lasercals->getLaserCorrection(detId, evtTimeStamp));
     
   }
@@ -320,8 +311,6 @@ private:
   //---- LC at the beginning of the time (first IOV of the GT == first time)
   //---- Using the different "tag", the one with "MC": exactly the same function as findLaserConstant_LC but with a different object
   double findLaserConstant_LC_prime(const DetId& detId) const {
-    
-//     return 1.0;
     
     const edm::Timestamp& evtTimeStamp = edm::Timestamp(m_iTime);
     return (m_lasercals_prime->getLaserCorrection(detId, evtTimeStamp));

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -172,7 +172,7 @@ public:
     // Ecal LaserCorrection Constants for laser correction ratio
     edm::ESHandle<EcalLaserDbService> laser;
     eventSetup->get<EcalLaserDbRecord>().get(laser);
-    edm::TimeValue_t eventTimeValue = 0; // needed for warning in compilation time. What should be the default?
+    edm::TimeValue_t eventTimeValue = 0;  // needed for warning in compilation time. What should be the default?
     if (theEventPrincipal) {
       //       eventTimeValue = theEventPrincipal->time().value();
       //

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -172,7 +172,7 @@ public:
     // Ecal LaserCorrection Constants for laser correction ratio
     edm::ESHandle<EcalLaserDbService> laser;
     eventSetup->get<EcalLaserDbRecord>().get(laser);
-    edm::TimeValue_t eventTimeValue;
+    edm::TimeValue_t eventTimeValue = 0; // needed for warning in compilation time. What should be the default?
     if (theEventPrincipal) {
       //       eventTimeValue = theEventPrincipal->time().value();
       //

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -48,6 +48,8 @@
 #include <iostream>
 #include <memory>
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 namespace edm {
   class ModuleCallingContext;
 }
@@ -188,7 +190,7 @@ public:
       //         for the MC from ECAL (apd/pn, alpha, whatever time dependent is needed)
       //
     } else {
-      std::cout << " theEventPrincipal not defined??? " << std::endl;
+      edm::LogError("EcalSignalGenerator") << " theEventPrincipal not defined??? " << std::endl;
     }
     m_iTime = eventTimeValue;
     m_lasercals = laser.product();

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -105,8 +105,20 @@ public:
     // Ecal LaserCorrection Constants for laser correction ratio
     edm::ESHandle<EcalLaserDbService> laser;
     eventSetup->get<EcalLaserDbRecord>().get(laser);
-    const edm::TimeValue_t eventTimeValue = theEvent->time().value();
+    
+//     const edm::TimeValue_t eventTimeValue = theEvent->time().value();
+    const edm::TimeValue_t eventTimeValue = theEvent->run(); 
+    //---- NB: this is a trick. Since the time dependent MC 
+    //         will be based on "run" (and lumisection)
+    //         to identify the IOV.
+    //         The "time" defined here as "run" 
+    //         will have to match in the generation of the tag 
+    //         for the MC from ECAL (apd/pn, alpha, whatever time dependent is needed)
+    //
     m_iTime = eventTimeValue;
+    
+    
+    
     m_lasercals = laser.product();
 //     std::cout << " ---> EcalSignalGenerator() : initializeEvent() :: eventTimeValue = " << eventTimeValue << std::endl;
 
@@ -169,7 +181,15 @@ public:
     eventSetup->get<EcalLaserDbRecord>().get(laser);
     edm::TimeValue_t eventTimeValue;
     if (theEventPrincipal) {
-      eventTimeValue = theEventPrincipal->time().value();
+//       eventTimeValue = theEventPrincipal->time().value();
+      eventTimeValue = theEventPrincipal->run();
+      //---- NB: this is a trick. Since the time dependent MC 
+      //         will be based on "run" (and lumisection)
+      //         to identify the IOV.
+      //         The "time" defined here as "run" 
+      //         will have to match in the generation of the tag 
+      //         for the MC from ECAL (apd/pn, alpha, whatever time dependent is needed)
+      //
     }
     else {
       std::cout << " theEventPrincipal not defined??? " << std::endl;

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -1,5 +1,9 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h"
 
+
+
+
+
 template <>
 CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi) {
   // calibration, for future reference:  (same block for all Ecal types)
@@ -41,17 +45,48 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
 
   CaloSamples result(detId, digi.size());
 
+  // correction facotr for premixed sample: ratio of laser corrections
+  float correction_factor_for_premixed_sample_transparency = 1.0;
+//   correction_factor_for_premixed_sample_transparency
+  double value_LC = 1.;
+  if (detId.subdetId() != 3) {
+    auto cache = m_valueLCCache_LC.find(detId);
+    if (cache != m_valueLCCache_LC.end()) {
+      value_LC = cache->second;
+    } else {
+      value_LC = findLaserConstant_LC(detId);
+      m_valueLCCache_LC.emplace(detId, value_LC);
+    }
+  }
+  
+  double value_LC_prime = 1.;
+  if (detId.subdetId() != 3) {
+    auto cache = m_valueLCCache_LC_prime.find(detId);
+    if (cache != m_valueLCCache_LC_prime.end()) {
+      value_LC_prime = cache->second;
+    } else {
+      value_LC_prime = findLaserConstant_LC_prime(detId);
+      m_valueLCCache_LC_prime.emplace(detId, value_LC_prime);
+    }
+  }
+  
+  correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
+  //
+  // LC' /  LC  (see formula)
+  //
+  
   for (int isample = 0; isample < digi.size(); ++isample) {
     int gainId = digi[isample].gainId();
     //int gainId = 1;
 
     if (gainId == 1) {
-      result[isample] = float(digi[isample].adc()) / 1000. / peToA;  // special coding
+      result[isample] = float(digi[isample].adc()) / 1000. / peToA * correction_factor_for_premixed_sample_transparency;  // special coding, save low level info
     } else if (gainId > 1) {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA;
-    }  // gain = 0
-    else {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA;
+      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA * correction_factor_for_premixed_sample_transparency; // bet that no pileup hit has an energy over Emax/2
+    } 
+    else {  // gain = 0
+      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA * correction_factor_for_premixed_sample_transparency;  //not sure we ever get here at gain=0, but hit wil be saturated anyway
+      // in EcalCoder.cc it is actually "LSB[3]" -> grrr
     }
 
     // old version:
@@ -108,17 +143,47 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
 
   CaloSamples result(detId, digi.size());
 
+  // correction facotr for premixed sample: ratio of laser corrections
+  float correction_factor_for_premixed_sample_transparency = 1.0;
+  //   correction_factor_for_premixed_sample_transparency
+  double value_LC = 1.;
+  if (detId.subdetId() != 3) {
+    auto cache = m_valueLCCache_LC.find(detId);
+    if (cache != m_valueLCCache_LC.end()) {
+      value_LC = cache->second;
+    } else {
+      value_LC = findLaserConstant_LC(detId);
+      m_valueLCCache_LC.emplace(detId, value_LC);
+    }
+  }
+  
+  double value_LC_prime = 1.;
+  if (detId.subdetId() != 3) {
+    auto cache = m_valueLCCache_LC_prime.find(detId);
+    if (cache != m_valueLCCache_LC_prime.end()) {
+      value_LC_prime = cache->second;
+    } else {
+      value_LC_prime = findLaserConstant_LC_prime(detId);
+      m_valueLCCache_LC_prime.emplace(detId, value_LC_prime);
+    }
+  }
+  
+  correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
+  //
+  // LC' /  LC  (see formula)
+  //
+  
   for (int isample = 0; isample < digi.size(); ++isample) {
     int gainId = digi[isample].gainId();
     //int gainId = 1;
 
     if (gainId == 1) {
-      result[isample] = float(digi[isample].adc()) / 1000. / peToA;  // special coding
+      result[isample] = float(digi[isample].adc()) / 1000. / peToA * correction_factor_for_premixed_sample_transparency;  // special coding
     } else if (gainId > 1) {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA;
+      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA * correction_factor_for_premixed_sample_transparency;
     }  // gain = 0
     else {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA;
+      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA * correction_factor_for_premixed_sample_transparency;
     }
 
     // old version

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -41,22 +41,17 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
       LSB[igain] = Emax / (MAXADC * gainRatios[igain]);
   }
 
-  //    std::cout << " intercal, LSBs, egains " << icalconst << " " << LSB[0] << " " << LSB[1] << " " << gainRatios[0] << " " << gainRatios[1] << " " << Emax << std::endl;
-
   CaloSamples result(detId, digi.size());
 
   // correction facotr for premixed sample: ratio of laser corrections
   float correction_factor_for_premixed_sample_transparency = 1.0;
-  //   correction_factor_for_premixed_sample_transparency
   double value_LC = 1.;
   if (detId.subdetId() != 3) {
-//     std::cout << " detId.subdetId() = " << detId.subdetId() << std::endl;
     auto cache = m_valueLCCache_LC.find(detId);
     if (cache != m_valueLCCache_LC.end()) {
       value_LC = cache->second;
     } else {
       value_LC = findLaserConstant_LC(detId);
-//       value_LC = 1.0;
       m_valueLCCache_LC.emplace(detId, value_LC);
     }
   }
@@ -73,7 +68,6 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
   }
   
   correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
-//   std::cout << " EB correction_factor_for_premixed_sample_transparency[" << detId() << "] = " << correction_factor_for_premixed_sample_transparency << " = " << value_LC_prime << " / " << value_LC << std::endl;
   //
   // LC' /  LC  (see formula)
   //
@@ -142,13 +136,10 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
       LSB[igain] = Emax / (MAXADC * gainRatios[igain]);
   }
 
-  //    std::cout << " intercal, LSBs, egains " << icalconst << " " << LSB[0] << " " << LSB[1] << " " << gainRatios[0] << " " << gainRatios[1] << " " << Emax << std::endl;
-
   CaloSamples result(detId, digi.size());
 
   // correction facotr for premixed sample: ratio of laser corrections
   float correction_factor_for_premixed_sample_transparency = 1.0;
-  //   correction_factor_for_premixed_sample_transparency
   double value_LC = 1.;
   if (detId.subdetId() != 3) {
     auto cache = m_valueLCCache_LC.find(detId);
@@ -172,7 +163,6 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
   }
   
   correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
-//   std::cout << " EE correction_factor_for_premixed_sample_transparency[" << detId() << "] = " << correction_factor_for_premixed_sample_transparency << " = " << value_LC_prime << " / " << value_LC << std::endl;
   //
   // LC' /  LC  (see formula)
   //

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -47,14 +47,16 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
 
   // correction facotr for premixed sample: ratio of laser corrections
   float correction_factor_for_premixed_sample_transparency = 1.0;
-//   correction_factor_for_premixed_sample_transparency
+  //   correction_factor_for_premixed_sample_transparency
   double value_LC = 1.;
   if (detId.subdetId() != 3) {
+//     std::cout << " detId.subdetId() = " << detId.subdetId() << std::endl;
     auto cache = m_valueLCCache_LC.find(detId);
     if (cache != m_valueLCCache_LC.end()) {
       value_LC = cache->second;
     } else {
       value_LC = findLaserConstant_LC(detId);
+//       value_LC = 1.0;
       m_valueLCCache_LC.emplace(detId, value_LC);
     }
   }
@@ -71,6 +73,7 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
   }
   
   correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
+//   std::cout << " EB correction_factor_for_premixed_sample_transparency[" << detId() << "] = " << correction_factor_for_premixed_sample_transparency << " = " << value_LC_prime << " / " << value_LC << std::endl;
   //
   // LC' /  LC  (see formula)
   //
@@ -93,13 +96,13 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
     //result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
   }
 
-  //std::cout << " EcalSignalGenerator:EB noise input " << digi << std::endl;
-
-  //std::cout << " converted noise sample " << std::endl;
-  //for(int isample = 0; isample<digi.size(); ++isample){
-  //  std::cout << " " << result[isample] ;
-  //}
-  //std::cout << std::endl;
+//   std::cout << " EcalSignalGenerator:EB noise input " << digi << std::endl;
+// 
+//   std::cout << " converted noise sample " << std::endl;
+//   for(int isample = 0; isample<digi.size(); ++isample){
+//    std::cout << " " << result[isample] ;
+//   }
+//   std::cout << std::endl;
 
   return result;
 }
@@ -169,6 +172,7 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
   }
   
   correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
+//   std::cout << " EE correction_factor_for_premixed_sample_transparency[" << detId() << "] = " << correction_factor_for_premixed_sample_transparency << " = " << value_LC_prime << " / " << value_LC << std::endl;
   //
   // LC' /  LC  (see formula)
   //
@@ -190,13 +194,13 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
     //result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
   }
 
-  //std::cout << " EcalSignalGenerator:EE noise input " << digi << std::endl;
-
-  //std::cout << " converted noise sample " << std::endl;
-  //for(int isample = 0; isample<digi.size(); ++isample){
-  //  std::cout << " " << result[isample] ;
-  // }
-  //std::cout << std::endl;
+//   std::cout << " EcalSignalGenerator:EE noise input " << digi << std::endl;
+// 
+//   std::cout << " converted noise sample " << std::endl;
+//   for(int isample = 0; isample<digi.size(); ++isample){
+//    std::cout << " " << result[isample] ;
+//   }
+//   std::cout << std::endl;
 
   return result;
 }
@@ -229,13 +233,13 @@ CaloSamples EcalSignalGenerator<ESDigitizerTraits>::samplesInPE(const DIGI &digi
     result[isample] = float(digi[isample].adc()) / icalconst * ESMIPToGeV;
   }
 
-  //std::cout << " EcalSignalGenerator:ES noise input " << digi << std::endl;
-
-  //std::cout << " converted noise sample " << std::endl;
-  //for(int isample = 0; isample<digi.size(); ++isample){
-  //  std::cout << " " << result[isample] ;
-  //}
-  //std::cout << std::endl;
+//   std::cout << " EcalSignalGenerator:ES noise input " << digi << std::endl;
+// 
+//   std::cout << " converted noise sample " << std::endl;
+//   for(int isample = 0; isample<digi.size(); ++isample){
+//    std::cout << " " << result[isample] ;
+//   }
+//   std::cout << std::endl;
 
   return result;
 }

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -1,9 +1,5 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h"
 
-
-
-
-
 template <>
 CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi) {
   // calibration, for future reference:  (same block for all Ecal types)
@@ -55,7 +51,7 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
       m_valueLCCache_LC.emplace(detId, value_LC);
     }
   }
-  
+
   double value_LC_prime = 1.;
   if (detId.subdetId() != 3) {
     auto cache = m_valueLCCache_LC_prime.find(detId);
@@ -66,23 +62,27 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
       m_valueLCCache_LC_prime.emplace(detId, value_LC_prime);
     }
   }
-  
+
   correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
   //
   // LC' /  LC  (see formula)
   //
-  
+
   for (int isample = 0; isample < digi.size(); ++isample) {
     int gainId = digi[isample].gainId();
     //int gainId = 1;
 
     if (gainId == 1) {
-      result[isample] = float(digi[isample].adc()) / 1000. / peToA * correction_factor_for_premixed_sample_transparency;  // special coding, save low level info
+      result[isample] = float(digi[isample].adc()) / 1000. / peToA *
+                        correction_factor_for_premixed_sample_transparency;  // special coding, save low level info
     } else if (gainId > 1) {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA * correction_factor_for_premixed_sample_transparency; // bet that no pileup hit has an energy over Emax/2
-    } 
-    else {  // gain = 0
-      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA * correction_factor_for_premixed_sample_transparency;  //not sure we ever get here at gain=0, but hit wil be saturated anyway
+      result[isample] =
+          float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA *
+          correction_factor_for_premixed_sample_transparency;  // bet that no pileup hit has an energy over Emax/2
+    } else {                                                   // gain = 0
+      result[isample] =
+          float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA *
+          correction_factor_for_premixed_sample_transparency;  //not sure we ever get here at gain=0, but hit wil be saturated anyway
       // in EcalCoder.cc it is actually "LSB[3]" -> grrr
     }
 
@@ -90,13 +90,13 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
     //result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
   }
 
-//   std::cout << " EcalSignalGenerator:EB noise input " << digi << std::endl;
-// 
-//   std::cout << " converted noise sample " << std::endl;
-//   for(int isample = 0; isample<digi.size(); ++isample){
-//    std::cout << " " << result[isample] ;
-//   }
-//   std::cout << std::endl;
+  //   std::cout << " EcalSignalGenerator:EB noise input " << digi << std::endl;
+  //
+  //   std::cout << " converted noise sample " << std::endl;
+  //   for(int isample = 0; isample<digi.size(); ++isample){
+  //    std::cout << " " << result[isample] ;
+  //   }
+  //   std::cout << std::endl;
 
   return result;
 }
@@ -150,7 +150,7 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
       m_valueLCCache_LC.emplace(detId, value_LC);
     }
   }
-  
+
   double value_LC_prime = 1.;
   if (detId.subdetId() != 3) {
     auto cache = m_valueLCCache_LC_prime.find(detId);
@@ -161,36 +161,39 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
       m_valueLCCache_LC_prime.emplace(detId, value_LC_prime);
     }
   }
-  
+
   correction_factor_for_premixed_sample_transparency = value_LC_prime / value_LC;
   //
   // LC' /  LC  (see formula)
   //
-  
+
   for (int isample = 0; isample < digi.size(); ++isample) {
     int gainId = digi[isample].gainId();
     //int gainId = 1;
 
     if (gainId == 1) {
-      result[isample] = float(digi[isample].adc()) / 1000. / peToA * correction_factor_for_premixed_sample_transparency;  // special coding
+      result[isample] = float(digi[isample].adc()) / 1000. / peToA *
+                        correction_factor_for_premixed_sample_transparency;  // special coding
     } else if (gainId > 1) {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA * correction_factor_for_premixed_sample_transparency;
+      result[isample] = float(digi[isample].adc()) * LSB[gainId - 1] * icalconst / peToA *
+                        correction_factor_for_premixed_sample_transparency;
     }  // gain = 0
     else {
-      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA * correction_factor_for_premixed_sample_transparency;
+      result[isample] = float(digi[isample].adc()) * LSB[gainId] * icalconst / peToA *
+                        correction_factor_for_premixed_sample_transparency;
     }
 
     // old version
     //result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
   }
 
-//   std::cout << " EcalSignalGenerator:EE noise input " << digi << std::endl;
-// 
-//   std::cout << " converted noise sample " << std::endl;
-//   for(int isample = 0; isample<digi.size(); ++isample){
-//    std::cout << " " << result[isample] ;
-//   }
-//   std::cout << std::endl;
+  //   std::cout << " EcalSignalGenerator:EE noise input " << digi << std::endl;
+  //
+  //   std::cout << " converted noise sample " << std::endl;
+  //   for(int isample = 0; isample<digi.size(); ++isample){
+  //    std::cout << " " << result[isample] ;
+  //   }
+  //   std::cout << std::endl;
 
   return result;
 }
@@ -223,13 +226,13 @@ CaloSamples EcalSignalGenerator<ESDigitizerTraits>::samplesInPE(const DIGI &digi
     result[isample] = float(digi[isample].adc()) / icalconst * ESMIPToGeV;
   }
 
-//   std::cout << " EcalSignalGenerator:ES noise input " << digi << std::endl;
-// 
-//   std::cout << " converted noise sample " << std::endl;
-//   for(int isample = 0; isample<digi.size(); ++isample){
-//    std::cout << " " << result[isample] ;
-//   }
-//   std::cout << std::endl;
+  //   std::cout << " EcalSignalGenerator:ES noise input " << digi << std::endl;
+  //
+  //   std::cout << " converted noise sample " << std::endl;
+  //   for(int isample = 0; isample<digi.size(); ++isample){
+  //    std::cout << " " << result[isample] ;
+  //   }
+  //   std::cout << std::endl;
 
   return result;
 }


### PR DESCRIPTION
First implementation of the ECAL run dependent MC
Similar to https://github.com/cms-sw/cmssw/pull/27970, but that was in 10_6_X

To be tested it needs this PR: #27649

Physics details in the presentation at ECAL DPG here: https://indico.cern.ch/event/847097/

This PR will affect only the mixing step, when the premixed library is mixed with the hard scattering. The idea is that the pileup response, that has been simulated with a given transparency for ECAL crystals, will be scaled to match the transparency of the corresponding IOV.
A new object is introduced ( EcalLaserAPDPNRatiosMCRcd ), that has 1 single IOV, thus allowing this to be used as reference for scaling.
Goal: correct simulation of the photostatistics for pileup, when producing run dependent MC with several IOVs (main changes in run dependent MC for ECAL are transparency and noise).

This PR is needed for testing via relval, checking physics performance and possibly imploved data-MC comparison.