### PR TITLE
Fix order of era modifiers for DeepTau 2017v2p1

### DIFF
--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -167,6 +167,14 @@ _variables80X =  cms.PSet(
 
 tauTable.variables = cms.PSet(_variablesMiniV2,_deepTauVars2017v2)
 
+for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:
+    era.toModify(tauTable,
+                 variables = cms.PSet(_variablesMiniV2,_deepTauVars2017v2p1)
+    )
+for era in [run2_nanoAOD_94X2016,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1]:
+    era.toModify(tauTable,
+                 variables = _variablesMiniV2
+    )
 for era in [run2_nanoAOD_94XMiniAODv1,]:
     era.toModify(tauTable,
                  variables = _variablesMiniV1
@@ -174,19 +182,6 @@ for era in [run2_nanoAOD_94XMiniAODv1,]:
 run2_miniAOD_80XLegacy.toModify(tauTable,
                                 variables = _variables80X
 )
-for era in [run2_nanoAOD_94X2016,run2_nanoAOD_94XMiniAODv2,run2_nanoAOD_102Xv1]:
-    era.toModify(tauTable.variables,
-                 rawDeepTau2017v2VSe = None,
-                 rawDeepTau2017v2VSmu = None,
-                 rawDeepTau2017v2VSjet = None,
-                 idDeepTau2017v2VSe = None,
-                 idDeepTau2017v2VSmu = None,
-                 idDeepTau2017v2VSjet = None
-    )
-for era in [run2_miniAOD_devel,run2_tau_ul_2016,run2_tau_ul_2018]:
-    era.toModify(tauTable,
-                 variables = cms.PSet(_variablesMiniV2,_deepTauVars2017v2p1)
-    )
 
 
 tauGenJets.GenParticles = cms.InputTag("prunedGenParticles")


### PR DESCRIPTION
#### PR description:

This PR fixes issue found in (already merged) #27882 by changing order of era modifiers.
The PR is hopefully directed to correct branch.

#### PR validation:

Successfully tested with `runTheMatrix.py -l 1325.51,1329.1,136.772,136.8521 -i all --ibeos`

