### PR TITLE
Add support for custom deleter to edm::ReusableObjectHolder

### DIFF
--- a/FWCore/Utilities/test/reusableobjectholder_t.cppunit.cpp
+++ b/FWCore/Utilities/test/reusableobjectholder_t.cppunit.cpp
@@ -24,6 +24,23 @@ public:
   void tearDown() {}
 };
 
+namespace {
+  class CustomDeleter {
+  public:
+    CustomDeleter() = default;
+    explicit CustomDeleter(int val) : expectedValue_{val} {}
+
+    void operator()(int* obj) {
+      CPPUNIT_ASSERT(obj != nullptr);
+      CPPUNIT_ASSERT(*obj == expectedValue_);
+      delete obj;
+    }
+
+  private:
+    int expectedValue_ = -1;
+  };
+}  // namespace
+
 void reusableobjectholder_test::testConstruction() {
   {
     edm::ReusableObjectHolder<int> intHolder;
@@ -55,6 +72,15 @@ void reusableobjectholder_test::testConstruction() {
 
     auto p2 = intHolder.tryToGet();
     CPPUNIT_ASSERT(p2.get() == 0);
+  }
+  {
+    edm::ReusableObjectHolder<int, CustomDeleter> intHolder;
+    auto p = intHolder.makeOrGet([]() { return std::unique_ptr<int, CustomDeleter>{new int{1}, CustomDeleter{1}}; });
+    CPPUNIT_ASSERT(p.get() != nullptr);
+    CPPUNIT_ASSERT(*p == 1);
+
+    auto p2 = intHolder.tryToGet();
+    CPPUNIT_ASSERT(p2.get() == nullptr);
   }
 }
 
@@ -126,6 +152,63 @@ void reusableobjectholder_test::testDeletion() {
       CPPUNIT_ASSERT(p.get() != 0);
       CPPUNIT_ASSERT(*p == 0);
       CPPUNIT_ASSERT(address == p.get());
+    }
+  }
+
+  {
+    edm::ReusableObjectHolder<int, CustomDeleter> intHolder;
+    {
+      auto p = intHolder.makeOrGet([]() { return std::unique_ptr<int, CustomDeleter>{new int{1}, CustomDeleter{2}}; });
+      CPPUNIT_ASSERT(p.get() != nullptr);
+      CPPUNIT_ASSERT(*p == 1);
+      *p = 2;
+
+      auto p2 = intHolder.tryToGet();
+      CPPUNIT_ASSERT(p2.get() == nullptr);
+    }
+    {
+      auto p = intHolder.makeOrGet([]() { return std::unique_ptr<int, CustomDeleter>{new int{1}, CustomDeleter{2}}; });
+      CPPUNIT_ASSERT(p.get() != nullptr);
+      CPPUNIT_ASSERT(*p == 2);
+
+      auto p2 = intHolder.tryToGet();
+      CPPUNIT_ASSERT(p2.get() == nullptr);
+    }
+    {
+      auto p = intHolder.makeOrGet([]() { return std::unique_ptr<int, CustomDeleter>{new int{1}, CustomDeleter{2}}; });
+      CPPUNIT_ASSERT(p.get() != nullptr);
+      CPPUNIT_ASSERT(*p == 2);
+
+      {
+        auto p3 = intHolder.makeOrGet([]() {
+          return std::unique_ptr<int, CustomDeleter>{new int{3}, CustomDeleter{3}};
+        });
+        CPPUNIT_ASSERT(p.get() != nullptr);
+        CPPUNIT_ASSERT(*p3 == 3);
+
+        auto p4 = intHolder.makeOrGet([]() {
+          return std::unique_ptr<int, CustomDeleter>{new int{4}, CustomDeleter{4}};
+        });
+        CPPUNIT_ASSERT(p.get() != nullptr);
+        CPPUNIT_ASSERT(*p4 == 4);
+      }
+
+      auto p34 = intHolder.makeOrGet([]() {
+        return std::unique_ptr<int, CustomDeleter>{new int{3}, CustomDeleter{3}};
+      });
+      CPPUNIT_ASSERT(p.get() != nullptr);
+      CPPUNIT_ASSERT(*p34 == 3 or *p34 == 4);
+
+      auto p43 = intHolder.makeOrGet([]() {
+        return std::unique_ptr<int, CustomDeleter>{new int{4}, CustomDeleter{4}};
+      });
+      CPPUNIT_ASSERT(p.get() != nullptr);
+      CPPUNIT_ASSERT(*p43 == 3 or *p43 == 4);
+      CPPUNIT_ASSERT(*p34 != *p43);
+
+      auto p5 = intHolder.makeOrGet([]() { return std::unique_ptr<int, CustomDeleter>{new int{5}, CustomDeleter{5}}; });
+      CPPUNIT_ASSERT(p.get() != nullptr);
+      CPPUNIT_ASSERT(*p5 == 5);
     }
   }
 }


### PR DESCRIPTION
#### PR description:

This PR adds support for custom deleter to the `edm::ReusableObjectHolder<T>`. The deleter type must be the same on all objects, and is a template parameter to the `ReusableObjectHolder<T, Deleter>`, defaulting to `std::default_delete<T>` (like in `std::unique_ptr`). For non-default deleters the object-making function must return `std::unique_ptr<T, Deleter>` (for default deleter a raw pointer `T*` is still allowed).

The deleter is allowed to have state, and the deleter object is passed around (between the returned `std::shared_ptr` and the internal `tbb::concurrent_queue`) along with the object `T`. The deleter object must be copyable.

#### PR validation:

Unit tests run, limited matrix runs.