### PR TITLE
Fix avoiding dqmofflineOnPAT_step duplications

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1964,6 +1964,18 @@ class ConfigBuilder(object):
                 #will get in the schedule, smoothly
                 getattr(self.process,pathName).insert(0,self.process.genstepfilter)
 
+
+        pathName='dqmofflineOnPAT_step'
+        for (i,sequence) in enumerate(postSequenceList):
+	    #Fix needed to avoid duplication of sequences not defined in autoDQM or without a PostDQM
+	    if (sequenceList[i]==postSequenceList[i]):
+		continue
+            if (i!=0):
+               	pathName='dqmofflineOnPAT_%d_step'%(i)
+ 
+            setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
+            self.schedule.append(getattr(self.process,pathName))
+
     def prepare_HARVESTING(self, sequence = None):
         """ Enrich the process with harvesting step """
         self.DQMSaverCFF='Configuration/StandardSequences/DQMSaver'+self._options.harvesting+'_cff'

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1971,8 +1971,7 @@ class ConfigBuilder(object):
 	    if (sequenceList[i]==postSequenceList[i]):
                 continue
             if (i!=0):
-		pathName='dqmofflineOnPAT_%d_step'%(i)
-		
+		pathName='dqmofflineOnPAT_%d_step'%(i)	
             setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
             self.schedule.append(getattr(self.process,pathName))
 

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1968,10 +1968,11 @@ class ConfigBuilder(object):
         pathName='dqmofflineOnPAT_step'
         for (i,sequence) in enumerate(postSequenceList):
 	    #Fix needed to avoid duplication of sequences not defined in autoDQM or without a PostDQM
-	    if (sequenceList[i]==postSequenceList[i]):
-                continue
+            if (sequenceList[i]==postSequenceList[i]):
+                      continue
             if (i!=0):
-		pathName='dqmofflineOnPAT_%d_step'%(i)	
+                pathName='dqmofflineOnPAT_%d_step'%(i)
+
             setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
             self.schedule.append(getattr(self.process,pathName))
 

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1969,7 +1969,7 @@ class ConfigBuilder(object):
         for (i,sequence) in enumerate(postSequenceList):
 	    #Fix needed to avoid duplication of sequences not defined in autoDQM or without a PostDQM
 	    if (sequenceList[i]==postSequenceList[i]):
-		continue
+                continue
             if (i!=0):
 		pathName='dqmofflineOnPAT_%d_step'%(i)
 		

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1964,14 +1964,6 @@ class ConfigBuilder(object):
                 #will get in the schedule, smoothly
                 getattr(self.process,pathName).insert(0,self.process.genstepfilter)
 
-        pathName='dqmofflineOnPAT_step'
-        for (i,sequence) in enumerate(postSequenceList):
-            if (i!=0):
-                pathName='dqmofflineOnPAT_%d_step'%(i)
-
-            setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
-            self.schedule.append(getattr(self.process,pathName))
-
     def prepare_HARVESTING(self, sequence = None):
         """ Enrich the process with harvesting step """
         self.DQMSaverCFF='Configuration/StandardSequences/DQMSaver'+self._options.harvesting+'_cff'

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1971,8 +1971,8 @@ class ConfigBuilder(object):
 	    if (sequenceList[i]==postSequenceList[i]):
 		continue
             if (i!=0):
-               	pathName='dqmofflineOnPAT_%d_step'%(i)
- 
+		pathName='dqmofflineOnPAT_%d_step'%(i)
+		
             setattr(self.process,pathName, cms.EndPath( getattr(self.process, sequence ) ) )
             self.schedule.append(getattr(self.process,pathName))
 


### PR DESCRIPTION
#### PR description:

Fix to avoid  duplicated sequences with dqmOffline_step for cmsDriver DQM:selections not defined in autoDQM or without PostDQM sequence

#### PR validation:

Tested with  runTheMatrix.py -l all -i all --ibeos

#### if this PR is a backport please specify the original PR:

No backport expected