### PR TITLE
Run3-hcx231 Preparing to remove accessing DDDCompactView from SimG4CMS/Calo code (Step 1)

### DIFF
--- a/CondFormats/GeometryObjects/interface/CaloSimulationParameters.h
+++ b/CondFormats/GeometryObjects/interface/CaloSimulationParameters.h
@@ -1,0 +1,23 @@
+#ifndef CondFormats_GeometryObjects_CaloSimulationParameters_h
+#define CondFormats_GeometryObjects_CaloSimulationParameters_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+class CaloSimulationParameters {
+public:
+  CaloSimulationParameters(void) {}
+  ~CaloSimulationParameters(void) {}
+
+  std::vector<std::string> caloNames_;
+  std::vector<int> levels_;
+  std::vector<int> neighbours_;
+  std::vector<std::string> insideNames_;
+  std::vector<int> insideLevel_;
+
+  std::vector<std::string> fCaloNames_;
+  std::vector<int> fLevels_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/GeometryObjects/src/T_EventSetup_HcalParameters.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_HcalParameters.cc
@@ -1,6 +1,8 @@
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "CondFormats/GeometryObjects/interface/HcalSimulationParameters.h"
+#include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(HcalParameters);
 TYPELOOKUP_DATA_REG(HcalSimulationParameters);
+TYPELOOKUP_DATA_REG(CaloSimulationParameters);

--- a/CondFormats/GeometryObjects/src/classes.h
+++ b/CondFormats/GeometryObjects/src/classes.h
@@ -9,4 +9,5 @@
 #include "CondFormats/GeometryObjects/interface/PMTDParameters.h"
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "CondFormats/GeometryObjects/interface/HcalSimulationParameters.h"
+#include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
 #include "CondFormats/GeometryObjects/interface/PHGCalParameters.h"

--- a/CondFormats/GeometryObjects/src/classes_def.xml
+++ b/CondFormats/GeometryObjects/src/classes_def.xml
@@ -166,7 +166,7 @@
    <field name="mode_"            mapping="blob"/>
    <field name="copiesInLayers_"  mapping="blob"/>
  </class>
- <class name="HcalSimulationParameters" class_version="0"> 
+ <class name="HcalSimulationParameters" class_version="1"> 
    <field name="attenuationLength_"     mapping="blob"/>
    <field name="lambdaLimits_"          mapping="blob"/>
    <field name="shortFiberLength_"      mapping="blob"/>

--- a/CondFormats/GeometryObjects/src/classes_def.xml
+++ b/CondFormats/GeometryObjects/src/classes_def.xml
@@ -167,14 +167,30 @@
    <field name="copiesInLayers_"  mapping="blob"/>
  </class>
  <class name="HcalSimulationParameters" class_version="0"> 
-   <field name="attenuationLength_"  mapping="blob"/>
-   <field name="lambdaLimits_"       mapping="blob"/>
-   <field name="shortFiberLength_"   mapping="blob"/>
-   <field name="longFiberLength_"    mapping="blob"/>
-   <field name="pmtRight_"           mapping="blob"/>
-   <field name="pmtFiberRight_"      mapping="blob"/>
-   <field name="pmtLeft_"            mapping="blob"/>
-   <field name="pmtFiberLeft_"       mapping="blob"/>
+   <field name="attenuationLength_"     mapping="blob"/>
+   <field name="lambdaLimits_"          mapping="blob"/>
+   <field name="shortFiberLength_"      mapping="blob"/>
+   <field name="longFiberLength_"       mapping="blob"/>
+   <field name="pmtRight_"              mapping="blob"/>
+   <field name="pmtFiberRight_"         mapping="blob"/>
+   <field name="pmtLeft_"               mapping="blob"/>
+   <field name="pmtFiberLeft_"          mapping="blob"/>
+   <field name="hfLevels_"              mapping="blob"/>
+   <field name="hfNames_"               mapping="blob"/>
+   <field name="hfFibreNames_"          mapping="blob"/>
+   <field name="hfPMTNames_"            mapping="blob"/>
+   <field name="hfFibreStraightNames_"  mapping="blob"/>
+   <field name="hfFibreConicalNames_"   mapping="blob"/>
+   <field name="hcalMaterialNames_"     mapping="blob"/>
+ </class>
+ <class name="CaloSimulationParameters" class_version="0"> 
+   <field name="caloNames_"             mapping="blob"/>
+   <field name="levels_"                mapping="blob"/>
+   <field name="neighbours_"            mapping="blob"/>
+   <field name="insideNames_"           mapping="blob"/>
+   <field name="insideLevel_"           mapping="blob"/>
+   <field name="fCaloNames_"            mapping="blob"/>
+   <field name="fLevels_"               mapping="blob"/>
  </class>
 
 </lcgdict> 

--- a/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.cc
@@ -23,7 +23,7 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 #include "DetectorDescription/Core/interface/DDAlgorithmFactory.h"
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 using namespace cms_units::operators;
 
 class DDHCalBarrelAlgo : public DDAlgorithm {

--- a/Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h
+++ b/Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h
@@ -17,7 +17,7 @@ public:
   CaloDDDSimulationConstants(const CaloSimulationParameters* cps);
   ~CaloDDDSimulationConstants();
 
-  const CaloSimulationParameters* claosimpar() const { return calospar_; }
+  const CaloSimulationParameters* caloSimPar() const { return calospar_; }
 
 private:
   const CaloSimulationParameters* calospar_;

--- a/Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h
+++ b/Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h
@@ -1,0 +1,26 @@
+#ifndef Geometry_HcalCommonData_CaloDDDSimulationConstants_h
+#define Geometry_HcalCommonData_CaloDDDSimulationConstants_h
+
+/** \class CaloDDDSimulationConstants
+ *
+ * this class reads the constant section of
+ * the xml-files related to calorimeter utility for Calo simulation
+ *  
+ * \author Sunanda Banerjee, FNAL <sunanda.banerjee@cern.ch>
+ *
+ */
+
+#include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
+
+class CaloDDDSimulationConstants {
+public:
+  CaloDDDSimulationConstants(const CaloSimulationParameters* cps);
+  ~CaloDDDSimulationConstants();
+
+  const CaloSimulationParameters* claosimpar() const { return calospar_; }
+
+private:
+  const CaloSimulationParameters* calospar_;
+};
+
+#endif

--- a/Geometry/HcalCommonData/interface/CaloSimParametersFromDD.h
+++ b/Geometry/HcalCommonData/interface/CaloSimParametersFromDD.h
@@ -1,0 +1,25 @@
+#ifndef HcalCommonData_CaloSimParametersFromDD_h
+#define HcalCommonData_CaloSimParametersFromDD_h
+
+#include "DetectorDescription/Core/interface/DDsvalues.h"
+#include <string>
+
+class DDCompactView;
+class DDFilteredView;
+class CaloSimulationParameters;
+
+class CaloSimParametersFromDD {
+public:
+  CaloSimParametersFromDD(bool fromDD4Hep);
+  virtual ~CaloSimParametersFromDD() {}
+
+  bool build(const DDCompactView*, CaloSimulationParameters&);
+
+private:
+  std::vector<std::string> getNames(const std::string&, const DDsvalues_type&, bool);
+  std::vector<int> getNumbers(const std::string&, const DDsvalues_type&, bool);
+
+  bool fromDD4Hep_;
+};
+
+#endif

--- a/Geometry/HcalCommonData/interface/HcalDDDSimulationConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDSimulationConstants.h
@@ -1,5 +1,5 @@
-#ifndef Geometry_HcalTowerAlgo_HcalDDDSimulationConstants_h
-#define Geometry_HcalTowerAlgo_HcalDDDSimulationConstants_h
+#ifndef Geometry_HcalCommonData_HcalDDDSimulationConstants_h
+#define Geometry_HcalCommonData_HcalDDDSimulationConstants_h
 
 /** \class HcalDDDSimulationConstants
  *
@@ -17,10 +17,10 @@ public:
   HcalDDDSimulationConstants(const HcalSimulationParameters* hps);
   ~HcalDDDSimulationConstants();
 
-  const HcalSimulationParameters* hcalsimpar() const { return hspar; }
+  const HcalSimulationParameters* hcalsimpar() const { return hspar_; }
 
 private:
-  const HcalSimulationParameters* hspar;
+  const HcalSimulationParameters* hspar_;
 };
 
 #endif

--- a/Geometry/HcalCommonData/plugins/CaloDDDSimulationConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/CaloDDDSimulationConstantsESModule.cc
@@ -1,0 +1,65 @@
+// -*- C++ -*-
+//
+// Package:    CaloDDDSimulationConstantsESModule
+// Class:      CaloDDDSimulationConstantsESModule
+//
+/**\class CaloDDDSimulationConstantsESModule Geometry/HcalCommonData/plugins/CaloDDDSimulationConstantsESModule.cc
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Sunanda Banerjee
+//         Created:  Mon Aug 12 16:40:29 PDT 2019
+//
+//
+
+#include <memory>
+
+#include <FWCore/Framework/interface/ModuleFactory.h>
+#include <FWCore/Framework/interface/ESProducer.h>
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
+
+#include <Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h>
+#include <Geometry/Records/interface/HcalSimNumberingRecord.h>
+
+//#define EDM_ML_DEBUG
+
+class CaloDDDSimulationConstantsESModule : public edm::ESProducer {
+public:
+  CaloDDDSimulationConstantsESModule(const edm::ParameterSet&);
+
+  using ReturnType = std::unique_ptr<CaloDDDSimulationConstants>;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  ReturnType produce(const HcalSimNumberingRecord&);
+
+private:
+  edm::ESGetToken<CaloSimulationParameters, HcalParametersRcd> parSimToken_;
+};
+
+CaloDDDSimulationConstantsESModule::CaloDDDSimulationConstantsESModule(const edm::ParameterSet&) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HcalGeom") << "constructing CaloDDDSimulationConstantsESModule";
+#endif
+  auto cc = setWhatProduced(this);
+  parSimToken_ = cc.consumesFrom<CaloSimulationParameters, HcalParametersRcd>(edm::ESInputTag{});
+}
+
+void CaloDDDSimulationConstantsESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("caloDDDSimulationConstants", desc);
+}
+
+// ------------ method called to produce the data  ------------
+CaloDDDSimulationConstantsESModule::ReturnType CaloDDDSimulationConstantsESModule::produce(
+    const HcalSimNumberingRecord& iRecord) {
+  const auto& parSim = iRecord.get(parSimToken_);
+  return std::make_unique<CaloDDDSimulationConstants>(&parSim);
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(CaloDDDSimulationConstantsESModule);

--- a/Geometry/HcalCommonData/plugins/CaloSimParametersESModule.cc
+++ b/Geometry/HcalCommonData/plugins/CaloSimParametersESModule.cc
@@ -1,0 +1,62 @@
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/HcalParametersRcd.h"
+#include "Geometry/HcalCommonData/interface/CaloSimParametersFromDD.h"
+
+#include <memory>
+
+//#define EDM_ML_DEBUG
+
+class CaloSimParametersESModule : public edm::ESProducer {
+public:
+  CaloSimParametersESModule(const edm::ParameterSet&);
+  ~CaloSimParametersESModule(void) override;
+
+  using ReturnType = std::unique_ptr<CaloSimulationParameters>;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  ReturnType produce(const HcalParametersRcd&);
+
+private:
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
+  bool fromDD4Hep_;
+};
+
+CaloSimParametersESModule::CaloSimParametersESModule(const edm::ParameterSet& ps)
+    : cpvToken_{setWhatProduced(this).consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{})} {
+  fromDD4Hep_ = ps.getParameter<bool>("fromDD4Hep");
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersESModule::CaloSimParametersESModule";
+#endif
+}
+
+CaloSimParametersESModule::~CaloSimParametersESModule() {}
+
+void CaloSimParametersESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("fromDD4Hep", false);
+  descriptions.add("caloSimulationParameters", desc);
+}
+
+CaloSimParametersESModule::ReturnType CaloSimParametersESModule::produce(const HcalParametersRcd& iRecord) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersESModule::produce(const HcalParametersRcd& iRecord)";
+#endif
+  edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvToken_);
+
+  auto ptp = std::make_unique<CaloSimulationParameters>();
+  CaloSimParametersFromDD builder(fromDD4Hep_);
+  builder.build(&(*cpv), *ptp);
+
+  return ptp;
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(CaloSimParametersESModule);

--- a/Geometry/HcalCommonData/src/CaloDDDSimulationConstants.cc
+++ b/Geometry/HcalCommonData/src/CaloDDDSimulationConstants.cc
@@ -1,0 +1,17 @@
+#include "Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#define EDM_ML_DEBUG
+
+CaloDDDSimulationConstants::CaloDDDSimulationConstants(const CaloSimulationParameters* csp) : calospar_(csp) {
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("HCalGeom")
+      << "CaloDDDSimulationConstants::CaloDDDSimulationConstants (const CaloSimulationParameters* csp) constructor\n";
+#endif
+}
+
+CaloDDDSimulationConstants::~CaloDDDSimulationConstants() {
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("HCalGeom") << "CaloDDDSimulationConstants::destructed!!!\n";
+#endif
+}

--- a/Geometry/HcalCommonData/src/CaloSimParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/CaloSimParametersFromDD.cc
@@ -11,7 +11,7 @@
 
 //#define EDM_ML_DEBUG
 
-CaloSimParametersFromDD::CaloSimParametersFromDD(bool fromDD4Hep) : fromDD4Hep_(fromDD4Hep) { 
+CaloSimParametersFromDD::CaloSimParametersFromDD(bool fromDD4Hep) : fromDD4Hep_(fromDD4Hep) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: initialized with fromDD4Hep = " << fromDD4Hep_;
 #endif
@@ -29,7 +29,8 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
   std::string value = "Calorimeter";
   php.caloNames_ = getNames(value, sv, false);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.caloNames_.size() << " entries for " << value << ":";
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.caloNames_.size() << " entries for " << value
+                               << ":";
   for (unsigned int i = 0; i < php.caloNames_.size(); i++)
     edm::LogVerbatim("HCaloGeom") << " (" << i << ") " << php.caloNames_[i];
 #endif
@@ -45,7 +46,8 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
   value = "Neighbours";
   php.neighbours_ = getNumbers(value, sv, false);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.neighbours_.size() << " entries for " << value << ":";
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.neighbours_.size() << " entries for " << value
+                               << ":";
   for (unsigned int i = 0; i < php.neighbours_.size(); i++)
     edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.neighbours_[i];
 #endif
@@ -53,7 +55,8 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
   value = "Inside";
   php.insideNames_ = getNames(value, sv, false);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.insideNames_.size() << " entries for " << value << ":";
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.insideNames_.size() << " entries for " << value
+                               << ":";
   for (unsigned int i = 0; i < php.insideNames_.size(); i++)
     edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.insideNames_[i];
 #endif
@@ -61,7 +64,8 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
   value = "InsideLevel";
   php.insideLevel_ = getNumbers(value, sv, false);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.insideLevel_.size() << " ebtries for " << value << ":";
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.insideLevel_.size() << " ebtries for " << value
+                               << ":";
   for (unsigned int i = 0; i < php.insideLevel_.size(); i++)
     edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.insideLevel_[i];
 #endif
@@ -69,7 +73,8 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
   value = "FineCalorimeter";
   php.fCaloNames_ = getNames(value, sv, true);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.fCaloNames_.size() << " entries for " << value << ":";
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.fCaloNames_.size() << " entries for " << value
+                               << ":";
   for (unsigned int i = 0; i < php.fCaloNames_.size(); i++)
     edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.fCaloNames_[i];
 #endif
@@ -84,7 +89,7 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
 
   if (php.caloNames_.size() < php.neighbours_.size()) {
     edm::LogError("HCalGeom") << "CaloSimParametersFromDD: # of Calorimeter bins " << php.caloNames_.size()
-                             << " does not match with " << php.neighbours_.size() << " ==> illegal ";
+                              << " does not match with " << php.neighbours_.size() << " ==> illegal ";
     throw cms::Exception("Unknown", "CaloSimParametersFromDD")
         << "Calorimeter array size does not match with size of neighbours\n";
   }
@@ -92,7 +97,9 @@ bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationPara
   return true;
 }
 
-std::vector<std::string> CaloSimParametersFromDD::getNames(const std::string& str, const DDsvalues_type& sv, bool ignore) {
+std::vector<std::string> CaloSimParametersFromDD::getNames(const std::string& str,
+                                                           const DDsvalues_type& sv,
+                                                           bool ignore) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD::getNames called for " << str;
 #endif

--- a/Geometry/HcalCommonData/src/CaloSimParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/CaloSimParametersFromDD.cc
@@ -1,0 +1,144 @@
+#include "Geometry/HcalCommonData/interface/CaloSimParametersFromDD.h"
+#include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDFilter.h"
+#include "DetectorDescription/Core/interface/DDValue.h"
+#include "DetectorDescription/Core/interface/DDutils.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+#include <iomanip>
+
+//#define EDM_ML_DEBUG
+
+CaloSimParametersFromDD::CaloSimParametersFromDD(bool fromDD4Hep) : fromDD4Hep_(fromDD4Hep) { 
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: initialized with fromDD4Hep = " << fromDD4Hep_;
+#endif
+}
+
+bool CaloSimParametersFromDD::build(const DDCompactView* cpv, CaloSimulationParameters& php) {
+  // Get the names
+  std::string attribute = "ReadOutName";
+  std::string name = "CaloHitsTk";
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, name, 0)};
+  DDFilteredView fv(*cpv, filter);
+  fv.firstChild();
+  DDsvalues_type sv(fv.mergedSpecifics());
+
+  std::string value = "Calorimeter";
+  php.caloNames_ = getNames(value, sv, false);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.caloNames_.size() << " entries for " << value << ":";
+  for (unsigned int i = 0; i < php.caloNames_.size(); i++)
+    edm::LogVerbatim("HCaloGeom") << " (" << i << ") " << php.caloNames_[i];
+#endif
+
+  value = "Levels";
+  php.levels_ = getNumbers(value, sv, false);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.levels_.size() << " entries for " << value << ":";
+  for (unsigned int i = 0; i < php.levels_.size(); i++)
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.levels_[i];
+#endif
+
+  value = "Neighbours";
+  php.neighbours_ = getNumbers(value, sv, false);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.neighbours_.size() << " entries for " << value << ":";
+  for (unsigned int i = 0; i < php.neighbours_.size(); i++)
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.neighbours_[i];
+#endif
+
+  value = "Inside";
+  php.insideNames_ = getNames(value, sv, false);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.insideNames_.size() << " entries for " << value << ":";
+  for (unsigned int i = 0; i < php.insideNames_.size(); i++)
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.insideNames_[i];
+#endif
+
+  value = "InsideLevel";
+  php.insideLevel_ = getNumbers(value, sv, false);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.insideLevel_.size() << " ebtries for " << value << ":";
+  for (unsigned int i = 0; i < php.insideLevel_.size(); i++)
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.insideLevel_[i];
+#endif
+
+  value = "FineCalorimeter";
+  php.fCaloNames_ = getNames(value, sv, true);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.fCaloNames_.size() << " entries for " << value << ":";
+  for (unsigned int i = 0; i < php.fCaloNames_.size(); i++)
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.fCaloNames_[i];
+#endif
+
+  value = "FineLevels";
+  php.fLevels_ = getNumbers(value, sv, true);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD: " << php.fLevels_.size() << " entries for " << value << ":";
+  for (unsigned int i = 0; i < php.fLevels_.size(); i++)
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << php.fLevels_[i];
+#endif
+
+  if (php.caloNames_.size() < php.neighbours_.size()) {
+    edm::LogError("HCalGeom") << "CaloSimParametersFromDD: # of Calorimeter bins " << php.caloNames_.size()
+                             << " does not match with " << php.neighbours_.size() << " ==> illegal ";
+    throw cms::Exception("Unknown", "CaloSimParametersFromDD")
+        << "Calorimeter array size does not match with size of neighbours\n";
+  }
+
+  return true;
+}
+
+std::vector<std::string> CaloSimParametersFromDD::getNames(const std::string& str, const DDsvalues_type& sv, bool ignore) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD::getNames called for " << str;
+#endif
+  DDValue value(str);
+  if (DDfetch(&sv, value)) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HCalGeom") << value;
+#endif
+    const std::vector<std::string>& fvec = value.strings();
+    int nval = fvec.size();
+    if ((nval < 1) && (!ignore)) {
+      edm::LogError("HCalGeom") << "CaloSimParametersFromDD: # of " << str << " bins " << nval << " < 1 ==> illegal ";
+      throw cms::Exception("Unknown", "CaloSimParametersFromDD") << "nval < 2 for array " << str << "\n";
+    }
+
+    return fvec;
+  } else if (ignore) {
+    std::vector<std::string> fvec;
+    return fvec;
+  } else {
+    edm::LogError("HCalGeom") << "CaloSimParametersFromDD: cannot get array " << str;
+    throw cms::Exception("Unknown", "CaloSimParametersFromDD") << "cannot get array " << str << "\n";
+  }
+}
+
+std::vector<int> CaloSimParametersFromDD::getNumbers(const std::string& str, const DDsvalues_type& sv, bool ignore) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "CaloSimParametersFromDD::getNumbers called for " << str;
+#endif
+  DDValue value(str);
+  if (DDfetch(&sv, value)) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HCalGeom") << value;
+#endif
+    const std::vector<double>& fvec = value.doubles();
+    int nval = fvec.size();
+    if ((nval < 1) && (!ignore)) {
+      edm::LogError("HCalGeom") << "CaloSimParametersFromDD: # of " << str << " bins " << nval << " < 1 ==> illegal ";
+      throw cms::Exception("Unknown", "CaloSimParametersFromDD") << "nval < 2 for array " << str << "\n";
+    }
+    return dbl_to_int(fvec);
+  } else if (ignore) {
+    std::vector<int> fvec;
+    return fvec;
+  } else {
+    edm::LogError("HCalGeom") << "CaloSimParametersFromDD: cannot get array " << str;
+    throw cms::Exception("Unknown", "CaloSimParametersFromDD") << "cannot get array " << str << "\n";
+  }
+}

--- a/Geometry/HcalCommonData/src/ES_HcalDDDConstants.cc
+++ b/Geometry/HcalCommonData/src/ES_HcalDDDConstants.cc
@@ -1,8 +1,10 @@
+#include "Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDSimConstants.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDSimulationConstants.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
+TYPELOOKUP_DATA_REG(CaloDDDSimulationConstants);
 TYPELOOKUP_DATA_REG(HcalDDDSimConstants);
 TYPELOOKUP_DATA_REG(HcalDDDSimulationConstants);
 TYPELOOKUP_DATA_REG(HcalDDDRecConstants);

--- a/Geometry/HcalCommonData/src/HcalDDDSimulationConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimulationConstants.cc
@@ -4,7 +4,7 @@
 
 //#define EDM_ML_DEBUG
 
-HcalDDDSimulationConstants::HcalDDDSimulationConstants(const HcalSimulationParameters* hsp) : hspar(hsp) {
+HcalDDDSimulationConstants::HcalDDDSimulationConstants(const HcalSimulationParameters* hsp) : hspar_(hsp) {
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom")
       << "HcalDDDSimulationConstants::HcalDDDSimulationConstants (const HcalSimulationParameters* hsp) constructor\n";

--- a/Geometry/HcalCommonData/test/BuildFile.xml
+++ b/Geometry/HcalCommonData/test/BuildFile.xml
@@ -3,15 +3,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <use   name="Geometry/Records"/>
-<library   file="HcalParametersAnalyzer.cc" name="testHcalParametersAnalyzer">
- <use name="CondFormats/GeometryObjects"/>
- <flags   EDM_PLUGIN="1"/>
-</library>
-<library   file="HcalSimNumberingTester.cc" name="testHcalSimNumberingTester">
- <use name="CondFormats/GeometryObjects"/>
- <flags   EDM_PLUGIN="1"/>
-</library>
-<library   file="HcalRecNumberingTester.cc" name="testHcalRecNumberingTester">
- <use name="CondFormats/GeometryObjects"/>
+<use   name="CondFormats/GeometryObjects"/>
+<library   file="*.cc" name="testHcalCommonDataAnalyzer">
  <flags   EDM_PLUGIN="1"/>
 </library>

--- a/Geometry/HcalCommonData/test/CaloSimParameterAnalyzer.cc
+++ b/Geometry/HcalCommonData/test/CaloSimParameterAnalyzer.cc
@@ -1,0 +1,53 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
+#include "Geometry/Records/interface/HcalParametersRcd.h"
+#include <iostream>
+
+class CaloSimParametersAnalyzer : public edm::one::EDAnalyzer<> {
+public:
+  explicit CaloSimParametersAnalyzer(const edm::ParameterSet&);
+  ~CaloSimParametersAnalyzer(void) override;
+
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+
+private:
+  edm::ESGetToken<CaloSimulationParameters, HcalParametersRcd> simparToken_;
+};
+
+CaloSimParametersAnalyzer::CaloSimParametersAnalyzer(const edm::ParameterSet&) {
+  simparToken_ = esConsumes<CaloSimulationParameters, HcalParametersRcd>(edm::ESInputTag{});
+}
+
+CaloSimParametersAnalyzer::~CaloSimParametersAnalyzer(void) {}
+
+void CaloSimParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  const auto& parS = iSetup.getData(simparToken_);
+  const CaloSimulationParameters* parsim = &parS;
+  if (parsim != nullptr) {
+    std::cout << "\ncaloNames_: ";
+    for (const auto& it : parsim->caloNames_)
+      std::cout << it << ", ";
+    std::cout << "\nlevels_: ";
+    for (const auto& it : parsim->levels_)
+      std::cout << it << ", ";
+    std::cout << "\nneighbours_: ";
+    for (const auto& it : parsim->neighbours_)
+      std::cout << it << ", ";
+    std::cout << "\ninsideNames_: ";
+    for (const auto& it : parsim->insideNames_)
+      std::cout << it << ", ";
+    std::cout << std::endl;
+
+    std::cout << "\nfCaloNames_: ";
+    for (const auto& it : parsim->fCaloNames_)
+      std::cout << it << ", ";
+    std::cout << "\nfLevels_: ";
+    for (const auto& it : parsim->fLevels_)
+      std::cout << it << ", ";
+    std::cout << std::endl;
+  }
+}
+
+DEFINE_FWK_MODULE(CaloSimParametersAnalyzer);

--- a/Geometry/HcalCommonData/test/python/runCaloPararemetrsAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runCaloPararemetrsAnalyzer_cfg.py
@@ -4,6 +4,7 @@ process = cms.Process("HcalParametersTest")
 process.load('Geometry.HcalCommonData.testPhase2GeometryFineXML_cfi')
 process.load('Geometry.HcalCommonData.hcalParameters_cfi')
 process.load('Geometry.HcalCommonData.hcalSimulationParameters_cfi')
+process.load('Geometry.HcalCommonData.caloSimulationParameters_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 process.source = cms.Source("EmptySource")
@@ -14,7 +15,7 @@ process.maxEvents = cms.untracked.PSet(
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.categories.append('HCalGeom')
 
-process.hpa = cms.EDAnalyzer("HcalParametersAnalyzer")
+process.hpa = cms.EDAnalyzer("CaloSimParametersAnalyzer")
 
 process.Timing = cms.Service("Timing")
 process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")


### PR DESCRIPTION
#### PR description:

Access spectra parameters to be used for simulation in the Geometry step and make it available for SIM so that SIM will not deal with DDDCompactView.

#### PR validation:

Use standard runTheMatrix.py

#### if this PR is a backport please specify the original PR:

Nothing special