### PR TITLE
Migrate EcalDeadChannelRecoveryBDTG to GBRForest

### DIFF
--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/interface/EcalDeadChannelRecoveryAlgos.h
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/interface/EcalDeadChannelRecoveryAlgos.h
@@ -22,7 +22,7 @@ public:
                 std::string algo,
                 double single8Cut,
                 double sum8Cut,
-                bool *accFlag);
+                bool &accFlag);
 
 private:
   EcalDeadChannelRecoveryBDTG<DetIdT> bdtg_;

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/interface/EcalDeadChannelRecoveryBDTG.h
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/interface/EcalDeadChannelRecoveryBDTG.h
@@ -9,10 +9,9 @@
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 
-#include "CommonTools/MVAUtils/interface/TMVAZipReader.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "TMVA/Reader.h"
+#include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 
 #include <string>
 #include <memory>
@@ -20,32 +19,17 @@
 template <typename DetIdT>
 class EcalDeadChannelRecoveryBDTG {
 public:
-  EcalDeadChannelRecoveryBDTG();
-  ~EcalDeadChannelRecoveryBDTG();
-
   void setParameters(const edm::ParameterSet &ps);
   void setCaloTopology(const CaloTopology *topo) { topology_ = topo; }
 
   double recover(
-      const DetIdT id, const EcalRecHitCollection &hit_collection, double single8Cut, double sum8Cut, bool *acceptFlag);
-
-  void loadFile();
-  void addVariables(TMVA::Reader *reader);
+      const DetIdT id, const EcalRecHitCollection &hit_collection, double single8Cut, double sum8Cut, bool &acceptFlag);
 
 private:
   const CaloTopology *topology_;
-  struct XtalMatrix {
-    std::array<float, 9> rEn, ieta, iphi;
-    float sumE8;
-  };
 
-  XtalMatrix mx_;
-
-  edm::FileInPath bdtWeightFileNoCracks_;
-  edm::FileInPath bdtWeightFileCracks_;
-
-  std::unique_ptr<TMVA::Reader> readerNoCrack;
-  std::unique_ptr<TMVA::Reader> readerCrack;
+  std::unique_ptr<const GBRForest> gbrForestNoCrack_;
+  std::unique_ptr<const GBRForest> gbrForestCrack_;
 };
 
 #endif

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/src/EcalDeadChannelRecoveryAlgos.cc
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/src/EcalDeadChannelRecoveryAlgos.cc
@@ -29,17 +29,17 @@ float EcalDeadChannelRecoveryAlgos<T>::correct(const T id,
                                                std::string algo,
                                                double single8Cut,
                                                double sum8Cut,
-                                               bool *acceptFlag) {
+                                               bool &acceptFlag) {
   // recover as single dead channel
   double newEnergy = 0.0;
   if (algo == "BDTG") {
-    *acceptFlag = false;
+    acceptFlag = false;
     newEnergy = this->bdtg_.recover(id, hit_collection, single8Cut, sum8Cut, acceptFlag);  //ADD here
     if (newEnergy > 0.)
-      *acceptFlag = true;  //bdtg set to 0 if there is more than one channel in the matrix that is not reponding
+      acceptFlag = true;  //bdtg set to 0 if there is more than one channel in the matrix that is not reponding
   } else {
     edm::LogError("EcalDeadChannelRecoveryAlgos") << "Invalid algorithm for dead channel recovery.";
-    *acceptFlag = false;
+    acceptFlag = false;
   }
 
   return newEnergy;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
@@ -131,7 +131,7 @@ bool EcalRecHitWorkerRecover::run(const edm::Event& evt,
     // channel recovery. Accepted new RecHit has the flag AcceptRecHit=TRUE
     bool AcceptRecHit = true;
     float ebEn = ebDeadChannelCorrector.correct(
-        detId, result, singleRecoveryMethod_, singleRecoveryThreshold_, sum8RecoveryThreshold_, &AcceptRecHit);
+        detId, result, singleRecoveryMethod_, singleRecoveryThreshold_, sum8RecoveryThreshold_, AcceptRecHit);
     EcalRecHit hit(detId, ebEn, 0., EcalRecHit::kDead);
 
     if (hit.energy() != 0 and AcceptRecHit == true) {
@@ -149,7 +149,7 @@ bool EcalRecHitWorkerRecover::run(const edm::Event& evt,
     // channel recovery. Accepted new RecHit has the flag AcceptRecHit=TRUE
     bool AcceptRecHit = true;
     float eeEn = eeDeadChannelCorrector.correct(
-        detId, result, singleRecoveryMethod_, singleRecoveryThreshold_, sum8RecoveryThreshold_, &AcceptRecHit);
+        detId, result, singleRecoveryMethod_, singleRecoveryThreshold_, sum8RecoveryThreshold_, AcceptRecHit);
     EcalRecHit hit(detId, eeEn, 0., EcalRecHit::kDead);
     if (hit.energy() != 0 and AcceptRecHit == true) {
       hit.setFlag(EcalRecHit::kNeighboursRecovered);


### PR DESCRIPTION
#### PR description:

I don't know what the plans are to resolve https://github.com/cms-sw/cmssw/issues/27648, but as I already wrote the code for the migration to find out if it would be possible and compared the output with TMVA (see https://github.com/cms-sw/cmssw/pull/27175#issuecomment-504985154), I thought I might as well do a PR with the code from back then.

#### PR validation:

CMSSW compiles, local matrix tests pass. However, I'm not sure if the comparisons would catch possible problems. Is the channel recovery now enabled by default so the matrix tests would capture possible differences? That would make validating this PR easier.

#### if this PR is a backport please specify the original PR:

No backport intended.