### PR TITLE
Fix problem with fromTrackerSeeds parameter in ElectronSeedProducer and improve LayerMeasurements class

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
@@ -50,7 +50,6 @@ FastTSGFromPropagation::FastTSGFromPropagation(const edm::ParameterSet& iConfig,
                                                const MuonServiceProxy* service,
                                                edm::ConsumesCollector& iC)
     : theCategory("FastSimulation|Muons|FastTSGFromPropagation"),
-      theTkLayerMeasurements(),
       theTracker(),
       theNavigation(),
       theService(service),
@@ -104,7 +103,7 @@ void FastTSGFromPropagation::trackerSeeds(const TrackCand& staMuon,
       if ((*inl == nullptr))
         break;
       //         if ( (inl != nls.end()-1 ) && ( (*inl)->subDetector() == GeomDetEnumerators::TEC ) && ( (*(inl+1))->subDetector() == GeomDetEnumerators::TOB ) ) continue;
-      alltm = findMeasurements_new(*inl, staState);
+      alltm = findMeasurements(*inl, staState);
       if ((!alltm.empty())) {
         LogTrace(theCategory) << "final compatible layer: " << ndesLayer;
         break;
@@ -373,7 +372,6 @@ void FastTSGFromPropagation::setEvent(const edm::Event& iEvent) {
 
   if (theUpdateStateFlag) {
     iEvent.getByToken(theMeasurementTrackerEventToken_, theMeasTrackerEvent);
-    theTkLayerMeasurements = LayerMeasurements(*theMeasTracker, *theMeasTrackerEvent);
   }
 
   bool trackerGeomChanged = false;
@@ -447,7 +445,7 @@ void FastTSGFromPropagation::validMeasurements(std::vector<TrajectoryMeasurement
   return;
 }
 
-std::vector<TrajectoryMeasurement> FastTSGFromPropagation::findMeasurements_new(
+std::vector<TrajectoryMeasurement> FastTSGFromPropagation::findMeasurements(
     const DetLayer* nl, const TrajectoryStateOnSurface& staState) const {
   std::vector<TrajectoryMeasurement> result;
 
@@ -471,14 +469,6 @@ std::vector<TrajectoryMeasurement> FastTSGFromPropagation::findMeasurements_new(
     }
   }
 
-  return result;
-}
-
-std::vector<TrajectoryMeasurement> FastTSGFromPropagation::findMeasurements(
-    const DetLayer* nl, const TrajectoryStateOnSurface& staState) const {
-  std::vector<TrajectoryMeasurement> result =
-      tkLayerMeasurements()->measurements((*nl), staState, *propagator(), *estimator());
-  validMeasurements(result);
   return result;
 }
 

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.h
@@ -75,8 +75,6 @@ private:
 
   TrajectoryStateOnSurface outerTkState(const TrackCand&) const;
 
-  const LayerMeasurements* tkLayerMeasurements() const { return &theTkLayerMeasurements; }
-
   const TrajectoryStateUpdator* updator() const { return theUpdator.get(); }
 
   const Chi2MeasurementEstimator* estimator() const { return theEstimator.get(); }
@@ -93,9 +91,6 @@ private:
 
   /// select valid measurements
   void validMeasurements(std::vector<TrajectoryMeasurement>&) const;
-
-  /// look for measurements on the first compatible layer (faster way)
-  std::vector<TrajectoryMeasurement> findMeasurements_new(const DetLayer*, const TrajectoryStateOnSurface&) const;
 
   /// look for measurements on the first compatible layer
   std::vector<TrajectoryMeasurement> findMeasurements(const DetLayer*, const TrajectoryStateOnSurface&) const;
@@ -132,8 +127,6 @@ private:
   unsigned long long theCacheId_TG;
 
   std::string theCategory;
-
-  LayerMeasurements theTkLayerMeasurements;
 
   edm::ESHandle<GeometricSearchTracker> theTracker;
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -93,11 +93,11 @@ private:
 
   const bool dynamicphiroad_;
   const bool fromTrackerSeeds_;
-  edm::Handle<std::vector<reco::Vertex> > theVertices;
-  edm::EDGetTokenT<std::vector<reco::Vertex> > verticesTag_;
+  edm::Handle<std::vector<reco::Vertex> > vertices_;
+  const edm::EDGetTokenT<std::vector<reco::Vertex> > verticesTag_;
 
-  edm::Handle<reco::BeamSpot> theBeamSpot;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
+  edm::Handle<reco::BeamSpot> beamSpot_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
 
   const float lowPtThreshold_;
   const float highPtThreshold_;
@@ -112,46 +112,43 @@ private:
   const double deltaPhi1Coef1_;
   const double deltaPhi1Coef2_;
 
-  const std::vector<const TrajectorySeedCollection*>* theInitialSeedCollV = nullptr;
+  const std::vector<const TrajectorySeedCollection*>* initialSeedCollectionVector_ = nullptr;
 
-  edm::ESHandle<MagneticField> theMagField;
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  //edm::ESHandle<GeometricSearchTracker>       theGeomSearchTracker;
+  edm::ESHandle<MagneticField> magField_;
+  edm::ESHandle<TrackerGeometry> trackerGeometry_;
   KFUpdator updator_;
   std::unique_ptr<PropagatorWithMaterial> propagator_;
 
-  const MeasurementTracker* theMeasurementTracker;
-  edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventTag;
+  const MeasurementTracker* measurementTracker_;
+  const edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventTag_;
 
-  const NavigationSchool* theNavigationSchool;
+  const NavigationSchool* navigationSchool_;
 
-  const edm::EventSetup* theSetup;
+  const edm::EventSetup* setup_;
 
   PRecHitContainer recHits_;
   PTrajectoryStateOnDet pts_;
 
   // keep cacheIds to get records only when necessary
   unsigned long long cacheIDMagField_;
-  //  unsigned long long cacheIDGeom_;
   unsigned long long cacheIDNavSchool_;
   unsigned long long cacheIDCkfComp_;
   unsigned long long cacheIDTrkGeom_;
 
-  std::string measurementTrackerName_;
+  const std::string measurementTrackerName_;
 
-  bool useRecoVertex_;
+  const bool useRecoVertex_;
 
-  float deltaPhi2B_;
-  float deltaPhi2F_;
+  const float deltaPhi2B_;
+  const float deltaPhi2F_;
 
-  float phiMin2B_;
-  float phiMin2F_;
-  float phiMax2B_;
-  float phiMax2F_;
+  const float phiMin2B_;
+  const float phiMin2F_;
+  const float phiMax2B_;
+  const float phiMax2F_;
 
   PixelHitMatcher electronMatcher_;
   PixelHitMatcher positronMatcher_;
-
 };
 
 #endif  // ElectronSeedGenerator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -91,15 +91,15 @@ private:
   void addSeed(reco::ElectronSeed& seed, const SeedWithInfo* info, bool positron, reco::ElectronSeedCollection& out);
   bool prepareElTrackSeed(ConstRecHitPointer outerhit, ConstRecHitPointer innerhit, const GlobalPoint& vertexPos);
 
-  const bool dynamicphiroad_;
+  const bool dynamicPhiRoad_;
   edm::Handle<std::vector<reco::Vertex> > vertices_;
   const edm::EDGetTokenT<std::vector<reco::Vertex> > verticesTag_;
 
   edm::Handle<reco::BeamSpot> beamSpot_;
   const edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
 
-  const float lowPtThreshold_;
-  const float highPtThreshold_;
+  const float lowPtThresh_;
+  const float highPtThresh_;
   const float nSigmasDeltaZ1_;     // first z window size if not using the reco vertex
   const float deltaZ1WithVertex_;  // first z window size when using the reco vertex
   const float sizeWindowENeg_;
@@ -107,9 +107,9 @@ private:
   const float deltaPhi1Low_;
   const float deltaPhi1High_;
 
-  // so that deltaPhi1 = deltaPhi1Coef1_ + deltaPhi1Coef2_/clusterEnergyT
-  const double deltaPhi1Coef1_;
-  const double deltaPhi1Coef2_;
+  // so that deltaPhi1 = dPhi1Coef1_ + dPhi1Coef2_/clusterEnergyT
+  const double dPhi1Coef2_;
+  const double dPhi1Coef1_;
 
   const std::vector<const TrajectorySeedCollection*>* initialSeedCollectionVector_ = nullptr;
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -92,7 +92,6 @@ private:
   bool prepareElTrackSeed(ConstRecHitPointer outerhit, ConstRecHitPointer innerhit, const GlobalPoint& vertexPos);
 
   const bool dynamicphiroad_;
-  const bool fromTrackerSeeds_;
   edm::Handle<std::vector<reco::Vertex> > vertices_;
   const edm::EDGetTokenT<std::vector<reco::Vertex> > verticesTag_;
 
@@ -130,10 +129,10 @@ private:
   PTrajectoryStateOnDet pts_;
 
   // keep cacheIds to get records only when necessary
-  unsigned long long cacheIDMagField_;
-  unsigned long long cacheIDNavSchool_;
-  unsigned long long cacheIDCkfComp_;
-  unsigned long long cacheIDTrkGeom_;
+  unsigned long long cacheIDMagField_ = 0;
+  unsigned long long cacheIDNavSchool_ = 0;
+  unsigned long long cacheIDCkfComp_ = 0;
+  unsigned long long cacheIDTrkGeom_ = 0;
 
   const std::string measurementTrackerName_;
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -25,7 +25,6 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-//#include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -38,9 +37,11 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+
 class PropagatorWithMaterial;
 class KFUpdator;
-class PixelHitMatcher;
+class PixelHitMatcher_;
 class MeasurementTracker;
 class NavigationSchool;
 class TrackerTopology;
@@ -59,7 +60,6 @@ public:
   typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
 
   ElectronSeedGenerator(const edm::ParameterSet&, const Tokens&);
-  ~ElectronSeedGenerator();
 
   void setupES(const edm::EventSetup& setup);
   void run(edm::Event&,
@@ -91,45 +91,35 @@ private:
   void addSeed(reco::ElectronSeed& seed, const SeedWithInfo* info, bool positron, reco::ElectronSeedCollection& out);
   bool prepareElTrackSeed(ConstRecHitPointer outerhit, ConstRecHitPointer innerhit, const GlobalPoint& vertexPos);
 
-  bool dynamicphiroad_;
-  bool fromTrackerSeeds_;
-  //  edm::EDGetTokenT<SomeClass> initialSeeds_;
-  bool useRecoVertex_;
+  const bool dynamicphiroad_;
+  const bool fromTrackerSeeds_;
   edm::Handle<std::vector<reco::Vertex> > theVertices;
   edm::EDGetTokenT<std::vector<reco::Vertex> > verticesTag_;
 
   edm::Handle<reco::BeamSpot> theBeamSpot;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
 
-  float lowPtThreshold_;
-  float highPtThreshold_;
-  float nSigmasDeltaZ1_;     // first z window size if not using the reco vertex
-  float deltaZ1WithVertex_;  // first z window size when using the reco vertex
-  float sizeWindowENeg_;
-  float phiMin2B_;
-  float phiMax2B_;
-  float phiMin2F_;
-  float phiMax2F_;
-  float deltaPhi1Low_, deltaPhi1High_;
-  float deltaPhi2B_;
-  float deltaPhi2F_;
+  const float lowPtThreshold_;
+  const float highPtThreshold_;
+  const float nSigmasDeltaZ1_;     // first z window size if not using the reco vertex
+  const float deltaZ1WithVertex_;  // first z window size when using the reco vertex
+  const float sizeWindowENeg_;
+
+  const float deltaPhi1Low_;
+  const float deltaPhi1High_;
 
   // so that deltaPhi1 = deltaPhi1Coef1_ + deltaPhi1Coef2_/clusterEnergyT
-  double deltaPhi1Coef1_;
-  double deltaPhi1Coef2_;
-
-  PixelHitMatcher* myMatchEle;
-  PixelHitMatcher* myMatchPos;
+  const double deltaPhi1Coef1_;
+  const double deltaPhi1Coef2_;
 
   const std::vector<const TrajectorySeedCollection*>* theInitialSeedCollV = nullptr;
 
   edm::ESHandle<MagneticField> theMagField;
   edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   //edm::ESHandle<GeometricSearchTracker>       theGeomSearchTracker;
-  KFUpdator* theUpdator;
-  PropagatorWithMaterial* thePropagator;
+  KFUpdator updator_;
+  std::unique_ptr<PropagatorWithMaterial> propagator_;
 
-  std::string theMeasurementTrackerName;
   const MeasurementTracker* theMeasurementTracker;
   edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventTag;
 
@@ -146,6 +136,22 @@ private:
   unsigned long long cacheIDNavSchool_;
   unsigned long long cacheIDCkfComp_;
   unsigned long long cacheIDTrkGeom_;
+
+  std::string measurementTrackerName_;
+
+  bool useRecoVertex_;
+
+  float deltaPhi2B_;
+  float deltaPhi2F_;
+
+  float phiMin2B_;
+  float phiMin2F_;
+  float phiMax2B_;
+  float phiMax2F_;
+
+  PixelHitMatcher electronMatcher_;
+  PixelHitMatcher positronMatcher_;
+
 };
 
 #endif  // ElectronSeedGenerator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -39,13 +39,6 @@
 
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
 
-class PropagatorWithMaterial;
-class KFUpdator;
-class PixelHitMatcher_;
-class MeasurementTracker;
-class NavigationSchool;
-class TrackerTopology;
-
 class ElectronSeedGenerator {
 public:
   struct Tokens {
@@ -74,22 +67,7 @@ private:
   void seedsFromThisCluster(edm::Ref<reco::SuperClusterCollection> seedCluster,
                             float hoe1,
                             float hoe2,
-                            reco::ElectronSeedCollection& out,
-                            const TrackerTopology* tTopo);
-  void seedsFromRecHits(std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> >& elePixelHits,
-                        PropagationDirection& dir,
-                        const GlobalPoint& vertexPos,
-                        const reco::ElectronSeed::CaloClusterRef& cluster,
-                        reco::ElectronSeedCollection& out,
-                        bool positron);
-  void seedsFromTrajectorySeeds(const std::vector<SeedWithInfo>& elePixelSeeds,
-                                const reco::ElectronSeed::CaloClusterRef& cluster,
-                                float hoe1,
-                                float hoe2,
-                                reco::ElectronSeedCollection& out,
-                                bool positron);
-  void addSeed(reco::ElectronSeed& seed, const SeedWithInfo* info, bool positron, reco::ElectronSeedCollection& out);
-  bool prepareElTrackSeed(ConstRecHitPointer outerhit, ConstRecHitPointer innerhit, const GlobalPoint& vertexPos);
+                            reco::ElectronSeedCollection& out);
 
   const bool dynamicPhiRoad_;
   edm::Handle<std::vector<reco::Vertex> > vertices_;

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -218,7 +218,7 @@ private:
   const GeometricSearchTracker* theGeometricSearchTracker;
   const MeasurementTrackerEvent* theTrackerEvent;
   const MeasurementTracker* theTracker;
-  LayerMeasurements theLayerMeasurements;
+  std::unique_ptr<LayerMeasurements> theLayerMeasurements;
   const MagneticField* theMagField;
   const TrackerGeometry* theTrackerGeometry;
 

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -35,6 +35,105 @@
 #include <vector>
 #include <utility>
 
+namespace {
+
+  bool equivalent(const TrajectorySeed &s1, const TrajectorySeed &s2) {
+    if (s1.nHits() != s2.nHits())
+      return false;
+
+    unsigned int nHits;
+    TrajectorySeed::range r1 = s1.recHits(), r2 = s2.recHits();
+    TrajectorySeed::const_iterator i1, i2;
+    for (i1 = r1.first, i2 = r2.first, nHits = 0; i1 != r1.second; ++i1, ++i2, ++nHits) {
+      if (!i1->isValid() || !i2->isValid())
+        return false;
+      if (i1->geographicalId() != i2->geographicalId())
+        return false;
+      if (!(i1->localPosition() == i2->localPosition()))
+        return false;
+    }
+
+    return true;
+  }
+
+  void addSeed(reco::ElectronSeed &seed, const SeedWithInfo *info, bool positron, reco::ElectronSeedCollection &out) {
+    if (!info) {
+      out.emplace_back(seed);
+      return;
+    }
+
+    if (positron) {
+      seed.setPosAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+    } else {
+      seed.setNegAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+    }
+    for (auto resItr = out.begin(); resItr != out.end(); ++resItr) {
+      if ((seed.caloCluster().key() == resItr->caloCluster().key()) && (seed.hitsMask() == resItr->hitsMask()) &&
+          equivalent(seed, *resItr)) {
+        if (positron) {
+          if (resItr->dRz2Pos() == std::numeric_limits<float>::infinity() &&
+              resItr->dRz2() != std::numeric_limits<float>::infinity()) {
+            resItr->setPosAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+            seed.setNegAttributes(resItr->dRz2(), resItr->dPhi2(), resItr->dRz1(), resItr->dPhi1());
+            break;
+          } else {
+            if (resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
+              if (resItr->dRz2Pos() != seed.dRz2Pos()) {
+                edm::LogWarning("ElectronSeedGenerator|BadValue")
+                    << "this similar old seed already has another dRz2Pos"
+                    << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
+                    << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
+                    << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
+                    << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
+              }
+            }
+          }
+        } else {
+          if (resItr->dRz2() == std::numeric_limits<float>::infinity() &&
+              resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
+            resItr->setNegAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+            seed.setPosAttributes(resItr->dRz2Pos(), resItr->dPhi2Pos(), resItr->dRz1Pos(), resItr->dPhi1Pos());
+            break;
+          } else {
+            if (resItr->dRz2() != std::numeric_limits<float>::infinity()) {
+              if (resItr->dRz2() != seed.dRz2()) {
+                edm::LogWarning("ElectronSeedGenerator|BadValue")
+                    << "this old seed already has another dRz2"
+                    << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
+                    << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
+                    << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
+                    << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
+              }
+            }
+          }
+        }
+      }
+    }
+
+    out.emplace_back(seed);
+  }
+
+  void seedsFromTrajectorySeeds(const std::vector<SeedWithInfo> &pixelSeeds,
+                                const reco::ElectronSeed::CaloClusterRef &cluster,
+                                float hoe1,
+                                float hoe2,
+                                reco::ElectronSeedCollection &out,
+                                bool positron) {
+    if (!pixelSeeds.empty()) {
+      LogDebug("ElectronSeedGenerator") << "Compatible " << (positron ? "positron" : "electron") << " seeds found.";
+    }
+
+    std::vector<SeedWithInfo>::const_iterator s;
+    for (s = pixelSeeds.begin(); s != pixelSeeds.end(); s++) {
+      reco::ElectronSeed seed(s->seed());
+      seed.setCaloCluster(cluster);
+      seed.initTwoHitSeed(s->hitsMask());
+      addSeed(seed, &*s, positron, out);
+    }
+  }
+
+}  // namespace
+
 ElectronSeedGenerator::ElectronSeedGenerator(const edm::ParameterSet &pset, const ElectronSeedGenerator::Tokens &ts)
     : dynamicPhiRoad_(pset.getParameter<bool>("dynamicPhiRoad")),
       verticesTag_(ts.token_vtx),
@@ -125,25 +224,6 @@ void ElectronSeedGenerator::setupES(const edm::EventSetup &setup) {
   }
 }
 
-bool equivalent(const TrajectorySeed &s1, const TrajectorySeed &s2) {
-  if (s1.nHits() != s2.nHits())
-    return false;
-
-  unsigned int nHits;
-  TrajectorySeed::range r1 = s1.recHits(), r2 = s2.recHits();
-  TrajectorySeed::const_iterator i1, i2;
-  for (i1 = r1.first, i2 = r2.first, nHits = 0; i1 != r1.second; ++i1, ++i2, ++nHits) {
-    if (!i1->isValid() || !i2->isValid())
-      return false;
-    if (i1->geographicalId() != i2->geographicalId())
-      return false;
-    if (!(i1->localPosition() == i2->localPosition()))
-      return false;
-  }
-
-  return true;
-}
-
 void ElectronSeedGenerator::run(edm::Event &e,
                                 const edm::EventSetup &setup,
                                 const reco::SuperClusterRefVector &sclRefs,
@@ -152,11 +232,6 @@ void ElectronSeedGenerator::run(edm::Event &e,
                                 const std::vector<const TrajectorySeedCollection *> &seedsV,
                                 reco::ElectronSeedCollection &out) {
   initialSeedCollectionVector_ = &seedsV;
-
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  setup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo = tTopoHand.product();
 
   setup_ = &setup;
 
@@ -178,7 +253,7 @@ void ElectronSeedGenerator::run(edm::Event &e,
     recHits_.clear();
 
     LogDebug("ElectronSeedGenerator") << "new cluster, calling seedsFromThisCluster";
-    seedsFromThisCluster(sclRefs[i], hoe1s[i], hoe2s[i], out, tTopo);
+    seedsFromThisCluster(sclRefs[i], hoe1s[i], hoe2s[i], out);
   }
 
   LogDebug("ElectronSeedGenerator") << ": For event " << e.id();
@@ -189,8 +264,7 @@ void ElectronSeedGenerator::run(edm::Event &e,
 void ElectronSeedGenerator::seedsFromThisCluster(edm::Ref<reco::SuperClusterCollection> seedCluster,
                                                  float hoe1,
                                                  float hoe2,
-                                                 reco::ElectronSeedCollection &out,
-                                                 const TrackerTopology *tTopo) {
+                                                 reco::ElectronSeedCollection &out) {
   float clusterEnergy = seedCluster->energy();
   GlobalPoint clusterPos(seedCluster->position().x(), seedCluster->position().y(), seedCluster->position().z());
   reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster);
@@ -282,166 +356,4 @@ void ElectronSeedGenerator::seedsFromThisCluster(edm::Ref<reco::SuperClusterColl
   }
 
   return;
-}
-
-void ElectronSeedGenerator::seedsFromRecHits(std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > &pixelHits,
-                                             PropagationDirection &dir,
-                                             const GlobalPoint &vertexPos,
-                                             const reco::ElectronSeed::CaloClusterRef &cluster,
-                                             reco::ElectronSeedCollection &out,
-                                             bool positron) {
-  if (!pixelHits.empty()) {
-    LogDebug("ElectronSeedGenerator") << "Compatible " << (positron ? "positron" : "electron") << " hits found.";
-  }
-
-  for (auto &v : pixelHits) {
-    if (!positron) {
-      v.first.invert();
-    }
-    if (!prepareElTrackSeed(v.first.recHit(), v.second, vertexPos)) {
-      continue;
-    }
-    reco::ElectronSeed seed(pts_, recHits_, dir);
-    seed.setCaloCluster(cluster);
-    addSeed(seed, nullptr, positron, out);
-  }
-}
-
-void ElectronSeedGenerator::seedsFromTrajectorySeeds(const std::vector<SeedWithInfo> &pixelSeeds,
-                                                     const reco::ElectronSeed::CaloClusterRef &cluster,
-                                                     float hoe1,
-                                                     float hoe2,
-                                                     reco::ElectronSeedCollection &out,
-                                                     bool positron) {
-  if (!pixelSeeds.empty()) {
-    LogDebug("ElectronSeedGenerator") << "Compatible " << (positron ? "positron" : "electron") << " seeds found.";
-  }
-
-  std::vector<SeedWithInfo>::const_iterator s;
-  for (s = pixelSeeds.begin(); s != pixelSeeds.end(); s++) {
-    reco::ElectronSeed seed(s->seed());
-    seed.setCaloCluster(cluster);
-    seed.initTwoHitSeed(s->hitsMask());
-    addSeed(seed, &*s, positron, out);
-  }
-}
-
-void ElectronSeedGenerator::addSeed(reco::ElectronSeed &seed,
-                                    const SeedWithInfo *info,
-                                    bool positron,
-                                    reco::ElectronSeedCollection &out) {
-  if (!info) {
-    out.emplace_back(seed);
-    return;
-  }
-
-  if (positron) {
-    seed.setPosAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
-  } else {
-    seed.setNegAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
-  }
-  for (auto resItr = out.begin(); resItr != out.end(); ++resItr) {
-    if ((seed.caloCluster().key() == resItr->caloCluster().key()) && (seed.hitsMask() == resItr->hitsMask()) &&
-        equivalent(seed, *resItr)) {
-      if (positron) {
-        if (resItr->dRz2Pos() == std::numeric_limits<float>::infinity() &&
-            resItr->dRz2() != std::numeric_limits<float>::infinity()) {
-          resItr->setPosAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
-          seed.setNegAttributes(resItr->dRz2(), resItr->dPhi2(), resItr->dRz1(), resItr->dPhi1());
-          break;
-        } else {
-          if (resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
-            if (resItr->dRz2Pos() != seed.dRz2Pos()) {
-              edm::LogWarning("ElectronSeedGenerator|BadValue")
-                  << "this similar old seed already has another dRz2Pos"
-                  << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
-                  << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
-                  << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
-                  << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
-            }
-          }
-        }
-      } else {
-        if (resItr->dRz2() == std::numeric_limits<float>::infinity() &&
-            resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
-          resItr->setNegAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
-          seed.setPosAttributes(resItr->dRz2Pos(), resItr->dPhi2Pos(), resItr->dRz1Pos(), resItr->dPhi1Pos());
-          break;
-        } else {
-          if (resItr->dRz2() != std::numeric_limits<float>::infinity()) {
-            if (resItr->dRz2() != seed.dRz2()) {
-              edm::LogWarning("ElectronSeedGenerator|BadValue")
-                  << "this old seed already has another dRz2"
-                  << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
-                  << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
-                  << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
-                  << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
-            }
-          }
-        }
-      }
-    }
-  }
-
-  out.emplace_back(seed);
-}
-
-bool ElectronSeedGenerator::prepareElTrackSeed(ConstRecHitPointer innerhit,
-                                               ConstRecHitPointer outerhit,
-                                               const GlobalPoint &vertexPos) {
-  // debug prints
-  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] inner PixelHit   x,y,z " << innerhit->globalPosition();
-  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] outer PixelHit   x,y,z " << outerhit->globalPosition();
-
-  recHits_.clear();
-
-  SiPixelRecHit *pixhit = nullptr;
-  SiStripMatchedRecHit2D *striphit = nullptr;
-  const SiPixelRecHit *constpixhit = dynamic_cast<const SiPixelRecHit *>(innerhit->hit());
-  if (constpixhit) {
-    pixhit = new SiPixelRecHit(*constpixhit);
-    recHits_.push_back(pixhit);
-  } else
-    return false;
-  constpixhit = dynamic_cast<const SiPixelRecHit *>(outerhit->hit());
-  if (constpixhit) {
-    pixhit = new SiPixelRecHit(*constpixhit);
-    recHits_.push_back(pixhit);
-  } else {
-    const SiStripMatchedRecHit2D *conststriphit = dynamic_cast<const SiStripMatchedRecHit2D *>(outerhit->hit());
-    if (conststriphit) {
-      striphit = new SiStripMatchedRecHit2D(*conststriphit);
-      recHits_.push_back(striphit);
-    } else
-      return false;
-  }
-
-  // FIXME to be optimized outside the loop
-  edm::ESHandle<MagneticField> bfield;
-  setup_->get<IdealMagneticFieldRecord>().get(bfield);
-  float nomField = bfield->nominalValue();
-
-  // make a spiral
-  FastHelix helix(outerhit->globalPosition(), innerhit->globalPosition(), vertexPos, nomField, &*bfield);
-  if (!helix.isValid()) {
-    return false;
-  }
-  FreeTrajectoryState fts(helix.stateAtVertex());
-  auto propagatedState = propagator_->propagate(fts, innerhit->det()->surface());
-  if (!propagatedState.isValid())
-    return false;
-  auto updatedState = updator_.update(propagatedState, *innerhit);
-
-  auto propagatedState_out = propagator_->propagate(updatedState, outerhit->det()->surface());
-  if (!propagatedState_out.isValid())
-    return false;
-  auto updatedState_out = updator_.update(propagatedState_out, *outerhit);
-  // debug prints
-  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] final TSOS, position: "
-               << updatedState_out.globalPosition() << " momentum: " << updatedState_out.globalMomentum();
-  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] final TSOS Pt: "
-               << updatedState_out.globalMomentum().perp();
-  pts_ = trajectoryStateTransform::persistentState(updatedState_out, outerhit->geographicalId().rawId());
-
-  return true;
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -278,8 +278,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
   TrajectoryStateOnSurface tsos(fts, *bpb(fts.position(), fts.momentum()));
 
   if (tsos.isValid()) {
-    vector<TrajectoryMeasurement> pixelMeasurements =
-        theLayerMeasurements->measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
+    auto pixelMeasurements = theLayerMeasurements->measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
 
     LogDebug("") << "[PixelHitMatcher::compatibleHits] nbr of hits compatible with extrapolation to first layer: "
                  << pixelMeasurements.size();
@@ -310,8 +309,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
     // check if there are compatible 1st hits in the second layer
     firstLayer++;
 
-    vector<TrajectoryMeasurement> pixel2Measurements =
-        theLayerMeasurements->measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
+    auto pixel2Measurements = theLayerMeasurements->measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
 
     for (aMeas m = pixel2Measurements.begin(); m != pixel2Measurements.end(); m++) {
       if (m->recHit()->isValid()) {
@@ -351,8 +349,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
       if (i == 1 && xmeas.z() > 100.)
         continue;
 
-      vector<TrajectoryMeasurement> pixelMeasurements =
-          theLayerMeasurements->measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
+      auto pixelMeasurements = theLayerMeasurements->measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
 
       for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
         if (m->recHit()->isValid()) {
@@ -372,8 +369,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
       if (searchInTIDTEC_) {
         flayer++;
 
-        vector<TrajectoryMeasurement> pixel2Measurements =
-            theLayerMeasurements->measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
+        auto pixel2Measurements = theLayerMeasurements->measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
 
         for (aMeas m = pixel2Measurements.begin(); m != pixel2Measurements.end(); m++) {
           if (m->recHit()->isValid()) {

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -70,7 +70,7 @@ void PixelHitMatcher::setUseRecoVertex(bool val) { useRecoVertex_ = val; }
 
 void PixelHitMatcher::setEvent(const MeasurementTrackerEvent &trackerData) {
   theTrackerEvent = &trackerData;
-  theLayerMeasurements = LayerMeasurements(*theTracker, *theTrackerEvent);
+  theLayerMeasurements = std::make_unique<LayerMeasurements>(*theTracker, *theTrackerEvent);
 }
 void PixelHitMatcher::setES(const MagneticField *magField,
                             const MeasurementTracker *theMeasurementTracker,
@@ -279,7 +279,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
 
   if (tsos.isValid()) {
     vector<TrajectoryMeasurement> pixelMeasurements =
-        theLayerMeasurements.measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
+        theLayerMeasurements->measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
 
     LogDebug("") << "[PixelHitMatcher::compatibleHits] nbr of hits compatible with extrapolation to first layer: "
                  << pixelMeasurements.size();
@@ -311,7 +311,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
     firstLayer++;
 
     vector<TrajectoryMeasurement> pixel2Measurements =
-        theLayerMeasurements.measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
+        theLayerMeasurements->measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
 
     for (aMeas m = pixel2Measurements.begin(); m != pixel2Measurements.end(); m++) {
       if (m->recHit()->isValid()) {
@@ -352,7 +352,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
         continue;
 
       vector<TrajectoryMeasurement> pixelMeasurements =
-          theLayerMeasurements.measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
+          theLayerMeasurements->measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
 
       for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
         if (m->recHit()->isValid()) {
@@ -373,7 +373,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
         flayer++;
 
         vector<TrajectoryMeasurement> pixel2Measurements =
-            theLayerMeasurements.measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
+            theLayerMeasurements->measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
 
         for (aMeas m = pixel2Measurements.begin(); m != pixel2Measurements.end(); m++) {
           if (m->recHit()->isValid()) {
@@ -428,7 +428,7 @@ vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatch
 
     FreeTrajectoryState secondFTS = FTSFromVertexToPointFactory::get(*theMagField, hitPos, vertexPred, energy, charge);
 
-    PixelMatchNextLayers secondHit(&theLayerMeasurements,
+    PixelMatchNextLayers secondHit(theLayerMeasurements.get(),
                                    newLayer,
                                    secondFTS,
                                    prop2ndLayer,

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -214,7 +214,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     theInitialSeedColl = nullptr;
   }
 
-  ElectronSeedCollection* seeds = new ElectronSeedCollection;
+  auto seeds = std::make_unique<ElectronSeedCollection>();
 
   // loop over barrel + endcap
   for (unsigned int i = 0; i < 2; i++) {
@@ -230,16 +230,14 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
   }
 
   // store the accumulated result
-  std::unique_ptr<ElectronSeedCollection> pSeeds(seeds);
-  ElectronSeedCollection::iterator is;
-  for (is = pSeeds->begin(); is != pSeeds->end(); is++) {
-    edm::RefToBase<CaloCluster> caloCluster = is->caloCluster();
+  for (auto const& seed : *seeds) {
+    edm::RefToBase<CaloCluster> caloCluster = seed.caloCluster();
     SuperClusterRef superCluster = caloCluster.castTo<SuperClusterRef>();
-    LogDebug("ElectronSeedProducer") << "new seed with " << (*is).nHits() << " hits"
-                                     << ", charge " << (*is).getCharge() << " and cluster energy "
+    LogDebug("ElectronSeedProducer") << "new seed with " << seed.nHits() << " hits"
+                                     << ", charge " << seed.getCharge() << " and cluster energy "
                                      << superCluster->energy() << " PID " << superCluster.id();
   }
-  e.put(std::move(pSeeds));
+  e.put(std::move(seeds));
   if (fromTrackerSeeds_ && prefilteredSeeds_)
     delete theInitialSeedColl;
 }

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -231,8 +231,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
 
   // store the accumulated result
   for (auto const& seed : *seeds) {
-    edm::RefToBase<CaloCluster> caloCluster = seed.caloCluster();
-    SuperClusterRef superCluster = caloCluster.castTo<SuperClusterRef>();
+    SuperClusterRef superCluster = seed.caloCluster().castTo<SuperClusterRef>();
     LogDebug("ElectronSeedProducer") << "new seed with " << seed.nHits() << " hits"
                                      << ", charge " << seed.getCharge() << " and cluster energy "
                                      << superCluster->energy() << " PID " << superCluster.id();

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -230,12 +230,14 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
   }
 
   // store the accumulated result
+#ifdef EDM_ML_DEBUG
   for (auto const& seed : *seeds) {
     SuperClusterRef superCluster = seed.caloCluster().castTo<SuperClusterRef>();
     LogDebug("ElectronSeedProducer") << "new seed with " << seed.nHits() << " hits"
                                      << ", charge " << seed.getCharge() << " and cluster energy "
                                      << superCluster->energy() << " PID " << superCluster.id();
   }
+#endif
   e.put(std::move(seeds));
   if (fromTrackerSeeds_ && prefilteredSeeds_)
     delete theInitialSeedColl;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.cc
@@ -32,8 +32,7 @@ TSGFromPropagation::TSGFromPropagation(const edm::ParameterSet& iConfig, edm::Co
 TSGFromPropagation::TSGFromPropagation(const edm::ParameterSet& iConfig,
                                        edm::ConsumesCollector& iC,
                                        const MuonServiceProxy* service)
-    : theTkLayerMeasurements(),
-      theTracker(nullptr),
+    : theTracker(nullptr),
       theMeasTracker(nullptr),
       theNavigation(nullptr),
       theService(service),
@@ -98,7 +97,7 @@ void TSGFromPropagation::trackerSeeds(const TrackCand& staMuon,
       if ((*inl == nullptr))
         break;
       //         if ( (inl != nls.end()-1 ) && ( (*inl)->subDetector() == GeomDetEnumerators::TEC ) && ( (*(inl+1))->subDetector() == GeomDetEnumerators::TOB ) ) continue;
-      alltm = findMeasurements_new(*inl, staState);
+      alltm = findMeasurements(*inl, staState);
       if ((!alltm.empty())) {
         LogTrace(theCategory) << "final compatible layer: " << ndesLayer;
         break;
@@ -213,7 +212,6 @@ void TSGFromPropagation::setEvent(const edm::Event& iEvent) {
 
   if (theUpdateStateFlag) {
     iEvent.getByToken(theMeasurementTrackerEventToken, theMeasTrackerEvent);
-    theTkLayerMeasurements = LayerMeasurements(*theMeasTracker, *theMeasTrackerEvent);
   }
 
   bool trackerGeomChanged = false;
@@ -291,7 +289,7 @@ void TSGFromPropagation::validMeasurements(std::vector<TrajectoryMeasurement>& t
   return;
 }
 
-std::vector<TrajectoryMeasurement> TSGFromPropagation::findMeasurements_new(
+std::vector<TrajectoryMeasurement> TSGFromPropagation::findMeasurements(
     const DetLayer* nl, const TrajectoryStateOnSurface& staState) const {
   std::vector<TrajectoryMeasurement> result;
 
@@ -315,14 +313,6 @@ std::vector<TrajectoryMeasurement> TSGFromPropagation::findMeasurements_new(
     }
   }
 
-  return result;
-}
-
-std::vector<TrajectoryMeasurement> TSGFromPropagation::findMeasurements(
-    const DetLayer* nl, const TrajectoryStateOnSurface& staState) const {
-  std::vector<TrajectoryMeasurement> result =
-      tkLayerMeasurements()->measurements((*nl), staState, *propagator(), *estimator());
-  validMeasurements(result);
   return result;
 }
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromPropagation.h
@@ -55,8 +55,6 @@ private:
 
   TrajectoryStateOnSurface outerTkState(const TrackCand&) const;
 
-  const LayerMeasurements* tkLayerMeasurements() const { return &theTkLayerMeasurements; }
-
   const TrajectoryStateUpdator* updator() const { return theUpdator; }
 
   const Chi2MeasurementEstimator* estimator() const { return theEstimator; }
@@ -73,9 +71,6 @@ private:
 
   /// select valid measurements
   void validMeasurements(std::vector<TrajectoryMeasurement>&) const;
-
-  /// look for measurements on the first compatible layer (faster way)
-  std::vector<TrajectoryMeasurement> findMeasurements_new(const DetLayer*, const TrajectoryStateOnSurface&) const;
 
   /// look for measurements on the first compatible layer
   std::vector<TrajectoryMeasurement> findMeasurements(const DetLayer*, const TrajectoryStateOnSurface&) const;
@@ -112,8 +107,6 @@ private:
   unsigned long long theCacheId_TG;
 
   std::string theCategory;
-
-  LayerMeasurements theTkLayerMeasurements;
 
   edm::ESHandle<GeometricSearchTracker> theTracker;
 

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -342,18 +342,7 @@ TrackingRegion::Hits RectangularEtaPhiTrackingRegion::hits(const edm::EventSetup
 
     LayerMeasurements lm(theMeasurementTracker->measurementTracker(), *theMeasurementTracker);
 
-    LayerMeasurements::SimpleHitContainer hits;
-    lm.recHits(hits, *detLayer, tsos, prop, *findDetAndHits);
-    /*
-    {  // old code
-      vector<TrajectoryMeasurement> meas = lm.measurements(*detLayer, tsos, prop, *findDetAndHits);
-      auto n=0UL;
-      for (auto const & im : meas) 
-	if(im.recHit()->isValid()) ++n;
-      assert(n==hits.size());
-      // std::cout << "old/new " << n <<'/'<<hits.size() << std::endl;      
-    }
-    */
+    auto hits = lm.recHits(*detLayer, tsos, prop, *findDetAndHits);
 
     result.reserve(hits.size());
     for (auto h : hits) {

--- a/TrackingTools/MeasurementDet/interface/LayerMeasurements.h
+++ b/TrackingTools/MeasurementDet/interface/LayerMeasurements.h
@@ -17,21 +17,14 @@ class DetGroup;
 
 class LayerMeasurements {
 public:
-  using SimpleHitContainer = std::vector<BaseTrackerRecHit*>;
-
-  // dummy default constructor (obviously you can't use any object created this way), but it can be needed in some cases
-  LayerMeasurements() : theDetSystem(nullptr), theData(nullptr) {}
-
-  // the constructor that most of the people should be using
   LayerMeasurements(const MeasurementDetSystem& detSystem, const MeasurementTrackerEvent& data)
-      : theDetSystem(&detSystem), theData(&data) {}
+      : detSystem_(detSystem), data_(data) {}
 
   // return just valid hits, no sorting (for seeding mostly)
-  bool recHits(SimpleHitContainer& result,
-               const DetLayer& layer,
-               const TrajectoryStateOnSurface& startingState,
-               const Propagator& prop,
-               const MeasurementEstimator& est) const;
+  std::vector<BaseTrackerRecHit*> recHits(const DetLayer& layer,
+                                          const TrajectoryStateOnSurface& startingState,
+                                          const Propagator& prop,
+                                          const MeasurementEstimator& est) const;
 
   std::vector<TrajectoryMeasurement> measurements(const DetLayer& layer,
                                                   const TrajectoryStateOnSurface& startingState,
@@ -43,13 +36,11 @@ public:
                                                               const Propagator& prop,
                                                               const MeasurementEstimator& est) const;
 
-  void addInvalidMeas(std::vector<TrajectoryMeasurement>& measVec, const DetGroup& group, const DetLayer& layer) const;
-
-  MeasurementDetWithData idToDet(const DetId& id) const { return theDetSystem->idToDet(id, *theData); }
+  MeasurementDetWithData idToDet(const DetId& id) const { return detSystem_.idToDet(id, data_); }
 
 private:
-  const MeasurementDetSystem* theDetSystem;
-  const MeasurementTrackerEvent* theData;
+  MeasurementDetSystem const& detSystem_;
+  MeasurementTrackerEvent const& data_;
 };
 
 #endif

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -24,9 +24,9 @@ namespace {
   typedef GeometricSearchDet::DetWithState DetWithState;
   inline void addInvalidMeas(std::vector<TrajectoryMeasurement>& result,
                              const TrajectoryStateOnSurface& ts,
-                             const GeomDet* det,
+                             const GeomDet& det,
                              const DetLayer& layer) {
-    result.emplace_back(ts, std::make_shared<InvalidTrackingRecHit>(*det, TrackingRecHit::missing), 0.F, &layer);
+    result.emplace_back(ts, std::make_shared<InvalidTrackingRecHit>(det, TrackingRecHit::missing), 0.F, &layer);
   }
 
   /** The std::vector<DetWithState> passed to this method should not be empty.
@@ -36,8 +36,8 @@ namespace {
    *  this efficiently, so it should be done by the caller, or an exception will
    *  be thrown (DetLogicError).
    */
-  inline std::vector<TrajectoryMeasurement> get(const MeasurementDetSystem* theDetSystem,
-                                                const MeasurementTrackerEvent* theData,
+  inline std::vector<TrajectoryMeasurement> get(MeasurementDetSystem const& detSystem,
+                                                MeasurementTrackerEvent const& data,
                                                 const DetLayer& layer,
                                                 std::vector<DetWithState> const& compatDets,
                                                 const TrajectoryStateOnSurface& ts,
@@ -49,7 +49,7 @@ namespace {
     tracking::TempMeasurements tmps;
 
     for (auto const& ds : compatDets) {
-      MeasurementDetWithData mdet = theDetSystem->idToDet(ds.first->geographicalId(), *theData);
+      MeasurementDetWithData mdet = detSystem.idToDet(ds.first->geographicalId(), data);
       if
         UNLIKELY(mdet.isNull()) { throw MeasurementDetException("MeasurementDet not found"); }
 
@@ -68,32 +68,56 @@ namespace {
 
     if (!result.empty()) {
       // invalidMeas on Det of most compatible hit
-      addInvalidMeas(result, result.front().predictedState(), result.front().recHit()->det(), layer);
+      addInvalidMeas(result, result.front().predictedState(), *(result.front().recHit()->det()), layer);
     } else {
       // invalid state on first compatible Det
-      addInvalidMeas(result, compatDets.front().second, compatDets.front().first, layer);
+      addInvalidMeas(result, compatDets.front().second, *(compatDets.front().first), layer);
     }
 
     return result;
   }
 
+  void addInvalidMeas(vector<TrajectoryMeasurement>& measVec,
+                                         const DetGroup& group,
+                                         const DetLayer& layer) {
+    if (!measVec.empty()) {
+      // invalidMeas on Det of most compatible hit
+      auto const& ts = measVec.front().predictedState();
+      auto toll = measVec.front().recHitR().det()->surface().bounds().significanceInside(ts.localPosition(),
+                                                                                         ts.localError().positionError());
+      measVec.emplace_back(
+          measVec.front().predictedState(),
+          std::make_shared<InvalidTrackingRecHit>(*measVec.front().recHitR().det(), TrackingRecHit::missing),
+          toll,
+          &layer);
+    } else if (!group.empty()) {
+      // invalid state on first compatible Det
+      auto const& ts = group.front().trajectoryState();
+      auto toll =
+          group.front().det()->surface().bounds().significanceInside(ts.localPosition(), ts.localError().positionError());
+      measVec.emplace_back(group.front().trajectoryState(),
+                           std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing),
+                           toll,
+                           &layer);
+    }
+  }
+
 }  // namespace
 
 // return just valid hits, no sorting (for seeding mostly)
-bool LayerMeasurements::recHits(SimpleHitContainer& result,
-                                const DetLayer& layer,
-                                const TrajectoryStateOnSurface& startingState,
-                                const Propagator& prop,
-                                const MeasurementEstimator& est) const {
+std::vector<BaseTrackerRecHit*> LayerMeasurements::recHits(const DetLayer& layer,
+                                                           const TrajectoryStateOnSurface& startingState,
+                                                           const Propagator& prop,
+                                                           const MeasurementEstimator& est) const {
+  std::vector<BaseTrackerRecHit*> result;
   auto const& compatDets = layer.compatibleDets(startingState, prop, est);
   if (compatDets.empty())
-    return false;
-  bool ret = false;
+    return result;
   for (auto const& ds : compatDets) {
-    auto mdet = theDetSystem->idToDet(ds.first->geographicalId(), *theData);
-    ret |= mdet.recHits(result, ds.second, est);
+    auto mdet = detSystem_.idToDet(ds.first->geographicalId(), data_);
+    mdet.recHits(result, ds.second, est);
   }
-  return ret;
+  return result;
 }
 
 vector<TrajectoryMeasurement> LayerMeasurements::measurements(const DetLayer& layer,
@@ -105,7 +129,7 @@ vector<TrajectoryMeasurement> LayerMeasurements::measurements(const DetLayer& la
   vector<DetWithState> const& compatDets = layer.compatibleDets(startingState, prop, est);
 
   if (!compatDets.empty())
-    return get(theDetSystem, theData, layer, compatDets, startingState, prop, est);
+    return get(detSystem_, data_, layer, compatDets, startingState, prop, est);
 
   vector<TrajectoryMeasurement> result;
   pair<bool, TrajectoryStateOnSurface> compat = layer.compatible(startingState, prop, est);
@@ -139,7 +163,7 @@ vector<TrajectoryMeasurementGroup> LayerMeasurements::groupedMeasurements(const 
 
     vector<TrajectoryMeasurement> tmpVec;
     for (auto const& det : grp) {
-      MeasurementDetWithData mdet = theDetSystem->idToDet(det.det()->geographicalId(), *theData);
+      MeasurementDetWithData mdet = detSystem_.idToDet(det.det()->geographicalId(), data_);
       if (mdet.isNull()) {
         throw MeasurementDetException("MeasurementDet not found");
       }
@@ -169,29 +193,4 @@ vector<TrajectoryMeasurementGroup> LayerMeasurements::groupedMeasurements(const 
     }
   }
   return result;
-}
-
-void LayerMeasurements::addInvalidMeas(vector<TrajectoryMeasurement>& measVec,
-                                       const DetGroup& group,
-                                       const DetLayer& layer) const {
-  if (!measVec.empty()) {
-    // invalidMeas on Det of most compatible hit
-    auto const& ts = measVec.front().predictedState();
-    auto toll = measVec.front().recHitR().det()->surface().bounds().significanceInside(ts.localPosition(),
-                                                                                       ts.localError().positionError());
-    measVec.emplace_back(
-        measVec.front().predictedState(),
-        std::make_shared<InvalidTrackingRecHit>(*measVec.front().recHitR().det(), TrackingRecHit::missing),
-        toll,
-        &layer);
-  } else if (!group.empty()) {
-    // invalid state on first compatible Det
-    auto const& ts = group.front().trajectoryState();
-    auto toll =
-        group.front().det()->surface().bounds().significanceInside(ts.localPosition(), ts.localError().positionError());
-    measVec.emplace_back(group.front().trajectoryState(),
-                         std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing),
-                         toll,
-                         &layer);
-  }
 }

--- a/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
+++ b/TrackingTools/MeasurementDet/src/LayerMeasurements.cc
@@ -77,14 +77,12 @@ namespace {
     return result;
   }
 
-  void addInvalidMeas(vector<TrajectoryMeasurement>& measVec,
-                                         const DetGroup& group,
-                                         const DetLayer& layer) {
+  void addInvalidMeas(vector<TrajectoryMeasurement>& measVec, const DetGroup& group, const DetLayer& layer) {
     if (!measVec.empty()) {
       // invalidMeas on Det of most compatible hit
       auto const& ts = measVec.front().predictedState();
-      auto toll = measVec.front().recHitR().det()->surface().bounds().significanceInside(ts.localPosition(),
-                                                                                         ts.localError().positionError());
+      auto toll = measVec.front().recHitR().det()->surface().bounds().significanceInside(
+          ts.localPosition(), ts.localError().positionError());
       measVec.emplace_back(
           measVec.front().predictedState(),
           std::make_shared<InvalidTrackingRecHit>(*measVec.front().recHitR().det(), TrackingRecHit::missing),
@@ -93,8 +91,8 @@ namespace {
     } else if (!group.empty()) {
       // invalid state on first compatible Det
       auto const& ts = group.front().trajectoryState();
-      auto toll =
-          group.front().det()->surface().bounds().significanceInside(ts.localPosition(), ts.localError().positionError());
+      auto toll = group.front().det()->surface().bounds().significanceInside(ts.localPosition(),
+                                                                             ts.localError().positionError());
       measVec.emplace_back(group.front().trajectoryState(),
                            std::make_shared<InvalidTrackingRecHit>(*group.front().det(), TrackingRecHit::missing),
                            toll,


### PR DESCRIPTION
#### PR description:

This PR intends to fix https://github.com/cms-sw/cmssw/issues/27541.

If the `fromTrackerSeeds` parameter in the `ElectronSeedProducer` would be set to `false`, a segfault would occur, as detected in the UBSAN IB. This never happened in practice because  `fromTrackerSeeds = False` is actually not supported and triggers an exception [1].

We understand now that` fromTrackerSeeds` is never supposed to be `False` and therefore we can just remove all branches in the code for this case, fixing both the issue and simplifying the code.

When I tried to fix the issue, I initially didn't know how it could be fixed and did some changes with the goal of making the problem more obvious to me. This involved changing the `LayerMeasurements` class such that there are no pointers anymore which can be `nullptr` and therefore cause trouble when dereferenced. In retrospect, this has nothing to do with the actual issue, but I include this change anyway in the PR as I think it's an improvement.

This caused the interface of `LayerMeasurements` to change a little bit, and while adapting the code I found an unused function in some muon plugins which could be removed. It was apparently replaced by a more efficient function.

[1] https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc#L275

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR:

No backports intended.