### PR TITLE
Corrected Egamma 2018 UL PF cluster corrections

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v6',
+    'run1_data'         :   '110X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v6',
+    'run2_data'         :   '110X_dataRun2_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v5',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v5',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v5',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v6',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -56,25 +56,25 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v3',
+    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v4',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

This PR contains a bug fix for the EGamma PF cluster corrections to be used in the 2018 UL reprocessing. The tags are described at [1] and the validation of the corrected tags is described at [2]. The corrections affect 2018 MC and the 2018 IOVs of the offline GTs. Since the same corrections used for 2018 are intended to be used for Run 3 as well, the Run 3 MC GTs are updated as well. No changes are expected for any other workflow.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4222/1/1.html
[2] https://indico.cern.ch/event/842863/contributions/3562026/attachments/1906927/3149650/updates_2018ULPFCorrections.pdf

**GT diffs**:
**Data offline GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v6/110X_dataRun2_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v6/110X_dataRun2_relval_v7

**Data prompt-like GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HEfail_v5/110X_dataRun2_PromptLike_HEfail_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_v5/110X_dataRun2_PromptLike_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HI_v5/110X_dataRun2_PromptLike_HI_v6

**2018 MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_v4/110X_upgrade2018_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HI_v3/110X_upgrade2018_realistic_HI_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HEfail_v4/110X_upgrade2018_realistic_HEfail_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_deco_v2/110X_upgrade2018cosmics_realistic_deco_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_peak_v2/110X_upgrade2018cosmics_realistic_peak_v3

**Run 3 GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_design_v2/110X_mcRun3_2021_design_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_v2/110X_mcRun3_2021_realistic_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_v2/110X_mcRun3_2023_realistic_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2024_realistic_v2/110X_mcRun3_2024_realistic_v3

#### PR validation:

See the description above for the physics validation of the tags. In addition, a technical test was performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR:

This PR is not a backport but it will be backported to 10_6_X.
