### PR TITLE
Extend EMTF interface with GEM pad digi clusters for Run-3

### DIFF
--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -46,6 +46,7 @@ namespace l1t {
 
 // GEM digi types
 class GEMPadDigi;
+class GEMPadDigiCluster;
 class GEMDetId;
 
 // ME0 digi types
@@ -190,6 +191,7 @@ namespace L1TMuon {
 
     // GEM
     TriggerPrimitive(const GEMDetId& detid, const GEMPadDigi& digi);
+    TriggerPrimitive(const GEMDetId& detid, const GEMPadDigiCluster& digi);
     TriggerPrimitive(const ME0DetId& detid, const ME0PadDigi& digi);
 
     //copy

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
 
 // detector ID types
@@ -175,6 +176,17 @@ TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid, const GEMPadDigi& digi
   _gem.pad = digi.pad();
   _gem.pad_low = digi.pad();
   _gem.pad_hi = digi.pad();
+  _gem.bx = digi.bx();
+  _gem.bend = 0;
+  _gem.isME0 = false;
+}
+
+TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid, const GEMPadDigiCluster& digi)
+    : _id(detid), _subsystem(TriggerPrimitive::kGEM) {
+  calculateGlobalSector(detid, _globalsector, _subsector);
+  _gem.pad = digi.pads().front();
+  _gem.pad_low = digi.pads().front();
+  _gem.pad_hi = digi.pads().back();
   _gem.bx = digi.bx();
   _gem.bend = 0;
   _gem.isME0 = false;

--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -46,6 +46,7 @@ typedef emtf::CSCTag CSCTag;
 typedef emtf::RPCTag RPCTag;
 typedef emtf::CPPFTag CPPFTag;
 typedef emtf::GEMTag GEMTag;
+typedef emtf::GEMClusterTag GEMClusterTag;
 typedef emtf::IRPCTag IRPCTag;
 typedef emtf::ME0Tag ME0Tag;
 typedef emtf::TTTag TTTag;

--- a/L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h
+++ b/L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemTag.h
@@ -8,6 +8,8 @@
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
@@ -32,6 +34,11 @@ namespace emtf {
   struct GEMTag {
     typedef GEMPadDigi digi_type;
     typedef GEMPadDigiCollection digi_collection;
+  };
+
+  struct GEMClusterTag {
+    typedef GEMPadDigiCluster digi_type;
+    typedef GEMPadDigiClusterCollection digi_collection;
   };
 
   struct IRPCTag {

--- a/L1Trigger/L1TMuonEndCap/interface/TrackFinder.h
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackFinder.h
@@ -39,11 +39,11 @@ private:
 
   const edm::ParameterSet config_;
 
-  const edm::EDGetToken tokenCSC_, tokenRPC_, tokenCPPF_, tokenGEM_;
+  const edm::EDGetToken tokenCSC_, tokenRPC_, tokenCPPF_, tokenGEM_, tokenGEMCluster_;
 
   int verbose_, primConvLUT_;
 
-  bool fwConfig_, useCSC_, useRPC_, useCPPF_, useGEM_;
+  bool fwConfig_, useCSC_, useRPC_, useCPPF_, useGEM_, useGEMClusters_;
 
   std::string era_;
 };

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -25,12 +25,14 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     RPCInput  = cms.InputTag('simMuonRPCDigis'),
     CPPFInput = cms.InputTag('simCPPFDigis'),  ## Cannot use in MC workflow, does not exist yet.  CPPFEnable set to False - AWB 01.06.18
     GEMInput  = cms.InputTag('simMuonGEMPadDigis'),
+    GEMClusterInput  = cms.InputTag('simMuonGEMPadDigiClusters'),
 
     # Run with CSC, RPC, GEM
     CSCEnable = cms.bool(True),   # Use CSC LCTs from the MPCs in track-building
     RPCEnable = cms.bool(True),   # Use clustered RPC hits from CPPF in track-building
     CPPFEnable = cms.bool(False), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits
     GEMEnable = cms.bool(False),  # Use hits from GEMs in track-building
+    GEMUseClusters = cms.bool(False), # Use clusters instead of single hits
 
     # Era (options: 'Run2_2016', 'Run2_2017', 'Run2_2018')
     Era = cms.string('Run2_2018'),

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -117,6 +117,32 @@ void EMTFSubsystemCollector::extractPrimitives(
   return;
 }
 
+template <>
+void EMTFSubsystemCollector::extractPrimitives(
+    GEMClusterTag tag,  // Defined in interface/EMTFSubsystemTag.h, maps to GEMPadDigiCluster
+    const edm::Event& iEvent,
+    const edm::EDGetToken& token,
+    TriggerPrimitiveCollection& out) const {
+  edm::Handle<GEMClusterTag::digi_collection> gemDigis;
+  iEvent.getByToken(token, gemDigis);
+
+  TriggerPrimitiveCollection clus_muon_primitives;
+
+  auto chamber = gemDigis->begin();
+  auto chend = gemDigis->end();
+  for (; chamber != chend; ++chamber) {
+    auto digi = (*chamber).second.first;
+    auto dend = (*chamber).second.second;
+    for (; digi != dend; ++digi) {
+      clus_muon_primitives.emplace_back((*chamber).first, *digi);
+    }
+  }
+
+  // Output
+  std::copy(clus_muon_primitives.begin(), clus_muon_primitives.end(), std::back_inserter(out));
+  return;
+}
+
 // _____________________________________________________________________________
 // RPC functions
 void EMTFSubsystemCollector::cluster_rpc(const TriggerPrimitiveCollection& muon_primitives,

--- a/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackFinder.cc
@@ -16,6 +16,8 @@ TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollecto
       tokenRPC_(iConsumes.consumes<RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("RPCInput"))),
       tokenCPPF_(iConsumes.consumes<CPPFTag::digi_collection>(iConfig.getParameter<edm::InputTag>("CPPFInput"))),
       tokenGEM_(iConsumes.consumes<GEMTag::digi_collection>(iConfig.getParameter<edm::InputTag>("GEMInput"))),
+      tokenGEMCluster_(
+          iConsumes.consumes<GEMClusterTag::digi_collection>(iConfig.getParameter<edm::InputTag>("GEMClusterInput"))),
       verbose_(iConfig.getUntrackedParameter<int>("verbosity")),
       primConvLUT_(iConfig.getParameter<edm::ParameterSet>("spPCParams16").getParameter<int>("PrimConvLUT")),
       fwConfig_(iConfig.getParameter<bool>("FWConfig")),
@@ -23,6 +25,7 @@ TrackFinder::TrackFinder(const edm::ParameterSet& iConfig, edm::ConsumesCollecto
       useRPC_(iConfig.getParameter<bool>("RPCEnable")),
       useCPPF_(iConfig.getParameter<bool>("CPPFEnable")),
       useGEM_(iConfig.getParameter<bool>("GEMEnable")),
+      useGEMClusters_(iConfig.getParameter<bool>("GEMUseClusters")),
       era_(iConfig.getParameter<std::string>("Era")) {
   if (era_ == "Run2_2016") {
     pt_assign_engine_.reset(new PtAssignmentEngine2016());
@@ -162,7 +165,9 @@ void TrackFinder::process(const edm::Event& iEvent,
     collector.extractPrimitives(CPPFTag(), iEvent, tokenCPPF_, muon_primitives);
   else if (useRPC_)
     collector.extractPrimitives(RPCTag(), iEvent, tokenRPC_, muon_primitives);
-  if (useGEM_)
+  if (useGEM_ && useGEMClusters_)
+    collector.extractPrimitives(GEMClusterTag(), iEvent, tokenGEMCluster_, muon_primitives);
+  else if (useGEM_)
     collector.extractPrimitives(GEMTag(), iEvent, tokenGEM_, muon_primitives);
 
   // Check trigger primitives


### PR DESCRIPTION
#### PR description:

This PR extends the EMTF interface with GEM pad digi clusters for Run-3 emulation. GEM clusters are not being used yet. There should be no change in performance.

#### PR validation:

I ran WF 11634.0 successfully.

@tahuang1991 @jiafulow @abrinke1 