### PR TITLE
Add consumes to CTPPSInterpolatedOpticalFunctionsESSource

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
@@ -26,21 +26,21 @@ public:
   std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> produce(const CTPPSInterpolatedOpticsRcd &);
 
 private:
-  std::string lhcInfoLabel_;
-
+  edm::ESGetToken<LHCOpticalFunctionsSetCollection, CTPPSOpticsRcd> opticsToken_;
+  edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+  std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> currentData_;
   float currentCrossingAngle_;
   bool currentDataValid_;
-  std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> currentData_;
 };
 
 //----------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------
 
 CTPPSInterpolatedOpticalFunctionsESSource::CTPPSInterpolatedOpticalFunctionsESSource(const edm::ParameterSet &iConfig)
-    : lhcInfoLabel_(iConfig.getParameter<std::string>("lhcInfoLabel")),
-      currentCrossingAngle_(-1.),
-      currentDataValid_(false) {
-  setWhatProduced(this, &CTPPSInterpolatedOpticalFunctionsESSource::produce);
+    : currentCrossingAngle_(-1.), currentDataValid_(false) {
+  setWhatProduced(this, &CTPPSInterpolatedOpticalFunctionsESSource::produce)
+      .setConsumes(opticsToken_)
+      .setConsumes(lhcInfoToken_, edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")));
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -58,18 +58,16 @@ void CTPPSInterpolatedOpticalFunctionsESSource::fillDescriptions(edm::Configurat
 std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSInterpolatedOpticalFunctionsESSource::produce(
     const CTPPSInterpolatedOpticsRcd &iRecord) {
   // get the input data
-  edm::ESHandle<LHCOpticalFunctionsSetCollection> hOFColl;
-  iRecord.getRecord<CTPPSOpticsRcd>().get(hOFColl);
+  LHCOpticalFunctionsSetCollection const &ofColl = iRecord.get(opticsToken_);
 
-  edm::ESHandle<LHCInfo> hLHCInfo;
-  iRecord.getRecord<LHCInfoRcd>().get(lhcInfoLabel_, hLHCInfo);
+  LHCInfo const &lhcInfo = iRecord.get(lhcInfoToken_);
 
   // is there anything to do?
-  if (currentDataValid_ && hLHCInfo->crossingAngle() == currentCrossingAngle_)
+  if (currentDataValid_ && lhcInfo.crossingAngle() == currentCrossingAngle_)
     return currentData_;
 
   // is crossing angle reasonable (LHCInfo is correctly filled in DB)?
-  if (hLHCInfo->crossingAngle() == 0.) {
+  if (lhcInfo.crossingAngle() == 0.) {
     edm::LogInfo("CTPPSInterpolatedOpticalFunctionsESSource")
         << "Invalid crossing angle, no optical functions produced.";
 
@@ -81,12 +79,12 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSInterpolatedO
   }
 
   // set new crossing angle
-  currentCrossingAngle_ = hLHCInfo->crossingAngle();
+  currentCrossingAngle_ = lhcInfo.crossingAngle();
   edm::LogInfo("CTPPSInterpolatedOpticalFunctionsESSource")
       << "Crossing angle has changed to " << currentCrossingAngle_ << ".";
 
   // is input optics available ?
-  if (hOFColl->empty()) {
+  if (ofColl.empty()) {
     edm::LogInfo("CTPPSInterpolatedOpticalFunctionsESSource")
         << "No input optics available, no optical functions produced.";
 
@@ -97,8 +95,8 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSInterpolatedO
   }
 
   // regular case with single-xangle input
-  if (hOFColl->size() == 1) {
-    const auto &it = hOFColl->begin();
+  if (ofColl.size() == 1) {
+    const auto &it = ofColl.begin();
 
     // does the input xangle correspond to the actual one?
     if (fabs(currentCrossingAngle_ - it->first) > 1e-6)
@@ -118,16 +116,16 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSInterpolatedO
   }
 
   // regular case with multi-xangle input
-  if (hOFColl->size() > 1) {
+  if (ofColl.size() > 1) {
     // find the closest xangle points for interpolation
-    auto it1 = hOFColl->begin();
+    auto it1 = ofColl.begin();
     auto it2 = std::next(it1);
 
     if (currentCrossingAngle_ > it1->first) {
-      for (; it1 != hOFColl->end(); ++it1) {
+      for (; it1 != ofColl.end(); ++it1) {
         it2 = std::next(it1);
 
-        if (it2 == hOFColl->end()) {
+        if (it2 == ofColl.end()) {
           it2 = it1;
           it1 = std::prev(it1);
           break;


### PR DESCRIPTION
#### PR description:

Call consumes and use the ESGetTokens.

#### PR validation:

Ran a runTheMatrix.py workflow using this module and it works.