### PR TITLE
Backport of #27988 (Truncate pt of PackedCandidate)

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -11,7 +11,8 @@ CovarianceParameterization pat::PackedCandidate::covarianceParameterization_;
 std::once_flag pat::PackedCandidate::covariance_load_flag;
 
 void pat::PackedCandidate::pack(bool unpackAfterwards) {
-  packedPt_ = MiniFloatConverter::float32to16(p4_.load()->Pt());
+  float unpackedPt = std::min<float>(p4_.load()->Pt(), MiniFloatConverter::max());
+  packedPt_ = MiniFloatConverter::float32to16(unpackedPt);
   packedEta_ = int16_t(std::round(p4_.load()->Eta() / 6.0f *
                                   std::numeric_limits<int16_t>::max()));
   packedPhi_ = int16_t(std::round(p4_.load()->Phi() / 3.2f *


### PR DESCRIPTION
Backport of changes from #27988

#### PR description:

In response to #27374, truncating pt of PackedCandidate in case the 32 bit representation is beyond the 16-bit max (represented by the "minifloat" as inf, as per that standard requirement here). This was giving problems downstream when the 16-bit "infinity" was widened to 32 bits and became inaccurate.


#### if this PR is a backport please specify the original PR:

Original PR is #27988