### PR TITLE
Updated 2018 Strips MC conditions to improve data/MC agreement

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -56,15 +56,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '110X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR updates several SiStrip conditions in order to improve data/MC agreement [1]. It is the counterpart of commit e859edc7081e3d4dc78e4381938e40d34ec9a07f of PR #28053. Note that commit e859edc7081e3d4dc78e4381938e40d34ec9a07f uses an incorrect tag for SiStripNoisesRcd, which is corrected in this PR. PR  #28053 will be updated accordingly.

**GT diffs:**

**2018 pp collisions MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_v6/110X_upgrade2018_realistic_v7
**2018 pp collisions MC with HE failure**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HEfail_v6/110X_upgrade2018_realistic_HEfail_v7
**2018 cosmics with strips in deco mode**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_deco_v3/110X_upgrade2018cosmics_realistic_deco_v4
**2018 cosmics with strips in peak mode**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_peak_v3/110X_upgrade2018cosmics_realistic_peak_v5

[1] https://indico.cern.ch/event/854616/#7-strip-mc-conditions-for-ul-2

#### PR validation:

See [1] for details. In addition, a technical test was performed: `runTheMatrix.py -l limited -i all --ibeos`

[1] https://indico.cern.ch/event/854616/#7-strip-mc-conditions-for-ul-2

#### if this PR is a backport please specify the original PR:

This PR is not a backport. PR #28053 is a 10_6_X backport that contains these updates.
