### PR TITLE
DQM: Remove Tags.

### DIFF
--- a/DQM/HLXMonitor/src/HLXMonitor.cc
+++ b/DQM/HLXMonitor/src/HLXMonitor.cc
@@ -169,8 +169,6 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
     Set2Above[iWedge] =
         iBooker.book1D("Set2_Above", "HF+ Wedge " + wedgeNum.str() + ": Above Threshold 2 - Set 2", NBINS, XMIN, XMAX);
     ETSum[iWedge] = iBooker.book1D("ETSum", "HF+ Wedge " + wedgeNum.str() + ": Transverse Energy", NBINS, XMIN, XMAX);
-
-    iBooker.tagContents(monitorName_ + "/HFPlus/Wedge" + tempStreamer.str(), iWedge + 1);
   }
 
   if (NUM_HLX > 17) {
@@ -197,8 +195,6 @@ void HLXMonitor::SetupHists(DQMStore::IBooker &iBooker) {
       Set2Above[iWedge] = iBooker.book1D(
           "Set2_Above", "HF- Wedge " + wedgeNum.str() + ": Above Threshold 2 - Set 2", NBINS, XMIN, XMAX);
       ETSum[iWedge] = iBooker.book1D("ETSum", "HF- Wedge " + wedgeNum.str() + ": Transverse Energy", NBINS, XMIN, XMAX);
-
-      iBooker.tagContents(monitorName_ + "/HFMinus/Wedge" + tempStreamer.str(), iWedge + 1);
     }
   }
 

--- a/DQM/RPCMonitorDigi/src/RPCBookDetUnitME.cc
+++ b/DQM/RPCMonitorDigi/src/RPCBookDetUnitME.cc
@@ -44,34 +44,28 @@ void RPCMonitorDigi::bookRollME(DQMStore::IBooker& ibooker,
   os.str("");
   os << "Occupancy_" << nameRoll;
   meMap[os.str()] = ibooker.book1D(os.str(), os.str(), nstrips, 0.5, nstrips + 0.5);
-  ibooker.tag(meMap[os.str()], rpcdqm::OCCUPANCY);
 
   os.str("");
   os << "BXDistribution_" << nameRoll;
   meMap[os.str()] = ibooker.book1D(os.str(), os.str(), 7, -3.5, 3.5);
-  ibooker.tag(meMap[os.str()], rpcdqm::BX);
 
   if (detId.region() == 0) {
     os.str("");
     os << "ClusterSize_" << nameRoll;
     meMap[os.str()] = ibooker.book1D(os.str(), os.str(), 15, 0.5, 15.5);
-    ibooker.tag(meMap[os.str()], rpcdqm::CLUSTERSIZE);
 
     os.str("");
     os << "Multiplicity_" << nameRoll;
     meMap[os.str()] = ibooker.book1D(os.str(), os.str(), 30, 0.5, 30.5);
-    ibooker.tag(meMap[os.str()], rpcdqm::MULTIPLICITY);
 
   } else {
     os.str("");
     os << "ClusterSize_" << nameRoll;
     meMap[os.str()] = ibooker.book1D(os.str(), os.str(), 10, 0.5, 10.5);
-    ibooker.tag(meMap[os.str()], rpcdqm::CLUSTERSIZE);
 
     os.str("");
     os << "Multiplicity_" << nameRoll;
     meMap[os.str()] = ibooker.book1D(os.str(), os.str(), 15, 0.5, 15.5);
-    ibooker.tag(meMap[os.str()], rpcdqm::MULTIPLICITY);
   }
 
   os.str("");

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -1141,7 +1141,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchncluson) {
     hid = hidmanager.createHistoId("NumberOfClusters", "det", detid);
     mod_single.NumberOfClusters = bookME1D("TH1nClusters", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.NumberOfClusters, detid);
     mod_single.NumberOfClusters->setAxisTitle("number of clusters in one detector module");
     mod_single.NumberOfClusters->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
@@ -1151,7 +1150,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
     short total_nr_strips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
     hid = hidmanager.createHistoId("ClusterPosition", "det", detid);
     mod_single.ClusterPosition = ibooker.book1D(hid, hid, total_nr_strips, 0.5, total_nr_strips + 0.5);
-    ibooker.tag(mod_single.ClusterPosition, detid);
     mod_single.ClusterPosition->setAxisTitle("cluster position [strip number +0.5]");
   }
 
@@ -1160,7 +1158,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
     short total_nr_strips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
     hid = hidmanager.createHistoId("ClusterDigiPosition", "det", detid);
     mod_single.ClusterDigiPosition = ibooker.book1D(hid, hid, total_nr_strips, 0.5, total_nr_strips + 0.5);
-    ibooker.tag(mod_single.ClusterDigiPosition, detid);
     mod_single.ClusterDigiPosition->setAxisTitle("digi in cluster position [strip number +0.5]");
   }
 
@@ -1168,7 +1165,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchcluswidthon) {
     hid = hidmanager.createHistoId("ClusterWidth", "det", detid);
     mod_single.ClusterWidth = bookME1D("TH1ClusterWidth", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.ClusterWidth, detid);
     mod_single.ClusterWidth->setAxisTitle("cluster width [nr strips]");
   }
 
@@ -1176,7 +1172,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchcluschargeon) {
     hid = hidmanager.createHistoId("ClusterCharge", "det", detid);
     mod_single.ClusterCharge = bookME1D("TH1ClusterCharge", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.ClusterCharge, detid);
     mod_single.ClusterCharge->setAxisTitle("cluster charge [ADC]");
   }
 
@@ -1184,7 +1179,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchclusnoiseon) {
     hid = hidmanager.createHistoId("ClusterNoise", "det", detid);
     mod_single.ClusterNoise = bookME1D("TH1ClusterNoise", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.ClusterNoise, detid);
     mod_single.ClusterNoise->setAxisTitle("cluster noise");
   }
 
@@ -1192,7 +1186,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchclusstonon) {
     hid = hidmanager.createHistoId("ClusterSignalOverNoise", "det", detid);
     mod_single.ClusterSignalOverNoise = bookME1D("TH1ClusterStoN", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.ClusterSignalOverNoise, detid);
     mod_single.ClusterSignalOverNoise->setAxisTitle("ratio of signal to noise for each cluster");
   }
 
@@ -1208,7 +1201,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
                                                                  Parameters.getParameter<int32_t>("Nbiny"),
                                                                  Parameters.getParameter<double>("ymin"),
                                                                  Parameters.getParameter<double>("ymax"));
-    ibooker.tag(mod_single.ClusterSignalOverNoiseVsPos, detid);
     mod_single.ClusterSignalOverNoiseVsPos->setAxisTitle("pos");
   }
 
@@ -1216,7 +1208,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchlocaloccupancy) {
     hid = hidmanager.createHistoId("ClusterLocalOccupancy", "det", detid);
     mod_single.ModuleLocalOccupancy = bookME1D("TH1ModuleLocalOccupancy", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.ModuleLocalOccupancy, detid);
     mod_single.ModuleLocalOccupancy->setAxisTitle("module local occupancy [% of clusterized strips]");
   }
 
@@ -1224,7 +1215,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
   if (moduleswitchnrclusterizedstrip) {
     hid = hidmanager.createHistoId("NrOfClusterizedStrips", "det", detid);
     mod_single.NrOfClusterizedStrips = bookME1D("TH1NrOfClusterizedStrips", hid.c_str(), ibooker);
-    ibooker.tag(mod_single.NrOfClusterizedStrips, detid);
     mod_single.NrOfClusterizedStrips->setAxisTitle("number of clusterized strips");
   }
 
@@ -1243,7 +1233,6 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
                                                          Parameters.getParameter<int32_t>("Nbinsy"),
                                                          Parameters.getParameter<double>("ymin"),
                                                          Parameters.getParameter<double>("ymax"));
-    ibooker.tag(mod_single.Module_ClusWidthVsAmpTH2, detid);
     mod_single.Module_ClusWidthVsAmpTH2->setAxisTitle("Amplitudes (integrated ADC counts)", 1);
     mod_single.Module_ClusWidthVsAmpTH2->setAxisTitle("Cluster widths", 2);
   }

--- a/DQM/SiStripMonitorDigi/src/SiStripBaselineValidator.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripBaselineValidator.cc
@@ -45,10 +45,8 @@ void SiStripBaselineValidator::bookHistograms(DQMStore::IBooker& ibooker,
   ibooker.setCurrentFolder("SiStrip/BaselineValidator");
 
   h1NumbadAPVsRes_ = ibooker.book1D("ResAPVs", ";#ResAPVs", 100, 1.0, 10001);
-  ibooker.tag(h1NumbadAPVsRes_, 1);
 
   h1ADC_vs_strip_ = ibooker.book2D("ADCvsAPVs", ";ADCvsAPVs", 768, -0.5, 767.5, 1023, -0.5, 1022.5);
-  ibooker.tag(h1ADC_vs_strip_, 2);
 
   return;
 }

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -1021,7 +1021,6 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
   if (moduleswitchnumdigison) {
     hid = hidmanager.createHistoId("NumberOfDigis", "det", detid);
     mod_single.NumberOfDigis = ibooker.book1D(hid, hid, 21, -0.5, 20.5);
-    ibooker.tag(mod_single.NumberOfDigis, detid);
     mod_single.NumberOfDigis->setAxisTitle("number of digis in one detector module");
     mod_single.NumberOfDigis->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
@@ -1031,7 +1030,6 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
     hid = hidmanager.createHistoId("NumberOfDigisPerStrip", "det", detid);
     short nstrips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;
     mod_single.NumberOfDigisPerStrip = ibooker.book1D(hid, hid, nstrips, -0.5, nstrips + 0.5);
-    ibooker.tag(mod_single.NumberOfDigisPerStrip, detid);
     mod_single.NumberOfDigisPerStrip->setAxisTitle("number of (digis > 0) per strip");
     mod_single.NumberOfDigisPerStrip->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
@@ -1039,7 +1037,6 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
   if (moduleswitchadchotteston) {
     hid = hidmanager.createHistoId("ADCsHottestStrip", "det", detid);
     mod_single.ADCsHottestStrip = bookME1D(ibooker, "TH1ADCsHottestStrip", hid.c_str());
-    ibooker.tag(mod_single.ADCsHottestStrip, detid);  // 6 APVs -> 768 strips
     mod_single.ADCsHottestStrip->setAxisTitle("number of ADCs for hottest strip");
   }
 
@@ -1047,7 +1044,6 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
   if (moduleswitchadccooleston) {
     hid = hidmanager.createHistoId("ADCsCoolestStrip", "det", detid);
     mod_single.ADCsCoolestStrip = bookME1D(ibooker, "TH1ADCsCoolestStrip", hid.c_str());
-    ibooker.tag(mod_single.ADCsCoolestStrip, detid);
     mod_single.ADCsCoolestStrip->setAxisTitle("number of ADCs for coolest strip");
   }
 
@@ -1055,7 +1051,6 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
   if (moduleswitchdigiadcson) {
     hid = hidmanager.createHistoId("DigiADCs", "det", detid);
     mod_single.DigiADCs = bookME1D(ibooker, "TH1DigiADCs", hid.c_str());
-    ibooker.tag(mod_single.DigiADCs, detid);
     mod_single.DigiADCs->setAxisTitle("number of ADCs for each digi");
   }
 
@@ -1063,7 +1058,6 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
   if (moduleswitchstripoccupancyon) {
     hid = hidmanager.createHistoId("StripOccupancy", "det", detid);
     mod_single.StripOccupancy = bookME1D(ibooker, "TH1StripOccupancy", hid.c_str());
-    ibooker.tag(mod_single.StripOccupancy, detid);
     mod_single.StripOccupancy->setAxisTitle("strip occupancy");
   }
 }

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorPedestals.cc
@@ -186,24 +186,20 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker, const edm::E
         hid = hidmanager.createHistoId("PedestalFromCondDB", "det", detid);
         local_modmes.PedsPerStripDB =
             ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);  // to modify the size binning
-        ibooker.tag(local_modmes.PedsPerStripDB, detid);
         (local_modmes.PedsPerStripDB)->setAxisTitle("Pedestal from CondDB(ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("NoiseFromCondDB", "det", detid);
         local_modmes.CMSubNoisePerStripDB = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
-        ibooker.tag(local_modmes.CMSubNoisePerStripDB, detid);
         (local_modmes.CMSubNoisePerStripDB)->setAxisTitle("CMSubNoise from CondDB(ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("BadStripFlagCondDB", "det", detid);
         local_modmes.BadStripsDB = ibooker.book2D(hid, hid, nStrip, 0.5, nStrip + 0.5, 6, -0.5, 5.5);
-        ibooker.tag(local_modmes.BadStripsDB, detid);
         (local_modmes.BadStripsDB)->setAxisTitle("Strip Flag from CondDB(ADC) vs Strip Number", 1);
       }
       if (runTypeFlag_ == RunMode2 || runTypeFlag_ == RunMode3) {
         // Pedestals histos
         hid = hidmanager.createHistoId("PedsPerStrip", "det", detid);
         local_modmes.PedsPerStrip = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);  // to modify the size binning
-        ibooker.tag(local_modmes.PedsPerStrip, detid);
         (local_modmes.PedsPerStrip)->setAxisTitle("Pedestal (ADC)  vs Strip Number ", 1);
 
         hid = hidmanager.createHistoId("PedsDistribution", "det", detid);
@@ -215,7 +211,6 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker, const edm::E
                                                        300,
                                                        200,
                                                        500);  // to modify the size binning
-        ibooker.tag(local_modmes.PedsDistribution, detid);
         (local_modmes.PedsDistribution)->setAxisTitle("Apv Number", 1);
         (local_modmes.PedsDistribution)->setAxisTitle("Mean Pedestal Value (ADC)", 2);
 
@@ -228,51 +223,42 @@ void SiStripMonitorPedestals::createMEs(DQMStore::IBooker &ibooker, const edm::E
                                                     50,
                                                     0.,
                                                     50.);  // to modify the size binning
-        ibooker.tag(local_modmes.PedsEvolution, detid);
         (local_modmes.PedsEvolution)->setAxisTitle("Apv Number", 1);
         (local_modmes.PedsEvolution)->setAxisTitle("Iteration Number", 2);
 
         // Noise histos
         hid = hidmanager.createHistoId("CMSubNoisePerStrip", "det", detid);
         local_modmes.CMSubNoisePerStrip = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
-        ibooker.tag(local_modmes.CMSubNoisePerStrip, detid);
         (local_modmes.CMSubNoisePerStrip)->setAxisTitle("CMSubNoise (ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("RawNoisePerStrip", "det", detid);
         local_modmes.RawNoisePerStrip = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
-        ibooker.tag(local_modmes.RawNoisePerStrip, detid);
         (local_modmes.RawNoisePerStrip)->setAxisTitle("RawNoise(ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("CMSubNoiseProfile", "det", detid);
         local_modmes.CMSubNoiseProfile = ibooker.bookProfile(hid, hid, nStrip, 0.5, nStrip + 0.5, 100, 0., 100.);
-        ibooker.tag(local_modmes.CMSubNoiseProfile, detid);
         (local_modmes.CMSubNoiseProfile)->setAxisTitle("Mean of CMSubNoise (ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("RawNoiseProfile", "det", detid);
         local_modmes.RawNoiseProfile = ibooker.bookProfile(hid, hid, nStrip, 0.5, nStrip + 0.5, 100, 0., 100.);
-        ibooker.tag(local_modmes.RawNoiseProfile, detid);
         (local_modmes.RawNoiseProfile)->setAxisTitle("Mean of RawNoise (ADC) vs Strip Number", 1);
 
         hid = hidmanager.createHistoId("NoisyStrips", "det", detid);
         local_modmes.NoisyStrips = ibooker.book2D(hid, hid, nStrip, 0.5, nStrip + 0.5, 6, -0.5, 5.5);
-        ibooker.tag(local_modmes.NoisyStrips, detid);
         (local_modmes.NoisyStrips)->setAxisTitle("Strip Number", 1);
         (local_modmes.NoisyStrips)->setAxisTitle("Flag Value", 2);
 
         hid = hidmanager.createHistoId("NoisyStripDistribution", "det", detid);
         local_modmes.NoisyStripDistribution = ibooker.book1D(hid, hid, 11, -0.5, 10.5);
-        ibooker.tag(local_modmes.NoisyStripDistribution, detid);
         (local_modmes.NoisyStripDistribution)->setAxisTitle("Flag Value", 1);
 
         // Common Mode histos
         hid = hidmanager.createHistoId("CMDistribution", "det", detid);
         local_modmes.CMDistribution = ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 150, -15., 15.);
-        ibooker.tag(local_modmes.CMDistribution, detid);
         (local_modmes.CMDistribution)->setAxisTitle("Common Mode (ADC) vs APV Number", 1);
 
         hid = hidmanager.createHistoId("CMSlopeDistribution", "det", detid);
         local_modmes.CMSlopeDistribution = ibooker.book2D(hid, hid, napvs, -0.5, napvs - 0.5, 100, -0.05, 0.05);
-        ibooker.tag(local_modmes.CMSlopeDistribution, detid);
         (local_modmes.CMSlopeDistribution)->setAxisTitle("Common Mode Slope vs APV Number", 1);
       }
       // data from CondDB

--- a/DQM/SiStripMonitorPedestals/src/SiStripMonitorQuality.cc
+++ b/DQM/SiStripMonitorPedestals/src/SiStripMonitorQuality.cc
@@ -114,7 +114,6 @@ void SiStripMonitorQuality::bookHistograms(DQMStore::IBooker &ibooker,
     hid = hidmanager.createHistoId("StripQualityFromCondDB", "det", detid);
 
     det_me = ibooker.book1D(hid, hid, nStrip, 0.5, nStrip + 0.5);
-    ibooker.tag(det_me, detid);
     det_me->setAxisTitle("Strip Number", 1);
     det_me->setAxisTitle("Quality Flag from CondDB ", 2);
     QualityMEs.insert(std::make_pair(detid, det_me));

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -762,7 +762,6 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs 
 
     // -----
 
-
   }  // if "lorentzangle"
 }
 // ----
@@ -823,7 +822,6 @@ void SiStripBaseCondObjDQM::bookSummaryCumulMEs(SiStripBaseCondObjDQM::ModMEs &C
 
   CondObj_ME.SummaryOfCumulDistr->setAxisTitle(hSummaryOfCumul_xTitle, 1);
   CondObj_ME.SummaryOfCumulDistr->setAxisTitle(hSummaryOfCumul_yTitle, 2);
-
 }
 // -----
 
@@ -908,7 +906,6 @@ void SiStripBaseCondObjDQM::bookSummaryMEs(SiStripBaseCondObjDQM::ModMEs &CondOb
       CondObj_ME.SummaryDistr->setBinLabel(iBin, sameLayerDetIds_Name);
   }
   // -----
-
 }
 
 //==========================================================

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -501,7 +501,6 @@ void SiStripBaseCondObjDQM::bookProfileMEs(SiStripBaseCondObjDQM::ModMEs &CondOb
   CondObj_ME.ProfileDistr = dqmStore_->book1D(hProfile_Name, hProfile, hProfile_NchX, hProfile_LowX, hProfile_HighX);
   CondObj_ME.ProfileDistr->setAxisTitle(hProfile_xTitle, 1);
   CondObj_ME.ProfileDistr->setAxisTitle(hProfile_yTitle, 2);
-  dqmStore_->tag(CondObj_ME.ProfileDistr, detId_);
 }
 // -----
 
@@ -537,7 +536,6 @@ void SiStripBaseCondObjDQM::bookCumulMEs(SiStripBaseCondObjDQM::ModMEs &CondObj_
   CondObj_ME.CumulDistr = dqmStore_->book1D(hCumul_name, hCumul_title, hCumul_NchX, hCumul_LowX, hCumul_HighX);
   CondObj_ME.CumulDistr->setAxisTitle(hCumul_xTitle, 1);
   CondObj_ME.CumulDistr->setAxisTitle(hCumul_yTitle, 2);
-  dqmStore_->tag(CondObj_ME.CumulDistr, detId_);
 }
 // ----
 
@@ -764,7 +762,6 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs 
 
     // -----
 
-    dqmStore_->tag(CondObj_ME.SummaryOfProfileDistr, layer_);
 
   }  // if "lorentzangle"
 }
@@ -827,7 +824,6 @@ void SiStripBaseCondObjDQM::bookSummaryCumulMEs(SiStripBaseCondObjDQM::ModMEs &C
   CondObj_ME.SummaryOfCumulDistr->setAxisTitle(hSummaryOfCumul_xTitle, 1);
   CondObj_ME.SummaryOfCumulDistr->setAxisTitle(hSummaryOfCumul_yTitle, 2);
 
-  dqmStore_->tag(CondObj_ME.SummaryOfCumulDistr, layer_);
 }
 // -----
 
@@ -913,7 +909,6 @@ void SiStripBaseCondObjDQM::bookSummaryMEs(SiStripBaseCondObjDQM::ModMEs &CondOb
   }
   // -----
 
-  dqmStore_->tag(CondObj_ME.SummaryDistr, layer_);
 }
 
 //==========================================================

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -424,27 +424,21 @@ void SiStripMonitorTrack::bookModMEs(DQMStore::IBooker& ibooker, const uint32_t 
     // Cluster Width
     theModMEs.ClusterWidth =
         bookME1D(ibooker, "TH1ClusterWidth", hidmanager.createHistoId("ClusterWidth_OnTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterWidth, id);
     // Cluster Gain
     theModMEs.ClusterGain =
         bookME1D(ibooker, "TH1ClusterGain", hidmanager.createHistoId("ClusterGain", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterGain, id);
     // Cluster Charge
     theModMEs.ClusterCharge =
         bookME1D(ibooker, "TH1ClusterCharge", hidmanager.createHistoId("ClusterCharge_OnTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterCharge, id);
     // Cluster Charge Raw (no gain )
     theModMEs.ClusterChargeRaw = bookME1D(
         ibooker, "TH1ClusterChargeRaw", hidmanager.createHistoId("ClusterChargeRaw_OnTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterChargeRaw, id);
     // Cluster Charge Corrected
     theModMEs.ClusterChargeCorr = bookME1D(
         ibooker, "TH1ClusterChargeCorr", hidmanager.createHistoId("ClusterChargeCorr_OnTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterChargeCorr, id);
     // Cluster StoN Corrected
     theModMEs.ClusterStoNCorr = bookME1D(
         ibooker, "TH1ClusterStoNCorrMod", hidmanager.createHistoId("ClusterStoNCorr_OnTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterStoNCorr, id);
     // Cluster Position
     short total_nr_strips = SiStripDetCabling_->nApvPairs(id) * 2 * 128;
     theModMEs.ClusterPos = ibooker.book1D(hidmanager.createHistoId("ClusterPosition_OnTrack", name, id).c_str(),
@@ -452,19 +446,15 @@ void SiStripMonitorTrack::bookModMEs(DQMStore::IBooker& ibooker, const uint32_t 
                                           total_nr_strips,
                                           0.5,
                                           total_nr_strips + 0.5);
-    ibooker.tag(theModMEs.ClusterPos, id);
     // Cluster PGV
     theModMEs.ClusterPGV =
         bookMEProfile(ibooker, "TProfileClusterPGV", hidmanager.createHistoId("PGV_OnTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterPGV, id);
     // Cluster Charge per cm
     theModMEs.ClusterChargePerCMfromTrack = bookME1D(
         ibooker, "TH1ClusterChargePerCM", hidmanager.createHistoId("ClusterChargePerCMfromTrack", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterChargePerCMfromTrack, id);
 
     theModMEs.ClusterChargePerCMfromOrigin = bookME1D(
         ibooker, "TH1ClusterChargePerCM", hidmanager.createHistoId("ClusterChargePerCMfromOrigin", name, id).c_str());
-    ibooker.tag(theModMEs.ClusterChargePerCMfromOrigin, id);
 
     ModMEsMap[hid] = theModMEs;
   }

--- a/DQMServices/Components/plugins/EDMtoMEConverter.cc
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.cc
@@ -354,10 +354,6 @@ void EDMtoMEConverter::getData(DQMStore::IBooker &iBooker, DQMStore::IGetter &iG
           AddMonitorElement<METype>::call(iBooker, iGetter, &metoedmobject[i].object, dir, name, iGetFrom);
       maybeSetLumiFlag(me, iGetFrom);
 
-      // attach taglist
-      for (const auto &tag : metoedmobject[i].tags) {
-        iBooker.tag(me, tag);
-      }
     }  // end loop thorugh metoedmobject
   });
 }

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -237,51 +237,51 @@ void MEtoEDMConverter::putData(DQMStore::IGetter& iGetter, T& iPutTo, bool iLumi
     // get monitor elements
     switch (me->kind()) {
       case MonitorElement::Kind::INT:
-        pOutInt->putMEtoEdmObject(me->getFullname(), me->getTags(), me->getIntValue());
+        pOutInt->putMEtoEdmObject(me->getFullname(), me->getIntValue());
         break;
 
       case MonitorElement::Kind::REAL:
-        pOutDouble->putMEtoEdmObject(me->getFullname(), me->getTags(), me->getFloatValue());
+        pOutDouble->putMEtoEdmObject(me->getFullname(), me->getFloatValue());
         break;
 
       case MonitorElement::Kind::STRING:
-        pOutString->putMEtoEdmObject(me->getFullname(), me->getTags(), me->getStringValue());
+        pOutString->putMEtoEdmObject(me->getFullname(), me->getStringValue());
         break;
 
       case MonitorElement::Kind::TH1F:
-        pOut1->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH1F());
+        pOut1->putMEtoEdmObject(me->getFullname(), *me->getTH1F());
         break;
 
       case MonitorElement::Kind::TH1S:
-        pOut1s->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH1S());
+        pOut1s->putMEtoEdmObject(me->getFullname(), *me->getTH1S());
         break;
 
       case MonitorElement::Kind::TH1D:
-        pOut1d->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH1D());
+        pOut1d->putMEtoEdmObject(me->getFullname(), *me->getTH1D());
         break;
 
       case MonitorElement::Kind::TH2F:
-        pOut2->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH2F());
+        pOut2->putMEtoEdmObject(me->getFullname(), *me->getTH2F());
         break;
 
       case MonitorElement::Kind::TH2S:
-        pOut2s->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH2S());
+        pOut2s->putMEtoEdmObject(me->getFullname(), *me->getTH2S());
         break;
 
       case MonitorElement::Kind::TH2D:
-        pOut2d->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH2D());
+        pOut2d->putMEtoEdmObject(me->getFullname(), *me->getTH2D());
         break;
 
       case MonitorElement::Kind::TH3F:
-        pOut3->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTH3F());
+        pOut3->putMEtoEdmObject(me->getFullname(), *me->getTH3F());
         break;
 
       case MonitorElement::Kind::TPROFILE:
-        pOutProf->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTProfile());
+        pOutProf->putMEtoEdmObject(me->getFullname(), *me->getTProfile());
         break;
 
       case MonitorElement::Kind::TPROFILE2D:
-        pOutProf2->putMEtoEdmObject(me->getFullname(), me->getTags(), *me->getTProfile2D());
+        pOutProf2->putMEtoEdmObject(me->getFullname(), *me->getTProfile2D());
         break;
 
       default:

--- a/DQMServices/Core/bin/DumpFile.cpp
+++ b/DQMServices/Core/bin/DumpFile.cpp
@@ -204,7 +204,7 @@ int main(int argc, char **argv) {
         getMEInfo(store, me, info);
         std::cout << "ME STYLE=" << info.style << " RUN=" << info.runnr << " DATASET='" << dataset << "' STEP='" << step
                   << "' SYSTEM='" << info.system << "' CATEGORY='" << info.category << "' KIND='"
-                  << kindToName(me.kind()) << "' TAG=" << me.getTag() << " FLAGS=0x" << std::hex << me.flags()
+                  << kindToName(me.kind()) << " FLAGS=0x" << std::hex << me.flags()
                   << std::dec << " NAME='" << info.name << "' DATA='" << hexlify(info.data) << "'\n";
       }
     } catch (std::exception &e) {

--- a/DQMServices/Core/bin/DumpFile.cpp
+++ b/DQMServices/Core/bin/DumpFile.cpp
@@ -204,8 +204,8 @@ int main(int argc, char **argv) {
         getMEInfo(store, me, info);
         std::cout << "ME STYLE=" << info.style << " RUN=" << info.runnr << " DATASET='" << dataset << "' STEP='" << step
                   << "' SYSTEM='" << info.system << "' CATEGORY='" << info.category << "' KIND='"
-                  << kindToName(me.kind()) << " FLAGS=0x" << std::hex << me.flags()
-                  << std::dec << " NAME='" << info.name << "' DATA='" << hexlify(info.data) << "'\n";
+                  << kindToName(me.kind()) << " FLAGS=0x" << std::hex << me.flags() << std::dec << " NAME='"
+                  << info.name << "' DATA='" << hexlify(info.data) << "'\n";
       }
     } catch (std::exception &e) {
       std::cerr << "*** FAILED TO READ FILE " << argv[arg] << ":\n" << e.what() << std::endl;

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -219,8 +219,6 @@ namespace dqm::impl {
       void setCurrentFolder(std::string const& fullpath);
       void goUp();
       std::string const& pwd();
-      void tag(MonitorElement*, unsigned int);
-      void tagContents(std::string const&, unsigned int);
 
       IBooker() = delete;
       IBooker(IBooker const&) = delete;
@@ -618,22 +616,13 @@ namespace dqm::impl {
     MonitorElement* bookProfile2D(char_string const& name, TProfile2D* h);
 
     //-------------------------------------------------------------------------
-    // ---------------------- public tagging ----------------------------------
-    void tag(MonitorElement* me, unsigned int myTag);
-    void tag(std::string const& path, unsigned int myTag);
-    void tagContents(std::string const& path, unsigned int myTag);
-    void tagAllContents(std::string const& path, unsigned int myTag);
-
-    //-------------------------------------------------------------------------
     // ---------------------- public ME getters -------------------------------
     std::vector<std::string> getSubdirs() const;
     std::vector<std::string> getMEs() const;
     bool containsAnyMonitorable(std::string const& path) const;
 
     MonitorElement* get(std::string const& path) const;
-    std::vector<MonitorElement*> get(unsigned int tag) const;
     std::vector<MonitorElement*> getContents(std::string const& path) const;
-    std::vector<MonitorElement*> getContents(std::string const& path, unsigned int tag) const;
     void getContents(std::vector<std::string>& into, bool showContents = true) const;
 
     // ---------------------- softReset methods -------------------------------

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -370,16 +370,6 @@ namespace dqm::impl {
       return scalar_.str;
     }
 
-    DQMNet::TagList getTags() const  // DEPRECATED
-    {
-      DQMNet::TagList tags;
-      if (data_.flags & DQMNet::DQM_PROP_TAGGED)
-        tags.push_back(data_.tag);
-      return tags;
-    }
-
-    const uint32_t getTag() const { return data_.tag; }
-
     const uint32_t run() const { return data_.run; }
     const uint32_t lumi() const { return data_.lumi; }
     const uint32_t moduleId() const { return data_.moduleId; }

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -85,7 +85,7 @@ namespace {
     }
     void doFill(MonitorElement* iElement) override {
       *m_fullNameBufferPtr = iElement->getFullname();
-      m_flagBuffer = iElement->getTag();
+      m_flagBuffer = 0;
       m_bufferPtr = dynamic_cast<T*>(iElement->getRootObject());
       assert(nullptr != m_bufferPtr);
       //std::cout <<"#entries: "<<m_bufferPtr->GetEntries()<<std::endl;
@@ -115,7 +115,7 @@ namespace {
 
     void doFill(MonitorElement* iElement) override {
       *m_fullNameBufferPtr = iElement->getFullname();
-      m_flagBuffer = iElement->getTag();
+      m_flagBuffer = 0;
       m_buffer = iElement->getIntValue();
       m_tree->Fill();
     }
@@ -140,7 +140,7 @@ namespace {
     }
     void doFill(MonitorElement* iElement) override {
       *m_fullNameBufferPtr = iElement->getFullname();
-      m_flagBuffer = iElement->getTag();
+      m_flagBuffer = 0;
       m_buffer = iElement->getFloatValue();
       m_tree->Fill();
     }
@@ -166,7 +166,7 @@ namespace {
     }
     void doFill(MonitorElement* iElement) override {
       *m_fullNameBufferPtr = iElement->getFullname();
-      m_flagBuffer = iElement->getTag();
+      m_flagBuffer = 0;
       m_buffer = iElement->getStringValue();
       m_tree->Fill();
     }

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -234,9 +234,6 @@ namespace {
         } else {
           mergeWithElement(element, m_buffer);
         }
-        if (0 != m_tag) {
-          iStore.tag(element, m_tag);
-        }
       } catch (cms::Exception& e) {
         e.addContext(std::string("While reading element ") + *m_fullName);
         e.raise();
@@ -275,9 +272,6 @@ namespace {
         }
       } else {
         mergeWithElement(element, m_buffer);
-      }
-      if (0 != m_tag) {
-        iStore.tag(element, m_tag);
       }
       return element;
     }

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -50,11 +50,10 @@ public:
 
   typedef std::vector<MEtoEDMObject> MEtoEdmObjectVector;
 
-  void putMEtoEdmObject(const std::string &name, const TagList &tags, const T &object) {
+  void putMEtoEdmObject(const std::string &name, const T &object) {
     typename MEtoEdmObjectVector::value_type temp;
     MEtoEdmObject.push_back(temp);
     MEtoEdmObject.back().name = name;
-    MEtoEdmObject.back().tags = tags;
     MEtoEdmObject.back().object = object;
   }
 

--- a/DataFormats/Histograms/test/metoedmformat_t.cc
+++ b/DataFormats/Histograms/test/metoedmformat_t.cc
@@ -61,16 +61,15 @@ bool areEquivalent(const MEtoEDM<T>& iLHS, const MEtoEDM<T>& iRHS) {
 void TestMEtoEDMFormat::testMergeInt64() {
   MEtoEDM<long long> empty(0);
 
-  MEtoEDM<long long>::TagList tList;
   MEtoEDM<long long> full(3);
-  full.putMEtoEdmObject("a", tList, 1);
-  full.putMEtoEdmObject("b", tList, 2);
-  full.putMEtoEdmObject("c", tList, 3);
+  full.putMEtoEdmObject("a", 1);
+  full.putMEtoEdmObject("b", 2);
+  full.putMEtoEdmObject("c", 3);
 
   MEtoEDM<long long> fullReordered(3);
-  fullReordered.putMEtoEdmObject("b", tList, 2);
-  fullReordered.putMEtoEdmObject("a", tList, 1);
-  fullReordered.putMEtoEdmObject("c", tList, 3);
+  fullReordered.putMEtoEdmObject("b", 2);
+  fullReordered.putMEtoEdmObject("a", 1);
+  fullReordered.putMEtoEdmObject("c", 3);
 
   MEtoEDM<long long> toMerge(full);
 
@@ -89,27 +88,27 @@ void TestMEtoEDMFormat::testMergeInt64() {
   CPPUNIT_ASSERT(areEquivalent(toMerge3, full));
 
   MEtoEDM<long long> part1(2);
-  part1.putMEtoEdmObject("a", tList, 1);
-  part1.putMEtoEdmObject("b", tList, 2);
+  part1.putMEtoEdmObject("a", 1);
+  part1.putMEtoEdmObject("b", 2);
   MEtoEDM<long long> part2(1);
-  part2.putMEtoEdmObject("c", tList, 3);
+  part2.putMEtoEdmObject("c", 3);
   part1.mergeProduct(part2);
   CPPUNIT_ASSERT(areEquivalent(part1, full));
 
   MEtoEDM<long long> specials1(3);
-  specials1.putMEtoEdmObject("EventInfo/processedEvents", tList, 1);
-  specials1.putMEtoEdmObject("EventInfo/iEvent", tList, 2);
-  specials1.putMEtoEdmObject("EventInfo/iLumiSection", tList, 3);
+  specials1.putMEtoEdmObject("EventInfo/processedEvents", 1);
+  specials1.putMEtoEdmObject("EventInfo/iEvent", 2);
+  specials1.putMEtoEdmObject("EventInfo/iLumiSection", 3);
 
   MEtoEDM<long long> specials2(3);
-  specials2.putMEtoEdmObject("EventInfo/processedEvents", tList, 1);
-  specials2.putMEtoEdmObject("EventInfo/iEvent", tList, 3);
-  specials2.putMEtoEdmObject("EventInfo/iLumiSection", tList, 2);
+  specials2.putMEtoEdmObject("EventInfo/processedEvents", 1);
+  specials2.putMEtoEdmObject("EventInfo/iEvent", 3);
+  specials2.putMEtoEdmObject("EventInfo/iLumiSection", 2);
 
   MEtoEDM<long long> specialsTotal(3);
-  specialsTotal.putMEtoEdmObject("EventInfo/processedEvents", tList, 2);
-  specialsTotal.putMEtoEdmObject("EventInfo/iEvent", tList, 3);
-  specialsTotal.putMEtoEdmObject("EventInfo/iLumiSection", tList, 3);
+  specialsTotal.putMEtoEdmObject("EventInfo/processedEvents", 2);
+  specialsTotal.putMEtoEdmObject("EventInfo/iEvent", 3);
+  specialsTotal.putMEtoEdmObject("EventInfo/iLumiSection", 3);
   specials1.mergeProduct(specials2);
   CPPUNIT_ASSERT(areEquivalent(specials1, specialsTotal));
 }
@@ -117,16 +116,15 @@ void TestMEtoEDMFormat::testMergeInt64() {
 void TestMEtoEDMFormat::testMergeDouble() {
   MEtoEDM<double> empty(0);
 
-  MEtoEDM<double>::TagList tList;
   MEtoEDM<double> full(3);
-  full.putMEtoEdmObject("a", tList, 1);
-  full.putMEtoEdmObject("b", tList, 2);
-  full.putMEtoEdmObject("c", tList, 3);
+  full.putMEtoEdmObject("a", 1);
+  full.putMEtoEdmObject("b", 2);
+  full.putMEtoEdmObject("c", 3);
 
   MEtoEDM<double> fullReordered(3);
-  fullReordered.putMEtoEdmObject("b", tList, 2);
-  fullReordered.putMEtoEdmObject("a", tList, 1);
-  fullReordered.putMEtoEdmObject("c", tList, 3);
+  fullReordered.putMEtoEdmObject("b", 2);
+  fullReordered.putMEtoEdmObject("a", 1);
+  fullReordered.putMEtoEdmObject("c", 3);
 
   MEtoEDM<double> toMerge(full);
 
@@ -145,10 +143,10 @@ void TestMEtoEDMFormat::testMergeDouble() {
   CPPUNIT_ASSERT(areEquivalent(toMerge3, full));
 
   MEtoEDM<double> part1(2);
-  part1.putMEtoEdmObject("a", tList, 1);
-  part1.putMEtoEdmObject("b", tList, 2);
+  part1.putMEtoEdmObject("a", 1);
+  part1.putMEtoEdmObject("b", 2);
   MEtoEDM<double> part2(1);
-  part2.putMEtoEdmObject("c", tList, 3);
+  part2.putMEtoEdmObject("c", 3);
   part1.mergeProduct(part2);
   CPPUNIT_ASSERT(areEquivalent(part1, full));
 }
@@ -163,16 +161,15 @@ bool operator!=(const TString& iLHS, const TString& iRHS) {
 void TestMEtoEDMFormat::testMergeTString() {
   MEtoEDM<TString> empty(0);
 
-  MEtoEDM<TString>::TagList tList;
   MEtoEDM<TString> full(3);
-  full.putMEtoEdmObject("a", tList, "1");
-  full.putMEtoEdmObject("b", tList, "2");
-  full.putMEtoEdmObject("c", tList, "3");
+  full.putMEtoEdmObject("a", "1");
+  full.putMEtoEdmObject("b", "2");
+  full.putMEtoEdmObject("c", "3");
 
   MEtoEDM<TString> fullReordered(3);
-  fullReordered.putMEtoEdmObject("b", tList, "2");
-  fullReordered.putMEtoEdmObject("a", tList, "1");
-  fullReordered.putMEtoEdmObject("c", tList, "3");
+  fullReordered.putMEtoEdmObject("b", "2");
+  fullReordered.putMEtoEdmObject("a", "1");
+  fullReordered.putMEtoEdmObject("c", "3");
 
   MEtoEDM<TString> toMerge(full);
 
@@ -191,10 +188,10 @@ void TestMEtoEDMFormat::testMergeTString() {
   CPPUNIT_ASSERT(areEquivalent(toMerge3, full));
 
   MEtoEDM<TString> part1(2);
-  part1.putMEtoEdmObject("a", tList, "1");
-  part1.putMEtoEdmObject("b", tList, "2");
+  part1.putMEtoEdmObject("a", "1");
+  part1.putMEtoEdmObject("b", "2");
   MEtoEDM<TString> part2(1);
-  part2.putMEtoEdmObject("c", tList, "3");
+  part2.putMEtoEdmObject("c", "3");
   part1.mergeProduct(part2);
   CPPUNIT_ASSERT(areEquivalent(part1, full));
 }
@@ -236,21 +233,20 @@ namespace {
 void TestMEtoEDMFormat::testMergeT() {
   MEtoEDM<Dummy> empty(0);
 
-  MEtoEDM<Dummy>::TagList tList;
   MEtoEDM<Dummy> full(3);
-  full.putMEtoEdmObject("a", tList, 1);
-  full.putMEtoEdmObject("b", tList, 2);
-  full.putMEtoEdmObject("c", tList, 3);
+  full.putMEtoEdmObject("a", 1);
+  full.putMEtoEdmObject("b", 2);
+  full.putMEtoEdmObject("c", 3);
 
   MEtoEDM<Dummy> fullReordered(3);
-  fullReordered.putMEtoEdmObject("b", tList, 2);
-  fullReordered.putMEtoEdmObject("a", tList, 1);
-  fullReordered.putMEtoEdmObject("c", tList, 3);
+  fullReordered.putMEtoEdmObject("b", 2);
+  fullReordered.putMEtoEdmObject("a", 1);
+  fullReordered.putMEtoEdmObject("c", 3);
 
   MEtoEDM<Dummy> doubleFull(3);
-  doubleFull.putMEtoEdmObject("a", tList, 2 * 1);
-  doubleFull.putMEtoEdmObject("b", tList, 2 * 2);
-  doubleFull.putMEtoEdmObject("c", tList, 2 * 3);
+  doubleFull.putMEtoEdmObject("a", 2 * 1);
+  doubleFull.putMEtoEdmObject("b", 2 * 2);
+  doubleFull.putMEtoEdmObject("c", 2 * 3);
 
   MEtoEDM<Dummy> toMerge(full);
 
@@ -269,10 +265,10 @@ void TestMEtoEDMFormat::testMergeT() {
   CPPUNIT_ASSERT(areEquivalent(toMerge3, doubleFull));
 
   MEtoEDM<Dummy> part1(2);
-  part1.putMEtoEdmObject("a", tList, 1);
-  part1.putMEtoEdmObject("b", tList, 2);
+  part1.putMEtoEdmObject("a", 1);
+  part1.putMEtoEdmObject("b", 2);
   MEtoEDM<Dummy> part2(1);
-  part2.putMEtoEdmObject("c", tList, 3);
+  part2.putMEtoEdmObject("c", 3);
   part1.mergeProduct(part2);
   CPPUNIT_ASSERT(areEquivalent(part1, full));
 }

--- a/Validation/GlobalHits/src/GlobalHitsTester.cc
+++ b/Validation/GlobalHits/src/GlobalHitsTester.cc
@@ -74,14 +74,6 @@ void GlobalHitsTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
   ibooker.setCurrentFolder("GlobalTestV/TProfile2D");
   meTestProfile2 = ibooker.bookProfile2D("Profile2", "Profile2", 100, -10., 10., 100, -10, 10., 100, -10., 10.);
 
-  ibooker.tag(meTestTH1F, 1);
-  ibooker.tag(meTestTH2F, 2);
-  ibooker.tag(meTestTH3F, 3);
-  ibooker.tag(meTestProfile1, 4);
-  ibooker.tag(meTestProfile2, 5);
-  ibooker.tag(meTestString, 6);
-  ibooker.tag(meTestInt, 7);
-  ibooker.tag(meTestFloat, 8);
 }
 
 void GlobalHitsTester::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {

--- a/Validation/GlobalHits/src/GlobalHitsTester.cc
+++ b/Validation/GlobalHits/src/GlobalHitsTester.cc
@@ -73,7 +73,6 @@ void GlobalHitsTester::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
 
   ibooker.setCurrentFolder("GlobalTestV/TProfile2D");
   meTestProfile2 = ibooker.bookProfile2D("Profile2", "Profile2", 100, -10., 10., 100, -10, 10., 100, -10., 10.);
-
 }
 
 void GlobalHitsTester::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {

--- a/Validation/RecoHI/plugins/HiBasicGenTest.cc
+++ b/Validation/RecoHI/plugins/HiBasicGenTest.cc
@@ -32,15 +32,9 @@ void HiBasicGenTest::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&,
 
     b[ibin] = ibooker.book1D(Form("b%d", ibin), ";b[fm];events", 100, 0.0, 20.0);
     dnchdphi[ibin] = ibooker.book1D(Form("dnchdphi%d", ibin), ";#phi;dN^{ch}/d#phi", 100, -3.2, 3.2);
-
-    ibooker.tag(dnchdeta[ibin], 1 + ibin * 4);
-    ibooker.tag(dnchdpt[ibin], 2 + ibin * 4);
-    ibooker.tag(b[ibin], 3 + ibin * 4);
-    ibooker.tag(dnchdphi[ibin], 4 + ibin * 4);
   }
 
   rp = ibooker.book1D("phi0", ";#phi_{RP};events", 100, -3.2, 3.2);
-  ibooker.tag(rp, 13);
 }
 
 void HiBasicGenTest::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) { iSetup.getData(pdt); }


### PR DESCRIPTION
#### PR description:

In the olden days, _tags_ could be associated with `MonitorElement`s for whatever purposes.

I fail to see any usage of tags today, so we will not support this in the future, and this PR removes the API as well as the I/O support. 

#### PR validation:
Runs through a simple workflow.

Special care must be taken to make sure that nothing in AlCa breaks; the code compiles fine without any of the get-by-tag APIs, so I suspect that actually none are used, but the SiStrip modules used for AlCa are among the few modules actually tagging MEs.
