### PR TITLE
Python3: Changes needed to run runTheMatrix with python2/3

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -899,7 +899,7 @@ class ConfigBuilder(object):
         if self._options.customise_commands:
             import string
             for com in self._options.customise_commands.split('\\n'):
-                com=string.lstrip(com)
+                com=com.lstrip()
                 self.executeAndRemember(com)
                 final_snippet +='\n'+com
 

--- a/Configuration/Applications/scripts/cmsDriver.py
+++ b/Configuration/Applications/scripts/cmsDriver.py
@@ -27,17 +27,17 @@ def run():
         
         configBuilder.prepare()
         # fetch the results and write it to file
-        config = file(options.python_filename,"w")
+        config = open(options.python_filename,"w")
         config.write(configBuilder.pythonCfgCode)
         config.close()
 
         # handle different dump options
         if options.dump_python:
             result = {}
-            execfile(options.python_filename, result)
+            exec(open(options.python_filename).read(), result)
             process = result["process"]
             expanded = process.dumpPython()
-            expandedFile = file(options.python_filename,"w")
+            expandedFile = open(options.python_filename,"w")
             expandedFile.write(expanded)
             expandedFile.close()
             print("Expanded config file", options.python_filename, "created")

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -416,7 +416,7 @@ class MatrixReader(object):
         return workflows
 
     def showWorkFlows(self, selected=None, extended=True, cafVeto=True):
-        if selected: selected = map(float,selected)
+        if selected: selected = list(map(float,selected))
         wfs = self.workFlowsByLocation(cafVeto)
         maxLen = 100 # for summary, limit width of output
         fmt1   = "%-6s %-35s [1]: %s ..."

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3047,9 +3047,9 @@ defaultDataSets['2024']='CMSSW_10_6_1-106X_mcRun3_2021_realistic_v1_rsb-v'
 defaultDataSets['2026D35']='CMSSW_10_4_0_mtd3-103X_upgrade2023_realistic_v2_2023D35noPU_2-v'
 defaultDataSets['2026D41']='CMSSW_10_6_0_patch2-106X_upgrade2023_realistic_v3_2023D41noPU-v'
 
-keys=defaultDataSets.keys()
-for key in keys:
-  defaultDataSets[key+'PU']=defaultDataSets[key]
+puDataSets = {}
+for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value
+defaultDataSets.update(puDataSets)
 
 # sometimes v1 won't be used - override it here - the dictionary key is gen fragment + '_' + geometry
 versionOverrides={'BuMixing_BMuonFilter_forSTEAM_13TeV_TuneCUETP8M1_2017':'2','HSCPstop_M_200_TuneCUETP8M1_13TeV_pythia8_2017':'2','RSGravitonToGammaGamma_kMpl01_M_3000_TuneCUETP8M1_13TeV_pythia8_2017':'2','WprimeToENu_M-2000_TuneCUETP8M1_13TeV-pythia8_2017':'2','DisplacedSUSY_stopToBottom_M_300_1000mm_TuneCUETP8M1_13TeV_pythia8_2017':'2','TenE_E_0_200_pythia8_2017':'2','TenE_E_0_200_pythia8_2017PU':'2', 'TenTau_E_15_500_pythia8_2018':'2','PhotonJet_Pt_10_13TeV_TuneCUETP8M1_2018':'2','Wjet_Pt_80_120_13TeV_TuneCUETP8M1_2018':'2'}

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -139,6 +139,6 @@ for year in upgradeKeys:
                                                       [slist[0]] +                      # Start with signal generation
                                                       stepList['Premix'] +              # Premixing stage1
                                                       [slist[1].replace("PUPRMX", "PUPRMXCombined")] + # Premixing stage2, customized for the combined (defined in relval_steps.py)
-                                                      map(nano, slist[2:])]             # Remaining standard steps
+                                                      list(map(nano, slist[2:]))]             # Remaining standard steps
 
             numWF+=1

--- a/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
+++ b/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
@@ -16,10 +16,8 @@ except:
 lumi_data = lumi_data['data']
 
 def match_in(sub_list,lumi_list):
-  sub_list = list(map(int,sub_list))
-  lumi_list = list(map(int,lumi_list))
-  for i in range(sub_list[0],sub_list[1]+1):
-    if i >= lumi_list[0] and i <= lumi_list[1]: return True
+  for i in range(int(sub_list[0]),int(sub_list[1])+1):
+    if i >= int(lumi_list[0]) and i <= int(lumi_list[1]): return True
   return False
 
 def check_lumi_ranges(given_lumi_list , sub_range):

--- a/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
+++ b/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
@@ -16,8 +16,8 @@ except:
 lumi_data = lumi_data['data']
 
 def match_in(sub_list,lumi_list):
-  sub_list = map(int,sub_list)
-  lumi_list = map(int,lumi_list)
+  sub_list = list(map(int,sub_list))
+  lumi_list = list(map(int,lumi_list))
   for i in range(sub_list[0],sub_list[1]+1):
     if i >= lumi_list[0] and i <= lumi_list[1]: return True
   return False

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -273,7 +273,9 @@ if __name__ == '__main__':
     opt,args = parser.parse_args()
     if opt.IBEos:
       import os
-      from commands import getstatusoutput as run_cmd
+      try:from commands import getstatusoutput as run_cmd
+      except:from subprocess import getstatusoutput as run_cmd
+
       ibeos_cache = os.path.join(os.getenv("LOCALRT"), "ibeos_cache.txt")
       if not os.path.exists(ibeos_cache):
         err, out = run_cmd("curl -L -s -o %s https://raw.githubusercontent.com/cms-sw/cms-sw.github.io/master/das_queries/ibeos.txt" % ibeos_cache)

--- a/FWCore/PythonUtilities/python/LumiList.py
+++ b/FWCore/PythonUtilities/python/LumiList.py
@@ -14,7 +14,10 @@ from builtins import range
 import copy
 import json
 import re
-import urllib2
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 class LumiList(object):
     """
@@ -57,7 +60,7 @@ class LumiList(object):
             self.compactList = json.load(jsonFile)
         elif url:
             self.url = url
-            jsonFile = urllib2.urlopen(url)
+            jsonFile = urlopen(url)
             self.compactList = json.load(jsonFile)
         elif lumis:
             runsAndLumis = {}
@@ -240,7 +243,7 @@ class LumiList(object):
         """
         theList = []
         runs = self.compactList.keys()
-        runs.sort(key=int)
+        runs = sorted(run, key=int)
         for run in runs:
             lumis = self.compactList[run]
             for lumiPair in sorted(lumis):
@@ -265,7 +268,7 @@ class LumiList(object):
 
         parts = []
         runs = self.compactList.keys()
-        runs.sort(key=int)
+        runs = sorted(runs, key=int)
         for run in runs:
             lumis = self.compactList[run]
             for lumiPair in sorted(lumis):


### PR DESCRIPTION
#### PR description:

Changes needed to run runTheMatrix with python3

#### PR validation:

Locally runing of runTheMatix (to dump relval commands) was successful. Order of command-line arguments to cmsDriver.py is not identical (because of change of `dict` behaviour in python3)


- **python2 runTheMatrix.py -n -e -l 137.8 -i all**
```
found a total of  794  workflows:
      of which the following 1 were selected:

137.8  RunEGamma2018C+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+RunEGamma2018D+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM+HARVEST2018_L1TEgDQM_MULTIRUN [1]: input from: /EGamma/Run2018C-v1/RAW with run [] 
                                           [2]: cmsDriver.py step2  --datatier FEVTDEBUGHLT --conditions auto:run2_hlt_relval -s L1REPACK:Full,HLT:@relval2018 --process reHLT --data  --era Run2_2018 --eventcontent FEVTDEBUGHLT -n 100 
                                           [3]: cmsDriver.py step3  --conditions auto:run2_data -s RAW2DIGI,L1Reco,RECO,SKIM:ZElectron+SinglePhotonJetPlusHOFilter+EXOMONOPOLE,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQMFakeHLT+@miniAODDQM+@L1TEgamma --runUnscheduled  --process reRECO --data  --era Run2_2018 --eventcontent RECO,MINIAOD,DQM --hltProcess reHLT --scenario pp --datatier RECO,MINIAOD,DQMIO --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 -n 100 
                                           [4]: input from: /EGamma/Run2018D-v1/RAW with run []
                                           [5]: cmsDriver.py step5  --datatier FEVTDEBUGHLT --conditions auto:run2_hlt_relval -s L1REPACK:Full,HLT:@relval2018 --process reHLT --data  --era Run2_2018 --eventcontent FEVTDEBUGHLT -n 100 
                                           [6]: cmsDriver.py step6  --conditions auto:run2_data_promptlike -s RAW2DIGI,L1Reco,RECO,SKIM:ZElectron+SinglePhotonJetPlusHOFilter+EXOMONOPOLE,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQMFakeHLT+@miniAODDQM+@L1TEgamma --runUnscheduled  --process reRECO --data  --era Run2_2018 --eventcontent RECO,MINIAOD,DQM --hltProcess reHLT --scenario pp --datatier RECO,MINIAOD,DQMIO --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 -n 100 
                                           [7]: cmsDriver.py step7  --conditions auto:run2_data -s HARVESTING:@standardDQMFakeHLT+@miniAODDQM+@L1TEgamma --data  --era Run2_2018 --filein file:step6_inDQM.root,file:step3_inDQM.root --scenario pp --filetype DQM --customise Configuration/StandardSequences/DQMSaverAtJobEnd_cff -n 100 

1 workflows with 7 steps

```
- **python3 runTheMatrix.py -n -e -l 137.8 -i all**
```
found a total of  794  workflows:
      of which the following 1 were selected:

137.8  RunEGamma2018C+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+RunEGamma2018D+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM+HARVEST2018_L1TEgDQM_MULTIRUN [1]: input from: /EGamma/Run2018C-v1/RAW with run [] 
                                           [2]: cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2018 --conditions auto:run2_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run2_2018 -n 100 
                                           [3]: cmsDriver.py step3  --runUnscheduled  --conditions auto:run2_data -s RAW2DIGI,L1Reco,RECO,SKIM:ZElectron+SinglePhotonJetPlusHOFilter+EXOMONOPOLE,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQMFakeHLT+@miniAODDQM+@L1TEgamma --datatier RECO,MINIAOD,DQMIO --eventcontent RECO,MINIAOD,DQM --data  --process reRECO --scenario pp --era Run2_2018 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --hltProcess reHLT -n 100 
                                           [4]: input from: /EGamma/Run2018D-v1/RAW with run []
                                           [5]: cmsDriver.py step5  --process reHLT -s L1REPACK:Full,HLT:@relval2018 --conditions auto:run2_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run2_2018 -n 100 
                                           [6]: cmsDriver.py step6  --runUnscheduled  --conditions auto:run2_data_promptlike -s RAW2DIGI,L1Reco,RECO,SKIM:ZElectron+SinglePhotonJetPlusHOFilter+EXOMONOPOLE,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@standardDQMFakeHLT+@miniAODDQM+@L1TEgamma --datatier RECO,MINIAOD,DQMIO --eventcontent RECO,MINIAOD,DQM --data  --process reRECO --scenario pp --era Run2_2018 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --hltProcess reHLT -n 100 
                                           [7]: cmsDriver.py step7  -s HARVESTING:@standardDQMFakeHLT+@miniAODDQM+@L1TEgamma --conditions auto:run2_data --data  --filetype DQM --scenario pp --era Run2_2018 --customise Configuration/StandardSequences/DQMSaverAtJobEnd_cff --filein file:step6_inDQM.root,file:step3_inDQM.root -n 100 

1 workflows with 7 steps
```