### PR TITLE
Explicitly declare copy assignment for bqueue

### DIFF
--- a/TrackingTools/PatternTools/interface/bqueue.h
+++ b/TrackingTools/PatternTools/interface/bqueue.h
@@ -138,6 +138,7 @@ namespace cmsutils {
       cp.m_size = 0;
     }
 
+    bqueue &operator=(bqueue<T> const &) = default;
     bqueue &operator=(bqueue<T> &&cp) noexcept {
       using std::swap;
       swap(m_size, cp.m_size);

--- a/TrackingTools/PatternTools/test/bqueue_t.cpp
+++ b/TrackingTools/PatternTools/test/bqueue_t.cpp
@@ -47,6 +47,15 @@ int main() {
   assert(cont.shared());
   assert(cont3.shared());
   verifySeq(cont3);
+  // copy assign
+  {
+    Cont cont_assign;
+    cont_assign = cont;
+    assert(cont.size() == cont_assign.size());
+    assert(cont.shared());
+    assert(cont_assign.shared());
+    verifySeq(cont_assign);
+  }
   // add
   cont.push_back(Cont::value_type(new int(10)));
   assert((*cont.back()) == 10);


### PR DESCRIPTION
#### PR description:

The clang compiler was warning about classes which had bqueue objects as members were unable to implement copy assignment operators because bqueue had not explicitly declared one.

#### PR validation:

Compiling under clang no longer gives a warning.
The extension of the unit test to test copy assignment passes.