### PR TITLE
DQM/Info: fix offline DCS bit summary

### DIFF
--- a/DQM/EcalMonitorClient/src/DQWorkerClient.cc
+++ b/DQM/EcalMonitorClient/src/DQWorkerClient.cc
@@ -176,7 +176,6 @@ namespace ecaldqm
       int i = 0;
       while (auto me = meset.second->getME(i)) {
         if (me->getLumiFlag()) {
-          std::cout << "+++ reset " << me->getFullname() << "\n";
           // reset per-lumi histograms in offline harvesting so that they only show
           // data of the current lumisection.
           me->Reset();

--- a/DQMServices/Components/plugins/DQMDcsInfoClient.cc
+++ b/DQMServices/Components/plugins/DQMDcsInfoClient.cc
@@ -62,6 +62,7 @@ DQMDcsInfoClient::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker, DQMStore::IG
       }
       DCS[nlumi] = word;
     }
+    DCSbyLS_->Reset();
   }
   return; 
 }

--- a/DQMServices/Components/scripts/dqmdumpme.py
+++ b/DQMServices/Components/scripts/dqmdumpme.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import sys
+import numpy
+import uproot
+import argparse
+
+numpy.set_printoptions(threshold=sys.maxsize)
+
+parser = argparse.ArgumentParser(description="Display in text format a single ME out of a DQM (legacy or DQMIO) file. " +
+                                             "If there is more than on copy, of one ME, all are shown.")
+
+parser.add_argument('filename', help='Name of local root file. For remote files, use edmCopyUtil first: `edmCopyUtil root://cms-xrd-global.cern.ch/<FILEPATH> .`')
+parser.add_argument('mepaths', metavar='ME', nargs='+', help='Path of ME to extract.')
+
+args = parser.parse_args()
+
+f = uproot.open(args.filename)
+things = f.keys()
+if 'Indices;1' in things:
+  # this is DQMIO data, TODO
+  pass
+elif 'DQMData;1' in things:
+  basedir = f['DQMData']
+  for run in basedir.keys():
+    rundir = basedir[run]
+    print("MEs for %s" % run)
+    for me in args.mepaths:
+      subsys, path = me.split('/', 1)
+      subsysdir = rundir[subsys]
+      # typically this will only be "Run summary"
+      for lumi in subsysdir.keys():
+        print("  MEs for %s" % lumi)
+        lumidir = subsysdir[lumi]
+        meobj = lumidir[path]
+        try:
+          print(meobj.show())
+        except:
+          print(meobj.numpy().__str__())
+
+

--- a/DQMServices/Components/scripts/dqmdumpme.py
+++ b/DQMServices/Components/scripts/dqmdumpme.py
@@ -18,8 +18,51 @@ args = parser.parse_args()
 f = uproot.open(args.filename)
 things = f.keys()
 if 'Indices;1' in things:
-  # this is DQMIO data, TODO
-  pass
+  # this is DQMIO data
+
+  treenames = [ # order matters!
+    "Ints",
+    "Floats",
+    "Strings",
+    "TH1Fs",
+    "TH1Ss",
+    "TH1Ds",
+    "TH2Fs",
+    "TH2Ss",
+    "TH2Ds",
+    "TH3Fs",
+    "TProfiles",
+    "TProfile2Ds"
+  ]
+  trees = [{"FullName": f[name]["FullName"].array(), "Value": f[name]["Value"].lazyarray()} for name in treenames]
+
+  def binsearch(a, key, lower, upper):
+    n = upper - lower
+    if n <= 1: return lower
+    mid = int(n / 2) + lower
+    if a[mid] < key: return binsearch(a, key, mid, upper)
+    else: return binsearch(a, key, lower, mid)
+  def linsearch(a, key, lower, upper):
+    for k in range(lower, upper):
+      if a[k] == key: return k
+    return 0
+
+  indices = f['Indices'].lazyarrays()
+  for idx in range(len(indices["Run"])):
+    run = indices["Run"][idx]
+    lumi = indices["Lumi"][idx]
+    type = indices["Type"][idx]
+    first = int(indices["FirstIndex"][idx])
+    last = int(indices["LastIndex"][idx])
+    if type == 1000: continue # no MEs here
+    names = trees[type]["FullName"]
+    for me in args.mepaths:
+      k = linsearch(names, me, first, last+1)
+      if names[k] == me:
+        meobj = trees[type]["Value"][k]
+        print("ME for run %d, lumi %d" % (run, lumi), meobj)
+        # uproot can't read most TH1 types from trees right now.
+
 elif 'DQMData;1' in things:
   basedir = f['DQMData']
   for run in basedir.keys():

--- a/DQMServices/Components/scripts/dqmiodumpmetadata.py
+++ b/DQMServices/Components/scripts/dqmiodumpmetadata.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import uproot
+import argparse
+
+from collections import defaultdict
+
+parser = argparse.ArgumentParser(description="Show which runs and lumisections are contained in a DQMIO file.")
+
+parser.add_argument('filename', help='Name of local root file. For remote files, use edmCopyUtil first: `edmCopyUtil root://cms-xrd-global.cern.ch/<FILEPATH> .`')
+
+args = parser.parse_args()
+
+f = uproot.open(args.filename)
+things = f.keys()
+if 'Indices;1' in things:
+  indices = f['Indices']
+  runs = indices.array("Run")
+  lumis = indices.array("Lumi")
+  firstindex = indices.array("FirstIndex")
+  lastindex = indices.array("LastIndex")
+  types = indices.array("Type")
+
+  counts = defaultdict(lambda: 0)
+  for run, lumi, first, last, type in zip(runs, lumis, firstindex, lastindex, types):
+    if type == 1000:
+      n = 0
+    else:
+      n = last - first + 1
+    counts[(run, lumi)] += n
+
+  # Try to condense lumis into ranges for more compact output
+  currentrun, currentcount = 0, 0
+  minlumi, maxlumi = 0, 0
+
+  def showrow():
+    if currentrun != 0: # suppress first, empty row
+      if (minlumi, maxlumi) == (0, 0): # run-based histos
+        print("Run %d, %d MEs" % (currentrun, currentcount))
+      else:
+        print("Run %d, Lumi %d-%d, %d MEs" % (currentrun, minlumi, maxlumi, currentcount))
+    
+  for ((run, lumi), count) in sorted(counts.iteritems()):
+    if (currentrun, currentcount) != (run, count) or (lumi != maxlumi+1):
+      showrow()
+      minlumi, maxlumi = lumi, lumi
+      currentrun, currentcount = run, count
+    else:
+      maxlumi = lumi # we assume order here
+  showrow()
+
+  print("Total: %d runs, %d lumisections." % (len([run for run, lumi in counts if lumi == 0]), len([lumi for run, lumi in counts if lumi != 0])))
+
+else:
+  print("This does not look like DQMIO data.")
+
+

--- a/DQMServices/Components/test/dqmiofilecopy.sh
+++ b/DQMServices/Components/test/dqmiofilecopy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# like '/SingleElectron/Run2017D-09Aug2019_UL2017-v1/DQMIO'
+DATASET=$1
+# like 302663
+RUN=$2
+
+SOURCE='root://cms-xrd-global.cern.ch/'
+
+DIR=$(echo $DATASET | tr / _)
+
+FILES=$(dasgoclient -query="file dataset=$DATASET run=$RUN" -limit=-1)
+mkdir $DIR
+
+echo 'process.source.fileNames = cms.untracked.vstring('
+for f in $FILES; do
+  edmCopyUtil "$SOURCE$f" $DIR &
+  echo "  'file:$DIR/$(basename $f)',"
+done
+echo ')'
+
+# wait for parallel transfers to complete
+wait
+
+
+
+
+

--- a/DQMServices/Components/test/test_reharvest_from_dqmio.sh
+++ b/DQMServices/Components/test/test_reharvest_from_dqmio.sh
@@ -1,0 +1,17 @@
+# DQMIO dataset to take data from and run to look at
+RUN=302663
+DATASET=/SingleElectron/Run2017D-09Aug2019_UL2017-v1/DQMIO
+# Workflow to take the HARVESTING step from
+WORKFLOW=136.834
+
+# run cmsDriver to generate baseline harvesting config
+$(runTheMatrix.py -l 136.834 -ne | fgrep 'HARVESTING:' | grep -o 'cmsDriver.*') --no_exec
+pythonname=$(echo step*_HARVESTING.py)
+
+# copy data to local folder and add it to config
+./dqmiofilecopy.sh $DATASET $RUN >> $pythonname
+
+echo '### Got all data, starting cmsRun!'
+
+cmsRun $pythonname
+

--- a/DQMServices/Components/test/test_reharvest_from_dqmio.sh
+++ b/DQMServices/Components/test/test_reharvest_from_dqmio.sh
@@ -1,5 +1,5 @@
 # DQMIO dataset to take data from and run to look at
-RUN=302570
+RUN=302663
 DATASET=/SingleElectron/Run2017D-09Aug2019_UL2017-v1/DQMIO
 # Workflow to take the HARVESTING step from
 WORKFLOW=136.834
@@ -12,7 +12,7 @@ pythonname=$(echo step*_HARVESTING.py)
 ./dqmiofilecopy.sh $DATASET $RUN >> $pythonname
 
 # no idea where this is injected in the prod setup, but it must be somewhere.
-echo "process.source.filterOnRun = cms.untracked.uint32($RUN)" >> $pythonname
+echo "process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('$RUN:1-$(($RUN+1)):0')" >> $pythonname
 
 echo '### Got all data, starting cmsRun!'
 

--- a/DQMServices/Components/test/test_reharvest_from_dqmio.sh
+++ b/DQMServices/Components/test/test_reharvest_from_dqmio.sh
@@ -1,5 +1,5 @@
 # DQMIO dataset to take data from and run to look at
-RUN=302663
+RUN=302570
 DATASET=/SingleElectron/Run2017D-09Aug2019_UL2017-v1/DQMIO
 # Workflow to take the HARVESTING step from
 WORKFLOW=136.834
@@ -10,6 +10,9 @@ pythonname=$(echo step*_HARVESTING.py)
 
 # copy data to local folder and add it to config
 ./dqmiofilecopy.sh $DATASET $RUN >> $pythonname
+
+# no idea where this is injected in the prod setup, but it must be somewhere.
+echo "process.source.filterOnRun = cms.untracked.uint32($RUN)" >> $pythonname
 
 echo '### Got all data, starting cmsRun!'
 


### PR DESCRIPTION
#### PR description:

This PR attempts to fix the DCS status plot at `Info/EventInfo/reportSummaryMap`. Since the harvesting semantic changes from #26232 this plot was showing incorrect values, depending on the order that LS where processed in.

The fix is a simple additional `Reset` call to restore the old semantics. However, there are more problems with this module: The `Physics Declared` row seems to not work correctly since a long time, and shows more arbitrary fluctuations with this change. Also, it is not clear if this code will work without the SCAL FED.

Therefore, in the longer term, we should drop this module and replace it with the logically much simpler online version. That, however, might require additional changes to the render plugins in DQMGUI.

This PR also contains some scripts to help debugging such problems in HARVESTING.


#### PR validation:

In the `runTheMatrix` workflows no changes are expected, since the problem only appears when more than one lumisecition is processed. This PR contains a test script that re-runs harvesting from production DQMIO data that was used to test this change.

#### if this PR is a backport please specify the original PR:

Not a backport, but we might want a backport for UL rereco.
