### PR TITLE
HGCal - bugfix: Fix clamp range in tiling

### DIFF
--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -18,7 +18,7 @@ public:
     static_assert(etaRange >= 0.f);
     float r = ticl::constants::nEtaBins / etaRange;
     int etaBin = (std::abs(eta) - ticl::constants::minEta) * r;
-    etaBin = std::clamp(etaBin, 0, ticl::constants::nEtaBins);
+    etaBin = std::clamp(etaBin, 0, ticl::constants::nEtaBins-1);
     return etaBin;
   }
 

--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -18,7 +18,7 @@ public:
     static_assert(etaRange >= 0.f);
     float r = ticl::constants::nEtaBins / etaRange;
     int etaBin = (std::abs(eta) - ticl::constants::minEta) * r;
-    etaBin = std::clamp(etaBin, 0, ticl::constants::nEtaBins-1);
+    etaBin = std::clamp(etaBin, 0, ticl::constants::nEtaBins - 1);
     return etaBin;
   }
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -41,7 +41,7 @@ public:
     static_assert(xRange >= 0.);
     constexpr float r = hgcaltilesconstants::nColumns / xRange;
     int xBin = (x - hgcaltilesconstants::minX) * r;
-    xBin = std::clamp(xBin, 0, hgcaltilesconstants::nColumns);
+    xBin = std::clamp(xBin, 0, hgcaltilesconstants::nColumns-1);
     return xBin;
   }
 
@@ -50,7 +50,7 @@ public:
     static_assert(yRange >= 0.);
     constexpr float r = hgcaltilesconstants::nRows / yRange;
     int yBin = (y - hgcaltilesconstants::minY) * r;
-    yBin = std::clamp(yBin, 0, hgcaltilesconstants::nRows);
+    yBin = std::clamp(yBin, 0, hgcaltilesconstants::nRows-1);
     return yBin;
   }
 
@@ -59,7 +59,7 @@ public:
     static_assert(etaRange >= 0.);
     constexpr float r = hgcaltilesconstants::nColumnsEta / etaRange;
     int etaBin = (eta - hgcaltilesconstants::minEta) * r;
-    etaBin = std::clamp(etaBin, 0, hgcaltilesconstants::nColumnsEta);
+    etaBin = std::clamp(etaBin, 0, hgcaltilesconstants::nColumnsEta-1);
     return etaBin;
   }
 
@@ -68,7 +68,7 @@ public:
     static_assert(phiRange >= 0.);
     constexpr float r = hgcaltilesconstants::nRowsPhi / phiRange;
     int phiBin = (phi - hgcaltilesconstants::minPhi) * r;
-    phiBin = std::clamp(phiBin, 0, hgcaltilesconstants::nRowsPhi);
+    phiBin = std::clamp(phiBin, 0, hgcaltilesconstants::nRowsPhi-1);
     return phiBin;
   }
 

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -41,7 +41,7 @@ public:
     static_assert(xRange >= 0.);
     constexpr float r = hgcaltilesconstants::nColumns / xRange;
     int xBin = (x - hgcaltilesconstants::minX) * r;
-    xBin = std::clamp(xBin, 0, hgcaltilesconstants::nColumns-1);
+    xBin = std::clamp(xBin, 0, hgcaltilesconstants::nColumns - 1);
     return xBin;
   }
 
@@ -50,7 +50,7 @@ public:
     static_assert(yRange >= 0.);
     constexpr float r = hgcaltilesconstants::nRows / yRange;
     int yBin = (y - hgcaltilesconstants::minY) * r;
-    yBin = std::clamp(yBin, 0, hgcaltilesconstants::nRows-1);
+    yBin = std::clamp(yBin, 0, hgcaltilesconstants::nRows - 1);
     return yBin;
   }
 
@@ -59,7 +59,7 @@ public:
     static_assert(etaRange >= 0.);
     constexpr float r = hgcaltilesconstants::nColumnsEta / etaRange;
     int etaBin = (eta - hgcaltilesconstants::minEta) * r;
-    etaBin = std::clamp(etaBin, 0, hgcaltilesconstants::nColumnsEta-1);
+    etaBin = std::clamp(etaBin, 0, hgcaltilesconstants::nColumnsEta - 1);
     return etaBin;
   }
 
@@ -68,7 +68,7 @@ public:
     static_assert(phiRange >= 0.);
     constexpr float r = hgcaltilesconstants::nRowsPhi / phiRange;
     int phiBin = (phi - hgcaltilesconstants::minPhi) * r;
-    phiBin = std::clamp(phiBin, 0, hgcaltilesconstants::nRowsPhi-1);
+    phiBin = std::clamp(phiBin, 0, hgcaltilesconstants::nRowsPhi - 1);
     return phiBin;
   }
 


### PR DESCRIPTION
#### PR description:
The upper limit when using `std::clamp` on the number of bins should be the number of bins minus 1.
When hitting the very last bin, this could lead to SEGFAULT.

@rovere @ZihengChen 