### PR TITLE
FastSim: fixes for dedx and charginos as muons - backport to 94X

### DIFF
--- a/FastSimulation/Calorimetry/src/CalorimetryManager.cc
+++ b/FastSimulation/Calorimetry/src/CalorimetryManager.cc
@@ -202,6 +202,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
   // Check that the particle hasn't decayed
   if(myTrack.noEndVertex()) {
     // Simulate energy smearing for photon and electrons
+    float charge_ = (float)(myTrack.charge());
     if ( pid == 11 || pid == 22 ) {
   
   if ( myTrack.onEcal() ) 
@@ -215,7 +216,7 @@ void CalorimetryManager::reconstructTrack(FSimTrack& myTrack, RandomEngineAndDis
           else reconstructHCAL(myTrack, random);
   }   
       } // electron or photon
-      else if (pid==13)
+      else if (pid == 13 || pid == 1000024 || (pid > 1000100 && pid < 1999999 && fabs(charge_) > 0.001))
   {
           MuonMipSimulation(myTrack, random);
   }
@@ -476,7 +477,8 @@ void CalorimetryManager::reconstructHCAL(const FSimTrack& myTrack,
   double EGen  = myTrack.hcalEntrance().e();
   double emeas = 0.;
   
-  if(pid == 13) { 
+  float charge_ = (float)myTrack.charge();
+  if (pid == 13 || pid == 1000024 || (pid > 1000100 && pid < 1999999 && fabs(charge_) > 0.001)) {
     emeas = myHDResponse_->responseHCAL(0, EGen, pathEta, 2, random); // 2=muon
     if(debug_)
       LogInfo("FastCalorimetry") << "CalorimetryManager::reconstructHCAL - MUON !!!" << std::endl;
@@ -1314,8 +1316,10 @@ void CalorimetryManager::loadMuonSimTracks(edm::SimTrackContainer &muons) const
   unsigned size=muons.size();
   for(unsigned i=0; i<size;++i)
     {
-      int id=muons[i].trackId();
-      if(abs(muons[i].type())!=13) continue;
+      int id = muons[i].trackId();
+      if (!(abs(muons[i].type()) == 13 || abs(muons[i].type()) == 1000024 ||
+          (abs(muons[i].type()) > 1000100 && abs(muons[i].type()) < 1999999)))
+        continue;
       // identify the corresponding muon in the local collection
       
       std::vector<FSimTrack>::const_iterator itcheck=find_if(muonSimTracks.begin(),muonSimTracks.end(),FSimTrackEqual(id));

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -183,7 +183,7 @@ MuonSimHitProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup) {
     // Decaying hadrons are now in the list, and so are their muon daughter
     // Ignore the hadrons here.
     int pid = mySimTrack.type(); 
-    if ( abs(pid) != 13 ) continue;
+    if ( abs(pid) != 13 && abs(pid) != 1000024) continue;
 
     double t0 = 0;
     GlobalPoint initialPosition;

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -248,8 +248,12 @@ void FastTrackDeDxProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 
 void FastTrackDeDxProducer::processHit(const FastTrackerRecHit &recHit, float trackMomentum, float& cosine, reco::DeDxHitCollection& dedxHits, int& NClusterSaturating){
 
+  if (!recHit.isValid()) return;
 
-  if(!recHit.isValid())return;
+  auto const& thit = static_cast<BaseTrackerRecHit const&>(recHit);
+  if (!thit.isValid()) return;
+
+    if (!thit.hasPositionAndError()) return;
 
   if(recHit.isPixel()){
     if(!usePixel) return;


### PR DESCRIPTION
#### PR description:
backport of #28235 for FastSim
-- The calorimeters and muon system now generate hits and energy depositions as if it the chargino were a muon instead of not at all.
-- Includes safety statements for FastSim tracker hits that are not associated to a cluster to avoid a segfault when producing long-lived signal samples with pileup.
-- The treatment of muons and charginos in the muon system is now extended cover charged R-hadrons (pid>1000100 && pid<1999999).

#### PR validation:

Regular tests.

#### if this PR is a backport please specify the original PR:

backport of #28235 

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
