### PR TITLE
MVAComputerContainer::find returns pointer instead of reference

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -255,7 +255,7 @@ namespace PhysicsTools {
       virtual ~MVAComputerContainer() {}
 
       MVAComputer &add(const std::string &label);
-      virtual const MVAComputer &find(const std::string &label) const;
+      virtual const MVAComputer *find(const std::string &label) const;
       virtual bool contains(const std::string &label) const;
 
       // cacheId stuff to detect changes

--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -159,7 +159,7 @@ namespace PhysicsTools {
       return entries.back().second;
     }
 
-    const MVAComputer &MVAComputerContainer::find(const std::string &label) const {
+    const MVAComputer *MVAComputerContainer::find(const std::string &label) const {
       std::vector<Entry>::const_iterator pos =
           std::find_if(entries.begin(), entries.end(), [&label](const MVAComputerContainer::Entry &entry) {
             return entry.first == label;
@@ -169,7 +169,7 @@ namespace PhysicsTools {
         throw cms::Exception("MVAComputerCalibration")
             << "Calibration record " << label << " not found in MVAComputerContainer." << std::endl;
 
-      return pos->second;
+      return &pos->second;
     }
 
     bool MVAComputerContainer::contains(const std::string &label) const {

--- a/PhysicsTools/MVAComputer/interface/MVAModuleHelper.h
+++ b/PhysicsTools/MVAComputer/interface/MVAModuleHelper.h
@@ -131,7 +131,7 @@ void MVAModuleHelper<Record, Object, Filler>::init(
 	const PhysicsTools::Calibration::MVAComputerContainer *container)
 {
 	const std::vector<PhysicsTools::Calibration::Variable> &vars =
-					container->find(label).inputSet;
+					container->find(label)->inputSet;
 	values.clear();
 	for(std::vector<PhysicsTools::Calibration::Variable>::const_iterator
 			iter = vars.begin(); iter != vars.end(); ++iter)

--- a/PhysicsTools/MVAComputer/interface/MVAModuleHelper.h
+++ b/PhysicsTools/MVAComputer/interface/MVAModuleHelper.h
@@ -30,7 +30,7 @@
 
 namespace PhysicsTools {
 
-/** \class MVAModuleHelperDefaultFiller
+  /** \class MVAModuleHelperDefaultFiller
  *
  * \short Default template for MVAModuleHelper "Filler" template argument
  *
@@ -38,16 +38,14 @@ namespace PhysicsTools {
  * on the object for each variable requested.
  *
  ************************************************************/
-template<typename Object>
-struct MVAModuleHelperDefaultFiller {
-	MVAModuleHelperDefaultFiller(const PhysicsTools::AtomicId &name) {}
+  template <typename Object>
+  struct MVAModuleHelperDefaultFiller {
+    MVAModuleHelperDefaultFiller(const PhysicsTools::AtomicId &name) {}
 
-	double operator()(const Object &object,
-	                  const PhysicsTools::AtomicId &name)
-	{ return object.compute(name); }
-};
+    double operator()(const Object &object, const PhysicsTools::AtomicId &name) { return object.compute(name); }
+  };
 
-/** \class MVAModuleHelper
+  /** \class MVAModuleHelper
  *
  * \short Template for automated variable collection and MVA computation in EDM modules
  *
@@ -57,123 +55,104 @@ struct MVAModuleHelperDefaultFiller {
  * is automatically collected from the EventSetup.
  *
  ************************************************************/
-template<class Record, typename Object,
-         class Filler = MVAModuleHelperDefaultFiller<Object> >
-class MVAModuleHelper {
+  template <class Record, typename Object, class Filler = MVAModuleHelperDefaultFiller<Object> >
+  class MVAModuleHelper {
+  public:
+    MVAModuleHelper(const std::string &label) : label(label) {}
+    MVAModuleHelper(const MVAModuleHelper &orig) : label(orig.label) {}
+    ~MVAModuleHelper() {}
+
+    void setEventSetup(const edm::EventSetup &setup);
+    void setEventSetup(const edm::EventSetup &setup, const char *esLabel);
+
+    double operator()(const Object &object) const;
+
+    void train(const Object &object, bool target, double weight = 1.0) const;
+
+  private:
+    void init(const PhysicsTools::Calibration::MVAComputerContainer *container);
+
+    const std::string label;
+    PhysicsTools::MVAComputerCache cache;
+
+    class Value {
     public:
-	MVAModuleHelper(const std::string &label) : label(label) {}
-	MVAModuleHelper(const MVAModuleHelper &orig) : label(orig.label) {}
-	~MVAModuleHelper() {}
+      Value(const std::string &name) : name(name), filler(name) {}
+      Value(const std::string &name, double value) : name(name), filler(name), value(value) {}
 
-	void setEventSetup(const edm::EventSetup &setup);
-	void setEventSetup(const edm::EventSetup &setup, const char *esLabel);
+      inline bool update(const Object &object) const {
+        value = filler(object, name);
+        return !std::isfinite(value);
+      }
 
-	double operator()(const Object &object) const;
-
-	void train(const Object &object, bool target, double weight = 1.0) const;
+      PhysicsTools::AtomicId getName() const { return name; }
+      double getValue() const { return value; }
 
     private:
-	void init(const PhysicsTools::Calibration::MVAComputerContainer *container);
+      PhysicsTools::AtomicId name;
+      Filler filler;
 
-	const std::string		label;
-	PhysicsTools::MVAComputerCache	cache;
+      mutable double value;
+    };
 
-	class Value {
-	    public:
-	    	Value(const std::string &name) :
-	    		name(name), filler(name) {}
-	    	Value(const std::string &name, double value) :
-			name(name), filler(name), value(value) {}
+    std::vector<Value> values;
+  };
 
-		inline bool update(const Object &object) const
-		{
-			value = filler(object, name);
-			return !std::isfinite(value);
-		}
+  template <class Record, typename Object, class Filler>
+  void MVAModuleHelper<Record, Object, Filler>::setEventSetup(const edm::EventSetup &setup) {
+    edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> handle;
+    setup.get<Record>().get(handle);
+    const PhysicsTools::Calibration::MVAComputerContainer *container = handle.product();
+    if (cache.update(container, label.c_str()) && cache)
+      init(container);
+  }
 
-		PhysicsTools::AtomicId getName() const { return name; }
-		double getValue() const { return value; }
+  template <class Record, typename Object, class Filler>
+  void MVAModuleHelper<Record, Object, Filler>::setEventSetup(const edm::EventSetup &setup, const char *esLabel) {
+    edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> handle;
+    setup.get<Record>().get(esLabel, handle);
+    const PhysicsTools::Calibration::MVAComputerContainer *container = handle.product();
+    if (cache.update(container, label.c_str()) && cache)
+      init(container);
+  }
 
-	    private:
-		PhysicsTools::AtomicId		name;
-		Filler				filler;
+  template <class Record, typename Object, class Filler>
+  void MVAModuleHelper<Record, Object, Filler>::init(const PhysicsTools::Calibration::MVAComputerContainer *container) {
+    const std::vector<PhysicsTools::Calibration::Variable> &vars = container->find(label)->inputSet;
+    values.clear();
+    for (std::vector<PhysicsTools::Calibration::Variable>::const_iterator iter = vars.begin(); iter != vars.end();
+         ++iter)
+      if (std::strncmp(iter->name.c_str(), "__", 2) != 0)
+        values.push_back(Value(iter->name));
+  }
 
-		mutable double			value;
-	};
+  template <class Record, typename Object, class Filler>
+  double MVAModuleHelper<Record, Object, Filler>::operator()(const Object &object) const {
+    std::for_each(values.begin(), values.end(), boost::bind(&Value::update, _1, object));
+    return cache->eval(values);
+  }
 
-	std::vector<Value>			values;
-};
+  template <class Record, typename Object, class Filler>
+  void MVAModuleHelper<Record, Object, Filler>::train(const Object &object, bool target, double weight) const {
+    static const PhysicsTools::AtomicId kTargetId("__TARGET__");
+    static const PhysicsTools::AtomicId kWeightId("__WEIGHT__");
 
-template<class Record, typename Object, class Filler>
-void MVAModuleHelper<Record, Object, Filler>::setEventSetup(
-						const edm::EventSetup &setup)
-{
-	edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> handle;
-	setup.get<Record>().get(handle);
-	const PhysicsTools::Calibration::MVAComputerContainer *container = handle.product();
-	if (cache.update(container, label.c_str()) && cache)
-		init(container);
-}
+    if (!cache)
+      return;
 
-template<class Record, typename Object, class Filler>
-void MVAModuleHelper<Record, Object, Filler>::setEventSetup(
-			const edm::EventSetup &setup, const char *esLabel)
-{
-	edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> handle;
-	setup.get<Record>().get(esLabel, handle);
-	const PhysicsTools::Calibration::MVAComputerContainer *container = handle.product();
-	if (cache.update(container, label.c_str()) && cache)
-		init(container);
-}
+    using boost::bind;
+    if (std::accumulate(values.begin(), values.end(), 0, bind(std::plus<int>(), _1, bind(&Value::update, _2, object))))
+      return;
 
-template<class Record, typename Object, class Filler>
-void MVAModuleHelper<Record, Object, Filler>::init(
-	const PhysicsTools::Calibration::MVAComputerContainer *container)
-{
-	const std::vector<PhysicsTools::Calibration::Variable> &vars =
-					container->find(label)->inputSet;
-	values.clear();
-	for(std::vector<PhysicsTools::Calibration::Variable>::const_iterator
-			iter = vars.begin(); iter != vars.end(); ++iter)
-		if (std::strncmp(iter->name.c_str(), "__", 2) != 0)
-			values.push_back(Value(iter->name));
-}
+    PhysicsTools::Variable::ValueList list;
+    list.add(kTargetId, target);
+    list.add(kWeightId, weight);
+    for (typename std::vector<Value>::const_iterator iter = values.begin(); iter != values.end(); ++iter)
+      list.add(iter->getName(), iter->getValue());
 
-template<class Record, typename Object, class Filler>
-double MVAModuleHelper<Record, Object, Filler>::operator()(
-						const Object &object) const
-{
-	std::for_each(values.begin(), values.end(),
-	              boost::bind(&Value::update, _1, object));
-	return cache->eval(values);
-}
+    cache->eval(list);
+  }
 
-template<class Record, typename Object, class Filler>
-void MVAModuleHelper<Record, Object, Filler>::train(
-		const Object &object, bool target, double weight) const
-{
-	static const PhysicsTools::AtomicId kTargetId("__TARGET__");
-	static const PhysicsTools::AtomicId kWeightId("__WEIGHT__");
+}  // namespace PhysicsTools
 
-	if (!cache)
-		return;
-
-	using boost::bind;
-	if (std::accumulate(values.begin(), values.end(), 0,
-	                    bind(std::plus<int>(), _1,
-	                         bind(&Value::update, _2, object))))
-		return;
-
-	PhysicsTools::Variable::ValueList list;
-	list.add(kTargetId, target);
-	list.add(kWeightId, weight);
-	for(typename std::vector<Value>::const_iterator iter = values.begin();
-	    iter != values.end(); ++iter)
-		list.add(iter->getName(), iter->getValue());
-
-	cache->eval(list);
-}
-
-} // namespace PhysicsTools
-
-#endif // PhysicsTools_MVAComputer_MVAModuleHelper_h
+#endif  // PhysicsTools_MVAComputer_MVAModuleHelper_h

--- a/PhysicsTools/MVAComputer/src/MVAComputerCache.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputerCache.cc
@@ -37,7 +37,7 @@ namespace PhysicsTools {
       return false;
 
     if (container) {
-      const Calibration::MVAComputer *computer = &container->find(calib);
+      const Calibration::MVAComputer *computer = container->find(calib);
       bool result = update(computer);
       containerCacheId = container->getCacheId();
       return result;

--- a/PhysicsTools/MVAComputer/test/testReadMVAComputerCondDB.cc
+++ b/PhysicsTools/MVAComputer/test/testReadMVAComputerCondDB.cc
@@ -35,7 +35,7 @@ testReadMVAComputerCondDB::testReadMVAComputerCondDB(const edm::ParameterSet& pa
 void testReadMVAComputerCondDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ESHandle<Calibration::MVAComputerContainer> calib;
   iSetup.get<BTauGenericMVAJetTagComputerRcd>().get(calib);
-  MVAComputer computer(&calib.product()->find("test"));
+  MVAComputer computer(calib.product()->find("test"));
 
   Variable::Value values[] = {
       Variable::Value("toast", 4.4), Variable::Value("toast", 4.5), Variable::Value("test", 4.6),

--- a/PhysicsTools/MVATrainer/interface/MVATrainerContainer.h
+++ b/PhysicsTools/MVATrainer/interface/MVATrainerContainer.h
@@ -15,10 +15,10 @@ namespace PhysicsTools {
   public:
     typedef MVATrainerLooper::TrainObject Value_t;
 
-    const Calibration::MVAComputer &find(const std::string &label) const override {
+    const Calibration::MVAComputer *find(const std::string &label) const override {
       Map_t::const_iterator pos = trainCalibs.find(label);
       if (pos != trainCalibs.end())
-        return *pos->second.get();
+        return pos->second.get();
 
       return Calibration::MVAComputerContainer::find(label);
     }

--- a/PhysicsTools/MVATrainer/src/MVATrainerContainerSave.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerContainerSave.cc
@@ -48,10 +48,10 @@ namespace PhysicsTools {
     std::unique_ptr<Calibration::MVAComputerContainer> calib(new Calibration::MVAComputerContainer);
 
     for (std::vector<std::string>::const_iterator iter = toCopy.begin(); iter != toCopy.end(); iter++)
-      calib->add(*iter) = toCopyCalib->find(*iter);
+      calib->add(*iter) = *toCopyCalib->find(*iter);
 
     for (std::vector<std::string>::const_iterator iter = toPut.begin(); iter != toPut.end(); iter++)
-      calib->add(*iter) = toPutCalib->find(*iter);
+      calib->add(*iter) = *toPutCalib->find(*iter);
 
     this->calib = std::move(calib);
   }

--- a/PhysicsTools/MVATrainer/src/MVATrainerFileSave.cc
+++ b/PhysicsTools/MVATrainer/src/MVATrainerFileSave.cc
@@ -54,7 +54,7 @@ namespace PhysicsTools {
     edm::LogInfo("MVATrainerFileSave") << "Saving calibration data into plain MVA files.";
 
     for (LabelFileMap::const_iterator iter = toPut.begin(); iter != toPut.end(); iter++) {
-      const Calibration::MVAComputer *calibration = &calib->find(iter->first);
+      const Calibration::MVAComputer *calibration = calib->find(iter->first);
 
       MVAComputer::writeCalibration(iter->second.c_str(), calibration);
     }

--- a/RecoBTau/JetTagComputer/src/GenericMVAComputerCache.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAComputerCache.cc
@@ -70,7 +70,7 @@ bool GenericMVAComputerCache::update(const MVAComputerContainer *calib) {
       continue;
     }
 
-    const MVAComputer *computerCalib = &calib->find(iter->label);
+    const MVAComputer *computerCalib = calib->find(iter->label);
     if (!computerCalib) {
       iter->computer.reset();
       continue;

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtFullHadSignalSelMVAComputer.cc
@@ -27,7 +27,7 @@ void TtFullHadSignalSelMVAComputer::produce(edm::Event& evt, const edm::EventSet
   edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> calibContainer;
   setup.get<TtFullHadSignalSelMVARcd>().get(calibContainer);
   std::vector<PhysicsTools::Calibration::VarProcessor*> processors =
-      (calibContainer->find("ttFullHadSignalSelMVA")).getProcessors();
+      (calibContainer->find("ttFullHadSignalSelMVA"))->getProcessors();
 
   edm::Handle<std::vector<pat::Jet> > jets;
   evt.getByToken(jetsToken_, jets);

--- a/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.cc
+++ b/TopQuarkAnalysis/TopEventSelection/plugins/TtSemiLepSignalSelMVAComputer.cc
@@ -30,7 +30,7 @@ void TtSemiLepSignalSelMVAComputer::produce(edm::Event& evt, const edm::EventSet
   edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> calibContainer;
   setup.get<TtSemiLepSignalSelMVARcd>().get(calibContainer);
   std::vector<PhysicsTools::Calibration::VarProcessor*> processors =
-      (calibContainer->find("ttSemiLepSignalSelMVA")).getProcessors();
+      (calibContainer->find("ttSemiLepSignalSelMVA"))->getProcessors();
 
   //make your preselection! This must!! be the same one as in TraintreeSaver.cc
   edm::Handle<edm::View<pat::MET> > MET_handle;

--- a/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
+++ b/TopQuarkAnalysis/TopJetCombination/plugins/TtSemiLepJetCombMVAComputer.cc
@@ -29,7 +29,7 @@ void TtSemiLepJetCombMVAComputer::produce(edm::Event& evt, const edm::EventSetup
   edm::ESHandle<PhysicsTools::Calibration::MVAComputerContainer> calibContainer;
   setup.get<TtSemiLepJetCombMVARcd>().get(calibContainer);
   std::vector<PhysicsTools::Calibration::VarProcessor*> processors =
-      (calibContainer->find("ttSemiLepJetCombMVA")).getProcessors();
+      (calibContainer->find("ttSemiLepJetCombMVA"))->getProcessors();
   *pOutMeth = (processors[processors.size() - 3])->getInstanceName();
   evt.put(std::move(pOutMeth), "Method");
 


### PR DESCRIPTION
#### PR description:

PhysicsTools::MVATrainerContainer inherits from MVAComputerContainer and it was returning a reference to null in its overriden find method. This was leading to unit test crashes under clang since clang (correctly) optimized away a check for null on the address of the returned reference.

All uses of find were updated to the new interface.

#### PR validation:

The original code caused the unit test in TopQuarkAnalysis/TopEventSelection to crash in CMSSW_11_0_CLANG_X_2019-09-10-2300 when optimizations were used. With this change the unit tests run without crashing.