### PR TITLE
Allow ConsumesCollector to be copied

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -39,9 +39,9 @@ namespace edm {
   class ConsumesCollector {
   public:
     ConsumesCollector() = delete;
-    ConsumesCollector(ConsumesCollector const&) = delete;
+    ConsumesCollector(ConsumesCollector const&);
     ConsumesCollector(ConsumesCollector&&) = default;
-    ConsumesCollector& operator=(ConsumesCollector const&) = delete;
+    ConsumesCollector& operator=(ConsumesCollector const&);
     ConsumesCollector& operator=(ConsumesCollector&&) = default;
 
     // ---------- member functions ---------------------------

--- a/FWCore/Framework/src/ConsumesCollector.cc
+++ b/FWCore/Framework/src/ConsumesCollector.cc
@@ -1,0 +1,12 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+namespace edm {
+
+  ConsumesCollector::ConsumesCollector(ConsumesCollector const& other) : m_consumer(get_underlying(other.m_consumer)) {}
+
+  ConsumesCollector& ConsumesCollector::operator=(ConsumesCollector const& other) {
+    m_consumer = get_underlying(other.m_consumer);
+    return *this;
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -101,9 +101,15 @@ namespace {
   public:
     IntsConsumesCollectorConsumer(std::vector<edm::InputTag> const& iTags) {
       m_tokens.reserve(iTags.size());
-      edm::ConsumesCollector c{consumesCollector()};
+      edm::ConsumesCollector collector{consumesCollector()};
+      edm::ConsumesCollector collectorCopy(collector);
+      edm::ConsumesCollector collectorCopy1(collector);
+      edm::ConsumesCollector collectorCopy2(collector);
+      collectorCopy1 = collectorCopy;
+      collectorCopy2 = std::move(collectorCopy1);
+
       for (auto const& tag : iTags) {
-        m_tokens.push_back(c.consumes<std::vector<int>>(tag));
+        m_tokens.push_back(collectorCopy2.consumes<std::vector<int>>(tag));
       }
     }
 


### PR DESCRIPTION
#### PR description:

Allow ConsumesCollector to be copied. Add copy constructor and copy assignment operator.

This makes ConsumesCollector and ProducesCollector consistent. After experience with ConsumesCollector over time we decided that not having these functions caused more difficulties than the protection it added. The original reason not to include them was to try to make it harder to save a ConsumesCollector as member data and use it late, but it is anyway possible to save using the move constructor and lack of copy functions made ConsumesCollector a little difficult to use.

#### PR validation:

New functions used in a unit test. Outside of that nothing uses these new functions so nothing should be changed. 

