### PR TITLE
DT DQM: Fixing inconsistency in L1Tstage2

### DIFF
--- a/DQM/DTMonitorModule/python/dtTriggerEfficiencyTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerEfficiencyTask_cfi.py
@@ -24,6 +24,6 @@ dtTriggerEfficiencyMonitor = DQMEDAnalyzer('DTTriggerEfficiencyTask',
 #
 # Modify for running in run 2 2016 data
 #
-from Configuration.Eras.Modifier_run2_common_cff import run2_common
-run2_common.toModify( dtTriggerEfficiencyMonitor, inputTagTM = cms.untracked.InputTag('twinMuxStage2Digis:PhIn'))
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify( dtTriggerEfficiencyMonitor, inputTagTM = cms.untracked.InputTag('twinMuxStage2Digis:PhIn'))
 


### PR DESCRIPTION
#### PR description:

This PR fixes problem reported in 
https://github.com/cms-sw/cmssw/pull/27996#issuecomment-537367012

#### PR validation:
 Tested with runTheMatrix.py -l limited -i all --ibeos 
and with the conflictive wfs:
runTheMatrix.py -l 134.701,134.702,134.703,134.704,134.705,134.706,134.707,134.708,134.709,134.71,134.801,134.802,134.803,134.804,134.805,134.806,134.807,134.808,134.809,134.81 -i all --ibeos

#### if this PR is a backport please specify the original PR:

No backport expected