### PR TITLE
Improve the treatment of genPUProtons in premix stage2 configuration

### DIFF
--- a/Configuration/StandardSequences/python/DigiDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiDM_cff.py
@@ -45,17 +45,3 @@ pdigiTask.remove(simEcalDigis)  # does zero suppression
 pdigiTask.remove(simEcalPreshowerDigis)  # does zero suppression
 pdigiTask.remove(simHcalDigis)
 pdigiTask.remove(simHcalTTPDigis)
-
-# premixing stage2 runs addPileupInfo, and muon digis after PreMixingModule (configured in DataMixerPreMix_cff)
-premix_stage2.toReplaceWith(pdigiTask, pdigiTask.copyAndExclude([addPileupInfo, genPUProtons, muonDigiTask]))
-
-# genPUProtons, on the other hand, is an EDAlias. In principle it is
-# already loaded with digitizers_cfi, but in practice that gets
-# overwritten by the EDProducer by loading this file. So we hack
-# around by adding a ProcessModifier with overwrites it back to
-# EDAlias (because we can't toReplaceWith() an EDProducer with an
-# EDAlias).
-def _loadPremixStage2Alias(process):
-    import SimGeneral.MixingModule.aliases_PreMix_cfi as _aliases
-    process.genPUProtons = _aliases.genPUProtons
-modifyDigiDM_loadPremixStage2Alias = premix_stage2.makeProcessModifier(_loadPremixStage2Alias)

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -28,10 +28,16 @@ from SimGeneral.Configuration.SimGeneral_cff import *
 # add updating the GEN information by default
 from Configuration.StandardSequences.Generator_cff import *
 from GeneratorInterface.Core.generatorSmeared_cfi import *
-from SimGeneral.PileupInformation.genPUProtons_cfi import *
 
 doAllDigiTask = cms.Task(generatorSmeared, calDigiTask, muonDigiTask)
-pdigiTask_nogen = cms.Task(generatorSmeared, cms.TaskPlaceholder("randomEngineStateProducer"), cms.TaskPlaceholder("mix"), doAllDigiTask, addPileupInfo, genPUProtons)
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+# premixing stage2 runs muon digis after PreMixingModule (configured in DataMixerPreMix_cff)
+premix_stage2.toReplaceWith(doAllDigiTask, doAllDigiTask.copyAndExclude([muonDigiTask]))
+
+pdigiTask_nogen = cms.Task(generatorSmeared, cms.TaskPlaceholder("randomEngineStateProducer"), cms.TaskPlaceholder("mix"), doAllDigiTask, addPileupInfo)
+# premixing stage2 runs addPileupInfo after PreMixingModule (configured in DataMixerPreMix_cff)
+premix_stage2.toReplaceWith(pdigiTask_nogen, pdigiTask_nogen.copyAndExclude([addPileupInfo]))
+
 pdigiTask = cms.Task(pdigiTask_nogen, fixGenInfoTask)
 
 doAllDigi = cms.Sequence(doAllDigiTask)
@@ -45,6 +51,13 @@ pdigiTask_hi = cms.Task(pdigiTask, heavyIon)
 pdigiTask_hi_nogen = cms.Task(pdigiTask_nogen, genJetMETTask, heavyIon)
 pdigi_hi=cms.Sequence(pdigiTask_hi)
 pdigi_hi_nogen=cms.Sequence(pdigiTask_hi_nogen)
+
+# define genPUProtons as an EDProducer only when not in premixing stage2 job
+# in premixing stage2 genPUProtons is an EDAlias, defined in aliases_PreMix_cfi
+def _premixStage2GenPUProtons(process):
+    process.load("SimGeneral.PileupInformation.genPUProtons_cfi")
+    process.pdigiTask_nogen.add(process.genPUProtons)
+modifyDigi_premixStage2GenPUProtons = (~premix_stage2).makeProcessModifier(_premixStage2GenPUProtons)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 def _fastSimDigis(process):


### PR DESCRIPTION
#### PR description:

This PR fixes the `process.None` that ends up in the `edmConfigDump` output of step3 configuration of 250202.181 reported in #28172 (the exact description of the problem is in https://github.com/cms-sw/cmssw/issues/28172#issuecomment-541840693).

The proposed fix is to define `genPUProtons` always either as an EDProducer (default) or as an EDAlias (`premix_stage2` Modifier) instead of going through EDAlias->EDProducer->EDAlias changes for `premix_stage2`. This is done by including `genPUProtons`-EDProducer via ProcessModifier in `Digi_cff`.

On the same go, this PR moves also the removal of `muonDigiTask` and `addPileupInfo` into `Digi_cff` where the original Tasks are defined.

#### PR validation:

Limited matrix runs, `edmConfigDump 250202.181*/step3*py` does not contain `process.None` anymore.