### PR TITLE
Tracker Alignment: update PV Validation tool as used in Ultra-Legacy

### DIFF
--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -8,7 +8,14 @@
 #include <utility>
 #include "TH1.h"
 
+#ifndef PLOTTING_MACRO
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#define COUT edm::LogWarning("PVValidationHelpers")
+#else
+#include <iostream>
+#define COUT std::cout << "PVValidationHelpers: "
+#endif
+
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
 namespace PVValHelper {
@@ -81,7 +88,7 @@ namespace PVValHelper {
       if (range.find(std::make_pair(type, plot)) != range.end()) {
         return range[std::make_pair(type, plot)];
       } else {
-        edm::LogWarning("PVValidationHelpers") << "Trying to get range for non-existent combination " << std::endl;
+        COUT << "Trying to get range for non-existent combination " << std::endl;
         return std::make_pair(0., 0.);
       }
     }
@@ -90,8 +97,7 @@ namespace PVValHelper {
       if (range.find(std::make_pair(type, plot)) != range.end()) {
         return range[std::make_pair(type, plot)].first;
       } else {
-        edm::LogWarning("PVValidationHelpers")
-            << "Trying to get low end of range for non-existent combination " << std::endl;
+        COUT << "Trying to get low end of range for non-existent combination " << std::endl;
         return 0.;
       }
     }
@@ -100,8 +106,7 @@ namespace PVValHelper {
       if (range.find(std::make_pair(type, plot)) != range.end()) {
         return range[std::make_pair(type, plot)].second;
       } else {
-        edm::LogWarning("PVValidationHelpers")
-            << "Trying get high end of range for non-existent combination " << std::endl;
+        COUT << "Trying get high end of range for non-existent combination " << std::endl;
         return 0.;
       }
     }

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -19,7 +19,7 @@ namespace PVValHelper {
   // helper logarithmic bin generator
 
   template <typename T, size_t N>
-  std::array<T, N+1> makeLogBins(const T& min, const T& max) {
+  std::array<T, N + 1> makeLogBins(const T& min, const T& max) {
     const T minLog10 = std::log10(min);
     const T maxLog10 = std::log10(max);
     const T width = (maxLog10 - minLog10) / N;

--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -13,10 +13,13 @@
 
 namespace PVValHelper {
 
+  const double max_eta_phase0 = 2.5;
+  const double max_eta_phase1 = 2.7;
+
   // helper logarithmic bin generator
 
   template <typename T, size_t N>
-  std::array<T, N + 1> makeLogBins(const T min, const T max) {
+  std::array<T, N+1> makeLogBins(const T& min, const T& max) {
     const T minLog10 = std::log10(min);
     const T maxLog10 = std::log10(max);
     const T width = (maxLog10 - minLog10) / N;

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -45,6 +45,7 @@
 #include <TStopwatch.h>
 //#include "Alignment/OfflineValidation/macros/TkAlStyle.cc" 
 #include "Alignment/OfflineValidation/macros/CMS_lumi.C"
+#define PLOTTING_MACRO // to remove message logger
 #include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
 
 /* 
@@ -315,8 +316,8 @@ Float_t _boundSx    = (nBins_/4.)-0.5;
 Float_t _boundDx    = 3*(nBins_/4.)-0.5;
 Float_t _boundMax   = nBins_-0.5;
 Float_t  etaRange   = 2.5;
-Float_t  minPt      = 1.; 
-Float_t  maxPt_     = 20.;
+Float_t  minPt_      = 1.;
+Float_t  maxPt_      = 20.;
 bool     isDebugMode = false;
 
 // pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf) 
@@ -768,9 +769,11 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     std::cout<<"FitPVResiduals::FitPVResiduals(): the pT binning is different"<<std::endl;
     std::cout<<"won't do the pT analysis..."<<std::endl;
     std::cout<<"======================================================"<<std::endl;
-    minPt = -1.;
+    minPt_ = -1.;
   } else {
     if(thePtMin[0]!=0.){
+      minPt_ = thePtMin[0];
+      maxPt_ = thePtMax[0];
       mypT_bins = PVValHelper::makeLogBins<float,nPtBins_>(thePtMin[0],thePtMax[0]);
       std::cout<<"======================================================"<<std::endl;
       std::cout<<"FitPVResiduals::FitPVResiduals(): log bins [" << thePtMin[0] << "," << thePtMax[0] <<"]"<< std::endl;
@@ -932,7 +935,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     dzEtaMeanTrend[i]   = new TH1F(Form("means_dz_eta_%i",i),"#LT d_{z} #GT vs #eta sector;track #eta;#LT d_{z} #GT [#mum]",nBins_,lowedge,highedge); 
     dzEtaWidthTrend[i]  = new TH1F(Form("widths_dz_eta_%i",i),"#sigma(d_{xy}) vs #eta sector;track #eta;#sigma(d_{z}) [#mum]",nBins_,lowedge,highedge);
 
-    if(minPt>0.){
+    if(minPt_>0.){
 
       dxyPtMeanTrend[i]   = new TH1F(Form("means_dxy_pT_%i",i),"#LT d_{xy} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy} #GT [#mum]",mypT_bins.size()-1,mypT_bins.data());
       dxyPtWidthTrend[i]  = new TH1F(Form("widths_dxy_pT_%i",i),"#sigma(d_{xy}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}) [#mum]",mypT_bins.size()-1,mypT_bins.data());
@@ -967,7 +970,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     dzNormEtaMeanTrend[i]  = new TH1F(Form("means_dzNorm_eta_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #eta sector;track #eta;#LT d_{z}/#sigma_{d_{z}} #GT",nBins_,lowedge,highedge); 
     dzNormEtaWidthTrend[i] = new TH1F(Form("widths_dzNorm_eta_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #eta sector;track #eta;#sigma(d_{z}/#sigma_{d_{z}})",nBins_,lowedge,highedge);
     
-    if(minPt>0.){
+    if(minPt_>0.){
 
       dxyNormPtMeanTrend[i] = new TH1F(Form("means_dxyNorm_pT_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy}/#sigma_{d_{xy}} #GT",mypT_bins.size()-1,mypT_bins.data());
       dxyNormPtWidthTrend[i]= new TH1F(Form("widths_dxyNorm_pT_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}/#sigma_{d_{xy}})",mypT_bins.size()-1,mypT_bins.data());
@@ -1033,7 +1036,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     FillTrendPlot(dzEtaMeanTrend[i]  ,dzEtaResiduals[i] ,params::MEAN,"eta",nBins_); 
     FillTrendPlot(dzEtaWidthTrend[i] ,dzEtaResiduals[i] ,params::WIDTH,"eta",nBins_);
 
-    if(minPt>0.){
+    if(minPt_>0.){
 
       FillTrendPlot(dxyPtMeanTrend[i] ,dxyPtResiduals[i],params::MEAN,"pT",nPtBins_); 
       FillTrendPlot(dxyPtWidthTrend[i],dxyPtResiduals[i],params::WIDTH,"pT",nPtBins_);
@@ -1072,7 +1075,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     MakeNiceTrendPlotStyle(dzEtaMeanTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dzEtaWidthTrend[i],colors[i],markers[i]);
 
-    if(minPt>0.){
+    if(minPt_>0.){
 
       MakeNiceTrendPlotStyle(dxyPtMeanTrend[i],colors[i],markers[i]);
       MakeNiceTrendPlotStyle(dxyPtWidthTrend[i],colors[i],markers[i]);
@@ -1105,7 +1108,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     FillTrendPlot(dzNormEtaMeanTrend[i]  ,dzNormEtaResiduals[i] ,params::MEAN,"eta",nBins_); 
     FillTrendPlot(dzNormEtaWidthTrend[i] ,dzNormEtaResiduals[i] ,params::WIDTH,"eta",nBins_);
 
-    if(minPt>0.){
+    if(minPt_>0.){
 
       FillTrendPlot(dxyNormPtMeanTrend[i] ,dxyNormPtResiduals[i],params::MEAN,"pT",nPtBins_);        
       FillTrendPlot(dxyNormPtWidthTrend[i],dxyNormPtResiduals[i],params::WIDTH,"pT",nPtBins_);       
@@ -1136,7 +1139,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     MakeNiceTrendPlotStyle(dzNormEtaMeanTrend[i],colors[i],markers[i]);
     MakeNiceTrendPlotStyle(dzNormEtaWidthTrend[i],colors[i],markers[i]);
 
-    if(minPt>0.){
+    if(minPt_>0.){
 
       MakeNiceTrendPlotStyle(dxyNormPtMeanTrend[i],colors[i],markers[i]);
       MakeNiceTrendPlotStyle(dxyNormPtWidthTrend[i],colors[i],markers[i]);
@@ -1313,7 +1316,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   dzPhiTrendFit->SaveAs("dzPhiTrendFit_"+theStrDate+theStrAlignment+".pdf");
   dzPhiTrendFit->SaveAs("dzPhiTrendFit_"+theStrDate+theStrAlignment+".png");
 
-  if(minPt>0.){
+  if(minPt_>0.){
 
     TCanvas *dxyPtTrend = new TCanvas("dxyPtTrend","dxyPtTrend",1200,600);
     arrangeCanvas(dxyPtTrend,dxyPtMeanTrend,dxyPtWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
@@ -1367,7 +1370,7 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   dzNormEtaTrend->SaveAs("dzEtaTrendNorm_"+theStrDate+theStrAlignment+".pdf");
   dzNormEtaTrend->SaveAs("dzEtaTrendNorm_"+theStrDate+theStrAlignment+".png");
 
-  if(minPt>0.){
+  if(minPt_>0.){
 
     TCanvas *dxyNormPtTrend = new TCanvas("dxyNormPtTrend","dxyNormPtTrend",1200,600);
     arrangeCanvas(dxyNormPtTrend,dxyNormPtMeanTrend,dxyNormPtWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
@@ -2157,9 +2160,9 @@ void arrangeFitCanvas(TCanvas *canv,TH1F* meanplots[100],Int_t nFiles, TString L
     
     deltaZ=(fright[j]->GetParameter(0) - fall[j]->GetParameter(0))/2;
     sigmadeltaZ=0.5*TMath::Sqrt(fright[j]->GetParError(0)*fright[j]->GetParError(0) + fall[j]->GetParError(0)*fall[j]->GetParError(0));
-    TString COUT = Form(" : #Delta z = %.f #pm %.f #mum",deltaZ,sigmadeltaZ);
+    TString MYOUT = Form(" : #Delta z = %.f #pm %.f #mum",deltaZ,sigmadeltaZ);
     
-    lego->AddEntry(meanplots[j],LegLabels[j]+COUT); 
+    lego->AddEntry(meanplots[j],LegLabels[j]+MYOUT);
 
     if(j==nFiles-1){ 
       outfile <<deltaZ<<"|"<<sigmadeltaZ<<endl;
@@ -2688,14 +2691,14 @@ void FillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], params::estimator 
       pt->SetTextAlign(22);
 
       //TF1 *tmp1 = (TF1*)residualsPlot[i]->GetListOfFunctions()->FindObject("tmp");
-      TString COUT;
+      TString MYOUT;
       if(tmp1){
-	COUT = Form("#chi^{2}/ndf=%.1f",tmp1->GetChisquare()/tmp1->GetNDF());
+	MYOUT = Form("#chi^{2}/ndf=%.1f",tmp1->GetChisquare()/tmp1->GetNDF());
       } else {
-	COUT = "!! no plot !!";
+	MYOUT = "!! no plot !!";
       }
        
-      TText *text1 = pt->AddText(COUT);
+      TText *text1 = pt->AddText(MYOUT);
       text1->SetTextFont(72);
       text1->SetTextColor(kBlue);
       pt->Draw("same");
@@ -3374,12 +3377,12 @@ void makeNewXAxis (TH1F *h)
     axmax = TMath::Pi();
     ndiv = 510;
   } else if (myTitle.Contains("pT")) {
-    axmin = 0;
-    axmax = 19.99;
+    axmin = minPt_;
+    axmax = maxPt_;
     ndiv = 510;
   } else if (myTitle.Contains("ladder")) {
     axmin = 0.5;
-    axmax = 12.5;
+    axmax = nLadders_+0.5;
   } else if (myTitle.Contains("modZ")) {
     axmin = 0.5;
     axmax = 8.5;

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -43,9 +43,9 @@
 #include <TSystem.h>
 #include <TTimeStamp.h>
 #include <TStopwatch.h>
-//#include "Alignment/OfflineValidation/macros/TkAlStyle.cc" 
+//#include "Alignment/OfflineValidation/macros/TkAlStyle.cc"
 #include "Alignment/OfflineValidation/macros/CMS_lumi.C"
-#define PLOTTING_MACRO // to remove message logger
+#define PLOTTING_MACRO  // to remove message logger
 #include "Alignment/OfflineValidation/interface/PVValidationHelpers.h"
 
 /* 
@@ -55,15 +55,16 @@
 
 class PVValidationVariables {
 public:
-  PVValidationVariables(TString fileName, TString baseDir, TString legName="", int color=1, int style=1);
-  int getLineColor(){ return lineColor; }
-  int getMarkerStyle(){ return markerStyle; }
-  int getLineStyle(){ return lineStyle; }
-  TString getName(){ return legendName; }
-  TFile* getFile(){ return file; }
-  TString getFileName() { return fname;}
+  PVValidationVariables(TString fileName, TString baseDir, TString legName = "", int color = 1, int style = 1);
+  int getLineColor() { return lineColor; }
+  int getMarkerStyle() { return markerStyle; }
+  int getLineStyle() { return lineStyle; }
+  TString getName() { return legendName; }
+  TFile *getFile() { return file; }
+  TString getFileName() { return fname; }
+
 private:
-  TFile* file;
+  TFile *file;
   int lineColor;
   int lineStyle;
   int markerStyle;
@@ -71,13 +72,13 @@ private:
   TString fname;
 };
 
-PVValidationVariables::PVValidationVariables(TString fileName, TString baseDir, TString legName, int lColor, int lStyle)
-{
+PVValidationVariables::PVValidationVariables(
+    TString fileName, TString baseDir, TString legName, int lColor, int lStyle) {
   fname = fileName;
   lineColor = lColor;
 
-  int ndigits = 1+std::floor(std::log10(lStyle));
-  if(ndigits==4){
+  int ndigits = 1 + std::floor(std::log10(lStyle));
+  if (ndigits == 4) {
     lineStyle = lStyle % 100;
     markerStyle = lStyle / 100;
   } else {
@@ -85,22 +86,23 @@ PVValidationVariables::PVValidationVariables(TString fileName, TString baseDir, 
     markerStyle = lStyle;
   }
 
-  if (legName=="") {
+  if (legName == "") {
     std::string s_fileName = fileName.Data();
     int start = 0;
-    if (s_fileName.find('/') ) start =s_fileName.find_last_of('/')+1;
+    if (s_fileName.find('/'))
+      start = s_fileName.find_last_of('/') + 1;
     int stop = s_fileName.find_last_of('.');
-    legendName = s_fileName.substr(start,stop-start);
-  } else { 
+    legendName = s_fileName.substr(start, stop - start);
+  } else {
     legendName = legName;
   }
 
   // check if the base dir exists
-  file = TFile::Open( fileName.Data(), "READ" );
-  if (file->Get( baseDir.Data() ) )  {
-    std::cout<<"found base directory: " << baseDir.Data()<<std::endl;
+  file = TFile::Open(fileName.Data(), "READ");
+  if (file->Get(baseDir.Data())) {
+    std::cout << "found base directory: " << baseDir.Data() << std::endl;
   } else {
-    std::cout<<"no directory named: "<<baseDir.Data()<<std::endl;
+    std::cout << "no directory named: " << baseDir.Data() << std::endl;
     assert(false);
   }
 }
@@ -109,190 +111,225 @@ PVValidationVariables::PVValidationVariables(TString fileName, TString baseDir, 
   This is an auxilliary enum and typedef used to handle the fit parameter types
 */
 
-namespace params
-{
+namespace params {
 
-  typedef std::pair<Double_t,Double_t> measurement;
-  
-  enum estimator 
-    { MEAN   = 1,
-      WIDTH  = 2, 
-      MEDIAN = 3,
-      MAD    = 4,
-      UNKWN  = -1
-    };
-}
+  typedef std::pair<Double_t, Double_t> measurement;
+
+  enum estimator { MEAN = 1, WIDTH = 2, MEDIAN = 3, MAD = 4, UNKWN = -1 };
+}  // namespace params
 
 /*
   This is an auxilliary struct used to handle the plot limits
 */
 
 struct Limits {
-
   // initializers list
 
-  Limits() : _m_dxyPhiMax(80.),     _m_dzPhiMax(80.),       
-	     _m_dxyEtaMax(80.),     _m_dzEtaMax(80.),       
-	     _m_dxyPhiNormMax(0.5), _m_dzPhiNormMax(0.5),   
-	     _m_dxyEtaNormMax(0.5), _m_dzEtaNormMax(0.5),   
-	     _w_dxyPhiMax(120.),    _w_dzPhiMax(180.),      
-	     _w_dxyEtaMax(120.),    _w_dzEtaMax(1000.),       
-	     _w_dxyPhiNormMax(2.0), _w_dzPhiNormMax(2.0),   
-	     _w_dxyEtaNormMax(2.0), _w_dzEtaNormMax(2.0) {}   
+  Limits()
+      : _m_dxyPhiMax(80.),
+        _m_dzPhiMax(80.),
+        _m_dxyEtaMax(80.),
+        _m_dzEtaMax(80.),
+        _m_dxyPhiNormMax(0.5),
+        _m_dzPhiNormMax(0.5),
+        _m_dxyEtaNormMax(0.5),
+        _m_dzEtaNormMax(0.5),
+        _w_dxyPhiMax(120.),
+        _w_dzPhiMax(180.),
+        _w_dxyEtaMax(120.),
+        _w_dzEtaMax(1000.),
+        _w_dxyPhiNormMax(2.0),
+        _w_dzPhiNormMax(2.0),
+        _w_dxyEtaNormMax(2.0),
+        _w_dzEtaNormMax(2.0) {}
 
   // getter methods
 
-  std::pair <float,float> get_dxyPhiMax() const {
-    std::pair <float,float> res(_m_dxyPhiMax,_w_dxyPhiMax);
+  std::pair<float, float> get_dxyPhiMax() const {
+    std::pair<float, float> res(_m_dxyPhiMax, _w_dxyPhiMax);
     return res;
   }
-  
-  std::pair <float,float> get_dzPhiMax() const {
-    std::pair <float,float> res(_m_dzPhiMax,_w_dzPhiMax);
+
+  std::pair<float, float> get_dzPhiMax() const {
+    std::pair<float, float> res(_m_dzPhiMax, _w_dzPhiMax);
     return res;
   }
-  
-  std::pair <float,float> get_dxyEtaMax() const {
-   std::pair <float,float> res(_m_dxyEtaMax,_w_dxyEtaMax);
-   return res;
- }
-  
-  std::pair <float,float> get_dzEtaMax() const {
-    std::pair <float,float> res(_m_dzEtaMax,_w_dzEtaMax);
+
+  std::pair<float, float> get_dxyEtaMax() const {
+    std::pair<float, float> res(_m_dxyEtaMax, _w_dxyEtaMax);
     return res;
   }
-  
- std::pair <float,float> get_dxyPhiNormMax() const {
-   std::pair <float,float> res(_m_dxyPhiNormMax,_w_dxyPhiNormMax);
-   return res;
- }
-  
-  std::pair <float,float> get_dzPhiNormMax() const {
-    std::pair <float,float> res(_m_dzPhiNormMax,_w_dzPhiNormMax);
+
+  std::pair<float, float> get_dzEtaMax() const {
+    std::pair<float, float> res(_m_dzEtaMax, _w_dzEtaMax);
     return res;
   }
-  
-  std::pair <float,float> get_dxyEtaNormMax() const {
-    std::pair <float,float> res(_m_dxyEtaNormMax,_w_dxyEtaNormMax);
+
+  std::pair<float, float> get_dxyPhiNormMax() const {
+    std::pair<float, float> res(_m_dxyPhiNormMax, _w_dxyPhiNormMax);
     return res;
   }
-  
-  std::pair <float,float> get_dzEtaNormMax() const {
-    std::pair <float,float> res(_m_dzEtaNormMax,_w_dzEtaNormMax);
+
+  std::pair<float, float> get_dzPhiNormMax() const {
+    std::pair<float, float> res(_m_dzPhiNormMax, _w_dzPhiNormMax);
+    return res;
+  }
+
+  std::pair<float, float> get_dxyEtaNormMax() const {
+    std::pair<float, float> res(_m_dxyEtaNormMax, _w_dxyEtaNormMax);
+    return res;
+  }
+
+  std::pair<float, float> get_dzEtaNormMax() const {
+    std::pair<float, float> res(_m_dzEtaNormMax, _w_dzEtaNormMax);
     return res;
   }
 
   // initializes to different values, if needed
 
-  void init(float m_dxyPhiMax,float m_dzPhiMax,float m_dxyEtaMax,float m_dzEtaMax,        		  
-	    float m_dxyPhiNormMax,float m_dzPhiNormMax,float m_dxyEtaNormMax,float m_dzEtaNormMax,    
-	    float w_dxyPhiMax,float w_dzPhiMax,float w_dxyEtaMax,float w_dzEtaMax,	  		  
-	    float w_dxyPhiNormMax,float w_dzPhiNormMax,float w_dxyEtaNormMax,float w_dzEtaNormMax){
-    
-    _m_dxyPhiMax     = m_dxyPhiMax;       
-    _m_dzPhiMax      = m_dzPhiMax;        
-    _m_dxyEtaMax     = m_dxyEtaMax;       
-    _m_dzEtaMax      = m_dzEtaMax;                                 
-    _m_dxyPhiNormMax = m_dxyPhiNormMax; 
-    _m_dzPhiNormMax  = m_dzPhiNormMax; 
-    _m_dxyEtaNormMax = m_dxyEtaNormMax; 
-    _m_dzEtaNormMax  = m_dzEtaNormMax;     
-    _w_dxyPhiMax     = w_dxyPhiMax; 
-    _w_dzPhiMax      = w_dzPhiMax; 
-    _w_dxyEtaMax     = w_dxyEtaMax; 
-    _w_dzEtaMax      = w_dzEtaMax;
-    _w_dxyPhiNormMax = w_dxyPhiNormMax; 
-    _w_dzPhiNormMax  = w_dzPhiNormMax; 
-    _w_dxyEtaNormMax = w_dxyEtaNormMax; 
-    _w_dzEtaNormMax  = w_dzEtaNormMax;    
-    
+  void init(float m_dxyPhiMax,
+            float m_dzPhiMax,
+            float m_dxyEtaMax,
+            float m_dzEtaMax,
+            float m_dxyPhiNormMax,
+            float m_dzPhiNormMax,
+            float m_dxyEtaNormMax,
+            float m_dzEtaNormMax,
+            float w_dxyPhiMax,
+            float w_dzPhiMax,
+            float w_dxyEtaMax,
+            float w_dzEtaMax,
+            float w_dxyPhiNormMax,
+            float w_dzPhiNormMax,
+            float w_dxyEtaNormMax,
+            float w_dzEtaNormMax) {
+    _m_dxyPhiMax = m_dxyPhiMax;
+    _m_dzPhiMax = m_dzPhiMax;
+    _m_dxyEtaMax = m_dxyEtaMax;
+    _m_dzEtaMax = m_dzEtaMax;
+    _m_dxyPhiNormMax = m_dxyPhiNormMax;
+    _m_dzPhiNormMax = m_dzPhiNormMax;
+    _m_dxyEtaNormMax = m_dxyEtaNormMax;
+    _m_dzEtaNormMax = m_dzEtaNormMax;
+    _w_dxyPhiMax = w_dxyPhiMax;
+    _w_dzPhiMax = w_dzPhiMax;
+    _w_dxyEtaMax = w_dxyEtaMax;
+    _w_dzEtaMax = w_dzEtaMax;
+    _w_dxyPhiNormMax = w_dxyPhiNormMax;
+    _w_dzPhiNormMax = w_dzPhiNormMax;
+    _w_dxyEtaNormMax = w_dxyEtaNormMax;
+    _w_dzEtaNormMax = w_dzEtaNormMax;
   }
 
-  void printAll(){
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"  The y-axis ranges on the plots will be the following:      "<<std::endl;
+  void printAll() {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "  The y-axis ranges on the plots will be the following:      " << std::endl;
 
-    std::cout<<"  mean of dxy vs Phi:         " <<  _m_dxyPhiMax<< std::endl;  
-    std::cout<<"  mean of dz  vs Phi:         " <<  _m_dzPhiMax<< std::endl;  
-    std::cout<<"  mean of dxy vs Eta:         " <<  _m_dxyEtaMax<< std::endl;  
-    std::cout<<"  mean of dz  vs Eta:         " <<  _m_dzEtaMax<< std::endl;  
-    
-    std::cout<<"  mean of dxy vs Phi (norm):  " <<  _m_dxyPhiNormMax<< std::endl; 
-    std::cout<<"  mean of dz  vs Phi (norm):  " <<  _m_dzPhiNormMax<< std::endl; 
-    std::cout<<"  mean of dxy vs Eta (norm):  " <<  _m_dxyEtaNormMax<< std::endl; 
-    std::cout<<"  mean of dz  vs Eta (norm):  " <<  _m_dzEtaNormMax<< std::endl; 
-    
-    std::cout<<"  width of dxy vs Phi:        " <<  _w_dxyPhiMax<< std::endl; 
-    std::cout<<"  width of dz  vs Phi:        " <<  _w_dzPhiMax<< std::endl; 
-    std::cout<<"  width of dxy vs Eta:        " <<  _w_dxyEtaMax<< std::endl; 
-    std::cout<<"  width of dz  vs Eta:        " <<  _w_dzEtaMax<< std::endl;
-    
-    std::cout<<"  width of dxy vs Phi (norm): " <<  _w_dxyPhiNormMax<< std::endl; 
-    std::cout<<"  width of dz  vs Phi (norm): " <<  _w_dzPhiNormMax<< std::endl; 
-    std::cout<<"  width of dxy vs Eta (norm): " <<  _w_dxyEtaNormMax<< std::endl; 
-    std::cout<<"  width of dz  vs Eta (norm): " <<  _w_dzEtaNormMax<< std::endl; 
- 
-    std::cout<<"======================================================"<<std::endl;
+    std::cout << "  mean of dxy vs Phi:         " << _m_dxyPhiMax << std::endl;
+    std::cout << "  mean of dz  vs Phi:         " << _m_dzPhiMax << std::endl;
+    std::cout << "  mean of dxy vs Eta:         " << _m_dxyEtaMax << std::endl;
+    std::cout << "  mean of dz  vs Eta:         " << _m_dzEtaMax << std::endl;
+
+    std::cout << "  mean of dxy vs Phi (norm):  " << _m_dxyPhiNormMax << std::endl;
+    std::cout << "  mean of dz  vs Phi (norm):  " << _m_dzPhiNormMax << std::endl;
+    std::cout << "  mean of dxy vs Eta (norm):  " << _m_dxyEtaNormMax << std::endl;
+    std::cout << "  mean of dz  vs Eta (norm):  " << _m_dzEtaNormMax << std::endl;
+
+    std::cout << "  width of dxy vs Phi:        " << _w_dxyPhiMax << std::endl;
+    std::cout << "  width of dz  vs Phi:        " << _w_dzPhiMax << std::endl;
+    std::cout << "  width of dxy vs Eta:        " << _w_dxyEtaMax << std::endl;
+    std::cout << "  width of dz  vs Eta:        " << _w_dzEtaMax << std::endl;
+
+    std::cout << "  width of dxy vs Phi (norm): " << _w_dxyPhiNormMax << std::endl;
+    std::cout << "  width of dz  vs Phi (norm): " << _w_dzPhiNormMax << std::endl;
+    std::cout << "  width of dxy vs Eta (norm): " << _w_dxyEtaNormMax << std::endl;
+    std::cout << "  width of dz  vs Eta (norm): " << _w_dzEtaNormMax << std::endl;
+
+    std::cout << "======================================================" << std::endl;
   }
 
 private:
-  float _m_dxyPhiMax;    
-  float _m_dzPhiMax;    
-  float _m_dxyEtaMax;    
-  float _m_dzEtaMax;                            
-  float _m_dxyPhiNormMax;   
-  float _m_dzPhiNormMax;   
-  float _m_dxyEtaNormMax;   
+  float _m_dxyPhiMax;
+  float _m_dzPhiMax;
+  float _m_dxyEtaMax;
+  float _m_dzEtaMax;
+  float _m_dxyPhiNormMax;
+  float _m_dzPhiNormMax;
+  float _m_dxyEtaNormMax;
   float _m_dzEtaNormMax;
-                           
-  float _w_dxyPhiMax;   
-  float _w_dzPhiMax;   
-  float _w_dxyEtaMax;   
-  float _w_dzEtaMax;                          
-  float _w_dxyPhiNormMax;   
-  float _w_dzPhiNormMax;   
-  float _w_dxyEtaNormMax;   
-  float _w_dzEtaNormMax;    
-  
+
+  float _w_dxyPhiMax;
+  float _w_dzPhiMax;
+  float _w_dxyEtaMax;
+  float _w_dzEtaMax;
+  float _w_dxyPhiNormMax;
+  float _w_dzPhiNormMax;
+  float _w_dxyEtaNormMax;
+  float _w_dzEtaNormMax;
 };
 
-Limits* thePlotLimits = new Limits();
-std::vector<PVValidationVariables*> sourceList;
+Limits *thePlotLimits = new Limits();
+std::vector<PVValidationVariables *> sourceList;
 
-#define ARRAY_SIZE(array) (sizeof((array))/sizeof((array[0])))
+#define ARRAY_SIZE(array) (sizeof((array)) / sizeof((array[0])))
 
-void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_t nFiles,TString LegLabels[10],TString theDate="bogus",bool onlyBias=false,bool setAutoLimits=true);
-void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_t nFiles,TString LegLabels[10],TString theDate="bogus");
-void arrangeFitCanvas(TCanvas *canv,TH1F* meanplots[100],Int_t nFiles, TString LegLabels[10],TString theDate="bogus");
+void arrangeCanvas(TCanvas *canv,
+                   TH1F *meanplots[100],
+                   TH1F *widthplots[100],
+                   Int_t nFiles,
+                   TString LegLabels[10],
+                   TString theDate = "bogus",
+                   bool onlyBias = false,
+                   bool setAutoLimits = true);
+void arrangeCanvas2D(TCanvas *canv,
+                     TH2F *meanmaps[100],
+                     TH2F *widthmaps[100],
+                     Int_t nFiles,
+                     TString LegLabels[10],
+                     TString theDate = "bogus");
+void arrangeFitCanvas(
+    TCanvas *canv, TH1F *meanplots[100], Int_t nFiles, TString LegLabels[10], TString theDate = "bogus");
 
-void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanTrend[100],TH1F* dxyEtaMeanTrend[100],TH1F* dzEtaMeanTrend[100],Int_t nFiles, TString LegLabels[10],TString theDate="bogus",bool setAutoLimits=true);
+void arrangeBiasCanvas(TCanvas *canv,
+                       TH1F *dxyPhiMeanTrend[100],
+                       TH1F *dzPhiMeanTrend[100],
+                       TH1F *dxyEtaMeanTrend[100],
+                       TH1F *dzEtaMeanTrend[100],
+                       Int_t nFiles,
+                       TString LegLabels[10],
+                       TString theDate = "bogus",
+                       bool setAutoLimits = true);
 
 params::measurement getMedian(TH1F *histo);
 params::measurement getMAD(TH1F *histo);
 
-std::pair<params::measurement, params::measurement  > fitResiduals(TH1 *hist,bool singleTime=false);
+std::pair<params::measurement, params::measurement> fitResiduals(TH1 *hist, bool singleTime = false);
 
-Double_t DoubleSidedCB(double* x, double* par);
-std::pair<params::measurement, params::measurement  > fitResidualsCB(TH1 *hist);
+Double_t DoubleSidedCB(double *x, double *par);
+std::pair<params::measurement, params::measurement> fitResidualsCB(TH1 *hist);
 
-Double_t tp0Fit( Double_t *x, Double_t *par5 );
-std::pair<params::measurement, params::measurement  > fitStudentTResiduals(TH1 *hist);
+Double_t tp0Fit(Double_t *x, Double_t *par5);
+std::pair<params::measurement, params::measurement> fitStudentTResiduals(TH1 *hist);
 
-void FillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], params::estimator firPar_, TString var_,Int_t nbins);
-void FillMap(TH2F* trendMap,std::vector<std::vector<TH1F*> >residualsMapPlot, params::estimator fitPar_);
+void FillTrendPlot(TH1F *trendPlot, TH1F *residualsPlot[100], params::estimator firPar_, TString var_, Int_t nbins);
+void FillMap(TH2F *trendMap, std::vector<std::vector<TH1F *> > residualsMapPlot, params::estimator fitPar_);
 
-std::pair<TH2F*,TH2F*> trimTheMap(TH2 *hist);
+std::pair<TH2F *, TH2F *> trimTheMap(TH2 *hist);
 
-void MakeNiceTrendPlotStyle(TH1 *hist,Int_t color,Int_t style);
+void MakeNiceTrendPlotStyle(TH1 *hist, Int_t color, Int_t style);
 void MakeNicePlotStyle(TH1 *hist);
 void MakeNiceMapStyle(TH2 *hist);
-void MakeNiceTF1Style(TF1 *f1,Int_t color);
+void MakeNiceTF1Style(TF1 *f1, Int_t color);
 
-void FitPVResiduals(TString namesandlabels,bool stdres=true,bool do2DMaps=false,TString theDate="bogus",bool setAutoLimits=true);
-TH1F* DrawZero(TH1F *hist,Int_t nbins,Double_t lowedge,Double_t highedge,Int_t iter);
-TH1F* DrawConstant(TH1F *hist,Int_t nbins,Double_t lowedge,Double_t highedge,Int_t iter,Double_t theConst);
-void makeNewXAxis (TH1F *h);
-void makeNewPairOfAxes (TH2F *h);
+void FitPVResiduals(TString namesandlabels,
+                    bool stdres = true,
+                    bool do2DMaps = false,
+                    TString theDate = "bogus",
+                    bool setAutoLimits = true);
+TH1F *DrawZero(TH1F *hist, Int_t nbins, Double_t lowedge, Double_t highedge, Int_t iter);
+TH1F *DrawConstant(TH1F *hist, Int_t nbins, Double_t lowedge, Double_t highedge, Int_t iter, Double_t theConst);
+void makeNewXAxis(TH1F *h);
+void makeNewPairOfAxes(TH2F *h);
 
 // ancillary fitting functions
 Double_t fULine(Double_t *x, Double_t *par);
@@ -300,7 +337,7 @@ Double_t fDLine(Double_t *x, Double_t *par);
 void FitULine(TH1 *hist);
 void FitDLine(TH1 *hist);
 
-params::measurement getTheRangeUser(TH1F* thePlot,Limits* thePlotLimits,bool tag=false);
+params::measurement getTheRangeUser(TH1F *thePlot, Limits *thePlotLimits, bool tag = false);
 
 void setStyle();
 
@@ -308,28 +345,31 @@ void setStyle();
 
 ofstream outfile("FittedDeltaZ.txt");
 
-Int_t nBins_     = 48;
-Int_t nLadders_  = 20;
+Int_t nBins_ = 48;
+Int_t nLadders_ = 20;
 const Int_t nPtBins_ = 48;
-Float_t _boundMin   = -0.5;
-Float_t _boundSx    = (nBins_/4.)-0.5;
-Float_t _boundDx    = 3*(nBins_/4.)-0.5;
-Float_t _boundMax   = nBins_-0.5;
-Float_t  etaRange   = 2.5;
-Float_t  minPt_      = 1.;
-Float_t  maxPt_      = 20.;
-bool     isDebugMode = false;
+Float_t _boundMin = -0.5;
+Float_t _boundSx = (nBins_ / 4.) - 0.5;
+Float_t _boundDx = 3 * (nBins_ / 4.) - 0.5;
+Float_t _boundMax = nBins_ - 0.5;
+Float_t etaRange = 2.5;
+Float_t minPt_ = 1.;
+Float_t maxPt_ = 20.;
+bool isDebugMode = false;
 
-// pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf) 
+// pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf)
 // this is the default
 
-std::array<float,nPtBins_+1> mypT_bins = {{0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9,3.0,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8,3.9,4.0,4.1,4.25,4.5,4.75,5.0,5.5,6.,7.,8.,9.,11.,14.,20.}};
+std::array<float, nPtBins_ + 1> mypT_bins = {{0.5,  0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,  1.7,
+                                              1.8,  1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,  3.0,
+                                              3.1,  3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.25, 4.5,
+                                              4.75, 5.0, 5.5, 6.,  7.,  8.,  9.,  11., 14., 20.}};
 
 // inline function
-int check(const double a[], int n)
-{   
-    while(--n>0 && a[n]==a[0]);
-    return n!=0;
+int check(const double a[], int n) {
+  while (--n > 0 && a[n] == a[0])
+    ;
+  return n != 0;
 }
 
 // fill the list of files
@@ -338,34 +378,42 @@ void loadFileList(const char *inputFile, TString baseDir, TString legendName, in
 //*************************************************************
 {
   gErrorIgnoreLevel = kFatal;
-  sourceList.push_back( new PVValidationVariables( inputFile, baseDir, legendName, lineColor, lineStyle ) ); 
+  sourceList.push_back(new PVValidationVariables(inputFile, baseDir, legendName, lineColor, lineStyle));
 }
 
 //*************************************************************
-void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString theDate,bool setAutoLimits)
+void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString theDate, bool setAutoLimits)
 //*************************************************************
 {
   // only for fatal errors (useful in debugging)
   gErrorIgnoreLevel = kFatal;
 
-  TH1::AddDirectory(kFALSE); 
+  TH1::AddDirectory(kFALSE);
   bool fromLoader = false;
 
   TTimeStamp start_time;
-  TStopwatch timer; 	 
+  TStopwatch timer;
   timer.Start();
 
-  if(!setAutoLimits){
-    std::cout<<"FitPVResiduals::FitPVResiduals(): Overriding autolimits!"<<std::endl;
+  if (!setAutoLimits) {
+    std::cout << "FitPVResiduals::FitPVResiduals(): Overriding autolimits!" << std::endl;
     thePlotLimits->printAll();
   } else {
-    std::cout<<"FitPVResiduals::FitPVResiduals(): plot axis range will be automatically adjusted"<<std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): plot axis range will be automatically adjusted" << std::endl;
   }
-    
+
   //TkAlStyle::set(INTERNAL);	// set publication status
 
-  Int_t def_markers[9] = {kFullSquare,kFullCircle,kFullTriangleDown,kOpenSquare,kDot,kOpenCircle,kFullTriangleDown,kFullTriangleUp,kOpenTriangleDown};
-  Int_t def_colors[9] = {kBlack,kRed,kBlue,kMagenta,kGreen,kCyan,kViolet,kOrange,kGreen+2};
+  Int_t def_markers[9] = {kFullSquare,
+                          kFullCircle,
+                          kFullTriangleDown,
+                          kOpenSquare,
+                          kDot,
+                          kOpenCircle,
+                          kFullTriangleDown,
+                          kFullTriangleUp,
+                          kOpenTriangleDown};
+  Int_t def_colors[9] = {kBlack, kRed, kBlue, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
 
   Int_t markers[9];
   Int_t colors[9];
@@ -373,88 +421,78 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   setStyle();
 
   // check if the loader is empty
-  if (sourceList.size()!=0){
+  if (sourceList.size() != 0) {
     fromLoader = true;
   }
 
   // if enters here, whatever is passed from command line is neglected
-  if(fromLoader) {
+  if (fromLoader) {
     std::cout << "FitPVResiduals::FitPVResiduals(): file list specified from loader" << std::endl;
     std::cout << "======================================================" << std::endl;
     std::cout << "!!    arguments passed from CLI will be neglected   !!" << std::endl;
     std::cout << "======================================================" << std::endl;
-    for(std::vector<PVValidationVariables*>::iterator it = sourceList.begin();
-	it != sourceList.end(); ++it){
-      std::cout<<"name:  "  << std::setw(20) << (*it)->getName()
-	       <<" |file:  " << std::setw(15) << (*it)->getFile()
-	       <<" |color: " << std::setw(5) << (*it)->getLineColor()
-	       <<" |style: " << std::setw(5) << (*it)->getLineStyle()
- 	       <<" |marker:" << std::setw(5) << (*it)->getMarkerStyle()
-	       << std::endl;
+    for (std::vector<PVValidationVariables *>::iterator it = sourceList.begin(); it != sourceList.end(); ++it) {
+      std::cout << "name:  " << std::setw(20) << (*it)->getName() << " |file:  " << std::setw(15) << (*it)->getFile()
+                << " |color: " << std::setw(5) << (*it)->getLineColor() << " |style: " << std::setw(5)
+                << (*it)->getLineStyle() << " |marker:" << std::setw(5) << (*it)->getMarkerStyle() << std::endl;
     }
     std::cout << "======================================================" << std::endl;
   }
 
-  Int_t theFileCount=0;
-  TList *FileList  = new TList();
+  Int_t theFileCount = 0;
+  TList *FileList = new TList();
   TList *LabelList = new TList();
 
-  if(!fromLoader){
-
+  if (!fromLoader) {
     namesandlabels.Remove(TString::kTrailing, ',');
     TObjArray *nameandlabelpairs = namesandlabels.Tokenize(",");
     for (Int_t i = 0; i < nameandlabelpairs->GetEntries(); ++i) {
       TObjArray *aFileLegPair = TString(nameandlabelpairs->At(i)->GetName()).Tokenize("=");
-    
-      if(aFileLegPair->GetEntries() == 2) {
-	FileList->Add( TFile::Open(aFileLegPair->At(0)->GetName(),"READ")  );  // 2
-	LabelList->Add( aFileLegPair->At(1) );
+
+      if (aFileLegPair->GetEntries() == 2) {
+        FileList->Add(TFile::Open(aFileLegPair->At(0)->GetName(), "READ"));  // 2
+        LabelList->Add(aFileLegPair->At(1));
+      } else {
+        std::cout << "Please give file name and legend entry in the following form:\n"
+                  << " filename1=legendentry1,filename2=legendentry2\n";
       }
-      else {
-	std::cout << "Please give file name and legend entry in the following form:\n" 
-		  << " filename1=legendentry1,filename2=legendentry2\n";
-      }    
     }
-    theFileCount=FileList->GetSize();
+    theFileCount = FileList->GetSize();
   } else {
-    
-    for(std::vector<PVValidationVariables*>::iterator it = sourceList.begin();
-	it != sourceList.end(); ++it){
+    for (std::vector<PVValidationVariables *>::iterator it = sourceList.begin(); it != sourceList.end(); ++it) {
       //FileList->Add((*it)->getFile()); // was extremely slow
-      FileList->Add( TFile::Open((*it)->getFileName(),"READ")  );  
+      FileList->Add(TFile::Open((*it)->getFileName(), "READ"));
     }
     theFileCount = sourceList.size();
   }
-  
+
   //  const Int_t nFiles_ = FileList->GetSize();
   const Int_t nFiles_ = theFileCount;
-  TString LegLabels[10];  
-  TFile *fins[nFiles_]; 
+  TString LegLabels[10];
+  TFile *fins[nFiles_];
 
   // already used in the global variables
   //const Int_t nBins_ =24;
-  
-  for(Int_t j=0; j < nFiles_; j++) {
-    
+
+  for (Int_t j = 0; j < nFiles_; j++) {
     // Retrieve files
-    fins[j] = (TFile*)FileList->At(j);    
-    
+    fins[j] = (TFile *)FileList->At(j);
+
     // Retrieve labels
-    if(!fromLoader){
-      TObjString* legend = (TObjString*)LabelList->At(j);
+    if (!fromLoader) {
+      TObjString *legend = (TObjString *)LabelList->At(j);
       LegLabels[j] = legend->String();
       markers[j] = def_markers[j];
-      colors[j]  = def_colors[j];
+      colors[j] = def_colors[j];
     } else {
       LegLabels[j] = sourceList[j]->getName();
       markers[j] = sourceList[j]->getMarkerStyle();
-      colors[j]  = sourceList[j]->getLineColor();
+      colors[j] = sourceList[j]->getLineColor();
     }
-    LegLabels[j].ReplaceAll("_"," ");
-    cout<<"FitPVResiduals::FitPVResiduals(): label["<<j<<"] "<<LegLabels[j]<<endl;
-    
+    LegLabels[j].ReplaceAll("_", " ");
+    cout << "FitPVResiduals::FitPVResiduals(): label[" << j << "] " << LegLabels[j] << endl;
   }
- 
+
   //
   // initialize all the histograms to be taken from file
   //
@@ -467,58 +505,58 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   TH1F *dzSigRefit[nFiles_];
 
   // dca absolute residuals
-  TH1F* dxyPhiResiduals[nFiles_][nBins_];
-  TH1F* dxyEtaResiduals[nFiles_][nBins_];
-  				        
-  TH1F* dzPhiResiduals[nFiles_][nBins_];
-  TH1F* dzEtaResiduals[nFiles_][nBins_];
+  TH1F *dxyPhiResiduals[nFiles_][nBins_];
+  TH1F *dxyEtaResiduals[nFiles_][nBins_];
+
+  TH1F *dzPhiResiduals[nFiles_][nBins_];
+  TH1F *dzEtaResiduals[nFiles_][nBins_];
 
   // dca transvers residuals
-  TH1F* dxPhiResiduals[nFiles_][nBins_];
-  TH1F* dxEtaResiduals[nFiles_][nBins_];
-  				        
-  TH1F* dyPhiResiduals[nFiles_][nBins_];
-  TH1F* dyEtaResiduals[nFiles_][nBins_];
+  TH1F *dxPhiResiduals[nFiles_][nBins_];
+  TH1F *dxEtaResiduals[nFiles_][nBins_];
+
+  TH1F *dyPhiResiduals[nFiles_][nBins_];
+  TH1F *dyEtaResiduals[nFiles_][nBins_];
 
   // dca normalized residuals
-  TH1F* dxyNormPhiResiduals[nFiles_][nBins_];
-  TH1F* dxyNormEtaResiduals[nFiles_][nBins_];
-  				        
-  TH1F* dzNormPhiResiduals[nFiles_][nBins_];
-  TH1F* dzNormEtaResiduals[nFiles_][nBins_];
-  
+  TH1F *dxyNormPhiResiduals[nFiles_][nBins_];
+  TH1F *dxyNormEtaResiduals[nFiles_][nBins_];
+
+  TH1F *dzNormPhiResiduals[nFiles_][nBins_];
+  TH1F *dzNormEtaResiduals[nFiles_][nBins_];
+
   // double-differential residuals
-  TH1F* dxyMapResiduals[nFiles_][nBins_][nBins_]; 
-  TH1F* dzMapResiduals[nFiles_][nBins_][nBins_];     
-  
-  TH1F* dxyNormMapResiduals[nFiles_][nBins_][nBins_];
-  TH1F* dzNormMapResiduals[nFiles_][nBins_][nBins_]; 
+  TH1F *dxyMapResiduals[nFiles_][nBins_][nBins_];
+  TH1F *dzMapResiduals[nFiles_][nBins_][nBins_];
+
+  TH1F *dxyNormMapResiduals[nFiles_][nBins_][nBins_];
+  TH1F *dzNormMapResiduals[nFiles_][nBins_][nBins_];
 
   // dca residuals vs pT
-  TH1F* dzNormPtResiduals[nFiles_][nPtBins_];
-  TH1F* dxyNormPtResiduals[nFiles_][nPtBins_];
+  TH1F *dzNormPtResiduals[nFiles_][nPtBins_];
+  TH1F *dxyNormPtResiduals[nFiles_][nPtBins_];
 
-  TH1F* dzPtResiduals[nFiles_][nPtBins_];
-  TH1F* dxyPtResiduals[nFiles_][nPtBins_];
+  TH1F *dzPtResiduals[nFiles_][nPtBins_];
+  TH1F *dxyPtResiduals[nFiles_][nPtBins_];
 
   // dca residuals vs module number/ladder
-  TH1F* dzNormLadderResiduals[nFiles_][nLadders_];
-  TH1F* dxyNormLadderResiduals[nFiles_][nLadders_];
-  
-  TH1F* dzLadderResiduals[nFiles_][nLadders_];
-  TH1F* dxyLadderResiduals[nFiles_][nLadders_];
+  TH1F *dzNormLadderResiduals[nFiles_][nLadders_];
+  TH1F *dxyNormLadderResiduals[nFiles_][nLadders_];
 
-  TH1F* dzNormModZResiduals[nFiles_][8];
-  TH1F* dxyNormModZResiduals[nFiles_][8];
-  
-  TH1F* dzModZResiduals[nFiles_][8];
-  TH1F* dxyModZResiduals[nFiles_][8];
+  TH1F *dzLadderResiduals[nFiles_][nLadders_];
+  TH1F *dxyLadderResiduals[nFiles_][nLadders_];
+
+  TH1F *dzNormModZResiduals[nFiles_][8];
+  TH1F *dxyNormModZResiduals[nFiles_][8];
+
+  TH1F *dzModZResiduals[nFiles_][8];
+  TH1F *dxyModZResiduals[nFiles_][8];
 
   // for sanity checks
-  TH1F* theEtaHistos[nFiles_];
-  TH1F* thebinsHistos[nFiles_];
-  TH1F* theLaddersHistos[nFiles_];
-  TH1F* thePtInfoHistos[nFiles_];
+  TH1F *theEtaHistos[nFiles_];
+  TH1F *thebinsHistos[nFiles_];
+  TH1F *theLaddersHistos[nFiles_];
+  TH1F *thePtInfoHistos[nFiles_];
 
   double theEtaMax_[nFiles_];
   double theNBINS[nFiles_];
@@ -530,182 +568,196 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
   TTimeStamp initialization_done;
 
-  if(isDebugMode){
+  if (isDebugMode) {
     timer.Stop();
-    std::cout<<"check point 1: "<< timer.CpuTime() << " " << timer.RealTime() << std::endl;
+    std::cout << "check point 1: " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
     timer.Continue();
   }
 
-  for(Int_t i=0;i<nFiles_;i++){
-
+  for (Int_t i = 0; i < nFiles_; i++) {
     fins[i]->cd("PVValidation/EventFeatures/");
 
-    if(gDirectory->GetListOfKeys()->Contains("etaMax")){
-      gDirectory->GetObject("etaMax",theEtaHistos[i]);
-      theEtaMax_[i]   = theEtaHistos[i]->GetBinContent(1)/theEtaHistos[i]->GetEntries();
-      std::cout<<"File n. "<<i<<" has theEtaMax["<<i<<"] = "<< theEtaMax_[i]<<std::endl;
+    if (gDirectory->GetListOfKeys()->Contains("etaMax")) {
+      gDirectory->GetObject("etaMax", theEtaHistos[i]);
+      theEtaMax_[i] = theEtaHistos[i]->GetBinContent(1) / theEtaHistos[i]->GetEntries();
+      std::cout << "File n. " << i << " has theEtaMax[" << i << "] = " << theEtaMax_[i] << std::endl;
     } else {
-      theEtaMax_[i]   = 2.5;
-      std::cout<<"File n. "<<i<<" getting the default pseudo-rapidity range: "<< theEtaMax_[i]<<std::endl;
+      theEtaMax_[i] = 2.5;
+      std::cout << "File n. " << i << " getting the default pseudo-rapidity range: " << theEtaMax_[i] << std::endl;
     }
-    	
-    if(gDirectory->GetListOfKeys()->Contains("nbins")){
-      gDirectory->GetObject("nbins",thebinsHistos[i]);
-      theNBINS[i] = thebinsHistos[i]->GetBinContent(1)/thebinsHistos[i]->GetEntries();	  
-      std::cout<<"File n. "<<i<<" has theNBINS["<<i<<"] = "<< theNBINS[i]<<std::endl;
+
+    if (gDirectory->GetListOfKeys()->Contains("nbins")) {
+      gDirectory->GetObject("nbins", thebinsHistos[i]);
+      theNBINS[i] = thebinsHistos[i]->GetBinContent(1) / thebinsHistos[i]->GetEntries();
+      std::cout << "File n. " << i << " has theNBINS[" << i << "] = " << theNBINS[i] << std::endl;
     } else {
       theNBINS[i] = 48.;
-      std::cout<<"File n. "<<i<<" getting the default n. of bins: "<< theNBINS[i]<<std::endl;
+      std::cout << "File n. " << i << " getting the default n. of bins: " << theNBINS[i] << std::endl;
     }
 
-    if(gDirectory->GetListOfKeys()->Contains("nladders")){
-      gDirectory->GetObject("nladders",theLaddersHistos[i]);
-      theLadders[i] = theLaddersHistos[i]->GetBinContent(1)/theLaddersHistos[i]->GetEntries();
-      std::cout<<"File n. "<<i<<" has theNLadders["<<i<<"] = "<< theLadders[i]<<std::endl;
+    if (gDirectory->GetListOfKeys()->Contains("nladders")) {
+      gDirectory->GetObject("nladders", theLaddersHistos[i]);
+      theLadders[i] = theLaddersHistos[i]->GetBinContent(1) / theLaddersHistos[i]->GetEntries();
+      std::cout << "File n. " << i << " has theNLadders[" << i << "] = " << theLadders[i] << std::endl;
     } else {
       theLadders[i] = -1.;
-      std::cout<<"File n. "<<i<<" getting the default n. ladders: "<< theLadders[i]<<std::endl;
+      std::cout << "File n. " << i << " getting the default n. ladders: " << theLadders[i] << std::endl;
     }
 
-    if(gDirectory->GetListOfKeys()->Contains("pTinfo")){
-      gDirectory->GetObject("pTinfo",thePtInfoHistos[i]);
-      thePTBINS[i]=thePtInfoHistos[i]->GetBinContent(1)*3./thePtInfoHistos[i]->GetEntries();;
-      thePtMin[i]=thePtInfoHistos[i]->GetBinContent(2)*3./thePtInfoHistos[i]->GetEntries();
-      thePtMax[i]=thePtInfoHistos[i]->GetBinContent(3)*3./thePtInfoHistos[i]->GetEntries();
-      std::cout<<"File n. "<<i<<" has thePTBINS["<<i<<"] = "<< thePTBINS[i]
-	       <<" pT min:  "<<thePtMin[i] << " pT max: "<<thePtMax[i] << std::endl;
+    if (gDirectory->GetListOfKeys()->Contains("pTinfo")) {
+      gDirectory->GetObject("pTinfo", thePtInfoHistos[i]);
+      thePTBINS[i] = thePtInfoHistos[i]->GetBinContent(1) * 3. / thePtInfoHistos[i]->GetEntries();
+      ;
+      thePtMin[i] = thePtInfoHistos[i]->GetBinContent(2) * 3. / thePtInfoHistos[i]->GetEntries();
+      thePtMax[i] = thePtInfoHistos[i]->GetBinContent(3) * 3. / thePtInfoHistos[i]->GetEntries();
+      std::cout << "File n. " << i << " has thePTBINS[" << i << "] = " << thePTBINS[i] << " pT min:  " << thePtMin[i]
+                << " pT max: " << thePtMax[i] << std::endl;
     } else {
       // if there is no histogram then set the extremes to 0, but the n. of bins should be still the default
       // this protects running against the old file format.
-      thePTBINS[i]=nPtBins_;
-      thePtMin[i]=0.;
-      thePtMax[i]=0.;
-      std::cout<<"File n. "<<i<<" getting the default pT binning: ";
-      for (const auto &bin : mypT_bins){
-	std::cout << bin << " ";
+      thePTBINS[i] = nPtBins_;
+      thePtMin[i] = 0.;
+      thePtMax[i] = 0.;
+      std::cout << "File n. " << i << " getting the default pT binning: ";
+      for (const auto &bin : mypT_bins) {
+        std::cout << bin << " ";
       }
-      std::cout<<std::endl;
+      std::cout << std::endl;
     }
 
     // get the non-differential residuals plots
 
     fins[i]->cd("PVValidation/ProbeTrackFeatures");
-    
-    gDirectory->GetObject("h_probedxyRefitV",dxyRefit[i]);  
-    gDirectory->GetObject("h_probedzRefitV",dzRefit[i]);   
-                        
-    gDirectory->GetObject("h_probeRefitVSigXY",dxySigRefit[i]);
-    gDirectory->GetObject("h_probeRefitVSigZ",dzSigRefit[i]);
 
-    for(Int_t j=0;j<theNBINS[i];j++){
-      
-      if(stdres){
-	// DCA absolute residuals
+    gDirectory->GetObject("h_probedxyRefitV", dxyRefit[i]);
+    gDirectory->GetObject("h_probedzRefitV", dzRefit[i]);
 
-	fins[i]->cd("PVValidation/Abs_Transv_Phi_Residuals/");
-	gDirectory->GetObject(Form("histo_dxy_phi_plot%i",j),dxyPhiResiduals[i][j]);
-	gDirectory->GetObject(Form("histo_dx_phi_plot%i",j),dxPhiResiduals[i][j]);
-	gDirectory->GetObject(Form("histo_dy_phi_plot%i",j),dyPhiResiduals[i][j]);
-		
-	fins[i]->cd("PVValidation/Abs_Transv_Eta_Residuals/");
-	gDirectory->GetObject(Form("histo_dxy_eta_plot%i",j),dxyEtaResiduals[i][j]);
-	gDirectory->GetObject(Form("histo_dx_eta_plot%i",j),dxEtaResiduals[i][j]);
-	gDirectory->GetObject(Form("histo_dy_eta_plot%i",j),dyEtaResiduals[i][j]);
+    gDirectory->GetObject("h_probeRefitVSigXY", dxySigRefit[i]);
+    gDirectory->GetObject("h_probeRefitVSigZ", dzSigRefit[i]);
 
-	dzPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Phi_Residuals/histo_dz_phi_plot%i",j));
-	dzEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Eta_Residuals/histo_dz_eta_plot%i",j));
-	
-	// DCA normalized residuals
-	dxyNormPhiResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_Phi_Residuals/histo_norm_dxy_phi_plot%i",j));
-	dxyNormEtaResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_Eta_Residuals/histo_norm_dxy_eta_plot%i",j));
-	dzNormPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_Phi_Residuals/histo_norm_dz_phi_plot%i",j));
-	dzNormEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_Eta_Residuals/histo_norm_dz_eta_plot%i",j));
+    for (Int_t j = 0; j < theNBINS[i]; j++) {
+      if (stdres) {
+        // DCA absolute residuals
 
-	// double differential residuals
+        fins[i]->cd("PVValidation/Abs_Transv_Phi_Residuals/");
+        gDirectory->GetObject(Form("histo_dxy_phi_plot%i", j), dxyPhiResiduals[i][j]);
+        gDirectory->GetObject(Form("histo_dx_phi_plot%i", j), dxPhiResiduals[i][j]);
+        gDirectory->GetObject(Form("histo_dy_phi_plot%i", j), dyPhiResiduals[i][j]);
 
-	if(do2DMaps) {
+        fins[i]->cd("PVValidation/Abs_Transv_Eta_Residuals/");
+        gDirectory->GetObject(Form("histo_dxy_eta_plot%i", j), dxyEtaResiduals[i][j]);
+        gDirectory->GetObject(Form("histo_dx_eta_plot%i", j), dxEtaResiduals[i][j]);
+        gDirectory->GetObject(Form("histo_dy_eta_plot%i", j), dyEtaResiduals[i][j]);
 
-	  for(Int_t k=0;k<theNBINS[i];k++){
-	  
-	    // absolute residuals
-	    fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals/");
-	    gDirectory->GetObject(Form("histo_dxy_eta_plot%i_phi_plot%i",j,k),dxyMapResiduals[i][j][k]);
-	    gDirectory->GetObject(Form("histo_dz_eta_plot%i_phi_plot%i",j,k),dzMapResiduals[i][j][k]);
-	    
-	    // normalized residuals
-	    fins[i]->cd("PVValidation/Norm_DoubleDiffResiduals/");	      
-	    gDirectory->GetObject(Form("histo_norm_dxy_eta_plot%i_phi_plot%i",j,k),dxyNormMapResiduals[i][j][k]);
-	    gDirectory->GetObject(Form("histo_norm_dz_eta_plot%i_phi_plot%i",j,k),dzNormMapResiduals[i][j][k]);
-	   	   
-	  }
-	}
+        dzPhiResiduals[i][j] = (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_Phi_Residuals/histo_dz_phi_plot%i", j));
+        dzEtaResiduals[i][j] = (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_Eta_Residuals/histo_dz_eta_plot%i", j));
+
+        // DCA normalized residuals
+        dxyNormPhiResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Transv_Phi_Residuals/histo_norm_dxy_phi_plot%i", j));
+        dxyNormEtaResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Transv_Eta_Residuals/histo_norm_dxy_eta_plot%i", j));
+        dzNormPhiResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_Phi_Residuals/histo_norm_dz_phi_plot%i", j));
+        dzNormEtaResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_Eta_Residuals/histo_norm_dz_eta_plot%i", j));
+
+        // double differential residuals
+
+        if (do2DMaps) {
+          for (Int_t k = 0; k < theNBINS[i]; k++) {
+            // absolute residuals
+            fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals/");
+            gDirectory->GetObject(Form("histo_dxy_eta_plot%i_phi_plot%i", j, k), dxyMapResiduals[i][j][k]);
+            gDirectory->GetObject(Form("histo_dz_eta_plot%i_phi_plot%i", j, k), dzMapResiduals[i][j][k]);
+
+            // normalized residuals
+            fins[i]->cd("PVValidation/Norm_DoubleDiffResiduals/");
+            gDirectory->GetObject(Form("histo_norm_dxy_eta_plot%i_phi_plot%i", j, k), dxyNormMapResiduals[i][j][k]);
+            gDirectory->GetObject(Form("histo_norm_dz_eta_plot%i_phi_plot%i", j, k), dzNormMapResiduals[i][j][k]);
+          }
+        }
       } else {
+        // DCA absolute residuals
+        dxyPhiResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_IP2D_phi_plot%i", j));
+        dxyEtaResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_IP2D_eta_plot%i", j));
+        dzPhiResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_Phi_Residuals/histo_resz_phi_plot%i", j));
+        dzEtaResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_Eta_Residuals/histo_resz_eta_plot%i", j));
 
-	// DCA absolute residuals
-	dxyPhiResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Phi_Residuals/histo_IP2D_phi_plot%i",j));
-	dxyEtaResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_Eta_Residuals/histo_IP2D_eta_plot%i",j));
-	dzPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Phi_Residuals/histo_resz_phi_plot%i",j));
-	dzEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_Eta_Residuals/histo_resz_eta_plot%i",j));
-	
-	// DCA normalized residuals
-	dxyNormPhiResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_Phi_Residuals/histo_norm_IP2D_phi_plot%i",j));
-	dxyNormEtaResiduals[i][j] = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_Eta_Residuals/histo_norm_IP2D_eta_plot%i",j));
-	dzNormPhiResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_Phi_Residuals/histo_norm_resz_phi_plot%i",j));
-	dzNormEtaResiduals[i][j]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_Eta_Residuals/histo_norm_resz_eta_plot%i",j));
+        // DCA normalized residuals
+        dxyNormPhiResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Transv_Phi_Residuals/histo_norm_IP2D_phi_plot%i", j));
+        dxyNormEtaResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Transv_Eta_Residuals/histo_norm_IP2D_eta_plot%i", j));
+        dzNormPhiResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_Phi_Residuals/histo_norm_resz_phi_plot%i", j));
+        dzNormEtaResiduals[i][j] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_Eta_Residuals/histo_norm_resz_eta_plot%i", j));
 
-	// double differential residuals
-	if(do2DMaps) {
-	  
-	  for(Int_t k=0;k<theNBINS[i];k++){
+        // double differential residuals
+        if (do2DMaps) {
+          for (Int_t k = 0; k < theNBINS[i]; k++) {
+            // absolute residuals
+            fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals");
+            gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i", j, k),
+                                  dxyMapResiduals[i][j][k]);
+            gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i", j, k),
+                                  dzMapResiduals[i][j][k]);
 
-	    // absolute residuals
-	    fins[i]->cd("PVValidation/Abs_DoubleDiffResiduals");
-	    gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dxy_eta_plot%i_phi_plot%i",j,k),dxyMapResiduals[i][j][k]);
-	    gDirectory->GetObject(Form("PVValidation/Abs_DoubleDiffResiduals/histo_dz_eta_plot%i_phi_plot%i",j,k),dzMapResiduals[i][j][k]);  
-	    
-	    // normalized residuals
-	    fins[i]->cd("PVValidation/Norm_DoubleDiffResiduals");
-	    gDirectory->GetObject(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i",j,k),dxyNormMapResiduals[i][j][k]);  
-	    gDirectory->GetObject(Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i",j,k),dzNormMapResiduals[i][j][k]);
-	  }
-	} // if do2DMaps
-      } 
+            // normalized residuals
+            fins[i]->cd("PVValidation/Norm_DoubleDiffResiduals");
+            gDirectory->GetObject(
+                Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dxy_eta_plot%i_phi_plot%i", j, k),
+                dxyNormMapResiduals[i][j][k]);
+            gDirectory->GetObject(
+                Form("PVValidation/Norm_DoubleDiffResiduals/histo_norm_dz_eta_plot%i_phi_plot%i", j, k),
+                dzNormMapResiduals[i][j][k]);
+          }
+        }  // if do2DMaps
+      }
     }
 
     // residuals vs pT
 
-    for (Int_t l=0;l<thePTBINS[i];l++){
-      
-      dxyPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_pT_Residuals/histo_dxy_pT_plot%i",l));
-      dzPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_pT_Residuals/histo_dz_pT_plot%i",l));
+    for (Int_t l = 0; l < thePTBINS[i]; l++) {
+      dxyPtResiduals[i][l] = (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Transv_pT_Residuals/histo_dxy_pT_plot%i", l));
+      dzPtResiduals[i][l] = (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_pT_Residuals/histo_dz_pT_plot%i", l));
 
-      dxyNormPtResiduals[i][l]  = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_pT_Residuals/histo_norm_dxy_pT_plot%i",l));
-      dzNormPtResiduals[i][l]   = (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_pT_Residuals/histo_norm_dz_pT_plot%i",l));
-    
+      dxyNormPtResiduals[i][l] =
+          (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Transv_pT_Residuals/histo_norm_dxy_pT_plot%i", l));
+      dzNormPtResiduals[i][l] =
+          (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_pT_Residuals/histo_norm_dz_pT_plot%i", l));
     }
 
     // residuals vs module number / ladder
 
-    if(theLadders[i]>0) {
+    if (theLadders[i] > 0) {
+      for (Int_t iLadder = 0; iLadder < theLadders[i]; iLadder++) {
+        dzNormLadderResiduals[i][iLadder] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_ladder_Residuals/histo_norm_dz_ladder_plot%i", iLadder));
+        dxyNormLadderResiduals[i][iLadder] = (TH1F *)fins[i]->Get(
+            Form("PVValidation/Norm_Transv_ladder_Residuals/histo_norm_dxy_ladder_plot%i", iLadder));
 
-      for (Int_t iLadder=0;iLadder<theLadders[i];iLadder++){
-	
-	dzNormLadderResiduals[i][iLadder]  =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_ladder_Residuals/histo_norm_dz_ladder_plot%i",iLadder));
-	dxyNormLadderResiduals[i][iLadder] =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_ladder_Residuals/histo_norm_dxy_ladder_plot%i",iLadder));
-	
-	dzLadderResiduals[i][iLadder]      =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_ladder_Residuals/histo_dz_ladder_plot%i",iLadder));
-	dxyLadderResiduals[i][iLadder]     =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_ladderNoOverlap_Residuals/histo_dxy_ladder_plot%i",iLadder));
-	
+        dzLadderResiduals[i][iLadder] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_ladder_Residuals/histo_dz_ladder_plot%i", iLadder));
+        dxyLadderResiduals[i][iLadder] = (TH1F *)fins[i]->Get(
+            Form("PVValidation/Abs_Transv_ladderNoOverlap_Residuals/histo_dxy_ladder_plot%i", iLadder));
       }
-      
-      for (Int_t iMod=0;iMod<8;iMod++){
-	
-	dzNormModZResiduals[i][iMod]  =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Long_modZ_Residuals/histo_norm_dz_modZ_plot%i",iMod));
-	dxyNormModZResiduals[i][iMod] =  (TH1F*)fins[i]->Get(Form("PVValidation/Norm_Transv_modZ_Residuals/histo_norm_dxy_modZ_plot%i",iMod));
-	
-	dzModZResiduals[i][iMod]      =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Long_modZ_Residuals/histo_dz_modZ_plot%i",iMod));
-	dxyModZResiduals[i][iMod]     =  (TH1F*)fins[i]->Get(Form("PVValidation/Abs_Transv_modZ_Residuals/histo_dxy_modZ_plot%i",iMod));
-	
+
+      for (Int_t iMod = 0; iMod < 8; iMod++) {
+        dzNormModZResiduals[i][iMod] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_modZ_Residuals/histo_norm_dz_modZ_plot%i", iMod));
+        dxyNormModZResiduals[i][iMod] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Transv_modZ_Residuals/histo_norm_dxy_modZ_plot%i", iMod));
+
+        dzModZResiduals[i][iMod] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Long_modZ_Residuals/histo_dz_modZ_plot%i", iMod));
+        dxyModZResiduals[i][iMod] =
+            (TH1F *)fins[i]->Get(Form("PVValidation/Abs_Transv_modZ_Residuals/histo_dxy_modZ_plot%i", iMod));
       }
     }
 
@@ -714,543 +766,787 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
   }
 
   TTimeStamp caching_done;
-    
-  if(isDebugMode){
+
+  if (isDebugMode) {
     timer.Stop();
-    std::cout<<"check point 2: "<< timer.CpuTime() << " " << timer.RealTime() << std::endl;
+    std::cout << "check point 2: " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
     timer.Continue();
-  }  
+  }
 
   // checks if all pseudo-rapidity ranges coincide
   // if not, exits
-  if(check(theEtaMax_,nFiles_)){
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the eta range is different"<<std::endl;
-    std::cout<<"exiting..."<<std::endl;
+  if (check(theEtaMax_, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the eta range is different" << std::endl;
+    std::cout << "exiting..." << std::endl;
     return;
   } else {
     etaRange = theEtaMax_[0];
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the eta range is ["<< -etaRange << " ; " << etaRange <<"]"<< std::endl;
-    std::cout<<"======================================================"<<std::endl;
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the eta range is [" << -etaRange << " ; " << etaRange << "]"
+              << std::endl;
+    std::cout << "======================================================" << std::endl;
   }
 
   // checks if all nbins ranges coincide
   // if not, exits
-  if(check(theNBINS,nFiles_)){
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the number of bins is different"<<std::endl;
-    std::cout<<"exiting..."<<std::endl;
+  if (check(theNBINS, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the number of bins is different" << std::endl;
+    std::cout << "exiting..." << std::endl;
     return;
   } else {
     nBins_ = theNBINS[0];
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the number of bins is: "<< nBins_ << std::endl;
-    std::cout<<"======================================================"<<std::endl;
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the number of bins is: " << nBins_ << std::endl;
+    std::cout << "======================================================" << std::endl;
   }
 
   // checks if the geometries are consistent to produce the ladder plots
-  if(check(theLadders,nFiles_)){
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the number of ladders is different"<<std::endl;
-    std::cout<<"won't do the ladder analysis..."<<std::endl;
-    std::cout<<"======================================================"<<std::endl;
+  if (check(theLadders, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the number of ladders is different" << std::endl;
+    std::cout << "won't do the ladder analysis..." << std::endl;
+    std::cout << "======================================================" << std::endl;
     nLadders_ = -1;
   } else {
     nLadders_ = theLadders[0];
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the number of ladders is: "<< nLadders_ << std::endl;
-    std::cout<<"======================================================"<<std::endl;
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the number of ladders is: " << nLadders_ << std::endl;
+    std::cout << "======================================================" << std::endl;
   }
 
   // checks if pT boundaries are consistent to produce the pT-binned plots
-  if(check(thePtMax,nFiles_) || check(thePtMin,nFiles_)){
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): the pT binning is different"<<std::endl;
-    std::cout<<"won't do the pT analysis..."<<std::endl;
-    std::cout<<"======================================================"<<std::endl;
+  if (check(thePtMax, nFiles_) || check(thePtMin, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the pT binning is different" << std::endl;
+    std::cout << "won't do the pT analysis..." << std::endl;
+    std::cout << "======================================================" << std::endl;
     minPt_ = -1.;
   } else {
-    if(thePtMin[0]!=0.){
+    if (thePtMin[0] != 0.) {
       minPt_ = thePtMin[0];
       maxPt_ = thePtMax[0];
-      mypT_bins = PVValHelper::makeLogBins<float,nPtBins_>(thePtMin[0],thePtMax[0]);
-      std::cout<<"======================================================"<<std::endl;
-      std::cout<<"FitPVResiduals::FitPVResiduals(): log bins [" << thePtMin[0] << "," << thePtMax[0] <<"]"<< std::endl;
-      std::cout<<"======================================================"<<std::endl;
+      mypT_bins = PVValHelper::makeLogBins<float, nPtBins_>(thePtMin[0], thePtMax[0]);
+      std::cout << "======================================================" << std::endl;
+      std::cout << "FitPVResiduals::FitPVResiduals(): log bins [" << thePtMin[0] << "," << thePtMax[0] << "]"
+                << std::endl;
+      std::cout << "======================================================" << std::endl;
     } else {
-      std::cout<<"======================================================"<<std::endl;
-      std::cout<<"FitPVResiduals::FitPVResiduals(): using default bins ";
-      for (const auto &bin : mypT_bins){
-	std::cout << bin << " ";
+      std::cout << "======================================================" << std::endl;
+      std::cout << "FitPVResiduals::FitPVResiduals(): using default bins ";
+      for (const auto &bin : mypT_bins) {
+        std::cout << bin << " ";
       }
-      std::cout<<std::endl;
-      std::cout<<"======================================================"<<std::endl;
+      std::cout << std::endl;
+      std::cout << "======================================================" << std::endl;
     }
   }
 
   // check now that all the files have events
-  bool areAllFilesFull=true;
-  for(Int_t i=0;i<nFiles_;i++){
-    if(dxyRefit[i]->GetEntries()==0.){
-      areAllFilesFull=false;
+  bool areAllFilesFull = true;
+  for (Int_t i = 0; i < nFiles_; i++) {
+    if (dxyRefit[i]->GetEntries() == 0.) {
+      areAllFilesFull = false;
       break;
     }
   }
 
-  if(! areAllFilesFull){
-    std::cout<<"======================================================"<<std::endl;
-    std::cout<<"FitPVResiduals::FitPVResiduals(): not all the files have events"<<std::endl;
-    std::cout<<"exiting (...to prevent a segmentation fault)"<<std::endl;
+  if (!areAllFilesFull) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): not all the files have events" << std::endl;
+    std::cout << "exiting (...to prevent a segmentation fault)" << std::endl;
     return;
   }
 
-  Double_t highedge=nBins_-0.5;
-  Double_t lowedge=-0.5;
-  
+  Double_t highedge = nBins_ - 0.5;
+  Double_t lowedge = -0.5;
+
   // DCA absolute
 
-  TH1F* dxyPhiMeanTrend[nFiles_];  
-  TH1F* dxyPhiWidthTrend[nFiles_]; 
+  TH1F *dxyPhiMeanTrend[nFiles_];
+  TH1F *dxyPhiWidthTrend[nFiles_];
 
-  TH1F* dxPhiMeanTrend[nFiles_];  
-  TH1F* dxPhiWidthTrend[nFiles_];
-  
-  TH1F* dyPhiMeanTrend[nFiles_];  
-  TH1F* dyPhiWidthTrend[nFiles_];
+  TH1F *dxPhiMeanTrend[nFiles_];
+  TH1F *dxPhiWidthTrend[nFiles_];
 
-  TH1F* dzPhiMeanTrend[nFiles_];   
-  TH1F* dzPhiWidthTrend[nFiles_];  
-  		       	 
-  TH1F* dxyEtaMeanTrend[nFiles_];  
-  TH1F* dxyEtaWidthTrend[nFiles_]; 
+  TH1F *dyPhiMeanTrend[nFiles_];
+  TH1F *dyPhiWidthTrend[nFiles_];
 
-  TH1F* dxEtaMeanTrend[nFiles_];  
-  TH1F* dxEtaWidthTrend[nFiles_]; 
+  TH1F *dzPhiMeanTrend[nFiles_];
+  TH1F *dzPhiWidthTrend[nFiles_];
 
-  TH1F* dyEtaMeanTrend[nFiles_];  
-  TH1F* dyEtaWidthTrend[nFiles_]; 
+  TH1F *dxyEtaMeanTrend[nFiles_];
+  TH1F *dxyEtaWidthTrend[nFiles_];
 
-  TH1F* dzEtaMeanTrend[nFiles_];   
-  TH1F* dzEtaWidthTrend[nFiles_];  
+  TH1F *dxEtaMeanTrend[nFiles_];
+  TH1F *dxEtaWidthTrend[nFiles_];
 
-  TH1F* dxyPtMeanTrend[nFiles_];  
-  TH1F* dxyPtWidthTrend[nFiles_]; 
+  TH1F *dyEtaMeanTrend[nFiles_];
+  TH1F *dyEtaWidthTrend[nFiles_];
 
-  TH1F* dzPtMeanTrend[nFiles_];   
-  TH1F* dzPtWidthTrend[nFiles_]; 
+  TH1F *dzEtaMeanTrend[nFiles_];
+  TH1F *dzEtaWidthTrend[nFiles_];
+
+  TH1F *dxyPtMeanTrend[nFiles_];
+  TH1F *dxyPtWidthTrend[nFiles_];
+
+  TH1F *dzPtMeanTrend[nFiles_];
+  TH1F *dzPtWidthTrend[nFiles_];
 
   // vs ladder and module number
 
-  TH1F* dxyLadderMeanTrend[nFiles_];  
-  TH1F* dxyLadderWidthTrend[nFiles_]; 
-  TH1F* dzLadderMeanTrend[nFiles_];   
-  TH1F* dzLadderWidthTrend[nFiles_]; 
+  TH1F *dxyLadderMeanTrend[nFiles_];
+  TH1F *dxyLadderWidthTrend[nFiles_];
+  TH1F *dzLadderMeanTrend[nFiles_];
+  TH1F *dzLadderWidthTrend[nFiles_];
 
-  TH1F* dxyModZMeanTrend[nFiles_];  
-  TH1F* dxyModZWidthTrend[nFiles_]; 
-  TH1F* dzModZMeanTrend[nFiles_];   
-  TH1F* dzModZWidthTrend[nFiles_]; 
+  TH1F *dxyModZMeanTrend[nFiles_];
+  TH1F *dxyModZWidthTrend[nFiles_];
+  TH1F *dzModZMeanTrend[nFiles_];
+  TH1F *dzModZWidthTrend[nFiles_];
 
   // DCA normalized
 
-  TH1F* dxyNormPhiMeanTrend[nFiles_];  
-  TH1F* dxyNormPhiWidthTrend[nFiles_]; 
-  TH1F* dzNormPhiMeanTrend[nFiles_];   
-  TH1F* dzNormPhiWidthTrend[nFiles_];  
-  		       	 
-  TH1F* dxyNormEtaMeanTrend[nFiles_];  
-  TH1F* dxyNormEtaWidthTrend[nFiles_]; 
-  TH1F* dzNormEtaMeanTrend[nFiles_];   
-  TH1F* dzNormEtaWidthTrend[nFiles_];  
+  TH1F *dxyNormPhiMeanTrend[nFiles_];
+  TH1F *dxyNormPhiWidthTrend[nFiles_];
+  TH1F *dzNormPhiMeanTrend[nFiles_];
+  TH1F *dzNormPhiWidthTrend[nFiles_];
 
-  TH1F* dxyNormPtMeanTrend[nFiles_];  
-  TH1F* dxyNormPtWidthTrend[nFiles_]; 
-  TH1F* dzNormPtMeanTrend[nFiles_];   
-  TH1F* dzNormPtWidthTrend[nFiles_];  
+  TH1F *dxyNormEtaMeanTrend[nFiles_];
+  TH1F *dxyNormEtaWidthTrend[nFiles_];
+  TH1F *dzNormEtaMeanTrend[nFiles_];
+  TH1F *dzNormEtaWidthTrend[nFiles_];
 
-  TH1F* dxyNormLadderMeanTrend[nFiles_];  
-  TH1F* dxyNormLadderWidthTrend[nFiles_]; 
-  TH1F* dzNormLadderMeanTrend[nFiles_];   
-  TH1F* dzNormLadderWidthTrend[nFiles_]; 
+  TH1F *dxyNormPtMeanTrend[nFiles_];
+  TH1F *dxyNormPtWidthTrend[nFiles_];
+  TH1F *dzNormPtMeanTrend[nFiles_];
+  TH1F *dzNormPtWidthTrend[nFiles_];
 
-  TH1F* dxyNormModZMeanTrend[nFiles_];  
-  TH1F* dxyNormModZWidthTrend[nFiles_]; 
-  TH1F* dzNormModZMeanTrend[nFiles_];   
-  TH1F* dzNormModZWidthTrend[nFiles_];
+  TH1F *dxyNormLadderMeanTrend[nFiles_];
+  TH1F *dxyNormLadderWidthTrend[nFiles_];
+  TH1F *dzNormLadderMeanTrend[nFiles_];
+  TH1F *dzNormLadderWidthTrend[nFiles_];
+
+  TH1F *dxyNormModZMeanTrend[nFiles_];
+  TH1F *dxyNormModZWidthTrend[nFiles_];
+  TH1F *dzNormModZMeanTrend[nFiles_];
+  TH1F *dzNormModZWidthTrend[nFiles_];
 
   // 2D maps
 
   // bias
-  TH2F* dxyMeanMap[nFiles_];  
-  TH2F* dzMeanMap[nFiles_];   
-  TH2F* dxyNormMeanMap[nFiles_];  
-  TH2F* dzNormMeanMap[nFiles_];
-   
+  TH2F *dxyMeanMap[nFiles_];
+  TH2F *dzMeanMap[nFiles_];
+  TH2F *dxyNormMeanMap[nFiles_];
+  TH2F *dzNormMeanMap[nFiles_];
+
   // width
-  TH2F* dxyWidthMap[nFiles_]; 
-  TH2F* dzWidthMap[nFiles_];  		
-  TH2F* dxyNormWidthMap[nFiles_]; 
-  TH2F* dzNormWidthMap[nFiles_];
+  TH2F *dxyWidthMap[nFiles_];
+  TH2F *dzWidthMap[nFiles_];
+  TH2F *dxyNormWidthMap[nFiles_];
+  TH2F *dzNormWidthMap[nFiles_];
 
   // trimmed maps
-  
+
   // bias
-  TH2F* t_dxyMeanMap[nFiles_];  
-  TH2F* t_dzMeanMap[nFiles_];   
-  TH2F* t_dxyNormMeanMap[nFiles_];  
-  TH2F* t_dzNormMeanMap[nFiles_];
-   
+  TH2F *t_dxyMeanMap[nFiles_];
+  TH2F *t_dzMeanMap[nFiles_];
+  TH2F *t_dxyNormMeanMap[nFiles_];
+  TH2F *t_dzNormMeanMap[nFiles_];
+
   // width
-  TH2F* t_dxyWidthMap[nFiles_]; 
-  TH2F* t_dzWidthMap[nFiles_];  		
-  TH2F* t_dxyNormWidthMap[nFiles_]; 
-  TH2F* t_dzNormWidthMap[nFiles_];
+  TH2F *t_dxyWidthMap[nFiles_];
+  TH2F *t_dzWidthMap[nFiles_];
+  TH2F *t_dxyNormWidthMap[nFiles_];
+  TH2F *t_dzNormWidthMap[nFiles_];
 
-  for(Int_t i=0;i<nFiles_;i++){
-
+  for (Int_t i = 0; i < nFiles_; i++) {
     // DCA trend plots
 
-    dxyPhiMeanTrend[i]  = new TH1F(Form("means_dxy_phi_%i",i),"#LT d_{xy} #GT vs #phi sector;track #phi [rad];#LT d_{xy} #GT [#mum]",nBins_,lowedge,highedge); 
-    dxyPhiWidthTrend[i] = new TH1F(Form("widths_dxy_phi_%i",i),"#sigma(d_{xy}) vs #phi sector;track #phi [rad];#sigma(d_{xy}) [#mum]",nBins_,lowedge,highedge);
+    dxyPhiMeanTrend[i] = new TH1F(Form("means_dxy_phi_%i", i),
+                                  "#LT d_{xy} #GT vs #phi sector;track #phi [rad];#LT d_{xy} #GT [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
+    dxyPhiWidthTrend[i] = new TH1F(Form("widths_dxy_phi_%i", i),
+                                   "#sigma(d_{xy}) vs #phi sector;track #phi [rad];#sigma(d_{xy}) [#mum]",
+                                   nBins_,
+                                   lowedge,
+                                   highedge);
 
-    dxPhiMeanTrend[i]   = new TH1F(Form("means_dx_phi_%i",i),"#LT d_{x} #GT vs #phi sector;track #phi [rad];#LT d_{x} #GT [#mum]",nBins_,lowedge,highedge); 
-    dxPhiWidthTrend[i]  = new TH1F(Form("widths_dx_phi_%i",i),"#sigma(d_{x}) vs #phi sector;track #phi [rad];#sigma(d_{x}) [#mum]",nBins_,lowedge,highedge);
+    dxPhiMeanTrend[i] = new TH1F(Form("means_dx_phi_%i", i),
+                                 "#LT d_{x} #GT vs #phi sector;track #phi [rad];#LT d_{x} #GT [#mum]",
+                                 nBins_,
+                                 lowedge,
+                                 highedge);
+    dxPhiWidthTrend[i] = new TH1F(Form("widths_dx_phi_%i", i),
+                                  "#sigma(d_{x}) vs #phi sector;track #phi [rad];#sigma(d_{x}) [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
 
-    dyPhiMeanTrend[i]   = new TH1F(Form("means_dy_phi_%i",i),"#LT d_{y} #GT vs #phi sector;track #phi [rad];#LT d_{y} #GT [#mum]",nBins_,lowedge,highedge); 
-    dyPhiWidthTrend[i]  = new TH1F(Form("widths_dy_phi_%i",i),"#sigma(d_{y}) vs #phi sector;track #phi [rad];#sigma(d_{y}) [#mum]",nBins_,lowedge,highedge);
+    dyPhiMeanTrend[i] = new TH1F(Form("means_dy_phi_%i", i),
+                                 "#LT d_{y} #GT vs #phi sector;track #phi [rad];#LT d_{y} #GT [#mum]",
+                                 nBins_,
+                                 lowedge,
+                                 highedge);
+    dyPhiWidthTrend[i] = new TH1F(Form("widths_dy_phi_%i", i),
+                                  "#sigma(d_{y}) vs #phi sector;track #phi [rad];#sigma(d_{y}) [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
 
-    dzPhiMeanTrend[i]   = new TH1F(Form("means_dz_phi_%i",i),"#LT d_{z} #GT vs #phi sector;track #phi [rad];#LT d_{z} #GT [#mum]",nBins_,lowedge,highedge); 
-    dzPhiWidthTrend[i]  = new TH1F(Form("widths_dz_phi_%i",i),"#sigma(d_{z}) vs #phi sector;track #phi [rad];#sigma(d_{z}) [#mum]",nBins_,lowedge,highedge);
-    
-    dxyEtaMeanTrend[i]  = new TH1F(Form("means_dxy_eta_%i",i),"#LT d_{xy} #GT vs #eta sector;track #eta;#LT d_{xy} #GT [#mum]",nBins_,lowedge,highedge);
-    dxyEtaWidthTrend[i] = new TH1F(Form("widths_dxy_eta_%i",i),"#sigma(d_{xy}) vs #eta sector;track #eta;#sigma(d_{xy}) [#mum]",nBins_,lowedge,highedge);
+    dzPhiMeanTrend[i] = new TH1F(Form("means_dz_phi_%i", i),
+                                 "#LT d_{z} #GT vs #phi sector;track #phi [rad];#LT d_{z} #GT [#mum]",
+                                 nBins_,
+                                 lowedge,
+                                 highedge);
+    dzPhiWidthTrend[i] = new TH1F(Form("widths_dz_phi_%i", i),
+                                  "#sigma(d_{z}) vs #phi sector;track #phi [rad];#sigma(d_{z}) [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
 
-    dxEtaMeanTrend[i]  = new TH1F(Form("means_dx_eta_%i",i),"#LT d_{x} #GT vs #eta sector;track #eta;#LT d_{x} #GT [#mum]",nBins_,lowedge,highedge);
-    dxEtaWidthTrend[i] = new TH1F(Form("widths_dx_eta_%i",i),"#sigma(d_{x}) vs #eta sector;track #eta;#sigma(d_{x}) [#mum]",nBins_,lowedge,highedge);
+    dxyEtaMeanTrend[i] = new TH1F(Form("means_dxy_eta_%i", i),
+                                  "#LT d_{xy} #GT vs #eta sector;track #eta;#LT d_{xy} #GT [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
+    dxyEtaWidthTrend[i] = new TH1F(Form("widths_dxy_eta_%i", i),
+                                   "#sigma(d_{xy}) vs #eta sector;track #eta;#sigma(d_{xy}) [#mum]",
+                                   nBins_,
+                                   lowedge,
+                                   highedge);
 
-    dyEtaMeanTrend[i]  = new TH1F(Form("means_dy_eta_%i",i),"#LT d_{y} #GT vs #eta sector;track #eta;#LT d_{y} #GT [#mum]",nBins_,lowedge,highedge);
-    dyEtaWidthTrend[i] = new TH1F(Form("widths_dy_eta_%i",i),"#sigma(d_{y}) vs #eta sector;track #eta;#sigma(d_{y}) [#mum]",nBins_,lowedge,highedge);
+    dxEtaMeanTrend[i] = new TH1F(Form("means_dx_eta_%i", i),
+                                 "#LT d_{x} #GT vs #eta sector;track #eta;#LT d_{x} #GT [#mum]",
+                                 nBins_,
+                                 lowedge,
+                                 highedge);
+    dxEtaWidthTrend[i] = new TH1F(Form("widths_dx_eta_%i", i),
+                                  "#sigma(d_{x}) vs #eta sector;track #eta;#sigma(d_{x}) [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
 
-    dzEtaMeanTrend[i]   = new TH1F(Form("means_dz_eta_%i",i),"#LT d_{z} #GT vs #eta sector;track #eta;#LT d_{z} #GT [#mum]",nBins_,lowedge,highedge); 
-    dzEtaWidthTrend[i]  = new TH1F(Form("widths_dz_eta_%i",i),"#sigma(d_{xy}) vs #eta sector;track #eta;#sigma(d_{z}) [#mum]",nBins_,lowedge,highedge);
+    dyEtaMeanTrend[i] = new TH1F(Form("means_dy_eta_%i", i),
+                                 "#LT d_{y} #GT vs #eta sector;track #eta;#LT d_{y} #GT [#mum]",
+                                 nBins_,
+                                 lowedge,
+                                 highedge);
+    dyEtaWidthTrend[i] = new TH1F(Form("widths_dy_eta_%i", i),
+                                  "#sigma(d_{y}) vs #eta sector;track #eta;#sigma(d_{y}) [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
 
-    if(minPt_>0.){
+    dzEtaMeanTrend[i] = new TH1F(Form("means_dz_eta_%i", i),
+                                 "#LT d_{z} #GT vs #eta sector;track #eta;#LT d_{z} #GT [#mum]",
+                                 nBins_,
+                                 lowedge,
+                                 highedge);
+    dzEtaWidthTrend[i] = new TH1F(Form("widths_dz_eta_%i", i),
+                                  "#sigma(d_{xy}) vs #eta sector;track #eta;#sigma(d_{z}) [#mum]",
+                                  nBins_,
+                                  lowedge,
+                                  highedge);
 
-      dxyPtMeanTrend[i]   = new TH1F(Form("means_dxy_pT_%i",i),"#LT d_{xy} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy} #GT [#mum]",mypT_bins.size()-1,mypT_bins.data());
-      dxyPtWidthTrend[i]  = new TH1F(Form("widths_dxy_pT_%i",i),"#sigma(d_{xy}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}) [#mum]",mypT_bins.size()-1,mypT_bins.data());
-      dzPtMeanTrend[i]    = new TH1F(Form("means_dz_pT_%i",i),"#LT d_{z} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z} #GT [#mum]",mypT_bins.size()-1,mypT_bins.data()); 
-      dzPtWidthTrend[i]   = new TH1F(Form("widths_dz_pT_%i",i),"#sigma(d_{z}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}) [#mum]",mypT_bins.size()-1,mypT_bins.data());
-      
+    if (minPt_ > 0.) {
+      dxyPtMeanTrend[i] = new TH1F(Form("means_dxy_pT_%i", i),
+                                   "#LT d_{xy} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy} #GT [#mum]",
+                                   mypT_bins.size() - 1,
+                                   mypT_bins.data());
+      dxyPtWidthTrend[i] = new TH1F(Form("widths_dxy_pT_%i", i),
+                                    "#sigma(d_{xy}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}) [#mum]",
+                                    mypT_bins.size() - 1,
+                                    mypT_bins.data());
+      dzPtMeanTrend[i] = new TH1F(Form("means_dz_pT_%i", i),
+                                  "#LT d_{z} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z} #GT [#mum]",
+                                  mypT_bins.size() - 1,
+                                  mypT_bins.data());
+      dzPtWidthTrend[i] = new TH1F(Form("widths_dz_pT_%i", i),
+                                   "#sigma(d_{z}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}) [#mum]",
+                                   mypT_bins.size() - 1,
+                                   mypT_bins.data());
     }
 
-    if(nLadders_>0){
+    if (nLadders_ > 0) {
+      dxyLadderMeanTrend[i] = new TH1F(Form("means_dxy_ladder_%i", i),
+                                       "#LT d_{xy} #GT vs Layer 1 ladder;ladder number;#LT d_{xy} #GT [#mum]",
+                                       theLadders[i],
+                                       0.,
+                                       theLadders[i]);
+      dxyLadderWidthTrend[i] = new TH1F(Form("widths_dxy_ladder_%i", i),
+                                        "#sigma(d_{xy}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}) [#mum]",
+                                        theLadders[i],
+                                        0.,
+                                        theLadders[i]);
+      dzLadderMeanTrend[i] = new TH1F(Form("means_dz_ladder_%i", i),
+                                      "#LT d_{z} #GT vs Layer 1 ladder;ladder number;#LT d_{z} #GT [#mum]",
+                                      theLadders[i],
+                                      0.,
+                                      theLadders[i]);
+      dzLadderWidthTrend[i] = new TH1F(Form("widths_dz_ladder_%i", i),
+                                       "#sigma(d_{z}) vs Layer 1 ladder;ladder number;#sigma(d_{z}) [#mum]",
+                                       theLadders[i],
+                                       0.,
+                                       theLadders[i]);
 
-      dxyLadderMeanTrend[i]  = new TH1F(Form("means_dxy_ladder_%i",i),"#LT d_{xy} #GT vs Layer 1 ladder;ladder number;#LT d_{xy} #GT [#mum]",theLadders[i],0.,theLadders[i]);
-      dxyLadderWidthTrend[i] = new TH1F(Form("widths_dxy_ladder_%i",i),"#sigma(d_{xy}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}) [#mum]",theLadders[i],0.,theLadders[i]);
-      dzLadderMeanTrend[i]   = new TH1F(Form("means_dz_ladder_%i",i),"#LT d_{z} #GT vs Layer 1 ladder;ladder number;#LT d_{z} #GT [#mum]",theLadders[i],0.,theLadders[i]);  
-      dzLadderWidthTrend[i]  = new TH1F(Form("widths_dz_ladder_%i",i),"#sigma(d_{z}) vs Layer 1 ladder;ladder number;#sigma(d_{z}) [#mum]",theLadders[i],0.,theLadders[i]);
-      
-      dxyModZMeanTrend[i]    = new TH1F(Form("means_dxy_modZ_%i",i),"#LT d_{xy} #GT vs Layer 1 module number;module number;#LT d_{xy} #GT [#mum]",8,0.,8.);
-      dxyModZWidthTrend[i]   = new TH1F(Form("widths_dxy_modZ_%i",i),"#sigma(d_{xy}) vs Layer 1 module number;module number;#sigma(d_{xy}) [#mum]",8,0.,8.);
-      dzModZMeanTrend[i]     = new TH1F(Form("means_dz_modZ_%i",i),"#LT d_{z} #GT vs Layer 1 module number;module number;#LT d_{z} #GT [#mum]",8,0.,8.);  
-      dzModZWidthTrend[i]    = new TH1F(Form("widths_dz_modZ_%i",i),"#sigma(d_{z}) vs Layer 1 module number;module number;#sigma(d_{z}) [#mum]",8,0.,8.);
-
+      dxyModZMeanTrend[i] = new TH1F(Form("means_dxy_modZ_%i", i),
+                                     "#LT d_{xy} #GT vs Layer 1 module number;module number;#LT d_{xy} #GT [#mum]",
+                                     8,
+                                     0.,
+                                     8.);
+      dxyModZWidthTrend[i] = new TH1F(Form("widths_dxy_modZ_%i", i),
+                                      "#sigma(d_{xy}) vs Layer 1 module number;module number;#sigma(d_{xy}) [#mum]",
+                                      8,
+                                      0.,
+                                      8.);
+      dzModZMeanTrend[i] = new TH1F(Form("means_dz_modZ_%i", i),
+                                    "#LT d_{z} #GT vs Layer 1 module number;module number;#LT d_{z} #GT [#mum]",
+                                    8,
+                                    0.,
+                                    8.);
+      dzModZWidthTrend[i] = new TH1F(Form("widths_dz_modZ_%i", i),
+                                     "#sigma(d_{z}) vs Layer 1 module number;module number;#sigma(d_{z}) [#mum]",
+                                     8,
+                                     0.,
+                                     8.);
     }
 
     // DCA normalized trend plots
 
-    dxyNormPhiMeanTrend[i] = new TH1F(Form("means_dxyNorm_phi_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs #phi sector;track #phi [rad];#LT d_{xy}/#sigma_{d_{xy}} #GT",nBins_,lowedge,highedge); 
-    dxyNormPhiWidthTrend[i]= new TH1F(Form("widths_dxyNorm_phi_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs #phi sector;track #phi [rad];#sigma(d_{xy}/#sigma_{d_{xy}})",nBins_,lowedge,highedge);
-    dzNormPhiMeanTrend[i]  = new TH1F(Form("means_dzNorm_phi_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #phi sector;track #phi [rad];#LT d_{z}/#sigma_{d_{z}} #GT",nBins_,lowedge,highedge); 
-    dzNormPhiWidthTrend[i] = new TH1F(Form("widths_dzNorm_phi_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #phi sector;track #phi [rad];#sigma(d_{z}/#sigma_{d_{z}})",nBins_,lowedge,highedge);
-    
-    dxyNormEtaMeanTrend[i] = new TH1F(Form("means_dxyNorm_eta_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs #eta sector;track #eta;#LT d_{xy}/#sigma_{d_{xy}} #GT",nBins_,lowedge,highedge);
-    dxyNormEtaWidthTrend[i]= new TH1F(Form("widths_dxyNorm_eta_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs #eta sector;track #eta;#sigma(d_{xy}/#sigma_{d_{xy}})",nBins_,lowedge,highedge);
-    dzNormEtaMeanTrend[i]  = new TH1F(Form("means_dzNorm_eta_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs #eta sector;track #eta;#LT d_{z}/#sigma_{d_{z}} #GT",nBins_,lowedge,highedge); 
-    dzNormEtaWidthTrend[i] = new TH1F(Form("widths_dzNorm_eta_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs #eta sector;track #eta;#sigma(d_{z}/#sigma_{d_{z}})",nBins_,lowedge,highedge);
-    
-    if(minPt_>0.){
+    dxyNormPhiMeanTrend[i] =
+        new TH1F(Form("means_dxyNorm_phi_%i", i),
+                 "#LT d_{xy}/#sigma_{d_{xy}} #GT vs #phi sector;track #phi [rad];#LT d_{xy}/#sigma_{d_{xy}} #GT",
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dxyNormPhiWidthTrend[i] =
+        new TH1F(Form("widths_dxyNorm_phi_%i", i),
+                 "#sigma(d_{xy}/#sigma_{d_{xy}}) vs #phi sector;track #phi [rad];#sigma(d_{xy}/#sigma_{d_{xy}})",
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dzNormPhiMeanTrend[i] =
+        new TH1F(Form("means_dzNorm_phi_%i", i),
+                 "#LT d_{z}/#sigma_{d_{z}} #GT vs #phi sector;track #phi [rad];#LT d_{z}/#sigma_{d_{z}} #GT",
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dzNormPhiWidthTrend[i] =
+        new TH1F(Form("widths_dzNorm_phi_%i", i),
+                 "#sigma(d_{z}/#sigma_{d_{z}}) vs #phi sector;track #phi [rad];#sigma(d_{z}/#sigma_{d_{z}})",
+                 nBins_,
+                 lowedge,
+                 highedge);
 
-      dxyNormPtMeanTrend[i] = new TH1F(Form("means_dxyNorm_pT_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy}/#sigma_{d_{xy}} #GT",mypT_bins.size()-1,mypT_bins.data());
-      dxyNormPtWidthTrend[i]= new TH1F(Form("widths_dxyNorm_pT_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}/#sigma_{d_{xy}})",mypT_bins.size()-1,mypT_bins.data());
-      dzNormPtMeanTrend[i]  = new TH1F(Form("means_dzNorm_pT_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z}/#sigma_{d_{z}} #GT",mypT_bins.size()-1,mypT_bins.data()); 
-      dzNormPtWidthTrend[i] = new TH1F(Form("widths_dzNorm_pT_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}/#sigma_{d_{z}})",mypT_bins.size()-1,mypT_bins.data());
+    dxyNormEtaMeanTrend[i] =
+        new TH1F(Form("means_dxyNorm_eta_%i", i),
+                 "#LT d_{xy}/#sigma_{d_{xy}} #GT vs #eta sector;track #eta;#LT d_{xy}/#sigma_{d_{xy}} #GT",
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dxyNormEtaWidthTrend[i] =
+        new TH1F(Form("widths_dxyNorm_eta_%i", i),
+                 "#sigma(d_{xy}/#sigma_{d_{xy}}) vs #eta sector;track #eta;#sigma(d_{xy}/#sigma_{d_{xy}})",
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dzNormEtaMeanTrend[i] =
+        new TH1F(Form("means_dzNorm_eta_%i", i),
+                 "#LT d_{z}/#sigma_{d_{z}} #GT vs #eta sector;track #eta;#LT d_{z}/#sigma_{d_{z}} #GT",
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dzNormEtaWidthTrend[i] =
+        new TH1F(Form("widths_dzNorm_eta_%i", i),
+                 "#sigma(d_{z}/#sigma_{d_{z}}) vs #eta sector;track #eta;#sigma(d_{z}/#sigma_{d_{z}})",
+                 nBins_,
+                 lowedge,
+                 highedge);
 
+    if (minPt_ > 0.) {
+      dxyNormPtMeanTrend[i] =
+          new TH1F(Form("means_dxyNorm_pT_%i", i),
+                   "#LT d_{xy}/#sigma_{d_{xy}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{xy}/#sigma_{d_{xy}} #GT",
+                   mypT_bins.size() - 1,
+                   mypT_bins.data());
+      dxyNormPtWidthTrend[i] =
+          new TH1F(Form("widths_dxyNorm_pT_%i", i),
+                   "#sigma(d_{xy}/#sigma_{d_{xy}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{xy}/#sigma_{d_{xy}})",
+                   mypT_bins.size() - 1,
+                   mypT_bins.data());
+      dzNormPtMeanTrend[i] =
+          new TH1F(Form("means_dzNorm_pT_%i", i),
+                   "#LT d_{z}/#sigma_{d_{z}} #GT vs p_{T} sector;track p_{T} [GeV];#LT d_{z}/#sigma_{d_{z}} #GT",
+                   mypT_bins.size() - 1,
+                   mypT_bins.data());
+      dzNormPtWidthTrend[i] =
+          new TH1F(Form("widths_dzNorm_pT_%i", i),
+                   "#sigma(d_{z}/#sigma_{d_{z}}) vs p_{T} sector;track p_{T} [GeV];#sigma(d_{z}/#sigma_{d_{z}})",
+                   mypT_bins.size() - 1,
+                   mypT_bins.data());
     }
 
-    if(nLadders_>0){
-    
-      dxyNormLadderMeanTrend[i]  = new TH1F(Form("means_dxyNorm_ladder_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 ladder;ladder number;#LT d_{xy}/#sigma_{d_{xy}} #GT",theLadders[i],0.,theLadders[i]);
-      dxyNormLadderWidthTrend[i] = new TH1F(Form("widths_dxyNorm_ladder_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}/#sigma_{d_{xy}})",theLadders[i],0.,theLadders[i]);
-      dzNormLadderMeanTrend[i]   = new TH1F(Form("means_dzNorm_ladder_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 ladder;ladder number;#LT d_{z}/#sigma_{d_{z}} #GT",theLadders[i],0.,theLadders[i]);  
-      dzNormLadderWidthTrend[i]  = new TH1F(Form("widths_dzNorm_ladder_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 ladder;ladder number;#sigma(d_{z}/#sigma_{d_{z}})",theLadders[i],0.,theLadders[i]);
-      
-      dxyNormModZMeanTrend[i]    = new TH1F(Form("means_dxyNorm_modZ_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 module number;module number;#LT d_{xy}/#sigma_{d_{xy}} #GT",8,0.,8.);
-      dxyNormModZWidthTrend[i]   = new TH1F(Form("widths_dxyNorm_modZ_%i",i),"#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 module number;module number;#sigma(d_{xy}/#sigma_{d_{xy}})",8,0.,8.);
-      dzNormModZMeanTrend[i]     = new TH1F(Form("means_dzNorm_modZ_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 module number;module number;#LT d_{z}/#sigma_{d_{z}} #GT",8,0.,8.);  
-      dzNormModZWidthTrend[i]    = new TH1F(Form("widths_dzNorm_modZ_%i",i),"#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 module number;module number;#sigma(d_{z}/#sigma_{d_{z}})",8,0.,8.);
+    if (nLadders_ > 0) {
+      dxyNormLadderMeanTrend[i] =
+          new TH1F(Form("means_dxyNorm_ladder_%i", i),
+                   "#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 ladder;ladder number;#LT d_{xy}/#sigma_{d_{xy}} #GT",
+                   theLadders[i],
+                   0.,
+                   theLadders[i]);
+      dxyNormLadderWidthTrend[i] =
+          new TH1F(Form("widths_dxyNorm_ladder_%i", i),
+                   "#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 ladder;ladder number;#sigma(d_{xy}/#sigma_{d_{xy}})",
+                   theLadders[i],
+                   0.,
+                   theLadders[i]);
+      dzNormLadderMeanTrend[i] =
+          new TH1F(Form("means_dzNorm_ladder_%i", i),
+                   "#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 ladder;ladder number;#LT d_{z}/#sigma_{d_{z}} #GT",
+                   theLadders[i],
+                   0.,
+                   theLadders[i]);
+      dzNormLadderWidthTrend[i] =
+          new TH1F(Form("widths_dzNorm_ladder_%i", i),
+                   "#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 ladder;ladder number;#sigma(d_{z}/#sigma_{d_{z}})",
+                   theLadders[i],
+                   0.,
+                   theLadders[i]);
 
+      dxyNormModZMeanTrend[i] = new TH1F(
+          Form("means_dxyNorm_modZ_%i", i),
+          "#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 module number;module number;#LT d_{xy}/#sigma_{d_{xy}} #GT",
+          8,
+          0.,
+          8.);
+      dxyNormModZWidthTrend[i] = new TH1F(
+          Form("widths_dxyNorm_modZ_%i", i),
+          "#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 module number;module number;#sigma(d_{xy}/#sigma_{d_{xy}})",
+          8,
+          0.,
+          8.);
+      dzNormModZMeanTrend[i] =
+          new TH1F(Form("means_dzNorm_modZ_%i", i),
+                   "#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 module number;module number;#LT d_{z}/#sigma_{d_{z}} #GT",
+                   8,
+                   0.,
+                   8.);
+      dzNormModZWidthTrend[i] =
+          new TH1F(Form("widths_dzNorm_modZ_%i", i),
+                   "#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 module number;module number;#sigma(d_{z}/#sigma_{d_{z}})",
+                   8,
+                   0.,
+                   8.);
     }
 
     // 2D maps
-    dxyMeanMap[i]      = new TH2F(Form("means_dxy_map_%i",i), "#LT d_{xy} #GT map;track #eta;track #phi [rad];#LT d_{xy} #GT [#mum]",nBins_,lowedge,highedge,nBins_,lowedge,highedge);		       
-    dzMeanMap[i]       = new TH2F(Form("means_dz_map_%i",i),"#LT d_{z} #GT map;track #eta;track #phi [rad];#LT d_{z} #GT [#mum]",nBins_,lowedge,highedge,nBins_,lowedge,highedge);  		       
-    dxyNormMeanMap[i]  = new TH2F(Form("norm_means_dxy_map_%i",i),"#LT d_{xy}/#sigma_{d_{xy}} #GT map;track #eta;track #phi [rad];#LT d_{xy}/#sigma_{d_{xy}} #GT",nBins_,lowedge,highedge,nBins_,lowedge,highedge);  
-    dzNormMeanMap[i]   = new TH2F(Form("norm_means_dz_map_%i",i),"#LT d_{z}/#sigma_{d_{z}} #GT map;track #eta;track #phi[rad];#LT d_{xy}/#sigma_{d_{z}} #GT",nBins_,lowedge,highedge,nBins_,lowedge,highedge);    
- 
-    dxyWidthMap[i]     = new TH2F(Form("widths_dxy_map_%i",i),"#sigma_{d_{xy}} map;track #eta;track #phi [rad];#sigma(d_{xy}) [#mum]",nBins_,lowedge,highedge,nBins_,lowedge,highedge);		       
-    dzWidthMap[i]      = new TH2F(Form("widths_dz_map_%i",i),"#sigma_{d_{z}} map;track #eta;track #phi [rad];#sigma(d_{z}) [#mum]",nBins_,lowedge,highedge,nBins_,lowedge,highedge);  		       
-    dxyNormWidthMap[i] = new TH2F(Form("norm_widths_dxy_map_%i",i),"width(d_{xy}/#sigma_{d_{xy}}) map;track #eta;track #phi[rad];#sigma(d_{xy}/#sigma_{d_{xy}})",nBins_,lowedge,highedge,nBins_,lowedge,highedge);  
-    dzNormWidthMap[i]  = new TH2F(Form("norm_widths_dz_map_%i",i),"width(d_{z}/#sigma_{d_{z}}) map;track #eta;track #phi [rad];#sigma(d_{z}/#sigma_{d_{z}})",nBins_,lowedge,highedge,nBins_,lowedge,highedge); 
+    dxyMeanMap[i] = new TH2F(Form("means_dxy_map_%i", i),
+                             "#LT d_{xy} #GT map;track #eta;track #phi [rad];#LT d_{xy} #GT [#mum]",
+                             nBins_,
+                             lowedge,
+                             highedge,
+                             nBins_,
+                             lowedge,
+                             highedge);
+    dzMeanMap[i] = new TH2F(Form("means_dz_map_%i", i),
+                            "#LT d_{z} #GT map;track #eta;track #phi [rad];#LT d_{z} #GT [#mum]",
+                            nBins_,
+                            lowedge,
+                            highedge,
+                            nBins_,
+                            lowedge,
+                            highedge);
+    dxyNormMeanMap[i] =
+        new TH2F(Form("norm_means_dxy_map_%i", i),
+                 "#LT d_{xy}/#sigma_{d_{xy}} #GT map;track #eta;track #phi [rad];#LT d_{xy}/#sigma_{d_{xy}} #GT",
+                 nBins_,
+                 lowedge,
+                 highedge,
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dzNormMeanMap[i] =
+        new TH2F(Form("norm_means_dz_map_%i", i),
+                 "#LT d_{z}/#sigma_{d_{z}} #GT map;track #eta;track #phi[rad];#LT d_{xy}/#sigma_{d_{z}} #GT",
+                 nBins_,
+                 lowedge,
+                 highedge,
+                 nBins_,
+                 lowedge,
+                 highedge);
+
+    dxyWidthMap[i] = new TH2F(Form("widths_dxy_map_%i", i),
+                              "#sigma_{d_{xy}} map;track #eta;track #phi [rad];#sigma(d_{xy}) [#mum]",
+                              nBins_,
+                              lowedge,
+                              highedge,
+                              nBins_,
+                              lowedge,
+                              highedge);
+    dzWidthMap[i] = new TH2F(Form("widths_dz_map_%i", i),
+                             "#sigma_{d_{z}} map;track #eta;track #phi [rad];#sigma(d_{z}) [#mum]",
+                             nBins_,
+                             lowedge,
+                             highedge,
+                             nBins_,
+                             lowedge,
+                             highedge);
+    dxyNormWidthMap[i] =
+        new TH2F(Form("norm_widths_dxy_map_%i", i),
+                 "width(d_{xy}/#sigma_{d_{xy}}) map;track #eta;track #phi[rad];#sigma(d_{xy}/#sigma_{d_{xy}})",
+                 nBins_,
+                 lowedge,
+                 highedge,
+                 nBins_,
+                 lowedge,
+                 highedge);
+    dzNormWidthMap[i] =
+        new TH2F(Form("norm_widths_dz_map_%i", i),
+                 "width(d_{z}/#sigma_{d_{z}}) map;track #eta;track #phi [rad];#sigma(d_{z}/#sigma_{d_{z}})",
+                 nBins_,
+                 lowedge,
+                 highedge,
+                 nBins_,
+                 lowedge,
+                 highedge);
 
     // DCA absolute
 
-    if(isDebugMode){
+    if (isDebugMode) {
       timer.Stop();
-      std::cout<<"check point 3-"<< i << " " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
+      std::cout << "check point 3-" << i << " " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
       timer.Continue();
     }
 
-    FillTrendPlot(dxyPhiMeanTrend[i] ,dxyPhiResiduals[i],params::MEAN,"phi",nBins_);  
-    FillTrendPlot(dxyPhiWidthTrend[i],dxyPhiResiduals[i],params::WIDTH,"phi",nBins_);
+    FillTrendPlot(dxyPhiMeanTrend[i], dxyPhiResiduals[i], params::MEAN, "phi", nBins_);
+    FillTrendPlot(dxyPhiWidthTrend[i], dxyPhiResiduals[i], params::WIDTH, "phi", nBins_);
 
-    FillTrendPlot(dxPhiMeanTrend[i] ,dxPhiResiduals[i],params::MEAN,"phi",nBins_);  
-    FillTrendPlot(dxPhiWidthTrend[i],dxPhiResiduals[i],params::WIDTH,"phi",nBins_);
+    FillTrendPlot(dxPhiMeanTrend[i], dxPhiResiduals[i], params::MEAN, "phi", nBins_);
+    FillTrendPlot(dxPhiWidthTrend[i], dxPhiResiduals[i], params::WIDTH, "phi", nBins_);
 
-    FillTrendPlot(dyPhiMeanTrend[i] ,dyPhiResiduals[i],params::MEAN,"phi",nBins_);  
-    FillTrendPlot(dyPhiWidthTrend[i],dyPhiResiduals[i],params::WIDTH,"phi",nBins_);
+    FillTrendPlot(dyPhiMeanTrend[i], dyPhiResiduals[i], params::MEAN, "phi", nBins_);
+    FillTrendPlot(dyPhiWidthTrend[i], dyPhiResiduals[i], params::WIDTH, "phi", nBins_);
 
-    FillTrendPlot(dzPhiMeanTrend[i]  ,dzPhiResiduals[i] ,params::MEAN,"phi",nBins_);   
-    FillTrendPlot(dzPhiWidthTrend[i] ,dzPhiResiduals[i] ,params::WIDTH,"phi",nBins_);  
-    
-    FillTrendPlot(dxyEtaMeanTrend[i] ,dxyEtaResiduals[i],params::MEAN,"eta",nBins_); 
-    FillTrendPlot(dxyEtaWidthTrend[i],dxyEtaResiduals[i],params::WIDTH,"eta",nBins_);
+    FillTrendPlot(dzPhiMeanTrend[i], dzPhiResiduals[i], params::MEAN, "phi", nBins_);
+    FillTrendPlot(dzPhiWidthTrend[i], dzPhiResiduals[i], params::WIDTH, "phi", nBins_);
 
-    FillTrendPlot(dxEtaMeanTrend[i] ,dxEtaResiduals[i],params::MEAN,"eta",nBins_); 
-    FillTrendPlot(dxEtaWidthTrend[i],dxEtaResiduals[i],params::WIDTH,"eta",nBins_);
+    FillTrendPlot(dxyEtaMeanTrend[i], dxyEtaResiduals[i], params::MEAN, "eta", nBins_);
+    FillTrendPlot(dxyEtaWidthTrend[i], dxyEtaResiduals[i], params::WIDTH, "eta", nBins_);
 
-    FillTrendPlot(dyEtaMeanTrend[i] ,dyEtaResiduals[i],params::MEAN,"eta",nBins_); 
-    FillTrendPlot(dyEtaWidthTrend[i],dyEtaResiduals[i],params::WIDTH,"eta",nBins_);
+    FillTrendPlot(dxEtaMeanTrend[i], dxEtaResiduals[i], params::MEAN, "eta", nBins_);
+    FillTrendPlot(dxEtaWidthTrend[i], dxEtaResiduals[i], params::WIDTH, "eta", nBins_);
 
-    FillTrendPlot(dzEtaMeanTrend[i]  ,dzEtaResiduals[i] ,params::MEAN,"eta",nBins_); 
-    FillTrendPlot(dzEtaWidthTrend[i] ,dzEtaResiduals[i] ,params::WIDTH,"eta",nBins_);
+    FillTrendPlot(dyEtaMeanTrend[i], dyEtaResiduals[i], params::MEAN, "eta", nBins_);
+    FillTrendPlot(dyEtaWidthTrend[i], dyEtaResiduals[i], params::WIDTH, "eta", nBins_);
 
-    if(minPt_>0.){
+    FillTrendPlot(dzEtaMeanTrend[i], dzEtaResiduals[i], params::MEAN, "eta", nBins_);
+    FillTrendPlot(dzEtaWidthTrend[i], dzEtaResiduals[i], params::WIDTH, "eta", nBins_);
 
-      FillTrendPlot(dxyPtMeanTrend[i] ,dxyPtResiduals[i],params::MEAN,"pT",nPtBins_); 
-      FillTrendPlot(dxyPtWidthTrend[i],dxyPtResiduals[i],params::WIDTH,"pT",nPtBins_);
-      FillTrendPlot(dzPtMeanTrend[i]  ,dzPtResiduals[i] ,params::MEAN,"pT",nPtBins_); 
-      FillTrendPlot(dzPtWidthTrend[i] ,dzPtResiduals[i] ,params::WIDTH,"pT",nPtBins_);
-
+    if (minPt_ > 0.) {
+      FillTrendPlot(dxyPtMeanTrend[i], dxyPtResiduals[i], params::MEAN, "pT", nPtBins_);
+      FillTrendPlot(dxyPtWidthTrend[i], dxyPtResiduals[i], params::WIDTH, "pT", nPtBins_);
+      FillTrendPlot(dzPtMeanTrend[i], dzPtResiduals[i], params::MEAN, "pT", nPtBins_);
+      FillTrendPlot(dzPtWidthTrend[i], dzPtResiduals[i], params::WIDTH, "pT", nPtBins_);
     }
 
-    if(nLadders_>0){
-      FillTrendPlot(dxyLadderMeanTrend[i] ,dxyLadderResiduals[i],params::MEAN,"else",nLadders_); 
-      FillTrendPlot(dxyLadderWidthTrend[i],dxyLadderResiduals[i],params::WIDTH,"else",nLadders_);
-      FillTrendPlot(dzLadderMeanTrend[i]  ,dzLadderResiduals[i] ,params::MEAN,"else",nLadders_); 
-      FillTrendPlot(dzLadderWidthTrend[i] ,dzLadderResiduals[i] ,params::WIDTH,"else",nLadders_);
-      
-      FillTrendPlot(dxyModZMeanTrend[i] ,dxyModZResiduals[i],params::MEAN,"else",8); 
-      FillTrendPlot(dxyModZWidthTrend[i],dxyModZResiduals[i],params::WIDTH,"else",8);
-      FillTrendPlot(dzModZMeanTrend[i]  ,dzModZResiduals[i] ,params::MEAN,"else",8); 
-      FillTrendPlot(dzModZWidthTrend[i] ,dzModZResiduals[i] ,params::WIDTH,"else",8);
+    if (nLadders_ > 0) {
+      FillTrendPlot(dxyLadderMeanTrend[i], dxyLadderResiduals[i], params::MEAN, "else", nLadders_);
+      FillTrendPlot(dxyLadderWidthTrend[i], dxyLadderResiduals[i], params::WIDTH, "else", nLadders_);
+      FillTrendPlot(dzLadderMeanTrend[i], dzLadderResiduals[i], params::MEAN, "else", nLadders_);
+      FillTrendPlot(dzLadderWidthTrend[i], dzLadderResiduals[i], params::WIDTH, "else", nLadders_);
+
+      FillTrendPlot(dxyModZMeanTrend[i], dxyModZResiduals[i], params::MEAN, "else", 8);
+      FillTrendPlot(dxyModZWidthTrend[i], dxyModZResiduals[i], params::WIDTH, "else", 8);
+      FillTrendPlot(dzModZMeanTrend[i], dzModZResiduals[i], params::MEAN, "else", 8);
+      FillTrendPlot(dzModZWidthTrend[i], dzModZResiduals[i], params::WIDTH, "else", 8);
     }
 
-    MakeNiceTrendPlotStyle(dxyPhiMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxyPhiWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxPhiMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxPhiWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dyPhiMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dyPhiWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzPhiMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzPhiWidthTrend[i],colors[i],markers[i]);
-  
-    MakeNiceTrendPlotStyle(dxyEtaMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxyEtaWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxEtaMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxEtaWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dyEtaMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dyEtaWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzEtaMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzEtaWidthTrend[i],colors[i],markers[i]);
+    MakeNiceTrendPlotStyle(dxyPhiMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxyPhiWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxPhiMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxPhiWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dyPhiMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dyPhiWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzPhiMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzPhiWidthTrend[i], colors[i], markers[i]);
 
-    if(minPt_>0.){
+    MakeNiceTrendPlotStyle(dxyEtaMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxyEtaWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxEtaMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxEtaWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dyEtaMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dyEtaWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzEtaMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzEtaWidthTrend[i], colors[i], markers[i]);
 
-      MakeNiceTrendPlotStyle(dxyPtMeanTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dxyPtWidthTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzPtMeanTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzPtWidthTrend[i],colors[i],markers[i]);
-      
+    if (minPt_ > 0.) {
+      MakeNiceTrendPlotStyle(dxyPtMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dxyPtWidthTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzPtMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzPtWidthTrend[i], colors[i], markers[i]);
     }
 
-    if(nLadders_>0){
-      MakeNiceTrendPlotStyle(dxyLadderMeanTrend[i],colors[i],markers[i]); 
-      MakeNiceTrendPlotStyle(dxyLadderWidthTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzLadderMeanTrend[i],colors[i],markers[i]);  
-      MakeNiceTrendPlotStyle(dzLadderWidthTrend[i],colors[i],markers[i]); 
-      
-      MakeNiceTrendPlotStyle(dxyModZMeanTrend[i] ,colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dxyModZWidthTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzModZMeanTrend[i]  ,colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzModZWidthTrend[i] ,colors[i],markers[i]);
-    }      
+    if (nLadders_ > 0) {
+      MakeNiceTrendPlotStyle(dxyLadderMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dxyLadderWidthTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzLadderMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzLadderWidthTrend[i], colors[i], markers[i]);
+
+      MakeNiceTrendPlotStyle(dxyModZMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dxyModZWidthTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzModZMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzModZWidthTrend[i], colors[i], markers[i]);
+    }
 
     // DCA normalized
 
-    FillTrendPlot(dxyNormPhiMeanTrend[i] ,dxyNormPhiResiduals[i],params::MEAN,"phi",nBins_);  
-    FillTrendPlot(dxyNormPhiWidthTrend[i],dxyNormPhiResiduals[i],params::WIDTH,"phi",nBins_);
-    FillTrendPlot(dzNormPhiMeanTrend[i]  ,dzNormPhiResiduals[i] ,params::MEAN,"phi",nBins_);   
-    FillTrendPlot(dzNormPhiWidthTrend[i] ,dzNormPhiResiduals[i] ,params::WIDTH,"phi",nBins_);  
-    
-    FillTrendPlot(dxyNormEtaMeanTrend[i] ,dxyNormEtaResiduals[i],params::MEAN,"eta",nBins_); 
-    FillTrendPlot(dxyNormEtaWidthTrend[i],dxyNormEtaResiduals[i],params::WIDTH,"eta",nBins_);
-    FillTrendPlot(dzNormEtaMeanTrend[i]  ,dzNormEtaResiduals[i] ,params::MEAN,"eta",nBins_); 
-    FillTrendPlot(dzNormEtaWidthTrend[i] ,dzNormEtaResiduals[i] ,params::WIDTH,"eta",nBins_);
+    FillTrendPlot(dxyNormPhiMeanTrend[i], dxyNormPhiResiduals[i], params::MEAN, "phi", nBins_);
+    FillTrendPlot(dxyNormPhiWidthTrend[i], dxyNormPhiResiduals[i], params::WIDTH, "phi", nBins_);
+    FillTrendPlot(dzNormPhiMeanTrend[i], dzNormPhiResiduals[i], params::MEAN, "phi", nBins_);
+    FillTrendPlot(dzNormPhiWidthTrend[i], dzNormPhiResiduals[i], params::WIDTH, "phi", nBins_);
 
-    if(minPt_>0.){
+    FillTrendPlot(dxyNormEtaMeanTrend[i], dxyNormEtaResiduals[i], params::MEAN, "eta", nBins_);
+    FillTrendPlot(dxyNormEtaWidthTrend[i], dxyNormEtaResiduals[i], params::WIDTH, "eta", nBins_);
+    FillTrendPlot(dzNormEtaMeanTrend[i], dzNormEtaResiduals[i], params::MEAN, "eta", nBins_);
+    FillTrendPlot(dzNormEtaWidthTrend[i], dzNormEtaResiduals[i], params::WIDTH, "eta", nBins_);
 
-      FillTrendPlot(dxyNormPtMeanTrend[i] ,dxyNormPtResiduals[i],params::MEAN,"pT",nPtBins_);        
-      FillTrendPlot(dxyNormPtWidthTrend[i],dxyNormPtResiduals[i],params::WIDTH,"pT",nPtBins_);       
-      FillTrendPlot(dzNormPtMeanTrend[i]  ,dzNormPtResiduals[i] ,params::MEAN,"pT",nPtBins_);       
-      FillTrendPlot(dzNormPtWidthTrend[i] ,dzNormPtResiduals[i] ,params::WIDTH,"pT",nPtBins_);
+    if (minPt_ > 0.) {
+      FillTrendPlot(dxyNormPtMeanTrend[i], dxyNormPtResiduals[i], params::MEAN, "pT", nPtBins_);
+      FillTrendPlot(dxyNormPtWidthTrend[i], dxyNormPtResiduals[i], params::WIDTH, "pT", nPtBins_);
+      FillTrendPlot(dzNormPtMeanTrend[i], dzNormPtResiduals[i], params::MEAN, "pT", nPtBins_);
+      FillTrendPlot(dzNormPtWidthTrend[i], dzNormPtResiduals[i], params::WIDTH, "pT", nPtBins_);
+    }
 
-    }    
+    if (nLadders_ > 0) {
+      FillTrendPlot(dxyNormLadderMeanTrend[i], dxyNormLadderResiduals[i], params::MEAN, "else", nLadders_);
+      FillTrendPlot(dxyNormLadderWidthTrend[i], dxyNormLadderResiduals[i], params::WIDTH, "else", nLadders_);
+      FillTrendPlot(dzNormLadderMeanTrend[i], dzNormLadderResiduals[i], params::MEAN, "else", nLadders_);
+      FillTrendPlot(dzNormLadderWidthTrend[i], dzNormLadderResiduals[i], params::WIDTH, "else", nLadders_);
 
-    if(nLadders_>0){
-      FillTrendPlot(dxyNormLadderMeanTrend[i] ,dxyNormLadderResiduals[i],params::MEAN,"else",nLadders_); 
-      FillTrendPlot(dxyNormLadderWidthTrend[i],dxyNormLadderResiduals[i],params::WIDTH,"else",nLadders_);
-      FillTrendPlot(dzNormLadderMeanTrend[i]  ,dzNormLadderResiduals[i] ,params::MEAN,"else",nLadders_); 
-      FillTrendPlot(dzNormLadderWidthTrend[i] ,dzNormLadderResiduals[i] ,params::WIDTH,"else",nLadders_);
-      
-      FillTrendPlot(dxyNormModZMeanTrend[i] ,dxyNormModZResiduals[i],params::MEAN,"else",8); 
-      FillTrendPlot(dxyNormModZWidthTrend[i],dxyNormModZResiduals[i],params::WIDTH,"else",8);
-      FillTrendPlot(dzNormModZMeanTrend[i]  ,dzNormModZResiduals[i] ,params::MEAN,"else",8); 
-      FillTrendPlot(dzNormModZWidthTrend[i] ,dzNormModZResiduals[i] ,params::WIDTH,"else",8);
-    }      
+      FillTrendPlot(dxyNormModZMeanTrend[i], dxyNormModZResiduals[i], params::MEAN, "else", 8);
+      FillTrendPlot(dxyNormModZWidthTrend[i], dxyNormModZResiduals[i], params::WIDTH, "else", 8);
+      FillTrendPlot(dzNormModZMeanTrend[i], dzNormModZResiduals[i], params::MEAN, "else", 8);
+      FillTrendPlot(dzNormModZWidthTrend[i], dzNormModZResiduals[i], params::WIDTH, "else", 8);
+    }
 
-    MakeNiceTrendPlotStyle(dxyNormPhiMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxyNormPhiWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzNormPhiMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzNormPhiWidthTrend[i],colors[i],markers[i]);
-  
-    MakeNiceTrendPlotStyle(dxyNormEtaMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxyNormEtaWidthTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzNormEtaMeanTrend[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzNormEtaWidthTrend[i],colors[i],markers[i]);
+    MakeNiceTrendPlotStyle(dxyNormPhiMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxyNormPhiWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzNormPhiMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzNormPhiWidthTrend[i], colors[i], markers[i]);
 
-    if(minPt_>0.){
+    MakeNiceTrendPlotStyle(dxyNormEtaMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxyNormEtaWidthTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzNormEtaMeanTrend[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzNormEtaWidthTrend[i], colors[i], markers[i]);
 
-      MakeNiceTrendPlotStyle(dxyNormPtMeanTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dxyNormPtWidthTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzNormPtMeanTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzNormPtWidthTrend[i],colors[i],markers[i]);
+    if (minPt_ > 0.) {
+      MakeNiceTrendPlotStyle(dxyNormPtMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dxyNormPtWidthTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzNormPtMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzNormPtWidthTrend[i], colors[i], markers[i]);
+    }
 
-    }    
+    if (nLadders_ > 0) {
+      MakeNiceTrendPlotStyle(dxyNormLadderMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dxyNormLadderWidthTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzNormLadderMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzNormLadderWidthTrend[i], colors[i], markers[i]);
 
-    if(nLadders_>0){
-      MakeNiceTrendPlotStyle(dxyNormLadderMeanTrend[i],colors[i],markers[i]); 
-      MakeNiceTrendPlotStyle(dxyNormLadderWidthTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzNormLadderMeanTrend[i],colors[i],markers[i]);  
-      MakeNiceTrendPlotStyle(dzNormLadderWidthTrend[i],colors[i],markers[i]); 
-      
-      MakeNiceTrendPlotStyle(dxyNormModZMeanTrend[i] ,colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dxyNormModZWidthTrend[i],colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzNormModZMeanTrend[i]  ,colors[i],markers[i]);
-      MakeNiceTrendPlotStyle(dzNormModZWidthTrend[i] ,colors[i],markers[i]);
+      MakeNiceTrendPlotStyle(dxyNormModZMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dxyNormModZWidthTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzNormModZMeanTrend[i], colors[i], markers[i]);
+      MakeNiceTrendPlotStyle(dzNormModZWidthTrend[i], colors[i], markers[i]);
     }
 
     // maps
 
     //TTimeStamp filling1D_done;
-    
-    if(do2DMaps){
 
-      if(isDebugMode){
-	timer.Stop();
-	std::cout<<"check point 4-"<< i << " " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
-	timer.Continue();
+    if (do2DMaps) {
+      if (isDebugMode) {
+        timer.Stop();
+        std::cout << "check point 4-" << i << " " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
+        timer.Continue();
       }
 
-      std::vector<std::vector<TH1F*> > v_dxyAbsMap; //(nBins_, std::vector<TH1F*>(nBins_));
-      std::vector<std::vector<TH1F*> > v_dzAbsMap;
-      std::vector<std::vector<TH1F*> > v_dxyNormMap;
-      std::vector<std::vector<TH1F*> > v_dzNormMap;
- 
-      for (Int_t index1=0;index1<nBins_;index1++){
+      std::vector<std::vector<TH1F *> > v_dxyAbsMap;  //(nBins_, std::vector<TH1F*>(nBins_));
+      std::vector<std::vector<TH1F *> > v_dzAbsMap;
+      std::vector<std::vector<TH1F *> > v_dxyNormMap;
+      std::vector<std::vector<TH1F *> > v_dzNormMap;
 
-	std::vector<TH1F*> a_temp_vec_xy;
-	std::vector<TH1F*> n_temp_vec_xy;
-	std::vector<TH1F*> a_temp_vec_z;
-	std::vector<TH1F*> n_temp_vec_z;
+      for (Int_t index1 = 0; index1 < nBins_; index1++) {
+        std::vector<TH1F *> a_temp_vec_xy;
+        std::vector<TH1F *> n_temp_vec_xy;
+        std::vector<TH1F *> a_temp_vec_z;
+        std::vector<TH1F *> n_temp_vec_z;
 
-	for (Int_t index2=0;index2<nBins_;index2++){
+        for (Int_t index2 = 0; index2 < nBins_; index2++) {
+          if (isDebugMode)
+            std::cout << index1 << " " << index2 << " " << (dxyMapResiduals[i][index1][index2])->GetName() << " "
+                      << (dxyMapResiduals[i][index1][index2])->GetEntries() << std::endl;
 
-	  if(isDebugMode)
-	    std::cout<<index1<<" "<<index2<<" " << (dxyMapResiduals[i][index1][index2])->GetName() 
-		     << " "<<  (dxyMapResiduals[i][index1][index2])->GetEntries() << std::endl;
+          a_temp_vec_xy.push_back(dxyMapResiduals[i][index1][index2]);
+          n_temp_vec_xy.push_back(dxyNormMapResiduals[i][index1][index2]);
+          a_temp_vec_z.push_back(dzMapResiduals[i][index1][index2]);
+          n_temp_vec_z.push_back(dzNormMapResiduals[i][index1][index2]);
+        }
 
-	  a_temp_vec_xy.push_back(dxyMapResiduals[i][index1][index2]);
-	  n_temp_vec_xy.push_back(dxyNormMapResiduals[i][index1][index2]);
-	  a_temp_vec_z.push_back(dzMapResiduals[i][index1][index2]);
-	  n_temp_vec_z.push_back(dzNormMapResiduals[i][index1][index2]);
-
-	}
-
-	v_dxyAbsMap.push_back(a_temp_vec_xy);
-	v_dzAbsMap.push_back(a_temp_vec_z); 
-	v_dxyNormMap.push_back(n_temp_vec_xy);
-	v_dzNormMap.push_back( n_temp_vec_z);
+        v_dxyAbsMap.push_back(a_temp_vec_xy);
+        v_dzAbsMap.push_back(a_temp_vec_z);
+        v_dxyNormMap.push_back(n_temp_vec_xy);
+        v_dzNormMap.push_back(n_temp_vec_z);
       }
-     
-      FillMap(dxyMeanMap[i]      ,v_dxyAbsMap  ,params::MEAN);
-      FillMap(dxyWidthMap[i]     ,v_dxyAbsMap  ,params::WIDTH);
-      FillMap(dzMeanMap[i]       ,v_dzAbsMap   ,params::MEAN); 
-      FillMap(dzWidthMap[i]      ,v_dzAbsMap   ,params::WIDTH);
-                                                  
-      FillMap(dxyNormMeanMap[i]  ,v_dxyNormMap ,params::MEAN); 
-      FillMap(dxyNormWidthMap[i] ,v_dxyNormMap ,params::WIDTH);
-      FillMap(dzNormMeanMap[i]   ,v_dzNormMap  ,params::MEAN); 
-      FillMap(dzNormWidthMap[i]  ,v_dzNormMap  ,params::WIDTH);
-     
-      if(isDebugMode){
-	timer.Stop();
-	std::cout<<"check point 5-"<< i << " " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
-	timer.Continue();
-      }	
 
-      t_dxyMeanMap[i]	   = trimTheMap(dxyMeanMap[i]).first;
-      t_dxyWidthMap[i]     = trimTheMap(dxyWidthMap[i]).first;
-      t_dzMeanMap[i]       = trimTheMap(dzMeanMap[i]).first;
-      t_dzWidthMap[i]      = trimTheMap(dzWidthMap[i]).first;
-                          		                    
-      t_dxyNormMeanMap[i]  = trimTheMap(dxyNormMeanMap[i]).first;
+      FillMap(dxyMeanMap[i], v_dxyAbsMap, params::MEAN);
+      FillMap(dxyWidthMap[i], v_dxyAbsMap, params::WIDTH);
+      FillMap(dzMeanMap[i], v_dzAbsMap, params::MEAN);
+      FillMap(dzWidthMap[i], v_dzAbsMap, params::WIDTH);
+
+      FillMap(dxyNormMeanMap[i], v_dxyNormMap, params::MEAN);
+      FillMap(dxyNormWidthMap[i], v_dxyNormMap, params::WIDTH);
+      FillMap(dzNormMeanMap[i], v_dzNormMap, params::MEAN);
+      FillMap(dzNormWidthMap[i], v_dzNormMap, params::WIDTH);
+
+      if (isDebugMode) {
+        timer.Stop();
+        std::cout << "check point 5-" << i << " " << timer.CpuTime() << " " << timer.RealTime() << std::endl;
+        timer.Continue();
+      }
+
+      t_dxyMeanMap[i] = trimTheMap(dxyMeanMap[i]).first;
+      t_dxyWidthMap[i] = trimTheMap(dxyWidthMap[i]).first;
+      t_dzMeanMap[i] = trimTheMap(dzMeanMap[i]).first;
+      t_dzWidthMap[i] = trimTheMap(dzWidthMap[i]).first;
+
+      t_dxyNormMeanMap[i] = trimTheMap(dxyNormMeanMap[i]).first;
       t_dxyNormWidthMap[i] = trimTheMap(dxyNormWidthMap[i]).first;
-      t_dzNormMeanMap[i]   = trimTheMap(dzNormMeanMap[i]).first;
-      t_dzNormWidthMap[i]  = trimTheMap(dzNormWidthMap[i]).first;
-    
+      t_dzNormMeanMap[i] = trimTheMap(dzNormMeanMap[i]).first;
+      t_dzNormWidthMap[i] = trimTheMap(dzNormWidthMap[i]).first;
+
       MakeNiceMapStyle(t_dxyMeanMap[i]);
-      MakeNiceMapStyle(t_dxyWidthMap[i]);     
-      MakeNiceMapStyle(t_dzMeanMap[i]);       
-      MakeNiceMapStyle(t_dzWidthMap[i]);      
-      
-      MakeNiceMapStyle(t_dxyNormMeanMap[i]); 
-      MakeNiceMapStyle(t_dxyNormWidthMap[i]); 
-      MakeNiceMapStyle(t_dzNormMeanMap[i]); 
-      MakeNiceMapStyle(t_dzNormWidthMap[i]);  
+      MakeNiceMapStyle(t_dxyWidthMap[i]);
+      MakeNiceMapStyle(t_dzMeanMap[i]);
+      MakeNiceMapStyle(t_dzWidthMap[i]);
+
+      MakeNiceMapStyle(t_dxyNormMeanMap[i]);
+      MakeNiceMapStyle(t_dxyNormWidthMap[i]);
+      MakeNiceMapStyle(t_dzNormMeanMap[i]);
+      MakeNiceMapStyle(t_dzNormWidthMap[i]);
     }
 
-    MakeNiceTrendPlotStyle(dxyRefit[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzRefit[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dxySigRefit[i],colors[i],markers[i]);
-    MakeNiceTrendPlotStyle(dzSigRefit[i],colors[i],markers[i]);
-    
+    MakeNiceTrendPlotStyle(dxyRefit[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzRefit[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dxySigRefit[i], colors[i], markers[i]);
+    MakeNiceTrendPlotStyle(dzSigRefit[i], colors[i], markers[i]);
   }
-  
+
   TTimeStamp filling2D_done;
 
-  TString theStrDate       = theDate;
-  TString theStrAlignment  = LegLabels[0];
+  TString theStrDate = theDate;
+  TString theStrAlignment = LegLabels[0];
 
   /*
     // in case labels are needed
@@ -1258,192 +1554,219 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
     vLabels.shrink_to_fit();
   */
 
-  for(Int_t j=1; j < nFiles_; j++) {
-    theStrAlignment+=("_vs_"+LegLabels[j]);
+  for (Int_t j = 1; j < nFiles_; j++) {
+    theStrAlignment += ("_vs_" + LegLabels[j]);
   }
 
-  theStrDate.ReplaceAll(" ","");
-  theStrAlignment.ReplaceAll(" ","_");
+  theStrDate.ReplaceAll(" ", "");
+  theStrAlignment.ReplaceAll(" ", "_");
 
   // non-differential
-  TCanvas *BareResiduals = new TCanvas("BareResiduals","BareResiduals",1200,1200);
-  arrangeBiasCanvas(BareResiduals,dxyRefit,dxySigRefit,dzRefit,dzSigRefit,nFiles_,LegLabels,theDate,true);
+  TCanvas *BareResiduals = new TCanvas("BareResiduals", "BareResiduals", 1200, 1200);
+  arrangeBiasCanvas(BareResiduals, dxyRefit, dxySigRefit, dzRefit, dzSigRefit, nFiles_, LegLabels, theDate, true);
 
-  BareResiduals->SaveAs("ResidualsCanvas_"+theStrDate+theStrAlignment+".pdf");
-  BareResiduals->SaveAs("ResidualsCanvas_"+theStrDate+theStrAlignment+".png");
+  BareResiduals->SaveAs("ResidualsCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  BareResiduals->SaveAs("ResidualsCanvas_" + theStrDate + theStrAlignment + ".png");
 
   // DCA absolute
-  
-  TCanvas *dxyPhiTrend = new TCanvas("dxyPhiTrend","dxyPhiTrend",1200,600);
-  arrangeCanvas(dxyPhiTrend,dxyPhiMeanTrend,dxyPhiWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
 
-  dxyPhiTrend->SaveAs("dxyPhiTrend_"+theStrDate+theStrAlignment+".pdf");
-  dxyPhiTrend->SaveAs("dxyPhiTrend_"+theStrDate+theStrAlignment+".png");
+  TCanvas *dxyPhiTrend = new TCanvas("dxyPhiTrend", "dxyPhiTrend", 1200, 600);
+  arrangeCanvas(dxyPhiTrend, dxyPhiMeanTrend, dxyPhiWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  TCanvas *dzPhiTrend = new TCanvas("dzPhiTrend","dzPhiTrend",1200,600);
-  arrangeCanvas(dzPhiTrend,dzPhiMeanTrend,dzPhiWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  dxyPhiTrend->SaveAs("dxyPhiTrend_" + theStrDate + theStrAlignment + ".pdf");
+  dxyPhiTrend->SaveAs("dxyPhiTrend_" + theStrDate + theStrAlignment + ".png");
 
-  dzPhiTrend->SaveAs("dzPhiTrend_"+theStrDate+theStrAlignment+".pdf");
-  dzPhiTrend->SaveAs("dzPhiTrend_"+theStrDate+theStrAlignment+".png");
+  TCanvas *dzPhiTrend = new TCanvas("dzPhiTrend", "dzPhiTrend", 1200, 600);
+  arrangeCanvas(dzPhiTrend, dzPhiMeanTrend, dzPhiWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  TCanvas *dxyEtaTrend = new TCanvas("dxyEtaTrend","dxyEtaTrend",1200,600);
-  arrangeCanvas(dxyEtaTrend,dxyEtaMeanTrend,dxyEtaWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  dzPhiTrend->SaveAs("dzPhiTrend_" + theStrDate + theStrAlignment + ".pdf");
+  dzPhiTrend->SaveAs("dzPhiTrend_" + theStrDate + theStrAlignment + ".png");
 
-  dxyEtaTrend->SaveAs("dxyEtaTrend_"+theStrDate+theStrAlignment+".pdf");
-  dxyEtaTrend->SaveAs("dxyEtaTrend_"+theStrDate+theStrAlignment+".png");
+  TCanvas *dxyEtaTrend = new TCanvas("dxyEtaTrend", "dxyEtaTrend", 1200, 600);
+  arrangeCanvas(dxyEtaTrend, dxyEtaMeanTrend, dxyEtaWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  TCanvas *dzEtaTrend = new TCanvas("dzEtaTrend","dzEtaTrend",1200,600);
-  arrangeCanvas(dzEtaTrend,dzEtaMeanTrend,dzEtaWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  dxyEtaTrend->SaveAs("dxyEtaTrend_" + theStrDate + theStrAlignment + ".pdf");
+  dxyEtaTrend->SaveAs("dxyEtaTrend_" + theStrDate + theStrAlignment + ".png");
 
-  dzEtaTrend->SaveAs("dzEtaTrend_"+theStrDate+theStrAlignment+".pdf");
-  dzEtaTrend->SaveAs("dzEtaTrend_"+theStrDate+theStrAlignment+".png");
+  TCanvas *dzEtaTrend = new TCanvas("dzEtaTrend", "dzEtaTrend", 1200, 600);
+  arrangeCanvas(dzEtaTrend, dzEtaMeanTrend, dzEtaWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  if(nLadders_>0){
-    TCanvas *dxyLadderTrend = new TCanvas("dxyLadderTrend","dxyLadderTrend",600,600);
-    arrangeCanvas(dxyLadderTrend,dxyLadderMeanTrend,dxyLadderWidthTrend,nFiles_,LegLabels,theDate,true,setAutoLimits);
-    
-    dxyLadderTrend->SaveAs("dxyLadderTrend_"+theStrDate+theStrAlignment+".pdf");
-    dxyLadderTrend->SaveAs("dxyLadderTrend_"+theStrDate+theStrAlignment+".png");
-    dxyLadderTrend->SaveAs("dxyLadderTrend_"+theStrDate+theStrAlignment+".root");
+  dzEtaTrend->SaveAs("dzEtaTrend_" + theStrDate + theStrAlignment + ".pdf");
+  dzEtaTrend->SaveAs("dzEtaTrend_" + theStrDate + theStrAlignment + ".png");
 
-    delete dxyLadderTrend; 
-  }    
+  if (nLadders_ > 0) {
+    TCanvas *dxyLadderTrend = new TCanvas("dxyLadderTrend", "dxyLadderTrend", 600, 600);
+    arrangeCanvas(
+        dxyLadderTrend, dxyLadderMeanTrend, dxyLadderWidthTrend, nFiles_, LegLabels, theDate, true, setAutoLimits);
+
+    dxyLadderTrend->SaveAs("dxyLadderTrend_" + theStrDate + theStrAlignment + ".pdf");
+    dxyLadderTrend->SaveAs("dxyLadderTrend_" + theStrDate + theStrAlignment + ".png");
+    dxyLadderTrend->SaveAs("dxyLadderTrend_" + theStrDate + theStrAlignment + ".root");
+
+    delete dxyLadderTrend;
+  }
 
   // fit dz vs phi
-  TCanvas *dzPhiTrendFit = new TCanvas("dzPhiTrendFit","dzPhiTrendFit",1200,600);
-  arrangeFitCanvas(dzPhiTrendFit,dzPhiMeanTrend,nFiles_,LegLabels,theDate);
+  TCanvas *dzPhiTrendFit = new TCanvas("dzPhiTrendFit", "dzPhiTrendFit", 1200, 600);
+  arrangeFitCanvas(dzPhiTrendFit, dzPhiMeanTrend, nFiles_, LegLabels, theDate);
 
-  dzPhiTrendFit->SaveAs("dzPhiTrendFit_"+theStrDate+theStrAlignment+".pdf");
-  dzPhiTrendFit->SaveAs("dzPhiTrendFit_"+theStrDate+theStrAlignment+".png");
+  dzPhiTrendFit->SaveAs("dzPhiTrendFit_" + theStrDate + theStrAlignment + ".pdf");
+  dzPhiTrendFit->SaveAs("dzPhiTrendFit_" + theStrDate + theStrAlignment + ".png");
 
-  if(minPt_>0.){
+  if (minPt_ > 0.) {
+    TCanvas *dxyPtTrend = new TCanvas("dxyPtTrend", "dxyPtTrend", 1200, 600);
+    arrangeCanvas(dxyPtTrend, dxyPtMeanTrend, dxyPtWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-    TCanvas *dxyPtTrend = new TCanvas("dxyPtTrend","dxyPtTrend",1200,600);
-    arrangeCanvas(dxyPtTrend,dxyPtMeanTrend,dxyPtWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
-  
-    dxyPtTrend->SaveAs("dxyPtTrend_"+theStrDate+theStrAlignment+".pdf");
-    dxyPtTrend->SaveAs("dxyPtTrend_"+theStrDate+theStrAlignment+".png");
+    dxyPtTrend->SaveAs("dxyPtTrend_" + theStrDate + theStrAlignment + ".pdf");
+    dxyPtTrend->SaveAs("dxyPtTrend_" + theStrDate + theStrAlignment + ".png");
 
-    TCanvas *dzPtTrend = new TCanvas("dzPtTrend","dzPtTrend",1200,600);
-    arrangeCanvas(dzPtTrend,dzPtMeanTrend,dzPtWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
-    
-    dzPtTrend->SaveAs("dzPtTrend_"+theStrDate+theStrAlignment+".pdf");
-    dzPtTrend->SaveAs("dzPtTrend_"+theStrDate+theStrAlignment+".png");
+    TCanvas *dzPtTrend = new TCanvas("dzPtTrend", "dzPtTrend", 1200, 600);
+    arrangeCanvas(dzPtTrend, dzPtMeanTrend, dzPtWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
+
+    dzPtTrend->SaveAs("dzPtTrend_" + theStrDate + theStrAlignment + ".pdf");
+    dzPtTrend->SaveAs("dzPtTrend_" + theStrDate + theStrAlignment + ".png");
 
     delete dxyPtTrend;
     delete dzPtTrend;
-
   }
 
   // delete all news
 
   delete BareResiduals;
   delete dxyPhiTrend;
-  delete dzPhiTrend; 
+  delete dzPhiTrend;
   delete dxyEtaTrend;
   delete dzEtaTrend;
   delete dzPhiTrendFit;
 
   // DCA normalized
 
-  TCanvas *dxyNormPhiTrend = new TCanvas("dxyNormPhiTrend","dxyNormPhiTrend",1200,600);
-  arrangeCanvas(dxyNormPhiTrend,dxyNormPhiMeanTrend,dxyNormPhiWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  TCanvas *dxyNormPhiTrend = new TCanvas("dxyNormPhiTrend", "dxyNormPhiTrend", 1200, 600);
+  arrangeCanvas(
+      dxyNormPhiTrend, dxyNormPhiMeanTrend, dxyNormPhiWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  dxyNormPhiTrend->SaveAs("dxyPhiTrendNorm_"+theStrDate+theStrAlignment+".pdf");
-  dxyNormPhiTrend->SaveAs("dxyPhiTrendNorm_"+theStrDate+theStrAlignment+".png");
+  dxyNormPhiTrend->SaveAs("dxyPhiTrendNorm_" + theStrDate + theStrAlignment + ".pdf");
+  dxyNormPhiTrend->SaveAs("dxyPhiTrendNorm_" + theStrDate + theStrAlignment + ".png");
 
-  TCanvas *dzNormPhiTrend = new TCanvas("dzNormPhiTrend","dzNormPhiTrend",1200,600);
-  arrangeCanvas(dzNormPhiTrend,dzNormPhiMeanTrend,dzNormPhiWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  TCanvas *dzNormPhiTrend = new TCanvas("dzNormPhiTrend", "dzNormPhiTrend", 1200, 600);
+  arrangeCanvas(
+      dzNormPhiTrend, dzNormPhiMeanTrend, dzNormPhiWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  dzNormPhiTrend->SaveAs("dzPhiTrendNorm_"+theStrDate+theStrAlignment+".pdf");
-  dzNormPhiTrend->SaveAs("dzPhiTrendNorm_"+theStrDate+theStrAlignment+".png");
+  dzNormPhiTrend->SaveAs("dzPhiTrendNorm_" + theStrDate + theStrAlignment + ".pdf");
+  dzNormPhiTrend->SaveAs("dzPhiTrendNorm_" + theStrDate + theStrAlignment + ".png");
 
-  TCanvas *dxyNormEtaTrend = new TCanvas("dxyNormEtaTrend","dxyNormEtaTrend",1200,600);
-  arrangeCanvas(dxyNormEtaTrend,dxyNormEtaMeanTrend,dxyNormEtaWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  TCanvas *dxyNormEtaTrend = new TCanvas("dxyNormEtaTrend", "dxyNormEtaTrend", 1200, 600);
+  arrangeCanvas(
+      dxyNormEtaTrend, dxyNormEtaMeanTrend, dxyNormEtaWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  dxyNormEtaTrend->SaveAs("dxyEtaTrendNorm_"+theStrDate+theStrAlignment+".pdf");
-  dxyNormEtaTrend->SaveAs("dxyEtaTrendNorm_"+theStrDate+theStrAlignment+".png");
+  dxyNormEtaTrend->SaveAs("dxyEtaTrendNorm_" + theStrDate + theStrAlignment + ".pdf");
+  dxyNormEtaTrend->SaveAs("dxyEtaTrendNorm_" + theStrDate + theStrAlignment + ".png");
 
-  TCanvas *dzNormEtaTrend = new TCanvas("dzNormEtaTrend","dzNormEtaTrend",1200,600);
-  arrangeCanvas(dzNormEtaTrend,dzNormEtaMeanTrend,dzNormEtaWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+  TCanvas *dzNormEtaTrend = new TCanvas("dzNormEtaTrend", "dzNormEtaTrend", 1200, 600);
+  arrangeCanvas(
+      dzNormEtaTrend, dzNormEtaMeanTrend, dzNormEtaWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-  dzNormEtaTrend->SaveAs("dzEtaTrendNorm_"+theStrDate+theStrAlignment+".pdf");
-  dzNormEtaTrend->SaveAs("dzEtaTrendNorm_"+theStrDate+theStrAlignment+".png");
+  dzNormEtaTrend->SaveAs("dzEtaTrendNorm_" + theStrDate + theStrAlignment + ".pdf");
+  dzNormEtaTrend->SaveAs("dzEtaTrendNorm_" + theStrDate + theStrAlignment + ".png");
 
-  if(minPt_>0.){
+  if (minPt_ > 0.) {
+    TCanvas *dxyNormPtTrend = new TCanvas("dxyNormPtTrend", "dxyNormPtTrend", 1200, 600);
+    arrangeCanvas(
+        dxyNormPtTrend, dxyNormPtMeanTrend, dxyNormPtWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-    TCanvas *dxyNormPtTrend = new TCanvas("dxyNormPtTrend","dxyNormPtTrend",1200,600);
-    arrangeCanvas(dxyNormPtTrend,dxyNormPtMeanTrend,dxyNormPtWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+    dxyNormPtTrend->SaveAs("dxyPtTrendNorm_" + theStrDate + theStrAlignment + ".pdf");
+    dxyNormPtTrend->SaveAs("dxyPtTrendNorm_" + theStrDate + theStrAlignment + ".png");
 
-    dxyNormPtTrend->SaveAs("dxyPtTrendNorm_"+theStrDate+theStrAlignment+".pdf");
-    dxyNormPtTrend->SaveAs("dxyPtTrendNorm_"+theStrDate+theStrAlignment+".png");
-    
-    TCanvas *dzNormPtTrend = new TCanvas("dzNormPtTrend","dzNormPtTrend",1200,600);
-    arrangeCanvas(dzNormPtTrend,dzNormPtMeanTrend,dzNormPtWidthTrend,nFiles_,LegLabels,theDate,false,setAutoLimits);
+    TCanvas *dzNormPtTrend = new TCanvas("dzNormPtTrend", "dzNormPtTrend", 1200, 600);
+    arrangeCanvas(
+        dzNormPtTrend, dzNormPtMeanTrend, dzNormPtWidthTrend, nFiles_, LegLabels, theDate, false, setAutoLimits);
 
-    dzNormPtTrend->SaveAs("dzPtTrendNorm_"+theStrDate+theStrAlignment+".pdf");
-    dzNormPtTrend->SaveAs("dzPtTrendNorm_"+theStrDate+theStrAlignment+".png");
-    
+    dzNormPtTrend->SaveAs("dzPtTrendNorm_" + theStrDate + theStrAlignment + ".pdf");
+    dzNormPtTrend->SaveAs("dzPtTrendNorm_" + theStrDate + theStrAlignment + ".png");
+
     delete dxyNormPtTrend;
     delete dzNormPtTrend;
-
   }
 
   // delete all news
-  
+
   delete dxyNormPhiTrend;
-  delete dzNormPhiTrend; 
+  delete dzNormPhiTrend;
   delete dxyNormEtaTrend;
   delete dzNormEtaTrend;
 
   // Bias plots
 
-  TCanvas *BiasesCanvas = new TCanvas("BiasCanvas","BiasCanvas",1200,1200);
-  arrangeBiasCanvas(BiasesCanvas,dxyPhiMeanTrend,dzPhiMeanTrend,dxyEtaMeanTrend,dzEtaMeanTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-  
-  BiasesCanvas->SaveAs("BiasesCanvas_"+theStrDate+theStrAlignment+".pdf");
-  BiasesCanvas->SaveAs("BiasesCanvas_"+theStrDate+theStrAlignment+".png");
+  TCanvas *BiasesCanvas = new TCanvas("BiasCanvas", "BiasCanvas", 1200, 1200);
+  arrangeBiasCanvas(BiasesCanvas,
+                    dxyPhiMeanTrend,
+                    dzPhiMeanTrend,
+                    dxyEtaMeanTrend,
+                    dzEtaMeanTrend,
+                    nFiles_,
+                    LegLabels,
+                    theDate,
+                    setAutoLimits);
+
+  BiasesCanvas->SaveAs("BiasesCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  BiasesCanvas->SaveAs("BiasesCanvas_" + theStrDate + theStrAlignment + ".png");
 
   // Bias plots (x and y)
 
-  TCanvas *BiasesCanvasXY = new TCanvas("BiasCanvasXY","BiasCanvasXY",1200,1200);
-  arrangeBiasCanvas(BiasesCanvasXY,dxPhiMeanTrend,dyPhiMeanTrend,dxEtaMeanTrend,dyEtaMeanTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-  
-  BiasesCanvasXY->SaveAs("BiasesCanvasXY_"+theStrDate+theStrAlignment+".pdf");
-  BiasesCanvasXY->SaveAs("BiasesCanvasXY_"+theStrDate+theStrAlignment+".png");
+  TCanvas *BiasesCanvasXY = new TCanvas("BiasCanvasXY", "BiasCanvasXY", 1200, 1200);
+  arrangeBiasCanvas(BiasesCanvasXY,
+                    dxPhiMeanTrend,
+                    dyPhiMeanTrend,
+                    dxEtaMeanTrend,
+                    dyEtaMeanTrend,
+                    nFiles_,
+                    LegLabels,
+                    theDate,
+                    setAutoLimits);
+
+  BiasesCanvasXY->SaveAs("BiasesCanvasXY_" + theStrDate + theStrAlignment + ".pdf");
+  BiasesCanvasXY->SaveAs("BiasesCanvasXY_" + theStrDate + theStrAlignment + ".png");
 
   // Bias plots (ladders and module number)
 
-  if(nLadders_>0){
-    TCanvas *BiasesCanvasLayer1 = new TCanvas("BiasCanvasLayer1","BiasCanvasLayer1",1200,1200);
-    arrangeBiasCanvas(BiasesCanvasLayer1,dxyLadderMeanTrend,dzLadderMeanTrend,dxyModZMeanTrend, dzModZMeanTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-    
-    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
-    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_"+theStrDate+theStrAlignment+".png");
+  if (nLadders_ > 0) {
+    TCanvas *BiasesCanvasLayer1 = new TCanvas("BiasCanvasLayer1", "BiasCanvasLayer1", 1200, 1200);
+    arrangeBiasCanvas(BiasesCanvasLayer1,
+                      dxyLadderMeanTrend,
+                      dzLadderMeanTrend,
+                      dxyModZMeanTrend,
+                      dzModZMeanTrend,
+                      nFiles_,
+                      LegLabels,
+                      theDate,
+                      setAutoLimits);
+
+    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_" + theStrDate + theStrAlignment + ".pdf");
+    BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_" + theStrDate + theStrAlignment + ".png");
 
     delete BiasesCanvasLayer1;
   }
 
-  TCanvas *dxyPhiBiasCanvas = new TCanvas("dxyPhiBiasCanvas","dxyPhiBiasCanvas",600,600);
-  TCanvas *dxyEtaBiasCanvas = new TCanvas("dxyEtaBiasCanvas","dxyEtaBiasCanvas",600,600);
-  TCanvas *dzPhiBiasCanvas  = new TCanvas("dzPhiBiasCanvas","dzPhiBiasCanvas",600,600);
-  TCanvas *dzEtaBiasCanvas  = new TCanvas("dzEtaBiasCanvas","dzEtaBiasCanvas",600,600);
-  
-  arrangeCanvas(dxyPhiBiasCanvas,dxyPhiMeanTrend,dxyPhiWidthTrend,nFiles_,LegLabels,theDate,true,setAutoLimits);
-  arrangeCanvas(dzPhiBiasCanvas,dzPhiMeanTrend,dzPhiWidthTrend,nFiles_,LegLabels,theDate,true,setAutoLimits);
-  arrangeCanvas(dxyEtaBiasCanvas,dxyEtaMeanTrend,dxyEtaWidthTrend,nFiles_,LegLabels,theDate,true,setAutoLimits);
-  arrangeCanvas(dzEtaBiasCanvas,dzEtaMeanTrend,dzEtaWidthTrend,nFiles_,LegLabels,theDate,true,setAutoLimits);
-  
-  dxyPhiBiasCanvas->SaveAs("dxyPhiBiasCanvas_"+theStrDate+theStrAlignment+".pdf");
-  dxyEtaBiasCanvas->SaveAs("dxyEtaBiasCanvas_"+theStrDate+theStrAlignment+".pdf");
-  dzPhiBiasCanvas->SaveAs("dzPhiBiasCanvas_"+theStrDate+theStrAlignment+".pdf"); 
-  dzEtaBiasCanvas->SaveAs("dzEtaBiasCanvas_"+theStrDate+theStrAlignment+".pdf"); 
-  
-  dxyPhiBiasCanvas->SaveAs("dxyPhiBiasCanvas_"+theStrDate+theStrAlignment+".png");
-  dxyEtaBiasCanvas->SaveAs("dxyEtaBiasCanvas_"+theStrDate+theStrAlignment+".png");
-  dzPhiBiasCanvas->SaveAs("dzPhiBiasCanvas_"+theStrDate+theStrAlignment+".png"); 
-  dzEtaBiasCanvas->SaveAs("dzEtaBiasCanvas_"+theStrDate+theStrAlignment+".png"); 
-  
+  TCanvas *dxyPhiBiasCanvas = new TCanvas("dxyPhiBiasCanvas", "dxyPhiBiasCanvas", 600, 600);
+  TCanvas *dxyEtaBiasCanvas = new TCanvas("dxyEtaBiasCanvas", "dxyEtaBiasCanvas", 600, 600);
+  TCanvas *dzPhiBiasCanvas = new TCanvas("dzPhiBiasCanvas", "dzPhiBiasCanvas", 600, 600);
+  TCanvas *dzEtaBiasCanvas = new TCanvas("dzEtaBiasCanvas", "dzEtaBiasCanvas", 600, 600);
+
+  arrangeCanvas(dxyPhiBiasCanvas, dxyPhiMeanTrend, dxyPhiWidthTrend, nFiles_, LegLabels, theDate, true, setAutoLimits);
+  arrangeCanvas(dzPhiBiasCanvas, dzPhiMeanTrend, dzPhiWidthTrend, nFiles_, LegLabels, theDate, true, setAutoLimits);
+  arrangeCanvas(dxyEtaBiasCanvas, dxyEtaMeanTrend, dxyEtaWidthTrend, nFiles_, LegLabels, theDate, true, setAutoLimits);
+  arrangeCanvas(dzEtaBiasCanvas, dzEtaMeanTrend, dzEtaWidthTrend, nFiles_, LegLabels, theDate, true, setAutoLimits);
+
+  dxyPhiBiasCanvas->SaveAs("dxyPhiBiasCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  dxyEtaBiasCanvas->SaveAs("dxyEtaBiasCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  dzPhiBiasCanvas->SaveAs("dzPhiBiasCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  dzEtaBiasCanvas->SaveAs("dzEtaBiasCanvas_" + theStrDate + theStrAlignment + ".pdf");
+
+  dxyPhiBiasCanvas->SaveAs("dxyPhiBiasCanvas_" + theStrDate + theStrAlignment + ".png");
+  dxyEtaBiasCanvas->SaveAs("dxyEtaBiasCanvas_" + theStrDate + theStrAlignment + ".png");
+  dzPhiBiasCanvas->SaveAs("dzPhiBiasCanvas_" + theStrDate + theStrAlignment + ".png");
+  dzEtaBiasCanvas->SaveAs("dzEtaBiasCanvas_" + theStrDate + theStrAlignment + ".png");
+
   // delete all news
 
   delete BiasesCanvas;
@@ -1455,43 +1778,82 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
   // Resolution plots
 
-  TCanvas *ResolutionsCanvas = new TCanvas("ResolutionsCanvas","ResolutionsCanvas",1200,1200);
-  arrangeBiasCanvas(ResolutionsCanvas,dxyPhiWidthTrend,dzPhiWidthTrend,dxyEtaWidthTrend,dzEtaWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-  
-  ResolutionsCanvas->SaveAs("ResolutionsCanvas_"+theStrDate+theStrAlignment+".pdf");
-  ResolutionsCanvas->SaveAs("ResolutionsCanvas_"+theStrDate+theStrAlignment+".png");
+  TCanvas *ResolutionsCanvas = new TCanvas("ResolutionsCanvas", "ResolutionsCanvas", 1200, 1200);
+  arrangeBiasCanvas(ResolutionsCanvas,
+                    dxyPhiWidthTrend,
+                    dzPhiWidthTrend,
+                    dxyEtaWidthTrend,
+                    dzEtaWidthTrend,
+                    nFiles_,
+                    LegLabels,
+                    theDate,
+                    setAutoLimits);
 
-  TCanvas *ResolutionsCanvasXY = new TCanvas("ResolutionsCanvasXY","ResolutionsCanvasXY",1200,1200);
-  arrangeBiasCanvas(ResolutionsCanvasXY,dxPhiWidthTrend,dyPhiWidthTrend,dxEtaWidthTrend,dyEtaWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-  
-  ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_"+theStrDate+theStrAlignment+".pdf");
-  ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_"+theStrDate+theStrAlignment+".png");
+  ResolutionsCanvas->SaveAs("ResolutionsCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  ResolutionsCanvas->SaveAs("ResolutionsCanvas_" + theStrDate + theStrAlignment + ".png");
 
-  if(nLadders_>0){
+  TCanvas *ResolutionsCanvasXY = new TCanvas("ResolutionsCanvasXY", "ResolutionsCanvasXY", 1200, 1200);
+  arrangeBiasCanvas(ResolutionsCanvasXY,
+                    dxPhiWidthTrend,
+                    dyPhiWidthTrend,
+                    dxEtaWidthTrend,
+                    dyEtaWidthTrend,
+                    nFiles_,
+                    LegLabels,
+                    theDate,
+                    setAutoLimits);
 
-    TCanvas *ResolutionsCanvasLayer1 = new TCanvas("ResolutionsCanvasLayer1","ResolutionsCanvasLayer1",1200,1200);
-    arrangeBiasCanvas(ResolutionsCanvasLayer1,dxyLadderWidthTrend,dzLadderWidthTrend,dxyModZWidthTrend,dzModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-    
-    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
-    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_"+theStrDate+theStrAlignment+".png");
+  ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_" + theStrDate + theStrAlignment + ".pdf");
+  ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_" + theStrDate + theStrAlignment + ".png");
+
+  if (nLadders_ > 0) {
+    TCanvas *ResolutionsCanvasLayer1 = new TCanvas("ResolutionsCanvasLayer1", "ResolutionsCanvasLayer1", 1200, 1200);
+    arrangeBiasCanvas(ResolutionsCanvasLayer1,
+                      dxyLadderWidthTrend,
+                      dzLadderWidthTrend,
+                      dxyModZWidthTrend,
+                      dzModZWidthTrend,
+                      nFiles_,
+                      LegLabels,
+                      theDate,
+                      setAutoLimits);
+
+    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_" + theStrDate + theStrAlignment + ".pdf");
+    ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_" + theStrDate + theStrAlignment + ".png");
 
     delete ResolutionsCanvasLayer1;
   }
 
   // Pull plots
 
-  TCanvas *PullsCanvas = new TCanvas("PullsCanvas","PullsCanvas",1200,1200);
-  arrangeBiasCanvas(PullsCanvas,dxyNormPhiWidthTrend,dzNormPhiWidthTrend,dxyNormEtaWidthTrend,dzNormEtaWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-  
-  PullsCanvas->SaveAs("PullsCanvas_"+theStrDate+theStrAlignment+".pdf");
-  PullsCanvas->SaveAs("PullsCanvas_"+theStrDate+theStrAlignment+".png");
+  TCanvas *PullsCanvas = new TCanvas("PullsCanvas", "PullsCanvas", 1200, 1200);
+  arrangeBiasCanvas(PullsCanvas,
+                    dxyNormPhiWidthTrend,
+                    dzNormPhiWidthTrend,
+                    dxyNormEtaWidthTrend,
+                    dzNormEtaWidthTrend,
+                    nFiles_,
+                    LegLabels,
+                    theDate,
+                    setAutoLimits);
 
-  if(nLadders_>0){
-    TCanvas *PullsCanvasLayer1 = new TCanvas("PullsCanvasLayer1","PullsCanvasLayer1",1200,1200);
-    arrangeBiasCanvas(PullsCanvasLayer1,dxyNormLadderWidthTrend,dzNormLadderWidthTrend,dxyNormModZWidthTrend,dzNormModZWidthTrend,nFiles_,LegLabels,theDate,setAutoLimits);
-    
-    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_"+theStrDate+theStrAlignment+".pdf");
-    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_"+theStrDate+theStrAlignment+".png");
+  PullsCanvas->SaveAs("PullsCanvas_" + theStrDate + theStrAlignment + ".pdf");
+  PullsCanvas->SaveAs("PullsCanvas_" + theStrDate + theStrAlignment + ".png");
+
+  if (nLadders_ > 0) {
+    TCanvas *PullsCanvasLayer1 = new TCanvas("PullsCanvasLayer1", "PullsCanvasLayer1", 1200, 1200);
+    arrangeBiasCanvas(PullsCanvasLayer1,
+                      dxyNormLadderWidthTrend,
+                      dzNormLadderWidthTrend,
+                      dxyNormModZWidthTrend,
+                      dzNormModZWidthTrend,
+                      nFiles_,
+                      LegLabels,
+                      theDate,
+                      setAutoLimits);
+
+    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_" + theStrDate + theStrAlignment + ".pdf");
+    PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_" + theStrDate + theStrAlignment + ".png");
 
     delete PullsCanvasLayer1;
   }
@@ -1503,69 +1865,73 @@ void FitPVResiduals(TString namesandlabels,bool stdres,bool do2DMaps,TString the
 
   // 2D Maps
 
-  if(do2DMaps){
-  
-    TCanvas *dxyAbsMap = new TCanvas("dxyAbsMap","dxyAbsMap",1200,500*nFiles_);
-    arrangeCanvas2D(dxyAbsMap,t_dxyMeanMap,t_dxyWidthMap,nFiles_,LegLabels,theDate);
-    dxyAbsMap->SaveAs("dxyAbsMap_"+theStrDate+theStrAlignment+".pdf");
-    dxyAbsMap->SaveAs("dxyAbsMap_"+theStrDate+theStrAlignment+".png");
-    
-    TCanvas *dzAbsMap = new TCanvas("dzAbsMap","dzAbsMap",1200,500*nFiles_);
-    arrangeCanvas2D(dzAbsMap,t_dzMeanMap,t_dzWidthMap,nFiles_,LegLabels,theDate);
-    dzAbsMap->SaveAs("dzAbsMap_"+theStrDate+theStrAlignment+".pdf");
-    dzAbsMap->SaveAs("dzAbsMap_"+theStrDate+theStrAlignment+".png");
-    
-    TCanvas *dxyNormMap = new TCanvas("dxyNormMap","dxyNormMap",1200,500*nFiles_);
-    arrangeCanvas2D(dxyNormMap,t_dxyNormMeanMap,t_dxyNormWidthMap,nFiles_,LegLabels,theDate);
-    dxyNormMap->SaveAs("dxyNormMap_"+theStrDate+theStrAlignment+".pdf");
-    dxyNormMap->SaveAs("dxyNormMap_"+theStrDate+theStrAlignment+".png");
+  if (do2DMaps) {
+    TCanvas *dxyAbsMap = new TCanvas("dxyAbsMap", "dxyAbsMap", 1200, 500 * nFiles_);
+    arrangeCanvas2D(dxyAbsMap, t_dxyMeanMap, t_dxyWidthMap, nFiles_, LegLabels, theDate);
+    dxyAbsMap->SaveAs("dxyAbsMap_" + theStrDate + theStrAlignment + ".pdf");
+    dxyAbsMap->SaveAs("dxyAbsMap_" + theStrDate + theStrAlignment + ".png");
 
-    TCanvas *dzNormMap = new TCanvas("dzNormMap","dzNormMap",1200,500*nFiles_);
-    arrangeCanvas2D(dzNormMap,t_dzNormMeanMap,t_dzNormWidthMap,nFiles_,LegLabels,theDate);
-    dzNormMap->SaveAs("dzNormMap_"+theStrDate+theStrAlignment+".pdf");
-    dzNormMap->SaveAs("dzNormMap_"+theStrDate+theStrAlignment+".png");
+    TCanvas *dzAbsMap = new TCanvas("dzAbsMap", "dzAbsMap", 1200, 500 * nFiles_);
+    arrangeCanvas2D(dzAbsMap, t_dzMeanMap, t_dzWidthMap, nFiles_, LegLabels, theDate);
+    dzAbsMap->SaveAs("dzAbsMap_" + theStrDate + theStrAlignment + ".pdf");
+    dzAbsMap->SaveAs("dzAbsMap_" + theStrDate + theStrAlignment + ".png");
+
+    TCanvas *dxyNormMap = new TCanvas("dxyNormMap", "dxyNormMap", 1200, 500 * nFiles_);
+    arrangeCanvas2D(dxyNormMap, t_dxyNormMeanMap, t_dxyNormWidthMap, nFiles_, LegLabels, theDate);
+    dxyNormMap->SaveAs("dxyNormMap_" + theStrDate + theStrAlignment + ".pdf");
+    dxyNormMap->SaveAs("dxyNormMap_" + theStrDate + theStrAlignment + ".png");
+
+    TCanvas *dzNormMap = new TCanvas("dzNormMap", "dzNormMap", 1200, 500 * nFiles_);
+    arrangeCanvas2D(dzNormMap, t_dzNormMeanMap, t_dzNormWidthMap, nFiles_, LegLabels, theDate);
+    dzNormMap->SaveAs("dzNormMap_" + theStrDate + theStrAlignment + ".pdf");
+    dzNormMap->SaveAs("dzNormMap_" + theStrDate + theStrAlignment + ".png");
 
     delete dxyAbsMap;
     delete dzAbsMap;
     delete dxyNormMap;
     delete dzNormMap;
-
   }
 
   delete thePlotLimits;
 
   // delete everything in the source list
-  for(std::vector<PVValidationVariables*>::iterator it = sourceList.begin();
-      it != sourceList.end(); ++it){
+  for (std::vector<PVValidationVariables *>::iterator it = sourceList.begin(); it != sourceList.end(); ++it) {
     delete (*it);
   }
 
   TTimeStamp plotting_done;
 
-  std::cout<<" ======   TIMING REPORT ====== "<< std::endl;
-  std::cout<<"time tp initialize = "<<initialization_done.AsDouble()-start_time.AsDouble()<<"s"<<std::endl;
-  std::cout<<"time to cache      = "<<caching_done.AsDouble()-initialization_done.AsDouble()<<"s"<<std::endl;
+  std::cout << " ======   TIMING REPORT ====== " << std::endl;
+  std::cout << "time tp initialize = " << initialization_done.AsDouble() - start_time.AsDouble() << "s" << std::endl;
+  std::cout << "time to cache      = " << caching_done.AsDouble() - initialization_done.AsDouble() << "s" << std::endl;
   //  std::cout<<"time to fill 1D    = "<<filling1D_done.AsDouble()-caching_done.AsDouble()<<"s"<<std::endl;
-  std::cout<<"time to fit        = "<<filling2D_done.AsDouble()-caching_done.AsDouble()<<"s"<<std::endl;
-  std::cout<<"time to plot       = "<<plotting_done.AsDouble()-filling2D_done.AsDouble()<<"s"<<std::endl;
-  
-  timer.Stop(); 	 
-  timer.Print();
+  std::cout << "time to fit        = " << filling2D_done.AsDouble() - caching_done.AsDouble() << "s" << std::endl;
+  std::cout << "time to plot       = " << plotting_done.AsDouble() - filling2D_done.AsDouble() << "s" << std::endl;
 
+  timer.Stop();
+  timer.Print();
 }
 
 //*************************************************************
-void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanTrend[100],TH1F* dxyEtaMeanTrend[100],TH1F* dzEtaMeanTrend[100],Int_t nFiles, TString LegLabels[10],TString theDate,bool setAutoLimits){
-//*************************************************************
+void arrangeBiasCanvas(TCanvas *canv,
+                       TH1F *dxyPhiMeanTrend[100],
+                       TH1F *dzPhiMeanTrend[100],
+                       TH1F *dxyEtaMeanTrend[100],
+                       TH1F *dzEtaMeanTrend[100],
+                       Int_t nFiles,
+                       TString LegLabels[10],
+                       TString theDate,
+                       bool setAutoLimits) {
+  //*************************************************************
 
-  TLegend *lego = new TLegend(0.22,0.80,0.79,0.91);
+  TLegend *lego = new TLegend(0.22, 0.80, 0.79, 0.91);
   // might be useful if many objects are compared
-  if(nFiles>3){
-    lego-> SetNColumns(2);
+  if (nFiles > 3) {
+    lego->SetNColumns(2);
   }
 
   lego->SetFillColor(10);
-  if(nFiles>3){
+  if (nFiles > 3) {
     lego->SetTextSize(0.032);
   } else {
     lego->SetTextSize(0.042);
@@ -1575,7 +1941,7 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
   lego->SetLineColor(10);
   lego->SetShadowColor(10);
 
-  TPaveText *ptDate =new TPaveText(0.20,0.95,0.50,0.99,"blNDC");
+  TPaveText *ptDate = new TPaveText(0.20, 0.95, 0.50, 0.99, "blNDC");
   //ptDate->SetFillColor(kYellow);
   ptDate->SetFillColor(10);
   ptDate->SetBorderSize(1);
@@ -1586,175 +1952,174 @@ void arrangeBiasCanvas(TCanvas *canv,TH1F* dxyPhiMeanTrend[100],TH1F* dzPhiMeanT
   textDate->SetTextSize(0.04);
   textDate->SetTextColor(kBlue);
 
-  canv->SetFillColor(10);  
-  canv->Divide(2,2);
- 
+  canv->SetFillColor(10);
+  canv->Divide(2, 2);
+
   canv->cd(1)->SetBottomMargin(0.14);
   canv->cd(1)->SetLeftMargin(0.18);
   canv->cd(1)->SetRightMargin(0.01);
-  canv->cd(1)->SetTopMargin(0.06);  
+  canv->cd(1)->SetTopMargin(0.06);
 
   canv->cd(2)->SetBottomMargin(0.14);
   canv->cd(2)->SetLeftMargin(0.18);
   canv->cd(2)->SetRightMargin(0.01);
-  canv->cd(2)->SetTopMargin(0.06);  
-  
+  canv->cd(2)->SetTopMargin(0.06);
+
   canv->cd(3)->SetBottomMargin(0.14);
   canv->cd(3)->SetLeftMargin(0.18);
   canv->cd(3)->SetRightMargin(0.01);
-  canv->cd(3)->SetTopMargin(0.06);  
+  canv->cd(3)->SetTopMargin(0.06);
 
   canv->cd(4)->SetBottomMargin(0.14);
   canv->cd(4)->SetLeftMargin(0.18);
   canv->cd(4)->SetRightMargin(0.01);
-  canv->cd(4)->SetTopMargin(0.06); 
-  
-  TH1F *dBiasTrend[4][nFiles]; 
-  
-  for(Int_t i=0;i<nFiles;i++){
+  canv->cd(4)->SetTopMargin(0.06);
+
+  TH1F *dBiasTrend[4][nFiles];
+
+  for (Int_t i = 0; i < nFiles; i++) {
     dBiasTrend[0][i] = dxyPhiMeanTrend[i];
     dBiasTrend[1][i] = dzPhiMeanTrend[i];
     dBiasTrend[2][i] = dxyEtaMeanTrend[i];
     dBiasTrend[3][i] = dzEtaMeanTrend[i];
   }
 
-  Double_t absmin[4]={999.,999.,999.,999.};
-  Double_t absmax[4]={-999.,-999.-999.,-999.};
+  Double_t absmin[4] = {999., 999., 999., 999.};
+  Double_t absmax[4] = {-999., -999. - 999., -999.};
 
-  for(Int_t k=0; k<4; k++){
+  for (Int_t k = 0; k < 4; k++) {
+    canv->cd(k + 1);
 
-    canv->cd(k+1);
-    
-    for(Int_t i=0; i<nFiles; i++){
-
-      if(TString(canv->GetName()).Contains("BareResiduals")){
-	dBiasTrend[k][i]->Scale(1./dBiasTrend[k][i]->GetSumOfWeights());
+    for (Int_t i = 0; i < nFiles; i++) {
+      if (TString(canv->GetName()).Contains("BareResiduals")) {
+        dBiasTrend[k][i]->Scale(1. / dBiasTrend[k][i]->GetSumOfWeights());
       }
 
-      if(dBiasTrend[k][i]->GetMaximum()>absmax[k]) absmax[k] = dBiasTrend[k][i]->GetMaximum();
-      if(dBiasTrend[k][i]->GetMinimum()<absmin[k]) absmin[k] = dBiasTrend[k][i]->GetMinimum();
+      if (dBiasTrend[k][i]->GetMaximum() > absmax[k])
+        absmax[k] = dBiasTrend[k][i]->GetMaximum();
+      if (dBiasTrend[k][i]->GetMinimum() < absmin[k])
+        absmin[k] = dBiasTrend[k][i]->GetMinimum();
     }
 
-    Double_t safeDelta=(absmax[k]-absmin[k])/8.;
+    Double_t safeDelta = (absmax[k] - absmin[k]) / 8.;
 
     // if(safeDelta<0.1*absmax[k]) safeDelta*=16;
 
-    Double_t theExtreme=std::max(absmax[k],TMath::Abs(absmin[k]));
+    Double_t theExtreme = std::max(absmax[k], TMath::Abs(absmin[k]));
 
-    for(Int_t i=0; i<nFiles; i++){
-      if(i==0){
+    for (Int_t i = 0; i < nFiles; i++) {
+      if (i == 0) {
+        TString theTitle = dBiasTrend[k][i]->GetName();
 
-	TString theTitle = dBiasTrend[k][i]->GetName();
-	
-	//std::cout << theTitle<< " --->" << safeDelta << std::endl;
+        //std::cout << theTitle<< " --->" << safeDelta << std::endl;
 
-	// if the autoLimits are not set
-	if(!setAutoLimits){
-	  
-	  params::measurement range = getTheRangeUser(dBiasTrend[k][i],thePlotLimits);
-	  dBiasTrend[k][i]->GetYaxis()->SetRangeUser(range.first,range.second);
-	 
-	} else {
-	
-	  if(theTitle.Contains("width")){
+        // if the autoLimits are not set
+        if (!setAutoLimits) {
+          params::measurement range = getTheRangeUser(dBiasTrend[k][i], thePlotLimits);
+          dBiasTrend[k][i]->GetYaxis()->SetRangeUser(range.first, range.second);
 
-	    if(theTitle.Contains("Norm"))
-	      safeDelta = (theTitle.Contains("ladder")==true||theTitle.Contains("modZ")==true) ? 1.  : safeDelta; 
-	    else
-	      safeDelta = (theTitle.Contains("ladder")==true||theTitle.Contains("modZ")==true) ? 50. : safeDelta; 
+        } else {
+          if (theTitle.Contains("width")) {
+            if (theTitle.Contains("Norm"))
+              safeDelta = (theTitle.Contains("ladder") == true || theTitle.Contains("modZ") == true) ? 1. : safeDelta;
+            else
+              safeDelta = (theTitle.Contains("ladder") == true || theTitle.Contains("modZ") == true) ? 50. : safeDelta;
 
-	    dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta/2.));
-	  } else {
+            dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., theExtreme + (safeDelta / 2.));
+          } else {
+            if (theTitle.Contains("Norm")) {
+              dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48, absmin[k] - (safeDelta / 2.)),
+                                                         std::max(0.48, absmax[k] + (safeDelta / 2.)));
+            } else if (theTitle.Contains("h_probe")) {
+              TGaxis::SetMaxDigits(4);
+              dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., theExtreme + (safeDelta * 2.));
+            } else {
+              dBiasTrend[k][i]->GetYaxis()->SetRangeUser(-theExtreme - (safeDelta / 2.), theExtreme + (safeDelta / 2.));
+            }
+          }
+        }
 
-	    if( theTitle.Contains("Norm")){
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-(safeDelta/2.)),std::max(0.48,absmax[k]+(safeDelta/2.)));
-	    } else if ( theTitle.Contains("h_probe")) {
-	      TGaxis::SetMaxDigits(4);   
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta*2.));
-	    } else {
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(-theExtreme-(safeDelta/2.),theExtreme+(safeDelta/2.));
-	    } 
-	  }
-	}
-	
-	if(TString(canv->GetName()).Contains("BareResiduals") && (k==0 || k==2)){
-	  dBiasTrend[k][i]->GetXaxis()->SetRangeUser(-0.11,0.11);
-	}
+        if (TString(canv->GetName()).Contains("BareResiduals") && (k == 0 || k == 2)) {
+          dBiasTrend[k][i]->GetXaxis()->SetRangeUser(-0.11, 0.11);
+        }
 
-	dBiasTrend[k][i]->Draw("e1");
-	makeNewXAxis(dBiasTrend[k][i]);
-	Int_t nbins =  dBiasTrend[k][i]->GetNbinsX();
-	Double_t lowedge  = dBiasTrend[k][i]->GetBinLowEdge(1);
-	Double_t highedge = dBiasTrend[k][i]->GetBinLowEdge(nbins+1);
+        dBiasTrend[k][i]->Draw("e1");
+        makeNewXAxis(dBiasTrend[k][i]);
+        Int_t nbins = dBiasTrend[k][i]->GetNbinsX();
+        Double_t lowedge = dBiasTrend[k][i]->GetBinLowEdge(1);
+        Double_t highedge = dBiasTrend[k][i]->GetBinLowEdge(nbins + 1);
 
-	/*
+        /*
 	  TH1F* zeros = DrawZero(dBiasTrend[k][i],nbins,lowedge,highedge,1);
 	  zeros->Draw("PLsame"); 
 	*/
 
-	Double_t theC = -1.;
-	
-	if(theTitle.Contains("width")){ 
-	  if(theTitle.Contains("Norm") ){
-	    theC = 1.;
-	  } else {
-	    theC = -1.;
-	  }
-	} else {
-	  theC = 0.;
-	}
+        Double_t theC = -1.;
 
-	TH1F* theConst = DrawConstant(dBiasTrend[k][i],nbins,lowedge,highedge,1,theC);
-	theConst->Draw("PLsame");
+        if (theTitle.Contains("width")) {
+          if (theTitle.Contains("Norm")) {
+            theC = 1.;
+          } else {
+            theC = -1.;
+          }
+        } else {
+          theC = 0.;
+        }
 
-      }
-      else {	       
+        TH1F *theConst = DrawConstant(dBiasTrend[k][i], nbins, lowedge, highedge, 1, theC);
+        theConst->Draw("PLsame");
 
-	if(TString(canv->GetName()).Contains("BareResiduals") && (k==0 || k==2)){
-	  dBiasTrend[k][i]->GetXaxis()->SetRangeUser(-0.11,0.11);
-	}
+      } else {
+        if (TString(canv->GetName()).Contains("BareResiduals") && (k == 0 || k == 2)) {
+          dBiasTrend[k][i]->GetXaxis()->SetRangeUser(-0.11, 0.11);
+        }
 
-	dBiasTrend[k][i]->Draw("e1sames");      
+        dBiasTrend[k][i]->Draw("e1sames");
       }
 
-      if(k==0){
-	lego->AddEntry(dBiasTrend[k][i],LegLabels[i]);
-      } 
-    }  
-  
+      if (k == 0) {
+        lego->AddEntry(dBiasTrend[k][i], LegLabels[i]);
+      }
+    }
+
     lego->Draw();
- 
-    TPad *current_pad = static_cast<TPad*>(canv->GetPad(k+1));
-    CMS_lumi(current_pad,4,33 );
-    if(theDate!="")
+
+    TPad *current_pad = static_cast<TPad *>(canv->GetPad(k + 1));
+    CMS_lumi(current_pad, 4, 33);
+    if (theDate != "")
       ptDate->Draw("same");
   }
-  
 }
 
-
 //*************************************************************
-void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_t nFiles, TString LegLabels[10],TString theDate,bool onlyBias,bool setAutoLimits){
-//*************************************************************
+void arrangeCanvas(TCanvas *canv,
+                   TH1F *meanplots[100],
+                   TH1F *widthplots[100],
+                   Int_t nFiles,
+                   TString LegLabels[10],
+                   TString theDate,
+                   bool onlyBias,
+                   bool setAutoLimits) {
+  //*************************************************************
 
-  TPaveText *ali = new TPaveText(0.18,0.85,0.50,0.93,"NDC");  
+  TPaveText *ali = new TPaveText(0.18, 0.85, 0.50, 0.93, "NDC");
   ali->SetFillColor(10);
   ali->SetTextColor(1);
   ali->SetTextFont(42);
   ali->SetMargin(0.);
   ali->SetLineColor(10);
   ali->SetShadowColor(10);
-  TText *alitext = ali->AddText("Alignment: PCL"); 
+  TText *alitext = ali->AddText("Alignment: PCL");
   alitext->SetTextSize(0.04);
 
-  TLegend *lego = new TLegend(0.22,0.80,0.78,0.91);
+  TLegend *lego = new TLegend(0.22, 0.80, 0.78, 0.91);
   // in case many objects are compared
-  if(nFiles>3){
-    lego-> SetNColumns(2);
+  if (nFiles > 3) {
+    lego->SetNColumns(2);
   }
   // TLegend *lego = new TLegend(0.18,0.77,0.50,0.86);
   lego->SetFillColor(10);
-  if(nFiles>3) {
+  if (nFiles > 3) {
     lego->SetTextSize(0.03);
   } else {
     lego->SetTextSize(0.04);
@@ -1766,14 +2131,14 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
 
   TPaveText *ptDate = NULL;
 
-  canv->SetFillColor(10);  
+  canv->SetFillColor(10);
 
-  if(!onlyBias){ 
-    ptDate =new TPaveText(0.20,0.95,0.50,0.99,"blNDC");
+  if (!onlyBias) {
+    ptDate = new TPaveText(0.20, 0.95, 0.50, 0.99, "blNDC");
   } else {
-    ptDate =new TPaveText(0.20,0.95,0.50,0.99,"blNDC");
+    ptDate = new TPaveText(0.20, 0.95, 0.50, 0.99, "blNDC");
   }
-  
+
   //ptDate->SetFillColor(kYellow);
   ptDate->SetFillColor(10);
   ptDate->SetBorderSize(1);
@@ -1784,167 +2149,161 @@ void arrangeCanvas(TCanvas *canv,TH1F* meanplots[100],TH1F* widthplots[100],Int_
   textDate->SetTextSize(0.04);
   textDate->SetTextColor(kBlue);
 
-  if(!onlyBias) {
-    
-    canv->Divide(2,1);
-        
+  if (!onlyBias) {
+    canv->Divide(2, 1);
+
     canv->cd(1)->SetBottomMargin(0.14);
     canv->cd(1)->SetLeftMargin(0.17);
     canv->cd(1)->SetRightMargin(0.02);
-    canv->cd(1)->SetTopMargin(0.06);  
-    
+    canv->cd(1)->SetTopMargin(0.06);
+
     canv->cd(2)->SetBottomMargin(0.14);
     canv->cd(2)->SetLeftMargin(0.17);
     canv->cd(2)->SetRightMargin(0.02);
-    canv->cd(2)->SetTopMargin(0.06);  
+    canv->cd(2)->SetTopMargin(0.06);
     canv->cd(1);
 
   } else {
-    
     canv->cd()->SetBottomMargin(0.14);
     canv->cd()->SetLeftMargin(0.17);
     canv->cd()->SetRightMargin(0.02);
-    canv->cd()->SetTopMargin(0.06);  
+    canv->cd()->SetTopMargin(0.06);
     canv->cd();
   }
 
   Double_t absmin(999.);
   Double_t absmax(-999.);
 
-  for(Int_t i=0; i<nFiles; i++){
-    if(meanplots[i]->GetMaximum()>absmax) absmax = meanplots[i]->GetMaximum();
-    if(meanplots[i]->GetMinimum()<absmin) absmin = meanplots[i]->GetMinimum();
+  for (Int_t i = 0; i < nFiles; i++) {
+    if (meanplots[i]->GetMaximum() > absmax)
+      absmax = meanplots[i]->GetMaximum();
+    if (meanplots[i]->GetMinimum() < absmin)
+      absmin = meanplots[i]->GetMinimum();
   }
 
-  Double_t safeDelta=(absmax-absmin)/2.;
-  Double_t theExtreme=std::max(absmax,TMath::Abs(absmin));
+  Double_t safeDelta = (absmax - absmin) / 2.;
+  Double_t theExtreme = std::max(absmax, TMath::Abs(absmin));
 
-  for(Int_t i=0; i<nFiles; i++){
-    
-    if(i==0){
-
+  for (Int_t i = 0; i < nFiles; i++) {
+    if (i == 0) {
       // if the autoLimits are not set
-      if(!setAutoLimits){
-
-	params::measurement range = getTheRangeUser(meanplots[i],thePlotLimits);
-	meanplots[i]->GetYaxis()->SetRangeUser(range.first,range.second);
+      if (!setAutoLimits) {
+        params::measurement range = getTheRangeUser(meanplots[i], thePlotLimits);
+        meanplots[i]->GetYaxis()->SetRangeUser(range.first, range.second);
 
       } else {
-
-	TString theTitle = meanplots[i]->GetName();
-	if( theTitle.Contains("Norm")){
-	  meanplots[i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin-safeDelta),std::max(0.48,absmax+safeDelta));
-	} else {
-	  if(!onlyBias){
-	    meanplots[i]->GetYaxis()->SetRangeUser(absmin-safeDelta,absmax+safeDelta);
-	  } else {
-	    meanplots[i]->GetYaxis()->SetRangeUser(-theExtreme-(TMath::Abs(absmin)/10.),theExtreme+(TMath::Abs(absmax/10.)));
-	  }
-	}
+        TString theTitle = meanplots[i]->GetName();
+        if (theTitle.Contains("Norm")) {
+          meanplots[i]->GetYaxis()->SetRangeUser(std::min(-0.48, absmin - safeDelta),
+                                                 std::max(0.48, absmax + safeDelta));
+        } else {
+          if (!onlyBias) {
+            meanplots[i]->GetYaxis()->SetRangeUser(absmin - safeDelta, absmax + safeDelta);
+          } else {
+            meanplots[i]->GetYaxis()->SetRangeUser(-theExtreme - (TMath::Abs(absmin) / 10.),
+                                                   theExtreme + (TMath::Abs(absmax / 10.)));
+          }
+        }
       }
-      
+
       meanplots[i]->Draw("e1");
-      if(TString(meanplots[i]->GetName()).Contains("pT")){
-       	//meanplots[i]->Draw("HIST][same");
-	gPad->SetLogx();
-	gPad->SetGridx();
-	gPad->SetGridy();
+      if (TString(meanplots[i]->GetName()).Contains("pT")) {
+        //meanplots[i]->Draw("HIST][same");
+        gPad->SetLogx();
+        gPad->SetGridx();
+        gPad->SetGridy();
       } else {
-	makeNewXAxis(meanplots[i]); 
+        makeNewXAxis(meanplots[i]);
       }
 
-      if(onlyBias){
-	canv->cd();
-	Int_t nbins =  meanplots[i]->GetNbinsX();
-	Double_t lowedge  = meanplots[i]->GetBinLowEdge(1);
-	Double_t highedge = meanplots[i]->GetBinLowEdge(nbins+1);
-	
-	TH1F* hzero = DrawZero(meanplots[i],nbins,lowedge,highedge,2);
-	hzero->Draw("PLsame");
-	
+      if (onlyBias) {
+        canv->cd();
+        Int_t nbins = meanplots[i]->GetNbinsX();
+        Double_t lowedge = meanplots[i]->GetBinLowEdge(1);
+        Double_t highedge = meanplots[i]->GetBinLowEdge(nbins + 1);
+
+        TH1F *hzero = DrawZero(meanplots[i], nbins, lowedge, highedge, 2);
+        hzero->Draw("PLsame");
       }
-    }
-    else meanplots[i]->Draw("e1sames");
+    } else
+      meanplots[i]->Draw("e1sames");
     //if(TString(meanplots[i]->GetName()).Contains("pT")){
     //  meanplots[i]->Draw("HIST][same");
     // }
 
-    lego->AddEntry(meanplots[i],LegLabels[i]); 
-  }  
-  
+    lego->AddEntry(meanplots[i], LegLabels[i]);
+  }
 
   lego->Draw();
-  
+
   //ali->Draw("same");
   //ptDate->Draw("same");
 
   TPad *current_pad;
-  if(!onlyBias){
-    current_pad = static_cast<TPad*>(canv->GetPad(1));
+  if (!onlyBias) {
+    current_pad = static_cast<TPad *>(canv->GetPad(1));
   } else {
-    current_pad = static_cast<TPad*>(canv->GetPad(0));
+    current_pad = static_cast<TPad *>(canv->GetPad(0));
   }
 
-  CMS_lumi(current_pad,4,33 );
-  if(theDate!="")
+  CMS_lumi(current_pad, 4, 33);
+  if (theDate != "")
     ptDate->Draw("same");
 
-  if(!onlyBias){
-
+  if (!onlyBias) {
     canv->cd(2);
     Double_t absmax2(-999.);
-    
-    for(Int_t i=0; i<nFiles; i++){
-      if(widthplots[i]->GetMaximum()>absmax2) absmax2 = widthplots[i]->GetMaximum();
+
+    for (Int_t i = 0; i < nFiles; i++) {
+      if (widthplots[i]->GetMaximum() > absmax2)
+        absmax2 = widthplots[i]->GetMaximum();
     }
-    
-    Double_t safeDelta2=absmax2/3.;
-    
-    for(Int_t i=0; i<nFiles; i++){
-      
+
+    Double_t safeDelta2 = absmax2 / 3.;
+
+    for (Int_t i = 0; i < nFiles; i++) {
       widthplots[i]->GetXaxis()->SetLabelOffset(999);
       widthplots[i]->GetXaxis()->SetTickLength(0);
-      
-      if(i==0){ 
 
-	if(!setAutoLimits){
-	  params::measurement range = getTheRangeUser(widthplots[i],thePlotLimits);
-	  widthplots[i]->GetYaxis()->SetRangeUser(range.first,range.second);
-	} else {
-	  widthplots[i]->SetMinimum(0.5);
-	  widthplots[i]->SetMaximum(absmax2+safeDelta2);
-	}
+      if (i == 0) {
+        if (!setAutoLimits) {
+          params::measurement range = getTheRangeUser(widthplots[i], thePlotLimits);
+          widthplots[i]->GetYaxis()->SetRangeUser(range.first, range.second);
+        } else {
+          widthplots[i]->SetMinimum(0.5);
+          widthplots[i]->SetMaximum(absmax2 + safeDelta2);
+        }
 
-	widthplots[i]->Draw("e1");
-	if(TString(widthplots[i]->GetName()).Contains("pT")){
-	  //widthplots[i]->Draw("HIST][same");
-	  gPad->SetGridx();
-	  gPad->SetGridy();
-	} 
-	makeNewXAxis(widthplots[i]);
+        widthplots[i]->Draw("e1");
+        if (TString(widthplots[i]->GetName()).Contains("pT")) {
+          //widthplots[i]->Draw("HIST][same");
+          gPad->SetGridx();
+          gPad->SetGridy();
+        }
+        makeNewXAxis(widthplots[i]);
       } else {
-	widthplots[i]->Draw("e1sames");
-	if(TString(widthplots[i]->GetName()).Contains("pT")){
-	  //widthplots[i]->Draw("HIST][same");
-	}
+        widthplots[i]->Draw("e1sames");
+        if (TString(widthplots[i]->GetName()).Contains("pT")) {
+          //widthplots[i]->Draw("HIST][same");
+        }
       }
     }
-    
-    lego->Draw();
-   
-    TPad *current_pad2 = static_cast<TPad*>(canv->GetPad(2));
-    CMS_lumi(current_pad2,4,33 );
-    if(theDate!="")
-      ptDate->Draw("same");
 
+    lego->Draw();
+
+    TPad *current_pad2 = static_cast<TPad *>(canv->GetPad(2));
+    CMS_lumi(current_pad2, 4, 33);
+    if (theDate != "")
+      ptDate->Draw("same");
   }
 }
 
 //*************************************************************
-void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_t nFiles,TString LegLabels[10],TString theDate)
+void arrangeCanvas2D(
+    TCanvas *canv, TH2F *meanmaps[100], TH2F *widthmaps[100], Int_t nFiles, TString LegLabels[10], TString theDate)
 //*************************************************************
 {
-  TLegend *lego = new TLegend(0.18,0.75,0.58,0.92);
+  TLegend *lego = new TLegend(0.18, 0.75, 0.58, 0.92);
   lego->SetFillColor(10);
   lego->SetTextSize(0.05);
   lego->SetTextFont(42);
@@ -1956,8 +2315,8 @@ void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_
   TPaveText *pt2[nFiles];
   TPaveText *pt3[nFiles];
 
-  for(Int_t i=0; i<nFiles; i++){
-    pt[i] = new TPaveText(0.13,0.95,0.191,0.975,"NDC");
+  for (Int_t i = 0; i < nFiles; i++) {
+    pt[i] = new TPaveText(0.13, 0.95, 0.191, 0.975, "NDC");
     //pt[i] = new TPaveText(gPad->GetUxmin(),gPad->GetUymax()+0.3,gPad->GetUxmin()+0.6,gPad->GetUymax()+0.3,"NDC");
     //std::cout<<"gPad->GetUymax():"<<gPad->GetUymax()<<std::endl;
     //pt[i] = new TPaveText(gPad->GetLeftMargin(),0.95,gPad->GetLeftMargin()+0.3,0.98,"NDC");
@@ -1965,13 +2324,13 @@ void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_
     pt[i]->SetTextColor(1);
     pt[i]->SetTextFont(61);
     pt[i]->SetTextAlign(22);
-    TText *text1 = pt[i]->AddText("CMS"); // preliminary 2015 p-p data, #sqrt{s}=8 TeV "+LegLabels[i]);
+    TText *text1 = pt[i]->AddText("CMS");  // preliminary 2015 p-p data, #sqrt{s}=8 TeV "+LegLabels[i]);
     text1->SetTextSize(0.05);
     //delete text1;
 
     //float extraOverCmsTextSize  = 0.76;
 
-    pt2[i] = new TPaveText(0.21,0.95,0.25,0.975,"NDC");
+    pt2[i] = new TPaveText(0.21, 0.95, 0.25, 0.975, "NDC");
     pt2[i]->SetFillColor(10);
     pt2[i]->SetTextColor(1);
     //pt[i]->SetTextSize(0.05);
@@ -1979,34 +2338,34 @@ void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_
     pt2[i]->SetTextAlign(12);
     // TText *text2 = pt2->AddText("run: "+theDate);
     TText *text2 = pt2[i]->AddText("INTERNAL");
-    text2->SetTextSize(0.06*extraOverCmsTextSize); 
-    
-    pt3[i] = new TPaveText(0.55,0.955,0.95,0.98,"NDC");
+    text2->SetTextSize(0.06 * extraOverCmsTextSize);
+
+    pt3[i] = new TPaveText(0.55, 0.955, 0.95, 0.98, "NDC");
     pt3[i]->SetFillColor(10);
     pt3[i]->SetTextColor(kBlue);
     pt3[i]->SetTextFont(61);
     pt3[i]->SetTextAlign(22);
     // TText *text2 = pt2->AddText("run: "+theDate);
     TText *text3 = pt3[i]->AddText(LegLabels[i]);
-    text3->SetTextSize(0.05); 
-
+    text3->SetTextSize(0.05);
   }
 
-  canv->SetFillColor(10);  
-  canv->Divide(2,nFiles);
-  
-  
+  canv->SetFillColor(10);
+  canv->Divide(2, nFiles);
+
   Double_t absmin(999.);
   Double_t absmax(-999.);
   Double_t maxwidth(-999.);
-  
-  for(Int_t i=0; i<nFiles; i++){
-    if(widthmaps[i]->GetMaximum()>maxwidth) maxwidth=widthmaps[i]->GetMaximum();
-    if(meanmaps[i]->GetMaximum()>absmax) absmax = meanmaps[i]->GetMaximum();
-    if(meanmaps[i]->GetMinimum()<absmin) absmin = meanmaps[i]->GetMinimum();
+
+  for (Int_t i = 0; i < nFiles; i++) {
+    if (widthmaps[i]->GetMaximum() > maxwidth)
+      maxwidth = widthmaps[i]->GetMaximum();
+    if (meanmaps[i]->GetMaximum() > absmax)
+      absmax = meanmaps[i]->GetMaximum();
+    if (meanmaps[i]->GetMinimum() < absmin)
+      absmin = meanmaps[i]->GetMinimum();
   }
- 
- 
+
   /*
   const Int_t nLevels = 255;
   Double_t levels[nLevels];
@@ -2018,21 +2377,20 @@ void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_
 
   //Double_t theExtreme = std::min(std::abs(absmin),std::abs(absmax));
 
-  for(Int_t i=0; i<nFiles; i++){
- 
-    canv->cd(2*i+1)->SetBottomMargin(0.13);
-    canv->cd(2*i+1)->SetLeftMargin(0.12);
-    canv->cd(2*i+1)->SetRightMargin(0.19);
-    canv->cd(2*i+1)->SetTopMargin(0.08);  
+  for (Int_t i = 0; i < nFiles; i++) {
+    canv->cd(2 * i + 1)->SetBottomMargin(0.13);
+    canv->cd(2 * i + 1)->SetLeftMargin(0.12);
+    canv->cd(2 * i + 1)->SetRightMargin(0.19);
+    canv->cd(2 * i + 1)->SetTopMargin(0.08);
 
     //meanmaps[i]->SetContour((sizeof(levels)/sizeof(Double_t)), levels);
-    meanmaps[i]->GetZaxis()->SetRangeUser(absmin,absmax);
+    meanmaps[i]->GetZaxis()->SetRangeUser(absmin, absmax);
     //meanmaps[i]->GetZaxis()->SetRangeUser(-theExtreme,theExtreme);
     meanmaps[i]->Draw("colz1");
 
     //TH2F* cloned = (TH2F*)meanmaps[i]->DrawClone("colz");// draw "axes", "contents", "statistics box
     //makeNewPairOfAxes(cloned);
-    //meanmaps[i]->GetZaxis()->SetRangeUser(absmin, absmax); // ... set the range ... 
+    //meanmaps[i]->GetZaxis()->SetRangeUser(absmin, absmax); // ... set the range ...
     //meanmaps[i]->Draw("colzsame"); // draw the "color palette"
 
     makeNewPairOfAxes(meanmaps[i]);
@@ -2041,44 +2399,43 @@ void arrangeCanvas2D(TCanvas *canv,TH2F* meanmaps[100],TH2F* widthmaps[100],Int_
     pt2[i]->Draw("same");
     pt3[i]->Draw("same");
 
-    canv->cd(2*(i+1))->SetBottomMargin(0.13);
-    canv->cd(2*(i+1))->SetLeftMargin(0.12);
-    canv->cd(2*(i+1))->SetRightMargin(0.19);
-    canv->cd(2*(i+1))->SetTopMargin(0.08);  
+    canv->cd(2 * (i + 1))->SetBottomMargin(0.13);
+    canv->cd(2 * (i + 1))->SetLeftMargin(0.12);
+    canv->cd(2 * (i + 1))->SetRightMargin(0.19);
+    canv->cd(2 * (i + 1))->SetTopMargin(0.08);
 
     widthmaps[i]->Draw("colz1");
     makeNewPairOfAxes(widthmaps[i]);
 
-    widthmaps[i]->GetZaxis()->SetRangeUser(0.,maxwidth);
+    widthmaps[i]->GetZaxis()->SetRangeUser(0., maxwidth);
 
     pt[i]->Draw("same");
     pt2[i]->Draw("same");
     pt3[i]->Draw("same");
-
   }
 }
 
 //*************************************************************
-void arrangeFitCanvas(TCanvas *canv,TH1F* meanplots[100],Int_t nFiles, TString LegLabels[10],TString theDate)
+void arrangeFitCanvas(TCanvas *canv, TH1F *meanplots[100], Int_t nFiles, TString LegLabels[10], TString theDate)
 //*************************************************************
 {
   canv->SetBottomMargin(0.14);
   canv->SetLeftMargin(0.1);
   canv->SetRightMargin(0.02);
-  canv->SetTopMargin(0.08);  
+  canv->SetTopMargin(0.08);
 
-  TLegend *lego = new TLegend(0.12,0.80,0.82,0.89);
+  TLegend *lego = new TLegend(0.12, 0.80, 0.82, 0.89);
   lego->SetFillColor(10);
   lego->SetTextSize(0.035);
   lego->SetTextFont(42);
   lego->SetFillColor(10);
   lego->SetLineColor(10);
-  if(nFiles>3){
+  if (nFiles > 3) {
     lego->SetNColumns(2);
   }
   lego->SetShadowColor(10);
 
-  TPaveText *ptDate =new TPaveText(0.12,0.95,0.50,0.99,"blNDC");
+  TPaveText *ptDate = new TPaveText(0.12, 0.95, 0.50, 0.99, "blNDC");
   //ptDate->SetFillColor(kYellow);
   ptDate->SetFillColor(10);
   ptDate->SetBorderSize(1);
@@ -2089,31 +2446,30 @@ void arrangeFitCanvas(TCanvas *canv,TH1F* meanplots[100],Int_t nFiles, TString L
   textDate->SetTextSize(0.04);
   textDate->SetTextColor(kBlue);
 
-  TF1 *fleft[nFiles]; 
+  TF1 *fleft[nFiles];
   TF1 *fright[nFiles];
-  TF1 *fall[nFiles];  
+  TF1 *fall[nFiles];
 
   TF1 *FitDzUp[nFiles];
   TF1 *FitDzDown[nFiles];
 
-  for(Int_t j=0;j<nFiles;j++){
-    
+  for (Int_t j = 0; j < nFiles; j++) {
     Double_t deltaZ(0);
     Double_t sigmadeltaZ(-1);
 
-    TCanvas *theNewCanvas2 = new TCanvas("NewCanvas2","Fitting Canvas 2",800,600);
-    theNewCanvas2->Divide(2,1);
+    TCanvas *theNewCanvas2 = new TCanvas("NewCanvas2", "Fitting Canvas 2", 800, 600);
+    theNewCanvas2->Divide(2, 1);
 
-    TH1F *hnewUp   = (TH1F*)meanplots[j]->Clone("hnewUp_dz_phi");
-    TH1F *hnewDown = (TH1F*)meanplots[j]->Clone("hnewDown_dz_phi");
-    
-    fleft[j]  = new TF1(Form("fleft_%i",j),fULine,_boundMin,_boundSx,1);
-    fright[j] = new TF1(Form("fright_%i",j),fULine,_boundDx,_boundMax,1);
-    fall[j]   = new TF1(Form("fall_%i",j),fDLine,_boundSx,_boundDx,1);
-    
-    FitULine(hnewUp);  
-    FitDzUp[j]   = (TF1*)hnewUp->GetListOfFunctions()->FindObject("lineUp"); 
-    if(FitDzUp[j]){
+    TH1F *hnewUp = (TH1F *)meanplots[j]->Clone("hnewUp_dz_phi");
+    TH1F *hnewDown = (TH1F *)meanplots[j]->Clone("hnewDown_dz_phi");
+
+    fleft[j] = new TF1(Form("fleft_%i", j), fULine, _boundMin, _boundSx, 1);
+    fright[j] = new TF1(Form("fright_%i", j), fULine, _boundDx, _boundMax, 1);
+    fall[j] = new TF1(Form("fall_%i", j), fDLine, _boundSx, _boundDx, 1);
+
+    FitULine(hnewUp);
+    FitDzUp[j] = (TF1 *)hnewUp->GetListOfFunctions()->FindObject("lineUp");
+    if (FitDzUp[j]) {
       fleft[j]->SetParameters(FitDzUp[j]->GetParameters());
       fleft[j]->SetParErrors(FitDzUp[j]->GetParErrors());
       hnewUp->GetListOfFunctions()->Add(fleft[j]);
@@ -2123,95 +2479,94 @@ void arrangeFitCanvas(TCanvas *canv,TH1F* meanplots[100],Int_t nFiles, TString L
       FitDzUp[j]->Delete();
 
       theNewCanvas2->cd(1);
-      MakeNiceTF1Style(fright[j],meanplots[j]->GetLineColor());
-      MakeNiceTF1Style(fleft[j],meanplots[j]->GetLineColor());
+      MakeNiceTF1Style(fright[j], meanplots[j]->GetLineColor());
+      MakeNiceTF1Style(fleft[j], meanplots[j]->GetLineColor());
       fright[j]->Draw("same");
       fleft[j]->Draw("same");
     }
-    
-    FitDLine(hnewDown);  
-    FitDzDown[j] = (TF1*)hnewDown->GetListOfFunctions()->FindObject("lineDown");    
-    
-    if(FitDzDown[j]){
+
+    FitDLine(hnewDown);
+    FitDzDown[j] = (TF1 *)hnewDown->GetListOfFunctions()->FindObject("lineDown");
+
+    if (FitDzDown[j]) {
       fall[j]->SetParameters(FitDzDown[j]->GetParameters());
       fall[j]->SetParErrors(FitDzDown[j]->GetParErrors());
       hnewDown->GetListOfFunctions()->Add(fall[j]);
       FitDzDown[j]->Delete();
       theNewCanvas2->cd(2);
-      MakeNiceTF1Style(fall[j],meanplots[j]->GetLineColor());
+      MakeNiceTF1Style(fall[j], meanplots[j]->GetLineColor());
       fall[j]->Draw("same");
       canv->cd();
       hnewUp->GetYaxis()->SetTitleOffset(0.7);
-      if(j==0){
-	hnewUp->Draw();
-	makeNewXAxis(hnewUp);
+      if (j == 0) {
+        hnewUp->Draw();
+        makeNewXAxis(hnewUp);
       } else {
-	hnewUp->Draw("same");
-	makeNewXAxis(hnewUp);
-      } 
+        hnewUp->Draw("same");
+        makeNewXAxis(hnewUp);
+      }
       fright[j]->Draw("sames");
       fleft[j]->Draw("same");
       fall[j]->Draw("same");
     }
-    
-    if(j==nFiles-1){
+
+    if (j == nFiles - 1) {
       theNewCanvas2->Close();
     }
-    
-    deltaZ=(fright[j]->GetParameter(0) - fall[j]->GetParameter(0))/2;
-    sigmadeltaZ=0.5*TMath::Sqrt(fright[j]->GetParError(0)*fright[j]->GetParError(0) + fall[j]->GetParError(0)*fall[j]->GetParError(0));
-    TString MYOUT = Form(" : #Delta z = %.f #pm %.f #mum",deltaZ,sigmadeltaZ);
-    
-    lego->AddEntry(meanplots[j],LegLabels[j]+MYOUT);
 
-    if(j==nFiles-1){ 
-      outfile <<deltaZ<<"|"<<sigmadeltaZ<<endl;
+    deltaZ = (fright[j]->GetParameter(0) - fall[j]->GetParameter(0)) / 2;
+    sigmadeltaZ = 0.5 * TMath::Sqrt(fright[j]->GetParError(0) * fright[j]->GetParError(0) +
+                                    fall[j]->GetParError(0) * fall[j]->GetParError(0));
+    TString MYOUT = Form(" : #Delta z = %.f #pm %.f #mum", deltaZ, sigmadeltaZ);
+
+    lego->AddEntry(meanplots[j], LegLabels[j] + MYOUT);
+
+    if (j == nFiles - 1) {
+      outfile << deltaZ << "|" << sigmadeltaZ << endl;
     }
-    
-    delete theNewCanvas2;
 
+    delete theNewCanvas2;
   }
- 
+
   //TkAlStyle::drawStandardTitle(Coll0T15);
   lego->Draw("same");
-  CMS_lumi( canv,4,33 );
-  if(theDate!="")
+  CMS_lumi(canv, 4, 33);
+  if (theDate != "")
     ptDate->Draw("same");
   //pt->Draw("same");
 }
 
 //*************************************************************
-std::pair<params::measurement, params::measurement  > fitStudentTResiduals(TH1 *hist)
+std::pair<params::measurement, params::measurement> fitStudentTResiduals(TH1 *hist)
 //*************************************************************
 {
-
   hist->SetMarkerStyle(21);
   hist->SetMarkerSize(0.8);
   hist->SetStats(1);
- 
+
   double dx = hist->GetBinWidth(1);
   double nmax = hist->GetBinContent(hist->GetMaximumBin());
   double xmax = hist->GetBinCenter(hist->GetMaximumBin());
-  double nn = 7*nmax;
-  
+  double nn = 7 * nmax;
+
   int nb = hist->GetNbinsX();
   double n1 = hist->GetBinContent(1);
   double n9 = hist->GetBinContent(nb);
-  double bg = 0.5*(n1+n9);
-  
+  double bg = 0.5 * (n1 + n9);
+
   double x1 = hist->GetBinCenter(1);
   double x9 = hist->GetBinCenter(nb);
-  
+
   // create a TF1 with the range from x1 to x9 and 5 parameters
-  
-  TF1 *tp0Fcn = new TF1("tmp", tp0Fit, x1, x9, 5 );
-  
-  tp0Fcn->SetParName( 0, "mean" );
-  tp0Fcn->SetParName( 1, "sigma" );
-  tp0Fcn->SetParName( 2, "nu" );
-  tp0Fcn->SetParName( 3, "area" );
-  tp0Fcn->SetParName( 4, "BG" );
-  
+
+  TF1 *tp0Fcn = new TF1("tmp", tp0Fit, x1, x9, 5);
+
+  tp0Fcn->SetParName(0, "mean");
+  tp0Fcn->SetParName(1, "sigma");
+  tp0Fcn->SetParName(2, "nu");
+  tp0Fcn->SetParName(3, "area");
+  tp0Fcn->SetParName(4, "BG");
+
   tp0Fcn->SetNpx(500);
   tp0Fcn->SetLineWidth(2);
   //tp0Fcn->SetLineColor(kMagenta);
@@ -2219,69 +2574,69 @@ std::pair<params::measurement, params::measurement  > fitStudentTResiduals(TH1 *
   tp0Fcn->SetLineColor(kRed);
 
   // set start values for some parameters:
-    
-  tp0Fcn->SetParameter( 0, xmax ); // peak position
-  tp0Fcn->SetParameter( 1, 4*dx ); // width
-  tp0Fcn->SetParameter( 2, 2.2 ); // nu
-  tp0Fcn->SetParameter( 3, nn ); // N
-  tp0Fcn->SetParameter( 4, bg );
-  
-  hist->Fit( "tmp", "R", "ep" );
+
+  tp0Fcn->SetParameter(0, xmax);    // peak position
+  tp0Fcn->SetParameter(1, 4 * dx);  // width
+  tp0Fcn->SetParameter(2, 2.2);     // nu
+  tp0Fcn->SetParameter(3, nn);      // N
+  tp0Fcn->SetParameter(4, bg);
+
+  hist->Fit("tmp", "R", "ep");
   // h->Fit("tmp","V+","ep");
-  
+
   hist->Draw("histepsame");  // data again on top
-  
-  float res_mean  = tp0Fcn->GetParameter(0);
+
+  float res_mean = tp0Fcn->GetParameter(0);
   float res_width = tp0Fcn->GetParameter(1);
-  
-  float res_mean_err  = tp0Fcn->GetParError(0);
+
+  float res_mean_err = tp0Fcn->GetParError(0);
   float res_width_err = tp0Fcn->GetParError(1);
 
   params::measurement resultM;
   params::measurement resultW;
 
-  resultM = std::make_pair(res_mean,res_mean_err);
-  resultW = std::make_pair(res_width,res_width_err);
+  resultM = std::make_pair(res_mean, res_mean_err);
+  resultW = std::make_pair(res_width, res_width_err);
 
-  std::pair<params::measurement, params::measurement  > result;
-  
-  result = std::make_pair(resultM,resultW);
+  std::pair<params::measurement, params::measurement> result;
+
+  result = std::make_pair(resultM, resultW);
   return result;
-
 }
 
 //*************************************************************
-Double_t tp0Fit( Double_t *x, Double_t *par5 ) 
+Double_t tp0Fit(Double_t *x, Double_t *par5)
 //*************************************************************
 {
   static int nn = 0;
   nn++;
   static double dx = 0.1;
   static double b1 = 0;
-  if( nn == 1 ) b1 = x[0];
-  if( nn == 2 ) dx = x[0] - b1;
+  if (nn == 1)
+    b1 = x[0];
+  if (nn == 2)
+    dx = x[0] - b1;
   //
   //--  Mean and width:
   //
   double xm = par5[0];
-  double t = ( x[0] - xm ) / par5[1];
-  double tt = t*t;
+  double t = (x[0] - xm) / par5[1];
+  double tt = t * t;
   //
   //--  exponent:
   //
   double rn = par5[2];
-  double xn = 0.5 * ( rn + 1.0 );
+  double xn = 0.5 * (rn + 1.0);
   //
   //--  Normalization needs Gamma function:
   //
   double pk = 0.0;
 
-  if( rn > 0.0 ) {
-
+  if (rn > 0.0) {
     double pi = 3.14159265358979323846;
-    double aa = dx / par5[1] / sqrt(rn*pi) * TMath::Gamma(xn) / TMath::Gamma(0.5*rn);
+    double aa = dx / par5[1] / sqrt(rn * pi) * TMath::Gamma(xn) / TMath::Gamma(0.5 * rn);
 
-    pk = par5[3] * aa * exp( -xn * log( 1.0 + tt/rn ) );
+    pk = par5[3] * aa * exp(-xn * log(1.0 + tt / rn));
   }
 
   return pk + par5[4];
@@ -2298,89 +2653,88 @@ params::measurement getMedian(TH1F *histo)
   double *x = new double[nbins];
   double *y = new double[nbins];
   for (int j = 0; j < nbins; j++) {
-    x[j] = histo->GetBinCenter(j+1);
-    y[j] = histo->GetBinContent(j+1);
+    x[j] = histo->GetBinCenter(j + 1);
+    y[j] = histo->GetBinContent(j + 1);
   }
   median = TMath::Median(nbins, x, y);
-  
-  delete[] x; x = 0;
-  delete [] y; y = 0;  
+
+  delete[] x;
+  x = 0;
+  delete[] y;
+  y = 0;
 
   params::measurement result;
-  result = std::make_pair(median,median/TMath::Sqrt(histo->GetEntries()));
+  result = std::make_pair(median, median / TMath::Sqrt(histo->GetEntries()));
 
   return result;
-
 }
 
 //*************************************************************
 params::measurement getMAD(TH1F *histo)
 //*************************************************************
 {
-
   int nbins = histo->GetNbinsX();
   Double_t median = getMedian(histo).first;
-  Double_t x_lastBin = histo->GetBinLowEdge(nbins+1);
-  const char *HistoName =histo->GetName();
-  TString Finalname = Form("resMed%s",HistoName);
-  TH1F *newHisto = new TH1F(Finalname,Finalname,nbins,0.,x_lastBin);
+  Double_t x_lastBin = histo->GetBinLowEdge(nbins + 1);
+  const char *HistoName = histo->GetName();
+  TString Finalname = Form("resMed%s", HistoName);
+  TH1F *newHisto = new TH1F(Finalname, Finalname, nbins, 0., x_lastBin);
   Double_t *residuals = new Double_t[nbins];
   Double_t *weights = new Double_t[nbins];
 
   for (int j = 0; j < nbins; j++) {
-    residuals[j] = TMath::Abs(median - histo->GetBinCenter(j+1));
-    weights[j]=histo->GetBinContent(j+1);
-    newHisto->Fill(residuals[j],weights[j]);
+    residuals[j] = TMath::Abs(median - histo->GetBinCenter(j + 1));
+    weights[j] = histo->GetBinContent(j + 1);
+    newHisto->Fill(residuals[j], weights[j]);
   }
-  
-  Double_t theMAD = (getMedian(newHisto).first)*1.4826;
+
+  Double_t theMAD = (getMedian(newHisto).first) * 1.4826;
   newHisto->Delete("");
-  
+
   params::measurement result;
-  result = std::make_pair(theMAD,theMAD/histo->GetEntries());
+  result = std::make_pair(theMAD, theMAD / histo->GetEntries());
 
   return result;
-
 }
 
 //*************************************************************
-std::pair<params::measurement, params::measurement  > fitResiduals(TH1 *hist,bool singleTime)
+std::pair<params::measurement, params::measurement> fitResiduals(TH1 *hist, bool singleTime)
 //*************************************************************
 {
-  
-  assert(hist!=nullptr) ;
+  assert(hist != nullptr);
 
-  if (hist->GetEntries() < 10){ 
+  if (hist->GetEntries() < 10) {
     // std::cout<<"hist name: "<<hist->GetName() << std::endl;
-    return std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));
+    return std::make_pair(std::make_pair(0., 0.), std::make_pair(0., 0.));
   }
-  
+
   float maxHist = hist->GetXaxis()->GetXmax();
   float minHist = hist->GetXaxis()->GetXmin();
-  float mean  = hist->GetMean();
+  float mean = hist->GetMean();
   float sigma = hist->GetRMS();
-  
-  if(TMath::IsNaN(mean) || TMath::IsNaN(sigma)){  
-    mean=0;
+
+  if (TMath::IsNaN(mean) || TMath::IsNaN(sigma)) {
+    mean = 0;
     //sigma= - hist->GetXaxis()->GetBinLowEdge(1) + hist->GetXaxis()->GetBinLowEdge(hist->GetNbinsX()+1);
-    sigma = - minHist + maxHist;
-    std::cout<< "FitPVResiduals::fitResiduals(): histogram" << hist->GetName()  << " mean or sigma are NaN!!"<< std::endl;
+    sigma = -minHist + maxHist;
+    std::cout << "FitPVResiduals::fitResiduals(): histogram" << hist->GetName() << " mean or sigma are NaN!!"
+              << std::endl;
   }
 
-  TF1 func("tmp", "gaus", mean - 2.*sigma, mean + 2.*sigma); 
-  if (0 == hist->Fit(&func,"QNR")) { // N: do not blow up file by storing fit!
-    mean  = func.GetParameter(1);
+  TF1 func("tmp", "gaus", mean - 2. * sigma, mean + 2. * sigma);
+  if (0 == hist->Fit(&func, "QNR")) {  // N: do not blow up file by storing fit!
+    mean = func.GetParameter(1);
     sigma = func.GetParameter(2);
 
-    if(!singleTime){
+    if (!singleTime) {
       // second fit: three sigma of first fit around mean of first fit
-      func.SetRange(std::max(mean - 2*sigma,minHist),std::min(mean + 2*sigma,maxHist));
+      func.SetRange(std::max(mean - 2 * sigma, minHist), std::min(mean + 2 * sigma, maxHist));
       // I: integral gives more correct results if binning is too wide
       // L: Likelihood can treat empty bins correctly (if hist not weighted...)
       if (0 == hist->Fit(&func, "Q0LR")) {
-	if (hist->GetFunction(func.GetName())) { // Take care that it is later on drawn:
-	  hist->GetFunction(func.GetName())->ResetBit(TF1::kNotDraw);
-	}
+        if (hist->GetFunction(func.GetName())) {  // Take care that it is later on drawn:
+          hist->GetFunction(func.GetName())->ResetBit(TF1::kNotDraw);
+        }
       }
     }
   }
@@ -2402,93 +2756,92 @@ std::pair<params::measurement, params::measurement  > fitResiduals(TH1 *hist,boo
   
   result = std::make_pair(resultM,resultW);
   */
-  return std::make_pair(std::make_pair(func.GetParameter(1),func.GetParError(1)),std::make_pair(func.GetParameter(2),func.GetParError(2)));
-
+  return std::make_pair(std::make_pair(func.GetParameter(1), func.GetParError(1)),
+                        std::make_pair(func.GetParameter(2), func.GetParError(2)));
 }
 
 //*************************************************************
-Double_t DoubleSidedCB(double* x, double* par){
-//*************************************************************
+Double_t DoubleSidedCB(double *x, double *par) {
+  //*************************************************************
 
-  double m      = x[0];
-  double m0     = par[0]; 
-  double sigma  = par[1];
+  double m = x[0];
+  double m0 = par[0];
+  double sigma = par[1];
   double alphaL = par[2];
   double alphaR = par[3];
-  double nL     = par[4];
-  double nR     = par[5];
-  double N      = par[6];
+  double nL = par[4];
+  double nR = par[5];
+  double N = par[6];
 
   Double_t arg = m - m0;
-  
+
   if (arg < 0.0) {
-    Double_t t = (m-m0)/sigma; //t < 0
-    Double_t absAlpha = fabs((Double_t)alphaL); //slightly redundant since alpha > 0 anyway, but never mind
-    if (t >= -absAlpha) { //-absAlpha <= t < 0
-      return N*exp(-0.5*t*t);
+    Double_t t = (m - m0) / sigma;               //t < 0
+    Double_t absAlpha = fabs((Double_t)alphaL);  //slightly redundant since alpha > 0 anyway, but never mind
+    if (t >= -absAlpha) {                        //-absAlpha <= t < 0
+      return N * exp(-0.5 * t * t);
     } else {
-      Double_t a = TMath::Power(nL/absAlpha,nL)*exp(-0.5*absAlpha*absAlpha);
-      Double_t b = nL/absAlpha - absAlpha;
-      return N*(a/TMath::Power(b - t, nL)); //b - t
+      Double_t a = TMath::Power(nL / absAlpha, nL) * exp(-0.5 * absAlpha * absAlpha);
+      Double_t b = nL / absAlpha - absAlpha;
+      return N * (a / TMath::Power(b - t, nL));  //b - t
     }
   } else {
-    Double_t t = (m-m0)/sigma; //t > 0
+    Double_t t = (m - m0) / sigma;  //t > 0
     Double_t absAlpha = fabs((Double_t)alphaR);
-    if (t <= absAlpha) { //0 <= t <= absAlpha
-      return N*exp(-0.5*t*t);
+    if (t <= absAlpha) {  //0 <= t <= absAlpha
+      return N * exp(-0.5 * t * t);
     } else {
-      Double_t a = TMath::Power(nR/absAlpha,nR)*exp(-0.5*absAlpha*absAlpha);
-      Double_t b = nR/absAlpha - absAlpha;   
-      return N*(a/TMath::Power(b + t, nR)); //b + t
+      Double_t a = TMath::Power(nR / absAlpha, nR) * exp(-0.5 * absAlpha * absAlpha);
+      Double_t b = nR / absAlpha - absAlpha;
+      return N * (a / TMath::Power(b + t, nR));  //b + t
     }
   }
 }
 
 //*************************************************************
-std::pair<params::measurement, params::measurement  > fitResidualsCB(TH1 *hist)
+std::pair<params::measurement, params::measurement> fitResidualsCB(TH1 *hist)
 //*************************************************************
 {
-  
   //hist->Rebin(2);
 
-  float mean  = hist->GetMean();
+  float mean = hist->GetMean();
   float sigma = hist->GetRMS();
   //int   nbinsX   = hist->GetNbinsX();
   float nentries = hist->GetEntries();
-  float meanerr  = sigma/TMath::Sqrt(nentries);
-  float sigmaerr = TMath::Sqrt(sigma*sigma*TMath::Sqrt(2/nentries));
+  float meanerr = sigma / TMath::Sqrt(nentries);
+  float sigmaerr = TMath::Sqrt(sigma * sigma * TMath::Sqrt(2 / nentries));
 
-  float lowBound  = hist->GetXaxis()->GetBinLowEdge(1);
-  float highBound = hist->GetXaxis()->GetBinLowEdge(hist->GetNbinsX()+1);
+  float lowBound = hist->GetXaxis()->GetBinLowEdge(1);
+  float highBound = hist->GetXaxis()->GetBinLowEdge(hist->GetNbinsX() + 1);
 
-  if(TMath::IsNaN(mean) || TMath::IsNaN(sigma)){  
-    mean=0;
-    sigma= - lowBound + highBound;
+  if (TMath::IsNaN(mean) || TMath::IsNaN(sigma)) {
+    mean = 0;
+    sigma = -lowBound + highBound;
   }
-  
-  TF1 func("tmp", "gaus", mean - 1.*sigma, mean + 1.*sigma); 
-  if (0 == hist->Fit(&func,"QNR")) { // N: do not blow up file by storing fit!
-    mean  = func.GetParameter(1);
+
+  TF1 func("tmp", "gaus", mean - 1. * sigma, mean + 1. * sigma);
+  if (0 == hist->Fit(&func, "QNR")) {  // N: do not blow up file by storing fit!
+    mean = func.GetParameter(1);
     sigma = func.GetParameter(2);
   }
-  
-  // first round
-  TF1 *doubleCB = new TF1("myDoubleCB",DoubleSidedCB,lowBound,highBound,7);
-  doubleCB->SetParameters(mean,sigma,1.5,1.5,2.5,2.5,100);
-  doubleCB->SetParLimits(0,mean-meanerr,mean+meanerr);
-  doubleCB->SetParLimits(1,0.,sigma+2*sigmaerr);
-  doubleCB->SetParLimits(2,0.,30.);
-  doubleCB->SetParLimits(3,0.,30.);
-  doubleCB->SetParLimits(4,0.,50.);
-  doubleCB->SetParLimits(5,0.,50.);
-  doubleCB->SetParLimits(6,0.,100*nentries);
 
-  doubleCB->SetParNames("#mu","#sigma","#alpha_{L}","#alpha_{R}","n_{L}","n_{R}","N");
+  // first round
+  TF1 *doubleCB = new TF1("myDoubleCB", DoubleSidedCB, lowBound, highBound, 7);
+  doubleCB->SetParameters(mean, sigma, 1.5, 1.5, 2.5, 2.5, 100);
+  doubleCB->SetParLimits(0, mean - meanerr, mean + meanerr);
+  doubleCB->SetParLimits(1, 0., sigma + 2 * sigmaerr);
+  doubleCB->SetParLimits(2, 0., 30.);
+  doubleCB->SetParLimits(3, 0., 30.);
+  doubleCB->SetParLimits(4, 0., 50.);
+  doubleCB->SetParLimits(5, 0., 50.);
+  doubleCB->SetParLimits(6, 0., 100 * nentries);
+
+  doubleCB->SetParNames("#mu", "#sigma", "#alpha_{L}", "#alpha_{R}", "n_{L}", "n_{R}", "N");
   doubleCB->SetLineColor(kRed);
   doubleCB->SetNpx(1000);
   // doubleCB->SetRange(0.8*lowBound,0.8*highBound);
 
-  hist->Fit(doubleCB,"QM");
+  hist->Fit(doubleCB, "QM");
 
   // second round
 
@@ -2499,7 +2852,7 @@ std::pair<params::measurement, params::measurement  > fitResidualsCB(TH1 *hist)
   float p4 = doubleCB->GetParameter(4);
   float p5 = doubleCB->GetParameter(5);
   float p6 = doubleCB->GetParameter(6);
-  
+
   float p0err = doubleCB->GetParError(0);
   float p1err = doubleCB->GetParError(1);
   float p2err = doubleCB->GetParError(2);
@@ -2508,10 +2861,9 @@ std::pair<params::measurement, params::measurement  > fitResidualsCB(TH1 *hist)
   float p5err = doubleCB->GetParError(5);
   float p6err = doubleCB->GetParError(6);
 
-  if( (doubleCB->GetChisquare()/doubleCB->GetNDF()) >5){
-
-    std::cout<<"------------------------"<<std::endl;
-    std::cout<<"chi2 1st:"<<doubleCB->GetChisquare()<<std::endl;
+  if ((doubleCB->GetChisquare() / doubleCB->GetNDF()) > 5) {
+    std::cout << "------------------------" << std::endl;
+    std::cout << "chi2 1st:" << doubleCB->GetChisquare() << std::endl;
 
     //std::cout<<"p0: "<<p0<<"+/-"<<p0err<<std::endl;
     //std::cout<<"p1: "<<p1<<"+/-"<<p1err<<std::endl;
@@ -2521,153 +2873,154 @@ std::pair<params::measurement, params::measurement  > fitResidualsCB(TH1 *hist)
     //std::cout<<"p5: "<<p5<<"+/-"<<p5err<<std::endl;
     //std::cout<<"p6: "<<p6<<"+/-"<<p6err<<std::endl;
 
-    doubleCB->SetParameters(p0,p1,3,3,6,6,p6);
-    doubleCB->SetParLimits(0,p0-2*p0err,p0+2*p0err);
-    doubleCB->SetParLimits(1,p1-2*p1err,p0+2*p1err);
-    doubleCB->SetParLimits(2,p2-2*p2err,p0+2*p2err);
-    doubleCB->SetParLimits(3,p3-2*p3err,p0+2*p3err);
-    doubleCB->SetParLimits(4,p4-2*p4err,p0+2*p4err);
-    doubleCB->SetParLimits(5,p5-2*p5err,p0+2*p5err);
-    doubleCB->SetParLimits(6,p6-2*p6err,p0+2*p6err);
+    doubleCB->SetParameters(p0, p1, 3, 3, 6, 6, p6);
+    doubleCB->SetParLimits(0, p0 - 2 * p0err, p0 + 2 * p0err);
+    doubleCB->SetParLimits(1, p1 - 2 * p1err, p0 + 2 * p1err);
+    doubleCB->SetParLimits(2, p2 - 2 * p2err, p0 + 2 * p2err);
+    doubleCB->SetParLimits(3, p3 - 2 * p3err, p0 + 2 * p3err);
+    doubleCB->SetParLimits(4, p4 - 2 * p4err, p0 + 2 * p4err);
+    doubleCB->SetParLimits(5, p5 - 2 * p5err, p0 + 2 * p5err);
+    doubleCB->SetParLimits(6, p6 - 2 * p6err, p0 + 2 * p6err);
 
-    hist->Fit(doubleCB,"MQ");
+    hist->Fit(doubleCB, "MQ");
 
     //gMinuit->Command("SCAn 1");
     //TGraph *gr = (TGraph*)gMinuit->GetPlot();
     //gr->SetMarkerStyle(21);
-    //gr->Draw("alp"); 
+    //gr->Draw("alp");
 
-    std::cout<<"chi2 2nd:"<<doubleCB->GetChisquare()<<std::endl;
-    
+    std::cout << "chi2 2nd:" << doubleCB->GetChisquare() << std::endl;
   }
 
-  float res_mean  = doubleCB->GetParameter(0);
+  float res_mean = doubleCB->GetParameter(0);
   float res_width = doubleCB->GetParameter(1);
-  
-  float res_mean_err  = doubleCB->GetParError(0);
+
+  float res_mean_err = doubleCB->GetParError(0);
   float res_width_err = doubleCB->GetParError(1);
 
   params::measurement resultM;
   params::measurement resultW;
 
-  resultM = std::make_pair(res_mean,res_mean_err);
-  resultW = std::make_pair(res_width,res_width_err);
+  resultM = std::make_pair(res_mean, res_mean_err);
+  resultW = std::make_pair(res_width, res_width_err);
 
-  std::pair<params::measurement, params::measurement  > result;
-  
-  result = std::make_pair(resultM,resultW);
+  std::pair<params::measurement, params::measurement> result;
+
+  result = std::make_pair(resultM, resultW);
   return result;
-
 }
 
 //*************************************************************
-void FillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], params::estimator fitPar_, TString var_,Int_t myBins_)
+void FillTrendPlot(TH1F *trendPlot, TH1F *residualsPlot[100], params::estimator fitPar_, TString var_, Int_t myBins_)
 //*************************************************************
 {
-
   //std::cout<<"trendPlot name: "<<trendPlot->GetName()<<std::endl;
 
   // float phiInterval = (360.)/myBins_;
-  float phiInterval = (2*TMath::Pi()/myBins_);
-  float etaInterval = 5./myBins_;
- 
-  for ( int i=0; i<myBins_; ++i ) {
-    
+  float phiInterval = (2 * TMath::Pi() / myBins_);
+  float etaInterval = 5. / myBins_;
+
+  for (int i = 0; i < myBins_; ++i) {
     //int binn = i+1;
 
     char phipositionString[129];
     // float phiposition = (-180+i*phiInterval)+(phiInterval/2);
-    float phiposition = (-TMath::Pi()+i*phiInterval)+(phiInterval/2);
-    sprintf(phipositionString,"%.1f",phiposition);
-    
+    float phiposition = (-TMath::Pi() + i * phiInterval) + (phiInterval / 2);
+    sprintf(phipositionString, "%.1f", phiposition);
+
     char etapositionString[129];
-    float etaposition = (-etaRange+i*etaInterval)+(etaInterval/2);
-    sprintf(etapositionString,"%.1f",etaposition);
+    float etaposition = (-etaRange + i * etaInterval) + (etaInterval / 2);
+    sprintf(etapositionString, "%.1f", etaposition);
 
-    std::pair<params::measurement, params::measurement > myFit = std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));
+    std::pair<params::measurement, params::measurement> myFit =
+        std::make_pair(std::make_pair(0., 0.), std::make_pair(0., 0.));
 
-    if ( ((TString)trendPlot->GetName()).Contains("Norm") ) {
+    if (((TString)trendPlot->GetName()).Contains("Norm")) {
       myFit = fitResiduals(residualsPlot[i]);
     } else {
       // myFit = fitStudentTResiduals(residualsPlot[i]);
       myFit = fitResiduals(residualsPlot[i]);
-     
+
       /*
 	if(TString(residualsPlot[i]->GetName()).Contains("dx") ||
 	TString(residualsPlot[i]->GetName()).Contains("dy")) {
 	std::cout<<residualsPlot[i]->GetName() << " " << myFit.first.first << "+/- " << myFit.first.second  << std::endl; 
 	}
       */
-      
     }
-    
-    switch (fitPar_)
-      {
-      case params::MEAN:
-	{
-	  float mean_      = myFit.first.first;
-	  float meanErr_   = myFit.first.second;
-	  trendPlot->SetBinContent(i+1,mean_);
-	  trendPlot->SetBinError(i+1,meanErr_);
-	  break;
-	} 
-      case params::WIDTH:
-	{
-	  float width_     = myFit.second.first;
-	  float widthErr_  = myFit.second.second;
-	  trendPlot->SetBinContent(i+1,width_);
-	  trendPlot->SetBinError(i+1,widthErr_);
-	  break;
-	} 
-      case params::MEDIAN:
-	{
-	  float median_    = getMedian(residualsPlot[i]).first;
-	  float medianErr_ = getMedian(residualsPlot[i]).second;
-	  trendPlot->SetBinContent(i+1,median_);
-	  trendPlot->SetBinError(i+1,medianErr_);
-	  break;
-	}
-      case params::MAD:
-	{
-	  float mad_       = getMAD(residualsPlot[i]).first; 
-	  float madErr_    = getMAD(residualsPlot[i]).second;
-	  trendPlot->SetBinContent(i+1,mad_);
-	  trendPlot->SetBinError(i+1,madErr_);
-	  break;
-	} 
-      default:
-	std::cout<<"PrimaryVertexValidation::FillTrendPlot() "<<fitPar_<<" unknown estimator!"<<std::endl;
-	break;
+
+    switch (fitPar_) {
+      case params::MEAN: {
+        float mean_ = myFit.first.first;
+        float meanErr_ = myFit.first.second;
+        trendPlot->SetBinContent(i + 1, mean_);
+        trendPlot->SetBinError(i + 1, meanErr_);
+        break;
       }
+      case params::WIDTH: {
+        float width_ = myFit.second.first;
+        float widthErr_ = myFit.second.second;
+        trendPlot->SetBinContent(i + 1, width_);
+        trendPlot->SetBinError(i + 1, widthErr_);
+        break;
+      }
+      case params::MEDIAN: {
+        float median_ = getMedian(residualsPlot[i]).first;
+        float medianErr_ = getMedian(residualsPlot[i]).second;
+        trendPlot->SetBinContent(i + 1, median_);
+        trendPlot->SetBinError(i + 1, medianErr_);
+        break;
+      }
+      case params::MAD: {
+        float mad_ = getMAD(residualsPlot[i]).first;
+        float madErr_ = getMAD(residualsPlot[i]).second;
+        trendPlot->SetBinContent(i + 1, mad_);
+        trendPlot->SetBinError(i + 1, madErr_);
+        break;
+      }
+      default:
+        std::cout << "PrimaryVertexValidation::FillTrendPlot() " << fitPar_ << " unknown estimator!" << std::endl;
+        break;
+    }
   }
 
   //trendPlot->GetXaxis()->LabelsOption("h");
 
-  if(fitPar_==params::MEAN || fitPar_==params::MEDIAN){
-
+  if (fitPar_ == params::MEAN || fitPar_ == params::MEDIAN) {
     TString res;
-    if(TString(residualsPlot[0]->GetName()).Contains("dxy")) res="dxy";
-    else if(TString(residualsPlot[0]->GetName()).Contains("dx")) res="dx";
-    else if(TString(residualsPlot[0]->GetName()).Contains("dy")) res="dy";
-    else if(TString(residualsPlot[0]->GetName()).Contains("dz")) res="dz";
-    else if(TString(residualsPlot[0]->GetName()).Contains("IP2D")) res="IP2D";
-    else if(TString(residualsPlot[0]->GetName()).Contains("resz")) res="resz";
-    
-    TCanvas *fitOutput = new TCanvas(Form("fitOutput_%s_%s_%s",res.Data(),var_.Data(),trendPlot->GetName()),Form("fitOutput_%s_%s",res.Data(),var_.Data()),1200,1200);
-    fitOutput->Divide(5,5);
-    
-    TCanvas *fitPulls = new TCanvas(Form("fitPulls_%s_%s_%s",res.Data(),var_.Data(),trendPlot->GetName()),Form("fitPulls_%s_%s",res.Data(),var_.Data()),1200,1200);
-    fitPulls->Divide(5,5);
+    if (TString(residualsPlot[0]->GetName()).Contains("dxy"))
+      res = "dxy";
+    else if (TString(residualsPlot[0]->GetName()).Contains("dx"))
+      res = "dx";
+    else if (TString(residualsPlot[0]->GetName()).Contains("dy"))
+      res = "dy";
+    else if (TString(residualsPlot[0]->GetName()).Contains("dz"))
+      res = "dz";
+    else if (TString(residualsPlot[0]->GetName()).Contains("IP2D"))
+      res = "IP2D";
+    else if (TString(residualsPlot[0]->GetName()).Contains("resz"))
+      res = "resz";
 
-    TH1F* residualsPull[myBins_];
+    TCanvas *fitOutput = new TCanvas(Form("fitOutput_%s_%s_%s", res.Data(), var_.Data(), trendPlot->GetName()),
+                                     Form("fitOutput_%s_%s", res.Data(), var_.Data()),
+                                     1200,
+                                     1200);
+    fitOutput->Divide(5, 5);
 
-    for(Int_t i=0;i<myBins_;i++){
-      
-      TF1 *tmp1 = (TF1*)residualsPlot[i]->GetListOfFunctions()->FindObject("tmp");
-      if(tmp1 && residualsPlot[i]->GetEntries()>0. && residualsPlot[i]->GetMinimum()>0.){   
-	fitOutput->cd(i+1)->SetLogy();
+    TCanvas *fitPulls = new TCanvas(Form("fitPulls_%s_%s_%s", res.Data(), var_.Data(), trendPlot->GetName()),
+                                    Form("fitPulls_%s_%s", res.Data(), var_.Data()),
+                                    1200,
+                                    1200);
+    fitPulls->Divide(5, 5);
+
+    TH1F *residualsPull[myBins_];
+
+    for (Int_t i = 0; i < myBins_; i++) {
+      TF1 *tmp1 = (TF1 *)residualsPlot[i]->GetListOfFunctions()->FindObject("tmp");
+      if (tmp1 && residualsPlot[i]->GetEntries() > 0. && residualsPlot[i]->GetMinimum() > 0.) {
+        fitOutput->cd(i + 1)->SetLogy();
       }
-      fitOutput->cd(i+1)->SetBottomMargin(0.16);
+      fitOutput->cd(i + 1)->SetBottomMargin(0.16);
       //fitOutput->cd(i+1)->SetTopMargin(0.05);
       //residualsPlot[i]->Sumw2();
       MakeNicePlotStyle(residualsPlot[i]);
@@ -2681,9 +3034,9 @@ void FillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], params::estimator 
       //std::cout<<"*********************"<<std::endl;
       //std::cout<<"fitOutput->cd("<<i+1<<")"<<std::endl;
       //std::cout<<"residualsPlot["<<i<<"]->GetTitle() = "<<residualsPlot[i]->GetTitle()<<std::endl;
-      
+
       // -- for chi2 ----
-      TPaveText *pt = new TPaveText(0.13,0.78,0.33,0.88,"NDC");
+      TPaveText *pt = new TPaveText(0.13, 0.78, 0.33, 0.88, "NDC");
       pt->SetFillColor(10);
       pt->SetTextColor(1);
       pt->SetTextSize(0.07);
@@ -2692,51 +3045,55 @@ void FillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], params::estimator 
 
       //TF1 *tmp1 = (TF1*)residualsPlot[i]->GetListOfFunctions()->FindObject("tmp");
       TString MYOUT;
-      if(tmp1){
-	MYOUT = Form("#chi^{2}/ndf=%.1f",tmp1->GetChisquare()/tmp1->GetNDF());
+      if (tmp1) {
+        MYOUT = Form("#chi^{2}/ndf=%.1f", tmp1->GetChisquare() / tmp1->GetNDF());
       } else {
-	MYOUT = "!! no plot !!";
+        MYOUT = "!! no plot !!";
       }
-       
+
       TText *text1 = pt->AddText(MYOUT);
       text1->SetTextFont(72);
       text1->SetTextColor(kBlue);
       pt->Draw("same");
-    
+
       // -- for bins --
-     
-      TPaveText *title = new TPaveText(0.1,0.93,0.8,0.95,"NDC");
+
+      TPaveText *title = new TPaveText(0.1, 0.93, 0.8, 0.95, "NDC");
       title->SetFillColor(10);
       title->SetTextColor(1);
       title->SetTextSize(0.07);
       title->SetTextFont(42);
       title->SetTextAlign(22);
- 
+
       //TText *text2 = title->AddText(residualsPlot[i]->GetTitle());
       //text2->SetTextFont(72);
       //text2->SetTextColor(kBlue);
 
       title->Draw("same");
 
-      fitPulls->cd(i+1);
-      fitPulls->cd(i+1)->SetBottomMargin(0.15);
-      fitPulls->cd(i+1)->SetLeftMargin(0.15); 
-      fitPulls->cd(i+1)->SetRightMargin(0.05); 
- 
-      residualsPull[i]=(TH1F*)residualsPlot[i]->Clone(Form("pull_%s",residualsPlot[i]->GetName()));
-      for(Int_t nbin=1;nbin<=residualsPull[i]->GetNbinsX(); nbin++){
-      	if(residualsPlot[i]->GetBinContent(nbin)!=0 && tmp1){ 
-	  residualsPull[i]->SetBinContent(nbin,(residualsPlot[i]->GetBinContent(nbin) - tmp1->Eval(residualsPlot[i]->GetBinCenter(nbin)))/residualsPlot[i]->GetBinContent(nbin));
-	  residualsPull[i]->SetBinError(nbin,0.1);
-	}
+      fitPulls->cd(i + 1);
+      fitPulls->cd(i + 1)->SetBottomMargin(0.15);
+      fitPulls->cd(i + 1)->SetLeftMargin(0.15);
+      fitPulls->cd(i + 1)->SetRightMargin(0.05);
+
+      residualsPull[i] = (TH1F *)residualsPlot[i]->Clone(Form("pull_%s", residualsPlot[i]->GetName()));
+      for (Int_t nbin = 1; nbin <= residualsPull[i]->GetNbinsX(); nbin++) {
+        if (residualsPlot[i]->GetBinContent(nbin) != 0 && tmp1) {
+          residualsPull[i]->SetBinContent(
+              nbin,
+              (residualsPlot[i]->GetBinContent(nbin) - tmp1->Eval(residualsPlot[i]->GetBinCenter(nbin))) /
+                  residualsPlot[i]->GetBinContent(nbin));
+          residualsPull[i]->SetBinError(nbin, 0.1);
+        }
       }
 
-      TF1* toDel = (TF1*)residualsPull[i]->FindObject("tmp");
-      if(toDel) residualsPull[i]->GetListOfFunctions()->Remove(toDel); 
+      TF1 *toDel = (TF1 *)residualsPull[i]->FindObject("tmp");
+      if (toDel)
+        residualsPull[i]->GetListOfFunctions()->Remove(toDel);
       residualsPull[i]->SetMarkerStyle(20);
       residualsPull[i]->SetMarkerSize(1.);
       residualsPull[i]->SetStats(0);
-			
+
       residualsPull[i]->GetYaxis()->SetTitle("(res-fit)/res");
       // residualsPull[i]->SetOptTitle(1);
       residualsPull[i]->GetXaxis()->SetLabelFont(42);
@@ -2749,268 +3106,252 @@ void FillTrendPlot(TH1F* trendPlot, TH1F* residualsPlot[100], params::estimator 
       residualsPull[i]->GetYaxis()->SetTitleOffset(1.2);
       residualsPull[i]->GetXaxis()->SetTitleFont(42);
       residualsPull[i]->GetYaxis()->SetTitleFont(42);
-      
+
       residualsPull[i]->Draw("e1");
       residualsPull[i]->GetYaxis()->UnZoom();
     }
-    
-    
-    TString tpName =trendPlot->GetName();
 
-    TString FitNameToSame  = Form("fitOutput_%s",(tpName.ReplaceAll("means_","").Data()));
+    TString tpName = trendPlot->GetName();
+
+    TString FitNameToSame = Form("fitOutput_%s", (tpName.ReplaceAll("means_", "").Data()));
     //fitOutput->SaveAs(FitNameToSame+".pdf");
     //fitOutput->SaveAs(FitNameToSame+".png");
-    TString PullNameToSave = Form("fitPulls_%s",(tpName.ReplaceAll("means_","").Data()));
+    TString PullNameToSave = Form("fitPulls_%s", (tpName.ReplaceAll("means_", "").Data()));
     //fitPulls->SaveAs(PullNameToSave+".pdf");
     //fitPulls->SaveAs(PullNameToSave+".png");
-    
-    if(isDebugMode){
-      fitOutput->SaveAs(Form("fitOutput_%s_%s_%s.pdf",res.Data(),var_.Data(),trendPlot->GetName()));
-      fitOutput->SaveAs(Form("fitOutput_%s.pdf",(((TString)trendPlot->GetName()).ReplaceAll("means_","")).Data()));
-      fitPulls->SaveAs(Form("fitPulls_%s.pdf",(((TString)trendPlot->GetName()).ReplaceAll("means_","")).Data()));
-      fitOutput->SaveAs(Form("fitOutput_%s.png",(((TString)trendPlot->GetName()).ReplaceAll("means_","")).Data()));
+
+    if (isDebugMode) {
+      fitOutput->SaveAs(Form("fitOutput_%s_%s_%s.pdf", res.Data(), var_.Data(), trendPlot->GetName()));
+      fitOutput->SaveAs(Form("fitOutput_%s.pdf", (((TString)trendPlot->GetName()).ReplaceAll("means_", "")).Data()));
+      fitPulls->SaveAs(Form("fitPulls_%s.pdf", (((TString)trendPlot->GetName()).ReplaceAll("means_", "")).Data()));
+      fitOutput->SaveAs(Form("fitOutput_%s.png", (((TString)trendPlot->GetName()).ReplaceAll("means_", "")).Data()));
     }
 
     delete fitOutput;
     delete fitPulls;
-
   }
 }
 
 //*************************************************************
-void FillMap_old(TH2F* trendMap, TH1F* residualsMapPlot[48][48], params::estimator fitPar_)
+void FillMap_old(TH2F *trendMap, TH1F *residualsMapPlot[48][48], params::estimator fitPar_)
 //*************************************************************
 {
- 
-  float phiInterval = (360.)/nBins_;
-  float etaInterval = (etaRange*2.0)/nBins_;
-  
-  switch (fitPar_)
-    {
-    case params::MEAN: 
-      {
-	
-	for ( int i=0; i<nBins_; ++i ) {
+  float phiInterval = (360.) / nBins_;
+  float etaInterval = (etaRange * 2.0) / nBins_;
 
-	  char phipositionString[129];
-	  float phiposition = (-180+i*phiInterval)+(phiInterval/2);
-	  sprintf(phipositionString,"%.f",phiposition);
-	  trendMap->GetYaxis()->SetBinLabel(i+1,phipositionString); 
+  switch (fitPar_) {
+    case params::MEAN: {
+      for (int i = 0; i < nBins_; ++i) {
+        char phipositionString[129];
+        float phiposition = (-180 + i * phiInterval) + (phiInterval / 2);
+        sprintf(phipositionString, "%.f", phiposition);
+        trendMap->GetYaxis()->SetBinLabel(i + 1, phipositionString);
 
-	  for ( int j=0; j<nBins_; ++j ) {
+        for (int j = 0; j < nBins_; ++j) {
+          char etapositionString[129];
+          float etaposition = (-etaRange + j * etaInterval) + (etaInterval / 2);
+          sprintf(etapositionString, "%.1f", etaposition);
 
-	    char etapositionString[129];
-	    float etaposition = (-etaRange+j*etaInterval)+(etaInterval/2);
-	    sprintf(etapositionString,"%.1f",etaposition);
-	    
-	    if(i==0) { trendMap->GetXaxis()->SetBinLabel(j+1,etapositionString); }
+          if (i == 0) {
+            trendMap->GetXaxis()->SetBinLabel(j + 1, etapositionString);
+          }
 
-	    std::pair<params::measurement, params::measurement > myFit = std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));
-	    
-	    myFit = fitResiduals(residualsMapPlot[i][j],true);
-	    
-	    float mean_      = myFit.first.first;
-	    float meanErr_   = myFit.first.second;
+          std::pair<params::measurement, params::measurement> myFit =
+              std::make_pair(std::make_pair(0., 0.), std::make_pair(0., 0.));
 
-	    trendMap->SetBinContent(j+1,i+1,mean_);
-	    trendMap->SetBinError(j+1,i+1,meanErr_);
-	  } 
-	}
-	
-	break;
+          myFit = fitResiduals(residualsMapPlot[i][j], true);
+
+          float mean_ = myFit.first.first;
+          float meanErr_ = myFit.first.second;
+
+          trendMap->SetBinContent(j + 1, i + 1, mean_);
+          trendMap->SetBinError(j + 1, i + 1, meanErr_);
+        }
       }
 
-    case params::WIDTH: 
-      { 
-	for ( int i=0; i<nBins_; ++i ) {
-
-	  char phipositionString[129];
-	  float phiposition = (-180+i*phiInterval)+(phiInterval/2);
-	  sprintf(phipositionString,"%.f",phiposition);
-	  trendMap->GetYaxis()->SetBinLabel(i+1,phipositionString);
-
-	  for ( int j=0; j<nBins_; ++j ) {
-	    
-	    char etapositionString[129];
-	    float etaposition = (-etaRange+j*etaInterval)+(etaInterval/2);
-	    sprintf(etapositionString,"%.1f",etaposition);
-	    
-	    if(i==0) { trendMap->GetXaxis()->SetBinLabel(j+1,etapositionString); }
-
-	    std::pair<params::measurement, params::measurement > myFit = std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));	    
-	    myFit = fitResiduals(residualsMapPlot[i][j],true);
-
-	    float width_     = myFit.second.first;
-	    float widthErr_  = myFit.second.second;
-	    trendMap->SetBinContent(j+1,i+1,width_);
-	    trendMap->SetBinError(j+1,i+1,widthErr_);
-	  }
-	} 
-	break;
-      }
-    case params::MEDIAN: 
-      {
-    
-	for ( int i=0; i<nBins_; ++i ) {
-
-	  char phipositionString[129];
-	  float phiposition = (-180+i*phiInterval)+(phiInterval/2);
-	  sprintf(phipositionString,"%.f",phiposition);
-	  trendMap->GetYaxis()->SetBinLabel(i+1,phipositionString);
-
-	  for ( int j=0; j<nBins_; ++j ) {
-	    
-	    char etapositionString[129];
-	    float etaposition = (-etaRange+j*etaInterval)+(etaInterval/2);
-	    sprintf(etapositionString,"%.1f",etaposition);
-
-	    if(i==0) { trendMap->GetXaxis()->SetBinLabel(j+1,etapositionString); }
-	    
-	    float median_    = getMedian(residualsMapPlot[i][j]).first;
-	    float medianErr_ = getMedian(residualsMapPlot[i][j]).second;
-	    trendMap->SetBinContent(j+1,i+1,median_);
-	    trendMap->SetBinError(j+1,i+1,medianErr_);
-	  } 
-	}
-	break;
-      }
-    case params::MAD: 
-      {
-    
-	for ( int i=0; i<nBins_; ++i ) {
-	  
-	  char phipositionString[129];
-	  float phiposition = (-180+i*phiInterval)+(phiInterval/2);
-	  sprintf(phipositionString,"%.f",phiposition);
-	  trendMap->GetYaxis()->SetBinLabel(i+1,phipositionString);
-	  
-	  for ( int j=0; j<nBins_; ++j ) {
-	    
-	    char etapositionString[129];
-	    float etaposition = (-etaRange+j*etaInterval)+(etaInterval/2);
-	    sprintf(etapositionString,"%.1f",etaposition);
-
-	    if(i==0) { trendMap->GetXaxis()->SetBinLabel(j+1,etapositionString); }
-	    
-	    float mad_       = getMAD(residualsMapPlot[i][j]).first; 
-	    float madErr_    = getMAD(residualsMapPlot[i][j]).second;
-	    trendMap->SetBinContent(j+1,i+1,mad_);
-	    trendMap->SetBinError(j+1,i+1,madErr_);
-	  }
-	}
-	break;
-      }
-    default: 
-      std::cout<<"FitPVResiduals::FillMap() "<<fitPar_<<" unknown estimator!"<<std::endl;
-      break;  
+      break;
     }
+
+    case params::WIDTH: {
+      for (int i = 0; i < nBins_; ++i) {
+        char phipositionString[129];
+        float phiposition = (-180 + i * phiInterval) + (phiInterval / 2);
+        sprintf(phipositionString, "%.f", phiposition);
+        trendMap->GetYaxis()->SetBinLabel(i + 1, phipositionString);
+
+        for (int j = 0; j < nBins_; ++j) {
+          char etapositionString[129];
+          float etaposition = (-etaRange + j * etaInterval) + (etaInterval / 2);
+          sprintf(etapositionString, "%.1f", etaposition);
+
+          if (i == 0) {
+            trendMap->GetXaxis()->SetBinLabel(j + 1, etapositionString);
+          }
+
+          std::pair<params::measurement, params::measurement> myFit =
+              std::make_pair(std::make_pair(0., 0.), std::make_pair(0., 0.));
+          myFit = fitResiduals(residualsMapPlot[i][j], true);
+
+          float width_ = myFit.second.first;
+          float widthErr_ = myFit.second.second;
+          trendMap->SetBinContent(j + 1, i + 1, width_);
+          trendMap->SetBinError(j + 1, i + 1, widthErr_);
+        }
+      }
+      break;
+    }
+    case params::MEDIAN: {
+      for (int i = 0; i < nBins_; ++i) {
+        char phipositionString[129];
+        float phiposition = (-180 + i * phiInterval) + (phiInterval / 2);
+        sprintf(phipositionString, "%.f", phiposition);
+        trendMap->GetYaxis()->SetBinLabel(i + 1, phipositionString);
+
+        for (int j = 0; j < nBins_; ++j) {
+          char etapositionString[129];
+          float etaposition = (-etaRange + j * etaInterval) + (etaInterval / 2);
+          sprintf(etapositionString, "%.1f", etaposition);
+
+          if (i == 0) {
+            trendMap->GetXaxis()->SetBinLabel(j + 1, etapositionString);
+          }
+
+          float median_ = getMedian(residualsMapPlot[i][j]).first;
+          float medianErr_ = getMedian(residualsMapPlot[i][j]).second;
+          trendMap->SetBinContent(j + 1, i + 1, median_);
+          trendMap->SetBinError(j + 1, i + 1, medianErr_);
+        }
+      }
+      break;
+    }
+    case params::MAD: {
+      for (int i = 0; i < nBins_; ++i) {
+        char phipositionString[129];
+        float phiposition = (-180 + i * phiInterval) + (phiInterval / 2);
+        sprintf(phipositionString, "%.f", phiposition);
+        trendMap->GetYaxis()->SetBinLabel(i + 1, phipositionString);
+
+        for (int j = 0; j < nBins_; ++j) {
+          char etapositionString[129];
+          float etaposition = (-etaRange + j * etaInterval) + (etaInterval / 2);
+          sprintf(etapositionString, "%.1f", etaposition);
+
+          if (i == 0) {
+            trendMap->GetXaxis()->SetBinLabel(j + 1, etapositionString);
+          }
+
+          float mad_ = getMAD(residualsMapPlot[i][j]).first;
+          float madErr_ = getMAD(residualsMapPlot[i][j]).second;
+          trendMap->SetBinContent(j + 1, i + 1, mad_);
+          trendMap->SetBinError(j + 1, i + 1, madErr_);
+        }
+      }
+      break;
+    }
+    default:
+      std::cout << "FitPVResiduals::FillMap() " << fitPar_ << " unknown estimator!" << std::endl;
+      break;
+  }
 }
 
 //*************************************************************
-void FillMap(TH2F* trendMap, std::vector<std::vector<TH1F* > >residualsMapPlot, params::estimator fitPar_)
+void FillMap(TH2F *trendMap, std::vector<std::vector<TH1F *> > residualsMapPlot, params::estimator fitPar_)
 //*************************************************************
 {
- 
-  float phiInterval = (360.)/nBins_;
-  float etaInterval = 5./nBins_;
+  float phiInterval = (360.) / nBins_;
+  float etaInterval = 5. / nBins_;
 
-  for ( int i=0; i<nBins_; ++i ) {
-    
+  for (int i = 0; i < nBins_; ++i) {
     char phipositionString[129];
-    float phiposition = (-180+i*phiInterval)+(phiInterval/2);
-    sprintf(phipositionString,"%.f",phiposition);
-    
-    trendMap->GetYaxis()->SetBinLabel(i+1,phipositionString); 
+    float phiposition = (-180 + i * phiInterval) + (phiInterval / 2);
+    sprintf(phipositionString, "%.f", phiposition);
 
-    for ( int j=0; j<nBins_; ++j ) {
-      
+    trendMap->GetYaxis()->SetBinLabel(i + 1, phipositionString);
+
+    for (int j = 0; j < nBins_; ++j) {
       //cout<<"(i,j)="<<i<<","<<j<<endl;
 
       char etapositionString[129];
-      float etaposition = (-etaRange+j*etaInterval)+(etaInterval/2);
-      sprintf(etapositionString,"%.1f",etaposition);
+      float etaposition = (-etaRange + j * etaInterval) + (etaInterval / 2);
+      sprintf(etapositionString, "%.1f", etaposition);
 
-      if(i==0) { trendMap->GetXaxis()->SetBinLabel(j+1,etapositionString); }
+      if (i == 0) {
+        trendMap->GetXaxis()->SetBinLabel(j + 1, etapositionString);
+      }
 
-      std::pair<params::measurement, params::measurement > myFit = std::make_pair(std::make_pair(0.,0.),std::make_pair(0.,0.));
-      
-      myFit = fitResiduals(residualsMapPlot[i][j],true);
+      std::pair<params::measurement, params::measurement> myFit =
+          std::make_pair(std::make_pair(0., 0.), std::make_pair(0., 0.));
+
+      myFit = fitResiduals(residualsMapPlot[i][j], true);
 
       // check if plot is normalized
       bool isNormalized = false;
-      if ( ((TString)trendMap->GetName()).Contains("Norm") )
-	isNormalized = true;
+      if (((TString)trendMap->GetName()).Contains("Norm"))
+        isNormalized = true;
 
-      switch (fitPar_)
-	{ 
-	case params::MEAN:
-	  {
-	    Double_t mean_      = myFit.first.first;
+      switch (fitPar_) {
+        case params::MEAN: {
+          Double_t mean_ = myFit.first.first;
 
-	    // do not allow crazy values 
-	    if(!isNormalized)
-	      mean_ = (mean_ > 0.) ? std::min(mean_,100.) : std::max(mean_,-100.);
-	    else 
-	      mean_ = (mean_ > 0.) ? std::min(mean_,2.) : std::max(mean_,-2.);
+          // do not allow crazy values
+          if (!isNormalized)
+            mean_ = (mean_ > 0.) ? std::min(mean_, 100.) : std::max(mean_, -100.);
+          else
+            mean_ = (mean_ > 0.) ? std::min(mean_, 2.) : std::max(mean_, -2.);
 
-	    float meanErr_   = myFit.first.second;
-	    //std::cout<<"bin i: "<<i<<" bin j: "<<j<<" mean: "<<mean_<<"+/-"<<meanErr_<<endl;
-	    trendMap->SetBinContent(j+1,i+1,mean_);
-	    trendMap->SetBinError(j+1,i+1,meanErr_);
-	    break;
-	  }
-	case params::WIDTH:
-	  {
-	    
-	    Double_t width_     = myFit.second.first;
+          float meanErr_ = myFit.first.second;
+          //std::cout<<"bin i: "<<i<<" bin j: "<<j<<" mean: "<<mean_<<"+/-"<<meanErr_<<endl;
+          trendMap->SetBinContent(j + 1, i + 1, mean_);
+          trendMap->SetBinError(j + 1, i + 1, meanErr_);
+          break;
+        }
+        case params::WIDTH: {
+          Double_t width_ = myFit.second.first;
 
-	    // do not allow crazy values 
-	    if(!isNormalized)
-	      width_ = std::min(width_,1500.);
-	    else 
-	      width_ = std::min(width_,3.); 
+          // do not allow crazy values
+          if (!isNormalized)
+            width_ = std::min(width_, 1500.);
+          else
+            width_ = std::min(width_, 3.);
 
-	    float widthErr_  = myFit.second.second;
-	    trendMap->SetBinContent(j+1,i+1,width_);
-	    trendMap->SetBinError(j+1,i+1,widthErr_);
-	    break;
-	    //std::cout<<"bin i: "<<i<<" bin j: "<<j<<" width: "<<width_<<"+/-"<<widthErr_<<endl;
-	  }
-	case params::MEDIAN:
-	  {
-	    float median_    = getMedian(residualsMapPlot[i][j]).first;
-	    float medianErr_ = getMedian(residualsMapPlot[i][j]).second;
-	    trendMap->SetBinContent(j+1,i+1,median_);
-	    trendMap->SetBinError(j+1,i+1,medianErr_);
-	    break;
-	  } 
-	case params::MAD:
-	  {
-	    float mad_       = getMAD(residualsMapPlot[i][j]).first; 
-	    float madErr_    = getMAD(residualsMapPlot[i][j]).second;
-	    trendMap->SetBinContent(j+1,i+1,mad_);
-	    trendMap->SetBinError(j+1,i+1,madErr_);
-	    break;
-	  }
-	default:
-	  std::cout<<"FitPVResiduals::FillMap() "<<fitPar_<<" unknown estimator!"<<std::endl;
-	  break;
-	} // closes the switch statement
-    } // closes loop on eta bins
-  } // cloeses loop on phi bins
+          float widthErr_ = myFit.second.second;
+          trendMap->SetBinContent(j + 1, i + 1, width_);
+          trendMap->SetBinError(j + 1, i + 1, widthErr_);
+          break;
+          //std::cout<<"bin i: "<<i<<" bin j: "<<j<<" width: "<<width_<<"+/-"<<widthErr_<<endl;
+        }
+        case params::MEDIAN: {
+          float median_ = getMedian(residualsMapPlot[i][j]).first;
+          float medianErr_ = getMedian(residualsMapPlot[i][j]).second;
+          trendMap->SetBinContent(j + 1, i + 1, median_);
+          trendMap->SetBinError(j + 1, i + 1, medianErr_);
+          break;
+        }
+        case params::MAD: {
+          float mad_ = getMAD(residualsMapPlot[i][j]).first;
+          float madErr_ = getMAD(residualsMapPlot[i][j]).second;
+          trendMap->SetBinContent(j + 1, i + 1, mad_);
+          trendMap->SetBinError(j + 1, i + 1, madErr_);
+          break;
+        }
+        default:
+          std::cout << "FitPVResiduals::FillMap() " << fitPar_ << " unknown estimator!" << std::endl;
+          break;
+      }  // closes the switch statement
+    }    // closes loop on eta bins
+  }      // cloeses loop on phi bins
 }
 
 /*--------------------------------------------------------------------*/
-void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color,Int_t style)
+void MakeNiceTrendPlotStyle(TH1 *hist, Int_t color, Int_t style)
 /*--------------------------------------------------------------------*/
-{ 
-
-  hist->SetStats(kFALSE);  
+{
+  hist->SetStats(kFALSE);
   hist->SetLineWidth(2);
   hist->GetXaxis()->CenterTitle(true);
   hist->GetYaxis()->CenterTitle(true);
-  hist->GetXaxis()->SetTitleFont(42); 
-  hist->GetYaxis()->SetTitleFont(42);  
+  hist->GetXaxis()->SetTitleFont(42);
+  hist->GetYaxis()->SetTitleFont(42);
   hist->GetXaxis()->SetTitleSize(0.065);
   hist->GetYaxis()->SetTitleSize(0.065);
   hist->GetXaxis()->SetTitleOffset(1.0);
@@ -3020,29 +3361,28 @@ void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color,Int_t style)
   hist->GetYaxis()->SetLabelSize(.05);
   hist->GetXaxis()->SetLabelSize(.07);
   //hist->GetXaxis()->SetNdivisions(505);
-  if(color!=8){
+  if (color != 8) {
     hist->SetMarkerSize(1.0);
   } else {
     hist->SetLineWidth(3);
-    hist->SetMarkerSize(0.0);    
+    hist->SetMarkerSize(0.0);
   }
   hist->SetMarkerStyle(style);
   hist->SetLineColor(color);
   hist->SetMarkerColor(color);
-
 }
 
 /*--------------------------------------------------------------------*/
 void MakeNicePlotStyle(TH1 *hist)
 /*--------------------------------------------------------------------*/
-{ 
-  hist->SetStats(kFALSE);  
+{
+  hist->SetStats(kFALSE);
   hist->SetLineWidth(2);
   hist->GetXaxis()->SetNdivisions(505);
   hist->GetXaxis()->CenterTitle(true);
   hist->GetYaxis()->CenterTitle(true);
-  hist->GetXaxis()->SetTitleFont(42); 
-  hist->GetYaxis()->SetTitleFont(42);  
+  hist->GetXaxis()->SetTitleFont(42);
+  hist->GetYaxis()->SetTitleFont(42);
   hist->GetXaxis()->SetTitleSize(0.07);
   hist->GetYaxis()->SetTitleSize(0.07);
   hist->GetXaxis()->SetTitleOffset(0.9);
@@ -3057,14 +3397,14 @@ void MakeNicePlotStyle(TH1 *hist)
 void MakeNiceMapStyle(TH2 *hist)
 /*--------------------------------------------------------------------*/
 {
-  hist->SetStats(kFALSE);  
+  hist->SetStats(kFALSE);
   hist->GetXaxis()->CenterTitle(true);
   hist->GetYaxis()->CenterTitle(true);
   hist->GetZaxis()->CenterTitle(true);
-  hist->GetXaxis()->SetTitleFont(42); 
+  hist->GetXaxis()->SetTitleFont(42);
   hist->GetYaxis()->SetTitleFont(42);
   hist->GetXaxis()->LabelsOption("v");
-  hist->GetZaxis()->SetTitleFont(42);  
+  hist->GetZaxis()->SetTitleFont(42);
   hist->GetXaxis()->SetTitleSize(0.06);
   hist->GetYaxis()->SetTitleSize(0.06);
   hist->GetZaxis()->SetTitleSize(0.06);
@@ -3079,125 +3419,132 @@ void MakeNiceMapStyle(TH2 *hist)
   hist->GetZaxis()->SetLabelSize(.05);
 }
 
+/*--------------------------------------------------------------------*/
+std::pair<TH2F *, TH2F *> trimTheMap(TH2 *hist) {
+  /*--------------------------------------------------------------------*/
 
-/*--------------------------------------------------------------------*/
-std::pair<TH2F*,TH2F*> trimTheMap(TH2 *hist){
-/*--------------------------------------------------------------------*/
-  
-  Int_t nXCells = hist->GetNbinsX(); 
+  Int_t nXCells = hist->GetNbinsX();
   Int_t nYCells = hist->GetNbinsY();
-  Int_t nCells = nXCells*nYCells;
-  
-  Double_t min = 9999.; 
+  Int_t nCells = nXCells * nYCells;
+
+  Double_t min = 9999.;
   Double_t max = -9999.;
-  
-  for(Int_t nX=1;nX<=nXCells;nX++){
-    for(Int_t nY=1;nY<=nYCells;nY++){
-      Double_t binContent = hist->GetBinContent(nX,nY);
-      if(binContent>max) max = binContent;
-      if(binContent<min) min = binContent;
+
+  for (Int_t nX = 1; nX <= nXCells; nX++) {
+    for (Int_t nY = 1; nY <= nYCells; nY++) {
+      Double_t binContent = hist->GetBinContent(nX, nY);
+      if (binContent > max)
+        max = binContent;
+      if (binContent < min)
+        min = binContent;
     }
   }
-  
-  TH1F *histContentByCell = new TH1F(Form("histContentByCell_%s",hist->GetName()),"histContentByCell",nCells,min,max);
-  
-  for(Int_t nX=1;nX<=nXCells;nX++){
-    for(Int_t nY=1;nY<=nYCells;nY++){
-      histContentByCell->Fill(hist->GetBinContent(nX,nY));
+
+  TH1F *histContentByCell =
+      new TH1F(Form("histContentByCell_%s", hist->GetName()), "histContentByCell", nCells, min, max);
+
+  for (Int_t nX = 1; nX <= nXCells; nX++) {
+    for (Int_t nY = 1; nY <= nYCells; nY++) {
+      histContentByCell->Fill(hist->GetBinContent(nX, nY));
     }
   }
 
   Double_t theMeanOfCells = histContentByCell->GetMean();
-  Double_t theRMSOfCells  = histContentByCell->GetRMS();
+  Double_t theRMSOfCells = histContentByCell->GetRMS();
   params::measurement theMAD = getMAD(histContentByCell);
 
-  if(isDebugMode){
-    std::cout<<std::setw(24)<< left << hist->GetName() << "| mean: "<<std::setw(10) << setprecision(4)<<theMeanOfCells<<"| min: "<<std::setw(10) << setprecision(4)<< min <<"| max: "<<std::setw(10) << setprecision(4)<<max<<"| rms: "<<std::setw(10) << setprecision(4)<<theRMSOfCells<<"| mad: "<<std::setw(10) << setprecision(4)<<theMAD.first<<std::endl;
+  if (isDebugMode) {
+    std::cout << std::setw(24) << left << hist->GetName() << "| mean: " << std::setw(10) << setprecision(4)
+              << theMeanOfCells << "| min: " << std::setw(10) << setprecision(4) << min << "| max: " << std::setw(10)
+              << setprecision(4) << max << "| rms: " << std::setw(10) << setprecision(4) << theRMSOfCells
+              << "| mad: " << std::setw(10) << setprecision(4) << theMAD.first << std::endl;
   }
 
-  TCanvas *cCheck = new TCanvas(Form("cCheck_%s",hist->GetName()),Form("cCheck_%s",hist->GetName()),1200,1000);
+  TCanvas *cCheck = new TCanvas(Form("cCheck_%s", hist->GetName()), Form("cCheck_%s", hist->GetName()), 1200, 1000);
 
-  cCheck->Divide(2,2);
-  for(Int_t i=1;i<=4;i++){
+  cCheck->Divide(2, 2);
+  for (Int_t i = 1; i <= 4; i++) {
     cCheck->cd(i)->SetBottomMargin(0.13);
     cCheck->cd(i)->SetLeftMargin(0.12);
-    if(i%2==1)
+    if (i % 2 == 1)
       cCheck->cd(i)->SetRightMargin(0.19);
-    else 
-      cCheck->cd(i)->SetRightMargin(0.07);  
-    cCheck->cd(i)->SetTopMargin(0.08);  
+    else
+      cCheck->cd(i)->SetRightMargin(0.07);
+    cCheck->cd(i)->SetTopMargin(0.08);
   }
 
   cCheck->cd(1);
   hist->SetStats(kFALSE);
   hist->Draw("colz");
   //makeNewPairOfAxes(hist);
-  
+
   cCheck->cd(2)->SetLogy();
   MakeNicePlotStyle(histContentByCell);
   histContentByCell->SetStats(kTRUE);
   histContentByCell->GetYaxis()->SetTitleOffset(0.9);
   histContentByCell->Draw();
-  
+
   //Double_t theNewMin = theMeanOfCells-theRMSOfCells;
   //Double_t theNewMax = theMeanOfCells+theRMSOfCells;
 
-  Double_t theNewMin = theMeanOfCells-theMAD.first*3;
-  Double_t theNewMax = theMeanOfCells+theMAD.first*3;
-  
-  TArrow *l0 = new TArrow(theMeanOfCells,cCheck->GetUymin(),theMeanOfCells,histContentByCell->GetMaximum(),0.3,"|>");
+  Double_t theNewMin = theMeanOfCells - theMAD.first * 3;
+  Double_t theNewMax = theMeanOfCells + theMAD.first * 3;
+
+  TArrow *l0 =
+      new TArrow(theMeanOfCells, cCheck->GetUymin(), theMeanOfCells, histContentByCell->GetMaximum(), 0.3, "|>");
   l0->SetAngle(60);
   l0->SetLineColor(kRed);
   l0->SetLineWidth(4);
   l0->Draw("same");
 
-  TArrow *l1 = new TArrow(theNewMin,cCheck->GetUymin(),theNewMin,histContentByCell->GetMaximum(),0.3,"|>");
+  TArrow *l1 = new TArrow(theNewMin, cCheck->GetUymin(), theNewMin, histContentByCell->GetMaximum(), 0.3, "|>");
   l1->SetAngle(60);
   l1->SetLineColor(kBlue);
   l1->SetLineWidth(4);
   l1->Draw("same");
-  
-  TArrow *l2 = new TArrow(theNewMax,cCheck->GetUymin(),theNewMax,histContentByCell->GetMaximum(),0.3,"|>");
+
+  TArrow *l2 = new TArrow(theNewMax, cCheck->GetUymin(), theNewMax, histContentByCell->GetMaximum(), 0.3, "|>");
   l2->SetAngle(60);
   l2->SetLineColor(kBlue);
   l2->SetLineWidth(4);
   l2->Draw("same");
 
-  TH2F* histoTrimmed = new TH2F(Form("%s_trimmed",hist->GetName()),
-				Form("Trimmed %s;%s;%s",hist->GetTitle(),hist->GetXaxis()->GetTitle(),hist->GetYaxis()->GetTitle()),
-				hist->GetNbinsX(),
-				hist->GetXaxis()->GetXmin(),
-				hist->GetXaxis()->GetXmax(),
-				hist->GetNbinsY(),
-				hist->GetYaxis()->GetXmin(),
-				hist->GetYaxis()->GetXmax());
-  
-  TH2F* histoMissed = new TH2F(Form("%s_Missed",hist->GetName()),
-			       Form("Missed %s",hist->GetTitle()),
-			       hist->GetNbinsX(),
-			       hist->GetXaxis()->GetXmin(),
-			       hist->GetXaxis()->GetXmax(),
-			       hist->GetNbinsY(),
-			       hist->GetYaxis()->GetXmin(),
-			       hist->GetYaxis()->GetXmax());
+  TH2F *histoTrimmed =
+      new TH2F(Form("%s_trimmed", hist->GetName()),
+               Form("Trimmed %s;%s;%s", hist->GetTitle(), hist->GetXaxis()->GetTitle(), hist->GetYaxis()->GetTitle()),
+               hist->GetNbinsX(),
+               hist->GetXaxis()->GetXmin(),
+               hist->GetXaxis()->GetXmax(),
+               hist->GetNbinsY(),
+               hist->GetYaxis()->GetXmin(),
+               hist->GetYaxis()->GetXmax());
 
-  for(Int_t nX=1;nX<=nXCells;nX++){
-    for(Int_t nY=1;nY<=nYCells;nY++){
-      Double_t binContent = hist->GetBinContent(nX,nY);
-      Double_t binError   = hist->GetBinError(nX,nY);
+  TH2F *histoMissed = new TH2F(Form("%s_Missed", hist->GetName()),
+                               Form("Missed %s", hist->GetTitle()),
+                               hist->GetNbinsX(),
+                               hist->GetXaxis()->GetXmin(),
+                               hist->GetXaxis()->GetXmax(),
+                               hist->GetNbinsY(),
+                               hist->GetYaxis()->GetXmin(),
+                               hist->GetYaxis()->GetXmax());
 
-      if(binContent==0. && binError==0.){
-	histoMissed->SetBinContent(nX,nY,1);
-      } else if (binContent<=theNewMin) {
-	histoTrimmed->SetBinContent(nX,nY,theNewMin);
-      } else if (binContent>=theNewMax){ 
-	histoTrimmed->SetBinContent(nX,nY,theNewMax);
+  for (Int_t nX = 1; nX <= nXCells; nX++) {
+    for (Int_t nY = 1; nY <= nYCells; nY++) {
+      Double_t binContent = hist->GetBinContent(nX, nY);
+      Double_t binError = hist->GetBinError(nX, nY);
+
+      if (binContent == 0. && binError == 0.) {
+        histoMissed->SetBinContent(nX, nY, 1);
+      } else if (binContent <= theNewMin) {
+        histoTrimmed->SetBinContent(nX, nY, theNewMin);
+      } else if (binContent >= theNewMax) {
+        histoTrimmed->SetBinContent(nX, nY, theNewMax);
       } else {
-	histoTrimmed->SetBinContent(nX,nY,binContent);
+        histoTrimmed->SetBinContent(nX, nY, binContent);
       }
     }
   }
-  
+
   cCheck->cd(3);
   histoTrimmed->SetStats(kFALSE);
   histoTrimmed->Draw("COLZ1");
@@ -3214,12 +3561,14 @@ std::pair<TH2F*,TH2F*> trimTheMap(TH2 *hist){
   histoMissed->Draw("box");
   makeNewPairOfAxes(histoMissed);
 
-  if(isDebugMode){
-    cCheck->SaveAs(Form("cCheck_%s.png",hist->GetName()));  
-    cCheck->SaveAs(Form("cCheck_%s.pdf",hist->GetName()));
- 
-    std::cout<<"histo:" << setw(25) << hist->GetName() <<" old min: "<< setw(10) << hist->GetMinimum() << " old max: "<< setw(10) <<hist->GetMaximum();
-    std::cout<<" | new min: " << setw(15) << hist->GetMinimum() << " new max: "<< setw(10) << hist->GetMaximum() << std::endl;
+  if (isDebugMode) {
+    cCheck->SaveAs(Form("cCheck_%s.png", hist->GetName()));
+    cCheck->SaveAs(Form("cCheck_%s.pdf", hist->GetName()));
+
+    std::cout << "histo:" << setw(25) << hist->GetName() << " old min: " << setw(10) << hist->GetMinimum()
+              << " old max: " << setw(10) << hist->GetMaximum();
+    std::cout << " | new min: " << setw(15) << hist->GetMinimum() << " new max: " << setw(10) << hist->GetMaximum()
+              << std::endl;
   }
 
   delete histContentByCell;
@@ -3228,16 +3577,15 @@ std::pair<TH2F*,TH2F*> trimTheMap(TH2 *hist){
   // hist->SetMaximum(0.999*theNewMax);
   delete cCheck;
 
-  return std::make_pair(histoTrimmed,histoMissed);
-
+  return std::make_pair(histoTrimmed, histoMissed);
 }
 
 /*--------------------------------------------------------------------*/
-void setStyle(){
-/*--------------------------------------------------------------------*/
+void setStyle() {
+  /*--------------------------------------------------------------------*/
 
-  writeExtraText = true;       // if extra text
-  lumi_13TeV     = "p-p collisions";
+  writeExtraText = true;  // if extra text
+  lumi_13TeV = "p-p collisions";
   extraText = "Internal";
 
   TH1::StatOverflows(kTRUE);
@@ -3256,7 +3604,7 @@ void setStyle(){
   gStyle->SetTitleBorderSize(0);
   gStyle->SetStatColor(kWhite);
   gStyle->SetStatFont(42);
-  gStyle->SetStatFontSize(0.05);///---> gStyle->SetStatFontSize(0.025);
+  gStyle->SetStatFontSize(0.05);  ///---> gStyle->SetStatFontSize(0.025);
   gStyle->SetStatTextColor(1);
   gStyle->SetStatFormat("6.4g");
   gStyle->SetStatBorderSize(1);
@@ -3269,11 +3617,11 @@ void setStyle(){
   // this is the standard palette
   const Int_t NRGBs = 5;
   const Int_t NCont = 255;
-  
-  Double_t stops[NRGBs] = { 0.00, 0.34, 0.61, 0.84, 1.00 };
-  Double_t red[NRGBs]   = { 0.00, 0.00, 0.87, 1.00, 0.51 };
-  Double_t green[NRGBs] = { 0.00, 0.81, 1.00, 0.20, 0.00 };
-  Double_t blue[NRGBs]  = { 0.51, 1.00, 0.12, 0.00, 0.00 };
+
+  Double_t stops[NRGBs] = {0.00, 0.34, 0.61, 0.84, 1.00};
+  Double_t red[NRGBs] = {0.00, 0.00, 0.87, 1.00, 0.51};
+  Double_t green[NRGBs] = {0.00, 0.81, 1.00, 0.20, 0.00};
+  Double_t blue[NRGBs] = {0.51, 1.00, 0.12, 0.00, 0.00};
   TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
   gStyle->SetNumberContours(NCont);
 
@@ -3290,7 +3638,7 @@ void setStyle(){
   TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
   gStyle->SetNumberContours(NCont);
 
-  */  
+  */
 
   /*
   const Int_t NRGBs = 9;
@@ -3320,59 +3668,59 @@ void setStyle(){
 
   TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
   gStyle->SetNumberContours(NCont);
-  */  
-
+  */
 }
 
 /*--------------------------------------------------------------------*/
-TH1F* DrawZero(TH1F *hist,Int_t nbins,Double_t lowedge,Double_t highedge,Int_t iter)
-/*--------------------------------------------------------------------*/
-{ 
-
-  TH1F *hzero = new TH1F(Form("hzero_%s_%i",hist->GetName(),iter),Form("hzero_%s_%i",hist->GetName(),iter),nbins,lowedge,highedge);
-  for (Int_t i=0;i<hzero->GetNbinsX();i++){
-    hzero->SetBinContent(i,0.);
-    hzero->SetBinError(i,0.);
-  }
-  hzero->SetLineWidth(2);
-  hzero->SetLineStyle(9);
-  hzero->SetLineColor(kMagenta);
-  
-  return hzero;
-}
-
-/*--------------------------------------------------------------------*/
-TH1F* DrawConstant(TH1F *hist,Int_t nbins,Double_t lowedge,Double_t highedge,Int_t iter,Double_t theConst)
-/*--------------------------------------------------------------------*/
-{ 
-
-  TH1F *hzero = new TH1F(Form("hconst_%s_%i",hist->GetName(),iter),Form("hconst_%s_%i",hist->GetName(),iter),nbins,lowedge,highedge);
-  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
-    hzero->SetBinContent(i,theConst);
-    hzero->SetBinError(i,0.);
-  }
-  hzero->SetLineWidth(2);
-  hzero->SetLineStyle(9);
-  hzero->SetLineColor(kMagenta);
-  
-  return hzero;
-}
-
-
-/*--------------------------------------------------------------------*/
-void makeNewXAxis (TH1F *h)
+TH1F *DrawZero(TH1F *hist, Int_t nbins, Double_t lowedge, Double_t highedge, Int_t iter)
 /*--------------------------------------------------------------------*/
 {
-  
+  TH1F *hzero = new TH1F(
+      Form("hzero_%s_%i", hist->GetName(), iter), Form("hzero_%s_%i", hist->GetName(), iter), nbins, lowedge, highedge);
+  for (Int_t i = 0; i < hzero->GetNbinsX(); i++) {
+    hzero->SetBinContent(i, 0.);
+    hzero->SetBinError(i, 0.);
+  }
+  hzero->SetLineWidth(2);
+  hzero->SetLineStyle(9);
+  hzero->SetLineColor(kMagenta);
+
+  return hzero;
+}
+
+/*--------------------------------------------------------------------*/
+TH1F *DrawConstant(TH1F *hist, Int_t nbins, Double_t lowedge, Double_t highedge, Int_t iter, Double_t theConst)
+/*--------------------------------------------------------------------*/
+{
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i", hist->GetName(), iter),
+                         Form("hconst_%s_%i", hist->GetName(), iter),
+                         nbins,
+                         lowedge,
+                         highedge);
+  for (Int_t i = 0; i <= hzero->GetNbinsX(); i++) {
+    hzero->SetBinContent(i, theConst);
+    hzero->SetBinError(i, 0.);
+  }
+  hzero->SetLineWidth(2);
+  hzero->SetLineStyle(9);
+  hzero->SetLineColor(kMagenta);
+
+  return hzero;
+}
+
+/*--------------------------------------------------------------------*/
+void makeNewXAxis(TH1F *h)
+/*--------------------------------------------------------------------*/
+{
   TString myTitle = h->GetName();
   float axmin = -999;
   float axmax = 999.;
   int ndiv = 510;
-  if(myTitle.Contains("eta")){
+  if (myTitle.Contains("eta")) {
     axmin = -etaRange;
     axmax = etaRange;
     ndiv = 505;
-  } else if (myTitle.Contains("phi")){
+  } else if (myTitle.Contains("phi")) {
     axmin = -TMath::Pi();
     axmax = TMath::Pi();
     ndiv = 510;
@@ -3382,56 +3730,47 @@ void makeNewXAxis (TH1F *h)
     ndiv = 510;
   } else if (myTitle.Contains("ladder")) {
     axmin = 0.5;
-    axmax = nLadders_+0.5;
+    axmax = nLadders_ + 0.5;
   } else if (myTitle.Contains("modZ")) {
     axmin = 0.5;
     axmax = 8.5;
-  } else if (myTitle.Contains("h_probe")){
+  } else if (myTitle.Contains("h_probe")) {
     ndiv = 505;
     axmin = h->GetXaxis()->GetBinCenter(h->GetXaxis()->GetFirst());
     axmax = h->GetXaxis()->GetBinCenter(h->GetXaxis()->GetLast());
-  } else  {
-    std::cout<<"unrecognized variable for histogram title: "<<myTitle<<std::endl;
+  } else {
+    std::cout << "unrecognized variable for histogram title: " << myTitle << std::endl;
   }
-  
+
   // Remove the current axis
   h->GetXaxis()->SetLabelOffset(999);
   h->GetXaxis()->SetTickLength(0);
-  
-   // Redraw the new axis
+
+  // Redraw the new axis
   gPad->Update();
-  
-  TGaxis *newaxis = new TGaxis(gPad->GetUxmin(),gPad->GetUymin(),
-			       gPad->GetUxmax(),gPad->GetUymin(),
-			       axmin,
-			       axmax,
-			       ndiv,"SDH");
-  
-  TGaxis *newaxisup =  new TGaxis(gPad->GetUxmin(),gPad->GetUymax(),
-                                  gPad->GetUxmax(),gPad->GetUymax(),
-                                  axmin,
-                                  axmax,                          
-                                  ndiv,"-SDH");
-    
+
+  TGaxis *newaxis =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymin(), gPad->GetUxmax(), gPad->GetUymin(), axmin, axmax, ndiv, "SDH");
+
+  TGaxis *newaxisup =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymax(), gPad->GetUxmax(), gPad->GetUymax(), axmin, axmax, ndiv, "-SDH");
+
   newaxis->SetLabelOffset(0.02);
   newaxis->SetLabelFont(42);
   newaxis->SetLabelSize(0.05);
-  
+
   newaxisup->SetLabelOffset(-0.02);
   newaxisup->SetLabelFont(42);
   newaxisup->SetLabelSize(0);
-  
+
   newaxis->Draw();
   newaxisup->Draw();
-
 }
 
-
 /*--------------------------------------------------------------------*/
-void makeNewPairOfAxes (TH2F *h)
+void makeNewPairOfAxes(TH2F *h)
 /*--------------------------------------------------------------------*/
 {
-  
   int ndivx = 505;
   float axmin = -etaRange;
   float axmax = etaRange;
@@ -3446,56 +3785,43 @@ void makeNewPairOfAxes (TH2F *h)
 
   h->GetYaxis()->SetLabelOffset(999);
   h->GetYaxis()->SetTickLength(0);
-  
-   // Redraw the new axis
-  gPad->Update();
-  
-  TGaxis *newXaxis = new TGaxis(gPad->GetUxmin(),gPad->GetUymin(),
-				gPad->GetUxmax(),gPad->GetUymin(),
-				axmin,
-				axmax,
-				ndivx,"SDH");
-  
-  TGaxis *newXaxisup =  new TGaxis(gPad->GetUxmin(),gPad->GetUymax(),
-				   gPad->GetUxmax(),gPad->GetUymax(),
-				   axmin,
-				   axmax,                          
-				   ndivx,"-SDH");
 
-  TGaxis *newYaxisR = new TGaxis(gPad->GetUxmin(),gPad->GetUymin(),
-				 gPad->GetUxmin(),gPad->GetUymax(),
-				 aymin,
-				 aymax,
-				 ndivy,"SDH");
-  
-  TGaxis *newYaxisL =  new TGaxis(gPad->GetUxmax(),gPad->GetUymin(),
-				  gPad->GetUxmax(),gPad->GetUymax(),
-				  aymin,
-				  aymax,                          
-				  ndivy,"-SDH");
-    
+  // Redraw the new axis
+  gPad->Update();
+
+  TGaxis *newXaxis =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymin(), gPad->GetUxmax(), gPad->GetUymin(), axmin, axmax, ndivx, "SDH");
+
+  TGaxis *newXaxisup =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymax(), gPad->GetUxmax(), gPad->GetUymax(), axmin, axmax, ndivx, "-SDH");
+
+  TGaxis *newYaxisR =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymin(), gPad->GetUxmin(), gPad->GetUymax(), aymin, aymax, ndivy, "SDH");
+
+  TGaxis *newYaxisL =
+      new TGaxis(gPad->GetUxmax(), gPad->GetUymin(), gPad->GetUxmax(), gPad->GetUymax(), aymin, aymax, ndivy, "-SDH");
+
   newXaxis->SetLabelOffset(0.02);
   newXaxis->SetLabelFont(42);
   newXaxis->SetLabelSize(0.055);
-  
+
   newXaxisup->SetLabelOffset(-0.02);
   newXaxisup->SetLabelFont(42);
   newXaxisup->SetLabelSize(0);
-  
+
   newXaxis->Draw();
   newXaxisup->Draw();
 
   newYaxisR->SetLabelOffset(0.02);
   newYaxisR->SetLabelFont(42);
   newYaxisR->SetLabelSize(0.055);
-  
+
   newYaxisL->SetLabelOffset(-0.02);
   newYaxisL->SetLabelFont(42);
   newYaxisL->SetLabelSize(0);
-  
+
   newYaxisR->Draw();
   newYaxisL->Draw();
-
 }
 
 /*--------------------------------------------------------------------*/
@@ -3523,18 +3849,17 @@ Double_t fULine(Double_t *x, Double_t *par)
 /*--------------------------------------------------------------------*/
 void FitULine(TH1 *hist)
 /*--------------------------------------------------------------------*/
-{ 
+{
   // define fitting function
-  TF1 func1("lineUp",fULine,_boundMin,_boundMax,1);
+  TF1 func1("lineUp", fULine, _boundMin, _boundMax, 1);
   //TF1 func1("lineUp","pol0",-0.5,11.5);
-  
-  if (0 == hist->Fit(&func1,"QR")) {
-    if (hist->GetFunction(func1.GetName())) { // Take care that it is later on drawn:
+
+  if (0 == hist->Fit(&func1, "QR")) {
+    if (hist->GetFunction(func1.GetName())) {  // Take care that it is later on drawn:
       hist->GetFunction(func1.GetName())->ResetBit(TF1::kNotDraw);
     }
     //cout<<"FitPVResiduals() fit Up done!"<<endl;
   }
-  
 }
 
 /*--------------------------------------------------------------------*/
@@ -3543,20 +3868,20 @@ void FitDLine(TH1 *hist)
 {
   // define fitting function
   // TF1 func1("lineDown",fDLine,-0.5,11.5,1);
-  
-  TF1 func2("lineDown","pol0",_boundSx,_boundDx);
-  func2.SetRange(_boundSx,_boundDx);
-  
-  if (0 == hist->Fit(&func2,"QR")) {
-    if (hist->GetFunction(func2.GetName())) { // Take care that it is later on drawn:
+
+  TF1 func2("lineDown", "pol0", _boundSx, _boundDx);
+  func2.SetRange(_boundSx, _boundDx);
+
+  if (0 == hist->Fit(&func2, "QR")) {
+    if (hist->GetFunction(func2.GetName())) {  // Take care that it is later on drawn:
       hist->GetFunction(func2.GetName())->ResetBit(TF1::kNotDraw);
     }
     // cout<<"FitPVResiduals() fit Down done!"<<endl;
-  } 
+  }
 }
 
 /*--------------------------------------------------------------------*/
-void MakeNiceTF1Style(TF1 *f1,Int_t color)
+void MakeNiceTF1Style(TF1 *f1, Int_t color)
 /*--------------------------------------------------------------------*/
 {
   f1->SetLineColor(color);
@@ -3565,7 +3890,7 @@ void MakeNiceTF1Style(TF1 *f1,Int_t color)
 }
 
 /*--------------------------------------------------------------------*/
-params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims, bool tag)
+params::measurement getTheRangeUser(TH1F *thePlot, Limits *lims, bool tag)
 /*--------------------------------------------------------------------*/
 {
   TString theTitle = thePlot->GetName();
@@ -3594,86 +3919,86 @@ params::measurement getTheRangeUser(TH1F* thePlot, Limits* lims, bool tag)
   */
 
   params::measurement result;
-  
-  if (theTitle.Contains("norm")){
-    if (theTitle.Contains("means")){
-      if(theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")){
-	if(theTitle.Contains("phi") || theTitle.Contains("pT")){
-	  result = std::make_pair(-lims->get_dxyPhiNormMax().first,lims->get_dxyPhiNormMax().first);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(-lims->get_dxyEtaNormMax().first,lims->get_dxyEtaNormMax().first);
-	} else {
-	  result = std::make_pair(-0.8,0.8);
-	}
-      } else if(theTitle.Contains("dz")){
-	if(theTitle.Contains("phi") || theTitle.Contains("pT")){
-	  result = std::make_pair(-lims->get_dzPhiNormMax().first,lims->get_dzPhiNormMax().first);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(-lims->get_dzEtaNormMax().first,lims->get_dzEtaNormMax().first);
-	} else {
-	  result = std::make_pair(-0.8,0.8);
-	}
-      } 
-    } else if (theTitle.Contains("widths")){
-      if(theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")){
-	if(theTitle.Contains("phi")){
-	  result = std::make_pair(0.,lims->get_dxyPhiNormMax().second);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(0.,lims->get_dxyEtaNormMax().second);
-	} else {
-	  result = std::make_pair(0.,2.);
-	}
-      } else if(theTitle.Contains("dz")){	
-	if(theTitle.Contains("phi")){
-	  result = std::make_pair(0.,lims->get_dzPhiNormMax().second);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(0.,lims->get_dzEtaNormMax().second);
-	} else {
-	  result = std::make_pair(0.,2.);
-	}
+
+  if (theTitle.Contains("norm")) {
+    if (theTitle.Contains("means")) {
+      if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+          result = std::make_pair(-lims->get_dxyPhiNormMax().first, lims->get_dxyPhiNormMax().first);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(-lims->get_dxyEtaNormMax().first, lims->get_dxyEtaNormMax().first);
+        } else {
+          result = std::make_pair(-0.8, 0.8);
+        }
+      } else if (theTitle.Contains("dz")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+          result = std::make_pair(-lims->get_dzPhiNormMax().first, lims->get_dzPhiNormMax().first);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(-lims->get_dzEtaNormMax().first, lims->get_dzEtaNormMax().first);
+        } else {
+          result = std::make_pair(-0.8, 0.8);
+        }
       }
-    } 
+    } else if (theTitle.Contains("widths")) {
+      if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
+        if (theTitle.Contains("phi")) {
+          result = std::make_pair(0., lims->get_dxyPhiNormMax().second);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(0., lims->get_dxyEtaNormMax().second);
+        } else {
+          result = std::make_pair(0., 2.);
+        }
+      } else if (theTitle.Contains("dz")) {
+        if (theTitle.Contains("phi")) {
+          result = std::make_pair(0., lims->get_dzPhiNormMax().second);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(0., lims->get_dzEtaNormMax().second);
+        } else {
+          result = std::make_pair(0., 2.);
+        }
+      }
+    }
   } else {
-    if (theTitle.Contains("means")){
-      if(theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")){
-	if(theTitle.Contains("phi") || theTitle.Contains("pT")){
-	  result = std::make_pair(-lims->get_dxyPhiMax().first,lims->get_dxyPhiMax().first);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(-lims->get_dxyEtaMax().first,lims->get_dxyEtaMax().first);
-	} else {
-	  result = std::make_pair(-40.,40.);
-	}
-      } else if(theTitle.Contains("dz")){
-	if(theTitle.Contains("phi") || theTitle.Contains("pT")){
-	  result = std::make_pair(-lims->get_dzPhiMax().first,lims->get_dzPhiMax().first);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(-lims->get_dzEtaMax().first,lims->get_dzEtaMax().first);
-	} else {
-	  result = std::make_pair(-80.,80.);
-	}
+    if (theTitle.Contains("means")) {
+      if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+          result = std::make_pair(-lims->get_dxyPhiMax().first, lims->get_dxyPhiMax().first);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(-lims->get_dxyEtaMax().first, lims->get_dxyEtaMax().first);
+        } else {
+          result = std::make_pair(-40., 40.);
+        }
+      } else if (theTitle.Contains("dz")) {
+        if (theTitle.Contains("phi") || theTitle.Contains("pT")) {
+          result = std::make_pair(-lims->get_dzPhiMax().first, lims->get_dzPhiMax().first);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(-lims->get_dzEtaMax().first, lims->get_dzEtaMax().first);
+        } else {
+          result = std::make_pair(-80., 80.);
+        }
       }
-    } else if (theTitle.Contains("widths")){
-      if(theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")){
-	if(theTitle.Contains("phi")){
-	  result = std::make_pair(0.,lims->get_dxyPhiMax().second);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(0.,lims->get_dxyEtaMax().second);
-	} else {
-	  result = std::make_pair(0.,150.);
-	}
-      } else if(theTitle.Contains("dz")){	
-	if(theTitle.Contains("phi")){
-	  result = std::make_pair(0.,lims->get_dzPhiMax().second);
-	} else if (theTitle.Contains("eta")){
-	  result = std::make_pair(0.,lims->get_dzEtaMax().second);
-	}  else {
-	  result = std::make_pair(0.,300.);
-	}
+    } else if (theTitle.Contains("widths")) {
+      if (theTitle.Contains("dxy") || theTitle.Contains("dx") || theTitle.Contains("dy")) {
+        if (theTitle.Contains("phi")) {
+          result = std::make_pair(0., lims->get_dxyPhiMax().second);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(0., lims->get_dxyEtaMax().second);
+        } else {
+          result = std::make_pair(0., 150.);
+        }
+      } else if (theTitle.Contains("dz")) {
+        if (theTitle.Contains("phi")) {
+          result = std::make_pair(0., lims->get_dzPhiMax().second);
+        } else if (theTitle.Contains("eta")) {
+          result = std::make_pair(0., lims->get_dzEtaMax().second);
+        } else {
+          result = std::make_pair(0., 300.);
+        }
       }
     }
   }
 
-  if(tag) std::cout<<theTitle << " " << result.first << " " << result.second << std::endl;
+  if (tag)
+    std::cout << theTitle << " " << result.first << " " << result.second << std::endl;
   return result;
-  
 }

--- a/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
+++ b/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
@@ -697,8 +697,8 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   //f_processData(0);
   //std::cout<<" post do-stuff: " <<  runs.size() << std::endl;
 
-  TProcPool procPool(nWorkers);
-  std::vector<size_t> range(nWorkers);
+  TProcPool procPool(std::min(nWorkers,intersection.size()));
+  std::vector<size_t> range(std::min(nWorkers,intersection.size()));
   std::iota(range.begin(),range.end(),0);
   //procPool.Map([&f_processData](size_t a) { f_processData(a); },{1,2,3});
   auto extracts = procPool.Map(f_processData,range);
@@ -964,7 +964,7 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   for(Int_t j=0; j < nDirs_; j++) {
 
     // check on the sanity
-    std::cout<<"x_ticks.size()= "<<x_ticks.size()<<"d xyPhiMeans_[LegLabels["<<j<<"]].size()="<<dxyPhiMeans_[LegLabels[j]].size()<<std::endl;
+    std::cout<<"x_ticks.size()= "<<x_ticks.size()<<" dxyPhiMeans_[LegLabels["<<j<<"]].size()="<<dxyPhiMeans_[LegLabels[j]].size()<<std::endl;
 
     // *************************************
     // dxy vs phi
@@ -2806,11 +2806,13 @@ outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDir
   outTrends ret;
   ret.init();
 
-  unsigned int pitch = std::ceil(intersection.size()/nWorkers)+1;
-  unsigned int first = iter*pitch;
-  unsigned int last  = std::min((iter+1)*pitch-1,intersection.size());
+  unsigned int effSize = std::min(nWorkers,intersection.size());
 
-  std::cout<< "pitch: " << pitch<< " first: "<< first << " last: "<< last<< std::endl;
+  unsigned int pitch = std::floor(intersection.size()/effSize);
+  unsigned int first = iter*pitch;
+  unsigned int last  = (iter==(effSize-1) ) ? intersection.size() : ((iter+1)*pitch);
+
+  std::cout<< "iter:" << iter << "| pitch: " << pitch<< " ["<< first << "-"<< last << ")" << std::endl;
 
   ret.m_index=iter;
 
@@ -2821,7 +2823,7 @@ outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDir
     //if(intersection.at(n)!=283946) 
     //  continue;
 
-    std::cout << n << " "<<intersection.at(n) << std::endl;
+    std::cout << "iter: " << iter << " " << n << " "<<intersection.at(n) << std::endl;
     
     TFile *fins[nDirs_];
 

--- a/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
+++ b/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
@@ -1,0 +1,2956 @@
+#include "TFile.h"
+#include "TSystemDirectory.h"
+#include "TSystemFile.h"
+#include "TObjArray.h"
+#include "TProcPool.h"
+#include "TList.h"
+#include "TMath.h"
+#include "TAxis.h"
+#include "TLegend.h"
+#include "TGaxis.h"
+#include "TPaveText.h"
+#include "TPad.h"
+#include "TLatex.h"
+#include "TStyle.h"
+#include "TSystem.h"
+#include "TROOT.h"
+#include "TProfile.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TF1.h"
+#include "TGraph.h"
+#include "TGraphErrors.h"
+#include "TGraphAsymmErrors.h"
+#include <TStopwatch.h>
+#include "TArrow.h"
+#include "TCanvas.h"
+#include "TObjString.h"
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <map>
+#include <functional>
+#include <iterator>
+#include <fstream>
+#include <bitset>
+#include <sstream>
+
+#define DEBUG true
+
+const size_t nWorkers = 10;
+
+typedef std::map<TString, std::vector<double> > alignmentTrend; 
+
+namespace pv{
+  enum view {
+    dxyphi,
+    dzphi,
+    dxyeta,
+    dzeta,
+    pT,
+    generic
+  };
+
+  // brief method to find first value that doesn not compare lett
+  int closest(std::vector<int> const& vec, int value) {
+    auto const it = std::lower_bound(vec.begin(), vec.end(), value);
+    if (it == vec.end()) { return -1; }
+    return *it;
+  }
+
+  const Int_t markers[8] = {kFullSquare,kOpenCircle,kFullTriangleDown,kOpenSquare,kOpenCircle,kFullTriangleUp,kOpenTriangleDown,kOpenTriangleUp};
+  const Int_t colors[8]  = {kBlack,kBlue,kRed,kGreen+2,kMagenta,kViolet,kCyan,kYellow};
+
+  struct biases {
+    
+    // contructor
+    biases(double mean,double rms,double wmean,double wrms,double min,double max,double chi2,int ndf,double ks){
+      m_mean=mean;
+      m_rms=rms;
+      m_w_mean=wmean;
+      m_w_rms=wrms;
+      m_min=min;
+      m_max=max;
+      m_chi2=chi2;
+      m_ndf=ndf;
+      m_ks=ks;
+    }
+    
+    // empty constructor
+    biases(){
+      init();
+    }    
+
+    void init(){
+      m_mean=0;
+      m_rms=0.;
+      m_min=+999.;
+      m_max=-999.;
+      m_w_mean=0.;
+      m_w_rms=0.;
+      m_chi2=-1.;
+      m_ndf=0.;
+      m_ks=9999.;
+    }
+
+    double getMean(){ return m_mean;}
+    double getWeightedMean(){return m_w_mean;}
+    double getRMS(){return m_rms;}
+    double getWeightedRMS(){return m_w_rms;}
+    double getMin(){return m_min;}
+    double getMax(){return m_max;}
+    double getChi2(){return m_chi2;}
+    double getNDF(){return m_ndf;}
+    double getNormChi2(){ return double(m_chi2)/double(m_ndf);}
+    double getChi2Prob(){ return TMath::Prob(m_chi2,m_ndf);}
+    double getKSScore(){ return m_ks;}
+
+  private:
+    double m_mean;
+    double m_min;
+    double m_max;
+    double m_rms;
+    double m_w_mean;
+    double m_w_rms;
+    double m_chi2;
+    int    m_ndf;
+    double m_ks;
+  };
+
+  
+  struct wrappedTrends {
+    
+    // constructor
+    wrappedTrends(alignmentTrend mean,
+		  alignmentTrend low, 
+		  alignmentTrend high,    
+		  alignmentTrend lowerr,   
+		  alignmentTrend higherr,   
+		  alignmentTrend chi2,    
+		  alignmentTrend KS){
+
+      std::cout<<"pv::wrappedTrends c'tor"<< std::endl;
+
+      m_mean    = mean;    
+      m_low     = low;    
+      m_high    = high;   
+      m_lowerr  = lowerr; 
+      m_higherr = higherr;
+      m_chi2    = chi2;   
+      m_KS      = KS;     
+    }
+    
+    alignmentTrend getMean()    const {return m_mean;}
+    alignmentTrend getLow()     const {return m_low;}
+    alignmentTrend getHigh()    const {return m_high;}
+    alignmentTrend getLowErr()  const {return m_lowerr;}
+    alignmentTrend getHighErr() const {return m_higherr;}
+    alignmentTrend getChi2()    const {return m_chi2;}
+    alignmentTrend getKS()      const {return m_KS;}
+
+  private:
+    alignmentTrend m_mean;
+    alignmentTrend m_low;
+    alignmentTrend m_high;
+    alignmentTrend m_lowerr;
+    alignmentTrend m_higherr;
+    alignmentTrend m_chi2;
+    alignmentTrend m_KS;      
+  };
+
+  struct bundle{
+    
+    bundle(int nObjects, const TString& dataType,const TString& dataTypeLabel,const std::map<int,double>& lumiMapByRun,const std::map<int,TDatime>& times,const bool& lumiaxisformat,const bool& timeaxisformat){
+
+      m_nObjects = nObjects;
+      m_datatype = dataType.Data();
+      m_datatypelabel = dataTypeLabel.Data();
+      m_lumiMapByRun = lumiMapByRun;
+      m_times = times;
+
+      std::cout<<"pv::bundle c'tor: "<< dataTypeLabel << " member: " <<    m_datatypelabel << std::endl;
+
+      // make sure you don't use them at the same time
+      if(lumiaxisformat || timeaxisformat){
+	assert(lumiaxisformat!=timeaxisformat); 
+      }
+
+      if(lumiaxisformat){
+	std::cout<<"is lumiaxis format"<<std::endl;
+	m_axis_types.set(0); 
+      }
+      else if(timeaxisformat){
+	std::cout<<"is timeaxis format"<<std::endl;
+	m_axis_types.set(1); 
+      } else {
+	std::cout<<"is runaxis format"<<std::endl;
+      }
+
+      std::cout<< m_axis_types << std::endl;
+      
+      m_totalLumi = lumiMapByRun.rbegin()->second;
+
+    }
+
+    int getNObjects() const {return m_nObjects;}
+    const char* getDataType() const {return m_datatype;}		  
+    const char* getDataTypeLabel() const {return m_datatypelabel;}	  
+    const std::map<int,double> getLumiMapByRun() const {return m_lumiMapByRun;}  
+    double getTotalLumi() const { return m_totalLumi;}
+    const std::map<int,TDatime> getTimes() const {return m_times;}	  
+    bool isLumiAxis() const {return m_axis_types.test(0);}
+    bool isTimeAxis() const {return m_axis_types.test(1);}
+    void printAll() {
+      std::cout<< "dataType      " << m_datatype << std::endl;
+      std::cout<< "dataTypeLabel " << m_datatypelabel << std::endl;
+      if(this->isLumiAxis()) std::cout<<"is lumi axis"<< std::endl;
+      if(this->isTimeAxis()) std::cout<<"is time axis"<< std::endl;
+    }
+
+  private:
+    int m_nObjects;
+    const char* m_datatype;
+    const char* m_datatypelabel;
+    float m_totalLumi;
+    std::map<int,double> m_lumiMapByRun;
+    std::map<int,TDatime> m_times;
+    std::bitset<2> m_axis_types;          
+  };
+
+
+}
+
+// auxilliary struct to store
+// histogram features
+struct unrolledHisto {
+  double m_y_min;
+  double m_y_max;
+  unsigned int m_n_bins;
+  std::vector<double> m_bincontents;
+
+  unrolledHisto(){
+    m_y_min  =0.;
+    m_y_max  =0.;
+    m_n_bins =0;
+    m_bincontents.clear();
+  } // first constructor empty
+
+  unrolledHisto(const double& y_min,const double& y_max, const unsigned int& n_bins, const std::vector<double>& bincontents){
+    m_y_min  = y_min;
+    m_y_max  = y_max;
+    m_n_bins = n_bins;
+    m_bincontents = bincontents;
+  } //look, a constructor
+  
+  double get_y_min(){
+    return m_y_min;
+  }
+
+  double get_y_max(){
+    return m_y_max;
+  }
+  
+  unsigned int get_n_bins(){
+    return m_n_bins;
+  }
+  
+  std::vector<double> get_bin_contents(){
+    return m_bincontents;
+  }
+
+  double get_integral(){
+    double ret(0.);
+    for(const auto &binc: m_bincontents){
+      ret+=binc;
+    }
+    return ret;
+  }
+
+};
+
+// auxilliary struct to be returned by the functor
+struct outTrends {
+
+  int m_index;
+  double m_lumiSoFar;
+  std::vector<double> m_runs;
+  std::vector<double> m_lumiByRun;
+  std::map<int,double> m_lumiMapByRun; 
+  alignmentTrend m_dxyPhiMeans;
+  alignmentTrend m_dxyPhiChi2;
+  alignmentTrend m_dxyPhiKS;   
+  alignmentTrend m_dxyPhiHi;
+  alignmentTrend m_dxyPhiLo;
+  alignmentTrend m_dxyEtaMeans;
+  alignmentTrend m_dxyEtaChi2;  
+  alignmentTrend m_dxyEtaKS;
+  alignmentTrend m_dxyEtaHi; 
+  alignmentTrend m_dxyEtaLo;
+  alignmentTrend m_dzPhiMeans;
+  alignmentTrend m_dzPhiChi2; 
+  alignmentTrend m_dzPhiKS;
+  alignmentTrend m_dzPhiHi; 
+  alignmentTrend m_dzPhiLo;	 	 
+  alignmentTrend m_dzEtaMeans;
+  alignmentTrend m_dzEtaChi2;  
+  alignmentTrend m_dzEtaKS;
+  alignmentTrend m_dzEtaHi; 
+  alignmentTrend m_dzEtaLo;       
+  std::map<TString,std::vector<unrolledHisto> > m_dxyVect;
+  std::map<TString,std::vector<unrolledHisto> > m_dzVect;
+
+  void init(){
+    m_index=-1;
+    m_lumiSoFar=0.;
+    m_runs.clear();
+    m_lumiByRun.clear();
+    m_lumiMapByRun.clear();
+
+    m_dxyPhiMeans.clear();
+    m_dxyPhiChi2.clear(); 
+    m_dxyPhiKS.clear();   
+    m_dxyPhiHi.clear();  
+    m_dxyPhiLo.clear();  
+
+    m_dxyEtaMeans.clear();
+    m_dxyEtaChi2.clear();
+    m_dxyEtaKS.clear();   
+    m_dxyEtaHi.clear();  
+    m_dxyEtaLo.clear();  
+
+    m_dzPhiMeans.clear();
+    m_dzPhiChi2.clear();
+    m_dzPhiKS.clear();
+    m_dzPhiHi.clear();   
+    m_dzPhiLo.clear();   
+
+    m_dzEtaMeans.clear();
+    m_dzEtaChi2.clear();
+    m_dzEtaKS.clear();
+    m_dzEtaHi.clear();
+    m_dzEtaLo.clear();   
+
+    m_dxyVect.clear();
+    m_dzVect.clear();
+  }
+};
+
+
+// forward declarations
+void MultiRunPVValidation(TString namesandlabels="",bool lumi_axis_format=false,bool time_axis_format=false,bool useRMS=true);
+outTrends doStuff(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10], bool useRMS);
+
+void arrangeOutCanvas(TCanvas *canv,
+		      TH1F* m_11Trend[100],
+		      TH1F* m_12Trend[100],
+		      TH1F* m_21Trend[100],
+		      TH1F* m_22Trend[100],
+		      Int_t nFiles, 
+		      TString LegLabels[10],
+		      unsigned int theRun);
+
+pv::biases getBiases(TH1F* hist);
+unrolledHisto getUnrolledHisto(TH1F* hist);
+
+TH1F* DrawConstant(TH1F *hist,Int_t iter,Double_t theConst);
+TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst);
+TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst);
+std::vector<int> list_files(const char *dirname=".", const char *ext=".root");
+TH1F* checkTH1AndReturn(TFile *f,TString address);
+void MakeNiceTrendPlotStyle(TH1 *hist,Int_t color);
+void cmsPrel(TPad* pad,size_t ipads=1);
+void makeNewXAxis (TH1 *h);
+void beautify(TGraph *g);
+void beautify(TH1 *h);
+void adjustmargins(TCanvas *canv);
+void adjustmargins(TVirtualPad*canv);
+void setStyle();
+pv::view checkTheView(const TString &toCheck);
+template<typename T> void timify(T *mgr);
+Double_t getMaximumFromArray(TObjArray *array);
+void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_format,const std::map<int,double> &lumiMapByRun,const std::map<int,TDatime>& timeMap);
+void outputGraphs(const pv::wrappedTrends& allInputs,
+		  const std::vector<double>& ticks,
+		  const std::vector<double>& ex_ticks,
+		  TCanvas* &canv,
+		  TCanvas* &mean_canv,
+		  TCanvas* &rms_canv,
+		  TGraph* &g_mean,
+		  TGraph* &g_chi2,
+		  TGraph* &g_KS,	  
+		  TGraph* &g_low,
+		  TGraph* &g_high,
+		  TGraphAsymmErrors* &g_asym,
+		  TH1F* h_RMS[],      
+		  const pv::bundle& mybundle,
+		  const pv::view& theView,
+		  const int index,
+		  TObjArray* &array,
+		  const TString& label,
+		  TLegend* &legend
+		  );
+
+// utility function to split strings
+/*--------------------------------------------------------------------*/
+std::vector<std::string> split(const std::string& s,char delimiter)
+/*--------------------------------------------------------------------*/
+{
+  std::vector<std::string> tokens;
+  std::string token;
+  std::istringstream tokenStream(s);
+  while (std::getline(tokenStream, token, delimiter)){
+    tokens.push_back(token);
+  }
+  return tokens;
+}
+
+///////////////////////////////////
+//
+//  Main function
+//
+///////////////////////////////////
+
+void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time_axis_format,bool useRMS){
+  
+  TStopwatch timer; 	 
+  timer.Start();
+
+  using namespace std::placeholders;  // for _1, _2, _3...
+  gROOT->ProcessLine("gErrorIgnoreLevel = kError;"); 	
+
+  ROOT::EnableThreadSafety();
+  TH1::AddDirectory(kFALSE);
+
+  // consistency check, we cannot do plot vs lumi if time_axis
+  if(lumi_axis_format && time_axis_format){
+    std::cout<<"##########################################################################################"<<std::endl;
+    std::cout<<"msg-i: MultiRunPVValidation(): you're requesting both summary vs lumi and vs time, "<< std::endl;
+    std::cout<<"       this combination is inconsistent --> exiting!"<< std::endl;
+    return;
+  }
+
+  // preload the dates from file
+  std::map<int,TDatime> times;
+  
+  if(time_axis_format){
+    
+    std::ifstream infile("times.txt");
+
+    if(!infile){
+      std::cout<<"missing input file :("<<std::endl;
+      std::cout<<" -- exiting" << std::endl;
+      return;
+    }
+
+    std::string line;
+    while (std::getline(infile, line)){
+
+      std::istringstream iss(line);
+      std::string a,b,c;
+      if (!(iss >> a >> b >> c)) { break; } // error
+      
+      //std::cout<<a<<"  "<<b<<"   "<<c<<"   "<<std::endl;
+      
+      int run  = std::stoi(a);
+      auto tokens_b = split(b,'-');
+      int year  = std::stoi(tokens_b[0]);
+      int month = std::stoi(tokens_b[1]);
+      int day   = std::stoi(tokens_b[2]);
+      
+      auto tokens_c  = split(c,'.');
+      auto tokens_c1 = split(tokens_c[0],':');
+
+      int hour   = std::stoi(tokens_c1[0]);
+      int minute = std::stoi(tokens_c1[2]);
+      int second = std::stoi(tokens_c1[2]);
+
+      //std::cout<<run<<" "<<year<<" "<<month<<" "<<day<<" "<<hour<<" "<<minute<<" "<<second<<" "<<std::endl;
+	
+      TDatime da(year,month,day,hour,minute,second);
+      times[run]=da;
+    }    
+  } // if time axis in the plots
+
+  //std::ofstream outfile ("lumiByRun.txt"); 
+  std::ofstream outfile ("log.txt"); 
+  setStyle();
+
+  TList *DirList   = new TList();
+  TList *LabelList = new TList();
+  
+  TObjArray *nameandlabelpairs = namesandlabels.Tokenize(",");
+  for (Int_t i = 0; i < nameandlabelpairs->GetEntries(); ++i) {
+    TObjArray *aFileLegPair = TString(nameandlabelpairs->At(i)->GetName()).Tokenize("=");
+    
+    if(aFileLegPair->GetEntries() == 2) {
+      DirList->Add(aFileLegPair->At(0)); 
+      LabelList->Add(aFileLegPair->At(1));
+    }
+    else {
+      std::cout << "Please give file name and legend entry in the following form:\n" 
+		<< " filename1=legendentry1,filename2=legendentry2\n"; 
+    }    
+  }
+
+  const Int_t nDirs_ = DirList->GetSize();
+  TString LegLabels[10];  
+  const char* dirs[10];
+
+  std::vector<int> intersection;
+  std::vector<double> runs;
+  std::vector<double> lumiByRun;
+  std::map<int,double> lumiMapByRun;
+  std::vector<double> x_ticks;
+  std::vector<double> ex_ticks = {0.};
+
+  std::vector<double> runtimes;
+  if(time_axis_format){
+    for(const auto &element : times){
+      runtimes.push_back((element.second).Convert());
+    }
+  }
+
+  for(Int_t j=0; j < nDirs_; j++) {
+    
+    // Retrieve labels
+    TObjString* legend = (TObjString*)LabelList->At(j);
+    TObjString* dir    = (TObjString*)DirList->At(j);
+    LegLabels[j] = legend->String();
+    dirs[j] = (dir->String()).Data();
+    cout<<"MultiRunPVValidation(): label["<<j<<"]"<<LegLabels[j]<<endl;
+    
+    std::vector<int> currentList = list_files(dirs[j]);
+    std::vector<int> tempSwap;
+    
+    std::sort(currentList.begin(),currentList.end());
+
+    if(j==0){
+      intersection = currentList;
+    }
+
+    std::sort(intersection.begin(),intersection.end());
+
+    std::set_intersection(currentList.begin(),currentList.end(),
+			  intersection.begin(),intersection.end(),
+			  std::back_inserter(tempSwap));
+    
+    intersection.clear();
+    intersection = tempSwap;
+    tempSwap.clear();
+  }
+  
+  // debug only
+  for(UInt_t index=0;index<intersection.size();index++){
+    std::cout<<index<<" "<<intersection[index]<<std::endl;
+  }
+
+  // book the vectors of values
+  alignmentTrend dxyPhiMeans_;
+  alignmentTrend dxyPhiChi2_;
+  alignmentTrend dxyPhiHiErr_;
+  alignmentTrend dxyPhiLoErr_;
+  alignmentTrend dxyPhiKS_;
+  alignmentTrend dxyPhiHi_;
+  alignmentTrend dxyPhiLo_;
+ 
+  alignmentTrend dxyEtaMeans_;
+  alignmentTrend dxyEtaChi2_;
+  alignmentTrend dxyEtaHiErr_; 
+  alignmentTrend dxyEtaLoErr_;
+  alignmentTrend dxyEtaKS_;
+  alignmentTrend dxyEtaHi_;
+  alignmentTrend dxyEtaLo_;
+  
+  alignmentTrend dzPhiMeans_;
+  alignmentTrend dzPhiChi2_;
+  alignmentTrend dzPhiHiErr_; 
+  alignmentTrend dzPhiLoErr_;	 	  
+  alignmentTrend dzPhiKS_;
+  alignmentTrend dzPhiHi_;
+  alignmentTrend dzPhiLo_;
+  
+  alignmentTrend dzEtaMeans_;
+  alignmentTrend dzEtaChi2_;
+  alignmentTrend dzEtaHiErr_; 
+  alignmentTrend dzEtaLoErr_;       
+  alignmentTrend dzEtaKS_;
+  alignmentTrend dzEtaHi_;
+  alignmentTrend dzEtaLo_;       
+
+  // unrolled histos
+  
+  std::map<TString,std::vector<unrolledHisto> > dxyVect;
+  std::map<TString,std::vector<unrolledHisto> > dzVect;
+
+  double lumiSoFar=0.0;
+
+  // loop over the runs in the intersection
+  //unsigned int last = (DEBUG==true) ? 50 : intersection.size();
+  
+  //std::function<void()> f_doStuff = std::bind(doStuff,1,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,dxyPhiMeans_,dxyPhiHi_,dxyPhiLo_,dxyEtaMeans_,dxyEtaHi_,dxyEtaLo_,dzPhiMeans_,dzPhiHi_,dzPhiLo_,dzEtaMeans_,dzEtaHi_,dzEtaLo_,dxyVect,dzVect);
+  
+  std::cout<<" pre do-stuff: " << runs.size() << std::endl;
+  
+  //we should use std::bind to create a functor and then pass it to the procPool
+  auto f_doStuff = std::bind(doStuff,_1,intersection,nDirs_,dirs,LegLabels,useRMS);
+  
+  //f_doStuff(0);
+  //std::cout<<" post do-stuff: " <<  runs.size() << std::endl;
+
+  TProcPool procPool(nWorkers);
+  std::vector<size_t> range(nWorkers);
+  std::iota(range.begin(),range.end(),0);
+  //procPool.Map([&f_doStuff](size_t a) { f_doStuff(a); },{1,2,3});
+  auto extracts = procPool.Map(f_doStuff,range);
+  
+  // sort the extracts according to the global index
+  std::sort(extracts.begin(), extracts.end(), 
+	    [](const outTrends & a, const outTrends & b) -> bool
+	    { 
+	      return a.m_index < b.m_index; 
+	    });
+  
+  // re-assemble everything together
+  for (auto extractedTrend : extracts){
+    std::cout << "lumiSoFar: " << lumiSoFar <<"/fb" << std::endl;
+
+    runs.insert(std::end(runs),std::begin(extractedTrend.m_runs), std::end(extractedTrend.m_runs));
+
+    // luminosity needs a different treatment
+    // we need to re-sum the luminosity so far
+
+    for (const auto &run : extractedTrend.m_runs){
+
+      std::cout<< run << " " << lumiSoFar+extractedTrend.m_lumiMapByRun[run] << std::endl;
+      lumiByRun.push_back(lumiSoFar+extractedTrend.m_lumiMapByRun[run]);
+      lumiMapByRun[run]=(lumiSoFar+extractedTrend.m_lumiMapByRun[run]);
+
+    }
+
+    lumiSoFar += (extractedTrend.m_lumiSoFar/1000.);
+ 
+    /*
+      lumiByRun.insert(std::end(lumiByRun), std::begin(extractedTrend.m_lumiByRun), std::end(extractedTrend.m_lumiByRun));
+      lumiMapByRun.insert(extractedTrend.m_lumiMapByRun.begin(),extractedTrend.m_lumiMapByRun.end());
+    */
+
+    for(const auto &label : LegLabels){
+
+      //******************************//
+      dxyPhiMeans_[label].insert(std::end(dxyPhiMeans_[label]), std::begin(extractedTrend.m_dxyPhiMeans[label]), std::end(extractedTrend.m_dxyPhiMeans[label]));
+      dxyPhiChi2_[label].insert(std::end(dxyPhiChi2_[label]), std::begin(extractedTrend.m_dxyPhiChi2[label]), std::end(extractedTrend.m_dxyPhiChi2[label]));
+      dxyPhiKS_[label].insert(std::end(dxyPhiKS_[label]), std::begin(extractedTrend.m_dxyPhiKS[label]), std::end(extractedTrend.m_dxyPhiKS[label]));
+
+      dxyPhiHi_[label].insert(std::end(dxyPhiHi_[label]), std::begin(extractedTrend.m_dxyPhiHi[label]), std::end(extractedTrend.m_dxyPhiHi[label]));
+      dxyPhiLo_[label].insert(std::end(dxyPhiLo_[label]), std::begin(extractedTrend.m_dxyPhiLo[label]), std::end(extractedTrend.m_dxyPhiLo[label]));
+
+      //******************************//
+      dzPhiMeans_[label].insert(std::end(dzPhiMeans_[label]), std::begin(extractedTrend.m_dzPhiMeans[label]), std::end(extractedTrend.m_dzPhiMeans[label]));
+      dzPhiChi2_[label].insert(std::end(dzPhiChi2_[label]), std::begin(extractedTrend.m_dzPhiChi2[label]), std::end(extractedTrend.m_dzPhiChi2[label]));
+      dzPhiKS_[label].insert(std::end(dzPhiKS_[label]), std::begin(extractedTrend.m_dzPhiKS[label]), std::end(extractedTrend.m_dzPhiKS[label]));
+
+      dzPhiHi_[label].insert(std::end(dzPhiHi_[label]), std::begin(extractedTrend.m_dzPhiHi[label]), std::end(extractedTrend.m_dzPhiHi[label]));
+      dzPhiLo_[label].insert(std::end(dzPhiLo_[label]), std::begin(extractedTrend.m_dzPhiLo[label]), std::end(extractedTrend.m_dzPhiLo[label]));
+
+      //******************************//
+      dxyEtaMeans_[label].insert(std::end(dxyEtaMeans_[label]), std::begin(extractedTrend.m_dxyEtaMeans[label]), std::end(extractedTrend.m_dxyEtaMeans[label]));
+      dxyEtaChi2_[label].insert(std::end(dxyEtaChi2_[label]), std::begin(extractedTrend.m_dxyEtaChi2[label]), std::end(extractedTrend.m_dxyEtaChi2[label]));
+      dxyEtaKS_[label].insert(std::end(dxyEtaKS_[label]), std::begin(extractedTrend.m_dxyEtaKS[label]), std::end(extractedTrend.m_dxyEtaKS[label]));
+
+      dxyEtaHi_[label].insert(std::end(dxyEtaHi_[label]), std::begin(extractedTrend.m_dxyEtaHi[label]), std::end(extractedTrend.m_dxyEtaHi[label]));
+      dxyEtaLo_[label].insert(std::end(dxyEtaLo_[label]), std::begin(extractedTrend.m_dxyEtaLo[label]), std::end(extractedTrend.m_dxyEtaLo[label]));
+
+      //******************************//
+      dzEtaMeans_[label].insert(std::end(dzEtaMeans_[label]), std::begin(extractedTrend.m_dzEtaMeans[label]), std::end(extractedTrend.m_dzEtaMeans[label]));
+      dzEtaChi2_[label].insert(std::end(dzEtaChi2_[label]), std::begin(extractedTrend.m_dzEtaChi2[label]), std::end(extractedTrend.m_dzEtaChi2[label]));
+      dzEtaKS_[label].insert(std::end(dzEtaKS_[label]), std::begin(extractedTrend.m_dzEtaKS[label]), std::end(extractedTrend.m_dzEtaKS[label]));
+
+      dzEtaHi_[label].insert(std::end(dzEtaHi_[label]), std::begin(extractedTrend.m_dzEtaHi[label]), std::end(extractedTrend.m_dzEtaHi[label]));
+      dzEtaLo_[label].insert(std::end(dzEtaLo_[label]), std::begin(extractedTrend.m_dzEtaLo[label]), std::end(extractedTrend.m_dzEtaLo[label]));
+     
+      //******************************//
+      dxyVect[label].insert(std::end(dxyVect[label]),std::begin(extractedTrend.m_dxyVect[label]),std::end(extractedTrend.m_dxyVect[label]));
+      dzVect[label].insert(std::end(dzVect[label]),std::begin(extractedTrend.m_dzVect[label]),std::end(extractedTrend.m_dzVect[label]));	 
+    }
+  }
+
+  // extra vectors for low and high boundaries
+
+  for(const auto &label : LegLabels){
+
+    for(unsigned int it=0;it<dxyPhiMeans_[label].size();it++){
+      dxyPhiHiErr_[label].push_back(std::abs(dxyPhiHi_[label][it]-dxyPhiMeans_[label][it]));
+      dxyPhiLoErr_[label].push_back(std::abs(dxyPhiLo_[label][it]-dxyPhiMeans_[label][it]));
+      dxyEtaHiErr_[label].push_back(std::abs(dxyEtaHi_[label][it]-dxyEtaMeans_[label][it])); 
+      dxyEtaLoErr_[label].push_back(std::abs(dxyEtaLo_[label][it]-dxyEtaMeans_[label][it]));
+
+      std::cout<<"label: "<<label << " means:" << dxyEtaMeans_[label][it] << " low: " << dxyEtaLo_[label][it] << " loErr: " << dxyEtaLoErr_[label][it] << std::endl;
+      
+      dzPhiHiErr_[label].push_back(std::abs(dzPhiHi_[label][it]-dzPhiMeans_[label][it])); 
+      dzPhiLoErr_[label].push_back(std::abs(dzPhiLo_[label][it]-dzPhiMeans_[label][it]));	 	  
+      dzEtaHiErr_[label].push_back(std::abs(dzEtaHi_[label][it]-dzEtaMeans_[label][it])); 
+      dzEtaLoErr_[label].push_back(std::abs(dzEtaLo_[label][it]-dzEtaMeans_[label][it]));      
+    }
+  }
+
+ 
+  // just check runs are ordered
+  //for(const auto &run : runs){
+  //  std::cout<<" "<< run ;
+  // }
+
+  // main function call
+  /*
+    doStuff(0,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,
+    dxyPhiMeans_,dxyPhiHi_,dxyPhiLo_,	 	                  
+    dxyEtaMeans_,dxyEtaHi_,dxyEtaLo_,	 	                  
+    dzPhiMeans_,dzPhiHi_,dzPhiLo_,	 	  
+    dzEtaMeans_,dzEtaHi_,dzEtaLo_,       
+    dxyVect,dzVect
+    );
+  */
+  
+  // do the trend-plotting!
+
+  TCanvas *c_dxy_phi_vs_run = new TCanvas("c_dxy_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
+  TCanvas *c_dxy_eta_vs_run = new TCanvas("c_dxy_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+  TCanvas *c_dz_phi_vs_run  = new TCanvas("c_dz_phi_vs_run" ,"dz(#phi) bias vs run number" ,2000,800);
+  TCanvas *c_dz_eta_vs_run  = new TCanvas("c_dz_eta_vs_run" ,"dz(#eta) bias vs run number" ,2000,800);
+
+  TCanvas *c_RMS_dxy_phi_vs_run = new TCanvas("c_RMS_dxy_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
+  TCanvas *c_RMS_dxy_eta_vs_run = new TCanvas("c_RMS_dxy_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+  TCanvas *c_RMS_dz_phi_vs_run  = new TCanvas("c_RMS_dz_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
+  TCanvas *c_RMS_dz_eta_vs_run  = new TCanvas("c_RMS_dz_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+
+  TCanvas *c_mean_dxy_phi_vs_run = new TCanvas("c_mean_dxy_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
+  TCanvas *c_mean_dxy_eta_vs_run = new TCanvas("c_mean_dxy_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+  TCanvas *c_mean_dz_phi_vs_run  = new TCanvas("c_mean_dz_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
+  TCanvas *c_mean_dz_eta_vs_run  = new TCanvas("c_mean_dz_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+
+  TCanvas *Scatter_dxy_vs_run = new TCanvas("Scatter_dxy_vs_run","dxy bias vs run number",2000,800);
+  Scatter_dxy_vs_run->Divide(1,nDirs_);
+  TCanvas *Scatter_dz_vs_run  = new TCanvas("Scatter_dz_vs_run","dxy bias vs run number",2000,800);
+  Scatter_dz_vs_run->Divide(1,nDirs_);    
+
+  TCanvas *c_chisquare_vs_run = new TCanvas("c_chisquare_vs_run","chi2 of pol0 fit vs run number",2000,1000);
+  c_chisquare_vs_run->Divide(2,2);
+
+  TCanvas *c_KSScore_vs_run = new TCanvas("c_KSScore_vs_run","KS score compatibility to 0 vs run number",2000,1000);
+  c_KSScore_vs_run->Divide(2,2);
+
+  // bias on the mean
+
+  TGraph *g_dxy_phi_vs_run[nDirs_];
+  TGraphAsymmErrors *gerr_dxy_phi_vs_run[nDirs_];
+  TGraph *g_chi2_dxy_phi_vs_run[nDirs_];
+  TGraph *g_KS_dxy_phi_vs_run[nDirs_];
+  TGraph *gprime_dxy_phi_vs_run[nDirs_];  
+  TGraph *g_dxy_phi_hi_vs_run[nDirs_];
+  TGraph *g_dxy_phi_lo_vs_run[nDirs_];
+  
+  TGraph *g_dxy_eta_vs_run[nDirs_];
+  TGraphAsymmErrors *gerr_dxy_eta_vs_run[nDirs_];
+  TGraph *g_chi2_dxy_eta_vs_run[nDirs_];
+  TGraph *g_KS_dxy_eta_vs_run[nDirs_];
+  TGraph *gprime_dxy_eta_vs_run[nDirs_];
+  TGraph *g_dxy_eta_hi_vs_run[nDirs_];
+  TGraph *g_dxy_eta_lo_vs_run[nDirs_];
+
+  TGraph *g_dz_phi_vs_run[nDirs_];
+  TGraphAsymmErrors *gerr_dz_phi_vs_run[nDirs_];
+  TGraph *g_chi2_dz_phi_vs_run[nDirs_];
+  TGraph *g_KS_dz_phi_vs_run[nDirs_];
+  TGraph *gprime_dz_phi_vs_run[nDirs_];
+  TGraph *g_dz_phi_hi_vs_run[nDirs_];
+  TGraph *g_dz_phi_lo_vs_run[nDirs_];
+
+  TGraph *g_dz_eta_vs_run[nDirs_];
+  TGraphAsymmErrors *gerr_dz_eta_vs_run[nDirs_];
+  TGraph *g_chi2_dz_eta_vs_run[nDirs_];
+  TGraph *g_KS_dz_eta_vs_run[nDirs_];
+  TGraph *gprime_dz_eta_vs_run[nDirs_];
+  TGraph *g_dz_eta_hi_vs_run[nDirs_];
+  TGraph *g_dz_eta_lo_vs_run[nDirs_];
+
+  // resolutions 
+
+  TH1F *h_RMS_dxy_phi_vs_run[nDirs_];
+  TH1F *h_RMS_dxy_eta_vs_run[nDirs_];
+  TH1F *h_RMS_dz_phi_vs_run[nDirs_];
+  TH1F *h_RMS_dz_eta_vs_run[nDirs_];   
+
+  // scatters of integrated bias
+
+  TH2F *h2_scatter_dxy_vs_run[nDirs_];
+  TH2F *h2_scatter_dz_vs_run[nDirs_];
+
+  // decide the type
+
+  TString theType="";
+  TString theTypeLabel="";
+  if(lumi_axis_format){
+    theType="luminosity";
+    theTypeLabel="processed luminosity (1/fb)";
+    x_ticks = lumiByRun;
+  } else {
+    if(!time_axis_format){
+      theType="run number";
+      theTypeLabel="run number";
+      x_ticks = runs;
+    } else {
+      theType="date";
+      theTypeLabel="UTC date";
+      for(const auto &run : runs){
+	x_ticks.push_back(times[run].Convert());
+      }
+    }
+  }
+  
+  TLegend *my_lego = new TLegend(0.08,0.80,0.18,0.93);
+  //my_lego-> SetNColumns(2);
+  my_lego->SetFillColor(10);
+  my_lego->SetTextSize(0.042);
+  my_lego->SetTextFont(42);
+  my_lego->SetFillColor(10);
+  my_lego->SetLineColor(10);
+  my_lego->SetShadowColor(10);
+
+  // arrays for storing RMS histograms
+  TObjArray *arr_dxy_phi = new TObjArray();
+  TObjArray *arr_dz_phi  = new TObjArray();
+  TObjArray *arr_dxy_eta = new TObjArray();
+  TObjArray *arr_dz_eta  = new TObjArray();
+
+  arr_dxy_phi->Expand(nDirs_);
+  arr_dz_phi->Expand(nDirs_);
+  arr_dxy_eta->Expand(nDirs_);
+  arr_dz_eta->Expand(nDirs_);
+
+  int ccc=0;
+  for(const auto &tick: x_ticks ){
+    outfile<<"***************************************"<< std::endl;
+    outfile<< tick  << std::endl;
+    for(Int_t j=0; j < nDirs_; j++) {
+
+      double RMSxyphi = std::abs(dxyPhiLo_[LegLabels[j]][ccc] - dxyPhiHi_[LegLabels[j]][ccc]);
+      double RMSxyeta =	std::abs(dxyEtaLo_[LegLabels[j]][ccc] - dxyEtaHi_[LegLabels[j]][ccc]);
+      double RMSzphi  =	std::abs(dzPhiLo_[LegLabels[j]][ccc]  - dzPhiHi_[LegLabels[j]][ccc]); 
+      double RMSzeta  =	std::abs(dzEtaLo_[LegLabels[j]][ccc]  - dzEtaHi_[LegLabels[j]][ccc]);
+
+      if(RMSxyphi>100 || RMSxyeta>100 || RMSzphi >100 || RMSzeta>100){ 
+
+	outfile << LegLabels[j] << " dxy(phi) " << dxyPhiMeans_[LegLabels[j]][ccc] << " " << dxyPhiLo_[LegLabels[j]][ccc] << " " << dxyPhiHi_[LegLabels[j]][ccc] <<" " << std::abs(dxyPhiLo_[LegLabels[j]][ccc] - dxyPhiHi_[LegLabels[j]][ccc]) << std::endl;
+	outfile << LegLabels[j] << " dxy(eta) " << dxyEtaMeans_[LegLabels[j]][ccc] << " " << dxyEtaLo_[LegLabels[j]][ccc] << " " << dxyEtaHi_[LegLabels[j]][ccc] <<" " << std::abs(dxyEtaLo_[LegLabels[j]][ccc] - dxyEtaHi_[LegLabels[j]][ccc]) << std::endl;
+	outfile << LegLabels[j] << " dz (phi) " << dzPhiMeans_[LegLabels[j]][ccc]  << " " << dzPhiLo_[LegLabels[j]][ccc]  << " " << dzPhiHi_[LegLabels[j]][ccc]  <<" " << std::abs(dzPhiLo_[LegLabels[j]][ccc]  - dzPhiHi_[LegLabels[j]][ccc])  << std::endl;
+	outfile << LegLabels[j] << " dz (eta) " << dzEtaMeans_[LegLabels[j]][ccc]  << " " << dzEtaLo_[LegLabels[j]][ccc]  << " " << dzEtaHi_[LegLabels[j]][ccc]  <<" " << std::abs(dzEtaLo_[LegLabels[j]][ccc]  - dzEtaHi_[LegLabels[j]][ccc])  << std::endl;
+      }
+    }
+    ccc++;
+  }
+  outfile <<  std::endl;
+
+  pv::bundle theBundle = pv::bundle(nDirs_,theType,theTypeLabel,lumiMapByRun,times,lumi_axis_format,time_axis_format);
+  theBundle.printAll();
+
+  for(Int_t j=0; j < nDirs_; j++) {
+
+    // check on the sanity
+    std::cout<<"x_ticks.size()= "<<x_ticks.size()<<"d xyPhiMeans_[LegLabels["<<j<<"]].size()="<<dxyPhiMeans_[LegLabels[j]].size()<<std::endl;
+
+    // *************************************
+    // dxy vs phi
+    // *************************************
+    
+    auto dxyPhiInputs = pv::wrappedTrends(dxyPhiMeans_,
+					  dxyPhiLo_,
+					  dxyPhiHi_,
+					  dxyPhiLoErr_,
+					  dxyPhiHiErr_,
+					  dxyPhiChi2_,
+					  dxyPhiKS_);
+
+    outputGraphs(dxyPhiInputs,x_ticks,ex_ticks,
+		 c_dxy_phi_vs_run,c_mean_dxy_phi_vs_run,c_RMS_dxy_phi_vs_run,
+		 g_dxy_phi_vs_run[j],           		     
+		 g_chi2_dxy_phi_vs_run[j],    			     
+		 g_KS_dxy_phi_vs_run[j],   			      
+		 g_dxy_phi_lo_vs_run[j],  			      	                          
+		 g_dxy_phi_hi_vs_run[j],  			     
+		 gerr_dxy_phi_vs_run[j],			     
+		 h_RMS_dxy_phi_vs_run,			      
+		 theBundle,
+		 pv::dxyphi,
+		 j,
+		 arr_dxy_phi,
+		 LegLabels[j],
+		 my_lego
+		 );
+    
+    // *************************************
+    // dxy vs eta
+    // *************************************
+
+    auto dxyEtaInputs = pv::wrappedTrends(dxyEtaMeans_,
+					  dxyEtaLo_,
+					  dxyEtaHi_,
+					  dxyEtaLoErr_,
+					  dxyEtaHiErr_,
+					  dxyEtaChi2_,
+					  dxyEtaKS_);
+
+    outputGraphs(dxyEtaInputs,x_ticks,ex_ticks,
+		 c_dxy_eta_vs_run,c_mean_dxy_eta_vs_run,c_RMS_dxy_eta_vs_run,
+		 g_dxy_eta_vs_run[j],           		     
+		 g_chi2_dxy_eta_vs_run[j],    			     
+		 g_KS_dxy_eta_vs_run[j],   			      
+		 g_dxy_eta_lo_vs_run[j],  			      	                          
+		 g_dxy_eta_hi_vs_run[j],  			     
+		 gerr_dxy_eta_vs_run[j],			     
+		 h_RMS_dxy_eta_vs_run,			      
+		 theBundle,
+		 pv::dxyeta,
+		 j,
+		 arr_dxy_eta,
+		 LegLabels[j],
+		 my_lego
+		 );
+
+    // *************************************
+    // dz vs phi
+    // *************************************
+    
+    auto dzPhiInputs = pv::wrappedTrends(dzPhiMeans_,
+					 dzPhiLo_,
+					 dzPhiHi_,
+					 dzPhiLoErr_,
+					 dzPhiHiErr_,
+					 dzPhiChi2_,
+					 dzPhiKS_);
+
+    outputGraphs(dzPhiInputs,x_ticks,ex_ticks,
+		 c_dz_phi_vs_run,c_mean_dz_phi_vs_run,c_RMS_dz_phi_vs_run,
+		 g_dz_phi_vs_run[j],           		     
+		 g_chi2_dz_phi_vs_run[j],    			     
+		 g_KS_dz_phi_vs_run[j],   			      
+		 g_dz_phi_lo_vs_run[j],  			      	                          
+		 g_dz_phi_hi_vs_run[j],  			     
+		 gerr_dz_phi_vs_run[j],			     
+		 h_RMS_dz_phi_vs_run,			      
+		 theBundle,
+		 pv::dzphi,
+		 j,
+		 arr_dz_phi,
+		 LegLabels[j],
+		 my_lego
+		 );
+
+    // *************************************
+    // dz vs eta
+    // *************************************
+
+    auto dzEtaInputs = pv::wrappedTrends(dzEtaMeans_,
+					 dzEtaLo_,
+					 dzEtaHi_,
+					 dzEtaLoErr_,
+					 dzEtaHiErr_,
+					 dzEtaChi2_,
+					 dzEtaKS_);
+
+    outputGraphs(dzEtaInputs,x_ticks,ex_ticks,
+		 c_dz_eta_vs_run,c_mean_dz_eta_vs_run,c_RMS_dz_eta_vs_run,
+		 g_dz_eta_vs_run[j],           		     
+		 g_chi2_dz_eta_vs_run[j],    			     
+		 g_KS_dz_eta_vs_run[j],   			      
+		 g_dz_eta_lo_vs_run[j],  			      	                          
+		 g_dz_eta_hi_vs_run[j],  			     
+		 gerr_dz_eta_vs_run[j],			     
+		 h_RMS_dz_eta_vs_run,			      
+		 theBundle,
+		 pv::dzeta,
+		 j,
+		 arr_dz_eta,
+		 LegLabels[j],
+		 my_lego
+		 );
+    
+    // *************************************
+    // Integrated bias dxy scatter plots
+    // *************************************
+
+    h2_scatter_dxy_vs_run[j] = new TH2F(Form("h2_scatter_dxy_%s",LegLabels[j].Data()),Form("scatter of d_{xy} vs %s;%s;d_{xy} [cm]",theType.Data(),theTypeLabel.Data()),x_ticks.size()-1,&(x_ticks[0]),dxyVect[LegLabels[j]][0].get_n_bins(),dxyVect[LegLabels[j]][0].get_y_min(),dxyVect[LegLabels[j]][0].get_y_max());
+    h2_scatter_dxy_vs_run[j]->SetStats(kFALSE);
+
+    for(unsigned int runindex=0;runindex<x_ticks.size();runindex++){
+      for(unsigned int binindex=0;binindex<dxyVect[LegLabels[j]][runindex].get_n_bins();binindex++){
+	h2_scatter_dxy_vs_run[j]->SetBinContent(runindex+1,binindex+1,dxyVect[LegLabels[j]][runindex].get_bin_contents().at(binindex)/dxyVect[LegLabels[j]][runindex].get_integral());
+      }
+    }
+  
+    //Scatter_dxy_vs_run->cd();
+    h2_scatter_dxy_vs_run[j]->SetFillColorAlpha(pv::colors[j],0.3);
+    h2_scatter_dxy_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    h2_scatter_dxy_vs_run[j]->SetLineColor(pv::colors[j]);
+    h2_scatter_dxy_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+
+    auto h_dxypfx_tmp = (TProfile*)(((TH2F*)h2_scatter_dxy_vs_run[j])->ProfileX(Form("_apfx_%i",j),1,-1,"o"));
+    h_dxypfx_tmp->SetName(TString(h2_scatter_dxy_vs_run[j]->GetName())+"_pfx");
+    h_dxypfx_tmp->SetStats(kFALSE);
+    h_dxypfx_tmp->SetMarkerColor(pv::colors[j]);
+    h_dxypfx_tmp->SetLineColor(pv::colors[j]);
+    h_dxypfx_tmp->SetLineWidth(2); 
+    h_dxypfx_tmp->SetMarkerSize(1); 
+    h_dxypfx_tmp->SetMarkerStyle(pv::markers[j]);
+
+    beautify(h2_scatter_dxy_vs_run[j]);
+    beautify(h_dxypfx_tmp);
+
+    Scatter_dxy_vs_run->cd(j+1);
+    adjustmargins(Scatter_dxy_vs_run->cd(j+1));
+    //h_dxypfx_tmp->GetYaxis()->SetRangeUser(-0.01,0.01);
+    //h2_scatter_dxy_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,0.5);
+    h2_scatter_dxy_vs_run[j]->Draw("colz");  
+    h_dxypfx_tmp->Draw("same");
+
+    // *************************************
+    // Integrated bias dz scatter plots
+    // *************************************
+
+    h2_scatter_dz_vs_run[j] = new TH2F(Form("h2_scatter_dz_%s",LegLabels[j].Data()),Form("scatter of d_{z} vs %s;%s;d_{z} [cm]",theType.Data(),theTypeLabel.Data()),x_ticks.size()-1,&(x_ticks[0]),dzVect[LegLabels[j]][0].get_n_bins(),dzVect[LegLabels[j]][0].get_y_min(),dzVect[LegLabels[j]][0].get_y_max());
+    h2_scatter_dz_vs_run[j]->SetStats(kFALSE);
+
+    for(unsigned int runindex=0;runindex<x_ticks.size();runindex++){
+      for(unsigned int binindex=0;binindex<dzVect[LegLabels[j]][runindex].get_n_bins();binindex++){
+	h2_scatter_dz_vs_run[j]->SetBinContent(runindex+1,binindex+1,dzVect[LegLabels[j]][runindex].get_bin_contents().at(binindex)/dzVect[LegLabels[j]][runindex].get_integral());
+      }
+    }
+    
+    //Scatter_dz_vs_run->cd();
+    h2_scatter_dz_vs_run[j]->SetFillColorAlpha(pv::colors[j],0.3);
+    h2_scatter_dz_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    h2_scatter_dz_vs_run[j]->SetLineColor(pv::colors[j]);
+    h2_scatter_dz_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+
+    auto h_dzpfx_tmp = (TProfile*)(((TH2F*)h2_scatter_dz_vs_run[j])->ProfileX(Form("_apfx_%i",j),1,-1,"o"));
+    h_dzpfx_tmp->SetName(TString(h2_scatter_dz_vs_run[j]->GetName())+"_pfx");
+    h_dzpfx_tmp->SetStats(kFALSE);
+    h_dzpfx_tmp->SetMarkerColor(pv::colors[j]);
+    h_dzpfx_tmp->SetLineColor(pv::colors[j]);
+    h_dzpfx_tmp->SetLineWidth(2); 
+    h_dzpfx_tmp->SetMarkerSize(1); 
+    h_dzpfx_tmp->SetMarkerStyle(pv::markers[j]);
+
+    beautify(h2_scatter_dz_vs_run[j]);
+    beautify(h_dzpfx_tmp);
+
+    Scatter_dz_vs_run->cd(j+1);
+    adjustmargins(Scatter_dz_vs_run->cd(j+1));
+    //h_dzpfx_tmp->GetYaxis()->SetRangeUser(-0.01,0.01);
+    //h2_scatter_dz_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,0.5); 
+    h2_scatter_dz_vs_run[j]->Draw("colz");  
+    h_dzpfx_tmp->Draw("same");
+
+    // **************************************** 
+    // Canvas for chi2 goodness of pol0 fit
+    // ****************************************
+
+    // 1st pad
+    c_chisquare_vs_run->cd(1);
+    adjustmargins(c_chisquare_vs_run->cd(1));
+    g_chi2_dxy_phi_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_chi2_dxy_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_chi2_dxy_phi_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_chi2_dxy_phi_vs_run[j]->SetName(Form("g_chi2_dxy_phi_%s",LegLabels[j].Data()));
+    g_chi2_dxy_phi_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{xy}(#varphi) fit vs %s",theType.Data()));
+    g_chi2_dxy_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{xy}(#phi) pol0 fit");
+    g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
+    beautify(g_chi2_dxy_phi_vs_run[j]);
+    //g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_chi2_dxy_phi_vs_run[j]->Draw("APL");
+    } else {
+      g_chi2_dxy_phi_vs_run[j]->Draw("PLsame");
+    }
+
+    if(time_axis_format){
+      timify(g_chi2_dxy_phi_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+    // 2nd pad
+    c_chisquare_vs_run->cd(2);
+    adjustmargins(c_chisquare_vs_run->cd(2));
+    g_chi2_dxy_eta_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_chi2_dxy_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_chi2_dxy_eta_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_chi2_dxy_eta_vs_run[j]->SetName(Form("g_chi2_dxy_eta_%s",LegLabels[j].Data()));
+    g_chi2_dxy_eta_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{xy}(#eta) fit vs %s",theType.Data()));
+    g_chi2_dxy_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{xy}(#eta) pol0 fit");
+    g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
+    beautify(g_chi2_dxy_eta_vs_run[j]);
+    //g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_chi2_dxy_eta_vs_run[j]->Draw("APL");
+    } else {
+      g_chi2_dxy_eta_vs_run[j]->Draw("PLsame");
+    }
+
+    if(time_axis_format){
+      timify(g_chi2_dxy_eta_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+    //3d pad
+    c_chisquare_vs_run->cd(3);
+    adjustmargins(c_chisquare_vs_run->cd(3));
+    g_chi2_dz_phi_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_chi2_dz_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_chi2_dz_phi_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_chi2_dz_phi_vs_run[j]->SetName(Form("g_chi2_dz_phi_%s",LegLabels[j].Data()));
+    g_chi2_dz_phi_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{z}(#varphi) fit vs %s",theType.Data()));
+    g_chi2_dz_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{z}(#phi) pol0 fit");
+    g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
+    beautify(g_chi2_dz_phi_vs_run[j]);
+    //g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_chi2_dz_phi_vs_run[j]->Draw("APL");
+    } else {
+      g_chi2_dz_phi_vs_run[j]->Draw("PLsame");
+    }
+
+    if(time_axis_format){
+      timify(g_chi2_dz_phi_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+    //4th pad
+    c_chisquare_vs_run->cd(4);
+    adjustmargins(c_chisquare_vs_run->cd(4));
+    g_chi2_dz_eta_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_chi2_dz_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_chi2_dz_eta_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_chi2_dz_eta_vs_run[j]->SetName(Form("g_chi2_dz_eta_%s",LegLabels[j].Data()));
+    g_chi2_dz_eta_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{z}(#eta) fit vs %s",theType.Data()));
+    g_chi2_dz_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{z}(#eta) pol0 fit");
+    g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
+    beautify(g_chi2_dz_eta_vs_run[j]);
+    //g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_chi2_dz_eta_vs_run[j]->Draw("APL");
+    } else {
+      g_chi2_dz_eta_vs_run[j]->Draw("PLsame");
+    }
+
+    if(time_axis_format){
+      timify(g_chi2_dz_eta_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+
+    // **************************************** 
+    // Canvas for Kolmogorov-Smirnov test
+    // ****************************************
+
+    // 1st pad
+    c_KSScore_vs_run->cd(1);
+    adjustmargins(c_KSScore_vs_run->cd(1));
+    g_KS_dxy_phi_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_KS_dxy_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_KS_dxy_phi_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_KS_dxy_phi_vs_run[j]->SetName(Form("g_KS_dxy_phi_%s",LegLabels[j].Data()));
+    g_KS_dxy_phi_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{xy}(#varphi) vs %s",theType.Data()));
+    g_KS_dxy_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{xy}(#phi) w.r.t 0");
+    g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    beautify(g_KS_dxy_phi_vs_run[j]);
+    //g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_KS_dxy_phi_vs_run[j]->Draw("AP");
+    } else {
+      g_KS_dxy_phi_vs_run[j]->Draw("Psame");
+    }
+
+    if(time_axis_format){
+      timify(g_KS_dxy_phi_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+    // 2nd pad
+    c_KSScore_vs_run->cd(2);
+    adjustmargins(c_KSScore_vs_run->cd(2));
+    g_KS_dxy_eta_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_KS_dxy_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_KS_dxy_eta_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_KS_dxy_eta_vs_run[j]->SetName(Form("g_KS_dxy_eta_%s",LegLabels[j].Data()));
+    g_KS_dxy_eta_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{xy}(#eta) vs %s",theType.Data()));
+    g_KS_dxy_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{xy}(#eta) w.r.t 0");
+    g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    beautify(g_KS_dxy_eta_vs_run[j]);
+    //g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_KS_dxy_eta_vs_run[j]->Draw("AP");
+    } else {
+      g_KS_dxy_eta_vs_run[j]->Draw("Psame");
+    }
+
+    if(time_axis_format){
+      timify(g_KS_dxy_eta_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+    //3d pad
+    c_KSScore_vs_run->cd(3);
+    adjustmargins(c_KSScore_vs_run->cd(3));
+    g_KS_dz_phi_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_KS_dz_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_KS_dz_phi_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_KS_dz_phi_vs_run[j]->SetName(Form("g_KS_dz_phi_%s",LegLabels[j].Data()));
+    g_KS_dz_phi_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{z}(#varphi) vs %s",theType.Data()));
+    g_KS_dz_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_KS_dz_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{z}(#phi) w.r.t 0");
+    g_KS_dz_phi_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    beautify(g_KS_dz_phi_vs_run[j]);
+    //g_KS_dz_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_KS_dz_phi_vs_run[j]->Draw("AP");
+    } else {
+      g_KS_dz_phi_vs_run[j]->Draw("Psame");
+    }
+
+    if(time_axis_format){
+      timify(g_KS_dz_phi_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+    //4th pad
+    c_KSScore_vs_run->cd(4);
+    adjustmargins(c_KSScore_vs_run->cd(4));
+    g_KS_dz_eta_vs_run[j]->SetMarkerStyle(pv::markers[j]);
+    g_KS_dz_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
+    g_KS_dz_eta_vs_run[j]->SetLineColor(pv::colors[j]);
+
+    g_KS_dz_eta_vs_run[j]->SetName(Form("g_KS_dz_eta_%s",LegLabels[j].Data()));
+    g_KS_dz_eta_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{z}(#eta) vs %s",theType.Data()));
+    g_KS_dz_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
+    g_KS_dz_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{z}(#eta) w.r.t 0");
+    g_KS_dz_eta_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    beautify(g_KS_dz_eta_vs_run[j]);
+    //g_KS_dz_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
+
+    if(j==0){
+      g_KS_dz_eta_vs_run[j]->Draw("AP");
+    } else {
+      g_KS_dz_eta_vs_run[j]->Draw("Psame");
+    }
+
+    if(time_axis_format){
+      timify(g_KS_dz_eta_vs_run[j]);
+    }
+
+    if(j==nDirs_-1){
+      my_lego->Draw("same");
+    }
+
+  }
+  
+  // delete the array for the maxima
+  delete arr_dxy_phi;
+  delete arr_dz_phi;
+  delete arr_dxy_eta;
+  delete arr_dz_eta;
+
+  TString append;
+  if(lumi_axis_format){ 
+    append = "lumi";
+  } else{ 
+    if(time_axis_format){
+      append = "date";
+    } else {
+      append = "run";
+    }
+  }   
+
+
+  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_"+append+".pdf");
+  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_"+append+".png");
+  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_"+append+".eps");
+
+  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_"+append+".pdf");
+  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_"+append+".png");
+  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_"+append+".eps");
+
+  c_dz_phi_vs_run->SaveAs("dz_phi_vs_"+append+".pdf");
+  c_dz_phi_vs_run->SaveAs("dz_phi_vs_"+append+".png");
+  c_dz_phi_vs_run->SaveAs("dz_phi_vs_"+append+".eps");
+
+  c_dz_eta_vs_run->SaveAs("dz_eta_vs_"+append+".pdf");
+  c_dz_eta_vs_run->SaveAs("dz_eta_vs_"+append+".png");
+  c_dz_eta_vs_run->SaveAs("dz_eta_vs_"+append+".eps");
+
+  TCanvas dummyC("dummyC","dummyC",2000,800); 
+  dummyC.Print("combined.pdf[");
+  c_dxy_phi_vs_run->Print("combined.pdf");
+  c_dxy_eta_vs_run->Print("combined.pdf");                  
+  c_dz_phi_vs_run->Print("combined.pdf");
+  c_dz_eta_vs_run->Print("combined.pdf");
+  dummyC.Print("combined.pdf]");
+
+  // mean
+
+  c_mean_dxy_phi_vs_run->SaveAs("mean_dxy_phi_vs_"+append+".pdf");
+  c_mean_dxy_phi_vs_run->SaveAs("mean_dxy_phi_vs_"+append+".png");
+
+  c_mean_dxy_eta_vs_run->SaveAs("mean_dxy_eta_vs_"+append+".pdf");
+  c_mean_dxy_eta_vs_run->SaveAs("mean_dxy_eta_vs_"+append+".png");
+
+  c_mean_dz_phi_vs_run->SaveAs("mean_dz_phi_vs_"+append+".pdf");
+  c_mean_dz_phi_vs_run->SaveAs("mean_dz_phi_vs_"+append+".png");
+
+  c_mean_dz_eta_vs_run->SaveAs("mean_dz_eta_vs_"+append+".pdf");
+  c_mean_dz_eta_vs_run->SaveAs("mean_dz_eta_vs_"+append+".png");
+
+  TCanvas dummyC2("dummyC2","dummyC2",2000,800); 
+  dummyC2.Print("means.pdf[");
+  c_mean_dxy_phi_vs_run->Print("means.pdf");
+  c_mean_dxy_eta_vs_run->Print("means.pdf");                  
+  c_mean_dz_phi_vs_run->Print("means.pdf");
+  c_mean_dz_eta_vs_run->Print("means.pdf");
+  dummyC2.Print("means.pdf]");
+
+  // RMS
+
+  c_RMS_dxy_phi_vs_run->SaveAs("RMS_dxy_phi_vs_"+append+".pdf");
+  c_RMS_dxy_phi_vs_run->SaveAs("RMS_dxy_phi_vs_"+append+".png");
+
+  c_RMS_dxy_eta_vs_run->SaveAs("RMS_dxy_eta_vs_"+append+".pdf");
+  c_RMS_dxy_eta_vs_run->SaveAs("RMS_dxy_eta_vs_"+append+".png");
+
+  c_RMS_dz_phi_vs_run->SaveAs("RMS_dz_phi_vs_"+append+".pdf");
+  c_RMS_dz_phi_vs_run->SaveAs("RMS_dz_phi_vs_"+append+".png");
+
+  c_RMS_dz_eta_vs_run->SaveAs("RMS_dz_eta_vs_"+append+".pdf");
+  c_RMS_dz_eta_vs_run->SaveAs("RMS_dz_eta_vs_"+append+".png");
+
+  TCanvas dummyC3("dummyC3","dummyC3",2000,800); 
+  dummyC3.Print("RMSs.pdf[");
+  c_RMS_dxy_phi_vs_run->Print("RMSs.pdf");
+  c_RMS_dxy_eta_vs_run->Print("RMSs.pdf");                  
+  c_RMS_dz_phi_vs_run->Print("RMSs.pdf");
+  c_RMS_dz_eta_vs_run->Print("RMSs.pdf");
+  dummyC3.Print("RMSs.pdf]");
+
+
+  // scatter
+
+  Scatter_dxy_vs_run->SaveAs("Scatter_dxy_vs_"+append+".pdf");
+  Scatter_dxy_vs_run->SaveAs("Scatter_dxy_vs_"+append+".png");
+
+  Scatter_dz_vs_run->SaveAs("Scatter_dz_vs_"+append+".pdf");
+  Scatter_dz_vs_run->SaveAs("Scatter_dz_vs_"+append+".png");
+
+  // chi2 
+
+  c_chisquare_vs_run->SaveAs("chi2pol0fit_vs_"+append+".pdf");
+  c_chisquare_vs_run->SaveAs("chi2pol0fit_vs_"+append+".png");
+
+  // KS score
+  
+  c_KSScore_vs_run->SaveAs("KSScore_vs_"+append+".pdf");
+  c_KSScore_vs_run->SaveAs("KSScore_vs_"+append+".png");
+
+  // do all the deletes
+
+  for(int iDir=0;iDir<nDirs_;iDir++){
+
+   delete g_dxy_phi_vs_run[iDir]; 
+   delete g_chi2_dxy_phi_vs_run[iDir];    
+   delete g_KS_dxy_phi_vs_run[iDir];    
+   delete g_dxy_phi_hi_vs_run[iDir]; 
+   delete g_dxy_phi_lo_vs_run[iDir]; 
+                               
+   delete g_dxy_eta_vs_run[iDir];    
+   delete g_chi2_dxy_eta_vs_run[iDir];    
+   delete g_KS_dxy_eta_vs_run[iDir];    
+   delete g_dxy_eta_hi_vs_run[iDir]; 
+   delete g_dxy_eta_lo_vs_run[iDir]; 
+                               
+   delete g_dz_phi_vs_run[iDir];   
+   delete g_chi2_dz_phi_vs_run[iDir];     
+   delete g_KS_dz_phi_vs_run[iDir];       
+   delete g_dz_phi_hi_vs_run[iDir];  
+   delete g_dz_phi_lo_vs_run[iDir];  
+                               
+   delete g_dz_eta_vs_run[iDir];  
+   delete g_chi2_dz_eta_vs_run[iDir];     
+   delete g_KS_dz_eta_vs_run[iDir];          
+   delete g_dz_eta_hi_vs_run[iDir];  
+   delete g_dz_eta_lo_vs_run[iDir];  
+                                                             
+   delete h_RMS_dxy_phi_vs_run[iDir];  
+   delete h_RMS_dxy_eta_vs_run[iDir];  
+   delete h_RMS_dz_phi_vs_run[iDir];   
+   delete h_RMS_dz_eta_vs_run[iDir];   
+
+  }
+
+  // mv the run-by-run plots into the folders
+
+  gSystem->mkdir("Biases");
+  TString processline = ".! mv Bias*.p* ./Biases/";
+  std::cout<<"Executing: \n"
+	   <<processline<< "\n"<<std::endl;
+  gROOT->ProcessLine(processline.Data());
+  gSystem->Sleep(100);
+  processline.Clear();
+
+  gSystem->mkdir("ResolutionsVsPt");
+  processline = ".! mv ResolutionsVsPt*.p* ./ResolutionsVsPt/";
+  std::cout<<"Executing: \n"
+	   <<processline<< "\n"<<std::endl;
+  gROOT->ProcessLine(processline.Data());
+  gSystem->Sleep(100);
+  processline.Clear();
+
+  gSystem->mkdir("Resolutions");
+  processline = ".! mv Resolutions*.p* ./Resolutions/";
+  std::cout<<"Executing: \n"
+	   <<processline<< "\n"<<std::endl;
+  gROOT->ProcessLine(processline.Data());
+  gSystem->Sleep(100);
+  processline.Clear();
+
+  gSystem->mkdir("Pulls");
+  processline = ".! mv Pulls*.p* ./Pulls/";
+  std::cout<<"Executing: \n"
+	   <<processline<< "\n" <<std::endl;
+  gROOT->ProcessLine(processline.Data());
+  gSystem->Sleep(100);
+  processline.Clear();
+
+  timer.Stop(); 	 
+  timer.Print();
+
+}
+
+/*--------------------------------------------------------------------*/
+void outputGraphs(const pv::wrappedTrends& allInputs,
+		  const std::vector<double>& ticks,
+		  const std::vector<double>& ex_ticks,
+		  TCanvas* &canv,
+		  TCanvas* &mean_canv,
+		  TCanvas* &rms_canv,
+		  TGraph* &g_mean,
+		  TGraph* &g_chi2,
+		  TGraph* &g_KS,	  
+		  TGraph* &g_low,
+		  TGraph* &g_high,
+		  TGraphAsymmErrors* &g_asym,
+		  TH1F* h_RMS[],      
+		  const pv::bundle& mybundle,
+		  const pv::view& theView,
+		  const int index,
+		  TObjArray* &array,
+		  const TString& label,
+		  TLegend* &legend
+		  )
+/*--------------------------------------------------------------------*/
+{
+
+  g_mean = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getMean()[label])[0]));
+  g_chi2 = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getChi2()[label])[0]));
+  g_KS   = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getKS()[label])[0]));
+  g_high = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getHigh()[label])[0]));
+  g_low  = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getLow()[label])[0]));
+
+  g_asym = new TGraphAsymmErrors(ticks.size(),&(ticks[0]),&((allInputs.getMean()[label])[0]),&(ex_ticks[0]),&(ex_ticks[0]),&((allInputs.getLowErr()[label])[0]),&((allInputs.getHighErr()[label])[0]));
+
+  adjustmargins(canv);
+  canv->cd();
+  g_asym->SetFillStyle(3005);
+  g_asym->SetFillColor(pv::colors[index]);
+  g_mean->SetMarkerStyle(pv::markers[index]);
+  g_mean->SetMarkerColor(pv::colors[index]);
+  g_mean->SetLineColor(pv::colors[index]);
+  g_mean->SetMarkerSize(1.5);
+  g_high->SetLineColor(pv::colors[index]);
+  g_low->SetLineColor(pv::colors[index]);
+  beautify(g_mean);
+  beautify(g_asym);
+
+  if(theView==pv::dxyphi){
+    legend->AddEntry(g_mean,label,"PL");
+  }
+
+  const char* coord;
+  const char* kin;
+  float ampl;
+
+  switch(theView){
+  case pv::dxyphi  :
+    coord = "xy";
+    kin   = "phi";
+    ampl  = 40;
+    break;
+  case pv::dzphi   : 
+    coord = "z";
+    kin   = "phi";
+    ampl  = 40;
+    break;
+  case pv::dxyeta  :
+    coord = "xy";
+    kin   = "eta";
+    ampl  = 40;
+    break;
+  case pv::dzeta   : 
+    coord = "z";
+    kin   = "eta";
+    ampl  = 60;
+    break;
+  default :
+    coord = "unknown";
+    kin   = "unknown";
+    break;
+  }
+
+  g_mean->SetName(Form("g_bias_d%s_%s_%s",coord,kin,label.Data()));
+  g_mean->SetTitle(Form("Bias of d_{%s}(#%s) vs %s",coord,kin,mybundle.getDataType()));
+  g_mean->GetXaxis()->SetTitle(mybundle.getDataTypeLabel());
+  g_mean->GetYaxis()->SetTitle(Form("#LT d_{%s}(#%s) #GT [#mum]",coord,kin));
+  g_mean->GetYaxis()->SetRangeUser(-ampl,ampl);
+
+
+  std::cout<<"===================================================================================================="<<std::endl;
+  std::cout<< mybundle.getTotalLumi() << std::endl;
+  std::cout<<"===================================================================================================="<<std::endl;
+
+  g_asym->SetName(Form("gerr_bias_d%s_%s_%s",coord,kin,label.Data()));
+  g_asym->SetTitle(Form("Bias of d_{%s}(#%s) vs %s",coord,kin,mybundle.getDataType()));
+  g_asym->GetXaxis()->SetTitle(mybundle.getDataTypeLabel());
+  g_asym->GetYaxis()->SetTitle(Form("#LT d_{%s}(#%s) #GT [#mum]",coord,kin));
+  g_asym->GetYaxis()->SetRangeUser(-ampl,ampl);
+
+  //g_mean->GetXaxis()->UnZoom();
+  //g_asym->GetXaxis()->UnZoom();
+
+  if(index==0){
+    g_asym->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+    g_mean->Draw("AP");
+    g_asym->Draw("P3same");
+  } else {
+    g_mean->Draw("Psame");
+    g_asym->Draw("3same");
+  }
+  g_high->Draw("Lsame");
+  g_low->Draw("Lsame");
+  
+  if(mybundle.isTimeAxis()){
+    timify(g_asym);
+    timify(g_mean);
+    timify(g_high);
+    timify(g_low);
+  }
+
+  if(mybundle.isLumiAxis()){
+    g_asym->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+    g_mean->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+    g_high->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+    g_low->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+  }
+
+  if(index==(mybundle.getNObjects()-1)){ 
+    legend->Draw("same");
+    TH1F* theZero = DrawConstantGraph(g_mean,1,0.);
+    theZero->Draw("E1same][");
+  }
+	
+  auto current_pad = static_cast<TPad*>(gPad);
+  cmsPrel(current_pad);
+
+  superImposeIOVBoundaries(canv,mybundle.isLumiAxis(),mybundle.isTimeAxis(),mybundle.getLumiMapByRun(),mybundle.getTimes());
+   
+  // mean only
+  adjustmargins(mean_canv);
+  mean_canv->cd();
+  auto gprime  =  (TGraph*)g_mean->Clone();
+  if(index==0){
+    gprime->GetYaxis()->SetRangeUser(-10.,10.);
+    if(mybundle.isLumiAxis()) gprime->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+    gprime->Draw("APL");
+  } else {
+    gprime->Draw("PLsame");
+  }
+  
+  if(index==(mybundle.getNObjects()-1)){ 
+    legend->Draw("same");
+  }
+  
+  if(index==0){
+    TH1F* theZero = DrawConstantGraph(gprime,2,0.);
+    theZero->Draw("E1same][");
+    
+    auto current_pad = static_cast<TPad*>(gPad);
+    cmsPrel(current_pad);
+    
+    superImposeIOVBoundaries(mean_canv,mybundle.isLumiAxis(),mybundle.isTimeAxis(),mybundle.getLumiMapByRun(),mybundle.getTimes());
+  }
+
+  // scatter or RMS TH1
+  h_RMS[index] = new TH1F(Form("h_RMS_dz_eta_%s",label.Data()),Form("scatter of d_{%s}(#%s) vs %s;%s;peak-to-peak deviation of d_{%s}(#%s) [#mum]",coord,kin,mybundle.getDataType(),mybundle.getDataTypeLabel(),coord,kin),ticks.size()-1,&(ticks[0]));
+  h_RMS[index]->SetStats(kFALSE);
+   
+  int bincounter=0;
+  for(const auto &tick : ticks ){
+    bincounter++;
+    h_RMS[index]->SetBinContent(bincounter,std::abs(allInputs.getHigh()[label][bincounter-1]-allInputs.getLow()[label][bincounter-1]));
+    h_RMS[index]->SetBinError(bincounter,0.01);
+  }
+   
+  h_RMS[index]->SetLineColor(pv::colors[index]);
+  h_RMS[index]->SetLineWidth(2);
+  h_RMS[index]->SetMarkerSize(1.5);
+  h_RMS[index]->SetMarkerStyle(pv::markers[index]);
+  h_RMS[index]->SetMarkerColor(pv::colors[index]);
+  adjustmargins(rms_canv);
+  rms_canv->cd();
+  beautify(h_RMS[index]);
+  
+  if(mybundle.isTimeAxis()){
+    timify(h_RMS[index]);
+  }
+  
+  array->Add(h_RMS[index]);
+   
+  // at the last file re-loop
+  if(index==(mybundle.getNObjects()-1)){
+     
+    auto theMax = getMaximumFromArray(array);
+    std::cout<< "the max for d"<< coord <<"("<<kin<<") RMS is "<< theMax << std::endl;
+    
+    for(Int_t k=0; k<mybundle.getNObjects() ; k++){
+      h_RMS[k]->GetYaxis()->SetRangeUser(-theMax*0.45,theMax*1.40);
+      if(k==0){
+  	h_RMS[k]->Draw("L");
+      } else {
+  	h_RMS[k]->Draw("Lsame");
+      }
+    }
+    legend->Draw("same");
+    TH1F* theConst = DrawConstant(h_RMS[index],1,0.);
+    theConst->Draw("same][");
+
+    current_pad = static_cast<TPad*>(gPad);
+    cmsPrel(current_pad);
+   
+    superImposeIOVBoundaries(rms_canv,mybundle.isLumiAxis(),mybundle.isTimeAxis(),mybundle.getLumiMapByRun(),mybundle.getTimes());
+
+  }
+  
+}
+
+
+/*--------------------------------------------------------------------*/
+std::vector<int> list_files(const char *dirname, const char *ext)
+/*--------------------------------------------------------------------*/
+{
+  std::vector<int> theRunNumbers;
+  
+  TSystemDirectory dir(dirname, dirname);
+  TList *files = dir.GetListOfFiles();
+  if (files) {
+    TSystemFile *file;
+    TString fname;
+    TIter next(files);
+    while ((file=(TSystemFile*)next())) {
+      fname = file->GetName();
+      if (!file->IsDirectory() && fname.EndsWith(ext) && fname.BeginsWith("PVValidation")) {
+	//std::cout << fname.Data() << std::endl;
+	TObjArray *bits = fname.Tokenize("_");
+	TString theRun = bits->At(2)->GetName();
+	//std::cout << theRun << std::endl;
+	TString formatRun = (theRun.ReplaceAll(".root","")).ReplaceAll("_","");
+	//std::cout << dirname << " "<< formatRun.Atoi() << std::endl;
+	theRunNumbers.push_back(formatRun.Atoi());
+      }
+    }
+  }
+  return theRunNumbers;
+}
+
+//*************************************************************
+void arrangeOutCanvas(TCanvas *canv, TH1F* m_11Trend[100],TH1F* m_12Trend[100],TH1F* m_21Trend[100],TH1F* m_22Trend[100],Int_t nDirs, TString LegLabels[10],unsigned int theRun){
+//*************************************************************
+
+  TLegend *lego = new TLegend(0.19,0.80,0.79,0.93);
+  //lego-> SetNColumns(2);
+  lego->SetFillColor(10);
+  lego->SetTextSize(0.042);
+  lego->SetTextFont(42);
+  lego->SetFillColor(10);
+  lego->SetLineColor(10);
+  lego->SetShadowColor(10);
+  
+  TPaveText *ptDate =new TPaveText(0.19,0.95,0.45,0.99,"blNDC");
+  ptDate->SetFillColor(kYellow);
+  //ptDate->SetFillColor(10);
+  ptDate->SetBorderSize(1);
+  ptDate->SetLineColor(kBlue);
+  ptDate->SetLineWidth(1);
+  ptDate->SetTextFont(42);
+  TText *textDate = ptDate->AddText(Form("Run: %i",theRun));
+  textDate->SetTextSize(0.04);
+  textDate->SetTextColor(kBlue);
+  textDate->SetTextAlign(22);
+
+  canv->SetFillColor(10);  
+  canv->Divide(2,2);
+ 
+  TH1F *dBiasTrend[4][nDirs]; 
+  
+  for(Int_t i=0;i<nDirs;i++){
+    dBiasTrend[0][i] = m_11Trend[i];
+    dBiasTrend[1][i] = m_12Trend[i];
+    dBiasTrend[2][i] = m_21Trend[i];
+    dBiasTrend[3][i] = m_22Trend[i];
+  }
+
+  Double_t absmin[4]={999.,999.,999.,999.};
+  Double_t absmax[4]={-999.,-999.-999.,-999.};
+
+  for(Int_t k=0; k<4; k++){
+
+    canv->cd(k+1)->SetBottomMargin(0.14);
+    canv->cd(k+1)->SetLeftMargin(0.18);
+    canv->cd(k+1)->SetRightMargin(0.01);
+    canv->cd(k+1)->SetTopMargin(0.06);
+    
+    canv->cd(k+1);
+    
+    for(Int_t i=0; i<nDirs; i++){
+      if(dBiasTrend[k][i]->GetMaximum()>absmax[k]) absmax[k] = dBiasTrend[k][i]->GetMaximum();
+      if(dBiasTrend[k][i]->GetMinimum()<absmin[k]) absmin[k] = dBiasTrend[k][i]->GetMinimum();
+    }
+
+    Double_t safeDelta=(absmax[k]-absmin[k])/8.;
+    Double_t theExtreme=std::max(absmax[k],TMath::Abs(absmin[k]));
+
+    for(Int_t i=0; i<nDirs; i++){
+      if(i==0){
+
+	TString theTitle = dBiasTrend[k][i]->GetName();
+	
+	if(theTitle.Contains("norm")){
+	  //dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-safeDelta/2.),std::max(0.48,absmax[k]+safeDelta/2.));
+	  dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,1.8);
+	} else {
+	  if(!theTitle.Contains("width")){
+	    if(theTitle.Contains("ladder") || theTitle.Contains("modZ")) {
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-40.,-theExtreme-(safeDelta/2.)),std::max(40.,theExtreme+(safeDelta/2.)));
+	    } else {
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(-40.,40.);
+	    }
+	  } else {
+	    // dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta/2.));
+	    // if(theTitle.Contains("eta")) {
+	    //   dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,500.);
+	    // } else {
+	    //   dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.);
+	    // }
+	    auto my_view = checkTheView(theTitle);
+
+	    //std::cout<<" ----------------------------------> " << theTitle << " view: " << my_view <<  std::endl;
+
+	    switch(my_view){
+	    case pv::dxyphi  : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.); 
+	      break;
+	    case pv::dzphi   : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,400.);
+	      break;
+	    case pv::dxyeta  : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,300.);
+	      break;
+	    case pv::dzeta   : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,1.e3);
+	      break;
+	    case pv::pT : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.);
+	      break;
+	    case pv::generic : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,350.);
+	      break;
+	    default : 
+	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,300.);
+	    }
+	  } 
+	}
+ 
+	dBiasTrend[k][i]->Draw("Le1");
+	makeNewXAxis(dBiasTrend[k][i]);
+      
+	Double_t theC = -1.;
+	
+	if(theTitle.Contains("width")){ 
+	  if(theTitle.Contains("norm") ){
+	    theC = 1.;
+	  } else {
+	    theC = -1.;
+	  }
+	} else {
+	  theC = 0.;
+	}
+	
+	TH1F* theConst = DrawConstant(dBiasTrend[k][i],1,theC);
+	theConst->Draw("PLsame][");
+
+      } else { 
+	dBiasTrend[k][i]->Draw("Le1sames");
+	makeNewXAxis(dBiasTrend[k][i]);
+      }
+      TPad *current_pad = static_cast<TPad*>(canv->GetPad(k+1));
+      cmsPrel(current_pad,2);
+      ptDate->Draw("same");
+
+      if(k==0){
+	lego->AddEntry(dBiasTrend[k][i],LegLabels[i]);
+      } 
+    }  
+  
+    lego->Draw();
+  } 
+}
+
+/*--------------------------------------------------------------------*/
+void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color)
+/*--------------------------------------------------------------------*/
+{ 
+  hist->SetStats(kFALSE);  
+  hist->SetLineWidth(2);
+  hist->GetXaxis()->CenterTitle(true);
+  hist->GetYaxis()->CenterTitle(true);
+  hist->GetXaxis()->SetTitleFont(42); 
+  hist->GetYaxis()->SetTitleFont(42);  
+  hist->GetXaxis()->SetTitleSize(0.065);
+  hist->GetYaxis()->SetTitleSize(0.065);
+  hist->GetXaxis()->SetTitleOffset(1.0);
+  hist->GetYaxis()->SetTitleOffset(1.2);
+  hist->GetXaxis()->SetLabelFont(42);
+  hist->GetYaxis()->SetLabelFont(42);
+  hist->GetYaxis()->SetLabelSize(.05);
+  hist->GetXaxis()->SetLabelSize(.07);
+  //hist->GetXaxis()->SetNdivisions(505);
+  if(color!=8){
+    hist->SetMarkerSize(1.5);
+  } else {
+    hist->SetLineWidth(3);
+    hist->SetMarkerSize(0.0);    
+  }
+  hist->SetMarkerStyle(pv::markers[color]);
+  hist->SetLineColor(pv::colors[color]);
+  hist->SetMarkerColor(pv::colors[color]);
+}
+
+
+/*--------------------------------------------------------------------*/
+void makeNewXAxis (TH1 *h)
+/*--------------------------------------------------------------------*/
+{
+  
+  TString myTitle = h->GetName();
+  float axmin = -999;
+  float axmax = 999.;
+  int ndiv = 510;
+  if(myTitle.Contains("eta")){
+    axmin = -2.7;
+    axmax = 2.7;
+    ndiv = 505;
+  } else if (myTitle.Contains("phi")){
+    axmin = -TMath::Pi();
+    axmax = TMath::Pi();
+    ndiv = 510;
+  } else if (myTitle.Contains("pT")) {
+    axmin = 0;
+    axmax = 19.99;
+    ndiv = 510;
+  } else if (myTitle.Contains("ladder")) {
+    axmin = 0;
+    axmax = 12;
+    ndiv  = 510;
+  } else if (myTitle.Contains("modZ")){
+    axmin = 0;
+    axmax = 8;
+    ndiv  = 510;
+  } else {
+    std::cout<<"unrecognized variable"<<std::endl;
+  }
+  
+  // Remove the current axis
+  h->GetXaxis()->SetLabelOffset(999);
+  h->GetXaxis()->SetTickLength(0);
+  
+  if (myTitle.Contains("phi")){
+    h->GetXaxis()->SetTitle("#varphi (sector) [rad]");
+  }
+
+   // Redraw the new axis
+  gPad->Update();
+  
+  TGaxis *newaxis = new TGaxis(gPad->GetUxmin(),gPad->GetUymin(),
+			       gPad->GetUxmax(),gPad->GetUymin(),
+			       axmin,
+			       axmax,
+			       ndiv,"SDH");
+  
+  TGaxis *newaxisup =  new TGaxis(gPad->GetUxmin(),gPad->GetUymax(),
+                                  gPad->GetUxmax(),gPad->GetUymax(),
+                                  axmin,
+                                  axmax,                          
+                                  ndiv,"-SDH");
+    
+  newaxis->SetLabelOffset(0.02);
+  newaxis->SetLabelFont(42);
+  newaxis->SetLabelSize(0.05);
+  
+  newaxisup->SetLabelOffset(-0.02);
+  newaxisup->SetLabelFont(42);
+  newaxisup->SetLabelSize(0);
+  
+  newaxis->Draw();
+  newaxisup->Draw();
+
+}
+
+
+/*--------------------------------------------------------------------*/
+void setStyle(){
+/*--------------------------------------------------------------------*/
+
+  TGaxis::SetMaxDigits(6);
+  
+  TH1::StatOverflows(kTRUE);
+  gStyle->SetOptTitle(0);
+  gStyle->SetOptStat("e");
+  //gStyle->SetPadTopMargin(0.05);
+  //gStyle->SetPadBottomMargin(0.15);
+  //gStyle->SetPadLeftMargin(0.17);
+  //gStyle->SetPadRightMargin(0.02);
+  gStyle->SetPadBorderMode(0);
+  gStyle->SetTitleFillColor(10);
+  gStyle->SetTitleFont(42);
+  gStyle->SetTitleColor(1);
+  gStyle->SetTitleTextColor(1);
+  gStyle->SetTitleFontSize(0.06);
+  gStyle->SetTitleBorderSize(0);
+  gStyle->SetStatColor(kWhite);
+  gStyle->SetStatFont(42);
+  gStyle->SetStatFontSize(0.05);///---> gStyle->SetStatFontSize(0.025);
+  gStyle->SetStatTextColor(1);
+  gStyle->SetStatFormat("6.4g");
+  gStyle->SetStatBorderSize(1);
+  gStyle->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
+  gStyle->SetPadTickY(1);
+  gStyle->SetPadBorderMode(0);
+  gStyle->SetOptFit(1);
+  gStyle->SetNdivisions(510);
+
+  //gStyle->SetPalette(kInvertedDarkBodyRadiator);
+
+  const Int_t NRGBs = 5;
+  const Int_t NCont = 255;
+
+  /*
+  Double_t stops[NRGBs] = { 0.00, 0.34, 0.61, 0.84, 1.00 };
+  Double_t red[NRGBs]   = { 0.00, 0.00, 0.87, 1.00, 0.51 };
+  Double_t green[NRGBs] = { 0.00, 0.81, 1.00, 0.20, 0.00 };
+  Double_t blue[NRGBs]  = { 0.51, 1.00, 0.12, 0.00, 0.00 };
+  */
+
+  Double_t stops[NRGBs] = {0.00, 0.01, 0.05, 0.09, 0.1};
+  Double_t red[NRGBs]   = {1.00, 0.84, 0.61, 0.34, 0.00};
+  Double_t green[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
+  Double_t blue[NRGBs]  = {1.00, 0.84, 0.61, 0.34, 0.00};
+
+  TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+  gStyle->SetNumberContours(NCont);
+
+}
+
+// /*--------------------------------------------------------------------*/
+// void cmsPrel(TPad* pad) {
+// /*--------------------------------------------------------------------*/
+  
+//   float H = pad->GetWh();
+//   float W = pad->GetWw();
+//   float l = pad->GetLeftMargin();
+//   float t = pad->GetTopMargin();
+//   float r = pad->GetRightMargin();
+//   float b = pad->GetBottomMargin();
+//   float relPosX = 0.009;
+//   float relPosY = 0.045;
+//   float lumiTextOffset = 0.8;
+
+//   TLatex *latex = new TLatex();
+//   latex->SetNDC();
+//   latex->SetTextSize(0.045);
+
+//   float posX_    = 1-r - relPosX*(1-l-r);
+//   float posXCMS_ = posX_- 0.125;
+//   float posY_ =  1-t + 0.05; /// - relPosY*(1-t-b);
+//   float factor = 1./0.86;
+
+//   latex->SetTextAlign(33);
+//   latex->SetTextFont(61);
+//   latex->SetTextSize(0.045*factor);
+//   latex->DrawLatex(posXCMS_,posY_,"CMS");
+//   latex->SetTextSize(0.045);
+//   latex->SetTextFont(42); //22
+//   latex->DrawLatex(posX_,posY_,"Internal (13 TeV)");
+//   //latex->DrawLatex(posX_,posY_,"CMS Preliminary (13 TeV)");
+//   //latex->DrawLatex(posX_,posY_,"CMS 2017 Work in progress (13 TeV)");
+  
+// }
+
+
+/*--------------------------------------------------------------------*/
+void cmsPrel(TPad* pad,size_t ipads) {
+/*--------------------------------------------------------------------*/
+  
+  float H = pad->GetWh();
+  float W = pad->GetWw();
+  float l = pad->GetLeftMargin();
+  float t = pad->GetTopMargin();
+  float r = pad->GetRightMargin();
+  float b = pad->GetBottomMargin();
+  float relPosX = 0.009;
+  float relPosY = 0.045;
+  float lumiTextOffset = 0.8;
+
+  TLatex *latex = new TLatex();
+  latex->SetNDC();
+  latex->SetTextSize(0.045);
+
+  float posX_    = 1-(r/ipads);
+  float posY_    = 1-t + 0.05; /// - relPosY*(1-t-b);
+  float factor   = 1./0.82;
+
+  latex->SetTextAlign(33);
+  latex->SetTextSize(0.045);
+  latex->SetTextFont(42); //22
+  latex->DrawLatex(posX_,posY_,"Internal (13 TeV)");
+
+  UInt_t w;
+  UInt_t h;
+  latex->GetTextExtent(w,h,"Internal (13 TeV)");
+  float size = w/(W/ipads);
+  //std::cout<<w<<" "<<" "<<W<<" "<<size<<std::endl;
+  float posXCMS_ = posX_- size*(1+0.025*ipads);
+
+  latex->SetTextAlign(33);
+  latex->SetTextFont(61);
+  latex->SetTextSize(0.045*factor);
+  latex->DrawLatex(posXCMS_,posY_+0.004,"CMS");
+
+  //latex->DrawLatex(posX_,posY_,"CMS Preliminary (13 TeV)");
+  //latex->DrawLatex(posX_,posY_,"CMS 2017 Work in progress (13 TeV)");
+  
+}
+
+/*--------------------------------------------------------------------*/
+TH1F* DrawConstant(TH1F *hist,Int_t iter,Double_t theConst)
+/*--------------------------------------------------------------------*/
+{ 
+  
+  Int_t nbins       = hist->GetNbinsX();
+  Double_t lowedge  = hist->GetBinLowEdge(1);
+  Double_t highedge = hist->GetBinLowEdge(nbins+1);
+  
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i",hist->GetName(),iter),Form("hconst_%s_%i",hist->GetName(),iter),nbins,lowedge,highedge);
+  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
+    hzero->SetBinContent(i,theConst);
+    hzero->SetBinError(i,0.);
+  }
+  hzero->SetLineWidth(2);
+  hzero->SetLineStyle(9);
+  hzero->SetLineColor(kMagenta);
+  
+  return hzero;
+}
+
+/*--------------------------------------------------------------------*/
+TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst)
+/*--------------------------------------------------------------------*/
+{ 
+
+  Int_t nbins       = hist->GetNbinsX();
+  Double_t lowedge  = hist->GetBinLowEdge(1);
+  Double_t highedge = hist->GetBinLowEdge(nbins+1);
+
+
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i",hist->GetName(),iter),Form("hconst_%s_%i",hist->GetName(),iter),nbins,lowedge,highedge);
+  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
+    hzero->SetBinContent(i,theConst);
+    hzero->SetBinError(i,hist->GetBinError(i));
+  }
+  hzero->SetLineWidth(2);
+  hzero->SetLineStyle(9);
+  hzero->SetLineColor(kMagenta);
+  
+  return hzero;
+}
+
+/*--------------------------------------------------------------------*/
+TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst)
+/*--------------------------------------------------------------------*/
+{ 
+ 
+  Double_t xmin = graph->GetXaxis()->GetXmin(); //TMath::MinElement(graph->GetN(),graph->GetX());
+  Double_t xmax = graph->GetXaxis()->GetXmax(); //TMath::MaxElement(graph->GetN(),graph->GetX()); 
+
+  //std::cout<<xmin<<" : "<<xmax<<std::endl;
+
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i",graph->GetName(),iter),Form("hconst_%s_%i",graph->GetName(),iter),graph->GetN(),xmin,xmax);
+  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
+    hzero->SetBinContent(i,theConst);
+    hzero->SetBinError(i,0.);
+  }
+  
+  hzero->SetLineWidth(2);
+  hzero->SetLineStyle(9);
+  hzero->SetLineColor(kMagenta);
+  
+  return hzero;
+}
+
+
+/*--------------------------------------------------------------------*/
+unrolledHisto getUnrolledHisto(TH1F* hist)
+/*--------------------------------------------------------------------*/
+{
+  
+  /*
+    Double_t y_min = hist->GetBinLowEdge(1);
+    Double_t y_max = hist->GetBinLowEdge(hist->GetNbinsX()+1);
+  */    
+
+  Double_t y_min = -0.1;
+  Double_t y_max = 0.1;
+
+  std::vector<Double_t> contents;
+  for (int j = 0; j < hist->GetNbinsX(); j++) {
+    if(std::abs(hist->GetXaxis()->GetBinCenter(j))<=0.1) contents.push_back(hist->GetBinContent(j+1));
+  }
+  
+  auto ret = unrolledHisto(y_min,y_max,contents.size(),contents);
+  return ret;
+
+}
+
+/*--------------------------------------------------------------------*/
+pv::biases getBiases(TH1F* hist)
+/*--------------------------------------------------------------------*/
+{
+  int nbins = hist->GetNbinsX();
+
+  //extract median from histogram
+  double *y   = new double[nbins];
+  double *err = new double[nbins];
+
+  // remember for weight means <x> = sum_i (x_i* w_i) / sum_i w_i ; where w_i = 1/sigma^2_i
+
+  for (int j = 0; j < nbins; j++) {
+    y[j]   = hist->GetBinContent(j+1);
+    if(hist->GetBinError(j+1)!=0.){
+      err[j] = 1./(hist->GetBinError(j+1)*hist->GetBinError(j+1));
+    } else {
+      err[j] = 0.;
+    }
+  }
+
+  Double_t w_mean = TMath::Mean(nbins,y,err);
+  Double_t w_rms  = TMath::RMS(nbins,y,err);
+
+  Double_t mean = TMath::Mean(nbins,y);
+  Double_t rms  = TMath::RMS(nbins,y);
+
+  Double_t max =hist->GetMaximum();
+  Double_t min =hist->GetMinimum();
+  
+  // in case one would like to use a pol0 fit
+  hist->Fit("pol0","Q0+");
+  TF1* f = (TF1*)hist->FindObject("pol0");
+  //f->SetLineColor(hist->GetLineColor());
+  //f->SetLineStyle(hist->GetLineStyle());
+  Double_t chi2 = f->GetChisquare();
+  Int_t    ndf  = f->GetNDF();
+
+  TH1F* theZero = DrawConstantWithErr(hist,1,1.);
+  TH1F* displaced = (TH1F*)hist->Clone("displaced");
+  displaced->Add(theZero);
+  Double_t ksScore   = std::max(-20.,TMath::Log10(displaced->KolmogorovTest(theZero)));
+  Double_t chi2Score = displaced->Chi2Test(theZero);
+
+  /*
+    std::pair<std::pair<Double_t,Double_t>, Double_t> result;
+    std::pair<Double_t,Double_t> resultBounds;
+    resultBounds = useRMS_ ? std::make_pair(mean-rms,mean+rms) :  std::make_pair(min,max)  ;
+    result = make_pair(resultBounds,mean);
+  */
+
+  pv::biases result(mean,rms,w_mean,w_rms,min,max,chi2,ndf,ksScore);
+
+  delete theZero;
+  delete displaced;
+  return result;
+
+}
+
+/*--------------------------------------------------------------------*/
+void beautify(TGraph *g){
+/*--------------------------------------------------------------------*/
+  g->GetXaxis()->SetLabelFont(42);
+  g->GetYaxis()->SetLabelFont(42);
+  g->GetYaxis()->SetLabelSize(.055);
+  g->GetXaxis()->SetLabelSize(.055);
+  g->GetYaxis()->SetTitleSize(.055);
+  g->GetXaxis()->SetTitleSize(.055);
+  g->GetXaxis()->SetTitleOffset(1.1);
+  g->GetYaxis()->SetTitleOffset(0.6);
+  g->GetXaxis()->SetTitleFont(42);
+  g->GetYaxis()->SetTitleFont(42);
+  g->GetXaxis()->CenterTitle(true);
+  g->GetYaxis()->CenterTitle(true);
+  g->GetXaxis()->SetNdivisions(505);
+}
+
+/*--------------------------------------------------------------------*/
+void beautify(TH1 *h){
+/*--------------------------------------------------------------------*/
+  h->SetMinimum(0.);
+  h->GetXaxis()->SetLabelFont(42);
+  h->GetYaxis()->SetLabelFont(42);
+  h->GetYaxis()->SetLabelSize(.055);
+  h->GetXaxis()->SetLabelSize(.055);
+  h->GetYaxis()->SetTitleSize(.055);
+  h->GetXaxis()->SetTitleSize(.055);
+  h->GetXaxis()->SetTitleOffset(1.1);
+  h->GetYaxis()->SetTitleOffset(0.6);
+  h->GetXaxis()->SetTitleFont(42);
+  h->GetYaxis()->SetTitleFont(42);
+  h->GetXaxis()->CenterTitle(true);
+  h->GetYaxis()->CenterTitle(true);
+  h->GetXaxis()->SetNdivisions(505);
+}
+
+/*--------------------------------------------------------------------*/
+void adjustmargins(TCanvas *canv){
+/*--------------------------------------------------------------------*/
+  canv->cd()->SetBottomMargin(0.14);
+  canv->cd()->SetLeftMargin(0.07);
+  canv->cd()->SetRightMargin(0.03);
+  canv->cd()->SetTopMargin(0.06);
+}
+
+/*--------------------------------------------------------------------*/
+void adjustmargins(TVirtualPad *canv){
+/*--------------------------------------------------------------------*/
+  canv->SetBottomMargin(0.12);
+  canv->SetLeftMargin(0.07);
+  canv->SetRightMargin(0.01);
+  canv->SetTopMargin(0.02);
+}
+
+/*--------------------------------------------------------------------*/
+TH1F* checkTH1AndReturn(TFile *f,TString address){
+/*--------------------------------------------------------------------*/
+  TH1F* h = NULL; 
+  if(f->GetListOfKeys()->Contains(address)){
+    h = (TH1F*)f->Get(address);
+  } 
+  return h;
+}
+
+/*--------------------------------------------------------------------*/
+pv::view checkTheView(const TString &toCheck){
+/*--------------------------------------------------------------------*/
+  if (toCheck.Contains("dxy")){
+    if (toCheck.Contains("phi") || toCheck.Contains("ladder")){
+      return pv::dxyphi;
+    } else if (toCheck.Contains("eta") || toCheck.Contains("modZ")){
+      return pv::dxyeta;
+    } else {
+      return pv::pT;
+    }
+  } else if (toCheck.Contains("dz")){
+    if (toCheck.Contains("phi") || toCheck.Contains("ladder")){
+      return pv::dzphi;
+    } else if (toCheck.Contains("eta") || toCheck.Contains("modZ")){
+      return pv::dzeta;
+    } else {
+      return pv::pT;
+    }
+  } else {
+    return pv::generic;	
+  } 
+}
+
+/*--------------------------------------------------------------------*/
+template<typename T>
+void timify(T *mgr)
+/*--------------------------------------------------------------------*/
+{
+  mgr->GetXaxis()->SetTimeDisplay(1);
+  mgr->GetXaxis()->SetNdivisions(510);
+  mgr->GetXaxis()->SetTimeFormat("%Y-%m-%d");
+  mgr->GetXaxis()->SetTimeOffset(0,"gmt");
+  mgr->GetXaxis()->SetLabelSize(.035);
+}
+
+
+struct increase
+{
+    template<class T>
+    bool operator()(T const &a, T const &b) const { return a > b; }
+};
+
+/*--------------------------------------------------------------------*/
+Double_t getMaximumFromArray(TObjArray *array)
+/*--------------------------------------------------------------------*/
+{
+
+  Double_t theMaximum = -999.; //(static_cast<TH1*>(array->At(0)))->GetMaximum();
+
+  for(Int_t i = 0; i< array->GetSize(); i++){
+    
+    double theMaxForThisHist;
+    auto hist = static_cast<TH1*>(array->At(i));
+    std::vector<double> maxima;
+    for (int j=0;j<hist->GetNbinsX();j++) maxima.push_back(hist->GetBinContent(j));
+    std::sort(std::begin(maxima), std::end(maxima));//,increase());
+    double rms_maxima  = TMath::RMS(hist->GetNbinsX(),&(maxima[0]));
+    double mean_maxima = TMath::Mean(hist->GetNbinsX(),&(maxima[0]));
+
+    const Int_t nq = 100;
+    Double_t xq[nq];  // position where to compute the quantiles in [0,1]
+    Double_t yq[nq];  // array to contain the quantiles
+    for (Int_t i=0;i<nq;i++) xq[i] = 0.9+(Float_t(i+1)/nq)*0.10;
+    TMath::Quantiles(maxima.size(),nq,&(maxima[0]),yq, xq);
+    
+    //for(int q=0;q<nq;q++){
+    //  std::cout<<q<<" "<<xq[q]<<" "<<yq[q]<<std::endl;
+    //}
+
+    //for (const auto &element : maxima){
+    //  if(element<1.5*mean_maxima){
+    //	theMaxForThisHist=element;
+    //	break;
+    //  }
+    //} 
+
+    theMaxForThisHist=yq[80];
+
+    std::cout<<"rms_maxima["<<i<<"]"<<rms_maxima<<" mean maxima["<<mean_maxima<<"] purged maximum:"<<theMaxForThisHist<<std::endl;
+
+    if(theMaxForThisHist>theMaximum) theMaximum=theMaxForThisHist;
+
+    /*
+    if( (static_cast<TH1*>(array->At(i)))->GetMaximum() > theMaximum){
+      theMaximum = (static_cast<TH1*>(array->At(i)))->GetMaximum();
+      //cout<<"i= "<<i<<" theMaximum="<<theMaximum<<endl;
+    }
+    */
+
+  }
+
+  return theMaximum;
+}
+
+/*--------------------------------------------------------------------*/
+void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_format,const std::map<int,double> &lumiMapByRun,const std::map<int,TDatime>& timeMap)
+/*--------------------------------------------------------------------*/
+{
+ 
+  /*
+    1   296641       2017-11-07 12:31:49  bf4bdd66393bee0623b730e11f3db799674c4daf  Alignments   
+    2   297179       2017-11-07 12:31:49  a5858bccd2e2c031a12aa6cbe38e8adaeca19331  Alignments   
+    3   297281       2017-11-07 12:31:49  b423ed0f118c16d99cf92d12a1bd33bb1902f533  Alignments   
+    4   298653       2017-11-07 12:31:49  3e598e771471289c59d755ef4ebb993e6c4b7890  Alignments   
+    5   299277       2017-11-07 12:31:49  d8631cc034f3971131f7e7551610acf790192cd2  Alignments   
+    6   299443       2017-11-07 12:31:49  58961d0e9322c4d7064b31e73d9edfe9a861e1f8  Alignments   
+    7   300389       2017-11-07 12:31:49  7c0a2dcfa527e8e336ff6b8b198827a5fcb9c287  Alignments   
+    8   301046       2017-11-07 12:31:49  4bf6bfbd7f8a202e8a6bba5e8730b27b00e5142b  Alignments   
+    9   302131       2017-11-07 12:31:49  387e5f629f808464f5c69ab8bb7319576d81e768  Alignments   
+    10  303790       2017-11-07 12:31:49  21b79cc2a163df4fbc6c059eed8c96b86f8a07ff  Alignments   
+    11  304911       2017-11-07 12:31:49  44c7e1e991484d1490ac5ad6b734b6622f1e9d85  Alignments   
+    12  305898       2017-11-28 16:03:38  64aae34a7273b374738ed4b9b20c332abf503ab4  Alignments   
+  */
+ 
+  // get the vector of runs in the lumiMap
+  std::vector<int> vruns;
+  for(auto const& imap: lumiMapByRun){
+    vruns.push_back(imap.first);
+    //std::cout<<" run:" << imap.first << " lumi: "<< imap.second << std::endl;
+  }
+
+  //std::vector<vint> truns;
+  for(auto const& imap: timeMap){
+    std::cout<<" run:" << imap.first << " time: "<< imap.second.Convert() << std::endl;
+  }
+
+  /* 2018 Prompt IOVs
+     314163       2018-04-13 12:46:08  1486775833f89de0ba96bfac647c11606f882b15  Alignments   
+     316006       2018-05-09 12:32:34  f67aa5b2d86737f947482a21e54074ab74b0ca7b  Alignments   
+     317393       2018-06-04 16:18:49  841254d3c88b0a906c241de3a906394c063a5b9d  Alignments  
+  */
+
+  /* 2018D Prompt IOVs
+     320551       2018-07-30 18:56:08  5ef1b88947a246ff4f44b56e66314c176889e32e  Alignments   
+     320812       2018-08-03 21:15:40  70ebb0c3b83e5a93b1662bd39617ae452da6540b  Alignments   
+     320845       2018-08-05 00:21:08  8b5f42f55164132f6a06889c1f3d96e7176ce924  Alignments   
+     320855       2018-08-05 09:28:41  e2436a8e838aeb1444f6f8214f675a4ab9c06cf4  Alignments   
+     320885       2018-08-05 22:00:35  680e859cdea640ce24744c27c58b564e669c0f9c  Alignments   
+     320901       2018-08-06 05:23:45  f1da7f661c087214fe452bd6714e25b131a58f3f  Alignments   
+     320918       2018-08-06 12:37:42  a6fe27aa494007e065d23e763b680748d8f0293b  Alignments   
+     320924       2018-08-06 23:41:03  f9a1eb4c6e7b44711d4c8e813d9a14270fe1f8ba  Alignments   
+     320932       2018-08-07 02:00:48  4d74559fdb483ca63401426c145110fb2f8d9c67  Alignments   
+     320972       2018-08-07 15:10:14  9d6e3283a09bdeb9beab05094fce4eb55e0a7aa2  Alignments   
+     320981       2018-08-07 15:41:48  ba0ca93b7605378b651afd8a928b51bb34ab01ed  Alignments   
+     320997       2018-08-07 22:00:42  f9a1eb4c6e7b44711d4c8e813d9a14270fe1f8ba  Alignments   
+     321013       2018-08-08 15:31:58  6324bd8162744eaf7ab0fd44e0b01301fb9ff102  Alignments   
+  */
+
+  /*2018 ReReco IOVs
+    1   Alignments|313041|a2131f53f578e09de59f48a6707dc8d4ca8ffb1c|2018-08-15 08:32:54.825398
+    2   Alignments|314881|5d354a6bd2a1a256ec2ff5a3f735facccd030f30|2018-08-15 08:33:02.877544
+    3   Alignments|315488|9231ad0c6737600ab90761498d97077afe549905|2018-08-15 08:33:10.975766
+    4   Alignments|315689|ca322cc8364407dde43256235833f92756497caf|2018-08-15 08:33:20.157337
+    5   Alignments|316559|0adc667ed82407644f10f9de96500f83451b29ca|2018-08-15 08:33:31.927466
+    6   Alignments|316758|faa90f0fc255d2b66a4b528f585c375b0053a00b|2018-08-15 08:33:39.992558
+    7   Alignments|317438|3940f07daa4fa5079ec9d2c7ea8571aaa258f605|2018-08-15 08:33:47.803401
+    8   Alignments|317527|08de11788363dc19f94deeb57655d1b3dc1d3926|2018-08-15 08:33:55.853235
+    9   Alignments|318228|35baae799b7a186f0bc6487ae4bdc5af75201acc|2018-08-15 08:34:07.181786
+    10  Alignments|319337|7ddd2bb52fa50f6e7b66af5576a0c064089d56b9|2018-08-15 08:34:15.024333
+    11  Alignments|320377|c8fbff3dbddd3f19a084b280a382f61a6cebdc47|2018-08-15 08:34:22.900776
+    12  Alignments|320688|6060521269c9f119df1bcb0668936caa311cc9b9|2018-08-15 08:34:31.094154
+   */
+
+  // static const int nIOVs=13;//       1       2}       3      4      5      6      7      8      9     10     11     12     13 
+  // int IOVboundaries[nIOVs]  = {320551,  320812,  320845,  320855,  320885,  320901,  320918,  320924,  320932,  320972,  320981,  320997,  321013};
+  // int benchmarkruns[nIOVs]  = {320551,  320812,  320845,  320855,  320885,  320901,  320918,  320924,  320932,  320972,  320981,  320997,  321013};
+
+  /* template IOVs
+     316758       2018-08-28 17:43:26  3a8abe693d1d3df829212e1049330e68f3392282  SiPixelTemplateDBObject  
+     317527       2018-08-28 17:43:26  356b03fcd7e869ef8f28153318f0cd32c27b1f40  SiPixelTemplateDBObject  
+     317661       2018-08-28 17:54:14  1cbb2fc3edf448c50d00fac3aa47c8cf3b19ac6f  SiPixelTemplateDBObject  
+     317664       2018-08-28 17:57:00  356b03fcd7e869ef8f28153318f0cd32c27b1f40  SiPixelTemplateDBObject  
+     318227       2018-08-28 17:58:17  1cbb2fc3edf448c50d00fac3aa47c8cf3b19ac6f  SiPixelTemplateDBObject  
+     320377       2018-09-04 18:20:50  5e9cd265167ec543aac49685cf706a58014c08f8  SiPixelTemplateDBObject  
+  */
+
+  /* 2017 ReReco template IOVs
+     280928       2017-11-07 10:57:51  65a7b7251f96dd52da4a224d921ae6c9e4e560e0  SiPixelTemplateDBObject  
+     290543       2017-11-07 10:59:05  05803622f45cf4ee2c07af2bb97875bd1010bfea  SiPixelTemplateDBObject  
+     297281       2017-11-07 11:04:10  0ed971165dda7ae1db50c6636dab049087cad9a1  SiPixelTemplateDBObject  
+     298653       2017-11-07 11:04:22  e3af935c8f4eded04455a88959501d7408895501  SiPixelTemplateDBObject  
+     299443       2017-11-07 11:04:37  053fae581c8fd47ed38142843774747aeecd0e29  SiPixelTemplateDBObject  
+     300389       2017-11-07 11:04:50  8d6d8297e767fe727b65107871ac6f7dca8c8c39  SiPixelTemplateDBObject  
+     302131       2017-11-07 11:05:03  13a584e147d1f069f8f25a84577721c01dbe9412  SiPixelTemplateDBObject  
+     303790       2017-11-07 11:05:28  db316ff818e117980e5b502a7d4a63064c02bf46  SiPixelTemplateDBObject  
+     304911       2017-11-07 11:05:40  cd4630efcc7c55593bf93a5211ba4b0f95a0ca2b  SiPixelTemplateDBObject  
+     305898       2017-12-01 10:17:44  6a3c710452af7134dd9e6408fb601b8c34542d10  SiPixelTemplateDBObject  
+   */
+
+
+  /*2018 2D Templates
+    314882       2019-01-25 22:39:07  9a89bb756a0c73a673b5bc445e8ca13b6e33ebfc  SiPixel2DTemplateDBObject  
+    316758       2019-01-25 22:42:29  f265af2c72edce9f0ebfddefaf7a3b291cdb4fbd  SiPixel2DTemplateDBObject  
+    317527       2019-01-25 22:43:52  f6d33ce60dd8a9b4543fbf7128c5f1db4854957e  SiPixel2DTemplateDBObject  
+    317661       2019-01-25 22:44:40  cc81e1fdeb11a989a583fdee51ef7678088eb3c4  SiPixel2DTemplateDBObject  
+    317664       2019-01-25 22:45:31  f6d33ce60dd8a9b4543fbf7128c5f1db4854957e  SiPixel2DTemplateDBObject  
+    318227       2019-01-25 22:46:28  cc81e1fdeb11a989a583fdee51ef7678088eb3c4  SiPixel2DTemplateDBObject  
+    320377       2019-01-25 22:47:13  c94706b8e034d272f864171260d3cd685e2c52f9  SiPixel2DTemplateDBObject  
+    321831       2019-01-25 22:48:13  a9c6e8e3f96b1bfd5267ecbdd23bddb41b14e8e6  SiPixel2DTemplateDBObject  
+    322510       2019-01-25 22:51:16  07a7408f23e270fc9fac0f357d7b6130939ea90a  SiPixel2DTemplateDBObject  
+    322603       2019-01-25 22:51:58  a9c6e8e3f96b1bfd5267ecbdd23bddb41b14e8e6  SiPixel2DTemplateDBObject  
+    323232       2019-01-25 22:52:41  916a68aa85d2bbbb4c61f0db8a1bdb6a30008829  SiPixel2DTemplateDBObject  
+    324245       2019-01-25 22:53:29  dd95892c7bcde1c2907c3a1165794763cbf5f519  SiPixel2DTemplateDBObject  
+   */
+
+  static const int nIOVs=12 ;   //       1         2       3        4        5        6        7        8        9       10       11        12   		      
+  //int IOVboundaries[nIOVs]  = {  313041,  314881,  315488,  315689,  316559,  316758,  317438,  317527,  318228,  319337,  320377,  320688};
+  //int IOVboundaries[nIOVs]  = {  316758,  317527,  317661,  317664,  318227,  320377};
+  //int benchmarkruns[nIOVs]  = {  316758,  317527,  317661,  317664,  318227,  320377};
+  //int benchmarkruns[nIOVs]  = {  313041,  314881,  315488,  315689,  316559,  316758,  317438,  317527,  318228,  319337,  320377,  320688};
+  //int IOVboundaries[nIOVs]  = {  290543,  297281,  298653,  299443,  300389,  302131,  303790,  304911,  305898};
+  //int benchmarkruns[nIOVs]  = {  290543,  297281,  298653,  299443,  300389,  302131,  303790,  304911,  305898};
+  
+  int IOVboundaries[nIOVs]    = {  314882,  316758,  317527,  317661,  317664,  318227,  320377,  321831,  322510,  322603,  323232,  324245};
+  int benchmarkruns[nIOVs]    = {  314882,  316758,  317527,  317661,  317664,  318227,  320377,  321831,  322510,  322603,  323232,  324245};
+
+  TArrow* IOV_lines[nIOVs];
+  c->cd();
+  c->Update();
+
+  TArrow* a_lines[nIOVs];
+  TArrow* b_lines[nIOVs];
+  for(Int_t IOV=0;IOV<nIOVs;IOV++){
+
+    // check we are not in the RMS histogram to avoid first line
+    if(IOVboundaries[IOV]<vruns.front() && ((TString)c->GetName()).Contains("RMS")) continue;
+    int closestrun = pv::closest(vruns,IOVboundaries[IOV]); 
+    int closestbenchmark = pv::closest(vruns,benchmarkruns[IOV]);
+
+    if(lumi_axis_format){
+
+      if(closestrun<0) continue;
+      //std::cout<< "natural boundary: " << IOVboundaries[IOV] << " closest:" << closestrun << std::endl;
+
+      a_lines[IOV] = new TArrow(lumiMapByRun.at(closestrun),(c->GetUymin()),lumiMapByRun.at(closestrun),0.65*c->GetUymax(),0.5,"|>");
+
+      if(closestbenchmark<0) continue;
+      b_lines[IOV] = new TArrow(lumiMapByRun.at(closestbenchmark),(c->GetUymin()),lumiMapByRun.at(closestbenchmark),0.65*c->GetUymax(),0.5,"|>");
+
+    } else if(time_axis_format){
+      
+      if(closestrun<0) continue;
+      std::cout<< "natural boundary: " << IOVboundaries[IOV] << " closest:" << closestrun << std::endl;
+      a_lines[IOV] = new TArrow(timeMap.at(closestrun).Convert(),(c->GetUymin()),timeMap.at(closestrun).Convert(),0.65*c->GetUymax(),0.5,"|>");
+
+      if(closestbenchmark<0) continue;
+      b_lines[IOV] = new TArrow(timeMap.at(closestbenchmark).Convert(),(c->GetUymin()),timeMap.at(closestbenchmark).Convert(),0.65*c->GetUymax(),0.5,"|>");
+
+    } else {
+      a_lines[IOV] = new TArrow(IOVboundaries[IOV],(c->GetUymin()),IOVboundaries[IOV],0.65*c->GetUymax(),0.5,"|>"); //(c->GetUymin()+0.2*(c->GetUymax()-c->GetUymin()) ),0.5,"|>");
+      b_lines[IOV] = new TArrow(benchmarkruns[IOV],(c->GetUymin()),benchmarkruns[IOV],0.65*c->GetUymax(),0.5,"|>"); //(c->GetUymin()+0.2*(c->GetUymax()-c->GetUymin()) ),0.5,"|>");
+      
+    }
+    a_lines[IOV]->SetLineColor(kRed);
+    a_lines[IOV]->SetLineStyle(9);
+    a_lines[IOV]->SetLineWidth(1);
+    a_lines[IOV]->Draw("same");
+
+    b_lines[IOV]->SetLineColor(kGray);
+    b_lines[IOV]->SetLineStyle(1);
+    b_lines[IOV]->SetLineWidth(2);
+    //b_lines[IOV]->Draw("same");
+
+  }
+
+  TPaveText* runnumbers[nIOVs];
+  
+  for(Int_t IOV=0;IOV<nIOVs;IOV++){
+
+    if(IOVboundaries[IOV]<vruns.front() && ((TString)c->GetName()).Contains("RMS")) continue;
+    int closestrun = pv::closest(vruns,IOVboundaries[IOV]);
+    
+    Int_t ix1;
+    Int_t ix2;
+    Int_t iw = gPad->GetWw();
+    Int_t ih = gPad->GetWh();
+    Double_t x1p,y1p,x2p,y2p;
+    gPad->GetPadPar(x1p,y1p,x2p,y2p);
+    ix1 = (Int_t)(iw*x1p);
+    ix2 = (Int_t)(iw*x2p);
+    Double_t wndc  = TMath::Min(1.,(Double_t)iw/(Double_t)ih);
+    Double_t rw    = wndc/(Double_t)iw;
+    Double_t x1ndc = (Double_t)ix1*rw;
+    Double_t x2ndc = (Double_t)ix2*rw;
+    Double_t rx1,ry1,rx2,ry2;
+    gPad->GetRange(rx1,ry1,rx2,ry2);
+    Double_t rx = (x2ndc-x1ndc)/(rx2-rx1);
+    Double_t _sx;
+    if(lumi_axis_format){
+      if(closestrun<0) break; 
+      _sx = rx*(lumiMapByRun.at(closestrun)-rx1)+x1ndc; //-0.05;
+    } else if(time_axis_format){
+      if(closestrun<0) break; 
+      _sx = rx*(timeMap.at(closestrun).Convert()-rx1)+x1ndc; //-0.05;
+    } else {
+      _sx = rx*(IOVboundaries[IOV]-rx1)+x1ndc; //-0.05
+    }
+    Double_t _dx = _sx+0.05;
+    
+    Int_t index = IOV%5;
+    // if(IOV<5) 
+    //   index=IOV;
+    // else{
+    //   index=IOV-5;
+    // }
+    
+    runnumbers[IOV] = new TPaveText(_sx+0.001,0.14+(0.03*index),_dx,(0.17+0.03*index),"blNDC");
+    //runnumbers[IOV]->SetTextAlign(11);
+    TText *textRun = runnumbers[IOV]->AddText(Form("%i",int(IOVboundaries[IOV])));
+    textRun->SetTextSize(0.028);
+    textRun->SetTextColor(kRed);
+    runnumbers[IOV]->SetFillColor(10);
+    runnumbers[IOV]->SetLineColor(kRed);
+    runnumbers[IOV]->SetBorderSize(1);
+    runnumbers[IOV]->SetLineWidth(1);
+    runnumbers[IOV]->SetTextColor(kRed);
+    runnumbers[IOV]->SetTextFont(42);
+    runnumbers[IOV]->Draw("same");
+  }
+}
+
+/*--------------------------------------------------------------------*/
+outTrends doStuff(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10],bool useRMS)
+/*--------------------------------------------------------------------*/
+{
+
+  outTrends ret;
+  ret.init();
+
+  unsigned int pitch = std::ceil(intersection.size()/nWorkers)+1;
+  unsigned int first = iter*pitch;
+  unsigned int last  = std::min((iter+1)*pitch-1,intersection.size());
+
+  std::cout<< "pitch: " << pitch<< " first: "<< first << " last: "<< last<< std::endl;
+
+  ret.m_index=iter;
+
+  for(unsigned int n=first; n<last;n++){
+    //in case of debug, use only 50
+    //for(unsigned int n=0; n<50;n++){
+    
+    //if(intersection.at(n)!=283946) 
+    //  continue;
+
+    std::cout << n << " "<<intersection.at(n) << std::endl;
+    
+    TFile *fins[nDirs_];
+
+    TH1F* dxyPhiMeanTrend[nDirs_];  
+    TH1F* dxyPhiWidthTrend[nDirs_]; 
+    TH1F* dzPhiMeanTrend[nDirs_];   
+    TH1F* dzPhiWidthTrend[nDirs_];  
+
+    TH1F* dxyLadderMeanTrend[nDirs_];    
+    TH1F* dxyLadderWidthTrend[nDirs_]; 
+    TH1F* dzLadderWidthTrend[nDirs_];  
+    TH1F* dzLadderMeanTrend[nDirs_];  
+
+    TH1F* dxyModZMeanTrend[nDirs_];  
+    TH1F* dxyModZWidthTrend[nDirs_]; 
+    TH1F* dzModZMeanTrend[nDirs_];   
+    TH1F* dzModZWidthTrend[nDirs_];  
+
+    TH1F* dxyEtaMeanTrend[nDirs_];  
+    TH1F* dxyEtaWidthTrend[nDirs_]; 
+    TH1F* dzEtaMeanTrend[nDirs_];   
+    TH1F* dzEtaWidthTrend[nDirs_];  
+    
+    TH1F* dxyNormPhiWidthTrend[nDirs_]; 
+    TH1F* dxyNormEtaWidthTrend[nDirs_]; 
+    TH1F* dzNormPhiWidthTrend[nDirs_]; 
+    TH1F* dzNormEtaWidthTrend[nDirs_]; 
+
+    TH1F* dxyNormPtWidthTrend[nDirs_];     
+    TH1F* dzNormPtWidthTrend[nDirs_];      
+    TH1F* dxyPtWidthTrend[nDirs_];
+    TH1F* dzPtWidthTrend[nDirs_]; 
+        
+    TH1F* dxyIntegralTrend[nDirs_];
+    TH1F* dzIntegralTrend[nDirs_];
+
+    bool areAllFilesOK = true;
+    Int_t lastOpen = 0;
+ 
+    // loop over the objects
+    for(Int_t j=0; j < nDirs_; j++) {
+
+      //fins[j] = TFile::Open(Form("%s/PVValidation_%s_%i.root",dirs[j],dirs[j],intersection[n]));
+
+      size_t position = std::string(dirs[j]).find("/");   
+      string stem = std::string(dirs[j]).substr(position+1);     // get from position to the end
+      
+      fins[j] = new TFile(Form("%s/PVValidation_%s_%i.root",dirs[j],stem.c_str(),intersection[n]));
+      if(fins[j]->IsZombie()){
+	std::cout<< Form("%s/PVValidation_%s_%i.root",dirs[j],stem.c_str(),intersection[n]) << " is a Zombie! cannot combine" << std::endl;
+	areAllFilesOK = false;
+	lastOpen=j;
+	break;
+      }
+
+      std::cout<< Form("%s/PVValidation_%s_%i.root",dirs[j],stem.c_str(),intersection[n]) 
+	       << " has size: "<<fins[j]->GetSize() << " b ";
+      
+      // sanity check
+      TH1F* h_tracks = (TH1F*)fins[j]->Get("PVValidation/EventFeatures/h_nTracks");
+      if(j==0){
+	TH1F* h_lumi   = (TH1F*)fins[j]->Get("PVValidation/EventFeatures/h_lumiFromConfig");
+	double lumi = h_lumi->GetBinContent(1);
+	ret.m_lumiSoFar+=lumi;
+	//std::cout<<"lumi: "<<lumi
+	//	 <<" ,lumi so far: "<<lumiSoFar<<std::endl;
+
+	//outfile<<"run "<<intersection[n]<<" lumi: "<<lumi
+	//     <<" ,lumi so far: "<<lumiSoFar<<std::endl;
+
+      }
+
+      Double_t numEvents = h_tracks->GetEntries();
+      if(numEvents<2500){
+	std::cout<<"excluding " << intersection[n] << "because it has less than 2.5k events" << std::endl;
+	areAllFilesOK = false;
+	lastOpen=j;
+	break;
+      }
+
+      dxyPhiMeanTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_phi");
+      //dxyPhiMeanTrend[j]     = checkTH1AndReturn(fins[j],"PVValidation/MeanTrends/means_dxy_phi");
+      dxyPhiWidthTrend[j]    = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_phi");
+      dzPhiMeanTrend[j]      = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_phi");
+      dzPhiWidthTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_phi");
+            
+      dxyLadderMeanTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_ladder");
+      dxyLadderWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_ladder");
+      dzLadderMeanTrend[j]   = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_ladder");
+      dzLadderWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_ladder");
+                              
+      dxyEtaMeanTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_eta");
+      dxyEtaWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_eta");
+      dzEtaMeanTrend[j]   = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_eta");
+      dzEtaWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_eta");
+      
+      dxyModZMeanTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_modZ");
+      dxyModZWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_modZ");
+      dzModZMeanTrend[j]   = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_modZ");
+      dzModZWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_modZ");
+      
+      dxyNormPhiWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_phi");
+      dxyNormEtaWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_eta");
+      dzNormPhiWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_phi");
+      dzNormEtaWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_eta");
+
+      dxyNormPtWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_pTCentral");
+      dzNormPtWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_pTCentral");
+      dxyPtWidthTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_pTCentral");
+      dzPtWidthTrend[j]      = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_pTCentral");
+
+      dxyIntegralTrend[j]    = (TH1F*)fins[j]->Get("PVValidation/ProbeTrackFeatures/h_probedxyRefitV");
+      dzIntegralTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/ProbeTrackFeatures/h_probedzRefitV");
+
+      // fill the vectors of biases
+      
+      auto dxyPhiBiases = getBiases(dxyPhiMeanTrend[j]);
+      
+      //std::cout<<"\n" <<j<<" "<< LegLabels[j] << " dxy(phi) mean: "<< dxyPhiBiases.getWeightedMean()
+      //       <<" dxy(phi) max: "<< dxyPhiBiases.getMax()
+      //       <<" dxy(phi) min: "<< dxyPhiBiases.getMin()
+      //       << std::endl;
+
+      ret.m_dxyPhiMeans[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean());
+      ret.m_dxyPhiChi2[LegLabels[j]].push_back(TMath::Log10(dxyPhiBiases.getNormChi2()));
+      ret.m_dxyPhiKS[LegLabels[j]].push_back(dxyPhiBiases.getKSScore());
+
+      //std::cout<<"\n" <<j<<" "<< LegLabels[j] << " dxy(phi) ks score: "<< dxyPhiBiases.getKSScore() << std::endl;
+
+      useRMS ? ret.m_dxyPhiLo[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean() - 2*dxyPhiBiases.getWeightedRMS()) : ret.m_dxyPhiLo[LegLabels[j]].push_back(dxyPhiBiases.getMin());
+      useRMS ? ret.m_dxyPhiHi[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean() + 2*dxyPhiBiases.getWeightedRMS()) : ret.m_dxyPhiHi[LegLabels[j]].push_back(dxyPhiBiases.getMax());
+
+      auto dxyEtaBiases = getBiases(dxyEtaMeanTrend[j]);
+      ret.m_dxyEtaMeans[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean());
+      ret.m_dxyEtaChi2[LegLabels[j]].push_back(TMath::Log10(dxyEtaBiases.getNormChi2()));
+      ret.m_dxyEtaKS[LegLabels[j]].push_back(dxyEtaBiases.getKSScore());
+      useRMS ? ret.m_dxyEtaLo[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean() - 2*dxyEtaBiases.getWeightedRMS()) :ret.m_dxyEtaLo[LegLabels[j]].push_back(dxyEtaBiases.getMin());
+      useRMS ? ret.m_dxyEtaHi[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean() + 2*dxyEtaBiases.getWeightedRMS()) :ret.m_dxyEtaHi[LegLabels[j]].push_back(dxyEtaBiases.getMax());
+
+      auto dzPhiBiases = getBiases(dzPhiMeanTrend[j]);
+      ret.m_dzPhiMeans[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean());
+      ret.m_dzPhiChi2[LegLabels[j]].push_back(TMath::Log10(dzPhiBiases.getNormChi2()));
+      ret.m_dzPhiKS[LegLabels[j]].push_back(dzPhiBiases.getKSScore());
+      useRMS ? ret.m_dzPhiLo[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean() - 2*dzPhiBiases.getWeightedRMS()) :ret.m_dzPhiLo[LegLabels[j]].push_back(dzPhiBiases.getMin());
+      useRMS ? ret.m_dzPhiHi[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean() + 2*dzPhiBiases.getWeightedRMS()) :ret.m_dzPhiHi[LegLabels[j]].push_back(dzPhiBiases.getMax());
+
+      auto dzEtaBiases = getBiases(dzEtaMeanTrend[j]);
+      ret.m_dzEtaMeans[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean());
+      ret.m_dzEtaChi2[LegLabels[j]].push_back(TMath::Log10(dzEtaBiases.getNormChi2()));
+      ret.m_dzEtaKS[LegLabels[j]].push_back(dzEtaBiases.getKSScore());
+      useRMS ? ret.m_dzEtaLo[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean() - 2*dzEtaBiases.getWeightedRMS()) :ret.m_dzEtaLo[LegLabels[j]].push_back(dzEtaBiases.getMin());
+      useRMS ? ret.m_dzEtaHi[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean() + 2*dzEtaBiases.getWeightedRMS()) :ret.m_dzEtaHi[LegLabels[j]].push_back(dzEtaBiases.getMax());
+
+      // unrolled histograms
+      ret.m_dxyVect[LegLabels[j]].push_back(getUnrolledHisto(dxyIntegralTrend[j]));
+      ret.m_dzVect[LegLabels[j]].push_back(getUnrolledHisto(dzIntegralTrend[j]));
+
+      //std::cout<<std::endl;
+      //std::cout<<" n. bins: "<< dxyVect[LegLabels[j]].back().get_n_bins() 
+      //       <<" y-min:   "<< dxyVect[LegLabels[j]].back().get_y_min()
+      //       <<" y-max:   "<< dxyVect[LegLabels[j]].back().get_y_max() << std::endl;
+
+      // beautify the histograms
+      MakeNiceTrendPlotStyle(dxyPhiMeanTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyPhiWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzPhiMeanTrend[j],j);
+      MakeNiceTrendPlotStyle(dzPhiWidthTrend[j],j);
+
+      MakeNiceTrendPlotStyle(dxyLadderMeanTrend[j],j); 
+      MakeNiceTrendPlotStyle(dxyLadderWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzLadderMeanTrend[j],j); 
+      MakeNiceTrendPlotStyle(dzLadderWidthTrend[j],j);
+
+      MakeNiceTrendPlotStyle(dxyEtaMeanTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyEtaWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzEtaMeanTrend[j],j);
+      MakeNiceTrendPlotStyle(dzEtaWidthTrend[j],j);  
+
+      MakeNiceTrendPlotStyle(dxyModZMeanTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyModZWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzModZMeanTrend[j],j);
+      MakeNiceTrendPlotStyle(dzModZWidthTrend[j],j);  
+
+      MakeNiceTrendPlotStyle(dxyNormPhiWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyNormEtaWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzNormPhiWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzNormEtaWidthTrend[j],j);
+
+      MakeNiceTrendPlotStyle(dxyNormPtWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzNormPtWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyPtWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dzPtWidthTrend[j],j);
+
+    }
+
+    if(!areAllFilesOK){
+       
+      // do all the necessary deletions
+      std::cout<<"\n====> not all files are OK"<<std::endl;
+
+      for(int i=0;i<lastOpen;i++){
+	fins[i]->Close();
+      }
+      continue;
+    } else {
+      ret.m_runs.push_back(intersection.at(n));
+      // push back the vector of lumi (in fb at this point)
+      ret.m_lumiByRun.push_back(ret.m_lumiSoFar/1000.);
+      ret.m_lumiMapByRun[intersection.at(n)]=ret.m_lumiSoFar/1000.;
+    }
+
+    std::cout<<"I am still here - runs.size(): "<<ret.m_runs.size()<<std::endl;
+
+    // Bias plots
+
+    TCanvas *BiasesCanvas = new TCanvas(Form("Biases_%i",intersection.at(n)),"Biases",1200,1200);
+    arrangeOutCanvas(BiasesCanvas,dxyPhiMeanTrend,dzPhiMeanTrend,dxyEtaMeanTrend,dzEtaMeanTrend,nDirs_,LegLabels,intersection.at(n));
+
+    BiasesCanvas->SaveAs(Form("Biases_%i.pdf",intersection.at(n)));
+    BiasesCanvas->SaveAs(Form("Biases_%i.png",intersection.at(n)));
+      
+    // Bias vs L1 modules position
+
+    TCanvas *BiasesL1Canvas = new TCanvas(Form("BiasesL1_%i",intersection.at(n)),"BiasesL1",1200,1200);
+    arrangeOutCanvas(BiasesL1Canvas,dxyLadderMeanTrend,dzLadderMeanTrend,dxyModZMeanTrend,dzModZMeanTrend,nDirs_,LegLabels,intersection.at(n));
+
+    BiasesL1Canvas->SaveAs(Form("BiasesL1_%i.pdf",intersection.at(n)));
+    BiasesL1Canvas->SaveAs(Form("BiasesL1_%i.png",intersection.at(n)));
+
+    // Resolution plots
+
+    TCanvas *ResolutionsCanvas = new TCanvas(Form("Resolutions_%i",intersection.at(n)),"Resolutions",1200,1200);
+    arrangeOutCanvas(ResolutionsCanvas,dxyPhiWidthTrend,dzPhiWidthTrend,dxyEtaWidthTrend,dzEtaWidthTrend,nDirs_,LegLabels,intersection.at(n));
+
+    ResolutionsCanvas->SaveAs(Form("Resolutions_%i.pdf",intersection.at(n)));
+    ResolutionsCanvas->SaveAs(Form("Resolutions_%i.png",intersection.at(n)));
+    
+    // Resolution plots vs L1 modules position
+
+    TCanvas *ResolutionsL1Canvas = new TCanvas(Form("ResolutionsL1_%i",intersection.at(n)),"Resolutions",1200,1200);
+    arrangeOutCanvas(ResolutionsL1Canvas,dxyLadderWidthTrend,dzLadderWidthTrend,dxyModZWidthTrend,dzModZWidthTrend,nDirs_,LegLabels,intersection.at(n));
+
+    ResolutionsL1Canvas->SaveAs(Form("ResolutionsL1_%i.pdf",intersection.at(n)));
+    ResolutionsL1Canvas->SaveAs(Form("ResolutionsL1_%i.png",intersection.at(n)));
+
+     // Pull plots
+
+    TCanvas *PullsCanvas = new TCanvas(Form("Pulls_%i",intersection.at(n)),"Pulls",1200,1200);
+    arrangeOutCanvas(PullsCanvas,dxyNormPhiWidthTrend,dzNormPhiWidthTrend,dxyNormEtaWidthTrend,dzNormEtaWidthTrend,nDirs_,LegLabels,intersection.at(n));
+
+    PullsCanvas->SaveAs(Form("Pulls_%i.pdf",intersection.at(n)));
+    PullsCanvas->SaveAs(Form("Pulls_%i.png",intersection.at(n)));
+
+    // pT plots
+
+    TCanvas *ResolutionsVsPt = new TCanvas(Form("ResolutionsVsPT_%i",intersection.at(n)),"ResolutionsVsPt",1200,1200);
+    arrangeOutCanvas(ResolutionsVsPt,dxyPtWidthTrend,dzPtWidthTrend,dxyNormPtWidthTrend,dzNormPtWidthTrend,nDirs_,LegLabels,intersection.at(n));
+
+    ResolutionsVsPt->SaveAs(Form("ResolutionsVsPt_%i.pdf",intersection.at(n)));
+    ResolutionsVsPt->SaveAs(Form("ResolutionsVsPt_%i.png",intersection.at(n)));
+
+    // do all the necessary deletions
+
+    for(int i=0;i<nDirs_;i++){
+
+      delete dxyPhiMeanTrend[i];
+      delete dzPhiMeanTrend[i];
+      delete dxyEtaMeanTrend[i];
+      delete dzEtaMeanTrend[i];
+      
+      delete dxyPhiWidthTrend[i];
+      delete dzPhiWidthTrend[i];
+      delete dxyEtaWidthTrend[i];
+      delete dzEtaWidthTrend[i];
+
+      delete dxyNormPhiWidthTrend[i];
+      delete dxyNormEtaWidthTrend[i];
+      delete dzNormPhiWidthTrend[i];
+      delete dzNormEtaWidthTrend[i];
+
+      delete dxyNormPtWidthTrend[i]; 
+      delete dzNormPtWidthTrend[i];  
+      delete dxyPtWidthTrend[i];
+      delete dzPtWidthTrend[i]; 
+    
+      fins[i]->Close();
+    }
+    
+    delete BiasesCanvas;
+    delete BiasesL1Canvas;
+    delete ResolutionsCanvas; 
+    delete ResolutionsL1Canvas;
+    delete PullsCanvas;
+    delete ResolutionsVsPt;
+
+    std::cout<<std::endl;
+  }
+  
+  return ret;
+
+}

--- a/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
+++ b/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
@@ -149,7 +149,6 @@ namespace pv{
     double m_ks;
   };
 
-
    /*! \struct wrappedTrends
    *  \brief Structure wrappedTrends
    *         Contains the ensemble vs run number of the alignmentTrend characterization
@@ -164,8 +163,11 @@ namespace pv{
    */
 
   struct wrappedTrends {
+
+    /*! \fn wrappedTrends
+     *  \brief Constructor of structure wrappedTrends, initialising all members from DMRs directly (with split)
+     */
     
-    // constructor
     wrappedTrends(alignmentTrend mean,
 		  alignmentTrend low, 
 		  alignmentTrend high,    
@@ -202,6 +204,19 @@ namespace pv{
     alignmentTrend m_chi2;
     alignmentTrend m_KS;      
   };
+
+  /*! \struct bundle
+   *  \brief Structure bundle
+   *         Contains the ensemble of all the information to build the graphs alignmentTrends
+   *
+   * @param nObjects                     int, number of alignments to be considered
+   * @param dataType                     TString, type of the data to be displayed (time, lumi)
+   * @param dataTypeLabel                TString, x-axis label
+   * @param lumiMapByrun                 std::map of the luminoisty by run number
+   * @param times                        std::map of the date (UTC) by run number
+   * @param lumiaxisformat               boolean, is the x-axis of the type lumi
+   * @param timeaxisformat               boolean, is the x-axis of the type time
+   */
 
   struct bundle{
     
@@ -313,7 +328,40 @@ struct unrolledHisto {
 
 };
 
-// auxilliary struct to be returned by the functor
+
+/*! \struct outTrends
+   *  \brief Structure outTrends
+   *         Contains the ensemble of all the alignmentTrends built by the functor
+   *
+   * @param m_index                     int, to keep track of which chunk of data has been processed
+   * @param m_lumiSoFar                 double, luminosity in this section of the data
+   * @param m_runs                      std::vector, list of the run processed in this section
+   * @param m_lumiByRun                 std::vector, list of the luminisoties per run, indexed
+   * @param m_lumiMarpByRun             std::map, map of the luminosities per run
+   * @param m_dxyPhiMeans               alignmentTrend of the mean values of the profile dxy vs phi
+   * @param m_dxyPhiChi2                alignmentTrend of chi2 of the linear fit per profile dxy vs phi
+   * @param m_dxyPhiKS                  alignmentTrend of Kolmogorow-Smirnov score of comparison of dxy vs phi profile with flat line
+   * @param m_dxyPhiHi                  alignmentTrend of the highest value of the profile dxy vs phi
+   * @param m_dxyPhiLo                  alignmentTrend of the lowest value of the profile dxy vs phi
+   * @param m_dxyEtaMeans               alignmentTrend of the mean values of the profile dxy vs eta
+   * @param m_dxyEtaChi2                alignmentTrend of chi2 of the linear fit per profile dxy vs eta
+   * @param m_dxyEtaKS                  alignmentTrend of Kolmogorow-Smirnov score of comparison of dxy vs eta profile with flat line
+   * @param m_dxyEtaHi                  alignmentTrend of the highest value of the profile dxy vs eta
+   * @param m_dxyEtaLo                  alignmentTrend of the lowest value of the profile dxy vs eta
+   * @param m_dzPhiMeans                alignmentTrend of the mean values of the profile dz vs phi
+   * @param m_dzPhiChi2                 alignmentTrend of chi2 of the linear fit per profile dz vs phi
+   * @param m_dzPhiKS                   alignmentTrend of Kolmogorow-Smirnov score of comparison of dz vs phi profile with flat line
+   * @param m_dzPhiHi                   alignmentTrend of the highest value of the profile dz vs phi
+   * @param m_dzPhiLo                   alignmentTrend of the lowest value of the profile dz vs phi
+   * @param m_dzEtaMeans                alignmentTrend of the mean values of the profile dz vs eta
+   * @param m_dzEtaChi2                 alignmentTrend of chi2 of the linear fit per profile dz vs eta
+   * @param m_dzEtaKS                   alignmentTrend of Kolmogorow-Smirnov score of comparison of dz vs eta profile with flat line
+   * @param m_dzEtaHi                   alignmentTrend of the highest value of the profile dz vs eta
+   * @param m_dzEtaLo                   alignmentTrend of the lowest value of the profile dz vs eta
+   * @param m_dxyVect                   map of the unrolled histograms for dxy residuals
+   * @param m_dzVect                    map of the unrolled histograms for dz residulas
+   */
+
 struct outTrends {
 
   int m_index;
@@ -383,7 +431,7 @@ struct outTrends {
 
 // forward declarations
 void MultiRunPVValidation(TString namesandlabels="",bool lumi_axis_format=false,bool time_axis_format=false,bool useRMS=true);
-outTrends doStuff(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10], bool useRMS);
+outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10], bool useRMS);
 
 void arrangeOutCanvas(TCanvas *canv,
 		      TH1F* m_11Trend[100],
@@ -435,7 +483,10 @@ void outputGraphs(const pv::wrappedTrends& allInputs,
 		  TLegend* &legend
 		  );
 
-// utility function to split strings
+/*! \fn split
+ *  \brief utility function to split strings
+ */
+
 /*--------------------------------------------------------------------*/
 std::vector<std::string> split(const std::string& s,char delimiter)
 /*--------------------------------------------------------------------*/
@@ -633,21 +684,21 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   // loop over the runs in the intersection
   //unsigned int last = (DEBUG==true) ? 50 : intersection.size();
   
-  //std::function<void()> f_doStuff = std::bind(doStuff,1,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,dxyPhiMeans_,dxyPhiHi_,dxyPhiLo_,dxyEtaMeans_,dxyEtaHi_,dxyEtaLo_,dzPhiMeans_,dzPhiHi_,dzPhiLo_,dzEtaMeans_,dzEtaHi_,dzEtaLo_,dxyVect,dzVect);
+  //std::function<void()> f_processData = std::bind(processData,1,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,dxyPhiMeans_,dxyPhiHi_,dxyPhiLo_,dxyEtaMeans_,dxyEtaHi_,dxyEtaLo_,dzPhiMeans_,dzPhiHi_,dzPhiLo_,dzEtaMeans_,dzEtaHi_,dzEtaLo_,dxyVect,dzVect);
   
   std::cout<<" pre do-stuff: " << runs.size() << std::endl;
   
   //we should use std::bind to create a functor and then pass it to the procPool
-  auto f_doStuff = std::bind(doStuff,_1,intersection,nDirs_,dirs,LegLabels,useRMS);
+  auto f_processData = std::bind(processData,_1,intersection,nDirs_,dirs,LegLabels,useRMS);
   
-  //f_doStuff(0);
+  //f_processData(0);
   //std::cout<<" post do-stuff: " <<  runs.size() << std::endl;
 
   TProcPool procPool(nWorkers);
   std::vector<size_t> range(nWorkers);
   std::iota(range.begin(),range.end(),0);
-  //procPool.Map([&f_doStuff](size_t a) { f_doStuff(a); },{1,2,3});
-  auto extracts = procPool.Map(f_doStuff,range);
+  //procPool.Map([&f_processData](size_t a) { f_processData(a); },{1,2,3});
+  auto extracts = procPool.Map(f_processData,range);
   
   // sort the extracts according to the global index
   std::sort(extracts.begin(), extracts.end(), 
@@ -747,7 +798,7 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
 
   // main function call
   /*
-    doStuff(0,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,
+    processData(0,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,
     dxyPhiMeans_,dxyPhiHi_,dxyPhiLo_,	 	                  
     dxyEtaMeans_,dxyEtaHi_,dxyEtaLo_,	 	                  
     dzPhiMeans_,dzPhiHi_,dzPhiLo_,	 	  
@@ -1517,6 +1568,10 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
 
 }
 
+/*! \fn outputGraphs
+ *  \brief function to build the output graphs
+ */
+
 /*--------------------------------------------------------------------*/
 void outputGraphs(const pv::wrappedTrends& allInputs,
 		  const std::vector<double>& ticks,
@@ -1732,6 +1787,9 @@ void outputGraphs(const pv::wrappedTrends& allInputs,
   
 }
 
+/*! \fn list_files
+ *  \brief utility function to list of filles in a directory
+ */
 
 /*--------------------------------------------------------------------*/
 std::vector<int> list_files(const char *dirname, const char *ext)
@@ -1761,9 +1819,13 @@ std::vector<int> list_files(const char *dirname, const char *ext)
   return theRunNumbers;
 }
 
-//*************************************************************
+/*! \fn arrangeOutCanvas
+ *  \brief utility function to arrange the plots per run nicely in a TCanvas
+ */
+
+/*--------------------------------------------------------------------*/
 void arrangeOutCanvas(TCanvas *canv, TH1F* m_11Trend[100],TH1F* m_12Trend[100],TH1F* m_21Trend[100],TH1F* m_22Trend[100],Int_t nDirs, TString LegLabels[10],unsigned int theRun){
-//*************************************************************
+/*--------------------------------------------------------------------*/
 
   TLegend *lego = new TLegend(0.19,0.80,0.79,0.93);
   //lego-> SetNColumns(2);
@@ -1904,6 +1966,10 @@ void arrangeOutCanvas(TCanvas *canv, TH1F* m_11Trend[100],TH1F* m_12Trend[100],T
   } 
 }
 
+/*! \fn MakeNiceTrendPlotStype
+ *  \brief utility function to embellish trend plot style
+ */
+
 /*--------------------------------------------------------------------*/
 void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color)
 /*--------------------------------------------------------------------*/
@@ -1934,6 +2000,10 @@ void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color)
   hist->SetMarkerColor(pv::colors[color]);
 }
 
+
+/*! \fn maxkeNewAxis
+ *  \brief utility function to re-make x-axis with correct binning
+ */
 
 /*--------------------------------------------------------------------*/
 void makeNewXAxis (TH1 *h)
@@ -2004,6 +2074,10 @@ void makeNewXAxis (TH1 *h)
 
 }
 
+
+/*! \fn setStyle
+ *  \brief main function to set the plotting style
+ */
 
 /*--------------------------------------------------------------------*/
 void setStyle(){
@@ -2095,6 +2169,11 @@ void setStyle(){
 // }
 
 
+
+/*! \fn cmsPrel
+ *  \brief utility function to put the CMS paraphernalia on canvas
+ */
+
 /*--------------------------------------------------------------------*/
 void cmsPrel(TPad* pad,size_t ipads) {
 /*--------------------------------------------------------------------*/
@@ -2139,6 +2218,10 @@ void cmsPrel(TPad* pad,size_t ipads) {
   
 }
 
+/*! \fn DrawConstant
+ *  \brief utility function to draw a constant histogram
+ */
+
 /*--------------------------------------------------------------------*/
 TH1F* DrawConstant(TH1F *hist,Int_t iter,Double_t theConst)
 /*--------------------------------------------------------------------*/
@@ -2159,6 +2242,11 @@ TH1F* DrawConstant(TH1F *hist,Int_t iter,Double_t theConst)
   
   return hzero;
 }
+
+
+/*! \fn DrawConstant
+ *  \brief utility function to draw a constant histogram with erros !=0
+ */
 
 /*--------------------------------------------------------------------*/
 TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst)
@@ -2181,6 +2269,10 @@ TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst)
   
   return hzero;
 }
+
+/*! \fn DrawConstantGraph
+ *  \brief utility function to draw a constant TGraph
+ */
 
 /*--------------------------------------------------------------------*/
 TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst)
@@ -2205,6 +2297,9 @@ TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst)
   return hzero;
 }
 
+/*! \fn getUnrolledHisto
+ *  \brief utility function to tranform a TH1 into a vector of floats
+ */
 
 /*--------------------------------------------------------------------*/
 unrolledHisto getUnrolledHisto(TH1F* hist)
@@ -2228,6 +2323,10 @@ unrolledHisto getUnrolledHisto(TH1F* hist)
   return ret;
 
 }
+
+/*! \fn getBiases
+ *  \brief utility function to extract characterization of the PV bias plot
+ */
 
 /*--------------------------------------------------------------------*/
 pv::biases getBiases(TH1F* hist)
@@ -2288,6 +2387,10 @@ pv::biases getBiases(TH1F* hist)
 
 }
 
+/*! \fn beautify
+ *  \brief utility function to beautify a TGraph
+ */
+
 /*--------------------------------------------------------------------*/
 void beautify(TGraph *g){
 /*--------------------------------------------------------------------*/
@@ -2305,6 +2408,10 @@ void beautify(TGraph *g){
   g->GetYaxis()->CenterTitle(true);
   g->GetXaxis()->SetNdivisions(505);
 }
+
+/*! \fn beautify
+ *  \brief utility function to beautify a TH1
+ */
 
 /*--------------------------------------------------------------------*/
 void beautify(TH1 *h){
@@ -2325,6 +2432,10 @@ void beautify(TH1 *h){
   h->GetXaxis()->SetNdivisions(505);
 }
 
+/*! \fn adjustmargins
+ *  \brief utility function to adjust margins of a TCanvas
+ */
+
 /*--------------------------------------------------------------------*/
 void adjustmargins(TCanvas *canv){
 /*--------------------------------------------------------------------*/
@@ -2333,6 +2444,10 @@ void adjustmargins(TCanvas *canv){
   canv->cd()->SetRightMargin(0.03);
   canv->cd()->SetTopMargin(0.06);
 }
+
+/*! \fn adjustmargins
+ *  \brief utility function to adjust margins of a TVirtualPad
+ */
 
 /*--------------------------------------------------------------------*/
 void adjustmargins(TVirtualPad *canv){
@@ -2343,6 +2458,11 @@ void adjustmargins(TVirtualPad *canv){
   canv->SetTopMargin(0.02);
 }
 
+
+/*! \fn checkTH1AndReturn
+ *  \brief utility function to check if a TH1 exists in a TFile before returning it
+ */
+
 /*--------------------------------------------------------------------*/
 TH1F* checkTH1AndReturn(TFile *f,TString address){
 /*--------------------------------------------------------------------*/
@@ -2352,6 +2472,10 @@ TH1F* checkTH1AndReturn(TFile *f,TString address){
   } 
   return h;
 }
+
+/*! \fn checkThView
+ *  \brief utility function to return the pv::view corresponding to a given PV bias plot
+ */
 
 /*--------------------------------------------------------------------*/
 pv::view checkTheView(const TString &toCheck){
@@ -2377,6 +2501,11 @@ pv::view checkTheView(const TString &toCheck){
   } 
 }
 
+
+/*! \fn timify
+ *  \brief utility function to make a histogram x-axis of the time type
+ */
+
 /*--------------------------------------------------------------------*/
 template<typename T>
 void timify(T *mgr)
@@ -2395,6 +2524,11 @@ struct increase
     template<class T>
     bool operator()(T const &a, T const &b) const { return a > b; }
 };
+
+
+/*! \fn getMaximumFromArray
+ *  \brief utility function to extract the maximum out of an array of histograms
+ */
 
 /*--------------------------------------------------------------------*/
 Double_t getMaximumFromArray(TObjArray *array)
@@ -2448,26 +2582,15 @@ Double_t getMaximumFromArray(TObjArray *array)
   return theMaximum;
 }
 
+/*! \fn superImposeIOVBoundaries
+ *  \brief utility function to superimpose the IOV boundaries on the trend plot
+ */
+
 /*--------------------------------------------------------------------*/
 void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_format,const std::map<int,double> &lumiMapByRun,const std::map<int,TDatime>& timeMap)
 /*--------------------------------------------------------------------*/
 {
- 
-  /*
-    1   296641       2017-11-07 12:31:49  bf4bdd66393bee0623b730e11f3db799674c4daf  Alignments   
-    2   297179       2017-11-07 12:31:49  a5858bccd2e2c031a12aa6cbe38e8adaeca19331  Alignments   
-    3   297281       2017-11-07 12:31:49  b423ed0f118c16d99cf92d12a1bd33bb1902f533  Alignments   
-    4   298653       2017-11-07 12:31:49  3e598e771471289c59d755ef4ebb993e6c4b7890  Alignments   
-    5   299277       2017-11-07 12:31:49  d8631cc034f3971131f7e7551610acf790192cd2  Alignments   
-    6   299443       2017-11-07 12:31:49  58961d0e9322c4d7064b31e73d9edfe9a861e1f8  Alignments   
-    7   300389       2017-11-07 12:31:49  7c0a2dcfa527e8e336ff6b8b198827a5fcb9c287  Alignments   
-    8   301046       2017-11-07 12:31:49  4bf6bfbd7f8a202e8a6bba5e8730b27b00e5142b  Alignments   
-    9   302131       2017-11-07 12:31:49  387e5f629f808464f5c69ab8bb7319576d81e768  Alignments   
-    10  303790       2017-11-07 12:31:49  21b79cc2a163df4fbc6c059eed8c96b86f8a07ff  Alignments   
-    11  304911       2017-11-07 12:31:49  44c7e1e991484d1490ac5ad6b734b6622f1e9d85  Alignments   
-    12  305898       2017-11-28 16:03:38  64aae34a7273b374738ed4b9b20c332abf503ab4  Alignments   
-  */
- 
+
   // get the vector of runs in the lumiMap
   std::vector<int> vruns;
   for(auto const& imap: lumiMapByRun){
@@ -2480,95 +2603,50 @@ void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_fo
     std::cout<<" run:" << imap.first << " time: "<< imap.second.Convert() << std::endl;
   }
 
-  /* 2018 Prompt IOVs
-     314163       2018-04-13 12:46:08  1486775833f89de0ba96bfac647c11606f882b15  Alignments   
-     316006       2018-05-09 12:32:34  f67aa5b2d86737f947482a21e54074ab74b0ca7b  Alignments   
-     317393       2018-06-04 16:18:49  841254d3c88b0a906c241de3a906394c063a5b9d  Alignments  
+  /* Run-2 Ultra-Legacy ReReco IOVs (from tag SiPixelTemplateDBObject_38T_v16_offline)
+     1      271866   2016-04-28   2cc9ecb98e8ba900b26701d6adf052ba59c1f5e1  SiPixelTemplateDBObject 2016
+     2      276315   2016-07-04   28a6077528012fe0abb03df9ef52e5976137c324  SiPixelTemplateDBObject
+     3      278271   2016-08-05   43744865be66299a3a37599961a9faf5a0d2bd78  SiPixelTemplateDBObject
+     4      280928   2016-09-16   7533fd5b60c10a9c55cddc6d2677d3fae6e8bb14  SiPixelTemplateDBObject
+     5      290543   2017-03-30   05803622f45cf4ee2c07af2bb97875bd1010bfea  SiPixelTemplateDBObject 2017
+     6      297281   2017-06-22   0ed971165dda7ae1db50c6636dab049087cad9a1  SiPixelTemplateDBObject
+     7      298653   2017-07-09   e3af935c8f4eded04455a88959501d7408895501  SiPixelTemplateDBObject
+     8      299443   2017-07-19   e2203ad6babf1885d754ae1392e4841a9b20c02e  SiPixelTemplateDBObject
+     9      300389   2017-08-03   d512d75856a89b7602c143046f9e030e112c81e5  SiPixelTemplateDBObject
+     10     301046   2017-08-12   c624d964356bf70df4a33761c32f8976a0d89257  SiPixelTemplateDBObject
+     11     302131   2017-08-31   ca6f56bb82434b69bd951d5ca89cdce841473ce0  SiPixelTemplateDBObject
+     12     303790   2017-09-23   cbb7b82c563a21f06bf7e57bec3a490625c98d18  SiPixelTemplateDBObject
+     13     303998   2017-09-27   7aec56e15aed26f7b686535ecaff59911947f802  SiPixelTemplateDBObject
+     14     304911   2017-10-13   d5bc4c312735d2d97e617ae3d45c735639a1cd82  SiPixelTemplateDBObject
+     15     313041   2018-03-28   f3752b4a1fac4aa65c6439ab75d216dcc3ed27a9  SiPixelTemplateDBObject 2018
+     16     314881   2018-04-22   bc8784a015d78068c51c9a581328b064299a31b4  SiPixelTemplateDBObject
+     17     316758   2018-05-22   3a8abe693d1d3df829212e1049330e68f3392282  SiPixelTemplateDBObject
+     18     317475   2018-06-05   83e09d34c122040bca0f5daf4b89a0435663c230  SiPixelTemplateDBObject
+     19     317485   2018-06-05   3a8abe693d1d3df829212e1049330e68f3392282  SiPixelTemplateDBObject
+     20     317527   2018-06-06   356b03fcd7e869ef8f28153318f0cd32c27b1f40  SiPixelTemplateDBObject
+     21     317661   2018-06-10   1cbb2fc3edf448c50d00fac3aa47c8cf3b19ac6f  SiPixelTemplateDBObject
+     22     317664   2018-06-11   356b03fcd7e869ef8f28153318f0cd32c27b1f40  SiPixelTemplateDBObject
+     23     318227   2018-06-21   1cbb2fc3edf448c50d00fac3aa47c8cf3b19ac6f  SiPixelTemplateDBObject
+     24     320377   2018-07-26   5e9cd265167ec543aac49685cf706a58014c08f8  SiPixelTemplateDBObject
+     25     321831   2018-08-27   e47d453934b47f06e53a323bd9ae16b38ec1bbd1  SiPixelTemplateDBObject
+     26     322510   2018-09-09   df783de5f30a99bc036d8973e48da78513206aba  SiPixelTemplateDBObject
+     27     322603   2018-09-09   e47d453934b47f06e53a323bd9ae16b38ec1bbd1  SiPixelTemplateDBObject
+     28     323232   2018-09-21   9e660fd65e392f01f69cde77a52f59e934d7737d  SiPixelTemplateDBObject
+     29     324245   2018-10-08   6caa50b30aa80ede330585888cdc5e804853d1da  SiPixelTemplateDBObject
   */
 
-  /* 2018D Prompt IOVs
-     320551       2018-07-30 18:56:08  5ef1b88947a246ff4f44b56e66314c176889e32e  Alignments   
-     320812       2018-08-03 21:15:40  70ebb0c3b83e5a93b1662bd39617ae452da6540b  Alignments   
-     320845       2018-08-05 00:21:08  8b5f42f55164132f6a06889c1f3d96e7176ce924  Alignments   
-     320855       2018-08-05 09:28:41  e2436a8e838aeb1444f6f8214f675a4ab9c06cf4  Alignments   
-     320885       2018-08-05 22:00:35  680e859cdea640ce24744c27c58b564e669c0f9c  Alignments   
-     320901       2018-08-06 05:23:45  f1da7f661c087214fe452bd6714e25b131a58f3f  Alignments   
-     320918       2018-08-06 12:37:42  a6fe27aa494007e065d23e763b680748d8f0293b  Alignments   
-     320924       2018-08-06 23:41:03  f9a1eb4c6e7b44711d4c8e813d9a14270fe1f8ba  Alignments   
-     320932       2018-08-07 02:00:48  4d74559fdb483ca63401426c145110fb2f8d9c67  Alignments   
-     320972       2018-08-07 15:10:14  9d6e3283a09bdeb9beab05094fce4eb55e0a7aa2  Alignments   
-     320981       2018-08-07 15:41:48  ba0ca93b7605378b651afd8a928b51bb34ab01ed  Alignments   
-     320997       2018-08-07 22:00:42  f9a1eb4c6e7b44711d4c8e813d9a14270fe1f8ba  Alignments   
-     321013       2018-08-08 15:31:58  6324bd8162744eaf7ab0fd44e0b01301fb9ff102  Alignments   
-  */
+  static const int nIOVs=29 ; //   1       2       3       4       5       6       7       8       9      10      11      12      13      14      15
+  int IOVboundaries[nIOVs] = {271866, 276315, 278271, 280928, 290543, 297281, 298653, 299443, 300389, 301046, 302131, 303790, 303998, 304911, 313041,
+			      //  16      17      18      19      20      21      22      23      24      25      26      27      28      29
+			      314881, 316758, 317475, 317485, 317527, 317661, 317664, 318227, 320377, 321831, 322510, 322603, 323232, 324245};
 
-  /*2018 ReReco IOVs
-    1   Alignments|313041|a2131f53f578e09de59f48a6707dc8d4ca8ffb1c|2018-08-15 08:32:54.825398
-    2   Alignments|314881|5d354a6bd2a1a256ec2ff5a3f735facccd030f30|2018-08-15 08:33:02.877544
-    3   Alignments|315488|9231ad0c6737600ab90761498d97077afe549905|2018-08-15 08:33:10.975766
-    4   Alignments|315689|ca322cc8364407dde43256235833f92756497caf|2018-08-15 08:33:20.157337
-    5   Alignments|316559|0adc667ed82407644f10f9de96500f83451b29ca|2018-08-15 08:33:31.927466
-    6   Alignments|316758|faa90f0fc255d2b66a4b528f585c375b0053a00b|2018-08-15 08:33:39.992558
-    7   Alignments|317438|3940f07daa4fa5079ec9d2c7ea8571aaa258f605|2018-08-15 08:33:47.803401
-    8   Alignments|317527|08de11788363dc19f94deeb57655d1b3dc1d3926|2018-08-15 08:33:55.853235
-    9   Alignments|318228|35baae799b7a186f0bc6487ae4bdc5af75201acc|2018-08-15 08:34:07.181786
-    10  Alignments|319337|7ddd2bb52fa50f6e7b66af5576a0c064089d56b9|2018-08-15 08:34:15.024333
-    11  Alignments|320377|c8fbff3dbddd3f19a084b280a382f61a6cebdc47|2018-08-15 08:34:22.900776
-    12  Alignments|320688|6060521269c9f119df1bcb0668936caa311cc9b9|2018-08-15 08:34:31.094154
-   */
-
-  // static const int nIOVs=13;//       1       2}       3      4      5      6      7      8      9     10     11     12     13 
-  // int IOVboundaries[nIOVs]  = {320551,  320812,  320845,  320855,  320885,  320901,  320918,  320924,  320932,  320972,  320981,  320997,  321013};
-  // int benchmarkruns[nIOVs]  = {320551,  320812,  320845,  320855,  320885,  320901,  320918,  320924,  320932,  320972,  320981,  320997,  321013};
-
-  /* template IOVs
-     316758       2018-08-28 17:43:26  3a8abe693d1d3df829212e1049330e68f3392282  SiPixelTemplateDBObject  
-     317527       2018-08-28 17:43:26  356b03fcd7e869ef8f28153318f0cd32c27b1f40  SiPixelTemplateDBObject  
-     317661       2018-08-28 17:54:14  1cbb2fc3edf448c50d00fac3aa47c8cf3b19ac6f  SiPixelTemplateDBObject  
-     317664       2018-08-28 17:57:00  356b03fcd7e869ef8f28153318f0cd32c27b1f40  SiPixelTemplateDBObject  
-     318227       2018-08-28 17:58:17  1cbb2fc3edf448c50d00fac3aa47c8cf3b19ac6f  SiPixelTemplateDBObject  
-     320377       2018-09-04 18:20:50  5e9cd265167ec543aac49685cf706a58014c08f8  SiPixelTemplateDBObject  
-  */
-
-  /* 2017 ReReco template IOVs
-     280928       2017-11-07 10:57:51  65a7b7251f96dd52da4a224d921ae6c9e4e560e0  SiPixelTemplateDBObject  
-     290543       2017-11-07 10:59:05  05803622f45cf4ee2c07af2bb97875bd1010bfea  SiPixelTemplateDBObject  
-     297281       2017-11-07 11:04:10  0ed971165dda7ae1db50c6636dab049087cad9a1  SiPixelTemplateDBObject  
-     298653       2017-11-07 11:04:22  e3af935c8f4eded04455a88959501d7408895501  SiPixelTemplateDBObject  
-     299443       2017-11-07 11:04:37  053fae581c8fd47ed38142843774747aeecd0e29  SiPixelTemplateDBObject  
-     300389       2017-11-07 11:04:50  8d6d8297e767fe727b65107871ac6f7dca8c8c39  SiPixelTemplateDBObject  
-     302131       2017-11-07 11:05:03  13a584e147d1f069f8f25a84577721c01dbe9412  SiPixelTemplateDBObject  
-     303790       2017-11-07 11:05:28  db316ff818e117980e5b502a7d4a63064c02bf46  SiPixelTemplateDBObject  
-     304911       2017-11-07 11:05:40  cd4630efcc7c55593bf93a5211ba4b0f95a0ca2b  SiPixelTemplateDBObject  
-     305898       2017-12-01 10:17:44  6a3c710452af7134dd9e6408fb601b8c34542d10  SiPixelTemplateDBObject  
-   */
+  int benchmarkruns[nIOVs] = {271866, 276315, 278271, 280928, 290543, 297281, 298653, 299443, 300389, 301046, 302131, 303790, 303998, 304911, 313041,
+			      314881, 316758, 317475, 317485, 317527, 317661, 317664, 318227, 320377, 321831, 322510, 322603, 323232, 324245};
 
 
-  /*2018 2D Templates
-    314882       2019-01-25 22:39:07  9a89bb756a0c73a673b5bc445e8ca13b6e33ebfc  SiPixel2DTemplateDBObject  
-    316758       2019-01-25 22:42:29  f265af2c72edce9f0ebfddefaf7a3b291cdb4fbd  SiPixel2DTemplateDBObject  
-    317527       2019-01-25 22:43:52  f6d33ce60dd8a9b4543fbf7128c5f1db4854957e  SiPixel2DTemplateDBObject  
-    317661       2019-01-25 22:44:40  cc81e1fdeb11a989a583fdee51ef7678088eb3c4  SiPixel2DTemplateDBObject  
-    317664       2019-01-25 22:45:31  f6d33ce60dd8a9b4543fbf7128c5f1db4854957e  SiPixel2DTemplateDBObject  
-    318227       2019-01-25 22:46:28  cc81e1fdeb11a989a583fdee51ef7678088eb3c4  SiPixel2DTemplateDBObject  
-    320377       2019-01-25 22:47:13  c94706b8e034d272f864171260d3cd685e2c52f9  SiPixel2DTemplateDBObject  
-    321831       2019-01-25 22:48:13  a9c6e8e3f96b1bfd5267ecbdd23bddb41b14e8e6  SiPixel2DTemplateDBObject  
-    322510       2019-01-25 22:51:16  07a7408f23e270fc9fac0f357d7b6130939ea90a  SiPixel2DTemplateDBObject  
-    322603       2019-01-25 22:51:58  a9c6e8e3f96b1bfd5267ecbdd23bddb41b14e8e6  SiPixel2DTemplateDBObject  
-    323232       2019-01-25 22:52:41  916a68aa85d2bbbb4c61f0db8a1bdb6a30008829  SiPixel2DTemplateDBObject  
-    324245       2019-01-25 22:53:29  dd95892c7bcde1c2907c3a1165794763cbf5f519  SiPixel2DTemplateDBObject  
-   */
-
-  static const int nIOVs=12 ;   //       1         2       3        4        5        6        7        8        9       10       11        12   		      
-  //int IOVboundaries[nIOVs]  = {  313041,  314881,  315488,  315689,  316559,  316758,  317438,  317527,  318228,  319337,  320377,  320688};
-  //int IOVboundaries[nIOVs]  = {  316758,  317527,  317661,  317664,  318227,  320377};
-  //int benchmarkruns[nIOVs]  = {  316758,  317527,  317661,  317664,  318227,  320377};
-  //int benchmarkruns[nIOVs]  = {  313041,  314881,  315488,  315689,  316559,  316758,  317438,  317527,  318228,  319337,  320377,  320688};
-  //int IOVboundaries[nIOVs]  = {  290543,  297281,  298653,  299443,  300389,  302131,  303790,  304911,  305898};
-  //int benchmarkruns[nIOVs]  = {  290543,  297281,  298653,  299443,  300389,  302131,  303790,  304911,  305898};
-  
-  int IOVboundaries[nIOVs]    = {  314882,  316758,  317527,  317661,  317664,  318227,  320377,  321831,  322510,  322603,  323232,  324245};
-  int benchmarkruns[nIOVs]    = {  314882,  316758,  317527,  317661,  317664,  318227,  320377,  321831,  322510,  322603,  323232,  324245};
+  std::string dates[nIOVs] = { "2016-04-28", "2016-07-04", "2016-08-05", "2016-09-16", "2017-03-30", "2017-06-22", "2017-07-09", "2017-07-19", "2017-08-03", "2017-08-12", "2017-08-31", "2017-09-23",
+			       "2017-09-27", "2017-10-13", "2018-03-28", "2018-04-22", "2018-05-22", "2018-06-05", "2018-06-05", "2018-06-06", "2018-06-10", "2018-06-11", "2018-06-21", "2018-07-26",
+			       "2018-08-27", "2018-09-09", "2018-09-09", "2018-09-21", "2018-10-08"};
 
   TArrow* IOV_lines[nIOVs];
   c->cd();
@@ -2675,8 +2753,13 @@ void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_fo
   }
 }
 
+
+/*! \fn processData
+ *  \brief function where the magic happens, take the raw inputs and creates the output trends
+ */
+
 /*--------------------------------------------------------------------*/
-outTrends doStuff(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10],bool useRMS)
+outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10],bool useRMS)
 /*--------------------------------------------------------------------*/
 {
 

--- a/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
+++ b/Alignment/OfflineValidation/macros/MultiRunAndPlotPVValidation.C
@@ -48,31 +48,32 @@ const size_t nWorkers = 10;
 /*!
  * \def basically the y-values of a TGraph
  */
-typedef std::map<TString, std::vector<double> > alignmentTrend; 
+typedef std::map<TString, std::vector<double> > alignmentTrend;
 
-namespace pv{
-  enum view {
-    dxyphi,
-    dzphi,
-    dxyeta,
-    dzeta,
-    pT,
-    generic
-  };
-
+namespace pv {
+  enum view { dxyphi, dzphi, dxyeta, dzeta, pT, generic };
 
   /*! \fn closest
    *  \brief method to find first value that doesn not compare left
    */
 
-  int closest(std::vector<int> const& vec, int value) {
+  int closest(std::vector<int> const &vec, int value) {
     auto const it = std::lower_bound(vec.begin(), vec.end(), value);
-    if (it == vec.end()) { return -1; }
+    if (it == vec.end()) {
+      return -1;
+    }
     return *it;
   }
 
-  const Int_t markers[8] = {kFullSquare,kFullCircle,kFullTriangleDown,kOpenSquare,kOpenCircle,kFullTriangleUp,kOpenTriangleDown,kOpenTriangleUp};
-  const Int_t colors[8]  = {kBlack,kRed,kBlue,kGreen+2,kMagenta,kViolet,kCyan,kYellow};
+  const Int_t markers[8] = {kFullSquare,
+                            kFullCircle,
+                            kFullTriangleDown,
+                            kOpenSquare,
+                            kOpenCircle,
+                            kFullTriangleUp,
+                            kOpenTriangleDown,
+                            kOpenTriangleUp};
+  const Int_t colors[8] = {kBlack, kRed, kBlue, kGreen + 2, kMagenta, kViolet, kCyan, kYellow};
 
   /*! \struct biases
    *  \brief Structure biases
@@ -90,52 +91,49 @@ namespace pv{
    */
 
   struct biases {
-    
     // contructor
-    biases(double mean,double rms,double wmean,double wrms,double min,double max,double chi2,int ndf,double ks){
-      m_mean=mean;
-      m_rms=rms;
-      m_w_mean=wmean;
-      m_w_rms=wrms;
-      m_min=min;
-      m_max=max;
-      m_chi2=chi2;
-      m_ndf=ndf;
-      m_ks=ks;
+    biases(double mean, double rms, double wmean, double wrms, double min, double max, double chi2, int ndf, double ks) {
+      m_mean = mean;
+      m_rms = rms;
+      m_w_mean = wmean;
+      m_w_rms = wrms;
+      m_min = min;
+      m_max = max;
+      m_chi2 = chi2;
+      m_ndf = ndf;
+      m_ks = ks;
     }
-    
+
     // empty constructor
-    biases(){
-      init();
-    }    
+    biases() { init(); }
 
     /*! \fn init
      *  \brief initialising all members one by one
      */
 
-    void init(){
-      m_mean=0;
-      m_rms=0.;
-      m_min=+999.;
-      m_max=-999.;
-      m_w_mean=0.;
-      m_w_rms=0.;
-      m_chi2=-1.;
-      m_ndf=0.;
-      m_ks=9999.;
+    void init() {
+      m_mean = 0;
+      m_rms = 0.;
+      m_min = +999.;
+      m_max = -999.;
+      m_w_mean = 0.;
+      m_w_rms = 0.;
+      m_chi2 = -1.;
+      m_ndf = 0.;
+      m_ks = 9999.;
     }
 
-    double getMean(){ return m_mean;}
-    double getWeightedMean(){return m_w_mean;}
-    double getRMS(){return m_rms;}
-    double getWeightedRMS(){return m_w_rms;}
-    double getMin(){return m_min;}
-    double getMax(){return m_max;}
-    double getChi2(){return m_chi2;}
-    double getNDF(){return m_ndf;}
-    double getNormChi2(){ return double(m_chi2)/double(m_ndf);}
-    double getChi2Prob(){ return TMath::Prob(m_chi2,m_ndf);}
-    double getKSScore(){ return m_ks;}
+    double getMean() { return m_mean; }
+    double getWeightedMean() { return m_w_mean; }
+    double getRMS() { return m_rms; }
+    double getWeightedRMS() { return m_w_rms; }
+    double getMin() { return m_min; }
+    double getMax() { return m_max; }
+    double getChi2() { return m_chi2; }
+    double getNDF() { return m_ndf; }
+    double getNormChi2() { return double(m_chi2) / double(m_ndf); }
+    double getChi2Prob() { return TMath::Prob(m_chi2, m_ndf); }
+    double getKSScore() { return m_ks; }
 
   private:
     double m_mean;
@@ -145,11 +143,11 @@ namespace pv{
     double m_w_mean;
     double m_w_rms;
     double m_chi2;
-    int    m_ndf;
+    int m_ndf;
     double m_ks;
   };
 
-   /*! \struct wrappedTrends
+  /*! \struct wrappedTrends
    *  \brief Structure wrappedTrends
    *         Contains the ensemble vs run number of the alignmentTrend characterization
    *
@@ -163,37 +161,35 @@ namespace pv{
    */
 
   struct wrappedTrends {
-
     /*! \fn wrappedTrends
      *  \brief Constructor of structure wrappedTrends, initialising all members from DMRs directly (with split)
      */
-    
+
     wrappedTrends(alignmentTrend mean,
-		  alignmentTrend low, 
-		  alignmentTrend high,    
-		  alignmentTrend lowerr,   
-		  alignmentTrend higherr,   
-		  alignmentTrend chi2,    
-		  alignmentTrend KS){
+                  alignmentTrend low,
+                  alignmentTrend high,
+                  alignmentTrend lowerr,
+                  alignmentTrend higherr,
+                  alignmentTrend chi2,
+                  alignmentTrend KS) {
+      std::cout << "pv::wrappedTrends c'tor" << std::endl;
 
-      std::cout<<"pv::wrappedTrends c'tor"<< std::endl;
-
-      m_mean    = mean;    
-      m_low     = low;    
-      m_high    = high;   
-      m_lowerr  = lowerr; 
+      m_mean = mean;
+      m_low = low;
+      m_high = high;
+      m_lowerr = lowerr;
       m_higherr = higherr;
-      m_chi2    = chi2;   
-      m_KS      = KS;     
+      m_chi2 = chi2;
+      m_KS = KS;
     }
-    
-    alignmentTrend getMean()    const {return m_mean;}
-    alignmentTrend getLow()     const {return m_low;}
-    alignmentTrend getHigh()    const {return m_high;}
-    alignmentTrend getLowErr()  const {return m_lowerr;}
-    alignmentTrend getHighErr() const {return m_higherr;}
-    alignmentTrend getChi2()    const {return m_chi2;}
-    alignmentTrend getKS()      const {return m_KS;}
+
+    alignmentTrend getMean() const { return m_mean; }
+    alignmentTrend getLow() const { return m_low; }
+    alignmentTrend getHigh() const { return m_high; }
+    alignmentTrend getLowErr() const { return m_lowerr; }
+    alignmentTrend getHighErr() const { return m_higherr; }
+    alignmentTrend getChi2() const { return m_chi2; }
+    alignmentTrend getKS() const { return m_KS; }
 
   private:
     alignmentTrend m_mean;
@@ -202,7 +198,7 @@ namespace pv{
     alignmentTrend m_lowerr;
     alignmentTrend m_higherr;
     alignmentTrend m_chi2;
-    alignmentTrend m_KS;      
+    alignmentTrend m_KS;
   };
 
   /*! \struct bundle
@@ -218,10 +214,15 @@ namespace pv{
    * @param timeaxisformat               boolean, is the x-axis of the type time
    */
 
-  struct bundle{
-    
-    bundle(int nObjects, const TString& dataType,const TString& dataTypeLabel,const std::map<int,double>& lumiMapByRun,const std::map<int,TDatime>& times,const bool& lumiaxisformat,const bool& timeaxisformat, const bool& useRMS){
-
+  struct bundle {
+    bundle(int nObjects,
+           const TString &dataType,
+           const TString &dataTypeLabel,
+           const std::map<int, double> &lumiMapByRun,
+           const std::map<int, TDatime> &times,
+           const bool &lumiaxisformat,
+           const bool &timeaxisformat,
+           const bool &useRMS) {
       m_nObjects = nObjects;
       m_datatype = dataType.Data();
       m_datatypelabel = dataTypeLabel.Data();
@@ -229,59 +230,58 @@ namespace pv{
       m_times = times;
       m_useRMS = useRMS;
 
-      std::cout<<"pv::bundle c'tor: "<< dataTypeLabel << " member: " <<    m_datatypelabel << std::endl;
+      std::cout << "pv::bundle c'tor: " << dataTypeLabel << " member: " << m_datatypelabel << std::endl;
 
       // make sure you don't use them at the same time
-      if(lumiaxisformat || timeaxisformat){
-	assert(lumiaxisformat!=timeaxisformat); 
+      if (lumiaxisformat || timeaxisformat) {
+        assert(lumiaxisformat != timeaxisformat);
       }
 
-      if(lumiaxisformat){
-	std::cout<<"is lumiaxis format"<<std::endl;
-	m_axis_types.set(0); 
-      }
-      else if(timeaxisformat){
-	std::cout<<"is timeaxis format"<<std::endl;
-	m_axis_types.set(1); 
+      if (lumiaxisformat) {
+        std::cout << "is lumiaxis format" << std::endl;
+        m_axis_types.set(0);
+      } else if (timeaxisformat) {
+        std::cout << "is timeaxis format" << std::endl;
+        m_axis_types.set(1);
       } else {
-	std::cout<<"is runaxis format"<<std::endl;
+        std::cout << "is runaxis format" << std::endl;
       }
 
-      std::cout<< m_axis_types << std::endl;
-      
-      m_totalLumi = lumiMapByRun.rbegin()->second;
+      std::cout << m_axis_types << std::endl;
 
+      m_totalLumi = lumiMapByRun.rbegin()->second;
     }
 
-    int getNObjects() const {return m_nObjects;}
-    const char* getDataType() const {return m_datatype;}		  
-    const char* getDataTypeLabel() const {return m_datatypelabel;}	  
-    const std::map<int,double> getLumiMapByRun() const {return m_lumiMapByRun;}  
-    double getTotalLumi() const { return m_totalLumi;}
-    const std::map<int,TDatime> getTimes() const {return m_times;}	  
-    bool isLumiAxis() const {return m_axis_types.test(0);}
-    bool isTimeAxis() const {return m_axis_types.test(1);}
-    bool isUsingRMS() const {return m_useRMS;}
+    int getNObjects() const { return m_nObjects; }
+    const char *getDataType() const { return m_datatype; }
+    const char *getDataTypeLabel() const { return m_datatypelabel; }
+    const std::map<int, double> getLumiMapByRun() const { return m_lumiMapByRun; }
+    double getTotalLumi() const { return m_totalLumi; }
+    const std::map<int, TDatime> getTimes() const { return m_times; }
+    bool isLumiAxis() const { return m_axis_types.test(0); }
+    bool isTimeAxis() const { return m_axis_types.test(1); }
+    bool isUsingRMS() const { return m_useRMS; }
     void printAll() {
-      std::cout<< "dataType      " << m_datatype << std::endl;
-      std::cout<< "dataTypeLabel " << m_datatypelabel << std::endl;
-      if(this->isLumiAxis()) std::cout<<"is lumi axis"<< std::endl;
-      if(this->isTimeAxis()) std::cout<<"is time axis"<< std::endl;
+      std::cout << "dataType      " << m_datatype << std::endl;
+      std::cout << "dataTypeLabel " << m_datatypelabel << std::endl;
+      if (this->isLumiAxis())
+        std::cout << "is lumi axis" << std::endl;
+      if (this->isTimeAxis())
+        std::cout << "is time axis" << std::endl;
     }
 
   private:
     int m_nObjects;
-    const char* m_datatype;
-    const char* m_datatypelabel;
+    const char *m_datatype;
+    const char *m_datatypelabel;
     float m_totalLumi;
-    std::map<int,double> m_lumiMapByRun;
-    std::map<int,TDatime> m_times;
+    std::map<int, double> m_lumiMapByRun;
+    std::map<int, TDatime> m_times;
     std::bitset<2> m_axis_types;
     bool m_useRMS;
   };
 
-
-}
+}  // namespace pv
 
 // auxilliary struct to store
 // histogram features
@@ -291,46 +291,39 @@ struct unrolledHisto {
   unsigned int m_n_bins;
   std::vector<double> m_bincontents;
 
-  unrolledHisto(){
-    m_y_min  =0.;
-    m_y_max  =0.;
-    m_n_bins =0;
+  unrolledHisto() {
+    m_y_min = 0.;
+    m_y_max = 0.;
+    m_n_bins = 0;
     m_bincontents.clear();
-  } // first constructor empty
+  }  // first constructor empty
 
-  unrolledHisto(const double& y_min,const double& y_max, const unsigned int& n_bins, const std::vector<double>& bincontents){
-    m_y_min  = y_min;
-    m_y_max  = y_max;
+  unrolledHisto(const double &y_min,
+                const double &y_max,
+                const unsigned int &n_bins,
+                const std::vector<double> &bincontents) {
+    m_y_min = y_min;
+    m_y_max = y_max;
     m_n_bins = n_bins;
     m_bincontents = bincontents;
-  } //look, a constructor
-  
-  double get_y_min(){
-    return m_y_min;
-  }
+  }  //look, a constructor
 
-  double get_y_max(){
-    return m_y_max;
-  }
-  
-  unsigned int get_n_bins(){
-    return m_n_bins;
-  }
-  
-  std::vector<double> get_bin_contents(){
-    return m_bincontents;
-  }
+  double get_y_min() { return m_y_min; }
 
-  double get_integral(){
+  double get_y_max() { return m_y_max; }
+
+  unsigned int get_n_bins() { return m_n_bins; }
+
+  std::vector<double> get_bin_contents() { return m_bincontents; }
+
+  double get_integral() {
     double ret(0.);
-    for(const auto &binc: m_bincontents){
-      ret+=binc;
+    for (const auto &binc : m_bincontents) {
+      ret += binc;
     }
     return ret;
   }
-
 };
-
 
 /*! \struct outTrends
    *  \brief Structure outTrends
@@ -366,138 +359,149 @@ struct unrolledHisto {
    */
 
 struct outTrends {
-
   int m_index;
   double m_lumiSoFar;
   std::vector<double> m_runs;
   std::vector<double> m_lumiByRun;
-  std::map<int,double> m_lumiMapByRun; 
+  std::map<int, double> m_lumiMapByRun;
   alignmentTrend m_dxyPhiMeans;
   alignmentTrend m_dxyPhiChi2;
-  alignmentTrend m_dxyPhiKS;   
+  alignmentTrend m_dxyPhiKS;
   alignmentTrend m_dxyPhiHi;
   alignmentTrend m_dxyPhiLo;
   alignmentTrend m_dxyEtaMeans;
-  alignmentTrend m_dxyEtaChi2;  
+  alignmentTrend m_dxyEtaChi2;
   alignmentTrend m_dxyEtaKS;
-  alignmentTrend m_dxyEtaHi; 
+  alignmentTrend m_dxyEtaHi;
   alignmentTrend m_dxyEtaLo;
   alignmentTrend m_dzPhiMeans;
-  alignmentTrend m_dzPhiChi2; 
+  alignmentTrend m_dzPhiChi2;
   alignmentTrend m_dzPhiKS;
-  alignmentTrend m_dzPhiHi; 
-  alignmentTrend m_dzPhiLo;	 	 
+  alignmentTrend m_dzPhiHi;
+  alignmentTrend m_dzPhiLo;
   alignmentTrend m_dzEtaMeans;
-  alignmentTrend m_dzEtaChi2;  
+  alignmentTrend m_dzEtaChi2;
   alignmentTrend m_dzEtaKS;
-  alignmentTrend m_dzEtaHi; 
-  alignmentTrend m_dzEtaLo;       
-  std::map<TString,std::vector<unrolledHisto> > m_dxyVect;
-  std::map<TString,std::vector<unrolledHisto> > m_dzVect;
+  alignmentTrend m_dzEtaHi;
+  alignmentTrend m_dzEtaLo;
+  std::map<TString, std::vector<unrolledHisto> > m_dxyVect;
+  std::map<TString, std::vector<unrolledHisto> > m_dzVect;
 
-  void init(){
-    m_index=-1;
-    m_lumiSoFar=0.;
+  void init() {
+    m_index = -1;
+    m_lumiSoFar = 0.;
     m_runs.clear();
     m_lumiByRun.clear();
     m_lumiMapByRun.clear();
 
     m_dxyPhiMeans.clear();
-    m_dxyPhiChi2.clear(); 
-    m_dxyPhiKS.clear();   
-    m_dxyPhiHi.clear();  
-    m_dxyPhiLo.clear();  
+    m_dxyPhiChi2.clear();
+    m_dxyPhiKS.clear();
+    m_dxyPhiHi.clear();
+    m_dxyPhiLo.clear();
 
     m_dxyEtaMeans.clear();
     m_dxyEtaChi2.clear();
-    m_dxyEtaKS.clear();   
-    m_dxyEtaHi.clear();  
-    m_dxyEtaLo.clear();  
+    m_dxyEtaKS.clear();
+    m_dxyEtaHi.clear();
+    m_dxyEtaLo.clear();
 
     m_dzPhiMeans.clear();
     m_dzPhiChi2.clear();
     m_dzPhiKS.clear();
-    m_dzPhiHi.clear();   
-    m_dzPhiLo.clear();   
+    m_dzPhiHi.clear();
+    m_dzPhiLo.clear();
 
     m_dzEtaMeans.clear();
     m_dzEtaChi2.clear();
     m_dzEtaKS.clear();
     m_dzEtaHi.clear();
-    m_dzEtaLo.clear();   
+    m_dzEtaLo.clear();
 
     m_dxyVect.clear();
     m_dzVect.clear();
   }
 };
 
-
 // forward declarations
-void MultiRunPVValidation(TString namesandlabels="",bool lumi_axis_format=false,bool time_axis_format=false,bool useRMS=true);
-outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10], bool useRMS);
+void MultiRunPVValidation(TString namesandlabels = "",
+                          bool lumi_axis_format = false,
+                          bool time_axis_format = false,
+                          bool useRMS = true);
+outTrends processData(size_t iter,
+                      std::vector<int> intersection,
+                      const Int_t nDirs_,
+                      const char *dirs[10],
+                      TString LegLabels[10],
+                      bool useRMS);
 
 void arrangeOutCanvas(TCanvas *canv,
-		      TH1F* m_11Trend[100],
-		      TH1F* m_12Trend[100],
-		      TH1F* m_21Trend[100],
-		      TH1F* m_22Trend[100],
-		      Int_t nFiles, 
-		      TString LegLabels[10],
-		      unsigned int theRun);
+                      TH1F *m_11Trend[100],
+                      TH1F *m_12Trend[100],
+                      TH1F *m_21Trend[100],
+                      TH1F *m_22Trend[100],
+                      Int_t nFiles,
+                      TString LegLabels[10],
+                      unsigned int theRun);
 
-pv::biases getBiases(TH1F* hist);
-unrolledHisto getUnrolledHisto(TH1F* hist);
+pv::biases getBiases(TH1F *hist);
+unrolledHisto getUnrolledHisto(TH1F *hist);
 
-TH1F* DrawConstant(TH1F *hist,Int_t iter,Double_t theConst);
-TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst);
-TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst);
-std::vector<int> list_files(const char *dirname=".", const char *ext=".root");
-TH1F* checkTH1AndReturn(TFile *f,TString address);
-void MakeNiceTrendPlotStyle(TH1 *hist,Int_t color);
-void cmsPrel(TPad* pad,size_t ipads=1);
-void makeNewXAxis (TH1 *h);
+TH1F *DrawConstant(TH1F *hist, Int_t iter, Double_t theConst);
+TH1F *DrawConstantWithErr(TH1F *hist, Int_t iter, Double_t theConst);
+TH1F *DrawConstantGraph(TGraph *graph, Int_t iter, Double_t theConst);
+std::vector<int> list_files(const char *dirname = ".", const char *ext = ".root");
+TH1F *checkTH1AndReturn(TFile *f, TString address);
+void MakeNiceTrendPlotStyle(TH1 *hist, Int_t color);
+void cmsPrel(TPad *pad, size_t ipads = 1);
+void makeNewXAxis(TH1 *h);
 void beautify(TGraph *g);
 void beautify(TH1 *h);
 void adjustmargins(TCanvas *canv);
-void adjustmargins(TVirtualPad*canv);
+void adjustmargins(TVirtualPad *canv);
 void setStyle();
 pv::view checkTheView(const TString &toCheck);
-template<typename T> void timify(T *mgr);
+template <typename T>
+void timify(T *mgr);
 Double_t getMaximumFromArray(TObjArray *array);
-void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_format,const std::map<int,double> &lumiMapByRun,const std::map<int,TDatime>& timeMap,bool drawText=true);
-void outputGraphs(const pv::wrappedTrends& allInputs,
-		  const std::vector<double>& ticks,
-		  const std::vector<double>& ex_ticks,
-		  TCanvas* &canv,
-		  TCanvas* &mean_canv,
-		  TCanvas* &rms_canv,
-		  TGraph*  &g_mean,
-		  TGraph*  &g_chi2,
-		  TGraph*  &g_KS,
-		  TGraph*  &g_low,
-		  TGraph*  &g_high,
-		  TGraphAsymmErrors* &g_asym,
-		  TH1F* h_RMS[],      
-		  const pv::bundle& mybundle,
-		  const pv::view& theView,
-		  const int index,
-		  TObjArray* &array,
-		  const TString& label,
-		  TLegend* &legend
-		  );
+void superImposeIOVBoundaries(TCanvas *c,
+                              bool lumi_axis_format,
+                              bool time_axis_format,
+                              const std::map<int, double> &lumiMapByRun,
+                              const std::map<int, TDatime> &timeMap,
+                              bool drawText = true);
+void outputGraphs(const pv::wrappedTrends &allInputs,
+                  const std::vector<double> &ticks,
+                  const std::vector<double> &ex_ticks,
+                  TCanvas *&canv,
+                  TCanvas *&mean_canv,
+                  TCanvas *&rms_canv,
+                  TGraph *&g_mean,
+                  TGraph *&g_chi2,
+                  TGraph *&g_KS,
+                  TGraph *&g_low,
+                  TGraph *&g_high,
+                  TGraphAsymmErrors *&g_asym,
+                  TH1F *h_RMS[],
+                  const pv::bundle &mybundle,
+                  const pv::view &theView,
+                  const int index,
+                  TObjArray *&array,
+                  const TString &label,
+                  TLegend *&legend);
 
 /*! \fn split
  *  \brief utility function to split strings
  */
 
 /*--------------------------------------------------------------------*/
-std::vector<std::string> split(const std::string& s,char delimiter)
+std::vector<std::string> split(const std::string &s, char delimiter)
 /*--------------------------------------------------------------------*/
 {
   std::vector<std::string> tokens;
   std::string token;
   std::istringstream tokenStream(s);
-  while (std::getline(tokenStream, token, delimiter)){
+  while (std::getline(tokenStream, token, delimiter)) {
     tokens.push_back(token);
   }
   return tokens;
@@ -509,139 +513,136 @@ std::vector<std::string> split(const std::string& s,char delimiter)
 //
 ///////////////////////////////////
 
-void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time_axis_format,bool useRMS){
-  
-  TStopwatch timer; 	 
+void MultiRunPVValidation(TString namesandlabels, bool lumi_axis_format, bool time_axis_format, bool useRMS) {
+  TStopwatch timer;
   timer.Start();
 
   using namespace std::placeholders;  // for _1, _2, _3...
-  gROOT->ProcessLine("gErrorIgnoreLevel = kError;"); 	
+  gROOT->ProcessLine("gErrorIgnoreLevel = kError;");
 
   ROOT::EnableThreadSafety();
   TH1::AddDirectory(kFALSE);
 
   // consistency check, we cannot do plot vs lumi if time_axis
-  if(lumi_axis_format && time_axis_format){
-    std::cout<<"##########################################################################################"<<std::endl;
-    std::cout<<"msg-i: MultiRunPVValidation(): you're requesting both summary vs lumi and vs time, "<< std::endl;
-    std::cout<<"       this combination is inconsistent --> exiting!"<< std::endl;
+  if (lumi_axis_format && time_axis_format) {
+    std::cout << "##########################################################################################"
+              << std::endl;
+    std::cout << "msg-i: MultiRunPVValidation(): you're requesting both summary vs lumi and vs time, " << std::endl;
+    std::cout << "       this combination is inconsistent --> exiting!" << std::endl;
     //return;
     exit(EXIT_FAILURE);
   }
 
   // preload the dates from file
-  std::map<int,TDatime> times;
-  
-  if(time_axis_format){
-    
+  std::map<int, TDatime> times;
+
+  if (time_axis_format) {
     std::ifstream infile("times.txt");
 
-    if(!infile){
-      std::cout<<"missing input file :("<<std::endl;
-      std::cout<<" -- exiting" << std::endl;
+    if (!infile) {
+      std::cout << "missing input file :(" << std::endl;
+      std::cout << " -- exiting" << std::endl;
       return;
     }
 
     std::string line;
-    while (std::getline(infile, line)){
-
+    while (std::getline(infile, line)) {
       std::istringstream iss(line);
-      std::string a,b,c;
-      if (!(iss >> a >> b >> c)) { break; } // error
-      
-      //std::cout<<a<<"  "<<b<<"   "<<c<<"   "<<std::endl;
-      
-      int run  = std::stoi(a);
-      auto tokens_b = split(b,'-');
-      int year  = std::stoi(tokens_b[0]);
-      int month = std::stoi(tokens_b[1]);
-      int day   = std::stoi(tokens_b[2]);
-      
-      auto tokens_c  = split(c,'.');
-      auto tokens_c1 = split(tokens_c[0],':');
+      std::string a, b, c;
+      if (!(iss >> a >> b >> c)) {
+        break;
+      }  // error
 
-      int hour   = std::stoi(tokens_c1[0]);
+      //std::cout<<a<<"  "<<b<<"   "<<c<<"   "<<std::endl;
+
+      int run = std::stoi(a);
+      auto tokens_b = split(b, '-');
+      int year = std::stoi(tokens_b[0]);
+      int month = std::stoi(tokens_b[1]);
+      int day = std::stoi(tokens_b[2]);
+
+      auto tokens_c = split(c, '.');
+      auto tokens_c1 = split(tokens_c[0], ':');
+
+      int hour = std::stoi(tokens_c1[0]);
       int minute = std::stoi(tokens_c1[2]);
       int second = std::stoi(tokens_c1[2]);
 
       //std::cout<<run<<" "<<year<<" "<<month<<" "<<day<<" "<<hour<<" "<<minute<<" "<<second<<" "<<std::endl;
-	
-      TDatime da(year,month,day,hour,minute,second);
-      times[run]=da;
-    }    
-  } // if time axis in the plots
 
-  //std::ofstream outfile ("lumiByRun.txt"); 
-  std::ofstream outfile ("log.txt"); 
+      TDatime da(year, month, day, hour, minute, second);
+      times[run] = da;
+    }
+  }  // if time axis in the plots
+
+  //std::ofstream outfile ("lumiByRun.txt");
+  std::ofstream outfile("log.txt");
   setStyle();
 
-  TList *DirList   = new TList();
+  TList *DirList = new TList();
   TList *LabelList = new TList();
-  
+
   TObjArray *nameandlabelpairs = namesandlabels.Tokenize(",");
   for (Int_t i = 0; i < nameandlabelpairs->GetEntries(); ++i) {
     TObjArray *aFileLegPair = TString(nameandlabelpairs->At(i)->GetName()).Tokenize("=");
-    
-    if(aFileLegPair->GetEntries() == 2) {
-      DirList->Add(aFileLegPair->At(0)); 
+
+    if (aFileLegPair->GetEntries() == 2) {
+      DirList->Add(aFileLegPair->At(0));
       LabelList->Add(aFileLegPair->At(1));
+    } else {
+      std::cout << "Please give file name and legend entry in the following form:\n"
+                << " filename1=legendentry1,filename2=legendentry2\n";
     }
-    else {
-      std::cout << "Please give file name and legend entry in the following form:\n" 
-		<< " filename1=legendentry1,filename2=legendentry2\n"; 
-    }    
   }
 
   const Int_t nDirs_ = DirList->GetSize();
-  TString LegLabels[10];  
-  const char* dirs[10];
+  TString LegLabels[10];
+  const char *dirs[10];
 
   std::vector<int> intersection;
   std::vector<double> runs;
   std::vector<double> lumiByRun;
-  std::map<int,double> lumiMapByRun;
+  std::map<int, double> lumiMapByRun;
   std::vector<double> x_ticks;
   std::vector<double> ex_ticks = {0.};
 
   std::vector<double> runtimes;
-  if(time_axis_format){
-    for(const auto &element : times){
+  if (time_axis_format) {
+    for (const auto &element : times) {
       runtimes.push_back((element.second).Convert());
     }
   }
 
-  for(Int_t j=0; j < nDirs_; j++) {
-    
+  for (Int_t j = 0; j < nDirs_; j++) {
     // Retrieve labels
-    TObjString* legend = (TObjString*)LabelList->At(j);
-    TObjString* dir    = (TObjString*)DirList->At(j);
+    TObjString *legend = (TObjString *)LabelList->At(j);
+    TObjString *dir = (TObjString *)DirList->At(j);
     LegLabels[j] = legend->String();
     dirs[j] = (dir->String()).Data();
-    cout<<"MultiRunPVValidation(): label["<<j<<"]"<<LegLabels[j]<<endl;
-    
+    cout << "MultiRunPVValidation(): label[" << j << "]" << LegLabels[j] << endl;
+
     std::vector<int> currentList = list_files(dirs[j]);
     std::vector<int> tempSwap;
-    
-    std::sort(currentList.begin(),currentList.end());
 
-    if(j==0){
+    std::sort(currentList.begin(), currentList.end());
+
+    if (j == 0) {
       intersection = currentList;
     }
 
-    std::sort(intersection.begin(),intersection.end());
+    std::sort(intersection.begin(), intersection.end());
 
-    std::set_intersection(currentList.begin(),currentList.end(),
-			  intersection.begin(),intersection.end(),
-			  std::back_inserter(tempSwap));
-    
+    std::set_intersection(
+        currentList.begin(), currentList.end(), intersection.begin(), intersection.end(), std::back_inserter(tempSwap));
+
     intersection.clear();
     intersection = tempSwap;
     tempSwap.clear();
   }
-  
+
   // debug only
-  for(UInt_t index=0;index<intersection.size();index++){
-    std::cout<<index<<" "<<intersection[index]<<std::endl;
+  for (UInt_t index = 0; index < intersection.size(); index++) {
+    std::cout << index << " " << intersection[index] << std::endl;
   }
 
   // book the vectors of values
@@ -652,148 +653,186 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   alignmentTrend dxyPhiKS_;
   alignmentTrend dxyPhiHi_;
   alignmentTrend dxyPhiLo_;
- 
+
   alignmentTrend dxyEtaMeans_;
   alignmentTrend dxyEtaChi2_;
-  alignmentTrend dxyEtaHiErr_; 
+  alignmentTrend dxyEtaHiErr_;
   alignmentTrend dxyEtaLoErr_;
   alignmentTrend dxyEtaKS_;
   alignmentTrend dxyEtaHi_;
   alignmentTrend dxyEtaLo_;
-  
+
   alignmentTrend dzPhiMeans_;
   alignmentTrend dzPhiChi2_;
-  alignmentTrend dzPhiHiErr_; 
-  alignmentTrend dzPhiLoErr_;	 	  
+  alignmentTrend dzPhiHiErr_;
+  alignmentTrend dzPhiLoErr_;
   alignmentTrend dzPhiKS_;
   alignmentTrend dzPhiHi_;
   alignmentTrend dzPhiLo_;
-  
+
   alignmentTrend dzEtaMeans_;
   alignmentTrend dzEtaChi2_;
-  alignmentTrend dzEtaHiErr_; 
-  alignmentTrend dzEtaLoErr_;       
+  alignmentTrend dzEtaHiErr_;
+  alignmentTrend dzEtaLoErr_;
   alignmentTrend dzEtaKS_;
   alignmentTrend dzEtaHi_;
-  alignmentTrend dzEtaLo_;       
+  alignmentTrend dzEtaLo_;
 
   // unrolled histos
-  
-  std::map<TString,std::vector<unrolledHisto> > dxyVect;
-  std::map<TString,std::vector<unrolledHisto> > dzVect;
 
-  double lumiSoFar=0.0;
+  std::map<TString, std::vector<unrolledHisto> > dxyVect;
+  std::map<TString, std::vector<unrolledHisto> > dzVect;
+
+  double lumiSoFar = 0.0;
 
   // loop over the runs in the intersection
   //unsigned int last = (DEBUG==true) ? 50 : intersection.size();
-  
+
   //std::function<void()> f_processData = std::bind(processData,1,intersection,nDirs_,dirs,LegLabels,lumiSoFar,runs,lumiByRun,lumiMapByRun,useRMS,dxyPhiMeans_,dxyPhiHi_,dxyPhiLo_,dxyEtaMeans_,dxyEtaHi_,dxyEtaLo_,dzPhiMeans_,dzPhiHi_,dzPhiLo_,dzEtaMeans_,dzEtaHi_,dzEtaLo_,dxyVect,dzVect);
-  
-  std::cout<<" pre do-stuff: " << runs.size() << std::endl;
-  
+
+  std::cout << " pre do-stuff: " << runs.size() << std::endl;
+
   //we should use std::bind to create a functor and then pass it to the procPool
-  auto f_processData = std::bind(processData,_1,intersection,nDirs_,dirs,LegLabels,useRMS);
-  
+  auto f_processData = std::bind(processData, _1, intersection, nDirs_, dirs, LegLabels, useRMS);
+
   //f_processData(0);
   //std::cout<<" post do-stuff: " <<  runs.size() << std::endl;
 
-  TProcPool procPool(std::min(nWorkers,intersection.size()));
-  std::vector<size_t> range(std::min(nWorkers,intersection.size()));
-  std::iota(range.begin(),range.end(),0);
+  TProcPool procPool(std::min(nWorkers, intersection.size()));
+  std::vector<size_t> range(std::min(nWorkers, intersection.size()));
+  std::iota(range.begin(), range.end(), 0);
   //procPool.Map([&f_processData](size_t a) { f_processData(a); },{1,2,3});
-  auto extracts = procPool.Map(f_processData,range);
-  
-  // sort the extracts according to the global index
-  std::sort(extracts.begin(), extracts.end(), 
-	    [](const outTrends & a, const outTrends & b) -> bool
-	    { 
-	      return a.m_index < b.m_index; 
-	    });
-  
-  // re-assemble everything together
-  for (auto extractedTrend : extracts){
-    std::cout << "lumiSoFar: " << lumiSoFar <<"/fb" << std::endl;
+  auto extracts = procPool.Map(f_processData, range);
 
-    runs.insert(std::end(runs),std::begin(extractedTrend.m_runs), std::end(extractedTrend.m_runs));
+  // sort the extracts according to the global index
+  std::sort(extracts.begin(), extracts.end(), [](const outTrends &a, const outTrends &b) -> bool {
+    return a.m_index < b.m_index;
+  });
+
+  // re-assemble everything together
+  for (auto extractedTrend : extracts) {
+    std::cout << "lumiSoFar: " << lumiSoFar << "/fb" << std::endl;
+
+    runs.insert(std::end(runs), std::begin(extractedTrend.m_runs), std::end(extractedTrend.m_runs));
 
     // luminosity needs a different treatment
     // we need to re-sum the luminosity so far
 
-    for (const auto &run : extractedTrend.m_runs){
-
-      std::cout<< run << " " << lumiSoFar+extractedTrend.m_lumiMapByRun[run] << std::endl;
-      lumiByRun.push_back(lumiSoFar+extractedTrend.m_lumiMapByRun[run]);
-      lumiMapByRun[run]=(lumiSoFar+extractedTrend.m_lumiMapByRun[run]);
-
+    for (const auto &run : extractedTrend.m_runs) {
+      std::cout << run << " " << lumiSoFar + extractedTrend.m_lumiMapByRun[run] << std::endl;
+      lumiByRun.push_back(lumiSoFar + extractedTrend.m_lumiMapByRun[run]);
+      lumiMapByRun[run] = (lumiSoFar + extractedTrend.m_lumiMapByRun[run]);
     }
 
-    lumiSoFar += (extractedTrend.m_lumiSoFar/1000.);
- 
+    lumiSoFar += (extractedTrend.m_lumiSoFar / 1000.);
+
     /*
       lumiByRun.insert(std::end(lumiByRun), std::begin(extractedTrend.m_lumiByRun), std::end(extractedTrend.m_lumiByRun));
       lumiMapByRun.insert(extractedTrend.m_lumiMapByRun.begin(),extractedTrend.m_lumiMapByRun.end());
     */
 
-    for(const auto &label : LegLabels){
+    for (const auto &label : LegLabels) {
+      //******************************//
+      dxyPhiMeans_[label].insert(std::end(dxyPhiMeans_[label]),
+                                 std::begin(extractedTrend.m_dxyPhiMeans[label]),
+                                 std::end(extractedTrend.m_dxyPhiMeans[label]));
+      dxyPhiChi2_[label].insert(std::end(dxyPhiChi2_[label]),
+                                std::begin(extractedTrend.m_dxyPhiChi2[label]),
+                                std::end(extractedTrend.m_dxyPhiChi2[label]));
+      dxyPhiKS_[label].insert(std::end(dxyPhiKS_[label]),
+                              std::begin(extractedTrend.m_dxyPhiKS[label]),
+                              std::end(extractedTrend.m_dxyPhiKS[label]));
+
+      dxyPhiHi_[label].insert(std::end(dxyPhiHi_[label]),
+                              std::begin(extractedTrend.m_dxyPhiHi[label]),
+                              std::end(extractedTrend.m_dxyPhiHi[label]));
+      dxyPhiLo_[label].insert(std::end(dxyPhiLo_[label]),
+                              std::begin(extractedTrend.m_dxyPhiLo[label]),
+                              std::end(extractedTrend.m_dxyPhiLo[label]));
 
       //******************************//
-      dxyPhiMeans_[label].insert(std::end(dxyPhiMeans_[label]), std::begin(extractedTrend.m_dxyPhiMeans[label]), std::end(extractedTrend.m_dxyPhiMeans[label]));
-      dxyPhiChi2_[label].insert(std::end(dxyPhiChi2_[label]), std::begin(extractedTrend.m_dxyPhiChi2[label]), std::end(extractedTrend.m_dxyPhiChi2[label]));
-      dxyPhiKS_[label].insert(std::end(dxyPhiKS_[label]), std::begin(extractedTrend.m_dxyPhiKS[label]), std::end(extractedTrend.m_dxyPhiKS[label]));
+      dzPhiMeans_[label].insert(std::end(dzPhiMeans_[label]),
+                                std::begin(extractedTrend.m_dzPhiMeans[label]),
+                                std::end(extractedTrend.m_dzPhiMeans[label]));
+      dzPhiChi2_[label].insert(std::end(dzPhiChi2_[label]),
+                               std::begin(extractedTrend.m_dzPhiChi2[label]),
+                               std::end(extractedTrend.m_dzPhiChi2[label]));
+      dzPhiKS_[label].insert(std::end(dzPhiKS_[label]),
+                             std::begin(extractedTrend.m_dzPhiKS[label]),
+                             std::end(extractedTrend.m_dzPhiKS[label]));
 
-      dxyPhiHi_[label].insert(std::end(dxyPhiHi_[label]), std::begin(extractedTrend.m_dxyPhiHi[label]), std::end(extractedTrend.m_dxyPhiHi[label]));
-      dxyPhiLo_[label].insert(std::end(dxyPhiLo_[label]), std::begin(extractedTrend.m_dxyPhiLo[label]), std::end(extractedTrend.m_dxyPhiLo[label]));
-
-      //******************************//
-      dzPhiMeans_[label].insert(std::end(dzPhiMeans_[label]), std::begin(extractedTrend.m_dzPhiMeans[label]), std::end(extractedTrend.m_dzPhiMeans[label]));
-      dzPhiChi2_[label].insert(std::end(dzPhiChi2_[label]), std::begin(extractedTrend.m_dzPhiChi2[label]), std::end(extractedTrend.m_dzPhiChi2[label]));
-      dzPhiKS_[label].insert(std::end(dzPhiKS_[label]), std::begin(extractedTrend.m_dzPhiKS[label]), std::end(extractedTrend.m_dzPhiKS[label]));
-
-      dzPhiHi_[label].insert(std::end(dzPhiHi_[label]), std::begin(extractedTrend.m_dzPhiHi[label]), std::end(extractedTrend.m_dzPhiHi[label]));
-      dzPhiLo_[label].insert(std::end(dzPhiLo_[label]), std::begin(extractedTrend.m_dzPhiLo[label]), std::end(extractedTrend.m_dzPhiLo[label]));
-
-      //******************************//
-      dxyEtaMeans_[label].insert(std::end(dxyEtaMeans_[label]), std::begin(extractedTrend.m_dxyEtaMeans[label]), std::end(extractedTrend.m_dxyEtaMeans[label]));
-      dxyEtaChi2_[label].insert(std::end(dxyEtaChi2_[label]), std::begin(extractedTrend.m_dxyEtaChi2[label]), std::end(extractedTrend.m_dxyEtaChi2[label]));
-      dxyEtaKS_[label].insert(std::end(dxyEtaKS_[label]), std::begin(extractedTrend.m_dxyEtaKS[label]), std::end(extractedTrend.m_dxyEtaKS[label]));
-
-      dxyEtaHi_[label].insert(std::end(dxyEtaHi_[label]), std::begin(extractedTrend.m_dxyEtaHi[label]), std::end(extractedTrend.m_dxyEtaHi[label]));
-      dxyEtaLo_[label].insert(std::end(dxyEtaLo_[label]), std::begin(extractedTrend.m_dxyEtaLo[label]), std::end(extractedTrend.m_dxyEtaLo[label]));
+      dzPhiHi_[label].insert(std::end(dzPhiHi_[label]),
+                             std::begin(extractedTrend.m_dzPhiHi[label]),
+                             std::end(extractedTrend.m_dzPhiHi[label]));
+      dzPhiLo_[label].insert(std::end(dzPhiLo_[label]),
+                             std::begin(extractedTrend.m_dzPhiLo[label]),
+                             std::end(extractedTrend.m_dzPhiLo[label]));
 
       //******************************//
-      dzEtaMeans_[label].insert(std::end(dzEtaMeans_[label]), std::begin(extractedTrend.m_dzEtaMeans[label]), std::end(extractedTrend.m_dzEtaMeans[label]));
-      dzEtaChi2_[label].insert(std::end(dzEtaChi2_[label]), std::begin(extractedTrend.m_dzEtaChi2[label]), std::end(extractedTrend.m_dzEtaChi2[label]));
-      dzEtaKS_[label].insert(std::end(dzEtaKS_[label]), std::begin(extractedTrend.m_dzEtaKS[label]), std::end(extractedTrend.m_dzEtaKS[label]));
+      dxyEtaMeans_[label].insert(std::end(dxyEtaMeans_[label]),
+                                 std::begin(extractedTrend.m_dxyEtaMeans[label]),
+                                 std::end(extractedTrend.m_dxyEtaMeans[label]));
+      dxyEtaChi2_[label].insert(std::end(dxyEtaChi2_[label]),
+                                std::begin(extractedTrend.m_dxyEtaChi2[label]),
+                                std::end(extractedTrend.m_dxyEtaChi2[label]));
+      dxyEtaKS_[label].insert(std::end(dxyEtaKS_[label]),
+                              std::begin(extractedTrend.m_dxyEtaKS[label]),
+                              std::end(extractedTrend.m_dxyEtaKS[label]));
 
-      dzEtaHi_[label].insert(std::end(dzEtaHi_[label]), std::begin(extractedTrend.m_dzEtaHi[label]), std::end(extractedTrend.m_dzEtaHi[label]));
-      dzEtaLo_[label].insert(std::end(dzEtaLo_[label]), std::begin(extractedTrend.m_dzEtaLo[label]), std::end(extractedTrend.m_dzEtaLo[label]));
-     
+      dxyEtaHi_[label].insert(std::end(dxyEtaHi_[label]),
+                              std::begin(extractedTrend.m_dxyEtaHi[label]),
+                              std::end(extractedTrend.m_dxyEtaHi[label]));
+      dxyEtaLo_[label].insert(std::end(dxyEtaLo_[label]),
+                              std::begin(extractedTrend.m_dxyEtaLo[label]),
+                              std::end(extractedTrend.m_dxyEtaLo[label]));
+
       //******************************//
-      dxyVect[label].insert(std::end(dxyVect[label]),std::begin(extractedTrend.m_dxyVect[label]),std::end(extractedTrend.m_dxyVect[label]));
-      dzVect[label].insert(std::end(dzVect[label]),std::begin(extractedTrend.m_dzVect[label]),std::end(extractedTrend.m_dzVect[label]));	 
+      dzEtaMeans_[label].insert(std::end(dzEtaMeans_[label]),
+                                std::begin(extractedTrend.m_dzEtaMeans[label]),
+                                std::end(extractedTrend.m_dzEtaMeans[label]));
+      dzEtaChi2_[label].insert(std::end(dzEtaChi2_[label]),
+                               std::begin(extractedTrend.m_dzEtaChi2[label]),
+                               std::end(extractedTrend.m_dzEtaChi2[label]));
+      dzEtaKS_[label].insert(std::end(dzEtaKS_[label]),
+                             std::begin(extractedTrend.m_dzEtaKS[label]),
+                             std::end(extractedTrend.m_dzEtaKS[label]));
+
+      dzEtaHi_[label].insert(std::end(dzEtaHi_[label]),
+                             std::begin(extractedTrend.m_dzEtaHi[label]),
+                             std::end(extractedTrend.m_dzEtaHi[label]));
+      dzEtaLo_[label].insert(std::end(dzEtaLo_[label]),
+                             std::begin(extractedTrend.m_dzEtaLo[label]),
+                             std::end(extractedTrend.m_dzEtaLo[label]));
+
+      //******************************//
+      dxyVect[label].insert(std::end(dxyVect[label]),
+                            std::begin(extractedTrend.m_dxyVect[label]),
+                            std::end(extractedTrend.m_dxyVect[label]));
+      dzVect[label].insert(std::end(dzVect[label]),
+                           std::begin(extractedTrend.m_dzVect[label]),
+                           std::end(extractedTrend.m_dzVect[label]));
     }
   }
 
   // extra vectors for low and high boundaries
 
-  for(const auto &label : LegLabels){
+  for (const auto &label : LegLabels) {
+    for (unsigned int it = 0; it < dxyPhiMeans_[label].size(); it++) {
+      dxyPhiHiErr_[label].push_back(std::abs(dxyPhiHi_[label][it] - dxyPhiMeans_[label][it]));
+      dxyPhiLoErr_[label].push_back(std::abs(dxyPhiLo_[label][it] - dxyPhiMeans_[label][it]));
+      dxyEtaHiErr_[label].push_back(std::abs(dxyEtaHi_[label][it] - dxyEtaMeans_[label][it]));
+      dxyEtaLoErr_[label].push_back(std::abs(dxyEtaLo_[label][it] - dxyEtaMeans_[label][it]));
 
-    for(unsigned int it=0;it<dxyPhiMeans_[label].size();it++){
-      dxyPhiHiErr_[label].push_back(std::abs(dxyPhiHi_[label][it]-dxyPhiMeans_[label][it]));
-      dxyPhiLoErr_[label].push_back(std::abs(dxyPhiLo_[label][it]-dxyPhiMeans_[label][it]));
-      dxyEtaHiErr_[label].push_back(std::abs(dxyEtaHi_[label][it]-dxyEtaMeans_[label][it])); 
-      dxyEtaLoErr_[label].push_back(std::abs(dxyEtaLo_[label][it]-dxyEtaMeans_[label][it]));
+      std::cout << "label: " << label << " means:" << dxyEtaMeans_[label][it] << " low: " << dxyEtaLo_[label][it]
+                << " loErr: " << dxyEtaLoErr_[label][it] << std::endl;
 
-      std::cout<<"label: "<<label << " means:" << dxyEtaMeans_[label][it] << " low: " << dxyEtaLo_[label][it] << " loErr: " << dxyEtaLoErr_[label][it] << std::endl;
-      
-      dzPhiHiErr_[label].push_back(std::abs(dzPhiHi_[label][it]-dzPhiMeans_[label][it])); 
-      dzPhiLoErr_[label].push_back(std::abs(dzPhiLo_[label][it]-dzPhiMeans_[label][it]));	 	  
-      dzEtaHiErr_[label].push_back(std::abs(dzEtaHi_[label][it]-dzEtaMeans_[label][it])); 
-      dzEtaLoErr_[label].push_back(std::abs(dzEtaLo_[label][it]-dzEtaMeans_[label][it]));      
+      dzPhiHiErr_[label].push_back(std::abs(dzPhiHi_[label][it] - dzPhiMeans_[label][it]));
+      dzPhiLoErr_[label].push_back(std::abs(dzPhiLo_[label][it] - dzPhiMeans_[label][it]));
+      dzEtaHiErr_[label].push_back(std::abs(dzEtaHi_[label][it] - dzEtaMeans_[label][it]));
+      dzEtaLoErr_[label].push_back(std::abs(dzEtaLo_[label][it] - dzEtaMeans_[label][it]));
     }
   }
 
- 
   // just check runs are ordered
   //for(const auto &run : runs){
   //  std::cout<<" "<< run ;
@@ -809,34 +848,34 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     dxyVect,dzVect
     );
   */
-  
+
   // do the trend-plotting!
 
-  TCanvas *c_dxy_phi_vs_run = new TCanvas("c_dxy_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
-  TCanvas *c_dxy_eta_vs_run = new TCanvas("c_dxy_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
-  TCanvas *c_dz_phi_vs_run  = new TCanvas("c_dz_phi_vs_run" ,"dz(#phi) bias vs run number" ,2000,800);
-  TCanvas *c_dz_eta_vs_run  = new TCanvas("c_dz_eta_vs_run" ,"dz(#eta) bias vs run number" ,2000,800);
+  TCanvas *c_dxy_phi_vs_run = new TCanvas("c_dxy_phi_vs_run", "dxy(#phi) bias vs run number", 2000, 800);
+  TCanvas *c_dxy_eta_vs_run = new TCanvas("c_dxy_eta_vs_run", "dxy(#eta) bias vs run number", 2000, 800);
+  TCanvas *c_dz_phi_vs_run = new TCanvas("c_dz_phi_vs_run", "dz(#phi) bias vs run number", 2000, 800);
+  TCanvas *c_dz_eta_vs_run = new TCanvas("c_dz_eta_vs_run", "dz(#eta) bias vs run number", 2000, 800);
 
-  TCanvas *c_RMS_dxy_phi_vs_run = new TCanvas("c_RMS_dxy_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
-  TCanvas *c_RMS_dxy_eta_vs_run = new TCanvas("c_RMS_dxy_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
-  TCanvas *c_RMS_dz_phi_vs_run  = new TCanvas("c_RMS_dz_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
-  TCanvas *c_RMS_dz_eta_vs_run  = new TCanvas("c_RMS_dz_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+  TCanvas *c_RMS_dxy_phi_vs_run = new TCanvas("c_RMS_dxy_phi_vs_run", "dxy(#phi) bias vs run number", 2000, 800);
+  TCanvas *c_RMS_dxy_eta_vs_run = new TCanvas("c_RMS_dxy_eta_vs_run", "dxy(#eta) bias vs run number", 2000, 800);
+  TCanvas *c_RMS_dz_phi_vs_run = new TCanvas("c_RMS_dz_phi_vs_run", "dxy(#phi) bias vs run number", 2000, 800);
+  TCanvas *c_RMS_dz_eta_vs_run = new TCanvas("c_RMS_dz_eta_vs_run", "dxy(#eta) bias vs run number", 2000, 800);
 
-  TCanvas *c_mean_dxy_phi_vs_run = new TCanvas("c_mean_dxy_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
-  TCanvas *c_mean_dxy_eta_vs_run = new TCanvas("c_mean_dxy_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
-  TCanvas *c_mean_dz_phi_vs_run  = new TCanvas("c_mean_dz_phi_vs_run","dxy(#phi) bias vs run number",2000,800);
-  TCanvas *c_mean_dz_eta_vs_run  = new TCanvas("c_mean_dz_eta_vs_run","dxy(#eta) bias vs run number",2000,800);
+  TCanvas *c_mean_dxy_phi_vs_run = new TCanvas("c_mean_dxy_phi_vs_run", "dxy(#phi) bias vs run number", 2000, 800);
+  TCanvas *c_mean_dxy_eta_vs_run = new TCanvas("c_mean_dxy_eta_vs_run", "dxy(#eta) bias vs run number", 2000, 800);
+  TCanvas *c_mean_dz_phi_vs_run = new TCanvas("c_mean_dz_phi_vs_run", "dxy(#phi) bias vs run number", 2000, 800);
+  TCanvas *c_mean_dz_eta_vs_run = new TCanvas("c_mean_dz_eta_vs_run", "dxy(#eta) bias vs run number", 2000, 800);
 
-  TCanvas *Scatter_dxy_vs_run = new TCanvas("Scatter_dxy_vs_run","dxy bias vs run number",2000,800);
-  Scatter_dxy_vs_run->Divide(1,nDirs_);
-  TCanvas *Scatter_dz_vs_run  = new TCanvas("Scatter_dz_vs_run","dxy bias vs run number",2000,800);
-  Scatter_dz_vs_run->Divide(1,nDirs_);    
+  TCanvas *Scatter_dxy_vs_run = new TCanvas("Scatter_dxy_vs_run", "dxy bias vs run number", 2000, 800);
+  Scatter_dxy_vs_run->Divide(1, nDirs_);
+  TCanvas *Scatter_dz_vs_run = new TCanvas("Scatter_dz_vs_run", "dxy bias vs run number", 2000, 800);
+  Scatter_dz_vs_run->Divide(1, nDirs_);
 
-  TCanvas *c_chisquare_vs_run = new TCanvas("c_chisquare_vs_run","chi2 of pol0 fit vs run number",2000,800);
-  c_chisquare_vs_run->Divide(2,2);
+  TCanvas *c_chisquare_vs_run = new TCanvas("c_chisquare_vs_run", "chi2 of pol0 fit vs run number", 2000, 800);
+  c_chisquare_vs_run->Divide(2, 2);
 
-  TCanvas *c_KSScore_vs_run = new TCanvas("c_KSScore_vs_run","KS score compatibility to 0 vs run number",2000,1000);
-  c_KSScore_vs_run->Divide(2,2);
+  TCanvas *c_KSScore_vs_run = new TCanvas("c_KSScore_vs_run", "KS score compatibility to 0 vs run number", 2000, 1000);
+  c_KSScore_vs_run->Divide(2, 2);
 
   // bias on the mean
 
@@ -844,10 +883,10 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   TGraphAsymmErrors *gerr_dxy_phi_vs_run[nDirs_];
   TGraph *g_chi2_dxy_phi_vs_run[nDirs_];
   TGraph *g_KS_dxy_phi_vs_run[nDirs_];
-  TGraph *gprime_dxy_phi_vs_run[nDirs_];  
+  TGraph *gprime_dxy_phi_vs_run[nDirs_];
   TGraph *g_dxy_phi_hi_vs_run[nDirs_];
   TGraph *g_dxy_phi_lo_vs_run[nDirs_];
-  
+
   TGraph *g_dxy_eta_vs_run[nDirs_];
   TGraphAsymmErrors *gerr_dxy_eta_vs_run[nDirs_];
   TGraph *g_chi2_dxy_eta_vs_run[nDirs_];
@@ -872,12 +911,12 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   TGraph *g_dz_eta_hi_vs_run[nDirs_];
   TGraph *g_dz_eta_lo_vs_run[nDirs_];
 
-  // resolutions 
+  // resolutions
 
   TH1F *h_RMS_dxy_phi_vs_run[nDirs_];
   TH1F *h_RMS_dxy_eta_vs_run[nDirs_];
   TH1F *h_RMS_dz_phi_vs_run[nDirs_];
-  TH1F *h_RMS_dz_eta_vs_run[nDirs_];   
+  TH1F *h_RMS_dz_eta_vs_run[nDirs_];
 
   // scatters of integrated bias
 
@@ -886,37 +925,37 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
 
   // decide the type
 
-  TString theType="";
-  TString theTypeLabel="";
-  if(lumi_axis_format){
-    theType="luminosity";
-    theTypeLabel="Processed luminosity [1/fb]";
+  TString theType = "";
+  TString theTypeLabel = "";
+  if (lumi_axis_format) {
+    theType = "luminosity";
+    theTypeLabel = "Processed luminosity [1/fb]";
     x_ticks = lumiByRun;
   } else {
-    if(!time_axis_format){
-      theType="run number";
-      theTypeLabel="run number";
+    if (!time_axis_format) {
+      theType = "run number";
+      theTypeLabel = "run number";
       x_ticks = runs;
     } else {
-      theType="date";
-      theTypeLabel="UTC date";
-      for(const auto &run : runs){
-	x_ticks.push_back(times[run].Convert());
+      theType = "date";
+      theTypeLabel = "UTC date";
+      for (const auto &run : runs) {
+        x_ticks.push_back(times[run].Convert());
       }
     }
   }
-  
+
   //TLegend *my_lego = new TLegend(0.08,0.80,0.18,0.93);
   //my_lego-> SetNColumns(2);
 
-  TLegend *my_lego = new TLegend(0.75,0.76,0.92,0.93);
+  TLegend *my_lego = new TLegend(0.75, 0.76, 0.92, 0.93);
   //TLegend *my_lego = new TLegend(0.75,0.26,0.92,0.43);
   //my_lego->SetHeader("2017 Data","C");
-  TLine *line = new TLine(0,0,1,0);
+  TLine *line = new TLine(0, 0, 1, 0);
   line->SetLineColor(kBlue);
   line->SetLineStyle(9);
   line->SetLineWidth(1);
-  my_lego->AddEntry(line,"pixel calibration update","L");
+  my_lego->AddEntry(line, "pixel calibration update", "L");
   my_lego->SetFillColor(10);
   my_lego->SetTextSize(0.042);
   my_lego->SetTextFont(42);
@@ -926,239 +965,258 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
 
   // arrays for storing RMS histograms
   TObjArray *arr_dxy_phi = new TObjArray();
-  TObjArray *arr_dz_phi  = new TObjArray();
+  TObjArray *arr_dz_phi = new TObjArray();
   TObjArray *arr_dxy_eta = new TObjArray();
-  TObjArray *arr_dz_eta  = new TObjArray();
+  TObjArray *arr_dz_eta = new TObjArray();
 
   arr_dxy_phi->Expand(nDirs_);
   arr_dz_phi->Expand(nDirs_);
   arr_dxy_eta->Expand(nDirs_);
   arr_dz_eta->Expand(nDirs_);
 
-  int ccc=0;
-  for(const auto &tick: x_ticks ){
-    outfile<<"***************************************"<< std::endl;
-    outfile<< tick  << std::endl;
-    for(Int_t j=0; j < nDirs_; j++) {
-
+  int ccc = 0;
+  for (const auto &tick : x_ticks) {
+    outfile << "***************************************" << std::endl;
+    outfile << tick << std::endl;
+    for (Int_t j = 0; j < nDirs_; j++) {
       double RMSxyphi = std::abs(dxyPhiLo_[LegLabels[j]][ccc] - dxyPhiHi_[LegLabels[j]][ccc]);
-      double RMSxyeta =	std::abs(dxyEtaLo_[LegLabels[j]][ccc] - dxyEtaHi_[LegLabels[j]][ccc]);
-      double RMSzphi  =	std::abs(dzPhiLo_[LegLabels[j]][ccc]  - dzPhiHi_[LegLabels[j]][ccc]); 
-      double RMSzeta  =	std::abs(dzEtaLo_[LegLabels[j]][ccc]  - dzEtaHi_[LegLabels[j]][ccc]);
+      double RMSxyeta = std::abs(dxyEtaLo_[LegLabels[j]][ccc] - dxyEtaHi_[LegLabels[j]][ccc]);
+      double RMSzphi = std::abs(dzPhiLo_[LegLabels[j]][ccc] - dzPhiHi_[LegLabels[j]][ccc]);
+      double RMSzeta = std::abs(dzEtaLo_[LegLabels[j]][ccc] - dzEtaHi_[LegLabels[j]][ccc]);
 
-      if(RMSxyphi>100 || RMSxyeta>100 || RMSzphi >100 || RMSzeta>100){ 
-
-	outfile << LegLabels[j] << " dxy(phi) " << dxyPhiMeans_[LegLabels[j]][ccc] << " " << dxyPhiLo_[LegLabels[j]][ccc] << " " << dxyPhiHi_[LegLabels[j]][ccc] <<" " << std::abs(dxyPhiLo_[LegLabels[j]][ccc] - dxyPhiHi_[LegLabels[j]][ccc]) << std::endl;
-	outfile << LegLabels[j] << " dxy(eta) " << dxyEtaMeans_[LegLabels[j]][ccc] << " " << dxyEtaLo_[LegLabels[j]][ccc] << " " << dxyEtaHi_[LegLabels[j]][ccc] <<" " << std::abs(dxyEtaLo_[LegLabels[j]][ccc] - dxyEtaHi_[LegLabels[j]][ccc]) << std::endl;
-	outfile << LegLabels[j] << " dz (phi) " << dzPhiMeans_[LegLabels[j]][ccc]  << " " << dzPhiLo_[LegLabels[j]][ccc]  << " " << dzPhiHi_[LegLabels[j]][ccc]  <<" " << std::abs(dzPhiLo_[LegLabels[j]][ccc]  - dzPhiHi_[LegLabels[j]][ccc])  << std::endl;
-	outfile << LegLabels[j] << " dz (eta) " << dzEtaMeans_[LegLabels[j]][ccc]  << " " << dzEtaLo_[LegLabels[j]][ccc]  << " " << dzEtaHi_[LegLabels[j]][ccc]  <<" " << std::abs(dzEtaLo_[LegLabels[j]][ccc]  - dzEtaHi_[LegLabels[j]][ccc])  << std::endl;
+      if (RMSxyphi > 100 || RMSxyeta > 100 || RMSzphi > 100 || RMSzeta > 100) {
+        outfile << LegLabels[j] << " dxy(phi) " << dxyPhiMeans_[LegLabels[j]][ccc] << " "
+                << dxyPhiLo_[LegLabels[j]][ccc] << " " << dxyPhiHi_[LegLabels[j]][ccc] << " "
+                << std::abs(dxyPhiLo_[LegLabels[j]][ccc] - dxyPhiHi_[LegLabels[j]][ccc]) << std::endl;
+        outfile << LegLabels[j] << " dxy(eta) " << dxyEtaMeans_[LegLabels[j]][ccc] << " "
+                << dxyEtaLo_[LegLabels[j]][ccc] << " " << dxyEtaHi_[LegLabels[j]][ccc] << " "
+                << std::abs(dxyEtaLo_[LegLabels[j]][ccc] - dxyEtaHi_[LegLabels[j]][ccc]) << std::endl;
+        outfile << LegLabels[j] << " dz (phi) " << dzPhiMeans_[LegLabels[j]][ccc] << " " << dzPhiLo_[LegLabels[j]][ccc]
+                << " " << dzPhiHi_[LegLabels[j]][ccc] << " "
+                << std::abs(dzPhiLo_[LegLabels[j]][ccc] - dzPhiHi_[LegLabels[j]][ccc]) << std::endl;
+        outfile << LegLabels[j] << " dz (eta) " << dzEtaMeans_[LegLabels[j]][ccc] << " " << dzEtaLo_[LegLabels[j]][ccc]
+                << " " << dzEtaHi_[LegLabels[j]][ccc] << " "
+                << std::abs(dzEtaLo_[LegLabels[j]][ccc] - dzEtaHi_[LegLabels[j]][ccc]) << std::endl;
       }
     }
     ccc++;
   }
-  outfile <<  std::endl;
+  outfile << std::endl;
 
-  pv::bundle theBundle = pv::bundle(nDirs_,theType,theTypeLabel,lumiMapByRun,times,lumi_axis_format,time_axis_format,useRMS);
+  pv::bundle theBundle =
+      pv::bundle(nDirs_, theType, theTypeLabel, lumiMapByRun, times, lumi_axis_format, time_axis_format, useRMS);
   theBundle.printAll();
 
-  for(Int_t j=0; j < nDirs_; j++) {
-
+  for (Int_t j = 0; j < nDirs_; j++) {
     // check on the sanity
-    std::cout<<"x_ticks.size()= "<<x_ticks.size()<<" dxyPhiMeans_[LegLabels["<<j<<"]].size()="<<dxyPhiMeans_[LegLabels[j]].size()<<std::endl;
+    std::cout << "x_ticks.size()= " << x_ticks.size() << " dxyPhiMeans_[LegLabels[" << j
+              << "]].size()=" << dxyPhiMeans_[LegLabels[j]].size() << std::endl;
 
     // *************************************
     // dxy vs phi
     // *************************************
-    
-    auto dxyPhiInputs = pv::wrappedTrends(dxyPhiMeans_,
-					  dxyPhiLo_,
-					  dxyPhiHi_,
-					  dxyPhiLoErr_,
-					  dxyPhiHiErr_,
-					  dxyPhiChi2_,
-					  dxyPhiKS_);
 
-    outputGraphs(dxyPhiInputs,x_ticks,ex_ticks,
-		 c_dxy_phi_vs_run,c_mean_dxy_phi_vs_run,c_RMS_dxy_phi_vs_run,
-		 g_dxy_phi_vs_run[j],           		     
-		 g_chi2_dxy_phi_vs_run[j],    			     
-		 g_KS_dxy_phi_vs_run[j],   			      
-		 g_dxy_phi_lo_vs_run[j],  			      	                          
-		 g_dxy_phi_hi_vs_run[j],  			     
-		 gerr_dxy_phi_vs_run[j],			     
-		 h_RMS_dxy_phi_vs_run,			      
-		 theBundle,
-		 pv::dxyphi,
-		 j,
-		 arr_dxy_phi,
-		 LegLabels[j],
-		 my_lego
-		 );
-    
+    auto dxyPhiInputs =
+        pv::wrappedTrends(dxyPhiMeans_, dxyPhiLo_, dxyPhiHi_, dxyPhiLoErr_, dxyPhiHiErr_, dxyPhiChi2_, dxyPhiKS_);
+
+    outputGraphs(dxyPhiInputs,
+                 x_ticks,
+                 ex_ticks,
+                 c_dxy_phi_vs_run,
+                 c_mean_dxy_phi_vs_run,
+                 c_RMS_dxy_phi_vs_run,
+                 g_dxy_phi_vs_run[j],
+                 g_chi2_dxy_phi_vs_run[j],
+                 g_KS_dxy_phi_vs_run[j],
+                 g_dxy_phi_lo_vs_run[j],
+                 g_dxy_phi_hi_vs_run[j],
+                 gerr_dxy_phi_vs_run[j],
+                 h_RMS_dxy_phi_vs_run,
+                 theBundle,
+                 pv::dxyphi,
+                 j,
+                 arr_dxy_phi,
+                 LegLabels[j],
+                 my_lego);
+
     // *************************************
     // dxy vs eta
     // *************************************
 
-    auto dxyEtaInputs = pv::wrappedTrends(dxyEtaMeans_,
-					  dxyEtaLo_,
-					  dxyEtaHi_,
-					  dxyEtaLoErr_,
-					  dxyEtaHiErr_,
-					  dxyEtaChi2_,
-					  dxyEtaKS_);
+    auto dxyEtaInputs =
+        pv::wrappedTrends(dxyEtaMeans_, dxyEtaLo_, dxyEtaHi_, dxyEtaLoErr_, dxyEtaHiErr_, dxyEtaChi2_, dxyEtaKS_);
 
-    outputGraphs(dxyEtaInputs,x_ticks,ex_ticks,
-		 c_dxy_eta_vs_run,c_mean_dxy_eta_vs_run,c_RMS_dxy_eta_vs_run,
-		 g_dxy_eta_vs_run[j],           		     
-		 g_chi2_dxy_eta_vs_run[j],    			     
-		 g_KS_dxy_eta_vs_run[j],   			      
-		 g_dxy_eta_lo_vs_run[j],  			      	                          
-		 g_dxy_eta_hi_vs_run[j],  			     
-		 gerr_dxy_eta_vs_run[j],			     
-		 h_RMS_dxy_eta_vs_run,			      
-		 theBundle,
-		 pv::dxyeta,
-		 j,
-		 arr_dxy_eta,
-		 LegLabels[j],
-		 my_lego
-		 );
+    outputGraphs(dxyEtaInputs,
+                 x_ticks,
+                 ex_ticks,
+                 c_dxy_eta_vs_run,
+                 c_mean_dxy_eta_vs_run,
+                 c_RMS_dxy_eta_vs_run,
+                 g_dxy_eta_vs_run[j],
+                 g_chi2_dxy_eta_vs_run[j],
+                 g_KS_dxy_eta_vs_run[j],
+                 g_dxy_eta_lo_vs_run[j],
+                 g_dxy_eta_hi_vs_run[j],
+                 gerr_dxy_eta_vs_run[j],
+                 h_RMS_dxy_eta_vs_run,
+                 theBundle,
+                 pv::dxyeta,
+                 j,
+                 arr_dxy_eta,
+                 LegLabels[j],
+                 my_lego);
 
     // *************************************
     // dz vs phi
     // *************************************
-    
-    auto dzPhiInputs = pv::wrappedTrends(dzPhiMeans_,
-					 dzPhiLo_,
-					 dzPhiHi_,
-					 dzPhiLoErr_,
-					 dzPhiHiErr_,
-					 dzPhiChi2_,
-					 dzPhiKS_);
 
-    outputGraphs(dzPhiInputs,x_ticks,ex_ticks,
-		 c_dz_phi_vs_run,c_mean_dz_phi_vs_run,c_RMS_dz_phi_vs_run,
-		 g_dz_phi_vs_run[j],           		     
-		 g_chi2_dz_phi_vs_run[j],    			     
-		 g_KS_dz_phi_vs_run[j],   			      
-		 g_dz_phi_lo_vs_run[j],  			      	                          
-		 g_dz_phi_hi_vs_run[j],  			     
-		 gerr_dz_phi_vs_run[j],			     
-		 h_RMS_dz_phi_vs_run,			      
-		 theBundle,
-		 pv::dzphi,
-		 j,
-		 arr_dz_phi,
-		 LegLabels[j],
-		 my_lego
-		 );
+    auto dzPhiInputs =
+        pv::wrappedTrends(dzPhiMeans_, dzPhiLo_, dzPhiHi_, dzPhiLoErr_, dzPhiHiErr_, dzPhiChi2_, dzPhiKS_);
+
+    outputGraphs(dzPhiInputs,
+                 x_ticks,
+                 ex_ticks,
+                 c_dz_phi_vs_run,
+                 c_mean_dz_phi_vs_run,
+                 c_RMS_dz_phi_vs_run,
+                 g_dz_phi_vs_run[j],
+                 g_chi2_dz_phi_vs_run[j],
+                 g_KS_dz_phi_vs_run[j],
+                 g_dz_phi_lo_vs_run[j],
+                 g_dz_phi_hi_vs_run[j],
+                 gerr_dz_phi_vs_run[j],
+                 h_RMS_dz_phi_vs_run,
+                 theBundle,
+                 pv::dzphi,
+                 j,
+                 arr_dz_phi,
+                 LegLabels[j],
+                 my_lego);
 
     // *************************************
     // dz vs eta
     // *************************************
 
-    auto dzEtaInputs = pv::wrappedTrends(dzEtaMeans_,
-					 dzEtaLo_,
-					 dzEtaHi_,
-					 dzEtaLoErr_,
-					 dzEtaHiErr_,
-					 dzEtaChi2_,
-					 dzEtaKS_);
+    auto dzEtaInputs =
+        pv::wrappedTrends(dzEtaMeans_, dzEtaLo_, dzEtaHi_, dzEtaLoErr_, dzEtaHiErr_, dzEtaChi2_, dzEtaKS_);
 
-    outputGraphs(dzEtaInputs,x_ticks,ex_ticks,
-		 c_dz_eta_vs_run,c_mean_dz_eta_vs_run,c_RMS_dz_eta_vs_run,
-		 g_dz_eta_vs_run[j],           		     
-		 g_chi2_dz_eta_vs_run[j],    			     
-		 g_KS_dz_eta_vs_run[j],   			      
-		 g_dz_eta_lo_vs_run[j],  			      	                          
-		 g_dz_eta_hi_vs_run[j],  			     
-		 gerr_dz_eta_vs_run[j],			     
-		 h_RMS_dz_eta_vs_run,			      
-		 theBundle,
-		 pv::dzeta,
-		 j,
-		 arr_dz_eta,
-		 LegLabels[j],
-		 my_lego
-		 );
-    
+    outputGraphs(dzEtaInputs,
+                 x_ticks,
+                 ex_ticks,
+                 c_dz_eta_vs_run,
+                 c_mean_dz_eta_vs_run,
+                 c_RMS_dz_eta_vs_run,
+                 g_dz_eta_vs_run[j],
+                 g_chi2_dz_eta_vs_run[j],
+                 g_KS_dz_eta_vs_run[j],
+                 g_dz_eta_lo_vs_run[j],
+                 g_dz_eta_hi_vs_run[j],
+                 gerr_dz_eta_vs_run[j],
+                 h_RMS_dz_eta_vs_run,
+                 theBundle,
+                 pv::dzeta,
+                 j,
+                 arr_dz_eta,
+                 LegLabels[j],
+                 my_lego);
+
     // *************************************
     // Integrated bias dxy scatter plots
     // *************************************
 
-    h2_scatter_dxy_vs_run[j] = new TH2F(Form("h2_scatter_dxy_%s",LegLabels[j].Data()),Form("scatter of d_{xy} vs %s;%s;d_{xy} [cm]",theType.Data(),theTypeLabel.Data()),x_ticks.size()-1,&(x_ticks[0]),dxyVect[LegLabels[j]][0].get_n_bins(),dxyVect[LegLabels[j]][0].get_y_min(),dxyVect[LegLabels[j]][0].get_y_max());
+    h2_scatter_dxy_vs_run[j] =
+        new TH2F(Form("h2_scatter_dxy_%s", LegLabels[j].Data()),
+                 Form("scatter of d_{xy} vs %s;%s;d_{xy} [cm]", theType.Data(), theTypeLabel.Data()),
+                 x_ticks.size() - 1,
+                 &(x_ticks[0]),
+                 dxyVect[LegLabels[j]][0].get_n_bins(),
+                 dxyVect[LegLabels[j]][0].get_y_min(),
+                 dxyVect[LegLabels[j]][0].get_y_max());
     h2_scatter_dxy_vs_run[j]->SetStats(kFALSE);
 
-    for(unsigned int runindex=0;runindex<x_ticks.size();runindex++){
-      for(unsigned int binindex=0;binindex<dxyVect[LegLabels[j]][runindex].get_n_bins();binindex++){
-	h2_scatter_dxy_vs_run[j]->SetBinContent(runindex+1,binindex+1,dxyVect[LegLabels[j]][runindex].get_bin_contents().at(binindex)/dxyVect[LegLabels[j]][runindex].get_integral());
+    for (unsigned int runindex = 0; runindex < x_ticks.size(); runindex++) {
+      for (unsigned int binindex = 0; binindex < dxyVect[LegLabels[j]][runindex].get_n_bins(); binindex++) {
+        h2_scatter_dxy_vs_run[j]->SetBinContent(runindex + 1,
+                                                binindex + 1,
+                                                dxyVect[LegLabels[j]][runindex].get_bin_contents().at(binindex) /
+                                                    dxyVect[LegLabels[j]][runindex].get_integral());
       }
     }
-  
+
     //Scatter_dxy_vs_run->cd();
-    h2_scatter_dxy_vs_run[j]->SetFillColorAlpha(pv::colors[j],0.3);
+    h2_scatter_dxy_vs_run[j]->SetFillColorAlpha(pv::colors[j], 0.3);
     h2_scatter_dxy_vs_run[j]->SetMarkerColor(pv::colors[j]);
     h2_scatter_dxy_vs_run[j]->SetLineColor(pv::colors[j]);
     h2_scatter_dxy_vs_run[j]->SetMarkerStyle(pv::markers[j]);
 
-    auto h_dxypfx_tmp = (TProfile*)(((TH2F*)h2_scatter_dxy_vs_run[j])->ProfileX(Form("_apfx_%i",j),1,-1,"o"));
-    h_dxypfx_tmp->SetName(TString(h2_scatter_dxy_vs_run[j]->GetName())+"_pfx");
+    auto h_dxypfx_tmp = (TProfile *)(((TH2F *)h2_scatter_dxy_vs_run[j])->ProfileX(Form("_apfx_%i", j), 1, -1, "o"));
+    h_dxypfx_tmp->SetName(TString(h2_scatter_dxy_vs_run[j]->GetName()) + "_pfx");
     h_dxypfx_tmp->SetStats(kFALSE);
     h_dxypfx_tmp->SetMarkerColor(pv::colors[j]);
     h_dxypfx_tmp->SetLineColor(pv::colors[j]);
-    h_dxypfx_tmp->SetLineWidth(2); 
-    h_dxypfx_tmp->SetMarkerSize(1); 
+    h_dxypfx_tmp->SetLineWidth(2);
+    h_dxypfx_tmp->SetMarkerSize(1);
     h_dxypfx_tmp->SetMarkerStyle(pv::markers[j]);
 
     beautify(h2_scatter_dxy_vs_run[j]);
     beautify(h_dxypfx_tmp);
 
-    Scatter_dxy_vs_run->cd(j+1);
-    adjustmargins(Scatter_dxy_vs_run->cd(j+1));
+    Scatter_dxy_vs_run->cd(j + 1);
+    adjustmargins(Scatter_dxy_vs_run->cd(j + 1));
     //h_dxypfx_tmp->GetYaxis()->SetRangeUser(-0.01,0.01);
     //h2_scatter_dxy_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,0.5);
-    h2_scatter_dxy_vs_run[j]->Draw("colz");  
+    h2_scatter_dxy_vs_run[j]->Draw("colz");
     h_dxypfx_tmp->Draw("same");
 
     // *************************************
     // Integrated bias dz scatter plots
     // *************************************
 
-    h2_scatter_dz_vs_run[j] = new TH2F(Form("h2_scatter_dz_%s",LegLabels[j].Data()),Form("scatter of d_{z} vs %s;%s;d_{z} [cm]",theType.Data(),theTypeLabel.Data()),x_ticks.size()-1,&(x_ticks[0]),dzVect[LegLabels[j]][0].get_n_bins(),dzVect[LegLabels[j]][0].get_y_min(),dzVect[LegLabels[j]][0].get_y_max());
+    h2_scatter_dz_vs_run[j] =
+        new TH2F(Form("h2_scatter_dz_%s", LegLabels[j].Data()),
+                 Form("scatter of d_{z} vs %s;%s;d_{z} [cm]", theType.Data(), theTypeLabel.Data()),
+                 x_ticks.size() - 1,
+                 &(x_ticks[0]),
+                 dzVect[LegLabels[j]][0].get_n_bins(),
+                 dzVect[LegLabels[j]][0].get_y_min(),
+                 dzVect[LegLabels[j]][0].get_y_max());
     h2_scatter_dz_vs_run[j]->SetStats(kFALSE);
 
-    for(unsigned int runindex=0;runindex<x_ticks.size();runindex++){
-      for(unsigned int binindex=0;binindex<dzVect[LegLabels[j]][runindex].get_n_bins();binindex++){
-	h2_scatter_dz_vs_run[j]->SetBinContent(runindex+1,binindex+1,dzVect[LegLabels[j]][runindex].get_bin_contents().at(binindex)/dzVect[LegLabels[j]][runindex].get_integral());
+    for (unsigned int runindex = 0; runindex < x_ticks.size(); runindex++) {
+      for (unsigned int binindex = 0; binindex < dzVect[LegLabels[j]][runindex].get_n_bins(); binindex++) {
+        h2_scatter_dz_vs_run[j]->SetBinContent(runindex + 1,
+                                               binindex + 1,
+                                               dzVect[LegLabels[j]][runindex].get_bin_contents().at(binindex) /
+                                                   dzVect[LegLabels[j]][runindex].get_integral());
       }
     }
-    
+
     //Scatter_dz_vs_run->cd();
-    h2_scatter_dz_vs_run[j]->SetFillColorAlpha(pv::colors[j],0.3);
+    h2_scatter_dz_vs_run[j]->SetFillColorAlpha(pv::colors[j], 0.3);
     h2_scatter_dz_vs_run[j]->SetMarkerColor(pv::colors[j]);
     h2_scatter_dz_vs_run[j]->SetLineColor(pv::colors[j]);
     h2_scatter_dz_vs_run[j]->SetMarkerStyle(pv::markers[j]);
 
-    auto h_dzpfx_tmp = (TProfile*)(((TH2F*)h2_scatter_dz_vs_run[j])->ProfileX(Form("_apfx_%i",j),1,-1,"o"));
-    h_dzpfx_tmp->SetName(TString(h2_scatter_dz_vs_run[j]->GetName())+"_pfx");
+    auto h_dzpfx_tmp = (TProfile *)(((TH2F *)h2_scatter_dz_vs_run[j])->ProfileX(Form("_apfx_%i", j), 1, -1, "o"));
+    h_dzpfx_tmp->SetName(TString(h2_scatter_dz_vs_run[j]->GetName()) + "_pfx");
     h_dzpfx_tmp->SetStats(kFALSE);
     h_dzpfx_tmp->SetMarkerColor(pv::colors[j]);
     h_dzpfx_tmp->SetLineColor(pv::colors[j]);
-    h_dzpfx_tmp->SetLineWidth(2); 
-    h_dzpfx_tmp->SetMarkerSize(1); 
+    h_dzpfx_tmp->SetLineWidth(2);
+    h_dzpfx_tmp->SetMarkerSize(1);
     h_dzpfx_tmp->SetMarkerStyle(pv::markers[j]);
 
     beautify(h2_scatter_dz_vs_run[j]);
     beautify(h_dzpfx_tmp);
 
-    Scatter_dz_vs_run->cd(j+1);
-    adjustmargins(Scatter_dz_vs_run->cd(j+1));
+    Scatter_dz_vs_run->cd(j + 1);
+    adjustmargins(Scatter_dz_vs_run->cd(j + 1));
     //h_dzpfx_tmp->GetYaxis()->SetRangeUser(-0.01,0.01);
-    //h2_scatter_dz_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,0.5); 
-    h2_scatter_dz_vs_run[j]->Draw("colz");  
+    //h2_scatter_dz_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,0.5);
+    h2_scatter_dz_vs_run[j]->Draw("colz");
     h_dzpfx_tmp->Draw("same");
 
-    // **************************************** 
+    // ****************************************
     // Canvas for chi2 goodness of pol0 fit
     // ****************************************
 
@@ -1169,33 +1227,33 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_chi2_dxy_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_chi2_dxy_phi_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_chi2_dxy_phi_vs_run[j]->SetName(Form("g_chi2_dxy_phi_%s",LegLabels[j].Data()));
-    g_chi2_dxy_phi_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{xy}(#varphi) fit vs %s",theType.Data()));
+    g_chi2_dxy_phi_vs_run[j]->SetName(Form("g_chi2_dxy_phi_%s", LegLabels[j].Data()));
+    g_chi2_dxy_phi_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{xy}(#varphi) fit vs %s", theType.Data()));
     g_chi2_dxy_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{xy}(#phi) pol0 fit");
-    g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
-    if(lumi_axis_format){
-      g_chi2_dxy_phi_vs_run[j]->GetXaxis()->SetRangeUser(0.,theBundle.getTotalLumi());
+    g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetRangeUser(-0.5, 4.5);
+    if (lumi_axis_format) {
+      g_chi2_dxy_phi_vs_run[j]->GetXaxis()->SetRangeUser(0., theBundle.getTotalLumi());
     }
     beautify(g_chi2_dxy_phi_vs_run[j]);
     //g_chi2_dxy_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_chi2_dxy_phi_vs_run[j]->Draw("APL");
     } else {
       g_chi2_dxy_phi_vs_run[j]->Draw("PLsame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_chi2_dxy_phi_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
-    auto current_pad = static_cast<TCanvas*>(gPad);
-    superImposeIOVBoundaries(current_pad,lumi_axis_format,time_axis_format,lumiMapByRun,times,false);
+    auto current_pad = static_cast<TCanvas *>(gPad);
+    superImposeIOVBoundaries(current_pad, lumi_axis_format, time_axis_format, lumiMapByRun, times, false);
 
     // 2nd pad
     c_chisquare_vs_run->cd(2);
@@ -1204,33 +1262,33 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_chi2_dxy_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_chi2_dxy_eta_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_chi2_dxy_eta_vs_run[j]->SetName(Form("g_chi2_dxy_eta_%s",LegLabels[j].Data()));
-    g_chi2_dxy_eta_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{xy}(#eta) fit vs %s",theType.Data()));
+    g_chi2_dxy_eta_vs_run[j]->SetName(Form("g_chi2_dxy_eta_%s", LegLabels[j].Data()));
+    g_chi2_dxy_eta_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{xy}(#eta) fit vs %s", theType.Data()));
     g_chi2_dxy_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{xy}(#eta) pol0 fit");
-    g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
-    if(lumi_axis_format){
-      g_chi2_dxy_eta_vs_run[j]->GetXaxis()->SetRangeUser(0.,theBundle.getTotalLumi());
+    g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetRangeUser(-0.5, 4.5);
+    if (lumi_axis_format) {
+      g_chi2_dxy_eta_vs_run[j]->GetXaxis()->SetRangeUser(0., theBundle.getTotalLumi());
     }
     beautify(g_chi2_dxy_eta_vs_run[j]);
     //g_chi2_dxy_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_chi2_dxy_eta_vs_run[j]->Draw("APL");
     } else {
       g_chi2_dxy_eta_vs_run[j]->Draw("PLsame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_chi2_dxy_eta_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
-    current_pad = static_cast<TCanvas*>(gPad);
-    superImposeIOVBoundaries(current_pad,lumi_axis_format,time_axis_format,lumiMapByRun,times,false);
+    current_pad = static_cast<TCanvas *>(gPad);
+    superImposeIOVBoundaries(current_pad, lumi_axis_format, time_axis_format, lumiMapByRun, times, false);
 
     //3d pad
     c_chisquare_vs_run->cd(3);
@@ -1239,33 +1297,33 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_chi2_dz_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_chi2_dz_phi_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_chi2_dz_phi_vs_run[j]->SetName(Form("g_chi2_dz_phi_%s",LegLabels[j].Data()));
-    g_chi2_dz_phi_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{z}(#varphi) fit vs %s",theType.Data()));
+    g_chi2_dz_phi_vs_run[j]->SetName(Form("g_chi2_dz_phi_%s", LegLabels[j].Data()));
+    g_chi2_dz_phi_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{z}(#varphi) fit vs %s", theType.Data()));
     g_chi2_dz_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{z}(#phi) pol0 fit");
-    g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
-    if(lumi_axis_format){
-      g_chi2_dz_phi_vs_run[j]->GetXaxis()->SetRangeUser(0.,theBundle.getTotalLumi());
+    g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetRangeUser(-0.5, 4.5);
+    if (lumi_axis_format) {
+      g_chi2_dz_phi_vs_run[j]->GetXaxis()->SetRangeUser(0., theBundle.getTotalLumi());
     }
     beautify(g_chi2_dz_phi_vs_run[j]);
     //g_chi2_dz_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_chi2_dz_phi_vs_run[j]->Draw("APL");
     } else {
       g_chi2_dz_phi_vs_run[j]->Draw("PLsame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_chi2_dz_phi_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
-    current_pad = static_cast<TCanvas*>(gPad);
-    superImposeIOVBoundaries(current_pad,lumi_axis_format,time_axis_format,lumiMapByRun,times,false);
+    current_pad = static_cast<TCanvas *>(gPad);
+    superImposeIOVBoundaries(current_pad, lumi_axis_format, time_axis_format, lumiMapByRun, times, false);
 
     //4th pad
     c_chisquare_vs_run->cd(4);
@@ -1274,35 +1332,35 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_chi2_dz_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_chi2_dz_eta_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_chi2_dz_eta_vs_run[j]->SetName(Form("g_chi2_dz_eta_%s",LegLabels[j].Data()));
-    g_chi2_dz_eta_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{z}(#eta) fit vs %s",theType.Data()));
+    g_chi2_dz_eta_vs_run[j]->SetName(Form("g_chi2_dz_eta_%s", LegLabels[j].Data()));
+    g_chi2_dz_eta_vs_run[j]->SetTitle(Form("log_{10}(#chi2/ndf) of d_{z}(#eta) fit vs %s", theType.Data()));
     g_chi2_dz_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(#chi^{2}/ndf) of d_{z}(#eta) pol0 fit");
-    g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetRangeUser(-0.5,4.5);
-    if(lumi_axis_format){
-      g_chi2_dz_eta_vs_run[j]->GetXaxis()->SetRangeUser(0.,theBundle.getTotalLumi());
+    g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetRangeUser(-0.5, 4.5);
+    if (lumi_axis_format) {
+      g_chi2_dz_eta_vs_run[j]->GetXaxis()->SetRangeUser(0., theBundle.getTotalLumi());
     }
     beautify(g_chi2_dz_eta_vs_run[j]);
     //g_chi2_dz_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_chi2_dz_eta_vs_run[j]->Draw("APL");
     } else {
       g_chi2_dz_eta_vs_run[j]->Draw("PLsame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_chi2_dz_eta_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
-    current_pad = static_cast<TCanvas*>(gPad);
-    superImposeIOVBoundaries(current_pad,lumi_axis_format,time_axis_format,lumiMapByRun,times,false);
+    current_pad = static_cast<TCanvas *>(gPad);
+    superImposeIOVBoundaries(current_pad, lumi_axis_format, time_axis_format, lumiMapByRun, times, false);
 
-    // **************************************** 
+    // ****************************************
     // Canvas for Kolmogorov-Smirnov test
     // ****************************************
 
@@ -1313,25 +1371,25 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_KS_dxy_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_KS_dxy_phi_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_KS_dxy_phi_vs_run[j]->SetName(Form("g_KS_dxy_phi_%s",LegLabels[j].Data()));
-    g_KS_dxy_phi_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{xy}(#varphi) vs %s",theType.Data()));
+    g_KS_dxy_phi_vs_run[j]->SetName(Form("g_KS_dxy_phi_%s", LegLabels[j].Data()));
+    g_KS_dxy_phi_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{xy}(#varphi) vs %s", theType.Data()));
     g_KS_dxy_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{xy}(#phi) w.r.t 0");
-    g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetRangeUser(-20., 1.);
     beautify(g_KS_dxy_phi_vs_run[j]);
     //g_KS_dxy_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_KS_dxy_phi_vs_run[j]->Draw("AP");
     } else {
       g_KS_dxy_phi_vs_run[j]->Draw("Psame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_KS_dxy_phi_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
@@ -1342,25 +1400,25 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_KS_dxy_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_KS_dxy_eta_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_KS_dxy_eta_vs_run[j]->SetName(Form("g_KS_dxy_eta_%s",LegLabels[j].Data()));
-    g_KS_dxy_eta_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{xy}(#eta) vs %s",theType.Data()));
+    g_KS_dxy_eta_vs_run[j]->SetName(Form("g_KS_dxy_eta_%s", LegLabels[j].Data()));
+    g_KS_dxy_eta_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{xy}(#eta) vs %s", theType.Data()));
     g_KS_dxy_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{xy}(#eta) w.r.t 0");
-    g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetRangeUser(-20., 1.);
     beautify(g_KS_dxy_eta_vs_run[j]);
     //g_KS_dxy_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_KS_dxy_eta_vs_run[j]->Draw("AP");
     } else {
       g_KS_dxy_eta_vs_run[j]->Draw("Psame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_KS_dxy_eta_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
@@ -1371,25 +1429,25 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_KS_dz_phi_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_KS_dz_phi_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_KS_dz_phi_vs_run[j]->SetName(Form("g_KS_dz_phi_%s",LegLabels[j].Data()));
-    g_KS_dz_phi_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{z}(#varphi) vs %s",theType.Data()));
+    g_KS_dz_phi_vs_run[j]->SetName(Form("g_KS_dz_phi_%s", LegLabels[j].Data()));
+    g_KS_dz_phi_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{z}(#varphi) vs %s", theType.Data()));
     g_KS_dz_phi_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_KS_dz_phi_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{z}(#phi) w.r.t 0");
-    g_KS_dz_phi_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    g_KS_dz_phi_vs_run[j]->GetYaxis()->SetRangeUser(-20., 1.);
     beautify(g_KS_dz_phi_vs_run[j]);
     //g_KS_dz_phi_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_KS_dz_phi_vs_run[j]->Draw("AP");
     } else {
       g_KS_dz_phi_vs_run[j]->Draw("Psame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_KS_dz_phi_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
 
@@ -1400,30 +1458,29 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
     g_KS_dz_eta_vs_run[j]->SetMarkerColor(pv::colors[j]);
     g_KS_dz_eta_vs_run[j]->SetLineColor(pv::colors[j]);
 
-    g_KS_dz_eta_vs_run[j]->SetName(Form("g_KS_dz_eta_%s",LegLabels[j].Data()));
-    g_KS_dz_eta_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{z}(#eta) vs %s",theType.Data()));
+    g_KS_dz_eta_vs_run[j]->SetName(Form("g_KS_dz_eta_%s", LegLabels[j].Data()));
+    g_KS_dz_eta_vs_run[j]->SetTitle(Form("log_{10}(KS-score) of d_{z}(#eta) vs %s", theType.Data()));
     g_KS_dz_eta_vs_run[j]->GetXaxis()->SetTitle(theTypeLabel.Data());
     g_KS_dz_eta_vs_run[j]->GetYaxis()->SetTitle("log_{10}(KS-score) of d_{z}(#eta) w.r.t 0");
-    g_KS_dz_eta_vs_run[j]->GetYaxis()->SetRangeUser(-20.,1.);
+    g_KS_dz_eta_vs_run[j]->GetYaxis()->SetRangeUser(-20., 1.);
     beautify(g_KS_dz_eta_vs_run[j]);
     //g_KS_dz_eta_vs_run[j]->GetYaxis()->SetTitleOffset(1.3);
 
-    if(j==0){
+    if (j == 0) {
       g_KS_dz_eta_vs_run[j]->Draw("AP");
     } else {
       g_KS_dz_eta_vs_run[j]->Draw("Psame");
     }
 
-    if(time_axis_format){
+    if (time_axis_format) {
       timify(g_KS_dz_eta_vs_run[j]);
     }
 
-    if(j==nDirs_-1){
+    if (j == nDirs_ - 1) {
       my_lego->Draw("same");
     }
-
   }
-  
+
   // delete the array for the maxima
   delete arr_dxy_phi;
   delete arr_dz_phi;
@@ -1431,176 +1488,167 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
   delete arr_dz_eta;
 
   TString append;
-  if(lumi_axis_format){ 
+  if (lumi_axis_format) {
     append = "lumi";
-  } else{ 
-    if(time_axis_format){
+  } else {
+    if (time_axis_format) {
       append = "date";
     } else {
       append = "run";
     }
-  }   
+  }
 
+  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_" + append + ".pdf");
+  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_" + append + ".png");
+  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_" + append + ".eps");
 
-  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_"+append+".pdf");
-  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_"+append+".png");
-  c_dxy_phi_vs_run->SaveAs("dxy_phi_vs_"+append+".eps");
+  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_" + append + ".pdf");
+  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_" + append + ".png");
+  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_" + append + ".eps");
 
-  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_"+append+".pdf");
-  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_"+append+".png");
-  c_dxy_eta_vs_run->SaveAs("dxy_eta_vs_"+append+".eps");
+  c_dz_phi_vs_run->SaveAs("dz_phi_vs_" + append + ".pdf");
+  c_dz_phi_vs_run->SaveAs("dz_phi_vs_" + append + ".png");
+  c_dz_phi_vs_run->SaveAs("dz_phi_vs_" + append + ".eps");
 
-  c_dz_phi_vs_run->SaveAs("dz_phi_vs_"+append+".pdf");
-  c_dz_phi_vs_run->SaveAs("dz_phi_vs_"+append+".png");
-  c_dz_phi_vs_run->SaveAs("dz_phi_vs_"+append+".eps");
+  c_dz_eta_vs_run->SaveAs("dz_eta_vs_" + append + ".pdf");
+  c_dz_eta_vs_run->SaveAs("dz_eta_vs_" + append + ".png");
+  c_dz_eta_vs_run->SaveAs("dz_eta_vs_" + append + ".eps");
 
-  c_dz_eta_vs_run->SaveAs("dz_eta_vs_"+append+".pdf");
-  c_dz_eta_vs_run->SaveAs("dz_eta_vs_"+append+".png");
-  c_dz_eta_vs_run->SaveAs("dz_eta_vs_"+append+".eps");
-
-  TCanvas dummyC("dummyC","dummyC",2000,800); 
+  TCanvas dummyC("dummyC", "dummyC", 2000, 800);
   dummyC.Print("combined.pdf[");
   c_dxy_phi_vs_run->Print("combined.pdf");
-  c_dxy_eta_vs_run->Print("combined.pdf");                  
+  c_dxy_eta_vs_run->Print("combined.pdf");
   c_dz_phi_vs_run->Print("combined.pdf");
   c_dz_eta_vs_run->Print("combined.pdf");
   dummyC.Print("combined.pdf]");
 
   // mean
 
-  c_mean_dxy_phi_vs_run->SaveAs("mean_dxy_phi_vs_"+append+".pdf");
-  c_mean_dxy_phi_vs_run->SaveAs("mean_dxy_phi_vs_"+append+".png");
+  c_mean_dxy_phi_vs_run->SaveAs("mean_dxy_phi_vs_" + append + ".pdf");
+  c_mean_dxy_phi_vs_run->SaveAs("mean_dxy_phi_vs_" + append + ".png");
 
-  c_mean_dxy_eta_vs_run->SaveAs("mean_dxy_eta_vs_"+append+".pdf");
-  c_mean_dxy_eta_vs_run->SaveAs("mean_dxy_eta_vs_"+append+".png");
+  c_mean_dxy_eta_vs_run->SaveAs("mean_dxy_eta_vs_" + append + ".pdf");
+  c_mean_dxy_eta_vs_run->SaveAs("mean_dxy_eta_vs_" + append + ".png");
 
-  c_mean_dz_phi_vs_run->SaveAs("mean_dz_phi_vs_"+append+".pdf");
-  c_mean_dz_phi_vs_run->SaveAs("mean_dz_phi_vs_"+append+".png");
+  c_mean_dz_phi_vs_run->SaveAs("mean_dz_phi_vs_" + append + ".pdf");
+  c_mean_dz_phi_vs_run->SaveAs("mean_dz_phi_vs_" + append + ".png");
 
-  c_mean_dz_eta_vs_run->SaveAs("mean_dz_eta_vs_"+append+".pdf");
-  c_mean_dz_eta_vs_run->SaveAs("mean_dz_eta_vs_"+append+".png");
+  c_mean_dz_eta_vs_run->SaveAs("mean_dz_eta_vs_" + append + ".pdf");
+  c_mean_dz_eta_vs_run->SaveAs("mean_dz_eta_vs_" + append + ".png");
 
-  TCanvas dummyC2("dummyC2","dummyC2",2000,800); 
+  TCanvas dummyC2("dummyC2", "dummyC2", 2000, 800);
   dummyC2.Print("means.pdf[");
   c_mean_dxy_phi_vs_run->Print("means.pdf");
-  c_mean_dxy_eta_vs_run->Print("means.pdf");                  
+  c_mean_dxy_eta_vs_run->Print("means.pdf");
   c_mean_dz_phi_vs_run->Print("means.pdf");
   c_mean_dz_eta_vs_run->Print("means.pdf");
   dummyC2.Print("means.pdf]");
 
   // RMS
 
-  c_RMS_dxy_phi_vs_run->SaveAs("RMS_dxy_phi_vs_"+append+".pdf");
-  c_RMS_dxy_phi_vs_run->SaveAs("RMS_dxy_phi_vs_"+append+".png");
+  c_RMS_dxy_phi_vs_run->SaveAs("RMS_dxy_phi_vs_" + append + ".pdf");
+  c_RMS_dxy_phi_vs_run->SaveAs("RMS_dxy_phi_vs_" + append + ".png");
 
-  c_RMS_dxy_eta_vs_run->SaveAs("RMS_dxy_eta_vs_"+append+".pdf");
-  c_RMS_dxy_eta_vs_run->SaveAs("RMS_dxy_eta_vs_"+append+".png");
+  c_RMS_dxy_eta_vs_run->SaveAs("RMS_dxy_eta_vs_" + append + ".pdf");
+  c_RMS_dxy_eta_vs_run->SaveAs("RMS_dxy_eta_vs_" + append + ".png");
 
-  c_RMS_dz_phi_vs_run->SaveAs("RMS_dz_phi_vs_"+append+".pdf");
-  c_RMS_dz_phi_vs_run->SaveAs("RMS_dz_phi_vs_"+append+".png");
+  c_RMS_dz_phi_vs_run->SaveAs("RMS_dz_phi_vs_" + append + ".pdf");
+  c_RMS_dz_phi_vs_run->SaveAs("RMS_dz_phi_vs_" + append + ".png");
 
-  c_RMS_dz_eta_vs_run->SaveAs("RMS_dz_eta_vs_"+append+".pdf");
-  c_RMS_dz_eta_vs_run->SaveAs("RMS_dz_eta_vs_"+append+".png");
+  c_RMS_dz_eta_vs_run->SaveAs("RMS_dz_eta_vs_" + append + ".pdf");
+  c_RMS_dz_eta_vs_run->SaveAs("RMS_dz_eta_vs_" + append + ".png");
 
-  TCanvas dummyC3("dummyC3","dummyC3",2000,800); 
+  TCanvas dummyC3("dummyC3", "dummyC3", 2000, 800);
   dummyC3.Print("RMSs.pdf[");
   c_RMS_dxy_phi_vs_run->Print("RMSs.pdf");
-  c_RMS_dxy_eta_vs_run->Print("RMSs.pdf");                  
+  c_RMS_dxy_eta_vs_run->Print("RMSs.pdf");
   c_RMS_dz_phi_vs_run->Print("RMSs.pdf");
   c_RMS_dz_eta_vs_run->Print("RMSs.pdf");
   dummyC3.Print("RMSs.pdf]");
 
-
   // scatter
 
-  Scatter_dxy_vs_run->SaveAs("Scatter_dxy_vs_"+append+".pdf");
-  Scatter_dxy_vs_run->SaveAs("Scatter_dxy_vs_"+append+".png");
+  Scatter_dxy_vs_run->SaveAs("Scatter_dxy_vs_" + append + ".pdf");
+  Scatter_dxy_vs_run->SaveAs("Scatter_dxy_vs_" + append + ".png");
 
-  Scatter_dz_vs_run->SaveAs("Scatter_dz_vs_"+append+".pdf");
-  Scatter_dz_vs_run->SaveAs("Scatter_dz_vs_"+append+".png");
+  Scatter_dz_vs_run->SaveAs("Scatter_dz_vs_" + append + ".pdf");
+  Scatter_dz_vs_run->SaveAs("Scatter_dz_vs_" + append + ".png");
 
-  // chi2 
+  // chi2
 
-  c_chisquare_vs_run->SaveAs("chi2pol0fit_vs_"+append+".pdf");
-  c_chisquare_vs_run->SaveAs("chi2pol0fit_vs_"+append+".png");
+  c_chisquare_vs_run->SaveAs("chi2pol0fit_vs_" + append + ".pdf");
+  c_chisquare_vs_run->SaveAs("chi2pol0fit_vs_" + append + ".png");
 
   // KS score
-  
-  c_KSScore_vs_run->SaveAs("KSScore_vs_"+append+".pdf");
-  c_KSScore_vs_run->SaveAs("KSScore_vs_"+append+".png");
+
+  c_KSScore_vs_run->SaveAs("KSScore_vs_" + append + ".pdf");
+  c_KSScore_vs_run->SaveAs("KSScore_vs_" + append + ".png");
 
   // do all the deletes
 
-  for(int iDir=0;iDir<nDirs_;iDir++){
+  for (int iDir = 0; iDir < nDirs_; iDir++) {
+    delete g_dxy_phi_vs_run[iDir];
+    delete g_chi2_dxy_phi_vs_run[iDir];
+    delete g_KS_dxy_phi_vs_run[iDir];
+    delete g_dxy_phi_hi_vs_run[iDir];
+    delete g_dxy_phi_lo_vs_run[iDir];
 
-   delete g_dxy_phi_vs_run[iDir]; 
-   delete g_chi2_dxy_phi_vs_run[iDir];    
-   delete g_KS_dxy_phi_vs_run[iDir];    
-   delete g_dxy_phi_hi_vs_run[iDir]; 
-   delete g_dxy_phi_lo_vs_run[iDir]; 
-                               
-   delete g_dxy_eta_vs_run[iDir];    
-   delete g_chi2_dxy_eta_vs_run[iDir];    
-   delete g_KS_dxy_eta_vs_run[iDir];    
-   delete g_dxy_eta_hi_vs_run[iDir]; 
-   delete g_dxy_eta_lo_vs_run[iDir]; 
-                               
-   delete g_dz_phi_vs_run[iDir];   
-   delete g_chi2_dz_phi_vs_run[iDir];     
-   delete g_KS_dz_phi_vs_run[iDir];       
-   delete g_dz_phi_hi_vs_run[iDir];  
-   delete g_dz_phi_lo_vs_run[iDir];  
-                               
-   delete g_dz_eta_vs_run[iDir];  
-   delete g_chi2_dz_eta_vs_run[iDir];     
-   delete g_KS_dz_eta_vs_run[iDir];          
-   delete g_dz_eta_hi_vs_run[iDir];  
-   delete g_dz_eta_lo_vs_run[iDir];  
-                                                             
-   delete h_RMS_dxy_phi_vs_run[iDir];  
-   delete h_RMS_dxy_eta_vs_run[iDir];  
-   delete h_RMS_dz_phi_vs_run[iDir];   
-   delete h_RMS_dz_eta_vs_run[iDir];   
+    delete g_dxy_eta_vs_run[iDir];
+    delete g_chi2_dxy_eta_vs_run[iDir];
+    delete g_KS_dxy_eta_vs_run[iDir];
+    delete g_dxy_eta_hi_vs_run[iDir];
+    delete g_dxy_eta_lo_vs_run[iDir];
 
+    delete g_dz_phi_vs_run[iDir];
+    delete g_chi2_dz_phi_vs_run[iDir];
+    delete g_KS_dz_phi_vs_run[iDir];
+    delete g_dz_phi_hi_vs_run[iDir];
+    delete g_dz_phi_lo_vs_run[iDir];
+
+    delete g_dz_eta_vs_run[iDir];
+    delete g_chi2_dz_eta_vs_run[iDir];
+    delete g_KS_dz_eta_vs_run[iDir];
+    delete g_dz_eta_hi_vs_run[iDir];
+    delete g_dz_eta_lo_vs_run[iDir];
+
+    delete h_RMS_dxy_phi_vs_run[iDir];
+    delete h_RMS_dxy_eta_vs_run[iDir];
+    delete h_RMS_dz_phi_vs_run[iDir];
+    delete h_RMS_dz_eta_vs_run[iDir];
   }
 
   // mv the run-by-run plots into the folders
 
   gSystem->mkdir("Biases");
   TString processline = ".! mv Bias*.p* ./Biases/";
-  std::cout<<"Executing: \n"
-	   <<processline<< "\n"<<std::endl;
+  std::cout << "Executing: \n" << processline << "\n" << std::endl;
   gROOT->ProcessLine(processline.Data());
   gSystem->Sleep(100);
   processline.Clear();
 
   gSystem->mkdir("ResolutionsVsPt");
   processline = ".! mv ResolutionsVsPt*.p* ./ResolutionsVsPt/";
-  std::cout<<"Executing: \n"
-	   <<processline<< "\n"<<std::endl;
+  std::cout << "Executing: \n" << processline << "\n" << std::endl;
   gROOT->ProcessLine(processline.Data());
   gSystem->Sleep(100);
   processline.Clear();
 
   gSystem->mkdir("Resolutions");
   processline = ".! mv Resolutions*.p* ./Resolutions/";
-  std::cout<<"Executing: \n"
-	   <<processline<< "\n"<<std::endl;
+  std::cout << "Executing: \n" << processline << "\n" << std::endl;
   gROOT->ProcessLine(processline.Data());
   gSystem->Sleep(100);
   processline.Clear();
 
   gSystem->mkdir("Pulls");
   processline = ".! mv Pulls*.p* ./Pulls/";
-  std::cout<<"Executing: \n"
-	   <<processline<< "\n" <<std::endl;
+  std::cout << "Executing: \n" << processline << "\n" << std::endl;
   gROOT->ProcessLine(processline.Data());
   gSystem->Sleep(100);
   processline.Clear();
 
-  timer.Stop(); 	 
+  timer.Stop();
   timer.Print();
-
 }
 
 /*! \fn outputGraphs
@@ -1608,36 +1656,40 @@ void MultiRunPVValidation(TString namesandlabels,bool lumi_axis_format,bool time
  */
 
 /*--------------------------------------------------------------------*/
-void outputGraphs(const pv::wrappedTrends& allInputs,
-		  const std::vector<double>& ticks,
-		  const std::vector<double>& ex_ticks,
-		  TCanvas* &canv,
-		  TCanvas* &mean_canv,
-		  TCanvas* &rms_canv,
-		  TGraph* &g_mean,
-		  TGraph* &g_chi2,
-		  TGraph* &g_KS,	  
-		  TGraph* &g_low,
-		  TGraph* &g_high,
-		  TGraphAsymmErrors* &g_asym,
-		  TH1F* h_RMS[],      
-		  const pv::bundle& mybundle,
-		  const pv::view& theView,
-		  const int index,
-		  TObjArray* &array,
-		  const TString& label,
-		  TLegend* &legend
-		  )
+void outputGraphs(const pv::wrappedTrends &allInputs,
+                  const std::vector<double> &ticks,
+                  const std::vector<double> &ex_ticks,
+                  TCanvas *&canv,
+                  TCanvas *&mean_canv,
+                  TCanvas *&rms_canv,
+                  TGraph *&g_mean,
+                  TGraph *&g_chi2,
+                  TGraph *&g_KS,
+                  TGraph *&g_low,
+                  TGraph *&g_high,
+                  TGraphAsymmErrors *&g_asym,
+                  TH1F *h_RMS[],
+                  const pv::bundle &mybundle,
+                  const pv::view &theView,
+                  const int index,
+                  TObjArray *&array,
+                  const TString &label,
+                  TLegend *&legend)
 /*--------------------------------------------------------------------*/
 {
+  g_mean = new TGraph(ticks.size(), &(ticks[0]), &((allInputs.getMean()[label])[0]));
+  g_chi2 = new TGraph(ticks.size(), &(ticks[0]), &((allInputs.getChi2()[label])[0]));
+  g_KS = new TGraph(ticks.size(), &(ticks[0]), &((allInputs.getKS()[label])[0]));
+  g_high = new TGraph(ticks.size(), &(ticks[0]), &((allInputs.getHigh()[label])[0]));
+  g_low = new TGraph(ticks.size(), &(ticks[0]), &((allInputs.getLow()[label])[0]));
 
-  g_mean = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getMean()[label])[0]));
-  g_chi2 = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getChi2()[label])[0]));
-  g_KS   = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getKS()[label])[0]));
-  g_high = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getHigh()[label])[0]));
-  g_low  = new TGraph(ticks.size(),&(ticks[0]),&((allInputs.getLow()[label])[0]));
-
-  g_asym = new TGraphAsymmErrors(ticks.size(),&(ticks[0]),&((allInputs.getMean()[label])[0]),&(ex_ticks[0]),&(ex_ticks[0]),&((allInputs.getLowErr()[label])[0]),&((allInputs.getHighErr()[label])[0]));
+  g_asym = new TGraphAsymmErrors(ticks.size(),
+                                 &(ticks[0]),
+                                 &((allInputs.getMean()[label])[0]),
+                                 &(ex_ticks[0]),
+                                 &(ex_ticks[0]),
+                                 &((allInputs.getLowErr()[label])[0]),
+                                 &((allInputs.getHighErr()[label])[0]));
 
   adjustmargins(canv);
   canv->cd();
@@ -1652,63 +1704,64 @@ void outputGraphs(const pv::wrappedTrends& allInputs,
   beautify(g_mean);
   beautify(g_asym);
 
-  if(theView==pv::dxyphi){
-    legend->AddEntry(g_mean,label,"PL");
+  if (theView == pv::dxyphi) {
+    legend->AddEntry(g_mean, label, "PL");
   }
 
-  const char* coord;
-  const char* kin;
+  const char *coord;
+  const char *kin;
   float ampl;
 
-  switch(theView){
-  case pv::dxyphi  :
-    coord = "xy";
-    kin   = "phi";
-    ampl  = 40;
-    break;
-  case pv::dzphi   : 
-    coord = "z";
-    kin   = "phi";
-    ampl  = 40;
-    break;
-  case pv::dxyeta  :
-    coord = "xy";
-    kin   = "eta";
-    ampl  = 40;
-    break;
-  case pv::dzeta   : 
-    coord = "z";
-    kin   = "eta";
-    ampl  = 60;
-    break;
-  default :
-    coord = "unknown";
-    kin   = "unknown";
-    break;
+  switch (theView) {
+    case pv::dxyphi:
+      coord = "xy";
+      kin = "phi";
+      ampl = 40;
+      break;
+    case pv::dzphi:
+      coord = "z";
+      kin = "phi";
+      ampl = 40;
+      break;
+    case pv::dxyeta:
+      coord = "xy";
+      kin = "eta";
+      ampl = 40;
+      break;
+    case pv::dzeta:
+      coord = "z";
+      kin = "eta";
+      ampl = 60;
+      break;
+    default:
+      coord = "unknown";
+      kin = "unknown";
+      break;
   }
 
-  g_mean->SetName(Form("g_bias_d%s_%s_%s",coord,kin,label.Data()));
-  g_mean->SetTitle(Form("Bias of d_{%s}(#%s) vs %s",coord,kin,mybundle.getDataType()));
+  g_mean->SetName(Form("g_bias_d%s_%s_%s", coord, kin, label.Data()));
+  g_mean->SetTitle(Form("Bias of d_{%s}(#%s) vs %s", coord, kin, mybundle.getDataType()));
   g_mean->GetXaxis()->SetTitle(mybundle.getDataTypeLabel());
-  g_mean->GetYaxis()->SetTitle(Form("#LT d_{%s}(#%s) #GT [#mum]",coord,kin));
-  g_mean->GetYaxis()->SetRangeUser(-ampl,ampl);
+  g_mean->GetYaxis()->SetTitle(Form("#LT d_{%s}(#%s) #GT [#mum]", coord, kin));
+  g_mean->GetYaxis()->SetRangeUser(-ampl, ampl);
 
+  std::cout << "===================================================================================================="
+            << std::endl;
+  std::cout << mybundle.getTotalLumi() << std::endl;
+  std::cout << "===================================================================================================="
+            << std::endl;
 
-  std::cout<<"===================================================================================================="<<std::endl;
-  std::cout<< mybundle.getTotalLumi() << std::endl;
-  std::cout<<"===================================================================================================="<<std::endl;
-
-  g_asym->SetName(Form("gerr_bias_d%s_%s_%s",coord,kin,label.Data()));
-  g_asym->SetTitle(Form("Bias of d_{%s}(#%s) vs %s",coord,kin,mybundle.getDataType()));
+  g_asym->SetName(Form("gerr_bias_d%s_%s_%s", coord, kin, label.Data()));
+  g_asym->SetTitle(Form("Bias of d_{%s}(#%s) vs %s", coord, kin, mybundle.getDataType()));
   g_asym->GetXaxis()->SetTitle(mybundle.getDataTypeLabel());
-  g_asym->GetYaxis()->SetTitle(Form("#LT d_{%s}(#%s) #GT [#mum]",coord,kin));
-  g_asym->GetYaxis()->SetRangeUser(-ampl,ampl);
+  g_asym->GetYaxis()->SetTitle(Form("#LT d_{%s}(#%s) #GT [#mum]", coord, kin));
+  g_asym->GetYaxis()->SetRangeUser(-ampl, ampl);
 
   //g_mean->GetXaxis()->UnZoom();
   //g_asym->GetXaxis()->UnZoom();
 
-  if(index==0){
-    g_asym->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+  if (index == 0) {
+    g_asym->GetXaxis()->SetRangeUser(0., mybundle.getTotalLumi());
     g_mean->Draw("AP");
     g_asym->Draw("P3same");
   } else {
@@ -1717,69 +1770,83 @@ void outputGraphs(const pv::wrappedTrends& allInputs,
   }
   g_high->Draw("Lsame");
   g_low->Draw("Lsame");
-  
-  if(mybundle.isTimeAxis()){
+
+  if (mybundle.isTimeAxis()) {
     timify(g_asym);
     timify(g_mean);
     timify(g_high);
     timify(g_low);
   }
 
-  if(mybundle.isLumiAxis()){
-    g_asym->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
-    g_mean->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
-    g_high->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
-    g_low->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+  if (mybundle.isLumiAxis()) {
+    g_asym->GetXaxis()->SetRangeUser(0., mybundle.getTotalLumi());
+    g_mean->GetXaxis()->SetRangeUser(0., mybundle.getTotalLumi());
+    g_high->GetXaxis()->SetRangeUser(0., mybundle.getTotalLumi());
+    g_low->GetXaxis()->SetRangeUser(0., mybundle.getTotalLumi());
   }
 
-  if(index==(mybundle.getNObjects()-1)){ 
+  if (index == (mybundle.getNObjects() - 1)) {
     legend->Draw("same");
-    TH1F* theZero = DrawConstantGraph(g_mean,1,0.);
+    TH1F *theZero = DrawConstantGraph(g_mean, 1, 0.);
     theZero->Draw("E1same][");
   }
-	
-  auto current_pad = static_cast<TPad*>(gPad);
+
+  auto current_pad = static_cast<TPad *>(gPad);
   cmsPrel(current_pad);
 
-  superImposeIOVBoundaries(canv,mybundle.isLumiAxis(),mybundle.isTimeAxis(),mybundle.getLumiMapByRun(),mybundle.getTimes());
-   
+  superImposeIOVBoundaries(
+      canv, mybundle.isLumiAxis(), mybundle.isTimeAxis(), mybundle.getLumiMapByRun(), mybundle.getTimes());
+
   // mean only
   adjustmargins(mean_canv);
   mean_canv->cd();
-  auto gprime  =  (TGraph*)g_mean->Clone();
-  if(index==0){
-    gprime->GetYaxis()->SetRangeUser(-10.,10.);
-    if(mybundle.isLumiAxis()) gprime->GetXaxis()->SetRangeUser(0.,mybundle.getTotalLumi());
+  auto gprime = (TGraph *)g_mean->Clone();
+  if (index == 0) {
+    gprime->GetYaxis()->SetRangeUser(-10., 10.);
+    if (mybundle.isLumiAxis())
+      gprime->GetXaxis()->SetRangeUser(0., mybundle.getTotalLumi());
     gprime->Draw("AP");
   } else {
     gprime->Draw("Psame");
   }
-  
-  if(index==(mybundle.getNObjects()-1)){ 
+
+  if (index == (mybundle.getNObjects() - 1)) {
     legend->Draw("same");
   }
-  
-  if(index==0){
-    TH1F* theZero = DrawConstantGraph(gprime,2,0.);
+
+  if (index == 0) {
+    TH1F *theZero = DrawConstantGraph(gprime, 2, 0.);
     theZero->Draw("E1same][");
-    
-    auto current_pad = static_cast<TPad*>(gPad);
+
+    auto current_pad = static_cast<TPad *>(gPad);
     cmsPrel(current_pad);
-    
-    superImposeIOVBoundaries(mean_canv,mybundle.isLumiAxis(),mybundle.isTimeAxis(),mybundle.getLumiMapByRun(),mybundle.getTimes());
+
+    superImposeIOVBoundaries(
+        mean_canv, mybundle.isLumiAxis(), mybundle.isTimeAxis(), mybundle.getLumiMapByRun(), mybundle.getTimes());
   }
 
   // scatter or RMS TH1
-  h_RMS[index] = new TH1F(Form("h_RMS_dz_eta_%s",label.Data()),Form("scatter of d_{%s}(#%s) vs %s;%s;%s of d_{%s}(#%s) [#mum]",coord,kin,mybundle.getDataType(),mybundle.getDataTypeLabel(),(mybundle.isUsingRMS() ? "RMS" : "peak-to-peak deviation" ),coord,kin),ticks.size()-1,&(ticks[0]));
+  h_RMS[index] = new TH1F(Form("h_RMS_dz_eta_%s", label.Data()),
+                          Form("scatter of d_{%s}(#%s) vs %s;%s;%s of d_{%s}(#%s) [#mum]",
+                               coord,
+                               kin,
+                               mybundle.getDataType(),
+                               mybundle.getDataTypeLabel(),
+                               (mybundle.isUsingRMS() ? "RMS" : "peak-to-peak deviation"),
+                               coord,
+                               kin),
+                          ticks.size() - 1,
+                          &(ticks[0]));
   h_RMS[index]->SetStats(kFALSE);
-   
-  int bincounter=0;
-  for(const auto &tick : ticks ){
+
+  int bincounter = 0;
+  for (const auto &tick : ticks) {
     bincounter++;
-    h_RMS[index]->SetBinContent(bincounter,std::abs(allInputs.getHigh()[label][bincounter-1]-allInputs.getLow()[label][bincounter-1]));
-    h_RMS[index]->SetBinError(bincounter,0.01);
+    h_RMS[index]->SetBinContent(
+        bincounter, std::abs(allInputs.getHigh()[label][bincounter - 1] - allInputs.getLow()[label][bincounter - 1]));
+    h_RMS[index]->SetBinError(bincounter, 0.01);
   }
-   
+
   h_RMS[index]->SetLineColor(pv::colors[index]);
   h_RMS[index]->SetLineWidth(2);
   h_RMS[index]->SetMarkerSize(1.5);
@@ -1788,39 +1855,37 @@ void outputGraphs(const pv::wrappedTrends& allInputs,
   adjustmargins(rms_canv);
   rms_canv->cd();
   beautify(h_RMS[index]);
-  
-  if(mybundle.isTimeAxis()){
+
+  if (mybundle.isTimeAxis()) {
     timify(h_RMS[index]);
   }
-  
+
   array->Add(h_RMS[index]);
-   
+
   // at the last file re-loop
-  if(index==(mybundle.getNObjects()-1)){
-     
+  if (index == (mybundle.getNObjects() - 1)) {
     auto theMax = getMaximumFromArray(array);
-    std::cout<< "the max for d"<< coord <<"("<<kin<<") RMS is "<< theMax << std::endl;
-    
-    for(Int_t k=0; k<mybundle.getNObjects() ; k++){
+    std::cout << "the max for d" << coord << "(" << kin << ") RMS is " << theMax << std::endl;
+
+    for (Int_t k = 0; k < mybundle.getNObjects(); k++) {
       //h_RMS[k]->GetYaxis()->SetRangeUser(-theMax*0.45,theMax*1.40);
-      h_RMS[k]->GetYaxis()->SetRangeUser(0.,theMax*1.80);
-      if(k==0){
-  	h_RMS[k]->Draw("L");
+      h_RMS[k]->GetYaxis()->SetRangeUser(0., theMax * 1.80);
+      if (k == 0) {
+        h_RMS[k]->Draw("L");
       } else {
-  	h_RMS[k]->Draw("Lsame");
+        h_RMS[k]->Draw("Lsame");
       }
     }
     legend->Draw("same");
-    TH1F* theConst = DrawConstant(h_RMS[index],1,0.);
+    TH1F *theConst = DrawConstant(h_RMS[index], 1, 0.);
     //theConst->Draw("same][");
 
-    current_pad = static_cast<TPad*>(gPad);
+    current_pad = static_cast<TPad *>(gPad);
     cmsPrel(current_pad);
-   
-    superImposeIOVBoundaries(rms_canv,mybundle.isLumiAxis(),mybundle.isTimeAxis(),mybundle.getLumiMapByRun(),mybundle.getTimes());
 
+    superImposeIOVBoundaries(
+        rms_canv, mybundle.isLumiAxis(), mybundle.isTimeAxis(), mybundle.getLumiMapByRun(), mybundle.getTimes());
   }
-  
 }
 
 /*! \fn list_files
@@ -1832,23 +1897,23 @@ std::vector<int> list_files(const char *dirname, const char *ext)
 /*--------------------------------------------------------------------*/
 {
   std::vector<int> theRunNumbers;
-  
+
   TSystemDirectory dir(dirname, dirname);
   TList *files = dir.GetListOfFiles();
   if (files) {
     TSystemFile *file;
     TString fname;
     TIter next(files);
-    while ((file=(TSystemFile*)next())) {
+    while ((file = (TSystemFile *)next())) {
       fname = file->GetName();
       if (!file->IsDirectory() && fname.EndsWith(ext) && fname.BeginsWith("PVValidation")) {
-	//std::cout << fname.Data() << std::endl;
-	TObjArray *bits = fname.Tokenize("_");
-	TString theRun = bits->At(2)->GetName();
-	//std::cout << theRun << std::endl;
-	TString formatRun = (theRun.ReplaceAll(".root","")).ReplaceAll("_","");
-	//std::cout << dirname << " "<< formatRun.Atoi() << std::endl;
-	theRunNumbers.push_back(formatRun.Atoi());
+        //std::cout << fname.Data() << std::endl;
+        TObjArray *bits = fname.Tokenize("_");
+        TString theRun = bits->At(2)->GetName();
+        //std::cout << theRun << std::endl;
+        TString formatRun = (theRun.ReplaceAll(".root", "")).ReplaceAll("_", "");
+        //std::cout << dirname << " "<< formatRun.Atoi() << std::endl;
+        theRunNumbers.push_back(formatRun.Atoi());
       }
     }
   }
@@ -1860,10 +1925,17 @@ std::vector<int> list_files(const char *dirname, const char *ext)
  */
 
 /*--------------------------------------------------------------------*/
-void arrangeOutCanvas(TCanvas *canv, TH1F* m_11Trend[100],TH1F* m_12Trend[100],TH1F* m_21Trend[100],TH1F* m_22Trend[100],Int_t nDirs, TString LegLabels[10],unsigned int theRun){
-/*--------------------------------------------------------------------*/
+void arrangeOutCanvas(TCanvas *canv,
+                      TH1F *m_11Trend[100],
+                      TH1F *m_12Trend[100],
+                      TH1F *m_21Trend[100],
+                      TH1F *m_22Trend[100],
+                      Int_t nDirs,
+                      TString LegLabels[10],
+                      unsigned int theRun) {
+  /*--------------------------------------------------------------------*/
 
-  TLegend *lego = new TLegend(0.19,0.80,0.79,0.93);
+  TLegend *lego = new TLegend(0.19, 0.80, 0.79, 0.93);
   //lego-> SetNColumns(2);
   lego->SetFillColor(10);
   lego->SetTextSize(0.042);
@@ -1871,135 +1943,136 @@ void arrangeOutCanvas(TCanvas *canv, TH1F* m_11Trend[100],TH1F* m_12Trend[100],T
   lego->SetFillColor(10);
   lego->SetLineColor(10);
   lego->SetShadowColor(10);
-  
-  TPaveText *ptDate =new TPaveText(0.19,0.95,0.45,0.99,"blNDC");
+
+  TPaveText *ptDate = new TPaveText(0.19, 0.95, 0.45, 0.99, "blNDC");
   ptDate->SetFillColor(kYellow);
   //ptDate->SetFillColor(10);
   ptDate->SetBorderSize(1);
   ptDate->SetLineColor(kBlue);
   ptDate->SetLineWidth(1);
   ptDate->SetTextFont(42);
-  TText *textDate = ptDate->AddText(Form("Run: %i",theRun));
+  TText *textDate = ptDate->AddText(Form("Run: %i", theRun));
   textDate->SetTextSize(0.04);
   textDate->SetTextColor(kBlue);
   textDate->SetTextAlign(22);
 
-  canv->SetFillColor(10);  
-  canv->Divide(2,2);
- 
-  TH1F *dBiasTrend[4][nDirs]; 
-  
-  for(Int_t i=0;i<nDirs;i++){
+  canv->SetFillColor(10);
+  canv->Divide(2, 2);
+
+  TH1F *dBiasTrend[4][nDirs];
+
+  for (Int_t i = 0; i < nDirs; i++) {
     dBiasTrend[0][i] = m_11Trend[i];
     dBiasTrend[1][i] = m_12Trend[i];
     dBiasTrend[2][i] = m_21Trend[i];
     dBiasTrend[3][i] = m_22Trend[i];
   }
 
-  Double_t absmin[4]={999.,999.,999.,999.};
-  Double_t absmax[4]={-999.,-999.-999.,-999.};
+  Double_t absmin[4] = {999., 999., 999., 999.};
+  Double_t absmax[4] = {-999., -999. - 999., -999.};
 
-  for(Int_t k=0; k<4; k++){
+  for (Int_t k = 0; k < 4; k++) {
+    canv->cd(k + 1)->SetBottomMargin(0.14);
+    canv->cd(k + 1)->SetLeftMargin(0.18);
+    canv->cd(k + 1)->SetRightMargin(0.01);
+    canv->cd(k + 1)->SetTopMargin(0.06);
 
-    canv->cd(k+1)->SetBottomMargin(0.14);
-    canv->cd(k+1)->SetLeftMargin(0.18);
-    canv->cd(k+1)->SetRightMargin(0.01);
-    canv->cd(k+1)->SetTopMargin(0.06);
-    
-    canv->cd(k+1);
-    
-    for(Int_t i=0; i<nDirs; i++){
-      if(dBiasTrend[k][i]->GetMaximum()>absmax[k]) absmax[k] = dBiasTrend[k][i]->GetMaximum();
-      if(dBiasTrend[k][i]->GetMinimum()<absmin[k]) absmin[k] = dBiasTrend[k][i]->GetMinimum();
+    canv->cd(k + 1);
+
+    for (Int_t i = 0; i < nDirs; i++) {
+      if (dBiasTrend[k][i]->GetMaximum() > absmax[k])
+        absmax[k] = dBiasTrend[k][i]->GetMaximum();
+      if (dBiasTrend[k][i]->GetMinimum() < absmin[k])
+        absmin[k] = dBiasTrend[k][i]->GetMinimum();
     }
 
-    Double_t safeDelta=(absmax[k]-absmin[k])/8.;
-    Double_t theExtreme=std::max(absmax[k],TMath::Abs(absmin[k]));
+    Double_t safeDelta = (absmax[k] - absmin[k]) / 8.;
+    Double_t theExtreme = std::max(absmax[k], TMath::Abs(absmin[k]));
 
-    for(Int_t i=0; i<nDirs; i++){
-      if(i==0){
+    for (Int_t i = 0; i < nDirs; i++) {
+      if (i == 0) {
+        TString theTitle = dBiasTrend[k][i]->GetName();
 
-	TString theTitle = dBiasTrend[k][i]->GetName();
-	
-	if(theTitle.Contains("norm")){
-	  //dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-safeDelta/2.),std::max(0.48,absmax[k]+safeDelta/2.));
-	  dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,1.8);
-	} else {
-	  if(!theTitle.Contains("width")){
-	    if(theTitle.Contains("ladder") || theTitle.Contains("modZ")) {
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-40.,-theExtreme-(safeDelta/2.)),std::max(40.,theExtreme+(safeDelta/2.)));
-	    } else {
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(-40.,40.);
-	    }
-	  } else {
-	    // dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta/2.));
-	    // if(theTitle.Contains("eta")) {
-	    //   dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,500.);
-	    // } else {
-	    //   dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.);
-	    // }
-	    auto my_view = checkTheView(theTitle);
+        if (theTitle.Contains("norm")) {
+          //dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-0.48,absmin[k]-safeDelta/2.),std::max(0.48,absmax[k]+safeDelta/2.));
+          dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 1.8);
+        } else {
+          if (!theTitle.Contains("width")) {
+            if (theTitle.Contains("ladder") || theTitle.Contains("modZ")) {
+              dBiasTrend[k][i]->GetYaxis()->SetRangeUser(std::min(-40., -theExtreme - (safeDelta / 2.)),
+                                                         std::max(40., theExtreme + (safeDelta / 2.)));
+            } else {
+              dBiasTrend[k][i]->GetYaxis()->SetRangeUser(-40., 40.);
+            }
+          } else {
+            // dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,theExtreme+(safeDelta/2.));
+            // if(theTitle.Contains("eta")) {
+            //   dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,500.);
+            // } else {
+            //   dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.);
+            // }
+            auto my_view = checkTheView(theTitle);
 
-	    //std::cout<<" ----------------------------------> " << theTitle << " view: " << my_view <<  std::endl;
+            //std::cout<<" ----------------------------------> " << theTitle << " view: " << my_view <<  std::endl;
 
-	    switch(my_view){
-	    case pv::dxyphi  : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.); 
-	      break;
-	    case pv::dzphi   : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,400.);
-	      break;
-	    case pv::dxyeta  : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,300.);
-	      break;
-	    case pv::dzeta   : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,1.e3);
-	      break;
-	    case pv::pT : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,200.);
-	      break;
-	    case pv::generic : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,350.);
-	      break;
-	    default : 
-	      dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0.,300.);
-	    }
-	  } 
-	}
- 
-	dBiasTrend[k][i]->Draw("Le1");
-	makeNewXAxis(dBiasTrend[k][i]);
-      
-	Double_t theC = -1.;
-	
-	if(theTitle.Contains("width")){ 
-	  if(theTitle.Contains("norm") ){
-	    theC = 1.;
-	  } else {
-	    theC = -1.;
-	  }
-	} else {
-	  theC = 0.;
-	}
-	
-	TH1F* theConst = DrawConstant(dBiasTrend[k][i],1,theC);
-	theConst->Draw("PLsame][");
+            switch (my_view) {
+              case pv::dxyphi:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 200.);
+                break;
+              case pv::dzphi:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 400.);
+                break;
+              case pv::dxyeta:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 300.);
+                break;
+              case pv::dzeta:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 1.e3);
+                break;
+              case pv::pT:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 200.);
+                break;
+              case pv::generic:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 350.);
+                break;
+              default:
+                dBiasTrend[k][i]->GetYaxis()->SetRangeUser(0., 300.);
+            }
+          }
+        }
 
-      } else { 
-	dBiasTrend[k][i]->Draw("Le1sames");
-	makeNewXAxis(dBiasTrend[k][i]);
+        dBiasTrend[k][i]->Draw("Le1");
+        makeNewXAxis(dBiasTrend[k][i]);
+
+        Double_t theC = -1.;
+
+        if (theTitle.Contains("width")) {
+          if (theTitle.Contains("norm")) {
+            theC = 1.;
+          } else {
+            theC = -1.;
+          }
+        } else {
+          theC = 0.;
+        }
+
+        TH1F *theConst = DrawConstant(dBiasTrend[k][i], 1, theC);
+        theConst->Draw("PLsame][");
+
+      } else {
+        dBiasTrend[k][i]->Draw("Le1sames");
+        makeNewXAxis(dBiasTrend[k][i]);
       }
-      TPad *current_pad = static_cast<TPad*>(canv->GetPad(k+1));
-      cmsPrel(current_pad,2);
+      TPad *current_pad = static_cast<TPad *>(canv->GetPad(k + 1));
+      cmsPrel(current_pad, 2);
       ptDate->Draw("same");
 
-      if(k==0){
-	lego->AddEntry(dBiasTrend[k][i],LegLabels[i]);
-      } 
-    }  
-  
+      if (k == 0) {
+        lego->AddEntry(dBiasTrend[k][i], LegLabels[i]);
+      }
+    }
+
     lego->Draw();
-  } 
+  }
 }
 
 /*! \fn MakeNiceTrendPlotStype
@@ -2007,15 +2080,15 @@ void arrangeOutCanvas(TCanvas *canv, TH1F* m_11Trend[100],TH1F* m_12Trend[100],T
  */
 
 /*--------------------------------------------------------------------*/
-void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color)
+void MakeNiceTrendPlotStyle(TH1 *hist, Int_t color)
 /*--------------------------------------------------------------------*/
-{ 
-  hist->SetStats(kFALSE);  
+{
+  hist->SetStats(kFALSE);
   hist->SetLineWidth(2);
   hist->GetXaxis()->CenterTitle(true);
   hist->GetYaxis()->CenterTitle(true);
-  hist->GetXaxis()->SetTitleFont(42); 
-  hist->GetYaxis()->SetTitleFont(42);  
+  hist->GetXaxis()->SetTitleFont(42);
+  hist->GetYaxis()->SetTitleFont(42);
   hist->GetXaxis()->SetTitleSize(0.065);
   hist->GetYaxis()->SetTitleSize(0.065);
   hist->GetXaxis()->SetTitleOffset(1.0);
@@ -2025,36 +2098,34 @@ void  MakeNiceTrendPlotStyle(TH1 *hist,Int_t color)
   hist->GetYaxis()->SetLabelSize(.05);
   hist->GetXaxis()->SetLabelSize(.07);
   //hist->GetXaxis()->SetNdivisions(505);
-  if(color!=8){
+  if (color != 8) {
     hist->SetMarkerSize(1.5);
   } else {
     hist->SetLineWidth(3);
-    hist->SetMarkerSize(0.0);    
+    hist->SetMarkerSize(0.0);
   }
   hist->SetMarkerStyle(pv::markers[color]);
   hist->SetLineColor(pv::colors[color]);
   hist->SetMarkerColor(pv::colors[color]);
 }
 
-
 /*! \fn maxkeNewAxis
  *  \brief utility function to re-make x-axis with correct binning
  */
 
 /*--------------------------------------------------------------------*/
-void makeNewXAxis (TH1 *h)
+void makeNewXAxis(TH1 *h)
 /*--------------------------------------------------------------------*/
 {
-  
   TString myTitle = h->GetName();
   float axmin = -999;
   float axmax = 999.;
   int ndiv = 510;
-  if(myTitle.Contains("eta")){
+  if (myTitle.Contains("eta")) {
     axmin = -2.7;
     axmax = 2.7;
     ndiv = 505;
-  } else if (myTitle.Contains("phi")){
+  } else if (myTitle.Contains("phi")) {
     axmin = -TMath::Pi();
     axmax = TMath::Pi();
     ndiv = 510;
@@ -2065,62 +2136,54 @@ void makeNewXAxis (TH1 *h)
   } else if (myTitle.Contains("ladder")) {
     axmin = 0;
     axmax = 12;
-    ndiv  = 510;
-  } else if (myTitle.Contains("modZ")){
+    ndiv = 510;
+  } else if (myTitle.Contains("modZ")) {
     axmin = 0;
     axmax = 8;
-    ndiv  = 510;
+    ndiv = 510;
   } else {
-    std::cout<<"unrecognized variable"<<std::endl;
+    std::cout << "unrecognized variable" << std::endl;
   }
-  
+
   // Remove the current axis
   h->GetXaxis()->SetLabelOffset(999);
   h->GetXaxis()->SetTickLength(0);
-  
-  if (myTitle.Contains("phi")){
+
+  if (myTitle.Contains("phi")) {
     h->GetXaxis()->SetTitle("#varphi (sector) [rad]");
   }
 
-   // Redraw the new axis
+  // Redraw the new axis
   gPad->Update();
-  
-  TGaxis *newaxis = new TGaxis(gPad->GetUxmin(),gPad->GetUymin(),
-			       gPad->GetUxmax(),gPad->GetUymin(),
-			       axmin,
-			       axmax,
-			       ndiv,"SDH");
-  
-  TGaxis *newaxisup =  new TGaxis(gPad->GetUxmin(),gPad->GetUymax(),
-                                  gPad->GetUxmax(),gPad->GetUymax(),
-                                  axmin,
-                                  axmax,                          
-                                  ndiv,"-SDH");
-    
+
+  TGaxis *newaxis =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymin(), gPad->GetUxmax(), gPad->GetUymin(), axmin, axmax, ndiv, "SDH");
+
+  TGaxis *newaxisup =
+      new TGaxis(gPad->GetUxmin(), gPad->GetUymax(), gPad->GetUxmax(), gPad->GetUymax(), axmin, axmax, ndiv, "-SDH");
+
   newaxis->SetLabelOffset(0.02);
   newaxis->SetLabelFont(42);
   newaxis->SetLabelSize(0.05);
-  
+
   newaxisup->SetLabelOffset(-0.02);
   newaxisup->SetLabelFont(42);
   newaxisup->SetLabelSize(0);
-  
+
   newaxis->Draw();
   newaxisup->Draw();
-
 }
-
 
 /*! \fn setStyle
  *  \brief main function to set the plotting style
  */
 
 /*--------------------------------------------------------------------*/
-void setStyle(){
-/*--------------------------------------------------------------------*/
+void setStyle() {
+  /*--------------------------------------------------------------------*/
 
   TGaxis::SetMaxDigits(6);
-  
+
   TH1::StatOverflows(kTRUE);
   gStyle->SetOptTitle(0);
   gStyle->SetOptStat("e");
@@ -2137,7 +2200,7 @@ void setStyle(){
   gStyle->SetTitleBorderSize(0);
   gStyle->SetStatColor(kWhite);
   gStyle->SetStatFont(42);
-  gStyle->SetStatFontSize(0.05);///---> gStyle->SetStatFontSize(0.025);
+  gStyle->SetStatFontSize(0.05);  ///---> gStyle->SetStatFontSize(0.025);
   gStyle->SetStatTextColor(1);
   gStyle->SetStatFormat("6.4g");
   gStyle->SetStatBorderSize(1);
@@ -2160,19 +2223,18 @@ void setStyle(){
   */
 
   Double_t stops[NRGBs] = {0.00, 0.01, 0.05, 0.09, 0.1};
-  Double_t red[NRGBs]   = {1.00, 0.84, 0.61, 0.34, 0.00};
+  Double_t red[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
   Double_t green[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
-  Double_t blue[NRGBs]  = {1.00, 0.84, 0.61, 0.34, 0.00};
+  Double_t blue[NRGBs] = {1.00, 0.84, 0.61, 0.34, 0.00};
 
   TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
   gStyle->SetNumberContours(NCont);
-
 }
 
 // /*--------------------------------------------------------------------*/
 // void cmsPrel(TPad* pad) {
 // /*--------------------------------------------------------------------*/
-  
+
 //   float H = pad->GetWh();
 //   float W = pad->GetWw();
 //   float l = pad->GetLeftMargin();
@@ -2201,19 +2263,17 @@ void setStyle(){
 //   latex->DrawLatex(posX_,posY_,"Internal (13 TeV)");
 //   //latex->DrawLatex(posX_,posY_,"CMS Preliminary (13 TeV)");
 //   //latex->DrawLatex(posX_,posY_,"CMS 2017 Work in progress (13 TeV)");
-  
+
 // }
-
-
 
 /*! \fn cmsPrel
  *  \brief utility function to put the CMS paraphernalia on canvas
  */
 
 /*--------------------------------------------------------------------*/
-void cmsPrel(TPad* pad,size_t ipads) {
-/*--------------------------------------------------------------------*/
-  
+void cmsPrel(TPad *pad, size_t ipads) {
+  /*--------------------------------------------------------------------*/
+
   float H = pad->GetWh();
   float W = pad->GetWw();
   float l = pad->GetLeftMargin();
@@ -2228,30 +2288,29 @@ void cmsPrel(TPad* pad,size_t ipads) {
   latex->SetNDC();
   latex->SetTextSize(0.045);
 
-  float posX_    = 1-(r/ipads);
-  float posY_    = 1-t + 0.05; /// - relPosY*(1-t-b);
-  float factor   = 1./0.82;
+  float posX_ = 1 - (r / ipads);
+  float posY_ = 1 - t + 0.05;  /// - relPosY*(1-t-b);
+  float factor = 1. / 0.82;
 
   latex->SetTextAlign(33);
   latex->SetTextSize(0.045);
-  latex->SetTextFont(42); //22
-  latex->DrawLatex(posX_,posY_,"Internal (13 TeV)");
+  latex->SetTextFont(42);  //22
+  latex->DrawLatex(posX_, posY_, "Internal (13 TeV)");
 
   UInt_t w;
   UInt_t h;
-  latex->GetTextExtent(w,h,"Internal (13 TeV)");
-  float size = w/(W/ipads);
+  latex->GetTextExtent(w, h, "Internal (13 TeV)");
+  float size = w / (W / ipads);
   //std::cout<<w<<" "<<" "<<W<<" "<<size<<std::endl;
-  float posXCMS_ = posX_- size*(1+0.025*ipads);
+  float posXCMS_ = posX_ - size * (1 + 0.025 * ipads);
 
   latex->SetTextAlign(33);
   latex->SetTextFont(61);
-  latex->SetTextSize(0.045*factor);
-  latex->DrawLatex(posXCMS_,posY_+0.004,"CMS");
+  latex->SetTextSize(0.045 * factor);
+  latex->DrawLatex(posXCMS_, posY_ + 0.004, "CMS");
 
   //latex->DrawLatex(posX_,posY_,"CMS Preliminary (13 TeV)");
   //latex->DrawLatex(posX_,posY_,"CMS 2017 Work in progress (13 TeV)");
-  
 }
 
 /*! \fn DrawConstant
@@ -2259,50 +2318,54 @@ void cmsPrel(TPad* pad,size_t ipads) {
  */
 
 /*--------------------------------------------------------------------*/
-TH1F* DrawConstant(TH1F *hist,Int_t iter,Double_t theConst)
+TH1F *DrawConstant(TH1F *hist, Int_t iter, Double_t theConst)
 /*--------------------------------------------------------------------*/
-{ 
-  
-  Int_t nbins       = hist->GetNbinsX();
-  Double_t lowedge  = hist->GetBinLowEdge(1);
-  Double_t highedge = hist->GetBinLowEdge(nbins+1);
-  
-  TH1F *hzero = new TH1F(Form("hconst_%s_%i",hist->GetName(),iter),Form("hconst_%s_%i",hist->GetName(),iter),nbins,lowedge,highedge);
-  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
-    hzero->SetBinContent(i,theConst);
-    hzero->SetBinError(i,0.);
+{
+  Int_t nbins = hist->GetNbinsX();
+  Double_t lowedge = hist->GetBinLowEdge(1);
+  Double_t highedge = hist->GetBinLowEdge(nbins + 1);
+
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i", hist->GetName(), iter),
+                         Form("hconst_%s_%i", hist->GetName(), iter),
+                         nbins,
+                         lowedge,
+                         highedge);
+  for (Int_t i = 0; i <= hzero->GetNbinsX(); i++) {
+    hzero->SetBinContent(i, theConst);
+    hzero->SetBinError(i, 0.);
   }
   hzero->SetLineWidth(2);
   hzero->SetLineStyle(9);
   hzero->SetLineColor(kMagenta);
-  
+
   return hzero;
 }
-
 
 /*! \fn DrawConstant
  *  \brief utility function to draw a constant histogram with erros !=0
  */
 
 /*--------------------------------------------------------------------*/
-TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst)
+TH1F *DrawConstantWithErr(TH1F *hist, Int_t iter, Double_t theConst)
 /*--------------------------------------------------------------------*/
-{ 
+{
+  Int_t nbins = hist->GetNbinsX();
+  Double_t lowedge = hist->GetBinLowEdge(1);
+  Double_t highedge = hist->GetBinLowEdge(nbins + 1);
 
-  Int_t nbins       = hist->GetNbinsX();
-  Double_t lowedge  = hist->GetBinLowEdge(1);
-  Double_t highedge = hist->GetBinLowEdge(nbins+1);
-
-
-  TH1F *hzero = new TH1F(Form("hconst_%s_%i",hist->GetName(),iter),Form("hconst_%s_%i",hist->GetName(),iter),nbins,lowedge,highedge);
-  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
-    hzero->SetBinContent(i,theConst);
-    hzero->SetBinError(i,hist->GetBinError(i));
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i", hist->GetName(), iter),
+                         Form("hconst_%s_%i", hist->GetName(), iter),
+                         nbins,
+                         lowedge,
+                         highedge);
+  for (Int_t i = 0; i <= hzero->GetNbinsX(); i++) {
+    hzero->SetBinContent(i, theConst);
+    hzero->SetBinError(i, hist->GetBinError(i));
   }
   hzero->SetLineWidth(2);
   hzero->SetLineStyle(9);
   hzero->SetLineColor(kMagenta);
-  
+
   return hzero;
 }
 
@@ -2311,25 +2374,28 @@ TH1F* DrawConstantWithErr(TH1F *hist,Int_t iter,Double_t theConst)
  */
 
 /*--------------------------------------------------------------------*/
-TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst)
+TH1F *DrawConstantGraph(TGraph *graph, Int_t iter, Double_t theConst)
 /*--------------------------------------------------------------------*/
-{ 
- 
-  Double_t xmin = graph->GetXaxis()->GetXmin(); //TMath::MinElement(graph->GetN(),graph->GetX());
-  Double_t xmax = graph->GetXaxis()->GetXmax(); //TMath::MaxElement(graph->GetN(),graph->GetX()); 
+{
+  Double_t xmin = graph->GetXaxis()->GetXmin();  //TMath::MinElement(graph->GetN(),graph->GetX());
+  Double_t xmax = graph->GetXaxis()->GetXmax();  //TMath::MaxElement(graph->GetN(),graph->GetX());
 
   //std::cout<<xmin<<" : "<<xmax<<std::endl;
 
-  TH1F *hzero = new TH1F(Form("hconst_%s_%i",graph->GetName(),iter),Form("hconst_%s_%i",graph->GetName(),iter),graph->GetN(),xmin,xmax);
-  for (Int_t i=0;i<=hzero->GetNbinsX();i++){
-    hzero->SetBinContent(i,theConst);
-    hzero->SetBinError(i,0.);
+  TH1F *hzero = new TH1F(Form("hconst_%s_%i", graph->GetName(), iter),
+                         Form("hconst_%s_%i", graph->GetName(), iter),
+                         graph->GetN(),
+                         xmin,
+                         xmax);
+  for (Int_t i = 0; i <= hzero->GetNbinsX(); i++) {
+    hzero->SetBinContent(i, theConst);
+    hzero->SetBinError(i, 0.);
   }
-  
+
   hzero->SetLineWidth(2);
   hzero->SetLineStyle(9);
   hzero->SetLineColor(kMagenta);
-  
+
   return hzero;
 }
 
@@ -2338,26 +2404,25 @@ TH1F* DrawConstantGraph(TGraph *graph,Int_t iter,Double_t theConst)
  */
 
 /*--------------------------------------------------------------------*/
-unrolledHisto getUnrolledHisto(TH1F* hist)
+unrolledHisto getUnrolledHisto(TH1F *hist)
 /*--------------------------------------------------------------------*/
 {
-  
   /*
     Double_t y_min = hist->GetBinLowEdge(1);
     Double_t y_max = hist->GetBinLowEdge(hist->GetNbinsX()+1);
-  */    
+  */
 
   Double_t y_min = -0.1;
   Double_t y_max = 0.1;
 
   std::vector<Double_t> contents;
   for (int j = 0; j < hist->GetNbinsX(); j++) {
-    if(std::abs(hist->GetXaxis()->GetBinCenter(j))<=0.1) contents.push_back(hist->GetBinContent(j+1));
+    if (std::abs(hist->GetXaxis()->GetBinCenter(j)) <= 0.1)
+      contents.push_back(hist->GetBinContent(j + 1));
   }
-  
-  auto ret = unrolledHisto(y_min,y_max,contents.size(),contents);
-  return ret;
 
+  auto ret = unrolledHisto(y_min, y_max, contents.size(), contents);
+  return ret;
 }
 
 /*! \fn getBiases
@@ -2365,47 +2430,47 @@ unrolledHisto getUnrolledHisto(TH1F* hist)
  */
 
 /*--------------------------------------------------------------------*/
-pv::biases getBiases(TH1F* hist)
+pv::biases getBiases(TH1F *hist)
 /*--------------------------------------------------------------------*/
 {
   int nbins = hist->GetNbinsX();
 
   //extract median from histogram
-  double *y   = new double[nbins];
+  double *y = new double[nbins];
   double *err = new double[nbins];
 
   // remember for weight means <x> = sum_i (x_i* w_i) / sum_i w_i ; where w_i = 1/sigma^2_i
 
   for (int j = 0; j < nbins; j++) {
-    y[j]   = hist->GetBinContent(j+1);
-    if(hist->GetBinError(j+1)!=0.){
-      err[j] = 1./(hist->GetBinError(j+1)*hist->GetBinError(j+1));
+    y[j] = hist->GetBinContent(j + 1);
+    if (hist->GetBinError(j + 1) != 0.) {
+      err[j] = 1. / (hist->GetBinError(j + 1) * hist->GetBinError(j + 1));
     } else {
       err[j] = 0.;
     }
   }
 
-  Double_t w_mean = TMath::Mean(nbins,y,err);
-  Double_t w_rms  = TMath::RMS(nbins,y,err);
+  Double_t w_mean = TMath::Mean(nbins, y, err);
+  Double_t w_rms = TMath::RMS(nbins, y, err);
 
-  Double_t mean = TMath::Mean(nbins,y);
-  Double_t rms  = TMath::RMS(nbins,y);
+  Double_t mean = TMath::Mean(nbins, y);
+  Double_t rms = TMath::RMS(nbins, y);
 
-  Double_t max =hist->GetMaximum();
-  Double_t min =hist->GetMinimum();
-  
+  Double_t max = hist->GetMaximum();
+  Double_t min = hist->GetMinimum();
+
   // in case one would like to use a pol0 fit
-  hist->Fit("pol0","Q0+");
-  TF1* f = (TF1*)hist->FindObject("pol0");
+  hist->Fit("pol0", "Q0+");
+  TF1 *f = (TF1 *)hist->FindObject("pol0");
   //f->SetLineColor(hist->GetLineColor());
   //f->SetLineStyle(hist->GetLineStyle());
   Double_t chi2 = f->GetChisquare();
-  Int_t    ndf  = f->GetNDF();
+  Int_t ndf = f->GetNDF();
 
-  TH1F* theZero = DrawConstantWithErr(hist,1,1.);
-  TH1F* displaced = (TH1F*)hist->Clone("displaced");
+  TH1F *theZero = DrawConstantWithErr(hist, 1, 1.);
+  TH1F *displaced = (TH1F *)hist->Clone("displaced");
   displaced->Add(theZero);
-  Double_t ksScore   = std::max(-20.,TMath::Log10(displaced->KolmogorovTest(theZero)));
+  Double_t ksScore = std::max(-20., TMath::Log10(displaced->KolmogorovTest(theZero)));
   Double_t chi2Score = displaced->Chi2Test(theZero);
 
   /*
@@ -2415,12 +2480,11 @@ pv::biases getBiases(TH1F* hist)
     result = make_pair(resultBounds,mean);
   */
 
-  pv::biases result(mean,rms,w_mean,w_rms,min,max,chi2,ndf,ksScore);
+  pv::biases result(mean, rms, w_mean, w_rms, min, max, chi2, ndf, ksScore);
 
   delete theZero;
   delete displaced;
   return result;
-
 }
 
 /*! \fn beautify
@@ -2428,8 +2492,8 @@ pv::biases getBiases(TH1F* hist)
  */
 
 /*--------------------------------------------------------------------*/
-void beautify(TGraph *g){
-/*--------------------------------------------------------------------*/
+void beautify(TGraph *g) {
+  /*--------------------------------------------------------------------*/
   g->GetXaxis()->SetLabelFont(42);
   g->GetYaxis()->SetLabelFont(42);
   g->GetYaxis()->SetLabelSize(.055);
@@ -2450,8 +2514,8 @@ void beautify(TGraph *g){
  */
 
 /*--------------------------------------------------------------------*/
-void beautify(TH1 *h){
-/*--------------------------------------------------------------------*/
+void beautify(TH1 *h) {
+  /*--------------------------------------------------------------------*/
   h->SetMinimum(0.);
   h->GetXaxis()->SetLabelFont(42);
   h->GetYaxis()->SetLabelFont(42);
@@ -2473,8 +2537,8 @@ void beautify(TH1 *h){
  */
 
 /*--------------------------------------------------------------------*/
-void adjustmargins(TCanvas *canv){
-/*--------------------------------------------------------------------*/
+void adjustmargins(TCanvas *canv) {
+  /*--------------------------------------------------------------------*/
   canv->cd()->SetBottomMargin(0.14);
   canv->cd()->SetLeftMargin(0.07);
   canv->cd()->SetRightMargin(0.03);
@@ -2486,26 +2550,25 @@ void adjustmargins(TCanvas *canv){
  */
 
 /*--------------------------------------------------------------------*/
-void adjustmargins(TVirtualPad *canv){
-/*--------------------------------------------------------------------*/
+void adjustmargins(TVirtualPad *canv) {
+  /*--------------------------------------------------------------------*/
   canv->SetBottomMargin(0.12);
   canv->SetLeftMargin(0.07);
   canv->SetRightMargin(0.01);
   canv->SetTopMargin(0.02);
 }
 
-
 /*! \fn checkTH1AndReturn
  *  \brief utility function to check if a TH1 exists in a TFile before returning it
  */
 
 /*--------------------------------------------------------------------*/
-TH1F* checkTH1AndReturn(TFile *f,TString address){
-/*--------------------------------------------------------------------*/
-  TH1F* h = NULL; 
-  if(f->GetListOfKeys()->Contains(address)){
-    h = (TH1F*)f->Get(address);
-  } 
+TH1F *checkTH1AndReturn(TFile *f, TString address) {
+  /*--------------------------------------------------------------------*/
+  TH1F *h = NULL;
+  if (f->GetListOfKeys()->Contains(address)) {
+    h = (TH1F *)f->Get(address);
+  }
   return h;
 }
 
@@ -2514,53 +2577,51 @@ TH1F* checkTH1AndReturn(TFile *f,TString address){
  */
 
 /*--------------------------------------------------------------------*/
-pv::view checkTheView(const TString &toCheck){
-/*--------------------------------------------------------------------*/
-  if (toCheck.Contains("dxy")){
-    if (toCheck.Contains("phi") || toCheck.Contains("ladder")){
+pv::view checkTheView(const TString &toCheck) {
+  /*--------------------------------------------------------------------*/
+  if (toCheck.Contains("dxy")) {
+    if (toCheck.Contains("phi") || toCheck.Contains("ladder")) {
       return pv::dxyphi;
-    } else if (toCheck.Contains("eta") || toCheck.Contains("modZ")){
+    } else if (toCheck.Contains("eta") || toCheck.Contains("modZ")) {
       return pv::dxyeta;
     } else {
       return pv::pT;
     }
-  } else if (toCheck.Contains("dz")){
-    if (toCheck.Contains("phi") || toCheck.Contains("ladder")){
+  } else if (toCheck.Contains("dz")) {
+    if (toCheck.Contains("phi") || toCheck.Contains("ladder")) {
       return pv::dzphi;
-    } else if (toCheck.Contains("eta") || toCheck.Contains("modZ")){
+    } else if (toCheck.Contains("eta") || toCheck.Contains("modZ")) {
       return pv::dzeta;
     } else {
       return pv::pT;
     }
   } else {
-    return pv::generic;	
-  } 
+    return pv::generic;
+  }
 }
-
 
 /*! \fn timify
  *  \brief utility function to make a histogram x-axis of the time type
  */
 
 /*--------------------------------------------------------------------*/
-template<typename T>
+template <typename T>
 void timify(T *mgr)
 /*--------------------------------------------------------------------*/
 {
   mgr->GetXaxis()->SetTimeDisplay(1);
   mgr->GetXaxis()->SetNdivisions(510);
   mgr->GetXaxis()->SetTimeFormat("%Y-%m-%d");
-  mgr->GetXaxis()->SetTimeOffset(0,"gmt");
+  mgr->GetXaxis()->SetTimeOffset(0, "gmt");
   mgr->GetXaxis()->SetLabelSize(.035);
 }
 
-
-struct increase
-{
-    template<class T>
-    bool operator()(T const &a, T const &b) const { return a > b; }
+struct increase {
+  template <class T>
+  bool operator()(T const &a, T const &b) const {
+    return a > b;
+  }
 };
-
 
 /*! \fn getMaximumFromArray
  *  \brief utility function to extract the maximum out of an array of histograms
@@ -2570,25 +2631,25 @@ struct increase
 Double_t getMaximumFromArray(TObjArray *array)
 /*--------------------------------------------------------------------*/
 {
+  Double_t theMaximum = -999.;  //(static_cast<TH1*>(array->At(0)))->GetMaximum();
 
-  Double_t theMaximum = -999.; //(static_cast<TH1*>(array->At(0)))->GetMaximum();
-
-  for(Int_t i = 0; i< array->GetSize(); i++){
-    
+  for (Int_t i = 0; i < array->GetSize(); i++) {
     double theMaxForThisHist;
-    auto hist = static_cast<TH1*>(array->At(i));
+    auto hist = static_cast<TH1 *>(array->At(i));
     std::vector<double> maxima;
-    for (int j=0;j<hist->GetNbinsX();j++) maxima.push_back(hist->GetBinContent(j));
-    std::sort(std::begin(maxima), std::end(maxima));//,increase());
-    double rms_maxima  = TMath::RMS(hist->GetNbinsX(),&(maxima[0]));
-    double mean_maxima = TMath::Mean(hist->GetNbinsX(),&(maxima[0]));
+    for (int j = 0; j < hist->GetNbinsX(); j++)
+      maxima.push_back(hist->GetBinContent(j));
+    std::sort(std::begin(maxima), std::end(maxima));  //,increase());
+    double rms_maxima = TMath::RMS(hist->GetNbinsX(), &(maxima[0]));
+    double mean_maxima = TMath::Mean(hist->GetNbinsX(), &(maxima[0]));
 
     const Int_t nq = 100;
     Double_t xq[nq];  // position where to compute the quantiles in [0,1]
     Double_t yq[nq];  // array to contain the quantiles
-    for (Int_t i=0;i<nq;i++) xq[i] = 0.9+(Float_t(i+1)/nq)*0.10;
-    TMath::Quantiles(maxima.size(),nq,&(maxima[0]),yq, xq);
-    
+    for (Int_t i = 0; i < nq; i++)
+      xq[i] = 0.9 + (Float_t(i + 1) / nq) * 0.10;
+    TMath::Quantiles(maxima.size(), nq, &(maxima[0]), yq, xq);
+
     //for(int q=0;q<nq;q++){
     //  std::cout<<q<<" "<<xq[q]<<" "<<yq[q]<<std::endl;
     //}
@@ -2598,13 +2659,15 @@ Double_t getMaximumFromArray(TObjArray *array)
     //	theMaxForThisHist=element;
     //	break;
     //  }
-    //} 
+    //}
 
-    theMaxForThisHist=yq[80];
+    theMaxForThisHist = yq[80];
 
-    std::cout<<"rms_maxima["<<i<<"]"<<rms_maxima<<" mean maxima["<<mean_maxima<<"] purged maximum:"<<theMaxForThisHist<<std::endl;
+    std::cout << "rms_maxima[" << i << "]" << rms_maxima << " mean maxima[" << mean_maxima
+              << "] purged maximum:" << theMaxForThisHist << std::endl;
 
-    if(theMaxForThisHist>theMaximum) theMaximum=theMaxForThisHist;
+    if (theMaxForThisHist > theMaximum)
+      theMaximum = theMaxForThisHist;
 
     /*
     if( (static_cast<TH1*>(array->At(i)))->GetMaximum() > theMaximum){
@@ -2612,7 +2675,6 @@ Double_t getMaximumFromArray(TObjArray *array)
       //cout<<"i= "<<i<<" theMaximum="<<theMaximum<<endl;
     }
     */
-
   }
 
   return theMaximum;
@@ -2623,20 +2685,24 @@ Double_t getMaximumFromArray(TObjArray *array)
  */
 
 /*--------------------------------------------------------------------*/
-void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_format,const std::map<int,double> &lumiMapByRun,const std::map<int,TDatime>& timeMap,bool drawText)
+void superImposeIOVBoundaries(TCanvas *c,
+                              bool lumi_axis_format,
+                              bool time_axis_format,
+                              const std::map<int, double> &lumiMapByRun,
+                              const std::map<int, TDatime> &timeMap,
+                              bool drawText)
 /*--------------------------------------------------------------------*/
 {
-
   // get the vector of runs in the lumiMap
   std::vector<int> vruns;
-  for(auto const& imap: lumiMapByRun){
+  for (auto const &imap : lumiMapByRun) {
     vruns.push_back(imap.first);
     //std::cout<<" run:" << imap.first << " lumi: "<< imap.second << std::endl;
   }
 
   //std::vector<vint> truns;
-  for(auto const& imap: timeMap){
-    std::cout<<" run:" << imap.first << " time: "<< imap.second.Convert() << std::endl;
+  for (auto const &imap : timeMap) {
+    std::cout << " run:" << imap.first << " time: " << imap.second.Convert() << std::endl;
   }
 
   /* Run-2 Ultra-Legacy ReReco IOVs (from tag SiPixelTemplateDBObject_38T_v16_offline)
@@ -2671,56 +2737,110 @@ void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_fo
      29     324245   2018-10-08   6caa50b30aa80ede330585888cdc5e804853d1da  SiPixelTemplateDBObject
   */
 
-  static const int nIOVs=29 ; //   1       2       3       4       5       6       7       8       9      10      11      12      13      14      15
-  int IOVboundaries[nIOVs] = {271866, 276315, 278271, 280928, 290543, 297281, 298653, 299443, 300389, 301046, 302131, 303790, 303998, 304911, 313041,
-			      //  16      17      18      19      20      21      22      23      24      25      26      27      28      29
-			      314881, 316758, 317475, 317485, 317527, 317661, 317664, 318227, 320377, 321831, 322510, 322603, 323232, 324245};
+  static const int nIOVs =
+      29;  //   1       2       3       4       5       6       7       8       9      10      11      12      13      14      15
+  int IOVboundaries[nIOVs] = {
+      271866,
+      276315,
+      278271,
+      280928,
+      290543,
+      297281,
+      298653,
+      299443,
+      300389,
+      301046,
+      302131,
+      303790,
+      303998,
+      304911,
+      313041,
+      //  16      17      18      19      20      21      22      23      24      25      26      27      28      29
+      314881,
+      316758,
+      317475,
+      317485,
+      317527,
+      317661,
+      317664,
+      318227,
+      320377,
+      321831,
+      322510,
+      322603,
+      323232,
+      324245};
 
-  int benchmarkruns[nIOVs] = {271866, 276315, 278271, 280928, 290543, 297281, 298653, 299443, 300389, 301046, 302131, 303790, 303998, 304911, 313041,
-			      314881, 316758, 317475, 317485, 317527, 317661, 317664, 318227, 320377, 321831, 322510, 322603, 323232, 324245};
+  int benchmarkruns[nIOVs] = {271866, 276315, 278271, 280928, 290543, 297281, 298653, 299443, 300389, 301046,
+                              302131, 303790, 303998, 304911, 313041, 314881, 316758, 317475, 317485, 317527,
+                              317661, 317664, 318227, 320377, 321831, 322510, 322603, 323232, 324245};
 
+  std::string dates[nIOVs] = {"2016-04-28", "2016-07-04", "2016-08-05", "2016-09-16", "2017-03-30", "2017-06-22",
+                              "2017-07-09", "2017-07-19", "2017-08-03", "2017-08-12", "2017-08-31", "2017-09-23",
+                              "2017-09-27", "2017-10-13", "2018-03-28", "2018-04-22", "2018-05-22", "2018-06-05",
+                              "2018-06-05", "2018-06-06", "2018-06-10", "2018-06-11", "2018-06-21", "2018-07-26",
+                              "2018-08-27", "2018-09-09", "2018-09-09", "2018-09-21", "2018-10-08"};
 
-  std::string dates[nIOVs] = { "2016-04-28", "2016-07-04", "2016-08-05", "2016-09-16", "2017-03-30", "2017-06-22", "2017-07-09", "2017-07-19", "2017-08-03", "2017-08-12", "2017-08-31", "2017-09-23",
-			       "2017-09-27", "2017-10-13", "2018-03-28", "2018-04-22", "2018-05-22", "2018-06-05", "2018-06-05", "2018-06-06", "2018-06-10", "2018-06-11", "2018-06-21", "2018-07-26",
-			       "2018-08-27", "2018-09-09", "2018-09-09", "2018-09-21", "2018-10-08"};
-
-  TArrow* IOV_lines[nIOVs];
+  TArrow *IOV_lines[nIOVs];
   c->cd();
   c->Update();
 
-  TArrow* a_lines[nIOVs];
-  TArrow* b_lines[nIOVs];
-  for(Int_t IOV=0;IOV<nIOVs;IOV++){
-
+  TArrow *a_lines[nIOVs];
+  TArrow *b_lines[nIOVs];
+  for (Int_t IOV = 0; IOV < nIOVs; IOV++) {
     // check we are not in the RMS histogram to avoid first line
-    if(IOVboundaries[IOV]<vruns.front() ) continue;
+    if (IOVboundaries[IOV] < vruns.front())
+      continue;
     //&& ((TString)c->GetName()).Contains("RMS")) continue;
-    int closestrun = pv::closest(vruns,IOVboundaries[IOV]); 
-    int closestbenchmark = pv::closest(vruns,benchmarkruns[IOV]);
+    int closestrun = pv::closest(vruns, IOVboundaries[IOV]);
+    int closestbenchmark = pv::closest(vruns, benchmarkruns[IOV]);
 
-    if(lumi_axis_format){
-
-      if(closestrun<0) continue;
+    if (lumi_axis_format) {
+      if (closestrun < 0)
+        continue;
       //std::cout<< "natural boundary: " << IOVboundaries[IOV] << " closest:" << closestrun << std::endl;
 
-      a_lines[IOV] = new TArrow(lumiMapByRun.at(closestrun),(c->GetUymin()),lumiMapByRun.at(closestrun),c->GetUymax(),0.5,"|>");
+      a_lines[IOV] = new TArrow(
+          lumiMapByRun.at(closestrun), (c->GetUymin()), lumiMapByRun.at(closestrun), c->GetUymax(), 0.5, "|>");
 
-      if(closestbenchmark<0) continue;
-      b_lines[IOV] = new TArrow(lumiMapByRun.at(closestbenchmark),(c->GetUymin()),lumiMapByRun.at(closestbenchmark),c->GetUymax(),0.5,"|>");
+      if (closestbenchmark < 0)
+        continue;
+      b_lines[IOV] = new TArrow(lumiMapByRun.at(closestbenchmark),
+                                (c->GetUymin()),
+                                lumiMapByRun.at(closestbenchmark),
+                                c->GetUymax(),
+                                0.5,
+                                "|>");
 
-    } else if(time_axis_format){
-      
-      if(closestrun<0) continue;
-      std::cout<< "natural boundary: " << IOVboundaries[IOV] << " closest:" << closestrun << std::endl;
-      a_lines[IOV] = new TArrow(timeMap.at(closestrun).Convert(),(c->GetUymin()),timeMap.at(closestrun).Convert(),c->GetUymax(),0.5,"|>");
+    } else if (time_axis_format) {
+      if (closestrun < 0)
+        continue;
+      std::cout << "natural boundary: " << IOVboundaries[IOV] << " closest:" << closestrun << std::endl;
+      a_lines[IOV] = new TArrow(
+          timeMap.at(closestrun).Convert(), (c->GetUymin()), timeMap.at(closestrun).Convert(), c->GetUymax(), 0.5, "|>");
 
-      if(closestbenchmark<0) continue;
-      b_lines[IOV] = new TArrow(timeMap.at(closestbenchmark).Convert(),(c->GetUymin()),timeMap.at(closestbenchmark).Convert(),c->GetUymax(),0.5,"|>");
+      if (closestbenchmark < 0)
+        continue;
+      b_lines[IOV] = new TArrow(timeMap.at(closestbenchmark).Convert(),
+                                (c->GetUymin()),
+                                timeMap.at(closestbenchmark).Convert(),
+                                c->GetUymax(),
+                                0.5,
+                                "|>");
 
     } else {
-      a_lines[IOV] = new TArrow(IOVboundaries[IOV],(c->GetUymin()),IOVboundaries[IOV],0.65*c->GetUymax(),0.5,"|>"); //(c->GetUymin()+0.2*(c->GetUymax()-c->GetUymin()) ),0.5,"|>");
-      b_lines[IOV] = new TArrow(benchmarkruns[IOV],(c->GetUymin()),benchmarkruns[IOV],0.65*c->GetUymax(),0.5,"|>"); //(c->GetUymin()+0.2*(c->GetUymax()-c->GetUymin()) ),0.5,"|>");
-      
+      a_lines[IOV] = new TArrow(IOVboundaries[IOV],
+                                (c->GetUymin()),
+                                IOVboundaries[IOV],
+                                0.65 * c->GetUymax(),
+                                0.5,
+                                "|>");  //(c->GetUymin()+0.2*(c->GetUymax()-c->GetUymin()) ),0.5,"|>");
+      b_lines[IOV] = new TArrow(benchmarkruns[IOV],
+                                (c->GetUymin()),
+                                benchmarkruns[IOV],
+                                0.65 * c->GetUymax(),
+                                0.5,
+                                "|>");  //(c->GetUymin()+0.2*(c->GetUymax()-c->GetUymin()) ),0.5,"|>");
     }
     a_lines[IOV]->SetLineColor(kBlue);
     a_lines[IOV]->SetLineStyle(9);
@@ -2731,55 +2851,56 @@ void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_fo
     b_lines[IOV]->SetLineStyle(1);
     b_lines[IOV]->SetLineWidth(2);
     //b_lines[IOV]->Draw("same");
-
   }
 
-  TPaveText* runnumbers[nIOVs];
-  
-  for(Int_t IOV=0;IOV<nIOVs;IOV++){
+  TPaveText *runnumbers[nIOVs];
 
-    if(IOVboundaries[IOV]<vruns.front()) continue;
+  for (Int_t IOV = 0; IOV < nIOVs; IOV++) {
+    if (IOVboundaries[IOV] < vruns.front())
+      continue;
     //&& ((TString)c->GetName()).Contains("RMS")) continue;
-    int closestrun = pv::closest(vruns,IOVboundaries[IOV]);
-    
+    int closestrun = pv::closest(vruns, IOVboundaries[IOV]);
+
     Int_t ix1;
     Int_t ix2;
     Int_t iw = gPad->GetWw();
     Int_t ih = gPad->GetWh();
-    Double_t x1p,y1p,x2p,y2p;
-    gPad->GetPadPar(x1p,y1p,x2p,y2p);
-    ix1 = (Int_t)(iw*x1p);
-    ix2 = (Int_t)(iw*x2p);
-    Double_t wndc  = TMath::Min(1.,(Double_t)iw/(Double_t)ih);
-    Double_t rw    = wndc/(Double_t)iw;
-    Double_t x1ndc = (Double_t)ix1*rw;
-    Double_t x2ndc = (Double_t)ix2*rw;
-    Double_t rx1,ry1,rx2,ry2;
-    gPad->GetRange(rx1,ry1,rx2,ry2);
-    Double_t rx = (x2ndc-x1ndc)/(rx2-rx1);
+    Double_t x1p, y1p, x2p, y2p;
+    gPad->GetPadPar(x1p, y1p, x2p, y2p);
+    ix1 = (Int_t)(iw * x1p);
+    ix2 = (Int_t)(iw * x2p);
+    Double_t wndc = TMath::Min(1., (Double_t)iw / (Double_t)ih);
+    Double_t rw = wndc / (Double_t)iw;
+    Double_t x1ndc = (Double_t)ix1 * rw;
+    Double_t x2ndc = (Double_t)ix2 * rw;
+    Double_t rx1, ry1, rx2, ry2;
+    gPad->GetRange(rx1, ry1, rx2, ry2);
+    Double_t rx = (x2ndc - x1ndc) / (rx2 - rx1);
     Double_t _sx;
-    if(lumi_axis_format){
-      if(closestrun<0) break; 
-      _sx = rx*(lumiMapByRun.at(closestrun)-rx1)+x1ndc; //-0.05;
-    } else if(time_axis_format){
-      if(closestrun<0) break; 
-      _sx = rx*(timeMap.at(closestrun).Convert()-rx1)+x1ndc; //-0.05;
+    if (lumi_axis_format) {
+      if (closestrun < 0)
+        break;
+      _sx = rx * (lumiMapByRun.at(closestrun) - rx1) + x1ndc;  //-0.05;
+    } else if (time_axis_format) {
+      if (closestrun < 0)
+        break;
+      _sx = rx * (timeMap.at(closestrun).Convert() - rx1) + x1ndc;  //-0.05;
     } else {
-      _sx = rx*(IOVboundaries[IOV]-rx1)+x1ndc; //-0.05
+      _sx = rx * (IOVboundaries[IOV] - rx1) + x1ndc;  //-0.05
     }
-    Double_t _dx = _sx+0.05;
-    
-    Int_t index = IOV%5;
-    // if(IOV<5) 
+    Double_t _dx = _sx + 0.05;
+
+    Int_t index = IOV % 5;
+    // if(IOV<5)
     //   index=IOV;
     // else{
     //   index=IOV-5;
     // }
-    
+
     //runnumbers[IOV] = new TPaveText(_sx+0.001,0.14+(0.03*index),_dx,(0.17+0.03*index),"blNDC");
-    runnumbers[IOV] = new TPaveText(_sx+0.001,0.89-(0.05*index),_dx+0.024,(0.92-0.05*index),"blNDC");
+    runnumbers[IOV] = new TPaveText(_sx + 0.001, 0.89 - (0.05 * index), _dx + 0.024, (0.92 - 0.05 * index), "blNDC");
     //runnumbers[IOV]->SetTextAlign(11);
-    TText *textRun = runnumbers[IOV]->AddText(Form("%i",int(IOVboundaries[IOV])));
+    TText *textRun = runnumbers[IOV]->AddText(Form("%i", int(IOVboundaries[IOV])));
     //TText *textRun = runnumbers[IOV]->AddText(Form("%s",dates[IOV].c_str()));
     textRun->SetTextSize(0.038);
     textRun->SetTextColor(kBlue);
@@ -2789,159 +2910,162 @@ void superImposeIOVBoundaries(TCanvas *c,bool lumi_axis_format,bool time_axis_fo
     runnumbers[IOV]->SetLineWidth(1);
     runnumbers[IOV]->SetTextColor(kBlue);
     runnumbers[IOV]->SetTextFont(42);
-    if(drawText) runnumbers[IOV]->Draw("same");
+    if (drawText)
+      runnumbers[IOV]->Draw("same");
   }
 }
-
 
 /*! \fn processData
  *  \brief function where the magic happens, take the raw inputs and creates the output trends
  */
 
 /*--------------------------------------------------------------------*/
-outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDirs_,const char* dirs[10], TString LegLabels[10],bool useRMS)
+outTrends processData(size_t iter,
+                      std::vector<int> intersection,
+                      const Int_t nDirs_,
+                      const char *dirs[10],
+                      TString LegLabels[10],
+                      bool useRMS)
 /*--------------------------------------------------------------------*/
 {
-
   outTrends ret;
   ret.init();
 
-  unsigned int effSize = std::min(nWorkers,intersection.size());
+  unsigned int effSize = std::min(nWorkers, intersection.size());
 
-  unsigned int pitch = std::floor(intersection.size()/effSize);
-  unsigned int first = iter*pitch;
-  unsigned int last  = (iter==(effSize-1) ) ? intersection.size() : ((iter+1)*pitch);
+  unsigned int pitch = std::floor(intersection.size() / effSize);
+  unsigned int first = iter * pitch;
+  unsigned int last = (iter == (effSize - 1)) ? intersection.size() : ((iter + 1) * pitch);
 
-  std::cout<< "iter:" << iter << "| pitch: " << pitch<< " ["<< first << "-"<< last << ")" << std::endl;
+  std::cout << "iter:" << iter << "| pitch: " << pitch << " [" << first << "-" << last << ")" << std::endl;
 
-  ret.m_index=iter;
+  ret.m_index = iter;
 
-  for(unsigned int n=first; n<last;n++){
+  for (unsigned int n = first; n < last; n++) {
     //in case of debug, use only 50
     //for(unsigned int n=0; n<50;n++){
-    
-    //if(intersection.at(n)!=283946) 
+
+    //if(intersection.at(n)!=283946)
     //  continue;
 
-    std::cout << "iter: " << iter << " " << n << " "<<intersection.at(n) << std::endl;
-    
+    std::cout << "iter: " << iter << " " << n << " " << intersection.at(n) << std::endl;
+
     TFile *fins[nDirs_];
 
-    TH1F* dxyPhiMeanTrend[nDirs_];  
-    TH1F* dxyPhiWidthTrend[nDirs_]; 
-    TH1F* dzPhiMeanTrend[nDirs_];   
-    TH1F* dzPhiWidthTrend[nDirs_];  
+    TH1F *dxyPhiMeanTrend[nDirs_];
+    TH1F *dxyPhiWidthTrend[nDirs_];
+    TH1F *dzPhiMeanTrend[nDirs_];
+    TH1F *dzPhiWidthTrend[nDirs_];
 
-    TH1F* dxyLadderMeanTrend[nDirs_];    
-    TH1F* dxyLadderWidthTrend[nDirs_]; 
-    TH1F* dzLadderWidthTrend[nDirs_];  
-    TH1F* dzLadderMeanTrend[nDirs_];  
+    TH1F *dxyLadderMeanTrend[nDirs_];
+    TH1F *dxyLadderWidthTrend[nDirs_];
+    TH1F *dzLadderWidthTrend[nDirs_];
+    TH1F *dzLadderMeanTrend[nDirs_];
 
-    TH1F* dxyModZMeanTrend[nDirs_];  
-    TH1F* dxyModZWidthTrend[nDirs_]; 
-    TH1F* dzModZMeanTrend[nDirs_];   
-    TH1F* dzModZWidthTrend[nDirs_];  
+    TH1F *dxyModZMeanTrend[nDirs_];
+    TH1F *dxyModZWidthTrend[nDirs_];
+    TH1F *dzModZMeanTrend[nDirs_];
+    TH1F *dzModZWidthTrend[nDirs_];
 
-    TH1F* dxyEtaMeanTrend[nDirs_];  
-    TH1F* dxyEtaWidthTrend[nDirs_]; 
-    TH1F* dzEtaMeanTrend[nDirs_];   
-    TH1F* dzEtaWidthTrend[nDirs_];  
-    
-    TH1F* dxyNormPhiWidthTrend[nDirs_]; 
-    TH1F* dxyNormEtaWidthTrend[nDirs_]; 
-    TH1F* dzNormPhiWidthTrend[nDirs_]; 
-    TH1F* dzNormEtaWidthTrend[nDirs_]; 
+    TH1F *dxyEtaMeanTrend[nDirs_];
+    TH1F *dxyEtaWidthTrend[nDirs_];
+    TH1F *dzEtaMeanTrend[nDirs_];
+    TH1F *dzEtaWidthTrend[nDirs_];
 
-    TH1F* dxyNormPtWidthTrend[nDirs_];     
-    TH1F* dzNormPtWidthTrend[nDirs_];      
-    TH1F* dxyPtWidthTrend[nDirs_];
-    TH1F* dzPtWidthTrend[nDirs_]; 
-        
-    TH1F* dxyIntegralTrend[nDirs_];
-    TH1F* dzIntegralTrend[nDirs_];
+    TH1F *dxyNormPhiWidthTrend[nDirs_];
+    TH1F *dxyNormEtaWidthTrend[nDirs_];
+    TH1F *dzNormPhiWidthTrend[nDirs_];
+    TH1F *dzNormEtaWidthTrend[nDirs_];
+
+    TH1F *dxyNormPtWidthTrend[nDirs_];
+    TH1F *dzNormPtWidthTrend[nDirs_];
+    TH1F *dxyPtWidthTrend[nDirs_];
+    TH1F *dzPtWidthTrend[nDirs_];
+
+    TH1F *dxyIntegralTrend[nDirs_];
+    TH1F *dzIntegralTrend[nDirs_];
 
     bool areAllFilesOK = true;
     Int_t lastOpen = 0;
- 
-    // loop over the objects
-    for(Int_t j=0; j < nDirs_; j++) {
 
+    // loop over the objects
+    for (Int_t j = 0; j < nDirs_; j++) {
       //fins[j] = TFile::Open(Form("%s/PVValidation_%s_%i.root",dirs[j],dirs[j],intersection[n]));
 
-      size_t position = std::string(dirs[j]).find("/");   
-      string stem = std::string(dirs[j]).substr(position+1);     // get from position to the end
-      
-      fins[j] = new TFile(Form("%s/PVValidation_%s_%i.root",dirs[j],stem.c_str(),intersection[n]));
-      if(fins[j]->IsZombie()){
-	std::cout<< Form("%s/PVValidation_%s_%i.root",dirs[j],stem.c_str(),intersection[n]) << " is a Zombie! cannot combine" << std::endl;
-	areAllFilesOK = false;
-	lastOpen=j;
-	break;
+      size_t position = std::string(dirs[j]).find("/");
+      string stem = std::string(dirs[j]).substr(position + 1);  // get from position to the end
+
+      fins[j] = new TFile(Form("%s/PVValidation_%s_%i.root", dirs[j], stem.c_str(), intersection[n]));
+      if (fins[j]->IsZombie()) {
+        std::cout << Form("%s/PVValidation_%s_%i.root", dirs[j], stem.c_str(), intersection[n])
+                  << " is a Zombie! cannot combine" << std::endl;
+        areAllFilesOK = false;
+        lastOpen = j;
+        break;
       }
 
-      std::cout<< Form("%s/PVValidation_%s_%i.root",dirs[j],stem.c_str(),intersection[n]) 
-	       << " has size: "<<fins[j]->GetSize() << " b ";
-      
+      std::cout << Form("%s/PVValidation_%s_%i.root", dirs[j], stem.c_str(), intersection[n])
+                << " has size: " << fins[j]->GetSize() << " b ";
+
       // sanity check
-      TH1F* h_tracks = (TH1F*)fins[j]->Get("PVValidation/EventFeatures/h_nTracks");
-      if(j==0){
-	TH1F* h_lumi   = (TH1F*)fins[j]->Get("PVValidation/EventFeatures/h_lumiFromConfig");
-	double lumi = h_lumi->GetBinContent(1);
-	ret.m_lumiSoFar+=lumi;
-	//std::cout<<"lumi: "<<lumi
-	//	 <<" ,lumi so far: "<<lumiSoFar<<std::endl;
+      TH1F *h_tracks = (TH1F *)fins[j]->Get("PVValidation/EventFeatures/h_nTracks");
+      if (j == 0) {
+        TH1F *h_lumi = (TH1F *)fins[j]->Get("PVValidation/EventFeatures/h_lumiFromConfig");
+        double lumi = h_lumi->GetBinContent(1);
+        ret.m_lumiSoFar += lumi;
+        //std::cout<<"lumi: "<<lumi
+        //	 <<" ,lumi so far: "<<lumiSoFar<<std::endl;
 
-	//outfile<<"run "<<intersection[n]<<" lumi: "<<lumi
-	//     <<" ,lumi so far: "<<lumiSoFar<<std::endl;
-
+        //outfile<<"run "<<intersection[n]<<" lumi: "<<lumi
+        //     <<" ,lumi so far: "<<lumiSoFar<<std::endl;
       }
 
       Double_t numEvents = h_tracks->GetEntries();
-      if(numEvents<2500){
-	std::cout<<"excluding " << intersection[n] << " because it has less than 2.5k events" << std::endl;
-	areAllFilesOK = false;
-	lastOpen=j;
-	break;
+      if (numEvents < 2500) {
+        std::cout << "excluding " << intersection[n] << " because it has less than 2.5k events" << std::endl;
+        areAllFilesOK = false;
+        lastOpen = j;
+        break;
       }
 
-      dxyPhiMeanTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_phi");
+      dxyPhiMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dxy_phi");
       //dxyPhiMeanTrend[j]     = checkTH1AndReturn(fins[j],"PVValidation/MeanTrends/means_dxy_phi");
-      dxyPhiWidthTrend[j]    = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_phi");
-      dzPhiMeanTrend[j]      = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_phi");
-      dzPhiWidthTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_phi");
-            
-      dxyLadderMeanTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_ladder");
-      dxyLadderWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_ladder");
-      dzLadderMeanTrend[j]   = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_ladder");
-      dzLadderWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_ladder");
-                              
-      dxyEtaMeanTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_eta");
-      dxyEtaWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_eta");
-      dzEtaMeanTrend[j]   = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_eta");
-      dzEtaWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_eta");
-      
-      dxyModZMeanTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dxy_modZ");
-      dxyModZWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_modZ");
-      dzModZMeanTrend[j]   = (TH1F*)fins[j]->Get("PVValidation/MeanTrends/means_dz_modZ");
-      dzModZWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_modZ");
-      
-      dxyNormPhiWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_phi");
-      dxyNormEtaWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_eta");
-      dzNormPhiWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_phi");
-      dzNormEtaWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_eta");
+      dxyPhiWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_phi");
+      dzPhiMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dz_phi");
+      dzPhiWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dz_phi");
 
-      dxyNormPtWidthTrend[j] = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_pTCentral");
-      dzNormPtWidthTrend[j]  = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_pTCentral");
-      dxyPtWidthTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_pTCentral");
-      dzPtWidthTrend[j]      = (TH1F*)fins[j]->Get("PVValidation/WidthTrends/widths_dz_pTCentral");
+      dxyLadderMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dxy_ladder");
+      dxyLadderWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_ladder");
+      dzLadderMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dz_ladder");
+      dzLadderWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dz_ladder");
 
-      dxyIntegralTrend[j]    = (TH1F*)fins[j]->Get("PVValidation/ProbeTrackFeatures/h_probedxyRefitV");
-      dzIntegralTrend[j]     = (TH1F*)fins[j]->Get("PVValidation/ProbeTrackFeatures/h_probedzRefitV");
+      dxyEtaMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dxy_eta");
+      dxyEtaWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_eta");
+      dzEtaMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dz_eta");
+      dzEtaWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dz_eta");
+
+      dxyModZMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dxy_modZ");
+      dxyModZWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_modZ");
+      dzModZMeanTrend[j] = (TH1F *)fins[j]->Get("PVValidation/MeanTrends/means_dz_modZ");
+      dzModZWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dz_modZ");
+
+      dxyNormPhiWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_phi");
+      dxyNormEtaWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_eta");
+      dzNormPhiWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_phi");
+      dzNormEtaWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_eta");
+
+      dxyNormPtWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dxy_pTCentral");
+      dzNormPtWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/norm_widths_dz_pTCentral");
+      dxyPtWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dxy_pTCentral");
+      dzPtWidthTrend[j] = (TH1F *)fins[j]->Get("PVValidation/WidthTrends/widths_dz_pTCentral");
+
+      dxyIntegralTrend[j] = (TH1F *)fins[j]->Get("PVValidation/ProbeTrackFeatures/h_probedxyRefitV");
+      dzIntegralTrend[j] = (TH1F *)fins[j]->Get("PVValidation/ProbeTrackFeatures/h_probedzRefitV");
 
       // fill the vectors of biases
-      
+
       auto dxyPhiBiases = getBiases(dxyPhiMeanTrend[j]);
-      
+
       //std::cout<<"\n" <<j<<" "<< LegLabels[j] << " dxy(phi) mean: "<< dxyPhiBiases.getWeightedMean()
       //       <<" dxy(phi) max: "<< dxyPhiBiases.getMax()
       //       <<" dxy(phi) min: "<< dxyPhiBiases.getMin()
@@ -2953,147 +3077,199 @@ outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDir
 
       //std::cout<<"\n" <<j<<" "<< LegLabels[j] << " dxy(phi) ks score: "<< dxyPhiBiases.getKSScore() << std::endl;
 
-      useRMS ? ret.m_dxyPhiLo[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean() - 2*dxyPhiBiases.getWeightedRMS()) : ret.m_dxyPhiLo[LegLabels[j]].push_back(dxyPhiBiases.getMin());
-      useRMS ? ret.m_dxyPhiHi[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean() + 2*dxyPhiBiases.getWeightedRMS()) : ret.m_dxyPhiHi[LegLabels[j]].push_back(dxyPhiBiases.getMax());
+      useRMS
+          ? ret.m_dxyPhiLo[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean() - 2 * dxyPhiBiases.getWeightedRMS())
+          : ret.m_dxyPhiLo[LegLabels[j]].push_back(dxyPhiBiases.getMin());
+      useRMS
+          ? ret.m_dxyPhiHi[LegLabels[j]].push_back(dxyPhiBiases.getWeightedMean() + 2 * dxyPhiBiases.getWeightedRMS())
+          : ret.m_dxyPhiHi[LegLabels[j]].push_back(dxyPhiBiases.getMax());
 
       auto dxyEtaBiases = getBiases(dxyEtaMeanTrend[j]);
       ret.m_dxyEtaMeans[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean());
       ret.m_dxyEtaChi2[LegLabels[j]].push_back(TMath::Log10(dxyEtaBiases.getNormChi2()));
       ret.m_dxyEtaKS[LegLabels[j]].push_back(dxyEtaBiases.getKSScore());
-      useRMS ? ret.m_dxyEtaLo[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean() - 2*dxyEtaBiases.getWeightedRMS()) :ret.m_dxyEtaLo[LegLabels[j]].push_back(dxyEtaBiases.getMin());
-      useRMS ? ret.m_dxyEtaHi[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean() + 2*dxyEtaBiases.getWeightedRMS()) :ret.m_dxyEtaHi[LegLabels[j]].push_back(dxyEtaBiases.getMax());
+      useRMS
+          ? ret.m_dxyEtaLo[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean() - 2 * dxyEtaBiases.getWeightedRMS())
+          : ret.m_dxyEtaLo[LegLabels[j]].push_back(dxyEtaBiases.getMin());
+      useRMS
+          ? ret.m_dxyEtaHi[LegLabels[j]].push_back(dxyEtaBiases.getWeightedMean() + 2 * dxyEtaBiases.getWeightedRMS())
+          : ret.m_dxyEtaHi[LegLabels[j]].push_back(dxyEtaBiases.getMax());
 
       auto dzPhiBiases = getBiases(dzPhiMeanTrend[j]);
       ret.m_dzPhiMeans[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean());
       ret.m_dzPhiChi2[LegLabels[j]].push_back(TMath::Log10(dzPhiBiases.getNormChi2()));
       ret.m_dzPhiKS[LegLabels[j]].push_back(dzPhiBiases.getKSScore());
-      useRMS ? ret.m_dzPhiLo[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean() - 2*dzPhiBiases.getWeightedRMS()) :ret.m_dzPhiLo[LegLabels[j]].push_back(dzPhiBiases.getMin());
-      useRMS ? ret.m_dzPhiHi[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean() + 2*dzPhiBiases.getWeightedRMS()) :ret.m_dzPhiHi[LegLabels[j]].push_back(dzPhiBiases.getMax());
+      useRMS ? ret.m_dzPhiLo[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean() - 2 * dzPhiBiases.getWeightedRMS())
+             : ret.m_dzPhiLo[LegLabels[j]].push_back(dzPhiBiases.getMin());
+      useRMS ? ret.m_dzPhiHi[LegLabels[j]].push_back(dzPhiBiases.getWeightedMean() + 2 * dzPhiBiases.getWeightedRMS())
+             : ret.m_dzPhiHi[LegLabels[j]].push_back(dzPhiBiases.getMax());
 
       auto dzEtaBiases = getBiases(dzEtaMeanTrend[j]);
       ret.m_dzEtaMeans[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean());
       ret.m_dzEtaChi2[LegLabels[j]].push_back(TMath::Log10(dzEtaBiases.getNormChi2()));
       ret.m_dzEtaKS[LegLabels[j]].push_back(dzEtaBiases.getKSScore());
-      useRMS ? ret.m_dzEtaLo[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean() - 2*dzEtaBiases.getWeightedRMS()) :ret.m_dzEtaLo[LegLabels[j]].push_back(dzEtaBiases.getMin());
-      useRMS ? ret.m_dzEtaHi[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean() + 2*dzEtaBiases.getWeightedRMS()) :ret.m_dzEtaHi[LegLabels[j]].push_back(dzEtaBiases.getMax());
+      useRMS ? ret.m_dzEtaLo[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean() - 2 * dzEtaBiases.getWeightedRMS())
+             : ret.m_dzEtaLo[LegLabels[j]].push_back(dzEtaBiases.getMin());
+      useRMS ? ret.m_dzEtaHi[LegLabels[j]].push_back(dzEtaBiases.getWeightedMean() + 2 * dzEtaBiases.getWeightedRMS())
+             : ret.m_dzEtaHi[LegLabels[j]].push_back(dzEtaBiases.getMax());
 
       // unrolled histograms
       ret.m_dxyVect[LegLabels[j]].push_back(getUnrolledHisto(dxyIntegralTrend[j]));
       ret.m_dzVect[LegLabels[j]].push_back(getUnrolledHisto(dzIntegralTrend[j]));
 
       //std::cout<<std::endl;
-      //std::cout<<" n. bins: "<< dxyVect[LegLabels[j]].back().get_n_bins() 
+      //std::cout<<" n. bins: "<< dxyVect[LegLabels[j]].back().get_n_bins()
       //       <<" y-min:   "<< dxyVect[LegLabels[j]].back().get_y_min()
       //       <<" y-max:   "<< dxyVect[LegLabels[j]].back().get_y_max() << std::endl;
 
       // beautify the histograms
-      MakeNiceTrendPlotStyle(dxyPhiMeanTrend[j],j);
-      MakeNiceTrendPlotStyle(dxyPhiWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzPhiMeanTrend[j],j);
-      MakeNiceTrendPlotStyle(dzPhiWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyPhiMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dxyPhiWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzPhiMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dzPhiWidthTrend[j], j);
 
-      MakeNiceTrendPlotStyle(dxyLadderMeanTrend[j],j); 
-      MakeNiceTrendPlotStyle(dxyLadderWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzLadderMeanTrend[j],j); 
-      MakeNiceTrendPlotStyle(dzLadderWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyLadderMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dxyLadderWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzLadderMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dzLadderWidthTrend[j], j);
 
-      MakeNiceTrendPlotStyle(dxyEtaMeanTrend[j],j);
-      MakeNiceTrendPlotStyle(dxyEtaWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzEtaMeanTrend[j],j);
-      MakeNiceTrendPlotStyle(dzEtaWidthTrend[j],j);  
+      MakeNiceTrendPlotStyle(dxyEtaMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dxyEtaWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzEtaMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dzEtaWidthTrend[j], j);
 
-      MakeNiceTrendPlotStyle(dxyModZMeanTrend[j],j);
-      MakeNiceTrendPlotStyle(dxyModZWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzModZMeanTrend[j],j);
-      MakeNiceTrendPlotStyle(dzModZWidthTrend[j],j);  
+      MakeNiceTrendPlotStyle(dxyModZMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dxyModZWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzModZMeanTrend[j], j);
+      MakeNiceTrendPlotStyle(dzModZWidthTrend[j], j);
 
-      MakeNiceTrendPlotStyle(dxyNormPhiWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dxyNormEtaWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzNormPhiWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzNormEtaWidthTrend[j],j);
+      MakeNiceTrendPlotStyle(dxyNormPhiWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dxyNormEtaWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzNormPhiWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzNormEtaWidthTrend[j], j);
 
-      MakeNiceTrendPlotStyle(dxyNormPtWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzNormPtWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dxyPtWidthTrend[j],j);
-      MakeNiceTrendPlotStyle(dzPtWidthTrend[j],j);
-
+      MakeNiceTrendPlotStyle(dxyNormPtWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzNormPtWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dxyPtWidthTrend[j], j);
+      MakeNiceTrendPlotStyle(dzPtWidthTrend[j], j);
     }
 
-    if(!areAllFilesOK){
-       
+    if (!areAllFilesOK) {
       // do all the necessary deletions
-      std::cout<<"\n====> not all files are OK"<<std::endl;
+      std::cout << "\n====> not all files are OK" << std::endl;
 
-      for(int i=0;i<lastOpen;i++){
-	fins[i]->Close();
+      for (int i = 0; i < lastOpen; i++) {
+        fins[i]->Close();
       }
       continue;
     } else {
       ret.m_runs.push_back(intersection.at(n));
       // push back the vector of lumi (in fb at this point)
-      ret.m_lumiByRun.push_back(ret.m_lumiSoFar/1000.);
-      ret.m_lumiMapByRun[intersection.at(n)]=ret.m_lumiSoFar/1000.;
+      ret.m_lumiByRun.push_back(ret.m_lumiSoFar / 1000.);
+      ret.m_lumiMapByRun[intersection.at(n)] = ret.m_lumiSoFar / 1000.;
     }
 
-    std::cout<<"I am still here - runs.size(): "<<ret.m_runs.size()<<std::endl;
+    std::cout << "I am still here - runs.size(): " << ret.m_runs.size() << std::endl;
 
     // Bias plots
 
-    TCanvas *BiasesCanvas = new TCanvas(Form("Biases_%i",intersection.at(n)),"Biases",1200,1200);
-    arrangeOutCanvas(BiasesCanvas,dxyPhiMeanTrend,dzPhiMeanTrend,dxyEtaMeanTrend,dzEtaMeanTrend,nDirs_,LegLabels,intersection.at(n));
+    TCanvas *BiasesCanvas = new TCanvas(Form("Biases_%i", intersection.at(n)), "Biases", 1200, 1200);
+    arrangeOutCanvas(BiasesCanvas,
+                     dxyPhiMeanTrend,
+                     dzPhiMeanTrend,
+                     dxyEtaMeanTrend,
+                     dzEtaMeanTrend,
+                     nDirs_,
+                     LegLabels,
+                     intersection.at(n));
 
-    BiasesCanvas->SaveAs(Form("Biases_%i.pdf",intersection.at(n)));
-    BiasesCanvas->SaveAs(Form("Biases_%i.png",intersection.at(n)));
-      
+    BiasesCanvas->SaveAs(Form("Biases_%i.pdf", intersection.at(n)));
+    BiasesCanvas->SaveAs(Form("Biases_%i.png", intersection.at(n)));
+
     // Bias vs L1 modules position
 
-    TCanvas *BiasesL1Canvas = new TCanvas(Form("BiasesL1_%i",intersection.at(n)),"BiasesL1",1200,1200);
-    arrangeOutCanvas(BiasesL1Canvas,dxyLadderMeanTrend,dzLadderMeanTrend,dxyModZMeanTrend,dzModZMeanTrend,nDirs_,LegLabels,intersection.at(n));
+    TCanvas *BiasesL1Canvas = new TCanvas(Form("BiasesL1_%i", intersection.at(n)), "BiasesL1", 1200, 1200);
+    arrangeOutCanvas(BiasesL1Canvas,
+                     dxyLadderMeanTrend,
+                     dzLadderMeanTrend,
+                     dxyModZMeanTrend,
+                     dzModZMeanTrend,
+                     nDirs_,
+                     LegLabels,
+                     intersection.at(n));
 
-    BiasesL1Canvas->SaveAs(Form("BiasesL1_%i.pdf",intersection.at(n)));
-    BiasesL1Canvas->SaveAs(Form("BiasesL1_%i.png",intersection.at(n)));
+    BiasesL1Canvas->SaveAs(Form("BiasesL1_%i.pdf", intersection.at(n)));
+    BiasesL1Canvas->SaveAs(Form("BiasesL1_%i.png", intersection.at(n)));
 
     // Resolution plots
 
-    TCanvas *ResolutionsCanvas = new TCanvas(Form("Resolutions_%i",intersection.at(n)),"Resolutions",1200,1200);
-    arrangeOutCanvas(ResolutionsCanvas,dxyPhiWidthTrend,dzPhiWidthTrend,dxyEtaWidthTrend,dzEtaWidthTrend,nDirs_,LegLabels,intersection.at(n));
+    TCanvas *ResolutionsCanvas = new TCanvas(Form("Resolutions_%i", intersection.at(n)), "Resolutions", 1200, 1200);
+    arrangeOutCanvas(ResolutionsCanvas,
+                     dxyPhiWidthTrend,
+                     dzPhiWidthTrend,
+                     dxyEtaWidthTrend,
+                     dzEtaWidthTrend,
+                     nDirs_,
+                     LegLabels,
+                     intersection.at(n));
 
-    ResolutionsCanvas->SaveAs(Form("Resolutions_%i.pdf",intersection.at(n)));
-    ResolutionsCanvas->SaveAs(Form("Resolutions_%i.png",intersection.at(n)));
-    
+    ResolutionsCanvas->SaveAs(Form("Resolutions_%i.pdf", intersection.at(n)));
+    ResolutionsCanvas->SaveAs(Form("Resolutions_%i.png", intersection.at(n)));
+
     // Resolution plots vs L1 modules position
 
-    TCanvas *ResolutionsL1Canvas = new TCanvas(Form("ResolutionsL1_%i",intersection.at(n)),"Resolutions",1200,1200);
-    arrangeOutCanvas(ResolutionsL1Canvas,dxyLadderWidthTrend,dzLadderWidthTrend,dxyModZWidthTrend,dzModZWidthTrend,nDirs_,LegLabels,intersection.at(n));
+    TCanvas *ResolutionsL1Canvas = new TCanvas(Form("ResolutionsL1_%i", intersection.at(n)), "Resolutions", 1200, 1200);
+    arrangeOutCanvas(ResolutionsL1Canvas,
+                     dxyLadderWidthTrend,
+                     dzLadderWidthTrend,
+                     dxyModZWidthTrend,
+                     dzModZWidthTrend,
+                     nDirs_,
+                     LegLabels,
+                     intersection.at(n));
 
-    ResolutionsL1Canvas->SaveAs(Form("ResolutionsL1_%i.pdf",intersection.at(n)));
-    ResolutionsL1Canvas->SaveAs(Form("ResolutionsL1_%i.png",intersection.at(n)));
+    ResolutionsL1Canvas->SaveAs(Form("ResolutionsL1_%i.pdf", intersection.at(n)));
+    ResolutionsL1Canvas->SaveAs(Form("ResolutionsL1_%i.png", intersection.at(n)));
 
-     // Pull plots
+    // Pull plots
 
-    TCanvas *PullsCanvas = new TCanvas(Form("Pulls_%i",intersection.at(n)),"Pulls",1200,1200);
-    arrangeOutCanvas(PullsCanvas,dxyNormPhiWidthTrend,dzNormPhiWidthTrend,dxyNormEtaWidthTrend,dzNormEtaWidthTrend,nDirs_,LegLabels,intersection.at(n));
+    TCanvas *PullsCanvas = new TCanvas(Form("Pulls_%i", intersection.at(n)), "Pulls", 1200, 1200);
+    arrangeOutCanvas(PullsCanvas,
+                     dxyNormPhiWidthTrend,
+                     dzNormPhiWidthTrend,
+                     dxyNormEtaWidthTrend,
+                     dzNormEtaWidthTrend,
+                     nDirs_,
+                     LegLabels,
+                     intersection.at(n));
 
-    PullsCanvas->SaveAs(Form("Pulls_%i.pdf",intersection.at(n)));
-    PullsCanvas->SaveAs(Form("Pulls_%i.png",intersection.at(n)));
+    PullsCanvas->SaveAs(Form("Pulls_%i.pdf", intersection.at(n)));
+    PullsCanvas->SaveAs(Form("Pulls_%i.png", intersection.at(n)));
 
     // pT plots
 
-    TCanvas *ResolutionsVsPt = new TCanvas(Form("ResolutionsVsPT_%i",intersection.at(n)),"ResolutionsVsPt",1200,1200);
-    arrangeOutCanvas(ResolutionsVsPt,dxyPtWidthTrend,dzPtWidthTrend,dxyNormPtWidthTrend,dzNormPtWidthTrend,nDirs_,LegLabels,intersection.at(n));
+    TCanvas *ResolutionsVsPt =
+        new TCanvas(Form("ResolutionsVsPT_%i", intersection.at(n)), "ResolutionsVsPt", 1200, 1200);
+    arrangeOutCanvas(ResolutionsVsPt,
+                     dxyPtWidthTrend,
+                     dzPtWidthTrend,
+                     dxyNormPtWidthTrend,
+                     dzNormPtWidthTrend,
+                     nDirs_,
+                     LegLabels,
+                     intersection.at(n));
 
-    ResolutionsVsPt->SaveAs(Form("ResolutionsVsPt_%i.pdf",intersection.at(n)));
-    ResolutionsVsPt->SaveAs(Form("ResolutionsVsPt_%i.png",intersection.at(n)));
+    ResolutionsVsPt->SaveAs(Form("ResolutionsVsPt_%i.pdf", intersection.at(n)));
+    ResolutionsVsPt->SaveAs(Form("ResolutionsVsPt_%i.png", intersection.at(n)));
 
     // do all the necessary deletions
 
-    for(int i=0;i<nDirs_;i++){
-
+    for (int i = 0; i < nDirs_; i++) {
       delete dxyPhiMeanTrend[i];
       delete dzPhiMeanTrend[i];
       delete dxyEtaMeanTrend[i];
       delete dzEtaMeanTrend[i];
-      
+
       delete dxyPhiWidthTrend[i];
       delete dzPhiWidthTrend[i];
       delete dxyEtaWidthTrend[i];
@@ -3104,24 +3280,23 @@ outTrends processData(size_t iter,std::vector<int> intersection,const Int_t nDir
       delete dzNormPhiWidthTrend[i];
       delete dzNormEtaWidthTrend[i];
 
-      delete dxyNormPtWidthTrend[i]; 
-      delete dzNormPtWidthTrend[i];  
+      delete dxyNormPtWidthTrend[i];
+      delete dzNormPtWidthTrend[i];
       delete dxyPtWidthTrend[i];
-      delete dzPtWidthTrend[i]; 
-    
+      delete dzPtWidthTrend[i];
+
       fins[i]->Close();
     }
-    
+
     delete BiasesCanvas;
     delete BiasesL1Canvas;
-    delete ResolutionsCanvas; 
+    delete ResolutionsCanvas;
     delete ResolutionsL1Canvas;
     delete PullsCanvas;
     delete ResolutionsVsPt;
 
-    std::cout<<std::endl;
+    std::cout << std::endl;
   }
-  
-  return ret;
 
+  return ret;
 }

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -20,6 +20,8 @@
 #include <vector>
 #include <regex>
 #include <cassert>
+#include <chrono>
+#include <iomanip>
 
 // user include files
 #include "Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h"
@@ -104,20 +106,17 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   theBeamspotToken = consumes<reco::BeamSpot>(BeamspotTag_);
 
   // select and configure the track filter
-  theTrackFilter_ = new TrackFilterForPVFinding(iConfig.getParameter<edm::ParameterSet>("TkFilterParameters"));
+  theTrackFilter_= std::unique_ptr<TrackFilterForPVFinding>(new TrackFilterForPVFinding(iConfig.getParameter<edm::ParameterSet>("TkFilterParameters")));
   // select and configure the track clusterizer
   std::string clusteringAlgorithm =
       iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<std::string>("algorithm");
   if (clusteringAlgorithm == "gap") {
-    theTrackClusterizer_ = new GapClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
-                                                     .getParameter<edm::ParameterSet>("TkGapClusParameters"));
+    theTrackClusterizer_ = std::unique_ptr<GapClusterizerInZ>(new GapClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkGapClusParameters")));
   } else if (clusteringAlgorithm == "DA") {
-    theTrackClusterizer_ = new DAClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
-                                                    .getParameter<edm::ParameterSet>("TkDAClusParameters"));
+    theTrackClusterizer_ = std::unique_ptr<DAClusterizerInZ>(new DAClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters")));
     // provide the vectorized version of the clusterizer, if supported by the build
   } else if (clusteringAlgorithm == "DA_vect") {
-    theTrackClusterizer_ = new DAClusterizerInZ_vect(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
-                                                         .getParameter<edm::ParameterSet>("TkDAClusParameters"));
+    theTrackClusterizer_ = std::unique_ptr<DAClusterizerInZ_vect>(new DAClusterizerInZ_vect(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters")));
   } else {
     throw VertexException("PrimaryVertexProducerAlgorithm: unknown clustering algorithm: " + clusteringAlgorithm);
   }
@@ -194,10 +193,6 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
 PrimaryVertexValidation::~PrimaryVertexValidation() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-  if (theTrackFilter_)
-    delete theTrackFilter_;
-  if (theTrackClusterizer_)
-    delete theTrackClusterizer_;
 }
 
 //
@@ -303,9 +298,9 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   }
 
   if (isPhase1_) {
-    etaOfProbe_ = std::min(etaOfProbe_, 2.7);
+    etaOfProbe_ = std::min(etaOfProbe_,PVValHelper::max_eta_phase1);
   } else {
-    etaOfProbe_ = std::min(etaOfProbe_, 2.5);
+    etaOfProbe_ = std::min(etaOfProbe_,PVValHelper::max_eta_phase0);
   }
 
   if (h_etaMax->GetEntries() == 0.) {
@@ -511,6 +506,18 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
 
   RunNumber_ = iEvent.eventAuxiliary().run();
   h_runNumber->Fill(RunNumber_);
+
+  if(!runNumbersTimesLog_.count(RunNumber_)){
+    auto times = getRunTime(iSetup);
+
+    if(debug_){
+      const time_t start_time = times.first/1000000;
+      edm::LogInfo("PrimaryVertexValidation") << RunNumber_ << " has start time: " << times.first << " - "<< times.second << std::endl;
+      edm::LogInfo("PrimaryVertexValidation") <<"human readable time: " << std::asctime(std::gmtime(&start_time)) << std::endl;
+    }
+
+    runNumbersTimesLog_[RunNumber_]=times;
+  }
 
   if (h_runFromEvent->GetEntries() == 0) {
     h_runFromEvent->SetBinContent(1, RunNumber_);
@@ -814,6 +821,13 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
               if (hit->isValid() && (subid == PixelSubdetector::PixelBarrel)) {
                 int layer = tTopo->pxbLayer(detId);
                 if (layer == 1) {
+
+		  const SiPixelRecHit* prechit = dynamic_cast<const SiPixelRecHit*>(hit);//to be used to get the associated cluster and the cluster probability      
+		  double clusterProbability= prechit->clusterProbability(0);
+		  if (clusterProbability > 0){
+		      h_probeL1ClusterProb_->Fill(log10(clusterProbability));
+		  }
+		  
                   L1BPixHitCount += 1;
                   ladder_num = tTopo->pxbLadder(detId);
                   module_num = tTopo->pxbModule(detId);
@@ -823,7 +837,16 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
 
             h_probeL1Ladder_->Fill(ladder_num);
             h_probeL1Module_->Fill(module_num);
+	    h2_probeLayer1Map_->Fill(module_num,ladder_num);
             h_probeHasBPixL1Overlap_->Fill(L1BPixHitCount);
+
+	    // residuals vs ladder and module number for map
+	    if(module_num > 0 && ladder_num > 0){ // only if we are on BPix Layer 1
+	      a_dxyL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dxyFromMyVertex*cmToum);
+	      a_dzL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dzFromMyVertex*cmToum); 
+	      n_dxyL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dxyFromMyVertex/s_ip2dpv_err);			    
+	      n_dzL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dzFromMyVertex/dz_err); 
+	    }
 
             // filling the pT-binned distributions
 
@@ -965,6 +988,9 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
                 PVValHelper::fillByIndex(h_dz_ladder_, ladder_num - 1, dzFromMyVertex * cmToum);
                 PVValHelper::fillByIndex(h_norm_dxy_ladder_, ladder_num - 1, dxyFromMyVertex / s_ip2dpv_err);
                 PVValHelper::fillByIndex(h_norm_dz_ladder_, ladder_num - 1, dzFromMyVertex / dz_err);
+
+		h2_probePassingLayer1Map_->Fill(module_num,ladder_num);
+
               }
 
               // filling the binned distributions
@@ -1380,8 +1406,11 @@ void PrimaryVertexValidation::beginJob() {
       ProbeFeatures.make<TH1F>("h_probeL1Ladder", "Ladder number (L1 hit); ladder number", 22, -1.5, 20.5);
   h_probeL1Module_ =
       ProbeFeatures.make<TH1F>("h_probeL1Module", "Module number (L1 hit); module number", 10, -1.5, 8.5);
-  h_probeHasBPixL1Overlap_ =
-      ProbeFeatures.make<TH1I>("h_probeHasBPixL1Overlap", "n. hits in L1;n. L1-BPix hits;tracks", 5, 0, 5);
+
+  h2_probeLayer1Map_       = ProbeFeatures.make<TH2F>("h2_probeLayer1Map","Position in Layer 1 of first hit;module number;ladder number",8,0.5,8.5,12,0.5,12.5);
+  h2_probePassingLayer1Map_= ProbeFeatures.make<TH2F>("h2_probePassingLayer1Map","Position in Layer 1 of first hit;module number;ladder number",8,0.5,8.5,12,0.5,12.5);
+  h_probeHasBPixL1Overlap_ = ProbeFeatures.make<TH1I>("h_probeHasBPixL1Overlap","n. hits in L1;n. L1-BPix hits;tracks",5,-0.5,4.5);
+  h_probeL1ClusterProb_    = ProbeFeatures.make<TH1F>("h_probeL1ClusterProb","log_{10}(Cluster Probability) for Layer1 hits;log_{10}(cluster probability); n. Layer1 hits",100,-10.,0.);
 
   // refit vertex features
   TFileDirectory RefitVertexFeatures = fs->mkdir("RefitVertexFeatures");
@@ -1497,6 +1526,9 @@ void PrimaryVertexValidation::beginJob() {
   TFileDirectory AbsDoubleDiffRes = fs->mkdir("Abs_DoubleDiffResiduals");
   TFileDirectory NormDoubleDiffRes = fs->mkdir("Norm_DoubleDiffResiduals");
 
+  TFileDirectory AbsL1Map   = fs->mkdir("Abs_L1Residuals");
+  TFileDirectory NormL1Map  = fs->mkdir("Norm_L1Residuals");
+
   // book residuals vs pT histograms
 
   TFileDirectory AbsTranspTRes = fs->mkdir("Abs_Transv_pT_Residuals");
@@ -1568,6 +1600,30 @@ void PrimaryVertexValidation::beginJob() {
   TFileDirectory NormLongLadderRes = fs->mkdir("Norm_Long_ladder_Residuals");
   h_norm_dz_ladder_ =
       bookResidualsHistogram(NormLongLadderRes, nLadders_, PVValHelper::norm_dz, PVValHelper::ladder, true);
+
+  // book residuals as function of nLadders and nModules
+  
+  for(unsigned int iLadder=0;iLadder<nLadders_;iLadder++){
+    for(unsigned int iModule=0;iModule<8;iModule++){
+
+      a_dxyL1ResidualsMap[iLadder][iModule] = AbsL1Map.make<TH1F>(Form("histo_dxy_ladder%i_module%i",iLadder,iModule),
+								  Form("d_{xy} ladder=%i module=%i;d_{xy} [#mum];tracks",iLadder,iModule),
+								  theDetails_.histobins,-dzmax_eta,dzmax_eta);
+
+      a_dzL1ResidualsMap[iLadder][iModule]  = AbsL1Map.make<TH1F>(Form("histo_dz_ladder%i_module%i",iLadder,iModule),
+								  Form("d_{z} ladder=%i module=%i;d_{z} [#mum];tracks",iLadder,iModule),
+								  theDetails_.histobins,-dzmax_eta,dzmax_eta);
+
+      n_dxyL1ResidualsMap[iLadder][iModule] = NormL1Map.make<TH1F>(Form("histo_norm_dxy_ladder%i_module%i",iLadder,iModule),
+								   Form("d_{xy} ladder=%i module=%i;d_{xy}/#sigma_{d_{xy}};tracks",iLadder,iModule),
+								   theDetails_.histobins,-dzmax_eta/100,dzmax_eta/100);
+
+      n_dzL1ResidualsMap[iLadder][iModule]  = NormL1Map.make<TH1F>(Form("histo_norm_dz_ladder%i_module%i",iLadder,iModule),
+								   Form("d_{z} ladder=%i module=%i;d_{z}/#sigma_{d_{z}};tracks",iLadder,iModule),
+								   theDetails_.histobins,-dzmax_eta/100,dzmax_eta/100);
+
+    }
+  }
 
   // book residuals as function of phi and eta
 
@@ -2504,6 +2560,24 @@ void PrimaryVertexValidation::beginJob() {
 }
 // ------------ method called once each job just after ending the event loop  ------------
 void PrimaryVertexValidation::endJob() {
+
+  TFileDirectory RunFeatures = fs->mkdir("RunFeatures");
+  h_runStartTimes = RunFeatures.make<TH1I>("runStartTimes","run start times",runNumbersTimesLog_.size(),0,runNumbersTimesLog_.size());
+  h_runEndTimes   = RunFeatures.make<TH1I>("runEndTimes","run end times",runNumbersTimesLog_.size(),0,runNumbersTimesLog_.size());
+
+  unsigned int count=1;
+  for(const auto &run: runNumbersTimesLog_){
+
+    // strip down the microseconds
+    h_runStartTimes->SetBinContent(count,run.second.first/10e6);
+    h_runStartTimes->GetXaxis()->SetBinLabel(count,(std::to_string(run.first)).c_str());
+
+    h_runEndTimes->SetBinContent(count,run.second.second/10e6);
+    h_runEndTimes->GetXaxis()->SetBinLabel(count,(std::to_string(run.first)).c_str());
+
+    count++;
+  }
+
   edm::LogInfo("PrimaryVertexValidation") << "######################################\n"
                                           << "# PrimaryVertexValidation::endJob()\n"
                                           << "# Number of analyzed events: " << Nevt_ << "\n"
@@ -2602,6 +2676,40 @@ void PrimaryVertexValidation::endJob() {
       0.,
       nLadders_);
 
+  // 2D maps of residuals in bins of L1 modules
+
+  a_dxyL1MeanMap       =  Mean2DMapsDir.make<TH2F>  ("means_dxy_l1map",
+						     "#LT d_{xy} #GT map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  a_dzL1MeanMap        =  Mean2DMapsDir.make<TH2F>  ("means_dz_l1map",
+						     "#LT d_{z} #GT map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  n_dxyL1MeanMap       =  Mean2DMapsDir.make<TH2F>  ("norm_means_dxy_l1map",
+						     "#LT d_{xy}/#sigma_{d_{xy}} #GT map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  n_dzL1MeanMap        =  Mean2DMapsDir.make<TH2F>  ("norm_means_dz_l1map",
+						     "#LT d_{z}/#sigma_{d_{z}} #GT map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  a_dxyL1WidthMap      =  Width2DMapsDir.make<TH2F> ("widths_dxy_l1map",
+						     "#sigma_{d_{xy}} map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  a_dzL1WidthMap       =  Width2DMapsDir.make<TH2F> ("widths_dz_l1map",
+						     "#sigma_{d_{z}} map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  n_dxyL1WidthMap      =  Width2DMapsDir.make<TH2F> ("norm_widths_dxy_l1map",
+						     "width(d_{xy}/#sigma_{d_{xy}}) map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
+  n_dzL1WidthMap       =  Width2DMapsDir.make<TH2F> ("norm_widths_dz_l1map",
+						     "width(d_{z}/#sigma_{d_{z}}) map;module number [z];ladder number [#varphi]",
+						     8,0.,8.,nLadders_,0.,nLadders_);
+
   if (useTracksFromRecoVtx_) {
     fillTrendPlotByIndex(a_dxyPhiMeanBiasTrend, a_dxyPhiBiasResiduals, PVValHelper::MEAN, PVValHelper::phi);
     fillTrendPlotByIndex(a_dxyPhiWidthBiasTrend, a_dxyPhiBiasResiduals, PVValHelper::WIDTH, PVValHelper::phi);
@@ -2647,15 +2755,16 @@ void PrimaryVertexValidation::endJob() {
 
     // 2d Maps
 
-    fillMap(a_dxyMeanBiasMap, a_dxyBiasResidualsMap, PVValHelper::MEAN);
-    fillMap(a_dxyWidthBiasMap, a_dxyBiasResidualsMap, PVValHelper::WIDTH);
-    fillMap(a_dzMeanBiasMap, a_dzBiasResidualsMap, PVValHelper::MEAN);
-    fillMap(a_dzWidthBiasMap, a_dzBiasResidualsMap, PVValHelper::WIDTH);
+    fillMap(a_dxyMeanBiasMap ,a_dxyBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+    fillMap(a_dxyWidthBiasMap,a_dxyBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+    fillMap(a_dzMeanBiasMap  ,a_dzBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+    fillMap(a_dzWidthBiasMap ,a_dzBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
 
-    fillMap(n_dxyMeanBiasMap, n_dxyBiasResidualsMap, PVValHelper::MEAN);
-    fillMap(n_dxyWidthBiasMap, n_dxyBiasResidualsMap, PVValHelper::WIDTH);
-    fillMap(n_dzMeanBiasMap, n_dzBiasResidualsMap, PVValHelper::MEAN);
-    fillMap(n_dzWidthBiasMap, n_dzBiasResidualsMap, PVValHelper::WIDTH);
+    fillMap(n_dxyMeanBiasMap ,n_dxyBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+    fillMap(n_dxyWidthBiasMap,n_dxyBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+    fillMap(n_dzMeanBiasMap  ,n_dzBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+    fillMap(n_dzWidthBiasMap ,n_dzBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+
   }
 
   // do profiles
@@ -2749,15 +2858,41 @@ void PrimaryVertexValidation::endJob() {
 
   // 2D Maps
 
-  fillMap(a_dxyMeanMap, a_dxyResidualsMap, PVValHelper::MEAN);
-  fillMap(a_dxyWidthMap, a_dxyResidualsMap, PVValHelper::WIDTH);
-  fillMap(a_dzMeanMap, a_dzResidualsMap, PVValHelper::MEAN);
-  fillMap(a_dzWidthMap, a_dzResidualsMap, PVValHelper::WIDTH);
+  fillMap(a_dxyMeanMap ,a_dxyResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+  fillMap(a_dxyWidthMap,a_dxyResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+  fillMap(a_dzMeanMap  ,a_dzResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+  fillMap(a_dzWidthMap ,a_dzResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
 
-  fillMap(n_dxyMeanMap, n_dxyResidualsMap, PVValHelper::MEAN);
-  fillMap(n_dxyWidthMap, n_dxyResidualsMap, PVValHelper::WIDTH);
-  fillMap(n_dzMeanMap, n_dzResidualsMap, PVValHelper::MEAN);
-  fillMap(n_dzWidthMap, n_dzResidualsMap, PVValHelper::WIDTH);
+  fillMap(n_dxyMeanMap ,n_dxyResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+  fillMap(n_dxyWidthMap,n_dxyResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+  fillMap(n_dzMeanMap  ,n_dzResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
+  fillMap(n_dzWidthMap ,n_dzResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+
+  // 2D Maps of residuals in bins of L1 modules
+
+  fillMap(a_dxyL1MeanMap ,a_dxyL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
+  fillMap(a_dxyL1WidthMap,a_dxyL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
+  fillMap(a_dzL1MeanMap  ,a_dzL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
+  fillMap(a_dzL1WidthMap ,a_dzL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
+
+  fillMap(n_dxyL1MeanMap ,n_dxyL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
+  fillMap(n_dxyL1WidthMap,n_dxyL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
+  fillMap(n_dzL1MeanMap  ,n_dzL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
+  fillMap(n_dzL1WidthMap ,n_dzL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
+
+}
+
+//*************************************************************
+std::pair<long long, long long> PrimaryVertexValidation::getRunTime(const edm::EventSetup& iSetup) const
+//*************************************************************
+{
+  edm::ESHandle<RunInfo> runInfo;
+  iSetup.get<RunInfoRcd>().get(runInfo);
+  if(debug_){
+    edm::LogInfo("PrimaryVertexValidation")<<runInfo.product()->m_start_time_str << " " << runInfo.product()->m_stop_time_str << std::endl;
+  }
+  return std::make_pair(runInfo.product()->m_start_time_ll,runInfo.product()->m_stop_time_ll);
+
 }
 
 //*************************************************************
@@ -2973,23 +3108,29 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,
 }
 
 //*************************************************************
-void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], PVValHelper::estimator fitPar_)
+ void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100],  PVValHelper::estimator fitPar_,const int nXBins_, const int nYBins_)
 //*************************************************************
 {
-  for (int i = 0; i < nBins_; ++i) {
+
+  for ( int i=0; i<nYBins_; ++i ) {
+
     char phibincenter[129];
     auto phiBins = theDetails_.trendbins[PVValHelper::phi];
     sprintf(phibincenter, "%.f", (phiBins[i] + phiBins[i + 1]) / 2.);
 
-    trendMap->GetYaxis()->SetBinLabel(i + 1, phibincenter);
+    if(nXBins_==nYBins_){
+      trendMap->GetYaxis()->SetBinLabel(i+1,phibincenter); 
+    }
 
-    for (int j = 0; j < nBins_; ++j) {
+    for ( int j=0; j<nXBins_; ++j ) {
       char etabincenter[129];
       auto etaBins = theDetails_.trendbins[PVValHelper::eta];
       sprintf(etabincenter, "%.1f", (etaBins[j] + etaBins[j + 1]) / 2.);
 
-      if (i == 0) {
-        trendMap->GetXaxis()->SetBinLabel(j + 1, etabincenter);
+      if(i==0) {
+	if(nXBins_==nYBins_){
+	  trendMap->GetXaxis()->SetBinLabel(j+1,etabincenter); 
+	}
       }
 
       switch (fitPar_) {

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -1347,7 +1347,7 @@ void PrimaryVertexValidation::beginJob() {
   h_probeNormChi2_ = ProbeFeatures.make<TH1F>(
       "h_probeNormChi2", " normalized #chi^{2} of probe track;track #chi^{2}/ndof; tracks", 100, 0., 10.);
   h_probeCharge_ =
-      ProbeFeatures.make<TH1F>("h_probeCharge", "charge of profe track;track charge Q;tracks", 3, -1.5, 1.5);
+      ProbeFeatures.make<TH1F>("h_probeCharge", "charge of probe track;track charge Q;tracks", 3, -1.5, 1.5);
   h_probeQoverP_ =
       ProbeFeatures.make<TH1F>("h_probeQoverP", "q/p of probe track; track Q/p (GeV^{-1});tracks", 200, -1., 1.);
   h_probedzRecoV_ = ProbeFeatures.make<TH1F>(

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -106,17 +106,24 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
   theBeamspotToken = consumes<reco::BeamSpot>(BeamspotTag_);
 
   // select and configure the track filter
-  theTrackFilter_= std::unique_ptr<TrackFilterForPVFinding>(new TrackFilterForPVFinding(iConfig.getParameter<edm::ParameterSet>("TkFilterParameters")));
+  theTrackFilter_ = std::unique_ptr<TrackFilterForPVFinding>(
+      new TrackFilterForPVFinding(iConfig.getParameter<edm::ParameterSet>("TkFilterParameters")));
   // select and configure the track clusterizer
   std::string clusteringAlgorithm =
       iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<std::string>("algorithm");
   if (clusteringAlgorithm == "gap") {
-    theTrackClusterizer_ = std::unique_ptr<GapClusterizerInZ>(new GapClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkGapClusParameters")));
+    theTrackClusterizer_ = std::unique_ptr<GapClusterizerInZ>(
+        new GapClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
+                                  .getParameter<edm::ParameterSet>("TkGapClusParameters")));
   } else if (clusteringAlgorithm == "DA") {
-    theTrackClusterizer_ = std::unique_ptr<DAClusterizerInZ>(new DAClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters")));
+    theTrackClusterizer_ = std::unique_ptr<DAClusterizerInZ>(
+        new DAClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
+                                 .getParameter<edm::ParameterSet>("TkDAClusParameters")));
     // provide the vectorized version of the clusterizer, if supported by the build
   } else if (clusteringAlgorithm == "DA_vect") {
-    theTrackClusterizer_ = std::unique_ptr<DAClusterizerInZ_vect>(new DAClusterizerInZ_vect(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters")));
+    theTrackClusterizer_ = std::unique_ptr<DAClusterizerInZ_vect>(
+        new DAClusterizerInZ_vect(iConfig.getParameter<edm::ParameterSet>("TkClusParameters")
+                                      .getParameter<edm::ParameterSet>("TkDAClusParameters")));
   } else {
     throw VertexException("PrimaryVertexProducerAlgorithm: unknown clustering algorithm: " + clusteringAlgorithm);
   }
@@ -298,9 +305,9 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   }
 
   if (isPhase1_) {
-    etaOfProbe_ = std::min(etaOfProbe_,PVValHelper::max_eta_phase1);
+    etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase1);
   } else {
-    etaOfProbe_ = std::min(etaOfProbe_,PVValHelper::max_eta_phase0);
+    etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase0);
   }
 
   if (h_etaMax->GetEntries() == 0.) {
@@ -507,16 +514,18 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   RunNumber_ = iEvent.eventAuxiliary().run();
   h_runNumber->Fill(RunNumber_);
 
-  if(!runNumbersTimesLog_.count(RunNumber_)){
+  if (!runNumbersTimesLog_.count(RunNumber_)) {
     auto times = getRunTime(iSetup);
 
-    if(debug_){
-      const time_t start_time = times.first/1000000;
-      edm::LogInfo("PrimaryVertexValidation") << RunNumber_ << " has start time: " << times.first << " - "<< times.second << std::endl;
-      edm::LogInfo("PrimaryVertexValidation") <<"human readable time: " << std::asctime(std::gmtime(&start_time)) << std::endl;
+    if (debug_) {
+      const time_t start_time = times.first / 1000000;
+      edm::LogInfo("PrimaryVertexValidation")
+          << RunNumber_ << " has start time: " << times.first << " - " << times.second << std::endl;
+      edm::LogInfo("PrimaryVertexValidation")
+          << "human readable time: " << std::asctime(std::gmtime(&start_time)) << std::endl;
     }
 
-    runNumbersTimesLog_[RunNumber_]=times;
+    runNumbersTimesLog_[RunNumber_] = times;
   }
 
   if (h_runFromEvent->GetEntries() == 0) {
@@ -821,13 +830,13 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
               if (hit->isValid() && (subid == PixelSubdetector::PixelBarrel)) {
                 int layer = tTopo->pxbLayer(detId);
                 if (layer == 1) {
+                  const SiPixelRecHit* prechit = dynamic_cast<const SiPixelRecHit*>(
+                      hit);  //to be used to get the associated cluster and the cluster probability
+                  double clusterProbability = prechit->clusterProbability(0);
+                  if (clusterProbability > 0) {
+                    h_probeL1ClusterProb_->Fill(log10(clusterProbability));
+                  }
 
-		  const SiPixelRecHit* prechit = dynamic_cast<const SiPixelRecHit*>(hit);//to be used to get the associated cluster and the cluster probability      
-		  double clusterProbability= prechit->clusterProbability(0);
-		  if (clusterProbability > 0){
-		      h_probeL1ClusterProb_->Fill(log10(clusterProbability));
-		  }
-		  
                   L1BPixHitCount += 1;
                   ladder_num = tTopo->pxbLadder(detId);
                   module_num = tTopo->pxbModule(detId);
@@ -837,16 +846,16 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
 
             h_probeL1Ladder_->Fill(ladder_num);
             h_probeL1Module_->Fill(module_num);
-	    h2_probeLayer1Map_->Fill(module_num,ladder_num);
+            h2_probeLayer1Map_->Fill(module_num, ladder_num);
             h_probeHasBPixL1Overlap_->Fill(L1BPixHitCount);
 
-	    // residuals vs ladder and module number for map
-	    if(module_num > 0 && ladder_num > 0){ // only if we are on BPix Layer 1
-	      a_dxyL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dxyFromMyVertex*cmToum);
-	      a_dzL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dzFromMyVertex*cmToum); 
-	      n_dxyL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dxyFromMyVertex/s_ip2dpv_err);			    
-	      n_dzL1ResidualsMap[ladder_num-1][module_num-1]->Fill(dzFromMyVertex/dz_err); 
-	    }
+            // residuals vs ladder and module number for map
+            if (module_num > 0 && ladder_num > 0) {  // only if we are on BPix Layer 1
+              a_dxyL1ResidualsMap[ladder_num - 1][module_num - 1]->Fill(dxyFromMyVertex * cmToum);
+              a_dzL1ResidualsMap[ladder_num - 1][module_num - 1]->Fill(dzFromMyVertex * cmToum);
+              n_dxyL1ResidualsMap[ladder_num - 1][module_num - 1]->Fill(dxyFromMyVertex / s_ip2dpv_err);
+              n_dzL1ResidualsMap[ladder_num - 1][module_num - 1]->Fill(dzFromMyVertex / dz_err);
+            }
 
             // filling the pT-binned distributions
 
@@ -989,8 +998,7 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
                 PVValHelper::fillByIndex(h_norm_dxy_ladder_, ladder_num - 1, dxyFromMyVertex / s_ip2dpv_err);
                 PVValHelper::fillByIndex(h_norm_dz_ladder_, ladder_num - 1, dzFromMyVertex / dz_err);
 
-		h2_probePassingLayer1Map_->Fill(module_num,ladder_num);
-
+                h2_probePassingLayer1Map_->Fill(module_num, ladder_num);
               }
 
               // filling the binned distributions
@@ -1407,10 +1415,24 @@ void PrimaryVertexValidation::beginJob() {
   h_probeL1Module_ =
       ProbeFeatures.make<TH1F>("h_probeL1Module", "Module number (L1 hit); module number", 10, -1.5, 8.5);
 
-  h2_probeLayer1Map_       = ProbeFeatures.make<TH2F>("h2_probeLayer1Map","Position in Layer 1 of first hit;module number;ladder number",8,0.5,8.5,12,0.5,12.5);
-  h2_probePassingLayer1Map_= ProbeFeatures.make<TH2F>("h2_probePassingLayer1Map","Position in Layer 1 of first hit;module number;ladder number",8,0.5,8.5,12,0.5,12.5);
-  h_probeHasBPixL1Overlap_ = ProbeFeatures.make<TH1I>("h_probeHasBPixL1Overlap","n. hits in L1;n. L1-BPix hits;tracks",5,-0.5,4.5);
-  h_probeL1ClusterProb_    = ProbeFeatures.make<TH1F>("h_probeL1ClusterProb","log_{10}(Cluster Probability) for Layer1 hits;log_{10}(cluster probability); n. Layer1 hits",100,-10.,0.);
+  h2_probeLayer1Map_ = ProbeFeatures.make<TH2F>(
+      "h2_probeLayer1Map", "Position in Layer 1 of first hit;module number;ladder number", 8, 0.5, 8.5, 12, 0.5, 12.5);
+  h2_probePassingLayer1Map_ = ProbeFeatures.make<TH2F>("h2_probePassingLayer1Map",
+                                                       "Position in Layer 1 of first hit;module number;ladder number",
+                                                       8,
+                                                       0.5,
+                                                       8.5,
+                                                       12,
+                                                       0.5,
+                                                       12.5);
+  h_probeHasBPixL1Overlap_ =
+      ProbeFeatures.make<TH1I>("h_probeHasBPixL1Overlap", "n. hits in L1;n. L1-BPix hits;tracks", 5, -0.5, 4.5);
+  h_probeL1ClusterProb_ = ProbeFeatures.make<TH1F>(
+      "h_probeL1ClusterProb",
+      "log_{10}(Cluster Probability) for Layer1 hits;log_{10}(cluster probability); n. Layer1 hits",
+      100,
+      -10.,
+      0.);
 
   // refit vertex features
   TFileDirectory RefitVertexFeatures = fs->mkdir("RefitVertexFeatures");
@@ -1526,8 +1548,8 @@ void PrimaryVertexValidation::beginJob() {
   TFileDirectory AbsDoubleDiffRes = fs->mkdir("Abs_DoubleDiffResiduals");
   TFileDirectory NormDoubleDiffRes = fs->mkdir("Norm_DoubleDiffResiduals");
 
-  TFileDirectory AbsL1Map   = fs->mkdir("Abs_L1Residuals");
-  TFileDirectory NormL1Map  = fs->mkdir("Norm_L1Residuals");
+  TFileDirectory AbsL1Map = fs->mkdir("Abs_L1Residuals");
+  TFileDirectory NormL1Map = fs->mkdir("Norm_L1Residuals");
 
   // book residuals vs pT histograms
 
@@ -1602,26 +1624,36 @@ void PrimaryVertexValidation::beginJob() {
       bookResidualsHistogram(NormLongLadderRes, nLadders_, PVValHelper::norm_dz, PVValHelper::ladder, true);
 
   // book residuals as function of nLadders and nModules
-  
-  for(unsigned int iLadder=0;iLadder<nLadders_;iLadder++){
-    for(unsigned int iModule=0;iModule<8;iModule++){
 
-      a_dxyL1ResidualsMap[iLadder][iModule] = AbsL1Map.make<TH1F>(Form("histo_dxy_ladder%i_module%i",iLadder,iModule),
-								  Form("d_{xy} ladder=%i module=%i;d_{xy} [#mum];tracks",iLadder,iModule),
-								  theDetails_.histobins,-dzmax_eta,dzmax_eta);
+  for (unsigned int iLadder = 0; iLadder < nLadders_; iLadder++) {
+    for (unsigned int iModule = 0; iModule < 8; iModule++) {
+      a_dxyL1ResidualsMap[iLadder][iModule] =
+          AbsL1Map.make<TH1F>(Form("histo_dxy_ladder%i_module%i", iLadder, iModule),
+                              Form("d_{xy} ladder=%i module=%i;d_{xy} [#mum];tracks", iLadder, iModule),
+                              theDetails_.histobins,
+                              -dzmax_eta,
+                              dzmax_eta);
 
-      a_dzL1ResidualsMap[iLadder][iModule]  = AbsL1Map.make<TH1F>(Form("histo_dz_ladder%i_module%i",iLadder,iModule),
-								  Form("d_{z} ladder=%i module=%i;d_{z} [#mum];tracks",iLadder,iModule),
-								  theDetails_.histobins,-dzmax_eta,dzmax_eta);
+      a_dzL1ResidualsMap[iLadder][iModule] =
+          AbsL1Map.make<TH1F>(Form("histo_dz_ladder%i_module%i", iLadder, iModule),
+                              Form("d_{z} ladder=%i module=%i;d_{z} [#mum];tracks", iLadder, iModule),
+                              theDetails_.histobins,
+                              -dzmax_eta,
+                              dzmax_eta);
 
-      n_dxyL1ResidualsMap[iLadder][iModule] = NormL1Map.make<TH1F>(Form("histo_norm_dxy_ladder%i_module%i",iLadder,iModule),
-								   Form("d_{xy} ladder=%i module=%i;d_{xy}/#sigma_{d_{xy}};tracks",iLadder,iModule),
-								   theDetails_.histobins,-dzmax_eta/100,dzmax_eta/100);
+      n_dxyL1ResidualsMap[iLadder][iModule] =
+          NormL1Map.make<TH1F>(Form("histo_norm_dxy_ladder%i_module%i", iLadder, iModule),
+                               Form("d_{xy} ladder=%i module=%i;d_{xy}/#sigma_{d_{xy}};tracks", iLadder, iModule),
+                               theDetails_.histobins,
+                               -dzmax_eta / 100,
+                               dzmax_eta / 100);
 
-      n_dzL1ResidualsMap[iLadder][iModule]  = NormL1Map.make<TH1F>(Form("histo_norm_dz_ladder%i_module%i",iLadder,iModule),
-								   Form("d_{z} ladder=%i module=%i;d_{z}/#sigma_{d_{z}};tracks",iLadder,iModule),
-								   theDetails_.histobins,-dzmax_eta/100,dzmax_eta/100);
-
+      n_dzL1ResidualsMap[iLadder][iModule] =
+          NormL1Map.make<TH1F>(Form("histo_norm_dz_ladder%i_module%i", iLadder, iModule),
+                               Form("d_{z} ladder=%i module=%i;d_{z}/#sigma_{d_{z}};tracks", iLadder, iModule),
+                               theDetails_.histobins,
+                               -dzmax_eta / 100,
+                               dzmax_eta / 100);
     }
   }
 
@@ -2560,20 +2592,20 @@ void PrimaryVertexValidation::beginJob() {
 }
 // ------------ method called once each job just after ending the event loop  ------------
 void PrimaryVertexValidation::endJob() {
-
   TFileDirectory RunFeatures = fs->mkdir("RunFeatures");
-  h_runStartTimes = RunFeatures.make<TH1I>("runStartTimes","run start times",runNumbersTimesLog_.size(),0,runNumbersTimesLog_.size());
-  h_runEndTimes   = RunFeatures.make<TH1I>("runEndTimes","run end times",runNumbersTimesLog_.size(),0,runNumbersTimesLog_.size());
+  h_runStartTimes = RunFeatures.make<TH1I>(
+      "runStartTimes", "run start times", runNumbersTimesLog_.size(), 0, runNumbersTimesLog_.size());
+  h_runEndTimes =
+      RunFeatures.make<TH1I>("runEndTimes", "run end times", runNumbersTimesLog_.size(), 0, runNumbersTimesLog_.size());
 
-  unsigned int count=1;
-  for(const auto &run: runNumbersTimesLog_){
-
+  unsigned int count = 1;
+  for (const auto& run : runNumbersTimesLog_) {
     // strip down the microseconds
-    h_runStartTimes->SetBinContent(count,run.second.first/10e6);
-    h_runStartTimes->GetXaxis()->SetBinLabel(count,(std::to_string(run.first)).c_str());
+    h_runStartTimes->SetBinContent(count, run.second.first / 10e6);
+    h_runStartTimes->GetXaxis()->SetBinLabel(count, (std::to_string(run.first)).c_str());
 
-    h_runEndTimes->SetBinContent(count,run.second.second/10e6);
-    h_runEndTimes->GetXaxis()->SetBinLabel(count,(std::to_string(run.first)).c_str());
+    h_runEndTimes->SetBinContent(count, run.second.second / 10e6);
+    h_runEndTimes->GetXaxis()->SetBinLabel(count, (std::to_string(run.first)).c_str());
 
     count++;
   }
@@ -2678,37 +2710,80 @@ void PrimaryVertexValidation::endJob() {
 
   // 2D maps of residuals in bins of L1 modules
 
-  a_dxyL1MeanMap       =  Mean2DMapsDir.make<TH2F>  ("means_dxy_l1map",
-						     "#LT d_{xy} #GT map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  a_dxyL1MeanMap = Mean2DMapsDir.make<TH2F>("means_dxy_l1map",
+                                            "#LT d_{xy} #GT map;module number [z];ladder number [#varphi]",
+                                            8,
+                                            0.,
+                                            8.,
+                                            nLadders_,
+                                            0.,
+                                            nLadders_);
 
-  a_dzL1MeanMap        =  Mean2DMapsDir.make<TH2F>  ("means_dz_l1map",
-						     "#LT d_{z} #GT map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  a_dzL1MeanMap = Mean2DMapsDir.make<TH2F>("means_dz_l1map",
+                                           "#LT d_{z} #GT map;module number [z];ladder number [#varphi]",
+                                           8,
+                                           0.,
+                                           8.,
+                                           nLadders_,
+                                           0.,
+                                           nLadders_);
 
-  n_dxyL1MeanMap       =  Mean2DMapsDir.make<TH2F>  ("norm_means_dxy_l1map",
-						     "#LT d_{xy}/#sigma_{d_{xy}} #GT map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  n_dxyL1MeanMap =
+      Mean2DMapsDir.make<TH2F>("norm_means_dxy_l1map",
+                               "#LT d_{xy}/#sigma_{d_{xy}} #GT map;module number [z];ladder number [#varphi]",
+                               8,
+                               0.,
+                               8.,
+                               nLadders_,
+                               0.,
+                               nLadders_);
 
-  n_dzL1MeanMap        =  Mean2DMapsDir.make<TH2F>  ("norm_means_dz_l1map",
-						     "#LT d_{z}/#sigma_{d_{z}} #GT map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  n_dzL1MeanMap = Mean2DMapsDir.make<TH2F>("norm_means_dz_l1map",
+                                           "#LT d_{z}/#sigma_{d_{z}} #GT map;module number [z];ladder number [#varphi]",
+                                           8,
+                                           0.,
+                                           8.,
+                                           nLadders_,
+                                           0.,
+                                           nLadders_);
 
-  a_dxyL1WidthMap      =  Width2DMapsDir.make<TH2F> ("widths_dxy_l1map",
-						     "#sigma_{d_{xy}} map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  a_dxyL1WidthMap = Width2DMapsDir.make<TH2F>("widths_dxy_l1map",
+                                              "#sigma_{d_{xy}} map;module number [z];ladder number [#varphi]",
+                                              8,
+                                              0.,
+                                              8.,
+                                              nLadders_,
+                                              0.,
+                                              nLadders_);
 
-  a_dzL1WidthMap       =  Width2DMapsDir.make<TH2F> ("widths_dz_l1map",
-						     "#sigma_{d_{z}} map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  a_dzL1WidthMap = Width2DMapsDir.make<TH2F>("widths_dz_l1map",
+                                             "#sigma_{d_{z}} map;module number [z];ladder number [#varphi]",
+                                             8,
+                                             0.,
+                                             8.,
+                                             nLadders_,
+                                             0.,
+                                             nLadders_);
 
-  n_dxyL1WidthMap      =  Width2DMapsDir.make<TH2F> ("norm_widths_dxy_l1map",
-						     "width(d_{xy}/#sigma_{d_{xy}}) map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  n_dxyL1WidthMap =
+      Width2DMapsDir.make<TH2F>("norm_widths_dxy_l1map",
+                                "width(d_{xy}/#sigma_{d_{xy}}) map;module number [z];ladder number [#varphi]",
+                                8,
+                                0.,
+                                8.,
+                                nLadders_,
+                                0.,
+                                nLadders_);
 
-  n_dzL1WidthMap       =  Width2DMapsDir.make<TH2F> ("norm_widths_dz_l1map",
-						     "width(d_{z}/#sigma_{d_{z}}) map;module number [z];ladder number [#varphi]",
-						     8,0.,8.,nLadders_,0.,nLadders_);
+  n_dzL1WidthMap =
+      Width2DMapsDir.make<TH2F>("norm_widths_dz_l1map",
+                                "width(d_{z}/#sigma_{d_{z}}) map;module number [z];ladder number [#varphi]",
+                                8,
+                                0.,
+                                8.,
+                                nLadders_,
+                                0.,
+                                nLadders_);
 
   if (useTracksFromRecoVtx_) {
     fillTrendPlotByIndex(a_dxyPhiMeanBiasTrend, a_dxyPhiBiasResiduals, PVValHelper::MEAN, PVValHelper::phi);
@@ -2755,16 +2830,15 @@ void PrimaryVertexValidation::endJob() {
 
     // 2d Maps
 
-    fillMap(a_dxyMeanBiasMap ,a_dxyBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-    fillMap(a_dxyWidthBiasMap,a_dxyBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
-    fillMap(a_dzMeanBiasMap  ,a_dzBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-    fillMap(a_dzWidthBiasMap ,a_dzBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+    fillMap(a_dxyMeanBiasMap, a_dxyBiasResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+    fillMap(a_dxyWidthBiasMap, a_dxyBiasResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
+    fillMap(a_dzMeanBiasMap, a_dzBiasResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+    fillMap(a_dzWidthBiasMap, a_dzBiasResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
 
-    fillMap(n_dxyMeanBiasMap ,n_dxyBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-    fillMap(n_dxyWidthBiasMap,n_dxyBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
-    fillMap(n_dzMeanBiasMap  ,n_dzBiasResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-    fillMap(n_dzWidthBiasMap ,n_dzBiasResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
-
+    fillMap(n_dxyMeanBiasMap, n_dxyBiasResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+    fillMap(n_dxyWidthBiasMap, n_dxyBiasResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
+    fillMap(n_dzMeanBiasMap, n_dzBiasResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+    fillMap(n_dzWidthBiasMap, n_dzBiasResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
   }
 
   // do profiles
@@ -2858,28 +2932,27 @@ void PrimaryVertexValidation::endJob() {
 
   // 2D Maps
 
-  fillMap(a_dxyMeanMap ,a_dxyResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-  fillMap(a_dxyWidthMap,a_dxyResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
-  fillMap(a_dzMeanMap  ,a_dzResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-  fillMap(a_dzWidthMap ,a_dzResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+  fillMap(a_dxyMeanMap, a_dxyResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+  fillMap(a_dxyWidthMap, a_dxyResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
+  fillMap(a_dzMeanMap, a_dzResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+  fillMap(a_dzWidthMap, a_dzResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
 
-  fillMap(n_dxyMeanMap ,n_dxyResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-  fillMap(n_dxyWidthMap,n_dxyResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
-  fillMap(n_dzMeanMap  ,n_dzResidualsMap,PVValHelper::MEAN,nBins_,nBins_); 
-  fillMap(n_dzWidthMap ,n_dzResidualsMap,PVValHelper::WIDTH,nBins_,nBins_);
+  fillMap(n_dxyMeanMap, n_dxyResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+  fillMap(n_dxyWidthMap, n_dxyResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
+  fillMap(n_dzMeanMap, n_dzResidualsMap, PVValHelper::MEAN, nBins_, nBins_);
+  fillMap(n_dzWidthMap, n_dzResidualsMap, PVValHelper::WIDTH, nBins_, nBins_);
 
   // 2D Maps of residuals in bins of L1 modules
 
-  fillMap(a_dxyL1MeanMap ,a_dxyL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
-  fillMap(a_dxyL1WidthMap,a_dxyL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
-  fillMap(a_dzL1MeanMap  ,a_dzL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
-  fillMap(a_dzL1WidthMap ,a_dzL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
+  fillMap(a_dxyL1MeanMap, a_dxyL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
+  fillMap(a_dxyL1WidthMap, a_dxyL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
+  fillMap(a_dzL1MeanMap, a_dzL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
+  fillMap(a_dzL1WidthMap, a_dzL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
 
-  fillMap(n_dxyL1MeanMap ,n_dxyL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
-  fillMap(n_dxyL1WidthMap,n_dxyL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
-  fillMap(n_dzL1MeanMap  ,n_dzL1ResidualsMap,PVValHelper::MEAN,8,nLadders_); 
-  fillMap(n_dzL1WidthMap ,n_dzL1ResidualsMap,PVValHelper::WIDTH,8,nLadders_);
-
+  fillMap(n_dxyL1MeanMap, n_dxyL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
+  fillMap(n_dxyL1WidthMap, n_dxyL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
+  fillMap(n_dzL1MeanMap, n_dzL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
+  fillMap(n_dzL1WidthMap, n_dzL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
 }
 
 //*************************************************************
@@ -2888,11 +2961,11 @@ std::pair<long long, long long> PrimaryVertexValidation::getRunTime(const edm::E
 {
   edm::ESHandle<RunInfo> runInfo;
   iSetup.get<RunInfoRcd>().get(runInfo);
-  if(debug_){
-    edm::LogInfo("PrimaryVertexValidation")<<runInfo.product()->m_start_time_str << " " << runInfo.product()->m_stop_time_str << std::endl;
+  if (debug_) {
+    edm::LogInfo("PrimaryVertexValidation")
+        << runInfo.product()->m_start_time_str << " " << runInfo.product()->m_stop_time_str << std::endl;
   }
-  return std::make_pair(runInfo.product()->m_start_time_ll,runInfo.product()->m_stop_time_ll);
-
+  return std::make_pair(runInfo.product()->m_start_time_ll, runInfo.product()->m_stop_time_ll);
 }
 
 //*************************************************************
@@ -3108,29 +3181,31 @@ void PrimaryVertexValidation::fillTrendPlotByIndex(TH1F* trendPlot,
 }
 
 //*************************************************************
- void PrimaryVertexValidation::fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100],  PVValHelper::estimator fitPar_,const int nXBins_, const int nYBins_)
+void PrimaryVertexValidation::fillMap(TH2F* trendMap,
+                                      TH1F* residualsMapPlot[100][100],
+                                      PVValHelper::estimator fitPar_,
+                                      const int nXBins_,
+                                      const int nYBins_)
 //*************************************************************
 {
-
-  for ( int i=0; i<nYBins_; ++i ) {
-
+  for (int i = 0; i < nYBins_; ++i) {
     char phibincenter[129];
     auto phiBins = theDetails_.trendbins[PVValHelper::phi];
     sprintf(phibincenter, "%.f", (phiBins[i] + phiBins[i + 1]) / 2.);
 
-    if(nXBins_==nYBins_){
-      trendMap->GetYaxis()->SetBinLabel(i+1,phibincenter); 
+    if (nXBins_ == nYBins_) {
+      trendMap->GetYaxis()->SetBinLabel(i + 1, phibincenter);
     }
 
-    for ( int j=0; j<nXBins_; ++j ) {
+    for (int j = 0; j < nXBins_; ++j) {
       char etabincenter[129];
       auto etaBins = theDetails_.trendbins[PVValHelper::eta];
       sprintf(etabincenter, "%.1f", (etaBins[j] + etaBins[j + 1]) / 2.);
 
-      if(i==0) {
-	if(nXBins_==nYBins_){
-	  trendMap->GetXaxis()->SetBinLabel(j+1,etabincenter); 
-	}
+      if (i == 0) {
+        if (nXBins_ == nYBins_) {
+          trendMap->GetXaxis()->SetBinLabel(j + 1, etabincenter);
+        }
       }
 
       switch (fitPar_) {

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -74,6 +74,7 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
+  std::pair<long long,long long> getRunTime(const edm::EventSetup& iSetup) const;
   bool isHit2D(const TrackingRecHit& hit) const;
   bool hasFirstLayerPixelHits(const reco::TransientTrack& track);
   std::pair<bool, bool> pixelHitsCheck(const reco::TransientTrack& track);
@@ -118,7 +119,7 @@ private:
   std::tuple<std::string, std::string, std::string> getTypeString(PVValHelper::residualType type);
   std::tuple<std::string, std::string, std::string> getVarString(PVValHelper::plotVariable var);
 
-  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], PVValHelper::estimator fitPar_);
+  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], PVValHelper::estimator fitPar_, const int nXBins_,const int nYBins_);
 
   inline double square(double x) { return x * x; }
 
@@ -126,8 +127,8 @@ private:
   edm::ParameterSet theConfig;
   int Nevt_;
 
-  TrackFilterForPVFindingBase* theTrackFilter_;
-  TrackClusterizerInZ* theTrackClusterizer_;
+  std::unique_ptr<TrackFilterForPVFindingBase> theTrackFilter_; 
+  std::unique_ptr<TrackClusterizerInZ> theTrackClusterizer_;
 
   // setting of the number of plots
   static const int nMaxBins_ = 100;  // maximum number of bookable histograms
@@ -287,6 +288,10 @@ private:
   TH1F* h_nbins;
   TH1F* h_nLadders;
   TH1F* h_pTinfo;
+  
+  std::map<unsigned int,std::pair<long long,long long> > runNumbersTimesLog_;
+  TH1I* h_runStartTimes;
+  TH1I* h_runEndTimes;
 
   // ---- directly histograms // ===> unbiased residuals
 
@@ -345,6 +350,13 @@ private:
   TH1F* n_dxyResidualsMap[nMaxBins_][nMaxBins_];
   TH1F* n_dzResidualsMap[nMaxBins_][nMaxBins_];
   TH1F* n_d3DResidualsMap[nMaxBins_][nMaxBins_];
+
+  // for the L1 maps
+
+  TH1F* a_dxyL1ResidualsMap[nMaxBins_][nMaxBins_];
+  TH1F* a_dzL1ResidualsMap[nMaxBins_][nMaxBins_];      				 				    
+  TH1F* n_dxyL1ResidualsMap[nMaxBins_][nMaxBins_];  				 
+  TH1F* n_dzL1ResidualsMap[nMaxBins_][nMaxBins_];
 
   // ---- trends as function of phi and eta
 
@@ -461,6 +473,21 @@ private:
 
   TH2F* n_dxyWidthMap;
   TH2F* n_dzWidthMap;
+
+  //2D maps of residuals in bins of L1 modules
+
+  TH2F* a_dxyL1MeanMap;
+  TH2F* a_dzL1MeanMap;
+
+  TH2F* n_dxyL1MeanMap;
+  TH2F* n_dzL1MeanMap;
+
+  TH2F* a_dxyL1WidthMap;
+  TH2F* a_dzL1WidthMap;
+
+  TH2F* n_dxyL1WidthMap;
+  TH2F* n_dzL1WidthMap;
+
 
   //
   // ---- directly histograms
@@ -618,6 +645,10 @@ private:
   TH1F* h_probeL1Ladder_;
   TH1F* h_probeL1Module_;
   TH1I* h_probeHasBPixL1Overlap_;
+  
+  TH1F* h_probeL1ClusterProb_;
+  TH2F* h2_probeLayer1Map_;
+  TH2F* h2_probePassingLayer1Map_;
 
   // check vertex
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -74,7 +74,7 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
-  std::pair<long long,long long> getRunTime(const edm::EventSetup& iSetup) const;
+  std::pair<long long, long long> getRunTime(const edm::EventSetup& iSetup) const;
   bool isHit2D(const TrackingRecHit& hit) const;
   bool hasFirstLayerPixelHits(const reco::TransientTrack& track);
   std::pair<bool, bool> pixelHitsCheck(const reco::TransientTrack& track);
@@ -119,7 +119,11 @@ private:
   std::tuple<std::string, std::string, std::string> getTypeString(PVValHelper::residualType type);
   std::tuple<std::string, std::string, std::string> getVarString(PVValHelper::plotVariable var);
 
-  void fillMap(TH2F* trendMap, TH1F* residualsMapPlot[100][100], PVValHelper::estimator fitPar_, const int nXBins_,const int nYBins_);
+  void fillMap(TH2F* trendMap,
+               TH1F* residualsMapPlot[100][100],
+               PVValHelper::estimator fitPar_,
+               const int nXBins_,
+               const int nYBins_);
 
   inline double square(double x) { return x * x; }
 
@@ -127,7 +131,7 @@ private:
   edm::ParameterSet theConfig;
   int Nevt_;
 
-  std::unique_ptr<TrackFilterForPVFindingBase> theTrackFilter_; 
+  std::unique_ptr<TrackFilterForPVFindingBase> theTrackFilter_;
   std::unique_ptr<TrackClusterizerInZ> theTrackClusterizer_;
 
   // setting of the number of plots
@@ -288,8 +292,8 @@ private:
   TH1F* h_nbins;
   TH1F* h_nLadders;
   TH1F* h_pTinfo;
-  
-  std::map<unsigned int,std::pair<long long,long long> > runNumbersTimesLog_;
+
+  std::map<unsigned int, std::pair<long long, long long> > runNumbersTimesLog_;
   TH1I* h_runStartTimes;
   TH1I* h_runEndTimes;
 
@@ -354,8 +358,8 @@ private:
   // for the L1 maps
 
   TH1F* a_dxyL1ResidualsMap[nMaxBins_][nMaxBins_];
-  TH1F* a_dzL1ResidualsMap[nMaxBins_][nMaxBins_];      				 				    
-  TH1F* n_dxyL1ResidualsMap[nMaxBins_][nMaxBins_];  				 
+  TH1F* a_dzL1ResidualsMap[nMaxBins_][nMaxBins_];
+  TH1F* n_dxyL1ResidualsMap[nMaxBins_][nMaxBins_];
   TH1F* n_dzL1ResidualsMap[nMaxBins_][nMaxBins_];
 
   // ---- trends as function of phi and eta
@@ -487,7 +491,6 @@ private:
 
   TH2F* n_dxyL1WidthMap;
   TH2F* n_dzL1WidthMap;
-
 
   //
   // ---- directly histograms
@@ -645,7 +648,7 @@ private:
   TH1F* h_probeL1Ladder_;
   TH1F* h_probeL1Module_;
   TH1I* h_probeHasBPixL1Overlap_;
-  
+
   TH1F* h_probeL1ClusterProb_;
   TH2F* h2_probeLayer1Map_;
   TH2F* h2_probePassingLayer1Map_;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -214,7 +214,8 @@ cp .oO[Alignment/OfflineValidation]Oo./macros/CMS_lumi.h .
 
  if [[ .oO[pvvalidationreference]Oo. == *store* ]]; then xrdcp -f .oO[pvvalidationreference]Oo. PVValidation_reference.root; else ln -fs .oO[pvvalidationreference]Oo. ./PVValidation_reference.root; fi
 
-root -b -q "FitPVResiduals.C(\\"${PWD}/${RootOutputFile}=${theLabel},${PWD}/PVValidation_reference.root=Design simulation\\",true,true,\\"$theDate\\")"
+echo "I am going to produce the comparison with IDEAL geometry of ${RootOutputFile}"
+root -b -q "FitPVResiduals.C++g(\\"${PWD}/${RootOutputFile}=${theLabel},${PWD}/PVValidation_reference.root=Design simulation\\",true,true,\\"$theDate\\")"
 
 mkdir -p .oO[plotsdir]Oo.
 for PngOutputFile in $(ls *png ); do

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -191,6 +191,8 @@ import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
 process.seqTrackselRefit = trackselRefit.getSequence(process,'TRACKTYPETEMPLATE')
 process.HighPurityTrackSelector.trackQualities = cms.vstring()
 process.HighPurityTrackSelector.pMin     = cms.double(0.)
+#process.TrackerTrackHitFilter.usePixelQualityFlag = cms.bool(False)    # do not use the pixel quality flag
+#process.TrackerTrackHitFilter.commands   = cms.vstring("drop PXB 1")   # drop BPix1 hits
 process.AlignmentTrackSelector.pMin      = cms.double(0.)
 process.AlignmentTrackSelector.ptMin     = cms.double(0.)
 process.AlignmentTrackSelector.nHitMin2D = cms.uint32(0)
@@ -222,7 +224,9 @@ if isDA:
                                            askFirstLayerHit = cms.bool(False),
                                            forceBeamSpot = cms.untracked.bool(False),
                                            probePt = cms.untracked.double(PTCUTTEMPLATE),
+                                           probeEta = cms.untracked.double(2.7),
                                            runControl = cms.untracked.bool(RUNCONTROLTEMPLATE),
+                                           intLumi = cms.untracked.double(INTLUMITEMPLATE),
                                            runControlNumber = cms.untracked.vuint32(int(runboundary)),
                                            
                                            TkFilterParameters = cms.PSet(algorithm=cms.string('filter'),                           
@@ -265,7 +269,9 @@ else:
                                            askFirstLayerHit = cms.bool(False),
                                            forceBeamSpot = cms.untracked.bool(False),
                                            probePt = cms.untracked.double(PTCUTTEMPLATE),
+                                           probeEta = cms.untracked.double(2.7),
                                            runControl = cms.untracked.bool(RUNCONTROLTEMPLATE),
+                                           intLumi = cms.untracked.double(INTLUMITEMPLATE),
                                            runControlNumber = cms.untracked.vuint32(int(runboundary)),
                                            
                                            TkFilterParameters = cms.PSet(algorithm=cms.string('filter'),                             


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to update the code of the PV Validation tool used in the tracker alignment to the standard used during the Run-2 Ultra-Legacy campaigns.
**N.B.**: the total amount of changes is large, but is actually due to the obligatory code-format that I've factorized in https://github.com/cms-sw/cmssw/commit/a6fd1395f5e2194f0f668a9fb7988f5609cae6d2

#### PR validation:

PR passes compilation and standard unit tests.
Extensive usage of the tool has been done during the Ultra-Legacy campaign, including the production of the recently approved results (see [Approved DPS](https://indico.cern.ch/event/845618/contributions/3552182/attachments/1902186/3140390/Tracker_DPG_Plots_Approval_30Aug2019_updated.pdf)).
Here an example of the approved results for 2017:

![RMS_dxy_phi_vs_lumi](https://user-images.githubusercontent.com/5082376/64795335-37300400-d57e-11e9-8e06-75ebf6c82ec2.png)

#### if this PR is a backport please specify the original PR:

This PR is not a backport
cc:
@adewit @connorpa 

