### PR TITLE
Update in IT-Pixel part of the Phase2Digitizer

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -134,9 +134,10 @@ void PixelDigitizerAlgorithm::add_cross_talk(const Phase2TrackerGeomDetUnit* pix
   // cross-talk calculation valid for the case of 25x100 pixels
   const float pitch_first = 0.0025;
   const float pitch_second = 0.0100;
+  const double pitch_tolerance(0.0005); // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
 
-  if (topol->pitch().first != pitch_first || topol->pitch().second != pitch_second)
-    return;  // please check that units are really cm!
+  if ( abs(topol->pitch().first - pitch_first) > pitch_tolerance ||
+       abs(topol->pitch().second - pitch_second) > pitch_tolerance ) return; 
 
   uint32_t detID = pixdet->geographicalId().rawId();
   signal_map_type& theSignal = _signal[detID];

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -134,8 +134,8 @@ void PixelDigitizerAlgorithm::add_cross_talk(const Phase2TrackerGeomDetUnit* pix
   // cross-talk calculation valid for the case of 25x100 pixels
   const float pitch_first = 0.0025;
   const float pitch_second = 0.0100;
-  const double pitch_tolerance(
-      0.0005);  // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
+  // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
+  const double pitch_tolerance(0.0005);  
 
   if (abs(topol->pitch().first - pitch_first) > pitch_tolerance ||
       abs(topol->pitch().second - pitch_second) > pitch_tolerance)

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -136,7 +136,7 @@ void PixelDigitizerAlgorithm::add_cross_talk(const Phase2TrackerGeomDetUnit* pix
   const float pitch_second = 0.0100;
   // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
   const double pitch_tolerance(0.0005);
- 
+
   if (abs(topol->pitch().first - pitch_first) > pitch_tolerance ||
       abs(topol->pitch().second - pitch_second) > pitch_tolerance)
     return;

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -134,10 +134,12 @@ void PixelDigitizerAlgorithm::add_cross_talk(const Phase2TrackerGeomDetUnit* pix
   // cross-talk calculation valid for the case of 25x100 pixels
   const float pitch_first = 0.0025;
   const float pitch_second = 0.0100;
-  const double pitch_tolerance(0.0005); // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
+  const double pitch_tolerance(
+      0.0005);  // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
 
-  if ( abs(topol->pitch().first - pitch_first) > pitch_tolerance ||
-       abs(topol->pitch().second - pitch_second) > pitch_tolerance ) return; 
+  if (abs(topol->pitch().first - pitch_first) > pitch_tolerance ||
+      abs(topol->pitch().second - pitch_second) > pitch_tolerance)
+    return;
 
   uint32_t detID = pixdet->geographicalId().rawId();
   signal_map_type& theSignal = _signal[detID];

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -135,8 +135,8 @@ void PixelDigitizerAlgorithm::add_cross_talk(const Phase2TrackerGeomDetUnit* pix
   const float pitch_first = 0.0025;
   const float pitch_second = 0.0100;
   // 0.5 um tolerance when comparing the pitch to accommodate the small changes in different TK geometrie (temporary fix)
-  const double pitch_tolerance(0.0005);  
-
+  const double pitch_tolerance(0.0005);
+ 
   if (abs(topol->pitch().first - pitch_first) > pitch_tolerance ||
       abs(topol->pitch().second - pitch_second) > pitch_tolerance)
     return;

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -44,7 +44,7 @@ phase2TrackerDigitizer = cms.PSet(
       Odd_column_interchannelCoupling_next_column = cms.double(0.0),
       Even_column_interchannelCoupling_next_column = cms.double(0.0),
       SigmaZero = cms.double(0.00037),  		#D.B.: 3.7um spread for 300um-thick sensor, renormalized in digitizerAlgo
-      SigmaCoeff = cms.double(1.80),  		#D.B.: to be confirmed with simulations in CMSSW_6.X
+      SigmaCoeff = cms.double(0),  		#S.D: setting SigmaCoeff=0 for IT-pixel
       ClusterWidth = cms.double(3),		#D.B.: this is used as number of sigmas for charge collection (3=+-3sigmas)
       LorentzAngle_DB = cms.bool(True),			
       TanLorentzAnglePerTesla_Endcap = cms.double(0.106),


### PR DESCRIPTION
#### PR description:
Two fixes  for the Phase2 IT (InnerTracker) pixel  (InnerTracker) digitizer algorithm and in configuration :
 - cross-talk implementation: added a tolerance of ~0.5 micron to select 25x100 um pixels by the pixel size as in the latest geometries the pixel dimension is 25x100.115 μm (NB: by default cross-talk is off so this change has no effect)

-  Parametrization of charge diffusion: SigmaCoeff=0 reverts the parametrization of charge diffusion to the predictions found in literature (accidentally charge diffusion in IT pixel was parametrized with a function derived in beam tests of OT modules).

#### PR validation:
Basic test procedure including runTheMatrix test works (followed (https://cms-sw.github.io/PRWorkflow.html) 
> 34 33 32 26 14 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@emiglior 