### PR TITLE
Enforce ESGetToken use for ESProducers

### DIFF
--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -57,7 +57,7 @@ namespace edm::eventsetup {
                         EventSetupImpl const* iEventSetupImpl) override {
       assert(iRecord.key() == RecordT::keyForClass());
       RecordType rec;
-      rec.setImpl(&iRecord, callback_->transitionID(), callback_->getTokenIndices(), iEventSetupImpl);
+      rec.setImpl(&iRecord, callback_->transitionID(), callback_->getTokenIndices(), iEventSetupImpl, true);
       (*callback_)(rec);
       return smart_pointer_traits::getPointer(data_);
     }

--- a/FWCore/Framework/interface/DataProxyTemplate.h
+++ b/FWCore/Framework/interface/DataProxyTemplate.h
@@ -57,7 +57,7 @@ namespace edm {
                           EventSetupImpl const* iEventSetupImpl) override {
         assert(iRecord.key() == RecordT::keyForClass());
         RecordT rec;
-        rec.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl);
+        rec.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl, true);
         return this->make(rec, iKey);
       }
 

--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -56,7 +56,8 @@ namespace edm {
             !std::is_same<FoundItrT, EndItrT>::value,
             "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
         try {
-          EventSetup const eventSetupT{this->eventSetup(), this->transitionID(), this->getTokenIndices()};
+          EventSetup const eventSetupT{
+              this->eventSetup(), this->transitionID(), this->getTokenIndices(), this->requireTokens()};
           return eventSetupT.get<DepRecordT>();
         } catch (cms::Exception& e) {
           std::ostringstream sstrm;
@@ -74,7 +75,8 @@ namespace edm {
         static_assert(
             !std::is_same<FoundItrT, EndItrT>::value,
             "Trying to get a Record from another Record where the second Record is not dependent on the first Record.");
-        EventSetup const eventSetupT{this->eventSetup(), this->transitionID(), this->getTokenIndices()};
+        EventSetup const eventSetupT{
+            this->eventSetup(), this->transitionID(), this->getTokenIndices(), this->requireTokens()};
         return eventSetupT.tryToGet<DepRecordT>();
       }
 

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -59,8 +59,11 @@ namespace edm {
     friend class edm::PileUp;
 
   public:
-    explicit EventSetup(EventSetupImpl const& iSetup, unsigned int iTransitionID, ESProxyIndex const* iGetTokenIndices)
-        : m_setup{iSetup}, m_getTokenIndices{iGetTokenIndices}, m_id{iTransitionID} {}
+    explicit EventSetup(EventSetupImpl const& iSetup,
+                        unsigned int iTransitionID,
+                        ESProxyIndex const* iGetTokenIndices,
+                        bool iRequireToken)
+        : m_setup{iSetup}, m_getTokenIndices{iGetTokenIndices}, m_id{iTransitionID}, m_requireToken(iRequireToken) {}
     EventSetup(EventSetup const&) = delete;
     EventSetup& operator=(EventSetup const&) = delete;
 
@@ -81,7 +84,7 @@ namespace edm {
         throw eventsetup::NoRecordException<T>(recordDoesExist(m_setup, eventsetup::EventSetupRecordKey::makeKey<T>()));
       }
       T returnValue;
-      returnValue.setImpl(temp, m_id, m_getTokenIndices, &m_setup);
+      returnValue.setImpl(temp, m_id, m_getTokenIndices, &m_setup, m_requireToken);
       return returnValue;
     }
 
@@ -99,7 +102,7 @@ namespace edm {
                                                 eventsetup::EventSetupRecordKey>());
       if (temp != nullptr) {
         T rec;
-        rec.setImpl(temp, m_id, m_getTokenIndices, &m_setup);
+        rec.setImpl(temp, m_id, m_getTokenIndices, &m_setup, m_requireToken);
         return rec;
       }
       return std::nullopt;
@@ -178,6 +181,7 @@ namespace edm {
     edm::EventSetupImpl const& m_setup;
     ESProxyIndex const* m_getTokenIndices;
     unsigned int m_id;
+    bool m_requireToken;
   };
 
   // Free functions to retrieve an object from the EventSetup.

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -116,7 +116,8 @@ namespace edm {
           RunIndex ri = rp.index();
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::BeginRun),
-                             this->consumer()->esGetTokenIndices(Transition::BeginRun)};
+                             this->consumer()->esGetTokenIndices(Transition::BeginRun),
+                             false};
           MyGlobalRun::beginRun(cnstR, c, m_global.get(), m_runs[ri]);
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
           MyGlobalRunSummary::beginRun(cnstR, c, &rc, m_runSummaries[ri]);
@@ -131,7 +132,8 @@ namespace edm {
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::EndRun),
-                             this->consumer()->esGetTokenIndices(Transition::EndRun)};
+                             this->consumer()->esGetTokenIndices(Transition::EndRun),
+                             false};
           MyGlobalRunSummary::globalEndRun(r, c, &rc, m_runSummaries[ri].get());
           MyGlobalRun::endRun(r, c, &rc);
         }
@@ -149,7 +151,8 @@ namespace edm {
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                             this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                             this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                             false};
           MyGlobalLuminosityBlock::beginLuminosityBlock(cnstLb, c, &rc, m_lumis[li]);
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
           MyGlobalLuminosityBlockSummary::beginLuminosityBlock(cnstLb, c, &lc, m_lumiSummaries[li]);
@@ -167,7 +170,8 @@ namespace edm {
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                             this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock)};
+                             this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock),
+                             false};
           MyGlobalLuminosityBlockSummary::globalEndLuminosityBlock(lb, c, &lc, m_lumiSummaries[li].get());
           MyGlobalLuminosityBlock::endLuminosityBlock(lb, c, &lc);
         }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -116,7 +116,8 @@ namespace edm {
           RunIndex ri = rp.index();
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::BeginRun),
-                             this->consumer()->esGetTokenIndices(Transition::BeginRun)};
+                             this->consumer()->esGetTokenIndices(Transition::BeginRun),
+                             false};
           MyGlobalRun::beginRun(cnstR, c, m_global.get(), m_runs[ri]);
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
           MyGlobalRunSummary::beginRun(cnstR, c, &rc, m_runSummaries[ri]);
@@ -136,7 +137,8 @@ namespace edm {
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::EndRun),
-                             this->consumer()->esGetTokenIndices(Transition::EndRun)};
+                             this->consumer()->esGetTokenIndices(Transition::EndRun),
+                             false};
           MyGlobalRunSummary::globalEndRun(r, c, &rc, m_runSummaries[ri].get());
           if constexpr (T::HasAbility::kEndRunProducer) {
             MyEndRunProduce::produce(r, c, &rc, m_runSummaries[ri].get());
@@ -160,7 +162,8 @@ namespace edm {
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                             this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                             this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                             false};
 
           MyGlobalLuminosityBlock::beginLuminosityBlock(cnstLb, c, &rc, m_lumis[li]);
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
@@ -185,7 +188,8 @@ namespace edm {
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
           const EventSetup c{ci,
                              static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                             this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock)};
+                             this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock),
+                             false};
           MyGlobalLuminosityBlockSummary::globalEndLuminosityBlock(lb, c, &lc, m_lumiSummaries[li].get());
           if constexpr (T::HasAbility::kEndLuminosityBlockProducer) {
             MyEndLuminosityBlockProduce::produce(lb, c, &lc, m_lumiSummaries[li].get());

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -35,7 +35,7 @@ namespace edm {
     e.setConsumer(this);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+    const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
     this->analyze(e, c);
     return true;
   }
@@ -52,7 +52,8 @@ namespace edm {
   bool EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+    const EventSetup c{
+        ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
     this->beginRun(r, c);
     return true;
   }
@@ -60,7 +61,7 @@ namespace edm {
   bool EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
     Run r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+    const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
     this->endRun(r, c);
     return true;
   }
@@ -72,7 +73,8 @@ namespace edm {
     lb.setConsumer(this);
     const EventSetup c{ci,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                       esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                       esGetTokenIndices(Transition::BeginLuminosityBlock),
+                       false};
     this->beginLuminosityBlock(lb, c);
     return true;
   }
@@ -84,7 +86,8 @@ namespace edm {
     lb.setConsumer(this);
     const EventSetup c{ci,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                       esGetTokenIndices(Transition::EndLuminosityBlock)};
+                       esGetTokenIndices(Transition::EndLuminosityBlock),
+                       false};
     this->endLuminosityBlock(lb, c);
     return true;
   }

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -35,7 +35,7 @@ namespace edm {
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
     rc = this->filter(
-        e, EventSetup{c, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)});
+        e, EventSetup{c, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
     commit_(e, &previousParentageId_);
     return rc;
   }
@@ -54,7 +54,8 @@ namespace edm {
     r.setConsumer(this);
     Run const& cnstR = r;
     this->beginRun(
-        cnstR, EventSetup{c, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)});
+        cnstR,
+        EventSetup{c, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
     commit_(r);
     return;
   }
@@ -63,8 +64,9 @@ namespace edm {
     Run r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
-    this->endRun(cnstR,
-                 EventSetup{c, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)});
+    this->endRun(
+        cnstR,
+        EventSetup{c, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false});
     commit_(r);
     return;
   }
@@ -78,7 +80,8 @@ namespace edm {
     this->beginLuminosityBlock(cnstLb,
                                EventSetup{c,
                                           static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                                          esGetTokenIndices(Transition::BeginLuminosityBlock)});
+                                          esGetTokenIndices(Transition::BeginLuminosityBlock),
+                                          false});
     commit_(lb);
   }
 
@@ -91,7 +94,8 @@ namespace edm {
     this->endLuminosityBlock(cnstLb,
                              EventSetup{c,
                                         static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                                        esGetTokenIndices(Transition::EndLuminosityBlock)});
+                                        esGetTokenIndices(Transition::EndLuminosityBlock),
+                                        false});
     commit_(lb);
     return;
   }

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -54,7 +54,7 @@ namespace edm {
 
     Status status = kContinue;
     try {
-      const EventSetup es{esi, static_cast<unsigned int>(Transition::Event), nullptr};
+      const EventSetup es{esi, static_cast<unsigned int>(Transition::Event), nullptr, false};
       status = duringLoop(event, es, ioController);
     } catch (cms::Exception& e) {
       e.addContext("Calling the 'duringLoop' method of a looper");
@@ -69,7 +69,7 @@ namespace edm {
   }
 
   EDLooperBase::Status EDLooperBase::doEndOfLoop(const edm::EventSetupImpl& esi) {
-    const EventSetup es{esi, static_cast<unsigned int>(Transition::EndRun), nullptr};
+    const EventSetup es{esi, static_cast<unsigned int>(Transition::EndRun), nullptr, false};
     return endOfLoop(es, iCounter_);
   }
 
@@ -82,7 +82,7 @@ namespace edm {
   }
 
   void EDLooperBase::beginOfJob(const edm::EventSetupImpl& iImpl) {
-    beginOfJob(EventSetup{iImpl, static_cast<unsigned int>(Transition::BeginRun), nullptr});
+    beginOfJob(EventSetup{iImpl, static_cast<unsigned int>(Transition::BeginRun), nullptr, false});
   }
   void EDLooperBase::beginOfJob(const edm::EventSetup&) { beginOfJob(); }
   void EDLooperBase::beginOfJob() {}
@@ -99,7 +99,7 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     Run run(iRP, moduleDescription_, &moduleCallingContext_, false);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginRun), nullptr};
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginRun), nullptr, false};
     beginRun(run, es);
   }
 
@@ -113,7 +113,7 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     Run run(iRP, moduleDescription_, &moduleCallingContext_, true);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndRun), nullptr};
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndRun), nullptr, false};
     endRun(run, es);
   }
   void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB,
@@ -128,7 +128,7 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, false);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginLuminosityBlock), nullptr};
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::BeginLuminosityBlock), nullptr, false};
     beginLuminosityBlock(luminosityBlock, es);
   }
   void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB,
@@ -143,7 +143,7 @@ namespace edm {
     ParentContext parentContext(&globalContext);
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     LuminosityBlock luminosityBlock(iLB, moduleDescription_, &moduleCallingContext_, true);
-    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndLuminosityBlock), nullptr};
+    const EventSetup es{iES, static_cast<unsigned int>(Transition::EndLuminosityBlock), nullptr, false};
     endLuminosityBlock(luminosityBlock, es);
   }
 

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -32,7 +32,7 @@ namespace edm {
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+    const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
     this->produce(e, c);
     commit_(e, &previousParentageId_);
     return true;
@@ -50,7 +50,8 @@ namespace edm {
     Run r(rp, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+    const EventSetup c{
+        ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
     this->beginRun(cnstR, c);
     commit_(r);
   }
@@ -59,7 +60,7 @@ namespace edm {
     Run r(rp, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+    const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
     this->endRun(cnstR, c);
     commit_(r);
   }
@@ -72,7 +73,8 @@ namespace edm {
     LuminosityBlock const& cnstLb = lb;
     const EventSetup c{ci,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                       esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                       esGetTokenIndices(Transition::BeginLuminosityBlock),
+                       false};
     this->beginLuminosityBlock(cnstLb, c);
     commit_(lb);
   }
@@ -84,7 +86,8 @@ namespace edm {
     lb.setConsumer(this);
     const EventSetup c{ci,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                       esGetTokenIndices(Transition::EndLuminosityBlock)};
+                       esGetTokenIndices(Transition::EndLuminosityBlock),
+                       false};
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, c);
     commit_(lb);

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -99,5 +99,12 @@ namespace edm {
          << "returned by the setWhatProduced function.";
       throw ex;
     }
+
+    void EventSetupRecord::throwCalledGetWithoutToken(const char* iTypeName, const char* iLabel) {
+      throw cms::Exception("MustUseESGetToken")
+          << "Called EventSetupRecord::get without using a ESGetToken.\n While requesting data type:" << iTypeName
+          << " label:'" << iLabel << "'";
+    }
+
   }  // namespace eventsetup
 }  // namespace edm

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -53,7 +53,7 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -72,7 +72,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
@@ -81,7 +82,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
@@ -94,7 +96,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
@@ -107,7 +110,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
     }
@@ -120,7 +124,8 @@ namespace edm {
                                           ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDAnalyzerBase::doStreamEndRun(StreamID id,
@@ -129,7 +134,8 @@ namespace edm {
                                         ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -141,7 +147,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -153,7 +160,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -56,7 +56,7 @@ namespace edm {
       e.setProducer(
           this, &previousParentages_[streamIndex], hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
@@ -72,7 +72,7 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -96,7 +96,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -109,7 +110,8 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -124,7 +126,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -141,7 +144,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -156,7 +160,8 @@ namespace edm {
                                         ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDFilterBase::doStreamEndRun(StreamID id,
@@ -165,7 +170,8 @@ namespace edm {
                                       ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -177,7 +183,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -189,7 +196,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -60,9 +60,10 @@ namespace edm {
       e.setProducer(
           this, &previousParentages_[streamIndex], hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act, mcc);
-      this->produce(e.streamID(),
-                    e,
-                    EventSetup{c, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)});
+      this->produce(
+          e.streamID(),
+          e,
+          EventSetup{c, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
     }
@@ -77,7 +78,7 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -101,7 +102,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -114,7 +116,8 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -129,7 +132,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -146,7 +150,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -164,7 +169,8 @@ namespace edm {
       this->doStreamBeginRun_(
           id,
           r,
-          EventSetup{c, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)});
+          EventSetup{
+              c, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
     }
     void EDProducerBase::doStreamEndRun(StreamID id,
                                         RunPrincipal const& rp,
@@ -172,7 +178,8 @@ namespace edm {
                                         ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -186,7 +193,8 @@ namespace edm {
                                           lb,
                                           EventSetup{c,
                                                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                                                     esGetTokenIndices(Transition::BeginLuminosityBlock)});
+                                                     esGetTokenIndices(Transition::BeginLuminosityBlock),
+                                                     false});
     }
 
     void EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
@@ -197,7 +205,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -54,7 +54,7 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -73,7 +73,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
@@ -82,7 +83,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
@@ -95,7 +97,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
@@ -108,7 +111,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
     }
@@ -121,7 +125,8 @@ namespace edm {
                                           ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDAnalyzerBase::doStreamEndRun(StreamID id,
@@ -130,7 +135,8 @@ namespace edm {
                                         ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -142,7 +148,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -154,7 +161,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -54,7 +54,7 @@ namespace edm {
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
       e.setProducer(this, &previousParentages_[streamIndex]);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       EventSignalsSentry sentry(act, mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
@@ -78,7 +78,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -91,7 +92,8 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -106,7 +108,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -123,7 +126,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -138,7 +142,8 @@ namespace edm {
                                         ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDFilterBase::doStreamEndRun(StreamID id,
@@ -147,7 +152,8 @@ namespace edm {
                                       ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -158,7 +164,8 @@ namespace edm {
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
@@ -171,7 +178,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -55,7 +55,7 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducer(this, &previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->produce(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
@@ -78,7 +78,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -91,7 +92,8 @@ namespace edm {
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -106,7 +108,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -123,7 +126,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -138,7 +142,8 @@ namespace edm {
                                           ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDProducerBase::doStreamEndRun(StreamID id,
@@ -147,7 +152,8 @@ namespace edm {
                                         ModuleCallingContext const* mcc) {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -159,7 +165,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -171,7 +178,8 @@ namespace edm {
       lb.setConsumer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -56,7 +56,7 @@ namespace edm {
       e.setConsumer(this);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->analyze(e, c);
       return true;
     }
@@ -86,7 +86,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
     }
 
@@ -94,7 +95,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRun_(cnstR, c);
     }
 
@@ -106,7 +108,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
     }
 
@@ -118,7 +121,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlock_(cnstLb, c);
     }
 

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -53,7 +53,7 @@ namespace edm {
       bool returnValue = true;
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       returnValue = this->filter(e, c);
       commit_(e, &previousParentageId_);
       return returnValue;
@@ -86,7 +86,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
@@ -97,7 +98,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRun_(cnstR, c);
       r.setProducer(this);
       this->doEndRunProduce_(r, c);
@@ -112,7 +114,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doBeginLuminosityBlockProduce_(lb, c);
@@ -127,7 +130,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doEndLuminosityBlockProduce_(lb, c);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -52,7 +52,7 @@ namespace edm {
       e.setProducer(this, &previousParentage_);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event)};
+      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->produce(e, c);
       commit_(e, &previousParentageId_);
       return true;
@@ -86,7 +86,8 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
@@ -98,7 +99,8 @@ namespace edm {
       r.setConsumer(this);
       Run const& cnstR = r;
       r.setProducer(this);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
@@ -112,7 +114,8 @@ namespace edm {
       LuminosityBlock const& cnstLb = lb;
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doBeginLuminosityBlockProduce_(lb, c);
@@ -127,7 +130,8 @@ namespace edm {
       lb.setProducer(this);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       this->doEndLuminosityBlockProduce_(lb, c);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlock_(cnstLb, c);

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -137,7 +137,8 @@ bool EDAnalyzerAdaptorBase::doEvent(EventPrincipal const& ep,
   auto mod = m_streamModules[ep.streamID()];
   Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
-  const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event)};
+  const EventSetup c{
+      ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
   EventSignalsSentry sentry(act, mcc);
   mod->analyze(e, c);
   return true;
@@ -155,7 +156,8 @@ void EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
   setupRun(mod, rp.index());
 
   Run r(rp, moduleDescription_, mcc, false);
-  const EventSetup c{ci, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun)};
+  const EventSetup c{
+      ci, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
   r.setConsumer(mod);
   mod->beginRun(r, c);
 }
@@ -167,7 +169,8 @@ void EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
   auto mod = m_streamModules[id];
   Run r(rp, moduleDescription_, mcc, true);
   r.setConsumer(mod);
-  const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun)};
+  const EventSetup c{
+      ci, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
   mod->endRun(r, c);
   streamEndRunSummary(mod, r, c);
 }
@@ -183,7 +186,8 @@ void EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
   lb.setConsumer(mod);
   const EventSetup c{ci,
                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                     mod->esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                     mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                     false};
   mod->beginLuminosityBlock(lb, c);
 }
 void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
@@ -195,7 +199,8 @@ void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
   lb.setConsumer(mod);
   const EventSetup c{ci,
                      static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                     mod->esGetTokenIndices(Transition::EndLuminosityBlock)};
+                     mod->esGetTokenIndices(Transition::EndLuminosityBlock),
+                     false};
   mod->endLuminosityBlock(lb, c);
   streamEndLuminosityBlockSummary(mod, lb, c);
 }

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -53,7 +53,8 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);
       return result;
@@ -70,7 +71,8 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -53,7 +53,8 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);
       return true;
@@ -70,7 +71,8 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -177,7 +177,7 @@ namespace edm {
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(mod);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun)};
+          ci, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
       mod->beginRun(r, c);
     }
     template <typename T>
@@ -188,7 +188,8 @@ namespace edm {
       auto mod = m_streamModules[id];
       Run r(rp, moduleDescription_, mcc, true);
       r.setConsumer(mod);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun)};
+      const EventSetup c{
+          ci, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
       mod->endRun(r, c);
       streamEndRunSummary(mod, r, c);
     }
@@ -205,7 +206,8 @@ namespace edm {
       lb.setConsumer(mod);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         mod->esGetTokenIndices(Transition::BeginLuminosityBlock)};
+                         mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                         false};
       mod->beginLuminosityBlock(lb, c);
     }
 
@@ -219,7 +221,8 @@ namespace edm {
       lb.setConsumer(mod);
       const EventSetup c{ci,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         mod->esGetTokenIndices(Transition::EndLuminosityBlock)};
+                         mod->esGetTokenIndices(Transition::EndLuminosityBlock),
+                         false};
       mod->endLuminosityBlock(lb, c);
       streamEndLuminosityBlockSummary(mod, lb, c);
     }

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -609,16 +609,16 @@ void testdependentrecord::timeAndRunTest() {
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
       long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, true);
       long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id2);
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, true);
       long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id3);
 
@@ -626,7 +626,7 @@ void testdependentrecord::timeAndRunTest() {
           edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(6)), edm::IOVSyncValue(edm::Timestamp(10))));
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, true);
       long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 != id4);
 
@@ -634,7 +634,7 @@ void testdependentrecord::timeAndRunTest() {
           edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), edm::IOVSyncValue(edm::EventID(1, 1, 10))));
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
-      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr, true);
       long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id4 != id5);
     }
@@ -663,30 +663,30 @@ void testdependentrecord::timeAndRunTest() {
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
       long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, true);
       long long id2 = eventSetup2.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id2);
 
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 2), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, true);
       long long id3 = eventSetup3.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id3);
 
       dummy2Finder->setInterval(
           edm::ValidityInterval(edm::IOVSyncValue(edm::Timestamp(6)), edm::IOVSyncValue::invalidIOVSyncValue()));
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, true);
       long long id4 = eventSetup4.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 != id4);
 
       dummyFinder->setInterval(
           edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 1, 6)), edm::IOVSyncValue::invalidIOVSyncValue()));
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(8)));
-      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup5(provider.eventSetupImpl(), 0, nullptr, true);
       long long id5 = eventSetup5.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id4 != id5);
     }
@@ -727,7 +727,7 @@ void testdependentrecord::getTest() {
   provider.add(depProv);
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
     const DepRecord& depRecord = eventSetup1.get<DepRecord>();
 
     depRecord.getRecord<DummyRecord>();
@@ -737,7 +737,7 @@ void testdependentrecord::getTest() {
   }
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 4)));
-    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, true);
     CPPUNIT_ASSERT_THROW(eventSetup2.get<DepRecord>(), edm::eventsetup::NoRecordException<DepRecord>);
   }
 }
@@ -807,7 +807,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
     }
@@ -816,7 +817,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
@@ -825,7 +827,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
       auto const& data = depRecord.get(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
@@ -835,7 +838,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       auto const& data = depRecord.get(consumer.m_token);
@@ -846,7 +850,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       auto const& data = depRecord.get(consumer.m_token);
@@ -857,7 +862,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       auto const& data1 = depRecord.get(consumer.m_token1);
@@ -871,7 +877,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       CPPUNIT_ASSERT_THROW(depRecord.get(consumer.m_token), cms::Exception);
@@ -881,7 +888,8 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       CPPUNIT_ASSERT_THROW(depRecord.get(consumer.m_token), cms::Exception);
@@ -937,7 +945,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -948,7 +957,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -959,7 +969,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESHandle<DummyData> data = depRecord.getHandle(consumer.m_token);
@@ -972,7 +983,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESHandle<DummyData> data = depRecord.getHandle(consumer.m_token);
@@ -985,7 +997,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESHandle<DummyData> data = depRecord.getHandle(consumer.m_token);
@@ -998,7 +1011,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESHandle<DummyData> data1 = depRecord.getHandle(consumer.m_token1);
@@ -1016,7 +1030,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       CPPUNIT_ASSERT(not depRecord.getHandle(consumer.m_token));
@@ -1027,7 +1042,8 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       CPPUNIT_ASSERT(not depRecord.getHandle(consumer.m_token));
@@ -1083,7 +1099,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -1094,7 +1111,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -1105,7 +1123,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESTransientHandle<DummyData> data = depRecord.getTransientHandle(consumer.m_token);
@@ -1118,7 +1137,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESTransientHandle<DummyData> data = depRecord.getTransientHandle(consumer.m_token);
@@ -1131,7 +1151,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESTransientHandle<DummyData> data = depRecord.getTransientHandle(consumer.m_token);
@@ -1144,7 +1165,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESTransientHandle<DummyData> data1 = depRecord.getTransientHandle(consumer.m_token1);
@@ -1162,7 +1184,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESTransientHandle<DummyData> data = depRecord.getTransientHandle(consumer.m_token);
@@ -1174,7 +1197,8 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       auto const& depRecord = eventSetup.get<DepRecord>();
 
       edm::ESTransientHandle<DummyData> data = depRecord.getTransientHandle(consumer.m_token);
@@ -1204,7 +1228,7 @@ void testdependentrecord::oneOfTwoRecordTest() {
   provider.add(depProv);
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
     const DepOn2Record& depRecord = eventSetup1.get<DepOn2Record>();
 
     depRecord.getRecord<DummyRecord>();
@@ -1238,7 +1262,7 @@ void testdependentrecord::resetTest() {
   provider.add(depProv);
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
     const DepRecord& depRecord = eventSetup1.get<DepRecord>();
     unsigned long long depCacheID = depRecord.cacheIdentifier();
     const DummyRecord& dummyRecord = depRecord.getRecord<DummyRecord>();
@@ -1387,14 +1411,14 @@ void testdependentrecord::extendIOVTest() {
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummy2Finder));
   {
     controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, true);
     unsigned long long id1 = eventSetup1.get<DepOn2Record>().cacheIdentifier();
     CPPUNIT_ASSERT(id1 == eventSetup1.get<DummyRecord>().cacheIdentifier());
     CPPUNIT_ASSERT(id1 == eventSetup1.get<Dummy2Record>().cacheIdentifier());
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 5), edm::Timestamp(2)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1404,7 +1428,7 @@ void testdependentrecord::extendIOVTest() {
     dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 7}}});
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 6), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1416,7 +1440,7 @@ void testdependentrecord::extendIOVTest() {
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 7), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1428,7 +1452,7 @@ void testdependentrecord::extendIOVTest() {
     dummyFinder->setInterval(edm::ValidityInterval{startSyncValue, edm::IOVSyncValue{edm::EventID{1, 1, 8}}});
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 8), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 == id);
       CPPUNIT_ASSERT(id1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1441,7 +1465,7 @@ void testdependentrecord::extendIOVTest() {
         edm::ValidityInterval{edm::IOVSyncValue{edm::EventID{1, 1, 9}}, edm::IOVSyncValue{edm::EventID{1, 1, 9}}});
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 9), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 + 1 == id);
       CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<DummyRecord>().cacheIdentifier());
@@ -1456,7 +1480,7 @@ void testdependentrecord::extendIOVTest() {
 
     {
       controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 10), edm::Timestamp(7)));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
       unsigned long long id = eventSetup.get<DepOn2Record>().cacheIdentifier();
       CPPUNIT_ASSERT(id1 + 2 == id);
       CPPUNIT_ASSERT(id1 + 1 == eventSetup.get<DummyRecord>().cacheIdentifier());

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -211,7 +211,7 @@ void testEsproducer::getFromTest() {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -234,7 +234,7 @@ void testEsproducer::getfromShareTest() {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -257,7 +257,7 @@ void testEsproducer::getfromUniqueTest() {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -279,7 +279,7 @@ void testEsproducer::getfromOptionalTest() {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());
@@ -303,7 +303,7 @@ void testEsproducer::labelTest() {
       const edm::Timestamp time(iTime);
       pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
       controller.eventSetupForInstance(edm::IOVSyncValue(time));
-      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+      const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get("foo", pDummy);
       CPPUNIT_ASSERT(0 != pDummy.product());
@@ -361,7 +361,7 @@ void testEsproducer::decoratorTest() {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
 
     CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
@@ -405,7 +405,7 @@ void testEsproducer::dependsOnTest() {
     const edm::Timestamp time(iTime);
     pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
     controller.eventSetupForInstance(edm::IOVSyncValue(time));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
 
     eventSetup.get<DepRecord>().get(pDummy);
@@ -429,7 +429,7 @@ void testEsproducer::forceCacheClearTest() {
   const edm::Timestamp time(1);
   pFinder->setInterval(edm::ValidityInterval(edm::IOVSyncValue(time), edm::IOVSyncValue(time)));
   controller.eventSetupForInstance(edm::IOVSyncValue(time));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
   {
     edm::ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
@@ -439,7 +439,7 @@ void testEsproducer::forceCacheClearTest() {
   provider.forceCacheClear();
   controller.eventSetupForInstance(edm::IOVSyncValue(time));
   {
-    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> pDummy;
     eventSetup2.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -155,7 +155,7 @@ void testEventsetup::constructTest() {
   bool newEventSetupImpl = false;
   auto eventSetupImpl = provider.eventSetupForInstance(timestamp, newEventSetupImpl);
   CPPUNIT_ASSERT(non_null(eventSetupImpl.get()));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
 }
 
 // Note there is a similar test in dependentrecord_t.cppunit.cc
@@ -171,7 +171,7 @@ void testEventsetup::getTest() {
   eventSetupImpl.setKeyIters(keys.begin(), keys.end());
   EventSetupRecordImpl dummyRecordImpl{key, &activityRegistry};
   eventSetupImpl.addRecordImpl(dummyRecordImpl);
-  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr);
+  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr, true);
   const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
   CPPUNIT_ASSERT(&dummyRecordImpl == gottenRecord.impl_);
 }
@@ -184,8 +184,9 @@ void testEventsetup::tryToGetTest() {
   eventSetupImpl.setKeyIters(keys.begin(), keys.end());
   EventSetupRecordImpl dummyRecordImpl{key, &activityRegistry};
   eventSetupImpl.addRecordImpl(dummyRecordImpl);
-  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr);
+  const edm::EventSetup eventSetup(eventSetupImpl, 0, nullptr, true);
   std::optional<DummyRecord> gottenRecord = eventSetup.tryToGet<DummyRecord>();
+  CPPUNIT_ASSERT(gottenRecord);
   CPPUNIT_ASSERT(&dummyRecordImpl == gottenRecord.value().impl_);
 }
 
@@ -194,7 +195,7 @@ void testEventsetup::getExcTest() {
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
   controller.eventSetupForInstance(edm::IOVSyncValue(edm::EventID(1, 1, 1), edm::Timestamp(1)));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
   eventSetup.get<DummyRecord>();
 }
 
@@ -233,24 +234,29 @@ void testEventsetup::recordValidityTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup1(provider.eventSetupImpl(), 0, nullptr, false);
   CPPUNIT_ASSERT(!eventSetup1.tryToGet<DummyRecord>().has_value());
 
   const Timestamp time_2(2);
   dummyFinder->setInterval(ValidityInterval(IOVSyncValue(time_2), IOVSyncValue(Timestamp(3))));
-  controller.eventSetupForInstance(IOVSyncValue(time_2));
-  const edm::EventSetup eventSetup2(provider.eventSetupImpl(), 0, nullptr);
-  eventSetup2.get<DummyRecord>();
-  CPPUNIT_ASSERT(eventSetup2.tryToGet<DummyRecord>().has_value());
+  {
+    controller.eventSetupForInstance(IOVSyncValue(time_2));
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    eventSetup.get<DummyRecord>();
+    CPPUNIT_ASSERT(eventSetup.tryToGet<DummyRecord>().has_value());
+  }
 
-  controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
-  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr);
-  eventSetup3.get<DummyRecord>();
-  CPPUNIT_ASSERT(eventSetup3.tryToGet<DummyRecord>().has_value());
-
-  controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
-  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr);
-  CPPUNIT_ASSERT(!eventSetup4.tryToGet<DummyRecord>().has_value());
+  {
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    eventSetup.get<DummyRecord>();
+    CPPUNIT_ASSERT(eventSetup.tryToGet<DummyRecord>().has_value());
+  }
+  {
+    controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
+    CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
+  }
 }
 
 void testEventsetup::recordValidityExcTest() {
@@ -267,7 +273,7 @@ void testEventsetup::recordValidityExcTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
   eventSetup.get<DummyRecord>();
 }
 
@@ -278,7 +284,7 @@ void testEventsetup::recordValidityNoFinderTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
   CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
 }
 
@@ -289,7 +295,7 @@ void testEventsetup::recordValidityNoFinderExcTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
   eventSetup.get<DummyRecord>();
 }
 
@@ -305,7 +311,7 @@ void testEventsetup::recordValidityProxyNoFinderTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
   CPPUNIT_ASSERT(!eventSetup.tryToGet<DummyRecord>().has_value());
 }
 
@@ -318,7 +324,7 @@ void testEventsetup::recordValidityProxyNoFinderExcTest() {
 
   Timestamp time_1(1);
   controller.eventSetupForInstance(IOVSyncValue(time_1));
-  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, true);
   eventSetup.get<DummyRecord>();
 }
 
@@ -386,11 +392,11 @@ void testEventsetup::twoSourceTest() {
   }
   //checking for conflicts is delayed until first eventSetupForInstance
   controller.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup3(provider.eventSetupImpl(), 0, nullptr, false);
   CPPUNIT_ASSERT(!eventSetup3.tryToGet<DummyRecord>().has_value());
   CPPUNIT_ASSERT(!eventSetup3.tryToGet<DummyEventSetupRecord>().has_value());
   controller.eventSetupForInstance(IOVSyncValue(Timestamp(3)));
-  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr);
+  const edm::EventSetup eventSetup4(provider.eventSetupImpl(), 0, nullptr, false);
   CPPUNIT_ASSERT(!eventSetup4.tryToGet<DummyRecord>().has_value());
   CPPUNIT_ASSERT(eventSetup4.tryToGet<DummyEventSetupRecord>().has_value());
   eventSetup4.get<DummyEventSetupRecord>();
@@ -427,7 +433,7 @@ void testEventsetup::provenanceTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -472,7 +478,7 @@ void testEventsetup::getDataWithLabelTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     edm::ESHandle<DummyData> data;
     eventSetup.getData("blah", data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -517,7 +523,7 @@ void testEventsetup::getDataWithESInputTagTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    const edm::EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     {
       edm::ESHandle<DummyData> data;
       edm::ESInputTag blahTag("", "blah");
@@ -734,7 +740,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
     }
@@ -744,7 +751,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
@@ -754,7 +762,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       auto const& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data.value_);
     }
@@ -764,7 +773,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       CPPUNIT_ASSERT_THROW(eventSetup.getData(consumer.m_token), cms::Exception);
     }
 
@@ -773,7 +783,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
@@ -782,7 +793,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
@@ -791,7 +803,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
@@ -800,7 +813,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       CPPUNIT_ASSERT_THROW(eventSetup.getData(consumer.m_token), cms::Exception);
     }
     {
@@ -808,7 +822,8 @@ void testEventsetup::getDataWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       const DummyData& data = eventSetup.getData(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data.value_);
     }
@@ -858,7 +873,8 @@ void testEventsetup::getHandleWithESGetTokenTest() {
 
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -870,7 +886,8 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -882,7 +899,8 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       edm::ESHandle<DummyData> data = eventSetup.getHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -894,7 +912,8 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       EventSetup eventSetup{provider.eventSetupImpl(),
                             static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event)};
+                            consumer.esGetTokenIndices(edm::Transition::Event),
+                            true};
       CPPUNIT_ASSERT(not eventSetup.getHandle(consumer.m_token));
       CPPUNIT_ASSERT_THROW(*eventSetup.getHandle(consumer.m_token), cms::Exception);
     }
@@ -949,7 +968,8 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -961,7 +981,8 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kBad.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -973,7 +994,8 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
       const edm::eventsetup::ComponentDescription* desc = data.description();
@@ -985,7 +1007,8 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       consumer.updateLookup(provider.recordsToProxyIndices());
       const edm::EventSetup eventSetup{provider.eventSetupImpl(),
                                        static_cast<unsigned int>(edm::Transition::Event),
-                                       consumer.esGetTokenIndices(edm::Transition::Event)};
+                                       consumer.esGetTokenIndices(edm::Transition::Event),
+                                       true};
       edm::ESTransientHandle<DummyData> data = eventSetup.getTransientHandle(consumer.m_token);
       CPPUNIT_ASSERT(not data);
       CPPUNIT_ASSERT_THROW(*data, cms::Exception);
@@ -1020,7 +1043,7 @@ void testEventsetup::sourceProducerResolutionTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    const EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    const EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1048,7 +1071,7 @@ void testEventsetup::sourceProducerResolutionTest() {
       provider.add(dummyProv);
     }
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
     CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1085,7 +1108,7 @@ void testEventsetup::preferTest() {
         provider.add(dummyProv);
       }
       controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1115,7 +1138,7 @@ void testEventsetup::preferTest() {
         provider.add(dummyProv);
       }
       controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1146,7 +1169,7 @@ void testEventsetup::preferTest() {
         provider.add(dummyProv);
       }
       controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
       edm::ESHandle<DummyData> data;
       eventSetup.getData(data);
       CPPUNIT_ASSERT(kGood.value_ == data->value_);
@@ -1191,7 +1214,7 @@ void testEventsetup::introspectionTest() {
     EventSetupRecordKey dummyRecordKey = EventSetupRecordKey::makeKey<DummyRecord>();
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(2)));
     {
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
 
       CPPUNIT_ASSERT(eventSetup.recordIsProvidedByAModule(dummyRecordKey));
       std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
@@ -1206,7 +1229,7 @@ void testEventsetup::introspectionTest() {
     // EventSetupImpl but has a null pointer.
     controller.eventSetupForInstance(IOVSyncValue(Timestamp(4)));
     {
-      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+      EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
 
       CPPUNIT_ASSERT(eventSetup.recordIsProvidedByAModule(dummyRecordKey));
       std::vector<edm::eventsetup::EventSetupRecordKey> recordKeys;
@@ -1238,12 +1261,12 @@ void testEventsetup::iovExtensionTest() {
 
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(3)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
@@ -1251,7 +1274,7 @@ void testEventsetup::iovExtensionTest() {
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{2}}, IOVSyncValue{Timestamp{4}}));
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(4)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 
@@ -1259,7 +1282,7 @@ void testEventsetup::iovExtensionTest() {
   finder->setInterval(ValidityInterval(IOVSyncValue{Timestamp{5}}, IOVSyncValue{Timestamp{6}}));
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(5)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, true};
     CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
   }
 }
@@ -1285,7 +1308,7 @@ void testEventsetup::resetProxiesTest() {
 
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
     CPPUNIT_ASSERT(2 == eventSetup.get<DummyRecord>().cacheIdentifier());
     edm::ESHandle<DummyData> data;
     eventSetup.getData(data);
@@ -1294,7 +1317,7 @@ void testEventsetup::resetProxiesTest() {
   provider.forceCacheClear();
   {
     controller.eventSetupForInstance(IOVSyncValue{Timestamp(2)});
-    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr};
+    EventSetup eventSetup{provider.eventSetupImpl(), 0, nullptr, false};
     eventSetup.get<DummyRecord>();
     CPPUNIT_ASSERT(3 == eventSetup.get<DummyRecord>().cacheIdentifier());
     dummyProv->incrementData();

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -181,7 +181,7 @@ void testEventsetupRecord::getTest() {
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr);
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
   ESHandle<Dummy> dummyPtr;
   CPPUNIT_ASSERT(not dummyRecord.get(dummyPtr));
   CPPUNIT_ASSERT(not dummyPtr.isValid());
@@ -276,7 +276,7 @@ namespace {
 
     DummyRecord makeRecord() {
       DummyRecord ret;
-      ret.setImpl(&dummyRecordImpl, 0, consumer.esGetTokenIndices(edm::Transition::Event), nullptr);
+      ret.setImpl(&dummyRecordImpl, 0, consumer.esGetTokenIndices(edm::Transition::Event), nullptr, false);
       return ret;
     }
   };
@@ -459,7 +459,7 @@ void testEventsetupRecord::getWithTokenTest() {
 void testEventsetupRecord::getNodataExpTest() {
   EventSetupRecordImpl recImpl(DummyRecord::keyForClass(), &activityRegistry);
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&recImpl, 0, nullptr, nullptr);
+  dummyRecord.setImpl(&recImpl, 0, nullptr, nullptr, false);
   FailingDummyProxy dummyProxy;
 
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
@@ -479,7 +479,7 @@ void testEventsetupRecord::getExepTest() {
   dummyRecordImpl.add(dummyDataKey, &dummyProxy);
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr);
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
   dummyRecord.get(dummyPtr);
   //CPPUNIT_ASSERT_THROW(dummyRecord.get(dummyPtr), ExceptionType);
 }
@@ -492,7 +492,7 @@ void testEventsetupRecord::doGetTest() {
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr);
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
   CPPUNIT_ASSERT(!dummyRecord.doGet(dummyDataKey));
 
   dummyRecordImpl.add(dummyDataKey, &dummyProxy);
@@ -536,7 +536,7 @@ void testEventsetupRecord::introspectionTest() {
   CPPUNIT_ASSERT(keys.empty());
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr);
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
 
   std::vector<ComponentDescription const*> esproducers;
   dummyRecordImpl.getESProducers(esproducers);
@@ -650,7 +650,7 @@ void testEventsetupRecord::doGetExepTest() {
   const DataKey dummyDataKey(DataKey::makeTypeTag<FailingDummyProxy::value_type>(), "");
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr);
+  dummyRecord.setImpl(&dummyRecordImpl, 0, nullptr, nullptr, false);
   CPPUNIT_ASSERT(!dummyRecord.doGet(dummyDataKey));
 
   dummyRecordImpl.add(dummyDataKey, &dummyProxy);
@@ -666,7 +666,7 @@ void testEventsetupRecord::proxyResetTest() {
   EventSetupRecordProvider const* constRecordProvider = dummyProvider.get();
 
   DummyRecord dummyRecord;
-  dummyRecord.setImpl(&constRecordProvider->firstRecordImpl(), 0, nullptr, nullptr);
+  dummyRecord.setImpl(&constRecordProvider->firstRecordImpl(), 0, nullptr, nullptr, false);
 
   Dummy myDummy;
   std::shared_ptr<WorkingDummyProxy> workingProxy = std::make_shared<WorkingDummyProxy>(&myDummy);
@@ -716,7 +716,7 @@ void testEventsetupRecord::transientTest() {
   auto dummyProvider = std::make_unique<EventSetupRecordProvider>(DummyRecord::keyForClass(), &activityRegistry);
 
   DummyRecord dummyRecordNoConst;
-  dummyRecordNoConst.setImpl(&dummyProvider->firstRecordImpl(), 0, nullptr, nullptr);
+  dummyRecordNoConst.setImpl(&dummyProvider->firstRecordImpl(), 0, nullptr, nullptr, false);
   EventSetupRecord const& dummyRecord = dummyRecordNoConst;
 
   eventsetup::EventSetupRecordImpl& nonConstDummyRecordImpl = *const_cast<EventSetupRecordImpl*>(dummyRecord.impl_);

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -81,7 +81,7 @@ void testfullChain::getfromDataproxyproviderTest() {
   for (unsigned int iTime = 1; iTime != 6; ++iTime) {
     const Timestamp time(iTime);
     controller.eventSetupForInstance(IOVSyncValue(time));
-    EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr);
+    EventSetup eventSetup(provider.eventSetupImpl(), 0, nullptr, false);
     ESHandle<DummyData> pDummy;
     eventSetup.get<DummyRecord>().get(pDummy);
     CPPUNIT_ASSERT(0 != pDummy.product());

--- a/FWCore/Integration/test/TestESSource.cc
+++ b/FWCore/Integration/test/TestESSource.cc
@@ -92,7 +92,7 @@ namespace edmtest {
     }
     testESSource_->busyWait("getImpl");
     ESTestRecordI record;
-    record.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl);
+    record.setImpl(&iRecord, std::numeric_limits<unsigned int>::max(), nullptr, iEventSetupImpl, true);
 
     edm::ValidityInterval iov = record.validityInterval();
     edm::LogAbsolute("TestESSoureTestProxy")


### PR DESCRIPTION
#### PR description:

EventSetupRecord and EventSetup now have an option to enforce the use of ESGetTokens. For ESProducers that option is enabled,  for ED modules it is disabled.

This is one of the steps to having concurrent running of ES modules.

#### PR validation:

By including #28215 #28216 #28217 and #28218 there are no failures in runTheMatrix.py related to this pull request.