### PR TITLE
Explicitly tell compiler to generate methods for SimplifiedGeometry

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/SimplifiedGeometry.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/SimplifiedGeometry.h
@@ -42,6 +42,12 @@ namespace fastsim {
         */
     SimplifiedGeometry(double geomProperty);
 
+    SimplifiedGeometry(SimplifiedGeometry&&) = default;
+    SimplifiedGeometry(SimplifiedGeometry const&) = delete;
+
+    SimplifiedGeometry& operator=(SimplifiedGeometry&&) = default;
+    SimplifiedGeometry& operator=(SimplifiedGeometry const&) = delete;
+
     //! Default destructor.
     virtual ~SimplifiedGeometry();
 


### PR DESCRIPTION
#### PR description:

Some inheriting types were explicitly asking the compiler to generate methods it could not because the base class SimplifiedGeometry did not have those methods (this caused clang warnings). Explicitly requesting those methods in SimplifiedGeometry fixes the warnings.

#### PR validation:

Compiling under CMSSW_11_0_CLANG_X_2019-09-12-2300 no longer generates warnings.