### PR TITLE
use python from env instead of /usr/bin/python

### DIFF
--- a/DQM/SiStripMonitorClient/scripts/DeadROCCounter.py
+++ b/DQM/SiStripMonitorClient/scripts/DeadROCCounter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 from ROOT import TFile, gStyle,gPad ,TObject, TCanvas, TH1, TH1F, TH2F, TLegend, TPaletteAxis, TList, TLine, TAttLine, TF1,TAxis
 import re

--- a/DQM/SiStripMonitorClient/scripts/TkMap_script_phase1.py
+++ b/DQM/SiStripMonitorClient/scripts/TkMap_script_phase1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import sys

--- a/GeneratorInterface/Herwig7Interface/scripts/parallelization.py
+++ b/GeneratorInterface/Herwig7Interface/scripts/parallelization.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 
 # This script sets up parallel jobs for the build, integrate and run
 # step when using Herwig with the CMSSW framework.

--- a/HLTrigger/HLTanalyzers/test/CreateCFGs.py
+++ b/HLTrigger/HLTanalyzers/test/CreateCFGs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 
 from __future__ import print_function

--- a/HLTrigger/HLTanalyzers/test/CreateFileLists.py
+++ b/HLTrigger/HLTanalyzers/test/CreateFileLists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 
 from __future__ import print_function

--- a/HLTrigger/HLTanalyzers/test/fixTrue.py
+++ b/HLTrigger/HLTanalyzers/test/fixTrue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import sys, os, string


### PR DESCRIPTION
Remove the hard coded `/usr/bin/python` and pick up python from PATH. This will make sure that we use the python provided by cmssw.