### PR TITLE
[10_6_X] Fix a discrepancy in Puppi weights when running on MiniAOD w/ useExistingWeights=False

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -257,9 +257,9 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       pVec.SetPxPyPzE(puppiMatched.px(),puppiMatched.py(),puppiMatched.pz(),puppiMatched.E());
       if(fClonePackedCands && (!fUseExistingWeights)) {
         if(fPuppiForLeptons)
-          pCand->setPuppiWeight(pCand->puppiWeight(),lWeights[iPuppiMatched]);
+          pCand->setPuppiWeight(pCand->puppiWeight(),lWeights[val]);
         else
-          pCand->setPuppiWeight(lWeights[iPuppiMatched],pCand->puppiWeightNoLep());
+          pCand->setPuppiWeight(lWeights[val],pCand->puppiWeightNoLep());
       }
     } else {
       pVec.SetPxPyPzE( 0, 0, 0, 0);


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/28033. 
This is a minimal fix without the code simplification in https://github.com/cms-sw/cmssw/pull/28033.

The discrepancy happens only when remaking puppi from miniAOD in analysis setup or other non-standard workflows, with `useExistingWeights=False`, and is fixed in this PR.  

Standard miniAOD or nanoAOD productions are not affected. 