### PR TITLE
Clean redundant member functions from ElectronSeed

### DIFF
--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -111,22 +111,6 @@ namespace reco {
     int layerOrDiskNr(size_t hitNr) const { return getVal(hitNr, &PMVars::layerOrDiskNr); }
     int nrLayersAlongTraj() const { return nrLayersAlongTraj_; }
 
-    //redundant, backwards compatible function names
-    //to be cleaned up asap
-    //no new code should use them
-    //they were created as time is short and there is less risk having
-    //the functions here rather than adapting all the function call to them in other
-    //CMSSW code
-    float dPhi1() const { return dPhiNeg(0); }
-    float dPhi1Pos() const { return dPhiPos(0); }
-    float dPhi2() const { return dPhiNeg(1); }
-    float dPhi2Pos() const { return dPhiPos(1); }
-    float dRz1() const { return dRZNeg(0); }
-    float dRz1Pos() const { return dRZPos(0); }
-    float dRz2() const { return dRZNeg(1); }
-    float dRz2Pos() const { return dRZPos(1); }
-    int subDet1() const { return subDet(0); }
-    int subDet2() const { return subDet(1); }
     unsigned int hitsMask() const;
     void initTwoHitSeed(const unsigned char hitMask);
     void setNegAttributes(const float dRZ2 = std::numeric_limits<float>::infinity(),

--- a/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
@@ -16,8 +16,6 @@ namespace reco {
   typedef edm::RefProd<ElectronSeedCollection> ElectronSeedRefProd;
   /// vector of objects in the same collection of ElectronSeed objects
   typedef edm::RefVector<ElectronSeedCollection> ElectronSeedRefVector;
-  /// iterator over a vector of reference to ElectronSeed objects
-  typedef ElectronSeedRefVector::iterator electronseed_iterator;
 }  // namespace reco
 
 #endif

--- a/HLTrigger/Egamma/plugins/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTElectronPixelMatchFilter.cc
@@ -62,20 +62,20 @@ HLTElectronPixelMatchFilter::HLTElectronPixelMatchFilter(const edm::ParameterSet
 HLTElectronPixelMatchFilter::~HLTElectronPixelMatchFilter() = default;
 
 float HLTElectronPixelMatchFilter::calDPhi1Sq(reco::ElectronSeedCollection::const_iterator seed, int charge) const {
-  const float dPhi1Const = seed->subDet1() == 1 ? seed->subDet2() == 1 ? sPhi1B_ : sPhi1I_ : sPhi1F_;
-  float dPhi1 = charge < 0 ? seed->dPhi1() / dPhi1Const : seed->dPhi1Pos() / dPhi1Const;
+  const float dPhi1Const = seed->subDet(0) == 1 ? seed->subDet(1) == 1 ? sPhi1B_ : sPhi1I_ : sPhi1F_;
+  float dPhi1 = charge < 0 ? seed->dPhiNeg(0) / dPhi1Const : seed->dPhiPos(0) / dPhi1Const;
   return dPhi1 * dPhi1;
 }
 
 float HLTElectronPixelMatchFilter::calDPhi2Sq(reco::ElectronSeedCollection::const_iterator seed, int charge) const {
-  const float dPhi2Const = seed->subDet1() == 1 ? seed->subDet2() == 1 ? sPhi2B_ : sPhi2I_ : sPhi2F_;
-  float dPhi2 = charge < 0 ? seed->dPhi2() / dPhi2Const : seed->dPhi2Pos() / dPhi2Const;
+  const float dPhi2Const = seed->subDet(0) == 1 ? seed->subDet(1) == 1 ? sPhi2B_ : sPhi2I_ : sPhi2F_;
+  float dPhi2 = charge < 0 ? seed->dPhiNeg(1) / dPhi2Const : seed->dPhiPos(1) / dPhi2Const;
   return dPhi2 * dPhi2;
 }
 
 float HLTElectronPixelMatchFilter::calDZ2Sq(reco::ElectronSeedCollection::const_iterator seed, int charge) const {
-  const float dRZ2Const = seed->subDet1() == 1 ? seed->subDet2() == 1 ? sZ2B_ : sR2I_ : sR2F_;
-  float dRZ2 = charge < 0 ? seed->dRz2() / dRZ2Const : seed->dRz2Pos() / dRZ2Const;
+  const float dRZ2Const = seed->subDet(0) == 1 ? seed->subDet(1) == 1 ? sZ2B_ : sR2I_ : sR2F_;
+  float dRZ2 = charge < 0 ? seed->dRZNeg(1) / dRZ2Const : seed->dRZPos(1) / dRZ2Const;
   return dRZ2 * dRZ2;
 }
 
@@ -170,7 +170,7 @@ int HLTElectronPixelMatchFilter::getNrOfMatches(edm::Handle<reco::ElectronSeedCo
         float s2Pos = calDPhi1Sq(seedIt, 1) + calDPhi2Sq(seedIt, 1) + calDZ2Sq(seedIt, 1);
 
         const float s2Thres =
-            seedIt->subDet1() == 1 ? seedIt->subDet2() == 1 ? s2BarrelThres_ : s2InterThres_ : s2ForwardThres_;
+            seedIt->subDet(0) == 1 ? seedIt->subDet(1) == 1 ? s2BarrelThres_ : s2InterThres_ : s2ForwardThres_;
         if (s2Neg < s2Thres || s2Pos < s2Thres)
           nrMatch++;
       } else

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -70,38 +70,38 @@ namespace {
       if ((seed.caloCluster().key() == resItr->caloCluster().key()) && (seed.hitsMask() == resItr->hitsMask()) &&
           equivalent(seed, *resItr)) {
         if (positron) {
-          if (resItr->dRz2Pos() == std::numeric_limits<float>::infinity() &&
-              resItr->dRz2() != std::numeric_limits<float>::infinity()) {
+          if (resItr->dRZPos(1) == std::numeric_limits<float>::infinity() &&
+              resItr->dRZNeg(1) != std::numeric_limits<float>::infinity()) {
             resItr->setPosAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
-            seed.setNegAttributes(resItr->dRz2(), resItr->dPhi2(), resItr->dRz1(), resItr->dPhi1());
+            seed.setNegAttributes(resItr->dRZNeg(1), resItr->dPhiNeg(1), resItr->dRZNeg(0), resItr->dPhiNeg(0));
             break;
           } else {
-            if (resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
-              if (resItr->dRz2Pos() != seed.dRz2Pos()) {
+            if (resItr->dRZPos(1) != std::numeric_limits<float>::infinity()) {
+              if (resItr->dRZPos(1) != seed.dRZPos(1)) {
                 edm::LogWarning("ElectronSeedGenerator|BadValue")
                     << "this similar old seed already has another dRz2Pos"
                     << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
-                    << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
+                    << resItr->dRZNeg(1) << "/" << resItr->dPhiNeg(1) << "/" << resItr->dRZPos(1) << "/" << resItr->dPhiPos(1)
                     << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
-                    << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
+                    << seed.dRZNeg(1) << "/" << seed.dPhiNeg(1) << "/" << seed.dRZPos(1) << "/" << seed.dPhiPos(1);
               }
             }
           }
         } else {
-          if (resItr->dRz2() == std::numeric_limits<float>::infinity() &&
-              resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
+          if (resItr->dRZNeg(1) == std::numeric_limits<float>::infinity() &&
+              resItr->dRZPos(1) != std::numeric_limits<float>::infinity()) {
             resItr->setNegAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
-            seed.setPosAttributes(resItr->dRz2Pos(), resItr->dPhi2Pos(), resItr->dRz1Pos(), resItr->dPhi1Pos());
+            seed.setPosAttributes(resItr->dRZPos(1), resItr->dPhiPos(1), resItr->dRZPos(0), resItr->dPhiPos(0));
             break;
           } else {
-            if (resItr->dRz2() != std::numeric_limits<float>::infinity()) {
-              if (resItr->dRz2() != seed.dRz2()) {
+            if (resItr->dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+              if (resItr->dRZNeg(1) != seed.dRZNeg(1)) {
                 edm::LogWarning("ElectronSeedGenerator|BadValue")
                     << "this old seed already has another dRz2"
                     << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
-                    << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
+                    << resItr->dRZNeg(1) << "/" << resItr->dPhiNeg(1) << "/" << resItr->dRZPos(1) << "/" << resItr->dPhiPos(1)
                     << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
-                    << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
+                    << seed.dRZNeg(1) << "/" << seed.dPhiNeg(1) << "/" << seed.dRZPos(1) << "/" << seed.dPhiPos(1);
               }
             }
           }

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -66,40 +66,40 @@ namespace {
     } else {
       seed.setNegAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
     }
-    for (auto resItr = out.begin(); resItr != out.end(); ++resItr) {
-      if ((seed.caloCluster().key() == resItr->caloCluster().key()) && (seed.hitsMask() == resItr->hitsMask()) &&
-          equivalent(seed, *resItr)) {
+    for (auto &res : out) {
+      if ((seed.caloCluster().key() == res.caloCluster().key()) && (seed.hitsMask() == res.hitsMask()) &&
+          equivalent(seed, res)) {
         if (positron) {
-          if (resItr->dRZPos(1) == std::numeric_limits<float>::infinity() &&
-              resItr->dRZNeg(1) != std::numeric_limits<float>::infinity()) {
-            resItr->setPosAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
-            seed.setNegAttributes(resItr->dRZNeg(1), resItr->dPhiNeg(1), resItr->dRZNeg(0), resItr->dPhiNeg(0));
+          if (res.dRZPos(1) == std::numeric_limits<float>::infinity() &&
+              res.dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+            res.setPosAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
+            seed.setNegAttributes(res.dRZNeg(1), res.dPhiNeg(1), res.dRZNeg(0), res.dPhiNeg(0));
             break;
           } else {
-            if (resItr->dRZPos(1) != std::numeric_limits<float>::infinity()) {
-              if (resItr->dRZPos(1) != seed.dRZPos(1)) {
+            if (res.dRZPos(1) != std::numeric_limits<float>::infinity()) {
+              if (res.dRZPos(1) != seed.dRZPos(1)) {
                 edm::LogWarning("ElectronSeedGenerator|BadValue")
                     << "this similar old seed already has another dRz2Pos"
-                    << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
-                    << resItr->dRZNeg(1) << "/" << resItr->dPhiNeg(1) << "/" << resItr->dRZPos(1) << "/" << resItr->dPhiPos(1)
+                    << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)res.hitsMask() << "/"
+                    << res.dRZNeg(1) << "/" << res.dPhiNeg(1) << "/" << res.dRZPos(1) << "/" << res.dPhiPos(1)
                     << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
                     << seed.dRZNeg(1) << "/" << seed.dPhiNeg(1) << "/" << seed.dRZPos(1) << "/" << seed.dPhiPos(1);
               }
             }
           }
         } else {
-          if (resItr->dRZNeg(1) == std::numeric_limits<float>::infinity() &&
-              resItr->dRZPos(1) != std::numeric_limits<float>::infinity()) {
-            resItr->setNegAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
-            seed.setPosAttributes(resItr->dRZPos(1), resItr->dPhiPos(1), resItr->dRZPos(0), resItr->dPhiPos(0));
+          if (res.dRZNeg(1) == std::numeric_limits<float>::infinity() &&
+              res.dRZPos(1) != std::numeric_limits<float>::infinity()) {
+            res.setNegAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
+            seed.setPosAttributes(res.dRZPos(1), res.dPhiPos(1), res.dRZPos(0), res.dPhiPos(0));
             break;
           } else {
-            if (resItr->dRZNeg(1) != std::numeric_limits<float>::infinity()) {
-              if (resItr->dRZNeg(1) != seed.dRZNeg(1)) {
+            if (res.dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+              if (res.dRZNeg(1) != seed.dRZNeg(1)) {
                 edm::LogWarning("ElectronSeedGenerator|BadValue")
                     << "this old seed already has another dRz2"
-                    << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
-                    << resItr->dRZNeg(1) << "/" << resItr->dPhiNeg(1) << "/" << resItr->dRZPos(1) << "/" << resItr->dPhiPos(1)
+                    << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)res.hitsMask() << "/"
+                    << res.dRZNeg(1) << "/" << res.dPhiNeg(1) << "/" << res.dRZPos(1) << "/" << res.dPhiPos(1)
                     << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
                     << seed.dRZNeg(1) << "/" << seed.dPhiNeg(1) << "/" << seed.dRZPos(1) << "/" << seed.dPhiPos(1);
               }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -628,7 +628,7 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::
     if (elseed.isNull()) {
       throw cms::Exception("GsfElectronAlgo|NotElectronSeed") << "The GsfTrack seed is not an ElectronSeed ?!";
     } else {
-      if (elseed->subDet2() == 6)
+      if (elseed->subDet(1) == 6)
         return;
     }
   }
@@ -976,12 +976,12 @@ void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron& ele) {
   } else {
     if (elseed.isNull()) {
     } else {
-      sd1 = elseed->subDet1();
-      sd2 = elseed->subDet2();
-      dPhi1 = (ele.charge() > 0) ? elseed->dPhi1Pos() : elseed->dPhi1();
-      dPhi2 = (ele.charge() > 0) ? elseed->dPhi2Pos() : elseed->dPhi2();
-      dRz1 = (ele.charge() > 0) ? elseed->dRz1Pos() : elseed->dRz1();
-      dRz2 = (ele.charge() > 0) ? elseed->dRz2Pos() : elseed->dRz2();
+      sd1 = elseed->subDet(0);
+      sd2 = elseed->subDet(1);
+      dPhi1 = (ele.charge() > 0) ? elseed->dPhiPos(0) : elseed->dPhiNeg(0);
+      dPhi2 = (ele.charge() > 0) ? elseed->dPhiPos(1) : elseed->dPhiNeg(1);
+      dRz1 = (ele.charge() > 0) ? elseed->dRZPos(0) : elseed->dRZNeg(0);
+      dRz2 = (ele.charge() > 0) ? elseed->dRZPos(1) : elseed->dRZNeg(1);
     }
   }
   ele.setPixelMatchSubdetectors(sd1, sd2);

--- a/RecoEgamma/Examples/plugins/DQMAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/DQMAnalyzer.cc
@@ -751,13 +751,13 @@ void DQMAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetu
     if (!readAOD_) { // track extra does not exist in AOD
             edm::RefToBase<TrajectorySeed> seed = gsfIter->gsfTrack()->extra()->seedRef();
       ElectronSeedRef elseed=seed.castTo<ElectronSeedRef>();
-      h_ele_seed_dphi2_-> Fill(elseed->dPhi2());
-            h_ele_seed_dphi2VsEta_-> Fill(gsfIter->eta(), elseed->dPhi2());
-            h_ele_seed_dphi2VsPt_-> Fill(gsfIter->pt(), elseed->dPhi2()) ;
-            h_ele_seed_drz2_-> Fill(elseed->dRz2());
-            h_ele_seed_drz2VsEta_-> Fill(gsfIter->eta(), elseed->dRz2());
-            h_ele_seed_drz2VsPt_-> Fill(gsfIter->pt(), elseed->dRz2());
-            h_ele_seed_subdet2_-> Fill(elseed->subDet2());
+      h_ele_seed_dphi2_-> Fill(elseed->dPhiNeg(1));
+            h_ele_seed_dphi2VsEta_-> Fill(gsfIter->eta(), elseed->dPhiNeg(1));
+            h_ele_seed_dphi2VsPt_-> Fill(gsfIter->pt(), elseed->dPhiNeg(1)) ;
+            h_ele_seed_drz2_-> Fill(elseed->dRZNeg(1));
+            h_ele_seed_drz2VsEta_-> Fill(gsfIter->eta(), elseed->dRZNeg(1));
+            h_ele_seed_drz2VsPt_-> Fill(gsfIter->pt(), elseed->dRZNeg(1));
+            h_ele_seed_subdet2_-> Fill(elseed->subDet(1));
           }
     */
 

--- a/RecoEgamma/Examples/plugins/GsfElectronDataAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronDataAnalyzer.cc
@@ -1687,13 +1687,13 @@ void GsfElectronDataAnalyzer::analyze(const edm::Event &iEvent, const edm::Event
     if (!readAOD_) {  // track extra does not exist in AOD
       edm::RefToBase<TrajectorySeed> seed = gsfIter->gsfTrack()->extra()->seedRef();
       ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-      h_ele_seed_dphi2_->Fill(elseed->dPhi2());
-      h_ele_seed_dphi2VsEta_->Fill(gsfIter->eta(), elseed->dPhi2());
-      h_ele_seed_dphi2VsPt_->Fill(gsfIter->pt(), elseed->dPhi2());
-      h_ele_seed_drz2_->Fill(elseed->dRz2());
-      h_ele_seed_drz2VsEta_->Fill(gsfIter->eta(), elseed->dRz2());
-      h_ele_seed_drz2VsPt_->Fill(gsfIter->pt(), elseed->dRz2());
-      h_ele_seed_subdet2_->Fill(elseed->subDet2());
+      h_ele_seed_dphi2_->Fill(elseed->dPhiNeg(1));
+      h_ele_seed_dphi2VsEta_->Fill(gsfIter->eta(), elseed->dPhiNeg(1));
+      h_ele_seed_dphi2VsPt_->Fill(gsfIter->pt(), elseed->dPhiNeg(1));
+      h_ele_seed_drz2_->Fill(elseed->dRZNeg(1));
+      h_ele_seed_drz2VsEta_->Fill(gsfIter->eta(), elseed->dRZNeg(1));
+      h_ele_seed_drz2VsPt_->Fill(gsfIter->pt(), elseed->dRZNeg(1));
+      h_ele_seed_subdet2_->Fill(elseed->subDet(1));
     }
     // match distributions
     h_ele_EoP->Fill(gsfIter->eSuperClusterOverP());

--- a/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronFakeAnalyzer.cc
@@ -1970,13 +1970,13 @@ void GsfElectronFakeAnalyzer::analyze(const edm::Event &iEvent, const edm::Event
       if (!readAOD_) {  // track extra does not exist in AOD
         edm::RefToBase<TrajectorySeed> seed = bestGsfElectron.gsfTrack()->extra()->seedRef();
         ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-        h_ele_seed_dphi2_->Fill(elseed->dPhi2());
-        h_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhi2());
-        h_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhi2());
-        h_ele_seed_drz2_->Fill(elseed->dRz2());
-        h_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRz2());
-        h_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRz2());
-        h_ele_seed_subdet2_->Fill(elseed->subDet2());
+        h_ele_seed_dphi2_->Fill(elseed->dPhiNeg(1));
+        h_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhiNeg(1));
+        h_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhiNeg(1));
+        h_ele_seed_drz2_->Fill(elseed->dRZNeg(1));
+        h_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRZNeg(1));
+        h_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRZNeg(1));
+        h_ele_seed_subdet2_->Fill(elseed->subDet(1));
       }
       // match distributions
       h_ele_EoP->Fill(bestGsfElectron.eSuperClusterOverP());

--- a/RecoEgamma/Examples/plugins/GsfElectronMCAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCAnalyzer.cc
@@ -2877,13 +2877,13 @@ void GsfElectronMCAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSe
           if (!readAOD_) {  // track extra does not exist in AOD
             edm::RefToBase<TrajectorySeed> seed = bestGsfElectron.gsfTrack()->extra()->seedRef();
             ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-            h_ele_seed_dphi2_->Fill(elseed->dPhi2());
-            h_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhi2());
-            h_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhi2());
-            h_ele_seed_drz2_->Fill(elseed->dRz2());
-            h_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRz2());
-            h_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRz2());
-            h_ele_seed_subdet2_->Fill(elseed->subDet2());
+            h_ele_seed_dphi2_->Fill(elseed->dPhiNeg(1));
+            h_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhiNeg(1));
+            h_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhiNeg(1));
+            h_ele_seed_drz2_->Fill(elseed->dRZNeg(1));
+            h_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRZNeg(1));
+            h_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRZNeg(1));
+            h_ele_seed_subdet2_->Fill(elseed->subDet(1));
           }
           // match distributions
           h_ele_EoP->Fill(bestGsfElectron.eSuperClusterOverP());

--- a/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/GsfElectronMCFakeAnalyzer.cc
@@ -1973,13 +1973,13 @@ void GsfElectronMCFakeAnalyzer::analyze(const edm::Event &iEvent, const edm::Eve
       if (!readAOD_) {  // track extra does not exist in AOD
         edm::RefToBase<TrajectorySeed> seed = bestGsfElectron.gsfTrack()->extra()->seedRef();
         ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-        h_ele_seed_dphi2_->Fill(elseed->dPhi2());
-        h_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhi2());
-        h_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhi2());
-        h_ele_seed_drz2_->Fill(elseed->dRz2());
-        h_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRz2());
-        h_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRz2());
-        h_ele_seed_subdet2_->Fill(elseed->subDet2());
+        h_ele_seed_dphi2_->Fill(elseed->dPhiNeg(1));
+        h_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhiNeg(1));
+        h_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhiNeg(1));
+        h_ele_seed_drz2_->Fill(elseed->dRZNeg(1));
+        h_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRZNeg(1));
+        h_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRZNeg(1));
+        h_ele_seed_subdet2_->Fill(elseed->subDet(1));
       }
       // match distributions
       h_ele_EoP->Fill(bestGsfElectron.eSuperClusterOverP());

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -2698,35 +2698,35 @@ void ElectronMcFakeValidator::analyze(const edm::Event &iEvent, const edm::Event
       if (!readAOD_) {  // track extra does not exist in AOD
         edm::RefToBase<TrajectorySeed> seed = bestGsfElectron.gsfTrack()->extra()->seedRef();
         ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-        h1_ele_seed_subdet2_->Fill(elseed->subDet2());
+        h1_ele_seed_subdet2_->Fill(elseed->subDet(1));
         h1_ele_seed_mask_->Fill(elseed->hitsMask());
-        if (elseed->subDet2() == 1) {
+        if (elseed->subDet(1) == 1) {
           h1_ele_seed_mask_bpix_->Fill(elseed->hitsMask());
-        } else if (elseed->subDet2() == 2) {
+        } else if (elseed->subDet(1) == 2) {
           h1_ele_seed_mask_fpix_->Fill(elseed->hitsMask());
-        } else if (elseed->subDet2() == 6) {
+        } else if (elseed->subDet(1) == 6) {
           h1_ele_seed_mask_tec_->Fill(elseed->hitsMask());
         }
 
-        if (elseed->dPhi2() != std::numeric_limits<float>::infinity()) {
-          h1_ele_seed_dphi2_->Fill(elseed->dPhi2());
-          h2_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhi2());
-          h2_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhi2());
+        if (elseed->dPhiNeg(1) != std::numeric_limits<float>::infinity()) {
+          h1_ele_seed_dphi2_->Fill(elseed->dPhiNeg(1));
+          h2_ele_seed_dphi2VsEta_->Fill(bestGsfElectron.eta(), elseed->dPhiNeg(1));
+          h2_ele_seed_dphi2VsPt_->Fill(bestGsfElectron.pt(), elseed->dPhiNeg(1));
         }
-        if (elseed->dPhi2Pos() != std::numeric_limits<float>::infinity()) {
-          h1_ele_seed_dphi2pos_->Fill(elseed->dPhi2Pos());
-          h2_ele_seed_dphi2posVsEta_->Fill(bestGsfElectron.eta(), elseed->dPhi2Pos());
-          h2_ele_seed_dphi2posVsPt_->Fill(bestGsfElectron.pt(), elseed->dPhi2Pos());
+        if (elseed->dPhiPos(1) != std::numeric_limits<float>::infinity()) {
+          h1_ele_seed_dphi2pos_->Fill(elseed->dPhiPos(1));
+          h2_ele_seed_dphi2posVsEta_->Fill(bestGsfElectron.eta(), elseed->dPhiPos(1));
+          h2_ele_seed_dphi2posVsPt_->Fill(bestGsfElectron.pt(), elseed->dPhiPos(1));
         }
-        if (elseed->dRz2() != std::numeric_limits<float>::infinity()) {
-          h1_ele_seed_drz2_->Fill(elseed->dRz2());
-          h2_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRz2());
-          h2_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRz2());
+        if (elseed->dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+          h1_ele_seed_drz2_->Fill(elseed->dRZNeg(1));
+          h2_ele_seed_drz2VsEta_->Fill(bestGsfElectron.eta(), elseed->dRZNeg(1));
+          h2_ele_seed_drz2VsPt_->Fill(bestGsfElectron.pt(), elseed->dRZNeg(1));
         }
-        if (elseed->dRz2Pos() != std::numeric_limits<float>::infinity()) {
-          h1_ele_seed_drz2pos_->Fill(elseed->dRz2Pos());
-          h2_ele_seed_drz2posVsEta_->Fill(bestGsfElectron.eta(), elseed->dRz2Pos());
-          h2_ele_seed_drz2posVsPt_->Fill(bestGsfElectron.pt(), elseed->dRz2Pos());
+        if (elseed->dRZPos(1) != std::numeric_limits<float>::infinity()) {
+          h1_ele_seed_drz2pos_->Fill(elseed->dRZPos(1));
+          h2_ele_seed_drz2posVsEta_->Fill(bestGsfElectron.eta(), elseed->dRZPos(1));
+          h2_ele_seed_drz2posVsPt_->Fill(bestGsfElectron.pt(), elseed->dRZPos(1));
         }
       }
       // match distributions

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -3858,36 +3858,36 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
     {
       edm::RefToBase<TrajectorySeed> seed = bestGsfElectron.gsfTrack()->extra()->seedRef();
       ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-      h1_ele_seed_subdet2->Fill(elseed->subDet2());
+      h1_ele_seed_subdet2->Fill(elseed->subDet(1));
       h1_ele_seed_mask->Fill(elseed->hitsMask());
-      if (elseed->subDet2() == 1) {
+      if (elseed->subDet(1) == 1) {
         h1_ele_seed_mask_bpix->Fill(elseed->hitsMask());
-      } else if (elseed->subDet2() == 2) {
+      } else if (elseed->subDet(1) == 2) {
         h1_ele_seed_mask_fpix->Fill(elseed->hitsMask());
-      } else if (elseed->subDet2() == 6) {
+      } else if (elseed->subDet(1) == 6) {
         h1_ele_seed_mask_tec->Fill(elseed->hitsMask());
       }
 
-      if (elseed->dPhi2() != std::numeric_limits<float>::infinity()) {
-        h1_ele_seed_dphi2->Fill(elseed->dPhi2());
-        h2_ele_seed_dphi2VsEta->Fill(bestGsfElectron.eta(), elseed->dPhi2());
-        h2_ele_seed_dphi2VsPt->Fill(bestGsfElectron.pt(), elseed->dPhi2());
+      if (elseed->dPhiNeg(1) != std::numeric_limits<float>::infinity()) {
+        h1_ele_seed_dphi2->Fill(elseed->dPhiNeg(1));
+        h2_ele_seed_dphi2VsEta->Fill(bestGsfElectron.eta(), elseed->dPhiNeg(1));
+        h2_ele_seed_dphi2VsPt->Fill(bestGsfElectron.pt(), elseed->dPhiNeg(1));
       } else {
       }
-      if (elseed->dPhi2Pos() != std::numeric_limits<float>::infinity()) {
-        h1_ele_seed_dphi2pos->Fill(elseed->dPhi2Pos());
-        h2_ele_seed_dphi2posVsEta->Fill(bestGsfElectron.eta(), elseed->dPhi2Pos());
-        h2_ele_seed_dphi2posVsPt->Fill(bestGsfElectron.pt(), elseed->dPhi2Pos());
+      if (elseed->dPhiPos(1) != std::numeric_limits<float>::infinity()) {
+        h1_ele_seed_dphi2pos->Fill(elseed->dPhiPos(1));
+        h2_ele_seed_dphi2posVsEta->Fill(bestGsfElectron.eta(), elseed->dPhiPos(1));
+        h2_ele_seed_dphi2posVsPt->Fill(bestGsfElectron.pt(), elseed->dPhiPos(1));
       }
-      if (elseed->dRz2() != std::numeric_limits<float>::infinity()) {
-        h1_ele_seed_drz2->Fill(elseed->dRz2());
-        h2_ele_seed_drz2VsEta->Fill(bestGsfElectron.eta(), elseed->dRz2());
-        h2_ele_seed_drz2VsPt->Fill(bestGsfElectron.pt(), elseed->dRz2());
+      if (elseed->dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+        h1_ele_seed_drz2->Fill(elseed->dRZNeg(1));
+        h2_ele_seed_drz2VsEta->Fill(bestGsfElectron.eta(), elseed->dRZNeg(1));
+        h2_ele_seed_drz2VsPt->Fill(bestGsfElectron.pt(), elseed->dRZNeg(1));
       }
-      if (elseed->dRz2Pos() != std::numeric_limits<float>::infinity()) {
-        h1_ele_seed_drz2pos->Fill(elseed->dRz2Pos());
-        h2_ele_seed_drz2posVsEta->Fill(bestGsfElectron.eta(), elseed->dRz2Pos());
-        h2_ele_seed_drz2posVsPt->Fill(bestGsfElectron.pt(), elseed->dRz2Pos());
+      if (elseed->dRZPos(1) != std::numeric_limits<float>::infinity()) {
+        h1_ele_seed_drz2pos->Fill(elseed->dRZPos(1));
+        h2_ele_seed_drz2posVsEta->Fill(bestGsfElectron.eta(), elseed->dRZPos(1));
+        h2_ele_seed_drz2posVsPt->Fill(bestGsfElectron.pt(), elseed->dRZPos(1));
       }
     }
 


### PR DESCRIPTION
#### PR description:

When I checked out the pixel matching code for my previous PR I noticed there were some redundant member functions in the `ElectronSeed` class that were flagged for a cleanup. These member functions were originally kept for backwards compatibility with the old `ElectronSeed` class so the new `ElectronSeed` could be quickly integrated without adapting function calls in all of CMSSW. in Probably it's now a good time for removing them.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR:

No backport intended.