### PR TITLE
Python3: changes needed to fix runTheMatrix errors for PY3 IBs

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -143,7 +143,7 @@ def filesFromDASQuery(query,option="",s=None):
         if count!=0:
             print('Sleeping, then retrying DAS')
             time.sleep(100)
-        p = Popen('dasgoclient %s --query "%s"'%(option,query), stdout=PIPE,shell=True)
+        p = Popen('dasgoclient %s --query "%s"'%(option,query), stdout=PIPE,shell=True, universal_newlines=True)
         pipe=p.stdout.read()
         tupleP = os.waitpid(p.pid, 0)
         eC=tupleP[1]

--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -29,7 +29,7 @@ def articleExist(artId):
 
     itExists = False
     theCommand = defaultEOSlistCommand+' '+defaultEOSRootPath
-    dirList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE)
+    dirList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE, universal_newlines=True)
     for line in dirList.stdout.readlines():
         if findXrdDir(line) == str(artId): 
             itExists = True
@@ -41,7 +41,7 @@ def lastArticle():
     artList = [0]
 
     theCommand = defaultEOSlistCommand+' '+defaultEOSRootPath
-    dirList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE)
+    dirList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE, universal_newlines=True)
     for line in dirList.stdout.readlines():
         try:
             if line.rstrip('\n') != '':
@@ -261,7 +261,7 @@ if __name__ == '__main__':
     elif options.artIdLi !=0:
         listPath = defaultEOSRootPath+'/'+str(options.artIdLi)
         theCommand = defaultEOSlistCommand+' '+listPath
-        exeList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE)
+        exeList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE, universal_newlines=True)
         for line in exeList.stdout.readlines():
             if findXrdDir(line) != None:
                 print(findXrdDir(line))

--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -194,7 +194,7 @@ class StandardTester(object):
             os.system(cmd)
 
         import pickle
-        pickle.dump(self.commands, open('logs/addOnTests.pkl', 'w') )
+        pickle.dump(self.commands, open('logs/addOnTests.pkl', 'wb'), protocol=2)
 
         os.chdir(actDir)
 


### PR DESCRIPTION
This change should allow to run most of relvals for Python3 IBs. There are still some errors but those are coming from external packages.