### PR TITLE
TEC: Add missing units

### DIFF
--- a/Geometry/TrackerCommonData/data/tecwheel6.xml
+++ b/Geometry/TrackerCommonData/data/tecwheel6.xml
@@ -4,7 +4,7 @@
     <ConstantsSection label="tecwheel6.xml" eval="true">
         <Constant name="zero" value="0.0*fm"/>
         <Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
-        <Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+        <Constant name="FixSuppW" value="2*mm*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
         <!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
         <Constant name="CableL" value="([tecwheel:CableRmax]-[tecring1:Rin])"/>
         <Constant name="CableR" value="([tecwheel:CableRmax]+[tecring1:Rin])/2"/>
@@ -19,7 +19,7 @@
         <Tubs name="TECWheel6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
         <Tubs name="TECWheelDisk6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
         <Tubs name="TECWheelNomex6" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
-        <Tubs name="TECFixSupport6" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-0.103339312*rad" deltaPhi="0.206678624*rad"/>
+        <Tubs name="TECFixSupport6" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
         <Tubs name="TECOptConnector6" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
         <Box name="TECBeamsplitter" dx="0.5*[BeamsplitterHeight]" dy="0.5*[BeamsplitterWidth]" dz="0.5*[BeamsplitterThick]"/>
     </SolidSection>

--- a/Geometry/TrackerCommonData/data/tecwheela.xml
+++ b/Geometry/TrackerCommonData/data/tecwheela.xml
@@ -3,7 +3,7 @@
 	<ConstantsSection label="tecwheela.xml" eval="true">
 		<Constant name="zero" value="0.0*fm"/>
 		<Constant name="FixSuppRmax" value="[tecpetal0:PetalContRmin]+            [tecwheel:FixSuppR]"/>
-		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal0:PetalContRmin]*[tecpetal0:PetalContRmin])"/>
+		<Constant name="FixSuppW" value="2*mm*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal0:PetalContRmin]*[tecpetal0:PetalContRmin])"/>
 		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
 		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring0:Rin])"/>
 		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring0:Rin])/2"/>
@@ -12,7 +12,7 @@
 		<Tubs name="TECWheelA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelDiskA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexA" rMin="[tecpetal0:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
-		<Tubs name="TECFixSupportA" rMin="[tecpetal0:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-0.137754002*rad" deltaPhi="0.275508004*rad"/>
+		<Tubs name="TECFixSupportA" rMin="[tecpetal0:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
 		<Tubs name="TECOptConnectorA" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT1]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheela.xml">

--- a/Geometry/TrackerCommonData/data/tecwheelb.xml
+++ b/Geometry/TrackerCommonData/data/tecwheelb.xml
@@ -3,7 +3,7 @@
 	<ConstantsSection label="tecwheelb.xml" eval="true">
 		<Constant name="zero" value="0.0*fm"/>
 		<Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
-		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+		<Constant name="FixSuppW" value="2*mm*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
 		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
 		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring1:Rin])"/>
 		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring1:Rin])/2"/>
@@ -12,7 +12,7 @@
 		<Tubs name="TECWheelB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelDiskB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexB" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
-		<Tubs name="TECFixSupportB" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-0.103339312*rad" deltaPhi="0.206678624*rad"/>
+		<Tubs name="TECFixSupportB" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
 		<Tubs name="TECOptConnectorB" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT2]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheelb.xml">

--- a/Geometry/TrackerCommonData/data/tecwheelc.xml
+++ b/Geometry/TrackerCommonData/data/tecwheelc.xml
@@ -3,7 +3,7 @@
 	<ConstantsSection label="tecwheelc.xml" eval="true">
 		<Constant name="zero" value="0.0*fm"/>
 		<Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
-		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+		<Constant name="FixSuppW" value="2*mm*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
 		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
 		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring2:Rin])"/>
 		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring2:Rin])/2"/>
@@ -12,7 +12,7 @@
 		<Tubs name="TECWheelC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelDiskC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexC" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
-		<Tubs name="TECFixSupportC" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-0.103339312*rad" deltaPhi="0.206678624*rad"/>
+		<Tubs name="TECFixSupportC" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
 		<Tubs name="TECOptConnectorC" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheelc.xml">

--- a/Geometry/TrackerCommonData/data/tecwheeld.xml
+++ b/Geometry/TrackerCommonData/data/tecwheeld.xml
@@ -3,7 +3,7 @@
 	<ConstantsSection label="tecwheeld.xml" eval="true">
 		<Constant name="zero" value="0.0*fm"/>
 		<Constant name="FixSuppRmax" value="[tecpetal3:PetalContRmin]+            [tecwheel:FixSuppR]"/>
-		<Constant name="FixSuppW" value="2*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
+		<Constant name="FixSuppW" value="2*mm*[tecwheel:FixSuppA]/([FixSuppRmax]*[FixSuppRmax]-[tecpetal3:PetalContRmin]*[tecpetal3:PetalContRmin])"/>
 		<!-- calculate the width to fit the area at this specific radius! thus the volume will be constant!-->
 		<Constant name="CableL" value="([tecwheel:CableRmax]-[tecring3:Rin])"/>
 		<Constant name="CableR" value="([tecwheel:CableRmax]+[tecring3:Rin])/2"/>
@@ -12,7 +12,7 @@
 		<Tubs name="TECWheelD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:WheelT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelDiskD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:WheelRmax]" dz="[tecwheel:DiskT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
 		<Tubs name="TECWheelNomexD" rMin="[tecpetal3:PetalContRmin]" rMax="[tecwheel:NomexRmax]" dz="[tecwheel:NomexT]/2" startPhi="0*deg" deltaPhi="360.*deg"/>
-		<Tubs name="TECFixSupportD" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-0.103339312*rad" deltaPhi="0.206678624*rad"/>
+		<Tubs name="TECFixSupportD" rMin="[tecpetal3:PetalContRmin]" rMax="[FixSuppRmax]" dz="[tecwheel:FixSuppT]/2" startPhi="-[FixSuppW]/2" deltaPhi="[FixSuppW]"/>
 		<Tubs name="TECOptConnectorD" rMin="[tecwheel:OptConnRmin]" rMax="[tecwheel:OptConnRmax]" dz="[tecwheel:OptConnT3]/2" startPhi="-[tecwheel:OptConnW]/2" deltaPhi="[tecwheel:OptConnW]"/>
 	</SolidSection>
 	<LogicalPartSection label="tecwheeld.xml">


### PR DESCRIPTION
#### PR description:

* Revert changes in xml files introduced in https://github.com/cms-sw/cmssw/pull/27752

The problem is missing units in calculating ```FixSuppW``` where 2 is not the scale but length: ```2*mm```

@vargasa - FYI 

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
