### PR TITLE
ExpressionEvaluatorUnitTest: reduce number of threads and payload

### DIFF
--- a/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
+++ b/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
@@ -74,10 +74,10 @@ int main() {
 
   // stress test
   std::atomic<int> j(0);
-#pragma omp parallel num_threads(8)
+#pragma omp parallel num_threads(2)
   {
     reco::genericExpression<bool, int, int> const* acut = nullptr;
-    for (int i = 0; i < 200; ++i) {
+    for (int i = 0; i < 20; ++i) {
       acut = reco_expressionEvaluator("CommonTools/Utils", SINGLE_ARG(reco::genericExpression<bool, int, int>), cut);
       (*acut)(2, 7);
       std::cerr << j++ << ',';


### PR DESCRIPTION
ExpressionEvaluatorUnitTest randomly fails mostly in situation when a PR triggers to rebuilt many packages (results in running many unit tests). This PR reduces the number of threads used by this unittest and also payload is reduced (See https://github.com/cms-sw/cmssw/pull/28153#issuecomment-541319783 )