### PR TITLE
fix unit test test_MpsWorkFlow

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/helper.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/helper.py
@@ -11,7 +11,7 @@ def checked_out_MPS():
     git_initialized = False
     try:
         with open(checked_out_packages, "r") as f:
-            packages = ("/Alignment/", "/Alignment/MillePedeAlignmentAlgorithm/")
+            packages = ("/Alignment/", "/Alignment/MillePedeAlignmentAlgorithm/","/*/")
             for line in f:
                 if line.strip() in packages:
                     checked_out = True


### PR DESCRIPTION
test_MpsWorkFlow fails during PR tests[a] if we build full cmssw. In this case we run 
```
git cms-addpkg *
``` 
which add `/*/` in `sparse-checkout` file instead of  `/Alignment/` or `/Alignment/MillePedeAlignmentAlgorithm/` . I think we can just check if  `$CMSSW_BASE/src//Alignment/MillePedeAlignmentAlgorithm` exists instead of looking in sparse-checkout file

[a]
```
>>> Created new campaign: mp5188
    - updated campaign list 'MP_ali_list.txt'
Traceback (most recent call last):
  File "CMSSW_11_0_ROOT6_X_2019-10-09-2300/bin/slc7_amd64_gcc820/mps_setup_new_align.py", line 258, in <module>
    main()
  File "CMSSW_11_0_ROOT6_X_2019-10-09-2300/bin/slc7_amd64_gcc820/mps_setup_new_align.py", line 102, in main
    copy_default_templates(args, next_campaign)
  File "CMSSW_11_0_ROOT6_X_2019-10-09-2300/bin/slc7_amd64_gcc820/mps_setup_new_align.py", line 209, in copy_default_templates
    shutil.copy(os.path.join(default_conf_dir, f), next_campaign)
  File "slc7_amd64_gcc820/external/python/2.7.15-pafccj/lib/python2.7/shutil.py", line 133, in copy
    copyfile(src, dst)
  File "slc7_amd64_gcc820/external/python/2.7.15-pafccj/lib/python2.7/shutil.py", line 96, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: 'src/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py'

---> test test_MpsWorkFlow had ERRORS
```