### PR TITLE
Run3-Sim47 Allow saving tracks with momentum above a certain threshold

### DIFF
--- a/Geometry/HGCalSimData/data/CaloUtil.xml
+++ b/Geometry/HGCalSimData/data/CaloUtil.xml
@@ -71,7 +71,7 @@
    <Parameter name="InsideLevel" value="3" eval="true"/>
    <Parameter name="InsideLevel" value="3" eval="true"/>
    <Parameter name="FineCalorimeter" value="HGCal" eval="false"/>
-   <Parameter name="FineLevels" value="8" eval="true"/>
+   <Parameter name="FineLevels" value="4" eval="true"/>
   </SpecPar>
  </SpecParSection>
 </DDDefinition>

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -64,7 +64,6 @@ private:
   double eMin_, eMinFine_, eMinFinePhoton_;
   int lastTrackID_;
   std::vector<Detector> detectors_, fineDetectors_;
-  const SimTrackManager* m_trackManager;
 };
 
 #endif

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -38,13 +38,6 @@ public:
   void fillHits(edm::PCaloHitContainer&, const std::string&) override {}
 
 private:
-  void update(const BeginOfEvent* evt) override;
-  void update(const G4Step*) override;
-  std::vector<std::string> getNames(G4String, const DDsvalues_type&);
-  std::vector<double> getNumbers(G4String, const DDsvalues_type&);
-  int isItCalo(const G4VTouchable*);
-  int isItInside(const G4VTouchable*, int, int);
-
   struct Detector {
     Detector() {}
     std::string name;
@@ -55,15 +48,22 @@ private:
     std::vector<int> fromLevels;
   };
 
+  void update(const BeginOfEvent* evt) override;
+  void update(const G4Step*) override;
+  std::vector<std::string> getNames(G4String, const DDsvalues_type&);
+  std::vector<double> getNumbers(G4String, const DDsvalues_type&);
+  int isItCalo(const G4VTouchable*, const std::vector<Detector>&);
+  int isItInside(const G4VTouchable*, int, int);
+
   // Utilities to get detector levels during a step
   int detLevels(const G4VTouchable*) const;
   G4LogicalVolume* detLV(const G4VTouchable*, int) const;
   void detectorLevel(const G4VTouchable*, int&, int*, G4String*) const;
 
-  bool testBeam, putHistory;
-  double eMin;
-  int lastTrackID;
-  std::vector<Detector> detectors;
+  bool testBeam_, putHistory_, doFineCalo_;
+  double eMin_, eMinFine_, eMinFinePhoton_;
+  int lastTrackID_;
+  std::vector<Detector> detectors_, fineDetectors_;
   const SimTrackManager* m_trackManager;
 };
 

--- a/SimG4CMS/Calo/interface/CaloTrkProcessing.h
+++ b/SimG4CMS/Calo/interface/CaloTrkProcessing.h
@@ -50,8 +50,8 @@ private:
 
   void update(const BeginOfEvent* evt) override;
   void update(const G4Step*) override;
-  std::vector<std::string> getNames(G4String, const DDsvalues_type&);
-  std::vector<double> getNumbers(G4String, const DDsvalues_type&);
+  std::vector<std::string> getNames(G4String, const DDsvalues_type&, bool);
+  std::vector<double> getNumbers(G4String, const DDsvalues_type&, bool);
   int isItCalo(const G4VTouchable*, const std::vector<Detector>&);
   int isItInside(const G4VTouchable*, int, int);
 

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -55,7 +55,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
   DDsvalues_type sv(fv.mergedSpecifics());
 
   G4String value = "Calorimeter";
-  std::vector<std::string> caloNames = getNames(value, sv, false);
+  const std::vector<std::string>& caloNames = getNames(value, sv, false);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << caloNames.size() << " entries for " << value << ":";
   for (unsigned int i = 0; i < caloNames.size(); i++)
@@ -63,7 +63,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
 #endif
 
   value = "Levels";
-  std::vector<double> levels = getNumbers(value, sv, false);
+  const std::vector<double>& levels = getNumbers(value, sv, false);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << levels.size() << " entries for " << value << ":";
   for (unsigned int i = 0; i < levels.size(); i++)
@@ -71,7 +71,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
 #endif
 
   value = "Neighbours";
-  std::vector<double> neighbours = getNumbers(value, sv, false);
+  const std::vector<double>& neighbours = getNumbers(value, sv, false);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << neighbours.size() << " entries for " << value << ":";
   for (unsigned int i = 0; i < neighbours.size(); i++)
@@ -79,7 +79,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
 #endif
 
   value = "Inside";
-  std::vector<std::string> insideNames = getNames(value, sv, false);
+  const std::vector<std::string>& insideNames = getNames(value, sv, false);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << insideNames.size() << " entries for " << value << ":";
   for (unsigned int i = 0; i < insideNames.size(); i++)
@@ -87,7 +87,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
 #endif
 
   value = "InsideLevel";
-  std::vector<double> insideLevel = getNumbers(value, sv, false);
+  const std::vector<double>& insideLevel = getNumbers(value, sv, false);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << insideLevel.size() << " ebtries for " << value << ":";
   for (unsigned int i = 0; i < insideLevel.size(); i++)
@@ -95,7 +95,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
 #endif
 
   value = "FineCalorimeter";
-  std::vector<std::string> fCaloNames = getNames(value, sv, true);
+  const std::vector<std::string>& fCaloNames = getNames(value, sv, true);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << fCaloNames.size() << " entries for " << value << ":";
   for (unsigned int i = 0; i < fCaloNames.size(); i++)
@@ -103,7 +103,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
 #endif
 
   value = "FineLevels";
-  std::vector<double> fLevels = getNumbers(value, sv, true);
+  const std::vector<double>& fLevels = getNumbers(value, sv, true);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: " << fLevels.size() << " entries for " << value << ":";
   for (unsigned int i = 0; i < fLevels.size(); i++)

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -266,6 +266,7 @@ void CaloTrkProcessing::update(const G4Step* aStep) {
           trkInfo->setCaloIDChecked(true);
           lastTrackID_ = id;
           if (theTrack->GetKineticEnergy() / MeV > eMin_)
+	    trkInfo->putInHistory();
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: set ID on Calo " << ical << " surface (Inside " << inside
                                       << ") to " << id << " of a Track with Kinetic Energy "

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -195,7 +195,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
       fineDetectors_.emplace_back(detector);
     }
   }
-  if (fineDetectors_.size() == 0) 
+  if (fineDetectors_.empty())
     doFineCalo_ = false;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: with " << fineDetectors_.size() << " special calorimetric volumes";

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -29,8 +29,8 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
                                      const edm::EventSetup& es,
                                      const SensitiveDetectorCatalog& clg,
                                      edm::ParameterSet const& p,
-                                     const SimTrackManager* manager)
-    : SensitiveCaloDetector(name, es, clg, p), lastTrackID_(-1), m_trackManager(manager) {
+                                     const SimTrackManager*)
+    : SensitiveCaloDetector(name, es, clg, p), lastTrackID_(-1) {
   //Initialise the parameter set
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("CaloTrkProcessing");
   testBeam_ = m_p.getParameter<bool>("TestBeam");

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -39,11 +39,11 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
   doFineCalo_ = m_p.getParameter<bool>("DoFineCalo");
   eMinFine_ = m_p.getParameter<double>("EminFineTrack") * MeV;
   eMinFinePhoton_ = m_p.getParameter<double>("EminFinePhoton") * MeV;
-#ifdef EDM_ML_DEBUG
+
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: Initailised with TestBeam = " << testBeam_ << " Emin = " << eMin_
                               << ":" << eMinFine_ << ":" << eMinFinePhoton_ << " MeV and Flags " << putHistory_
                               << " (History), " << doFineCalo_ << " (Special Calorimeter)";
-#endif
+
   edm::ESTransientHandle<DDCompactView> cpv;
   es.get<IdealGeometryRecord>().get(cpv);
 
@@ -163,7 +163,7 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
     }
     istart += number;
   }
-#ifdef EDM_ML_DEBUG
+
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: with " << detectors_.size() << " calorimetric volumes";
   for (unsigned int i = 0; i < detectors_.size(); i++) {
     edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: Calorimeter volume " << i << " " << detectors_[i].name << " LV "
@@ -173,7 +173,6 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
       edm::LogVerbatim("CaloSim") << "                   Element " << k << " " << detectors_[i].fromDets[k] << " LV "
                                   << detectors_[i].fromDetL[k] << " at level " << detectors_[i].fromLevels[k];
   }
-#endif
 
   for (unsigned int i = 0; i < fCaloNames.size(); i++) {
     G4LogicalVolume* lv = nullptr;
@@ -197,12 +196,11 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
   }
   if (fineDetectors_.empty())
     doFineCalo_ = false;
-#ifdef EDM_ML_DEBUG
+
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: with " << fineDetectors_.size() << " special calorimetric volumes";
   for (unsigned int i = 0; i < detectors_.size(); i++)
     edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: Calorimeter volume " << i << " " << detectors_[i].name << " LV "
                                 << detectors_[i].lv << " at level " << detectors_[i].level;
-#endif
 }
 
 CaloTrkProcessing::~CaloTrkProcessing() {}

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -41,8 +41,8 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
   eMinFinePhoton_ = m_p.getParameter<double>("EminFinePhoton") * MeV;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: Initailised with TestBeam = " << testBeam_ << " Emin = " << eMin_
-                              << ":" << eMinFine_ << ":" << eMinFinePhoton_ << " MeV and Flags "
-                              << putHistory_ << " (History), " << doFineCalo_ << " (Special Calorimeter)";
+                              << ":" << eMinFine_ << ":" << eMinFinePhoton_ << " MeV and Flags " << putHistory_
+                              << " (History), " << doFineCalo_ << " (Special Calorimeter)";
 #endif
   edm::ESTransientHandle<DDCompactView> cpv;
   es.get<IdealGeometryRecord>().get(cpv);
@@ -197,13 +197,13 @@ CaloTrkProcessing::CaloTrkProcessing(const std::string& name,
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: with " << fineDetectors_.size() << " special calorimetric volumes";
-  for (unsigned int i = 0; i < detectors_.size(); i++) 
+  for (unsigned int i = 0; i < detectors_.size(); i++)
     edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: Calorimeter volume " << i << " " << detectors_[i].name << " LV "
                                 << detectors_[i].lv << " at level " << detectors_[i].level;
 #endif
 }
 
-CaloTrkProcessing::~CaloTrkProcessing() { }
+CaloTrkProcessing::~CaloTrkProcessing() {}
 
 void CaloTrkProcessing::update(const BeginOfEvent* evt) { lastTrackID_ = -1; }
 
@@ -266,7 +266,7 @@ void CaloTrkProcessing::update(const G4Step* aStep) {
           trkInfo->setCaloIDChecked(true);
           lastTrackID_ = id;
           if (theTrack->GetKineticEnergy() / MeV > eMin_)
-	    trkInfo->putInHistory();
+            trkInfo->putInHistory();
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: set ID on Calo " << ical << " surface (Inside " << inside
                                       << ") to " << id << " of a Track with Kinetic Energy "
@@ -282,11 +282,11 @@ void CaloTrkProcessing::update(const G4Step* aStep) {
       int pdg = aStep->GetTrack()->GetDefinition()->GetPDGEncoding();
       double cut = (pdg == 22) ? eMinFinePhoton_ : eMinFine_;
       if (aStep->GetTrack()->GetKineticEnergy() / MeV > cut)
-	trkInfo->putInHistory();
+        trkInfo->putInHistory();
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: the track with PDGID " << pdg << " and kinetic energy " 
-				  << aStep->GetTrack()->GetKineticEnergy() / MeV << " is tested against " << cut
-				  << " to be put in history";
+      edm::LogVerbatim("CaloSim") << "CaloTrkProcessing: the track with PDGID " << pdg << " and kinetic energy "
+                                  << aStep->GetTrack()->GetKineticEnergy() / MeV << " is tested against " << cut
+                                  << " to be put in history";
 #endif
     }
   }

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -345,8 +345,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         EminTrack  = cms.double(0.01),
         PutHistory = cms.bool(False),
         DoFineCalo = cms.bool(False),
-        EminFineTrack = cms.double(100000.0),
-        EminFinePhoton = cms.double(50000.0)
+        EminFineTrack = cms.double(10000.0),
+        EminFinePhoton = cms.double(5000.0)
     ),
     HFShower = cms.PSet(
         common_UsePMT,
@@ -562,5 +562,3 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify( g4SimHits.ECalSD,
                              StoreLayerTimeSim = cms.untracked.bool(True),
                              TimeSliceUnit = cms.double(0.001) )
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify( g4SimHits.CaloTrkProcessing, DoFineCalo = True)

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -345,8 +345,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         EminTrack  = cms.double(0.01),
         PutHistory = cms.bool(False),
         DoFineCalo = cms.bool(False),
-        EminFineTrack = cms.double(2000.0),
-        EminFinePhoton = cms.double(500.0)
+        EminFineTrack = cms.double(50000.0),
+        EminFinePhoton = cms.double(20000.0)
     ),
     HFShower = cms.PSet(
         common_UsePMT,

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -345,8 +345,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         EminTrack  = cms.double(0.01),
         PutHistory = cms.bool(False),
         DoFineCalo = cms.bool(False),
-        EminFineTrack = cms.double(50000.0),
-        EminFinePhoton = cms.double(20000.0)
+        EminFineTrack = cms.double(100000.0),
+        EminFinePhoton = cms.double(50000.0)
     ),
     HFShower = cms.PSet(
         common_UsePMT,

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -343,7 +343,10 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     CaloTrkProcessing = cms.PSet(
         TestBeam   = cms.bool(False),
         EminTrack  = cms.double(0.01),
-        PutHistory = cms.bool(False)
+        PutHistory = cms.bool(False),
+        DoFineCalo = cms.bool(False),
+        EminFineTrack = cms.double(2000.0),
+        EminFinePhoton = cms.double(500.0)
     ),
     HFShower = cms.PSet(
         common_UsePMT,
@@ -559,3 +562,5 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify( g4SimHits.ECalSD,
                              StoreLayerTimeSim = cms.untracked.bool(True),
                              TimeSliceUnit = cms.double(0.001) )
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify( g4SimHits.CaloTrkProcessing, DoFineCalo = True)


### PR DESCRIPTION
#### PR description:

These changes allow saving some of the Sim tracks entering in the HGCal region and have kinetic energies above a threshold. By default the thresholds are set high - one need to configure it to allow tracks at lower energies

#### PR validation:

Tested with cfg files in SimG4CMS/Calo/test/python area and also with the standard run matrix

#### if this PR is a backport please specify the original PR:

Nothing special