### PR TITLE
A fix for DQM HV per lumi plot

### DIFF
--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -240,6 +240,9 @@ void DQMProvInfo::beginLuminosityBlock(const edm::LuminosityBlock& l,
   for (int vbin = 1; vbin <= MAX_DCS_VBINS; vbin++) {
     dcsBits_[vbin] = false;
   }
+  // Boolean that tells the analyse method that we encountered the first real
+  // dcs info
+  foundFirstDcsBits_ = false;
 }
 
 void DQMProvInfo::analyze(const edm::Event& event, const edm::EventSetup& c) {


### PR DESCRIPTION
#### PR description:

A fix for DQM HV per lumisection plot where only first lumisection was being showed.

#### PR validation:

PR was validated in the online playback system.

Backport of #28025
