### PR TITLE
Bug fix for concurrent IOVs

### DIFF
--- a/FWCore/Framework/interface/DataProxyProvider.h
+++ b/FWCore/Framework/interface/DataProxyProvider.h
@@ -78,7 +78,8 @@ namespace edm {
 
         EventSetupRecordKey const& recordKey() const;
 
-        void insert(std::vector<std::pair<DataKey, std::shared_ptr<DataProxy>>>&&);
+        void insert(std::vector<std::pair<DataKey, std::shared_ptr<DataProxy>>>&&,
+                    std::string const& appendToDataLabel);
 
         bool contains(DataKey const& dataKey) const;
 


### PR DESCRIPTION
#### PR description:

Only affects corner case with nConcurrentIOVs set to
more than one and the appendToDataLabel parameter set
to a non-empty value. The symptom is an assert failure,
when the assert should pass. The assert check didn't take
into account that the parameter could change the DataKey
labels.

#### PR validation:

Existing tests should be sufficient. The failure was in code
that is itself only a sanity check.
