### PR TITLE
Adding trigonometric functions into the FormulaEvaluator

### DIFF
--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -607,7 +607,7 @@ namespace {
   const std::string k_TMath__ASinH("TMath::ASinH");
   const std::string k_atanh("atanh");
   const std::string k_TMath__ATanH("TMath::ATanH");
-  
+
   EvaluatorInfo FunctionFinder::createEvaluator(std::string::const_iterator iBegin,
                                                 std::string::const_iterator iEnd) const {
     EvaluatorInfo info;

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -581,6 +581,32 @@ namespace {
   const std::string k_TMath__Sqrt("TMath::Sqrt");
   const std::string k_abs("abs");
   const std::string k_TMath__Abs("TMath::Abs");
+  const std::string k_cos("cos");
+  const std::string k_sin("sin");
+  const std::string k_tan("tan");
+  const std::string k_acos("acos");
+  const std::string k_asin("asin");
+  const std::string k_atan("atan");
+  const std::string k_atan2("atan2");
+  const std::string k_cosh("cosh");
+  const std::string k_sinh("sinh");
+  const std::string k_tanh("tanh");
+  const std::string k_acosh("acosh");
+  const std::string k_asinh("asinh");
+  const std::string k_atanh("atanh");
+  const std::string k_TMath__Cos("TMath::Cos");
+  const std::string k_TMath__Sin("TMath::Sin");
+  const std::string k_TMath__Tan("TMath::Tan");
+  const std::string k_TMath__ACos("TMath::ACos");
+  const std::string k_TMath__ASin("TMath::ASin");
+  const std::string k_TMath__ATan("TMath::ATan");
+  const std::string k_TMath__ATan2("TMath::ATan2");
+  const std::string k_TMath__CosH("TMath::CosH");
+  const std::string k_TMath__SinH("TMath::SinH");
+  const std::string k_TMath__TanH("TMath::TanH");
+  const std::string k_TMath__ACosH("TMath::ACosH");
+  const std::string k_TMath__ASinH("TMath::ASinH");
+  const std::string k_TMath__ATanH("TMath::ATanH");
 
   EvaluatorInfo FunctionFinder::createEvaluator(std::string::const_iterator iBegin,
                                                 std::string::const_iterator iEnd) const {
@@ -633,7 +659,7 @@ namespace {
     if (info.evaluator.get() != nullptr) {
       return info;
     }
-
+    
     info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__Sqrt, [](double iArg) -> double { return std::sqrt(iArg); });
     if (info.evaluator.get() != nullptr) {
@@ -648,6 +674,165 @@ namespace {
 
     info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__Abs, [](double iArg) -> double { return std::abs(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_cos, [](double iArg) -> double { return std::cos(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_sin, [](double iArg) -> double { return std::sin(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_tan, [](double iArg) -> double { return std::tan(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_acos, [](double iArg) -> double { return std::acos(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_asin, [](double iArg) -> double { return std::asin(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_atan, [](double iArg) -> double { return std::atan(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_cosh, [](double iArg) -> double { return std::cosh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_sinh, [](double iArg) -> double { return std::sinh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_tanh, [](double iArg) -> double { return std::tanh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_acosh, [](double iArg) -> double { return std::acosh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_asinh, [](double iArg) -> double { return std::asinh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_atanh, [](double iArg) -> double { return std::atanh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Cos, [](double iArg) -> double { return std::cos(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Sin, [](double iArg) -> double { return std::sin(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__Tan, [](double iArg) -> double { return std::tan(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ACos, [](double iArg) -> double { return std::acos(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ASin, [](double iArg) -> double { return std::asin(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ATan, [](double iArg) -> double { return std::atan(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__CosH, [](double iArg) -> double { return std::cosh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__SinH, [](double iArg) -> double { return std::sinh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__TanH, [](double iArg) -> double { return std::tanh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ACosH, [](double iArg) -> double { return std::acosh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ASinH, [](double iArg) -> double { return std::asinh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ATanH, [](double iArg) -> double { return std::atanh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(iBegin, iEnd, m_expressionFinder, k_atan2, [](double iArg1, double iArg2) -> double {
+      return std::atan2(iArg1, iArg2);
+    });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForTwoArgsFunction(
+        iBegin, iEnd, m_expressionFinder, k_TMath__ATan2, [](double iArg1, double iArg2) -> double {
+          return std::atan2(iArg1, iArg2);
+        });
     if (info.evaluator.get() != nullptr) {
       return info;
     }

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -659,7 +659,7 @@ namespace {
     if (info.evaluator.get() != nullptr) {
       return info;
     }
-    
+
     info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__Sqrt, [](double iArg) -> double { return std::sqrt(iArg); });
     if (info.evaluator.get() != nullptr) {

--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -582,32 +582,32 @@ namespace {
   const std::string k_abs("abs");
   const std::string k_TMath__Abs("TMath::Abs");
   const std::string k_cos("cos");
-  const std::string k_sin("sin");
-  const std::string k_tan("tan");
-  const std::string k_acos("acos");
-  const std::string k_asin("asin");
-  const std::string k_atan("atan");
-  const std::string k_atan2("atan2");
-  const std::string k_cosh("cosh");
-  const std::string k_sinh("sinh");
-  const std::string k_tanh("tanh");
-  const std::string k_acosh("acosh");
-  const std::string k_asinh("asinh");
-  const std::string k_atanh("atanh");
   const std::string k_TMath__Cos("TMath::Cos");
+  const std::string k_sin("sin");
   const std::string k_TMath__Sin("TMath::Sin");
+  const std::string k_tan("tan");
   const std::string k_TMath__Tan("TMath::Tan");
+  const std::string k_acos("acos");
   const std::string k_TMath__ACos("TMath::ACos");
+  const std::string k_asin("asin");
   const std::string k_TMath__ASin("TMath::ASin");
+  const std::string k_atan("atan");
   const std::string k_TMath__ATan("TMath::ATan");
+  const std::string k_atan2("atan2");
   const std::string k_TMath__ATan2("TMath::ATan2");
+  const std::string k_cosh("cosh");
   const std::string k_TMath__CosH("TMath::CosH");
+  const std::string k_sinh("sinh");
   const std::string k_TMath__SinH("TMath::SinH");
+  const std::string k_tanh("tanh");
   const std::string k_TMath__TanH("TMath::TanH");
+  const std::string k_acosh("acosh");
   const std::string k_TMath__ACosH("TMath::ACosH");
+  const std::string k_asinh("asinh");
   const std::string k_TMath__ASinH("TMath::ASinH");
+  const std::string k_atanh("atanh");
   const std::string k_TMath__ATanH("TMath::ATanH");
-
+  
   EvaluatorInfo FunctionFinder::createEvaluator(std::string::const_iterator iBegin,
                                                 std::string::const_iterator iEnd) const {
     EvaluatorInfo info;
@@ -685,73 +685,13 @@ namespace {
     }
 
     info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_sin, [](double iArg) -> double { return std::sin(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_tan, [](double iArg) -> double { return std::tan(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_acos, [](double iArg) -> double { return std::acos(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_asin, [](double iArg) -> double { return std::asin(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_atan, [](double iArg) -> double { return std::atan(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_cosh, [](double iArg) -> double { return std::cosh(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_sinh, [](double iArg) -> double { return std::sinh(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_tanh, [](double iArg) -> double { return std::tanh(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_acosh, [](double iArg) -> double { return std::acosh(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_asinh, [](double iArg) -> double { return std::asinh(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
-        iBegin, iEnd, m_expressionFinder, k_atanh, [](double iArg) -> double { return std::atanh(iArg); });
-    if (info.evaluator.get() != nullptr) {
-      return info;
-    }
-
-    info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__Cos, [](double iArg) -> double { return std::cos(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_sin, [](double iArg) -> double { return std::sin(iArg); });
     if (info.evaluator.get() != nullptr) {
       return info;
     }
@@ -763,7 +703,19 @@ namespace {
     }
 
     info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_tan, [](double iArg) -> double { return std::tan(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__Tan, [](double iArg) -> double { return std::tan(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_acos, [](double iArg) -> double { return std::acos(iArg); });
     if (info.evaluator.get() != nullptr) {
       return info;
     }
@@ -775,7 +727,19 @@ namespace {
     }
 
     info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_asin, [](double iArg) -> double { return std::asin(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__ASin, [](double iArg) -> double { return std::asin(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_atan, [](double iArg) -> double { return std::atan(iArg); });
     if (info.evaluator.get() != nullptr) {
       return info;
     }
@@ -787,7 +751,19 @@ namespace {
     }
 
     info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_cosh, [](double iArg) -> double { return std::cosh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__CosH, [](double iArg) -> double { return std::cosh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_sinh, [](double iArg) -> double { return std::sinh(iArg); });
     if (info.evaluator.get() != nullptr) {
       return info;
     }
@@ -799,7 +775,19 @@ namespace {
     }
 
     info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_tanh, [](double iArg) -> double { return std::tanh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__TanH, [](double iArg) -> double { return std::tanh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_acosh, [](double iArg) -> double { return std::acosh(iArg); });
     if (info.evaluator.get() != nullptr) {
       return info;
     }
@@ -811,7 +799,19 @@ namespace {
     }
 
     info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_asinh, [](double iArg) -> double { return std::asinh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
         iBegin, iEnd, m_expressionFinder, k_TMath__ASinH, [](double iArg) -> double { return std::asinh(iArg); });
+    if (info.evaluator.get() != nullptr) {
+      return info;
+    }
+
+    info = checkForSingleArgFunction(
+        iBegin, iEnd, m_expressionFinder, k_atanh, [](double iArg) -> double { return std::atanh(iArg); });
     if (info.evaluator.get() != nullptr) {
       return info;
     }

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -590,7 +590,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::cos(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::cos(0.5)) < 1e-9);
   }
 
   {
@@ -598,7 +598,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Cos(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::Cos(0.5)) < 1e-9);
   }
 
   {
@@ -606,7 +606,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::sin(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::sin(0.5)) < 1e-9);
   }
 
   {
@@ -614,7 +614,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Sin(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::Sin(0.5)) < 1e-9);
   }
 
   {
@@ -622,7 +622,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::tan(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::tan(0.5)) < 1e-9);
   }
 
   {
@@ -630,7 +630,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Tan(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::Tan(0.5)) < 1e-9);
   }
 
   {
@@ -638,7 +638,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::acos(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::acos(0.5)) < 1e-9);
   }
 
   {
@@ -646,7 +646,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ACos(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ACos(0.5)) < 1e-9);
   }
 
   {
@@ -654,7 +654,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::asin(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::asin(0.5)) < 1e-9);
   }
 
   {
@@ -662,7 +662,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ASin(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ASin(0.5)) < 1e-9);
   }
 
   {
@@ -670,7 +670,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atan(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::atan(0.5)) < 1e-9);
   }
 
   {
@@ -678,7 +678,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ATan(0.5)) < 1e-9);
   }
 
   {
@@ -686,7 +686,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atan2(-0.5, 0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::atan2(-0.5, 0.5)) < 1e-9);
   }
 
   {
@@ -694,7 +694,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan2(-0.5, 0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ATan2(-0.5, 0.5)) < 1e-9);
   }
 
   {
@@ -702,7 +702,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::cosh(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::cosh(0.5)) < 1e-9);
   }
 
   {
@@ -710,7 +710,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::CosH(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::CosH(0.5)) < 1e-9);
   }
 
   {
@@ -718,7 +718,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::sinh(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::sinh(0.5)) < 1e-9);
   }
 
   {
@@ -726,7 +726,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::SinH(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::SinH(0.5)) < 1e-9);
   }
 
   {
@@ -734,7 +734,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::tanh(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::tanh(0.5)) < 1e-9);
   }
 
   {
@@ -742,7 +742,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::TanH(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::TanH(0.5)) < 1e-9);
   }
 
   {
@@ -750,7 +750,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::acosh(2.0));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::acosh(2.0)) < 1e-9);
   }
 
   {
@@ -758,7 +758,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ACosH(2.0));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ACosH(2.0)) < 1e-9);
   }
 
   {
@@ -766,7 +766,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::asinh(2.0));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::asinh(2.0)) < 1e-9);
   }
 
   {
@@ -774,7 +774,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ASinH(2.0));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ASinH(2.0)) < 1e-9);
   }
 
   {
@@ -782,7 +782,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atanh(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::atanh(0.5)) < 1e-9);
   }
 
   {
@@ -790,7 +790,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATanH(0.5));
+    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ATanH(0.5)) < 1e-9);
   }
 
   {

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -745,7 +745,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
     CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::TanH(0.5));
   }
 
-  // std::acosh and std::atanh are using delta fabs instead of equality because gcc compute the value differently at compile time. 
+  // std::acosh and std::atanh are using delta fabs instead of equality because gcc compute the value differently at compile time.
   {
     reco::FormulaEvaluator f("acosh(2.0)");
 

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -745,6 +745,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
     CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::TanH(0.5));
   }
 
+  // std::acosh and std::atanh are using delta fabs instead of equality because gcc compute the value differently at compile time. 
   {
     reco::FormulaEvaluator f("acosh(2.0)");
 

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -590,7 +590,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::cos(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::cos(0.5));
   }
 
   {
@@ -598,7 +598,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::Cos(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Cos(0.5));
   }
 
   {
@@ -606,7 +606,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::sin(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::sin(0.5));
   }
 
   {
@@ -614,7 +614,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::Sin(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Sin(0.5));
   }
 
   {
@@ -622,7 +622,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::tan(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::tan(0.5));
   }
 
   {
@@ -630,7 +630,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::Tan(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Tan(0.5));
   }
 
   {
@@ -638,7 +638,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::acos(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::acos(0.5));
   }
 
   {
@@ -646,7 +646,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ACos(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ACos(0.5));
   }
 
   {
@@ -654,7 +654,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::asin(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::asin(0.5));
   }
 
   {
@@ -662,7 +662,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ASin(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ASin(0.5));
   }
 
   {
@@ -670,7 +670,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::atan(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atan(0.5));
   }
 
   {
@@ -678,7 +678,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ATan(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan(0.5));
   }
 
   {
@@ -686,7 +686,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::atan2(-0.5, 0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atan2(-0.5, 0.5));
   }
 
   {
@@ -694,7 +694,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ATan2(-0.5, 0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan2(-0.5, 0.5));
   }
 
   {
@@ -702,7 +702,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::cosh(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::cosh(0.5));
   }
 
   {
@@ -710,7 +710,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::CosH(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::CosH(0.5));
   }
 
   {
@@ -718,7 +718,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::sinh(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::sinh(0.5));
   }
 
   {
@@ -726,7 +726,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::SinH(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::SinH(0.5));
   }
 
   {
@@ -734,7 +734,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::tanh(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::tanh(0.5));
   }
 
   {
@@ -742,7 +742,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::TanH(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::TanH(0.5));
   }
 
   {
@@ -758,7 +758,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ACosH(2.0)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ACosH(2.0));
   }
 
   {
@@ -766,7 +766,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - std::asinh(2.0)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::asinh(2.0));
   }
 
   {
@@ -774,7 +774,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ASinH(2.0)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ASinH(2.0));
   }
 
   {
@@ -790,7 +790,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
 
     std::vector<double> emptyV;
 
-    CPPUNIT_ASSERT(fabs(f.evaluate(emptyV, emptyV) - TMath::ATanH(0.5)) < 1e-9);
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATanH(0.5));
   }
 
   {

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -695,7 +695,7 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
     std::vector<double> emptyV;
 
     CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan2(-0.5, 0.5));
-  }  
+  }
 
   {
     reco::FormulaEvaluator f("cosh(0.5)");

--- a/CommonTools/Utils/test/testFormulaEvaluator.cc
+++ b/CommonTools/Utils/test/testFormulaEvaluator.cc
@@ -586,6 +586,214 @@ void testFormulaEvaluator::checkFormulaEvaluator() {
   }
 
   {
+    reco::FormulaEvaluator f("cos(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::cos(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Cos(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Cos(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("sin(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::sin(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Sin(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Sin(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("tan(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::tan(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::Tan(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::Tan(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("acos(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::acos(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ACos(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ACos(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("asin(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::asin(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ASin(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ASin(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("atan(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atan(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ATan(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("atan2(-0.5, 0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atan2(-0.5, 0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ATan2(-0.5, 0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATan2(-0.5, 0.5));
+  }  
+
+  {
+    reco::FormulaEvaluator f("cosh(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::cosh(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::CosH(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::CosH(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("sinh(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::sinh(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::SinH(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::SinH(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("tanh(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::tanh(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::TanH(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::TanH(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("acosh(2.0)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::acosh(2.0));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ACosH(2.0)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ACosH(2.0));
+  }
+
+  {
+    reco::FormulaEvaluator f("asinh(2.0)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::asinh(2.0));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ASinH(2.0)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ASinH(2.0));
+  }
+
+  {
+    reco::FormulaEvaluator f("atanh(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == std::atanh(0.5));
+  }
+
+  {
+    reco::FormulaEvaluator f("TMath::ATanH(0.5)");
+
+    std::vector<double> emptyV;
+
+    CPPUNIT_ASSERT(f.evaluate(emptyV, emptyV) == TMath::ATanH(0.5));
+  }
+
+  {
     reco::FormulaEvaluator f("max(max(5,3),2)");
 
     std::vector<double> emptyV;


### PR DESCRIPTION
Adding trigonometric functions to FormulaEvaluator. This is the first step in modifying JER scale factors application to be jet pT dependent. Latest JER scale factors might need trigonometric functions for parameterization as a function of pT.