### PR TITLE
Adding the regression config for light by light

### DIFF
--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -90,6 +90,96 @@ regressionModifier106XUL = cms.PSet(
     )
 )
 
+regressionModifier103XLowPtPho = cms.PSet(
+    modifierName = cms.string('EGRegressionModifierV3'),       
+    rhoTag = cms.InputTag('fixedGridRhoFastjetAllTmp'),
+    useClosestToCentreSeedCrysDef = cms.bool(False),
+    maxRawEnergyForLowPtEBSigma = cms.double(-1), 
+    maxRawEnergyForLowPtEESigma = cms.double(1200.),
+    eleRegs = cms.PSet(
+        ecalOnlyMean = cms.PSet(
+            rangeMinLowEt = cms.double(0.2),
+            rangeMaxLowEt = cms.double(2.0),
+            rangeMinHighEt = cms.double(-1.),
+            rangeMaxHighEt = cms.double(3.0),
+            forceHighEnergyTrainingIfSaturated = cms.bool(True),
+            lowEtHighEtBoundary = cms.double(999999.),
+            ebLowEtForestName = cms.string("electron_eb_ecalOnly_1To20_0p2To2_mean"),
+            ebHighEtForestName = cms.string("electron_eb_ECALonly"),
+            eeLowEtForestName = cms.string("electron_ee_ecalOnly_1To20_0p2To2_mean"),
+            eeHighEtForestName = cms.string("electron_ee_ECALonly"),
+            ),
+        ecalOnlySigma = cms.PSet(
+            rangeMinLowEt = cms.double(0.0002),
+            rangeMaxLowEt = cms.double(0.5),
+            rangeMinHighEt = cms.double(0.0002),
+            rangeMaxHighEt = cms.double(0.5),
+            forceHighEnergyTrainingIfSaturated = cms.bool(True),
+            lowEtHighEtBoundary = cms.double(999999.),
+            ebLowEtForestName = cms.string("electron_eb_ecalOnly_1To20_0p0002To0p5_sigma"),
+            ebHighEtForestName = cms.string("electron_eb_ECALonly_var"),
+            eeLowEtForestName = cms.string("electron_ee_ecalOnly_1To20_0p0002To0p5_sigma"),
+            eeHighEtForestName = cms.string("electron_ee_ECALonly_var"),
+            ),
+        epComb = cms.PSet(
+            ecalTrkRegressionConfig = cms.PSet(
+                rangeMinLowEt = cms.double(0.2),
+                rangeMaxLowEt = cms.double(2.0),
+                rangeMinHighEt = cms.double(0.2),
+                rangeMaxHighEt = cms.double(2.0),
+                lowEtHighEtBoundary = cms.double(999999.),
+                forceHighEnergyTrainingIfSaturated = cms.bool(False),
+                ebLowEtForestName = cms.string('electron_eb_ecalTrk_1To20_0p2To2_mean'),
+                ebHighEtForestName = cms.string('electron_eb_ecalTrk_1To20_0p2To2_mean'),
+                eeLowEtForestName = cms.string('electron_ee_ecalTrk_1To20_0p2To2_mean'),
+                eeHighEtForestName = cms.string('electron_ee_ecalTrk_1To20_0p2To2_mean'),
+                ),
+            ecalTrkRegressionUncertConfig = cms.PSet(
+                rangeMinLowEt = cms.double(0.0002),
+                rangeMaxLowEt = cms.double(0.5),
+                rangeMinHighEt = cms.double(0.0002),
+                rangeMaxHighEt = cms.double(0.5),
+                lowEtHighEtBoundary = cms.double(999999.),  
+                forceHighEnergyTrainingIfSaturated = cms.bool(False),
+                ebLowEtForestName = cms.string('electron_eb_ecalTrk_1To20_0p0002To0p5_sigma'),
+                ebHighEtForestName = cms.string('electron_eb_ecalTrk_1To20_0p0002To0p5_sigma'),
+                eeLowEtForestName = cms.string('electron_ee_ecalTrk_1To20_0p0002To0p5_sigma'),
+                eeHighEtForestName = cms.string('electron_ee_ecalTrk_1To20_0p0002To0p5_sigma'),
+                ),
+            maxEcalEnergyForComb=cms.double(200.),
+            minEOverPForComb=cms.double(0.025),
+            maxEPDiffInSigmaForComb=cms.double(15.),
+            maxRelTrkMomErrForComb=cms.double(10.),                
+            )
+        ),
+    phoRegs = cms.PSet(
+        ecalOnlyMean = cms.PSet(
+            rangeMinLowEt = cms.double(0.2),
+            rangeMaxLowEt = cms.double(2.0),
+            rangeMinHighEt = cms.double(-1.),
+            rangeMaxHighEt = cms.double(3.0),
+            forceHighEnergyTrainingIfSaturated = cms.bool(True),
+            lowEtHighEtBoundary = cms.double(999999.),
+            ebLowEtForestName = cms.string("photon_eb_ecalOnly_1To20_0p2To2_mean"),
+            ebHighEtForestName = cms.string("photon_eb_ECALonly"),
+            eeLowEtForestName = cms.string("photon_ee_ecalOnly_1To20_0p2To2_mean"),
+            eeHighEtForestName = cms.string("photon_ee_ECALonly"),
+            ),
+        ecalOnlySigma = cms.PSet(
+            rangeMinLowEt = cms.double(0.0002),
+            rangeMaxLowEt = cms.double(0.5),
+            rangeMinHighEt = cms.double(0.0002),
+            rangeMaxHighEt = cms.double(0.5),
+            forceHighEnergyTrainingIfSaturated = cms.bool(True),
+            lowEtHighEtBoundary = cms.double(999999.),
+            ebLowEtForestName = cms.string("photon_eb_ecalOnly_1To20_0p0002To0p5_sigma"),
+            ebHighEtForestName = cms.string("photon_eb_ECALonly_var"),
+            eeLowEtForestName = cms.string("photon_ee_ecalOnly_1To20_0p0002To0p5_sigma"),
+            eeHighEtForestName = cms.string("photon_ee_ECALonly_var"),
+        ),
+    )
+)
+
 regressionModifier94X = \
     cms.PSet( modifierName    = cms.string('EGRegressionModifierV2'),  
 
@@ -155,3 +245,6 @@ run2_egamma_2017.toReplaceWith(regressionModifier,regressionModifier106XUL)
 
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 run2_egamma_2018.toReplaceWith(regressionModifier,regressionModifier106XUL)
+
+from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
+egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)


### PR DESCRIPTION
Adds the regression config and enables it for the correct modifier for the light by light regression.

No changes expected to any workflow that does not use the light by light modifier. 

Note no changes are needed for the supercluster regression as 106X+ uses by default the settings the low pt regression needs for that.