### PR TITLE
Added consumes to DTConfigDBProducer

### DIFF
--- a/CondTools/DT/BuildFile.xml
+++ b/CondTools/DT/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="CondFormats/DataRecord"/>
 <use   name="CoralBase"/>
 <use   name="DataFormats/Provenance"/>
-<use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="CondCore/DBOutputService"/>

--- a/CondTools/DT/interface/DTKeyedConfigCache.h
+++ b/CondTools/DT/interface/DTKeyedConfigCache.h
@@ -18,8 +18,9 @@
 #include <string>
 #include <vector>
 
+#include "CondCore/CondDB/interface/KeyList.h"
+
 class DTKeyedConfig;
-class DTKeyedConfigListRcd;
 
 //              ---------------------
 //              -- Class Interface --
@@ -30,9 +31,9 @@ public:
   DTKeyedConfigCache();
   virtual ~DTKeyedConfigCache();
 
-  int get(const DTKeyedConfigListRcd& keyRecord, int cfgId, const DTKeyedConfig*& obj);
+  int get(cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj);
 
-  void getData(const DTKeyedConfigListRcd& keyRecord, int cfgId, std::vector<std::string>& list);
+  void getData(cond::persistency::KeyList& keyList, int cfgId, std::vector<std::string>& list);
 
   void purge();
 

--- a/CondTools/DT/src/DTHVStatusHandler.cc
+++ b/CondTools/DT/src/DTHVStatusHandler.cc
@@ -22,8 +22,6 @@
 
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "RelationalAccess/ISchema.h"
 #include "RelationalAccess/ITable.h"
 #include "RelationalAccess/ICursor.h"

--- a/CondTools/DT/src/DTKeyedConfigCache.cc
+++ b/CondTools/DT/src/DTKeyedConfigCache.cc
@@ -19,9 +19,7 @@
 // Collaborating Class Headers --
 //-------------------------------
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
-#include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
 #include "CondCore/CondDB/interface/KeyList.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <memory>
 //-------------------
@@ -41,7 +39,7 @@ DTKeyedConfigCache::DTKeyedConfigCache() : cachedBrickNumber(0), cachedStringNum
 //--------------
 DTKeyedConfigCache::~DTKeyedConfigCache() { purge(); }
 
-int DTKeyedConfigCache::get(const DTKeyedConfigListRcd& keyRecord, int cfgId, const DTKeyedConfig*& obj) {
+int DTKeyedConfigCache::get(cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj) {
   bool cacheFound = false;
   int cacheAge = 999999999;
   std::map<int, counted_brick>::iterator cache_iter = brickMap.begin();
@@ -77,26 +75,13 @@ int DTKeyedConfigCache::get(const DTKeyedConfigListRcd& keyRecord, int cfgId, co
     }
   }
 
-  // get dummy brick list
-  edm::ESHandle<cond::persistency::KeyList> klh;
-  keyRecord.get(klh);
-  cond::persistency::KeyList const& kl = *klh.product();
-  // This const_cast and usage of KeyList is a problem
-  // that will need to be addressed in the future.
-  // I'm not fixing now, because I want to finish what I am
-  // fixing. One thing at a time. (This was already in the
-  // the code I copied to make this file)
-  cond::persistency::KeyList* keyList = const_cast<cond::persistency::KeyList*>(&kl);
-  if (keyList == nullptr)
-    return 999;
-
   std::vector<unsigned long long> checkedKeys;
   std::shared_ptr<DTKeyedConfig> kBrick;
   checkedKeys.push_back(cfgId);
   bool brickFound = false;
   try {
-    keyList->load(checkedKeys);
-    kBrick = keyList->get<DTKeyedConfig>(0);
+    keyList.load(checkedKeys);
+    kBrick = keyList.get<DTKeyedConfig>(0);
     if (kBrick.get())
       brickFound = (kBrick->getId() == cfgId);
   } catch (std::exception const& e) {
@@ -130,9 +115,9 @@ int DTKeyedConfigCache::get(const DTKeyedConfigListRcd& keyRecord, int cfgId, co
   return 999;
 }
 
-void DTKeyedConfigCache::getData(const DTKeyedConfigListRcd& keyRecord, int cfgId, std::vector<std::string>& list) {
+void DTKeyedConfigCache::getData(cond::persistency::KeyList& keyList, int cfgId, std::vector<std::string>& list) {
   const DTKeyedConfig* obj = nullptr;
-  get(keyRecord, cfgId, obj);
+  get(keyList, cfgId, obj);
   if (obj == nullptr)
     return;
   DTKeyedConfig::data_iterator d_iter = obj->dataBegin();
@@ -142,7 +127,7 @@ void DTKeyedConfigCache::getData(const DTKeyedConfigListRcd& keyRecord, int cfgI
   DTKeyedConfig::link_iterator l_iter = obj->linkBegin();
   DTKeyedConfig::link_iterator l_iend = obj->linkEnd();
   while (l_iter != l_iend)
-    getData(keyRecord, *l_iter++, list);
+    getData(keyList, *l_iter++, list);
   return;
 }
 

--- a/CondTools/DT/test/stubs/DTKeyedConfigDump.cc
+++ b/CondTools/DT/test/stubs/DTKeyedConfigDump.cc
@@ -12,21 +12,18 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "CondTools/DT/test/stubs/DTKeyedConfigDump.h"
-#include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
-#include "CondFormats/DataRecord/interface/DTCCBConfigRcd.h"
-#include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
 
 namespace edmtest {
 
-  DTKeyedConfigDump::DTKeyedConfigDump(edm::ParameterSet const& p) {
-    dumpCCBKeys = p.getParameter<bool>("dumpCCBKeys");
-    dumpAllData = p.getParameter<bool>("dumpAllData");
+  DTKeyedConfigDump::DTKeyedConfigDump(edm::ParameterSet const& p)
+      : dumpCCBKeys{p.getParameter<bool>("dumpCCBKeys")},
+        dumpAllData{p.getParameter<bool>("dumpAllData")},
+        configToken_{esConsumes<DTCCBConfig, DTCCBConfigRcd>()} {
+    if (dumpCCBKeys) {
+      keyListToken_ = esConsumes<cond::persistency::KeyList, DTKeyedConfigListRcd>();
+    }
   }
-
-  DTKeyedConfigDump::DTKeyedConfigDump(int i) {}
-
-  DTKeyedConfigDump::~DTKeyedConfigDump() {}
 
   void DTKeyedConfigDump::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
@@ -35,10 +32,10 @@ namespace edmtest {
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;
 
     // get configuration for current run
-    edm::ESHandle<DTCCBConfig> conf;
-    context.get<DTCCBConfigRcd>().get(conf);
-    std::cout << conf->version() << std::endl;
-    std::cout << std::distance(conf->begin(), conf->end()) << " data in the container" << std::endl;
+    auto const& conf = context.getData(configToken_);
+
+    std::cout << conf.version() << std::endl;
+    std::cout << std::distance(conf.begin(), conf.end()) << " data in the container" << std::endl;
     edm::ValidityInterval iov(context.get<DTCCBConfigRcd>().validityInterval());
     unsigned int currValidityStart = iov.first().eventID().run();
     unsigned int currValidityEnd = iov.last().eventID().run();
@@ -50,8 +47,9 @@ namespace edmtest {
     const DTKeyedConfig** allBricks = new const DTKeyedConfig*[100000];
     int nBricks = 0;
 
+    auto& keyList = const_cast<cond::persistency::KeyList&>(context.getData(keyListToken_));
     // loop over chambers
-    DTCCBConfig::ccb_config_map configKeys(conf->configKeyMap());
+    DTCCBConfig::ccb_config_map configKeys(conf.configKeyMap());
     DTCCBConfig::ccb_config_iterator iter = configKeys.begin();
     DTCCBConfig::ccb_config_iterator iend = configKeys.end();
     while (iter != iend) {
@@ -73,7 +71,7 @@ namespace edmtest {
         if (!dumpAllData)
           continue;
         const DTKeyedConfig* kBrick = 0;
-        cfgCache.get(context.get<DTKeyedConfigListRcd>(), id, kBrick);
+        cfgCache.get(keyList, id, kBrick);
         allBricks[nBricks++] = kBrick;
         if (kBrick == 0) {
           std::cout << "brick missing" << std::endl;

--- a/CondTools/DT/test/stubs/DTKeyedConfigDump.h
+++ b/CondTools/DT/test/stubs/DTKeyedConfigDump.h
@@ -11,7 +11,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
 #include "CondTools/DT/interface/DTKeyedConfigCache.h"
+#include "CondFormats/DTObjects/interface/DTCCBConfig.h"
+#include "CondFormats/DataRecord/interface/DTCCBConfigRcd.h"
+#include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
 
 #include <string>
 
@@ -19,13 +24,14 @@ namespace edmtest {
   class DTKeyedConfigDump : public edm::EDAnalyzer {
   public:
     explicit DTKeyedConfigDump(edm::ParameterSet const& p);
-    explicit DTKeyedConfigDump(int i);
-    virtual ~DTKeyedConfigDump();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
-    bool dumpCCBKeys;
-    bool dumpAllData;
+    const bool dumpCCBKeys;
+    const bool dumpAllData;
     DTKeyedConfigCache cfgCache;
+    const edm::ESGetToken<DTCCBConfig, DTCCBConfigRcd> configToken_;
+    edm::ESGetToken<cond::persistency::KeyList, DTKeyedConfigListRcd> keyListToken_;
   };
 }  // namespace edmtest

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -373,6 +373,11 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTCon
   if (ccb_conf.configKeyMap().size() != 250)  // check the number of chambers!!!
     return -1;
 
+  // This const_cast and usage of KeyList is a problem
+  // that will need to be addressed in the future.
+  // I'm not fixing now, because I want to finish what I am
+  // fixing. One thing at a time. (This was already in the
+  // the DTKeyedConfigCache which copied to make this file)
   auto &keyList = const_cast<cond::persistency::KeyList &>(keyRecord.get(m_keyListToken));
 
   // read data from CCBConfig
@@ -418,11 +423,6 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTCon
       // create strings list
       std::vector<std::string> list;
 
-      // This const_cast and usage of KeyList is a problem
-      // that will need to be addressed in the future.
-      // I'm not fixing now, because I want to finish what I am
-      // fixing. One thing at a time. (This was already in the
-      // the DTKeyedConfigCache which copied to make this file)
       cfgCache.getData(keyList, id, list);
 
       // loop over strings

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -93,6 +93,7 @@ private:
   edm::ESGetToken<DTTPGParameters, DTTPGParametersRcd> m_dttpgParamsToken;
   edm::ESGetToken<DTT0, DTT0Rcd> m_t0iToken;
   edm::ESGetToken<DTCCBConfig, DTCCBConfigRcd> m_ccb_confToken;
+  edm::ESGetToken<cond::persistency::KeyList, DTKeyedConfigListRcd> m_keyListToken;
 
   // debug flags
   bool m_debugDB;
@@ -142,7 +143,7 @@ DTConfigDBProducer::DTConfigDBProducer(const edm::ParameterSet &p) {
   m_UseT0 = p.getParameter<bool>("UseT0");  // CB check for a better way to do it
 
   if (not cfgConfig) {
-    cc.setConsumes(m_dttpgParamsToken).setConsumes(m_ccb_confToken);
+    cc.setConsumes(m_dttpgParamsToken).setConsumes(m_ccb_confToken).setConsumes(m_keyListToken);
     if (m_UseT0) {
       cc.setConsumes(m_t0iToken);
     }
@@ -372,6 +373,8 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTCon
   if (ccb_conf.configKeyMap().size() != 250)  // check the number of chambers!!!
     return -1;
 
+  auto &keyList = const_cast<cond::persistency::KeyList &>(keyRecord.get(m_keyListToken));
+
   // read data from CCBConfig
   while (iter != iend) {
     // 110628 SV moved here from constructor, to check config consistency for
@@ -414,7 +417,13 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTCon
 
       // create strings list
       std::vector<std::string> list;
-      cfgCache.getData(keyRecord, id, list);
+
+      // This const_cast and usage of KeyList is a problem
+      // that will need to be addressed in the future.
+      // I'm not fixing now, because I want to finish what I am
+      // fixing. One thing at a time. (This was already in the
+      // the DTKeyedConfigCache which copied to make this file)
+      cfgCache.getData(keyList, id, list);
 
       // loop over strings
       std::vector<std::string>::const_iterator s_iter = list.begin();


### PR DESCRIPTION
#### PR description:

- Required change to DTKeyedConfigCache to not get `cond::persistency::KeyList` itself but instead have the object passed to it.
- Changed DTConfigDBProducer and DTKeyedConfigDump to use ESGetTokens.

#### PR validation:

runTheMatrix.py tests using the ESProducer still run.