### PR TITLE
DD4hep: get a current node SpecPar value by name

### DIFF
--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -302,12 +302,12 @@ std::string_view DDFilteredView::get<string_view>(const char* key) const {
       int count = names.size();
       bool flag = false;
       for (int nit = level; count > 0 && nit > 0; --nit) {
-	if(!compareEqual(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), names[--count])) {
-	  flag = false;
-	  break;
-	} else {
-	  flag = true;
-	}
+        if (!compareEqual(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), names[--count])) {
+          flag = false;
+          break;
+        } else {
+          flag = true;
+        }
       }
       return flag;
     });

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -295,9 +295,21 @@ std::string_view DDFilteredView::get<string_view>(const char* key) const {
   std::string_view result;
   DDSpecParRefs refs;
   registry_->filter(refs, key);
+  int level = it_.back().GetLevel();
   for_each(begin(refs), end(refs), [&](auto const& i) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
-      return (compareEqual(name(), *rbegin(split(realTopName(j), "/"))));
+      auto const& names = split(realTopName(j), "/");
+      int count = names.size();
+      bool flag = false;
+      for (int nit = level; count > 0 && nit > 0; --nit) {
+	if(!compareEqual(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), names[--count])) {
+	  flag = false;
+	  break;
+	} else {
+	  flag = true;
+	}
+      }
+      return flag;
     });
     if (k != end(i->paths)) {
       result = i->strValue(key);


### PR DESCRIPTION
#### PR description:

* Compare a full path to the node with the SpecPar selection paths to avoid false positive when a node name matches a regular expression in a different path

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
