### PR TITLE
Removed unimplementable assignment ops from TrackerAlignableIndexer

### DIFF
--- a/Alignment/TrackerAlignment/interface/TrackerAlignableIndexer.h
+++ b/Alignment/TrackerAlignment/interface/TrackerAlignableIndexer.h
@@ -26,9 +26,9 @@ public:
   /// Build the counters map.
   TrackerAlignableIndexer(const align::TrackerNameSpace&);
   TrackerAlignableIndexer(const TrackerAlignableIndexer&) = default;
-  TrackerAlignableIndexer& operator=(const TrackerAlignableIndexer&) = default;
+  TrackerAlignableIndexer& operator=(const TrackerAlignableIndexer&) = delete;
   TrackerAlignableIndexer(TrackerAlignableIndexer&&) = default;
-  TrackerAlignableIndexer& operator=(TrackerAlignableIndexer&&) = default;
+  TrackerAlignableIndexer& operator=(TrackerAlignableIndexer&&) = delete;
   ~TrackerAlignableIndexer() override = default;
 
 private:


### PR DESCRIPTION
#### PR description:

The const member data prohibits the compiler from being able to generate the assignment operators.

This change fixes clang warnings.
#### PR validation:

Compiling under CMSSW_11_0_CLANG_X_2019-09-12-2300 no longer generates warnings.