### PR TITLE
make track quality requirement in GeneralTracksImporter and PFTrackAl…

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -15,8 +15,9 @@ public:
       : BlockElementImporterBase(conf, sumes),
         src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
         muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
-	trackQuality_(
-	  (conf.existsAs<std::string>("trackQuality")) ? conf.getParameter<std::string>("trackQuality") : trackQuality_ = "highPurity"),
+        trackQuality_((conf.existsAs<std::string>("trackQuality"))
+                          ? reco::TrackBase::qualityByName(conf.getParameter<std::string>("trackQuality"))
+                          : reco::TrackBase::qualityByName("highPurity")),
         DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
         NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
         useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
@@ -33,7 +34,7 @@ private:
 
   edm::EDGetTokenT<reco::PFRecTrackCollection> src_;
   edm::EDGetTokenT<reco::MuonCollection> muons_;
-  std::string trackQuality_;
+  const reco::TrackBase::TrackQuality trackQuality_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
   const bool useIterTracking_, cleanBadConvBrems_, debug_;
@@ -65,7 +66,8 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
         if (trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) && cRef.empty() && dvRef.isNull() &&
             v0Ref.isNull()) {
           // if the Pt resolution is bad we kill this element
-          if (!PFTrackAlgoTools::goodPtResolution(trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_, trackQuality_)) {
+          if (!PFTrackAlgoTools::goodPtResolution(
+                  trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_, debug_)) {
             itr = elems.erase(itr);
             continue;
           }
@@ -117,7 +119,8 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
                               (pfmu_->hasValidTrack(muonref, false) && PFMuonAlgo::isMuon(muonref)));
     }
     if (thisIsAPotentialMuon ||
-        PFTrackAlgoTools::goodPtResolution(pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_, trackQuality_)) {
+        PFTrackAlgoTools::goodPtResolution(
+            pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_, debug_)) {
       trkElem = new reco::PFBlockElementTrack(pftrackref);
       if (thisIsAPotentialMuon && debug_) {
         std::cout << "Potential Muon P " << pftrackref->trackRef()->p() << " pt " << pftrackref->trackRef()->p()

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -1,3 +1,4 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
@@ -22,8 +23,7 @@ public:
         NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
         useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
         cleanBadConvBrems_(
-            conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
-        debug_(conf.getUntrackedParameter<bool>("debug", false)) {
+            conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false) {
     pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo(conf));
   }
 
@@ -37,7 +37,7 @@ private:
   const reco::TrackBase::TrackQuality trackQuality_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
-  const bool useIterTracking_, cleanBadConvBrems_, debug_;
+  const bool useIterTracking_, cleanBadConvBrems_;
   std::unique_ptr<PFMuonAlgo> pfmu_;
 };
 
@@ -67,7 +67,7 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
             v0Ref.isNull()) {
           // if the Pt resolution is bad we kill this element
           if (!PFTrackAlgoTools::goodPtResolution(
-                  trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_, debug_)) {
+                  trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_)) {
             itr = elems.erase(itr);
             continue;
           }
@@ -118,13 +118,12 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
       thisIsAPotentialMuon = ((pfmu_->hasValidTrack(muonref, true) && PFMuonAlgo::isLooseMuon(muonref)) ||
                               (pfmu_->hasValidTrack(muonref, false) && PFMuonAlgo::isMuon(muonref)));
     }
-    if (thisIsAPotentialMuon ||
-        PFTrackAlgoTools::goodPtResolution(
-            pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_, debug_)) {
+    if (thisIsAPotentialMuon || PFTrackAlgoTools::goodPtResolution(
+                                    pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_)) {
       trkElem = new reco::PFBlockElementTrack(pftrackref);
-      if (thisIsAPotentialMuon && debug_) {
-        std::cout << "Potential Muon P " << pftrackref->trackRef()->p() << " pt " << pftrackref->trackRef()->p()
-                  << std::endl;
+      if (thisIsAPotentialMuon) {
+        LogDebug("GeneralTracksImporter")
+            << "Potential Muon P " << pftrackref->trackRef()->p() << " pt " << pftrackref->trackRef()->p() << std::endl;
       }
       if (muId != -1)
         trkElem->setMuonRef(muonref);

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -17,7 +17,7 @@ public:
         muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
         trackQuality_((conf.existsAs<std::string>("trackQuality"))
                           ? reco::TrackBase::qualityByName(conf.getParameter<std::string>("trackQuality"))
-                          : reco::TrackBase::qualityByName("highPurity")),
+                          : reco::TrackBase::highPurity),
         DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
         NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
         useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -15,6 +15,8 @@ public:
       : BlockElementImporterBase(conf, sumes),
         src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
         muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
+	trackQuality_(
+	  (conf.existsAs<std::string>("trackQuality")) ? conf.getParameter<std::string>("trackQuality") : trackQuality_ = "highPurity"),
         DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
         NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
         useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
@@ -31,10 +33,10 @@ private:
 
   edm::EDGetTokenT<reco::PFRecTrackCollection> src_;
   edm::EDGetTokenT<reco::MuonCollection> muons_;
+  std::string trackQuality_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
   const bool useIterTracking_, cleanBadConvBrems_, debug_;
-
   std::unique_ptr<PFMuonAlgo> pfmu_;
 };
 
@@ -63,7 +65,7 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
         if (trkel->trackType(reco::PFBlockElement::T_FROM_GAMMACONV) && cRef.empty() && dvRef.isNull() &&
             v0Ref.isNull()) {
           // if the Pt resolution is bad we kill this element
-          if (!PFTrackAlgoTools::goodPtResolution(trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_)) {
+          if (!PFTrackAlgoTools::goodPtResolution(trkel->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_, trackQuality_)) {
             itr = elems.erase(itr);
             continue;
           }
@@ -115,7 +117,7 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
                               (pfmu_->hasValidTrack(muonref, false) && PFMuonAlgo::isMuon(muonref)));
     }
     if (thisIsAPotentialMuon ||
-        PFTrackAlgoTools::goodPtResolution(pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_)) {
+        PFTrackAlgoTools::goodPtResolution(pftrackref->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_, trackQuality_)) {
       trkElem = new reco::PFBlockElementTrack(pftrackref);
       if (thisIsAPotentialMuon && debug_) {
         std::cout << "Potential Muon P " << pftrackref->trackRef()->p() << " pt " << pftrackref->trackRef()->p()

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -18,7 +18,7 @@ public:
         muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
         trackQuality_((conf.existsAs<std::string>("trackQuality"))
                           ? reco::TrackBase::qualityByName(conf.getParameter<std::string>("trackQuality"))
-                          : reco::TrackBase::qualityByName("highPurity")),
+                          : reco::TrackBase::highPurity),
         DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
         NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
         useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -41,6 +41,7 @@ particleFlowBlock = cms.EDProducer(
         cms.PSet( importerName = cms.string("GeneralTracksImporter"),
                   source = cms.InputTag("pfTrack"),
                   muonSrc = cms.InputTag("muons1stStep"),
+		  trackQuality = cms.string("highPurity"),
                   cleanBadConvertedBrems = cms.bool(True),
                   useIterativeTracking = cms.bool(True),
                   maxDPtOPt      = cms.double(1.),                                 

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -44,7 +44,6 @@ particleFlowBlock = cms.EDProducer(
 		  trackQuality = cms.string("highPurity"),
                   cleanBadConvertedBrems = cms.bool(True),
                   useIterativeTracking = cms.bool(True),
-                  maxDPtOPt      = cms.double(1.),                                 
                   DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,
                                                            10.0,10.0,5.0),
                   NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3)

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -18,5 +18,6 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        bool debug = false);
+                        bool debug = false,
+			std::string trackQuality = "highPurity");
 }  // namespace PFTrackAlgoTools

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -18,6 +18,6 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        const reco::TrackBase::TrackQuality trackQuality = reco::TrackBase::qualityByName("highPurity"),
+                        const reco::TrackBase::TrackQuality trackQuality = reco::TrackBase::highPurity,
                         bool debug = false);
 }  // namespace PFTrackAlgoTools

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -18,6 +18,6 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        bool debug = false,
-			std::string trackQuality = "highPurity");
+                        const reco::TrackBase::TrackQuality trackQuality = reco::TrackBase::qualityByName("highPurity"),
+                        bool debug = false);
 }  // namespace PFTrackAlgoTools

--- a/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h
@@ -18,6 +18,6 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        const reco::TrackBase::TrackQuality trackQuality = reco::TrackBase::highPurity,
-                        bool debug = false);
+                        //const reco::TrackBase::TrackQuality trackQuality = reco::TrackBase::highPurity,
+                        const reco::TrackBase::TrackQuality trackQuality);
 }  // namespace PFTrackAlgoTools

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -52,7 +52,7 @@ private:
 
   // variables needed for copied goodPtResolution function
   // need to go back and figure out sensible values
-  bool debug_;
+
   const reco::TrackBase::TrackQuality trackQuality_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
@@ -74,7 +74,6 @@ private:
 
 HGCalTrackCollectionProducer::HGCalTrackCollectionProducer(const edm::ParameterSet& iConfig)
     : src_(consumes<edm::View<reco::PFRecTrack> >(iConfig.getParameter<edm::InputTag>("src"))),
-      debug_(iConfig.getParameter<bool>("debug")),
       trackQuality_((iConfig.existsAs<std::string>("trackQuality"))
                         ? reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("trackQuality"))
                         : reco::TrackBase::highPurity),
@@ -138,8 +137,8 @@ void HGCalTrackCollectionProducer::produce(edm::Event& evt, const edm::EventSetu
 
   for (unsigned int i = 0; i < tracks.size(); i++) {
     const auto track = tracks.ptrAt(i);
-    bool isGood = PFTrackAlgoTools::goodPtResolution(
-        track->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_, debug_);
+    bool isGood =
+        PFTrackAlgoTools::goodPtResolution(track->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_);
     LogDebug("HGCalTrackCollectionProducer") << "HGCalTrackCollectionProducer Track number " << i
                                              << " has a goodPtResolution result of " << isGood << std::endl;
     if (!isGood)

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -77,7 +77,7 @@ HGCalTrackCollectionProducer::HGCalTrackCollectionProducer(const edm::ParameterS
       debug_(iConfig.getParameter<bool>("debug")),
       trackQuality_((iConfig.existsAs<std::string>("trackQuality"))
                         ? reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("trackQuality"))
-                        : reco::TrackBase::qualityByName("highPurity")),
+                        : reco::TrackBase::highPurity),
       DPtovPtCut_(iConfig.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
       NHitCut_(iConfig.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
       useIterTracking_(iConfig.getParameter<bool>("useIterativeTracking")) {

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -53,6 +53,7 @@ private:
   // variables needed for copied goodPtResolution function
   // need to go back and figure out sensible values
   bool debug_;
+  const reco::TrackBase::TrackQuality trackQuality_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
   const bool useIterTracking_;
@@ -74,6 +75,9 @@ private:
 HGCalTrackCollectionProducer::HGCalTrackCollectionProducer(const edm::ParameterSet& iConfig)
     : src_(consumes<edm::View<reco::PFRecTrack> >(iConfig.getParameter<edm::InputTag>("src"))),
       debug_(iConfig.getParameter<bool>("debug")),
+      trackQuality_((iConfig.existsAs<std::string>("trackQuality"))
+                        ? reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("trackQuality"))
+                        : reco::TrackBase::qualityByName("highPurity")),
       DPtovPtCut_(iConfig.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
       NHitCut_(iConfig.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
       useIterTracking_(iConfig.getParameter<bool>("useIterativeTracking")) {
@@ -134,8 +138,8 @@ void HGCalTrackCollectionProducer::produce(edm::Event& evt, const edm::EventSetu
 
   for (unsigned int i = 0; i < tracks.size(); i++) {
     const auto track = tracks.ptrAt(i);
-    bool isGood =
-        PFTrackAlgoTools::goodPtResolution(track->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, debug_);
+    bool isGood = PFTrackAlgoTools::goodPtResolution(
+        track->trackRef(), DPtovPtCut_, NHitCut_, useIterTracking_, trackQuality_, debug_);
     LogDebug("HGCalTrackCollectionProducer") << "HGCalTrackCollectionProducer Track number " << i
                                              << " has a goodPtResolution result of " << isGood << std::endl;
     if (!isGood)

--- a/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
@@ -3,9 +3,8 @@ import FWCore.ParameterSet.Config as cms
 hgcalTrackCollection = cms.EDProducer(
     "HGCalTrackCollectionProducer",
     src = cms.InputTag("pfTrack"),
-    debug = cms.bool(False),
+    trackQuality = cms.string("highPurity"),
     # From GeneralTracksImporter
-
     useIterativeTracking = cms.bool(True),
     DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,10.0,10.0,5.0),
     NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,32700), # the last value is nonsense

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -237,8 +237,7 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        reco::TrackBase::TrackQuality trackQuality,
-                        bool debug) {
+                        reco::TrackBase::TrackQuality trackQuality) {
     //check quality of tracks
     if (!trackref->quality(trackQuality))
       return false;

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -237,11 +237,10 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        bool debug,
-			std::string trackQuality) {
-    
+                        reco::TrackBase::TrackQuality trackQuality,
+                        bool debug) {
     //check quality of tracks
-    if(!trackref->quality(reco::TrackBase::qualityByName(trackQuality)))
+    if (!trackref->quality(trackQuality))
       return false;
 
     const double p = trackref->p();

--- a/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackAlgoTools.cc
@@ -237,9 +237,11 @@ namespace PFTrackAlgoTools {
                         const std::vector<double>& DPtovPtCut,
                         const std::vector<unsigned>& NHitCut,
                         bool useIterTracking,
-                        bool debug) {
-    //recheck that the track is high purity!
-    if (!trackref->quality(reco::TrackBase::highPurity))
+                        bool debug,
+			std::string trackQuality) {
+    
+    //check quality of tracks
+    if(!trackref->quality(reco::TrackBase::qualityByName(trackQuality)))
       return false;
 
     const double p = trackref->p();


### PR DESCRIPTION
…goTools configurable

#### PR description:

Track Quality requirements in the PFBlockProducer are hardcoded. This PR is intended add configurability.

#### PR validation:

I ran OnLine_HLT_GRun.py with the new input for different track quality requirements in "process.hltParticleFlowBlock" PFBlockProducer. Locally I did a print out to check if bools are set correctly and the string correctly passed.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)