### PR TITLE
Fix use of TimeType enum after PR 28186

### DIFF
--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -221,9 +221,9 @@ def getSchema(tp):
 class Tag:
     __tablename__       = 'TAG'
     columns             = { 'name': (sqlalchemy.String(name_length),_Col.pk), 
-                            'time_type': (sqlalchemy.Enum(TimeType),_Col.notNull),
+                            'time_type': (sqlalchemy.Enum(*tuple(TimeType.__members__.keys())),_Col.notNull),
                             'object_type': (sqlalchemy.String(name_length),_Col.notNull),
-                            'synchronization': (sqlalchemy.Enum(Synchronization),_Col.notNull),
+                            'synchronization': (sqlalchemy.Enum(*tuple(Synchronization.__members__.keys())),_Col.notNull),
                             'description': (sqlalchemy.String(description_length),_Col.notNull),
                             'last_validated_time':(sqlalchemy.BIGINT,_Col.notNull),
                             'end_of_validity':(sqlalchemy.BIGINT,_Col.notNull),

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -657,10 +657,10 @@ def _since_filter(time_type):
     each 32-bit wide. The filter returns a string with both numbers, split.
     '''
 
-    if time_type == conddb.TimeType.time:
+    if time_type == conddb.TimeType.Time:
         return lambda since: '%s (%s)' % (_convertTimeType(since), since)
 
-    if time_type == conddb.TimeType.lumi:
+    if time_type == conddb.TimeType.Lumi:
         return lambda since: '%s : %5s (%s)' % (_high(since), _low(since), since)
 
     return lambda since: since
@@ -973,9 +973,9 @@ def list_(args):
                 scalar()
 
             sinceLabel = 'Since: Run '
-            if time_type == conddb.TimeType.time:
+            if time_type == conddb.TimeType.Time:
                 sinceLabel = 'Since: UTC          (timestamp)'
-            if time_type == conddb.TimeType.lumi:
+            if time_type == conddb.TimeType.Lumi:
                 sinceLabel = '  Run  : Lumi  (rawSince)'
 
             output_table(args,


### PR DESCRIPTION
#### PR description:

Addressing problems with conddb in unit tests after #28157, #28161 and #28186. This PR adapts ```conddb``` to the change by @davidlange6 in #28186.

#### PR validation:

The code correctly compile in python (both 2 and 3).