### PR TITLE
Enable pt-dependent JER-SF and phi-dependent JEC application in PAT

### DIFF
--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -186,11 +186,13 @@ void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup&
     m_res_vs_eta->Fill(jet.eta(), r);
 
     // We do the same thing to access the scale factors
-    float sf = res_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}});
+    float sf = res_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}});
 
     // Access up and down variation of the scale factor
-    float sf_up = res_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, Variation::UP);
-    float sf_down = res_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, Variation::DOWN);
+    float sf_up =
+        res_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}}, Variation::UP);
+    float sf_down =
+        res_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}}, Variation::DOWN);
 
     if (m_debug) {
       std::cout << "Scale factors (Nominal / Up / Down) : " << sf << " / " << sf_up << " / " << sf_down << std::endl;

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -163,10 +163,12 @@ float JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet
   if (patjet) {
     corrector->setJetEta(patjet->correctedP4(0).eta());
     corrector->setJetPt(patjet->correctedP4(0).pt());
+    corrector->setJetPhi(patjet->correctedP4(0).phi());
     corrector->setJetE(patjet->correctedP4(0).energy());
   } else {
     corrector->setJetEta(jet->eta());
     corrector->setJetPt(jet->pt());
+    corrector->setJetPhi(jet->phi());
     corrector->setJetE(jet->energy());
   }
   if (emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)) {

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -225,7 +225,8 @@ public:
 
       double jet_resolution = resolution.getResolution(
           {{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
-      double jer_sf = resolution_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, m_systematic_variation);
+      double jer_sf = resolution_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}},
+                                                   m_systematic_variation);
 
       if (m_debug) {
         std::cout << "jet:  pt: " << jet.pt() << "  eta: " << jet.eta() << "  phi: " << jet.phi()

--- a/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
+++ b/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
@@ -9,12 +9,14 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('PAT2',eras.Run2_2016)
 
+### Example how to check timing
 #process.Timing = cms.Service("Timing",
 #  summaryOnly = cms.untracked.bool(False),
 #  useJobReport = cms.untracked.bool(True)
 #)
 
-process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",ignoreTotal = cms.untracked.int32(1) ) 
+### Example how to check memory
+#process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",ignoreTotal = cms.untracked.int32(1) )
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -35,7 +37,7 @@ process.maxEvents = cms.untracked.PSet(
 # Input source
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    'file:////afs/cern.ch/user/h/hinzmann/workspace/tmp/102D73A7-5B87-E611-936E-0CC47A1E0472.root',
+    '/store/relval/CMSSW_11_0_0_pre6/RelValTTbar_13/MINIAODSIM/PU25ns_110X_upgrade2018_realistic_v3-v1/20000/F38B9A9F-4B4B-3D4B-8C9D-9A9B945194EF.root',
     ),
     secondaryFileNames = cms.untracked.vstring(),
     skipEvents = cms.untracked.uint32(145)
@@ -73,6 +75,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
+### Pick a global tag that includes the desired JER-SFs
 process.GlobalTag = GlobalTag(process.GlobalTag, '102X_mcRun2_asymptotic_v7', '')
 
 # Path and EndPath definitions
@@ -80,29 +83,30 @@ process.MINIAODSIMoutput_step = cms.EndPath(process.MINIAODSIMoutput)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
-from CondCore.DBCommon.CondDBSetup_cfi import *
 
-process.jer = cms.ESSource("PoolDBESSource",
-        CondDBSetup,
-        toGet = cms.VPSet(
-            # Resolution
-            cms.PSet(
-                record = cms.string('JetResolutionRcd'),
-                tag    = cms.string('JR_Autumn18_V7_MC_PtResolution_AK4PFchs'),
-                label  = cms.untracked.string('AK4PFchs_pt')
-                ),
-
-            # Scale factors
-            cms.PSet(
-                record = cms.string('JetResolutionScaleFactorRcd'),
-                tag    = cms.string('JR_Autumn18_V7_MC_SF_AK4PFchs'),
-                label  = cms.untracked.string('AK4PFchs')
-                ),
-            ),
-        connect = cms.string('sqlite:Autumn18_V7_MC.db')
-        )
-
-process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
+### Example how to read the JER-SF from a db file
+#from CondCore.DBCommon.CondDBSetup_cfi import *
+#process.jer = cms.ESSource("PoolDBESSource",
+#        CondDBSetup,
+#        toGet = cms.VPSet(
+#            # Resolution
+#            cms.PSet(
+#                record = cms.string('JetResolutionRcd'),
+#                tag    = cms.string('JR_Autumn18_V7_MC_PtResolution_AK4PFchs'),
+#                label  = cms.untracked.string('AK4PFchs_pt')
+#                ),
+#
+#            # Scale factors
+#            cms.PSet(
+#                record = cms.string('JetResolutionScaleFactorRcd'),
+#                tag    = cms.string('JR_Autumn18_V7_MC_SF_AK4PFchs'),
+#                label  = cms.untracked.string('AK4PFchs')
+#                ),
+#            ),
+#        connect = cms.string('sqlite:Autumn18_V7_MC.db')
+#        )
+#
+#process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
 
 process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
        src = cms.InputTag('slimmedJets'),

--- a/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
+++ b/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
@@ -1,0 +1,128 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: miniAOD-prod -s PAT --eventcontent MINIAODSIM --runUnscheduled --mc --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4 --era Run2_2016 --no_exec --filein /store/relval/CMSSW_8_0_20/RelValTTbar_13/MINIAODSIM/PU25ns_80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1/00000/A8C282AE-D37A-E611-8603-0CC47A4C8ECE.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('PAT2',eras.Run2_2016)
+
+#process.Timing = cms.Service("Timing",
+#  summaryOnly = cms.untracked.bool(False),
+#  useJobReport = cms.untracked.bool(True)
+#)
+
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",ignoreTotal = cms.untracked.int32(1) ) 
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+#process.load('PhysicsTools.PatAlgos.slimming.metFilterPaths_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+    'file:////afs/cern.ch/user/h/hinzmann/workspace/tmp/102D73A7-5B87-E611-936E-0CC47A1E0472.root',
+    ),
+    secondaryFileNames = cms.untracked.vstring(),
+    skipEvents = cms.untracked.uint32(145)
+)
+
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('miniAOD-prod nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    dropMetaData = cms.untracked.string('ALL'),
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    fastCloning = cms.untracked.bool(False),
+    fileName = cms.untracked.string('NewMiniAOD.root'),
+    outputCommands = cms.untracked.vstring('keep *'),
+    overrideInputFileSplitLevels = cms.untracked.bool(True)
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '102X_mcRun2_asymptotic_v7', '')
+
+# Path and EndPath definitions
+process.MINIAODSIMoutput_step = cms.EndPath(process.MINIAODSIMoutput)
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+process.jer = cms.ESSource("PoolDBESSource",
+        CondDBSetup,
+        toGet = cms.VPSet(
+            # Resolution
+            cms.PSet(
+                record = cms.string('JetResolutionRcd'),
+                tag    = cms.string('JR_Autumn18_V7_MC_PtResolution_AK4PFchs'),
+                label  = cms.untracked.string('AK4PFchs_pt')
+                ),
+
+            # Scale factors
+            cms.PSet(
+                record = cms.string('JetResolutionScaleFactorRcd'),
+                tag    = cms.string('JR_Autumn18_V7_MC_SF_AK4PFchs'),
+                label  = cms.untracked.string('AK4PFchs')
+                ),
+            ),
+        connect = cms.string('sqlite:Autumn18_V7_MC.db')
+        )
+
+process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
+
+process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
+       src = cms.InputTag('slimmedJets'),
+       enabled = cms.bool(True),
+       rho = cms.InputTag("fixedGridRhoFastjetAll"),
+       algo = cms.string('AK4PFchs'),
+       algopt = cms.string('AK4PFchs_pt'),
+
+       genJets = cms.InputTag('slimmedGenJets'),
+       dRMax = cms.double(0.2),
+       dPtMaxFactor = cms.double(3),
+
+       debug = cms.untracked.bool(False),
+   # Systematic variation
+   # 0: Nominal
+   # -1: -1 sigma (down variation)
+   # 1: +1 sigma (up variation)
+   variation = cms.int32(0),  # If not specified, default to 0
+       )
+
+process.p=cms.Path(process.slimmedJetsSmeared)
+
+process.schedule=cms.Schedule(process.p,process.MINIAODSIMoutput_step)


### PR DESCRIPTION
#### PR description:

Enable pt-dependent jet resolution scale factors in PAT. This is needed to apply Autumn18_V7 JER-SF, released last week.
Enable phi-dependent jet energy scale in PAT. This will be needed for 2018 JEC to deal with the HEM issue.
This PR has no impact with the current global tags in any release. However, it will enable using a new global tag (currently in the makings) with pt-dependent JER-SFs and later with phi-dependent JECs.

A test config to apply resolution smearing from a db file has been added under /test.
Here is an example db-file containing pt-dependent JER-SFs:
https://github.com/cms-jet/JRDatabase/blob/master/SQLiteFiles/Autumn18_V7_MC.db

#### PR validation:

Test config runs after inclusion of this PR. It was checked that this does not change the memory consumption, compared to using the old code with Autumn18_V1_MC.db (no pt-dependence).