### PR TITLE
Make puppi algo better readable

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiAlgo.h
+++ b/CommonTools/PileupAlgos/interface/PuppiAlgo.h
@@ -14,7 +14,7 @@ public:
   void reset();
   void fixAlgoEtaBin(int i_eta);
   void add(const PuppiCandidate &iParticle, const double &iVal, const unsigned int iAlgo);
-  void computeMedRMS(const unsigned int &iAlgo, const double &iPVFrac);
+  void computeMedRMS(const unsigned int &iAlgo);
   //Get the Weight
   double compute(std::vector<double> const &iVals, double iChi2) const;
   const std::vector<float> &alphas() { return fPups; }

--- a/CommonTools/PileupAlgos/src/PuppiAlgo.cc
+++ b/CommonTools/PileupAlgos/src/PuppiAlgo.cc
@@ -92,35 +92,25 @@ void PuppiAlgo::add(const PuppiCandidate &iParticle, const double &iVal, const u
   // In CMSSW we use the user_index to specify the index in the input collection, so I invented
   // a new mechanism using the fastjet UserInfo functionality. Of course, it's still just an integer
   // but that interface could be changed (or augmented) if desired / needed.
-  int puppi_register = iParticle.puppi_register();
-  if (puppi_register == std::numeric_limits<int>::lowest()) {
+  int puppi_id = iParticle.puppi_register();
+  if (puppi_id == std::numeric_limits<int>::lowest()) {
     throw cms::Exception("PuppiRegisterNotSet") << "The puppi register is not set. This must be set before use.\n";
   }
 
-  //// original code
-  // if(fCharged[iAlgo] && std::abs(puppi_register)  < 1) return;
-  // if(fCharged[iAlgo] && (std::abs(puppi_register) >=1 && std::abs(puppi_register) <=2)) fPupsPV.push_back(iVal);
-  //if(fCharged[iAlgo] && std::abs(puppi_register) < 3) return;
-  //// if used fCharged and not CHPU, just return
-  // fPups.push_back(iVal); //original
-  // fNCount[iAlgo]++;
-
   // added by Nhan -- for all eta regions, compute mean/RMS from the central charged PU
-  //std::cout << "std::abs(puppi_register) = " << std::abs(puppi_register) << std::endl;
-  if ((std::abs(iParticle.eta()) < fEtaMaxExtrap) && (std::abs(puppi_register) >= 3)) {
+  if ((std::abs(iParticle.eta()) < fEtaMaxExtrap) && (puppi_id==2)) {
     fPups.push_back(iVal);
-    // fPupsPV.push_back(iVal);
     fNCount[iAlgo]++;
   }
   // for the low PU case, correction.  for checking that the PU-only median will be below the PV particles
-  if (std::abs(iParticle.eta()) < fEtaMaxExtrap && (std::abs(puppi_register) >= 1 && std::abs(puppi_register) <= 2))
+  if (std::abs(iParticle.eta()) < fEtaMaxExtrap && (puppi_id==1))
     fPupsPV.push_back(iVal);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 //NHAN'S VERSION
-void PuppiAlgo::computeMedRMS(const unsigned int &iAlgo, const double &iPVFrac) {
+void PuppiAlgo::computeMedRMS(const unsigned int &iAlgo) {
   //std::cout << "fNCount[iAlgo] = " << fNCount[iAlgo] << std::endl;
   if (iAlgo >= fNAlgos)
     return;

--- a/CommonTools/PileupAlgos/src/PuppiAlgo.cc
+++ b/CommonTools/PileupAlgos/src/PuppiAlgo.cc
@@ -98,12 +98,12 @@ void PuppiAlgo::add(const PuppiCandidate &iParticle, const double &iVal, const u
   }
 
   // added by Nhan -- for all eta regions, compute mean/RMS from the central charged PU
-  if ((std::abs(iParticle.eta()) < fEtaMaxExtrap) && (puppi_id==2)) {
+  if ((std::abs(iParticle.eta()) < fEtaMaxExtrap) && (puppi_id == 2)) {
     fPups.push_back(iVal);
     fNCount[iAlgo]++;
   }
   // for the low PU case, correction.  for checking that the PU-only median will be below the PV particles
-  if (std::abs(iParticle.eta()) < fEtaMaxExtrap && (puppi_id==1))
+  if (std::abs(iParticle.eta()) < fEtaMaxExtrap && (puppi_id == 1))
     fPupsPV.push_back(iVal);
 }
 

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -52,28 +52,16 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
       curPseudoJet.reset_PtYPhiM(0, 99., 0, 0);  //skipping may have been a better choice
     }
     //curPseudoJet.reset_PtYPhiM(rParticle.pt,rParticle.eta,rParticle.phi,rParticle.m);
-    int puppi_register = 0;
-    if (rParticle.id == 0 or rParticle.charge == 0)
-      puppi_register = 0;  // zero is neutral hadron
-    if (rParticle.id == 1 and rParticle.charge != 0)
-      puppi_register = rParticle.charge;  // from PV use the
-    if (rParticle.id == 2 and rParticle.charge != 0)
-      puppi_register = rParticle.charge + 5;  // from NPV use the charge as key +5 as key
-    curPseudoJet.set_info(puppi_register);
+    // fill puppi_register
+    curPseudoJet.set_info(rParticle.id);
     // fill vector of pseudojets for internal references
     fPFParticles.push_back(curPseudoJet);
     //Take Charged particles associated to PV
     if (std::abs(rParticle.id) == 1)
       fChargedPV.push_back(curPseudoJet);
-    if (std::abs(rParticle.id) >= 1)
-      fPVFrac += 1.;
     //if(rParticle.id == 3) _chargedNoPV.push_back(curPseudoJet);
     // if(fNPV < rParticle.vtxId) fNPV = rParticle.vtxId;
   }
-  if (fPVFrac != 0)
-    fPVFrac = double(fChargedPV.size()) / fPVFrac;
-  else
-    fPVFrac = 0;
 }
 PuppiContainer::~PuppiContainer() {}
 
@@ -192,7 +180,7 @@ void PuppiContainer::getRMSAvg(int iOpt,
     }
   }
   for (int i0 = 0; i0 < fNAlgos; i0++)
-    fPuppiAlgo[i0].computeMedRMS(iOpt, fPVFrac);
+    fPuppiAlgo[i0].computeMedRMS(iOpt);
 }
 //In fact takes the median not the average
 void PuppiContainer::getRawAlphas(int iOpt,


### PR DESCRIPTION
Make puppi algo better readable. Consistently use one ID for particles throughout the code.