### PR TITLE
DD4hep: Add access to vectors in SecPars from DDFilteredView

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
+++ b/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
@@ -10,6 +10,7 @@
     <debug_namespaces/>
     <debug_placements/>
     <debug_algorithms/>
+    <debug_specpars/>
     <debug_visattr/>
   </debug>
 

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -131,11 +131,11 @@ namespace cms {
 
     //! extract attribute value
     template <typename T>
-      T get(const char*) const;
-    
+    T get(const char*) const;
+
     //! extract attribute value in SpecPar
     template <typename T>
-      T get(const char*, const char*) const;
+    T get(const char*, const char*) const;
 
     std::string_view getString(const std::string&) const;
 

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -131,7 +131,11 @@ namespace cms {
 
     //! extract attribute value
     template <typename T>
-    T get(const char*) const;
+      T get(const char*) const;
+    
+    //! extract attribute value in SpecPar
+    template <typename T>
+      T get(const char*, const char*) const;
 
     std::string_view getString(const std::string&) const;
 

--- a/DetectorDescription/DDCMS/interface/DDSpecParRegistry.h
+++ b/DetectorDescription/DDCMS/interface/DDSpecParRegistry.h
@@ -16,6 +16,9 @@ namespace cms {
     bool hasValue(const char* key) const;
     double dblValue(const char*) const;
 
+    template <typename T>
+    T value(const char*) const;
+
     DDPaths paths;
     DDPartSelectionMap spars;
     DDVectorsMap numpars;
@@ -27,6 +30,9 @@ namespace cms {
   struct DDSpecParRegistry {
     void filter(DDSpecParRefs&, std::string_view, std::string_view) const;
     void filter(DDSpecParRefs&, std::string_view) const;
+    std::vector<std::string_view> names() const;
+    bool hasSpecPar(std::string_view) const;
+    const DDSpecPar* specPar(std::string_view) const;
 
     DDSpecParMap specpars;
   };

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -328,6 +328,22 @@ double DDFilteredView::get<double>(const char* key) const {
   return result;
 }
 
+template <>
+std::vector<double> DDFilteredView::get<std::vector<double>>(const char* name, const char* key) const {
+  if(registry_->hasSpecPar(name))
+    return registry_->specPar(name)->value<std::vector<double>>(key);
+  else
+    return std::vector<double>();
+}
+
+template <>
+std::vector<std::string> DDFilteredView::get<std::vector<std::string>>(const char* name, const char* key) const {
+  if(registry_->hasSpecPar(name))
+    return registry_->specPar(name)->value<std::vector<std::string>>(key);
+  else
+    return std::vector<std::string>();
+}
+
 std::string_view DDFilteredView::getString(const std::string& key) const {
   assert(currentFilter_);
   assert(currentFilter_->spec);

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -330,7 +330,7 @@ double DDFilteredView::get<double>(const char* key) const {
 
 template <>
 std::vector<double> DDFilteredView::get<std::vector<double>>(const char* name, const char* key) const {
-  if(registry_->hasSpecPar(name))
+  if (registry_->hasSpecPar(name))
     return registry_->specPar(name)->value<std::vector<double>>(key);
   else
     return std::vector<double>();
@@ -338,7 +338,7 @@ std::vector<double> DDFilteredView::get<std::vector<double>>(const char* name, c
 
 template <>
 std::vector<std::string> DDFilteredView::get<std::vector<std::string>>(const char* name, const char* key) const {
-  if(registry_->hasSpecPar(name))
+  if (registry_->hasSpecPar(name))
     return registry_->specPar(name)->value<std::vector<std::string>>(key);
   else
     return std::vector<std::string>();

--- a/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
+++ b/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
@@ -24,35 +24,35 @@ bool DDSpecPar::hasValue(const char* key) const {
     return false;
 }
 
-template<>
+template <>
 std::vector<double> DDSpecPar::value<std::vector<double>>(const char* key) const {
-
   std::vector<double> result;
 
   auto const& nitem = numpars.find(key);
   if (nitem != end(numpars)) {
     return std::vector<double>(begin(nitem->second), end(nitem->second));
   }
-  
+
   auto const& sitem = spars.find(key);
   if (sitem != end(spars)) {
-    std::transform(begin(sitem->second), end(sitem->second), std::back_inserter(result),
-                   [](auto& i) -> double { return dd4hep::_toDouble(i); });
+    std::transform(begin(sitem->second), end(sitem->second), std::back_inserter(result), [](auto& i) -> double {
+      return dd4hep::_toDouble(i);
+    });
   }
-  
+
   return result;
 }
 
-template<>
+template <>
 std::vector<std::string> DDSpecPar::value<std::vector<std::string>>(const char* key) const {
-
   std::vector<std::string> result;
 
   auto const& nitem = numpars.find(key);
   if (nitem != end(numpars)) {
-    std::transform(begin(nitem->second), end(nitem->second), std::back_inserter(result),
-                   [](auto& i) -> std::string { return std::to_string(i); });
-   
+    std::transform(begin(nitem->second), end(nitem->second), std::back_inserter(result), [](auto& i) -> std::string {
+      return std::to_string(i);
+    });
+
     return result;
   }
 
@@ -60,7 +60,7 @@ std::vector<std::string> DDSpecPar::value<std::vector<std::string>>(const char* 
   if (sitem != end(spars)) {
     return std::vector<std::string>(begin(sitem->second), end(sitem->second));
   }
-  
+
   return result;
 }
 
@@ -106,21 +106,23 @@ void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute) const
 
 std::vector<std::string_view> DDSpecParRegistry::names() const {
   std::vector<std::string_view> result;
-  for_each(begin(specpars), end(specpars), [&result](const auto& i) {result.emplace_back(i.first);});
+  for_each(begin(specpars), end(specpars), [&result](const auto& i) { result.emplace_back(i.first); });
   return result;
 }
 
 bool DDSpecParRegistry::hasSpecPar(std::string_view name) const {
-  auto const& result = find_if(begin(specpars), end(specpars), [&name](const auto& i) { return (i.first.compare(name) == 0); });
-  if(result != end(specpars))
+  auto const& result =
+      find_if(begin(specpars), end(specpars), [&name](const auto& i) { return (i.first.compare(name) == 0); });
+  if (result != end(specpars))
     return true;
   else
     return false;
 }
 
 const DDSpecPar* DDSpecParRegistry::specPar(std::string_view name) const {
-  auto const& result = find_if(begin(specpars), end(specpars), [&name](const auto& i) { return (i.first.compare(name) == 0); });
-  if(result != end(specpars)) {
+  auto const& result =
+      find_if(begin(specpars), end(specpars), [&name](const auto& i) { return (i.first.compare(name) == 0); });
+  if (result != end(specpars)) {
     return &result->second;
   } else {
     return nullptr;

--- a/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
+++ b/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
@@ -2,9 +2,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DD4hep/Detector.h"
 #include <algorithm>
-#include <iterator>
-#include <regex>
-#include <iostream>
 
 using namespace std;
 using namespace cms;

--- a/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
+++ b/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
@@ -1,8 +1,10 @@
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DD4hep/Detector.h"
 #include <algorithm>
 #include <iterator>
 #include <regex>
+#include <iostream>
 
 using namespace std;
 using namespace cms;
@@ -20,6 +22,46 @@ bool DDSpecPar::hasValue(const char* key) const {
     return true;
   else
     return false;
+}
+
+template<>
+std::vector<double> DDSpecPar::value<std::vector<double>>(const char* key) const {
+
+  std::vector<double> result;
+
+  auto const& nitem = numpars.find(key);
+  if (nitem != end(numpars)) {
+    return std::vector<double>(begin(nitem->second), end(nitem->second));
+  }
+  
+  auto const& sitem = spars.find(key);
+  if (sitem != end(spars)) {
+    std::transform(begin(sitem->second), end(sitem->second), std::back_inserter(result),
+                   [](auto& i) -> double { return dd4hep::_toDouble(i); });
+  }
+  
+  return result;
+}
+
+template<>
+std::vector<std::string> DDSpecPar::value<std::vector<std::string>>(const char* key) const {
+
+  std::vector<std::string> result;
+
+  auto const& nitem = numpars.find(key);
+  if (nitem != end(numpars)) {
+    std::transform(begin(nitem->second), end(nitem->second), std::back_inserter(result),
+                   [](auto& i) -> std::string { return std::to_string(i); });
+   
+    return result;
+  }
+
+  auto const& sitem = spars.find(key);
+  if (sitem != end(spars)) {
+    return std::vector<std::string>(begin(sitem->second), end(sitem->second));
+  }
+  
+  return result;
 }
 
 double DDSpecPar::dblValue(const char* key) const {
@@ -60,4 +102,27 @@ void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute) const
       refs.emplace_back(&k.second);
     }
   });
+}
+
+std::vector<std::string_view> DDSpecParRegistry::names() const {
+  std::vector<std::string_view> result;
+  for_each(begin(specpars), end(specpars), [&result](const auto& i) {result.emplace_back(i.first);});
+  return result;
+}
+
+bool DDSpecParRegistry::hasSpecPar(std::string_view name) const {
+  auto const& result = find_if(begin(specpars), end(specpars), [&name](const auto& i) { return (i.first.compare(name) == 0); });
+  if(result != end(specpars))
+    return true;
+  else
+    return false;
+}
+
+const DDSpecPar* DDSpecParRegistry::specPar(std::string_view name) const {
+  auto const& result = find_if(begin(specpars), end(specpars), [&name](const auto& i) { return (i.first.compare(name) == 0); });
+  if(result != end(specpars)) {
+    return &result->second;
+  } else {
+    return nullptr;
+  }
 }

--- a/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
@@ -26,12 +26,23 @@ public:
 
 private:
   string fileName_;
+  vector<double> refdattl_;
+  vector<string> refsattl_;
+  vector<double> refdLongFL_;
+  vector<string> refsLongFL_;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testDDFilteredView);
 
 void testDDFilteredView::setUp() {
-  fileName_ = edm::FileInPath("DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml").fullPath();
+  fileName_ = edm::FileInPath("DetectorDescription/DDCMS/data/cms-geometry-2021.xml").fullPath();
+  refdattl_ = {0.000809653, 0.000713002, 0.000654918, 0.000602767, 0.000566295, 0.000541647, 0.000516174, 0.000502512,
+	       0.000504225, 0.000506212, 0.000506275, 0.000487621, 0.000473034, 0.000454002, 0.000442383, 0.000441043,
+	       0.000443609, 0.000433124, 0.000440188, 0.000435257, 0.000439224, 0.000431385, 0.00041707, 0.000415677,
+	       0.000408389, 0.000400293, 0.000400989, 0.000395417, 0.00038936, 0.000383942};
+  refsattl_ = {"0.8096535E-03/cm", "0.7130018E-03/cm", "0.6549183E-03/cm", "0.6027666E-03/cm", "0.5662951E-03/cm", "0.5416475E-03/cm", "0.5161745E-03/cm", "0.5025120E-03/cm", "0.5042249E-03/cm", "0.5062117E-03/cm", "0.5062750E-03/cm", "0.4876212E-03/cm", "0.4730343E-03/cm", "0.4540021E-03/cm", "0.4423832E-03/cm", "0.4410428E-03/cm", "0.4436095E-03/cm", "0.4331241E-03/cm", "0.4401879E-03/cm", "0.4352570E-03/cm", "0.4392237E-03/cm", "0.4313847E-03/cm", "0.4170704E-03/cm", "0.4156771E-03/cm", "0.4083890E-03/cm", "0.4002930E-03/cm", "0.4009888E-03/cm", "0.3954170E-03/cm", "0.3893599E-03/cm", "0.3839422E-03/cm"};
+  refdLongFL_ = {227.993, 237.122, 241.701, 256.48, 266.754, 275.988, 276.982, 284.989, 286.307, 290.478, 290.5, 292, 295.5};
+  refsLongFL_ = {"227.9925651*cm", "237.1215213*cm", "241.7005445*cm", "256.47981*cm", "266.7540042*cm", "275.987715*cm", "276.9823529*cm", "284.9889299*cm", "286.3065327*cm", "290.4779412*cm", "290.5*cm", "292.0*cm", "295.5*cm"};
 }
 
 void testDDFilteredView::checkFilteredView() {
@@ -41,4 +52,47 @@ void testDDFilteredView::checkFilteredView() {
   std::cout << fview.name() << " is a " << cms::dd::name(cms::DDSolidShapeMap, fview.shape()) << "\n";
   fview.parent();
   std::cout << fview.name() << " is a " << cms::dd::name(cms::DDSolidShapeMap, fview.shape()) << "\n";
+
+  std::cout << "All SpecPar names:\n";
+  for( auto const n : det->specpars().names())
+    std::cout << n << "\n";
+
+  //
+  // SpecPar Reference values
+  //
+  // Name: hf
+  // Paths: //HVQX, //HVQF
+  // LongFL = 227.9925651*cm, 237.1215213*cm, 241.7005445*cm, 256.47981*cm, 266.7540042*cm, 275.987715*cm, 276.9823529*cm, 284.9889299*cm, 286.3065327*cm, 290.4779412*cm, 290.5*cm, 292.0*cm, 295.5*cm
+  // ShortFL = 206.0*cm, 211.8810861*cm, 220.3822464*cm, 235.5520581*cm, 245.6204691*cm, 253.9086538*cm, 255.0117647*cm, 263.0073529*cm, 264.3480392*cm, 268.5*cm, 268.5*cm, 270.0*cm, 273.5*cm
+  // Volume = HF
+  // lambLim = 300.0, 600.0
+  // attl = 0.8096535E-03/cm, 0.7130018E-03/cm, 0.6549183E-03/cm, 0.6027666E-03/cm, 0.5662951E-03/cm, 0.5416475E-03/cm, 0.5161745E-03/cm, 0.5025120E-03/cm, 0.5042249E-03/cm, 0.5062117E-03/cm, 0.5062750E-03/cm, 0.4876212E-03/cm, 0.4730343E-03/cm, 0.4540021E-03/cm, 0.4423832E-03/cm, 0.4410428E-03/cm, 0.4436095E-03/cm, 0.4331241E-03/cm, 0.4401879E-03/cm, 0.4352570E-03/cm, 0.4392237E-03/cm, 0.4313847E-03/cm, 0.4170704E-03/cm, 0.4156771E-03/cm, 0.4083890E-03/cm, 0.4002930E-03/cm, 0.4009888E-03/cm, 0.3954170E-03/cm, 0.3893599E-03/cm, 0.3839422E-03/cm
+  // Levels => 4, 5
+
+  cout << "Get attl from hf as double values:\n";
+  vector<double> attl = fview.get<vector<double>>("hf", "attl");
+  int count(0);
+  for( auto const & i : attl) {
+    std::cout << "attl " << i << " == " << refdattl_[count] << "\n";
+    CPPUNIT_ASSERT(abs(i - refdattl_[count]) < 10e-6);
+    count++;
+  }
+
+  std::cout << "Get LongFL from hf as double values:\n";
+  count = 0;
+  std::vector<double> LongFL = fview.get<std::vector<double>>("hf", "LongFL");
+  for( auto const & i : LongFL) {
+    std::cout << "LongFL " << i << " == " << refdLongFL_[count] << "\n";
+    CPPUNIT_ASSERT(abs(i - refdLongFL_[count]) < 10e-2);
+    count++;
+  }
+  
+  std::cout << "Get LongFL from hf as string values:\n";
+  count = 0;
+  std::vector<std::string> sLongFL = fview.get<std::vector<std::string>>("hf", "LongFL");
+  for( auto const & i : sLongFL) {
+    std::cout << "LongFL " << i << " == " << refsLongFL_[count] << "\n";
+    CPPUNIT_ASSERT(i.compare(refsLongFL_[count]) == 0);
+    count++;
+  }
 }

--- a/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
@@ -37,12 +37,30 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testDDFilteredView);
 void testDDFilteredView::setUp() {
   fileName_ = edm::FileInPath("DetectorDescription/DDCMS/data/cms-geometry-2021.xml").fullPath();
   refdattl_ = {0.000809653, 0.000713002, 0.000654918, 0.000602767, 0.000566295, 0.000541647, 0.000516174, 0.000502512,
-	       0.000504225, 0.000506212, 0.000506275, 0.000487621, 0.000473034, 0.000454002, 0.000442383, 0.000441043,
-	       0.000443609, 0.000433124, 0.000440188, 0.000435257, 0.000439224, 0.000431385, 0.00041707, 0.000415677,
-	       0.000408389, 0.000400293, 0.000400989, 0.000395417, 0.00038936, 0.000383942};
-  refsattl_ = {"0.8096535E-03/cm", "0.7130018E-03/cm", "0.6549183E-03/cm", "0.6027666E-03/cm", "0.5662951E-03/cm", "0.5416475E-03/cm", "0.5161745E-03/cm", "0.5025120E-03/cm", "0.5042249E-03/cm", "0.5062117E-03/cm", "0.5062750E-03/cm", "0.4876212E-03/cm", "0.4730343E-03/cm", "0.4540021E-03/cm", "0.4423832E-03/cm", "0.4410428E-03/cm", "0.4436095E-03/cm", "0.4331241E-03/cm", "0.4401879E-03/cm", "0.4352570E-03/cm", "0.4392237E-03/cm", "0.4313847E-03/cm", "0.4170704E-03/cm", "0.4156771E-03/cm", "0.4083890E-03/cm", "0.4002930E-03/cm", "0.4009888E-03/cm", "0.3954170E-03/cm", "0.3893599E-03/cm", "0.3839422E-03/cm"};
-  refdLongFL_ = {227.993, 237.122, 241.701, 256.48, 266.754, 275.988, 276.982, 284.989, 286.307, 290.478, 290.5, 292, 295.5};
-  refsLongFL_ = {"227.9925651*cm", "237.1215213*cm", "241.7005445*cm", "256.47981*cm", "266.7540042*cm", "275.987715*cm", "276.9823529*cm", "284.9889299*cm", "286.3065327*cm", "290.4779412*cm", "290.5*cm", "292.0*cm", "295.5*cm"};
+               0.000504225, 0.000506212, 0.000506275, 0.000487621, 0.000473034, 0.000454002, 0.000442383, 0.000441043,
+               0.000443609, 0.000433124, 0.000440188, 0.000435257, 0.000439224, 0.000431385, 0.00041707,  0.000415677,
+               0.000408389, 0.000400293, 0.000400989, 0.000395417, 0.00038936,  0.000383942};
+  refsattl_ = {"0.8096535E-03/cm", "0.7130018E-03/cm", "0.6549183E-03/cm", "0.6027666E-03/cm", "0.5662951E-03/cm",
+               "0.5416475E-03/cm", "0.5161745E-03/cm", "0.5025120E-03/cm", "0.5042249E-03/cm", "0.5062117E-03/cm",
+               "0.5062750E-03/cm", "0.4876212E-03/cm", "0.4730343E-03/cm", "0.4540021E-03/cm", "0.4423832E-03/cm",
+               "0.4410428E-03/cm", "0.4436095E-03/cm", "0.4331241E-03/cm", "0.4401879E-03/cm", "0.4352570E-03/cm",
+               "0.4392237E-03/cm", "0.4313847E-03/cm", "0.4170704E-03/cm", "0.4156771E-03/cm", "0.4083890E-03/cm",
+               "0.4002930E-03/cm", "0.4009888E-03/cm", "0.3954170E-03/cm", "0.3893599E-03/cm", "0.3839422E-03/cm"};
+  refdLongFL_ = {
+      227.993, 237.122, 241.701, 256.48, 266.754, 275.988, 276.982, 284.989, 286.307, 290.478, 290.5, 292, 295.5};
+  refsLongFL_ = {"227.9925651*cm",
+                 "237.1215213*cm",
+                 "241.7005445*cm",
+                 "256.47981*cm",
+                 "266.7540042*cm",
+                 "275.987715*cm",
+                 "276.9823529*cm",
+                 "284.9889299*cm",
+                 "286.3065327*cm",
+                 "290.4779412*cm",
+                 "290.5*cm",
+                 "292.0*cm",
+                 "295.5*cm"};
 }
 
 void testDDFilteredView::checkFilteredView() {
@@ -54,7 +72,7 @@ void testDDFilteredView::checkFilteredView() {
   std::cout << fview.name() << " is a " << cms::dd::name(cms::DDSolidShapeMap, fview.shape()) << "\n";
 
   std::cout << "All SpecPar names:\n";
-  for( auto const n : det->specpars().names())
+  for (auto const n : det->specpars().names())
     std::cout << n << "\n";
 
   //
@@ -72,7 +90,7 @@ void testDDFilteredView::checkFilteredView() {
   cout << "Get attl from hf as double values:\n";
   vector<double> attl = fview.get<vector<double>>("hf", "attl");
   int count(0);
-  for( auto const & i : attl) {
+  for (auto const& i : attl) {
     std::cout << "attl " << i << " == " << refdattl_[count] << "\n";
     CPPUNIT_ASSERT(abs(i - refdattl_[count]) < 10e-6);
     count++;
@@ -81,16 +99,16 @@ void testDDFilteredView::checkFilteredView() {
   std::cout << "Get LongFL from hf as double values:\n";
   count = 0;
   std::vector<double> LongFL = fview.get<std::vector<double>>("hf", "LongFL");
-  for( auto const & i : LongFL) {
+  for (auto const& i : LongFL) {
     std::cout << "LongFL " << i << " == " << refdLongFL_[count] << "\n";
     CPPUNIT_ASSERT(abs(i - refdLongFL_[count]) < 10e-2);
     count++;
   }
-  
+
   std::cout << "Get LongFL from hf as string values:\n";
   count = 0;
   std::vector<std::string> sLongFL = fview.get<std::vector<std::string>>("hf", "LongFL");
-  for( auto const & i : sLongFL) {
+  for (auto const& i : sLongFL) {
     std::cout << "LongFL " << i << " == " << refsLongFL_[count] << "\n";
     CPPUNIT_ASSERT(i.compare(refsLongFL_[count]) == 0);
     count++;

--- a/DetectorDescription/DDCMS/test/python/testDDSpecPars.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecPars.py
@@ -39,16 +39,16 @@ process.MessageLogger = cms.Service(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
-                                            appendToDataLabel = cms.string('MUON')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-geometry-2021.xml'),
+                                            appendToDataLabel = cms.string('CMS')
                                             )
 
 process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                                     appendToDataLabel = cms.string('MUON')
+                                                     appendToDataLabel = cms.string('CMS')
                                                      )
 
 process.test = cms.EDAnalyzer("DDTestSpecPars",
-                              DDDetector = cms.ESInputTag('','MUON')
+                              DDDetector = cms.ESInputTag('','CMS')
                               )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
@@ -38,16 +38,16 @@ process.MessageLogger = cms.Service(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml'),
-                                            appendToDataLabel = cms.string('MUON')
+                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-geometry-2021.xml'),
+                                            appendToDataLabel = cms.string('CMS')
                                             )
 
 process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                                     appendToDataLabel = cms.string('MUON')
+                                                     appendToDataLabel = cms.string('CMS')
                                                      )
 
 process.test = cms.EDAnalyzer("DDTestSpecParsFilter",
-                              DDDetector = cms.ESInputTag('','MUON'),
+                              DDDetector = cms.ESInputTag('','CMS'),
                               attribute = cms.untracked.string('MuStructure'),
                               value = cms.untracked.string('MuonBarrelDT')
                               )


### PR DESCRIPTION
#### PR description:

* Add an easier access to vectors by names of the SpecPar and its attribute
* Specialize the accessor for ```std::vector<std::string>``` and ```std::vector<double>``` 

Example:
```
std::vector<double> result = fview.get<std::vector<double>>("hf", "LongFL");
```
or 
```
std::vector<std::string> result = fview.get<std::vector<std::string>>("hf", "LongFL");
```

@bsunanda - FYI

#### PR validation:

```DDFilteredView.cppunit.cc``` runs automatically. It compares the hard-coded expected reference values with the actually retrieved from xml for ```hf``` SpecPar and ```attl``` and ```LongFL``` attributes.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
