### PR TITLE
Fix a discrepancy in Puppi weights when running on MiniAOD w/ useExistingWeights=False

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -20,10 +20,8 @@ public:
   // const std::vector<double> puppiAlpha   () {return fAlpha;}
   const std::vector<double> &puppiAlphasMed() { return fAlphaMed; }
   const std::vector<double> &puppiAlphasRMS() { return fAlphaRMS; }
-  const std::vector<int> &recoToPup() const { return fRecoToPup; }
 
   int puppiNAlgos() { return fNAlgos; }
-  std::vector<PuppiCandidate> const &puppiParticles() const { return fPupParticles; }
 
 protected:
   double goodVar(PuppiCandidate const &iPart, std::vector<PuppiCandidate> const &iParts, int iOpt, const double iRCone);
@@ -46,13 +44,11 @@ protected:
   const std::vector<RecoObj> *fRecoParticles;
   std::vector<PuppiCandidate> fPFParticles;
   std::vector<PuppiCandidate> fChargedPV;
-  std::vector<PuppiCandidate> fPupParticles;
   std::vector<double> fWeights;
   std::vector<double> fVals;
   std::vector<double> fRawAlphas;
   std::vector<double> fAlphaMed;
   std::vector<double> fAlphaRMS;
-  std::vector<int> fRecoToPup;
 
   bool fApplyCHS;
   bool fInvert;

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -28,7 +28,6 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
   //Clear everything
   fPFParticles.resize(0);
   fChargedPV.resize(0);
-  fPupParticles.resize(0);
   fWeights.resize(0);
   fVals.resize(0);
   fRawAlphas.resize(0);
@@ -39,8 +38,6 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
   fPVFrac = 0.;
   fNPV = 1.;
   fRecoParticles = &iRecoObjects;
-  fRecoToPup.clear();
-  fRecoToPup.reserve(fRecoParticles->size());
   for (auto const &rParticle : *fRecoParticles) {
     PuppiCandidate curPseudoJet;
     // float nom = sqrt((rParticle.m)*(rParticle.m) + (rParticle.pt)*(rParticle.pt)*(cosh(rParticle.eta))*(cosh(rParticle.eta))) + (rParticle.pt)*sinh(rParticle.eta);//hacked
@@ -255,8 +252,6 @@ double PuppiContainer::getChi2FromdZ(double iDZ) {
 std::vector<double> const &PuppiContainer::puppiWeights() {
   int lNParticles = fRecoParticles->size();
 
-  fPupParticles.clear();
-  fPupParticles.reserve(lNParticles);
   fWeights.clear();
   fWeights.reserve(lNParticles);
   fVals.clear();
@@ -284,14 +279,12 @@ std::vector<double> const &PuppiContainer::puppiWeights() {
     const auto &rParticle = (*fRecoParticles)[i0];
     int pPupId = getPuppiId(rParticle.pt, rParticle.eta);
     if (pPupId == -1) {
-      fWeights.push_back(pWeight);
+      fWeights.push_back(0);
       fAlphaMed.push_back(-10);
       fAlphaRMS.push_back(-10);
-      fRecoToPup.push_back(-1);
       continue;
-    } else {
-      fRecoToPup.push_back(fPupParticles.size());  //watch out: there should be no skips after this
     }
+
     // fill the p-values
     double pChi2 = 0;
     if (fUseExp) {
@@ -338,14 +331,6 @@ std::vector<double> const &PuppiContainer::puppiWeights() {
     // leave these lines in, in case want to move eventually to having no 1-to-1 correspondence between puppi and pf cands
     // if( std::abs(pWeight) < std::numeric_limits<double>::denorm_min() ) continue; // this line seems not to work like it's supposed to...
     // if(std::abs(pWeight) <= 0. ) continue;
-
-    //Produce
-    PuppiCandidate curjet(pWeight * fPFParticles[i0].px(),
-                          pWeight * fPFParticles[i0].py(),
-                          pWeight * fPFParticles[i0].pz(),
-                          pWeight * fPFParticles[i0].e());
-    curjet.set_user_index(i0);
-    fPupParticles.push_back(curjet);
   }
   return fWeights;
 }


### PR DESCRIPTION
#### PR description:

When running Puppi on MiniAOD w/ `useExistingWeights=False`, in some cases there is a discrepancy between the puppiWeight and the rescaled pT (i.e., rescaled pT != original pT * packCand->puppiWeight()). This is tracked to:

https://github.com/cms-sw/cmssw/blob/fb7c976b0bd6784c61295852158c36675939be56/CommonTools/PileupAlgos/plugins/PuppiProducer.cc#L275-L291

on L281 and L283, `iPuppiMatched` should not be used to access the puppi weight from `lWeights`, as `lWeights` is 1-to-1 with `hPFProduct` -- instead `val` is the correct index. 

As this only affects the puppi weights set for the new packedCandidates, this discrepancy does not affect cases when `useExistingWeights=True`, or running on RECO/AOD inputs.

This PR fixes this discrepancy and also simplifies the logic to compute the Puppi-scaled p4.

@ahinzmann 