### PR TITLE
updated architecture to mach cc* too

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -31,9 +31,9 @@
 </bin>
 <bin   file="testGroupSelection.cpp" name="testGroupSelection">
 </bin>
-<architecture name="slc.*_amd64_.*">
-<bin   file="testConnectionPool.cpp" name="testConnectionPool">
-  <use   name="CondFormats/RunInfo"/>
-</bin>
+<architecture name="(slc|cc).*_amd64_.*">
+  <bin   file="testConnectionPool.cpp" name="testConnectionPool">
+    <use   name="CondFormats/RunInfo"/>
+  </bin>
   <test name="condTestRegression" command="condTestRegression.py"/>
 </architecture>

--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="CondTools/Ecal"/>
 
-<architecture name="slc.*_amd64_.*">
+<architecture name="(slc|cc).*_amd64_.*">
   <ifcxx11_abi value="1">
     <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
   </ifcxx11_abi>

--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="CondTools/RunInfo"/>
 
-<architecture name="slc.*_amd64_.*">
+<architecture name="(slc|cc).*_amd64_.*">
   <use name="py2-sqlalchemy"/>
   <test name="RunInfoStart_O2O_test" command="RunInfoStart_O2O_test.sh"/>
 </architecture>

--- a/CondTools/SiStrip/test/BuildFile.xml
+++ b/CondTools/SiStrip/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<architecture name="slc.*_amd64_.*">
+<architecture name="(slc|cc).*_amd64_.*">
   <ifcxx11_abi value="1">
     <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
   </ifcxx11_abi>


### PR DESCRIPTION
As for CentOS8 we are going to use `cc` instead of `slc` in SCRAM_ARCH, so updated cmssw BuildFiles to match `cc` too