### PR TITLE
Removed move assignment op from SeedingLayerSetsBuilder

### DIFF
--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
@@ -77,7 +77,7 @@ private:
     LayerSpec(const LayerSpec&) = delete;
     LayerSpec& operator=(const LayerSpec&) = delete;
     LayerSpec(LayerSpec&&) = default;
-    LayerSpec& operator=(LayerSpec&&) = default;
+    LayerSpec& operator=(LayerSpec&&) = delete;
     const unsigned short nameIndex;
     std::string pixelHitProducer;
     bool usePixelHitProducer;


### PR DESCRIPTION
#### PR description:

The class has const member data so the compiler was never able to generate the move assignment operator anyway.

This fixes a clang warning.

#### PR validation:

Compiling under CMSSW_11_0_CLANG_X_2019-09-12-2300 no longer generates the warning.