### PR TITLE
added missing dependency on DataFormats/GeometryCommonDetAlgo

### DIFF
--- a/Geometry/CommonDetUnit/BuildFile.xml
+++ b/Geometry/CommonDetUnit/BuildFile.xml
@@ -1,6 +1,7 @@
 <export>
   <lib   name="1"/>
 </export>
+<use   name="DataFormats/GeometryCommonDetAlgo"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>


### PR DESCRIPTION
Added missing dependency on DataFormats/GeometryCommonDetAlgo. This should fix the fwlite builds

```
Geometry/CommonDetUnit/src/TrackerGeomDet.cc:#include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
Geometry/CommonDetUnit/src/MTDGeomDet.cc:#include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
```