### PR TITLE
Enable pt-dependent JER-SF and phi-dependent JEC application in PAT [102X backport]

### DIFF
--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -23,192 +23,183 @@
 //
 
 class JetResolutionDemo : public edm::EDAnalyzer {
-    public:
-        explicit JetResolutionDemo(const edm::ParameterSet&);
-        ~JetResolutionDemo() override;
+public:
+  explicit JetResolutionDemo(const edm::ParameterSet&);
+  ~JetResolutionDemo() override;
 
-    private:
-        void analyze(const edm::Event&, const edm::EventSetup&) override;
-        void endJob() override;
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-        edm::EDGetTokenT<std::vector<pat::Jet>> m_jets_token;
-        edm::EDGetTokenT<double> m_rho_token;
+  edm::EDGetTokenT<std::vector<pat::Jet>> m_jets_token;
+  edm::EDGetTokenT<double> m_rho_token;
 
-        bool m_debug = false;
-        bool m_use_conddb = false;
+  bool m_debug = false;
+  bool m_use_conddb = false;
 
-        std::string m_payload;
-        std::string m_resolutions_file;
-        std::string m_scale_factors_file;
+  std::string m_payload;
+  std::string m_resolutions_file;
+  std::string m_scale_factors_file;
 
-        edm::Service<TFileService> fs;
+  edm::Service<TFileService> fs;
 
-        TH2* m_res_vs_eta = nullptr;
+  TH2* m_res_vs_eta = nullptr;
 };
 //
 //----------- Class Implementation ------------------------------------------
 //
 //---------------------------------------------------------------------------
-JetResolutionDemo::JetResolutionDemo(const edm::ParameterSet& iConfig)
-{
-    m_jets_token = consumes<std::vector<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jets"));
-    m_rho_token  = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
-    m_debug      = iConfig.getUntrackedParameter<bool>("debug", false);
-    m_use_conddb = iConfig.getUntrackedParameter<bool>("useCondDB", false);
+JetResolutionDemo::JetResolutionDemo(const edm::ParameterSet& iConfig) {
+  m_jets_token = consumes<std::vector<pat::Jet>>(iConfig.getParameter<edm::InputTag>("jets"));
+  m_rho_token = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+  m_debug = iConfig.getUntrackedParameter<bool>("debug", false);
+  m_use_conddb = iConfig.getUntrackedParameter<bool>("useCondDB", false);
 
-    if (m_use_conddb)
-        m_payload    = iConfig.getParameter<std::string>("payload");
-    else {
-        m_resolutions_file = iConfig.getParameter<edm::FileInPath>("resolutionsFile").fullPath();
-        m_scale_factors_file = iConfig.getParameter<edm::FileInPath>("scaleFactorsFile").fullPath();
-    }
+  if (m_use_conddb)
+    m_payload = iConfig.getParameter<std::string>("payload");
+  else {
+    m_resolutions_file = iConfig.getParameter<edm::FileInPath>("resolutionsFile").fullPath();
+    m_scale_factors_file = iConfig.getParameter<edm::FileInPath>("scaleFactorsFile").fullPath();
+  }
 }
 //---------------------------------------------------------------------------
-JetResolutionDemo::~JetResolutionDemo()
-{
-
-}
+JetResolutionDemo::~JetResolutionDemo() {}
 
 //---------------------------------------------------------------------------
-void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<pat::Jet>> jets;
+  iEvent.getByToken(m_jets_token, jets);
 
-    edm::Handle<std::vector<pat::Jet>> jets;
-    iEvent.getByToken(m_jets_token, jets);
+  edm::Handle<double> rho;
+  iEvent.getByToken(m_rho_token, rho);
 
-    edm::Handle<double> rho;
-    iEvent.getByToken(m_rho_token, rho);
+  // Access jet resolution and scale factor from the condition database
+  // or from text files
+  JME::JetResolution resolution;
+  JME::JetResolutionScaleFactor res_sf;
 
-    // Access jet resolution and scale factor from the condition database
-    // or from text files
-    JME::JetResolution resolution;
-    JME::JetResolutionScaleFactor res_sf;
+  // Two differents way to create a class instance
+  if (m_use_conddb) {
+    // First way, using the get() static method
+    resolution = JME::JetResolution::get(iSetup, m_payload);
+    res_sf = JME::JetResolutionScaleFactor::get(iSetup, m_payload);
+  } else {
+    // Second way, using the constructor
+    resolution = JME::JetResolution(m_resolutions_file);
+    res_sf = JME::JetResolutionScaleFactor(m_scale_factors_file);
+  }
 
-    // Two differents way to create a class instance
-    if (m_use_conddb) {
-        // First way, using the get() static method
-        resolution = JME::JetResolution::get(iSetup, m_payload);
-        res_sf = JME::JetResolutionScaleFactor::get(iSetup, m_payload);
-    } else {
-        // Second way, using the constructor
-        resolution = JME::JetResolution(m_resolutions_file);
-        res_sf = JME::JetResolutionScaleFactor(m_scale_factors_file);
+  if (m_debug) {
+    // Dump resolution
+    resolution.dump();
+  }
+
+  if (!m_res_vs_eta) {
+    // Advanced usage. Create the histogram by retriving the eta binning directly from the JetResolutionObject. This suppose you need that the parametrization only depends on eta.
+
+    // Get the list of bins of this object
+    const std::vector<JME::Binning>& bins = resolution.getResolutionObject()->getDefinition().getBins();
+
+    // Check that the first bin is eta
+    if ((bins.size()) && (bins[0] == JME::Binning::JetEta)) {
+      const std::vector<JME::JetResolutionObject::Record> records = resolution.getResolutionObject()->getRecords();
+      // Get all records from the object. Each record correspond to a different binning and different parameters
+
+      std::vector<float> etas;
+      for (const auto& record : records) {
+        if (etas.empty()) {
+          etas.push_back(record.getBinsRange()[0].min);
+          etas.push_back(record.getBinsRange()[0].max);
+        } else {
+          etas.push_back(record.getBinsRange()[0].max);
+        }
+      }
+
+      std::vector<float> res;
+      for (std::size_t i = 0; i < 40; i++) {
+        res.push_back(i * 0.005);
+      }
+
+      m_res_vs_eta = fs->make<TH2F>("res_vs_eta", "res_vs_eta", etas.size() - 1, &etas[0], res.size() - 1, &res[0]);
     }
+  }
 
+  for (const auto& jet : *jets) {
     if (m_debug) {
-        // Dump resolution
-        resolution.dump();
+      std::cout << "New jet; pt=" << jet.pt() << "  eta=" << jet.eta() << "  phi=" << jet.phi()
+                << "  e=" << jet.energy() << "  rho=" << *rho << std::endl;
     }
 
-    if (! m_res_vs_eta) {
-        
-        // Advanced usage. Create the histogram by retriving the eta binning directly from the JetResolutionObject. This suppose you need that the parametrization only depends on eta.
+    // Get resolution for this jet
+    // The method to use is getResolution(const JME::JetParameters& parameters) from a JetResolution object
 
-        // Get the list of bins of this object
-        const std::vector<JME::Binning>& bins = resolution.getResolutionObject()->getDefinition().getBins();
+    // You *must* now in advance which variables are needed for getting the resolution. For the moment, only pt and eta are needed, but this will
+    // probably change in the futur when PU dependency is added. Please keep an eye on the twiki page
+    //     https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution
+    // to stay up-to-date. All currently supported parameters (ie, 'set' functions) are available here:
+    //     https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution#List_of_supported_parameters
 
-        // Check that the first bin is eta
-        if ((bins.size()) && (bins[0] == JME::Binning::JetEta)) {
-        
-            const std::vector<JME::JetResolutionObject::Record> records = resolution.getResolutionObject()->getRecords();
-            // Get all records from the object. Each record correspond to a different binning and different parameters
-                
-            std::vector<float> etas;
-            for (const auto& record: records) {
-                if (etas.empty()) {
-                    etas.push_back(record.getBinsRange()[0].min);
-                    etas.push_back(record.getBinsRange()[0].max);
-                } else {
-                    etas.push_back(record.getBinsRange()[0].max);
-                }   
-            }
+    // Three way to create a JetParameters object
 
-            std::vector<float> res;
-            for (std::size_t i = 0; i < 40; i++) {
-                res.push_back(i * 0.005);
-            }
+    // First, using 'set' functions
+    JME::JetParameters parameters_1;
+    parameters_1.setJetPt(jet.pt());
+    parameters_1.setJetEta(jet.eta());
+    parameters_1.setRho(*rho);
 
-            m_res_vs_eta = fs->make<TH2F>("res_vs_eta", "res_vs_eta", etas.size() - 1, &etas[0], res.size() - 1, &res[0]);
-        }
+    // You can also chain calls
+
+    JME::JetParameters parameters_2;
+    parameters_2.setJetPt(jet.pt()).setJetEta(jet.eta()).setRho(*rho);
+
+    // Second, using the set() function
+    JME::JetParameters parameters_3;
+    parameters_3.set(JME::Binning::JetPt, jet.pt());
+    parameters_3.set({JME::Binning::JetEta, jet.eta()});
+    parameters_3.set({JME::Binning::Rho, *rho});
+
+    // Or
+
+    JME::JetParameters parameters_4;
+    parameters_4.set(JME::Binning::JetPt, jet.pt()).set(JME::Binning::JetEta, jet.eta()).set(JME::Binning::Rho, *rho);
+
+    // Third, using a initializer_list
+    JME::JetParameters parameters_5 = {
+        {JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}};
+
+    // Now, get the resolution
+
+    float r = resolution.getResolution(parameters_1);
+    if (m_debug) {
+      std::cout << "Resolution with parameters_1: " << r << std::endl;
+      std::cout << "Resolution with parameters_2: " << resolution.getResolution(parameters_2) << std::endl;
+      std::cout << "Resolution with parameters_3: " << resolution.getResolution(parameters_3) << std::endl;
+      std::cout << "Resolution with parameters_4: " << resolution.getResolution(parameters_4) << std::endl;
+      std::cout << "Resolution with parameters_5: " << resolution.getResolution(parameters_5) << std::endl;
+
+      // You can also use a shortcut to get the resolution
+      float r2 = resolution.getResolution(
+          {{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
+      std::cout << "Resolution using shortcut   : " << r2 << std::endl;
     }
 
-    for (const auto& jet: *jets) {
-        if (m_debug) {
-            std::cout << "New jet; pt=" << jet.pt() << "  eta=" << jet.eta() << "  phi=" << jet.phi() << "  e=" << jet.energy() << "  rho=" << *rho << std::endl;
-        }
+    m_res_vs_eta->Fill(jet.eta(), r);
 
+    // We do the same thing to access the scale factors
+    float sf = res_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}});
 
-        // Get resolution for this jet
-        // The method to use is getResolution(const JME::JetParameters& parameters) from a JetResolution object
-        
-        // You *must* now in advance which variables are needed for getting the resolution. For the moment, only pt and eta are needed, but this will
-        // probably change in the futur when PU dependency is added. Please keep an eye on the twiki page
-        //     https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution
-        // to stay up-to-date. All currently supported parameters (ie, 'set' functions) are available here:
-        //     https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution#List_of_supported_parameters
-        
-
-        // Three way to create a JetParameters object
-
-        // First, using 'set' functions
-        JME::JetParameters parameters_1;
-        parameters_1.setJetPt(jet.pt());
-        parameters_1.setJetEta(jet.eta());
-        parameters_1.setRho(*rho);
-
-        // You can also chain calls
-
-        JME::JetParameters parameters_2;
-        parameters_2.setJetPt(jet.pt()).setJetEta(jet.eta()).setRho(*rho);
-
-        // Second, using the set() function
-        JME::JetParameters parameters_3;
-        parameters_3.set(JME::Binning::JetPt, jet.pt());
-        parameters_3.set({JME::Binning::JetEta, jet.eta()});
-        parameters_3.set({JME::Binning::Rho, *rho});
-
-        // Or
-
-        JME::JetParameters parameters_4;
-        parameters_4.set(JME::Binning::JetPt, jet.pt()).set(JME::Binning::JetEta, jet.eta()).set(JME::Binning::Rho, *rho);
-    
-        // Third, using a initializer_list
-        JME::JetParameters parameters_5 = {{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}};
-
-        // Now, get the resolution
-
-        float r = resolution.getResolution(parameters_1);
-        if (m_debug) {
-            std::cout << "Resolution with parameters_1: " << r << std::endl;
-            std::cout << "Resolution with parameters_2: " << resolution.getResolution(parameters_2) << std::endl;
-            std::cout << "Resolution with parameters_3: " << resolution.getResolution(parameters_3) << std::endl;
-            std::cout << "Resolution with parameters_4: " << resolution.getResolution(parameters_4) << std::endl;
-            std::cout << "Resolution with parameters_5: " << resolution.getResolution(parameters_5) << std::endl;
-
-            // You can also use a shortcut to get the resolution
-            float r2 = resolution.getResolution({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
-            std::cout << "Resolution using shortcut   : " << r2 << std::endl;
-        }
-
-        m_res_vs_eta->Fill(jet.eta(), r);
-
-        // We do the same thing to access the scale factors
-        float sf = res_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}});
-
-        // Access up and down variation of the scale factor
-        float sf_up = res_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, Variation::UP);
-        float sf_down = res_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, Variation::DOWN);
-
-        if (m_debug) {
-            std::cout << "Scale factors (Nominal / Up / Down) : " << sf << " / " << sf_up << " / " << sf_down << std::endl;
-        }
+    // Access up and down variation of the scale factor
+    float sf_up =
+        res_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}}, Variation::UP);
+    float sf_down =
+        res_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}}, Variation::DOWN);
+    if (m_debug) {
+      std::cout << "Scale factors (Nominal / Up / Down) : " << sf << " / " << sf_up << " / " << sf_down << std::endl;
     }
+  }
 }
 //---------------------------------------------------------------------------
-void JetResolutionDemo::endJob()
-{
-
-}
+void JetResolutionDemo::endJob() {}
 //---------------------------------------------------------------------------
 //define this as a plug-in
 DEFINE_FWK_MODULE(JetResolutionDemo);

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -16,19 +16,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-
 using namespace pat;
 
-JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
-  emf_(cfg.getParameter<bool>( "emf" )),
-  srcToken_(consumes<edm::View<reco::Jet> >(cfg.getParameter<edm::InputTag>( "src" ))),
-  type_ (cfg.getParameter<std::string>("flavorType")),
-  label_(cfg.getParameter<std::string>( "@module_label" )),
-  payload_( cfg.getParameter<std::string>("payload") ),
-  useNPV_(cfg.getParameter<bool>("useNPV")),
-  useRho_(cfg.getParameter<bool>("useRho")),
-  cacheId_(0)
-{
+JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg)
+    : emf_(cfg.getParameter<bool>("emf")),
+      srcToken_(consumes<edm::View<reco::Jet> >(cfg.getParameter<edm::InputTag>("src"))),
+      type_(cfg.getParameter<std::string>("flavorType")),
+      label_(cfg.getParameter<std::string>("@module_label")),
+      payload_(cfg.getParameter<std::string>("payload")),
+      useNPV_(cfg.getParameter<bool>("useNPV")),
+      useRho_(cfg.getParameter<bool>("useRho")),
+      cacheId_(0) {
   std::vector<std::string> levels = cfg.getParameter<std::vector<std::string> >("levels");
   // fill the std::map for levels_, which might be flavor dependent or not;
   // flavor dependency is determined from the fact whether the std::string
@@ -38,160 +36,163 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
   // and 'L7Parton' will be expanded accordingly; if not levels_ is filled
   // with only one vector of strings according to NONE. This vector will be
   // equivalent to the original vector of strings.
-  if(std::find(levels.begin(), levels.end(), "L5Flavor")!=levels.end() || std::find(levels.begin(), levels.end(), "L7Parton")!=levels.end()){
-    levels_[JetCorrFactors::GLUON ] = expand(levels, JetCorrFactors::GLUON );
-    levels_[JetCorrFactors::UDS   ] = expand(levels, JetCorrFactors::UDS   );
-    levels_[JetCorrFactors::CHARM ] = expand(levels, JetCorrFactors::CHARM );
+  if (std::find(levels.begin(), levels.end(), "L5Flavor") != levels.end() ||
+      std::find(levels.begin(), levels.end(), "L7Parton") != levels.end()) {
+    levels_[JetCorrFactors::GLUON] = expand(levels, JetCorrFactors::GLUON);
+    levels_[JetCorrFactors::UDS] = expand(levels, JetCorrFactors::UDS);
+    levels_[JetCorrFactors::CHARM] = expand(levels, JetCorrFactors::CHARM);
     levels_[JetCorrFactors::BOTTOM] = expand(levels, JetCorrFactors::BOTTOM);
-  }
-  else{
-    levels_[JetCorrFactors::NONE  ] = levels;
+  } else {
+    levels_[JetCorrFactors::NONE] = levels;
   }
   // if the std::string L1JPTOffset can be found in levels an additional
   // parameter extraJPTOffset is needed, which should pass on the the usual
   // L1Offset correction, which is an additional input to the L1JPTOffset
   // corrector
-  if(std::find(levels.begin(), levels.end(), "L1JPTOffset")!=levels.end()){
-    if(cfg.existsAs<std::string>("extraJPTOffset")){
+  if (std::find(levels.begin(), levels.end(), "L1JPTOffset") != levels.end()) {
+    if (cfg.existsAs<std::string>("extraJPTOffset")) {
       extraJPTOffset_.push_back(cfg.getParameter<std::string>("extraJPTOffset"));
-    }
-    else{
+    } else {
       throw cms::Exception("No parameter extraJPTOffset specified")
-	<< "The configured correction levels contain a L1JPTOffset correction, which re- \n"
-	<< "quires the additional parameter extraJPTOffset or type std::string. This     \n"
-	<< "string should correspond to the L1Offset corrections that should be applied  \n"
-	<< "together with the JPTL1Offset corrections. These corrections can be of type  \n"
-	<< "L1Offset or L1FastJet.                                                       \n";
+          << "The configured correction levels contain a L1JPTOffset correction, which re- \n"
+          << "quires the additional parameter extraJPTOffset or type std::string. This     \n"
+          << "string should correspond to the L1Offset corrections that should be applied  \n"
+          << "together with the JPTL1Offset corrections. These corrections can be of type  \n"
+          << "L1Offset or L1FastJet.                                                       \n";
     }
   }
   // if the std::string L1Offset can be found in levels an additional para-
   // meter primaryVertices is needed, which should pass on the offline pri-
   // mary vertex collection. The size of this collection is needed for the
   // L1Offset correction.
-  if(useNPV_){
-    if(cfg.existsAs<edm::InputTag>("primaryVertices")){
-      primaryVertices_=cfg.getParameter<edm::InputTag>("primaryVertices");
-      primaryVerticesToken_=mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
-    }
-    else{
+  if (useNPV_) {
+    if (cfg.existsAs<edm::InputTag>("primaryVertices")) {
+      primaryVertices_ = cfg.getParameter<edm::InputTag>("primaryVertices");
+      primaryVerticesToken_ = mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
+    } else {
       throw cms::Exception("No primaryVertices specified")
-	<< "The configured correction levels contain an L1Offset or L1FastJet correction, \n"
-	<< "which requires the number of offlinePrimaryVertices. Please specify this col- \n"
-	<< "lection as additional optional parameter primaryVertices of type edm::InputTag\n"
-	<< "in the jetCorrFactors module.                                                 \n";
+          << "The configured correction levels contain an L1Offset or L1FastJet correction, \n"
+          << "which requires the number of offlinePrimaryVertices. Please specify this col- \n"
+          << "lection as additional optional parameter primaryVertices of type edm::InputTag\n"
+          << "in the jetCorrFactors module.                                                 \n";
     }
   }
   // if the std::string L1FastJet can be found in levels an additional
   // parameter rho is needed, which should pass on the energy density
   // parameter for the corresponding jet collection.
-  if(useRho_){
-    if((!extraJPTOffset_.empty() && extraJPTOffset_.front()==std::string("L1FastJet")) || std::find(levels.begin(), levels.end(), "L1FastJet")!=levels.end()){
-      if(cfg.existsAs<edm::InputTag>("rho")){
-	rho_=cfg.getParameter<edm::InputTag>("rho");
-	rhoToken_=mayConsume<double>(rho_);
+  if (useRho_) {
+    if ((!extraJPTOffset_.empty() && extraJPTOffset_.front() == std::string("L1FastJet")) ||
+        std::find(levels.begin(), levels.end(), "L1FastJet") != levels.end()) {
+      if (cfg.existsAs<edm::InputTag>("rho")) {
+        rho_ = cfg.getParameter<edm::InputTag>("rho");
+        rhoToken_ = mayConsume<double>(rho_);
+      } else {
+        throw cms::Exception("No parameter rho specified")
+            << "The configured correction levels contain a L1FastJet correction, which re- \n"
+            << "quires the energy density parameter rho. Please specify this collection as \n"
+            << "additional optional parameter rho of type edm::InputTag in the jetCorrFac- \n"
+            << "tors module.                                                               \n";
       }
-      else{
-	throw cms::Exception("No parameter rho specified")
-	  << "The configured correction levels contain a L1FastJet correction, which re- \n"
-	  << "quires the energy density parameter rho. Please specify this collection as \n"
-	  << "additional optional parameter rho of type edm::InputTag in the jetCorrFac- \n"
-	  << "tors module.                                                               \n";
-      }
-    }
-    else{
-      edm::LogInfo message( "Parameter rho not used" );
+    } else {
+      edm::LogInfo message("Parameter rho not used");
       message << "Module is configured to use the parameter rho, but rho is only used     \n"
-	      << "for L1FastJet corrections. The configuration of levels does not contain \n"
-	      << "L1FastJet corrections though, so rho will not be used by this module.   \n";
+              << "for L1FastJet corrections. The configuration of levels does not contain \n"
+              << "L1FastJet corrections though, so rho will not be used by this module.   \n";
     }
   }
   produces<JetCorrFactorsMap>();
 }
 
-std::vector<std::string>
-JetCorrFactorsProducer::expand(const std::vector<std::string>& levels, const JetCorrFactors::Flavor& flavor)
-{
+std::vector<std::string> JetCorrFactorsProducer::expand(const std::vector<std::string>& levels,
+                                                        const JetCorrFactors::Flavor& flavor) {
   std::vector<std::string> expand;
-  for(std::vector<std::string>::const_iterator level=levels.begin(); level!=levels.end(); ++level){
-    if((*level)=="L5Flavor" || (*level)=="L7Parton"){
-      if(flavor==JetCorrFactors::GLUON ){
-	if(*level=="L7Parton" && type_=="T"){
-	  edm::LogWarning message( "L7Parton::GLUON not available" );
-	  message << "Jet energy corrections requested for level: L7Parton and type: 'T'. \n"
-		  << "For this combination there is no GLUON correction available. The    \n"
-		  << "correction for this flavor type will be taken from 'J'.";
-	}
-	expand.push_back(std::string(*level).append("_").append("g").append("J"));
+  for (std::vector<std::string>::const_iterator level = levels.begin(); level != levels.end(); ++level) {
+    if ((*level) == "L5Flavor" || (*level) == "L7Parton") {
+      if (flavor == JetCorrFactors::GLUON) {
+        if (*level == "L7Parton" && type_ == "T") {
+          edm::LogWarning message("L7Parton::GLUON not available");
+          message << "Jet energy corrections requested for level: L7Parton and type: 'T'. \n"
+                  << "For this combination there is no GLUON correction available. The    \n"
+                  << "correction for this flavor type will be taken from 'J'.";
+        }
+        expand.push_back(std::string(*level).append("_").append("g").append("J"));
       }
-      if(flavor==JetCorrFactors::UDS   ) expand.push_back(std::string(*level).append("_").append("q").append(type_));
-      if(flavor==JetCorrFactors::CHARM ) expand.push_back(std::string(*level).append("_").append("c").append(type_));
-      if(flavor==JetCorrFactors::BOTTOM) expand.push_back(std::string(*level).append("_").append("b").append(type_));
-    }
-    else{
+      if (flavor == JetCorrFactors::UDS)
+        expand.push_back(std::string(*level).append("_").append("q").append(type_));
+      if (flavor == JetCorrFactors::CHARM)
+        expand.push_back(std::string(*level).append("_").append("c").append(type_));
+      if (flavor == JetCorrFactors::BOTTOM)
+        expand.push_back(std::string(*level).append("_").append("b").append(type_));
+    } else {
       expand.push_back(*level);
     }
   }
   return expand;
 }
 
-std::vector<JetCorrectorParameters>
-JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameters, const std::vector<std::string>& levels) const
-{
+std::vector<JetCorrectorParameters> JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameters,
+                                                                   const std::vector<std::string>& levels) const {
   std::vector<JetCorrectorParameters> params;
-  for(std::vector<std::string>::const_iterator level=levels.begin(); level!=levels.end(); ++level){
-    const JetCorrectorParameters& ip = parameters[*level]; //ip.printScreen();
+  for (std::vector<std::string>::const_iterator level = levels.begin(); level != levels.end(); ++level) {
+    const JetCorrectorParameters& ip = parameters[*level];  //ip.printScreen();
     params.push_back(ip);
   }
   return params;
 }
 
-float
-JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet, const JetCorrFactors::Flavor& flavor, int level)
-{
+float JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet,
+                                       const JetCorrFactors::Flavor& flavor,
+                                       int level) {
   std::unique_ptr<FactorizedJetCorrector>& corrector = correctors_.find(flavor)->second;
   // add parameters for JPT corrections
-  const reco::JPTJet* jpt = dynamic_cast<reco::JPTJet const *>( &*jet );
-  if( jpt ){
-    TLorentzVector p4; p4.SetPtEtaPhiE(jpt->getCaloJetRef()->pt(), jpt->getCaloJetRef()->eta(), jpt->getCaloJetRef()->phi(), jpt->getCaloJetRef()->energy());
-    if( extraJPTOffsetCorrector_ ){
+  const reco::JPTJet* jpt = dynamic_cast<reco::JPTJet const*>(&*jet);
+  if (jpt) {
+    TLorentzVector p4;
+    p4.SetPtEtaPhiE(jpt->getCaloJetRef()->pt(),
+                    jpt->getCaloJetRef()->eta(),
+                    jpt->getCaloJetRef()->phi(),
+                    jpt->getCaloJetRef()->energy());
+    if (extraJPTOffsetCorrector_) {
       extraJPTOffsetCorrector_->setJPTrawP4(p4);
       corrector->setJPTrawOff(extraJPTOffsetCorrector_->getSubCorrections()[0]);
     }
     corrector->setJPTrawP4(p4);
   }
   //For PAT jets undo previous jet energy corrections
-  const Jet* patjet = dynamic_cast<Jet const *>( &*jet );
-  if( patjet ){
-    corrector->setJetEta(patjet->correctedP4(0).eta()); corrector->setJetPt(patjet->correctedP4(0).pt()); corrector->setJetE(patjet->correctedP4(0).energy());
+  const Jet* patjet = dynamic_cast<Jet const*>(&*jet);
+  if (patjet) {
+    corrector->setJetEta(patjet->correctedP4(0).eta());
+    corrector->setJetPt(patjet->correctedP4(0).pt());
+    corrector->setJetPhi(patjet->correctedP4(0).phi());
+    corrector->setJetE(patjet->correctedP4(0).energy());
   } else {
-    corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy());
+    corrector->setJetEta(jet->eta());
+    corrector->setJetPt(jet->pt());
+    corrector->setJetPhi(jet->phi());
+    corrector->setJetE(jet->energy());
   }
-  if( emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)){
+  if (emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)) {
     corrector->setJetEMF(dynamic_cast<const reco::CaloJet*>(&*jet)->emEnergyFraction());
   }
   return corrector->getSubCorrections()[level];
 }
 
-std::string
-JetCorrFactorsProducer::payload()
-{
-  return payload_;
-}
+std::string JetCorrFactorsProducer::payload() { return payload_; }
 
-void
-JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-{
+void JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   // get jet collection from the event
   edm::Handle<edm::View<reco::Jet> > jets;
   event.getByToken(srcToken_, jets);
 
   // get primary vertices for L1Offset correction level if needed
   edm::Handle<std::vector<reco::Vertex> > primaryVertices;
-  if(!primaryVertices_.label().empty()) event.getByToken(primaryVerticesToken_, primaryVertices);
+  if (!primaryVertices_.label().empty())
+    event.getByToken(primaryVerticesToken_, primaryVertices);
 
   // get parameter rho for L1FastJet correction level if needed
   edm::Handle<double> rho;
-  if(!rho_.label().empty()) event.getByToken(rhoToken_, rho);
+  if (!rho_.label().empty())
+    event.getByToken(rhoToken_, rho);
 
   auto const& rec = setup.get<JetCorrectionsRecord>();
   if (cacheId_ != rec.cacheIdentifier()) {
@@ -199,19 +200,19 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     edm::ESHandle<JetCorrectorParametersCollection> parameters;
     setup.get<JetCorrectionsRecord>().get(payload(), parameters);
     // initialize jet correctors
-    for(FlavorCorrLevelMap::const_iterator flavor=levels_.begin(); flavor!=levels_.end(); ++flavor){
-      correctors_[flavor->first].reset( new FactorizedJetCorrector(params(*parameters, flavor->second)) );
+    for (FlavorCorrLevelMap::const_iterator flavor = levels_.begin(); flavor != levels_.end(); ++flavor) {
+      correctors_[flavor->first].reset(new FactorizedJetCorrector(params(*parameters, flavor->second)));
     }
     // initialize extra jet corrector for jpt if needed
-    if(!extraJPTOffset_.empty()){
-      extraJPTOffsetCorrector_.reset( new FactorizedJetCorrector(params(*parameters, extraJPTOffset_)) );
+    if (!extraJPTOffset_.empty()) {
+      extraJPTOffsetCorrector_.reset(new FactorizedJetCorrector(params(*parameters, extraJPTOffset_)));
     }
     cacheId_ = rec.cacheIdentifier();
   }
 
   // fill the jetCorrFactors
   std::vector<JetCorrFactors> jcfs;
-  for(edm::View<reco::Jet>::const_iterator jet = jets->begin(); jet!=jets->end(); ++jet){
+  for (edm::View<reco::Jet>::const_iterator jet = jets->begin(); jet != jets->end(); ++jet) {
     // the JetCorrFactors::CorrectionFactor is a std::pair<std::string, std::vector<float> >
     // the string corresponds to the label of the correction level, the vector contains four
     // floats if flavor dependent and one float else. Per construction jet energy corrections
@@ -219,50 +220,51 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     // pendent afterwards. The first correction level is predefined with label 'Uncorrected'.
     // Per definition it is flavor independent. The correction factor is 1.
     std::vector<JetCorrFactors::CorrectionFactor> jec;
-    jec.push_back(std::make_pair<std::string, std::vector<float> >(std::string("Uncorrected"), std::vector<float>(1, 1)));
+    jec.push_back(
+        std::make_pair<std::string, std::vector<float> >(std::string("Uncorrected"), std::vector<float>(1, 1)));
 
     // pick the first element in the map (which could be the only one) and loop all jec
     // levels listed for that element. If this is not the only element all jec levels, which
     // are flavor independent will give the same correction factors until the first flavor
     // dependent correction level is reached. So the first element is still a good choice.
-    FlavorCorrLevelMap::const_iterator corrLevel=levels_.begin();
-    if(corrLevel==levels_.end()){
-      throw cms::Exception("No JECFactors") << "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
-					    << "This makes no sense, either you should correct this or drop the module from \n"
-					    << "the sequence.";
+    FlavorCorrLevelMap::const_iterator corrLevel = levels_.begin();
+    if (corrLevel == levels_.end()) {
+      throw cms::Exception("No JECFactors")
+          << "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
+          << "This makes no sense, either you should correct this or drop the module from \n"
+          << "the sequence.";
     }
-    for(unsigned int idx=0; idx<corrLevel->second.size(); ++idx){
+    for (unsigned int idx = 0; idx < corrLevel->second.size(); ++idx) {
       std::vector<float> factors;
-      if(corrLevel->second[idx].find("L5Flavor")!=std::string::npos ||
-	 corrLevel->second[idx].find("L7Parton")!=std::string::npos){
-	for(FlavorCorrLevelMap::const_iterator flavor=corrLevel; flavor!=levels_.end(); ++flavor){
-	  if(!primaryVertices_.label().empty()){
-	    // if primaryVerticesToken_ has a value the number of primary vertices needs to be
-	    // specified
-	    correctors_.find(flavor->first)->second->setNPV(numberOf(primaryVertices));
-	  }
-	  if(!rho_.label().empty()){
-	    // if rhoToken_ has a value the energy density parameter rho and the jet area need
-	    //  to be specified
-	    correctors_.find(flavor->first)->second->setRho(*rho);
-	    correctors_.find(flavor->first)->second->setJetA(jet->jetArea());
-	  }
-	  factors.push_back(evaluate(jet, flavor->first, idx));
-	}
-      }
-      else{
-	if(!primaryVertices_.label().empty()){
-	  // if primaryVerticesToken_ has a value the number of primary vertices needs to be
-	  // specified
-	  correctors_.find(corrLevel->first)->second->setNPV(numberOf(primaryVertices));
-	}
-	if(!rho_.label().empty()){
-	  // if rhoToken_ has a value the energy density parameter rho and the jet area need
-	  // to be specified
-	  correctors_.find(corrLevel->first)->second->setRho(*rho);
-	  correctors_.find(corrLevel->first)->second->setJetA(jet->jetArea());
-	}
-	factors.push_back(evaluate(jet, corrLevel->first, idx));
+      if (corrLevel->second[idx].find("L5Flavor") != std::string::npos ||
+          corrLevel->second[idx].find("L7Parton") != std::string::npos) {
+        for (FlavorCorrLevelMap::const_iterator flavor = corrLevel; flavor != levels_.end(); ++flavor) {
+          if (!primaryVertices_.label().empty()) {
+            // if primaryVerticesToken_ has a value the number of primary vertices needs to be
+            // specified
+            correctors_.find(flavor->first)->second->setNPV(numberOf(primaryVertices));
+          }
+          if (!rho_.label().empty()) {
+            // if rhoToken_ has a value the energy density parameter rho and the jet area need
+            //  to be specified
+            correctors_.find(flavor->first)->second->setRho(*rho);
+            correctors_.find(flavor->first)->second->setJetA(jet->jetArea());
+          }
+          factors.push_back(evaluate(jet, flavor->first, idx));
+        }
+      } else {
+        if (!primaryVertices_.label().empty()) {
+          // if primaryVerticesToken_ has a value the number of primary vertices needs to be
+          // specified
+          correctors_.find(corrLevel->first)->second->setNPV(numberOf(primaryVertices));
+        }
+        if (!rho_.label().empty()) {
+          // if rhoToken_ has a value the energy density parameter rho and the jet area need
+          // to be specified
+          correctors_.find(corrLevel->first)->second->setRho(*rho);
+          correctors_.find(corrLevel->first)->second->setJetA(jet->jetArea());
+        }
+        factors.push_back(evaluate(jet, corrLevel->first, idx));
       }
       // push back the set of JetCorrFactors: the first entry corresponds to the label
       // of the correction level, which is taken from the first element in levels_. For
@@ -284,14 +286,12 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
   JetCorrFactorsMap::Filler filler(*jetCorrsMap);
   // jets and jetCorrs have their indices aligned by construction
   filler.insert(jets, jcfs.begin(), jcfs.end());
-  filler.fill(); // do the actual filling
+  filler.fill();  // do the actual filling
   // put our produced stuff in the event
   event.put(std::move(jetCorrsMap));
 }
 
-void
-JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription iDesc;
   iDesc.add<bool>("emf", false);
   iDesc.add<std::string>("flavorType", "J");
@@ -304,12 +304,12 @@ JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions & descri
   iDesc.add<std::string>("extraJPTOffset", "L1Offset");
 
   std::vector<std::string> levels;
-  levels.push_back(std::string("L1Offset"  ));
+  levels.push_back(std::string("L1Offset"));
   levels.push_back(std::string("L2Relative"));
   levels.push_back(std::string("L3Absolute"));
   levels.push_back(std::string("L2L3Residual"));
-  levels.push_back(std::string("L5Flavor"  ));
-  levels.push_back(std::string("L7Parton"  ));
+  levels.push_back(std::string("L5Flavor"));
+  levels.push_back(std::string("L7Parton"));
   iDesc.add<std::vector<std::string> >("levels", levels);
   descriptions.add("JetCorrFactorsProducer", iDesc);
 }

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -37,289 +37,288 @@
 #include <random>
 
 namespace pat {
-    class GenJetMatcher {
-        public:
-            GenJetMatcher(const edm::ParameterSet& cfg, edm::ConsumesCollector&& collector):
-                m_genJetsToken(collector.consumes<reco::GenJetCollection>(cfg.getParameter<edm::InputTag>("genJets"))),
-                m_dR_max(cfg.getParameter<double>("dRMax")),
-                m_dPt_max_factor(cfg.getParameter<double>("dPtMaxFactor")) {
-                // Empty
-            }
+  class GenJetMatcher {
+  public:
+    GenJetMatcher(const edm::ParameterSet& cfg, edm::ConsumesCollector&& collector)
+        : m_genJetsToken(collector.consumes<reco::GenJetCollection>(cfg.getParameter<edm::InputTag>("genJets"))),
+          m_dR_max(cfg.getParameter<double>("dRMax")),
+          m_dPt_max_factor(cfg.getParameter<double>("dPtMaxFactor")) {
+      // Empty
+    }
 
-            static void fillDescriptions(edm::ParameterSetDescription& desc) {
-                desc.add<edm::InputTag>("genJets");
-                desc.add<double>("dRMax");
-                desc.add<double>("dPtMaxFactor");
-            }
+    static void fillDescriptions(edm::ParameterSetDescription& desc) {
+      desc.add<edm::InputTag>("genJets");
+      desc.add<double>("dRMax");
+      desc.add<double>("dPtMaxFactor");
+    }
 
-            void getTokens(const edm::Event& event) {
-               event.getByToken(m_genJetsToken, m_genJets);
-            }
+    void getTokens(const edm::Event& event) { event.getByToken(m_genJetsToken, m_genJets); }
 
-            template<class T>
-            const reco::GenJet* match(const T& jet, double resolution) {
-                const reco::GenJetCollection& genJets = *m_genJets;
+    template <class T>
+    const reco::GenJet* match(const T& jet, double resolution) {
+      const reco::GenJetCollection& genJets = *m_genJets;
 
-                // Try to find a gen jet matching
-                // dR < m_dR_max
-                // dPt < m_dPt_max_factor * resolution
+      // Try to find a gen jet matching
+      // dR < m_dR_max
+      // dPt < m_dPt_max_factor * resolution
 
-                double min_dR = std::numeric_limits<double>::infinity();
-                const reco::GenJet* matched_genJet = nullptr;
+      double min_dR = std::numeric_limits<double>::infinity();
+      const reco::GenJet* matched_genJet = nullptr;
 
-                for (const auto& genJet: genJets) {
-                    double dR = deltaR(genJet, jet);
+      for (const auto& genJet : genJets) {
+        double dR = deltaR(genJet, jet);
 
-                    if (dR > min_dR)
-                        continue;
+        if (dR > min_dR)
+          continue;
 
-                    if (dR < m_dR_max) {
-                        double dPt = std::abs(genJet.pt() - jet.pt());
-                        if (dPt > m_dPt_max_factor * resolution)
-                            continue;
+        if (dR < m_dR_max) {
+          double dPt = std::abs(genJet.pt() - jet.pt());
+          if (dPt > m_dPt_max_factor * resolution)
+            continue;
 
-                        min_dR = dR;
-                        matched_genJet = &genJet;
-                    }
-                }
+          min_dR = dR;
+          matched_genJet = &genJet;
+        }
+      }
 
-                return matched_genJet;
-            }
+      return matched_genJet;
+    }
 
-        private:
-            edm::EDGetTokenT<reco::GenJetCollection> m_genJetsToken;
-            edm::Handle<reco::GenJetCollection> m_genJets;
+  private:
+    edm::EDGetTokenT<reco::GenJetCollection> m_genJetsToken;
+    edm::Handle<reco::GenJetCollection> m_genJets;
 
-            double m_dR_max;
-            double m_dPt_max_factor;
-    };
-};
+    double m_dR_max;
+    double m_dPt_max_factor;
+  };
+};  // namespace pat
 
 template <typename T>
 class SmearedJetProducerT : public edm::stream::EDProducer<> {
+  using JetCollection = std::vector<T>;
 
-    using JetCollection = std::vector<T>;
+public:
+  explicit SmearedJetProducerT(const edm::ParameterSet& cfg)
+      : m_enabled(cfg.getParameter<bool>("enabled")),
+        m_useDeterministicSeed(cfg.getParameter<bool>("useDeterministicSeed")),
+        m_debug(cfg.getUntrackedParameter<bool>("debug", false)) {
+    m_jets_token = consumes<JetCollection>(cfg.getParameter<edm::InputTag>("src"));
 
-    public:
-        explicit SmearedJetProducerT(const edm::ParameterSet& cfg):
-            m_enabled(cfg.getParameter<bool>("enabled")),
-            m_useDeterministicSeed(cfg.getParameter<bool>("useDeterministicSeed")),
-            m_debug(cfg.getUntrackedParameter<bool>("debug", false)) {
+    if (m_enabled) {
+      m_rho_token = consumes<double>(cfg.getParameter<edm::InputTag>("rho"));
 
-            m_jets_token = consumes<JetCollection>(cfg.getParameter<edm::InputTag>("src"));
+      m_use_txt_files = cfg.exists("resolutionFile") && cfg.exists("scaleFactorFile");
 
-            if (m_enabled) {
-                m_rho_token = consumes<double>(cfg.getParameter<edm::InputTag>("rho"));
+      if (m_use_txt_files) {
+        std::string resolutionFile = cfg.getParameter<edm::FileInPath>("resolutionFile").fullPath();
+        std::string scaleFactorFile = cfg.getParameter<edm::FileInPath>("scaleFactorFile").fullPath();
 
-                m_use_txt_files = cfg.exists("resolutionFile") && cfg.exists("scaleFactorFile");
+        m_resolution_from_file.reset(new JME::JetResolution(resolutionFile));
+        m_scale_factor_from_file.reset(new JME::JetResolutionScaleFactor(scaleFactorFile));
+      } else {
+        m_jets_algo = cfg.getParameter<std::string>("algo");
+        m_jets_algo_pt = cfg.getParameter<std::string>("algopt");
+      }
 
-                if (m_use_txt_files) {
-                    std::string resolutionFile = cfg.getParameter<edm::FileInPath>("resolutionFile").fullPath();
-                    std::string scaleFactorFile = cfg.getParameter<edm::FileInPath>("scaleFactorFile").fullPath();
+      std::uint32_t seed = cfg.getParameter<std::uint32_t>("seed");
+      m_random_generator = std::mt19937(seed);
 
-                    m_resolution_from_file.reset(new JME::JetResolution(resolutionFile));
-                    m_scale_factor_from_file.reset(new JME::JetResolutionScaleFactor(scaleFactorFile));
-                } else {
-                    m_jets_algo = cfg.getParameter<std::string>("algo");
-                    m_jets_algo_pt = cfg.getParameter<std::string>("algopt");
-                }
+      bool skipGenMatching = cfg.getParameter<bool>("skipGenMatching");
+      if (!skipGenMatching)
+        m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
 
-                std::uint32_t seed = cfg.getParameter<std::uint32_t>("seed");
-                m_random_generator = std::mt19937(seed);
+      std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
+      m_nomVar = 1;
+      if (variation == 0)
+        m_systematic_variation = Variation::NOMINAL;
+      else if (variation == 1)
+        m_systematic_variation = Variation::UP;
+      else if (variation == -1)
+        m_systematic_variation = Variation::DOWN;
+      else if (variation == 101) {
+        m_systematic_variation = Variation::NOMINAL;
+        m_nomVar = 1;
+      } else if (variation == -101) {
+        m_systematic_variation = Variation::NOMINAL;
+        m_nomVar = -1;
+      } else
+        throw edm::Exception(edm::errors::ConfigFileReadError,
+                             "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
+    }
 
-                bool skipGenMatching = cfg.getParameter<bool>("skipGenMatching");
-                if (! skipGenMatching)
-                    m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
+    produces<JetCollection>();
+  }
 
-                std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
-		m_nomVar=1;
-                if (variation == 0)
-                    m_systematic_variation = Variation::NOMINAL;
-                else if (variation == 1)
-                    m_systematic_variation = Variation::UP;
-                else if (variation == -1)
-                    m_systematic_variation = Variation::DOWN;
-		else if (variation == 101) {
-		  m_systematic_variation = Variation::NOMINAL;
-		  m_nomVar=1;
-		}
-		else if (variation == -101) {
-		  m_systematic_variation = Variation::NOMINAL;
-		  m_nomVar=-1;
-		}
-                else
-                    throw edm::Exception(edm::errors::ConfigFileReadError, "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
-            }
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
 
-            produces<JetCollection>();
-        }
+    desc.add<edm::InputTag>("src");
+    desc.add<bool>("enabled");
+    desc.add<edm::InputTag>("rho");
+    desc.add<std::int32_t>("variation", 0);
+    desc.add<std::uint32_t>("seed", 37428479);
+    desc.add<bool>("skipGenMatching", false);
+    desc.add<bool>("useDeterministicSeed", true);
+    desc.addUntracked<bool>("debug", false);
 
-        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-            edm::ParameterSetDescription desc;
+    auto source = (edm::ParameterDescription<std::string>("algo", true) and
+                   edm::ParameterDescription<std::string>("algopt", true)) xor
+                  (edm::ParameterDescription<edm::FileInPath>("resolutionFile", true) and
+                   edm::ParameterDescription<edm::FileInPath>("scaleFactorFile", true));
+    desc.addNode(std::move(source));
 
-            desc.add<edm::InputTag>("src");
-            desc.add<bool>("enabled");
-            desc.add<edm::InputTag>("rho");
-            desc.add<std::int32_t>("variation", 0);
-            desc.add<std::uint32_t>("seed", 37428479);
-            desc.add<bool>("skipGenMatching", false);
-            desc.add<bool>("useDeterministicSeed", true);
-            desc.addUntracked<bool>("debug", false);
+    pat::GenJetMatcher::fillDescriptions(desc);
 
-            auto source =
-	      (edm::ParameterDescription<std::string>("algo", true) and edm::ParameterDescription<std::string>("algopt", true)) xor
-	      (edm::ParameterDescription<edm::FileInPath>("resolutionFile", true) and edm::ParameterDescription<edm::FileInPath>("scaleFactorFile", true));
-            desc.addNode(std::move(source));
+    descriptions.addDefault(desc);
+  }
 
-            pat::GenJetMatcher::fillDescriptions(desc);
+  void produce(edm::Event& event, const edm::EventSetup& setup) override {
+    edm::Handle<JetCollection> jets_collection;
+    event.getByToken(m_jets_token, jets_collection);
 
-            descriptions.addDefault(desc);
-        }
+    // Disable the module when running on real data
+    if (m_enabled && event.isRealData()) {
+      m_enabled = false;
+      m_genJetMatcher.reset();
+    }
 
-        void produce(edm::Event& event, const edm::EventSetup& setup) override {
+    edm::Handle<double> rho;
+    if (m_enabled)
+      event.getByToken(m_rho_token, rho);
 
-            edm::Handle<JetCollection> jets_collection;
-            event.getByToken(m_jets_token, jets_collection);
+    JME::JetResolution resolution;
+    JME::JetResolutionScaleFactor resolution_sf;
 
-            // Disable the module when running on real data
-            if (m_enabled && event.isRealData()) {
-                m_enabled = false;
-                m_genJetMatcher.reset();
-            }
+    const JetCollection& jets = *jets_collection;
 
-            edm::Handle<double> rho;
-            if (m_enabled)
-                event.getByToken(m_rho_token, rho);
+    if (m_enabled) {
+      if (m_use_txt_files) {
+        resolution = *m_resolution_from_file;
+        resolution_sf = *m_scale_factor_from_file;
+      } else {
+        resolution = JME::JetResolution::get(setup, m_jets_algo_pt);
+        resolution_sf = JME::JetResolutionScaleFactor::get(setup, m_jets_algo);
+      }
 
-            JME::JetResolution resolution;
-            JME::JetResolutionScaleFactor resolution_sf;
+      if (m_useDeterministicSeed) {
+        unsigned int runNum_uint = static_cast<unsigned int>(event.id().run());
+        unsigned int lumiNum_uint = static_cast<unsigned int>(event.id().luminosityBlock());
+        unsigned int evNum_uint = static_cast<unsigned int>(event.id().event());
+        unsigned int jet0eta = uint32_t(jets.empty() ? 0 : jets[0].eta() / 0.01);
+        std::uint32_t seed = jet0eta + m_nomVar + (lumiNum_uint << 10) + (runNum_uint << 20) + evNum_uint;
+        m_random_generator.seed(seed);
+      }
+    }
 
-            const JetCollection& jets = *jets_collection;
+    if (m_genJetMatcher)
+      m_genJetMatcher->getTokens(event);
 
-            if (m_enabled) {
-                if (m_use_txt_files) {
-                    resolution = *m_resolution_from_file;
-                    resolution_sf = *m_scale_factor_from_file;
-                } else {
-                    resolution = JME::JetResolution::get(setup, m_jets_algo_pt);
-                    resolution_sf = JME::JetResolutionScaleFactor::get(setup, m_jets_algo);
-                }
+    auto smearedJets = std::make_unique<JetCollection>();
 
-                if(m_useDeterministicSeed) {
-                    unsigned int runNum_uint = static_cast <unsigned int> (event.id().run());
-                    unsigned int lumiNum_uint = static_cast <unsigned int> (event.id().luminosityBlock());
-                    unsigned int evNum_uint = static_cast <unsigned int> (event.id().event());
-                    unsigned int jet0eta = uint32_t(jets.empty() ? 0 : jets[0].eta()/0.01);
-                    std::uint32_t seed = jet0eta + m_nomVar + (lumiNum_uint<<10) + (runNum_uint<<20) + evNum_uint;
-                    m_random_generator.seed(seed);
-                }
-            }
+    for (const auto& jet : jets) {
+      if ((!m_enabled) || (jet.pt() == 0)) {
+        // Module disabled or invalid p4. Simply copy the input jet.
+        smearedJets->push_back(jet);
 
-            if (m_genJetMatcher)
-                m_genJetMatcher->getTokens(event);
+        continue;
+      }
 
-            auto smearedJets = std::make_unique<JetCollection>();
+      double jet_resolution = resolution.getResolution(
+          {{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
+      double jer_sf = resolution_sf.getScaleFactor({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}},
+                                                   m_systematic_variation);
+      if (m_debug) {
+        std::cout << "jet:  pt: " << jet.pt() << "  eta: " << jet.eta() << "  phi: " << jet.phi()
+                  << "  e: " << jet.energy() << std::endl;
+        std::cout << "resolution: " << jet_resolution << std::endl;
+        std::cout << "resolution scale factor: " << jer_sf << std::endl;
+      }
 
-            for (const auto& jet: jets) {
+      const reco::GenJet* genJet = nullptr;
+      if (m_genJetMatcher)
+        genJet = m_genJetMatcher->match(jet, jet.pt() * jet_resolution);
 
-                if ((! m_enabled) || (jet.pt() == 0)) {
-                    // Module disabled or invalid p4. Simply copy the input jet.
-                    smearedJets->push_back(jet);
+      double smearFactor = 1.;
 
-                    continue;
-                }
-
-                double jet_resolution = resolution.getResolution({{JME::Binning::JetPt, jet.pt()}, {JME::Binning::JetEta, jet.eta()}, {JME::Binning::Rho, *rho}});
-                double jer_sf = resolution_sf.getScaleFactor({{JME::Binning::JetEta, jet.eta()}}, m_systematic_variation);
-
-                if (m_debug) {
-                    std::cout << "jet:  pt: " << jet.pt() << "  eta: " << jet.eta() << "  phi: " << jet.phi() << "  e: " << jet.energy() << std::endl;
-                    std::cout << "resolution: " << jet_resolution << std::endl;
-                    std::cout << "resolution scale factor: " << jer_sf << std::endl;
-                }
-
-                const reco::GenJet* genJet = nullptr;
-                if (m_genJetMatcher)
-                    genJet = m_genJetMatcher->match(jet, jet.pt() * jet_resolution);
-
-                double smearFactor = 1.;
-
-                if (genJet) {
-                    /*
+      if (genJet) {
+        /*
                      * Case 1: we have a "good" gen jet matched to the reco jet
                      */
 
-                    if (m_debug) {
-                        std::cout << "gen jet:  pt: " << genJet->pt() << "  eta: " << genJet->eta() << "  phi: " << genJet->phi() << "  e: " << genJet->energy() << std::endl;
-                    }
+        if (m_debug) {
+          std::cout << "gen jet:  pt: " << genJet->pt() << "  eta: " << genJet->eta() << "  phi: " << genJet->phi()
+                    << "  e: " << genJet->energy() << std::endl;
+        }
 
-                    double dPt = jet.pt() - genJet->pt();
-                    smearFactor = 1 + m_nomVar*(jer_sf - 1.) * dPt / jet.pt();
+        double dPt = jet.pt() - genJet->pt();
+        smearFactor = 1 + m_nomVar * (jer_sf - 1.) * dPt / jet.pt();
 
-                } else if (jer_sf > 1) {
-                    /*
+      } else if (jer_sf > 1) {
+        /*
                      * Case 2: we don't have a gen jet. Smear jet pt using a random gaussian variation
                      */
 
-                    double sigma = jet_resolution * std::sqrt(jer_sf * jer_sf - 1);
-                    if (m_debug) {
-                        std::cout << "gaussian width: " << sigma << std::endl;
-                    }
-
-                    std::normal_distribution<> d(0, sigma);
-                    smearFactor = 1. + m_nomVar*d(m_random_generator);
-                } else if (m_debug) {
-                    std::cout << "Impossible to smear this jet" << std::endl;
-                }
-
-                if (jet.energy() * smearFactor < MIN_JET_ENERGY) {
-                    // Negative or too small smearFactor. We would change direction of the jet
-                    // and this is not what we want.
-                    // Recompute the smearing factor in order to have jet.energy() == MIN_JET_ENERGY
-                    double newSmearFactor = MIN_JET_ENERGY / jet.energy();
-                    if (m_debug) {
-                        std::cout << "The smearing factor (" << smearFactor << ") is either negative or too small. Fixing it to " << newSmearFactor << " to avoid change of direction." << std::endl;
-                    }
-                    smearFactor = newSmearFactor;
-                }
-
-                T smearedJet = jet;
-                smearedJet.scaleEnergy(smearFactor);
-
-                if (m_debug) {
-                    std::cout << "smeared jet (" << smearFactor << "):  pt: " << smearedJet.pt() << "  eta: " << smearedJet.eta() << "  phi: " << smearedJet.phi() << "  e: " << smearedJet.energy() << std::endl;
-                }
-
-                smearedJets->push_back(smearedJet);
-            }
-
-            // Sort jets by pt
-            std::sort(smearedJets->begin(), smearedJets->end(), jetPtComparator);
-
-            event.put(std::move(smearedJets));
+        double sigma = jet_resolution * std::sqrt(jer_sf * jer_sf - 1);
+        if (m_debug) {
+          std::cout << "gaussian width: " << sigma << std::endl;
         }
 
-    private:
-        static constexpr const double MIN_JET_ENERGY = 1e-2;
+        std::normal_distribution<> d(0, sigma);
+        smearFactor = 1. + m_nomVar * d(m_random_generator);
+      } else if (m_debug) {
+        std::cout << "Impossible to smear this jet" << std::endl;
+      }
 
-        edm::EDGetTokenT<JetCollection> m_jets_token;
-        edm::EDGetTokenT<double> m_rho_token;
-        bool m_enabled;
-        std::string m_jets_algo_pt;
-        std::string m_jets_algo;
-        Variation m_systematic_variation;
-        bool m_useDeterministicSeed;
-        bool m_debug;
-        std::shared_ptr<pat::GenJetMatcher> m_genJetMatcher;
+      if (jet.energy() * smearFactor < MIN_JET_ENERGY) {
+        // Negative or too small smearFactor. We would change direction of the jet
+        // and this is not what we want.
+        // Recompute the smearing factor in order to have jet.energy() == MIN_JET_ENERGY
+        double newSmearFactor = MIN_JET_ENERGY / jet.energy();
+        if (m_debug) {
+          std::cout << "The smearing factor (" << smearFactor << ") is either negative or too small. Fixing it to "
+                    << newSmearFactor << " to avoid change of direction." << std::endl;
+        }
+        smearFactor = newSmearFactor;
+      }
 
-        bool m_use_txt_files;
-        std::unique_ptr<JME::JetResolution> m_resolution_from_file;
-        std::unique_ptr<JME::JetResolutionScaleFactor> m_scale_factor_from_file;
+      T smearedJet = jet;
+      smearedJet.scaleEnergy(smearFactor);
 
-        std::mt19937 m_random_generator;
+      if (m_debug) {
+        std::cout << "smeared jet (" << smearFactor << "):  pt: " << smearedJet.pt() << "  eta: " << smearedJet.eta()
+                  << "  phi: " << smearedJet.phi() << "  e: " << smearedJet.energy() << std::endl;
+      }
 
-        GreaterByPt<T> jetPtComparator;
+      smearedJets->push_back(smearedJet);
+    }
 
-	int m_nomVar;
+    // Sort jets by pt
+    std::sort(smearedJets->begin(), smearedJets->end(), jetPtComparator);
+
+    event.put(std::move(smearedJets));
+  }
+
+private:
+  static constexpr const double MIN_JET_ENERGY = 1e-2;
+
+  edm::EDGetTokenT<JetCollection> m_jets_token;
+  edm::EDGetTokenT<double> m_rho_token;
+  bool m_enabled;
+  std::string m_jets_algo_pt;
+  std::string m_jets_algo;
+  Variation m_systematic_variation;
+  bool m_useDeterministicSeed;
+  bool m_debug;
+  std::shared_ptr<pat::GenJetMatcher> m_genJetMatcher;
+
+  bool m_use_txt_files;
+  std::unique_ptr<JME::JetResolution> m_resolution_from_file;
+  std::unique_ptr<JME::JetResolutionScaleFactor> m_scale_factor_from_file;
+
+  std::mt19937 m_random_generator;
+
+  GreaterByPt<T> jetPtComparator;
+
+  int m_nomVar;
 };
 #endif

--- a/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
+++ b/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
@@ -9,12 +9,14 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('PAT2',eras.Run2_2016)
 
+### Example how to check timing
 #process.Timing = cms.Service("Timing",
 #  summaryOnly = cms.untracked.bool(False),
 #  useJobReport = cms.untracked.bool(True)
 #)
 
-process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",ignoreTotal = cms.untracked.int32(1) ) 
+### Example how to check memory
+#process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",ignoreTotal = cms.untracked.int32(1) )
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -35,7 +37,7 @@ process.maxEvents = cms.untracked.PSet(
 # Input source
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    'file:////afs/cern.ch/user/h/hinzmann/workspace/tmp/102D73A7-5B87-E611-936E-0CC47A1E0472.root',
+    '/store/relval/CMSSW_11_0_0_pre6/RelValTTbar_13/MINIAODSIM/PU25ns_110X_upgrade2018_realistic_v3-v1/20000/F38B9A9F-4B4B-3D4B-8C9D-9A9B945194EF.root',
     ),
     secondaryFileNames = cms.untracked.vstring(),
     skipEvents = cms.untracked.uint32(145)
@@ -73,6 +75,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
+### Pick a global tag that includes the desired JER-SFs
 process.GlobalTag = GlobalTag(process.GlobalTag, '102X_mcRun2_asymptotic_v7', '')
 
 # Path and EndPath definitions
@@ -80,29 +83,30 @@ process.MINIAODSIMoutput_step = cms.EndPath(process.MINIAODSIMoutput)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
-from CondCore.DBCommon.CondDBSetup_cfi import *
 
-process.jer = cms.ESSource("PoolDBESSource",
-        CondDBSetup,
-        toGet = cms.VPSet(
-            # Resolution
-            cms.PSet(
-                record = cms.string('JetResolutionRcd'),
-                tag    = cms.string('JR_Autumn18_V7_MC_PtResolution_AK4PFchs'),
-                label  = cms.untracked.string('AK4PFchs_pt')
-                ),
-
-            # Scale factors
-            cms.PSet(
-                record = cms.string('JetResolutionScaleFactorRcd'),
-                tag    = cms.string('JR_Autumn18_V7_MC_SF_AK4PFchs'),
-                label  = cms.untracked.string('AK4PFchs')
-                ),
-            ),
-        connect = cms.string('sqlite:Autumn18_V7_MC.db')
-        )
-
-process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
+### Example how to read the JER-SF from a db file
+#from CondCore.DBCommon.CondDBSetup_cfi import *
+#process.jer = cms.ESSource("PoolDBESSource",
+#        CondDBSetup,
+#        toGet = cms.VPSet(
+#            # Resolution
+#            cms.PSet(
+#                record = cms.string('JetResolutionRcd'),
+#                tag    = cms.string('JR_Autumn18_V7_MC_PtResolution_AK4PFchs'),
+#                label  = cms.untracked.string('AK4PFchs_pt')
+#                ),
+#
+#            # Scale factors
+#            cms.PSet(
+#                record = cms.string('JetResolutionScaleFactorRcd'),
+#                tag    = cms.string('JR_Autumn18_V7_MC_SF_AK4PFchs'),
+#                label  = cms.untracked.string('AK4PFchs')
+#                ),
+#            ),
+#        connect = cms.string('sqlite:Autumn18_V7_MC.db')
+#        )
+#
+#process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
 
 process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
        src = cms.InputTag('slimmedJets'),

--- a/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
+++ b/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
@@ -1,0 +1,128 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: miniAOD-prod -s PAT --eventcontent MINIAODSIM --runUnscheduled --mc --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4 --era Run2_2016 --no_exec --filein /store/relval/CMSSW_8_0_20/RelValTTbar_13/MINIAODSIM/PU25ns_80X_mcRun2_asymptotic_2016_TrancheIV_v4_Tr4GT_v4-v1/00000/A8C282AE-D37A-E611-8603-0CC47A4C8ECE.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('PAT2',eras.Run2_2016)
+
+#process.Timing = cms.Service("Timing",
+#  summaryOnly = cms.untracked.bool(False),
+#  useJobReport = cms.untracked.bool(True)
+#)
+
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",ignoreTotal = cms.untracked.int32(1) ) 
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+#process.load('PhysicsTools.PatAlgos.slimming.metFilterPaths_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+    'file:////afs/cern.ch/user/h/hinzmann/workspace/tmp/102D73A7-5B87-E611-936E-0CC47A1E0472.root',
+    ),
+    secondaryFileNames = cms.untracked.vstring(),
+    skipEvents = cms.untracked.uint32(145)
+)
+
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('miniAOD-prod nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    dropMetaData = cms.untracked.string('ALL'),
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    fastCloning = cms.untracked.bool(False),
+    fileName = cms.untracked.string('NewMiniAOD.root'),
+    outputCommands = cms.untracked.vstring('keep *'),
+    overrideInputFileSplitLevels = cms.untracked.bool(True)
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '102X_mcRun2_asymptotic_v7', '')
+
+# Path and EndPath definitions
+process.MINIAODSIMoutput_step = cms.EndPath(process.MINIAODSIMoutput)
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+process.jer = cms.ESSource("PoolDBESSource",
+        CondDBSetup,
+        toGet = cms.VPSet(
+            # Resolution
+            cms.PSet(
+                record = cms.string('JetResolutionRcd'),
+                tag    = cms.string('JR_Autumn18_V7_MC_PtResolution_AK4PFchs'),
+                label  = cms.untracked.string('AK4PFchs_pt')
+                ),
+
+            # Scale factors
+            cms.PSet(
+                record = cms.string('JetResolutionScaleFactorRcd'),
+                tag    = cms.string('JR_Autumn18_V7_MC_SF_AK4PFchs'),
+                label  = cms.untracked.string('AK4PFchs')
+                ),
+            ),
+        connect = cms.string('sqlite:Autumn18_V7_MC.db')
+        )
+
+process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
+
+process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
+       src = cms.InputTag('slimmedJets'),
+       enabled = cms.bool(True),
+       rho = cms.InputTag("fixedGridRhoFastjetAll"),
+       algo = cms.string('AK4PFchs'),
+       algopt = cms.string('AK4PFchs_pt'),
+
+       genJets = cms.InputTag('slimmedGenJets'),
+       dRMax = cms.double(0.2),
+       dPtMaxFactor = cms.double(3),
+
+       debug = cms.untracked.bool(False),
+   # Systematic variation
+   # 0: Nominal
+   # -1: -1 sigma (down variation)
+   # 1: +1 sigma (up variation)
+   variation = cms.int32(0),  # If not specified, default to 0
+       )
+
+process.p=cms.Path(process.slimmedJetsSmeared)
+
+process.schedule=cms.Schedule(process.p,process.MINIAODSIMoutput_step)


### PR DESCRIPTION
#### PR description:

Enable pt-dependent jet resolution scale factors in PAT. This is needed to apply Autumn18_V7 JER-SF, released last week.
Enable phi-dependent jet energy scale in PAT. This will be needed for 2018 JEC to deal with the HEM issue.
This PR has no impact with the current global tags in any release. However, it will enable using a new global tag (currently in the makings) with pt-dependent JER-SFs and later with phi-dependent JECs.

A test config to apply resolution smearing from a db file has been added under /test.
Here is an example db-file containing pt-dependent JER-SFs:
https://github.com/cms-jet/JRDatabase/blob/master/SQLiteFiles/Autumn18_V7_MC.db

#### PR validation:

Test config runs after inclusion of this PR. It was checked that this does not change the memory consumption, compared to using the old code with Autumn18_V1_MC.db (no pt-dependence).

#### if this PR is a backport please specify the original PR:

Backport of #28096
