### PR TITLE
Enable ME0TriggerPseudoDigiProducer in Phase-2 L1T sequence

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -134,6 +134,7 @@ def _appendME0PseudoStubs(obj):
         'keep *_simMuonME0PseudoReDigisCoarse__*',
         'keep *_me0RecHitsCoarse__*',
         'keep *_me0TriggerPseudoDigis__*',
+        'keep *_me0TriggerConvertedPseudoDigis__*',
         ]
     obj.outputCommands += l1ME0PseudoStubs
 

--- a/L1Trigger/ME0Trigger/python/me0TriggerConvertedPseudoDigis_cfi.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerConvertedPseudoDigis_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-me0TriggerPseudoDigis = cms.EDProducer("ME0TriggerPseudoProducer",
+me0TriggerConvertedPseudoDigis = cms.EDProducer("ME0TriggerPseudoProducer",
     ME0SegmentProducer = cms.InputTag("me0Segments"),
     info = cms.untracked.int32(0),
     DeltaPhiResolution = cms.untracked.double(0.25)# in term of trigger pad

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -32,5 +32,8 @@ me0TriggerPseudoDigiTask = cms.Task(
     simMuonME0PseudoReDigisCoarse,
     me0RecHitsCoarse,
     me0TriggerPseudoDigis,
+    ## need to run the standard ME0 RECO sequence for converted triggers
+    me0RecHits,
+    me0Segments,
     me0TriggerConvertedPseudoDigis
 )

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -8,6 +8,7 @@ import FWCore.ParameterSet.Config as cms
 from SimMuon.GEMDigitizer.muonME0PseudoReDigis_cfi import *
 from RecoLocalMuon.GEMRecHit.me0RecHits_cfi import *
 from RecoLocalMuon.GEMSegment.me0Segments_cfi import *
+from L1Trigger.ME0Trigger.me0TriggerConvertedPseudoDigis_cfi import *
 
 simMuonME0PseudoReDigisCoarse = simMuonME0PseudoReDigis.clone(
     usePads = cms.bool(True)
@@ -30,5 +31,6 @@ me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiSeeds = cms.double(maxPhi)
 me0TriggerPseudoDigiTask = cms.Task(
     simMuonME0PseudoReDigisCoarse,
     me0RecHitsCoarse,
-    me0TriggerPseudoDigis
+    me0TriggerPseudoDigis,
+    me0TriggerConvertedPseudoDigis
 )

--- a/L1Trigger/ME0Trigger/test/ME0TPEmulator_cfg.py
+++ b/L1Trigger/ME0Trigger/test/ME0TPEmulator_cfg.py
@@ -38,8 +38,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
-process.load('L1Trigger/ME0Trigger/me0TriggerPseudoDigis_cfi')
-process.me0TriggerPseudoDigis.info = 3
+process.load('L1Trigger.ME0Trigger.me0TriggerConvertedPseudoDigis_cfi')
+process.me0TriggerConvertedPseudoDigis.info = 3
 
 
 # ======
@@ -52,5 +52,5 @@ process.output = cms.OutputModule("PoolOutputModule",
 
 # Scheduler path
 # ==============
-process.p = cms.Path(process.me0TriggerPseudoDigis)
+process.p = cms.Path(process.me0TriggerConvertedPseudoDigis)
 process.out = cms.EndPath(process.output)

--- a/L1Trigger/ME0Trigger/test/runME0_Reco_L1.py
+++ b/L1Trigger/ME0Trigger/test/runME0_Reco_L1.py
@@ -1,7 +1,7 @@
 # Auto generated configuration file
-# using: 
-# Revision: 1.19 
-# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# using:
+# Revision: 1.19
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
 # with command line options: step2 --conditions auto:phase2_realistic -s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2 --datatier GEN-SIM-DIGI-RAW -n 10 --geometry Extended2023D22 --era Phase2 --eventcontent FEVTDEBUGHLT --filein file:step1.root --fileout file:step2.root
 import FWCore.ParameterSet.Config as cms
 
@@ -24,7 +24,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 
 process.me0RecoSequence = cms.Sequence(
-   process.me0RecHits * process.me0Segments 
+   process.me0RecHits * process.me0Segments
 )
 
 
@@ -37,22 +37,22 @@ process.source = cms.Source("PoolSource",
     dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
     fileNames = cms.untracked.vstring('file:step2.root'),
     inputCommands = cms.untracked.vstring(
-        'keep *', 
-        'drop *_genParticles_*_*', 
-        'drop *_genParticlesForJets_*_*', 
-        'drop *_kt4GenJets_*_*', 
-        'drop *_kt6GenJets_*_*', 
-        'drop *_iterativeCone5GenJets_*_*', 
-        'drop *_ak4GenJets_*_*', 
-        'drop *_ak7GenJets_*_*', 
-        'drop *_ak8GenJets_*_*', 
-        'drop *_ak4GenJetsNoNu_*_*', 
-        'drop *_ak8GenJetsNoNu_*_*', 
-        'drop *_genCandidatesForMET_*_*', 
-        'drop *_genParticlesForMETAllVisible_*_*', 
-        'drop *_genMetCalo_*_*', 
-        'drop *_genMetCaloAndNonPrompt_*_*', 
-        'drop *_genMetTrue_*_*', 
+        'keep *',
+        'drop *_genParticles_*_*',
+        'drop *_genParticlesForJets_*_*',
+        'drop *_kt4GenJets_*_*',
+        'drop *_kt6GenJets_*_*',
+        'drop *_iterativeCone5GenJets_*_*',
+        'drop *_ak4GenJets_*_*',
+        'drop *_ak7GenJets_*_*',
+        'drop *_ak8GenJets_*_*',
+        'drop *_ak4GenJetsNoNu_*_*',
+        'drop *_ak8GenJetsNoNu_*_*',
+        'drop *_genCandidatesForMET_*_*',
+        'drop *_genParticlesForMETAllVisible_*_*',
+        'drop *_genMetCalo_*_*',
+        'drop *_genMetCaloAndNonPrompt_*_*',
+        'drop *_genMetTrue_*_*',
         'drop *_genMetIC5GenJs_*_*'
     ),
     secondaryFileNames = cms.untracked.vstring()
@@ -88,15 +88,15 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 
-process.load('L1Trigger/ME0Trigger/me0TriggerPseudoDigis_cfi')
-process.me0TriggerPseudoDigis.info = 3
-process.me0TriggerPseudoDigis.ME0SegmentProducer = cms.InputTag("me0Segments")
+process.load('L1Trigger.ME0Trigger.me0TriggerConvertedPseudoDigis_cfi')
+process.me0TriggerConvertedPseudoDigis.info = 3
+process.me0TriggerConvertedPseudoDigis.ME0SegmentProducer = cms.InputTag("me0Segments")
 
 
 # Path and EndPath definitions
 #process.ME0_step = cms.Path(process.me0RecoSequence_all)
 process.ME0Reco_step = cms.Path(process.me0RecoSequence)
-process.ME0L1_step = cms.Path(process.me0TriggerPseudoDigis)
+process.ME0L1_step = cms.Path(process.me0TriggerConvertedPseudoDigis)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 
@@ -109,7 +109,7 @@ associatePatAlgosToolsTask(process)
 # customisation of the process.
 
 # Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC
-#from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC 
+#from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC
 
 #call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
 #process = customizeHLTforMC(process)


### PR DESCRIPTION
#### PR description:

Following a request by folks in the GEM DPG who are studying LFV tau to 3 muon decay, I'm enabling the `ME0TriggerPseudoDigiProducer` in the Phase-2 L1T sequence. This PR also addresses a question that was asked a while ago [here](https://github.com/cms-sw/cmssw/pull/25685#issuecomment-458535838). I should note that these `ME0TriggerDigi` can also be used in the Phase-2 EMTF in the near future.

I did rename the configuration from `me0TriggerPseudoDigis_cfi` to `me0TriggerConvertedPseudoDigis_cfi`, otherwise `me0TriggerPseudoDigis_cfi` would clash with modules defined in `me0TriggerPseudoDigis_cff`. (The new objects are in fact converted ME0Segments.) I also added the standard `me0RecHits` and `me0Segments` modules in the sequence so that `me0TriggerConvertedPseudoDigis` has all the required inputs.

#### PR validation:

I ran matrix test 20434.0 to check that the triggers are produced and saved in the event content. That is indeed the case as you can see below. The new `Converted` pseudo digis are of type `ME0TriggerDigi` in contrast to `me0TriggerPseudoDigis` which is of type `ME0Segment`.

```
-bash-4.2$ edmEventSize -a -v step2.root | grep me0Trigger
ME0DetIdME0SegmentsOwnedRangeMap_me0TriggerPseudoDigis__HLT. 1299 666
ME0DetIdME0TriggerDigiMuonDigiCollection_me0TriggerConvertedPseudoDigis__HLT. 495.6 328.2
```

FYI: @tahuang1991 @mmaggi