### PR TITLE
DD4Hep: DDDetector from DB - allow to delay a Solid Definition

### DIFF
--- a/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-2015-muon-geometry.xml
@@ -61,11 +61,4 @@
     <Include ref='Geometry/MuonSimData/data/muonSens.xml'/>
     <Include ref='DetectorDescription/DDCMS/data/trackerParameters.xml'/>
   </IncludeSection>
-  
-  <PosPartSection label="">
-    <PosPart copyNumber="1">
-      <rParent name=":world_volume"/>
-      <rChild name="cms:OCMS"/>
-    </PosPart>
-  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
+++ b/DetectorDescription/DDCMS/data/cms-geometry-2021.xml
@@ -307,12 +307,4 @@
     <Include ref='Geometry/ForwardSimData/data/ForwardShieldProdCuts.xml'/>
     <Include ref='Geometry/CMSCommonData/data/FieldParameters.xml'/>
   </IncludeSection>
-  
-  <PosPartSection label="">
-    <PosPart copyNumber="2">
-	<rParent name=":world_volume"/>
-	<rChild name="cms:OCMS"/>
-   </PosPart>
-  </PosPartSection>
-
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
+++ b/DetectorDescription/DDCMS/data/cms-mf-geometry.xml
@@ -29,11 +29,4 @@
     <Include ref='MagneticField/GeomBuilder/data/MagneticFieldVolumes_160812_2.xml'/>
     <Include ref='Geometry/CMSCommonData/data/materials.xml'/>
   </IncludeSection>
-  
-  <PosPartSection label="">
-    <PosPart copyNumber="2">
-      <rParent name=":world_volume"/>
-      <rChild name="cms:MCMS"/>
-    </PosPart>
-  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-test-ddgemangular-algorithm.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-ddgemangular-algorithm.xml
@@ -40,11 +40,4 @@
     <Include ref='Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml'/>
   </IncludeSection>
-  
-  <PosPartSection label="">
-    <PosPart copyNumber="1">
-      <rParent name=":world_volume"/>
-      <rChild name="cms:OCMS"/>
-    </PosPart>
-  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-test-ddvectors.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-ddvectors.xml
@@ -38,11 +38,4 @@
     <Include ref='DetectorDescription/DDCMS/data/trackerParameters.xml'/>
     <Include ref='DetectorDescription/DDCMS/data/testDDVectors.xml'/>
   </IncludeSection>
-  
-  <PosPartSection label="">
-    <PosPart copyNumber="1">
-      <rParent name=":world_volume"/>
-      <rChild name="cms:OCMS"/>
-    </PosPart>
-  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-test-shapes.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-shapes.xml
@@ -36,4 +36,10 @@
     <Include ref="DetectorDescription/DDCMS/data/testAlgorithm.xml"/>
     <Include ref="DetectorDescription/DDCMS/data/materials.xml"/>
   </IncludeSection>
+  <PosPartSection label="">
+    <PosPart copyNumber="2">
+      <rParent name=":world_volume"/>
+      <rChild name="testLogicalParts:MotherOfAllBoxes"/>
+    </PosPart>
+  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-test-shapes.xml
+++ b/DetectorDescription/DDCMS/data/cms-test-shapes.xml
@@ -36,11 +36,4 @@
     <Include ref="DetectorDescription/DDCMS/data/testAlgorithm.xml"/>
     <Include ref="DetectorDescription/DDCMS/data/materials.xml"/>
   </IncludeSection>
-  
-  <PosPartSection label="">
-    <PosPart copyNumber="2">
-      <rParent name=":world_volume"/>
-      <rChild name="testLogicalParts:MotherOfAllBoxes"/>
-    </PosPart>
-  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-tracker-2021.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker-2021.xml
@@ -238,4 +238,10 @@
         <Include ref="Geometry/TrackerCommonData/data/v2/trackerbulkhead.xml"/>
         <Include ref="Geometry/TrackerCommonData/data/trackerother.xml"/>
   </IncludeSection>
-</DDDefinition>
+  <PosPartSection label="">
+    <PosPart copyNumber="2">
+      <rParent name=":world_volume"/>
+      <rChild name="tracker:Tracker"/>
+    </PosPart>
+  </PosPartSection>
+ </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-tracker-2021.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker-2021.xml
@@ -238,12 +238,4 @@
         <Include ref="Geometry/TrackerCommonData/data/v2/trackerbulkhead.xml"/>
         <Include ref="Geometry/TrackerCommonData/data/trackerother.xml"/>
   </IncludeSection>
-
-  <PosPartSection label="">
-    <PosPart copyNumber="2">
-	<rParent name=":world_volume"/>
-	<rChild name="tracker:Tracker"/>
-   </PosPart>
-  </PosPartSection>
-
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker.xml
@@ -256,12 +256,4 @@
     <Include ref="DetectorDescription/DDCMS/data/trackertob.xml"/>
 
   </IncludeSection>
-
-  <PosPartSection label="">
-    <PosPart copyNumber="2">
-	<rParent name=":world_volume"/>
-	<rChild name="tracker:Tracker"/>
-   </PosPart>
-  </PosPartSection>
-
 </DDDefinition>

--- a/DetectorDescription/DDCMS/data/cms-tracker.xml
+++ b/DetectorDescription/DDCMS/data/cms-tracker.xml
@@ -256,4 +256,10 @@
     <Include ref="DetectorDescription/DDCMS/data/trackertob.xml"/>
 
   </IncludeSection>
+  <PosPartSection label="">
+    <PosPart copyNumber="2">
+      <rParent name=":world_volume"/>
+      <rChild name="tracker:Tracker"/>
+    </PosPart>
+  </PosPartSection>
 </DDDefinition>

--- a/DetectorDescription/DDCMS/interface/DDParsingContext.h
+++ b/DetectorDescription/DDCMS/interface/DDParsingContext.h
@@ -4,6 +4,7 @@
 #include "DD4hep/Detector.h"
 
 #include <string>
+#include <variant>
 #include "tbb/concurrent_unordered_map.h"
 #include "tbb/concurrent_vector.h"
 #include "tbb/concurrent_queue.h"
@@ -38,6 +39,26 @@ namespace cms {
     tbb::concurrent_unordered_map<std::string, dd4hep::Volume> volumes;
     tbb::concurrent_vector<std::string> disabledAlgs;
     tbb::concurrent_queue<std::string> namespaces;
+
+    template <class TYPE>
+    struct BooleanShape {
+    BooleanShape(const std::string& aName, const std::string& bName, dd4hep::Transform3D t)
+	: firstSolidName(aName),
+	  secondSolidName(bName),
+	  transform(t) {}
+      
+      const std::string firstSolidName;
+      const std::string secondSolidName;
+      dd4hep::Transform3D transform;
+      
+      dd4hep::Solid make(dd4hep::Solid firstSolid, dd4hep::Solid secondSolid) {
+	return TYPE(firstSolid, secondSolid, transform);
+      }
+    };
+
+    std::map<std::string, std::variant<BooleanShape<dd4hep::UnionSolid>,
+      BooleanShape<dd4hep::SubtractionSolid>,
+      BooleanShape<dd4hep::IntersectionSolid>>> unresolvedShapes;
 
     bool geo_inited = false;
 

--- a/DetectorDescription/DDCMS/interface/DDParsingContext.h
+++ b/DetectorDescription/DDCMS/interface/DDParsingContext.h
@@ -42,23 +42,23 @@ namespace cms {
 
     template <class TYPE>
     struct BooleanShape {
-    BooleanShape(const std::string& aName, const std::string& bName, dd4hep::Transform3D t)
-	: firstSolidName(aName),
-	  secondSolidName(bName),
-	  transform(t) {}
-      
+      BooleanShape(const std::string& aName, const std::string& bName, dd4hep::Transform3D t)
+          : firstSolidName(aName), secondSolidName(bName), transform(t) {}
+
       const std::string firstSolidName;
       const std::string secondSolidName;
       dd4hep::Transform3D transform;
-      
+
       dd4hep::Solid make(dd4hep::Solid firstSolid, dd4hep::Solid secondSolid) {
-	return TYPE(firstSolid, secondSolid, transform);
+        return TYPE(firstSolid, secondSolid, transform);
       }
     };
 
-    std::map<std::string, std::variant<BooleanShape<dd4hep::UnionSolid>,
-      BooleanShape<dd4hep::SubtractionSolid>,
-      BooleanShape<dd4hep::IntersectionSolid>>> unresolvedShapes;
+    std::map<std::string,
+             std::variant<BooleanShape<dd4hep::UnionSolid>,
+                          BooleanShape<dd4hep::SubtractionSolid>,
+                          BooleanShape<dd4hep::IntersectionSolid>>>
+        unresolvedShapes;
 
     bool geo_inited = false;
 

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -48,7 +48,7 @@ namespace dd4hep {
 
     class ConstantsSection;
     class DDLConstant;
-    
+
     struct DDRegistry {
       tbb::concurrent_vector<xml::Document> includes;
       tbb::concurrent_unordered_map<std::string, std::string> unresolvedConst, allConst, originalConst;
@@ -1010,18 +1010,18 @@ static void convert_boolean(cms::DDParsingContext* context, xml_h element) {
            "+++ BooleanSolid: %s Left: %-32s Right: %-32s",
            nam.c_str(),
            ((solids[0].ptr() == nullptr) ? solidName[0].c_str() : solids[0]->GetName()),
-	   ((solids[1].ptr() == nullptr) ? solidName[1].c_str() : solids[1]->GetName()));
+           ((solids[1].ptr() == nullptr) ? solidName[1].c_str() : solids[1]->GetName()));
 
   if (solids[0].isValid() && solids[1].isValid()) {
     Transform3D trafo;
     Converter<DDLTransform3D>(*context->description, context, &trafo)(element);
     boolean = TYPE(solids[0], solids[1], trafo);
-  }
-  else {
+  } else {
     // Register it for later processing
     Transform3D trafo;
     Converter<DDLTransform3D>(*context->description, context, &trafo)(element);
-    ns.context()->unresolvedShapes.emplace(nam, DDParsingContext::BooleanShape<TYPE>(solidName[0], solidName[1], trafo));
+    ns.context()->unresolvedShapes.emplace(nam,
+                                           DDParsingContext::BooleanShape<TYPE>(solidName[0], solidName[1], trafo));
   }
   if (!boolean.isValid()) {
     // Delay processing the shape
@@ -1884,21 +1884,22 @@ static long load_dddefinition(Detector& det, xml_h element) {
       // component shapes
 
       while (!context.unresolvedShapes.empty()) {
-	for (auto& it : context.unresolvedShapes) {
-	  auto const& name = it.first;
-	  auto const& aname = std::visit([](auto&& arg) -> std::string { return arg.firstSolidName;}, it.second);
-	  auto const& bname = std::visit([](auto&& arg) -> std::string { return arg.secondSolidName;}, it.second);
+        for (auto& it : context.unresolvedShapes) {
+          auto const& name = it.first;
+          auto const& aname = std::visit([](auto&& arg) -> std::string { return arg.firstSolidName; }, it.second);
+          auto const& bname = std::visit([](auto&& arg) -> std::string { return arg.secondSolidName; }, it.second);
 
-	  auto const& ait = context.shapes.find(aname);
-	  if(ait->second.isValid()) {
-	    auto const& bit = context.shapes.find(bname);
-	    if(bit->second.isValid()) {
-	      dd4hep::Solid shape = std::visit([&ait, &bit](auto&& arg) -> dd4hep::Solid { return arg.make(ait->second, bit->second);}, it.second);
-	      context.shapes[name] = shape;
-	      context.unresolvedShapes.erase(name);
-	    }
-	  }
-	}
+          auto const& ait = context.shapes.find(aname);
+          if (ait->second.isValid()) {
+            auto const& bit = context.shapes.find(bname);
+            if (bit->second.isValid()) {
+              dd4hep::Solid shape = std::visit(
+                  [&ait, &bit](auto&& arg) -> dd4hep::Solid { return arg.make(ait->second, bit->second); }, it.second);
+              context.shapes[name] = shape;
+              context.unresolvedShapes.erase(name);
+            }
+          }
+        }
       }
     }
     xml_coll_t(dddef, DD_CMU(LogicalPartSection)).for_each(Converter<LogicalPartSection>(det, &context));
@@ -1915,13 +1916,13 @@ static long load_dddefinition(Detector& det, xml_h element) {
   if (close_geometry) {
     Volume wv = det.worldVolume();
     Volume geomv = ns.volume("cms:OCMS", false);
-    if(geomv.isValid())
+    if (geomv.isValid())
       wv.placeVolume(geomv, 1);
     Volume mfv = ns.volume("cmsMagneticField:MAGF", false);
-    if(mfv.isValid())
+    if (mfv.isValid())
       wv.placeVolume(mfv, 1);
     Volume mfv1 = ns.volume("MagneticFieldVolumes:MAGF", false);
-    if(mfv1.isValid())
+    if (mfv1.isValid())
       wv.placeVolume(mfv1, 1);
 
     det.endDocument();

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -48,6 +48,7 @@ namespace dd4hep {
 
     class ConstantsSection;
     class DDLConstant;
+    
     struct DDRegistry {
       tbb::concurrent_vector<xml::Document> includes;
       tbb::concurrent_unordered_map<std::string, std::string> unresolvedConst, allConst, originalConst;
@@ -983,37 +984,50 @@ static void convert_boolean(cms::DDParsingContext* context, xml_h element) {
   cms::DDNamespace ns(context);
   xml_dim_t e(element);
   string nam = e.nameStr();
+  string solidName[2];
   Solid solids[2];
   Solid boolean;
   int cnt = 0;
-
-  if (e.hasChild(DD_CMU(rSolid))) {  // Old version
-    for (xml_coll_t c(element, DD_CMU(rSolid)); cnt < 2 && c; ++c, ++cnt)
+  if (e.hasChild(DD_CMU(rSolid))) {
+    for (xml_coll_t c(element, DD_CMU(rSolid)); cnt < 2 && c; ++c, ++cnt) {
+      solidName[cnt] = c.attr<string>(_U(name));
       solids[cnt] = ns.solid(c.attr<string>(_U(name)));
+    }
   } else {
+    solidName[0] = e.attr<string>(DD_CMU(firstSolid));
     if ((solids[0] = ns.solid(e.attr<string>(DD_CMU(firstSolid)))).isValid())
       ++cnt;
+    solidName[1] = e.attr<string>(DD_CMU(secondSolid));
     if ((solids[1] = ns.solid(e.attr<string>(DD_CMU(secondSolid)))).isValid())
       ++cnt;
   }
   if (cnt != 2) {
     except("DD4CMS", "+++ Failed to create boolean solid %s. Found only %d parts.", nam.c_str(), cnt);
   }
+
   printout(ns.context()->debug_placements ? ALWAYS : DEBUG,
            "DD4CMS",
            "+++ BooleanSolid: %s Left: %-32s Right: %-32s",
            nam.c_str(),
-           solids[0]->GetName(),
-           solids[1]->GetName());
+           ((solids[0].ptr() == nullptr) ? solidName[0] : solids[0]->GetName()),
+	   ((solids[1].ptr() == nullptr) ? solidName[1] : solids[1]->GetName()));
 
   if (solids[0].isValid() && solids[1].isValid()) {
     Transform3D trafo;
     Converter<DDLTransform3D>(*context->description, context, &trafo)(element);
     boolean = TYPE(solids[0], solids[1], trafo);
   }
-  if (!boolean.isValid())
-    except("DD4CMS", "+++ FAILED to construct subtraction solid: %s", nam.c_str());
-  ns.addSolid(nam, boolean);
+  else {
+    // Register it for later processing
+    Transform3D trafo;
+    Converter<DDLTransform3D>(*context->description, context, &trafo)(element);
+    ns.context()->unresolvedShapes.emplace(nam, DDParsingContext::BooleanShape<TYPE>(solidName[0], solidName[1], trafo));
+  }
+  if (!boolean.isValid()) {
+    // Delay processing the shape
+    ns.context()->shapes.emplace(nam, dd4hep::Solid(nullptr));
+  } else
+    ns.addSolid(nam, boolean);
 }
 
 /// Converter for <UnionSolid/> tags
@@ -1792,8 +1806,8 @@ static long load_dddefinition(Detector& det, xml_h element) {
 
   xml_elt_t dddef(element);
   string fname = xml::DocumentHandler::system_path(element);
-  bool open_geometry = dddef.hasChild(DD_CMU(open_geometry));
-  bool close_geometry = dddef.hasChild(DD_CMU(close_geometry));
+  bool open_geometry = dddef.hasChild(DD_CMU(open_geometry)) ? dddef.child(DD_CMU(open_geometry)) : true;
+  bool close_geometry = dddef.hasChild(DD_CMU(close_geometry)) ? dddef.hasChild(DD_CMU(close_geometry)) : true;
 
   xml_coll_t(dddef, _U(debug)).for_each(Converter<debug>(det, &context));
 
@@ -1863,6 +1877,30 @@ static long load_dddefinition(Detector& det, xml_h element) {
     print_doc((doc = dddef.document()).root());
     // Now process the actual geometry items
     xml_coll_t(dddef, DD_CMU(SolidSection)).for_each(Converter<SolidSection>(det, &context));
+    {
+      // Before we continue, we have to resolve all shapes NOW!
+      // Note: This only happens in a legacy DB payloads where
+      // boolean shapes can be defined before thier
+      // component shapes
+
+      while (!context.unresolvedShapes.empty()) {
+	for (auto& it : context.unresolvedShapes) {
+	  auto const& name = it.first;
+	  auto const& aname = std::visit([](auto&& arg) -> std::string { return arg.firstSolidName;}, it.second);
+	  auto const& bname = std::visit([](auto&& arg) -> std::string { return arg.secondSolidName;}, it.second);
+
+	  auto const& ait = context.shapes.find(aname);
+	  if(ait->second.isValid()) {
+	    auto const& bit = context.shapes.find(bname);
+	    if(bit->second.isValid()) {
+	      dd4hep::Solid shape = std::visit([&ait, &bit](auto&& arg) -> dd4hep::Solid { return arg.make(ait->second, bit->second);}, it.second);
+	      context.shapes[name] = shape;
+	      context.unresolvedShapes.erase(name);
+	    }
+	  }
+	}
+      }
+    }
     xml_coll_t(dddef, DD_CMU(LogicalPartSection)).for_each(Converter<LogicalPartSection>(det, &context));
     xml_coll_t(dddef, DD_CMU(Algorithm)).for_each(Converter<DDLAlgorithm>(det, &context));
     xml_coll_t(dddef, DD_CMU(PosPartSection)).for_each(Converter<PosPartSection>(det, &context));
@@ -1875,6 +1913,17 @@ static long load_dddefinition(Detector& det, xml_h element) {
 
   /// This should be the end of all processing....close the geometry
   if (close_geometry) {
+    Volume wv = det.worldVolume();
+    Volume geomv = ns.volume("cms:OCMS", false);
+    if(geomv.isValid())
+      wv.placeVolume(geomv, 1);
+    Volume mfv = ns.volume("cmsMagneticField:MAGF", false);
+    if(mfv.isValid())
+      wv.placeVolume(mfv, 1);
+    Volume mfv1 = ns.volume("MagneticFieldVolumes:MAGF", false);
+    if(mfv1.isValid())
+      wv.placeVolume(mfv1, 1);
+
     det.endDocument();
   }
   printout(INFO, "DDDefinition", "+++ Finished processing %s", fname.c_str());

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -1009,8 +1009,8 @@ static void convert_boolean(cms::DDParsingContext* context, xml_h element) {
            "DD4CMS",
            "+++ BooleanSolid: %s Left: %-32s Right: %-32s",
            nam.c_str(),
-           ((solids[0].ptr() == nullptr) ? solidName[0] : solids[0]->GetName()),
-	   ((solids[1].ptr() == nullptr) ? solidName[1] : solids[1]->GetName()));
+           ((solids[0].ptr() == nullptr) ? solidName[0].c_str() : solids[0]->GetName()),
+	   ((solids[1].ptr() == nullptr) ? solidName[1].c_str() : solids[1]->GetName()));
 
   if (solids[0].isValid() && solids[1].isValid()) {
     Transform3D trafo;

--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -144,9 +144,6 @@ const dd4hep::Rotation3D& DDNamespace::rotation(const string& nam) const {
     if (i != m_context->rotations.end())
       return (*i).second;
   }
-  for (const auto& r : m_context->rotations) {
-    cout << r.first << endl;
-  }
   throw runtime_error("Unknown rotation identifier:" + nam);
 }
 
@@ -207,7 +204,10 @@ dd4hep::Solid DDNamespace::addSolidNS(const string& name, dd4hep::Solid solid) c
                    solid->IsA()->GetName(),
                    name.c_str());
 
-  m_context->shapes.emplace(name, solid.setName(name));
+  auto shape = m_context->shapes.emplace(name, solid.setName(name));
+  if (!shape.second) {
+    m_context->shapes[name] = solid.setName(name);
+  }
 
   return solid;
 }
@@ -232,7 +232,9 @@ dd4hep::Solid DDNamespace::solid(const string& nam) const {
   i = m_context->shapes.find(nam);
   if (i != m_context->shapes.end())
     return (*i).second;
-  throw runtime_error("Unknown shape identifier:" + nam);
+  // Register a temporary shape
+  auto tmpShape = m_context->shapes.emplace(nam, dd4hep::Solid(nullptr));
+  return (*tmpShape.first).second;
 }
 
 std::vector<double> DDNamespace::vecDbl(const std::string& name) const {

--- a/DetectorDescription/DDCMS/test/runTest.sh
+++ b/DetectorDescription/DDCMS/test/runTest.sh
@@ -22,6 +22,8 @@ F17=${LOCAL_TEST_DIR}/python/testMuonNumbering.py
 F18=${LOCAL_TEST_DIR}/python/testDDHGCalCellAlgorithm.py
 F19=${LOCAL_TEST_DIR}/python/testDDCompactView.py
 F20=${LOCAL_TEST_DIR}/python/testDDGEMAngularAlgorithm.py
+F21=${LOCAL_TEST_DIR}/python/testGeometry2021.py
+F22=${LOCAL_TEST_DIR}/python/testGeometry2021FromDB.py
 
 echo " testing DetectorDescription/DDCMS"
 
@@ -68,3 +70,7 @@ echo "===== Test \"cmsRun testDDCompactView.py\" ===="
 (cmsRun $F19) || die "Failure using cmsRun $F19" $?
 echo "===== Test \"cmsRun testDDGEMAngularAlgorithm.py\" ===="
 (cmsRun $F20) || die "Failure using cmsRun $F20" $?
+echo "===== Test \"cmsRun testGeometry2021.py\" ===="
+(cmsRun $F21) || die "Failure using cmsRun $F21" $?
+echo "===== Test \"cmsRun testGeometry2021FromDB.py\" ===="
+(cmsRun $F22) || die "Failure using cmsRun $F22" $?


### PR DESCRIPTION
#### PR description:

* Allow different order of the solids in the XML definition

#### PR validation:

```
cmsRun DetectorDescription/DDCMS/test/python/testGeometry2021FromDB.py
```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
