### PR TITLE
Removed unimplemented move constructor from StorageAccount

### DIFF
--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -48,8 +48,6 @@ public:
           timeMin{0.},
           timeMax{0.} {}
 
-    Counter(Counter&&) = default;
-
     //NOTE: This is needed by tbb::concurrent_unordered_map when it
     // is constructing a new one. This would not give correct results
     // if the object being passed were being updated, but that is not


### PR DESCRIPTION
#### PR description:

Although the move constructor was marked '=default' the compiler was unable to generate it. Given all member data of the class as atomics of builtin types, a move constructor would be no
different from a copy constructor anyway.

#### PR validation:

Compiling using clang no longer generates the warning.