### PR TITLE
Replace boost::array with std::array

### DIFF
--- a/CondFormats/HcalObjects/interface/HFPhase1PMTData.h
+++ b/CondFormats/HcalObjects/interface/HFPhase1PMTData.h
@@ -12,6 +12,8 @@
 #endif
 #include "CondFormats/HcalObjects/interface/AbsHcalFunctor.h"
 
+#include <array>
+
 class HFPhase1PMTData {
 public:
   // Functor enum for the cut shapes
@@ -26,7 +28,7 @@ public:
     ASYMM_MAX,    // Maximum allowed asymmetry
     N_PMT_CUTS
   };
-  typedef boost::array<std::shared_ptr<AbsHcalFunctor>, N_PMT_CUTS> Cuts;
+  typedef std::array<std::shared_ptr<AbsHcalFunctor>, N_PMT_CUTS> Cuts;
 
   // Dummy constructor, to be used for deserialization only
   inline HFPhase1PMTData() : minCharge0_(0.0), minCharge1_(0.0), minChargeAsymm_(0.0) {}

--- a/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <array>
 
-#include "boost/array.hpp"
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
 #include "boost/serialization/shared_ptr.hpp"
@@ -76,7 +75,7 @@ public:
   inline bool operator!=(const HcalItemArrayColl& r) const { return !(*this == r); }
 
 private:
-  typedef boost::array<std::shared_ptr<Item>, N> StoredArray;
+  typedef std::array<std::shared_ptr<Item>, N> StoredArray;
   std::vector<StoredArray> data_;
 
   friend class boost::serialization::access;

--- a/CondFormats/HcalObjects/interface/HcalItemArrayCollById.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayCollById.h
@@ -133,7 +133,7 @@ protected:
   }
 
 private:
-  typedef boost::array<std::shared_ptr<Item>, N> StoredArray;
+  typedef std::array<std::shared_ptr<Item>, N> StoredArray;
 
   HcalItemArrayColl<Item, N> coll_;
   HcalIndexLookup lookup_;

--- a/RecoMET/METAlgorithms/interface/HcalHPDRBXMap.h
+++ b/RecoMET/METAlgorithms/interface/HcalHPDRBXMap.h
@@ -15,9 +15,9 @@
 //   author: J.P. Chou, Brown
 //
 
-#include "boost/array.hpp"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include <vector>
+#include <array>
 
 class HcalHPDRBXMap {
 public:
@@ -66,7 +66,7 @@ public:
   // returns a list of HPD indices found in a given RBX
   // exception is thrown if rbxindex is invalid
   // HPD indices are ordered in phi-space
-  void static indicesHPDfromRBX(int rbxindex, boost::array<int, NUM_HPDS_PER_RBX>& hpdindices);
+  void static indicesHPDfromRBX(int rbxindex, std::array<int, NUM_HPDS_PER_RBX>& hpdindices);
 
   // returns the RBX index given an HPD index
   // exception is thrown if hpdindex is invalid

--- a/RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h
+++ b/RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h
@@ -12,7 +12,6 @@
 //
 //
 
-
 #include "DataFormats/METReco/interface/HcalNoiseHPD.h"
 #include "DataFormats/METReco/interface/HcalNoiseRBX.h"
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"

--- a/RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h
+++ b/RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h
@@ -4,7 +4,7 @@
 //
 // HcalNoiseRBXArray.h
 //
-//   description: A boost::array of 72 HcalNoiseRBXs designed to simply search/sorting of elements
+//   description: A std::array of 72 HcalNoiseRBXs designed to simply search/sorting of elements
 //                Automatically labels each RBX individually, and provides O(1) searching tools
 //
 //
@@ -12,7 +12,6 @@
 //
 //
 
-#include "boost/array.hpp"
 
 #include "DataFormats/METReco/interface/HcalNoiseHPD.h"
 #include "DataFormats/METReco/interface/HcalNoiseRBX.h"
@@ -21,10 +20,11 @@
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "RecoMET/METAlgorithms/interface/HcalHPDRBXMap.h"
+#include <array>
 
 namespace reco {
 
-  class HcalNoiseRBXArray : public boost::array<HcalNoiseRBX, HcalHPDRBXMap::NUM_RBXS> {
+  class HcalNoiseRBXArray : public std::array<HcalNoiseRBX, HcalHPDRBXMap::NUM_RBXS> {
   public:
     // constructor/destructor
     HcalNoiseRBXArray();

--- a/RecoMET/METAlgorithms/src/HcalHPDRBXMap.cc
+++ b/RecoMET/METAlgorithms/src/HcalHPDRBXMap.cc
@@ -116,7 +116,7 @@ int HcalHPDRBXMap::iphiloRBX(int index) {
         << " RBX index " << index << " is invalid in HcalHPDRBXMap::iphiloRBX().\n";
 
   // get the list of HPD indices in the RBX
-  boost::array<int, NUM_HPDS_PER_RBX> arr;
+  std::array<int, NUM_HPDS_PER_RBX> arr;
   indicesHPDfromRBX(index, arr);
 
   // return the lowest iphi of the first HPD
@@ -154,7 +154,7 @@ int HcalHPDRBXMap::iphihiRBX(int index) {
         << " RBX index " << index << " is invalid in HcalHPDRBXMap::iphihiRBX().\n";
 
   // get the list of HPD indices in the RBX
-  boost::array<int, NUM_HPDS_PER_RBX> arr;
+  std::array<int, NUM_HPDS_PER_RBX> arr;
   indicesHPDfromRBX(index, arr);
 
   // return the highest iphi of the last HPD
@@ -162,7 +162,7 @@ int HcalHPDRBXMap::iphihiRBX(int index) {
 }
 
 // returns the list of HPD indices found in a given RBX
-void HcalHPDRBXMap::indicesHPDfromRBX(int rbxindex, boost::array<int, NUM_HPDS_PER_RBX>& hpdindices) {
+void HcalHPDRBXMap::indicesHPDfromRBX(int rbxindex, std::array<int, NUM_HPDS_PER_RBX>& hpdindices) {
   if (!isValidRBX(rbxindex))
     throw edm::Exception(edm::errors::LogicError)
         << " RBX index " << rbxindex << " is invalid in HcalHPDRBXMap::indicesHPD().\n";

--- a/RecoMET/METAlgorithms/src/HcalNoiseRBXArray.cc
+++ b/RecoMET/METAlgorithms/src/HcalNoiseRBXArray.cc
@@ -20,7 +20,7 @@ HcalNoiseRBXArray::HcalNoiseRBXArray() {
     rbx.idnumber_ = i;
 
     // set the hpdnumber here
-    boost::array<int, HcalHPDRBXMap::NUM_HPDS_PER_RBX> hpdindices;
+    std::array<int, HcalHPDRBXMap::NUM_HPDS_PER_RBX> hpdindices;
     HcalHPDRBXMap::indicesHPDfromRBX(i, hpdindices);
     for (int j = 0; j < HcalHPDRBXMap::NUM_HPDS_PER_RBX; j++) {
       rbx.hpds_[j].idnumber_ = hpdindices[j];


### PR DESCRIPTION
#### PR description:

Replace boost::array with std::array

we do appear to store and use data of type HFPhase1PMTData, which is affected by this PR. both boost::array and std::array are written out as T[N] from what I see. The other CondFormats are not used afaik (but also should be fine in case there is some payload somewhere.)

#### PR validation:

compilation ok, 2018 workflows run ok. They should test all changes
 