### PR TITLE
Fix snapshot in data offline GTs and Egamma regression, and update Strip 2018 MC conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,7 +52,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v5',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v9',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
@@ -64,7 +64,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_upgrade2021_design_v4', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
     'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v11', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,16 +24,16 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v22',
+    'run1_data'         :   '106X_dataRun2_v24',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v22',
+    'run2_data'         :   '106X_dataRun2_v24',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v21',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v22',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v11',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v12',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v12',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v12',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v13',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v13',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -54,21 +54,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v8',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v9',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v5',
+    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v8',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v4',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v4', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v10', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v11', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '106X_upgrade2023_realistic_v5'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,15 +54,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v9',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v11',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v9',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,17 +52,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v9',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v10',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v9',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -62,7 +62,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v7',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -52,17 +52,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v7',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v10',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v9',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v10',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v6',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR contains a fix of snapshot for data offline GTs addressed at [1].
EGamma PF cluster correction tags[2] for 2018 ultra-legacy reprocessing are updated due a bug described at [3]. The corrections affect 2018 MC and the 2018 IOVs of the offline GTs. Since the same corrections used for 2018 are intended to be used for Run 3 as well, the Run 3 MC GTs are updated as well. 
Strip MC conditions for 2018 are updated to have a better data V.S. MC comparison[4]

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4223.html
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4222/1/1.html
[3] https://indico.cern.ch/event/842863/contributions/3562026/attachments/1906927/3149650/updates_2018ULPFCorrections.pdf
[4]https://indico.cern.ch/event/854616/#7-strip-mc-conditions-for-ul-2

GT diffs:
**Data offline GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v24/106X_dataRun2_v23
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v22/106X_dataRun2_relval_v21

**Data prompt-like GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_v13/106X_dataRun2_PromptLike_v12
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_v12/106X_dataRun2_PromptLike_HEfail_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_v13/106X_dataRun2_PromptLike_HI_v12

**2018 MC GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_design_v6/106X_upgrade2018_design_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v11/106X_upgrade2018_realistic_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v11/106X_upgrade2018_realistic_HEfail_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HI_v6/106X_upgrade2018_realistic_HI_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_deco_v7/106X_upgrade2018cosmics_realistic_deco_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_peak_v8/106X_upgrade2018cosmics_realistic_peak_v4

**Run 3 MC GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_design_v5/106X_upgrade2021_design_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_v11/106X_upgrade2021_realistic_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021cosmics_realistic_deco_v4/106X_upgrade2021cosmics_realistic_deco_v3

#### PR validation:
See the description above for the physics validation of the tags. 

In addition, a technical test was performed: runTheMatrix.py -l limited -i all --ibeos

