### PR TITLE
Add APV simulation in PreMixingSiStripWorker

### DIFF
--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 
@@ -21,6 +22,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 #include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
 #include "CondFormats/SiStripObjects/interface/SiStripThreshold.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
 #include "SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h"
 #include "SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h"
@@ -121,6 +123,13 @@ private:
   std::map<unsigned int, size_t> firstChannelsWithSignal;
   std::map<unsigned int, size_t> lastChannelsWithSignal;
 
+  bool includeAPVSimulation_;
+  const double fracOfEventsToSimAPV_;
+  const double apv_maxResponse_;
+  const double apv_rate_;
+  const double apv_mVPerQ_;
+  const double apv_fCPerElectron_;
+
   //----------------------------
 
   class StrictWeakOrdering {
@@ -146,7 +155,13 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
       theFedAlgo(ps.getParameter<int>("FedAlgorithm_PM")),
       geometryType(ps.getParameter<std::string>("GeometryType")),
       theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
-      theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false))  // no premixing
+      theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false)),  // no premixing
+      includeAPVSimulation_(ps.getParameter<bool>("includeAPVSimulation")),
+      fracOfEventsToSimAPV_(ps.getParameter<double>("fracOfEventsToSimAPV")),
+      apv_maxResponse_(ps.getParameter<double>("apv_maxResponse")),
+      apv_rate_(ps.getParameter<double>("apv_rate")),
+      apv_mVPerQ_(ps.getParameter<double>("apv_mVPerQ")),
+      apv_fCPerElectron_(ps.getParameter<double>("apvfCPerElectron"))
 
 {
   // declare the products to produce
@@ -331,6 +346,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   edm::ESHandle<SiStripThreshold> thresholdHandle;
   edm::ESHandle<SiStripPedestals> pedestalHandle;
   edm::ESHandle<SiStripBadStrip> deadChannelHandle;
+  edm::ESHandle<SiStripApvSimulationParameters> apvSimulationParametersHandle;
+  edm::ESHandle<TrackerTopology> tTopo;
   iSetup.get<SiStripGainSimRcd>().get(gainLabel, gainHandle);
   iSetup.get<SiStripNoisesRcd>().get(noiseHandle);
   iSetup.get<SiStripThresholdRcd>().get(thresholdHandle);
@@ -338,6 +355,23 @@ void PreMixingSiStripWorker::put(edm::Event& e,
 
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+
+  const bool simulateAPVInThisEvent = includeAPVSimulation_ && (CLHEP::RandFlat::shoot(engine) < fracOfEventsToSimAPV_);
+  float nTruePU = 0.;  // = ps.getTrueNumInteractions();
+  if (simulateAPVInThisEvent) {
+    iSetup.get<TrackerTopologyRcd>().get(tTopo);
+    iSetup.get<SiStripApvSimulationParametersRcd>().get(apvSimulationParametersHandle);
+    const auto it = std::find_if(
+        std::begin(ps), std::end(ps), [](const PileupSummaryInfo& bxps) { return bxps.getBunchCrossing() == 0; });
+    if (it != std::begin(ps)) {
+      nTruePU = it->getTrueNumInteractions();
+      edm::LogInfo("PreMixingSiStripWorker") << "True number of interactions for current bunch crossing: " << nTruePU;
+    } else {
+      edm::LogWarning("PreMixingSiStripWorker") << "Could not find PileupSummaryInfo for current bunch crossing";
+      nTruePU = std::begin(ps)->getTrueNumInteractions();
+    }
+  } else {
+  }
 
   std::map<int, std::bitset<6>> DeadAPVList;
   DeadAPVList.clear();
@@ -520,6 +554,56 @@ void PreMixingSiStripWorker::put(edm::Event& e,
       for (int strip = 0; strip < numStrips; ++strip) {
         if (badChannels[strip])
           detAmpl[strip] = 0.;
+      }
+
+      if (simulateAPVInThisEvent) {
+        // Get index in apv baseline distributions corresponding to z of detSet and PU
+        const StripTopology* topol = dynamic_cast<const StripTopology*>(&(sgd->specificTopology()));
+        LocalPoint localPos = topol->localPosition(0);
+        GlobalPoint globalPos = sgd->surface().toGlobal(Local3DPoint(localPos.x(), localPos.y(), localPos.z()));
+        float detSet_z = fabs(globalPos.z());
+
+        const uint32_t SubDet = DetId(detID).subdetId();
+        // Simulate APV response for each strip
+        if (SubDet == SiStripSubdetector::TIB || SubDet == SiStripSubdetector::TOB) {
+          for (int strip = 0; strip < numStrips; ++strip) {
+            if (detAmpl[strip] > 0) {
+              // Convert charge from electrons to fC
+              double stripCharge = detAmpl[strip] * apv_fCPerElectron_;
+
+              // Get APV baseline
+              double baselineV = 0;
+              if (SubDet == SiStripSubdetector::TIB) {
+                baselineV = apvSimulationParametersHandle->sampleTIB(tTopo->tibLayer(detID), detSet_z, nTruePU, engine);
+              } else if (SubDet == SiStripSubdetector::TOB) {
+                baselineV = apvSimulationParametersHandle->sampleTOB(tTopo->tobLayer(detID), detSet_z, nTruePU, engine);
+              }
+              // Fitted parameters from G Hall/M Raymond
+              double maxResponse = apv_maxResponse_;
+              double rate = apv_rate_;
+
+              double outputChargeInADC = 0;
+              if (baselineV < apv_maxResponse_) {
+                // Convert V0 into baseline charge
+                double baselineQ = -1.0 * rate * log(2 * maxResponse / (baselineV + maxResponse) - 1);
+
+                // Add charge deposited in this BX
+                double newStripCharge = baselineQ + stripCharge;
+
+                // Apply APV response
+                double signalV = 2 * maxResponse / (1 + exp(-1.0 * newStripCharge / rate)) - maxResponse;
+                double gain = signalV - baselineV;
+
+                // Convert gain (mV) to charge (assuming linear region of APV) and then to electrons
+                double outputCharge = gain / apv_mVPerQ_;
+                outputChargeInADC = outputCharge / apv_fCPerElectron_;
+              }
+
+              // Output charge back to original container
+              detAmpl[strip] = outputChargeInADC;
+            }
+          }
+        }
       }
 
       if (APVSaturationFromHIP_) {

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -173,6 +173,7 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
   SistripAPVListDM_ = ps.getParameter<std::string>("SiStripAPVListDM");
 
   producer.produces<edm::DetSetVector<SiStripDigi>>(SiStripDigiCollectionDM_);
+  producer.produces<bool>(SiStripDigiCollectionDM_ + "SimulatedAPVDynamicGain");
 
   if (APVSaturationFromHIP_) {
     SistripAPVLabelSig_ = ps.getParameter<edm::InputTag>("SistripAPVLabelSig");
@@ -365,12 +366,10 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         std::begin(ps), std::end(ps), [](const PileupSummaryInfo& bxps) { return bxps.getBunchCrossing() == 0; });
     if (it != std::begin(ps)) {
       nTruePU = it->getTrueNumInteractions();
-      edm::LogInfo("PreMixingSiStripWorker") << "True number of interactions for current bunch crossing: " << nTruePU;
     } else {
       edm::LogWarning("PreMixingSiStripWorker") << "Could not find PileupSummaryInfo for current bunch crossing";
       nTruePU = std::begin(ps)->getTrueNumInteractions();
     }
-  } else {
   }
 
   std::map<int, std::bitset<6>> DeadAPVList;
@@ -700,6 +699,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   // put collection
 
   e.put(std::move(MySiStripDigis), SiStripDigiCollectionDM_);
+  e.put(std::make_unique<bool>(simulateAPVInThisEvent), SiStripDigiCollectionDM_ + "SimulatedAPVDynamicGain");
 
   // clear local storage for this event
   SiHitStorage_.clear();


### PR DESCRIPTION
#### PR description:

This adds the new APV simulation from https://github.com/cms-sw/cmssw/pull/27823 also to the PreMixingSiStripWorker, which is used instead of the SiStripDigitizer when premixing is used.
It goes together with the configuration changes in https://github.com/cms-sw/cmssw/pull/28024 .

#### PR validation:

by @mmusich, see https://github.com/cms-sw/cmssw/pull/28024 : when enabling the APV simulation at the data mixing step (and not when making the premixing pileup library) the cluster charge distribution matches with the non-premixing scenario.

CC: @EmyrClement 