### PR TITLE
Phase2-hcx228 Add possibility of mapping DetId/TriggerId to ModuleId and viceversa

### DIFF
--- a/DataFormats/ForwardDetId/interface/HFNoseDetId.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetId.h
@@ -42,7 +42,8 @@ public:
   ForwardSubdetector subdet() const { return HFNose; }
 
   /** Converter for a geometry cell id */
-  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), type(), layer(), waferU(), waferV(), 0, 0); }
+  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), 0, layer(), waferU(), waferV(), 0, 0); }
+  HFNoseDetId moduleId() const { return HFNoseDetId(zside(), type(), layer(), waferU(), waferV(), 0, 0); }
 
   /// get the type
   int type() const { return (id_ >> kHFNoseTypeOffset) & kHFNoseTypeMask; }

--- a/DataFormats/ForwardDetId/interface/HFNoseDetId.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetId.h
@@ -42,7 +42,7 @@ public:
   ForwardSubdetector subdet() const { return HFNose; }
 
   /** Converter for a geometry cell id */
-  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), 0, layer(), waferU(), waferV(), 0, 0); }
+  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), type(), layer(), waferU(), waferV(), 0, 0); }
 
   /// get the type
   int type() const { return (id_ >> kHFNoseTypeOffset) & kHFNoseTypeMask; }

--- a/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
@@ -10,8 +10,8 @@ public:
   /** This translated TriggerDetId to Module and viceversa for HFNose*/
   HFNoseDetIdToModule();
 
-  static const HFNoseDetId getModule(HFNoseDetId const& id) { return id.geometryCell(); }
-  static const HFNoseDetId getModule(HFNoseTriggerDetId const& id) { return id.geometryCell(); }
+  static const HFNoseDetId getModule(HFNoseDetId const& id) { return id.moduleId(); }
+  static const HFNoseDetId getModule(HFNoseTriggerDetId const& id) { return id.moduleId(); }
   std::vector<HFNoseDetId> getDetIds(HFNoseDetId const& id) const;
   std::vector<HFNoseTriggerDetId> getTriggerDetIds(HFNoseDetId const& id) const;
 };

--- a/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
@@ -13,5 +13,6 @@ public:
   static const HFNoseDetId getModule(HFNoseDetId const& id) { return id.geometryCell(); }
   static const HFNoseDetId getModule(HFNoseTriggerDetId const& id) { return id.geometryCell(); }
   std::vector<HFNoseDetId> getDetIds(HFNoseDetId const& id) const;
+  std::vector<HFNoseTriggerDetId> getTriggerDetIds(HFNoseDetId const& id) const;
 };
 #endif

--- a/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
@@ -10,12 +10,8 @@ public:
   /** This translated TriggerDetId to Module and viceversa for HFNose*/
   HFNoseDetIdToModule();
 
-  static const HFNoseDetId getModule(HFNoseDetId const& id) {
-    return id.geometryCell();
-  }
-  static const HFNoseDetId getModule(HFNoseTriggerDetId const& id) {
-    return id.geometryCell();
-  }
+  static const HFNoseDetId getModule(HFNoseDetId const& id) { return id.geometryCell(); }
+  static const HFNoseDetId getModule(HFNoseTriggerDetId const& id) { return id.geometryCell(); }
   std::vector<HFNoseDetId> getDetIds(HFNoseDetId const& id) const;
 };
 #endif

--- a/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h
@@ -1,0 +1,21 @@
+#ifndef DataFormats_ForwardDetId_HFNoseDetIdToModule_H
+#define DataFormats_ForwardDetId_HFNoseDetIdToModule_H 1
+
+#include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include <vector>
+
+class HFNoseDetIdToModule {
+public:
+  /** This translated TriggerDetId to Module and viceversa for HFNose*/
+  HFNoseDetIdToModule();
+
+  static const HFNoseDetId getModule(HFNoseDetId const& id) {
+    return id.geometryCell();
+  }
+  static const HFNoseDetId getModule(HFNoseTriggerDetId const& id) {
+    return id.geometryCell();
+  }
+  std::vector<HFNoseDetId> getDetIds(HFNoseDetId const& id) const;
+};
+#endif

--- a/DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
 
 /* \brief description of the bit assigment
    [0:3]   u-coordinate of the cell (measured from the lower left
@@ -50,6 +51,9 @@ public:
 
   /// get the layer #
   int layer() const { return (id_ >> kHFNoseLayerOffset) & kHFNoseLayerMask; }
+
+  /** Converter for a geometry cell id */
+  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), type(), layer(), waferU(), waferV(), 0, 0); }
 
   /// get the cell #'s in u,v or in x,y
   int triggerCellU() const { return (id_ >> kHFNoseCellUOffset) & kHFNoseCellUMask; }

--- a/DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h
@@ -53,7 +53,8 @@ public:
   int layer() const { return (id_ >> kHFNoseLayerOffset) & kHFNoseLayerMask; }
 
   /** Converter for a geometry cell id */
-  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), type(), layer(), waferU(), waferV(), 0, 0); }
+  HFNoseDetId geometryCell() const { return HFNoseDetId(zside(), 0, layer(), waferU(), waferV(), 0, 0); }
+  HFNoseDetId moduleId() const { return HFNoseDetId(zside(), type(), layer(), waferU(), waferV(), 0, 0); }
 
   /// get the cell #'s in u,v or in x,y
   int triggerCellU() const { return (id_ >> kHFNoseCellUOffset) & kHFNoseCellUMask; }

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
@@ -39,7 +39,9 @@ public:
   HGCSiliconDetId& operator=(const DetId& id);
 
   /** Converter for a geometry cell id */
-  HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0); }
+  HGCSiliconDetId geometryCell() const {
+    return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0);
+  }
 
   /// get the subdetector
   DetId::Detector subdet() const { return det(); }

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
@@ -39,7 +39,7 @@ public:
   HGCSiliconDetId& operator=(const DetId& id);
 
   /** Converter for a geometry cell id */
-  HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0); }
+  HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0); }
 
   /// get the subdetector
   DetId::Detector subdet() const { return det(); }

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
@@ -40,6 +40,9 @@ public:
 
   /** Converter for a geometry cell id */
   HGCSiliconDetId geometryCell() const {
+    return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0);
+  }
+  HGCSiliconDetId moduleId() const {
     return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0);
   }
 

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
@@ -39,9 +39,7 @@ public:
   HGCSiliconDetId& operator=(const DetId& id);
 
   /** Converter for a geometry cell id */
-  HGCSiliconDetId geometryCell() const {
-    return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0);
-  }
+  HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0); }
   HGCSiliconDetId moduleId() const {
     return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0);
   }

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
@@ -10,8 +10,8 @@ public:
   /** This translated TriggerDetId to Module and viceversa for HGCSilicon*/
   HGCSiliconDetIdToModule();
 
-  static const HGCSiliconDetId getModule(HGCalTriggerDetId const& id) { return id.geometryCell(); }
-  static const HGCSiliconDetId getModule(HGCSiliconDetId const& id) { return id.geometryCell(); }
+  static const HGCSiliconDetId getModule(HGCalTriggerDetId const& id) { return id.moduleId(); }
+  static const HGCSiliconDetId getModule(HGCSiliconDetId const& id) { return id.moduleId(); }
   std::vector<HGCSiliconDetId> getDetIds(HGCSiliconDetId const& id) const;
   std::vector<HGCalTriggerDetId> getDetTriggerIds(HGCSiliconDetId const& id) const;
 };

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
@@ -10,12 +10,8 @@ public:
   /** This translated TriggerDetId to Module and viceversa for HGCSilicon*/
   HGCSiliconDetIdToModule();
 
-  static const HGCSiliconDetId getModule(HGCalTriggerDetId const& id) {
-    return id.geometryCell();
-  }
-  static const HGCSiliconDetId getModule(HGCSiliconDetId const& id) {
-    return id.geometryCell();
-  }
+  static const HGCSiliconDetId getModule(HGCalTriggerDetId const& id) { return id.geometryCell(); }
+  static const HGCSiliconDetId getModule(HGCSiliconDetId const& id) { return id.geometryCell(); }
   std::vector<HGCSiliconDetId> getDetIds(HGCSiliconDetId const& id) const;
 };
 #endif

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
@@ -13,5 +13,6 @@ public:
   static const HGCSiliconDetId getModule(HGCalTriggerDetId const& id) { return id.geometryCell(); }
   static const HGCSiliconDetId getModule(HGCSiliconDetId const& id) { return id.geometryCell(); }
   std::vector<HGCSiliconDetId> getDetIds(HGCSiliconDetId const& id) const;
+  std::vector<HGCalTriggerDetId> getDetTriggerIds(HGCSiliconDetId const& id) const;
 };
 #endif

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h
@@ -1,0 +1,21 @@
+#ifndef DataFormats_ForwardDetId_HGCSiliconDetIdToModule_H
+#define DataFormats_ForwardDetId_HGCSiliconDetIdToModule_H 1
+
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include <vector>
+
+class HGCSiliconDetIdToModule {
+public:
+  /** This translated TriggerDetId to Module and viceversa for HGCSilicon*/
+  HGCSiliconDetIdToModule();
+
+  static const HGCSiliconDetId getModule(HGCalTriggerDetId const& id) {
+    return id.geometryCell();
+  }
+  static const HGCSiliconDetId getModule(HGCSiliconDetId const& id) {
+    return id.geometryCell();
+  }
+  std::vector<HGCSiliconDetId> getDetIds(HGCSiliconDetId const& id) const;
+};
+#endif

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h
@@ -1,7 +1,10 @@
 #ifndef DataFormats_ForwardDetId_HGCSiliconDetIdToROC_H
 #define DataFormats_ForwardDetId_HGCSiliconDetIdToROC_H 1
 
+#include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 #include <iostream>
 #include <map>
 #include <utility>
@@ -14,6 +17,15 @@ public:
   HGCSiliconDetIdToROC();
 
   int getROCNumber(HGCalTriggerDetId const& id) const {
+    return getROCNumber(id.triggerCellU(), id.triggerCellV(), id.type());
+  }
+  int getROCNumber(HGCSiliconDetId const& id) const {
+    return getROCNumber(id.triggerCellU(), id.triggerCellV(), id.type());
+  }
+  int getROCNumber(HFNoseDetId const& id) const {
+    return getROCNumber(id.triggerCellU(), id.triggerCellV(), id.type());
+  }
+  int getROCNumber(HFNoseTriggerDetId const& id) const {
     return getROCNumber(id.triggerCellU(), id.triggerCellV(), id.type());
   }
   int getROCNumber(int triggerCellU, int triggerCellV, int type) const;

--- a/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
@@ -52,6 +52,9 @@ public:
   /// get the layer #
   int layer() const { return (id_ >> kHGCalLayerOffset) & kHGCalLayerMask; }
 
+  /** Converter for a geometry cell id */
+  HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0); }
+
   /// get the cell #'s in u,v or in x,y
   int triggerCellU() const { return (id_ >> kHGCalCellUOffset) & kHGCalCellUMask; }
   int triggerCellV() const { return (id_ >> kHGCalCellVOffset) & kHGCalCellVMask; }

--- a/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
@@ -54,7 +54,9 @@ public:
 
   /** Converter for a geometry cell id */
   HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0); }
-  HGCSiliconDetId moduleId() const { return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0); }
+  HGCSiliconDetId moduleId() const {
+    return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0);
+  }
 
   /// get the cell #'s in u,v or in x,y
   int triggerCellU() const { return (id_ >> kHGCalCellUOffset) & kHGCalCellUMask; }

--- a/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h
@@ -54,6 +54,7 @@ public:
 
   /** Converter for a geometry cell id */
   HGCSiliconDetId geometryCell() const { return HGCSiliconDetId(det(), zside(), 0, layer(), waferU(), waferV(), 0, 0); }
+  HGCSiliconDetId moduleId() const { return HGCSiliconDetId(det(), zside(), type(), layer(), waferU(), waferV(), 0, 0); }
 
   /// get the cell #'s in u,v or in x,y
   int triggerCellU() const { return (id_ >> kHGCalCellUOffset) & kHGCalCellUMask; }

--- a/DataFormats/ForwardDetId/src/HFNoseDetIdToModule.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetIdToModule.cc
@@ -1,0 +1,18 @@
+#include "DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h"
+
+HFNoseDetIdToModule::HFNoseDetIdToModule() {}
+
+std::vector<HFNoseDetId> HFNoseDetIdToModule::getDetIds(HFNoseDetId const& id) const {
+  std::vector<HFNoseDetId> ids;
+  int nCells = (id.type() == 0) ? HFNoseDetId::HFNoseFineN : HFNoseDetId::HFNoseCoarseN;
+  for (int u = 0; u < 2 * nCells; ++u) {
+    for (int v = 0; v < 2 * nCells; ++v) {
+      if (((v - u) < nCells) && (u - v) <= nCells) {
+	HFNoseDetId newId(id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
+	ids.emplace_back(newId);
+      }
+    }
+  }
+  return ids;
+}
+

--- a/DataFormats/ForwardDetId/src/HFNoseDetIdToModule.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetIdToModule.cc
@@ -15,3 +15,17 @@ std::vector<HFNoseDetId> HFNoseDetIdToModule::getDetIds(HFNoseDetId const& id) c
   }
   return ids;
 }
+
+std::vector<HFNoseTriggerDetId> HFNoseDetIdToModule::getTriggerDetIds(HFNoseDetId const& id) const {
+  std::vector<HFNoseTriggerDetId> ids;
+  int nCells = HFNoseDetId::HFNoseFineN / HFNoseDetId::HFNoseFineTrigger;
+  for (int u = 0; u < 2 * nCells; ++u) {
+    for (int v = 0; v < 2 * nCells; ++v) {
+      if (((v - u) < nCells) && (u - v) <= nCells) {
+        HFNoseTriggerDetId newId(HFNoseTrigger, id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
+        ids.emplace_back(newId);
+      }
+    }
+  }
+  return ids;
+}

--- a/DataFormats/ForwardDetId/src/HFNoseDetIdToModule.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetIdToModule.cc
@@ -8,11 +8,10 @@ std::vector<HFNoseDetId> HFNoseDetIdToModule::getDetIds(HFNoseDetId const& id) c
   for (int u = 0; u < 2 * nCells; ++u) {
     for (int v = 0; v < 2 * nCells; ++v) {
       if (((v - u) < nCells) && (u - v) <= nCells) {
-	HFNoseDetId newId(id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
-	ids.emplace_back(newId);
+        HFNoseDetId newId(id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
+        ids.emplace_back(newId);
       }
     }
   }
   return ids;
 }
-

--- a/DataFormats/ForwardDetId/src/HGCSiliconDetIdToModule.cc
+++ b/DataFormats/ForwardDetId/src/HGCSiliconDetIdToModule.cc
@@ -8,8 +8,8 @@ std::vector<HGCSiliconDetId> HGCSiliconDetIdToModule::getDetIds(HGCSiliconDetId 
   for (int u = 0; u < 2 * nCells; ++u) {
     for (int v = 0; v < 2 * nCells; ++v) {
       if (((v - u) < nCells) && (u - v) <= nCells) {
-	HGCSiliconDetId newId(id.det(), id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
-	ids.emplace_back(newId);
+        HGCSiliconDetId newId(id.det(), id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
+        ids.emplace_back(newId);
       }
     }
   }

--- a/DataFormats/ForwardDetId/src/HGCSiliconDetIdToModule.cc
+++ b/DataFormats/ForwardDetId/src/HGCSiliconDetIdToModule.cc
@@ -1,0 +1,17 @@
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h"
+
+HGCSiliconDetIdToModule::HGCSiliconDetIdToModule() {}
+
+std::vector<HGCSiliconDetId> HGCSiliconDetIdToModule::getDetIds(HGCSiliconDetId const& id) const {
+  std::vector<HGCSiliconDetId> ids;
+  int nCells = (id.type() == 0) ? HGCSiliconDetId::HGCalFineN : HGCSiliconDetId::HGCalCoarseN;
+  for (int u = 0; u < 2 * nCells; ++u) {
+    for (int v = 0; v < 2 * nCells; ++v) {
+      if (((v - u) < nCells) && (u - v) <= nCells) {
+	HGCSiliconDetId newId(id.det(), id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
+	ids.emplace_back(newId);
+      }
+    }
+  }
+  return ids;
+}

--- a/DataFormats/ForwardDetId/src/HGCSiliconDetIdToModule.cc
+++ b/DataFormats/ForwardDetId/src/HGCSiliconDetIdToModule.cc
@@ -15,3 +15,18 @@ std::vector<HGCSiliconDetId> HGCSiliconDetIdToModule::getDetIds(HGCSiliconDetId 
   }
   return ids;
 }
+
+std::vector<HGCalTriggerDetId> HGCSiliconDetIdToModule::getDetTriggerIds(HGCSiliconDetId const& id) const {
+  std::vector<HGCalTriggerDetId> ids;
+  int nCells = HGCSiliconDetId::HGCalFineN / HGCSiliconDetId::HGCalFineTrigger;
+  int subdet = (id.det() == DetId::HGCalEE) ? HGCalEETrigger : HGCalHSiTrigger;
+  for (int u = 0; u < 2 * nCells; ++u) {
+    for (int v = 0; v < 2 * nCells; ++v) {
+      if (((v - u) < nCells) && (u - v) <= nCells) {
+        HGCalTriggerDetId newId(subdet, id.zside(), id.type(), id.layer(), id.waferU(), id.waferV(), u, v);
+        ids.emplace_back(newId);
+      }
+    }
+  }
+  return ids;
+}

--- a/DataFormats/ForwardDetId/test/testHFNoseDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHFNoseDetId.cc
@@ -1,5 +1,6 @@
 #include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
 #include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseDetIdToModule.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include <cmath>
@@ -138,10 +139,27 @@ void testTriggerCell(int type) {
             << std::endl;
 }
 
+void testModule(HFNoseDetId const& id) {
+  HFNoseDetIdToModule hfn;
+  HFNoseDetId module = hfn.getModule(id);
+  std::vector<HFNoseDetId> ids = hfn.getDetIds(module);
+  std::string ok = "***** ERROR *****";
+  for (auto const& id0 : ids) {
+    if (id0 == id) {
+      ok = ""; break;
+    }
+  }
+  std::cout << "Module ID of " << id << " is " << module << " which has " << ids.size() << " cells " << ok << std::endl;
+  for (unsigned int k = 0; k < ids.size(); ++k)
+    std::cout << "ID[" << k << "] " << ids[k] << std::endl;
+}
+  
 int main() {
   testCell(0);
   testWafer(1, 299.47, 1041.45);
   testWafer(8, 312.55, 1086.97);
   testTriggerCell(0);
+  testModule(HFNoseDetId(1,0,1,3,3,0,5));
+  testModule(HFNoseDetId(-1,0,5,2,-2,7,5));
   return 0;
 }

--- a/DataFormats/ForwardDetId/test/testHFNoseDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHFNoseDetId.cc
@@ -146,20 +146,21 @@ void testModule(HFNoseDetId const& id) {
   std::string ok = "***** ERROR *****";
   for (auto const& id0 : ids) {
     if (id0 == id) {
-      ok = ""; break;
+      ok = "";
+      break;
     }
   }
   std::cout << "Module ID of " << id << " is " << module << " which has " << ids.size() << " cells " << ok << std::endl;
   for (unsigned int k = 0; k < ids.size(); ++k)
     std::cout << "ID[" << k << "] " << ids[k] << std::endl;
 }
-  
+
 int main() {
   testCell(0);
   testWafer(1, 299.47, 1041.45);
   testWafer(8, 312.55, 1086.97);
   testTriggerCell(0);
-  testModule(HFNoseDetId(1,0,1,3,3,0,5));
-  testModule(HFNoseDetId(-1,0,5,2,-2,7,5));
+  testModule(HFNoseDetId(1, 0, 1, 3, 3, 0, 5));
+  testModule(HFNoseDetId(-1, 0, 5, 2, -2, 7, 5));
   return 0;
 }

--- a/DataFormats/ForwardDetId/test/testHGCDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHGCDetId.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToModule.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetIdToROC.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
@@ -186,6 +187,21 @@ void testROC() {
   }
 }
 
+void testModule(HGCSiliconDetId const& id) {
+  HGCSiliconDetIdToModule hgc;
+  HGCSiliconDetId module = hgc.getModule(id);
+  std::vector<HGCSiliconDetId> ids = hgc.getDetIds(module);
+  std::string ok = "***** ERROR *****";
+  for (auto const& id0 : ids) {
+    if (id0 == id) {
+      ok = ""; break;
+    }
+  }
+  std::cout << "Module ID of " << id << " is " << module << " which has " << ids.size() << " cells " << ok << std::endl;
+  for (unsigned int k = 0; k < ids.size(); ++k)
+    std::cout << "ID[" << k << "] " << ids[k] << std::endl;
+}
+
 int main() {
   testCell(0);
   testCell(1);
@@ -196,6 +212,7 @@ int main() {
   testTriggerCell(0);
   testTriggerCell(1);
   testROC();
-
+  testModule(HGCSiliconDetId(DetId::HGCalEE,1,0,1,5,4,0,10));
+  testModule(HGCSiliconDetId(DetId::HGCalHSi,-1,1,30,-6,-4,5,5));
   return 0;
 }

--- a/DataFormats/ForwardDetId/test/testHGCDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHGCDetId.cc
@@ -194,7 +194,8 @@ void testModule(HGCSiliconDetId const& id) {
   std::string ok = "***** ERROR *****";
   for (auto const& id0 : ids) {
     if (id0 == id) {
-      ok = ""; break;
+      ok = "";
+      break;
     }
   }
   std::cout << "Module ID of " << id << " is " << module << " which has " << ids.size() << " cells " << ok << std::endl;
@@ -212,7 +213,7 @@ int main() {
   testTriggerCell(0);
   testTriggerCell(1);
   testROC();
-  testModule(HGCSiliconDetId(DetId::HGCalEE,1,0,1,5,4,0,10));
-  testModule(HGCSiliconDetId(DetId::HGCalHSi,-1,1,30,-6,-4,5,5));
+  testModule(HGCSiliconDetId(DetId::HGCalEE, 1, 0, 1, 5, 4, 0, 10));
+  testModule(HGCSiliconDetId(DetId::HGCalHSi, -1, 1, 30, -6, -4, 5, 5));
   return 0;
 }


### PR DESCRIPTION
#### PR description:

Add hooks for going  from DetId or TriggerDetId to ModuleId and vice versa

#### PR validation:

Tested with a test code in DataFormats/ForwardDetId/test and standard matrix

#### if this PR is a backport please specify the original PR:

Nothing special