### PR TITLE
Add missing header for TLeaf to avoid incomplete type complain

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -7,6 +7,7 @@
 #include "TTree.h"
 #include "TTreeIndex.h"
 #include "TTreeCache.h"
+#include "TLeaf.h"
 
 #include <cassert>
 #include <iostream>


### PR DESCRIPTION
#### PR description:

Add a header for TLeaf to shut this:
error: invalid use of incomplete type 'class TLeaf'
result of 
TBranch* br = leaf->GetBranch();
on line 162

#### PR validation:

It compiles. It was failing to compile. Needed for https://github.com/cms-sw/cmsdist/pull/5276

