### PR TITLE
Default LCT type is ALCTCLCT

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -3,7 +3,7 @@
 
 /**\class CSCCorrelatedLCTDigi
  *
- * Digi for Correlated LCT trigger primitives. 
+ * Digi for Correlated LCT trigger primitives.
  *
  *
  * \author L. Gray, UF
@@ -120,8 +120,8 @@ public:
 
   /// SIMULATION ONLY ////
   enum Type {
+    ALCTCLCT,      // ALCT-centric (default)
     CLCTALCT,      // CLCT-centric
-    ALCTCLCT,      // ALCT-centric
     ALCTCLCTGEM,   // ALCT-CLCT-1 GEM pad
     ALCTCLCT2GEM,  // ALCT-CLCT-2 GEM pads in coincidence
     ALCT2GEM,      // ALCT-2 GEM pads in coincidence

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -81,10 +81,17 @@ void CSCCorrelatedLCTDigi::print() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
-  return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
-           << " MPC Link = " << digi.getMPCLink() << " cscID = " << digi.getCSCID() << "\n"
-           << "  cathode info: Strip = " << digi.getStrip() << " Pattern = " << digi.getPattern()
+  return o << "CSC LCT #" << digi.getTrknmb()
+           << ": Valid = " << digi.isValid()
+           << " Quality = " << digi.getQuality()
+           << " MPC Link = " << digi.getMPCLink()
+           << " cscID = " << digi.getCSCID()
+           << " type = " << digi.getType() << "\n"
+           << "   cathode info: Strip = " << digi.getStrip()
+           << " Pattern = " << digi.getPattern()
            << " Bend = " << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"
-           << "    anode info: Key wire = " << digi.getKeyWG() << " BX = " << digi.getBX() << " bx0 = " << digi.getBX0()
-           << " syncErr = " << digi.getSyncErr() << "\n";
+           << "   anode info: Key wire = " << digi.getKeyWG()
+           << " BX = " << digi.getBX()
+           << " bx0 = " << digi.getBX0()
+           << " syncErr = " << digi.getSyncErr() <<"\n";
 }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -81,17 +81,11 @@ void CSCCorrelatedLCTDigi::print() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
-  return o << "CSC LCT #" << digi.getTrknmb()
-           << ": Valid = " << digi.isValid()
-           << " Quality = " << digi.getQuality()
-           << " MPC Link = " << digi.getMPCLink()
-           << " cscID = " << digi.getCSCID()
-           << " type = " << digi.getType() << "\n"
-           << "   cathode info: Strip = " << digi.getStrip()
-           << " Pattern = " << digi.getPattern()
+  return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
+           << " MPC Link = " << digi.getMPCLink() << " cscID = " << digi.getCSCID() << " type = " << digi.getType()
+           << "\n"
+           << "   cathode info: Strip = " << digi.getStrip() << " Pattern = " << digi.getPattern()
            << " Bend = " << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"
-           << "   anode info: Key wire = " << digi.getKeyWG()
-           << " BX = " << digi.getBX()
-           << " bx0 = " << digi.getBX0()
-           << " syncErr = " << digi.getSyncErr() <<"\n";
+           << "   anode info: Key wire = " << digi.getKeyWG() << " BX = " << digi.getBX() << " bx0 = " << digi.getBX0()
+           << " syncErr = " << digi.getSyncErr() << "\n";
 }


### PR DESCRIPTION
#### PR description:

This PR changes the default LCT type from `CLCTALCT` (CLCT-centric) to `ALCTCLCT` (ALCT-centric). I also added the LCT type to the print-out operator.

#### PR validation:

I tested it with a single muon gun using `cmsDriver.py SingleMuPt100_pythia8_cfi.py --conditions auto:phase2_realistic -n 10 --era Phase2 --eventcontent FEVTDEBUG -s GEN,SIM --datatier GEN-SIM --beamspot HLLHC --geometry Extended2023D41 --python SingleMuPt100_2023tilted_GenSimFull.py --no_exec --fileout file:step1.root`

FYI @tahuang1991 