### PR TITLE
Fix dependencies and includes for FWCore and DataFormats

### DIFF
--- a/DataFormats/CTPPSReco/BuildFile.xml
+++ b/DataFormats/CTPPSReco/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CTPPSDigi"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/GeometrySurface"/>
 <use name="root"/>
 <use name="rootmath"/>
 

--- a/DataFormats/Candidate/BuildFile.xml
+++ b/DataFormats/Candidate/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Math"/>
+<use   name="DataFormats/GeometryVector"/>
 <use   name="FWCore/Utilities"/>
 <use   name="rootmath"/>
 <export>

--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/EgammaReco"/>
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/HLTReco/interface/HLTPerformanceInfo.h
+++ b/DataFormats/HLTReco/interface/HLTPerformanceInfo.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <cassert>
 
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"

--- a/DataFormats/HLTReco/interface/TriggerEvent.h
+++ b/DataFormats/HLTReco/interface/TriggerEvent.h
@@ -17,6 +17,7 @@
 #include "DataFormats/Common/interface/traits.h"
 #include <string>
 #include <vector>
+#include <cassert>
 
 namespace trigger {
 

--- a/DataFormats/HeavyIonEvent/BuildFile.xml
+++ b/DataFormats/HeavyIonEvent/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="CondFormats/HIObjects"/>
 <use   name="CondFormats/DataRecord"/>
+<use   name="DataFormats/Candidate"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/Phase2TrackerDigi"/>
+<use   name="DataFormats/SiStripDetId"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/TauReco/src/classes_3.h
+++ b/DataFormats/TauReco/src/classes_3.h
@@ -29,8 +29,6 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/PatCandidates/interface/Jet.h"
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include <vector>
 #include <map>


### PR DESCRIPTION
#### PR description:
Enable C++ modules for FWCore and FWCore (small fixes in dependencies and header includes)
cc: @vgvassilev  @davidlange6 @smuzaffar 
