### PR TITLE
Fix gcc 9 warnings in SimMuon/MCTruth

### DIFF
--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -266,7 +266,7 @@ void MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event &iEvent, con
   gemtruth_.reset(new GEMHitAssociator(iEvent, iSetup, config_));
 
   MuonAssociatorByHitsHelper::Resources resources = {
-      tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get()};
+      tTopo, trackertruth_.get(), csctruth_.get(), dttruth_.get(), rpctruth_.get(), gemtruth_.get(), {}};
 
   if (diagnostics_) {
     diagnostics_->read(iEvent);

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -177,7 +177,8 @@ RecoToSimCollection MuonAssociatorByHits::associateRecoToSim(
   // GEM hit association
   GEMHitAssociator gemtruth(*e, *setup, conf_);
 
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};
 
   if (diagnostics_) {
     resources.diagnostics_ = [this, e](const TrackHitsCollection &hC, const TrackingParticleCollection &pC) {
@@ -224,7 +225,8 @@ SimToRecoCollection MuonAssociatorByHits::associateSimToReco(
   // GEM hit association
   GEMHitAssociator gemtruth(*e, *setup, conf_);
 
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};
 
   auto bareAssoc = helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
@@ -138,7 +138,8 @@ void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection &recToSim,
   // GEM hit association
   GEMHitAssociator gemtruth(*event, *setup, conf_);
 
-  MuonAssociatorByHitsHelper::Resources resources = {tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth};
+  MuonAssociatorByHitsHelper::Resources resources = {
+      tTopo, &trackertruth, &csctruth, &dttruth, &rpctruth, &gemtruth, {}};
 
   auto recSimColl = helper_.associateRecoToSimIndices(muonHitRefs, tPC, resources);
   for (auto it = recSimColl.begin(), ed = recSimColl.end(); it != ed; ++it) {


### PR DESCRIPTION
#### PR description:

Make sure all elements of a struct are set.

#### PR validation:

Code compiles without warnings under gcc9 IB.