### PR TITLE
add missing DataFormats dependencies to BuildFile.xmls

### DIFF
--- a/DataFormats/NanoAOD/BuildFile.xml
+++ b/DataFormats/NanoAOD/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="FWCore/Common"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>
+<use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h
+++ b/DataFormats/Provenance/interface/MergeableRunProductMetadataBase.h
@@ -1,3 +1,5 @@
+#ifndef DataFormats_Provenance_MergeableRunProductMetadataBase_h
+#define DataFormats_Provenance_MergeableRunProductMetadataBase_h
 #include <string>
 
 namespace edm {
@@ -9,3 +11,4 @@ namespace edm {
     virtual bool knownImproperlyMerged(std::string const& processThatCreatedProduct) const = 0;
   };
 }  // namespace edm
+#endif

--- a/DataFormats/SiStripCommon/BuildFile.xml
+++ b/DataFormats/SiStripCommon/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>
-
+<use   name="DataFormats/SiStripDetId"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/TestObjects/BuildFile.xml
+++ b/DataFormats/TestObjects/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/Provenance"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

Looking into using root modules in cmssw, we find some missing dependencies in DataFormats packages (as well as missing header guards)

