### PR TITLE
Updating Puppiproducer to include fillDescriptions (backport 106X)

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiAlgo.h
+++ b/CommonTools/PileupAlgos/interface/PuppiAlgo.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "CommonTools/PileupAlgos/interface/PuppiCandidate.h"
 #include <vector>
 
@@ -10,6 +11,7 @@ class PuppiAlgo{
 public:
   PuppiAlgo(edm::ParameterSet &iConfig);
   ~PuppiAlgo();
+  static void fillDescriptionsPuppiAlgo(edm::ParameterSetDescription &desc);
   //Computing Mean and RMS
   void   reset();
   void   fixAlgoEtaBin(int i_eta );

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -335,11 +335,27 @@ void PuppiProducer::endJob() {
 }
 // ------------------------------------------------------------------------------------------
 void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<bool>("puppiDiagnostics", false);
+  desc.add<bool>("puppiForLeptons", false);
+  desc.add<bool>("UseDeltaZCut", true);
+  desc.add<double>("DeltaZCut", 0.3);
+  desc.add<double>("PtMaxNeutrals", 200.);
+  desc.add<bool>("useExistingWeights", false);
+  desc.add<bool>("useWeightsNoLep", false);
+  desc.add<bool>("clonePackedCands", false);
+  desc.add<int>("vtxNdofCut", 4);
+  desc.add<double>("vtxZCut", 24);
+  desc.add<edm::InputTag>("candName", edm::InputTag("particleFlow"));
+  desc.add<edm::InputTag>("vertexName", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<bool>("applyCHS", true);
+  desc.add<bool>("invertPuppi", false);
+  desc.add<bool>("useExp", false);
+  desc.add<double>("MinPuppiWeight", .01);
+
+  PuppiAlgo::fillDescriptionsPuppiAlgo(desc);
+
+  descriptions.add("PuppiProducer", desc);
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(PuppiProducer);

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -17,6 +17,7 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "CommonTools/PileupAlgos/interface/PuppiContainer.h"
+#include "CommonTools/PileupAlgos/interface/PuppiAlgo.h"
 
 // ------------------------------------------------------------------------------------------
 class PuppiProducer : public edm::stream::EDProducer<> {

--- a/CommonTools/PileupAlgos/src/PuppiAlgo.cc
+++ b/CommonTools/PileupAlgos/src/PuppiAlgo.cc
@@ -213,3 +213,48 @@ double PuppiAlgo::compute(std::vector<double> const &iVals,double iChi2) const {
     return lPVal;
 
 }
+// ------------------------------------------------------------------------------------------
+void PuppiAlgo::fillDescriptionsPuppiAlgo(edm::ParameterSetDescription &desc) {
+  edm::ParameterSetDescription puppialgos;
+  puppialgos.add<int>("algoId", 5);
+  puppialgos.add<bool>("useCharged", false);
+  puppialgos.add<bool>("applyLowPUCorr", false);
+  puppialgos.add<int>("combOpt", 5);
+  puppialgos.add<double>("cone", .4);
+  puppialgos.add<double>("rmsPtMin", .1);
+  puppialgos.add<double>("rmsScaleFactor", 1.0);
+  std::vector<edm::ParameterSet> VPSetPuppiAlgos;
+  edm::ParameterSet puppiset;
+  puppiset.addParameter<int>("algoId", 5);
+  puppiset.addParameter<bool>("useCharged", false);
+  puppiset.addParameter<bool>("applyLowPUCorr", false);
+  puppiset.addParameter<int>("combOpt", 5);
+  puppiset.addParameter<double>("cone", .4);
+  puppiset.addParameter<double>("rmsPtMin", .1);
+  puppiset.addParameter<double>("rmsScaleFactor", 1.0);
+  VPSetPuppiAlgos.push_back(puppiset);
+
+  edm::ParameterSetDescription algos;
+  algos.addVPSet("puppiAlgos", puppialgos, VPSetPuppiAlgos);
+  std::vector<edm::ParameterSet> VPSetAlgos;
+  edm::ParameterSet algosset;
+  algos.add<std::vector<double>>("etaMin", {0.});
+  algos.add<std::vector<double>>("etaMax", {2.5});
+  algos.add<std::vector<double>>("ptMin", {0.});
+  algos.add<std::vector<double>>("MinNeutralPt", {0.2});
+  algos.add<std::vector<double>>("MinNeutralPtSlope", {0.015});
+  algos.add<std::vector<double>>("RMSEtaSF", {1.0});
+  algos.add<std::vector<double>>("MedEtaSF", {1.0});
+  algos.add<double>("EtaMaxExtrap", 2.0);
+  algosset.addParameter<std::vector<double>>("etaMin", {0.});
+  algosset.addParameter<std::vector<double>>("etaMax", {2.5});
+  algosset.addParameter<std::vector<double>>("ptMin", {0.});
+  algosset.addParameter<std::vector<double>>("MinNeutralPt", {0.2});
+  algosset.addParameter<std::vector<double>>("MinNeutralPtSlope", {0.015});
+  algosset.addParameter<std::vector<double>>("RMSEtaSF", {1.0});
+  algosset.addParameter<std::vector<double>>("MedEtaSF", {1.0});
+  algosset.addParameter<double>("EtaMaxExtrap", 2.0);
+  algosset.addParameter<std::vector<edm::ParameterSet>>("puppiAlgos", VPSetPuppiAlgos);
+  VPSetAlgos.push_back(algosset);
+  desc.addVPSet("algos", algos, VPSetAlgos);
+}


### PR DESCRIPTION
#### PR description:

This is a backport from #28020 
To test PUPPI at HLT for Run3/PhaseII, PuppiProducer has to be updated with the fillDescription function to be recognized in condfb. This PR introduces this function in that producer. This change should be completely transparent to the PUPPI algorithm itself, or any other part of CMSSW.

#### PR validation:

Run `runTheMatrix.py -l limited -i all --ibeos`, and all the test passed. 
