### PR TITLE
HLTTauDQM: moved some warnings behind a verbose flag

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauDQML1Plotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQML1Plotter.h
@@ -20,7 +20,8 @@ public:
                      double maxhighpt,
                      bool ref,
                      double dr,
-                     const std::string& dqmBaseFolder);
+                     const std::string& dqmBaseFolder,
+                     bool verb);
   ~HLTTauDQML1Plotter();
 
   using HLTTauDQMPlotter::isValid;
@@ -46,6 +47,8 @@ private:
   const int binsEta_;
   const int binsPhi_;
   const double maxEta_;
+
+  bool verbose;
 
   //MonitorElements general
   MonitorElement* l1tauEt_;

--- a/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
@@ -70,6 +70,8 @@ private:
   std::vector<HLTTauDQMPathPlotter> pathPlotters_;
   std::unique_ptr<HLTTauDQMPathSummaryPlotter> pathSummaryPlotter_;
   std::vector<std::unique_ptr<HLTTauDQMTagAndProbePlotter> > tagandprobePlotters_;
+
+  bool verbose;
 };
 
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauDQMPath.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPath.h
@@ -35,7 +35,8 @@ public:
     const int id;  // from TriggerTypeDefs.h
   };
 
-  HLTTauDQMPath(std::string pathName, std::string hltProcess, bool doRefAnalysis, const HLTConfigProvider& HLTCP, bool verbose);
+  HLTTauDQMPath(
+      std::string pathName, std::string hltProcess, bool doRefAnalysis, const HLTConfigProvider& HLTCP, bool verbose);
   ~HLTTauDQMPath();
 
   bool isValid() const { return isValid_; }

--- a/DQMOffline/Trigger/interface/HLTTauDQMPath.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPath.h
@@ -35,7 +35,7 @@ public:
     const int id;  // from TriggerTypeDefs.h
   };
 
-  HLTTauDQMPath(std::string pathName, std::string hltProcess, bool doRefAnalysis, const HLTConfigProvider& HLTCP);
+  HLTTauDQMPath(std::string pathName, std::string hltProcess, bool doRefAnalysis, const HLTConfigProvider& HLTCP, bool verbose);
   ~HLTTauDQMPath();
 
   bool isValid() const { return isValid_; }
@@ -159,6 +159,8 @@ private:
   size_t firstL2METFilterIndex_;
   bool isFirstL1Seed_;
   bool isValid_;
+
+  bool verbose_;
 };
 
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
@@ -30,7 +30,8 @@ public:
                        double ptmax,
                        double highptmax,
                        double l1MatchDr,
-                       double hltMatchDr);
+                       double hltMatchDr,
+                       bool verbose);
   ~HLTTauDQMPathPlotter();
 
   using HLTTauDQMPlotter::isValid;
@@ -54,6 +55,8 @@ private:
   const double l1MatchDr_;
   const double hltMatchDr_;
   const bool doRefAnalysis_;
+
+  bool verbose_;
 
   HLTTauDQMPath hltPath_;
 

--- a/DQMOffline/Trigger/plugins/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauDQMOfflineSource.cc
@@ -32,8 +32,10 @@ HLTTauDQMOfflineSource::HLTTauDQMOfflineSource(const edm::ParameterSet& ps)
   edm::ParameterSet matching = ps.getParameter<edm::ParameterSet>("Matching");
   doRefAnalysis_ = matching.getUntrackedParameter<bool>("doMatching");
 
-  if (ps.exists("Verbose")) verbose = ps.getUntrackedParameter<bool>("Verbose", false);
-  else verbose = false;
+  if (ps.exists("Verbose"))
+    verbose = ps.getUntrackedParameter<bool>("Verbose", false);
+  else
+    verbose = false;
 
   if (ps.exists("L1Plotter") && !ps.exists("TagAndProbe")) {
     l1Plotter_ = std::make_unique<HLTTauDQML1Plotter>(ps.getUntrackedParameter<edm::ParameterSet>("L1Plotter"),

--- a/DQMOffline/Trigger/plugins/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauDQMOfflineSource.cc
@@ -32,6 +32,9 @@ HLTTauDQMOfflineSource::HLTTauDQMOfflineSource(const edm::ParameterSet& ps)
   edm::ParameterSet matching = ps.getParameter<edm::ParameterSet>("Matching");
   doRefAnalysis_ = matching.getUntrackedParameter<bool>("doMatching");
 
+  if (ps.exists("Verbose")) verbose = ps.getUntrackedParameter<bool>("Verbose", false);
+  else verbose = false;
+
   if (ps.exists("L1Plotter") && !ps.exists("TagAndProbe")) {
     l1Plotter_ = std::make_unique<HLTTauDQML1Plotter>(ps.getUntrackedParameter<edm::ParameterSet>("L1Plotter"),
                                                       consumesCollector(),
@@ -40,7 +43,8 @@ HLTTauDQMOfflineSource::HLTTauDQMOfflineSource(const edm::ParameterSet& ps)
                                                       highPtMax_,
                                                       doRefAnalysis_,
                                                       l1MatchDr_,
-                                                      dqmBaseFolder_);
+                                                      dqmBaseFolder_,
+                                                      verbose);
   }
   if (ps.exists("PathSummaryPlotter")) {
     pathSummaryPlotter_ = std::make_unique<HLTTauDQMPathSummaryPlotter>(
@@ -100,7 +104,8 @@ void HLTTauDQMOfflineSource::dqmBeginRun(const edm::Run& iRun, const edm::EventS
                                      ptMax_,
                                      highPtMax_,
                                      l1MatchDr_,
-                                     hltMatchDr_);
+                                     hltMatchDr_,
+                                     verbose);
           if (pathPlotters_.back().isValid()) {
             pathObjects.push_back(pathPlotters_.back().getPathObject());
           }

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -79,6 +79,7 @@ hltTauOfflineMonitor_PFTaus = DQMEDAnalyzer('HLTTauDQMOfflineSource',
     DQMBaseFolder = cms.untracked.string("HLT/TAU/PFTaus"),
     TriggerResultsSrc = cms.untracked.InputTag("TriggerResults", "", hltTauDQMofflineProcess),
     TriggerEventSrc = cms.untracked.InputTag("hltTriggerSummaryAOD", "", hltTauDQMofflineProcess),
+    #Verbose = cms.untracked.bool(True),
     L1Plotter = cms.untracked.PSet(
         DQMFolder             = cms.untracked.string('L1'),
         L1Taus                = cms.untracked.InputTag("caloStage2Digis", "Tau"),

--- a/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
@@ -22,7 +22,8 @@ HLTTauDQML1Plotter::HLTTauDQML1Plotter(const edm::ParameterSet& ps,
                                        double maxhighpt,
                                        bool ref,
                                        double dr,
-                                       const std::string& dqmBaseFolder)
+                                       const std::string& dqmBaseFolder,
+                                       bool verb)
     : HLTTauDQMPlotter(ps, dqmBaseFolder),
       doRefAnalysis_(ref),
       matchDeltaR_(dr),
@@ -34,6 +35,8 @@ HLTTauDQML1Plotter::HLTTauDQML1Plotter(const edm::ParameterSet& ps,
       maxEta_(getMaxEta(binsEta_, ps.getUntrackedParameter<double>("EtaHistoBinWidth", 0.348))) {
   if (!configValid_)
     return;
+
+  verbose = verb;
 
   //Process PSet
   l1stage2Taus_ = ps.getUntrackedParameter<edm::InputTag>("L1Taus");
@@ -218,6 +221,7 @@ void HLTTauDQML1Plotter::analyze(const edm::Event& iEvent,
       }
     }
   } else {
+    if(verbose)
     edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 tau collection "
                                         << l1stage2Taus_.encode();
   }
@@ -233,6 +237,7 @@ void HLTTauDQML1Plotter::analyze(const edm::Event& iEvent,
       }
     }
   } else {
+    if(verbose)
     edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 met collection "
                                         << l1stage2Sums_.encode();
   }

--- a/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
@@ -221,9 +221,9 @@ void HLTTauDQML1Plotter::analyze(const edm::Event& iEvent,
       }
     }
   } else {
-    if(verbose)
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 tau collection "
-                                        << l1stage2Taus_.encode();
+    if (verbose)
+      edm::LogWarning("HLTTauDQMOffline")
+          << "HLTTauDQML1Plotter::analyze: unable to read L1 tau collection " << l1stage2Taus_.encode();
   }
 
   if (sums.isValid() && sums.product()->size() > 0) {
@@ -237,9 +237,9 @@ void HLTTauDQML1Plotter::analyze(const edm::Event& iEvent,
       }
     }
   } else {
-    if(verbose)
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 met collection "
-                                        << l1stage2Sums_.encode();
+    if (verbose)
+      edm::LogWarning("HLTTauDQMOffline")
+          << "HLTTauDQML1Plotter::analyze: unable to read L1 met collection " << l1stage2Sums_.encode();
   }
 
   //Now do the efficiency matching

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -203,9 +203,10 @@ namespace {
     if (pset.existsAs<int>(parameterName))
       return pset.getParameter<int>(parameterName);
     else {
-      if(verbose)
-      edm::LogWarning("HLTTauDQMOfflineSource") << "No parameter '" << parameterName << "' in configuration of filter "
-                                                << filterName << " pset " << pset.dump() << std::endl;
+      if (verbose)
+        edm::LogWarning("HLTTauDQMOfflineSource")
+            << "No parameter '" << parameterName << "' in configuration of filter " << filterName << " pset "
+            << pset.dump() << std::endl;
       return 0;
     }
   }
@@ -351,11 +352,8 @@ namespace {
   }
 }  // namespace
 
-HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
-                             std::string hltProcess,
-                             bool doRefAnalysis,
-                             const HLTConfigProvider& HLTCP,
-                             bool verbose)
+HLTTauDQMPath::HLTTauDQMPath(
+    std::string pathName, std::string hltProcess, bool doRefAnalysis, const HLTConfigProvider& HLTCP, bool verbose)
     : hltProcess_(std::move(hltProcess)),
       doRefAnalysis_(doRefAnalysis),
       pathName_(std::move(pathName)),
@@ -375,7 +373,6 @@ HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
 
       isFirstL1Seed_(false),
       isValid_(false) {
-
   verbose_ = verbose;
 
 #ifdef EDM_ML_DEBUG

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -197,11 +197,13 @@ namespace {
 
   int getParameterSafe(const HLTConfigProvider& HLTCP,
                        const std::string& filterName,
-                       const std::string& parameterName) {
+                       const std::string& parameterName,
+                       bool verbose) {
     const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
     if (pset.existsAs<int>(parameterName))
       return pset.getParameter<int>(parameterName);
     else {
+      if(verbose)
       edm::LogWarning("HLTTauDQMOfflineSource") << "No parameter '" << parameterName << "' in configuration of filter "
                                                 << filterName << " pset " << pset.dump() << std::endl;
       return 0;
@@ -219,7 +221,8 @@ namespace {
   TauLeptonMultiplicity inferTauLeptonMultiplicity(const HLTConfigProvider& HLTCP,
                                                    const std::string& filterName,
                                                    const std::string& moduleType,
-                                                   const std::string& pathName) {
+                                                   const std::string& pathName,
+                                                   bool verbose) {
     TauLeptonMultiplicity n;
     //std::cout << "check menu " << HLTCP.tableName() << std::endl;
     if (moduleType == "HLTL1TSeed") {
@@ -247,51 +250,51 @@ namespace {
       }
     } else if (moduleType == "HLT1CaloMET") {
       n.level = 2;
-      if (getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerMET) {
+      if (getParameterSafe(HLTCP, filterName, "triggerType", verbose) == trigger::TriggerMET) {
         n.met = 1;
       }
     } else if (moduleType == "HLT1CaloJet") {
       n.level = 2;
-      if (getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerTau) {
-        n.tau = getParameterSafe(HLTCP, filterName, "MinN");
+      if (getParameterSafe(HLTCP, filterName, "triggerType", verbose) == trigger::TriggerTau) {
+        n.tau = getParameterSafe(HLTCP, filterName, "MinN", verbose);
       }
     } else if (moduleType == "HLT1PFJet") {
       n.level = 3;
       //const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
       //pset.getParameter<int>("triggerType") == trigger::TriggerTau) {
-      if (getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerTau) {
+      if (getParameterSafe(HLTCP, filterName, "triggerType", verbose) == trigger::TriggerTau) {
         //n.tau = pset.getParameter<int>("MinN");
-        n.tau = getParameterSafe(HLTCP, filterName, "MinN");
+        n.tau = getParameterSafe(HLTCP, filterName, "MinN", verbose);
       }
     } else if (moduleType == "HLTCaloJetTag") {
       n.level = 2;
       //const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
       //if(pset.getParameter<int>("triggerType") == trigger::TriggerTau) {
-      if (getParameterSafe(HLTCP, filterName, "TriggerType") == trigger::TriggerTau) {
+      if (getParameterSafe(HLTCP, filterName, "TriggerType", verbose) == trigger::TriggerTau) {
         //n.tau = pset.getParameter<int>("MinJets");
-        n.tau = getParameterSafe(HLTCP, filterName, "MinJets");
+        n.tau = getParameterSafe(HLTCP, filterName, "MinJets", verbose);
       }
     } else if (moduleType == "HLT1Tau" || moduleType == "HLT1PFTau") {
       n.level = 3;
       //n.tau = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
-      n.tau = getParameterSafe(HLTCP, filterName, "MinN");
+      n.tau = getParameterSafe(HLTCP, filterName, "MinN", verbose);
     } else if (moduleType == "HLTPFTauPairDzMatchFilter") {
       n.level = 3;
       n.tau = 2;
     } else if (moduleType == "HLTEgammaGenericFilter") {
       n.level = 3;
-      n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
+      n.electron = getParameterSafe(HLTCP, filterName, "ncandcut", verbose);
     } else if (moduleType == "HLTElectronGenericFilter") {
       n.level = 3;
       //n.electron = HLTCP.modulePSet(filterName).getParameter<int>("ncandcut");
-      n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
+      n.electron = getParameterSafe(HLTCP, filterName, "ncandcut", verbose);
     } else if (moduleType == "HLTMuonL2PreFilter") {
       n.level = 2;
       //n.muon = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
-      n.muon = getParameterSafe(HLTCP, filterName, "MinN");
+      n.muon = getParameterSafe(HLTCP, filterName, "MinN", verbose);
     } else if (moduleType == "HLTMuonIsoFilter" || moduleType == "HLTMuonL3PreFilter") {
       n.level = 3;
-      n.muon = getParameterSafe(HLTCP, filterName, "MinN");
+      n.muon = getParameterSafe(HLTCP, filterName, "MinN", verbose);
     } else if (moduleType == "HLTMuonGenericFilter") {
       n.level = 3;
       n.muon = 1;
@@ -299,13 +302,13 @@ namespace {
                moduleType == "HLT2PhotonPFTau") {
       n.level = 3;
       //int num = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
-      int num = getParameterSafe(HLTCP, filterName, "MinN");
+      int num = getParameterSafe(HLTCP, filterName, "MinN", verbose);
       n.tau = num;
       n.electron = num;
     } else if (moduleType == "HLT2MuonTau" || moduleType == "HLT2MuonPFTau") {
       n.level = 3;
       //int num = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
-      int num = getParameterSafe(HLTCP, filterName, "MinN");
+      int num = getParameterSafe(HLTCP, filterName, "MinN", verbose);
       n.tau = num;
       n.muon = num;
     } else if (moduleType == "HLTPrescaler") {  // || moduleType == "HLT1CaloMET") {
@@ -351,7 +354,8 @@ namespace {
 HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
                              std::string hltProcess,
                              bool doRefAnalysis,
-                             const HLTConfigProvider& HLTCP)
+                             const HLTConfigProvider& HLTCP,
+                             bool verbose)
     : hltProcess_(std::move(hltProcess)),
       doRefAnalysis_(doRefAnalysis),
       pathName_(std::move(pathName)),
@@ -371,6 +375,9 @@ HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
 
       isFirstL1Seed_(false),
       isValid_(false) {
+
+  verbose_ = verbose;
+
 #ifdef EDM_ML_DEBUG
   std::stringstream ss;
   ss << "HLTTauDQMPath: " << pathName_ << "\n";
@@ -400,7 +407,7 @@ HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
     const std::string& filterName = std::get<kName>(filterIndice);
     const std::string& moduleType = HLTCP.moduleType(filterName);
 
-    TauLeptonMultiplicity n = inferTauLeptonMultiplicity(HLTCP, filterName, moduleType, pathName_);
+    TauLeptonMultiplicity n = inferTauLeptonMultiplicity(HLTCP, filterName, moduleType, pathName_, verbose_);
     filterTauN_.push_back(n.tau);
     filterElectronN_.push_back(n.electron);
     filterMuonN_.push_back(n.muon);
@@ -467,7 +474,7 @@ HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
     if(getFilterNTaus(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)
       lastL3TauFilterIndex_ = i;
   }
-*/
+  */
   for (size_t i = 0; i < filtersSize(); ++i) {
     // Tau
     if (getFilterLevel(i) == 2 && getFilterNTaus(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -23,7 +23,8 @@ HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const std::string& pathName,
                                            double ptmax,
                                            double highptmax,
                                            double l1MatchDr,
-                                           double hltMatchDr)
+                                           double hltMatchDr,
+                                           bool verbose)
     : HLTTauDQMPlotter(stripVersion(pathName), dqmBaseFolder),
       ptbins_(ptbins),
       etabins_(etabins),
@@ -33,7 +34,7 @@ HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const std::string& pathName,
       l1MatchDr_(l1MatchDr),
       hltMatchDr_(hltMatchDr),
       doRefAnalysis_(doRefAnalysis),
-      hltPath_(pathName, hltProcess, doRefAnalysis_, HLTCP) {
+      hltPath_(pathName, hltProcess, doRefAnalysis_, HLTCP, verbose) {
   configValid_ = configValid_ && hltPath_.isValid();
 }
 


### PR DESCRIPTION
#### PR description:

HLTTauDQM was filling logs with warnings. Those warnings are now moved behind a verbose parameter, false by default. 

#### PR validation:

Tested that the Verbose flag disables/enables the warning printouts with false/true.
