### PR TITLE
Initial Implementation of ProducesCollector

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/PackingSetup.h
+++ b/EventFilter/L1TRawToDigi/interface/PackingSetup.h
@@ -3,6 +3,7 @@
 
 #include <map>
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "EventFilter/L1TRawToDigi/interface/Packer.h"
@@ -15,9 +16,6 @@ namespace edm {
   class ConsumesCollector;
   class Event;
   class ParameterSet;
-  namespace stream {
-    class EDProducerBase;
-  }
 }  // namespace edm
 
 namespace l1t {
@@ -31,7 +29,7 @@ namespace l1t {
     PackingSetup(){};
     virtual ~PackingSetup(){};
     virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet&, edm::ConsumesCollector&) = 0;
-    virtual void registerProducts(edm::stream::EDProducerBase&) = 0;
+    virtual void registerProducts(edm::ProducesCollector) = 0;
 
     // Get a map of (amc #, board id) ↔ list of packing functions for a specific FED, FW combination
     virtual PackerMap getPackers(int fed, unsigned int fw) = 0;

--- a/EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc
@@ -107,7 +107,7 @@ namespace l1t {
     }
 
     prov_ = PackingSetupFactory::get()->make(config.getParameter<std::string>("Setup"));
-    prov_->registerProducts(*this);
+    prov_->registerProducts(producesCollector());
 
     slinkHeaderSize_ = config.getUntrackedParameter<int>("lenSlinkHeader");
     slinkTrailerSize_ = config.getUntrackedParameter<int>("lenSlinkTrailer");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
@@ -43,7 +42,7 @@ PackerMap CaloSetup::getPackers(int fed, unsigned int fw) {
   return res;
 }
 
-void CaloSetup::registerProducts(edm::stream::EDProducerBase& prod) {
+void CaloSetup::registerProducts(edm::ProducesCollector prod) {
   prod.produces<L1CaloEmCollection>();
   prod.produces<CaloSpareBxCollection>("HFBitCounts");
   prod.produces<CaloSpareBxCollection>("HFRingSums");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.h
@@ -5,6 +5,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "CaloCollections.h"
 #include "CaloTokens.h"
@@ -17,7 +18,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
@@ -1,5 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
-
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
@@ -61,7 +59,7 @@ namespace l1t {
       return res;
     }  //getPackers
 
-    void BMTFSetup::registerProducts(edm::stream::EDProducerBase& prod) {
+    void BMTFSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<RegionalMuonCandBxCollection>("BMTF");
       prod.produces<RegionalMuonCandBxCollection>("BMTF2");
       prod.produces<L1MuDTChambPhContainer>();

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
@@ -4,6 +4,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Packer.h"
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "BMTFCollections.h"
 #include "BMTFTokens.h"
@@ -16,7 +17,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
@@ -52,7 +51,7 @@ namespace l1t {
       return res;
     }
 
-    void CaloLayer1Setup::registerProducts(edm::stream::EDProducerBase& prod) {
+    void CaloLayer1Setup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<EcalTrigPrimDigiCollection>();
       prod.produces<HcalTrigPrimDigiCollection>();
       prod.produces<L1CaloRegionCollection>();

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.h
@@ -5,6 +5,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "CaloLayer1Collections.h"
 #include "CaloLayer1Tokens.h"
@@ -16,7 +17,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.cc
@@ -1,5 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
-
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
@@ -32,7 +30,7 @@ namespace l1t {
       return res;
     }
 
-    void CaloSetup::registerProducts(edm::stream::EDProducerBase& prod) {
+    void CaloSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<CaloTowerBxCollection>("CaloTower");
       prod.produces<EGammaBxCollection>("EGamma");
       prod.produces<EtSumBxCollection>("EtSum");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSetup.h
@@ -5,6 +5,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "CaloCollections.h"
 #include "CaloTokens.h"
@@ -16,7 +17,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
@@ -35,7 +34,7 @@ namespace l1t {
       return res;
     }
 
-    void EMTFSetup::registerProducts(edm::stream::EDProducerBase& prod) {
+    void EMTFSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<RegionalMuonCandBxCollection>();
       prod.produces<EMTFDaqOutCollection>();
       prod.produces<EMTFHitCollection>();

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.h
@@ -5,6 +5,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "EMTFCollections.h"
 #include "EMTFTokens.h"
@@ -16,7 +17,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
@@ -48,7 +47,7 @@ namespace l1t {
       return res;
     }
 
-    void GMTSetup::registerProducts(edm::stream::EDProducerBase& prod) {
+    void GMTSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<RegionalMuonCandBxCollection>("BMTF");
       prod.produces<RegionalMuonCandBxCollection>("OMTF");
       prod.produces<RegionalMuonCandBxCollection>("EMTF");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.h
@@ -5,6 +5,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "GMTCollections.h"
 #include "GMTTokens.h"
@@ -16,7 +17,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -1,5 +1,3 @@
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
-
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
@@ -47,7 +45,7 @@ namespace l1t {
       return res;
     }
 
-    void GTSetup::registerProducts(edm::stream::EDProducerBase& prod) {
+    void GTSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<MuonBxCollection>("Muon");
       prod.produces<EGammaBxCollection>("EGamma");
       prod.produces<EtSumBxCollection>("EtSum");

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.h
@@ -5,6 +5,7 @@
 #include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
 
 #include "EventFilter/L1TRawToDigi/interface/PackingSetup.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "GTCollections.h"
 #include "GTTokens.h"
@@ -17,7 +18,7 @@ namespace l1t {
       std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
       void fillDescription(edm::ParameterSetDescription& desc) override;
       PackerMap getPackers(int fed, unsigned int fw) override;
-      void registerProducts(edm::stream::EDProducerBase& prod) override;
+      void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
     };

--- a/EventFilter/RPCRawToDigi/plugins/RPCAMCRawToDigi.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCAMCRawToDigi.cc
@@ -22,8 +22,8 @@ RPCAMCRawToDigi::RPCAMCRawToDigi(edm::ParameterSet const &config)
       fill_counters_(config.getParameter<bool>("fillCounters")),
       rpc_unpacker_(
           RPCAMCUnpackerFactory::get()->create(config.getParameter<std::string>("RPCAMCUnpacker"),
-                                               *this,
-                                               config.getParameter<edm::ParameterSet>("RPCAMCUnpackerSettings"))) {
+                                               config.getParameter<edm::ParameterSet>("RPCAMCUnpackerSettings"),
+                                               producesCollector())) {
   if (fill_counters_) {
     produces<RPCAMCLinkCounters>();
   }

--- a/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpacker.cc
@@ -2,8 +2,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-RPCAMCUnpacker::RPCAMCUnpacker(edm::stream::EDProducerBase& producer, edm::ParameterSet const& config) {}
-
+RPCAMCUnpacker::RPCAMCUnpacker(edm::ParameterSet const&, edm::ProducesCollector) {}
 RPCAMCUnpacker::~RPCAMCUnpacker() {}
 
 void RPCAMCUnpacker::fillDescription(edm::ParameterSetDescription& desc) {

--- a/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpacker.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpacker.h
@@ -6,6 +6,7 @@
 
 #include "CondFormats/RPCObjects/interface/RPCAMCLink.h"
 #include "EventFilter/RPCRawToDigi/interface/RPCAMC13Record.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 namespace edm {
   class Event;
@@ -13,14 +14,11 @@ namespace edm {
   class ParameterSet;
   class ParameterSetDescription;
   class Run;
-  namespace stream {
-    class EDProducerBase;
-  }  // namespace stream
 }  // namespace edm
 
 class RPCAMCUnpacker {
 public:
-  RPCAMCUnpacker(edm::stream::EDProducerBase& producer, edm::ParameterSet const& config);
+  RPCAMCUnpacker(edm::ParameterSet const&, edm::ProducesCollector);
   virtual ~RPCAMCUnpacker();
 
   static void fillDescription(edm::ParameterSetDescription& desc);

--- a/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpackerFactory.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpackerFactory.h
@@ -1,18 +1,16 @@
 #ifndef EventFilter_RPCRawToDigi_RPCAMCUnpackerFactory_h
 #define EventFilter_RPCRawToDigi_RPCAMCUnpackerFactory_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
 namespace edm {
   class ParameterSet;
-  namespace stream {
-    class EDProducerBase;
-  }  // namespace stream
 }  // namespace edm
 
 class RPCAMCUnpacker;
 
-typedef edmplugin::PluginFactory<RPCAMCUnpacker *(edm::stream::EDProducerBase &producer, edm::ParameterSet const &)>
+typedef edmplugin::PluginFactory<RPCAMCUnpacker *(edm::ParameterSet const &, edm::ProducesCollector)>
     RPCAMCUnpackerFactory;
 
 #endif  // EventFilter_RPCRawToDigi_RPCAMCUnpackerFactory_h

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -5,7 +5,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/stream/EDProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -16,15 +15,15 @@
 #include "EventFilter/RPCRawToDigi/interface/RPCAMCLinkEvents.h"
 #include "EventFilter/RPCRawToDigi/interface/RPCMP7Record.h"
 
-RPCCPPFUnpacker::RPCCPPFUnpacker(edm::stream::EDProducerBase& producer, edm::ParameterSet const& config)
-    : RPCAMCUnpacker(producer, config),
+RPCCPPFUnpacker::RPCCPPFUnpacker(edm::ParameterSet const& config, edm::ProducesCollector producesCollector)
+    : RPCAMCUnpacker(config, producesCollector),
       fill_counters_(config.getParameter<bool>("fillAMCCounters")),
       bx_min_(config.getParameter<int>("bxMin")),
       bx_max_(config.getParameter<int>("bxMax")) {
-  producer.produces<RPCDigiCollection>();
-  producer.produces<l1t::CPPFDigiCollection>();
+  producesCollector.produces<RPCDigiCollection>();
+  producesCollector.produces<l1t::CPPFDigiCollection>();
   if (fill_counters_) {
-    producer.produces<RPCAMCLinkCounters>("RPCAMCUnpacker");
+    producesCollector.produces<RPCAMCLinkCounters>("RPCAMCUnpacker");
   }
 }
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.h
@@ -6,6 +6,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "CondFormats/DataRecord/interface/RPCCPPFLinkMapRcd.h"
 #include "CondFormats/RPCObjects/interface/RPCAMCLinkMap.h"
@@ -21,7 +22,7 @@ class RPCAMCLinkCounters;
 
 class RPCCPPFUnpacker : public RPCAMCUnpacker {
 public:
-  RPCCPPFUnpacker(edm::stream::EDProducerBase& producer, edm::ParameterSet const& config);
+  RPCCPPFUnpacker(edm::ParameterSet const&, edm::ProducesCollector);
 
   void beginRun(edm::Run const& run, edm::EventSetup const& setup) override;
   void produce(edm::Event& event,

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -20,6 +20,7 @@ EDProducts into an Event.
 namespace edm {
   class BranchDescription;
   class ModuleDescription;
+  class ProducesCollector;
   class ProductRegistry;
   class Event;
   class LuminosityBlock;
@@ -72,7 +73,6 @@ namespace edm {
 
     void registerProducts(ProducerBase*, ProductRegistry*, ModuleDescription const&);
 
-    using ProductRegistryHelper::produces;
     using ProductRegistryHelper::recordProvenanceList;
     using ProductRegistryHelper::typeLabelList;
 
@@ -93,6 +93,10 @@ namespace edm {
     std::vector<edm::ProductResolverIndex> const& putTokenIndexToProductResolverIndex() const {
       return putTokenToResolverIndex_;
     }
+
+  protected:
+    ProducesCollector producesCollector();
+    using ProductRegistryHelper::produces;
 
   private:
     friend class EDProducer;

--- a/FWCore/Framework/interface/ProducesCollector.h
+++ b/FWCore/Framework/interface/ProducesCollector.h
@@ -1,0 +1,90 @@
+#ifndef FWCore_Framework_ProducesCollector_h
+#define FWCore_Framework_ProducesCollector_h
+
+// Package:     FWCore/Framework
+// Class  :     edm::ProducesCollector
+//
+/**\class edm::ProducesCollector
+
+ Description: Helper class to gather produces information for the ProducerBase class.
+
+ Usage:
+    The constructor of a module can get an instance of edm::ProducesCollector by calling its
+producesCollector() method. This instance can then be passed to helper classes in order to register
+the data the helper will put into the Event, LuminosityBlock or Run.
+
+    Note this only supports use of the Transition enum. The produce template functions using
+the BranchType enum are not supported by this class. We still support the BranchType enum in
+ProducerBase for backward compatibility reasons, but even there they are deprecated and we
+are trying to migrate client code to use the template functions using the Transition enum.
+
+     WARNING: The ProducesCollector should be used during the time that modules are being
+constructed. It should not be saved and used later. It will not work if it is used to call
+the produces function during beginJob, beginRun, beginLuminosity block, event processing or
+at any later time. It can be used while the module constructor is running or be contained in
+a functor passed to the Framework with a call to callWhenNewProductsRegistered.
+
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  24 September 2019
+
+#include "FWCore/Framework/interface/ProductRegistryHelper.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
+#include <string>
+#include <utility>
+
+namespace edm {
+
+  class TypeID;
+
+  class ProducesCollector {
+  public:
+    ProducesCollector() = delete;
+    ProducesCollector(ProducesCollector const&);
+    ProducesCollector(ProducesCollector&&) = default;
+    ProducesCollector& operator=(ProducesCollector const&);
+    ProducesCollector& operator=(ProducesCollector&&) = default;
+
+    template <class ProductType>
+    ProductRegistryHelper::BranchAliasSetterT<ProductType> produces() {
+      return helper_->produces<ProductType>();
+    }
+
+    template <class ProductType>
+    ProductRegistryHelper::BranchAliasSetterT<ProductType> produces(std::string instanceName) {
+      return helper_->produces<ProductType>(std::move(instanceName));
+    }
+
+    template <typename ProductType, Transition B>
+    ProductRegistryHelper::BranchAliasSetterT<ProductType> produces() {
+      return helper_->produces<ProductType, B>();
+    }
+
+    template <typename ProductType, Transition B>
+    ProductRegistryHelper::BranchAliasSetterT<ProductType> produces(std::string instanceName) {
+      return helper_->produces<ProductType, B>(std::move(instanceName));
+    }
+
+    ProductRegistryHelper::BranchAliasSetter produces(const TypeID& id,
+                                                      std::string instanceName = std::string(),
+                                                      bool recordProvenance = true);
+
+    template <Transition B>
+    ProductRegistryHelper::BranchAliasSetter produces(const TypeID& id,
+                                                      std::string instanceName = std::string(),
+                                                      bool recordProvenance = true) {
+      return helper_->produces<B>(id, std::move(instanceName), recordProvenance);
+    }
+
+  private:
+    friend class ProducerBase;
+    ProducesCollector(ProductRegistryHelper* helper);
+
+    propagate_const<ProductRegistryHelper*> helper_;
+  };
+
+}  // namespace edm
+#endif

--- a/FWCore/Framework/src/ProducerBase.cc
+++ b/FWCore/Framework/src/ProducerBase.cc
@@ -8,6 +8,7 @@
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include <sstream>
 
@@ -100,4 +101,7 @@ namespace edm {
       }
     }
   }
+
+  ProducesCollector ProducerBase::producesCollector() { return ProducesCollector{this}; }
+
 }  // namespace edm

--- a/FWCore/Framework/src/ProducesCollector.cc
+++ b/FWCore/Framework/src/ProducesCollector.cc
@@ -1,0 +1,20 @@
+#include "FWCore/Framework/interface/ProducesCollector.h"
+
+namespace edm {
+
+  ProducesCollector::ProducesCollector(ProducesCollector const& other) : helper_(get_underlying(other.helper_)) {}
+
+  ProducesCollector& ProducesCollector::operator=(ProducesCollector const& other) {
+    helper_ = get_underlying(other.helper_);
+    return *this;
+  }
+
+  ProductRegistryHelper::BranchAliasSetter ProducesCollector::produces(const TypeID& id,
+                                                                       std::string instanceName,
+                                                                       bool recordProvenance) {
+    return helper_->produces(id, std::move(instanceName), recordProvenance);
+  }
+
+  ProducesCollector::ProducesCollector(ProductRegistryHelper* helper) : helper_(helper) {}
+
+}  // namespace edm

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -79,6 +79,13 @@ namespace {
 
     std::vector<EDGetTokenT<edmtest::IntProduct>> m_tokens;
   };
+
+  template <typename T>
+  class TestProducer : public edm::ProducerBase {
+  public:
+    TestProducer(std::string const& productInstanceName) { token_ = produces<T>(productInstanceName); }
+    EDPutTokenT<T> token_;
+  };
 }  // namespace
 
 class testEvent : public CppUnit::TestFixture {
@@ -235,8 +242,7 @@ ProductID testEvent::addProduct(std::unique_ptr<T> product, std::string const& t
 
   ModuleCallingContext mcc(&description->second);
   Event temporaryEvent(*principal_, description->second, &mcc);
-  ProducerBase prod;
-  prod.produces<T>(productLabel);
+  TestProducer<T> prod(productLabel);
   const_cast<std::vector<edm::ProductResolverIndex>&>(prod.putTokenIndexToProductResolverIndex())
       .push_back(principal_->productLookup().index(PRODUCT_TYPE,
                                                    edm::TypeID(typeid(T)),
@@ -255,8 +261,7 @@ template <class T>
 std::unique_ptr<ProducerBase> testEvent::putProduct(std::unique_ptr<T> product,
                                                     std::string const& productInstanceLabel,
                                                     bool doCommit) {
-  auto prod = std::make_unique<ProducerBase>();
-  prod->produces<edmtest::IntProduct>(productInstanceLabel);
+  auto prod = std::make_unique<TestProducer<edmtest::IntProduct>>(productInstanceLabel);
   auto index = principal_->productLookup().index(PRODUCT_TYPE,
                                                  edm::TypeID(typeid(T)),
                                                  currentModuleDescription_->moduleLabel().c_str(),
@@ -276,8 +281,8 @@ template <class T>
 std::unique_ptr<ProducerBase> testEvent::putProductUsingToken(std::unique_ptr<T> product,
                                                               std::string const& productInstanceLabel,
                                                               bool doCommit) {
-  auto prod = std::make_unique<ProducerBase>();
-  EDPutTokenT<edmtest::IntProduct> token = prod->produces<edmtest::IntProduct>(productInstanceLabel);
+  auto prod = std::make_unique<TestProducer<edmtest::IntProduct>>(productInstanceLabel);
+  EDPutTokenT<edmtest::IntProduct> token = prod->token_;
   auto index = principal_->productLookup().index(PRODUCT_TYPE,
                                                  edm::TypeID(typeid(T)),
                                                  currentModuleDescription_->moduleLabel().c_str(),
@@ -297,8 +302,8 @@ template <class T>
 std::unique_ptr<ProducerBase> testEvent::emplaceProduct(T product,
                                                         std::string const& productInstanceLabel,
                                                         bool doCommit) {
-  auto prod = std::make_unique<ProducerBase>();
-  EDPutTokenT<edmtest::IntProduct> token = prod->produces<edmtest::IntProduct>(productInstanceLabel);
+  auto prod = std::make_unique<TestProducer<edmtest::IntProduct>>(productInstanceLabel);
+  EDPutTokenT<edmtest::IntProduct> token = prod->token_;
   auto index = principal_->productLookup().index(PRODUCT_TYPE,
                                                  edm::TypeID(typeid(T)),
                                                  currentModuleDescription_->moduleLabel().c_str(),

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -19,6 +19,7 @@ Test of the EventPrincipal class.
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -57,6 +58,13 @@ private:
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testEventGetRefBeforePut);
+
+namespace {
+  class TestProducer : public edm::ProducerBase {
+  public:
+    TestProducer(std::string const& productInstanceName) { produces<edmtest::IntProduct>(productInstanceName); }
+  };
+}  // namespace
 
 void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   auto preg = std::make_unique<edm::ProductRegistry>();
@@ -182,8 +190,7 @@ void testEventGetRefBeforePut::getRefTest() {
     edm::ModuleDescription modDesc("Blah", label, pcPtr.get());
 
     edm::Event event(ep, modDesc, nullptr);
-    edm::ProducerBase prod;
-    prod.produces<edmtest::IntProduct>(productInstanceName);
+    TestProducer prod(productInstanceName);
     const_cast<std::vector<edm::ProductResolverIndex>&>(prod.putTokenIndexToProductResolverIndex()).push_back(0);
     event.setProducer(&prod, nullptr);
     auto pr = std::make_unique<edmtest::IntProduct>();

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -161,7 +161,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,WaitingThreadIntProducer.cc, ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc,PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <lib   name="FWCoreIntegrationWaitingServer"/>
     <use   name="FWCore/Framework"/>

--- a/FWCore/Integration/test/ProducerUsingCollector.cc
+++ b/FWCore/Integration/test/ProducerUsingCollector.cc
@@ -1,0 +1,144 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      ProducerUsingCollector
+//
+/**\class edmtest::ProducerUsingCollector
+
+  Description: Used in tests of the ProducesCollector. It uses all
+the different functions in ProducesCollector for no reason other
+than to test them all.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  26 September 2019
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+namespace edmtest {
+
+  class ProducerHelperUsingCollector {
+  public:
+    ProducerHelperUsingCollector(edm::ProducesCollector&&);
+    void putEventProducts(edm::Event&) const;
+    void putBeginRunProducts(edm::Run&) const;
+    void putEndRunProducts(edm::Run&) const;
+    void putBeginLumiProducts(edm::LuminosityBlock&) const;
+    void putEndLumiProducts(edm::LuminosityBlock&) const;
+
+  private:
+    edm::EDPutTokenT<IntProduct> eventToken_;
+    edm::EDPutTokenT<IntProduct> eventWithInstanceToken_;
+    edm::EDPutTokenT<UInt64Product> eventWithTransitionToken_;
+    edm::EDPutToken eventUsingTypeIDToken_;
+    edm::EDPutTokenT<IntProduct> brToken_;
+    edm::EDPutTokenT<IntProduct> erToken_;
+    edm::EDPutToken blToken_;
+    edm::EDPutToken elToken_;
+  };
+
+  ProducerHelperUsingCollector::ProducerHelperUsingCollector(edm::ProducesCollector&& producesCollector)
+      : eventToken_(producesCollector.produces<IntProduct>()),
+        eventWithInstanceToken_(producesCollector.produces<IntProduct>("event")),
+        eventWithTransitionToken_(producesCollector.produces<UInt64Product, edm::Transition::Event>()),
+        eventUsingTypeIDToken_(producesCollector.produces(edm::TypeID(typeid(IntProduct)), "eventOther")),
+        brToken_(producesCollector.produces<IntProduct, edm::Transition::BeginRun>("beginRun")),
+        blToken_(producesCollector.produces<edm::Transition::BeginLuminosityBlock>(edm::TypeID(typeid(IntProduct)),
+                                                                                   "beginLumi")) {
+    edm::ProducesCollector copy(producesCollector);
+    erToken_ = copy.produces<IntProduct, edm::Transition::EndRun>("endRun");
+
+    copy = producesCollector;
+    edm::ProducesCollector copy2(producesCollector);
+    copy2 = std::move(copy);
+    elToken_ = copy.produces<edm::Transition::EndLuminosityBlock>(edm::TypeID(typeid(IntProduct)), "endLumi");
+  }
+
+  void ProducerHelperUsingCollector::putEventProducts(edm::Event& event) const {
+    event.emplace(eventToken_, 1);
+    event.emplace(eventWithInstanceToken_, 2);
+    event.emplace(eventWithTransitionToken_, 3);
+    event.put(eventUsingTypeIDToken_, std::make_unique<IntProduct>(4));
+  }
+
+  void ProducerHelperUsingCollector::putBeginRunProducts(edm::Run& run) const { run.emplace(brToken_, 5); }
+
+  void ProducerHelperUsingCollector::putEndRunProducts(edm::Run& run) const { run.emplace(erToken_, 6); }
+
+  void ProducerHelperUsingCollector::putBeginLumiProducts(edm::LuminosityBlock& luminosityBlock) const {
+    luminosityBlock.put(blToken_, std::make_unique<IntProduct>(7));
+  }
+
+  void ProducerHelperUsingCollector::putEndLumiProducts(edm::LuminosityBlock& luminosityBlock) const {
+    luminosityBlock.put(elToken_, std::make_unique<IntProduct>(8));
+  }
+
+  class ProducerUsingCollector : public edm::global::EDProducer<edm::BeginRunProducer,
+                                                                edm::EndRunProducer,
+                                                                edm::EndLuminosityBlockProducer,
+                                                                edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit ProducerUsingCollector(edm::ParameterSet const&);
+
+    ~ProducerUsingCollector() override;
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override;
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override;
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override;
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    ProducerHelperUsingCollector helper_;
+  };
+
+  ProducerUsingCollector::ProducerUsingCollector(edm::ParameterSet const&) : helper_(producesCollector()) {}
+
+  ProducerUsingCollector::~ProducerUsingCollector() {}
+
+  void ProducerUsingCollector::produce(edm::StreamID, edm::Event& event, edm::EventSetup const&) const {
+    helper_.putEventProducts(event);
+  }
+
+  void ProducerUsingCollector::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& lb,
+                                                                 edm::EventSetup const&) const {
+    helper_.putBeginLumiProducts(lb);
+  }
+
+  void ProducerUsingCollector::globalEndLuminosityBlockProduce(edm::LuminosityBlock& lb, edm::EventSetup const&) const {
+    helper_.putEndLumiProducts(lb);
+  }
+
+  void ProducerUsingCollector::globalBeginRunProduce(edm::Run& run, edm::EventSetup const&) const {
+    helper_.putBeginRunProducts(run);
+  }
+
+  void ProducerUsingCollector::globalEndRunProduce(edm::Run& run, edm::EventSetup const&) const {
+    helper_.putEndRunProducts(run);
+  }
+
+  void ProducerUsingCollector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+using edmtest::ProducerUsingCollector;
+DEFINE_FWK_MODULE(ProducerUsingCollector);

--- a/FWCore/Integration/test/TestFindProduct.cc
+++ b/FWCore/Integration/test/TestFindProduct.cc
@@ -14,11 +14,14 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/getProducerParameterSet.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -26,13 +29,17 @@
 #include <vector>
 
 namespace edmtest {
-  class TestFindProduct : public edm::EDAnalyzer {
+  class TestFindProduct : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
   public:
     explicit TestFindProduct(edm::ParameterSet const& pset);
     virtual ~TestFindProduct();
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& es);
-    virtual void endJob();
+    void analyze(edm::Event const& e, edm::EventSetup const& es) override;
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+    void endRun(edm::Run const&, edm::EventSetup const&) override;
+    void endJob();
 
   private:
     std::vector<edm::InputTag> inputTags_;
@@ -42,10 +49,16 @@ namespace edmtest {
     bool getByTokenFirst_;
     std::vector<edm::InputTag> inputTagsView_;
     bool runProducerParameterCheck_;
+    std::vector<edm::InputTag> inputTagsUInt64_;
+    std::vector<edm::InputTag> inputTagsEndLumi_;
+    std::vector<edm::InputTag> inputTagsEndRun_;
 
-    std::vector<edm::EDGetTokenT<IntProduct> > tokens_;
-    std::vector<edm::EDGetTokenT<IntProduct> > tokensNotFound_;
-    std::vector<edm::EDGetTokenT<edm::View<int> > > tokensView_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokens_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensNotFound_;
+    std::vector<edm::EDGetTokenT<edm::View<int>>> tokensView_;
+    std::vector<edm::EDGetTokenT<UInt64Product>> tokensUInt64_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensEndLumi_;
+    std::vector<edm::EDGetTokenT<IntProduct>> tokensEndRun_;
   };  // class TestFindProduct
 
   //--------------------------------------------------------------------
@@ -53,7 +66,7 @@ namespace edmtest {
   // Implementation details
 
   TestFindProduct::TestFindProduct(edm::ParameterSet const& pset)
-      : inputTags_(pset.getUntrackedParameter<std::vector<edm::InputTag> >("inputTags")),
+      : inputTags_(pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTags")),
         expectedSum_(pset.getUntrackedParameter<int>("expectedSum", 0)),
         sum_(0),
         inputTagsNotFound_(),
@@ -61,8 +74,11 @@ namespace edmtest {
         inputTagsView_(),
         runProducerParameterCheck_(pset.getUntrackedParameter<bool>("runProducerParameterCheck", false)) {
     std::vector<edm::InputTag> emptyTagVector;
-    inputTagsNotFound_ = pset.getUntrackedParameter<std::vector<edm::InputTag> >("inputTagsNotFound", emptyTagVector);
-    inputTagsView_ = pset.getUntrackedParameter<std::vector<edm::InputTag> >("inputTagsView", emptyTagVector);
+    inputTagsNotFound_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsNotFound", emptyTagVector);
+    inputTagsView_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsView", emptyTagVector);
+    inputTagsUInt64_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsUInt64", emptyTagVector);
+    inputTagsEndLumi_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndLumi", emptyTagVector);
+    inputTagsEndRun_ = pset.getUntrackedParameter<std::vector<edm::InputTag>>("inputTagsEndRun", emptyTagVector);
 
     for (auto const& tag : inputTags_) {
       tokens_.push_back(consumes<IntProduct>(tag));
@@ -71,7 +87,16 @@ namespace edmtest {
       tokensNotFound_.push_back(consumes<IntProduct>(tag));
     }
     for (auto const& tag : inputTagsView_) {
-      tokensView_.push_back(consumes<edm::View<int> >(tag));
+      tokensView_.push_back(consumes<edm::View<int>>(tag));
+    }
+    for (auto const& tag : inputTagsUInt64_) {
+      tokensUInt64_.push_back(consumes<UInt64Product>(tag));
+    }
+    for (auto const& tag : inputTagsEndLumi_) {
+      tokensEndLumi_.push_back(consumes<IntProduct, edm::InLumi>(tag));
+    }
+    for (auto const& tag : inputTagsEndRun_) {
+      tokensEndRun_.push_back(consumes<IntProduct, edm::InRun>(tag));
     }
   }
 
@@ -80,10 +105,10 @@ namespace edmtest {
   void TestFindProduct::analyze(edm::Event const& e, edm::EventSetup const&) {
     edm::Handle<IntProduct> h;
     edm::Handle<IntProduct> hToken;
-    edm::Handle<edm::View<int> > hView;
-    edm::Handle<edm::View<int> > hViewToken;
+    edm::Handle<edm::View<int>> hView;
+    edm::Handle<edm::View<int>> hViewToken;
 
-    std::vector<edm::EDGetTokenT<IntProduct> >::const_iterator iToken = tokens_.begin();
+    std::vector<edm::EDGetTokenT<IntProduct>>::const_iterator iToken = tokens_.begin();
     for (std::vector<edm::InputTag>::const_iterator iter = inputTags_.begin(), iEnd = inputTags_.end(); iter != iEnd;
          ++iter, ++iToken) {
       if (getByTokenFirst_) {
@@ -137,7 +162,7 @@ namespace edmtest {
         abort();
       }
     }
-    std::vector<edm::EDGetTokenT<edm::View<int> > >::const_iterator iTokenView = tokensView_.begin();
+    std::vector<edm::EDGetTokenT<edm::View<int>>>::const_iterator iTokenView = tokensView_.begin();
     for (std::vector<edm::InputTag>::const_iterator iter = inputTagsView_.begin(), iEnd = inputTagsView_.end();
          iter != iEnd;
          ++iter, ++iTokenView) {
@@ -154,6 +179,35 @@ namespace edmtest {
         std::cerr << "TestFindProduct::analyze getByLabel and getByToken return inconsistent results " << std::endl;
         abort();
       }
+    }
+
+    // Get these also and add them into the sum
+    edm::Handle<UInt64Product> h64;
+    for (auto const& token : tokensUInt64_) {
+      e.getByToken(token, h64);
+      sum_ += h64->value;
+    }
+  }
+
+  void TestFindProduct::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
+
+  void TestFindProduct::endLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const&) {
+    // Get these also and add them into the sum
+    edm::Handle<IntProduct> h;
+    for (auto const& token : tokensEndLumi_) {
+      lb.getByToken(token, h);
+      sum_ += h->value;
+    }
+  }
+
+  void TestFindProduct::beginRun(edm::Run const&, edm::EventSetup const&) {}
+
+  void TestFindProduct::endRun(edm::Run const& run, edm::EventSetup const&) {
+    // Get these also and add them into the sum
+    edm::Handle<IntProduct> h;
+    for (auto const& token : tokensEndRun_) {
+      run.getByToken(token, h);
+      sum_ += h->value;
     }
   }
 

--- a/FWCore/Integration/test/TestFindProduct.cc
+++ b/FWCore/Integration/test/TestFindProduct.cc
@@ -39,7 +39,7 @@ namespace edmtest {
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void endRun(edm::Run const&, edm::EventSetup const&) override;
-    void endJob();
+    void endJob() override;
 
   private:
     std::vector<edm::InputTag> inputTags_;

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -39,6 +39,9 @@ pushd ${LOCAL_TMP_DIR}
   echo "testGetByPlaceholder"
   cmsRun -p ${LOCAL_TEST_DIR}/${test}Placeholder_cfg.py || die "cmsRun ${test}Placeholder_cfg.py" $?
 
+  echo "testProducesCollector"
+  cmsRun -p ${LOCAL_TEST_DIR}/testProducesCollector_cfg.py || die "cmsRun testProducesCollector_cfg.py" $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/testProducesCollector_cfg.py
+++ b/FWCore/Integration/test/testProducesCollector_cfg.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.producerUsingCollector = cms.EDProducer("ProducerUsingCollector")
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testProducesCollector.root')
+)
+
+process.test = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(cms.InputTag("producerUsingCollector"),
+                                      cms.InputTag("producerUsingCollector", "event"),
+                                      cms.InputTag("producerUsingCollector", "eventOther")),
+  inputTagsUInt64 = cms.untracked.VInputTag(cms.InputTag("producerUsingCollector")),
+  inputTagsEndLumi = cms.untracked.VInputTag(cms.InputTag("producerUsingCollector", "beginLumi"),
+                                             cms.InputTag("producerUsingCollector", "endLumi")),
+  inputTagsEndRun = cms.untracked.VInputTag(cms.InputTag("producerUsingCollector", "beginRun"),
+                                            cms.InputTag("producerUsingCollector", "endRun")),
+  expectedSum = cms.untracked.int32(56)
+)
+
+process.p = cms.Path(process.producerUsingCollector * process.test)
+
+process.e = cms.EndPath(process.out)

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/InteractionModel.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/InteractionModel.h
@@ -1,6 +1,8 @@
 #ifndef FASTSIM_INTERACTIONMODEL
 #define FASTSIM_INTERACTIONMODEL
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
+
 #include <string>
 #include <vector>
 #include <memory>
@@ -12,7 +14,6 @@
 
 namespace edm {
   class Event;
-  class ProducerBase;
 }  // namespace edm
 
 class RandomEngineAndDistribution;
@@ -49,7 +50,7 @@ namespace fastsim {
                           const RandomEngineAndDistribution& random) = 0;
 
     //! In case interaction produces and stores content in the event (e.g. TrackerSimHits).
-    virtual void registerProducts(edm::ProducerBase& producer) const { ; }
+    virtual void registerProducts(edm::ProducesCollector) const {}
 
     //! In case interaction produces and stores content in the event (e.g. TrackerSimHits).
     virtual void storeProducts(edm::Event& iEvent) { ; }

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -147,7 +147,7 @@ FastSimProducer::FastSimProducer(const edm::ParameterSet& iConfig)
   produces<edm::SimVertexContainer>();
   // products of interaction models, i.e. simHits
   for (auto& interactionModel : interactionModels_) {
-    interactionModel->registerProducts(*this);
+    interactionModel->registerProducts(producesCollector());
   }
   produces<edm::PCaloHitContainer>("EcalHitsEB");
   produces<edm::PCaloHitContainer>("EcalHitsEE");

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/TrackerSimHitProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/TrackerSimHitProducer.cc
@@ -3,6 +3,7 @@
 
 // framework
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "MagneticField/UniformEngine/interface/UniformMagneticField.h"
 
@@ -33,7 +34,6 @@
 // other
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "CondFormats/External/interface/DetID.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 
 ///////////////////////////////////////////////
 // Author: L. Vanelderen, S. Kurz
@@ -70,7 +70,7 @@ namespace fastsim {
                   const RandomEngineAndDistribution& random) override;
 
     //! Register the SimHit collection.
-    void registerProducts(edm::ProducerBase& producer) const override;
+    void registerProducts(edm::ProducesCollector) const override;
 
     //! Store the SimHit collection.
     void storeProducts(edm::Event& iEvent) override;
@@ -113,8 +113,8 @@ fastsim::TrackerSimHitProducer::TrackerSimHitProducer(const std::string& name, c
   doHitsFromInboundParticles_ = cfg.getParameter<bool>("doHitsFromInboundParticles");
 }
 
-void fastsim::TrackerSimHitProducer::registerProducts(edm::ProducerBase& producer) const {
-  producer.produces<edm::PSimHitContainer>("TrackerHits");
+void fastsim::TrackerSimHitProducer::registerProducts(edm::ProducesCollector producesCollector) const {
+  producesCollector.produces<edm::PSimHitContainer>("TrackerHits");
 }
 
 void fastsim::TrackerSimHitProducer::storeProducts(edm::Event& iEvent) {

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -1,19 +1,18 @@
 #include "FastSimulation/Tracking/plugins/RecoTrackAccumulator.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
 RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf,
-                                           edm::ProducerBase& mixMod,
+                                           edm::ProducesCollector producesCollector,
                                            edm::ConsumesCollector& iC)
     : signalTracksTag(conf.getParameter<edm::InputTag>("signalTracks")),
       pileUpTracksTag(conf.getParameter<edm::InputTag>("pileUpTracks")),
       outputLabel(conf.getParameter<std::string>("outputLabel")) {
-  mixMod.produces<reco::TrackCollection>(outputLabel);
-  mixMod.produces<TrackingRecHitCollection>(outputLabel);
-  mixMod.produces<reco::TrackExtraCollection>(outputLabel);
+  producesCollector.produces<reco::TrackCollection>(outputLabel);
+  producesCollector.produces<TrackingRecHitCollection>(outputLabel);
+  producesCollector.produces<reco::TrackExtraCollection>(outputLabel);
 
   iC.consumes<reco::TrackCollection>(signalTracksTag);
   iC.consumes<TrackingRecHitCollection>(signalTracksTag);

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -16,6 +16,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -26,13 +27,12 @@ namespace edm {
   class ConsumesCollector;
   template <typename T>
   class Handle;
-  class ProducerBase;
   class StreamID;
 }  // namespace edm
 
 class RecoTrackAccumulator : public DigiAccumulatorMixMod {
 public:
-  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::ProducesCollector, edm::ConsumesCollector& iC);
   ~RecoTrackAccumulator() override;
 
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/HLTrigger/Muon/plugins/HLTMuonTrackSelector.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrackSelector.cc
@@ -16,7 +16,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 HLTMuonTrackSelector::HLTMuonTrackSelector(const edm::ParameterSet& iConfig)
-    : collectionCloner(*this, iConfig, true),
+    : collectionCloner(producesCollector(), iConfig, true),
       collectionClonerTokens(iConfig.getParameter<edm::InputTag>("track"), consumesCollector()),
       token_muon(consumes<vector<reco::Muon> >(iConfig.getParameter<edm::InputTag>("muon"))),
       token_originalMVAVals(consumes<MVACollection>(iConfig.getParameter<edm::InputTag>("originalMVAVals"))),

--- a/PhysicsTools/UtilAlgos/interface/CompleteNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/CompleteNTupler.h
@@ -1,3 +1,4 @@
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "PhysicsTools/UtilAlgos/interface/NTupler.h"
 
 #include "PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h"
@@ -25,13 +26,13 @@ public:
     */
   }
 
-  uint registerleaves(edm::ProducerBase* producer) override {
+  uint registerleaves(edm::ProducesCollector producesCollector) override {
     uint nLeaves = 0;
-    nLeaves += sN->registerleaves(producer);
+    nLeaves += sN->registerleaves(producesCollector);
     if (vN)
-      nLeaves += vN->registerleaves(producer);
+      nLeaves += vN->registerleaves(producesCollector);
     //    if (aN)
-    //      nLeaves+=aN->registerleaves(producer);
+    //      nLeaves+=aN->registerleaves(producesCollector);
     return nLeaves;
   }
   void fill(edm::Event& iEvent) override {

--- a/PhysicsTools/UtilAlgos/interface/NTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/NTupler.h
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "TTree.h"
@@ -22,7 +22,7 @@ public:
   NTupler() : useTFileService_(false) {}
   virtual ~NTupler() {}
 
-  virtual unsigned int registerleaves(edm::ProducerBase* producer) = 0;
+  virtual unsigned int registerleaves(edm::ProducesCollector) = 0;
   virtual void fill(edm::Event& iEvent) = 0;
 
 protected:

--- a/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
@@ -7,7 +7,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EDFilter.h"
-#include <FWCore/Framework/interface/ProducerBase.h>
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 //#include "PhysicsTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
@@ -285,7 +285,7 @@ public:
     }
   }
 
-  uint registerleaves(edm::ProducerBase* producer) override {
+  uint registerleaves(edm::ProducesCollector producesCollector) override {
     uint nLeaves = 0;
 
     if (useTFileService_) {
@@ -346,13 +346,13 @@ public:
       for (; iB != iB_end; ++iB) {
         //the index. should produce it only once
         // a simple uint for the index
-        producer->produces<uint>(iB->first).setBranchAlias(iB->first);
+        producesCollector.produces<uint>(iB->first).setBranchAlias(iB->first);
         std::vector<TreeBranch>::iterator iL = iB->second.begin();
         std::vector<TreeBranch>::iterator iL_end = iB->second.end();
         for (; iL != iL_end; ++iL) {
           TreeBranch& b = *iL;
           //a vector of float for each leave
-          producer->produces<std::vector<float> >(b.branchName()).setBranchAlias(b.branchAlias());
+          producesCollector.produces<std::vector<float> >(b.branchName()).setBranchAlias(b.branchAlias());
           nLeaves++;
         }
       }

--- a/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
@@ -8,7 +8,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EDFilter.h"
-#include <FWCore/Framework/interface/ProducerBase.h>
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 //#include "PhysicsTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
@@ -50,7 +50,7 @@ public:
     }
   }
 
-  uint registerleaves(edm::ProducerBase* producer) override {
+  uint registerleaves(edm::ProducesCollector producesCollector) override {
     uint nLeaves = 0;
     if (useTFileService_) {
       //loop the leaves registered
@@ -89,7 +89,7 @@ public:
         nLeaves++;
         std::string lName(i->first);
         std::replace(lName.begin(), lName.end(), '_', '0');
-        producer->produces<double>(lName).setBranchAlias(i->first);
+        producesCollector.produces<double>(lName).setBranchAlias(i->first);
       }
     }
     return nLeaves;

--- a/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
+++ b/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
@@ -108,7 +108,7 @@ ConfigurableAnalysis::ConfigurableAnalysis(const edm::ParameterSet& iConfig) {
 
   //ntupler needs to register its products
   if (ntupler_)
-    ntupler_->registerleaves(this);
+    ntupler_->registerleaves(producesCollector());
 }
 
 //

--- a/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
+++ b/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
@@ -66,7 +66,7 @@ NTuplingDevice::NTuplingDevice(const edm::ParameterSet& iConfig) {
   ntupler_ = NTuplerFactory::get()->create(ntuplerName, ntPset);
 
   //register the leaves from the ntupler
-  ntupler_->registerleaves(this);
+  ntupler_->registerleaves(producesCollector());
 
   //put a dummy product if the ntupler does not output on edm
   produces<double>("dummy");

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletEDProducerT.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -45,7 +46,7 @@ namespace hitTripletEDProducerT {
     ImplBase() = default;
     virtual ~ImplBase() = default;
 
-    virtual void produces(edm::ProducerBase& producer) const = 0;
+    virtual void produces(edm::ProducesCollector) const = 0;
     virtual void produce(const IntermediateHitDoublets& regionDoublets,
                          edm::Event& iEvent,
                          const edm::EventSetup& iSetup) = 0;
@@ -73,9 +74,9 @@ namespace hitTripletEDProducerT {
         : ImplGeneratorBase<T_HitTripletGenerator>(iConfig, iC) {}
     ~Impl() override = default;
 
-    void produces(edm::ProducerBase& producer) const override {
-      T_SeedingHitSets::produces(producer);
-      T_IntermediateHitTriplets::produces(producer);
+    void produces(edm::ProducesCollector producesCollector) const override {
+      T_SeedingHitSets::produces(producesCollector);
+      T_IntermediateHitTriplets::produces(producesCollector);
     };
 
     void produce(const IntermediateHitDoublets& regionDoublets,
@@ -182,7 +183,7 @@ namespace hitTripletEDProducerT {
     DoNothing() {}
     explicit DoNothing(const SeedingLayerSetsHits* layers) {}
 
-    static void produces(edm::ProducerBase&) {}
+    static void produces(edm::ProducesCollector) {}
 
     void reserve(size_t, size_t) {}
 
@@ -205,7 +206,9 @@ namespace hitTripletEDProducerT {
   public:
     ImplSeedingHitSets() : seedingHitSets_(std::make_unique<RegionsSeedingHitSets>()) {}
 
-    static void produces(edm::ProducerBase& producer) { producer.produces<RegionsSeedingHitSets>(); }
+    static void produces(edm::ProducesCollector producesCollector) {
+      producesCollector.produces<RegionsSeedingHitSets>();
+    }
 
     void reserve(size_t regionsSize, size_t localRAupper) { seedingHitSets_->reserve(regionsSize, localRAupper); }
 
@@ -237,7 +240,9 @@ namespace hitTripletEDProducerT {
     explicit ImplIntermediateHitTriplets(const SeedingLayerSetsHits* layers)
         : intermediateHitTriplets_(std::make_unique<IntermediateHitTriplets>(layers)), layers_(layers) {}
 
-    static void produces(edm::ProducerBase& producer) { producer.produces<IntermediateHitTriplets>(); }
+    static void produces(edm::ProducesCollector producesCollector) {
+      producesCollector.produces<IntermediateHitTriplets>();
+    }
 
     void reserve(size_t regionsSize, size_t localRAupper) {
       intermediateHitTriplets_->reserve(regionsSize, layers_->size(), localRAupper);
@@ -305,7 +310,7 @@ HitTripletEDProducerT<T_HitTripletGenerator>::HitTripletEDProducerT(const edm::P
         << "HitTripletEDProducerT requires either produceIntermediateHitTriplets or produceSeedingHitSets to be True. "
            "If neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
 
-  impl_->produces(*this);
+  impl_->produces(producesCollector());
 }
 
 template <typename T_HitTripletGenerator>

--- a/RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackCollectionCloner.h
@@ -14,6 +14,7 @@
 #include <utility>
 #include <memory>
 #include <algorithm>
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -30,19 +31,18 @@ public:
 
   using Tokens = TrackCollectionTokens;
 
-  template <typename Producer>
-  TrackCollectionCloner(Producer& producer, const edm::ParameterSet& cfg, bool copyDefault)
+  TrackCollectionCloner(edm::ProducesCollector producesCollector, const edm::ParameterSet& cfg, bool copyDefault)
       : copyExtras_(cfg.template getUntrackedParameter<bool>("copyExtras", copyDefault)),
         copyTrajectories_(cfg.template getUntrackedParameter<bool>("copyTrajectories", copyDefault)) {
     std::string alias(cfg.getParameter<std::string>("@module_label"));
-    producer.template produces<reco::TrackCollection>().setBranchAlias(alias + "Tracks");
+    producesCollector.produces<reco::TrackCollection>().setBranchAlias(alias + "Tracks");
     if (copyExtras_) {
-      producer.template produces<reco::TrackExtraCollection>().setBranchAlias(alias + "TrackExtras");
-      producer.template produces<TrackingRecHitCollection>().setBranchAlias(alias + "RecHits");
+      producesCollector.produces<reco::TrackExtraCollection>().setBranchAlias(alias + "TrackExtras");
+      producesCollector.produces<TrackingRecHitCollection>().setBranchAlias(alias + "RecHits");
     }
     if (copyTrajectories_) {
-      producer.template produces<std::vector<Trajectory> >().setBranchAlias(alias + "Trajectories");
-      producer.template produces<TrajTrackAssociationCollection>().setBranchAlias(alias +
+      producesCollector.produces<std::vector<Trajectory> >().setBranchAlias(alias + "Trajectories");
+      producesCollector.produces<TrajTrackAssociationCollection>().setBranchAlias(alias +
                                                                                   "TrajectoryTrackAssociations");
     }
   }

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -101,7 +101,7 @@ namespace {
   }
 
   DuplicateListMerger::DuplicateListMerger(const edm::ParameterSet& iPara)
-      : collectionCloner(*this, iPara, true),
+      : collectionCloner(producesCollector(), iPara, true),
         mergedTrackSource_(iPara.getParameter<edm::InputTag>("mergedSource"), consumesCollector()),
         originalTrackSource_(iPara.getParameter<edm::InputTag>("originalSource"), consumesCollector()),
         priorityName_(iPara.getParameter<std::string>("trackAlgoPriorityOrder")) {

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -77,7 +77,7 @@ namespace {
   }
 
   TrackCollectionFilterCloner::TrackCollectionFilterCloner(const edm::ParameterSet& iConfig)
-      : collectionCloner(*this, iConfig, true),
+      : collectionCloner(producesCollector(), iConfig, true),
         originalTrackSource_(iConfig.getParameter<edm::InputTag>("originalSource"), consumesCollector()),
         originalMVAValsToken_(consumes<MVACollection>(iConfig.getParameter<edm::InputTag>("originalMVAVals"))),
         originalQualValsToken_(

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionMerger.cc
@@ -28,7 +28,7 @@ namespace {
   class TrackCollectionMerger final : public edm::global::EDProducer<> {
   public:
     explicit TrackCollectionMerger(const edm::ParameterSet& conf)
-        : collectionCloner(*this, conf, true),
+        : collectionCloner(producesCollector(), conf, true),
           priorityName_(conf.getParameter<std::string>("trackAlgoPriorityOrder")),
           m_foundHitBonus(conf.getParameter<double>("foundHitBonus")),
           m_lostHitPenalty(conf.getParameter<double>("lostHitPenalty")),

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -20,7 +20,7 @@
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
 CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet &ps,
-                                       edm::ProducerBase &mixMod,
+                                       edm::ProducesCollector producesCollector,
                                        edm::ConsumesCollector &iC)
     : theParameterMap(new CastorSimParameterMap(ps)),
       theCastorShape(new CastorShape()),
@@ -35,7 +35,7 @@ CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet &ps,
   theHitsProducerTag = ps.getParameter<edm::InputTag>("hitsProducer");
   iC.consumes<std::vector<PCaloHit>>(theHitsProducerTag);
 
-  mixMod.produces<CastorDigiCollection>();
+  producesCollector.produces<CastorDigiCollection>();
 
   theCastorResponse->setHitFilter(&theCastorHitFilter);
 

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
@@ -34,7 +34,7 @@ class PileUpEventPrincipal;
 
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
-  explicit CastorDigiProducer(const edm::ParameterSet &ps, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
+  explicit CastorDigiProducer(const edm::ParameterSet &ps, edm::ProducesCollector, edm::ConsumesCollector &iC);
   ~CastorDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -2,6 +2,7 @@
 #define SimCalorimetry_EcalSimProducers_EcalDigiProducer_h
 
 #include "DataFormats/Math/interface/Error.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/APDShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEShape.h"
@@ -42,7 +43,6 @@ class PileUpEventPrincipal;
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class Event;
   class EventSetup;
   template <typename T>
@@ -57,7 +57,7 @@ namespace CLHEP {
 
 class EcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  EcalDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
+  EcalDigiProducer(const edm::ParameterSet &params, edm::ProducesCollector, edm::ConsumesCollector &iC);
   EcalDigiProducer(const edm::ParameterSet &params, edm::ConsumesCollector &iC);
   ~EcalDigiProducer() override;
 

--- a/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
@@ -5,12 +5,11 @@
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalDigitizerTraits.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-
-#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include <vector>
 
@@ -31,7 +30,7 @@ namespace edm {
 
 class EcalTimeDigiProducer : public DigiAccumulatorMixMod {
 public:
-  EcalTimeDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod, edm::ConsumesCollector &);
+  EcalTimeDigiProducer(const edm::ParameterSet &params, edm::ProducesCollector, edm::ConsumesCollector &);
   ~EcalTimeDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;

--- a/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/PreMixingEcalWorker.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -19,7 +19,7 @@
 
 class PreMixingEcalWorker : public PreMixingWorker {
 public:
-  PreMixingEcalWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer, edm::ConsumesCollector &&iC);
+  PreMixingEcalWorker(const edm::ParameterSet &ps, edm::ProducesCollector, edm::ConsumesCollector &&iC);
   ~PreMixingEcalWorker() override = default;
 
   PreMixingEcalWorker(const PreMixingEcalWorker &) = delete;
@@ -58,7 +58,7 @@ private:
 
 // Constructor
 PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet &ps,
-                                         edm::ProducerBase &producer,
+                                         edm::ProducesCollector producesCollector,
                                          edm::ConsumesCollector &&iC)
     : EBPileInputTag_(ps.getParameter<edm::InputTag>("EBPileInputTag")),
       EEPileInputTag_(ps.getParameter<edm::InputTag>("EEPileInputTag")),
@@ -78,9 +78,9 @@ PreMixingEcalWorker::PreMixingEcalWorker(const edm::ParameterSet &ps,
   EEDigiCollectionDM_ = ps.getParameter<std::string>("EEDigiCollectionDM");
   ESDigiCollectionDM_ = ps.getParameter<std::string>("ESDigiCollectionDM");
 
-  producer.produces<EBDigiCollection>(EBDigiCollectionDM_);
-  producer.produces<EEDigiCollection>(EEDigiCollectionDM_);
-  producer.produces<ESDigiCollection>(ESDigiCollectionDM_);
+  producesCollector.produces<EBDigiCollection>(EBDigiCollectionDM_);
+  producesCollector.produces<EEDigiCollection>(EEDigiCollectionDM_);
+  producesCollector.produces<ESDigiCollection>(ESDigiCollectionDM_);
 
   myEcalDigitizer_.setEBNoiseSignalGenerator(&theEBSignalGenerator);
   myEcalDigitizer_.setEENoiseSignalGenerator(&theEESignalGenerator);

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -29,7 +29,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -54,15 +53,15 @@
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
 EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
-                                   edm::ProducerBase &mixMod,
+                                   edm::ProducesCollector producesCollector,
                                    edm::ConsumesCollector &iC)
     : EcalDigiProducer(params, iC) {
   if (m_apdSeparateDigi)
-    mixMod.produces<EBDigiCollection>(m_apdDigiTag);
+    producesCollector.produces<EBDigiCollection>(m_apdDigiTag);
 
-  mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
-  mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
-  mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
+  producesCollector.produces<EBDigiCollection>(m_EBdigiCollection);
+  producesCollector.produces<EEDigiCollection>(m_EEdigiCollection);
+  producesCollector.produces<ESDigiCollection>(m_ESdigiCollection);
 }
 
 // version for Pre-Mixing, for use outside of MixingModule

--- a/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
@@ -21,7 +21,7 @@
 //#define ecal_time_debug 1
 
 EcalTimeDigiProducer::EcalTimeDigiProducer(const edm::ParameterSet &params,
-                                           edm::ProducerBase &mixMod,
+                                           edm::ProducesCollector producesCollector,
                                            edm::ConsumesCollector &sumes)
     : DigiAccumulatorMixMod(),
       m_EBdigiCollection(params.getParameter<std::string>("EBtimeDigiCollection")),
@@ -33,8 +33,8 @@ EcalTimeDigiProducer::EcalTimeDigiProducer(const edm::ParameterSet &params,
       m_timeLayerEB(params.getParameter<int>("timeLayerBarrel")),
       m_timeLayerEE(params.getParameter<int>("timeLayerEndcap")),
       m_Geometry(nullptr) {
-  mixMod.produces<EcalTimeDigiCollection>(m_EBdigiCollection);
-  mixMod.produces<EcalTimeDigiCollection>(m_EEdigiCollection);
+  producesCollector.produces<EcalTimeDigiCollection>(m_EBdigiCollection);
+  producesCollector.produces<EcalTimeDigiCollection>(m_EEdigiCollection);
 
   m_BarrelDigitizer = new EcalTimeMapDigitizer(EcalBarrel);
   m_EndcapDigitizer = new EcalTimeMapDigitizer(EcalEndcap);

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -1,6 +1,7 @@
 #ifndef SimCalorimetry_EcalTestBeam_EcalTBDigiProducer_h
 #define SimCalorimetry_EcalTestBeam_EcalTBDigiProducer_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "RecoTBCalo/EcalTBTDCReconstructor/interface/EcalTBTDCRecInfoAlgo.h"
 #include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
@@ -9,7 +10,6 @@
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -19,7 +19,7 @@ class PileUpEventPrincipal;
 
 class EcalTBDigiProducer : public EcalDigiProducer {
 public:
-  EcalTBDigiProducer(const edm::ParameterSet &params, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
+  EcalTBDigiProducer(const edm::ParameterSet &params, edm::ProducesCollector, edm::ConsumesCollector &iC);
   ~EcalTBDigiProducer() override;
 
   void initializeEvent(edm::Event const &, edm::EventSetup const &) override;

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -3,7 +3,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
@@ -13,15 +12,15 @@
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
 EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
-                                       edm::ProducerBase &mixMod,
+                                       edm::ProducesCollector producesCollector,
                                        edm::ConsumesCollector &iC)
-    : EcalDigiProducer(params, mixMod, iC) {
+    : EcalDigiProducer(params, producesCollector, iC) {
   std::string const instance("simEcalUnsuppressedDigis");
   m_EBdigiFinalTag = params.getParameter<std::string>("EBdigiFinalCollection");
   m_EBdigiTempTag = params.getParameter<std::string>("EBdigiCollection");
 
-  mixMod.produces<EBDigiCollection>(instance + m_EBdigiFinalTag);  // after selective readout
-  mixMod.produces<EcalTBTDCRawInfo>(instance);
+  producesCollector.produces<EBDigiCollection>(instance + m_EBdigiFinalTag);  // after selective readout
+  producesCollector.produces<EcalTBTDCRawInfo>(instance);
 
   const bool syncPhase(params.getParameter<bool>("syncPhase"));
 

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -8,12 +8,14 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 
 //
-HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
+HGCDigiProducer::HGCDigiProducer(edm::ParameterSet const& pset,
+                                 edm::ProducesCollector producesCollector,
+                                 edm::ConsumesCollector& iC)
     : HGCDigiProducer(pset, iC) {
   if (pset.getParameter<bool>("premixStage1")) {
-    mixMod.produces<PHGCSimAccumulator>(theDigitizer_.digiCollection());
+    producesCollector.produces<PHGCSimAccumulator>(theDigitizer_.digiCollection());
   } else {
-    mixMod.produces<HGCalDigiCollection>(theDigitizer_.digiCollection());
+    producesCollector.produces<HGCalDigiCollection>(theDigitizer_.digiCollection());
   }
 }
 

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
@@ -1,9 +1,9 @@
 #ifndef SimCalorimetry_HGCSimProducers_HGCDigiProducer_h
 #define SimCalorimetry_HGCSimProducers_HGCDigiProducer_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include <vector>
 
@@ -22,7 +22,7 @@ namespace CLHEP {
 
 class HGCDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  HGCDigiProducer(edm::ParameterSet const& pset, edm::ProducesCollector, edm::ConsumesCollector& iC);
   HGCDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC);
 
   void initializeEvent(edm::Event const&, edm::EventSetup const&) override;

--- a/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -18,7 +18,7 @@
 
 class PreMixingHGCalWorker : public PreMixingWorker {
 public:
-  PreMixingHGCalWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingHGCalWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
   ~PreMixingHGCalWorker() override = default;
 
   PreMixingHGCalWorker(const PreMixingHGCalWorker&) = delete;
@@ -40,12 +40,12 @@ private:
 };
 
 PreMixingHGCalWorker::PreMixingHGCalWorker(const edm::ParameterSet& ps,
-                                           edm::ProducerBase& producer,
+                                           edm::ProducesCollector producesCollector,
                                            edm::ConsumesCollector&& iC)
     : signalToken_(iC.consumes<PHGCSimAccumulator>(ps.getParameter<edm::InputTag>("digiTagSig"))),
       pileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
       digitizer_(ps, iC) {
-  producer.produces<HGCalDigiCollection>(digitizer_.digiCollection());
+  producesCollector.produces<HGCalDigiCollection>(digitizer_.digiCollection());
 }
 
 void PreMixingHGCalWorker::beginRun(const edm::Run& run, const edm::EventSetup& ES) { digitizer_.beginRun(ES); }

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h
@@ -1,6 +1,7 @@
 #ifndef SimCalorimetry_HcalSimProducers_HcalDigiProducer_h
 #define SimCalorimetry_HcalSimProducers_HcalDigiProducer_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
@@ -8,7 +9,6 @@
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class ParameterSet;
   class StreamID;
 }  // namespace edm
@@ -19,7 +19,7 @@ namespace CLHEP {
 
 class HcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HcalDigiProducer(edm::ParameterSet const &pset, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
+  HcalDigiProducer(edm::ParameterSet const &pset, edm::ProducesCollector, edm::ConsumesCollector &iC);
 
   HcalDigiProducer(edm::ParameterSet const &pset, edm::ConsumesCollector &iC);
 

--- a/SimCalorimetry/HcalSimProducers/plugins/PreMixingHcalWorker.cc
+++ b/SimCalorimetry/HcalSimProducers/plugins/PreMixingHcalWorker.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -21,7 +21,7 @@
 
 class PreMixingHcalWorker : public PreMixingWorker {
 public:
-  PreMixingHcalWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer, edm::ConsumesCollector &&iC);
+  PreMixingHcalWorker(const edm::ParameterSet &ps, edm::ProducesCollector, edm::ConsumesCollector &&iC);
   ~PreMixingHcalWorker() override = default;
 
   PreMixingHcalWorker(const PreMixingHcalWorker &) = delete;
@@ -68,7 +68,7 @@ private:
 
 // Constructor
 PreMixingHcalWorker::PreMixingHcalWorker(const edm::ParameterSet &ps,
-                                         edm::ProducerBase &producer,
+                                         edm::ProducesCollector producesCollector,
                                          edm::ConsumesCollector &&iC)
     : HBHEPileInputTag_(ps.getParameter<edm::InputTag>("HBHEPileInputTag")),
       HOPileInputTag_(ps.getParameter<edm::InputTag>("HOPileInputTag")),
@@ -101,13 +101,13 @@ PreMixingHcalWorker::PreMixingHcalWorker(const edm::ParameterSet &ps,
   QIE10DigiCollectionDM_ = ps.getParameter<std::string>("QIE10DigiCollectionDM");
   QIE11DigiCollectionDM_ = ps.getParameter<std::string>("QIE11DigiCollectionDM");
 
-  producer.produces<HBHEDigiCollection>();
-  producer.produces<HODigiCollection>();
-  producer.produces<HFDigiCollection>();
-  producer.produces<ZDCDigiCollection>();
+  producesCollector.produces<HBHEDigiCollection>();
+  producesCollector.produces<HODigiCollection>();
+  producesCollector.produces<HFDigiCollection>();
+  producesCollector.produces<ZDCDigiCollection>();
 
-  producer.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
-  producer.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
+  producesCollector.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
+  producesCollector.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
 
   // initialize HcalDigitizer here...
   myHcalDigitizer_.setHBHENoiseSignalGenerator(&theHBHESignalGenerator);

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigiProducer.cc
@@ -1,23 +1,24 @@
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigiProducer.h"
 
-HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const &pset, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC)
+HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const &pset,
+                                   edm::ProducesCollector producesCollector,
+                                   edm::ConsumesCollector &iC)
     : DigiAccumulatorMixMod(), theDigitizer_(pset, iC) {
-  mixMod.produces<HBHEDigiCollection>();
-  mixMod.produces<HODigiCollection>();
-  mixMod.produces<HFDigiCollection>();
-  mixMod.produces<ZDCDigiCollection>();
-  mixMod.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
-  mixMod.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
+  producesCollector.produces<HBHEDigiCollection>();
+  producesCollector.produces<HODigiCollection>();
+  producesCollector.produces<HFDigiCollection>();
+  producesCollector.produces<ZDCDigiCollection>();
+  producesCollector.produces<QIE10DigiCollection>("HFQIE10DigiCollection");
+  producesCollector.produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
   if (pset.getParameter<bool>("debugCaloSamples")) {
-    mixMod.produces<CaloSamplesCollection>("HcalSamples");
+    producesCollector.produces<CaloSamplesCollection>("HcalSamples");
   }
   if (pset.getParameter<bool>("injectTestHits")) {
-    mixMod.produces<edm::PCaloHitContainer>("HcalHits");
+    producesCollector.produces<edm::PCaloHitContainer>("HcalHits");
   }
 }
 

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
@@ -34,7 +34,7 @@ namespace CLHEP {
 
 class HcalTBDigiProducer : public DigiAccumulatorMixMod {
 public:
-  explicit HcalTBDigiProducer(const edm::ParameterSet &ps, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
+  explicit HcalTBDigiProducer(const edm::ParameterSet &ps, edm::ProducesCollector, edm::ConsumesCollector &iC);
   ~HcalTBDigiProducer() override;
 
   void initializeEvent(edm::Event const &e, edm::EventSetup const &c) override;

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -20,7 +20,7 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
 
 HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
-                                       edm::ProducerBase &mixMod,
+                                       edm::ProducesCollector producesCollector,
                                        edm::ConsumesCollector &iC)
     : theParameterMap(new HcalTBSimParameterMap(ps)),
       theHcalShape(new HcalShape()),
@@ -37,8 +37,8 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
       theHOHits(),
       thisPhaseShift(0) {
   std::string const instance("simHcalDigis");
-  mixMod.produces<HBHEDigiCollection>(instance);
-  mixMod.produces<HODigiCollection>(instance);
+  producesCollector.produces<HBHEDigiCollection>(instance);
+  producesCollector.produces<HODigiCollection>(instance);
   iC.consumes<std::vector<PCaloHit>>(edm::InputTag("g4SimHits", "HcalHits"));
 
   DetId detId(DetId::Hcal, 1);

--- a/SimFastTiming/FastTimingCommon/interface/FTLDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/FTLDigitizer.h
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -48,8 +49,8 @@ namespace ftl_digitizer {
   template <class SensorPhysics, class ElectronicsSim>
   class FTLDigitizer : public FTLDigitizerBase {
   public:
-    FTLDigitizer(const edm::ParameterSet& config, edm::ConsumesCollector& iC, edm::ProducerBase& parent)
-        : FTLDigitizerBase(config, iC, parent),
+    FTLDigitizer(const edm::ParameterSet& config, edm::ProducesCollector producesCollector, edm::ConsumesCollector& iC)
+        : FTLDigitizerBase(config, producesCollector, iC),
           deviceSim_(config.getParameterSet("DeviceSimulation")),
           electronicsSim_(config.getParameterSet("ElectronicsSimulation")),
           maxSimHitsAccTime_(config.getParameter<uint32_t>("maxSimHitsAccTime")),

--- a/SimFastTiming/FastTimingCommon/interface/FTLDigitizerBase.h
+++ b/SimFastTiming/FastTimingCommon/interface/FTLDigitizerBase.h
@@ -1,10 +1,10 @@
 #ifndef FastTimingSimProducers_FastTimingCommon_FTLDigitizerBase_h
 #define FastTimingSimProducers_FastTimingCommon_FTLDigitizerBase_h
 
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
@@ -29,7 +29,9 @@ class PileUpEventPrincipal;
 
 class FTLDigitizerBase {
 public:
-  FTLDigitizerBase(const edm::ParameterSet& config, edm::ConsumesCollector& iC, edm::ProducerBase& parent)
+  FTLDigitizerBase(const edm::ParameterSet& config,
+                   edm::ProducesCollector producesCollector,
+                   edm::ConsumesCollector& iC)
       : inputSimHits_(config.getParameter<edm::InputTag>("inputSimHits")),
         digiCollection_(config.getParameter<std::string>("digiCollectionTag")),
         mySubDet_(FastTime),
@@ -37,7 +39,7 @@ public:
         refSpeed_(0.1 * CLHEP::c_light),
         name_(config.getParameter<std::string>("digitizerName")) {
     iC.consumes<std::vector<PSimHit> >(inputSimHits_);
-    parent.produces<FTLDigiCollection>(digiCollection_);
+    producesCollector.produces<FTLDigiCollection>(digiCollection_);
   }
 
   virtual ~FTLDigitizerBase() {}
@@ -85,7 +87,7 @@ private:
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory<FTLDigitizerBase*(
-    const edm::ParameterSet&, edm::ConsumesCollector&, edm::ProducerBase&)>
+    const edm::ParameterSet&, edm::ProducesCollector, edm::ConsumesCollector&)>
     FTLDigitizerFactory;
 
 #endif

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -11,6 +11,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
@@ -129,8 +130,8 @@ namespace mtd_digitizer {
     typedef typename Traits::ElectronicsSim ElectronicsSim;
     typedef typename Traits::DigiCollection DigiCollection;
 
-    MTDDigitizer(const edm::ParameterSet& config, edm::ConsumesCollector& iC, edm::ProducerBase& parent)
-        : MTDDigitizerBase(config, iC, parent),
+    MTDDigitizer(const edm::ParameterSet& config, edm::ProducesCollector producesCollector, edm::ConsumesCollector& iC)
+        : MTDDigitizerBase(config, producesCollector, iC),
           geom_(nullptr),
           deviceSim_(config.getParameterSet("DeviceSimulation")),
           electronicsSim_(config.getParameterSet("ElectronicsSimulation")),

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerBase.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerBase.h
@@ -1,10 +1,10 @@
 #ifndef FastTimingSimProducers_FastTimingCommon_MTDDigitizerBase_h
 #define FastTimingSimProducers_FastTimingCommon_MTDDigitizerBase_h
 
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
@@ -30,7 +30,9 @@ class PileUpEventPrincipal;
 
 class MTDDigitizerBase {
 public:
-  MTDDigitizerBase(const edm::ParameterSet& config, edm::ConsumesCollector& iC, edm::ProducerBase& parent)
+  MTDDigitizerBase(const edm::ParameterSet& config,
+                   edm::ProducesCollector producesCollector,
+                   edm::ConsumesCollector& iC)
       : inputSimHits_(config.getParameter<edm::InputTag>("inputSimHits")),
         digiCollection_(config.getParameter<std::string>("digiCollectionTag")),
         verbosity_(config.getUntrackedParameter<uint32_t>("verbosity", 0)),
@@ -43,15 +45,15 @@ public:
 
     if (name_ == "BTLTileDigitizer" || name_ == "BTLBarDigitizer") {
       if (premixStage1_) {
-        parent.produces<PMTDSimAccumulator>(digiCollection_);
+        producesCollector.produces<PMTDSimAccumulator>(digiCollection_);
       } else {
-        parent.produces<BTLDigiCollection>(digiCollection_);
+        producesCollector.produces<BTLDigiCollection>(digiCollection_);
       }
     } else if (name_ == "ETLDigitizer")
       if (premixStage1_) {
-        parent.produces<PMTDSimAccumulator>(digiCollection_);
+        producesCollector.produces<PMTDSimAccumulator>(digiCollection_);
       } else {
-        parent.produces<ETLDigiCollection>(digiCollection_);
+        producesCollector.produces<ETLDigiCollection>(digiCollection_);
       }
     else
       throw cms::Exception("[MTDDigitizerBase::MTDDigitizerBase]") << name_ << " is an invalid MTD digitizer name";
@@ -109,7 +111,7 @@ private:
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory<MTDDigitizerBase*(
-    const edm::ParameterSet&, edm::ConsumesCollector&, edm::ProducerBase&)>
+    const edm::ParameterSet&, edm::ProducesCollector, edm::ConsumesCollector&)>
     MTDDigitizerFactory;
 
 #endif

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.cc
@@ -1,14 +1,16 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
 //
-FTLDigiProducer::FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
+FTLDigiProducer::FTLDigiProducer(edm::ParameterSet const& pset,
+                                 edm::ProducesCollector producesCollector,
+                                 edm::ConsumesCollector& iC)
     : DigiAccumulatorMixMod() {
   std::vector<std::string> psetNames;
 
@@ -17,7 +19,7 @@ FTLDigiProducer::FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducerBas
   for (const auto& psname : psetNames) {
     const auto& ps = pset.getParameterSet(psname);
     const std::string& digitizerName = ps.getParameter<std::string>("digitizerName");
-    theDigitizers_.emplace_back(FTLDigitizerFactory::get()->create(digitizerName, ps, iC, mixMod));
+    theDigitizers_.emplace_back(FTLDigitizerFactory::get()->create(digitizerName, ps, producesCollector, iC));
   }
 }
 

--- a/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
+++ b/SimFastTiming/FastTimingCommon/plugins/FTLDigiProducer.h
@@ -1,6 +1,7 @@
 #ifndef SimFastTiming_FastTimingCommon_FTLDigiProducer_h
 #define SimFastTiming_FastTimingCommon_FTLDigiProducer_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimFastTiming/FastTimingCommon/interface/FTLDigitizerBase.h"
 
@@ -9,7 +10,6 @@
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class ParameterSet;
   class StreamID;
 }  // namespace edm
@@ -20,7 +20,7 @@ namespace CLHEP {
 
 class FTLDigiProducer : public DigiAccumulatorMixMod {
 public:
-  FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  FTLDigiProducer(edm::ParameterSet const& pset, edm::ProducesCollector, edm::ConsumesCollector& iC);
   FTLDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC) {
     throw cms::Exception("DeprecatedConstructor")
         << "Please make sure you're calling this with the threaded mixing module...";

--- a/SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.cc
@@ -1,14 +1,15 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
 //
-MTDDigiProducer::MTDDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
+MTDDigiProducer::MTDDigiProducer(edm::ParameterSet const& pset,
+                                 edm::ProducesCollector producesCollector,
+                                 edm::ConsumesCollector& iC)
     : DigiAccumulatorMixMod() {
   std::vector<std::string> psetNames;
 
@@ -17,7 +18,7 @@ MTDDigiProducer::MTDDigiProducer(edm::ParameterSet const& pset, edm::ProducerBas
   for (const auto& psname : psetNames) {
     const auto& ps = pset.getParameterSet(psname);
     const std::string& digitizerName = ps.getParameter<std::string>("digitizerName");
-    theDigitizers_.emplace_back(MTDDigitizerFactory::get()->create(digitizerName, ps, iC, mixMod));
+    theDigitizers_.emplace_back(MTDDigitizerFactory::get()->create(digitizerName, ps, producesCollector, iC));
   }
 }
 

--- a/SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.h
+++ b/SimFastTiming/FastTimingCommon/plugins/MTDDigiProducer.h
@@ -1,6 +1,7 @@
 #ifndef SimFastTiming_FastTimingCommon_MTDDigiProducer_h
 #define SimFastTiming_FastTimingCommon_MTDDigiProducer_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimFastTiming/FastTimingCommon/interface/MTDDigitizerBase.h"
 
@@ -9,7 +10,6 @@
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class ParameterSet;
   class StreamID;
 }  // namespace edm
@@ -20,7 +20,7 @@ namespace CLHEP {
 
 class MTDDigiProducer : public DigiAccumulatorMixMod {
 public:
-  MTDDigiProducer(edm::ParameterSet const& pset, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  MTDDigiProducer(edm::ParameterSet const& pset, edm::ProducesCollector, edm::ConsumesCollector& iC);
   MTDDigiProducer(edm::ParameterSet const& pset, edm::ConsumesCollector& iC) {
     throw cms::Exception("DeprecatedConstructor")
         << "Please make sure you're calling this with the threaded mixing module...";

--- a/SimFastTiming/FastTimingCommon/plugins/PreMixingMTDWorker.cc
+++ b/SimFastTiming/FastTimingCommon/plugins/PreMixingMTDWorker.cc
@@ -1,7 +1,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -18,7 +18,7 @@
 
 class PreMixingMTDWorker : public PreMixingWorker {
 public:
-  PreMixingMTDWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingMTDWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
   ~PreMixingMTDWorker() override = default;
 
   PreMixingMTDWorker(const PreMixingMTDWorker&) = delete;
@@ -40,11 +40,12 @@ private:
 };
 
 PreMixingMTDWorker::PreMixingMTDWorker(const edm::ParameterSet& ps,
-                                       edm::ProducerBase& producer,
+                                       edm::ProducesCollector producesCollector,
                                        edm::ConsumesCollector&& iC)
     : signalToken_(iC.consumes<PMTDSimAccumulator>(ps.getParameter<edm::InputTag>("digiTagSig"))),
       pileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
-      digitizer_(MTDDigitizerFactory::get()->create(ps.getParameter<std::string>("digitizerName"), ps, iC, producer)) {}
+      digitizer_(MTDDigitizerFactory::get()->create(
+          ps.getParameter<std::string>("digitizerName"), ps, producesCollector, iC)) {}
 
 void PreMixingMTDWorker::beginRun(const edm::Run& run, const edm::EventSetup& ES) { digitizer_->beginRun(ES); }
 

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -126,7 +126,7 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
   auto& producers = m_runManagerWorker->producers();
 
   for (Producers::iterator itProd = producers.begin(); itProd != producers.end(); ++itProd) {
-    (*itProd)->registerProducts(*this);
+    (*itProd)->registerProducts(producesCollector());
   }
 }
 

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -129,7 +129,7 @@ OscarProducer::OscarProducer(edm::ParameterSet const& p) {
   m_producers = m_runManager->producers();
 
   for (Producers::iterator itProd = m_producers.begin(); itProd != m_producers.end(); ++itProd) {
-    (*itProd)->registerProducts(*this);
+    (*itProd)->registerProducts(producesCollector());
   }
 
   //UIsession manager for message handling

--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -24,7 +24,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -123,7 +123,7 @@ using DecayChain = adjacency_list<listS, vecS, directedS, VertexMotherParticlePr
 
 class CaloTruthAccumulator : public DigiAccumulatorMixMod {
 public:
-  explicit CaloTruthAccumulator(const edm::ParameterSet &config, edm::ProducerBase &mixMod, edm::ConsumesCollector &iC);
+  explicit CaloTruthAccumulator(const edm::ParameterSet &config, edm::ProducesCollector, edm::ConsumesCollector &iC);
 
 private:
   void initializeEvent(const edm::Event &event, const edm::EventSetup &setup) override;
@@ -355,7 +355,7 @@ namespace {
 }  // namespace
 
 CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet &config,
-                                           edm::ProducerBase &mixMod,
+                                           edm::ProducesCollector producesCollector,
                                            edm::ConsumesCollector &iC)
     : messageCategory_("CaloTruthAccumulator"),
       maximumPreviousBunchCrossing_(config.getParameter<unsigned int>("maximumPreviousBunchCrossing")),
@@ -369,10 +369,10 @@ CaloTruthAccumulator::CaloTruthAccumulator(const edm::ParameterSet &config,
       maxPseudoRapidity_(config.getParameter<double>("MaxPseudoRapidity")),
       premixStage1_(config.getParameter<bool>("premixStage1")),
       geometryType_(-1) {
-  mixMod.produces<SimClusterCollection>("MergedCaloTruth");
-  mixMod.produces<CaloParticleCollection>("MergedCaloTruth");
+  producesCollector.produces<SimClusterCollection>("MergedCaloTruth");
+  producesCollector.produces<CaloParticleCollection>("MergedCaloTruth");
   if (premixStage1_) {
-    mixMod.produces<std::vector<std::pair<unsigned int, float>>>("MergedCaloTruth");
+    producesCollector.produces<std::vector<std::pair<unsigned int, float>>>("MergedCaloTruth");
   }
 
   iC.consumes<std::vector<SimTrack>>(simTrackLabel_);

--- a/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
+++ b/SimGeneral/CaloAnalysis/plugins/PreMixingCaloParticleWorker.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -16,7 +16,7 @@
 
 class PreMixingCaloParticleWorker : public PreMixingWorker {
 public:
-  PreMixingCaloParticleWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer, edm::ConsumesCollector &&iC);
+  PreMixingCaloParticleWorker(const edm::ParameterSet &ps, edm::ProducesCollector, edm::ConsumesCollector &&iC);
   ~PreMixingCaloParticleWorker() override = default;
 
   void initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
@@ -47,15 +47,15 @@ private:
 };
 
 PreMixingCaloParticleWorker::PreMixingCaloParticleWorker(const edm::ParameterSet &ps,
-                                                         edm::ProducerBase &producer,
+                                                         edm::ProducesCollector producesCollector,
                                                          edm::ConsumesCollector &&iC)
     : sigClusterToken_(iC.consumes<SimClusterCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
       sigParticleToken_(iC.consumes<CaloParticleCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
       sigEnergyToken_(iC.consumes<EnergyMap>(ps.getParameter<edm::InputTag>("labelSig"))),
       particlePileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
       particleCollectionDM_(ps.getParameter<std::string>("collectionDM")) {
-  producer.produces<SimClusterCollection>(particleCollectionDM_);
-  producer.produces<CaloParticleCollection>(particleCollectionDM_);
+  producesCollector.produces<SimClusterCollection>(particleCollectionDM_);
+  producesCollector.produces<CaloParticleCollection>(particleCollectionDM_);
 }
 
 void PreMixingCaloParticleWorker::initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) {

--- a/SimGeneral/MixingModule/BuildFile.xml
+++ b/SimGeneral/MixingModule/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
 <export>

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -1,15 +1,15 @@
 #ifndef SimGeneral_MixingModule_DigiAccumulatorMixModFactory_h
 #define SimGeneral_MixingModule_DigiAccumulatorMixModFactory_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 
 namespace edm {
   class ConsumesCollector;
   class ParameterSet;
 
-  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, ProducerBase&, ConsumesCollector&);
+  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, ProducesCollector, ConsumesCollector&);
   typedef edmplugin::PluginFactory<DAFunc> DigiAccumulatorMixModPluginFactory;
 
   class DigiAccumulatorMixModFactory {
@@ -19,7 +19,7 @@ namespace edm {
     static DigiAccumulatorMixModFactory const* get();
 
     std::unique_ptr<DigiAccumulatorMixMod> makeDigiAccumulator(ParameterSet const&,
-                                                               ProducerBase&,
+                                                               ProducesCollector,
                                                                ConsumesCollector&) const;
 
   private:

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -274,7 +274,7 @@ namespace edm {
         consumes<HepMCProduct>(pset.getParameter<edm::InputTag>("HepMCProductLabel"));
       }
       std::unique_ptr<DigiAccumulatorMixMod> accumulator = std::unique_ptr<DigiAccumulatorMixMod>(
-          DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
+          DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, producesCollector(), iC));
       // Create appropriate DigiAccumulator
       if (accumulator.get() != nullptr) {
         digiAccumulators_.push_back(accumulator.release());

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -24,10 +24,10 @@ namespace edm {
   }
 
   std::unique_ptr<DigiAccumulatorMixMod> DigiAccumulatorMixModFactory::makeDigiAccumulator(
-      ParameterSet const& conf, ProducerBase& mixMod, ConsumesCollector& iC) const {
+      ParameterSet const& conf, ProducesCollector producesCollector, ConsumesCollector& iC) const {
     std::string accumulatorType = conf.getParameter<std::string>("accumulatorType");
     FDEBUG(1) << "DigiAccumulatorMixModFactory: digi_accumulator_type = " << accumulatorType << std::endl;
-    auto wm = DigiAccumulatorMixModPluginFactory::get()->create(accumulatorType, conf, mixMod, iC);
+    auto wm = DigiAccumulatorMixModPluginFactory::get()->create(accumulatorType, conf, producesCollector, iC);
 
     if (wm.get() == nullptr) {
       throw edm::Exception(errors::Configuration, "NoSourceModule")

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -63,7 +63,7 @@
 
 namespace cms {
   PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig,
-                                                   edm::ProducerBase& mixMod,
+                                                   edm::ProducesCollector producesCollector,
                                                    edm::ConsumesCollector& iC)
       : Mtag_(iConfig.getParameter<edm::InputTag>("vtxTag")),
         fallbackMtag_(iConfig.getParameter<edm::InputTag>("vtxFallbackTag")),
@@ -72,7 +72,7 @@ namespace cms {
 
     const std::string alias("PileupVertexAccum");
 
-    mixMod.produces<PileupVertexContent>().setBranchAlias(alias);
+    producesCollector.produces<PileupVertexContent>().setBranchAlias(alias);
 
     iC.consumes<edm::HepMCProduct>(Mtag_);
     iC.mayConsume<edm::HepMCProduct>(fallbackMtag_);

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
@@ -18,8 +18,9 @@
 #include <vector>
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
+
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -39,9 +40,7 @@ class PileUpEventPrincipal;
 namespace cms {
   class PileupVertexAccumulator : public DigiAccumulatorMixMod {
   public:
-    explicit PileupVertexAccumulator(const edm::ParameterSet& conf,
-                                     edm::ProducerBase& mixMod,
-                                     edm::ConsumesCollector& iC);
+    explicit PileupVertexAccumulator(const edm::ParameterSet& conf, edm::ProducesCollector, edm::ConsumesCollector& iC);
 
     ~PileupVertexAccumulator() override;
 

--- a/SimGeneral/PreMixingModule/interface/PreMixingDigiSimLinkWorker.h
+++ b/SimGeneral/PreMixingModule/interface/PreMixingDigiSimLinkWorker.h
@@ -5,7 +5,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -15,7 +15,7 @@
 template <typename DigiSimLinkCollection>
 class PreMixingDigiSimLinkWorker : public PreMixingWorker {
 public:
-  PreMixingDigiSimLinkWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingDigiSimLinkWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
   ~PreMixingDigiSimLinkWorker() override = default;
 
   void initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) override {}
@@ -36,12 +36,12 @@ private:
 
 template <typename DigiSimLinkCollection>
 PreMixingDigiSimLinkWorker<DigiSimLinkCollection>::PreMixingDigiSimLinkWorker(const edm::ParameterSet& ps,
-                                                                              edm::ProducerBase& producer,
+                                                                              edm::ProducesCollector producesCollector,
                                                                               edm::ConsumesCollector&& iC)
     : signalToken_(iC.consumes<DigiSimLinkCollection>(ps.getParameter<edm::InputTag>("labelSig"))),
       pileupTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
       collectionDM_(ps.getParameter<std::string>("collectionDM")) {
-  producer.produces<DigiSimLinkCollection>(collectionDM_);
+  producesCollector.produces<DigiSimLinkCollection>(collectionDM_);
 }
 
 template <typename DigiSimLinkCollection>

--- a/SimGeneral/PreMixingModule/interface/PreMixingMuonWorker.h
+++ b/SimGeneral/PreMixingModule/interface/PreMixingMuonWorker.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -14,9 +14,11 @@
 template <typename DigiCollection>
 class PreMixingMuonWorker : public PreMixingWorker {
 public:
-  PreMixingMuonWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC)
-      : PreMixingMuonWorker(ps, producer, iC) {}
-  PreMixingMuonWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector& iC);
+  PreMixingMuonWorker(const edm::ParameterSet& ps,
+                      edm::ProducesCollector producesCollector,
+                      edm::ConsumesCollector&& iC)
+      : PreMixingMuonWorker(ps, producesCollector, iC) {}
+  PreMixingMuonWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector& iC);
   ~PreMixingMuonWorker() override = default;
 
   void initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) override {}
@@ -41,12 +43,12 @@ private:
 
 template <typename DigiCollection>
 PreMixingMuonWorker<DigiCollection>::PreMixingMuonWorker(const edm::ParameterSet& ps,
-                                                         edm::ProducerBase& producer,
+                                                         edm::ProducesCollector producesCollector,
                                                          edm::ConsumesCollector& iC)
     : signalToken_(iC.consumes<DigiCollection>(ps.getParameter<edm::InputTag>("digiTagSig"))),
       pileupTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
       collectionDM_(ps.getParameter<std::string>("collectionDM")) {
-  producer.produces<DigiCollection>(collectionDM_);
+  producesCollector.produces<DigiCollection>(collectionDM_);
 }
 
 template <typename DigiCollection>

--- a/SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h
+++ b/SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h
@@ -1,7 +1,7 @@
 #ifndef SimGeneral_PreMixingModule_PreMixingWorkerFactory_h
 #define SimGeneral_PreMixingModule_PreMixingWorkerFactory_h
 
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
 
@@ -11,7 +11,7 @@ namespace edm {
 }  // namespace edm
 
 using PreMixingWorkerFactory = edmplugin::PluginFactory<PreMixingWorker*(
-    const edm::ParameterSet&, edm::ProducerBase&, edm::ConsumesCollector&& iC)>;
+    const edm::ParameterSet&, edm::ProducesCollector, edm::ConsumesCollector&& iC)>;
 
 #define DEFINE_PREMIXING_WORKER(TYPE) DEFINE_EDM_PLUGIN(PreMixingWorkerFactory, TYPE, #TYPE)
 

--- a/SimGeneral/PreMixingModule/plugins/PreMixingCrossingFrameWorker.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingCrossingFrameWorker.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorker.h"
@@ -15,7 +15,7 @@ namespace edm {
   template <typename T>
   class PreMixingCrossingFrameWorker : public PreMixingWorker {
   public:
-    PreMixingCrossingFrameWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+    PreMixingCrossingFrameWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
     ~PreMixingCrossingFrameWorker() override = default;
 
     void initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) override {}
@@ -36,14 +36,14 @@ namespace edm {
 
   template <typename T>
   PreMixingCrossingFrameWorker<T>::PreMixingCrossingFrameWorker(const edm::ParameterSet& ps,
-                                                                edm::ProducerBase& producer,
+                                                                edm::ProducesCollector producesCollector,
                                                                 edm::ConsumesCollector&& iC)
       : signalToken_(iC.consumes<CrossingFrame<T> >(ps.getParameter<edm::InputTag>("labelSig"))),
         pileupTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
         collectionDM_(ps.getParameter<std::string>("collectionDM")) {
-    producer.produces<PCrossingFrame<T> >(
+    producesCollector.produces<PCrossingFrame<T> >(
         collectionDM_);  // TODO: this is needed only to store the pointed-to objects, do we really need it?
-    producer.produces<CrossingFrame<T> >(collectionDM_);
+    producesCollector.produces<CrossingFrame<T> >(collectionDM_);
   }
 
   template <typename T>

--- a/SimGeneral/PreMixingModule/plugins/PreMixingDigiAccumulatorWorker.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingDigiAccumulatorWorker.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
@@ -13,9 +13,11 @@
 
 class PreMixingDigiAccumulatorWorker : public PreMixingWorker {
 public:
-  PreMixingDigiAccumulatorWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC)
+  PreMixingDigiAccumulatorWorker(const edm::ParameterSet& ps,
+                                 edm::ProducesCollector producesCollector,
+                                 edm::ConsumesCollector&& iC)
       : accumulator_(edm::DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(
-            ps.getParameter<edm::ParameterSet>("accumulator"), producer, iC)) {}
+            ps.getParameter<edm::ParameterSet>("accumulator"), producesCollector, iC)) {}
   ~PreMixingDigiAccumulatorWorker() override = default;
 
   void initializeEvent(const edm::Event& e, const edm::EventSetup& ES) override {

--- a/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingModule.cc
@@ -105,7 +105,7 @@ namespace edm {
   PreMixingModule::PreMixingModule(const edm::ParameterSet& ps, MixingCache::Config const* globalConf)
       : BMixingModule(ps, globalConf),
         puWorker_(ps.getParameter<edm::ParameterSet>("workers").getParameter<edm::ParameterSet>("pileup"),
-                  *this,
+                  producesCollector(),
                   consumesCollector()),
         pileupAdjusters_(
             edm::vector_transform(ps.getParameter<std::vector<edm::ParameterSet>>("adjustPileupDistribution"),
@@ -143,7 +143,8 @@ namespace edm {
       }
       const auto& pset = workers.getParameter<edm::ParameterSet>(name);
       std::string type = pset.getParameter<std::string>("workerType");
-      workers_.emplace_back(PreMixingWorkerFactory::get()->create(type, pset, *this, consumesCollector()));
+      workers_.emplace_back(
+          PreMixingWorkerFactory::get()->create(type, pset, producesCollector(), consumesCollector()));
     }
   }
 

--- a/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.cc
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.cc
@@ -1,7 +1,6 @@
 #include "PreMixingPileupCopy.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -11,18 +10,18 @@
 
 namespace edm {
   PreMixingPileupCopy::PreMixingPileupCopy(const edm::ParameterSet& ps,
-                                           edm::ProducerBase& producer,
+                                           edm::ProducesCollector producesCollector,
                                            edm::ConsumesCollector&& iC)
       : pileupInfoInputTag_(ps.getParameter<edm::InputTag>("PileupInfoInputTag")),
         bunchSpacingInputTag_(ps.getParameter<edm::InputTag>("BunchSpacingInputTag")),
         cfPlaybackInputTag_(ps.getParameter<edm::InputTag>("CFPlaybackInputTag")),
         genPUProtonsInputTags_(ps.getParameter<std::vector<edm::InputTag>>("GenPUProtonsInputTags")) {
-    producer.produces<std::vector<PileupSummaryInfo>>();
-    producer.produces<int>("bunchSpacing");
-    producer.produces<CrossingFramePlaybackInfoNew>();
+    producesCollector.produces<std::vector<PileupSummaryInfo>>();
+    producesCollector.produces<int>("bunchSpacing");
+    producesCollector.produces<CrossingFramePlaybackInfoNew>();
 
     for (const auto& tag : genPUProtonsInputTags_) {
-      producer.produces<std::vector<reco::GenParticle>>(tag.label());
+      producesCollector.produces<std::vector<reco::GenParticle>>(tag.label());
     }
   }
 

--- a/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.h
+++ b/SimGeneral/PreMixingModule/plugins/PreMixingPileupCopy.h
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -32,7 +33,7 @@ namespace edm {
 
   class PreMixingPileupCopy {
   public:
-    PreMixingPileupCopy(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+    PreMixingPileupCopy(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
     ~PreMixingPileupCopy() = default;
 
     float getTrueNumInteractions(PileUpEventPrincipal const& pep) const;

--- a/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/PreMixingTrackingParticleWorker.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -14,9 +14,7 @@
 
 class PreMixingTrackingParticleWorker : public PreMixingWorker {
 public:
-  PreMixingTrackingParticleWorker(const edm::ParameterSet &ps,
-                                  edm::ProducerBase &producer,
-                                  edm::ConsumesCollector &&iC);
+  PreMixingTrackingParticleWorker(const edm::ParameterSet &ps, edm::ProducesCollector, edm::ConsumesCollector &&iC);
   ~PreMixingTrackingParticleWorker() override = default;
 
   void initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
@@ -45,14 +43,14 @@ private:
 };
 
 PreMixingTrackingParticleWorker::PreMixingTrackingParticleWorker(const edm::ParameterSet &ps,
-                                                                 edm::ProducerBase &producer,
+                                                                 edm::ProducesCollector producesCollector,
                                                                  edm::ConsumesCollector &&iC)
     : TrackSigToken_(iC.consumes<std::vector<TrackingParticle>>(ps.getParameter<edm::InputTag>("labelSig"))),
       VtxSigToken_(iC.consumes<std::vector<TrackingVertex>>(ps.getParameter<edm::InputTag>("labelSig"))),
       TrackingParticlePileInputTag_(ps.getParameter<edm::InputTag>("pileInputTag")),
       TrackingParticleCollectionDM_(ps.getParameter<std::string>("collectionDM")) {
-  producer.produces<std::vector<TrackingParticle>>(TrackingParticleCollectionDM_);
-  producer.produces<std::vector<TrackingVertex>>(TrackingParticleCollectionDM_);
+  producesCollector.produces<std::vector<TrackingParticle>>(TrackingParticleCollectionDM_);
+  producesCollector.produces<std::vector<TrackingVertex>>(TrackingParticleCollectionDM_);
 }
 
 void PreMixingTrackingParticleWorker::initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) {

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -35,7 +35,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -257,7 +256,7 @@ namespace {
 //---------------------------------------------------------------------------------
 
 TrackingTruthAccumulator::TrackingTruthAccumulator(const edm::ParameterSet &config,
-                                                   edm::ProducerBase &mixMod,
+                                                   edm::ProducesCollector producesCollector,
                                                    edm::ConsumesCollector &iC)
     : messageCategory_("TrackingTruthAccumulator"),
       volumeRadius_(config.getParameter<double>("volumeRadius")),
@@ -321,17 +320,17 @@ TrackingTruthAccumulator::TrackingTruthAccumulator(const edm::ParameterSet &conf
   // configured to be created.
   //
   if (createUnmergedCollection_) {
-    mixMod.produces<TrackingVertexCollection>();
-    mixMod.produces<TrackingParticleCollection>();
+    producesCollector.produces<TrackingVertexCollection>();
+    producesCollector.produces<TrackingParticleCollection>();
   }
 
   if (createMergedCollection_) {
-    mixMod.produces<TrackingParticleCollection>("MergedTrackTruth");
-    mixMod.produces<TrackingVertexCollection>("MergedTrackTruth");
+    producesCollector.produces<TrackingParticleCollection>("MergedTrackTruth");
+    producesCollector.produces<TrackingVertexCollection>("MergedTrackTruth");
   }
 
   if (createInitialVertexCollection_) {
-    mixMod.produces<TrackingVertexCollection>("InitialVertices");
+    producesCollector.produces<TrackingVertexCollection>("InitialVertices");
   }
 
   iC.consumes<std::vector<SimTrack>>(simTrackLabel_);

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -1,6 +1,7 @@
 #ifndef TrackingAnalysis_TrackingTruthAccumulator_h
 #define TrackingAnalysis_TrackingTruthAccumulator_h
 
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
@@ -11,7 +12,6 @@
 namespace edm {
   class ParameterSet;
   class ConsumesCollector;
-  class ProducerBase;
   class Event;
   class EventSetup;
   class StreamID;
@@ -89,7 +89,7 @@ class PSimHit;
 class TrackingTruthAccumulator : public DigiAccumulatorMixMod {
 public:
   explicit TrackingTruthAccumulator(const edm::ParameterSet &config,
-                                    edm::ProducerBase &mixMod,
+                                    edm::ProducesCollector,
                                     edm::ConsumesCollector &iC);
 
 private:

--- a/SimMuon/CSCDigitizer/plugins/PreMixingCSCWorker.cc
+++ b/SimMuon/CSCDigitizer/plugins/PreMixingCSCWorker.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingMuonWorker.h"
 #include "SimGeneral/PreMixingModule/interface/PreMixingWorkerFactory.h"
 
@@ -101,10 +102,10 @@ void PreMixingMuonWorker<CSCStripDigiCollection>::put(edm::Event &iEvent) {
 // CSC has three digi collections
 class PreMixingCSCWorker : public PreMixingWorker {
 public:
-  PreMixingCSCWorker(const edm::ParameterSet &ps, edm::ProducerBase &producer, edm::ConsumesCollector &&iC)
-      : stripWorker_(ps.getParameter<edm::ParameterSet>("strip"), producer, iC),
-        wireWorker_(ps.getParameter<edm::ParameterSet>("wire"), producer, iC),
-        comparatorWorker_(ps.getParameter<edm::ParameterSet>("comparator"), producer, iC) {}
+  PreMixingCSCWorker(const edm::ParameterSet &ps, edm::ProducesCollector producesCollector, edm::ConsumesCollector &&iC)
+      : stripWorker_(ps.getParameter<edm::ParameterSet>("strip"), producesCollector, iC),
+        wireWorker_(ps.getParameter<edm::ParameterSet>("wire"), producesCollector, iC),
+        comparatorWorker_(ps.getParameter<edm::ParameterSet>("comparator"), producesCollector, iC) {}
   ~PreMixingCSCWorker() override = default;
 
   void initializeEvent(edm::Event const &iEvent, edm::EventSetup const &iSetup) override {}

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -77,7 +77,7 @@
 namespace cms {
 
   Phase2TrackerDigitizer::Phase2TrackerDigitizer(const edm::ParameterSet& iConfig,
-                                                 edm::ProducerBase& mixMod,
+                                                 edm::ProducesCollector producesCollector,
                                                  edm::ConsumesCollector& iC)
       : first_(true),
         hitsProducer_(iConfig.getParameter<std::string>("hitsProducer")),
@@ -89,9 +89,9 @@ namespace cms {
             iConfig.getParameter<edm::ParameterSet>("AlgorithmCommon").getUntrackedParameter<bool>("makeDigiSimLinks")) {
     //edm::LogInfo("Phase2TrackerDigitizer") << "Initialize Digitizer Algorithms";
     const std::string alias1("simSiPixelDigis");
-    mixMod.produces<edm::DetSetVector<PixelDigi> >("Pixel").setBranchAlias(alias1);
+    producesCollector.produces<edm::DetSetVector<PixelDigi> >("Pixel").setBranchAlias(alias1);
     if (makeDigiSimLinks_) {
-      mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Pixel").setBranchAlias(alias1);
+      producesCollector.produces<edm::DetSetVector<PixelDigiSimLink> >("Pixel").setBranchAlias(alias1);
     }
 
     if (!iConfig.getParameter<bool>("isOTreadoutAnalog")) {
@@ -99,12 +99,12 @@ namespace cms {
       if (premixStage1_) {
         // Premixing exploits the ADC field of PixelDigi to store the collected charge
         // But we still want everything else to be treated like for Phase2TrackerDigi
-        mixMod.produces<edm::DetSetVector<PixelDigi> >("Tracker").setBranchAlias(alias2);
+        producesCollector.produces<edm::DetSetVector<PixelDigi> >("Tracker").setBranchAlias(alias2);
       } else {
-        mixMod.produces<edm::DetSetVector<Phase2TrackerDigi> >("Tracker").setBranchAlias(alias2);
+        producesCollector.produces<edm::DetSetVector<Phase2TrackerDigi> >("Tracker").setBranchAlias(alias2);
       }
       if (makeDigiSimLinks_) {
-        mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >("Tracker").setBranchAlias(alias2);
+        producesCollector.produces<edm::DetSetVector<PixelDigiSimLink> >("Tracker").setBranchAlias(alias2);
       }
     }
     // creating algorithm objects and pushing them into the map

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -21,7 +21,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <unordered_map>
@@ -52,7 +52,7 @@ namespace cms {
     typedef std::unordered_map<unsigned, TrackerGeometry::ModuleType> ModuleTypeCache;
 
     explicit Phase2TrackerDigitizer(const edm::ParameterSet& iConfig,
-                                    edm::ProducerBase& mixMod,
+                                    edm::ProducesCollector,
                                     edm::ConsumesCollector& iC);
     ~Phase2TrackerDigitizer() override;
     void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PreMixingPhase2TrackerWorker.cc
@@ -1,11 +1,11 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
@@ -20,7 +20,7 @@
 
 class PreMixingPhase2TrackerWorker : public PreMixingWorker {
 public:
-  PreMixingPhase2TrackerWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingPhase2TrackerWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
   ~PreMixingPhase2TrackerWorker() override = default;
 
   void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& es) override;
@@ -48,9 +48,9 @@ private:
 };
 
 PreMixingPhase2TrackerWorker::PreMixingPhase2TrackerWorker(const edm::ParameterSet& ps,
-                                                           edm::ProducerBase& producer,
+                                                           edm::ProducesCollector producesCollector,
                                                            edm::ConsumesCollector&& iC)
-    : digitizer_(ps, producer, iC),
+    : digitizer_(ps, producesCollector, iC),
       pixelSignalToken_(iC.consumes<edm::DetSetVector<PixelDigi>>(ps.getParameter<edm::InputTag>("pixelLabelSig"))),
       trackerSignalToken_(iC.consumes<edm::DetSetVector<PixelDigi>>(ps.getParameter<edm::InputTag>("trackerLabelSig"))),
       pixelPileupLabel_(ps.getParameter<edm::InputTag>("pixelPileInputTag")),

--- a/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/PreMixingSiPixelWorker.cc
@@ -1,11 +1,11 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
@@ -40,7 +40,7 @@
 
 class PreMixingSiPixelWorker : public PreMixingWorker {
 public:
-  PreMixingSiPixelWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingSiPixelWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
   ~PreMixingSiPixelWorker() override = default;
 
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
@@ -81,7 +81,7 @@ private:
 
 // Constructor
 PreMixingSiPixelWorker::PreMixingSiPixelWorker(const edm::ParameterSet& ps,
-                                               edm::ProducerBase& producer,
+                                               edm::ProducesCollector producesCollector,
                                                edm::ConsumesCollector&& iC)
     : digitizer_(ps), geometryType_(ps.getParameter<std::string>("PixGeometryType")) {
   // declare the products to produce
@@ -93,8 +93,8 @@ PreMixingSiPixelWorker::PreMixingSiPixelWorker(const edm::ParameterSet& ps,
   PixelDigiToken_ = iC.consumes<edm::DetSetVector<PixelDigi>>(pixeldigi_collectionSig_);
   PixelDigiPToken_ = iC.consumes<edm::DetSetVector<PixelDigi>>(pixeldigi_collectionPile_);
 
-  producer.produces<edm::DetSetVector<PixelDigi>>(PixelDigiCollectionDM_);
-  producer.produces<PixelFEDChannelCollection>(PixelDigiCollectionDM_);
+  producesCollector.produces<edm::DetSetVector<PixelDigi>>(PixelDigiCollectionDM_);
+  producesCollector.produces<PixelFEDChannelCollection>(PixelDigiCollectionDM_);
 
   // clear local storage for this event
   SiHitStorage_.clear();

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -28,7 +28,6 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -84,7 +83,7 @@
 
 namespace cms {
   SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig,
-                                     edm::ProducerBase& mixMod,
+                                     edm::ProducesCollector producesCollector,
                                      edm::ConsumesCollector& iC)
       : firstInitializeEvent_(true),
         firstFinalizeEvent_(true),
@@ -98,8 +97,8 @@ namespace cms {
 
     const std::string alias("simSiPixelDigis");
 
-    mixMod.produces<edm::DetSetVector<PixelDigi> >().setBranchAlias(alias);
-    mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >().setBranchAlias(alias + "siPixelDigiSimLink");
+    producesCollector.produces<edm::DetSetVector<PixelDigi> >().setBranchAlias(alias);
+    producesCollector.produces<edm::DetSetVector<PixelDigiSimLink> >().setBranchAlias(alias + "siPixelDigiSimLink");
 
     for (auto const& trackerContainer : trackerContainers) {
       edm::InputTag tag(hitsProducer, trackerContainer);
@@ -115,7 +114,7 @@ namespace cms {
 
     _pixeldigialgo.reset(new SiPixelDigitizerAlgorithm(iConfig));
     if (NumberOfEndcapDisks != 2)
-      mixMod.produces<PixelFEDChannelCollection>();
+      producesCollector.produces<PixelFEDChannelCollection>();
   }
 
   SiPixelDigitizer::~SiPixelDigitizer() { edm::LogInfo("PixelDigitizer ") << "Destruct the Pixel Digitizer"; }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -20,11 +20,11 @@
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -47,7 +47,7 @@ namespace CLHEP {
 namespace cms {
   class SiPixelDigitizer : public DigiAccumulatorMixMod {
   public:
-    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::ProducesCollector, edm::ConsumesCollector& iC);
 
     ~SiPixelDigitizer() override;
 

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -44,7 +44,7 @@
 
 class PreMixingSiStripWorker : public PreMixingWorker {
 public:
-  PreMixingSiStripWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
+  PreMixingSiStripWorker(const edm::ParameterSet& ps, edm::ProducesCollector, edm::ConsumesCollector&& iC);
   ~PreMixingSiStripWorker() override = default;
 
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
@@ -144,7 +144,7 @@ private:
 };
 
 PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
-                                               edm::ProducerBase& producer,
+                                               edm::ProducesCollector producesCollector,
                                                edm::ConsumesCollector&& iC)
     : gainLabel(ps.getParameter<std::string>("Gain")),
       SingleStripNoise(ps.getParameter<bool>("SingleStripNoise")),
@@ -172,8 +172,8 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
   SiStripDigiCollectionDM_ = ps.getParameter<std::string>("SiStripDigiCollectionDM");
   SistripAPVListDM_ = ps.getParameter<std::string>("SiStripAPVListDM");
 
-  producer.produces<edm::DetSetVector<SiStripDigi>>(SiStripDigiCollectionDM_);
-  producer.produces<bool>(SiStripDigiCollectionDM_ + "SimulatedAPVDynamicGain");
+  producesCollector.produces<edm::DetSetVector<SiStripDigi>>(SiStripDigiCollectionDM_);
+  producesCollector.produces<bool>(SiStripDigiCollectionDM_ + "SimulatedAPVDynamicGain");
 
   if (APVSaturationFromHIP_) {
     SistripAPVLabelSig_ = ps.getParameter<edm::InputTag>("SistripAPVLabelSig");

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -21,7 +21,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ProducerBase.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -57,7 +56,9 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CLHEP/Random/RandFlat.h"
 
-SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
+SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf,
+                                   edm::ProducesCollector producesCollector,
+                                   edm::ConsumesCollector& iC)
     : gainLabel(conf.getParameter<std::string>("Gain")),
       hitsProducer(conf.getParameter<std::string>("hitsProducer")),
       trackerContainers(conf.getParameter<std::vector<std::string>>("ROUList")),
@@ -73,17 +74,20 @@ SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerB
       fracOfEventsToSimAPV_(conf.getParameter<double>("fracOfEventsToSimAPV")) {
   const std::string alias("simSiStripDigis");
 
-  mixMod.produces<edm::DetSetVector<SiStripDigi>>(ZSDigi).setBranchAlias(ZSDigi);
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>(SCDigi).setBranchAlias(alias + SCDigi);
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>(VRDigi).setBranchAlias(alias + VRDigi);
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>("StripAmplitudes").setBranchAlias(alias + "StripAmplitudes");
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>("StripAmplitudesPostAPV")
+  producesCollector.produces<edm::DetSetVector<SiStripDigi>>(ZSDigi).setBranchAlias(ZSDigi);
+  producesCollector.produces<edm::DetSetVector<SiStripRawDigi>>(SCDigi).setBranchAlias(alias + SCDigi);
+  producesCollector.produces<edm::DetSetVector<SiStripRawDigi>>(VRDigi).setBranchAlias(alias + VRDigi);
+  producesCollector.produces<edm::DetSetVector<SiStripRawDigi>>("StripAmplitudes")
+      .setBranchAlias(alias + "StripAmplitudes");
+  producesCollector.produces<edm::DetSetVector<SiStripRawDigi>>("StripAmplitudesPostAPV")
       .setBranchAlias(alias + "StripAmplitudesPostAPV");
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>("StripAPVBaselines").setBranchAlias(alias + "StripAPVBaselines");
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>(PRDigi).setBranchAlias(alias + PRDigi);
-  mixMod.produces<edm::DetSetVector<StripDigiSimLink>>().setBranchAlias(alias + "siStripDigiSimLink");
-  mixMod.produces<bool>("SimulatedAPVDynamicGain").setBranchAlias(alias + "SimulatedAPVDynamicGain");
-  mixMod.produces<std::vector<std::pair<int, std::bitset<6>>>>("AffectedAPVList").setBranchAlias(alias + "AffectedAPV");
+  producesCollector.produces<edm::DetSetVector<SiStripRawDigi>>("StripAPVBaselines")
+      .setBranchAlias(alias + "StripAPVBaselines");
+  producesCollector.produces<edm::DetSetVector<SiStripRawDigi>>(PRDigi).setBranchAlias(alias + PRDigi);
+  producesCollector.produces<edm::DetSetVector<StripDigiSimLink>>().setBranchAlias(alias + "siStripDigiSimLink");
+  producesCollector.produces<bool>("SimulatedAPVDynamicGain").setBranchAlias(alias + "SimulatedAPVDynamicGain");
+  producesCollector.produces<std::vector<std::pair<int, std::bitset<6>>>>("AffectedAPVList")
+      .setBranchAlias(alias + "AffectedAPV");
   for (auto const& trackerContainer : trackerContainers) {
     edm::InputTag tag(hitsProducer, trackerContainer);
     iC.consumes<std::vector<PSimHit>>(edm::InputTag(hitsProducer, trackerContainer));

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -9,6 +9,7 @@
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
 
 class TrackerTopology;
 
@@ -18,7 +19,6 @@ namespace CLHEP {
 
 namespace edm {
   class ConsumesCollector;
-  class ProducerBase;
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -44,7 +44,7 @@ class TrackerGeometry;
  */
 class SiStripDigitizer : public DigiAccumulatorMixMod {
 public:
-  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
+  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducesCollector, edm::ConsumesCollector& iC);
 
   ~SiStripDigitizer() override;
 


### PR DESCRIPTION
#### PR description:

Initial implementation of the ProducesCollector. The ProducerBase::produces function is now a protected member of ProducerBase. When produces needs to be called in a helper class (outside the module constructor), the ProducesCollector must be used. This PR also migrates all the code in the repository to work with this change. It does not affect modules that call produces directly inside their constructor.  The purpose is to reduce the number of things that depend on ProducerBase. Helper classes used by modules no longer need to depend on it.

#### PR validation:

Includes a new unit test for the ProducesCollector class.
