### PR TITLE
Run3-hcx229 Correct some of the cfg files and make file naming more homogeneous

### DIFF
--- a/Geometry/HcalAlgo/data/cms-test-ddhcalForwardShield-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalForwardShield-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -28,6 +26,7 @@
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/normal/cmsextent.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/cms.xml"/>
+    <Include ref="Geometry/HcalAlgo/test/data/world.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/muonBase.xml"/>
     <Include ref="Geometry/ForwardCommonData/data/bundle/forwardshield.xml"/>
   </IncludeSection>

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalHB-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalHB-algorithm.xml
@@ -26,6 +26,7 @@
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/normal/cmsextent.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/cms.xml"/>
+    <Include ref="Geometry/HcalAlgo/test/data/world.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/caloBase.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/muonBase.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalalgo.xml"/>

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalHEPhase0-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalHEPhase0-algorithm.xml
@@ -26,6 +26,7 @@
     <Include ref="Geometry/CMSCommonData/data/eta3/etaMax.xml"/>
     <Include ref="Geometry/CMSCommonData/data/normal/cmsextent.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/cms.xml"/>
+    <Include ref="Geometry/HcalAlgo/test/data/world.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/caloBase.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/muonBase.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalalgo.xml"/>

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalHF-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalHF-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -28,6 +26,7 @@
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/normal/cmsextent.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/cms.xml"/>
+    <Include ref="Geometry/HcalAlgo/test/data/world.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/muonBase.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalforwardalgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalforwardfibre.xml"/>

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalHO-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalHO-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -28,6 +26,7 @@
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/normal/cmsextent.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/cms.xml"/>
+    <Include ref="Geometry/HcalAlgo/test/data/world.xml"/>
     <Include ref="Geometry/HcalAlgo/test/data/muonBase.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalouteralgo.xml"/>
   </IncludeSection>

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalTBCable-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalTBCable-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -26,6 +24,7 @@
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal.xml"/>
+    <Include ref="Geometry/HcalAlgo/data/world.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcalCable.xml"/>
   </IncludeSection>
   

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalTBZpos-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalTBZpos-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -27,6 +25,7 @@
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal.xml"/>
+    <Include ref="Geometry/HcalAlgo/data/world.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal06HcalOuter.xml"/>
   </IncludeSection>
   

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalTestBeam-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalTestBeam-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -26,6 +24,7 @@
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal.xml"/>
+    <Include ref="Geometry/HcalAlgo/data/world.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal06BeamLine.xml"/>
   </IncludeSection>
   

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalXtal-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalXtal-algorithm.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <debug>
+<!-- 
     <debug_shapes/>
     <debug_includes/>
     <debug_rotations/>
     <debug_includes/>
     <debug_volumes/>
     <debug_constants/>
-    <!-- debug_materials/ -->
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
-
-<!-- 
     <debug_materials/>
     <debug_visattr/>
 -->
@@ -25,6 +23,7 @@
     <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal.xml"/>
+    <Include ref="Geometry/HcalAlgo/data/world.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcalXtal.xml"/>
   </IncludeSection>
   

--- a/Geometry/HcalAlgo/data/world.xml
+++ b/Geometry/HcalAlgo/data/world.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+<PosPartSection label="">
+  <PosPart copyNumber="2">
+    <rParent name=":world_volume"/>
+    <rChild name="TBHcal:OTBHCal"/>
+  </PosPart>
+</PosPartSection>
+
+</DDDefinition>

--- a/Geometry/HcalAlgo/test/python/dumpForwardShield_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpForwardShield_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('ForwardShieldDDD.root')
+                              outputFileName = cms.untracked.string('forwardShieldDDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/dumpHFGeom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpHFGeom_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('HF.root')
+                              outputFileName = cms.untracked.string('hfDDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/dumpHOGeom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpHOGeom_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('HO.root')
+                              outputFileName = cms.untracked.string('hoDDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/dumpHcalXtal_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpHcalXtal_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('HcalXtal.root')
+                              outputFileName = cms.untracked.string('hcalXtalDDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/dumpTBCable_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpTBCable_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('TBCableDDD.root')
+                              outputFileName = cms.untracked.string('tbCableDDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/dumpTBHOGeom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpTBHOGeom_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('TBHODDD.root')
+                              outputFileName = cms.untracked.string('tbHODDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/dumpTestBeam_cfg.py
+++ b/Geometry/HcalAlgo/test/python/dumpTestBeam_cfg.py
@@ -23,7 +23,7 @@ process.add_(cms.ESProducer("TGeoMgrFromDdd",
 
 
 process.dump = cms.EDAnalyzer("DumpSimGeometry",
-                              outputFileName = cms.untracked.string('BeamLineDDD.root')
+                              outputFileName = cms.untracked.string('testBeamDDD.root')
 )
 
 process.p = cms.Path(process.dump)

--- a/Geometry/HcalAlgo/test/python/testForwardShield_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testForwardShield_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('ForwardShieldDD4Hep.root'),
+                                  outputFileName = cms.untracked.string('forwardShieldDD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalFibreBundle')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testHEPhase1Geom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testHEPhase1Geom_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('HEPhase1DD4Hep.root'),
+                                  outputFileName = cms.untracked.string('hePhase1DD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalHEPhase1')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testHFGeom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testHFGeom_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('HFDD4Hep.root'),
+                                  outputFileName = cms.untracked.string('hfDD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalHF')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testHOGeom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testHOGeom_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('HODD4Hep.root'),
+                                  outputFileName = cms.untracked.string('hoDD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalHO')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testHcalXtal_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testHcalXtal_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('HcalXtalDD4Hep.root'),
+                                  outputFileName = cms.untracked.string('hcalXtalDD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalXtalAlgo')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testTBCable_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testTBCable_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('TBCableDD4Hep.root'),
+                                  outputFileName = cms.untracked.string('tbCableDD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalTBCable')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testTBHOGeom_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testTBHOGeom_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('TBHODD4Hep.root'),
+                                  outputFileName = cms.untracked.string('tbHODD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalTBHO')
                                   )
 

--- a/Geometry/HcalAlgo/test/python/testTestBeam_cfg.py
+++ b/Geometry/HcalAlgo/test/python/testTestBeam_cfg.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  outputFileName = cms.untracked.string('BeamLineDD4Hep.root'),
+                                  outputFileName = cms.untracked.string('testBeamDD4Hep.root'),
                                   DDDetector = cms.ESInputTag('','DDHCalTestBeam')
                                   )
 


### PR DESCRIPTION
#### PR description:

Correct the cfg files to get dumped root files which can be visualized by fireworks geometry. Also tried to have more similar file naming conventions

#### PR validation:

Tested using the cfg files in Geometry/HcalAlgo/test/python

#### if this PR is a backport please specify the original PR:

Nothing special
