### PR TITLE
Use CMSSW_FULL_RELEASE_BASE env to fix put cmssw patch relese

### DIFF
--- a/CommonTools/Utils/src/ExpressionEvaluator.cc
+++ b/CommonTools/Utils/src/ExpressionEvaluator.cc
@@ -38,13 +38,6 @@ namespace {
     system(rm.c_str());
   }
 
-  std::string patchArea() {
-    auto n1 = execSysCommand("pushd $CMSSW_BASE > /dev/null;scram tool tag cmssw CMSSW_BASE; popd > /dev/null");
-    n1.pop_back();
-    COUT << "base area " << n1 << std::endl;
-    return n1[0] == '/' ? n1 : std::string();
-  }
-
 }  // namespace
 
 namespace reco {
@@ -82,7 +75,7 @@ namespace reco {
           incDir = relDir + incDir;
         } else {
           // look in release is a patch area
-          auto paDir = patchArea();
+          auto paDir = edm::getEnvironmentVariable("CMSSW_FULL_RELEASE_BASE");
           if (paDir.empty())
             throw cms::Exception("ExpressionEvaluator", "error in opening patch area for " + baseDir);
           std::string file = paDir + incDir + pch + ".cxxflags";


### PR DESCRIPTION
Unit test ExpressionEvaluatorUnitTest sometimes fails. We should use `CMSSW_FULL_RELEASE_BASE` environment variable to get the patch release path instead of call `scram tool `

[a]
https://github.com/cms-sw/cmsdist/pull/5268#issuecomment-539612277

[b] 
```
An exception of category 'ExpressionEvaluator' occurred.
Exception Message:
error in opening patch area for /build/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_11_0_CXXMODULE_X_2019-10-07-1100 
```