### PR TITLE
Python2to3: cmp to key conversion in list sort substitute

### DIFF
--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -422,8 +422,6 @@ def printStalledModulesInOrder(stalledModules):
         t.sort(reverse=True)
         priorities.append((name,sum(t),t))
 
-    def sumSort(i,j):
-        return cmp(i[1],j[1])
     priorities.sort(key=lambda a: a[1], reverse=True)
 
     nameColumn = "Stalled Module"

--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -6,7 +6,6 @@ from operator import attrgetter,itemgetter
 import sys
 from collections import defaultdict
 import six
-from functools import cmp_to_key
 #----------------------------------------------
 def printHelp():
     s = '''

--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -6,7 +6,7 @@ from operator import attrgetter,itemgetter
 import sys
 from collections import defaultdict
 import six
-
+from functools import cmp_to_key
 #----------------------------------------------
 def printHelp():
     s = '''
@@ -424,7 +424,7 @@ def printStalledModulesInOrder(stalledModules):
 
     def sumSort(i,j):
         return cmp(i[1],j[1])
-    priorities.sort(cmp=sumSort, reverse=True)
+    priorities.sort(key=cmp_to_key(sumSort), reverse=True)
 
     nameColumn = "Stalled Module"
     maxNameSize = max(maxNameSize, len(nameColumn))

--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -424,7 +424,7 @@ def printStalledModulesInOrder(stalledModules):
 
     def sumSort(i,j):
         return cmp(i[1],j[1])
-    priorities.sort(key=cmp_to_key(sumSort), reverse=True)
+    priorities.sort(key=lambda a: a[1], reverse=True)
 
     nameColumn = "Stalled Module"
     maxNameSize = max(maxNameSize, len(nameColumn))


### PR DESCRIPTION
#### PR description:
Fixes python3 implementation of list sorting using a comparison function
as described here: 
https://stackoverflow.com/questions/2531952/how-to-use-a-custom-comparison-function-in-python-3
#### PR validation:
Works both with py2 and py3

