### PR TITLE
Avoid switch fallthrough in JetAnalyzer_HeavyIons

### DIFF
--- a/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer_HeavyIons.cc
@@ -833,6 +833,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_Unknown->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_Unknown->Fill(pfPt);
+          break;
         case 1:
           mPFCandpT_vs_eta_ChargedHadron->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -841,6 +842,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_ChargedHadron->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_ChargedHadron->Fill(pfPt);
+          break;
         case 2:
           mPFCandpT_vs_eta_electron->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -849,6 +851,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_electron->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_electron->Fill(pfPt);
+          break;
         case 3:
           mPFCandpT_vs_eta_muon->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -857,6 +860,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_muon->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_muon->Fill(pfPt);
+          break;
         case 4:
           mPFCandpT_vs_eta_photon->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -865,6 +869,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_photon->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_photon->Fill(pfPt);
+          break;
         case 5:
           mPFCandpT_vs_eta_NeutralHadron->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -873,6 +878,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_NeutralHadron->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_NeutralHadron->Fill(pfPt);
+          break;
         case 6:
           mPFCandpT_vs_eta_HadE_inHF->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -881,6 +887,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_HadE_inHF->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_HadE_inHF->Fill(pfPt);
+          break;
         case 7:
           mPFCandpT_vs_eta_EME_inHF->Fill(pfPt, pfEta);
           if (isBarrel)
@@ -889,6 +896,7 @@ void JetAnalyzer_HeavyIons::analyze(const edm::Event &mEvent, const edm::EventSe
             mPFCandpT_Endcap_EME_inHF->Fill(pfPt);
           if (isForward)
             mPFCandpT_Forward_EME_inHF->Fill(pfPt);
+          break;
       }
 
       //Fill 2d vector matrix


### PR DESCRIPTION

#### PR description:

This was found by gcc 9.

#### PR validation:

Compiling using the gcc 9 IB no longer gives warnings.