### PR TITLE
Simplify jet daughter processing in DeepBoostedJet

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -638,27 +638,15 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
             if btagInfo == 'pfDeepBoostedJetTagInfos':
                 if pfCandidates.value() == 'packedPFCandidates':
                     # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
-                    jetSrcName = jetSource.value().lower()
-                    if 'updated' in jetSrcName:
-                        puppi_value_map = ""
-                        vertex_associator = ""
-                        if 'withpuppidaughter' in jetSrcName:
-                            # special case for Puppi jets reclustered from MiniAOD by analyzers
-                            # need to specify 'WithPuppiDaughters' in the postfix when calling updateJetCollection
-                            # daughters of these jets are already scaled by their puppi weights
-                            has_puppi_weighted_daughters = True
-                        else:
-                            # default case for updating jet collection stored in MiniAOD, e.g., slimmedJetsAK8
-                            # daughters are links to the original PackedCandidates, so NOT scaled by their puppi weights yet
-                            has_puppi_weighted_daughters = False
-                    else:
+                    if 'updated' not in jetSource.value().lower():
                         raise ValueError("Invalid jet collection: %s. pfDeepBoostedJetTagInfos only supports running via updateJetCollection." % jetSource.value())
+                    puppi_value_map = ""
+                    vertex_associator = ""
                 elif pfCandidates.value() == 'particleFlow':
                     raise ValueError("Running pfDeepBoostedJetTagInfos with reco::PFCandidates is currently not supported.")
                     # case 2: running on new jet collection whose daughters are PFCandidates (e.g., cluster jets in RECO/AOD)
                     # daughters are the particles used in jet clustering, so already scaled by their puppi weights
                     # Uncomment the lines below after running pfDeepBoostedJetTagInfos with reco::PFCandidates becomes supported
-#                     has_puppi_weighted_daughters = True
 #                     puppi_value_map = "puppi"
 #                     vertex_associator = "primaryVertexAssociation:original"
                 else:
@@ -668,7 +656,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                       jets = jetSource,
                                       vertices = pvSource,
                                       secondary_vertices = svSource,
-                                      has_puppi_weighted_daughters = has_puppi_weighted_daughters,
+                                      pf_candidates = pfCandidates,
                                       puppi_value_map = puppi_value_map,
                                       vertex_associator = vertex_associator,
                                       ),


### PR DESCRIPTION
#### PR description:

This PR simplifies the treatment of Puppi jet daughters in DeepAK8. In the past, we rely on a postfix string to distinguish whether the AK8 jets have puppi scaled daughters or not, which is quite fragile. Now we unifies it to always first get the original candidate (via the `key()`, inspired by @raggleton's [RekeyJets](https://github.com/UHH2/UHH2/blob/RunII_102X_v1/core/plugins/RekeyJets.cc)) and then scaled it by the puppi weight. 

#### PR validation:

Tested in a boosted TT sample and no change in the discriminator outputs found.