### PR TITLE
Truncate pt of PackedCandidate

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -11,7 +11,7 @@ CovarianceParameterization pat::PackedCandidate::covarianceParameterization_;
 std::once_flag pat::PackedCandidate::covariance_load_flag;
 
 void pat::PackedCandidate::pack(bool unpackAfterwards) {
-  float unpackedPt = std::min(p4_.load()->Pt(),MiniFloatConverter::max());
+  float unpackedPt = std::min(p4_.load()->Pt(), MiniFloatConverter::max());
   packedPt_ = MiniFloatConverter::float32to16(unpackedPt);
   packedEta_ = int16_t(std::round(p4_.load()->Eta() / 6.0f * std::numeric_limits<int16_t>::max()));
   packedPhi_ = int16_t(std::round(p4_.load()->Phi() / 3.2f * std::numeric_limits<int16_t>::max()));

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -11,7 +11,7 @@ CovarianceParameterization pat::PackedCandidate::covarianceParameterization_;
 std::once_flag pat::PackedCandidate::covariance_load_flag;
 
 void pat::PackedCandidate::pack(bool unpackAfterwards) {
-  float unpackedPt = std::min(p4_.load()->Pt(), MiniFloatConverter::max());
+  float unpackedPt = std::min<float>(p4_.load()->Pt(), MiniFloatConverter::max());
   packedPt_ = MiniFloatConverter::float32to16(unpackedPt);
   packedEta_ = int16_t(std::round(p4_.load()->Eta() / 6.0f * std::numeric_limits<int16_t>::max()));
   packedPhi_ = int16_t(std::round(p4_.load()->Phi() / 3.2f * std::numeric_limits<int16_t>::max()));

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -11,7 +11,8 @@ CovarianceParameterization pat::PackedCandidate::covarianceParameterization_;
 std::once_flag pat::PackedCandidate::covariance_load_flag;
 
 void pat::PackedCandidate::pack(bool unpackAfterwards) {
-  packedPt_ = MiniFloatConverter::float32to16(p4_.load()->Pt());
+  float unpackedPt = std::min(p4_.load()->Pt(),MiniFloatConverter::max());
+  packedPt_ = MiniFloatConverter::float32to16(unpackedPt);
   packedEta_ = int16_t(std::round(p4_.load()->Eta() / 6.0f * std::numeric_limits<int16_t>::max()));
   packedPhi_ = int16_t(std::round(p4_.load()->Phi() / 3.2f * std::numeric_limits<int16_t>::max()));
   packedM_ = MiniFloatConverter::float32to16(p4_.load()->M());


### PR DESCRIPTION
#### PR description:

In response to #27374, truncating pt of PackedCandidate in case the 32 bit representation is beyond the 16-bit max (represented by the "minifloat" as inf, as per that standard requirement [here](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf)).  This was giving problems downstream when the 16-bit "infinity" was widened to 32 bits and became inaccurate.



#### PR validation:

This is so deep in the software stack that it is challenging to predict the behavior without ALL of the validations being run. 
