### PR TITLE
AutoCond update for 2017 and 2021 cosmic GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,7 +70,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2021
     'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,9 +50,9 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    :  '110X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector


### PR DESCRIPTION
#### PR description:

This PR updates the 2017 and 2021 cosmic GTs so that they have only the desired differences with respect to the collision GTs. For 2017, both PEAK and DECO cosmic GTs are updated.  For 2021, only DECO cosmic GT is updated (the PEAK version does not exist at the moment).

Desired differences with respected collision GTs are described in [1]. Updates of other cosmic GTs will follow once Ultralegacy campaigns are done.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4194.html

**GT diffs wrt. collision GTs:**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mc2017_realistic_v1/110X_mc2017cosmics_realistic_deco_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mc2017_realistic_v1/110X_mc2017cosmics_realistic_peak_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_v2/110X_mcRun3_2021cosmics_realistic_deco_v2

#### PR validation:
A technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR:
This PR is not a backport.
