### PR TITLE
Move LCTContainer to separate file

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboard.h
@@ -13,6 +13,7 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeAnodeLCTProcessor.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h"
+#include "L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h"
 
 // generic container type
 namespace {
@@ -33,37 +34,6 @@ namespace {
 
 class CSCUpgradeMotherboard : public CSCMotherboard {
 public:
-  /** for the case when more than 2 LCTs/BX are allowed;
-      maximum match window = 15 */
-  class LCTContainer {
-  public:
-    // constructor
-    LCTContainer(unsigned int trig_window_size);
-
-    // access the LCT in a particular ALCT BX, a particular CLCT matched BX
-    // and particular LCT number
-    CSCCorrelatedLCTDigi& operator()(int bx, int match_bx, int lct);
-
-    // get the matching LCTs for a certain ALCT BX
-    void getTimeMatched(const int bx, std::vector<CSCCorrelatedLCTDigi>&) const;
-
-    // get all LCTs in the 16 BX readout window
-    void getMatched(std::vector<CSCCorrelatedLCTDigi>&) const;
-
-    // clear the array with stubs
-    void clear();
-
-    // array with stored LCTs
-    // 1st index: depth of pipeline that stores the ALCT and CLCT
-    // 2nd index: BX number of the ALCT-CLCT match in the matching window
-    // 3rd index: LCT number in the time bin
-    CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_TBINS][CSCConstants::MAX_MATCH_WINDOW_SIZE]
-                             [CSCConstants::MAX_LCTS_PER_CSC];
-
-    // matching trigger window
-    const unsigned int match_trig_window_size_;
-  };
-
   // standard constructor
   CSCUpgradeMotherboard(unsigned endcap,
                         unsigned station,

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h
@@ -1,0 +1,49 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_LCTContainer_h
+#define L1Trigger_CSCTriggerPrimitives_LCTContainer_h
+
+/** \class LCTContainer
+ *
+ * This class is a helper class that contains LCTs per BX
+ *
+ * Author: Nick McColl
+ *
+ */
+
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+
+#include <vector>
+#include <algorithm>
+
+/** for the case when more than 2 LCTs/BX are allowed;
+    maximum match window = 15 */
+class LCTContainer {
+ public:
+  // constructor
+  LCTContainer(unsigned int trig_window_size);
+
+  // access the LCT in a particular ALCT BX, a particular CLCT matched BX
+  // and particular LCT number
+  CSCCorrelatedLCTDigi& operator()(int bx, int match_bx, int lct);
+
+  // get the matching LCTs for a certain ALCT BX
+  void getTimeMatched(const int bx, std::vector<CSCCorrelatedLCTDigi>&) const;
+
+  // get all LCTs in the 16 BX readout window
+  void getMatched(std::vector<CSCCorrelatedLCTDigi>&) const;
+
+  // clear the array with stubs
+  void clear();
+
+  // array with stored LCTs
+  // 1st index: depth of pipeline that stores the ALCT and CLCT
+  // 2nd index: BX number of the ALCT-CLCT match in the matching window
+  // 3rd index: LCT number in the time bin
+  CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_TBINS][CSCConstants::MAX_MATCH_WINDOW_SIZE]
+    [CSCConstants::MAX_LCTS_PER_CSC];
+
+  // matching trigger window
+  const unsigned int match_trig_window_size_;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h
@@ -18,7 +18,7 @@
 /** for the case when more than 2 LCTs/BX are allowed;
     maximum match window = 15 */
 class LCTContainer {
- public:
+public:
   // constructor
   LCTContainer(unsigned int trig_window_size);
 
@@ -40,7 +40,7 @@ class LCTContainer {
   // 2nd index: BX number of the ALCT-CLCT match in the matching window
   // 3rd index: LCT number in the time bin
   CSCCorrelatedLCTDigi data[CSCConstants::MAX_LCT_TBINS][CSCConstants::MAX_MATCH_WINDOW_SIZE]
-    [CSCConstants::MAX_LCTS_PER_CSC];
+                           [CSCConstants::MAX_LCTS_PER_CSC];
 
   // matching trigger window
   const unsigned int match_trig_window_size_;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeMotherboard.cc
@@ -1,49 +1,5 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboard.h"
 
-CSCUpgradeMotherboard::LCTContainer::LCTContainer(unsigned int trig_window_size)
-    : match_trig_window_size_(trig_window_size) {}
-
-CSCCorrelatedLCTDigi& CSCUpgradeMotherboard::LCTContainer::operator()(int bx, int match_bx, int lct) {
-  return data[bx][match_bx][lct];
-}
-
-void CSCUpgradeMotherboard::LCTContainer::getTimeMatched(const int bx, std::vector<CSCCorrelatedLCTDigi>& lcts) const {
-  for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
-    for (int i = 0; i < CSCConstants::MAX_LCTS_PER_CSC; i++) {
-      // consider only valid LCTs
-      if (not data[bx][mbx][i].isValid())
-        continue;
-
-      // remove duplicated LCTs
-      if (std::find(lcts.begin(), lcts.end(), data[bx][mbx][i]) != lcts.end())
-        continue;
-
-      lcts.push_back(data[bx][mbx][i]);
-    }
-  }
-}
-
-void CSCUpgradeMotherboard::LCTContainer::getMatched(std::vector<CSCCorrelatedLCTDigi>& lcts) const {
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
-    std::vector<CSCCorrelatedLCTDigi> temp_lcts;
-    CSCUpgradeMotherboard::LCTContainer::getTimeMatched(bx, temp_lcts);
-    lcts.insert(std::end(lcts), std::begin(temp_lcts), std::end(temp_lcts));
-  }
-}
-
-void CSCUpgradeMotherboard::LCTContainer::clear() {
-  // Loop over all time windows
-  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
-    // Loop over all matched trigger windows
-    for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
-      // Loop over all stubs
-      for (int i = 0; i < CSCConstants::MAX_LCTS_PER_CSC; i++) {
-        data[bx][mbx][i].clear();
-      }
-    }
-  }
-}
-
 CSCUpgradeMotherboard::CSCUpgradeMotherboard(unsigned endcap,
                                              unsigned station,
                                              unsigned sector,

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTContainer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTContainer.cc
@@ -1,0 +1,45 @@
+#include "L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h"
+
+LCTContainer::LCTContainer(unsigned int trig_window_size)
+    : match_trig_window_size_(trig_window_size) {}
+
+CSCCorrelatedLCTDigi& LCTContainer::operator()(int bx, int match_bx, int lct) {
+  return data[bx][match_bx][lct];
+}
+
+void LCTContainer::getTimeMatched(const int bx, std::vector<CSCCorrelatedLCTDigi>& lcts) const {
+  for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
+    for (int i = 0; i < CSCConstants::MAX_LCTS_PER_CSC; i++) {
+      // consider only valid LCTs
+      if (not data[bx][mbx][i].isValid())
+        continue;
+
+      // remove duplicated LCTs
+      if (std::find(lcts.begin(), lcts.end(), data[bx][mbx][i]) != lcts.end())
+        continue;
+
+      lcts.push_back(data[bx][mbx][i]);
+    }
+  }
+}
+
+void LCTContainer::getMatched(std::vector<CSCCorrelatedLCTDigi>& lcts) const {
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
+    std::vector<CSCCorrelatedLCTDigi> temp_lcts;
+    LCTContainer::getTimeMatched(bx, temp_lcts);
+    lcts.insert(std::end(lcts), std::begin(temp_lcts), std::end(temp_lcts));
+  }
+}
+
+void LCTContainer::clear() {
+  // Loop over all time windows
+  for (int bx = 0; bx < CSCConstants::MAX_LCT_TBINS; bx++) {
+    // Loop over all matched trigger windows
+    for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {
+      // Loop over all stubs
+      for (int i = 0; i < CSCConstants::MAX_LCTS_PER_CSC; i++) {
+        data[bx][mbx][i].clear();
+      }
+    }
+  }
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTContainer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTContainer.cc
@@ -1,11 +1,8 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h"
 
-LCTContainer::LCTContainer(unsigned int trig_window_size)
-    : match_trig_window_size_(trig_window_size) {}
+LCTContainer::LCTContainer(unsigned int trig_window_size) : match_trig_window_size_(trig_window_size) {}
 
-CSCCorrelatedLCTDigi& LCTContainer::operator()(int bx, int match_bx, int lct) {
-  return data[bx][match_bx][lct];
-}
+CSCCorrelatedLCTDigi& LCTContainer::operator()(int bx, int match_bx, int lct) { return data[bx][match_bx][lct]; }
 
 void LCTContainer::getTimeMatched(const int bx, std::vector<CSCCorrelatedLCTDigi>& lcts) const {
   for (unsigned int mbx = 0; mbx < match_trig_window_size_; mbx++) {


### PR DESCRIPTION
#### PR description:

This PR simply moves `LCTContainer` from inside `CSCUpgradeMotherboard` to a separate class definition `LCTContainer.h`. It is part of my ongoing mission to make the CSC local trigger as simple as possible to understand.

#### PR validation:



FYI @tahuang1991 @nickmccoll 