### PR TITLE
stronger edm::propagate_const const-correctness

### DIFF
--- a/FWCore/Utilities/interface/propagate_const.h
+++ b/FWCore/Utilities/interface/propagate_const.h
@@ -61,35 +61,39 @@ namespace edm {
     }
 
     // ---------- const member functions ---------------------
-    element_type const* get() const {
-      return to_raw_pointer(m_value);
-    }
+    element_type const* get() const { return to_raw_pointer(m_value); }
     element_type const* operator->() const { return this->get(); }
     element_type const& operator*() const { return *m_value; }
 
     operator element_type const*() const { return this->get(); }
 
     // ---------- member functions ---------------------------
-    element_type* get() {
-      return to_raw_pointer(m_value);
-    }
+    element_type* get() { return to_raw_pointer(m_value); }
     element_type* operator->() { return this->get(); }
     element_type& operator*() { return *m_value; }
 
     operator element_type*() { return this->get(); }
 
   private:
-    template <typename Up> static constexpr element_type*
-    to_raw_pointer(Up* u) { return u; }
+    template <typename Up>
+    static constexpr element_type* to_raw_pointer(Up* u) {
+      return u;
+    }
 
-    template <typename Up> static constexpr element_type*
-    to_raw_pointer(Up& u) { return u.get(); }
+    template <typename Up>
+    static constexpr element_type* to_raw_pointer(Up& u) {
+      return u.get();
+    }
 
-    template <typename Up> static constexpr const element_type*
-    to_raw_pointer(const Up* u) { return u; }
+    template <typename Up>
+    static constexpr const element_type* to_raw_pointer(const Up* u) {
+      return u;
+    }
 
-    template <typename Up> static constexpr const element_type*
-    to_raw_pointer(const Up& u) { return u.get(); }
+    template <typename Up>
+    static constexpr const element_type* to_raw_pointer(const Up& u) {
+      return u.get();
+    }
 
     // ---------- member data --------------------------------
     T m_value;

--- a/FWCore/Utilities/interface/propagate_const.h
+++ b/FWCore/Utilities/interface/propagate_const.h
@@ -62,11 +62,7 @@ namespace edm {
 
     // ---------- const member functions ---------------------
     element_type const* get() const {
-      if constexpr (std::is_pointer<T>::value) {
-        return m_value;
-      } else {
-        return m_value.get();
-      }
+      return to_raw_pointer(m_value);
     }
     element_type const* operator->() const { return this->get(); }
     element_type const& operator*() const { return *m_value; }
@@ -75,11 +71,7 @@ namespace edm {
 
     // ---------- member functions ---------------------------
     element_type* get() {
-      if constexpr (std::is_pointer<T>::value) {
-        return m_value;
-      } else {
-        return m_value.get();
-      }
+      return to_raw_pointer(m_value);
     }
     element_type* operator->() { return this->get(); }
     element_type& operator*() { return *m_value; }
@@ -87,6 +79,18 @@ namespace edm {
     operator element_type*() { return this->get(); }
 
   private:
+    template <typename Up> static constexpr element_type*
+    to_raw_pointer(Up* u) { return u; }
+
+    template <typename Up> static constexpr element_type*
+    to_raw_pointer(Up& u) { return u.get(); }
+
+    template <typename Up> static constexpr const element_type*
+    to_raw_pointer(const Up* u) { return u; }
+
+    template <typename Up> static constexpr const element_type*
+    to_raw_pointer(const Up& u) { return u.get(); }
+
     // ---------- member data --------------------------------
     T m_value;
   };

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -42,7 +42,7 @@ namespace edm {
     std::shared_ptr<ProductRegistry>& productRegistry() { return get_underlying_safe(productRegistry_); }
 
     edm::propagate_const<std::shared_ptr<ProductRegistry>> productRegistry_;
-    edm::propagate_const<std::shared_ptr<VectorInputSource> const> secInput_;
+    edm::propagate_const<std::shared_ptr<VectorInputSource>> secInput_;
     edm::propagate_const<std::unique_ptr<ProcessConfiguration>> processConfiguration_;
     edm::propagate_const<std::unique_ptr<EventPrincipal>> eventPrincipal_;
     bool sequential_;


### PR DESCRIPTION
#### PR description:

The current edm::propagate_const permits a const smart pointer to contain a non-const object.  This is not allowed by the gcc and llvm implementations of the  proposed std::experimental::propagate_const it is meant to emulate.  This PR modifies edm::propagate_const to match the behavior of the gcc and llvm implementations.

#### PR validation:

"checkdeps -a -A" checked out ~95% of CMSSW, but only one violation of the stricter check was found.  The only effects of this change should be compile time errors, but nevertheless a limited matrix was run, with no unexpected errors (some workflows failed with step 1 DAS errors).
