### PR TITLE
Removed assignment ops from ProcessCallGraph

### DIFF
--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -114,8 +114,8 @@ public:
     ProcessType(ProcessType const &other) = default;
     ProcessType(ProcessType &&other) = default;
 
-    ProcessType &operator=(ProcessType const &other) = default;
-    ProcessType &operator=(ProcessType &&other) = default;
+    ProcessType &operator=(ProcessType const &other) = delete;
+    ProcessType &operator=(ProcessType &&other) = delete;
   };
 
 public:


### PR DESCRIPTION
#### PR description:

The compiler can not generate the assignment ops for ProcessCallGraph since the class holds a reference (which can not be reassigned).

This fixes a clang warning.

#### PR validation:

Compiling under CMSSW_11_0_CLANG_X_2019-09-12-2300 no longer generate warnings.