### PR TITLE
Fix ExpandVisitor.result() to work also with an empty result (10_6_X)

### DIFF
--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -822,12 +822,15 @@ class ExpandVisitor(object):
         if isinstance(visitee,_UnarySequenceOperator):
             self.l[-1] = visitee
     def result(self):
-        # why doesn't (sum(self.l) work?
-        seq = self.l[0]
-        if len(self.l) > 1:
+        tsk = Task(*self.taskLeaves)
+        if len(self.l) > 0:
+            # why doesn't (sum(self.l) work?
+            seq = self.l[0]
             for el in self.l[1:]:
                 seq += el
-        return self._type(seq, Task(*self.taskLeaves))
+            return self._type(seq, tsk)
+        else:
+            return self._type(tsk)
     def resultString(self):
         sep = ''
         returnValue = ''
@@ -1949,6 +1952,14 @@ if __name__=="__main__":
             p2.visit(namesVisitor)
             self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
             self.assertTrue(p2.dumpPython(None) == "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.Task(process.m6, process.m7, process.m8, process.m9))\n")
+
+            t1 = Task(m1,m2,m3)
+            s1 = Sequence(t1)
+            s2 = s1.expandAndClone()
+            l[:] = []
+            s2.visit(namesVisitor)
+            self.assertEqual(l, [])
+            self.assertTrue(s2.dumpPython(None) == "cms.Sequence(cms.Task(process.m1, process.m2, process.m3))\n")
 
             t1 = Task(m1,m2)
             t2 = Task(m1,m3,t1)


### PR DESCRIPTION
#### PR description:

> If a `cms.Sequence` holds only Tasks, the `Sequence.expandAndClone()` fails with an `IndexError` from `ExpandVisitor.result()`. There the internal list of sequenceable objects is empty, and `self.l[0]` leads to an `IndexError`. This PR fixes the error by first checking the length of the sequenceable object list, and if empty, return the sequence type with only the Task part.
>
> The error was reported in https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3538.html

#### PR validation:

Unit tests run.

#### if this PR is a backport please specify the original PR:

Backport of #28006.