### PR TITLE
move away from boost::uint and boost::int in favor of C++11 classes

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -16,7 +16,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Alignment/CommonAlignment/interface/Alignable.h"
-#include <boost/cstdint.hpp>
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterSelector.h"

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -13,7 +13,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Alignment/CommonAlignment/interface/Alignable.h"
-#include <boost/cstdint.hpp>
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h"

--- a/CalibFormats/SiStripObjects/interface/NumberOfDevices.h
+++ b/CalibFormats/SiStripObjects/interface/NumberOfDevices.h
@@ -2,9 +2,9 @@
 #ifndef CalibFormats_SiStripObjects_NumberOfDevices_H
 #define CalibFormats_SiStripObjects_NumberOfDevices_H
 
-#include <boost/cstdint.hpp>
 #include <ostream>
 #include <sstream>
+#include <cstdint>
 
 /**
     @class NumberOfDevices

--- a/CalibFormats/SiStripObjects/interface/SiStripCcu.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripCcu.h
@@ -4,8 +4,8 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripModule.h"
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 /**
     \class SiStripCcu

--- a/CalibFormats/SiStripObjects/interface/SiStripDetCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripDetCabling.h
@@ -13,10 +13,10 @@
 //         Created:  Wed Mar 22 12:24:20 CET 2006
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
-#include <boost/cstdint.hpp>
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 class TrackerTopology;
 class SiStripDetCabling {
 public:

--- a/CalibFormats/SiStripObjects/interface/SiStripFec.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFec.h
@@ -4,8 +4,8 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripRing.h"
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 /**
     \class SiStripFec

--- a/CalibFormats/SiStripObjects/interface/SiStripFecCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFecCabling.h
@@ -6,10 +6,10 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripFecCrate.h"
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
-#include <boost/cstdint.hpp>
 #include <ostream>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 class SiStripFecCabling;
 

--- a/CalibFormats/SiStripObjects/interface/SiStripFecCrate.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFecCrate.h
@@ -4,8 +4,8 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripFec.h"
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 /**
     \class SiStripFecCrate

--- a/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
@@ -4,9 +4,9 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #include <iomanip>
 #include <vector>
+#include <cstdint>
 
 class SiStripHashedDetId;
 std::ostream &operator<<(std::ostream &os, const SiStripHashedDetId &);

--- a/CalibFormats/SiStripObjects/interface/SiStripModule.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripModule.h
@@ -4,11 +4,11 @@
 
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
 #include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
-#include <boost/cstdint.hpp>
 #include <map>
 #include <ostream>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 class SiStripModule;
 

--- a/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
@@ -4,11 +4,11 @@
 
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include <boost/cstdint.hpp>
 #include <cmath>
 #include <map>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    Author: pwing

--- a/CalibFormats/SiStripObjects/interface/SiStripRing.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripRing.h
@@ -4,8 +4,8 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripCcu.h"
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 /**
     \class SiStripRing

--- a/CalibFormats/SiStripObjects/test/plugins/testSiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/plugins/testSiStripHashedDetId.cc
@@ -13,11 +13,11 @@
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #include <iostream>
 #include <sstream>
 #include <time.h>
 #include <vector>
+#include <cstdint>
 
 using namespace sistrip;
 

--- a/CalibMuon/RPCCalibration/interface/RPCFakeCalibration.h
+++ b/CalibMuon/RPCCalibration/interface/RPCFakeCalibration.h
@@ -8,7 +8,6 @@
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <memory>
 
 class RPCCalibSetUp;

--- a/CalibMuon/RPCCalibration/interface/RPCPerformanceESSource.h
+++ b/CalibMuon/RPCCalibration/interface/RPCPerformanceESSource.h
@@ -5,7 +5,6 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <memory>
 
 class RPCStripNoises;

--- a/CalibTracker/SiPixelConnectivity/interface/PixelBarrelLinkMaker.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelBarrelLinkMaker.h
@@ -5,7 +5,6 @@
  * Assign barrel pixel modules (defined by name and unit) to links
  */
 
-#include <boost/cstdint.hpp>
 #include <vector>
 
 #include "CalibTracker/SiPixelConnectivity/interface/TRange.h"
@@ -14,6 +13,7 @@ class PixelModuleName;
 class PixelBarrelName;
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDLink.h"
+#include <cstdint>
 
 class PixelBarrelLinkMaker {
 public:

--- a/CalibTracker/SiPixelConnectivity/interface/PixelEndcapLinkMaker.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelEndcapLinkMaker.h
@@ -1,7 +1,6 @@
 #ifndef PixelEndcapLinkMaker_H
 #define PixelEndcapLinkMaker_H
 
-#include <boost/cstdint.hpp>
 #include <vector>
 
 #include "CalibTracker/SiPixelConnectivity/interface/TRange.h"
@@ -10,6 +9,7 @@ class PixelModuleName;
 class PixelEndcapName;
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDLink.h"
+#include <cstdint>
 
 class PixelEndcapLinkMaker {
 public:

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelDetInfoFileReader {
 public:

--- a/CalibTracker/SiStripAPVAnalysis/interface/ApvAnalysis.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/ApvAnalysis.h
@@ -10,7 +10,6 @@
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "boost/cstdint.hpp"
 
 //#define DEBUG_INSTANCE_COUNTING
 

--- a/CalibTracker/SiStripAPVAnalysis/interface/ApvFactoryService.h
+++ b/CalibTracker/SiStripAPVAnalysis/interface/ApvFactoryService.h
@@ -16,7 +16,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-#include "boost/cstdint.hpp"
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h
@@ -23,9 +23,9 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-#include <boost/cstdint.hpp>
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <cstdint>
 
 class SiStripDetInfoFileReader {
 public:

--- a/CalibTracker/SiStripCommon/interface/SiStripFedIdListReader.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripFedIdListReader.h
@@ -1,10 +1,10 @@
 #ifndef CalibTracker_SiStripCommon_SiStripFedIdListReader_h
 #define CalibTracker_SiStripCommon_SiStripFedIdListReader_h
 
-#include <boost/cstdint.hpp>
 #include <fstream>
 #include <ostream>
 #include <vector>
+#include <cstdint>
 
 class SiStripFedIdListReader;
 

--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -2,8 +2,8 @@
 #define CalibTracker_SiStripCommon_TKHistoMap_h
 
 #include <vector>
-#include <boost/cstdint.hpp>
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/CalibTracker/SiStripDCS/interface/SiStripPsuDetIdMap.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripPsuDetIdMap.h
@@ -14,13 +14,13 @@
 #include "OnlineDB/SiStripConfigDb/interface/SiStripDbParams.h"
 #include "DeviceFactory.h"
 
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <string>
 #include <iostream>
 #include <fstream>
 #include <sstream>
 #include <ostream>
+#include <cstdint>
 
 class SiStripConfigDb;
 

--- a/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/Phase2TrackerCablingESProducer.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <memory>
 
 class Phase2TrackerCabling;

--- a/CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h
@@ -3,8 +3,8 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <memory>
+#include <cstdint>
 
 class SiStripFedCabling;
 class SiStripFedCablingRcd;

--- a/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripNoiseESSource.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <memory>
 
 class SiStripNoises;

--- a/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripPedestalsESSource.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <memory>
 
 class SiStripPedestals;

--- a/CalibTracker/SiStripESProducers/src/SiStripGainESSource.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripGainESSource.cc
@@ -3,7 +3,6 @@
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
-#include "boost/cstdint.hpp"
 #include <iostream>
 
 using namespace sistrip;

--- a/CondFormats/Alignment/interface/Definitions.h
+++ b/CondFormats/Alignment/interface/Definitions.h
@@ -10,7 +10,6 @@
  *  \author Chung Khim Lae
  */
 
-
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/GeometrySurface/interface/TkRotation.h"
 #include "DataFormats/GeometryVector/interface/GlobalTag.h"

--- a/CondFormats/Alignment/interface/Definitions.h
+++ b/CondFormats/Alignment/interface/Definitions.h
@@ -10,7 +10,6 @@
  *  \author Chung Khim Lae
  */
 
-#include <boost/cstdint.hpp>
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 #include "DataFormats/GeometrySurface/interface/TkRotation.h"
@@ -20,6 +19,7 @@
 #include "DataFormats/GeometryVector/interface/Vector3DBase.h"
 #include "DataFormats/Math/interface/Error.h"
 #include "DataFormats/Math/interface/Vector.h"
+#include <cstdint>
 
 namespace align {
   typedef uint32_t ID;

--- a/CondFormats/Calibration/interface/boostTypeObj.h
+++ b/CondFormats/Calibration/interface/boostTypeObj.h
@@ -3,7 +3,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class boostTypeObj {
 public:
   int8_t a;

--- a/CondFormats/Calibration/interface/boostTypeObj.h
+++ b/CondFormats/Calibration/interface/boostTypeObj.h
@@ -1,15 +1,15 @@
 #ifndef BOOSTTYPEOBJ_H
 #define BOOSTTYPEOBJ_H
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class boostTypeObj {
 public:
-  boost::int8_t a;
-  boost::int16_t b;
-  boost::uint8_t aa;
-  boost::uint16_t bb;
+  int8_t a;
+  int16_t b;
+  uint8_t aa;
+  uint16_t bb;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/Calibration/interface/mySiStripNoises.h
+++ b/CondFormats/Calibration/interface/mySiStripNoises.h
@@ -5,8 +5,8 @@
 
 #include <vector>
 #include <map>
+#include <cstdint>
 //#include<iostream>
-#include <boost/cstdint.hpp>
 
 //typedef float SiStripNoise;
 //typedef bool  SiStripDisable;

--- a/CondFormats/CastorObjects/interface/CastorCalibrationQIECoder.h
+++ b/CondFormats/CastorObjects/interface/CastorCalibrationQIECoder.h
@@ -12,7 +12,7 @@ $Id
 
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class CastorCalibrationQIECoder {
 public:

--- a/CondFormats/CastorObjects/interface/CastorChannelStatus.h
+++ b/CondFormats/CastorObjects/interface/CastorChannelStatus.h
@@ -9,8 +9,8 @@ contains one channel status and corresponding DetId
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 class CastorChannelStatus {
 public:

--- a/CondFormats/CastorObjects/interface/CastorElectronicsMap.h
+++ b/CondFormats/CastorObjects/interface/CastorElectronicsMap.h
@@ -15,7 +15,6 @@ Modified for CASTOR by L. Mundim
 
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif
@@ -26,6 +25,7 @@ Modified for CASTOR by L. Mundim
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/CastorElectronicsId.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include <cstdint>
 //
 class CastorElectronicsMap {
 public:

--- a/CondFormats/CastorObjects/interface/CastorGain.h
+++ b/CondFormats/CastorObjects/interface/CastorGain.h
@@ -8,8 +8,8 @@ POOL object to store Gain values 4xCapId
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class CastorGain {
 public:

--- a/CondFormats/CastorObjects/interface/CastorGain.h
+++ b/CondFormats/CastorObjects/interface/CastorGain.h
@@ -10,7 +10,6 @@ POOL object to store Gain values 4xCapId
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class CastorGain {
 public:
   /// get value for all capId = 0..3

--- a/CondFormats/CastorObjects/interface/CastorGainWidth.h
+++ b/CondFormats/CastorObjects/interface/CastorGainWidth.h
@@ -9,7 +9,6 @@ POOL object to store GainWidth values 4xCapId
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class CastorGainWidth {
 public:
   /// get value for all capId = 0..3

--- a/CondFormats/CastorObjects/interface/CastorGainWidth.h
+++ b/CondFormats/CastorObjects/interface/CastorGainWidth.h
@@ -7,8 +7,8 @@
 POOL object to store GainWidth values 4xCapId
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class CastorGainWidth {
 public:

--- a/CondFormats/CastorObjects/interface/CastorPedestal.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestal.h
@@ -13,7 +13,6 @@ Adapted for CASTOR by L. Mundim (26/03/2009)
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class CastorPedestal {
 public:
   /// get value for all capId = 0..3

--- a/CondFormats/CastorObjects/interface/CastorPedestal.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestal.h
@@ -11,8 +11,8 @@ $Revision: 1.8 $
 Adapted for CASTOR by L. Mundim (26/03/2009)
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class CastorPedestal {
 public:

--- a/CondFormats/CastorObjects/interface/CastorPedestalWidth.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestalWidth.h
@@ -11,8 +11,8 @@ $Revision: 1.10 $
 Adapted for CASTOR by L. Mundim
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class CastorPedestalWidth {
 public:

--- a/CondFormats/CastorObjects/interface/CastorPedestalWidth.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestalWidth.h
@@ -13,7 +13,6 @@ Adapted for CASTOR by L. Mundim
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class CastorPedestalWidth {
 public:
   /// get value for all capId = 0..3, 10 values in total

--- a/CondFormats/CastorObjects/interface/CastorQIECoder.h
+++ b/CondFormats/CastorObjects/interface/CastorQIECoder.h
@@ -12,7 +12,6 @@ Modified for CASTOR by L. Mundim
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-
 #include <vector>
 #include <algorithm>
 #include <cstdint>

--- a/CondFormats/CastorObjects/interface/CastorQIECoder.h
+++ b/CondFormats/CastorObjects/interface/CastorQIECoder.h
@@ -12,10 +12,10 @@ Modified for CASTOR by L. Mundim
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 
 #include <vector>
 #include <algorithm>
+#include <cstdint>
 
 class CastorQIEShape;
 

--- a/CondFormats/CastorObjects/interface/CastorRawGain.h
+++ b/CondFormats/CastorObjects/interface/CastorRawGain.h
@@ -6,8 +6,8 @@
 \author Panos Katsas (UoA)
 POOL object to store raw Gain values
 */
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 class CastorRawGain {
 public:

--- a/CondFormats/CastorObjects/interface/CastorRecoParam.h
+++ b/CondFormats/CastorObjects/interface/CastorRecoParam.h
@@ -8,8 +8,8 @@ POOL object to store timeslice reco values
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class CastorRecoParam {
 public:

--- a/CondFormats/CastorObjects/interface/CastorRecoParam.h
+++ b/CondFormats/CastorObjects/interface/CastorRecoParam.h
@@ -10,7 +10,6 @@ POOL object to store timeslice reco values
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class CastorRecoParam {
 public:
   CastorRecoParam() : mId(0), mFirstSample(0), mSamplesToAdd(0) {}

--- a/CondFormats/CastorObjects/interface/CastorSaturationCorr.h
+++ b/CondFormats/CastorObjects/interface/CastorSaturationCorr.h
@@ -8,8 +8,8 @@ POOL object to store saturation correction values
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class CastorSaturationCorr {
 public:

--- a/CondFormats/CastorObjects/interface/CastorSaturationCorr.h
+++ b/CondFormats/CastorObjects/interface/CastorSaturationCorr.h
@@ -10,7 +10,6 @@ POOL object to store saturation correction values
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class CastorSaturationCorr {
 public:
   CastorSaturationCorr() : mId(0), mSatCorr(0) {}

--- a/CondFormats/Common/interface/Constants.h
+++ b/CondFormats/Common/interface/Constants.h
@@ -1,12 +1,11 @@
 #ifndef CondCommon_Constants_h
-#define CondCommon_Constants_h 
-#include<utility>
+#define CondCommon_Constants_h
+#include <utility>
 #include <string>
 #include <limits>
 
 /* constants other than time used in cond
  */
-
 
 namespace cond {
 
@@ -14,4 +13,4 @@ namespace cond {
 
 }
 
-#endif //CondCommon_Constants_h
+#endif  //CondCommon_Constants_h

--- a/CondFormats/Common/interface/Constants.h
+++ b/CondFormats/Common/interface/Constants.h
@@ -3,7 +3,6 @@
 #include<utility>
 #include <string>
 #include <limits>
-#include <boost/cstdint.hpp>
 
 /* constants other than time used in cond
  */

--- a/CondFormats/DQMObjects/interface/HDQMSummary.h
+++ b/CondFormats/DQMObjects/interface/HDQMSummary.h
@@ -6,8 +6,8 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 #include "FWCore/Utilities/interface/Exception.h"
+#include <cstdint>
 
 /**
  @class HDQMSummary

--- a/CondFormats/ESObjects/interface/ESChannelStatusCode.h
+++ b/CondFormats/ESObjects/interface/ESChannelStatusCode.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class ESChannelStatusCode {
 public:

--- a/CondFormats/ESObjects/interface/ESTBWeights.h
+++ b/CondFormats/ESObjects/interface/ESTBWeights.h
@@ -4,7 +4,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
 #include "CondFormats/ESObjects/interface/ESStripGroupId.h"
 #include "CondFormats/ESObjects/interface/ESWeightSet.h"
 

--- a/CondFormats/ESObjects/src/classes.h
+++ b/CondFormats/ESObjects/src/classes.h
@@ -1,4 +1,3 @@
-#include <boost/cstdint.hpp>
 
 #include "CondFormats/ESObjects/interface/ESCondObjectContainer.h"
 #include "CondFormats/ESObjects/interface/ESPedestals.h"

--- a/CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
+++ b/CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
@@ -30,7 +30,6 @@
 #include <vector>
 #include <algorithm>
 #include <map>
-#include <boost/cstdint.hpp>
 
 class DetId;
 

--- a/CondFormats/EcalCorrections/interface/EcalShowerContainmentCorrections.h
+++ b/CondFormats/EcalCorrections/interface/EcalShowerContainmentCorrections.h
@@ -37,7 +37,6 @@
 #include <vector>
 #include <algorithm>
 #include <map>
-#include <boost/cstdint.hpp>
 
 #include <DataFormats/Math/interface/Point3D.h>
 

--- a/CondFormats/EcalObjects/interface/EcalChannelStatusCode.h
+++ b/CondFormats/EcalObjects/interface/EcalChannelStatusCode.h
@@ -8,7 +8,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /**
    

--- a/CondFormats/EcalObjects/interface/EcalDAQStatusCode.h
+++ b/CondFormats/EcalObjects/interface/EcalDAQStatusCode.h
@@ -9,7 +9,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalDAQStatusCode {
 public:

--- a/CondFormats/EcalObjects/interface/EcalDCUTemperatures.h
+++ b/CondFormats/EcalObjects/interface/EcalDCUTemperatures.h
@@ -9,7 +9,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalDCUTemperatures {
 public:

--- a/CondFormats/EcalObjects/interface/EcalDQMStatusCode.h
+++ b/CondFormats/EcalObjects/interface/EcalDQMStatusCode.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalDQMStatusCode {
 public:

--- a/CondFormats/EcalObjects/interface/EcalPTMTemperatures.h
+++ b/CondFormats/EcalObjects/interface/EcalPTMTemperatures.h
@@ -9,7 +9,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalPTMTemperatures {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTBWeights.h
+++ b/CondFormats/EcalObjects/interface/EcalTBWeights.h
@@ -9,7 +9,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
 #include "CondFormats/EcalObjects/interface/EcalXtalGroupId.h"
 #include "CondFormats/EcalObjects/interface/EcalWeightSet.h"
 

--- a/CondFormats/EcalObjects/interface/EcalTPGCrystalStatusCode.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGCrystalStatusCode.h
@@ -9,7 +9,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGCrystalStatusCode {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGFineGrainConstEB.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGFineGrainConstEB.h
@@ -4,7 +4,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class EcalTPGFineGrainConstEB {
 public:
   EcalTPGFineGrainConstEB();

--- a/CondFormats/EcalObjects/interface/EcalTPGFineGrainConstEB.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGFineGrainConstEB.h
@@ -2,8 +2,8 @@
 #define EcalTPGFineGrainConstEB_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class EcalTPGFineGrainConstEB {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h
@@ -4,8 +4,8 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainConstEB.h"
+#include <cstdint>
 
 class EcalTPGFineGrainEBIdMap {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGFineGrainStripEE.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGFineGrainStripEE.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGFineGrainStripEE {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGFineGrainTowerEE.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGFineGrainTowerEE.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGFineGrainTowerEE {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGGroups.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGGroups.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /*
 this class is used to define groups which associate a rawId to an objectId where:

--- a/CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGLutIdMap.h
@@ -4,8 +4,8 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
 #include "CondFormats/EcalObjects/interface/EcalTPGLut.h"
+#include <cstdint>
 
 class EcalTPGLutIdMap {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGPhysicsConst.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGPhysicsConst {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGSlidingWindow.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGSlidingWindow.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGSlidingWindow {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGSpike.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGSpike.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGSpike {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGStripStatus.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGStripStatus.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGStripStatus {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGTowerStatus {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h
@@ -4,8 +4,8 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
 #include "CondFormats/EcalObjects/interface/EcalTPGWeights.h"
+#include <cstdint>
 
 class EcalTPGWeightIdMap {
 public:

--- a/CondFormats/EcalObjects/interface/EcalTPGWeights.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGWeights.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalTPGWeights {
 public:

--- a/CondFormats/EcalObjects/src/classes.h
+++ b/CondFormats/EcalObjects/src/classes.h
@@ -1,4 +1,3 @@
-#include <boost/cstdint.hpp>
 
 #include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
 #include "CondFormats/EcalObjects/interface/EcalCondTowerObjectContainer.h"
@@ -65,6 +64,7 @@
 #include "CondFormats/EcalObjects/interface/EcalTPGSpike.h"
 #include "CondFormats/EcalObjects/interface/EcalSRSettings.h"
 #include "CondFormats/EcalObjects/interface/EcalSimPulseShape.h"
+#include <cstdint>
 
 namespace CondFormats_EcalObjects {
   struct dictionary {

--- a/CondFormats/HcalObjects/interface/HBHEChannelGroups.h
+++ b/CondFormats/HcalObjects/interface/HBHEChannelGroups.h
@@ -3,11 +3,11 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/cstdint.hpp"
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/vector.hpp"
 
 #include "CondFormats/HcalObjects/interface/HBHELinearMap.h"
+#include <cstdint>
 
 class HBHEChannelGroups {
 public:

--- a/CondFormats/HcalObjects/interface/HBHENegativeEFilter.h
+++ b/CondFormats/HcalObjects/interface/HBHENegativeEFilter.h
@@ -5,13 +5,13 @@
 #include <utility>
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/cstdint.hpp"
 #include "boost/serialization/utility.hpp"
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/split_member.hpp"
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CondFormats/HcalObjects/interface/PiecewiseScalingPolynomial.h"
+#include <cstdint>
 
 class HBHENegativeEFilter {
 public:

--- a/CondFormats/HcalObjects/interface/HcalCalibrationQIECoder.h
+++ b/CondFormats/HcalObjects/interface/HcalCalibrationQIECoder.h
@@ -12,7 +12,7 @@ $Id
 
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class HcalCalibrationQIECoder {
 public:

--- a/CondFormats/HcalObjects/interface/HcalChannelStatus.h
+++ b/CondFormats/HcalObjects/interface/HcalChannelStatus.h
@@ -10,7 +10,6 @@ contains one channel status and corresponding DetId
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalChannelStatus {
 public:
   // contains the defined bits for easy access, see https://twiki.cern.ch/twiki/bin/view/CMS/HcalDataValidationWorkflow

--- a/CondFormats/HcalObjects/interface/HcalChannelStatus.h
+++ b/CondFormats/HcalObjects/interface/HcalChannelStatus.h
@@ -8,8 +8,8 @@ contains one channel status and corresponding DetId
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalChannelStatus {
 public:

--- a/CondFormats/HcalObjects/interface/HcalDcsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalDcsMap.h
@@ -16,7 +16,6 @@ $Revision: 1.1 $
 #include <set>
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif
@@ -25,6 +24,7 @@ $Revision: 1.1 $
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDcsDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include <cstdint>
 
 //forward declaration
 namespace HcalDcsMapAddons {

--- a/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
@@ -14,7 +14,6 @@ $Revision: 1.16 $
 
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -22,6 +21,7 @@ $Revision: 1.16 $
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include <cstdint>
 
 //forward declaration
 namespace HcalElectronicsMapAddons {

--- a/CondFormats/HcalObjects/interface/HcalFlagHFDigiTimeParam.h
+++ b/CondFormats/HcalObjects/interface/HcalFlagHFDigiTimeParam.h
@@ -19,8 +19,8 @@ Flag parameters stored are:
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 class HcalFlagHFDigiTimeParam {
   // Default constructor sets parameters according to 6-TS digis

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -6,7 +6,6 @@
 #include <set>
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif
@@ -14,6 +13,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalFrontEndId.h"
+#include <cstdint>
 
 //forward declaration
 namespace HcalFrontEndMapAddons {

--- a/CondFormats/HcalObjects/interface/HcalGain.h
+++ b/CondFormats/HcalObjects/interface/HcalGain.h
@@ -11,8 +11,8 @@ $Revision: 1.5 $
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalGain {
 public:

--- a/CondFormats/HcalObjects/interface/HcalGain.h
+++ b/CondFormats/HcalObjects/interface/HcalGain.h
@@ -13,7 +13,6 @@ $Revision: 1.5 $
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalGain {
 public:
   /// get value for all capId = 0..3

--- a/CondFormats/HcalObjects/interface/HcalGainWidth.h
+++ b/CondFormats/HcalObjects/interface/HcalGainWidth.h
@@ -12,7 +12,6 @@ $Revision: 1.5 $
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalGainWidth {
 public:
   /// get value for all capId = 0..3

--- a/CondFormats/HcalObjects/interface/HcalGainWidth.h
+++ b/CondFormats/HcalObjects/interface/HcalGainWidth.h
@@ -10,8 +10,8 @@ $Date: 2007/12/10 18:37:06 $
 $Revision: 1.5 $
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalGainWidth {
 public:

--- a/CondFormats/HcalObjects/interface/HcalL1TriggerObject.h
+++ b/CondFormats/HcalObjects/interface/HcalL1TriggerObject.h
@@ -8,8 +8,8 @@
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalL1TriggerObject {
 public:

--- a/CondFormats/HcalObjects/interface/HcalL1TriggerObject.h
+++ b/CondFormats/HcalObjects/interface/HcalL1TriggerObject.h
@@ -10,7 +10,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalL1TriggerObject {
 public:
   HcalL1TriggerObject() : mId(0), mAvrgPed(0.), mRespCorrGain(0.), mFlag(0) {}

--- a/CondFormats/HcalObjects/interface/HcalLongRecoParam.h
+++ b/CondFormats/HcalObjects/interface/HcalLongRecoParam.h
@@ -9,8 +9,8 @@ POOL object to store timeslice reco values, long version (for ZDC)
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 class HcalLongRecoParam {
 public:

--- a/CondFormats/HcalObjects/interface/HcalMCParam.h
+++ b/CondFormats/HcalObjects/interface/HcalMCParam.h
@@ -10,7 +10,6 @@ POOL object to store MC information
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 // definition 8.Feb.2011
 // MC signal shape integer variable assigned to each readout this way:
 // 0 - regular HPD  HB/HE/HO shape

--- a/CondFormats/HcalObjects/interface/HcalMCParam.h
+++ b/CondFormats/HcalObjects/interface/HcalMCParam.h
@@ -8,8 +8,8 @@ POOL object to store MC information
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 // definition 8.Feb.2011
 // MC signal shape integer variable assigned to each readout this way:

--- a/CondFormats/HcalObjects/interface/HcalPedestal.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestal.h
@@ -10,8 +10,8 @@ $Date: 2007/12/14 13:19:53 $
 $Revision: 1.7 $
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalPedestal {
 public:

--- a/CondFormats/HcalObjects/interface/HcalPedestal.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestal.h
@@ -12,7 +12,6 @@ $Revision: 1.7 $
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalPedestal {
 public:
   /// get value for all capId = 0..3

--- a/CondFormats/HcalObjects/interface/HcalPedestalWidth.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestalWidth.h
@@ -12,7 +12,6 @@ $Revision: 1.9 $
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalPedestalWidth {
 public:
   /// get value for all capId = 0..3, 10 values in total

--- a/CondFormats/HcalObjects/interface/HcalPedestalWidth.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestalWidth.h
@@ -10,8 +10,8 @@ $Date: 2008/11/07 16:05:50 $
 $Revision: 1.9 $
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalPedestalWidth {
 public:

--- a/CondFormats/HcalObjects/interface/HcalQIECoder.h
+++ b/CondFormats/HcalObjects/interface/HcalQIECoder.h
@@ -11,7 +11,6 @@ $Revision: 1.9 $
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-
 #include <vector>
 #include <algorithm>
 #include <cstdint>

--- a/CondFormats/HcalObjects/interface/HcalQIECoder.h
+++ b/CondFormats/HcalObjects/interface/HcalQIECoder.h
@@ -11,10 +11,10 @@ $Revision: 1.9 $
 */
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 
 #include <vector>
 #include <algorithm>
+#include <cstdint>
 
 class HcalQIEShape;
 

--- a/CondFormats/HcalObjects/interface/HcalRawGain.h
+++ b/CondFormats/HcalObjects/interface/HcalRawGain.h
@@ -9,8 +9,8 @@ $Author: ratnikov
 $Date: 2007/12/10 18:38:20 $
 $Revision: 1.4 $
 */
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 class HcalRawGain {
 public:

--- a/CondFormats/HcalObjects/interface/HcalRecoParam.h
+++ b/CondFormats/HcalObjects/interface/HcalRecoParam.h
@@ -11,8 +11,8 @@ mParam1, mParam2 re-define to keep more parameters   28-Oct-2011  sk.
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalRecoParam {
 public:

--- a/CondFormats/HcalObjects/interface/HcalRecoParam.h
+++ b/CondFormats/HcalObjects/interface/HcalRecoParam.h
@@ -13,7 +13,6 @@ mParam1, mParam2 re-define to keep more parameters   28-Oct-2011  sk.
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalRecoParam {
 public:
   constexpr HcalRecoParam() : mId(0), mParam1(0), mParam2(0) {}

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <set>
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif

--- a/CondFormats/HcalObjects/interface/HcalSiPMParameter.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMParameter.h
@@ -2,7 +2,7 @@
 #define CondFormatsHcalObjectsHcalSiPMParameter_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class HcalSiPMParameter {
 public:

--- a/CondFormats/HcalObjects/interface/HcalTPChannelParameter.h
+++ b/CondFormats/HcalObjects/interface/HcalTPChannelParameter.h
@@ -2,7 +2,7 @@
 #define CondFormatsHcalObjectsHcalTPChannelParameter_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class HcalTPChannelParameter {
 public:

--- a/CondFormats/HcalObjects/interface/HcalTPParameters.h
+++ b/CondFormats/HcalObjects/interface/HcalTPParameters.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 #include <algorithm>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class HcalTPParameters {
 public:

--- a/CondFormats/HcalObjects/interface/HcalTimingParam.h
+++ b/CondFormats/HcalObjects/interface/HcalTimingParam.h
@@ -2,8 +2,8 @@
 #define HcalTimingParam_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalTimingParam {
 public:

--- a/CondFormats/HcalObjects/interface/HcalTimingParam.h
+++ b/CondFormats/HcalObjects/interface/HcalTimingParam.h
@@ -4,7 +4,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalTimingParam {
 public:
   HcalTimingParam() : mId(0), m_nhits(0), m_phase(0.0), m_rms(0.0) {}

--- a/CondFormats/HcalObjects/interface/HcalZDCLowGainFraction.h
+++ b/CondFormats/HcalObjects/interface/HcalZDCLowGainFraction.h
@@ -10,7 +10,6 @@ POOL object to store lowGainFrac values
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalZDCLowGainFraction {
 public:
   HcalZDCLowGainFraction() : mId(0), mValue(0) {}

--- a/CondFormats/HcalObjects/interface/HcalZDCLowGainFraction.h
+++ b/CondFormats/HcalObjects/interface/HcalZDCLowGainFraction.h
@@ -8,8 +8,8 @@ POOL object to store lowGainFrac values
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalZDCLowGainFraction {
 public:

--- a/CondFormats/HcalObjects/interface/HcalZSThreshold.h
+++ b/CondFormats/HcalObjects/interface/HcalZSThreshold.h
@@ -8,8 +8,8 @@ contains one threshold + corresponding DetId
 */
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class HcalZSThreshold {
 public:

--- a/CondFormats/HcalObjects/interface/HcalZSThreshold.h
+++ b/CondFormats/HcalObjects/interface/HcalZSThreshold.h
@@ -10,7 +10,6 @@ contains one threshold + corresponding DetId
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class HcalZSThreshold {
 public:
   HcalZSThreshold() : mId(0), mLevel(0) {}

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
@@ -4,12 +4,12 @@
 #include <cmath>
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "boost/cstdint.hpp"
 #include "boost/serialization/vector.hpp"
 #include "boost/serialization/version.hpp"
 
 #include "CondFormats/HcalObjects/interface/AbsOOTPileupCorrection.h"
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrDataFcn.h"
+#include <cstdint>
 
 class OOTPileupCorrData : public AbsOOTPileupCorrection {
 public:

--- a/CondFormats/HcalObjects/interface/ScalingExponential.h
+++ b/CondFormats/HcalObjects/interface/ScalingExponential.h
@@ -3,9 +3,9 @@
 
 #include <cmath>
 
-#include "boost/cstdint.hpp"
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
+#include <cstdint>
 
 class ScalingExponential {
 public:

--- a/CondFormats/L1TObjects/interface/GlobalStableParameters.h
+++ b/CondFormats/L1TObjects/interface/GlobalStableParameters.h
@@ -22,7 +22,6 @@
 
 #include <ostream>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class

--- a/CondFormats/L1TObjects/interface/GlobalStableParameters.h
+++ b/CondFormats/L1TObjects/interface/GlobalStableParameters.h
@@ -22,7 +22,6 @@
 
 #include <ostream>
 
-
 // user include files
 //   base class
 

--- a/CondFormats/L1TObjects/interface/L1CaloEtScale.h
+++ b/CondFormats/L1TObjects/interface/L1CaloEtScale.h
@@ -22,9 +22,9 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 #include <vector>
 #include <ostream>
+#include <cstdint>
 
 class L1CaloEtScale {
 public:

--- a/CondFormats/L1TObjects/interface/L1GtBoard.h
+++ b/CondFormats/L1TObjects/interface/L1GtBoard.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <map>
 
-
 // user include files
 #include "CondFormats/L1TObjects/interface/L1GtFwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"

--- a/CondFormats/L1TObjects/interface/L1GtBoard.h
+++ b/CondFormats/L1TObjects/interface/L1GtBoard.h
@@ -24,11 +24,11 @@
 #include <vector>
 #include <map>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 #include "CondFormats/L1TObjects/interface/L1GtFwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
+#include <cstdint>
 
 // forward declarations
 
@@ -122,7 +122,7 @@ public:
   void setGtInputPsbChannels(const std::map<int, std::vector<L1GtObject> >&);
 
   /// get the board ID
-  const boost::uint16_t gtBoardId() const;
+  const uint16_t gtBoardId() const;
 
   /// return board name - it depends on L1GtBoardType enum!!!
   std::string gtBoardName() const;

--- a/CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h
@@ -24,7 +24,6 @@
 #include <string>
 #include <iosfwd>
 
-
 // user include files
 
 //   base class

--- a/CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h
@@ -24,7 +24,6 @@
 #include <string>
 #include <iosfwd>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 

--- a/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <iosfwd>
 
-
 // user include files
 
 //   base class

--- a/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtEnergySumTemplate.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <iosfwd>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 

--- a/CondFormats/L1TObjects/interface/L1GtJetCountsTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtJetCountsTemplate.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <iosfwd>
 
-
 // user include files
 
 //   base class

--- a/CondFormats/L1TObjects/interface/L1GtJetCountsTemplate.h
+++ b/CondFormats/L1TObjects/interface/L1GtJetCountsTemplate.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <iosfwd>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 

--- a/CondFormats/L1TObjects/interface/L1GtParameters.h
+++ b/CondFormats/L1TObjects/interface/L1GtParameters.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <cstdint>
 
-
 // user include files
 //   base class
 

--- a/CondFormats/L1TObjects/interface/L1GtParameters.h
+++ b/CondFormats/L1TObjects/interface/L1GtParameters.h
@@ -22,8 +22,8 @@
 
 #include <ostream>
 #include <vector>
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class
@@ -46,14 +46,14 @@ public:
   void setGtTotalBxInEvent(const int&);
 
   /// get / set the active boards for L1 GT DAQ record
-  inline const boost::uint16_t gtDaqActiveBoards() const { return m_daqActiveBoards; }
+  inline const uint16_t gtDaqActiveBoards() const { return m_daqActiveBoards; }
 
-  void setGtDaqActiveBoards(const boost::uint16_t&);
+  void setGtDaqActiveBoards(const uint16_t&);
 
   /// get / set the active boards for L1 GT EVM record
-  inline const boost::uint16_t gtEvmActiveBoards() const { return m_evmActiveBoards; }
+  inline const uint16_t gtEvmActiveBoards() const { return m_evmActiveBoards; }
 
-  void setGtEvmActiveBoards(const boost::uint16_t&);
+  void setGtEvmActiveBoards(const uint16_t&);
 
   /// get / set the number of Bx per board for L1 GT DAQ record
   inline const std::vector<int>& gtDaqNrBxBoard() const { return m_daqNrBxBoard; }
@@ -81,10 +81,10 @@ private:
   int m_totalBxInEvent;
 
   /// active boards in the L1 DAQ record
-  boost::uint16_t m_daqActiveBoards;
+  uint16_t m_daqActiveBoards;
 
   /// active boards in the L1 EVM record
-  boost::uint16_t m_evmActiveBoards;
+  uint16_t m_evmActiveBoards;
 
   /// number of Bx per board in the DAQ record
   std::vector<int> m_daqNrBxBoard;

--- a/CondFormats/L1TObjects/interface/L1GtStableParameters.h
+++ b/CondFormats/L1TObjects/interface/L1GtStableParameters.h
@@ -24,7 +24,6 @@
 
 #include <ostream>
 
-
 // user include files
 //   base class
 

--- a/CondFormats/L1TObjects/interface/L1GtStableParameters.h
+++ b/CondFormats/L1TObjects/interface/L1GtStableParameters.h
@@ -24,7 +24,6 @@
 
 #include <ostream>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class

--- a/CondFormats/L1TObjects/interface/L1RCTParameters.h
+++ b/CondFormats/L1TObjects/interface/L1RCTParameters.h
@@ -21,7 +21,6 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 #include <vector>
 #include <ostream>
 

--- a/CondFormats/L1TObjects/src/L1GtBoard.cc
+++ b/CondFormats/L1TObjects/src/L1GtBoard.cc
@@ -217,8 +217,8 @@ void L1GtBoard::setGtInputPsbChannels(const std::map<int, std::vector<L1GtObject
 }
 
 // get the board ID
-const boost::uint16_t L1GtBoard::gtBoardId() const {
-  boost::uint16_t boardIdValue = 0;
+const uint16_t L1GtBoard::gtBoardId() const {
+  uint16_t boardIdValue = 0;
 
   if (m_gtBoardType == GTFE) {
     boardIdValue = boardIdValue | m_gtBoardSlot;
@@ -265,7 +265,7 @@ std::string L1GtBoard::gtBoardName() const {
 
 /// print board
 void L1GtBoard::print(std::ostream& myCout) const {
-  boost::uint16_t boardId = gtBoardId();
+  uint16_t boardId = gtBoardId();
   std::string boardName = gtBoardName();
 
   myCout << "Board ID:                        " << std::hex << boardId << std::dec << std::endl

--- a/CondFormats/L1TObjects/src/L1GtBoard.cc
+++ b/CondFormats/L1TObjects/src/L1GtBoard.cc
@@ -432,7 +432,9 @@ void L1GtBoard::print(std::ostream& myCout) const {
         }
 
         break;
-        default: { myCout << " ERROR: Unknown type " << (*itObj); } break;
+        default: {
+          myCout << " ERROR: Unknown type " << (*itObj);
+        } break;
       }
     }
   }

--- a/CondFormats/L1TObjects/src/L1GtBoardMaps.cc
+++ b/CondFormats/L1TObjects/src/L1GtBoardMaps.cc
@@ -57,7 +57,7 @@ void L1GtBoardMaps::printGtDaqRecordMap(std::ostream& myCout) const {
 
   int nrBoards = 0;
   int posRec = -1;
-  boost::uint16_t boardId = 0;
+  uint16_t boardId = 0;
   std::string boardName;
 
   for (std::vector<L1GtBoard>::const_iterator cIt = m_gtBoardMaps.begin(); cIt != m_gtBoardMaps.end(); ++cIt) {
@@ -84,7 +84,7 @@ void L1GtBoardMaps::printGtEvmRecordMap(std::ostream& myCout) const {
 
   int nrBoards = 0;
   int posRec = -1;
-  boost::uint16_t boardId = 0;
+  uint16_t boardId = 0;
   std::string boardName;
 
   for (std::vector<L1GtBoard>::const_iterator cIt = m_gtBoardMaps.begin(); cIt != m_gtBoardMaps.end(); ++cIt) {
@@ -111,7 +111,7 @@ void L1GtBoardMaps::printGtDaqActiveBoardsMap(std::ostream& myCout) const {
 
   int nrBoards = 0;
   int posRec = -1;
-  boost::uint16_t boardId = 0;
+  uint16_t boardId = 0;
   std::string boardName;
 
   for (std::vector<L1GtBoard>::const_iterator cIt = m_gtBoardMaps.begin(); cIt != m_gtBoardMaps.end(); ++cIt) {
@@ -138,7 +138,7 @@ void L1GtBoardMaps::printGtEvmActiveBoardsMap(std::ostream& myCout) const {
 
   int nrBoards = 0;
   int posRec = -1;
-  boost::uint16_t boardId = 0;
+  uint16_t boardId = 0;
   std::string boardName;
 
   for (std::vector<L1GtBoard>::const_iterator cIt = m_gtBoardMaps.begin(); cIt != m_gtBoardMaps.end(); ++cIt) {
@@ -165,7 +165,7 @@ void L1GtBoardMaps::printGtBoardSlotMap(std::ostream& myCout) const {
 
   int nrBoards = 0;
   int posRec = -1;
-  boost::uint16_t boardId = 0;
+  uint16_t boardId = 0;
   std::string boardName;
 
   for (std::vector<L1GtBoard>::const_iterator cIt = m_gtBoardMaps.begin(); cIt != m_gtBoardMaps.end(); ++cIt) {
@@ -192,7 +192,7 @@ void L1GtBoardMaps::printGtBoardHexNameMap(std::ostream& myCout) const {
 
   int nrBoards = 0;
   int posRec = -1;
-  boost::uint16_t boardId = 0;
+  uint16_t boardId = 0;
   std::string boardName;
 
   for (std::vector<L1GtBoard>::const_iterator cIt = m_gtBoardMaps.begin(); cIt != m_gtBoardMaps.end(); ++cIt) {

--- a/CondFormats/L1TObjects/src/L1GtParameters.cc
+++ b/CondFormats/L1TObjects/src/L1GtParameters.cc
@@ -39,14 +39,10 @@ L1GtParameters::~L1GtParameters() {
 void L1GtParameters::setGtTotalBxInEvent(const int& totalBxInEventValue) { m_totalBxInEvent = totalBxInEventValue; }
 
 // set active boards for L1 GT DAQ record
-void L1GtParameters::setGtDaqActiveBoards(const uint16_t& activeBoardsValue) {
-  m_daqActiveBoards = activeBoardsValue;
-}
+void L1GtParameters::setGtDaqActiveBoards(const uint16_t& activeBoardsValue) { m_daqActiveBoards = activeBoardsValue; }
 
 // set active boards for L1 GT EVM record
-void L1GtParameters::setGtEvmActiveBoards(const uint16_t& activeBoardsValue) {
-  m_evmActiveBoards = activeBoardsValue;
-}
+void L1GtParameters::setGtEvmActiveBoards(const uint16_t& activeBoardsValue) { m_evmActiveBoards = activeBoardsValue; }
 
 // set number of Bx for L1 GT DAQ record
 void L1GtParameters::setGtDaqNrBxBoard(const std::vector<int>& nrBxBoardValue) { m_daqNrBxBoard = nrBxBoardValue; }

--- a/CondFormats/L1TObjects/src/L1GtParameters.cc
+++ b/CondFormats/L1TObjects/src/L1GtParameters.cc
@@ -39,12 +39,12 @@ L1GtParameters::~L1GtParameters() {
 void L1GtParameters::setGtTotalBxInEvent(const int& totalBxInEventValue) { m_totalBxInEvent = totalBxInEventValue; }
 
 // set active boards for L1 GT DAQ record
-void L1GtParameters::setGtDaqActiveBoards(const boost::uint16_t& activeBoardsValue) {
+void L1GtParameters::setGtDaqActiveBoards(const uint16_t& activeBoardsValue) {
   m_daqActiveBoards = activeBoardsValue;
 }
 
 // set active boards for L1 GT EVM record
-void L1GtParameters::setGtEvmActiveBoards(const boost::uint16_t& activeBoardsValue) {
+void L1GtParameters::setGtEvmActiveBoards(const uint16_t& activeBoardsValue) {
   m_evmActiveBoards = activeBoardsValue;
 }
 

--- a/CondFormats/RPCObjects/interface/DccSpec.h
+++ b/CondFormats/RPCObjects/interface/DccSpec.h
@@ -9,7 +9,6 @@
 
 #include <vector>
 #include <string>
-#include <boost/cstdint.hpp>
 #include "CondFormats/RPCObjects/interface/TriggerBoardSpec.h"
 
 struct ChamberLocationSpec;

--- a/CondFormats/RPCObjects/interface/RPCClusterSize.h
+++ b/CondFormats/RPCObjects/interface/RPCClusterSize.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class RPCClusterSize {
 public:

--- a/CondFormats/RPCObjects/interface/RPCDQMObject.h
+++ b/CondFormats/RPCObjects/interface/RPCDQMObject.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class RPCDQMObject {
 public:

--- a/CondFormats/RPCObjects/interface/RPCDeadStrips.h
+++ b/CondFormats/RPCObjects/interface/RPCDeadStrips.h
@@ -5,7 +5,6 @@
 
 #include <vector>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class RPCDeadStrips {
 public:

--- a/CondFormats/RPCObjects/interface/RPCEMap.h
+++ b/CondFormats/RPCObjects/interface/RPCEMap.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <string>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class RPCEMap {
 public:

--- a/CondFormats/RPCObjects/interface/RPCMaskedStrips.h
+++ b/CondFormats/RPCObjects/interface/RPCMaskedStrips.h
@@ -5,7 +5,6 @@
 
 #include <vector>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class RPCMaskedStrips {
 public:

--- a/CondFormats/RPCObjects/interface/RPCReadOutMapping.h
+++ b/CondFormats/RPCObjects/interface/RPCReadOutMapping.h
@@ -12,11 +12,11 @@
 #include <vector>
 #include <utility>
 #include <string>
-#include <boost/cstdint.hpp>
 
 #include "CondFormats/RPCObjects/interface/DccSpec.h"
 #include "CondFormats/RPCObjects/interface/LinkBoardElectronicIndex.h"
 #include "CondFormats/RPCObjects/interface/LinkBoardPackedStrip.h"
+#include <cstdint>
 class LinkBoardSpec;
 
 class RPCReadOutMapping {

--- a/CondFormats/RPCObjects/interface/RPCStripNoises.h
+++ b/CondFormats/RPCObjects/interface/RPCStripNoises.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class RPCStripNoises {
 public:

--- a/CondFormats/RPCObjects/interface/TriggerBoardSpec.h
+++ b/CondFormats/RPCObjects/interface/TriggerBoardSpec.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include <boost/cstdint.hpp>
 #include "CondFormats/RPCObjects/interface/LinkConnSpec.h"
 #include <string>
+#include <cstdint>
 
 /** \class TriggerBoardSpec
  * RPC Trigger Board specification for readout decoding

--- a/CondFormats/SiPixelObjects/interface/DetectorIndex.h
+++ b/CondFormats/SiPixelObjects/interface/DetectorIndex.h
@@ -2,7 +2,6 @@
 #ifndef CondFormats_SiPixelObjects_DetectorIndex_H
 #define CondFormats_SiPixelObjects_DetectorIndex_H
 
-
 namespace sipixelobjects {
   struct DetectorIndex {
     uint32_t rawId;

--- a/CondFormats/SiPixelObjects/interface/DetectorIndex.h
+++ b/CondFormats/SiPixelObjects/interface/DetectorIndex.h
@@ -1,7 +1,7 @@
+#include <cstdint>
 #ifndef CondFormats_SiPixelObjects_DetectorIndex_H
 #define CondFormats_SiPixelObjects_DetectorIndex_H
 
-#include <boost/cstdint.hpp>
 
 namespace sipixelobjects {
   struct DetectorIndex {

--- a/CondFormats/SiPixelObjects/interface/FrameConversion.h
+++ b/CondFormats/SiPixelObjects/interface/FrameConversion.h
@@ -2,7 +2,6 @@
 #define SiPixelObjects_FrameConversion_H
 
 #include "CondFormats/SiPixelObjects/interface/LinearConversion.h"
-#include <boost/cstdint.hpp>
 
 class PixelEndcapName;
 class PixelBarrelName;

--- a/CondFormats/SiPixelObjects/interface/PixelFEDLink.h
+++ b/CondFormats/SiPixelObjects/interface/PixelFEDLink.h
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 class PixelModuleName;

--- a/CondFormats/SiPixelObjects/interface/PixelROC.h
+++ b/CondFormats/SiPixelObjects/interface/PixelROC.h
@@ -6,8 +6,8 @@
 #include "CondFormats/SiPixelObjects/interface/FrameConversion.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 /** \class PixelROC
  * Represents ReadOut Chip of DetUnit. 

--- a/CondFormats/SiPixelObjects/interface/SiPixelDbItem.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDbItem.h
@@ -18,7 +18,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <cstdint>
 
-
 class SiPixelDbItem {
   typedef uint32_t PackedPixDbType;
 

--- a/CondFormats/SiPixelObjects/interface/SiPixelDbItem.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDbItem.h
@@ -16,8 +16,8 @@
 //-----------------------------------------------------------------------------
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class SiPixelDbItem {
   typedef uint32_t PackedPixDbType;

--- a/CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelDynamicInefficiency.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelDynamicInefficiency {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
@@ -11,7 +11,6 @@
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <cstdint>
 
-
 class SiPixelFrameConverter {
 public:
   typedef sipixelobjects::PixelFEDCabling PixelFEDCabling;

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
@@ -9,8 +9,8 @@
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class SiPixelFrameConverter {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
@@ -10,8 +10,8 @@
 #include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class SiPixelFedCablingMap;
 

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
@@ -12,7 +12,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include <cstdint>
 
-
 class SiPixelFedCablingMap;
 
 class SiPixelFrameReverter {

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
@@ -24,7 +24,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelGainCalibration {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
@@ -24,7 +24,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelGainCalibrationForHLT {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
@@ -24,7 +24,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelGainCalibrationOffline {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelLorentzAngle {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelPerformanceSummary.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelPerformanceSummary.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #define kDetSummarySize 60  // float numbers kept in DetSummary.performanceValues
 #define kDefaultValue -99.9

--- a/CondFormats/SiStripObjects/interface/ApvLatencyAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/ApvLatencyAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
    @class ApvLatencyAnalysis

--- a/CondFormats/SiStripObjects/interface/ApvTimingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/ApvTimingAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    @class ApvTimingAnalysis

--- a/CondFormats/SiStripObjects/interface/CalibrationAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/CalibrationAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    @class CalibrationAnalysis

--- a/CondFormats/SiStripObjects/interface/CalibrationScanAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/CalibrationScanAnalysis.h
@@ -3,12 +3,12 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
 #include <map>
 #include "TGraph.h"
 #include "TGraph2D.h"
+#include <cstdint>
 
 /**
    @class CalibrationScanAnalysis

--- a/CondFormats/SiStripObjects/interface/CommissioningAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/CommissioningAnalysis.h
@@ -3,10 +3,10 @@
 
 #include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
 #include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 /**
    @class CommissioningAnalysis

--- a/CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/DaqScopeModeAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    @class DaqScopeModeAnalysis

--- a/CondFormats/SiStripObjects/interface/FastFedCablingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/FastFedCablingAnalysis.h
@@ -3,10 +3,10 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 /** 
    @class FastFedCablingAnalysis

--- a/CondFormats/SiStripObjects/interface/FedCablingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/FedCablingAnalysis.h
@@ -3,10 +3,10 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 /** 
    @class FedCablingAnalysis

--- a/CondFormats/SiStripObjects/interface/FedChannelConnection.h
+++ b/CondFormats/SiStripObjects/interface/FedChannelConnection.h
@@ -4,9 +4,9 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <ostream>
 #include <sstream>
+#include <cstdint>
 
 class FedChannelConnection;
 

--- a/CondFormats/SiStripObjects/interface/FedTimingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/FedTimingAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    @class FedTimingAnalysis

--- a/CondFormats/SiStripObjects/interface/NoiseAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/NoiseAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
     @class NoiseAnalysis

--- a/CondFormats/SiStripObjects/interface/OptoScanAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/OptoScanAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
    @class OptoScanAnalysis

--- a/CondFormats/SiStripObjects/interface/PedestalsAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/PedestalsAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
     @class PedestalsAnalysis

--- a/CondFormats/SiStripObjects/interface/PedsFullNoiseAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/PedsFullNoiseAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
     @class PedsFullNoiseAnalysis

--- a/CondFormats/SiStripObjects/interface/PedsOnlyAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/PedsOnlyAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
     @class PedsOnlyAnalysis

--- a/CondFormats/SiStripObjects/interface/SamplingAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/SamplingAnalysis.h
@@ -4,9 +4,9 @@
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripCommon/interface/SiStripEnumsAndStrings.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    @class SamplingAnalysis

--- a/CondFormats/SiStripObjects/interface/SiStripApvGain.h
+++ b/CondFormats/SiStripObjects/interface/SiStripApvGain.h
@@ -6,8 +6,8 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h
@@ -6,9 +6,9 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 // #include "CondFormats/SiStripObjects/interface/SiStripBaseObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
+#include <cstdint>
 
 /**
  * Author: Loic Quertenmont.  THis class is adapted from SiStripLorentzAngle

--- a/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
@@ -6,8 +6,8 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 #include "DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h"
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/CondFormats/SiStripObjects/interface/SiStripDetVOff.h
+++ b/CondFormats/SiStripObjects/interface/SiStripDetVOff.h
@@ -6,8 +6,8 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/CondFormats/SiStripObjects/interface/SiStripFedCabling.h
+++ b/CondFormats/SiStripObjects/interface/SiStripFedCabling.h
@@ -5,10 +5,10 @@
 
 #include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
 #include <boost/range/iterator_range.hpp>
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #define SISTRIPCABLING_USING_NEW_STRUCTURE
 #define SISTRIPCABLING_USING_NEW_INTERFACE

--- a/CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h
+++ b/CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h
@@ -6,9 +6,9 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 // #include "CondFormats/SiStripObjects/interface/SiStripBaseObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
+#include <cstdint>
 
 /**
  * Stores the lorentz angle value for all DetIds. <br>

--- a/CondFormats/SiStripObjects/interface/SiStripNoises.h
+++ b/CondFormats/SiStripObjects/interface/SiStripNoises.h
@@ -6,10 +6,10 @@
 #include <vector>
 #include <utility>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 #include <cassert>
 #include <cstring>
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/CondFormats/SiStripObjects/interface/SiStripPedestals.h
+++ b/CondFormats/SiStripObjects/interface/SiStripPedestals.h
@@ -6,10 +6,10 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 // #include "CondFormats/SiStripObjects/interface/SiStripBaseObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
+#include <cstdint>
 
 /**
  * Stores the pedestal of every strip. <br>

--- a/CondFormats/SiStripObjects/interface/SiStripRunSummary.h
+++ b/CondFormats/SiStripObjects/interface/SiStripRunSummary.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <string>
 #include <iostream>
-#include <boost/cstdint.hpp>
 
 class SiStripRunSummary {
 public:

--- a/CondFormats/SiStripObjects/interface/SiStripSummary.h
+++ b/CondFormats/SiStripObjects/interface/SiStripSummary.h
@@ -6,8 +6,8 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 #include "FWCore/Utilities/interface/Exception.h"
+#include <cstdint>
 
 /**
  @class SiStripSummary

--- a/CondFormats/SiStripObjects/interface/SiStripThreshold.h
+++ b/CondFormats/SiStripObjects/interface/SiStripThreshold.h
@@ -6,9 +6,9 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
 #include "DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h"
 #include <sstream>
+#include <cstdint>
 
 class TrackerTopology;
 

--- a/CondFormats/SiStripObjects/interface/VpspScanAnalysis.h
+++ b/CondFormats/SiStripObjects/interface/VpspScanAnalysis.h
@@ -3,9 +3,9 @@
 
 #include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /** 
    @class VpspScanAnalysis

--- a/CondTools/Ecal/interface/EcalErrorDictionary.h
+++ b/CondTools/Ecal/interface/EcalErrorDictionary.h
@@ -8,9 +8,9 @@
  *
  *  This class holds no dynamic data and all the methods are static.
  */
-#include <boost/cstdint.hpp>
 #include <iostream>
 #include <vector>
+#include <cstdint>
 
 class EcalErrorDictionary {
 public:

--- a/CondTools/SiStrip/interface/SiStripCondObjBuilderBase.h
+++ b/CondTools/SiStrip/interface/SiStripCondObjBuilderBase.h
@@ -2,7 +2,6 @@
 #define CondTools_SiStrip_SiStripCondObjBuilderBase_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <string>
 

--- a/CondTools/SiStrip/interface/SiStripCondObjBuilderBase.h
+++ b/CondTools/SiStrip/interface/SiStripCondObjBuilderBase.h
@@ -7,27 +7,24 @@
 
 template <typename T>
 class SiStripCondObjBuilderBase {
-  
- public:
+public:
+  SiStripCondObjBuilderBase(const edm::ParameterSet& pset) : _pset(pset){};
+  virtual ~SiStripCondObjBuilderBase() noexcept(false){};
 
-  SiStripCondObjBuilderBase(const edm::ParameterSet& pset):_pset(pset){};
-  virtual ~SiStripCondObjBuilderBase() noexcept(false) {};
-  
   virtual void initialize(){};
-			    
+
   /** Returns MetaData information in a stringstream */
   virtual void getMetaDataString(std::stringstream& ss){};
 
   /** Check MetaData information in a stringstream */
-  virtual bool checkForCompatibility(std::string ss){return true;}
+  virtual bool checkForCompatibility(std::string ss) { return true; }
 
   /** Returns the CondObj */
-  virtual void getObj(T* & obj){};
-  
- protected:
-  
+  virtual void getObj(T*& obj){};
+
+protected:
   T* obj_;
   edm::ParameterSet _pset;
 };
 
-#endif // CondTools_SiStrip_SiStripCondObjBuilderBase_H
+#endif  // CondTools_SiStrip_SiStripCondObjBuilderBase_H

--- a/CondTools/SiStrip/interface/SiStripDepCondObjBuilderBase.h
+++ b/CondTools/SiStrip/interface/SiStripDepCondObjBuilderBase.h
@@ -2,7 +2,6 @@
 #define CondTools_SiStrip_SiStripDepCondObjBuilderBase_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <string>
 

--- a/CondTools/SiStrip/interface/SiStripDepCondObjBuilderBase.h
+++ b/CondTools/SiStrip/interface/SiStripDepCondObjBuilderBase.h
@@ -7,27 +7,24 @@
 
 template <typename T, typename D>
 class SiStripDepCondObjBuilderBase {
-  
- public:
-
-  SiStripDepCondObjBuilderBase(const edm::ParameterSet& pset):_pset(pset){};
+public:
+  SiStripDepCondObjBuilderBase(const edm::ParameterSet& pset) : _pset(pset){};
   virtual ~SiStripDepCondObjBuilderBase(){};
-  
+
   virtual void initialize(){};
-			    
+
   /** Returns MetaData information in a stringstream */
   virtual void getMetaDataString(std::stringstream& ss){};
 
   /** Check MetaData information in a stringstream */
-  virtual bool checkForCompatibility(std::string ss){return true;}
+  virtual bool checkForCompatibility(std::string ss) { return true; }
 
   /** Returns the CondObj */
-  virtual void getObj(T* & obj, const D* depObj){};
-  
- protected:
-  
+  virtual void getObj(T*& obj, const D* depObj){};
+
+protected:
   T* obj_;
   edm::ParameterSet _pset;
 };
 
-#endif // CondTools_SiStrip_SiStripDepCondObjBuilderBase_H
+#endif  // CondTools_SiStrip_SiStripDepCondObjBuilderBase_H

--- a/DQM/DTMonitorClient/src/DTLocalTriggerBaseTest.h
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerBaseTest.h
@@ -26,7 +26,6 @@
 
 #include <DQMServices/Core/interface/DQMEDHarvester.h>
 
-#include <boost/cstdint.hpp>
 #include <string>
 #include <map>
 

--- a/DQM/L1TMonitor/interface/L1TGT.h
+++ b/DQM/L1TMonitor/interface/L1TGT.h
@@ -171,8 +171,8 @@ private:
   /// histogram folder for L1 GT plots
   std::string m_histFolder;
 
-  boost::uint64_t preGps_;
-  boost::uint64_t preOrb_;
+  uint64_t preGps_;
+  uint64_t preOrb_;
 
   std::string algoBitToName[128];
   std::string techBitToName[64];

--- a/DQM/L1TMonitor/src/L1GtHwValidation.cc
+++ b/DQM/L1TMonitor/src/L1GtHwValidation.cc
@@ -829,8 +829,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get BoardId value
-  const boost::uint16_t boardIdData = gtfeBlockData.boardId();
-  const boost::uint16_t boardIdEmul = gtfeBlockEmul.boardId();
+  const uint16_t boardIdData = gtfeBlockData.boardId();
+  const uint16_t boardIdEmul = gtfeBlockEmul.boardId();
 
   if (boardIdData == boardIdEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE boardId identical.";
@@ -849,8 +849,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get record length for alternative 1
-  const boost::uint16_t recordLength1Data = gtfeBlockData.recordLength1();
-  const boost::uint16_t recordLength1Emul = gtfeBlockEmul.recordLength1();
+  const uint16_t recordLength1Data = gtfeBlockData.recordLength1();
+  const uint16_t recordLength1Emul = gtfeBlockEmul.recordLength1();
 
   if (recordLength1Data == recordLength1Emul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE recordLength for alternative 1 identical.";
@@ -866,8 +866,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get record length for alternative 0
-  const boost::uint16_t recordLengthData = gtfeBlockData.recordLength();
-  const boost::uint16_t recordLengthEmul = gtfeBlockEmul.recordLength();
+  const uint16_t recordLengthData = gtfeBlockData.recordLength();
+  const uint16_t recordLengthEmul = gtfeBlockEmul.recordLength();
 
   if (recordLengthData == recordLengthEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE recordLength for alternative 0 identical.";
@@ -883,8 +883,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get bunch cross number as counted in the GTFE board
-  const boost::uint16_t bxNrData = gtfeBlockData.bxNr();
-  const boost::uint16_t bxNrEmul = gtfeBlockEmul.bxNr();
+  const uint16_t bxNrData = gtfeBlockData.bxNr();
+  const uint16_t bxNrEmul = gtfeBlockEmul.bxNr();
 
   if (bxNrData == bxNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE bxNr identical.";
@@ -900,8 +900,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get setup version
-  const boost::uint32_t setupVersionData = gtfeBlockData.setupVersion();
-  const boost::uint32_t setupVersionEmul = gtfeBlockEmul.setupVersion();
+  const uint32_t setupVersionData = gtfeBlockData.setupVersion();
+  const uint32_t setupVersionEmul = gtfeBlockEmul.setupVersion();
 
   if (setupVersionData == setupVersionEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE setupVersion identical.";
@@ -917,8 +917,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get boards contributing to EVM respectively DAQ record
-  const boost::uint16_t activeBoardsData = gtfeBlockData.activeBoards();
-  const boost::uint16_t activeBoardsEmul = gtfeBlockEmul.activeBoards();
+  const uint16_t activeBoardsData = gtfeBlockData.activeBoards();
+  const uint16_t activeBoardsEmul = gtfeBlockEmul.activeBoards();
 
   if (activeBoardsData == activeBoardsEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE activeBoards identical.";
@@ -939,8 +939,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   ///     correlated with active boards
   ///     bit value is 0: take alternative 0
   ///     bit value is 1: take alternative 1
-  const boost::uint16_t altNrBxBoardData = gtfeBlockData.altNrBxBoard();
-  const boost::uint16_t altNrBxBoardEmul = gtfeBlockEmul.altNrBxBoard();
+  const uint16_t altNrBxBoardData = gtfeBlockData.altNrBxBoard();
+  const uint16_t altNrBxBoardEmul = gtfeBlockEmul.altNrBxBoard();
 
   if (altNrBxBoardData == altNrBxBoardEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE altNrBxBoard identical.";
@@ -956,8 +956,8 @@ void L1GtHwValidation::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get total number of L1A sent since start of run
-  const boost::uint32_t totalTriggerNrData = gtfeBlockData.totalTriggerNr();
-  const boost::uint32_t totalTriggerNrEmul = gtfeBlockEmul.totalTriggerNr();
+  const uint32_t totalTriggerNrData = gtfeBlockData.totalTriggerNr();
+  const uint32_t totalTriggerNrEmul = gtfeBlockEmul.totalTriggerNr();
 
   if (totalTriggerNrData == totalTriggerNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated GTFE totalTriggerNr identical.";
@@ -1053,8 +1053,8 @@ void L1GtHwValidation::compareFDL(const edm::Event& iEvent,
   // loop over algorithms and increase the corresponding counters
 
   // get BoardId value
-  const boost::uint16_t boardIdData = fdlBlockData.boardId();
-  const boost::uint16_t boardIdEmul = fdlBlockEmul.boardId();
+  const uint16_t boardIdData = fdlBlockData.boardId();
+  const uint16_t boardIdEmul = fdlBlockEmul.boardId();
 
   if (boardIdData == boardIdEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL boardId identical.";
@@ -1082,8 +1082,8 @@ void L1GtHwValidation::compareFDL(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get BxNr - bunch cross number of the actual bx
-  const boost::uint16_t bxNrData = fdlBlockData.bxNr();
-  const boost::uint16_t bxNrEmul = fdlBlockEmul.bxNr();
+  const uint16_t bxNrData = fdlBlockData.bxNr();
+  const uint16_t bxNrEmul = fdlBlockEmul.bxNr();
 
   if (bxNrData == bxNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL bxNr identical.";
@@ -1108,8 +1108,8 @@ void L1GtHwValidation::compareFDL(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get event number since last L1 reset generated in FDL
-  const boost::uint32_t eventNrData = fdlBlockData.eventNr();
-  const boost::uint32_t eventNrEmul = fdlBlockEmul.eventNr();
+  const uint32_t eventNrData = fdlBlockData.eventNr();
+  const uint32_t eventNrEmul = fdlBlockEmul.eventNr();
 
   if (eventNrData == eventNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL eventNr identical.";
@@ -1541,8 +1541,8 @@ void L1GtHwValidation::compareFDL(const edm::Event& iEvent,
   }
 
   // get  NoAlgo
-  const boost::uint16_t noAlgoData = fdlBlockData.noAlgo();
-  const boost::uint16_t noAlgoEmul = fdlBlockEmul.noAlgo();
+  const uint16_t noAlgoData = fdlBlockData.noAlgo();
+  const uint16_t noAlgoEmul = fdlBlockEmul.noAlgo();
 
   if (noAlgoData == noAlgoEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL noAlgo identical.";
@@ -1563,8 +1563,8 @@ void L1GtHwValidation::compareFDL(const edm::Event& iEvent,
   }
 
   // get  "Final OR" bits
-  const boost::uint16_t finalORData = fdlBlockData.finalOR();
-  const boost::uint16_t finalOREmul = fdlBlockEmul.finalOR();
+  const uint16_t finalORData = fdlBlockData.finalOR();
+  const uint16_t finalOREmul = fdlBlockEmul.finalOR();
 
   if (finalORData == finalOREmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL finalOR identical.";
@@ -1610,8 +1610,8 @@ void L1GtHwValidation::compareFDL(const edm::Event& iEvent,
   }
 
   // get  local bunch cross number of the actual bx
-  const boost::uint16_t localBxNrData = fdlBlockData.localBxNr();
-  const boost::uint16_t localBxNrEmul = fdlBlockEmul.localBxNr();
+  const uint16_t localBxNrData = fdlBlockData.localBxNr();
+  const uint16_t localBxNrEmul = fdlBlockEmul.localBxNr();
 
   if (localBxNrData == localBxNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL localBxNr identical.";
@@ -1661,8 +1661,8 @@ void L1GtHwValidation::comparePSB(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get BoardId value
-  const boost::uint16_t boardIdData = psbBlockData.boardId();
-  const boost::uint16_t boardIdEmul = psbBlockEmul.boardId();
+  const uint16_t boardIdData = psbBlockData.boardId();
+  const uint16_t boardIdEmul = psbBlockEmul.boardId();
 
   if (boardIdData == boardIdEmul) {
     m_myCoutStream << "\nData and emulated PSB boardId identical.";
@@ -1696,8 +1696,8 @@ void L1GtHwValidation::comparePSB(const edm::Event& iEvent,
   }
 
   // get BxNr - bunch cross number of the actual bx
-  const boost::uint16_t bxNrData = psbBlockData.bxNr();
-  const boost::uint16_t bxNrEmul = psbBlockEmul.bxNr();
+  const uint16_t bxNrData = psbBlockData.bxNr();
+  const uint16_t bxNrEmul = psbBlockEmul.bxNr();
 
   if (bxNrData == bxNrEmul) {
     m_myCoutStream << "\nData and emulated PSB bxNr identical.";
@@ -1712,8 +1712,8 @@ void L1GtHwValidation::comparePSB(const edm::Event& iEvent,
   }
 
   // get event number since last L1 reset generated in FDL
-  const boost::uint32_t eventNrData = psbBlockData.eventNr();
-  const boost::uint32_t eventNrEmul = psbBlockEmul.eventNr();
+  const uint32_t eventNrData = psbBlockData.eventNr();
+  const uint32_t eventNrEmul = psbBlockEmul.eventNr();
 
   if (eventNrData == eventNrEmul) {
     m_myCoutStream << "\nData and emulated PSB eventNr identical.";
@@ -1728,8 +1728,8 @@ void L1GtHwValidation::comparePSB(const edm::Event& iEvent,
   }
 
   /// get/set A_DATA_CH_IA
-  boost::uint16_t valData;
-  boost::uint16_t valEmul;
+  uint16_t valData;
+  uint16_t valEmul;
 
   for (int iA = 0; iA < psbBlockData.NumberAData; ++iA) {
     valData = psbBlockData.aData(iA);
@@ -1773,8 +1773,8 @@ void L1GtHwValidation::comparePSB(const edm::Event& iEvent,
   }
 
   // get  local bunch cross number of the actual bx
-  const boost::uint16_t localBxNrData = psbBlockData.localBxNr();
-  const boost::uint16_t localBxNrEmul = psbBlockEmul.localBxNr();
+  const uint16_t localBxNrData = psbBlockData.localBxNr();
+  const uint16_t localBxNrEmul = psbBlockEmul.localBxNr();
 
   if (localBxNrData == localBxNrEmul) {
     m_myCoutStream << "\nData and emulated PSB localBxNr identical.";
@@ -1902,7 +1902,7 @@ void L1GtHwValidation::compareDaqRecord(const edm::Event& iEvent, const edm::Eve
   // in unpacker: every PSB in all BxInEvent
   for (int iPsb = 0; iPsb < gtPsbVectorDataSize; ++iPsb) {
     const L1GtPsbWord& psbBlockData = gtPsbVectorData[iPsb];
-    const boost::uint16_t boardIdData = psbBlockData.boardId();
+    const uint16_t boardIdData = psbBlockData.boardId();
     const int bxInEventData = psbBlockData.bxInEvent();
 
     // search the corresponding PSB in the emulated record using the
@@ -1912,7 +1912,7 @@ void L1GtHwValidation::compareDaqRecord(const edm::Event& iEvent, const edm::Eve
 
     for (int iPsbF = 0; iPsbF < gtPsbVectorEmulSize; ++iPsbF) {
       const L1GtPsbWord& psbBlockEmul = gtPsbVectorEmul[iPsbF];
-      const boost::uint16_t boardIdEmul = psbBlockEmul.boardId();
+      const uint16_t boardIdEmul = psbBlockEmul.boardId();
       const int bxInEventEmul = psbBlockEmul.bxInEvent();
 
       if ((boardIdEmul == boardIdData) && (bxInEventData == bxInEventEmul)) {

--- a/DQM/L1TMonitor/src/L1TGT.cc
+++ b/DQM/L1TMonitor/src/L1TGT.cc
@@ -382,13 +382,13 @@ void L1TGT::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
       evnum_trignum_lumi->Fill(lsNumber,
                                static_cast<double>(tcsWord.eventNr()) / static_cast<double>(tcsWord.partTrigNr()));
 
-      boost::uint16_t master = gtfeEvmExtWord.bstMasterStatus();
-      boost::uint32_t turnCount = gtfeEvmExtWord.turnCountNumber();
-      boost::uint32_t lhcFill = gtfeEvmExtWord.lhcFillNumber();
-      boost::uint16_t beam = gtfeEvmExtWord.beamMode();
-      boost::uint16_t momentum = gtfeEvmExtWord.beamMomentum();
-      boost::uint32_t intensity1 = gtfeEvmExtWord.totalIntensityBeam1();
-      boost::uint32_t intensity2 = gtfeEvmExtWord.totalIntensityBeam2();
+      uint16_t master = gtfeEvmExtWord.bstMasterStatus();
+      uint32_t turnCount = gtfeEvmExtWord.turnCountNumber();
+      uint32_t lhcFill = gtfeEvmExtWord.lhcFillNumber();
+      uint16_t beam = gtfeEvmExtWord.beamMode();
+      uint16_t momentum = gtfeEvmExtWord.beamMomentum();
+      uint32_t intensity1 = gtfeEvmExtWord.totalIntensityBeam1();
+      uint32_t intensity2 = gtfeEvmExtWord.totalIntensityBeam2();
 
       BST_MasterStatus->Fill(lsNumber, static_cast<double>(master));
       BST_turnCountNumber->Fill(lsNumber, static_cast<double>(turnCount));
@@ -404,10 +404,10 @@ void L1TGT::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
                               << std::endl;
       }
 
-      boost::uint64_t gpsr = gtfeEvmExtWord.gpsTime();
-      boost::uint64_t gpshi = (gpsr >> 32) & 0xffffffff;
-      boost::uint64_t gpslo = gpsr & 0xffffffff;
-      boost::uint64_t gps = gpshi * 1000000 + gpslo;
+      uint64_t gpsr = gtfeEvmExtWord.gpsTime();
+      uint64_t gpshi = (gpsr >> 32) & 0xffffffff;
+      uint64_t gpslo = gpsr & 0xffffffff;
+      uint64_t gps = gpshi * 1000000 + gpslo;
       //  edm::LogInfo("L1TGT") << "  gpsr = " << std::hex << gpsr << " hi=" << gpshi << " lo=" << gpslo << " gps=" << gps << std::endl;
 
       Long64_t delorb = orbitTcs - preOrb_;
@@ -659,7 +659,7 @@ void L1TGT::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
 
     // fill the index of actual prescale factor set
     // the index for technical triggers and algorithm trigger is the same (constraint in L1 GT TS)
-    // so we read only pfIndexAlgoTrig (boost::uint16_t)
+    // so we read only pfIndexAlgoTrig (uint16_t)
 
     const int pfIndexAlgoTrig = fdlWord.gtPrescaleFactorIndexAlgo();
     m_monL1PrescaleFactorSet->Fill(lsNumber, static_cast<float>(pfIndexAlgoTrig));

--- a/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
+++ b/DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h
@@ -20,8 +20,8 @@ Usage:
 // Original Author:  chiochia
 //         Created:  Thu Jan 26 23:49:46 CET 2006
 #include "DQMServices/Core/interface/DQMStore.h"
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 class SiPixelFolderOrganizer {
 public:

--- a/DQM/SiPixelCommon/interface/SiPixelHistogramId.h
+++ b/DQM/SiPixelCommon/interface/SiPixelHistogramId.h
@@ -19,8 +19,8 @@
 //         Created:  Wed Feb 22 16:07:51 CET 2006
 //
 
-#include <boost/cstdint.hpp>
 #include <string>
+#include <cstdint>
 
 class SiPixelHistogramId {
 public:

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
@@ -25,7 +25,6 @@
 #include "TH2F.h"
 #include "TPaveText.h"
 
-#include <boost/cstdint.hpp>
 #include <fstream>
 #include <map>
 #include <sstream>

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
@@ -26,12 +26,12 @@
 #include "TH2F.h"
 #include "TPaveText.h"
 
-#include <boost/cstdint.hpp>
 #include <fstream>
 #include <map>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class SiPixelEDAClient;
 class SiPixelWebInterface;

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -23,7 +23,6 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/cstdint.hpp>
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -36,6 +35,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include <cstdint>
 
 class SiPixelClusterModule {
 public:

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -44,7 +44,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -44,7 +44,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <boost/cstdint.hpp>
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
@@ -55,6 +54,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include <cstdint>
 
 class SiPixelClusterSource : public DQMEDAnalyzer {
 public:

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
@@ -28,7 +28,6 @@
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
-#include <boost/cstdint.hpp>
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
@@ -40,6 +39,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+#include <cstdint>
 
 class SiPixelDigiModule {
 public:

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -43,7 +43,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <cstdint>
 
-
 class SiPixelDigiSource : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElements> {
 public:
   explicit SiPixelDigiSource(const edm::ParameterSet& conf);

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -41,8 +41,8 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class SiPixelDigiSource : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElements> {
 public:

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
@@ -43,7 +43,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-#include <boost/cstdint.hpp>
 
 class SiPixelHLTSource : public DQMEDAnalyzer {
 public:

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
@@ -43,7 +43,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-
 class SiPixelHLTSource : public DQMEDAnalyzer {
 public:
   explicit SiPixelHLTSource(const edm::ParameterSet &conf);

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h
@@ -24,7 +24,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelRawDataErrorModule {
 public:

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -49,7 +49,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <cstdint>
 
-
 class SiPixelRawDataErrorSource : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElements> {
 public:
   explicit SiPixelRawDataErrorSource(const edm::ParameterSet &conf);

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -47,8 +47,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class SiPixelRawDataErrorSource : public one::DQMEDAnalyzer<one::DQMLuminosityBlockElements> {
 public:

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -29,7 +29,7 @@ detector segment (detID)
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class SiPixelRecHitModule {
 public:

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -48,7 +48,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <cstdint>
 
-
 class SiPixelRecHitSource : public DQMEDAnalyzer {
 public:
   explicit SiPixelRecHitSource(const edm::ParameterSet &conf);

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -46,8 +46,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 class SiPixelRecHitSource : public DQMEDAnalyzer {
 public:

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -13,7 +13,6 @@
 #ifndef SiPixelMonitorTrack_SiPixelHitEfficiencyModule_h
 #define SiPixelMonitorTrack_SiPixelHitEfficiencyModule_h
 
-#include <boost/cstdint.hpp>
 #include <utility>
 
 //#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
@@ -22,6 +21,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include <cstdint>
 
 namespace edm {
   class EventSetup;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -14,7 +14,6 @@
 // Original Authors: Romain Rougny & Luca Mucibello
 //         Created: Mar Nov 10 13:29:00 CET 2009
 
-#include <boost/cstdint.hpp>
 
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -40,6 +39,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include <cstdint>
 
 class SiPixelHitEfficiencySource : public DQMEDAnalyzer {
 public:

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -14,7 +14,6 @@
 // Original Authors: Romain Rougny & Luca Mucibello
 //         Created: Mar Nov 10 13:29:00 CET 2009
 
-
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -14,12 +14,12 @@
 #ifndef SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 #define SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 
-#include <boost/cstdint.hpp>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include <cstdint>
 
 namespace edm {
   class EventSetup;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -14,7 +14,6 @@
 #ifndef SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 #define SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -16,7 +16,6 @@
 // Updated by: Lukas Wehrli
 // for pixel offline DQM
 
-
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -16,7 +16,6 @@
 // Updated by: Lukas Wehrli
 // for pixel offline DQM
 
-#include <boost/cstdint.hpp>
 
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -45,6 +44,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include <cstdint>
 
 class SiPixelTrackResidualSource : public DQMEDAnalyzer {
 public:

--- a/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
@@ -37,7 +37,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <boost/cstdint.hpp>
 
 class SiPixelPhase1Summary : public DQMEDHarvester {
 public:

--- a/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
@@ -37,7 +37,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 class SiPixelPhase1Summary : public DQMEDHarvester {
 public:
   explicit SiPixelPhase1Summary(const edm::ParameterSet& conf);

--- a/DQM/SiStripCommissioningAnalysis/interface/OptoScanAlgorithm.h
+++ b/DQM/SiStripCommissioningAnalysis/interface/OptoScanAlgorithm.h
@@ -3,8 +3,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQM/SiStripCommissioningAnalysis/interface/CommissioningAlgorithm.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 class OptoScanAnalysis;
 class TProfile;

--- a/DQM/SiStripCommissioningAnalysis/src/Utility.h
+++ b/DQM/SiStripCommissioningAnalysis/src/Utility.h
@@ -2,9 +2,9 @@
 #define DQM_SiStripCommissioningAnalysis_Utility_H
 
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <vector>
 #include <cmath>
+#include <cstdint>
 
 namespace sistrip {
 

--- a/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
+++ b/DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h
@@ -9,7 +9,6 @@
 #include "DQM/SiStripCommissioningSummary/interface/CommissioningSummaryFactory.h"
 #include "DQM/SiStripCommon/interface/ExtractTObject.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include <boost/cstdint.hpp>
 #include "TProfile.h"
 #include "TH1.h"
 #include <iostream>
@@ -17,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 class CommissioningAnalysis;
 

--- a/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
+++ b/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
@@ -19,7 +19,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include <boost/cstdint.hpp>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -28,6 +27,7 @@
 #include <dirent.h>
 #include <cerrno>
 #include "TProfile.h"
+#include <cstdint>
 
 using namespace sistrip;
 

--- a/DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h
@@ -5,7 +5,6 @@
 #include "DQM/SiStripCommissioningClients/interface/CalibrationHistograms.h"
 #include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
 #include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
-#include <boost/cstdint.hpp>
 #include <string>
 #include <map>
 

--- a/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h
@@ -6,9 +6,9 @@
 #include "DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h"
 #include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
 #include "boost/range/iterator_range.hpp"
-#include <boost/cstdint.hpp>
 #include <string>
 #include <map>
+#include <cstdint>
 
 class SiStripConfigDb;
 class SiStripFedCabling;

--- a/DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h
@@ -5,7 +5,6 @@
 #include "DQM/SiStripCommissioningClients/interface/SamplingHistograms.h"
 #include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
 #include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
-#include <boost/cstdint.hpp>
 #include <string>
 #include <map>
 

--- a/DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h
@@ -5,7 +5,6 @@
 #include "DQM/SiStripCommissioningClients/interface/SamplingHistograms.h"
 #include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
 #include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
-#include <boost/cstdint.hpp>
 #include <string>
 #include <map>
 

--- a/DQM/SiStripCommissioningSources/interface/Averages.h
+++ b/DQM/SiStripCommissioningSources/interface/Averages.h
@@ -2,9 +2,9 @@
 #define DQM_SiStripCommissioningSources_Averages_H
 
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 /** */
 class Averages {

--- a/DQM/SiStripCommissioningSources/interface/CommissioningTask.h
+++ b/DQM/SiStripCommissioningSources/interface/CommissioningTask.h
@@ -7,11 +7,11 @@
 #include "DataFormats/SiStripCommon/interface/SiStripEventSummary.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "boost/cstdint.hpp"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <vector>
 #include <string>
 #include <iomanip>
+#include <cstdint>
 
 class TAxis;
 namespace edm {

--- a/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
+++ b/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
@@ -14,10 +14,10 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include <boost/cstdint.hpp>
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 class CommissioningTask;
 class FedChannelConnection;

--- a/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
+++ b/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
@@ -31,7 +31,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include <boost/cstdint.hpp>
 #include <ctime>
 #include <iomanip>
 #include <memory>
@@ -46,6 +45,7 @@
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/unistd.h>
+#include <cstdint>
 
 using namespace sistrip;
 

--- a/DQM/SiStripCommissioningSummary/interface/CommissioningSummaryFactory.h
+++ b/DQM/SiStripCommissioningSummary/interface/CommissioningSummaryFactory.h
@@ -3,8 +3,8 @@
 
 #include "DQM/SiStripCommissioningSummary/interface/SummaryPlotFactory.h"
 #include "DQM/SiStripCommissioningSummary/interface/SummaryPlotFactoryBase.h"
-#include <boost/cstdint.hpp>
 #include <map>
+#include <cstdint>
 
 class CommissioningAnalysis;
 

--- a/DQM/SiStripCommissioningSummary/interface/SummaryGenerator.h
+++ b/DQM/SiStripCommissioningSummary/interface/SummaryGenerator.h
@@ -2,10 +2,10 @@
 #define DQM_SiStripCommon_SummaryGenerator_H
 
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include "boost/cstdint.hpp"
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 class TH1;
 

--- a/DQM/SiStripCommissioningSummary/interface/SummaryHistogramFactory.h
+++ b/DQM/SiStripCommissioningSummary/interface/SummaryHistogramFactory.h
@@ -2,10 +2,10 @@
 #define DQM_SiStripCommissioningSummary_SummaryHistogramFactory_H
 
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include "TH1.h"
 #include <string>
 #include <map>
+#include <cstdint>
 
 class SummaryGenerator;
 

--- a/DQM/SiStripCommissioningSummary/interface/SummaryPlotFactory.h
+++ b/DQM/SiStripCommissioningSummary/interface/SummaryPlotFactory.h
@@ -3,10 +3,10 @@
 
 #include "DQM/SiStripCommissioningSummary/interface/SummaryPlotFactoryBase.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
-#include <boost/cstdint.hpp>
 #include "TH1.h"
 #include <string>
 #include <map>
+#include <cstdint>
 
 template <class T>
 class SummaryPlotFactory : public SummaryPlotFactoryBase {

--- a/DQM/SiStripCommissioningSummary/interface/ViewTranslator.h
+++ b/DQM/SiStripCommissioningSummary/interface/ViewTranslator.h
@@ -2,10 +2,10 @@
 #define DQM_SiStripCommissioningSummary_ViewTranslator_H
 
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
-#include <boost/cstdint.hpp>
 #include <vector>
 #include <string>
 #include <map>
+#include <cstdint>
 
 /**
    \class ViewTranslator

--- a/DQM/SiStripCommon/interface/SiStripHistoId.h
+++ b/DQM/SiStripCommon/interface/SiStripHistoId.h
@@ -19,7 +19,7 @@
 //
 
 #include <string>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class TrackerTopology;
 class SiStripHistoId {

--- a/DQM/SiStripCommon/interface/UpdateTProfile.h
+++ b/DQM/SiStripCommon/interface/UpdateTProfile.h
@@ -2,7 +2,6 @@
 #ifndef DQM_SiStripCommon_UpdateTProfile_H
 #define DQM_SiStripCommon_UpdateTProfile_H
 
-
 class TProfile;
 
 /** */

--- a/DQM/SiStripCommon/interface/UpdateTProfile.h
+++ b/DQM/SiStripCommon/interface/UpdateTProfile.h
@@ -1,7 +1,7 @@
+#include <cstdint>
 #ifndef DQM_SiStripCommon_UpdateTProfile_H
 #define DQM_SiStripCommon_UpdateTProfile_H
 
-#include "boost/cstdint.hpp"
 
 class TProfile;
 

--- a/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
@@ -1,10 +1,10 @@
 #ifndef DQM_SiStripMonitorHardware_SiStripFEDSpyBuffer_H
 #define DQM_SiStripMonitorHardware_SiStripFEDSpyBuffer_H
 
-#include "boost/cstdint.hpp"
 #include <string>
 #include <ostream>
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
+#include <cstdint>
 
 namespace sistrip {
 

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyDigiConverter.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyDigiConverter.h
@@ -1,7 +1,6 @@
 #ifndef DQM_SiStripMonitorHardware_SiStripSpyDigiConverter_H
 #define DQM_SiStripMonitorHardware_SiStripSpyDigiConverter_H
 
-#include "boost/cstdint.hpp"
 #include <memory>
 #include <vector>
 
@@ -9,6 +8,7 @@
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 
 #include "DQM/SiStripMonitorHardware/interface/SiStripSpyUtilities.h"
+#include <cstdint>
 
 // Forward define other classes
 class SiStripFedCabling;

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -8,12 +8,12 @@
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "boost/cstdint.hpp"
 
 #include <set>
 #include <map>
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 //forward declarations
 class FEDRawDataCollection;

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyUnpacker.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyUnpacker.h
@@ -4,9 +4,9 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 
 // Standard includes.
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <utility>
+#include <cstdint>
 
 // Other classes
 class FEDRawDataCollection;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverterModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDigiConverterModule.cc
@@ -2,7 +2,6 @@
 #include <memory>
 #include <vector>
 #include <utility>
-#include "boost/cstdint.hpp"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -169,5 +168,6 @@ namespace sistrip {
 }  // namespace sistrip
 
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include <cstdint>
 typedef sistrip::SpyDigiConverterModule SiStripSpyDigiConverterModule;
 DEFINE_FWK_MODULE(SiStripSpyDigiConverterModule);

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -4,7 +4,6 @@
 #ifdef SiStripMonitorHardware_BuildEventMatchingCode
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "boost/cstdint.hpp"
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -184,6 +183,7 @@ namespace sistrip {
 }  // namespace sistrip
 
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include <cstdint>
 typedef sistrip::SpyEventMatcherModule SiStripSpyEventMatcherModule;
 DEFINE_FWK_MODULE(SiStripSpyEventMatcherModule);
 

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -23,7 +23,7 @@
 #include <memory>
 #include <string>
 #include "boost/scoped_array.hpp"
-#include "boost/cstdint.hpp"
+#include <cstdint>
 
 using edm::LogError;
 using edm::LogInfo;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpackerModule.cc
@@ -35,7 +35,7 @@
 #include <memory>
 #include <utility>
 #include <string>
-#include "boost/cstdint.hpp"
+#include <cstdint>
 
 namespace sistrip {
   class SpyUnpacker;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
@@ -43,10 +43,10 @@
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
-#include "boost/cstdint.hpp"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iomanip>
 #include <string>
+#include <cstdint>
 
 class ApvAnalysisFactory;
 class SiStripDetCabling;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
@@ -33,11 +33,11 @@
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
-#include "boost/cstdint.hpp"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class SiStripDetCabling;
 class SiStripQuality;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
@@ -37,11 +37,11 @@
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
-#include "boost/cstdint.hpp"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class SiStripDetCabling;
 

--- a/DQM/SiStripMonitorSummary/interface/SiStripClassToMonitorCondData.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripClassToMonitorCondData.h
@@ -21,11 +21,11 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/cstdint.hpp"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class SiStripPedestalsDQM;
 class SiStripNoisesDQM;

--- a/DQM/SiStripMonitorSummary/interface/SiStripMonitorCondData.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripMonitorCondData.h
@@ -22,7 +22,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/cstdint.hpp"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iostream>
 #include <string>

--- a/DQM/SiStripMonitorSummary/interface/SiStripMonitorCondDataOnDemandExample.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripMonitorCondDataOnDemandExample.h
@@ -21,7 +21,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "boost/cstdint.hpp"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/DataFormats/Common/interface/ConditionsInEdm.h
+++ b/DataFormats/Common/interface/ConditionsInEdm.h
@@ -2,7 +2,6 @@
 #ifndef DataFormats_Common_ConditionsInEdm_h
 #define DataFormats_Common_ConditionsInEdm_h
 
-
 namespace edm {
 
   class ConditionsInLumiBlock {

--- a/DataFormats/Common/interface/ConditionsInEdm.h
+++ b/DataFormats/Common/interface/ConditionsInEdm.h
@@ -1,14 +1,14 @@
+#include <cstdint>
 #ifndef DataFormats_Common_ConditionsInEdm_h
 #define DataFormats_Common_ConditionsInEdm_h
 
-#include <boost/cstdint.hpp>
 
 namespace edm {
 
   class ConditionsInLumiBlock {
   public:
-    boost::uint32_t totalIntensityBeam1;
-    boost::uint32_t totalIntensityBeam2;
+    uint32_t totalIntensityBeam1;
+    uint32_t totalIntensityBeam2;
 
     bool isProductEqual(ConditionsInLumiBlock const& newThing) const {
       return ((totalIntensityBeam1 == newThing.totalIntensityBeam1) &&
@@ -18,11 +18,11 @@ namespace edm {
 
   class ConditionsInRunBlock {
   public:
-    boost::uint16_t beamMode;
-    boost::uint16_t beamMomentum;
-    //    boost::uint16_t particleTypeBeam1;
-    //    boost::uint16_t particleTypeBeam2;
-    boost::uint32_t lhcFillNumber;
+    uint16_t beamMode;
+    uint16_t beamMomentum;
+    //    uint16_t particleTypeBeam1;
+    //    uint16_t particleTypeBeam2;
+    uint32_t lhcFillNumber;
     float BStartCurrent;
     float BStopCurrent;
     float BAvgCurrent;
@@ -33,8 +33,8 @@ namespace edm {
 
   class ConditionsInEventBlock {
   public:
-    boost::uint16_t bstMasterStatus;
-    boost::uint32_t turnCountNumber;
+    uint16_t bstMasterStatus;
+    uint32_t turnCountNumber;
   };
 }  // namespace edm
 #endif

--- a/DataFormats/Common/interface/HLTPathStatus.h
+++ b/DataFormats/Common/interface/HLTPathStatus.h
@@ -26,8 +26,8 @@
  */
 
 #include "DataFormats/Common/interface/HLTenums.h"
-#include <boost/cstdint.hpp>
 #include <cassert>
+#include <cstdint>
 
 namespace edm {
   class HLTPathStatus {

--- a/DataFormats/DTDigi/interface/DTDDUWords.h
+++ b/DataFormats/DTDigi/interface/DTDDUWords.h
@@ -77,8 +77,8 @@
 #define SC_TRIGGERDLY_SHIFT 12
 #define SC_BXC_MASK 0xFFF
 
-#include <boost/cstdint.hpp>
 #include <iostream>
+#include <cstdint>
 
 /** \class DTROSWordType
  *  Enumeration of DT Read Out Sector (ROS) word types.

--- a/DataFormats/DTDigi/interface/DTDigi.h
+++ b/DataFormats/DTDigi/interface/DTDigi.h
@@ -12,7 +12,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class DTDigi {
 public:
@@ -73,6 +73,7 @@ private:
 };
 
 #include <iostream>
+#include <cstdint>
 inline std::ostream& operator<<(std::ostream& o, const DTDigi& digi) {
   return o << " " << digi.wire() << " " << digi.time() << " " << digi.number();
 }

--- a/DataFormats/DTDigi/interface/DTLocalTrigger.h
+++ b/DataFormats/DTDigi/interface/DTLocalTrigger.h
@@ -10,7 +10,8 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
+
 
 class DTLocalTrigger {
 public:

--- a/DataFormats/DTDigi/interface/DTLocalTrigger.h
+++ b/DataFormats/DTDigi/interface/DTLocalTrigger.h
@@ -12,7 +12,6 @@
 
 #include <cstdint>
 
-
 class DTLocalTrigger {
 public:
   /// Constructor

--- a/DataFormats/DetId/src/classes.h
+++ b/DataFormats/DetId/src/classes.h
@@ -1,5 +1,4 @@
 #include "DataFormats/DetId/interface/DetId.h"
-#include <boost/cstdint.hpp>
 #include <map>
 #include <vector>
 

--- a/DataFormats/EcalDetId/src/classes.h
+++ b/DataFormats/EcalDetId/src/classes.h
@@ -1,5 +1,4 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "DataFormats/EcalDetId/interface/EcalElectronicsId.h"

--- a/DataFormats/EcalDigi/interface/ESSample.h
+++ b/DataFormats/EcalDigi/interface/ESSample.h
@@ -2,7 +2,7 @@
 #define DIGIECAL_ESSAMPLE_H
 
 #include <ostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class ESSample {
 public:

--- a/DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h
+++ b/DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h
@@ -4,15 +4,13 @@
 #include <ostream>
 #include <cstdint>
 
-
-
 /** \class EcalEBTriggerPrimitiveSample
 \author N. Marinelli - Univ of Notre Dame
 
 */
 
 class EcalEBTriggerPrimitiveSample {
- public:
+public:
   EcalEBTriggerPrimitiveSample();
   EcalEBTriggerPrimitiveSample(uint16_t data);
   EcalEBTriggerPrimitiveSample(int encodedEt);
@@ -20,37 +18,32 @@ class EcalEBTriggerPrimitiveSample {
   EcalEBTriggerPrimitiveSample(int encodedEt, bool isASpike, int timing);
 
   ///Set data
-  void setValue(uint16_t data){ theSample = data;}
+  void setValue(uint16_t data) { theSample = data; }
   // The sample is a 16 bit word defined as:
   //
   //     o o o o o    o     o o o o o o o o o o
-  //     |________|        |____________________| 
+  //     |________|        |____________________|
   //      ~60ps res  spike         Et
   //      time info  flag
   //
-
 
   /// get the raw word
   uint16_t raw() const { return theSample; }
 
   /// get the encoded Et (10 bits)
-  int encodedEt() const { return theSample&0x3FF; }
+  int encodedEt() const { return theSample & 0x3FF; }
 
-  bool l1aSpike() const  { return (theSample&0x400)!=0; }
+  bool l1aSpike() const { return (theSample & 0x400) != 0; }
 
-  int time() const { return theSample>>11; }
-  
+  int time() const { return theSample >> 11; }
+
   /// for streaming
   uint16_t operator()() { return theSample; }
 
- private:
+private:
   uint16_t theSample;
-
 };
 
 std::ostream& operator<<(std::ostream& s, const EcalEBTriggerPrimitiveSample& samp);
-  
-
-
 
 #endif

--- a/DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h
+++ b/DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h
@@ -1,8 +1,8 @@
 #ifndef ECALEBTRIGGERPRIMITIVESAMPLE_H
 #define ECALEBTRIGGERPRIMITIVESAMPLE_H 1
 
-#include <boost/cstdint.hpp>
 #include <ostream>
+#include <cstdint>
 
 
 

--- a/DataFormats/EcalDigi/interface/EcalFEMSample.h
+++ b/DataFormats/EcalDigi/interface/EcalFEMSample.h
@@ -2,7 +2,7 @@
 #define DIGIECAL_ECALFEMSAMPLE_H
 
 #include <ostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /** \class EcalFEMSample
  *  Simple container packer/unpacker for a single sample from the FEM electronics

--- a/DataFormats/EcalDigi/interface/EcalMGPASample.h
+++ b/DataFormats/EcalDigi/interface/EcalMGPASample.h
@@ -2,7 +2,7 @@
 #define DIGIECAL_ECALMGPASAMPLE_H
 
 #include <iosfwd>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace ecalMGPA {
   typedef uint16_t sample_type;

--- a/DataFormats/EcalDigi/interface/EcalPseudoStripInputSample.h
+++ b/DataFormats/EcalDigi/interface/EcalPseudoStripInputSample.h
@@ -1,8 +1,8 @@
 #ifndef ECALPSEUDOSTRIPINPUTSAMPLE_H
 #define ECALPSEUDOSTRIPINPUTSAMPLE_H
 
-#include <boost/cstdint.hpp>
 #include <ostream>
+#include <cstdint>
 
 /** \class EcalPseudoStripInputSample
       

--- a/DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h
+++ b/DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h
@@ -1,8 +1,8 @@
 #ifndef ECALTRIGGERPRIMITIVESAMPLE_H
 #define ECALTRIGGERPRIMITIVESAMPLE_H 1
 
-#include <boost/cstdint.hpp>
 #include <ostream>
+#include <cstdint>
 
 /** \class EcalTriggerPrimitiveSample
       

--- a/DataFormats/EcalRawData/interface/ESDCCHeaderBlock.h
+++ b/DataFormats/EcalRawData/interface/ESDCCHeaderBlock.h
@@ -1,6 +1,5 @@
 #ifndef RAWECAL_ESDCCHEADERBLOCK_H
 #define RAWECAL_ESDCCHEADERBLOCK_H
-#include <boost/cstdint.hpp>
 #include <vector>
 
 class ESDCCHeaderBlock {

--- a/DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h
+++ b/DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h
@@ -1,7 +1,6 @@
 #ifndef RAWECAL_ECALDCCHEADERBLOCK_H
 #define RAWECAL_ECALDCCHEADERBLOCK_H
 
-
 /** \class EcalDCCHeaderBlock
  *  Container for ECAL specific DCC Header information
  *

--- a/DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h
+++ b/DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h
@@ -1,7 +1,6 @@
 #ifndef RAWECAL_ECALDCCHEADERBLOCK_H
 #define RAWECAL_ECALDCCHEADERBLOCK_H
 
-#include <boost/cstdint.hpp>
 
 /** \class EcalDCCHeaderBlock
  *  Container for ECAL specific DCC Header information

--- a/DataFormats/EcalRecHit/src/classes.h
+++ b/DataFormats/EcalRecHit/src/classes.h
@@ -13,4 +13,3 @@
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitComparison.h"
-#include "boost/cstdint.hpp"

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -42,4 +42,3 @@
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
-#include <boost/cstdint.hpp>

--- a/DataFormats/EgammaTrackReco/src/classes.h
+++ b/DataFormats/EgammaTrackReco/src/classes.h
@@ -1,6 +1,5 @@
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/Track.h"

--- a/DataFormats/FTLDigi/interface/FTLSample.h
+++ b/DataFormats/FTLDigi/interface/FTLSample.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <ostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /**
    @class FTLSample

--- a/DataFormats/FTLRecHit/src/classes.h
+++ b/DataFormats/FTLRecHit/src/classes.h
@@ -17,4 +17,3 @@
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitComparison.h"
-#include "boost/cstdint.hpp"

--- a/DataFormats/ForwardDetId/src/classes.h
+++ b/DataFormats/ForwardDetId/src/classes.h
@@ -1,4 +1,3 @@
-#include <boost/cstdint.hpp>
 #include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"

--- a/DataFormats/GsfTrackReco/src/classes.h
+++ b/DataFormats/GsfTrackReco/src/classes.h
@@ -4,7 +4,6 @@
 #include "Math/Cartesian3D.h"
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <ostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /**
    @class HGCSample

--- a/DataFormats/HGCRecHit/src/classes.h
+++ b/DataFormats/HGCRecHit/src/classes.h
@@ -13,4 +13,3 @@
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/HGCRecHit/interface/HGCRecHitComparison.h"
-#include "boost/cstdint.hpp"

--- a/DataFormats/HcalDetId/src/classes.h
+++ b/DataFormats/HcalDetId/src/classes.h
@@ -1,6 +1,5 @@
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
 #include "DataFormats/HcalDetId/interface/HcalFrontEndId.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalOtherDetId.h"

--- a/DataFormats/HcalDigi/interface/HOTriggerPrimitiveDigi.h
+++ b/DataFormats/HcalDigi/interface/HOTriggerPrimitiveDigi.h
@@ -1,9 +1,9 @@
 #ifndef DIGIHCAL_HOTRIGGERPRIMITIVEDIGI_H
 #define DIGIHCAL_HOTRIGGERPRIMITIVEDIGI_H
 
-#include <boost/cstdint.hpp>
 #include <ostream>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include <cstdint>
 
 /** \class HOTriggerprimitiveDigi
  *  Simple container packer/unpacker for a single 

--- a/DataFormats/HcalDigi/interface/HcalHistogramDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalHistogramDigi.h
@@ -2,8 +2,8 @@
 #define DATAFORMATS_HCALDIGI_HCALHISTOGRAMDIGI_H 1
 
 #include <ostream>
-#include <boost/cstdint.hpp>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include <cstdint>
 
 /** \class HcalHistogramDigi
   *  

--- a/DataFormats/HcalDigi/interface/HcalLaserDigi.h
+++ b/DataFormats/HcalDigi/interface/HcalLaserDigi.h
@@ -1,8 +1,8 @@
 #ifndef DATAFORMATS_HCALDIGI_HCALLASERDIGI_H
 #define DATAFORMATS_HCALDIGI_HCALLASERDIGI_H 1
 
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 class HcalLaserDigi {
 public:

--- a/DataFormats/HcalDigi/interface/HcalQIESample.h
+++ b/DataFormats/HcalDigi/interface/HcalQIESample.h
@@ -2,7 +2,7 @@
 #define DIGIHCAL_HCALQIESAMPLE_H
 
 #include <ostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 static
 #ifdef __CUDA_ARCH__

--- a/DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h
+++ b/DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h
@@ -1,8 +1,8 @@
 #ifndef HCALTRIGGERPRIMITIVESAMPLE_H
 #define HCALTRIGGERPRIMITIVESAMPLE_H 1
 
-#include <boost/cstdint.hpp>
 #include <ostream>
+#include <cstdint>
 
 /** \class HcalTriggerPrimitiveSample
     

--- a/DataFormats/HcalRecHit/src/classes.h
+++ b/DataFormats/HcalRecHit/src/classes.h
@@ -1,5 +1,4 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/HcalRecHit/interface/HFPreRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HFRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HORecHit.h"

--- a/DataFormats/L1GlobalCaloTrigger/src/classes.h
+++ b/DataFormats/L1GlobalCaloTrigger/src/classes.h
@@ -1,6 +1,5 @@
 
 #include <vector>
-#include <boost/cstdint.hpp>
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/L1TCalorimeter/src/classes.h
+++ b/DataFormats/L1TCalorimeter/src/classes.h
@@ -4,7 +4,6 @@
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 
 #include "DataFormats/L1TCalorimeter/interface/CaloRegion.h"

--- a/DataFormats/L1TMuon/interface/EMTF/AMC13Header.h
+++ b/DataFormats/L1TMuon/interface/EMTF/AMC13Header.h
@@ -4,7 +4,7 @@
 #define __l1t_emtf_AMC13Header_h__
 
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/AMC13Trailer.h
+++ b/DataFormats/L1TMuon/interface/EMTF/AMC13Trailer.h
@@ -4,7 +4,7 @@
 #define __l1t_emtf_AMC13Trailer_h__
 
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/Counters.h
+++ b/DataFormats/L1TMuon/interface/EMTF/Counters.h
@@ -1,9 +1,9 @@
+#include <cstdint>
 // Class for Block of Counters
 
 #ifndef __l1t_emtf_Counters_h__
 #define __l1t_emtf_Counters_h__
 
-#include <boost/cstdint.hpp>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/Counters.h
+++ b/DataFormats/L1TMuon/interface/EMTF/Counters.h
@@ -4,7 +4,6 @@
 #ifndef __l1t_emtf_Counters_h__
 #define __l1t_emtf_Counters_h__
 
-
 namespace l1t {
   namespace emtf {
     class Counters {

--- a/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
+++ b/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
@@ -4,7 +4,6 @@
 #ifndef __l1t_emtf_EventHeader_h__
 #define __l1t_emtf_EventHeader_h__
 
-
 namespace l1t {
   namespace emtf {
     class EventHeader {

--- a/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
+++ b/DataFormats/L1TMuon/interface/EMTF/EventHeader.h
@@ -1,9 +1,9 @@
+#include <cstdint>
 // Class for Event Record Header
 
 #ifndef __l1t_emtf_EventHeader_h__
 #define __l1t_emtf_EventHeader_h__
 
-#include <boost/cstdint.hpp>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/EventTrailer.h
+++ b/DataFormats/L1TMuon/interface/EMTF/EventTrailer.h
@@ -4,7 +4,6 @@
 #ifndef __l1t_emtf_EventTrailer_h__
 #define __l1t_emtf_EventTrailer_h__
 
-
 namespace l1t {
   namespace emtf {
     class EventTrailer {

--- a/DataFormats/L1TMuon/interface/EMTF/EventTrailer.h
+++ b/DataFormats/L1TMuon/interface/EMTF/EventTrailer.h
@@ -1,9 +1,9 @@
+#include <cstdint>
 // Class for Event Record Trailer
 
 #ifndef __l1t_emtf_EventTrailer_h__
 #define __l1t_emtf_EventTrailer_h__
 
-#include <boost/cstdint.hpp>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/ME.h
+++ b/DataFormats/L1TMuon/interface/EMTF/ME.h
@@ -3,9 +3,9 @@
 #ifndef __l1t_emtf_ME_h__
 #define __l1t_emtf_ME_h__
 
-#include <boost/cstdint.hpp>
 
 #include <vector>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/ME.h
+++ b/DataFormats/L1TMuon/interface/EMTF/ME.h
@@ -3,7 +3,6 @@
 #ifndef __l1t_emtf_ME_h__
 #define __l1t_emtf_ME_h__
 
-
 #include <vector>
 #include <cstdint>
 

--- a/DataFormats/L1TMuon/interface/EMTF/MTF7Header.h
+++ b/DataFormats/L1TMuon/interface/EMTF/MTF7Header.h
@@ -4,7 +4,7 @@
 #define __l1t_emtf_MTF7Header_h__
 
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/MTF7Trailer.h
+++ b/DataFormats/L1TMuon/interface/EMTF/MTF7Trailer.h
@@ -4,7 +4,7 @@
 #define __l1t_emtf_MTF7Trailer_h__
 
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/RPC.h
+++ b/DataFormats/L1TMuon/interface/EMTF/RPC.h
@@ -3,9 +3,9 @@
 #ifndef __l1t_emtf_RPC_h__
 #define __l1t_emtf_RPC_h__
 
-#include <boost/cstdint.hpp>
 
 #include <vector>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/RPC.h
+++ b/DataFormats/L1TMuon/interface/EMTF/RPC.h
@@ -3,7 +3,6 @@
 #ifndef __l1t_emtf_RPC_h__
 #define __l1t_emtf_RPC_h__
 
-
 #include <vector>
 #include <cstdint>
 

--- a/DataFormats/L1TMuon/interface/EMTF/SP.h
+++ b/DataFormats/L1TMuon/interface/EMTF/SP.h
@@ -3,9 +3,9 @@
 #ifndef __l1t_emtf_SP_h__
 #define __l1t_emtf_SP_h__
 
-#include <boost/cstdint.hpp>
 
 #include <vector>
+#include <cstdint>
 
 namespace l1t {
   namespace emtf {

--- a/DataFormats/L1TMuon/interface/EMTF/SP.h
+++ b/DataFormats/L1TMuon/interface/EMTF/SP.h
@@ -3,7 +3,6 @@
 #ifndef __l1t_emtf_SP_h__
 #define __l1t_emtf_SP_h__
 
-
 #include <vector>
 #include <cstdint>
 

--- a/DataFormats/L1TMuon/interface/EMTFDaqOut.h
+++ b/DataFormats/L1TMuon/interface/EMTFDaqOut.h
@@ -4,7 +4,6 @@
 #define __l1t_EMTF_output_h__
 
 #include <vector>
-#include <boost/cstdint.hpp>  // For uint64_t and other types. Also found in DataFormats/L1Trigger/src/classes.h
 
 #include "EMTF/AMC13Header.h"
 #include "EMTF/MTF7Header.h"
@@ -16,6 +15,7 @@
 #include "EMTF/EventTrailer.h"
 #include "EMTF/MTF7Trailer.h"
 #include "EMTF/AMC13Trailer.h"
+#include <cstdint>
 
 // All comments below apply equally to classes in EMTF/ directory - AWB 28.01.16
 

--- a/DataFormats/L1Trigger/interface/HOTPDigiTwinMux.h
+++ b/DataFormats/L1Trigger/interface/HOTPDigiTwinMux.h
@@ -1,9 +1,9 @@
 #ifndef DataFormats_L1Trigger_HOTPDigiTwinMux_h
 #define DataFormats_L1Trigger_HOTPDigiTwinMux_h
 
-#include <boost/cstdint.hpp>
 #include <ostream>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include <cstdint>
 
 /** \class HOTPDigiTwinMux
   *  Simple container packer/unpacker for HO TriggerPrimittive in TwinMUX

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -4,7 +4,6 @@
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCand.h"
 #include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"

--- a/DataFormats/METReco/src/classes.h
+++ b/DataFormats/METReco/src/classes.h
@@ -3,7 +3,6 @@
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
-#include <boost/cstdint.hpp>
 #include <Rtypes.h>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/METReco/interface/METFwd.h"

--- a/DataFormats/MuonDetId/src/classes.h
+++ b/DataFormats/MuonDetId/src/classes.h
@@ -1,6 +1,5 @@
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include <DataFormats/MuonDetId/interface/MuonSubdetId.h>
-#include <boost/cstdint.hpp>
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"

--- a/DataFormats/MuonReco/src/classes.h
+++ b/DataFormats/MuonReco/src/classes.h
@@ -8,7 +8,6 @@
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonIsolation.h"
 #include "DataFormats/MuonReco/interface/MuonPFIsolation.h"

--- a/DataFormats/ParticleFlowReco/src/classes_1.h
+++ b/DataFormats/ParticleFlowReco/src/classes_1.h
@@ -17,7 +17,6 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "Math/PxPyPzE4D.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"

--- a/DataFormats/ParticleFlowReco/src/classes_2.h
+++ b/DataFormats/ParticleFlowReco/src/classes_2.h
@@ -17,7 +17,6 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "Math/PxPyPzE4D.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"

--- a/DataFormats/PatCandidates/interface/Flags.h
+++ b/DataFormats/PatCandidates/interface/Flags.h
@@ -13,7 +13,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace pat {
   struct Flags {

--- a/DataFormats/PatCandidates/interface/LookupTableRecord.h
+++ b/DataFormats/PatCandidates/interface/LookupTableRecord.h
@@ -13,7 +13,7 @@
  */
 
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1DFloat.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace pat {
   class LookupTableRecord {

--- a/DataFormats/PatCandidates/interface/TriggerEvent.h
+++ b/DataFormats/PatCandidates/interface/TriggerEvent.h
@@ -27,12 +27,12 @@
 
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp>
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include <cstdint>
 
 namespace pat {
 
@@ -52,21 +52,21 @@ namespace pat {
     /// PhysicsDeclared GT bit
     bool physDecl_;
     /// LHC fill number
-    boost::uint32_t lhcFill_;
+    uint32_t lhcFill_;
     /// LHC beam mode
     /// as defined in http://bdidev1.cern.ch/bdisoft/operational/abbdisw_wiki/LHC/BST-config --> Beam mode.
-    boost::uint16_t beamMode_;
+    uint16_t beamMode_;
     /// LHC beam momentum in GeV
-    boost::uint16_t beamMomentum_;
+    uint16_t beamMomentum_;
     /// LHC beam 1 intensity in ???
-    boost::uint32_t intensityBeam1_;
+    uint32_t intensityBeam1_;
     /// LHC beam 2 intensity in ???
-    boost::uint32_t intensityBeam2_;
+    uint32_t intensityBeam2_;
     /// LHC master status
     /// as defined in http://bdidev1.cern.ch/bdisoft/operational/abbdisw_wiki/LHC/BST-config
-    boost::uint16_t bstMasterStatus_;
+    uint16_t bstMasterStatus_;
     /// LHC beam turn counter
-    boost::uint32_t turnCount_;
+    uint32_t turnCount_;
     /// CMS magnet current in ??? at start of run
     float bCurrentStart_;
     /// CMS magnet current in ??? at end of run
@@ -123,19 +123,19 @@ namespace pat {
     /// Set the PhysicsDeclared GT bit
     void setPhysDecl(bool physDecl) { physDecl_ = physDecl; };
     /// Set the LHC fill number
-    void setLhcFill(boost::uint32_t lhcFill) { lhcFill_ = lhcFill; };
+    void setLhcFill(uint32_t lhcFill) { lhcFill_ = lhcFill; };
     /// Set the LHC beam mode
-    void setBeamMode(boost::uint16_t beamMode) { beamMode_ = beamMode; };
+    void setBeamMode(uint16_t beamMode) { beamMode_ = beamMode; };
     /// Set the LHC beam momentum
-    void setBeamMomentum(boost::uint16_t beamMomentum) { beamMomentum_ = beamMomentum; };
+    void setBeamMomentum(uint16_t beamMomentum) { beamMomentum_ = beamMomentum; };
     /// Set the LHC beam 1 intensity
-    void setIntensityBeam1(boost::uint32_t intensityBeam1) { intensityBeam1_ = intensityBeam1; };
+    void setIntensityBeam1(uint32_t intensityBeam1) { intensityBeam1_ = intensityBeam1; };
     /// Set the LHC beam 2 intensity
-    void setIntensityBeam2(boost::uint32_t intensityBeam2) { intensityBeam2_ = intensityBeam2; };
+    void setIntensityBeam2(uint32_t intensityBeam2) { intensityBeam2_ = intensityBeam2; };
     /// Set the LHC master status
-    void setBstMasterStatus(boost::uint16_t bstMasterStatus) { bstMasterStatus_ = bstMasterStatus; };
+    void setBstMasterStatus(uint16_t bstMasterStatus) { bstMasterStatus_ = bstMasterStatus; };
     /// Set the LHC beam turn counter
-    void setTurnCount(boost::uint32_t turnCount) { turnCount_ = turnCount; };
+    void setTurnCount(uint32_t turnCount) { turnCount_ = turnCount; };
     /// Set the CMS magnet current at start of run
     void setBCurrentStart(float bCurrentStart) { bCurrentStart_ = bCurrentStart; };
     /// Set the CMS magnet current at end of run
@@ -155,19 +155,19 @@ namespace pat {
     /// Get the PhysicsDeclared GT bit
     bool wasPhysDecl() const { return physDecl_; };
     /// Get the LHC fill number
-    boost::uint32_t lhcFill() const { return lhcFill_; };
+    uint32_t lhcFill() const { return lhcFill_; };
     /// Get the LHC beam mode
-    boost::uint16_t beamMode() const { return beamMode_; };
+    uint16_t beamMode() const { return beamMode_; };
     /// Get the LHC beam momentum
-    boost::uint16_t beamMomentum() const { return beamMomentum_; };
+    uint16_t beamMomentum() const { return beamMomentum_; };
     /// Get the LHC beam 1 intensity
-    boost::uint32_t intensityBeam1() const { return intensityBeam1_; };
+    uint32_t intensityBeam1() const { return intensityBeam1_; };
     /// Get the LHC beam 2 intensity
-    boost::uint32_t intensityBeam2() const { return intensityBeam2_; };
+    uint32_t intensityBeam2() const { return intensityBeam2_; };
     /// Get the LHC master status
-    boost::uint16_t bstMasterStatus() const { return bstMasterStatus_; };
+    uint16_t bstMasterStatus() const { return bstMasterStatus_; };
     /// Get the LHC beam turn counter
-    boost::uint32_t turnCount() const { return turnCount_; };
+    uint32_t turnCount() const { return turnCount_; };
     /// Get the CMS magnet current at start of run
     float bCurrentStart() const { return bCurrentStart_; };
     /// Get the CMS magnet current at end of run

--- a/DataFormats/Provenance/interface/LuminosityBlockID.h
+++ b/DataFormats/Provenance/interface/LuminosityBlockID.h
@@ -19,11 +19,11 @@
 // system include files
 #include <functional>
 #include <iosfwd>
-#include "boost/cstdint.hpp"
 
 // user include files
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include <cstdint>
 
 // forward declarations
 namespace edm {
@@ -31,7 +31,7 @@ namespace edm {
   class LuminosityBlockID {
   public:
     LuminosityBlockID() : run_(invalidRunNumber), luminosityBlock_(invalidLuminosityBlockNumber) {}
-    explicit LuminosityBlockID(boost::uint64_t id);
+    explicit LuminosityBlockID(uint64_t id);
     LuminosityBlockID(RunNumber_t iRun, LuminosityBlockNumber_t iLuminosityBlock)
         : run_(iRun), luminosityBlock_(iLuminosityBlock) {}
 
@@ -41,7 +41,7 @@ namespace edm {
     RunNumber_t run() const { return run_; }
     LuminosityBlockNumber_t luminosityBlock() const { return luminosityBlock_; }
 
-    boost::uint64_t value() const;
+    uint64_t value() const;
 
     //moving from one LuminosityBlockID to another one
     LuminosityBlockID next() const {

--- a/DataFormats/Provenance/src/LuminosityBlockID.cc
+++ b/DataFormats/Provenance/src/LuminosityBlockID.cc
@@ -6,12 +6,12 @@ namespace edm {
 
   static unsigned int const shift = 8 * sizeof(unsigned int);
 
-  LuminosityBlockID::LuminosityBlockID(boost::uint64_t id)
+  LuminosityBlockID::LuminosityBlockID(uint64_t id)
       : run_(static_cast<RunNumber_t>(id >> shift)),
         luminosityBlock_(static_cast<LuminosityBlockNumber_t>(std::numeric_limits<unsigned int>::max() & id)) {}
 
-  boost::uint64_t LuminosityBlockID::value() const {
-    boost::uint64_t id = run_;
+  uint64_t LuminosityBlockID::value() const {
+    uint64_t id = run_;
     id = id << shift;
     id += luminosityBlock_;
     return id;

--- a/DataFormats/Provenance/src/LuminosityBlockRange.cc
+++ b/DataFormats/Provenance/src/LuminosityBlockRange.cc
@@ -8,15 +8,15 @@ namespace edm {
 
   //   static unsigned int const shift = 8 * sizeof(unsigned int);
   //
-  //   LuminosityBlockID::LuminosityBlockID(boost::uint64_t id) :
+  //   LuminosityBlockID::LuminosityBlockID(uint64_t id) :
   //    run_(static_cast<RunNumber_t>(id >> shift)),
   //    luminosityBlock_(static_cast<LuminosityBlockNumber_t>(std::numeric_limits<unsigned int>::max() & id))
   //   {
   //   }
   //
-  //   boost::uint64_t
+  //   uint64_t
   //   LuminosityBlockID::value() const {
-  //    boost::uint64_t id = run_;
+  //    uint64_t id = run_;
   //    id = id << shift;
   //    id += luminosityBlock_;
   //    return id;

--- a/DataFormats/RPCDigi/interface/DataRecord.h
+++ b/DataFormats/RPCDigi/interface/DataRecord.h
@@ -1,10 +1,10 @@
 #ifndef DataFormats_RPCDigi_DataRecord_H
 #define DataFormats_RPCDigi_DataRecord_H
 
-#include <boost/cstdint.hpp>
 #include <string>
 #include <bitset>
 #include <sstream>
+#include <cstdint>
 
 namespace rpcrawtodigi {
   class DataRecord {

--- a/DataFormats/RecoCandidate/src/classes.h
+++ b/DataFormats/RecoCandidate/src/classes.h
@@ -3,7 +3,6 @@
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
 #include "Math/PxPyPzE4D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h"

--- a/DataFormats/Scalers/src/classes.h
+++ b/DataFormats/Scalers/src/classes.h
@@ -1,6 +1,5 @@
 
 #include <vector>
-#include <boost/cstdint.hpp>
 #include "DataFormats/Scalers/interface/L1AcceptBunchCrossing.h"
 #include "DataFormats/Scalers/interface/L1TriggerScalers.h"
 #include "DataFormats/Scalers/interface/L1TriggerRates.h"

--- a/DataFormats/SiPixelDetId/src/classes.h
+++ b/DataFormats/SiPixelDetId/src/classes.h
@@ -1,5 +1,4 @@
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"

--- a/DataFormats/SiPixelDigi/interface/SiPixelCalibDigi.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelCalibDigi.h
@@ -4,7 +4,7 @@
 #include <utility>
 #include <vector>
 #include <iostream>
-#include "boost/cstdint.hpp"
+#include <cstdint>
 
 class SiPixelCalibDigi {
 public:

--- a/DataFormats/SiPixelDigi/interface/SiPixelCalibDigiError.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelCalibDigiError.h
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <utility>
 #include <string>
-#include "boost/cstdint.hpp"
+#include <cstdint>
 
 class SiPixelCalibDigiError {
 private:

--- a/DataFormats/SiPixelDigi/src/classes.h
+++ b/DataFormats/SiPixelDigi/src/classes.h
@@ -8,7 +8,6 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "boost/cstdint.hpp"
 #include <vector>
 
 #endif  // SIPIXELDIGI_CLASSES_H

--- a/DataFormats/SiStripCommon/interface/SiStripKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripKey.h
@@ -3,10 +3,10 @@
 #define DataFormats_SiStripCommon_SiStripKey_H
 
 #include "DataFormats/SiStripCommon/interface/ConstantsForGranularity.h"
-#include <boost/cstdint.hpp>
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 class SiStripKey;
 

--- a/DataFormats/SiStripCommon/src/classes.h
+++ b/DataFormats/SiStripCommon/src/classes.h
@@ -5,7 +5,6 @@
 
 #include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
 #include "DataFormats/SiStripCommon/interface/Constants.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
 #include "DataFormats/SiStripCommon/interface/SiStripDetKey.h"
 #include "DataFormats/SiStripCommon/interface/SiStripNullKey.h"

--- a/DataFormats/SiStripCommon/test/plugins/examples_SiStripFecKey.h
+++ b/DataFormats/SiStripCommon/test/plugins/examples_SiStripFecKey.h
@@ -3,8 +3,8 @@
 #define DataFormats_SiStripCommon_examplesSiStripFecKey_H
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 /**
    @class examplesSiStripFecKey 

--- a/DataFormats/SiStripCommon/test/plugins/perf_SiStripFecKey.h
+++ b/DataFormats/SiStripCommon/test/plugins/perf_SiStripFecKey.h
@@ -5,8 +5,8 @@
 #include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
 #include "DataFormats/SiStripCommon/interface/SiStripKey.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 /**
    @class perfSiStripFecKey 

--- a/DataFormats/SiStripDigi/interface/SiStripDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripDigi.h
@@ -1,8 +1,8 @@
 #ifndef DataFormats_SiStripDigi_SiStripDigi_H
 #define DataFormats_SiStripDigi_SiStripDigi_H
 
-#include "boost/cstdint.hpp"
 #include <iosfwd>
+#include <cstdint>
 
 /**  
      @brief A Digi for the silicon strip detector, containing both

--- a/DataFormats/SiStripDigi/src/classes.h
+++ b/DataFormats/SiStripDigi/src/classes.h
@@ -11,7 +11,6 @@
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
-#include "boost/cstdint.hpp"
 
 #include "DataFormats/SiStripDigi/interface/SiStripProcessedRawDigi.h"
 

--- a/DataFormats/TrackCandidate/src/classes.h
+++ b/DataFormats/TrackCandidate/src/classes.h
@@ -1,6 +1,5 @@
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/TrackerRecHit2D/src/classes.h
+++ b/DataFormats/TrackerRecHit2D/src/classes.h
@@ -5,7 +5,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1DCollection.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"

--- a/DataFormats/TrajectorySeed/src/classes.h
+++ b/DataFormats/TrajectorySeed/src/classes.h
@@ -1,6 +1,5 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "DataFormats/CLHEP/interface/Migration.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/RefVectorIterator.h"

--- a/EventFilter/DTRawToDigi/interface/DTROChainCoding.h
+++ b/EventFilter/DTRawToDigi/interface/DTROChainCoding.h
@@ -10,8 +10,8 @@
 #include <DataFormats/DTDigi/interface/DTDDUWords.h>
 
 #include <vector>
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 /// FIXEME:
 /*

--- a/EventFilter/DTRawToDigi/interface/DTROChainCoding.h
+++ b/EventFilter/DTRawToDigi/interface/DTROChainCoding.h
@@ -12,7 +12,6 @@
 #include <vector>
 #include <cstdint>
 
-
 /// FIXEME:
 /*
   A major problem is the numbering of the

--- a/EventFilter/SiStripRawToDigi/interface/SiStripDetSetVectorFiller.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripDetSetVectorFiller.h
@@ -2,10 +2,10 @@
 #define EventFilter_SiStripRawToDigi_SiStripDetSetVectorFiller_H
 
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <algorithm>
 #include <memory>
+#include <cstdint>
 class SiStripRawDigi;
 class SiStripDigi;
 

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -1,7 +1,6 @@
 #ifndef EventFilter_SiStripRawToDigi_SiStripFEDBuffer_H
 #define EventFilter_SiStripRawToDigi_SiStripFEDBuffer_H
 
-#include "boost/cstdint.hpp"
 #include <string>
 #include <vector>
 #include <memory>
@@ -11,6 +10,7 @@
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include <cstdint>
 
 namespace sistrip {
   constexpr uint16_t BITS_PER_BYTE = 8;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -1,13 +1,13 @@
 #ifndef EventFilter_SiStripRawToDigi_SiStripFEDBufferComponents_H
 #define EventFilter_SiStripRawToDigi_SiStripFEDBufferComponents_H
 
-#include "boost/cstdint.hpp"
 #include <ostream>
 #include <memory>
 #include <cstring>
 #include <vector>
 #include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include <cstdint>
 
 namespace sistrip {
 

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -1,13 +1,13 @@
 #ifndef EventFilter_SiStripRawToDigi_SiStripFEDBufferGenerator_H
 #define EventFilter_SiStripRawToDigi_SiStripFEDBufferGenerator_H
 
-#include "boost/cstdint.hpp"
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include <vector>
 #include <list>
 #include <utility>
 #include <memory>
+#include <cstdint>
 
 namespace sistrip {
 

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
@@ -15,10 +15,10 @@
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "boost/cstdint.hpp"
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace sistrip {
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.h
@@ -6,11 +6,11 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "boost/cstdint.hpp"
 #include <string>
 
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h"
 #include "WarningSummary.h"
+#include <cstdint>
 
 class SiStripFedCabling;
 class FEDRawDataCollection;

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRawModule.h
@@ -8,8 +8,8 @@
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "boost/cstdint.hpp"
 #include <string>
+#include <cstdint>
 namespace edm {
   class ConfigurationDescriptions;
 }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiModule.h
@@ -6,8 +6,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "boost/cstdint.hpp"
 #include <string>
+#include <cstdint>
 
 namespace sistrip {
   class RawToDigiModule;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.h
@@ -2,10 +2,10 @@
 #define EventFilter_SiStripRawToDigi_test_AnalyzeSiStripDigis_H
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "boost/cstdint.hpp"
 #include <string>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 /**
    @class SiStripDigiAnalyzer

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h
@@ -3,7 +3,6 @@
 #define EventFilter_SiStripRawToDigi_SiStripTrivialDigiSource_H
 
 #include "FWCore/Framework/interface/EDProducer.h"
-#include "boost/cstdint.hpp"
 
 /**
     @file EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -333,7 +333,7 @@ namespace edmtest {
 
   private:
     const edm::EDPutTokenT<Int16_tProduct> token_;
-    const boost::int16_t value_;
+    const int16_t value_;
   };
 
   void Int16_tProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {

--- a/Geometry/EcalCommonData/interface/EcalNumberingScheme.h
+++ b/Geometry/EcalCommonData/interface/EcalNumberingScheme.h
@@ -9,7 +9,7 @@
 #include "Geometry/CaloGeometry/interface/CaloNumberingScheme.h"
 #include "Geometry/EcalCommonData/interface/EcalBaseNumber.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class EcalNumberingScheme : public CaloNumberingScheme {
 public:

--- a/HLTrigger/HLTfilters/plugins/HLTBeamModeFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTBeamModeFilter.cc
@@ -19,7 +19,6 @@
 #include <vector>
 #include <iostream>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/Event.h"
@@ -113,7 +112,7 @@ bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent,
     return false;
   }
 
-  const boost::uint16_t beamModeValue = (gtEvmReadoutRecord->gtfeWord()).beamMode();
+  const uint16_t beamModeValue = (gtEvmReadoutRecord->gtfeWord()).beamMode();
 
   edm::LogInfo("HLTBeamModeFilter") << "Beam mode: " << beamModeValue;
 
@@ -134,4 +133,5 @@ bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent,
 
 // register as framework plugin
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include <cstdint>
 DEFINE_FWK_MODULE(HLTBeamModeFilter);

--- a/HLTrigger/HLTfilters/plugins/HLTBeamModeFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTBeamModeFilter.cc
@@ -19,7 +19,6 @@
 #include <vector>
 #include <iostream>
 
-
 // user include files
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
@@ -272,7 +272,7 @@ bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent,
   }
 
   //
-  boost::uint16_t gtFinalOR = gtReadoutRecord->finalOR();
+  uint16_t gtFinalOR = gtReadoutRecord->finalOR();
   int physicsDaqPartition = 0;
   bool gtDecision = static_cast<bool>(gtFinalOR & (1 << physicsDaqPartition));
 

--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
@@ -17,7 +17,7 @@
 
 #include <ostream>
 #include <fstream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class DTDDUFileReader : public edm::EDProducer {
 public:

--- a/IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h
+++ b/IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h
@@ -2,7 +2,6 @@
 #ifndef DaqSource_DTFileReaderHelpers_h
 #define DaqSource_DTFileReaderHelpers_h
 
-
 template <class T>
 char* dataPointer(const T* ptr) {
   union bPtr {

--- a/IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h
+++ b/IORawData/DTCommissioning/plugins/DTFileReaderHelpers.h
@@ -1,7 +1,7 @@
+#include <cstdint>
 #ifndef DaqSource_DTFileReaderHelpers_h
 #define DaqSource_DTFileReaderHelpers_h
 
-#include <boost/cstdint.hpp>
 
 template <class T>
 char* dataPointer(const T* ptr) {

--- a/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
@@ -18,7 +18,7 @@
 
 #include <ostream>
 #include <fstream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class DTROS25FileReader : public edm::EDProducer {
 public:

--- a/IORawData/DTCommissioning/plugins/DTSpyReader.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyReader.h
@@ -19,7 +19,7 @@
 
 #include <ostream>
 #include <fstream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class DTSpyReader : public edm::EDProducer {
 public:

--- a/IORawData/HcalTBInputService/plugins/HcalTBWriter.cc
+++ b/IORawData/HcalTBInputService/plugins/HcalTBWriter.cc
@@ -6,7 +6,6 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include <unistd.h>
-#include <boost/cstdint.hpp>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 HcalTBWriter::HcalTBWriter(const edm::ParameterSet& pset)
@@ -155,5 +154,6 @@ void HcalTBWriter::extractEventInfo(const FEDRawDataCollection& raw, const edm::
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include <cstdint>
 
 DEFINE_FWK_MODULE(HcalTBWriter);

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctHardwareJetFinder.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctHardwareJetFinder.h
@@ -3,7 +3,6 @@
 
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GctJetFinderBase.h"
 
-#include <boost/cstdint.hpp>  //for uint16_t
 #include <vector>
 
 /*! \class L1GctHardwareJetFinder

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctJet.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctJet.h
@@ -1,13 +1,13 @@
 #ifndef L1GCTJET_H_
 #define L1GCTJET_H_
 
-#include <boost/cstdint.hpp>  //for uint16_t
 #include <functional>
 #include <vector>
 #include <ostream>
 #include <memory>
 
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h"
+#include <cstdint>
 
 /*!
  * \author Jim Brooke & Robert Frazier

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctJetFinderBase.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctJetFinderBase.h
@@ -12,7 +12,6 @@
 #include "L1Trigger/GlobalCaloTrigger/src/L1GctUnsignedInt.h"
 #include "L1Trigger/GlobalCaloTrigger/src/L1GctJetCount.h"
 
-#include <boost/cstdint.hpp>  //for uint16_t
 #include <vector>
 
 class L1GctInternJetData;

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctNullJetFinder.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctNullJetFinder.h
@@ -3,7 +3,6 @@
 
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GctJetFinderBase.h"
 
-#include <boost/cstdint.hpp>  //for uint16_t
 #include <vector>
 
 /*! \class L1GctNullJetFinder

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctSimpleJetFinder.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctSimpleJetFinder.h
@@ -17,19 +17,15 @@
  * \date June 2006
  */
 
-
-
-class L1GctSimpleJetFinder : public L1GctJetFinderBase
-{
- public:
-
+class L1GctSimpleJetFinder : public L1GctJetFinderBase {
+public:
   /// id is 0-8 for -ve Eta jetfinders, 9-17 for +ve Eta, for increasing Phi.
   L1GctSimpleJetFinder(int id);
-                 
+
   ~L1GctSimpleJetFinder();
-   
+
   /// Overload << operator
-  friend std::ostream& operator << (std::ostream& os, const L1GctSimpleJetFinder& algo);
+  friend std::ostream& operator<<(std::ostream& os, const L1GctSimpleJetFinder& algo);
 
   /// get input data from sources
   virtual void fetchInput();
@@ -37,8 +33,7 @@ class L1GctSimpleJetFinder : public L1GctJetFinderBase
   /// process the data, fill output buffers
   virtual void process();
 
- protected:
-
+protected:
   // Each jetFinder must define the constants as private and copy the
   // function definitions below.
   virtual unsigned maxRegionsIn() const { return MAX_REGIONS_IN; }
@@ -46,16 +41,14 @@ class L1GctSimpleJetFinder : public L1GctJetFinderBase
   virtual unsigned nCols() const { return N_COLS; }
 
 private:
-
   /// The real jetFinders must define these constants
-  static const unsigned int MAX_REGIONS_IN; ///< Dependent on number of rows and columns.
+  static const unsigned int MAX_REGIONS_IN;  ///< Dependent on number of rows and columns.
   static const unsigned int N_COLS;
   static const unsigned int CENTRAL_COL0;
 
-  void findJets();  
-
+  void findJets();
 };
 
-std::ostream& operator << (std::ostream& os, const L1GctSimpleJetFinder& algo);
+std::ostream& operator<<(std::ostream& os, const L1GctSimpleJetFinder& algo);
 
 #endif /*L1GCTSIMPLEJETFINDER_H_*/

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctSimpleJetFinder.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctSimpleJetFinder.h
@@ -3,7 +3,6 @@
 
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GctJetFinderBase.h"
 
-#include <boost/cstdint.hpp> //for uint16_t
 #include <vector>
 
 /*! \class L1GctSimpleJetFinder

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctTdrJetFinder.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctTdrJetFinder.h
@@ -3,7 +3,6 @@
 
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GctJetFinderBase.h"
 
-#include <boost/cstdint.hpp>  //for uint16_t
 #include <vector>
 
 /*! \class L1GctTdrJetFinder

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctJetCount.h
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctJetCount.h
@@ -4,7 +4,6 @@
 #include "L1Trigger/GlobalCaloTrigger/src/L1GctUnsignedInt.h"
 #include "L1Trigger/GlobalCaloTrigger/src/L1GctTwosComplement.h"
 
-#include <boost/cstdint.hpp>
 #include <ostream>
 
 /*!

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctLut.h
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctLut.h
@@ -1,10 +1,10 @@
 #ifndef L1GCTLUT_H_
 #define L1GCTLUT_H_
 
-#include <boost/cstdint.hpp>  //for uint16_t
 
 #include <iomanip>
 #include <sstream>
+#include <cstdint>
 
 /*!
  * \author Greg Heath

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctLut.h
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctLut.h
@@ -1,7 +1,6 @@
 #ifndef L1GCTLUT_H_
 #define L1GCTLUT_H_
 
-
 #include <iomanip>
 #include <sstream>
 #include <cstdint>

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctTwosComplement.h
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctTwosComplement.h
@@ -1,8 +1,8 @@
 #ifndef L1GCTETTYPES_H
 #define L1GCTETTYPES_H
 
-#include <boost/cstdint.hpp>
 #include <ostream>
+#include <cstdint>
 
 /*!
  * \class L1GctTwosComplement

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctUnsignedInt.h
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctUnsignedInt.h
@@ -1,7 +1,6 @@
 #ifndef L1GCTUNSIGNEDINT_H
 #define L1GCTUNSIGNEDINT_H
 
-#include <boost/cstdint.hpp>
 #include <ostream>
 
 /*!

--- a/L1Trigger/GlobalMuonTrigger/test/L1MuGMTTree.h
+++ b/L1Trigger/GlobalMuonTrigger/test/L1MuGMTTree.h
@@ -72,8 +72,8 @@ private:
   int eventn;
   int lumi;
   int bx;
-  boost::uint64_t orbitn;
-  boost::uint64_t timest;
+  uint64_t orbitn;
+  uint64_t timest;
 
   // Generator info
   float weight;
@@ -157,9 +157,9 @@ private:
   int idxCSC[MAXGMT];
 
   // GT info
-  boost::uint64_t gttw1[3];
-  boost::uint64_t gttw2[3];
-  boost::uint64_t gttt[3];
+  uint64_t gttw1[3];
+  uint64_t gttw2[3];
+  uint64_t gttt[3];
 
   //PSB info
   int nele;

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFDL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFDL.h
@@ -18,7 +18,6 @@
 // system include files
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
@@ -28,6 +27,7 @@
 
 #include "CondFormats/L1TObjects/interface/L1GtBoard.h"
 #include "CondFormats/L1TObjects/interface/L1GtFwd.h"
+#include <cstdint>
 
 // forward declarations
 class L1GlobalTriggerReadoutRecord;
@@ -72,7 +72,7 @@ public:
 
   /// fill the FDL block in the L1 GT DAQ record for iBxInEvent
   void fillDaqFdlBlock(const int iBxInEvent,
-                       const boost::uint16_t &activeBoardsGtDaq,
+                       const uint16_t &activeBoardsGtDaq,
                        const int recordLength0,
                        const int recordLength1,
                        const unsigned int altNrBxBoardDaq,
@@ -81,7 +81,7 @@ public:
 
   /// fill the FDL block in the L1 GT EVM record for iBxInEvent
   void fillEvmFdlBlock(const int iBxInEvent,
-                       const boost::uint16_t &activeBoardsGtEvm,
+                       const uint16_t &activeBoardsGtEvm,
                        const int recordLength0,
                        const int recordLength1,
                        const unsigned int altNrBxBoardEvm,

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFDL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerFDL.h
@@ -18,7 +18,6 @@
 // system include files
 #include <vector>
 
-
 // user include files
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerPSB.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerPSB.h
@@ -19,7 +19,6 @@
  */
 
 // system include files
-#include <boost/cstdint.hpp>
 #include <vector>
 
 // user include files
@@ -36,6 +35,7 @@
 #include "CondFormats/L1TObjects/interface/L1GtBoardMaps.h"
 #include "CondFormats/L1TObjects/interface/L1GtFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include <cstdint>
 
 // forward declarations
 class L1GctCand;
@@ -126,7 +126,7 @@ public:
 
   /// fill the content of active PSB boards
   void fillPsbBlock(edm::Event &iEvent,
-                    const boost::uint16_t &activeBoardsGtDaq,
+                    const uint16_t &activeBoardsGtDaq,
                     const int recordLength0,
                     const int recordLength1,
                     const unsigned int altNrBxBoardDaq,

--- a/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
@@ -27,7 +27,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // if hash map is used
 

--- a/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h
@@ -27,7 +27,6 @@
 #include <string>
 #include <vector>
 
-
 // if hash map is used
 
 #include <ext/hash_map>

--- a/L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 
@@ -31,6 +30,7 @@
 //
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cstdint>
 
 // forward declarations
 
@@ -148,7 +148,7 @@ const bool L1GtConditionEvaluation::checkThreshold(const Type1 &threshold,
 // check if a bit with a given number is set in a mask
 template <class Type1>
 const bool L1GtConditionEvaluation::checkBit(const Type1 &mask, const unsigned int bitNumber) const {
-  boost::uint64_t oneBit = 1ULL;
+  uint64_t oneBit = 1ULL;
 
   if (bitNumber >= (sizeof(oneBit) * 8)) {
     if (m_verbosity) {

--- a/L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GtConditionEvaluation.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-
 // user include files
 
 //   base class

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.cc
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.cc
@@ -21,7 +21,6 @@
 #include <iostream>
 #include <memory>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //#include
@@ -83,6 +82,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cstdint>
 
 // constructors
 
@@ -646,9 +646,9 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
   // fill in emulator the same bunch crossing (12 bits - hardwired number of
   // bits...) and the same local bunch crossing for all boards
   int bxCross = iEvent.bunchCrossing();
-  boost::uint16_t bxCrossHw = 0;
+  uint16_t bxCrossHw = 0;
   if ((bxCross & 0xFFF) == bxCross) {
-    bxCrossHw = static_cast<boost::uint16_t>(bxCross);
+    bxCrossHw = static_cast<uint16_t>(bxCross);
   } else {
     bxCrossHw = 0;  // Bx number too large, set to 0!
     if (m_verbosity) {
@@ -679,11 +679,11 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
 
               gtfeWordValue.setBoardId(itBoard->gtBoardId());
 
-              // cast int to boost::uint16_t
+              // cast int to uint16_t
               // there are normally 3 or 5 BxInEvent
-              gtfeWordValue.setRecordLength(static_cast<boost::uint16_t>(recordLength0));
+              gtfeWordValue.setRecordLength(static_cast<uint16_t>(recordLength0));
 
-              gtfeWordValue.setRecordLength1(static_cast<boost::uint16_t>(recordLength1));
+              gtfeWordValue.setRecordLength1(static_cast<uint16_t>(recordLength1));
 
               // bunch crossing
               gtfeWordValue.setBxNr(bxCrossHw);
@@ -692,12 +692,12 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
               gtfeWordValue.setActiveBoards(m_activeBoardsGtDaq);
 
               // set alternative for number of BX per board
-              gtfeWordValue.setAltNrBxBoard(static_cast<boost::uint16_t>(m_alternativeNrBxBoardDaq));
+              gtfeWordValue.setAltNrBxBoard(static_cast<uint16_t>(m_alternativeNrBxBoardDaq));
 
               // set the TOTAL_TRIGNR as read from iEvent
               // TODO check again - PTC stuff
 
-              gtfeWordValue.setTotalTriggerNr(static_cast<boost::uint32_t>(iEvent.id().event()));
+              gtfeWordValue.setTotalTriggerNr(static_cast<uint32_t>(iEvent.id().event()));
 
               // ** fill L1GtfeWord in GT DAQ record
 
@@ -768,11 +768,11 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
 
               gtfeWordValue.setBoardId(itBoard->gtBoardId());
 
-              // cast int to boost::uint16_t
+              // cast int to uint16_t
               // there are normally 3 or 5 BxInEvent
-              gtfeWordValue.setRecordLength(static_cast<boost::uint16_t>(recordLength0));
+              gtfeWordValue.setRecordLength(static_cast<uint16_t>(recordLength0));
 
-              gtfeWordValue.setRecordLength1(static_cast<boost::uint16_t>(recordLength1));
+              gtfeWordValue.setRecordLength1(static_cast<uint16_t>(recordLength1));
 
               // bunch crossing
               gtfeWordValue.setBxNr(bxCrossHw);
@@ -781,12 +781,12 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
               gtfeWordValue.setActiveBoards(m_activeBoardsGtEvm);
 
               // set alternative for number of BX per board
-              gtfeWordValue.setAltNrBxBoard(static_cast<boost::uint16_t>(m_alternativeNrBxBoardEvm));
+              gtfeWordValue.setAltNrBxBoard(static_cast<uint16_t>(m_alternativeNrBxBoardEvm));
 
               // set the TOTAL_TRIGNR as read from iEvent
               // TODO check again - PTC stuff
 
-              gtfeWordValue.setTotalTriggerNr(static_cast<boost::uint32_t>(iEvent.id().event()));
+              gtfeWordValue.setTotalTriggerNr(static_cast<uint32_t>(iEvent.id().event()));
 
               // set the GPS time to the value read from Timestamp
               edm::TimeValue_t evTime = iEvent.time().value();
@@ -799,7 +799,7 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
               //<< std::dec << std::endl;
 
               // source of BST message: DDDD simulated data
-              boost::uint16_t bstSourceVal = 0xDDDD;
+              uint16_t bstSourceVal = 0xDDDD;
               gtfeWordValue.setBstSource(bstSourceVal);
 
               // ** fill L1GtfeWord in GT EVM record
@@ -821,17 +821,17 @@ void L1GlobalTrigger::produce(edm::Event &iEvent, const edm::EventSetup &evSetup
               // bunch crossing
               tcsWordValue.setBxNr(bxCrossHw);
 
-              boost::uint16_t trigType = 0x5;  // 0101 simulated event
+              uint16_t trigType = 0x5;  // 0101 simulated event
               tcsWordValue.setTriggerType(trigType);
 
               // luminosity segment number
-              tcsWordValue.setLuminositySegmentNr(static_cast<boost::uint16_t>(iEvent.luminosityBlock()));
+              tcsWordValue.setLuminositySegmentNr(static_cast<uint16_t>(iEvent.luminosityBlock()));
 
               // set the Event_Nr as read from iEvent
-              tcsWordValue.setEventNr(static_cast<boost::uint32_t>(iEvent.id().event()));
+              tcsWordValue.setEventNr(static_cast<uint32_t>(iEvent.id().event()));
 
               // orbit number
-              tcsWordValue.setOrbitNr(static_cast<boost::uint64_t>(iEvent.orbitNumber()));
+              tcsWordValue.setOrbitNr(static_cast<uint64_t>(iEvent.orbitNumber()));
 
               // ** fill L1TcsWord in the EVM record
 

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.cc
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.cc
@@ -21,7 +21,6 @@
 #include <iostream>
 #include <memory>
 
-
 // user include files
 //#include
 //"DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-
 // user include files
 
 #include "CondFormats/L1TObjects/interface/L1GtBoard.h"

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 
@@ -38,6 +37,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include <cstdint>
 
 // forward classes
 class L1GlobalTriggerPSB;
@@ -111,8 +111,8 @@ private:
   int m_totalBxInEvent;
 
   ///    active boards in L1 GT DAQ record and in L1 GT EVM record
-  boost::uint16_t m_activeBoardsGtDaq;
-  boost::uint16_t m_activeBoardsGtEvm;
+  uint16_t m_activeBoardsGtDaq;
+  uint16_t m_activeBoardsGtEvm;
 
   /// length of BST record (in bytes) from event setup
   unsigned int m_bstLengthBytes;

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerFDL.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerFDL.cc
@@ -210,7 +210,7 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
   // compute the final decision word per DAQ partition
   //
 
-  boost::uint16_t finalOrValue = 0;
+  uint16_t finalOrValue = 0;
 
   for (unsigned int iDaq = 0; iDaq < numberDaqPartitions; ++iDaq) {
     bool daqPartitionFinalOR = false;
@@ -319,7 +319,7 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
     }
 
     // push it in finalOrValue
-    boost::uint16_t daqPartitionFinalORValue = static_cast<boost::uint16_t>(daqPartitionFinalOR);
+    uint16_t daqPartitionFinalORValue = static_cast<uint16_t>(daqPartitionFinalOR);
 
     finalOrValue = finalOrValue | (daqPartitionFinalORValue << iDaq);
   }
@@ -339,9 +339,9 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
       // fill in emulator the same bunch crossing (12 bits - hardwired number of
       // bits...) and the same local bunch crossing for all boards
       int bxCross = iEvent.bunchCrossing();
-      boost::uint16_t bxCrossHw = 0;
+      uint16_t bxCrossHw = 0;
       if ((bxCross & 0xFFF) == bxCross) {
-        bxCrossHw = static_cast<boost::uint16_t>(bxCross);
+        bxCrossHw = static_cast<uint16_t>(bxCross);
       } else {
         bxCrossHw = 0;  // Bx number too large, set to 0!
         if (m_verbosity) {
@@ -354,7 +354,7 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
       m_gtFdlWord->setBxNr(bxCrossHw);
 
       // set event number since last L1 reset generated in FDL
-      m_gtFdlWord->setEventNr(static_cast<boost::uint32_t>(iEvent.id().event()));
+      m_gtFdlWord->setEventNr(static_cast<uint32_t>(iEvent.id().event()));
 
       // technical trigger decision word
       m_gtFdlWord->setGtTechnicalTriggerWord(techDecisionWord);
@@ -363,8 +363,8 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
       m_gtFdlWord->setGtDecisionWord(algoDecisionWord);
 
       // index of prescale factor set - technical triggers and algo
-      m_gtFdlWord->setGtPrescaleFactorIndexTech(static_cast<boost::uint16_t>(pfTechSetIndex));
-      m_gtFdlWord->setGtPrescaleFactorIndexAlgo(static_cast<boost::uint16_t>(pfAlgoSetIndex));
+      m_gtFdlWord->setGtPrescaleFactorIndexTech(static_cast<uint16_t>(pfTechSetIndex));
+      m_gtFdlWord->setGtPrescaleFactorIndexAlgo(static_cast<uint16_t>(pfAlgoSetIndex));
 
       // NoAlgo bit FIXME
 
@@ -372,10 +372,10 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
       m_gtFdlWord->setFinalOR(finalOrValue);
 
       // orbit number
-      m_gtFdlWord->setOrbitNr(static_cast<boost::uint32_t>(iEvent.orbitNumber()));
+      m_gtFdlWord->setOrbitNr(static_cast<uint32_t>(iEvent.orbitNumber()));
 
       // luminosity segment number
-      m_gtFdlWord->setLumiSegmentNr(static_cast<boost::uint16_t>(iEvent.luminosityBlock()));
+      m_gtFdlWord->setLumiSegmentNr(static_cast<uint16_t>(iEvent.luminosityBlock()));
 
       // local bunch crossing - set identical with absolute BxNr
       m_gtFdlWord->setLocalBxNr(bxCrossHw);
@@ -385,7 +385,7 @@ void L1GlobalTriggerFDL::run(edm::Event &iEvent,
 
 // fill the FDL block in the L1 GT DAQ record for iBxInEvent
 void L1GlobalTriggerFDL::fillDaqFdlBlock(const int iBxInEvent,
-                                         const boost::uint16_t &activeBoardsGtDaq,
+                                         const uint16_t &activeBoardsGtDaq,
                                          const int recordLength0,
                                          const int recordLength1,
                                          const unsigned int altNrBxBoardDaq,
@@ -429,7 +429,7 @@ void L1GlobalTriggerFDL::fillDaqFdlBlock(const int iBxInEvent,
 
 // fill the FDL block in the L1 GT EVM record for iBxInEvent
 void L1GlobalTriggerFDL::fillEvmFdlBlock(const int iBxInEvent,
-                                         const boost::uint16_t &activeBoardsGtEvm,
+                                         const uint16_t &activeBoardsGtEvm,
                                          const int recordLength0,
                                          const int recordLength1,
                                          const unsigned int altNrBxBoardEvm,

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerPSB.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerPSB.cc
@@ -571,7 +571,7 @@ void L1GlobalTriggerPSB::receiveTechnicalTriggers(edm::Event &iEvent,
 
 // fill the content of active PSB boards
 void L1GlobalTriggerPSB::fillPsbBlock(edm::Event &iEvent,
-                                      const boost::uint16_t &activeBoardsGtDaq,
+                                      const uint16_t &activeBoardsGtDaq,
                                       const int recordLength0,
                                       const int recordLength1,
                                       const unsigned int altNrBxBoardDaq,
@@ -581,9 +581,9 @@ void L1GlobalTriggerPSB::fillPsbBlock(edm::Event &iEvent,
   // fill in emulator the same bunch crossing (12 bits - hardwired number of
   // bits...) and the same local bunch crossing for all boards
   int bxCross = iEvent.bunchCrossing();
-  boost::uint16_t bxCrossHw = 0;
+  uint16_t bxCrossHw = 0;
   if ((bxCross & 0xFFF) == bxCross) {
-    bxCrossHw = static_cast<boost::uint16_t>(bxCross);
+    bxCrossHw = static_cast<uint16_t>(bxCross);
   } else {
     bxCrossHw = 0;  // Bx number too large, set to 0!
     if (m_verbosity) {
@@ -651,15 +651,15 @@ void L1GlobalTriggerPSB::fillPsbBlock(edm::Event &iEvent,
         psbWordValue.setBxInEvent(iBxInEvent);
 
         // set bunch cross number of the actual bx
-        boost::uint16_t bxNrValue = bxCrossHw;
+        uint16_t bxNrValue = bxCrossHw;
         psbWordValue.setBxNr(bxNrValue);
 
         // set event number since last L1 reset generated in PSB
-        psbWordValue.setEventNr(static_cast<boost::uint32_t>(iEvent.id().event()));
+        psbWordValue.setEventNr(static_cast<uint32_t>(iEvent.id().event()));
 
         // set local bunch cross number of the actual bx
         // set identical to bxCrossHw - other solution?
-        boost::uint16_t localBxNrValue = bxCrossHw;
+        uint16_t localBxNrValue = bxCrossHw;
         psbWordValue.setLocalBxNr(localBxNrValue);
 
         // get the objects coming to this PSB and the quadruplet index
@@ -670,8 +670,8 @@ void L1GlobalTriggerPSB::fillPsbBlock(edm::Event &iEvent,
         std::vector<L1GtPsbQuad> quadInPsb = itBoard->gtQuadInPsb();
         int nrCables = quadInPsb.size();
 
-        boost::uint16_t aDataVal = 0;
-        boost::uint16_t bDataVal = 0;
+        uint16_t aDataVal = 0;
+        uint16_t bDataVal = 0;
 
         int iCable = -1;
         for (std::vector<L1GtPsbQuad>::const_iterator itQuad = quadInPsb.begin(); itQuad != quadInPsb.end(); ++itQuad) {
@@ -696,7 +696,7 @@ void L1GlobalTriggerPSB::fillPsbBlock(edm::Event &iEvent,
               aDataVal = 0;
 
               int iBit = 0;
-              boost::uint16_t bitVal = 0;
+              uint16_t bitVal = 0;
 
               for (int i = 0; i < bitsPerWord; ++i) {
                 if (m_gtTechnicalTriggers[iBit]) {

--- a/L1Trigger/GlobalTrigger/src/L1GtMuonCondition.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtMuonCondition.cc
@@ -313,7 +313,7 @@ const bool L1GtMuonCondition::evaluateCondition() const {
         }
       }
 
-      // delta_phi bitmask is saved in two boost::uint64_t words
+      // delta_phi bitmask is saved in two uint64_t words
       if (candDeltaPhi < 64) {
         if (!checkBit(corrPar.deltaPhiRange0Word, candDeltaPhi)) {
           continue;

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternLine.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternLine.h
@@ -18,7 +18,7 @@
 
 #include <string>
 #include <map>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /** A class representing the contents of one line in a pattern file. 
     The contents are represented as (name, value) pairs. Column ids
@@ -32,13 +32,13 @@ public:
                     consists of prefix + the lowest free number (starting at 1)
       @param value  The actual data content of the column.
   */
-  void push(const std::string& prefix, boost::uint32_t value);
+  void push(const std::string& prefix, uint32_t value);
 
   /** Manipulate an existing value. 
       @param name  the name (prefix + no) of the column to set. Do not use _h or _l values here!
       @param value the new value for the column.
   */
-  void set(const std::string& name, boost::uint32_t value);
+  void set(const std::string& name, uint32_t value);
 
   /** Debug dump of contents */
   void print(std::ostream& out) const;
@@ -56,10 +56,10 @@ public:
   std::string name(const std::string& prefix, unsigned int i) const;
 
   /** Accessor. @see has*/
-  boost::uint32_t get(const std::string& name) const;
+  uint32_t get(const std::string& name) const;
 
 private:
-  typedef std::map<std::string, boost::uint32_t> ColumnMap;
+  typedef std::map<std::string, uint32_t> ColumnMap;
   ColumnMap m_columns;
 };
 

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternWriter.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternWriter.h
@@ -18,7 +18,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class L1GtPatternMap;
 class L1GtPatternLine;
@@ -42,8 +42,8 @@ public:
                     const std::string& header,
                     const std::string& footer,
                     const std::vector<std::string>& columns,
-                    const std::vector<boost::uint32_t>& lengths,
-                    const std::vector<boost::uint32_t>& defaultValues,
+                    const std::vector<uint32_t>& lengths,
+                    const std::vector<uint32_t>& defaultValues,
                     const std::vector<int>& bx,
                     bool debug = false);
 
@@ -59,21 +59,21 @@ public:
   virtual ~L1GtPatternWriter();
 
 protected:
-  /** Returns an and-mask to truncate an boost::uint32_t to a specified
+  /** Returns an and-mask to truncate an uint32_t to a specified
       length. */
-  static boost::uint32_t mask(boost::uint32_t length);
+  static uint32_t mask(uint32_t length);
 
 private:
   std::ostream& m_dest;
   std::string m_header;
   std::string m_footer;
   std::vector<std::string> m_columns;
-  std::vector<boost::uint32_t> m_lengths;
-  std::vector<boost::uint32_t> m_defaults;
+  std::vector<uint32_t> m_lengths;
+  std::vector<uint32_t> m_defaults;
   std::vector<int> m_bx;
   bool m_debug;
 
-  boost::uint32_t m_lineNo;
+  uint32_t m_lineNo;
 };
 
 #endif /*GlobalTriggerAnalyzer_L1GtPatternWriter_h*/

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtAnalyzer.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtAnalyzer.cc
@@ -1319,9 +1319,9 @@ void L1GtAnalyzer::analyzeConditionsInRunBlock(const edm::Run& iRun, const edm::
     return;
   }
 
-  const boost::uint16_t beamModeVal = condInRunBlock->beamMode;
-  const boost::uint16_t beamMomentumVal = condInRunBlock->beamMomentum;
-  const boost::uint32_t lhcFillNumberVal = condInRunBlock->lhcFillNumber;
+  const uint16_t beamModeVal = condInRunBlock->beamMode;
+  const uint16_t beamMomentumVal = condInRunBlock->beamMomentum;
+  const uint32_t lhcFillNumberVal = condInRunBlock->lhcFillNumber;
 
   // print via supplied "print" function
   myCoutStream << "\nLHC quantities in run " << iRun.run() << "\n  Beam Mode = " << beamModeVal
@@ -1351,8 +1351,8 @@ void L1GtAnalyzer::analyzeConditionsInLumiBlock(const edm::LuminosityBlock& iLum
     return;
   }
 
-  const boost::uint32_t totalIntensityBeam1Val = condInLumiBlock->totalIntensityBeam1;
-  const boost::uint32_t totalIntensityBeam2Val = condInLumiBlock->totalIntensityBeam2;
+  const uint32_t totalIntensityBeam1Val = condInLumiBlock->totalIntensityBeam1;
+  const uint32_t totalIntensityBeam2Val = condInLumiBlock->totalIntensityBeam2;
 
   myCoutStream << "\nLHC quantities in luminosity section "
 
@@ -1381,8 +1381,8 @@ void L1GtAnalyzer::analyzeConditionsInEventBlock(const edm::Event& iEvent, const
     return;
   }
 
-  const boost::uint16_t bstMasterStatusVal = condInEventBlock->bstMasterStatus;
-  const boost::uint32_t turnCountNumberVal = condInEventBlock->turnCountNumber;
+  const uint16_t bstMasterStatusVal = condInEventBlock->bstMasterStatus;
+  const uint32_t turnCountNumberVal = condInEventBlock->turnCountNumber;
 
   myCoutStream << "\nLHC quantities in event " << iEvent.id().event() << " from luminosity section "
                << iEvent.luminosityBlock() << " from run " << iEvent.run()

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
@@ -17,7 +17,6 @@
 #include <vector>
 #include <iostream>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 #include "FWCore/Framework/interface/Event.h"
@@ -33,6 +32,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
+#include <cstdint>
 
 // constructor(s)
 L1GtBeamModeFilter::L1GtBeamModeFilter(const edm::ParameterSet& parSet)
@@ -92,7 +92,7 @@ bool L1GtBeamModeFilter::filter(edm::Event& iEvent, const edm::EventSetup& evSet
   // data
 
   // initialize beam mode value
-  boost::uint16_t beamModeValue = 0;
+  uint16_t beamModeValue = 0;
 
   // get Run Data - the same code can be run in beginRun, with getByLabel from edm::Run
   // TODO should I cache the run/luminosity section? to be decided after moving beamMode to LumiBlock

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
@@ -17,7 +17,6 @@
 #include <vector>
 #include <iostream>
 
-
 // user include files
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtDataEmulAnalyzer.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtDataEmulAnalyzer.cc
@@ -111,8 +111,8 @@ void L1GtDataEmulAnalyzer::compareGTFE(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get BoardId value
-  const boost::uint16_t boardIdData = gtfeBlockData.boardId();
-  const boost::uint16_t boardIdEmul = gtfeBlockEmul.boardId();
+  const uint16_t boardIdData = gtfeBlockData.boardId();
+  const uint16_t boardIdEmul = gtfeBlockEmul.boardId();
 
   if (boardIdData == boardIdEmul) {
     m_myCoutStream << "\nData and emulated GTFE boardId identical.";
@@ -131,8 +131,8 @@ void L1GtDataEmulAnalyzer::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get record length: 3 bx for standard, 5 bx for debug
-  const boost::uint16_t recordLengthData = gtfeBlockData.recordLength();
-  const boost::uint16_t recordLengthEmul = gtfeBlockEmul.recordLength();
+  const uint16_t recordLengthData = gtfeBlockData.recordLength();
+  const uint16_t recordLengthEmul = gtfeBlockEmul.recordLength();
 
   if (recordLengthData == recordLengthEmul) {
     m_myCoutStream << "\nData and emulated GTFE recordLength identical.";
@@ -148,8 +148,8 @@ void L1GtDataEmulAnalyzer::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get bunch cross number as counted in the GTFE board
-  const boost::uint16_t bxNrData = gtfeBlockData.bxNr();
-  const boost::uint16_t bxNrEmul = gtfeBlockEmul.bxNr();
+  const uint16_t bxNrData = gtfeBlockData.bxNr();
+  const uint16_t bxNrEmul = gtfeBlockEmul.bxNr();
 
   if (bxNrData == bxNrEmul) {
     m_myCoutStream << "\nData and emulated GTFE bxNr identical.";
@@ -165,8 +165,8 @@ void L1GtDataEmulAnalyzer::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get setup version
-  const boost::uint32_t setupVersionData = gtfeBlockData.setupVersion();
-  const boost::uint32_t setupVersionEmul = gtfeBlockEmul.setupVersion();
+  const uint32_t setupVersionData = gtfeBlockData.setupVersion();
+  const uint32_t setupVersionEmul = gtfeBlockEmul.setupVersion();
 
   if (setupVersionData == setupVersionEmul) {
     m_myCoutStream << "\nData and emulated GTFE setupVersion identical.";
@@ -182,8 +182,8 @@ void L1GtDataEmulAnalyzer::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get boards contributing to EVM respectively DAQ record
-  const boost::uint16_t activeBoardsData = gtfeBlockData.activeBoards();
-  const boost::uint16_t activeBoardsEmul = gtfeBlockEmul.activeBoards();
+  const uint16_t activeBoardsData = gtfeBlockData.activeBoards();
+  const uint16_t activeBoardsEmul = gtfeBlockEmul.activeBoards();
 
   if (activeBoardsData == activeBoardsEmul) {
     m_myCoutStream << "\nData and emulated GTFE activeBoards identical.";
@@ -202,8 +202,8 @@ void L1GtDataEmulAnalyzer::compareGTFE(const edm::Event& iEvent,
   }
 
   /// get total number of L1A sent since start of run
-  const boost::uint32_t totalTriggerNrData = gtfeBlockData.totalTriggerNr();
-  const boost::uint32_t totalTriggerNrEmul = gtfeBlockEmul.totalTriggerNr();
+  const uint32_t totalTriggerNrData = gtfeBlockData.totalTriggerNr();
+  const uint32_t totalTriggerNrEmul = gtfeBlockEmul.totalTriggerNr();
 
   if (totalTriggerNrData == totalTriggerNrEmul) {
     m_myCoutStream << "\nData and emulated GTFE totalTriggerNr identical.";
@@ -353,8 +353,8 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   }
 
   // get BoardId value
-  const boost::uint16_t boardIdData = fdlBlockData.boardId();
-  const boost::uint16_t boardIdEmul = fdlBlockEmul.boardId();
+  const uint16_t boardIdData = fdlBlockData.boardId();
+  const uint16_t boardIdEmul = fdlBlockEmul.boardId();
 
   if (boardIdData == boardIdEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL boardId identical.";
@@ -382,8 +382,8 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get BxNr - bunch cross number of the actual bx
-  const boost::uint16_t bxNrData = fdlBlockData.bxNr();
-  const boost::uint16_t bxNrEmul = fdlBlockEmul.bxNr();
+  const uint16_t bxNrData = fdlBlockData.bxNr();
+  const uint16_t bxNrEmul = fdlBlockEmul.bxNr();
 
   if (bxNrData == bxNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL bxNr identical.";
@@ -408,8 +408,8 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get event number since last L1 reset generated in FDL
-  const boost::uint32_t eventNrData = fdlBlockData.eventNr();
-  const boost::uint32_t eventNrEmul = fdlBlockEmul.eventNr();
+  const uint32_t eventNrData = fdlBlockData.eventNr();
+  const uint32_t eventNrEmul = fdlBlockEmul.eventNr();
 
   if (eventNrData == eventNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL eventNr identical.";
@@ -679,8 +679,8 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   }
 
   // get  NoAlgo
-  const boost::uint16_t noAlgoData = fdlBlockData.noAlgo();
-  const boost::uint16_t noAlgoEmul = fdlBlockEmul.noAlgo();
+  const uint16_t noAlgoData = fdlBlockData.noAlgo();
+  const uint16_t noAlgoEmul = fdlBlockEmul.noAlgo();
 
   if (noAlgoData == noAlgoEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL noAlgo identical.";
@@ -701,8 +701,8 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   }
 
   // get  "Final OR" bits
-  const boost::uint16_t finalORData = fdlBlockData.finalOR();
-  const boost::uint16_t finalOREmul = fdlBlockEmul.finalOR();
+  const uint16_t finalORData = fdlBlockData.finalOR();
+  const uint16_t finalOREmul = fdlBlockEmul.finalOR();
 
   if (finalORData == finalOREmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL finalOR identical.";
@@ -748,8 +748,8 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   }
 
   // get  local bunch cross number of the actual bx
-  const boost::uint16_t localBxNrData = fdlBlockData.localBxNr();
-  const boost::uint16_t localBxNrEmul = fdlBlockEmul.localBxNr();
+  const uint16_t localBxNrData = fdlBlockData.localBxNr();
+  const uint16_t localBxNrEmul = fdlBlockEmul.localBxNr();
 
   if (localBxNrData == localBxNrEmul) {
     m_myCoutStream << "\n" << recString << " Data and emulated FDL localBxNr identical.";
@@ -799,8 +799,8 @@ void L1GtDataEmulAnalyzer::comparePSB(const edm::Event& iEvent,
   m_myCoutStream.clear();
 
   // get BoardId value
-  const boost::uint16_t boardIdData = psbBlockData.boardId();
-  const boost::uint16_t boardIdEmul = psbBlockEmul.boardId();
+  const uint16_t boardIdData = psbBlockData.boardId();
+  const uint16_t boardIdEmul = psbBlockEmul.boardId();
 
   if (boardIdData == boardIdEmul) {
     m_myCoutStream << "\nData and emulated PSB boardId identical.";
@@ -834,8 +834,8 @@ void L1GtDataEmulAnalyzer::comparePSB(const edm::Event& iEvent,
   }
 
   // get BxNr - bunch cross number of the actual bx
-  const boost::uint16_t bxNrData = psbBlockData.bxNr();
-  const boost::uint16_t bxNrEmul = psbBlockEmul.bxNr();
+  const uint16_t bxNrData = psbBlockData.bxNr();
+  const uint16_t bxNrEmul = psbBlockEmul.bxNr();
 
   if (bxNrData == bxNrEmul) {
     m_myCoutStream << "\nData and emulated PSB bxNr identical.";
@@ -850,8 +850,8 @@ void L1GtDataEmulAnalyzer::comparePSB(const edm::Event& iEvent,
   }
 
   // get event number since last L1 reset generated in FDL
-  const boost::uint32_t eventNrData = psbBlockData.eventNr();
-  const boost::uint32_t eventNrEmul = psbBlockEmul.eventNr();
+  const uint32_t eventNrData = psbBlockData.eventNr();
+  const uint32_t eventNrEmul = psbBlockEmul.eventNr();
 
   if (eventNrData == eventNrEmul) {
     m_myCoutStream << "\nData and emulated PSB eventNr identical.";
@@ -866,8 +866,8 @@ void L1GtDataEmulAnalyzer::comparePSB(const edm::Event& iEvent,
   }
 
   /// get/set A_DATA_CH_IA
-  boost::uint16_t valData;
-  boost::uint16_t valEmul;
+  uint16_t valData;
+  uint16_t valEmul;
 
   for (int iA = 0; iA < psbBlockData.NumberAData; ++iA) {
     valData = psbBlockData.aData(iA);
@@ -911,8 +911,8 @@ void L1GtDataEmulAnalyzer::comparePSB(const edm::Event& iEvent,
   }
 
   // get  local bunch cross number of the actual bx
-  const boost::uint16_t localBxNrData = psbBlockData.localBxNr();
-  const boost::uint16_t localBxNrEmul = psbBlockEmul.localBxNr();
+  const uint16_t localBxNrData = psbBlockData.localBxNr();
+  const uint16_t localBxNrEmul = psbBlockEmul.localBxNr();
 
   if (localBxNrData == localBxNrEmul) {
     m_myCoutStream << "\nData and emulated PSB localBxNr identical.";
@@ -1028,7 +1028,7 @@ void L1GtDataEmulAnalyzer::compareDaqRecord(const edm::Event& iEvent, const edm:
   // in unpacker: every PSB in all BxInEvent
   for (int iPsb = 0; iPsb < gtPsbVectorDataSize; ++iPsb) {
     const L1GtPsbWord& psbBlockData = gtPsbVectorData[iPsb];
-    const boost::uint16_t boardIdData = psbBlockData.boardId();
+    const uint16_t boardIdData = psbBlockData.boardId();
     const int bxInEventData = psbBlockData.bxInEvent();
 
     // search the corresponding PSB in the emulated record using the
@@ -1038,7 +1038,7 @@ void L1GtDataEmulAnalyzer::compareDaqRecord(const edm::Event& iEvent, const edm:
 
     for (int iPsbF = 0; iPsbF < gtPsbVectorEmulSize; ++iPsbF) {
       const L1GtPsbWord& psbBlockEmul = gtPsbVectorEmul[iPsbF];
-      const boost::uint16_t boardIdEmul = psbBlockEmul.boardId();
+      const uint16_t boardIdEmul = psbBlockEmul.boardId();
       const int bxInEventEmul = psbBlockEmul.bxInEvent();
 
       if ((boardIdEmul == boardIdData) && (bxInEventData == bxInEventEmul)) {

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPackUnpackAnalyzer.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPackUnpackAnalyzer.cc
@@ -163,7 +163,7 @@ void L1GtPackUnpackAnalyzer::analyzeGT(const edm::Event& iEvent, const edm::Even
     // TODO can be fixed?
     for (int iPsb = 0; iPsb < gtPsbVectorInitialSize; ++iPsb) {
       const L1GtPsbWord& psbWordInitial = gtPsbVectorInitial[iPsb];
-      const boost::uint16_t boardIdInitial = psbWordInitial.boardId();
+      const uint16_t boardIdInitial = psbWordInitial.boardId();
       const int bxInEventInitial = psbWordInitial.bxInEvent();
 
       // search the corresponding PSB in the final record using the
@@ -173,7 +173,7 @@ void L1GtPackUnpackAnalyzer::analyzeGT(const edm::Event& iEvent, const edm::Even
 
       for (int iPsbF = 0; iPsbF < gtPsbVectorFinalSize; ++iPsbF) {
         const L1GtPsbWord& psbWordFinal = gtPsbVectorFinal[iPsbF];
-        const boost::uint16_t boardIdFinal = psbWordFinal.boardId();
+        const uint16_t boardIdFinal = psbWordFinal.boardId();
         const int bxInEventFinal = psbWordFinal.bxInEvent();
 
         if ((boardIdFinal == boardIdInitial) && (bxInEventInitial == bxInEventFinal)) {

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -363,7 +363,7 @@ void L1GtTrigReport::analyze(const edm::Event& iEvent, const edm::EventSetup& ev
                                    << " has gtFdlVector of size " << fdlVecSize << std::endl;
 
         // get Global Trigger finalOR and the decision word
-        boost::uint16_t gtFinalOR = gtReadoutRecord->finalOR();
+        uint16_t gtFinalOR = gtReadoutRecord->finalOR();
 
         gtDecisionWordBeforeMask = gtReadoutRecord->decisionWord();
         technicalTriggerWordBeforeMask = gtReadoutRecord->technicalTriggerWord();

--- a/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
@@ -29,7 +29,6 @@
 #include <stack>
 #include <queue>
 
-
 // if hash map is used
 
 #include <ext/hash_map>

--- a/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h
@@ -29,7 +29,6 @@
 #include <stack>
 #include <queue>
 
-#include <boost/cstdint.hpp>
 
 // if hash map is used
 

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-
 // user include files
 
 //   base class

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 
@@ -31,6 +30,7 @@
 //
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cstdint>
 
 // forward declarations
 
@@ -208,7 +208,7 @@ namespace l1t {
   // check if a bit with a given number is set in a mask
   template <class Type1>
   const bool ConditionEvaluation::checkBit(const Type1& mask, const unsigned int bitNumber) const {
-    boost::uint64_t oneBit = 1ULL;
+    uint64_t oneBit = 1ULL;
 
     if (bitNumber >= (sizeof(oneBit) * 8)) {
       if (m_verbosity) {

--- a/L1Trigger/L1TGlobal/interface/CorrelationTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CorrelationTemplate.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <iosfwd>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 

--- a/L1Trigger/L1TGlobal/interface/CorrelationTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CorrelationTemplate.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <iosfwd>
 
-
 // user include files
 
 //   base class

--- a/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <iosfwd>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 

--- a/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CorrelationWithOverlapRemovalTemplate.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <iosfwd>
 
-
 // user include files
 
 //   base class

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -10,7 +10,6 @@
 #include <iomanip>
 #include <algorithm>
 
-#include <boost/cstdint.hpp>
 
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -498,9 +497,9 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
   // fill in emulator the same bunch crossing (12 bits - hardwired number of bits...)
   // and the same local bunch crossing for all boards
   int bxCross = iEvent.bunchCrossing();
-  boost::uint16_t bxCrossHw = 0;
+  uint16_t bxCrossHw = 0;
   if ((bxCross & 0xFFF) == bxCross) {
-    bxCrossHw = static_cast<boost::uint16_t>(bxCross);
+    bxCrossHw = static_cast<uint16_t>(bxCross);
   } else {
     bxCrossHw = 0;  // Bx number too large, set to 0!
     if (m_verbosity) {
@@ -645,4 +644,5 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 //define this as a plug-in
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include <cstdint>
 DEFINE_FWK_MODULE(L1TGlobalProducer);

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -10,7 +10,6 @@
 #include <iomanip>
 #include <algorithm>
 
-
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"

--- a/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/StableParametersTrivialProducer.cc
@@ -3,7 +3,6 @@
 
 #include <memory>
 #include <vector>
-#include <boost/cstdint.hpp>
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -30,7 +30,6 @@
 #include <iomanip>
 #include <cmath>
 
-#include <boost/cstdint.hpp>
 
 #include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
 
@@ -45,6 +44,7 @@
 #include "tmEventSetup/esCut.hh"
 #include "tmEventSetup/esScale.hh"
 #include "tmGrammar/Algorithm.hh"
+#include <cstdint>
 
 // constructor
 l1t::TriggerMenuParser::TriggerMenuParser()
@@ -1026,7 +1026,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
   MuonTemplate::CorrelationParameter corrParameter;
 
   // need at least two values for deltaPhi
-  std::vector<boost::uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
+  std::vector<uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
   tmpValues.reserve(nrObj);
 
   if (int(condMu.getObjects().size()) != nrObj) {
@@ -1251,7 +1251,7 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   MuonTemplate::CorrelationParameter corrParameter;
 
   // need at least two values for deltaPhi
-  std::vector<boost::uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
+  std::vector<uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
   tmpValues.reserve(nrObj);
 
   // BLW TO DO: How do we deal with these in the new format
@@ -1541,7 +1541,7 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
   CaloTemplate::CorrelationParameter corrParameter;
 
   // need at least one value for deltaPhiRange
-  std::vector<boost::uint64_t> tmpValues((nrObj > 1) ? nrObj : 1);
+  std::vector<uint64_t> tmpValues((nrObj > 1) ? nrObj : 1);
   tmpValues.reserve(nrObj);
 
   if (int(condCalo.getObjects().size()) != nrObj) {
@@ -1552,8 +1552,8 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
   }
 
   //    std::string str_condCalo = "";
-  //    boost::uint64_t tempUIntH, tempUIntL;
-  //    boost::uint64_t dst;
+  //    uint64_t tempUIntH, tempUIntL;
+  //    uint64_t dst;
   int cnt = 0;
 
   // BLW TO DO: These needs to the added to the object rather than the whole condition.
@@ -1783,7 +1783,7 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
   CaloTemplate::CorrelationParameter corrParameter;
 
   // need at least one value for deltaPhiRange
-  std::vector<boost::uint64_t> tmpValues((nrObj > 1) ? nrObj : 1);
+  std::vector<uint64_t> tmpValues((nrObj > 1) ? nrObj : 1);
   tmpValues.reserve(nrObj);
 
   // BLW TO DO: These needs to the added to the object rather than the whole condition.

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -30,7 +30,6 @@
 #include <iomanip>
 #include <cmath>
 
-
 #include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -2642,7 +2641,9 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
         case esObjectType::Tau: {
           objType[jj] = gtTau;
         } break;
-        default: { } break; }
+        default: {
+        } break;
+      }
       condCateg[jj] = CondCalo;
 
     } else if (object.getType() == esObjectType::ETM || object.getType() == esObjectType::ETMHF ||
@@ -2666,7 +2667,9 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
         case esObjectType::TOWERCOUNT: {
           objType[jj] = GlobalObject::gtTowerCount;
         } break;
-        default: { } break; }
+        default: {
+        } break;
+      }
       condCateg[jj] = CondEnergySum;
 
     } else {
@@ -2928,7 +2931,9 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
         case esObjectType::Tau: {
           objType[jj] = gtTau;
         } break;
-        default: { } break; }
+        default: {
+        } break;
+      }
       condCateg[jj] = CondCalo;
 
     } else if (object.getType() == esObjectType::ETM || object.getType() == esObjectType::ETMHF ||
@@ -2952,7 +2957,9 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
         case esObjectType::TOWERCOUNT: {
           objType[jj] = GlobalObject::gtTowerCount;
         } break;
-        default: { } break; }
+        default: {
+        } break;
+      }
       condCateg[jj] = CondEnergySum;
 
     } else {

--- a/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
+++ b/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
@@ -20,7 +20,6 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "L1Trigger/L1TMuonEndCap/interface/TrackTools.h"
 
-#include <boost/cstdint.hpp>
 #include <iostream>
 #include <memory>
 #include <sstream>

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisEventDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisEventDataFormat.h
@@ -31,9 +31,9 @@ namespace L1Analysis {
     unsigned long long event;
     unsigned lumi;
     unsigned bx;
-    //boost::uint64_t orbit;
+    //uint64_t orbit;
     ULong64_t orbit;
-    //boost::uint64_t time;
+    //uint64_t time;
     ULong64_t time;
     int nPV;
     int nPV_True;

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h
@@ -29,7 +29,6 @@
 #include "L1TriggerConfig/DTTPGConfig/interface/BitArray.h"
 #include <cstdint>
 
-
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h
@@ -27,8 +27,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfig.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/BitArray.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 //              ---------------------
 //              -- Class Interface --

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigSectColl.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigSectColl.h
@@ -29,7 +29,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfig.h"
-#include "boost/cstdint.hpp"
 
 //              ---------------------
 //              -- Class Interface --

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigTSPhi.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigTSPhi.h
@@ -28,7 +28,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/BitArray.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfig.h"
-#include "boost/cstdint.hpp"
 
 //              ---------------------
 //              -- Class Interface --

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigTraco.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigTraco.h
@@ -30,7 +30,6 @@
 #include "L1TriggerConfig/DTTPGConfig/interface/BitArray.h"
 #include <cstdint>
 
-
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigTraco.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigTraco.h
@@ -28,8 +28,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/DTConfig.h"
 #include "L1TriggerConfig/DTTPGConfig/interface/BitArray.h"
+#include <cstdint>
 
-#include <boost/cstdint.hpp>
 
 //              ---------------------
 //              -- Class Interface --

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <vector>
 
-
 // user include files
 //   base class
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTrivialProducer.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class
@@ -29,6 +28,7 @@
 
 #include "CondFormats/L1TObjects/interface/L1GtParameters.h"
 #include "CondFormats/DataRecord/interface/L1GtParametersRcd.h"
+#include <cstdint>
 
 // forward declarations
 
@@ -51,10 +51,10 @@ private:
   int m_totalBxInEvent;
 
   /// active boards in the L1 DAQ record
-  boost::uint16_t m_daqActiveBoards;
+  uint16_t m_daqActiveBoards;
 
   /// active boards in the L1 EVM record
-  boost::uint16_t m_evmActiveBoards;
+  uint16_t m_evmActiveBoards;
 
   /// number of Bx per board in the DAQ record
   std::vector<int> m_daqNrBxBoard;

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
@@ -20,7 +20,6 @@
 
 #include <vector>
 
-
 // user include files
 //   base class
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTrivialProducer.h
@@ -20,7 +20,6 @@
 
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlParser.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlParser.h
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-
 #include <xercesc/sax/HandlerBase.hpp>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlParser.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlParser.h
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/cstdint.hpp>
 
 #include <xercesc/sax/HandlerBase.hpp>
 #include <xercesc/dom/DOM.hpp>
@@ -43,6 +42,7 @@
 #include "CondFormats/L1TObjects/interface/L1GtCorrelationTemplate.h"
 #include "CondFormats/L1TObjects/interface/L1GtBptxTemplate.h"
 #include "CondFormats/L1TObjects/interface/L1GtExternalTemplate.h"
+#include <cstdint>
 
 // forward declarations
 class L1GtCondition;
@@ -264,14 +264,14 @@ private:
   /// get the text value of a xml node as string
   std::string getXMLTextValue(XERCES_CPP_NAMESPACE::DOMNode* node);
 
-  /// convert a hexadecimal string with up to 128 to 2 boost::uint64_t
-  bool hexString2UInt128(const std::string& hexString, boost::uint64_t& dstL, boost::uint64_t& dstH);
+  /// convert a hexadecimal string with up to 128 to 2 uint64_t
+  bool hexString2UInt128(const std::string& hexString, uint64_t& dstL, uint64_t& dstH);
 
   /// get a hexadecimal value of a xml node containing text with up to 128 bit
-  bool getXMLHexTextValue128(XERCES_CPP_NAMESPACE::DOMNode* node, boost::uint64_t& dstL, boost::uint64_t& dstH);
+  bool getXMLHexTextValue128(XERCES_CPP_NAMESPACE::DOMNode* node, uint64_t& dstL, uint64_t& dstH);
 
   /// get a hexadecimal value of a xml node containing text
-  bool getXMLHexTextValue(XERCES_CPP_NAMESPACE::DOMNode* node, boost::uint64_t& dst);
+  bool getXMLHexTextValue(XERCES_CPP_NAMESPACE::DOMNode* node, uint64_t& dst);
 
   /// get the number of bits in the max attribute of a condition child
   bool countConditionChildMaxBits(XERCES_CPP_NAMESPACE::DOMNode* node, const std::string& childName, unsigned int& dst);
@@ -280,7 +280,7 @@ private:
   bool getConditionChildValues(XERCES_CPP_NAMESPACE::DOMNode* node,
                                const std::string& childName,
                                unsigned int num,
-                               std::vector<boost::uint64_t>& dst);
+                               std::vector<uint64_t>& dst);
 
   /// shutdown the xml utils and deallocate parser and error handler
   void cleanupXML(XERCES_CPP_NAMESPACE::XercesDOMParser* parser);

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 
-
 // user include files
 //   base class
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersConfigOnlineProd.cc
@@ -178,7 +178,7 @@ std::unique_ptr<L1GtParameters> L1GtParametersConfigOnlineProd::newObject(const 
   // get the mapping of boards to active bits
 
   // active boards in the L1 DAQ record & number of BXs per board
-  boost::uint16_t daqActiveBoardsVal = 0;
+  uint16_t daqActiveBoardsVal = 0;
 
   int daqActiveBoardsLength = 16;  // ...hard...
   std::vector<int> daqNrBxBoard(daqActiveBoardsLength, 0);
@@ -245,7 +245,7 @@ std::unique_ptr<L1GtParameters> L1GtParametersConfigOnlineProd::newObject(const 
   //daqNrBxBoard.at(iActiveBit) = boost::lexical_cast<int>(daqNrBxBoardStrTIM);
 
   // active boards in the L1 EVM record
-  boost::uint16_t evmActiveBoardsVal = 0;
+  uint16_t evmActiveBoardsVal = 0;
 
   int evmActiveBoardsLength = 16;  // ...hard...
   std::vector<int> evmNrBxBoard(evmActiveBoardsLength, 0);

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
@@ -18,7 +18,6 @@
 // system include files
 #include <memory>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 //   base class
@@ -30,6 +29,7 @@
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
 #include "CondFormats/DataRecord/interface/L1GtParametersRcd.h"
+#include <cstdint>
 
 // forward declarations
 
@@ -62,9 +62,9 @@ L1GtParametersTrivialProducer::L1GtParametersTrivialProducer(const edm::Paramete
     m_totalBxInEvent = 1;
   }
 
-  m_daqActiveBoards = static_cast<boost::uint16_t>(parSet.getParameter<unsigned int>("DaqActiveBoards"));
+  m_daqActiveBoards = static_cast<uint16_t>(parSet.getParameter<unsigned int>("DaqActiveBoards"));
 
-  m_evmActiveBoards = static_cast<boost::uint16_t>(parSet.getParameter<unsigned int>("EvmActiveBoards"));
+  m_evmActiveBoards = static_cast<uint16_t>(parSet.getParameter<unsigned int>("EvmActiveBoards"));
 
   m_daqNrBxBoard = parSet.getParameter<std::vector<int> >("DaqNrBxBoard");
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTrivialProducer.cc
@@ -18,7 +18,6 @@
 // system include files
 #include <memory>
 
-
 // user include files
 //   base class
 #include "FWCore/Framework/interface/ESProducer.h"

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
@@ -23,7 +23,6 @@
 #include <fstream>
 #include <iomanip>
 
-
 // user include files
 // base class
 #include "L1TriggerConfig/L1GtConfigProducers/interface/L1GtXmlParserTags.h"
@@ -457,9 +456,7 @@ std::string L1GtTriggerMenuXmlParser::getXMLTextValue(XERCES_CPP_NAMESPACE::DOMN
  * @return true if conversion succeeded, false if an error occurred.
  */
 
-bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString,
-                                                 uint64_t& dstL,
-                                                 uint64_t& dstH) {
+bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString, uint64_t& dstL, uint64_t& dstH) {
   // string to determine start of hex value, do not ignore leading zeros
   static const std::string valid_hex_start("0123456789ABCDEFabcdef");
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
@@ -23,7 +23,6 @@
 #include <fstream>
 #include <iomanip>
 
-#include <boost/cstdint.hpp>
 
 // user include files
 // base class
@@ -35,6 +34,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 #include "Utilities/Xerces/interface/Xerces.h"
+#include <cstdint>
 
 // constructor
 L1GtTriggerMenuXmlParser::L1GtTriggerMenuXmlParser()
@@ -448,7 +448,7 @@ std::string L1GtTriggerMenuXmlParser::getXMLTextValue(XERCES_CPP_NAMESPACE::DOMN
 }
 
 /**
- * hexString2UInt128 converts an up to 128 bit hexadecimal string to two boost::uint64_t
+ * hexString2UInt128 converts an up to 128 bit hexadecimal string to two uint64_t
  *
  * @param hex The string to be converted.
  * @param dstL The target for the lower 64 bit.
@@ -458,8 +458,8 @@ std::string L1GtTriggerMenuXmlParser::getXMLTextValue(XERCES_CPP_NAMESPACE::DOMN
  */
 
 bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString,
-                                                 boost::uint64_t& dstL,
-                                                 boost::uint64_t& dstH) {
+                                                 uint64_t& dstL,
+                                                 uint64_t& dstH) {
   // string to determine start of hex value, do not ignore leading zeros
   static const std::string valid_hex_start("0123456789ABCDEFabcdef");
 
@@ -499,7 +499,7 @@ bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString,
 
   // convert lower 64bit
   char* endPtr = (char*)tempStrL.c_str();
-  boost::uint64_t tempUIntL = strtoull(tempStrL.c_str(), &endPtr, 16);
+  uint64_t tempUIntL = strtoull(tempStrL.c_str(), &endPtr, 16);
 
   if (*endPtr != 0) {
     LogDebug("L1GtTriggerMenuXmlParser") << "Unable to convert " << tempStr << " to hex." << std::endl;
@@ -509,7 +509,7 @@ bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString,
 
   // convert higher64 bit
   endPtr = (char*)tempStrH.c_str();
-  boost::uint64_t tempUIntH = strtoull(tempStrH.c_str(), &endPtr, 16);
+  uint64_t tempUIntH = strtoull(tempStrH.c_str(), &endPtr, 16);
 
   if (*endPtr != 0) {
     LogDebug("L1GtTriggerMenuXmlParser") << "Unable to convert " << tempStr << " to hex." << std::endl;
@@ -534,15 +534,15 @@ bool L1GtTriggerMenuXmlParser::hexString2UInt128(const std::string& hexString,
  */
 
 bool L1GtTriggerMenuXmlParser::getXMLHexTextValue128(XERCES_CPP_NAMESPACE::DOMNode* node,
-                                                     boost::uint64_t& dstL,
-                                                     boost::uint64_t& dstH) {
+                                                     uint64_t& dstL,
+                                                     uint64_t& dstH) {
   if (node == nullptr) {
     LogDebug("L1GtTriggerMenuXmlParser") << "node == 0 in " << __PRETTY_FUNCTION__ << std::endl;
 
     return false;
   }
 
-  boost::uint64_t tempUIntH, tempUIntL;
+  uint64_t tempUIntH, tempUIntL;
 
   std::string tempStr = getXMLTextValue(node);
   if (!hexString2UInt128(tempStr, tempUIntL, tempUIntH)) {
@@ -566,9 +566,9 @@ bool L1GtTriggerMenuXmlParser::getXMLHexTextValue128(XERCES_CPP_NAMESPACE::DOMNo
  *
  */
 
-bool L1GtTriggerMenuXmlParser::getXMLHexTextValue(XERCES_CPP_NAMESPACE::DOMNode* node, boost::uint64_t& dst) {
-  boost::uint64_t dummyH;    // dummy for eventual higher 64bit
-  boost::uint64_t tempUInt;  // temporary unsigned integer
+bool L1GtTriggerMenuXmlParser::getXMLHexTextValue(XERCES_CPP_NAMESPACE::DOMNode* node, uint64_t& dst) {
+  uint64_t dummyH;    // dummy for eventual higher 64bit
+  uint64_t tempUInt;  // temporary unsigned integer
 
   if (!getXMLHexTextValue128(node, tempUInt, dummyH)) {
     return false;
@@ -639,7 +639,7 @@ bool L1GtTriggerMenuXmlParser::countConditionChildMaxBits(XERCES_CPP_NAMESPACE::
 
   // do the hex conversion
 
-  boost::uint64_t maxBitsL, maxBitsH;
+  uint64_t maxBitsL, maxBitsH;
   if (!hexString2UInt128(maxString, maxBitsL, maxBitsH)) {
     return false;
   }
@@ -698,7 +698,7 @@ bool L1GtTriggerMenuXmlParser::countConditionChildMaxBits(XERCES_CPP_NAMESPACE::
  * @param node The xml node of the condition.
  * @param childName The name of the child the values should be extracted from.
  * @param num The number of values needed.
- * @param dst A pointer to a vector of boost::uint64_t where the results are written.
+ * @param dst A pointer to a vector of uint64_t where the results are written.
  *
  * @return true if succeeded. false if an error occurred or not enough values found.
  */
@@ -706,7 +706,7 @@ bool L1GtTriggerMenuXmlParser::countConditionChildMaxBits(XERCES_CPP_NAMESPACE::
 bool L1GtTriggerMenuXmlParser::getConditionChildValues(XERCES_CPP_NAMESPACE::DOMNode* node,
                                                        const std::string& childName,
                                                        unsigned int num,
-                                                       std::vector<boost::uint64_t>& dst) {
+                                                       std::vector<uint64_t>& dst) {
   XERCES_CPP_NAMESPACE_USE
 
   if (node == nullptr) {
@@ -1286,7 +1286,7 @@ bool L1GtTriggerMenuXmlParser::parseMuon(XERCES_CPP_NAMESPACE::DOMNode* node,
   L1GtMuonTemplate::CorrelationParameter corrParameter;
 
   // need at least two values for deltaPhi
-  std::vector<boost::uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
+  std::vector<uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
 
   // get ptHighThreshold values and fill into structure
   if (!getConditionChildValues(node, m_xmlTagPtHighThreshold, nrObj, tmpValues)) {
@@ -1566,7 +1566,7 @@ bool L1GtTriggerMenuXmlParser::parseCalo(XERCES_CPP_NAMESPACE::DOMNode* node,
   L1GtCaloTemplate::CorrelationParameter corrParameter;
 
   // need at least one value for deltaPhiRange
-  std::vector<boost::uint64_t> tmpValues((nrObj > 1) ? nrObj : 1);
+  std::vector<uint64_t> tmpValues((nrObj > 1) ? nrObj : 1);
 
   // get etThreshold values and fill into structure
   if (!getConditionChildValues(node, m_xmlTagEtThreshold, nrObj, tmpValues)) {
@@ -1763,7 +1763,7 @@ bool L1GtTriggerMenuXmlParser::parseEnergySum(XERCES_CPP_NAMESPACE::DOMNode* nod
   std::vector<L1GtEnergySumTemplate::ObjectParameter> objParameter(nrObj);
 
   // need at least two values for phi
-  std::vector<boost::uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
+  std::vector<uint64_t> tmpValues((nrObj > 2) ? nrObj : 2);
 
   // get etThreshold values and fill into structure
   if (!getConditionChildValues(node, m_xmlTagEtThreshold, nrObj, tmpValues)) {
@@ -1946,7 +1946,7 @@ bool L1GtTriggerMenuXmlParser::parseJetCounts(XERCES_CPP_NAMESPACE::DOMNode* nod
   objParameter[0].countIndex = static_cast<unsigned int>(typeInt);
 
   // get count threshold values and fill into structure
-  std::vector<boost::uint64_t> tmpValues(nrObj);
+  std::vector<uint64_t> tmpValues(nrObj);
 
   if (!getConditionChildValues(node, m_xmlTagCountThreshold, nrObj, tmpValues)) {
     return false;
@@ -2172,7 +2172,7 @@ bool L1GtTriggerMenuXmlParser::parseHfBitCounts(XERCES_CPP_NAMESPACE::DOMNode* n
   objParameter[0].countIndex = static_cast<unsigned int>(typeInt);
 
   // get count threshold values and fill into structure
-  std::vector<boost::uint64_t> tmpValues(nrObj);
+  std::vector<uint64_t> tmpValues(nrObj);
 
   if (!getConditionChildValues(node, m_xmlTagCountThreshold, nrObj, tmpValues)) {
     return false;
@@ -2292,7 +2292,7 @@ bool L1GtTriggerMenuXmlParser::parseHfRingEtSums(XERCES_CPP_NAMESPACE::DOMNode* 
   objParameter[0].etSumIndex = static_cast<unsigned int>(typeInt);
 
   // get ET sum threshold values and fill into structure
-  std::vector<boost::uint64_t> tmpValues(nrObj);
+  std::vector<uint64_t> tmpValues(nrObj);
 
   if (!getConditionChildValues(node, m_xmlTagEtThreshold, nrObj, tmpValues)) {
     return false;
@@ -2646,7 +2646,7 @@ bool L1GtTriggerMenuXmlParser::parseCorrelation(XERCES_CPP_NAMESPACE::DOMNode* n
 
   // temporary storage of the parameters
   L1GtCorrelationTemplate::CorrelationParameter corrParameter;
-  std::vector<boost::uint64_t> tmpValues(nrObj);
+  std::vector<uint64_t> tmpValues(nrObj);
 
   // get deltaEtaRange
   //    if ( !getConditionChildValues(node, m_xmlTagDeltaEta, 1, tmpValues) ) {

--- a/L1TriggerOffline/L1Analyzer/interface/L1PromptAnalysis.h
+++ b/L1TriggerOffline/L1Analyzer/interface/L1PromptAnalysis.h
@@ -5,7 +5,7 @@
 /**
  *   Description:  This code is designed for l1 prompt analysis
 //                 starting point is a GMTTreeMaker By Ivan Mikulec. 
-*/                
+*/
 //
 //   I. Mikulec            HEPHY Vienna
 //
@@ -31,7 +31,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
@@ -47,251 +46,243 @@ class TTree;
 //              -- Class Interface --
 //              ---------------------
 
-    const int MAXGEN = 20;
-    const int MAXRPC = 12;
-    const int MAXDTBX = 12;
-    const int MAXCSC = 12;    
-    const int MAXGMT = 12;
-    const int MAXGT = 12;
-    const int MAXRCTREG = 400;
-    const int MAXDTPH = 50;
-    const int MAXDTTH = 50;
-    const int MAXDTTR = 50;
+const int MAXGEN = 20;
+const int MAXRPC = 12;
+const int MAXDTBX = 12;
+const int MAXCSC = 12;
+const int MAXGMT = 12;
+const int MAXGT = 12;
+const int MAXRCTREG = 400;
+const int MAXDTPH = 50;
+const int MAXDTTH = 50;
+const int MAXDTTR = 50;
 
 class L1PromptAnalysis : public edm::EDAnalyzer {
+public:
+  // constructor
+  explicit L1PromptAnalysis(const edm::ParameterSet&);
+  virtual ~L1PromptAnalysis();
 
- 
-  public:
+  // fill tree
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void book();
 
-    // constructor
-    explicit L1PromptAnalysis(const edm::ParameterSet&);
-    virtual ~L1PromptAnalysis();
+  virtual void beginJob();
+  virtual void endJob();
 
-    // fill tree
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    void book();
+private:
+  //GENERAL block
+  int runn;
+  int eventn;
+  int lumi;
+  int bx;
+  uint64_t orbitn;
+  uint64_t timest;
 
-    virtual void beginJob();
-    virtual void endJob();
+  // Generator info
+  float weight;
+  float pthat;
 
-  private:
+  // simulation block
+  int ngen;
+  float pxgen[MAXGEN];
+  float pygen[MAXGEN];
+  float pzgen[MAXGEN];
+  float ptgen[MAXGEN];
+  float etagen[MAXGEN];
+  float phigen[MAXGEN];
+  int chagen[MAXGEN];
+  float vxgen[MAXGEN];
+  float vygen[MAXGEN];
+  float vzgen[MAXGEN];
+  int pargen[MAXGEN];
 
-    //GENERAL block
-    int             runn;
-    int             eventn;
-    int             lumi;
-    int             bx;
-    uint64_t orbitn;
-    uint64_t timest;
-    
-    // Generator info
-    float           weight;
-    float           pthat;
- 
-    // simulation block
-    int             ngen;
-    float           pxgen[MAXGEN];
-    float           pygen[MAXGEN];
-    float           pzgen[MAXGEN];
-    float           ptgen[MAXGEN];
-    float           etagen[MAXGEN];
-    float           phigen[MAXGEN];
-    int             chagen[MAXGEN];
-    float           vxgen[MAXGEN];
-    float           vygen[MAXGEN];
-    float           vzgen[MAXGEN];
-    int             pargen[MAXGEN];
-    
-    // GMT data
-    int             bxgmt;
-    
-    //DTBX Trigger block
-    int             ndt;
-    int             bxd[MAXDTBX];
-    float           ptd[MAXDTBX];
-    int             chad[MAXDTBX];
-    float           etad[MAXDTBX];
-    int             etafined[MAXDTBX];
-    float           phid[MAXDTBX];
-    int             quald[MAXDTBX];
-    int             dwd[MAXDTBX];
-    int             chd[MAXDTBX];
+  // GMT data
+  int bxgmt;
 
-    //CSC Trigger block
-    int             ncsc;
-    int             bxc[MAXCSC];
-    float           ptc[MAXCSC];
-    int             chac[MAXCSC];
-    float           etac[MAXCSC];
-    float           phic[MAXCSC];
-    int             qualc[MAXCSC];
-    int             dwc[MAXCSC];
+  //DTBX Trigger block
+  int ndt;
+  int bxd[MAXDTBX];
+  float ptd[MAXDTBX];
+  int chad[MAXDTBX];
+  float etad[MAXDTBX];
+  int etafined[MAXDTBX];
+  float phid[MAXDTBX];
+  int quald[MAXDTBX];
+  int dwd[MAXDTBX];
+  int chd[MAXDTBX];
 
-    //RPCb Trigger
-    int             nrpcb ;
-    int             bxrb[MAXRPC];
-    float           ptrb[MAXRPC];
-    int             charb[MAXRPC];
-    float           etarb[MAXRPC];
-    float           phirb[MAXRPC];
-    int             qualrb[MAXRPC];
-    int             dwrb[MAXRPC];
+  //CSC Trigger block
+  int ncsc;
+  int bxc[MAXCSC];
+  float ptc[MAXCSC];
+  int chac[MAXCSC];
+  float etac[MAXCSC];
+  float phic[MAXCSC];
+  int qualc[MAXCSC];
+  int dwc[MAXCSC];
 
-    //RPCf Trigger
-    int             nrpcf ;
-    int             bxrf[MAXRPC];
-    float           ptrf[MAXRPC];
-    int             charf[MAXRPC];
-    float           etarf[MAXRPC];
-    float           phirf[MAXRPC];
-    int             qualrf[MAXRPC];
-    int             dwrf[MAXRPC];
+  //RPCb Trigger
+  int nrpcb;
+  int bxrb[MAXRPC];
+  float ptrb[MAXRPC];
+  int charb[MAXRPC];
+  float etarb[MAXRPC];
+  float phirb[MAXRPC];
+  int qualrb[MAXRPC];
+  int dwrb[MAXRPC];
 
-    //Global Muon Trigger
-    int             ngmt;
-    int             bxg[MAXGMT];
-    float           ptg[MAXGMT];
-    int             chag[MAXGMT];
-    float           etag[MAXGMT];
-    float           phig[MAXGMT];
-    int             qualg[MAXGMT];
-    int             detg[MAXGMT];
-    int             rankg[MAXGMT];
-    int             isolg[MAXGMT];
-    int             mipg[MAXGMT];
-    int             dwg[MAXGMT];
-    int             idxRPCb[MAXGMT];
-    int             idxRPCf[MAXGMT];
-    int             idxDTBX[MAXGMT];
-    int             idxCSC[MAXGMT];
-    
-    // GT info
-    uint64_t gttw1[3];
-    uint64_t gttw2[3];
-    uint64_t gttt[3];
+  //RPCf Trigger
+  int nrpcf;
+  int bxrf[MAXRPC];
+  float ptrf[MAXRPC];
+  int charf[MAXRPC];
+  float etarf[MAXRPC];
+  float phirf[MAXRPC];
+  int qualrf[MAXRPC];
+  int dwrf[MAXRPC];
 
-    
-    //PSB info
-    int             nele;
-    int             bxel[MAXGT];
-    float           rankel[MAXGT];
-    float           phiel[MAXGT];
-    float           etael[MAXGT];
-    
-    int             njet;
-    int             bxjet[MAXGT];
-    float           rankjet[MAXGT];
-    float           phijet[MAXGT];
-    float           etajet[MAXGT];
+  //Global Muon Trigger
+  int ngmt;
+  int bxg[MAXGMT];
+  float ptg[MAXGMT];
+  int chag[MAXGMT];
+  float etag[MAXGMT];
+  float phig[MAXGMT];
+  int qualg[MAXGMT];
+  int detg[MAXGMT];
+  int rankg[MAXGMT];
+  int isolg[MAXGMT];
+  int mipg[MAXGMT];
+  int dwg[MAXGMT];
+  int idxRPCb[MAXGMT];
+  int idxRPCf[MAXGMT];
+  int idxDTBX[MAXGMT];
+  int idxCSC[MAXGMT];
 
-    //GCT
-    edm::InputTag gctCenJetsSource_ ;
-    edm::InputTag gctForJetsSource_ ;
-    edm::InputTag gctTauJetsSource_ ;
-    edm::InputTag gctEnergySumsSource_;
-    edm::InputTag gctIsoEmSource_ ;
-    edm::InputTag gctNonIsoEmSource_ ;
-    
-    int gctIsoEmSize;
-    float gctIsoEmEta[4];
-    float gctIsoEmPhi[4];
-    float gctIsoEmRnk[4];
-    int gctNonIsoEmSize;
-    float gctNonIsoEmEta[4];
-    float gctNonIsoEmPhi[4];
-    float gctNonIsoEmRnk[4];
-    int gctCJetSize;
-    float gctCJetEta[4];
-    float gctCJetPhi[4];
-    float gctCJetRnk[4];
-    int gctFJetSize;
-    float gctFJetEta[4];
-    float gctFJetPhi[4];
-    float gctFJetRnk[4];
-    int gctTJetSize;
-    float gctTJetEta[4];
-    float gctTJetPhi[4];
-    float gctTJetRnk[4];
-    float gctEtMiss;
-    float gctEtMissPhi;
-    float gctEtHad;
-    float gctEtTot;
-    int gctHFRingEtSumSize;
-    float gctHFRingEtSumEta[4];
-    float gctHFBitCountsSize;
-    float gctHFBitCountsEta[4];
-//  RCT
-     
-    edm::InputTag rctSource_; 
-    int rctRegSize;
-    float rctRegEta[MAXRCTREG];
-    float rctRegPhi[MAXRCTREG];
-    float rctRegRnk[MAXRCTREG];
-    int rctRegVeto[MAXRCTREG];
-    int rctRegBx[MAXRCTREG];
-    int rctRegOverFlow[MAXRCTREG];
-    int rctRegMip[MAXRCTREG];
-    int rctRegFGrain[MAXRCTREG];
-    int rctEmSize;
-    int rctIsIsoEm[MAXRCTREG];
-    float rctEmEta[MAXRCTREG];
-    float rctEmPhi[MAXRCTREG];
-    float rctEmRnk[MAXRCTREG];
-    int rctEmBx[MAXRCTREG];
-    
-// DTTF
-    edm::InputTag dttfSource_; 
-        
-    int dttf_phSize;
-    int dttf_phBx[MAXDTPH]; 
-    int dttf_phWh[MAXDTPH]; 
-    int dttf_phSe[MAXDTPH]; 
-    int dttf_phSt[MAXDTPH]; 
-    float dttf_phAng[MAXDTPH];
-    float dttf_phBandAng[MAXDTPH];
-    int dttf_phCode[MAXDTPH]; 
-    float dttf_phX[MAXDTPH];
-    float dttf_phY[MAXDTPH];
+  // GT info
+  uint64_t gttw1[3];
+  uint64_t gttw2[3];
+  uint64_t gttt[3];
 
-    int dttf_thSize;
-    int dttf_thBx[MAXDTTH];
-    int dttf_thWh[MAXDTTH];
-    int dttf_thSe[MAXDTTH];
-    int dttf_thSt[MAXDTTH];
-    float dttf_thX[MAXDTTH]; 
-    float dttf_thY[MAXDTTH]; 
-    float dttf_thTheta[MAXDTTH][7];
-    int dttf_thCode[MAXDTTH][7]; 
-    
-    int dttf_trSize;
-    int dttf_trBx[MAXDTTR]; 
-    int dttf_trTag[MAXDTTR];
-    int dttf_trQual[MAXDTTR]; 
-    int dttf_trPtPck[MAXDTTR];
-    float dttf_trPtVal[MAXDTTR];
-    int dttf_trPhiPck[MAXDTTR]; 
-    float dttf_trPhiVal[MAXDTTR]; 
-    int dttf_trPhiGlob[MAXDTTR]; 
-    int dttf_trChPck[MAXDTTR];
-    int dttf_trWh[MAXDTTR]; 
-    int dttf_trSc[MAXDTTR]; 
-///  
+  //PSB info
+  int nele;
+  int bxel[MAXGT];
+  float rankel[MAXGT];
+  float phiel[MAXGT];
+  float etael[MAXGT];
 
+  int njet;
+  int bxjet[MAXGT];
+  float rankjet[MAXGT];
+  float phijet[MAXGT];
+  float etajet[MAXGT];
 
-    TFile* m_file;
-    TTree* m_tree;
+  //GCT
+  edm::InputTag gctCenJetsSource_;
+  edm::InputTag gctForJetsSource_;
+  edm::InputTag gctTauJetsSource_;
+  edm::InputTag gctEnergySumsSource_;
+  edm::InputTag gctIsoEmSource_;
+  edm::InputTag gctNonIsoEmSource_;
 
-    edm::InputTag m_GMTInputTag;
-    edm::InputTag m_GTEvmInputTag;
-    edm::InputTag m_GTInputTag;
-    edm::InputTag m_GeneratorInputTag;
-    edm::InputTag m_SimulationInputTag;
-    
-    bool m_PhysVal;
-    bool verbose_;
-    std::string m_outfilename;
-      
+  int gctIsoEmSize;
+  float gctIsoEmEta[4];
+  float gctIsoEmPhi[4];
+  float gctIsoEmRnk[4];
+  int gctNonIsoEmSize;
+  float gctNonIsoEmEta[4];
+  float gctNonIsoEmPhi[4];
+  float gctNonIsoEmRnk[4];
+  int gctCJetSize;
+  float gctCJetEta[4];
+  float gctCJetPhi[4];
+  float gctCJetRnk[4];
+  int gctFJetSize;
+  float gctFJetEta[4];
+  float gctFJetPhi[4];
+  float gctFJetRnk[4];
+  int gctTJetSize;
+  float gctTJetEta[4];
+  float gctTJetPhi[4];
+  float gctTJetRnk[4];
+  float gctEtMiss;
+  float gctEtMissPhi;
+  float gctEtHad;
+  float gctEtTot;
+  int gctHFRingEtSumSize;
+  float gctHFRingEtSumEta[4];
+  float gctHFBitCountsSize;
+  float gctHFBitCountsEta[4];
+  //  RCT
+
+  edm::InputTag rctSource_;
+  int rctRegSize;
+  float rctRegEta[MAXRCTREG];
+  float rctRegPhi[MAXRCTREG];
+  float rctRegRnk[MAXRCTREG];
+  int rctRegVeto[MAXRCTREG];
+  int rctRegBx[MAXRCTREG];
+  int rctRegOverFlow[MAXRCTREG];
+  int rctRegMip[MAXRCTREG];
+  int rctRegFGrain[MAXRCTREG];
+  int rctEmSize;
+  int rctIsIsoEm[MAXRCTREG];
+  float rctEmEta[MAXRCTREG];
+  float rctEmPhi[MAXRCTREG];
+  float rctEmRnk[MAXRCTREG];
+  int rctEmBx[MAXRCTREG];
+
+  // DTTF
+  edm::InputTag dttfSource_;
+
+  int dttf_phSize;
+  int dttf_phBx[MAXDTPH];
+  int dttf_phWh[MAXDTPH];
+  int dttf_phSe[MAXDTPH];
+  int dttf_phSt[MAXDTPH];
+  float dttf_phAng[MAXDTPH];
+  float dttf_phBandAng[MAXDTPH];
+  int dttf_phCode[MAXDTPH];
+  float dttf_phX[MAXDTPH];
+  float dttf_phY[MAXDTPH];
+
+  int dttf_thSize;
+  int dttf_thBx[MAXDTTH];
+  int dttf_thWh[MAXDTTH];
+  int dttf_thSe[MAXDTTH];
+  int dttf_thSt[MAXDTTH];
+  float dttf_thX[MAXDTTH];
+  float dttf_thY[MAXDTTH];
+  float dttf_thTheta[MAXDTTH][7];
+  int dttf_thCode[MAXDTTH][7];
+
+  int dttf_trSize;
+  int dttf_trBx[MAXDTTR];
+  int dttf_trTag[MAXDTTR];
+  int dttf_trQual[MAXDTTR];
+  int dttf_trPtPck[MAXDTTR];
+  float dttf_trPtVal[MAXDTTR];
+  int dttf_trPhiPck[MAXDTTR];
+  float dttf_trPhiVal[MAXDTTR];
+  int dttf_trPhiGlob[MAXDTTR];
+  int dttf_trChPck[MAXDTTR];
+  int dttf_trWh[MAXDTTR];
+  int dttf_trSc[MAXDTTR];
+  ///
+
+  TFile* m_file;
+  TTree* m_tree;
+
+  edm::InputTag m_GMTInputTag;
+  edm::InputTag m_GTEvmInputTag;
+  edm::InputTag m_GTInputTag;
+  edm::InputTag m_GeneratorInputTag;
+  edm::InputTag m_SimulationInputTag;
+
+  bool m_PhysVal;
+  bool verbose_;
+  std::string m_outfilename;
 };
-
 
 #endif

--- a/L1TriggerOffline/L1Analyzer/interface/L1PromptAnalysis.h
+++ b/L1TriggerOffline/L1Analyzer/interface/L1PromptAnalysis.h
@@ -81,8 +81,8 @@ class L1PromptAnalysis : public edm::EDAnalyzer {
     int             eventn;
     int             lumi;
     int             bx;
-    boost::uint64_t orbitn;
-    boost::uint64_t timest;
+    uint64_t orbitn;
+    uint64_t timest;
     
     // Generator info
     float           weight;
@@ -166,9 +166,9 @@ class L1PromptAnalysis : public edm::EDAnalyzer {
     int             idxCSC[MAXGMT];
     
     // GT info
-    boost::uint64_t gttw1[3];
-    boost::uint64_t gttw2[3];
-    boost::uint64_t gttt[3];
+    uint64_t gttw1[3];
+    uint64_t gttw2[3];
+    uint64_t gttt[3];
 
     
     //PSB info

--- a/OnlineDB/EcalCondDB/interface/RunCrystalErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunCrystalErrorsDat.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <stdexcept>
-#include <boost/cstdint.hpp>
 
 #include "OnlineDB/EcalCondDB/interface/IDataItem.h"
 #include "OnlineDB/EcalCondDB/interface/RunIOV.h"
 #include "OnlineDB/EcalCondDB/interface/EcalLogicID.h"
+#include <cstdint>
 
 class RunCrystalErrorsDat : public IDataItem {
 public:

--- a/OnlineDB/EcalCondDB/interface/RunMemChErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunMemChErrorsDat.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <stdexcept>
-#include <boost/cstdint.hpp>
 
 #include "OnlineDB/EcalCondDB/interface/IDataItem.h"
 #include "OnlineDB/EcalCondDB/interface/RunIOV.h"
 #include "OnlineDB/EcalCondDB/interface/EcalLogicID.h"
+#include <cstdint>
 
 class RunMemChErrorsDat : public IDataItem {
 public:

--- a/OnlineDB/EcalCondDB/interface/RunMemTTErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunMemTTErrorsDat.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <stdexcept>
-#include <boost/cstdint.hpp>
 
 #include "OnlineDB/EcalCondDB/interface/IDataItem.h"
 #include "OnlineDB/EcalCondDB/interface/RunIOV.h"
 #include "OnlineDB/EcalCondDB/interface/EcalLogicID.h"
+#include <cstdint>
 
 class RunMemTTErrorsDat : public IDataItem {
 public:

--- a/OnlineDB/EcalCondDB/interface/RunPNErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunPNErrorsDat.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <stdexcept>
-#include <boost/cstdint.hpp>
 
 #include "OnlineDB/EcalCondDB/interface/IDataItem.h"
 #include "OnlineDB/EcalCondDB/interface/RunIOV.h"
 #include "OnlineDB/EcalCondDB/interface/EcalLogicID.h"
+#include <cstdint>
 
 class RunPNErrorsDat : public IDataItem {
 public:

--- a/OnlineDB/EcalCondDB/interface/RunTTErrorsDat.h
+++ b/OnlineDB/EcalCondDB/interface/RunTTErrorsDat.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <stdexcept>
-#include <boost/cstdint.hpp>
 
 #include "OnlineDB/EcalCondDB/interface/IDataItem.h"
 #include "OnlineDB/EcalCondDB/interface/RunIOV.h"
 #include "OnlineDB/EcalCondDB/interface/EcalLogicID.h"
+#include <cstdint>
 
 class RunTTErrorsDat : public IDataItem {
 public:

--- a/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h
+++ b/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h
@@ -16,7 +16,6 @@
 #include "OnlineDB/SiStripConfigDb/interface/SiStripDbParams.h"
 #include "DeviceFactory.h"
 #include "boost/range/iterator_range.hpp"
-#include "boost/cstdint.hpp"
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -28,6 +27,7 @@
 #include <atomic>
 
 #include "DbClient.h"
+#include <cstdint>
 
 namespace sistrip {
   static const uint16_t FEC_CRATE_OFFSET = 0;  //@@ temporary

--- a/OnlineDB/SiStripConfigDb/interface/SiStripDbParams.h
+++ b/OnlineDB/SiStripConfigDb/interface/SiStripDbParams.h
@@ -5,7 +5,6 @@
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "OnlineDB/SiStripConfigDb/interface/SiStripPartition.h"
-#include "boost/cstdint.hpp"
 #include "boost/range/iterator_range.hpp"
 #include <ostream>
 #include <sstream>

--- a/OnlineDB/SiStripConfigDb/interface/SiStripPartition.h
+++ b/OnlineDB/SiStripConfigDb/interface/SiStripPartition.h
@@ -4,11 +4,11 @@
 
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <string>
 #include <ostream>
 #include <sstream>
+#include <cstdint>
 
 class SiStripConfigDb;
 class SiStripPartition;

--- a/OnlineDB/SiStripESSources/interface/SiStripCondObjBuilderFromDb.h
+++ b/OnlineDB/SiStripESSources/interface/SiStripCondObjBuilderFromDb.h
@@ -24,11 +24,11 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
-#include "boost/cstdint.hpp"
 #include <memory>
 #include <vector>
 #include <string>
 #include <typeinfo>
+#include <cstdint>
 
 class SiStripFecCabling;
 class SiStripDetCabling;

--- a/OnlineDB/SiStripESSources/interface/SiStripFedCablingBuilderFromDb.h
+++ b/OnlineDB/SiStripESSources/interface/SiStripFedCablingBuilderFromDb.h
@@ -5,9 +5,9 @@
 #include "CalibTracker/SiStripESProducers/interface/SiStripFedCablingESProducer.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
-#include "boost/cstdint.hpp"
 #include <vector>
 #include <string>
+#include <cstdint>
 
 class SiStripFedCablingRcd;
 class SiStripFedCabling;

--- a/RecoLocalCalo/CaloTowersCreator/interface/HcalMaterials.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/HcalMaterials.h
@@ -2,7 +2,6 @@
 #define HcalMaterials_h
 
 #include "DataFormats/DetId/interface/DetId.h"
-#include <boost/cstdint.hpp>
 #include <vector>
 // place to implement a real working class for material corrections
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/rawEnergy.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/rawEnergy.h
@@ -2,7 +2,6 @@
 #ifndef RecoLocalCalo_HcalRecAlgos_rawEnergy_h
 #define RecoLocalCalo_HcalRecAlgos_rawEnergy_h
 
-
 namespace HcalRecAlgosPrivate {
   template <typename T>
   class IsClassType {

--- a/RecoLocalCalo/HcalRecAlgos/interface/rawEnergy.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/rawEnergy.h
@@ -1,7 +1,7 @@
+#include <cstdint>
 #ifndef RecoLocalCalo_HcalRecAlgos_rawEnergy_h
 #define RecoLocalCalo_HcalRecAlgos_rawEnergy_h
 
-#include "boost/cstdint.hpp"
 
 namespace HcalRecAlgosPrivate {
   template <typename T>

--- a/RecoLocalMuon/GEMRecHit/interface/GEMCluster.h
+++ b/RecoLocalMuon/GEMRecHit/interface/GEMCluster.h
@@ -1,6 +1,6 @@
+#include <cstdint>
 #ifndef RecoLocalMuon_GEMRecHit_GEMCluster_h
 #define RecoLocalMuon_GEMRecHit_GEMCluster_h
-#include <boost/cstdint.hpp>
 
 class GEMCluster {
 public:

--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.h
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.h
@@ -1,6 +1,6 @@
+#include <cstdint>
 #ifndef RecoLocalMuon_RPCCluster_h
 #define RecoLocalMuon_RPCCluster_h
-#include <boost/cstdint.hpp>
 class RPCCluster {
 public:
   RPCCluster();

--- a/RecoRomanPot/RecoFP420/interface/ClusterNoiseFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/ClusterNoiseFP420.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 //#define mynsdebug0
 
 typedef float ElectrodNoise;

--- a/SimDataFormats/CaloHit/interface/CaloHit.h
+++ b/SimDataFormats/CaloHit/interface/CaloHit.h
@@ -5,9 +5,9 @@
 // Hit class for QIE analysis
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <boost/cstdint.hpp>
 #include <iostream>
 #include <cmath>
+#include <cstdint>
 
 class CaloHit {
 public:

--- a/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
+++ b/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #ifndef SimDataFormats_HGCalTestNumbering_h
 #define SimDataFormats_HGCalTestNumbering_h
 ///////////////////////////////////////////////////////////////////////////////
@@ -5,7 +6,6 @@
 // Description: Numbering scheme for high granularity calorimeter (SIM step)
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <boost/cstdint.hpp>
 
 class HGCalTestNumbering {
 public:

--- a/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
+++ b/SimDataFormats/CaloTest/interface/HGCalTestNumbering.h
@@ -6,7 +6,6 @@
 // Description: Numbering scheme for high granularity calorimeter (SIM step)
 ///////////////////////////////////////////////////////////////////////////////
 
-
 class HGCalTestNumbering {
 public:
   static const int kHGCalCellSOffset = 0;

--- a/SimDataFormats/CaloTest/interface/HcalTestHistoClass.h
+++ b/SimDataFormats/CaloTest/interface/HcalTestHistoClass.h
@@ -8,7 +8,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/CaloHit/interface/CaloHit.h"
 
-#include <boost/cstdint.hpp>
 #include <string>
 #include <vector>
 #include <memory>

--- a/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
+++ b/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
@@ -1,7 +1,6 @@
 #ifndef DigiSimLinks_DTDigiSimLink_h
 #define DigiSimLinks_DTDigiSimLink_h
 
-#include "boost/cstdint.hpp"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 
 class DTDigiSimLink {
@@ -63,6 +62,7 @@ private:
 };
 
 #include <iostream>
+#include <cstdint>
 inline std::ostream& operator<<(std::ostream& o, const DTDigiSimLink& digisimlink) {
   return o << "wire:" << digisimlink.wire() << " digi:" << digisimlink.number() << " time:" << digisimlink.time()
            << " SimTrack:" << digisimlink.SimTrackId() << " eventId:" << digisimlink.eventId().rawId();

--- a/SimDataFormats/EncodedEventId/interface/EncodedEventId.h
+++ b/SimDataFormats/EncodedEventId/interface/EncodedEventId.h
@@ -2,8 +2,8 @@
 #define SimDataFormats_EncodedEventId_H 1
 
 #include <TMath.h>
-#include <boost/cstdint.hpp>  //INCLUDECHECKER:SKIP
 #include <ostream>
+#include <cstdint>
 
 /** \class EncodedEventId
 

--- a/SimDataFormats/EncodedEventId/src/classes.h
+++ b/SimDataFormats/EncodedEventId/src/classes.h
@@ -1,3 +1,2 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
-#include <boost/cstdint.hpp>
 #include <vector>

--- a/SimDataFormats/HcalTestBeam/interface/HcalTestBeamNumbering.h
+++ b/SimDataFormats/HcalTestBeam/interface/HcalTestBeamNumbering.h
@@ -6,7 +6,6 @@
 // Description: Numbering scheme for high granularity calorimeter (SIM step)
 ///////////////////////////////////////////////////////////////////////////////
 
-
 class HcalTestBeamNumbering {
 public:
   static const int kHcalBeamXValueOffset = 0;

--- a/SimDataFormats/HcalTestBeam/interface/HcalTestBeamNumbering.h
+++ b/SimDataFormats/HcalTestBeam/interface/HcalTestBeamNumbering.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #ifndef SimDataFormats_HcalTestBeamNumbering_h
 #define SimDataFormats_HcalTestBeamNumbering_h
 ///////////////////////////////////////////////////////////////////////////////
@@ -5,7 +6,6 @@
 // Description: Numbering scheme for high granularity calorimeter (SIM step)
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <boost/cstdint.hpp>
 
 class HcalTestBeamNumbering {
 public:

--- a/SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h
+++ b/SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h
@@ -1,7 +1,6 @@
 #ifndef RPCOBJECTS_RPCDIGISIMLINK_H
 #define RPCOBJECTS_RPCDIGISIMLINK_H
 
-#include "boost/cstdint.hpp"
 #include <map>
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"

--- a/SimDataFormats/RandomEngine/interface/RandomEngineState.h
+++ b/SimDataFormats/RandomEngine/interface/RandomEngineState.h
@@ -21,7 +21,7 @@ service.
 
 #include <vector>
 #include <string>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 class RandomEngineState {
 public:

--- a/SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h
@@ -1,8 +1,8 @@
 #ifndef TRACKINGOBJECTS_PIXELDIGISIMLINK_H
 #define TRACKINGOBJECTS_PIXELDIGISIMLINK_H
 
-#include "boost/cstdint.hpp"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include <cstdint>
 
 //typedef std::pair<unsigned int ,unsigned int > PixelDigiSimLink;
 class PixelDigiSimLink {

--- a/SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h
@@ -3,9 +3,9 @@
 
 #include <map>
 #include <algorithm>
-#include <boost/cstdint.hpp>
 #include <boost/range.hpp>
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include <cstdint>
 
 class StripCompactDigiSimLinks {
 public:

--- a/SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h
+++ b/SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h
@@ -1,8 +1,8 @@
 #ifndef SimDataFormats_TrackerDigiSimLink_StripDigiSimLink_h
 #define SimDataFormats_TrackerDigiSimLink_StripDigiSimLink_h
 
-#include "boost/cstdint.hpp"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include <cstdint>
 
 class StripDigiSimLink {
 public:

--- a/SimG4CMS/FP420/interface/FP420G4Hit.h
+++ b/SimG4CMS/FP420/interface/FP420G4Hit.h
@@ -10,7 +10,6 @@
 #define FP420G4Hit_h
 
 #include "G4VHit.hh"
-#include <boost/cstdint.hpp>
 #include <iostream>
 
 #include "G4Step.hh"

--- a/SimG4CMS/FP420/interface/FP420G4HitCollection.h
+++ b/SimG4CMS/FP420/interface/FP420G4HitCollection.h
@@ -10,7 +10,6 @@
 #include "G4THitsCollection.hh"
 #include "SimG4CMS/FP420/interface/FP420G4Hit.h"
 #include "G4Step.hh"
-#include <boost/cstdint.hpp>
 
 typedef G4THitsCollection<FP420G4Hit> FP420G4HitCollection;
 

--- a/SimG4CMS/FP420/interface/FP420NumberingScheme.h
+++ b/SimG4CMS/FP420/interface/FP420NumberingScheme.h
@@ -7,7 +7,6 @@
 #ifndef FP420NumberingScheme_h
 #define FP420NumberingScheme_h
 
-#include <boost/cstdint.hpp>
 #include <map>
 
 class G4Step;

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
@@ -61,7 +61,7 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "Randomize.hh"
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace CLHEP {
   class HepRandomEngine;

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTBNumberingScheme.h
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTBNumberingScheme.h
@@ -17,8 +17,8 @@
 //
 
 // system include files
-#include <boost/cstdint.hpp>
 #include <vector>
+#include <cstdint>
 
 // user include files
 

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardAnalysis.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardAnalysis.h
@@ -23,7 +23,6 @@
 #include "TFile.h"
 #include "TTree.h"
 
-#include <boost/cstdint.hpp>
 #include <vector>
 #include <string>
 

--- a/TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopePlaneRawHits.h
+++ b/TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopePlaneRawHits.h
@@ -3,7 +3,6 @@
 
 #include <ostream>
 #include <vector>
-#include <boost/cstdint.hpp>
 
 /** \class EcalTBHodoscopePlaneRawHits
  *  Simple container for rawHits 

--- a/TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRawInfo.h
+++ b/TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRawInfo.h
@@ -2,7 +2,6 @@
 #define DIGIECAL_ECALTBHODOSCOPERAWINFO_H 1
 
 #include <ostream>
-#include <boost/cstdint.hpp>
 
 /** \class EcalTBHodoscopeRawInfo
  *  Simple container for plane RawHits 

--- a/TBDataFormats/EcalTBObjects/interface/EcalTBTDCSample.h
+++ b/TBDataFormats/EcalTBObjects/interface/EcalTBTDCSample.h
@@ -2,7 +2,7 @@
 #define DIGIECAL_ECALTBTDCSAMPLE_H 1
 
 #include <ostream>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 /** \class EcalTBTDCSample
  *  Simple container packer/unpacker for a single sample from the TB TDC raw data

--- a/TBDataFormats/HcalTBObjects/interface/HcalTBBeamCounters.h
+++ b/TBDataFormats/HcalTBObjects/interface/HcalTBBeamCounters.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <iostream>
 #include <vector>
-#include "boost/cstdint.hpp"
 
 class HcalTBBeamCounters {
 public:

--- a/TBDataFormats/HcalTBObjects/interface/HcalTBEventPosition.h
+++ b/TBDataFormats/HcalTBObjects/interface/HcalTBEventPosition.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <iostream>
 #include <vector>
-#include "boost/cstdint.hpp"
 
 /** \class HcalTBEventPosition
 

--- a/TBDataFormats/HcalTBObjects/interface/HcalTBParticleId.h
+++ b/TBDataFormats/HcalTBObjects/interface/HcalTBParticleId.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <iostream>
 #include <vector>
-#include "boost/cstdint.hpp"
 
 class HcalTBParticleId {
 public:

--- a/TBDataFormats/HcalTBObjects/interface/HcalTBRunData.h
+++ b/TBDataFormats/HcalTBObjects/interface/HcalTBRunData.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include <iostream>
-#include "boost/cstdint.hpp"
 
 /** \class HcalTBRunData
 

--- a/TBDataFormats/HcalTBObjects/interface/HcalTBTiming.h
+++ b/TBDataFormats/HcalTBObjects/interface/HcalTBTiming.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <iostream>
 #include <vector>
-#include "boost/cstdint.hpp"
 
 /** \class HcalTBTiming
 

--- a/TBDataFormats/HcalTBObjects/interface/HcalTBTriggerData.h
+++ b/TBDataFormats/HcalTBObjects/interface/HcalTBTriggerData.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <iostream>
-#include "boost/cstdint.hpp"
+#include <cstdint>
 
 /** \class HcalTBTriggerData
 

--- a/TrackingTools/PatternTools/src/classes.h
+++ b/TrackingTools/PatternTools/src/classes.h
@@ -5,7 +5,6 @@
 #include "Math/Cartesian3D.h"
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"

--- a/TrackingTools/TrajectoryState/src/classes.h
+++ b/TrackingTools/TrajectoryState/src/classes.h
@@ -5,7 +5,6 @@
 #include "Math/Cartesian3D.h"
 #include "Math/Polar3D.h"
 #include "Math/CylindricalEta3D.h"
-#include <boost/cstdint.hpp>
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"


### PR DESCRIPTION
#### PR description:

removed usage of boost::uint<8,16,32,64>_t in favor of uint<8,16,32,64>_t
removed usage of boost::int<8,16,32,64>_t in favor of int<8,16,32,64>_t
removed include boost/cstdint.hpp and added include cstdint in an file modified. 

Many other CMSSW files should also include <cstdint> based on their existing usage of these types.  Fixing that is not a part of this pull request

#### PR validation:

compiles and runs tests in runTheMatrix - should be transparent.

