### PR TITLE
Removed __user__ option in Skeleton generator

### DIFF
--- a/FWCore/Skeletons/python/pkg.py
+++ b/FWCore/Skeletons/python/pkg.py
@@ -144,7 +144,6 @@ class AbstractPkg(object):
         "Return keyword arguments to be used in methods"
         kwds  = {'__pkgname__': self.config.get('pkgname', 'Package'),
                  '__author__': self.author,
-                 '__user__': os.getlogin(),
                  '__date__': self.date,
                  '__class__': self.pname,
                  '__class_lowercase__': self.pname.lower(),


### PR DESCRIPTION
#### PR description:

This __user__ option was not being used by any skeleton and it caused a failure when used in a docker container.

#### PR validation:

With this change I was able to generate skeletons in the docker container on my laptop.