### PR TITLE
reintroduce missing lseek() for header-less files

### DIFF
--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -962,7 +962,6 @@ namespace evf {
       close(infile);
       infile = -1;
     }
-    //else lseek(infile,0,SEEK_SET);
 
     if (sz_read < 0) {
       edm::LogError("EvFDaqDirector") << "parseFRDFileHeader - unable to read " << rawSourcePath << " : "
@@ -989,6 +988,7 @@ namespace evf {
         return -1;
       } else {
         //no header, but valid file
+        lseek(infile, 0, SEEK_SET);
         rawHeaderSize = 0;
         lsFromHeader = 0;
         eventsFromHeader = -1;


### PR DESCRIPTION
#### PR description:

Fix a problem encountered reading legacy FED RAW data files in "file list" mode.

#### PR validation:

Reading legacy files now works.