### PR TITLE
Adapt Configuration/DataProcessing to python3

### DIFF
--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -84,7 +84,7 @@ class RunAlcaHarvesting:
             pickle.dump(process, pklFile)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
-            psetFile.write("handle = open('RunAlcaHarvestingCfg.pkl')\n")
+            psetFile.write("handle = open('RunAlcaHarvestingCfg.pkl','rb')\n")
             psetFile.write("process = pickle.load(handle)\n")
             psetFile.write("handle.close()\n")
             psetFile.close()

--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -78,7 +78,7 @@ class RunAlcaHarvesting:
         process.source.fileNames.append(self.inputLFN)
 
 
-        pklFile = open("RunAlcaHarvestingCfg.pkl", "w")
+        pklFile = open("RunAlcaHarvestingCfg.pkl", "wb")
         psetFile = open("RunAlcaHarvestingCfg.py", "w")
         try:
             pickle.dump(process, pklFile)

--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -81,7 +81,7 @@ class RunAlcaHarvesting:
         pklFile = open("RunAlcaHarvestingCfg.pkl", "wb")
         psetFile = open("RunAlcaHarvestingCfg.py", "w")
         try:
-            pickle.dump(process, pklFile)
+            pickle.dump(process, pklFile, protocol=0)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
             psetFile.write("handle = open('RunAlcaHarvestingCfg.pkl','rb')\n")

--- a/Configuration/DataProcessing/test/RunAlcaSkimming.py
+++ b/Configuration/DataProcessing/test/RunAlcaSkimming.py
@@ -68,7 +68,7 @@ class RunAlcaSkimming:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
-        pklFile = open("RunAlcaSkimmingCfg.pkl", "w")
+        pklFile = open("RunAlcaSkimmingCfg.pkl", "wb")
         psetFile = open("RunAlcaSkimmingCfg.py", "w")
         try:
             pickle.dump(process, pklFile)

--- a/Configuration/DataProcessing/test/RunAlcaSkimming.py
+++ b/Configuration/DataProcessing/test/RunAlcaSkimming.py
@@ -74,7 +74,7 @@ class RunAlcaSkimming:
             pickle.dump(process, pklFile)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
-            psetFile.write("handle = open('RunAlcaSkimmingCfg.pkl')\n")
+            psetFile.write("handle = open('RunAlcaSkimmingCfg.pkl','rb')\n")
             psetFile.write("process = pickle.load(handle)\n")
             psetFile.write("handle.close()\n")
             psetFile.close()

--- a/Configuration/DataProcessing/test/RunAlcaSkimming.py
+++ b/Configuration/DataProcessing/test/RunAlcaSkimming.py
@@ -71,7 +71,7 @@ class RunAlcaSkimming:
         pklFile = open("RunAlcaSkimmingCfg.pkl", "wb")
         psetFile = open("RunAlcaSkimmingCfg.py", "w")
         try:
-            pickle.dump(process, pklFile)
+            pickle.dump(process, pklFile, protocol=0)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
             psetFile.write("handle = open('RunAlcaSkimmingCfg.pkl','rb')\n")

--- a/Configuration/DataProcessing/test/RunDQMHarvesting.py
+++ b/Configuration/DataProcessing/test/RunDQMHarvesting.py
@@ -74,7 +74,7 @@ class RunDQMHarvesting:
         process.source.fileNames.append(self.inputLFN)
 
 
-        pklFile = open("RunDQMHarvestingCfg.pkl", "w")
+        pklFile = open("RunDQMHarvestingCfg.pkl", "wb")
         psetFile = open("RunDQMHarvestingCfg.py", "w")
         try:
             pickle.dump(process, pklFile)

--- a/Configuration/DataProcessing/test/RunDQMHarvesting.py
+++ b/Configuration/DataProcessing/test/RunDQMHarvesting.py
@@ -77,7 +77,7 @@ class RunDQMHarvesting:
         pklFile = open("RunDQMHarvestingCfg.pkl", "wb")
         psetFile = open("RunDQMHarvestingCfg.py", "w")
         try:
-            pickle.dump(process, pklFile)
+            pickle.dump(process, pklFile, protocol=0)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
             psetFile.write("handle = open('RunDQMHarvestingCfg.pkl','rb')\n")

--- a/Configuration/DataProcessing/test/RunDQMHarvesting.py
+++ b/Configuration/DataProcessing/test/RunDQMHarvesting.py
@@ -80,7 +80,7 @@ class RunDQMHarvesting:
             pickle.dump(process, pklFile)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
-            psetFile.write("handle = open('RunDQMHarvestingCfg.pkl')\n")
+            psetFile.write("handle = open('RunDQMHarvestingCfg.pkl','rb')\n")
             psetFile.write("process = pickle.load(handle)\n")
             psetFile.write("handle.close()\n")
             psetFile.close()

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -110,7 +110,7 @@ class RunExpressProcessing:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
-        pklFile = open("RunExpressProcessingCfg.pkl", "w")
+        pklFile = open("RunExpressProcessingCfg.pkl", "wb")
         psetFile = open("RunExpressProcessingCfg.py", "w")
         try:
             pickle.dump(process, pklFile)

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -116,7 +116,7 @@ class RunExpressProcessing:
             pickle.dump(process, pklFile)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
-            psetFile.write("handle = open('RunExpressProcessingCfg.pkl')\n")
+            psetFile.write("handle = open('RunExpressProcessingCfg.pkl','rb')\n")
             psetFile.write("process = pickle.load(handle)\n")
             psetFile.write("handle.close()\n")
             psetFile.close()

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -113,7 +113,7 @@ class RunExpressProcessing:
         pklFile = open("RunExpressProcessingCfg.pkl", "wb")
         psetFile = open("RunExpressProcessingCfg.py", "w")
         try:
-            pickle.dump(process, pklFile)
+            pickle.dump(process, pklFile, protocol=0)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
             psetFile.write("handle = open('RunExpressProcessingCfg.pkl','rb')\n")

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -125,7 +125,7 @@ class RunPromptReco:
             pickle.dump(process, pklFile)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
-            psetFile.write("handle = open('RunPromptRecoCfg.pkl')\n")
+            psetFile.write("handle = open('RunPromptRecoCfg.pkl','rb')\n")
             psetFile.write("process = pickle.load(handle)\n")
             psetFile.write("handle.close()\n")
             psetFile.close()

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -122,7 +122,7 @@ class RunPromptReco:
         pklFile = open("RunPromptRecoCfg.pkl", "wb")
         psetFile = open("RunPromptRecoCfg.py", "w")
         try:
-            pickle.dump(process, pklFile)
+            pickle.dump(process, pklFile, protocol=0)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
             psetFile.write("handle = open('RunPromptRecoCfg.pkl','rb')\n")

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -21,8 +21,8 @@ class RunPromptReco:
         self.writeRECO = False
         self.writeAOD = False
         self.writeMINIAOD = False
-	self.writeDQM = False
-	self.writeDQMIO = False
+        self.writeDQM = False
+        self.writeDQMIO = False
         self.noOutput = False
         self.globalTag = None
         self.inputLFN = None
@@ -65,10 +65,10 @@ class RunPromptReco:
         if self.writeMINIAOD:
             dataTiers.append("MINIAOD")
             print("Configuring to Write out MiniAOD")
-	if self.writeDQM:
+        if self.writeDQM:
             dataTiers.append("DQM")
             print("Configuring to Write out DQM")
-	if self.writeDQMIO:
+        if self.writeDQMIO:
             dataTiers.append("DQMIO")
             print("Configuring to Write out DQMIO")
         if self.alcaRecos:
@@ -119,7 +119,7 @@ class RunPromptReco:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
-        pklFile = open("RunPromptRecoCfg.pkl", "w")
+        pklFile = open("RunPromptRecoCfg.pkl", "wb")
         psetFile = open("RunPromptRecoCfg.py", "w")
         try:
             pickle.dump(process, pklFile)

--- a/Configuration/DataProcessing/test/RunVisualizationProcessing.py
+++ b/Configuration/DataProcessing/test/RunVisualizationProcessing.py
@@ -116,7 +116,7 @@ class RunVisualizationProcessing:
             pickle.dump(process, pklFile)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
-            psetFile.write("handle = open('RunVisualizationProcessingCfg.pkl')\n")
+            psetFile.write("handle = open('RunVisualizationProcessingCfg.pkl','rb')\n")
             psetFile.write("process = pickle.load(handle)\n")
             psetFile.write("handle.close()\n")
             psetFile.close()

--- a/Configuration/DataProcessing/test/RunVisualizationProcessing.py
+++ b/Configuration/DataProcessing/test/RunVisualizationProcessing.py
@@ -113,7 +113,7 @@ class RunVisualizationProcessing:
         pklFile = open("RunVisualizationProcessingCfg.pkl", "wb")
         psetFile = open("RunVisualizationProcessingCfg.py", "w")
         try:
-            pickle.dump(process, pklFile)
+            pickle.dump(process, pklFile, protocol=0)
             psetFile.write("import FWCore.ParameterSet.Config as cms\n")
             psetFile.write("import pickle\n")
             psetFile.write("handle = open('RunVisualizationProcessingCfg.pkl','rb')\n")

--- a/Configuration/DataProcessing/test/RunVisualizationProcessing.py
+++ b/Configuration/DataProcessing/test/RunVisualizationProcessing.py
@@ -110,7 +110,7 @@ class RunVisualizationProcessing:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
-        pklFile = open("RunVisualizationProcessingCfg.pkl", "w")
+        pklFile = open("RunVisualizationProcessingCfg.pkl", "wb")
         psetFile = open("RunVisualizationProcessingCfg.py", "w")
         try:
             pickle.dump(process, pklFile)


### PR DESCRIPTION
#### PR description:

Minimal adjustments to Configuration/DataProcessing to pass the unit test in the _PY3_ IB.

#### PR validation:

```scram b runtests``` is passed both in the standard (python2) and python3 builds. The output comparison requires ```edmConfigDump``` to work in python3, features independently added by #28173