### PR TITLE
Removed implicitly dropped move assignment from RectangularEtaPhiTrackingRegion

### DIFF
--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -55,7 +55,7 @@ public:
 
   RectangularEtaPhiTrackingRegion& operator=(RectangularEtaPhiTrackingRegion const&) = delete;
   RectangularEtaPhiTrackingRegion(RectangularEtaPhiTrackingRegion&&) = default;
-  RectangularEtaPhiTrackingRegion& operator=(RectangularEtaPhiTrackingRegion&&) = default;
+  RectangularEtaPhiTrackingRegion& operator=(RectangularEtaPhiTrackingRegion&&) = delete;
 
   typedef TkTrackingRegionsMargin<float> Margin;
 


### PR DESCRIPTION
#### PR description:

The compiler was implictly not implementing the move assignment operator even though it was marked as '=default'. The reason is there is a const member data which prohibits any assignments.

#### PR validation:

Compiling using clang no longer gives a warning.