### PR TITLE
add missing dependencies in DataFormats BuildFiles

### DIFF
--- a/DataFormats/CTPPSReco/BuildFile.xml
+++ b/DataFormats/CTPPSReco/BuildFile.xml
@@ -1,8 +1,10 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CTPPSDigi"/>
+<use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/Math"/>
-<use name="root"/>
+<use name="rootsmatrix"/>
 <use name="rootmath"/>
+<use name="rootphysics"/>
 
 <export>
   <lib name="1"/>

--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/EgammaReco"/>
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/Phase2TrackerDigi"/>
+<use   name="DataFormats/SiStripDetId"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

missing things identified as part of the root modules work.

