### PR TITLE
Fix a scaling issue in MagneticField/VolumeBasedEngine

### DIFF
--- a/MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.cc
+++ b/MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.cc
@@ -65,7 +65,7 @@ bool MagGeometryExerciser::testFindVolume(const GlobalPoint& gp) {
 
   if (vol == 0) {
     cout << "Test ERROR: No volume found! Global point: " << gp << " , GP Z = " << gp.z() << ", GP perp = " << gp.perp()
-         << " isBarrel: " << theGeometry->inBarrel(gp) << endl;
+         << " isBarrel: " << theGeometry->inBarrel(gp.perp(), fabs(gp.z())) << endl;
 
     // Try with a linear search
     vol = (MagVolume6Faces const*)theGeometry->findVolume1(gp, tolerance);

--- a/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
+++ b/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
@@ -61,8 +61,6 @@ private:
 
   bool inBarrel(float R, float Z) const;
 
-  mutable std::atomic<MagVolume const*> lastVolume;  // Cache last volume found
-
   std::vector<MagBLayer const*> theBLayers;
   std::vector<MagESector const*> theESectors;
 

--- a/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
+++ b/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
@@ -59,7 +59,7 @@ private:
   // Linear search (for debug purposes only)
   MagVolume const* findVolume1(const GlobalPoint& gp, double tolerance = 0.) const;
 
-  bool inBarrel(const GlobalPoint& gp) const;
+  bool inBarrel(float R, float Z) const;
 
   mutable std::atomic<MagVolume const*> lastVolume;  // Cache last volume found
 
@@ -75,5 +75,6 @@ private:
 
   bool cacheLastVolume;
   int geometryVersion;
+  float R1, R2, Z0, Z1, Z2;
 };
 #endif


### PR DESCRIPTION
#### PR description:

In commit 0f77253518f774b8ed2c627a202d378b57a34df6, the MagGeometry was made thread-safe by using an `std::atomic<>` for caching the last volume used. This means that all threads, despite working on unrelated events, share a common cached volume, which is not suitable most of the time. The atomic also creates problems for concurrency, since whenever a thread caches a volume, the  CPU cacheline is invalidated, forcing all other threads to fetch the value of the cached volume from memory every time, consequently suffering from higher latency. Since that volume is not suitable, it's likely that each thread will then replace it with a new value, which is not good for the other threads, and so on, significantly slowing down the whole simulation, since the magnetic field is called many times for each track to integrate its trajectory.

This problem has been profiled and benchmarked in Intel's VTune Amplifier against cmssw branch `CMSSW_11_0_GEANT4_X_2019-10-10-2300`. The results are shown below with labels `before` and `after` the changes from this pull request. In all cases, hyper-threading was disabled, and the threads were pinned using `taskset` with an appropriate number of CPUs. The machine where all runs were performed is a dual-socket [Intel Xeon E5-2698 v3](https://ark.intel.com/content/www/us/en/ark/products/81060/intel-xeon-processor-e5-2698-v3-40m-cache-2-30-ghz.html) with 64GB of RAM. We simulate minimum bias events at E<sub>cm</sub> = 13TeV, and vary the total number of events and number of threads in each analysis.  The `cmsDriver` command used to create the input file is shown below:
```
cmsDriver.py MinBias_13TeV_cfi --era Run2_2018 -s GEN,SIM --pileup=NoPileUp
--conditions auto:phase1_2018_realistic --geometry DB:Extended
--eventcontent=RAWSIM --datatier GEN-SIM --dirout=./ -n $nevents --nThreads $nthreads
--fileout file:scaling.root --mc --no_exec cmsRun MinBias_13TeV_cfi_GEN_SIM.py
```

#### PR validation:

There is no functional change introduced by this pull request. It is purely a performance optimization. The only thing that is different is that some barrel properties are computed only once at initialization rather than at every call to the magnetic field, as that seemed like a sensible thing to do as extra optimization.

Here is a scaling plot showing scaling before and after the changes:
<p align="center">
<img src="https://user-images.githubusercontent.com/249404/66829180-1f6be700-ef53-11e9-831a-5816e29132f6.png" /></p>

A throughput table before and after the changes is shown below. Throughput is calculated as (1024 events) / Δt, where Δt = (t₂ - t₁), t₁ is the start time for processing the first event, and t₂ is the end of the job (i.e. estimate of total time minus initialization time).

|Threads|Throughput (Events/s) [before]|Throughput (Events/s) [after]|Percent Change|
|-|-|-|-|
1|0.290|0.289|-0.34|
2|0.609|0.594|-2.46|
4|1.166|1.206|+3.43|
8|1.903|1.950|+2.47|
12|2.767|2.868|+3.65|
16|3.368|3.390|+0.65|
24|4.675|5.120|+9.52|
32|4.471|6.059|+35.52|

Comparison of hotspots analysis at 32 threads in Intel VTune Amplifier (before - after):
<p align="center">
<img src="https://user-images.githubusercontent.com/249404/66845832-0eca6980-ef71-11e9-9b01-d42731e5151b.png" />
</p>

Comparison of micro-architecture analysis at 32 threads in Intel VTune Amplifier (before - after):
![screenshot](https://user-images.githubusercontent.com/249404/66847352-87322a00-ef73-11e9-8b46-aa64da165d8b.png)

Bottom-up micro-architecture comparison of before and after for 32 threads in Intel VTune Amplifier:
![screenshot](https://user-images.githubusercontent.com/249404/66848101-c14ffb80-ef74-11e9-870d-645fd00949ba.png)

Best regards,
—Guilherme



