### PR TITLE
Use lzma/l4 for raw data

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -142,6 +142,8 @@ RAWEventContent = cms.PSet(
         'keep  FEDRawDataCollection_rawDataCollector_*_*',
         'keep  FEDRawDataCollection_source_*_*'),
     splitLevel = cms.untracked.int32(0),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(4)
 )
 #
 #


### PR DESCRIPTION
#### PR description:

Proposal to use LZMA level 4 to compress the RAW data tier. Tests on a double muon raw file from run 324970 (containing the highest lumi part of the run) shows 15% reduction in file size at the cost of a 0.25 seconds/event extra time writing (repack noticeably slower) and 0.05 seconds/event extra reading (eg, 5x more read back overhead)

It will be interesting to test also standard when it is part of root (6.20 or 6.22 it seems), but using LZMA appears to be a much better usage of storage vs write/read resources given our usual usage of RAW data. 

Searches of GitHub suggest we have only rediscovered this change as a way to gain in RAW data size with minimal cost oil CPU, so perhaps there is a good reason not to do it.