### PR TITLE
Run3-hcx227 Small fixes to dd4hep algorithms

### DIFF
--- a/Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalEE-algorithm.xml
+++ b/Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalEE-algorithm.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
 
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->

--- a/Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalHEsil-algorithm.xml
+++ b/Geometry/HGCalCommonData/data/dd4hep/cms-test-ddhgcalHEsil-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
@@ -61,7 +61,8 @@ struct HGCalEEAlgo {
   std::unordered_set<int> copies_;      // List of copy #'s
   double alpha_, cosAlpha_;
 
-  HGCalEEAlgo() {}
+  HGCalEEAlgo() { throw cms::Exception("HGCalGeom") << "Wrong initialization to HGCalEEAlgo"; }
+
   HGCalEEAlgo(cms::DDParsingContext& ctxt, xml_h e) {
     cms::DDNamespace ns(ctxt, e, true);
     cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
@@ -61,7 +61,7 @@ struct HGCalEEAlgo {
   std::unordered_set<int> copies_;      // List of copy #'s
   double alpha_, cosAlpha_;
 
-  HGCalEEAlgo() { throw cms::Exception("HGCalGeom") << "Wrong initialization to HGCalEEAlgo"; }
+  HGCalEEAlgo() = delete;
 
   HGCalEEAlgo(cms::DDParsingContext& ctxt, xml_h e) {
     cms::DDNamespace ns(ctxt, e, true);

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalHEPhase1-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalHEPhase1-algorithm.xml
@@ -21,14 +21,16 @@
 
   <IncludeSection>
     <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/Run2/trackermaterial.xml"/>
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/eta3/etaMax.xml"/>
     <Include ref="Geometry/CMSCommonData/data/normal/cmsextent.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/cms.xml"/>
+    <Include ref="Geometry/HcalAlgo/test/data/world.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/caloBase.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/muonBase.xml"/>
-    <Include ref="Geometry/HcalCommonData/data/hcalalgo.xml"/>
+    <Include ref="Geometry/HcalCommonData/data/hcal/PhaseI/hcalalgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalcablealgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalendcap/PhaseI/hcalendcapalgo.xml"/>
   </IncludeSection>

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
@@ -82,7 +82,7 @@ struct HCalEndcapModuleAlgo {
           zpos(z) {}
   };
 
-  HCalEndcapModuleAlgo() { throw cms::Exception("HCalGeom") << "Wrong initialization to HcalEndcapModuleAlgo"; }
+  HCalEndcapModuleAlgo() = delete;
 
   HCalEndcapModuleAlgo(cms::DDParsingContext& ctxt, xml_h e) {
     cms::DDNamespace ns(ctxt, e, true);

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
@@ -82,7 +82,8 @@ struct HCalEndcapModuleAlgo {
           zpos(z) {}
   };
 
-  HCalEndcapModuleAlgo() {}
+  HCalEndcapModuleAlgo() { throw cms::Exception("HCalGeom") << "Wrong initialization to HcalEndcapModuleAlgo"; }
+
   HCalEndcapModuleAlgo(cms::DDParsingContext& ctxt, xml_h e) {
     cms::DDNamespace ns(ctxt, e, true);
     cms::DDAlgoArguments args(ctxt, e);
@@ -183,7 +184,7 @@ struct HCalEndcapModuleAlgo {
     //Pointers to the Materials
     dd4hep::Material matabsorbr = ns.material(absorberMat);
     dd4hep::Material matplastic = ns.material(plasticMat);
-    dd4hep::Rotation3D rot = getRotation(rotstr);
+    dd4hep::Rotation3D rot = getRotation(rotstr, ns);
 
     int layer = layerNumber[0];
     int layer0 = layerNumber[1];
@@ -293,7 +294,7 @@ struct HCalEndcapModuleAlgo {
     //Pointers to the Rotation Matrices and to the Materials
     dd4hep::Material matter = ns.material(genMaterial);
     dd4hep::Material matplastic = ns.material(plasticMat);
-    dd4hep::Rotation3D rot = getRotation(rotstr);
+    dd4hep::Rotation3D rot = getRotation(rotstr, ns);
 
     double alpha = (1._pi) / sectors;
     double zi = zMinBlock;
@@ -535,9 +536,12 @@ struct HCalEndcapModuleAlgo {
     return r;
   }
 
-  dd4hep::Rotation3D getRotation(const std::string& rotstr) {
-    return ((rotstr == "hcalrotations::YXZ4") ? cms::makeRotation3D(90._deg, -90._deg, 90._deg, 0., 0., 0.)
-                                              : cms::makeRotation3D(90._deg, 0., 90._deg, 90._deg, 0., 0.));
+  dd4hep::Rotation3D getRotation(const std::string& rotstr, cms::DDNamespace& ns) {
+    std::string rot = (strchr(rotstr.c_str(), NAMESPACE_SEP) == nullptr) ? ("rotations:" + rotstr) : rotstr;
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HCalGeom") << "getRotation: " << rotstr << ":" << rot << ":" << ns.rotation(rot);
+#endif
+    return ns.rotation(rot);
   }
 };
 

--- a/Geometry/HcalAlgo/test/data/world.xml
+++ b/Geometry/HcalAlgo/test/data/world.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<PosPartSection label="">
+  <PosPart copyNumber="2">
+    <rParent name=":world_volume"/>
+    <rChild name="cms:OCMS"/>
+  </PosPart>
+</PosPartSection>
+
+</DDDefinition>


### PR DESCRIPTION
#### PR description:

Fixes to the codes with unwanted constructors and also access to already defined rotation matrix

#### PR validation:

Tested with cfg files in the test/python areas of Geometry/HcalAlgo and Geometry/HGCalCommonData

#### if this PR is a backport please specify the original PR:

Nothing special