### PR TITLE
Use ESGetToken in MTDTopologyEP

### DIFF
--- a/Geometry/MTDNumberingBuilder/plugins/MTDTopologyEP.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/MTDTopologyEP.cc
@@ -41,14 +41,12 @@ void MTDTopologyEP::fillDescriptions(edm::ConfigurationDescriptions& description
 
 MTDTopologyEP::ReturnType MTDTopologyEP::produce(const MTDTopologyRcd& iRecord) {
   edm::LogInfo("MTDTopologyEP") << "MTDTopologyEP::produce(const MTDTopologyRcd& iRecord)";
-  edm::ESHandle<PMTDParameters> ptp;
-  iRecord.getRecord<PMTDParametersRcd>().get(ptp);
 
   int mtdTopologyMode;
   MTDTopology::BTLValues btlVals;
   MTDTopology::ETLValues etlVals;
 
-  fillParameters(*ptp, mtdTopologyMode, btlVals, etlVals);
+  fillParameters(iRecord.get(token_), mtdTopologyMode, btlVals, etlVals);
 
   return std::make_unique<MTDTopology>(mtdTopologyMode, btlVals, etlVals);
 }


### PR DESCRIPTION
#### PR description:

The token was being set but not used to get the data.

#### PR validation:

Ran a runTheMatrix.py workflow using the module and it ran fine.