### PR TITLE
Fix undersized buffers.

### DIFF
--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -705,7 +705,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
     _cCapid_BadvsFEDvsLSmod60.book(ib, _subsystem, "BadvsLSmod60");
   }
   for (int i = 0; i < 4; ++i) {
-    constexpr unsigned int kSize = 16;
+    constexpr unsigned int kSize = 32;
     char aux[kSize];
     snprintf(aux, kSize, "%d_uTCA", i);
     _cCapidMinusBXmod4_CrateSlotuTCA[i].book(ib, _subsystem, aux);

--- a/DQM/L1TMonitor/src/BxTiming.cc
+++ b/DQM/L1TMonitor/src/BxTiming.cc
@@ -154,7 +154,7 @@ void BxTiming::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm:
     for (int i = 0; i < nttype_; i++) {
       lbl.clear();
       lbl += "BxOccyGtTrigType";
-      char *ii = new char[10];
+      char *ii = new char[16];
       std::sprintf(ii, "%d", i + 1);
       lbl += ii;
       hBxOccyGtTrigType[i] = ibooker.book1D(lbl.data(), lbl.data(), norb_ + 1, -0.5, norb_ + 0.5);
@@ -237,7 +237,7 @@ void BxTiming::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm:
     hBxOccyGtTrigType[i]->setAxisTitle("bx", 1);
     lbl.clear();
     lbl += "GT occupancy for trigger type ";
-    char *ii = new char[10];
+    char *ii = new char[16];
     std::sprintf(ii, "%d", i + 1);
     lbl += ii;
     hBxOccyGtTrigType[i]->setAxisTitle(lbl, 2);

--- a/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
@@ -858,7 +858,7 @@ void SiPixelDataQuality::fillGlobalQualityPlot(DQMStore::IBooker &iBooker,
       }
       for (int j = 0; j < 4; ++j) {
         static const char buf[] = "Pixel/Barrel/NClustertoChargeRatio_NormMod%i";
-        char modplot[sizeof(buf) + 2];
+        char modplot[sizeof(buf) + 16];
         sprintf(modplot, buf, j + 1);
         MonitorElement *meFinal = iGetter.get(modplot);
         if (!meFinal)

--- a/DQM/TrigXMonitorClient/src/HLTScalersClient.cc
+++ b/DQM/TrigXMonitorClient/src/HLTScalersClient.cc
@@ -196,7 +196,7 @@ void HLTScalersClient::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, c
     dbe_->setCurrentFolder(folderName_);
 
     // split hlt scalers up into groups of 20
-    const int maxlen = 40;
+    const int maxlen = 64;
     char metitle[maxlen];                     // histo name
     char mename[maxlen];                      // ME name
     int numHistos = int(npaths / kPerHisto);  // this hasta be w/o remainders

--- a/DQM/TrigXMonitorClient/src/L1ScalersClient.cc
+++ b/DQM/TrigXMonitorClient/src/L1ScalersClient.cc
@@ -106,13 +106,13 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
   std::string algodir2 = "/AlgoBits";
   dbe_->setCurrentFolder(folderName_ + algodir2);
 
-  char metitle1[40];  // histo name
-  char mename1[40];   // ME name
+  char metitle1[64];  // histo name
+  char mename1[64];   // ME name
   for (int k = 0; k < kNumAlgoHistos; k++) {
     int npath_low = kPerHisto * k;
     int npath_high = kPerHisto * (k + 1) - 1;
-    snprintf(mename1, 40, "L1AlgoBits_%0d", k);
-    snprintf(metitle1, 40, "L1 rates - Algo Bits %d to %d", npath_low, npath_high);
+    snprintf(mename1, 64, "L1AlgoBits_%0d", k);
+    snprintf(metitle1, 64, "L1 rates - Algo Bits %d to %d", npath_low, npath_high);
     l1AlgoCurrentRatePerAlgo_[k] = dbe_->book1D(mename1, metitle1, kPerHisto, -0.5 + npath_low, npath_high + 0.5);
   }
 
@@ -121,13 +121,13 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
   std::string techdir2 = "/TechBits";
   dbe_->setCurrentFolder(folderName_ + techdir2);
 
-  char metitle2[40];  // histo name
-  char mename2[40];   // ME name
+  char metitle2[64];  // histo name
+  char mename2[64];   // ME name
   for (int k = 0; k < kNumTTHistos; k++) {
     int npath_low = kPerHisto * k;
     int npath_high = kPerHisto * (k + 1) - 1;
-    snprintf(mename2, 40, "L1TechBits_%0d", k);
-    snprintf(metitle2, 40, "L1 rates - Tech. Trig. Bits %d to %d", npath_low, npath_high);
+    snprintf(mename2, 64, "L1TechBits_%0d", k);
+    snprintf(metitle2, 64, "L1 rates - Tech. Trig. Bits %d to %d", npath_low, npath_high);
     l1TechTrigCurrentRatePerAlgo_[k] = dbe_->book1D(mename2, metitle2, kPerHisto, -0.5 + npath_low, npath_high + 0.5);
   }
 


### PR DESCRIPTION
#### PR description:

Trying to compile large parts of CMSSW with `USER_CXXFLAGS='-g -Og' scram b`, I got compilation errors on these files: `-Werror=format-truncation`.

(Using GCC 8.3.1 20190225, as shipped by a recent IB.)

I simply increased all affected buffer sizes to next power of two.

#### PR validation:

None so far. No changes expected.