### PR TITLE
[PPS] Removed all 'get' prefixes from PPS DataFormat objects

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSRPAlignmentCorrectionsData.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSRPAlignmentCorrectionsData.cc
@@ -50,7 +50,7 @@ CTPPSRPAlignmentCorrectionData CTPPSRPAlignmentCorrectionsData::getFullSensorCor
   CTPPSRPAlignmentCorrectionData align_corr;
 
   // try to get alignment correction of the full RP
-  auto rpIt = rps_.find(CTPPSDetId(id).getRPId());
+  auto rpIt = rps_.find(CTPPSDetId(id).rpId());
   if (rpIt != rps_.end())
     align_corr = rpIt->second;
 

--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSRPAlignmentCorrectionsMethods.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSRPAlignmentCorrectionsMethods.cc
@@ -357,7 +357,7 @@ void CTPPSRPAlignmentCorrectionsMethods::writeXMLBlock(const CTPPSRPAlignmentCor
 
   for (auto it = sensors.begin(); it != sensors.end(); ++it) {
     CTPPSDetId sensorId(it->first);
-    unsigned int rpId = sensorId.getRPId();
+    unsigned int rpId = sensorId.rpId();
     unsigned int decRPId = sensorId.arm() * 100 + sensorId.station() * 10 + sensorId.rp();
 
     // start a RP block

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -351,7 +351,7 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
   map<unsigned int, set<signed int>> ms_rp_idx_arm;
 
   for (auto &tr : *hTracks) {
-    const CTPPSDetId rpId(tr.getRPId());
+    const CTPPSDetId rpId(tr.rpId());
     const unsigned int arm = rpId.arm();
     const unsigned int stNum = rpId.station();
     const unsigned int rpNum = rpId.rp();
@@ -429,7 +429,7 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
   map<unsigned int, set<unsigned int>> mTop, mHor, mBot;
 
   for (auto &tr : *hTracks) {
-    CTPPSDetId rpId(tr.getRPId());
+    CTPPSDetId rpId(tr.rpId());
     const unsigned int rpNum = rpId.rp();
     const unsigned int armIdx = rpId.arm();
 
@@ -447,8 +447,8 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
     {
       auto it = ap.trackingRPPlots.find(rpDecId);
       if (it != ap.trackingRPPlots.end()) {
-        it->second.h_x->Fill(tr.getX());
-        it->second.h_y->Fill(tr.getY());
+        it->second.h_x->Fill(tr.x());
+        it->second.h_y->Fill(tr.y());
       }
     }
 
@@ -456,8 +456,8 @@ void CTPPSCommonDQMSource::analyzeTracks(edm::Event const &event, edm::EventSetu
     {
       auto it = ap.timingRPPlots.find(rpDecId);
       if (it != ap.timingRPPlots.end()) {
-        it->second.h_x->Fill(tr.getX());
-        it->second.h_time->Fill(tr.getTime());
+        it->second.h_x->Fill(tr.x());
+        it->second.h_time->Fill(tr.time());
       }
     }
   }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -44,7 +44,7 @@ bool channelAlignedWithTrack(const CTPPSGeometry* geom,
                              const CTPPSDiamondDetId& detid,
                              const CTPPSDiamondLocalTrack& localTrack,
                              const float tolerance = 1) {
-  const DetGeomDesc* det = geom->getSensor(detid);
+  const DetGeomDesc* det = geom->sensor(detid);
   const float x_pos = det->translation().x(),
               x_width = 2.0 * det->params().at(0);  // parameters stand for half the size
   return ((x_pos + 0.5 * x_width > localTrack.x0() - localTrack.x0Sigma() - tolerance &&
@@ -512,13 +512,13 @@ void CTPPSDiamondDQMSource::dqmBeginRun(const edm::Run& iRun, const edm::EventSe
   iSetup.get<VeryForwardRealGeometryRecord>().get(geometry_);
   const CTPPSGeometry* geom = geometry_.product();
   const CTPPSDiamondDetId detid(0, CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID, 0, 0);
-  const DetGeomDesc* det = geom->getSensor(detid);
+  const DetGeomDesc* det = geom->sensor(detid);
   horizontalShiftOfDiamond_ = det->translation().x() - det->params().at(0);
 
   // Rough alignement of pixel detector for diamond thomography
   const CTPPSPixelDetId pixid(0, CTPPS_PIXEL_STATION_ID, CTPPS_FAR_RP_ID, 0);
   if (iRun.run() > 300000) {  //Pixel installed
-    det = geom->getSensor(pixid);
+    det = geom->sensor(pixid);
     horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at(0) - horizontalShiftOfDiamond_ - 1;
   }
 }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -47,12 +47,12 @@ bool channelAlignedWithTrack(const CTPPSGeometry* geom,
   const DetGeomDesc* det = geom->getSensor(detid);
   const float x_pos = det->translation().x(),
               x_width = 2.0 * det->params().at(0);  // parameters stand for half the size
-  return ((x_pos + 0.5 * x_width > localTrack.getX0() - localTrack.getX0Sigma() - tolerance &&
-           x_pos + 0.5 * x_width < localTrack.getX0() + localTrack.getX0Sigma() + tolerance) ||
-          (x_pos - 0.5 * x_width > localTrack.getX0() - localTrack.getX0Sigma() - tolerance &&
-           x_pos - 0.5 * x_width < localTrack.getX0() + localTrack.getX0Sigma() + tolerance) ||
-          (x_pos - 0.5 * x_width < localTrack.getX0() - localTrack.getX0Sigma() - tolerance &&
-           x_pos + 0.5 * x_width > localTrack.getX0() + localTrack.getX0Sigma() + tolerance));
+  return ((x_pos + 0.5 * x_width > localTrack.x0() - localTrack.x0Sigma() - tolerance &&
+           x_pos + 0.5 * x_width < localTrack.x0() + localTrack.x0Sigma() + tolerance) ||
+          (x_pos - 0.5 * x_width > localTrack.x0() - localTrack.x0Sigma() - tolerance &&
+           x_pos - 0.5 * x_width < localTrack.x0() + localTrack.x0Sigma() + tolerance) ||
+          (x_pos - 0.5 * x_width < localTrack.x0() - localTrack.x0Sigma() - tolerance &&
+           x_pos + 0.5 * x_width > localTrack.x0() + localTrack.x0Sigma() + tolerance));
 }
 
 namespace dds {
@@ -727,67 +727,67 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
 
     for (const auto& rechit : rechits) {
       planes_inclusive[detId_pot].insert(detId.plane());
-      if (excludeMultipleHits_ && rechit.getMultipleHits() > 0)
+      if (excludeMultipleHits_ && rechit.multipleHits() > 0)
         continue;
-      if (rechit.getToT() != 0 && centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_)
+      if (rechit.toT() != 0 && centralOOT_ != -999 && rechit.ootIndex() == centralOOT_)
         planes[detId_pot].insert(detId.plane());
 
       if (potPlots_.find(detId_pot) == potPlots_.end())
         continue;
 
       float UFSDShift = 0.0;
-      if (rechit.getYWidth() < 3)
+      if (rechit.yWidth() < 3)
         UFSDShift = 0.5;  // Display trick for UFSD that have 2 pixels with same X
 
-      if (rechit.getToT() != 0 && centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_) {
+      if (rechit.toT() != 0 && centralOOT_ != -999 && rechit.ootIndex() == centralOOT_) {
         TH2F* hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis* hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-        int startBin = hitHistoTmpYAxis->FindBin(rechit.getX() - horizontalShiftOfDiamond_ - 0.5 * rechit.getXWidth());
-        int numOfBins = rechit.getXWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int startBin = hitHistoTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+        int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
           hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
         }
 
         hitHistoTmp = lumiCache->hitDistribution2dMap[detId_pot].get();
         hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-        startBin = hitHistoTmpYAxis->FindBin(rechit.getX() - horizontalShiftOfDiamond_ - 0.5 * rechit.getXWidth());
-        numOfBins = rechit.getXWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        startBin = hitHistoTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+        numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
           hitHistoTmp->Fill(detId.plane() + UFSDShift, hitHistoTmpYAxis->GetBinCenter(startBin + i));
         }
       }
 
-      if (rechit.getToT() != 0) {
+      if (rechit.toT() != 0) {
         // Both
-        potPlots_[detId_pot].leadingEdgeCumulative_both->Fill(rechit.getT() + 25 * rechit.getOOTIndex());
-        potPlots_[detId_pot].timeOverThresholdCumulativePot->Fill(rechit.getToT());
+        potPlots_[detId_pot].leadingEdgeCumulative_both->Fill(rechit.t() + 25 * rechit.ootIndex());
+        potPlots_[detId_pot].timeOverThresholdCumulativePot->Fill(rechit.toT());
 
         TH2F* hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
         TAxis* hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
         int startBin =
-            hitHistoOOTTmpYAxis->FindBin(rechit.getX() - horizontalShiftOfDiamond_ - 0.5 * rechit.getXWidth());
-        int numOfBins = rechit.getXWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+            hitHistoOOTTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+        int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
-          hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.getOOTIndex(),
+          hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.ootIndex(),
                                hitHistoOOTTmpYAxis->GetBinCenter(startBin + i));
         }
       } else {
-        if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING) {
+        if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING) {
           // Only leading
           TH2F* hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis* hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin =
-              hitHistoOOTTmpYAxis->FindBin(rechit.getX() - horizontalShiftOfDiamond_ - 0.5 * rechit.getXWidth());
-          int numOfBins = rechit.getXWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+              hitHistoOOTTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+          int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for (int i = 0; i < numOfBins; ++i) {
-            hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.getOOTIndex(),
+            hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.ootIndex(),
                                  hitHistoOOTTmpYAxis->GetBinCenter(startBin + i));
           }
         }
       }
-      if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
-          potPlots_[detId_pot].activity_per_bx.count(rechit.getOOTIndex()) > 0)
-        potPlots_[detId_pot].activity_per_bx.at(rechit.getOOTIndex())->Fill(event.bunchCrossing());
+      if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
+          potPlots_[detId_pot].activity_per_bx.count(rechit.ootIndex()) > 0)
+        potPlots_[detId_pot].activity_per_bx.at(rechit.ootIndex())->Fill(event.bunchCrossing());
     }
   }
 
@@ -806,25 +806,25 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
     for (const auto& track : tracks) {
       if (!track.isValid())
         continue;
-      if (track.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING)
+      if (track.ootIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING)
         continue;
-      if (excludeMultipleHits_ && track.getMultipleHits() > 0)
+      if (excludeMultipleHits_ && track.multipleHits() > 0)
         continue;
       if (potPlots_.find(detId_pot) == potPlots_.end())
         continue;
 
       TH2F* trackHistoOOTTmp = potPlots_[detId_pot].trackDistributionOOT->getTH2F();
       TAxis* trackHistoOOTTmpYAxis = trackHistoOOTTmp->GetYaxis();
-      int startBin = trackHistoOOTTmpYAxis->FindBin(track.getX0() - horizontalShiftOfDiamond_ - track.getX0Sigma());
-      int numOfBins = 2 * track.getX0Sigma() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+      int startBin = trackHistoOOTTmpYAxis->FindBin(track.x0() - horizontalShiftOfDiamond_ - track.x0Sigma());
+      int numOfBins = 2 * track.x0Sigma() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
       for (int i = 0; i < numOfBins; ++i) {
-        trackHistoOOTTmp->Fill(track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin + i));
+        trackHistoOOTTmp->Fill(track.ootIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin + i));
       }
 
-      if (centralOOT_ != -999 && track.getOOTIndex() == centralOOT_) {
+      if (centralOOT_ != -999 && track.ootIndex() == centralOOT_) {
         TH1F* trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
-        int startBin = trackHistoInTimeTmp->FindBin(track.getX0() - horizontalShiftOfDiamond_ - track.getX0Sigma());
-        int numOfBins = 2 * track.getX0Sigma() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int startBin = trackHistoInTimeTmp->FindBin(track.x0() - horizontalShiftOfDiamond_ - track.x0Sigma());
+        int numOfBins = 2 * track.x0Sigma() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
           trackHistoInTimeTmp->Fill(trackHistoInTimeTmp->GetBinCenter(startBin + i));
         }
@@ -893,9 +893,9 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
     detId_pot.setChannel(0);
     const CTPPSDiamondDetId detId(rechits.detId());
     for (const auto& rechit : rechits) {
-      if (excludeMultipleHits_ && rechit.getMultipleHits() > 0)
+      if (excludeMultipleHits_ && rechit.multipleHits() > 0)
         continue;
-      if (rechit.getToT() == 0)
+      if (rechit.toT() == 0)
         continue;
       if (!pixelTracks.isValid())
         continue;
@@ -910,12 +910,12 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
           continue;
         for (const auto& lt : ds) {
           if (lt.isValid() && pixId.arm() == detId_pot.arm()) {
-            if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getOOTIndex() >= 0 &&
-                potPlots_[detId_pot].pixelTomographyAll.count(rechit.getOOTIndex()) > 0 &&
-                lt.getX0() - horizontalShiftBwDiamondPixels_ < 24)
+            if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.ootIndex() >= 0 &&
+                potPlots_[detId_pot].pixelTomographyAll.count(rechit.ootIndex()) > 0 &&
+                lt.x0() - horizontalShiftBwDiamondPixels_ < 24)
               potPlots_[detId_pot]
-                  .pixelTomographyAll.at(rechit.getOOTIndex())
-                  ->Fill(lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * detId.plane(), lt.getY0());
+                  .pixelTomographyAll.at(rechit.ootIndex())
+                  ->Fill(lt.x0() - horizontalShiftBwDiamondPixels_ + 25 * detId.plane(), lt.y0());
           }
         }
       }
@@ -982,15 +982,15 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
     CTPPSDiamondDetId detId_plane(rechits.detId());
     detId_plane.setChannel(0);
     for (const auto& rechit : rechits) {
-      if (excludeMultipleHits_ && rechit.getMultipleHits() > 0)
+      if (excludeMultipleHits_ && rechit.multipleHits() > 0)
         continue;
-      if (rechit.getToT() == 0)
+      if (rechit.toT() == 0)
         continue;
       if (planePlots_.find(detId_plane) != planePlots_.end()) {
-        if (centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_) {
+        if (centralOOT_ != -999 && rechit.ootIndex() == centralOOT_) {
           TH1F* hitHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
-          int startBin = hitHistoTmp->FindBin(rechit.getX() - horizontalShiftOfDiamond_ - 0.5 * rechit.getXWidth());
-          int numOfBins = rechit.getXWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int startBin = hitHistoTmp->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+          int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for (int i = 0; i < numOfBins; ++i) {
             hitHistoTmp->Fill(hitHistoTmp->GetBinCenter(startBin + i));
           }
@@ -1010,31 +1010,31 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
       if (lt.isValid()) {
         // For efficieny
         CTPPSDiamondDetId detId_pot(pixId.arm(), CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID);
-        potPlots_[detId_pot].pixelTracksMap.Fill(lt.getX0() - horizontalShiftBwDiamondPixels_, lt.getY0());
+        potPlots_[detId_pot].pixelTracksMap.Fill(lt.x0() - horizontalShiftBwDiamondPixels_, lt.y0());
 
         std::set<CTPPSDiamondDetId> planesWitHits_set;
         for (const auto& rechits : *diamondRecHits) {
           CTPPSDiamondDetId detId_plane(rechits.detId());
           detId_plane.setChannel(0);
           for (const auto& rechit : rechits) {
-            if (excludeMultipleHits_ && rechit.getMultipleHits() > 0)
+            if (excludeMultipleHits_ && rechit.multipleHits() > 0)
               continue;
-            if (rechit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING || rechit.getToT() == 0)
+            if (rechit.ootIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING || rechit.toT() == 0)
               continue;
             if (planePlots_.find(detId_plane) == planePlots_.end())
               continue;
-            if (pixId.arm() == detId_plane.arm() && lt.getX0() - horizontalShiftBwDiamondPixels_ < 24) {
+            if (pixId.arm() == detId_plane.arm() && lt.x0() - horizontalShiftBwDiamondPixels_ < 24) {
               planePlots_[detId_plane].pixelTomography_far->Fill(
-                  lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * rechit.getOOTIndex(), lt.getY0());
-              if (centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_)
+                  lt.x0() - horizontalShiftBwDiamondPixels_ + 25 * rechit.ootIndex(), lt.y0());
+              if (centralOOT_ != -999 && rechit.ootIndex() == centralOOT_)
                 planesWitHits_set.insert(detId_plane);
             }
           }
         }
 
         for (auto& planeId : planesWitHits_set)
-          planePlots_[planeId].pixelTracksMapWithDiamonds.Fill(lt.getX0() - horizontalShiftBwDiamondPixels_,
-                                                               lt.getY0());
+          planePlots_[planeId].pixelTracksMapWithDiamonds.Fill(lt.x0() - horizontalShiftBwDiamondPixels_,
+                                                               lt.y0());
       }
     }
   }
@@ -1084,19 +1084,19 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
   for (const auto& rechits : *diamondRecHits) {
     CTPPSDiamondDetId detId(rechits.detId());
     for (const auto& rechit : rechits) {
-      if (excludeMultipleHits_ && rechit.getMultipleHits() > 0)
+      if (excludeMultipleHits_ && rechit.multipleHits() > 0)
         continue;
       if (channelPlots_.find(detId) != channelPlots_.end()) {
-        if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.getToT() != 0) {
-          channelPlots_[detId].leadingEdgeCumulative_both->Fill(rechit.getT() + 25 * rechit.getOOTIndex());
-          channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill(rechit.getToT());
+        if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.toT() != 0) {
+          channelPlots_[detId].leadingEdgeCumulative_both->Fill(rechit.t() + 25 * rechit.ootIndex());
+          channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill(rechit.toT());
         }
         ++(lumiCache->hitsCounterMap[detId]);
       }
 
-      if (rechit.getOOTIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
-          channelPlots_[detId].activity_per_bx.count(rechit.getOOTIndex()) > 0)
-        channelPlots_[detId].activity_per_bx.at(rechit.getOOTIndex())->Fill(event.bunchCrossing());
+      if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
+          channelPlots_[detId].activity_per_bx.count(rechit.ootIndex()) > 0)
+        channelPlots_[detId].activity_per_bx.at(rechit.ootIndex())->Fill(event.bunchCrossing());
     }
   }
 
@@ -1104,9 +1104,9 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
   for (const auto& rechits : *diamondRecHits) {
     const CTPPSDiamondDetId detId(rechits.detId());
     for (const auto& rechit : rechits) {
-      if (excludeMultipleHits_ && rechit.getMultipleHits() > 0)
+      if (excludeMultipleHits_ && rechit.multipleHits() > 0)
         continue;
-      if (rechit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING || rechit.getToT() == 0)
+      if (rechit.ootIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING || rechit.toT() == 0)
         continue;
       if (!pixelTracks.isValid())
         continue;
@@ -1120,9 +1120,9 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         if (ds.size() > 1)
           continue;
         for (const auto& lt : ds) {
-          if (lt.isValid() && pixId.arm() == detId.arm() && lt.getX0() - horizontalShiftBwDiamondPixels_ < 24)
+          if (lt.isValid() && pixId.arm() == detId.arm() && lt.x0() - horizontalShiftBwDiamondPixels_ < 24)
             channelPlots_[detId].pixelTomography_far->Fill(
-                lt.getX0() - horizontalShiftBwDiamondPixels_ + 25 * rechit.getOOTIndex(), lt.getY0());
+                lt.x0() - horizontalShiftBwDiamondPixels_ + 25 * rechit.ootIndex(), lt.y0());
         }
       }
     }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -756,7 +756,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
 
       if (rechit.toT() != 0) {
         // Both
-        potPlots_[detId_pot].leadingEdgeCumulative_both->Fill(rechit.t() + 25 * rechit.ootIndex());
+        potPlots_[detId_pot].leadingEdgeCumulative_both->Fill(rechit.time() + 25 * rechit.ootIndex());
         potPlots_[detId_pot].timeOverThresholdCumulativePot->Fill(rechit.toT());
 
         TH2F* hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
@@ -1082,7 +1082,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         continue;
       if (channelPlots_.find(detId) != channelPlots_.end()) {
         if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && rechit.toT() != 0) {
-          channelPlots_[detId].leadingEdgeCumulative_both->Fill(rechit.t() + 25 * rechit.ootIndex());
+          channelPlots_[detId].leadingEdgeCumulative_both->Fill(rechit.time() + 25 * rechit.ootIndex());
           channelPlots_[detId].TimeOverThresholdCumulativePerChannel->Fill(rechit.toT());
         }
         ++(lumiCache->hitsCounterMap[detId]);

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -679,35 +679,32 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
       // Check Event Number
       for (const auto& optorx : *fedInfo) {
         if (detId.arm() == 1 && optorx.fedId() == CTPPS_FED_ID_56) {
-          potPlots_[detId_pot].ECCheck->Fill((int)((optorx.lv1() & 0xFF) - ((unsigned int)status.ec() & 0xFF)) &
-                                             0xFF);
+          potPlots_[detId_pot].ECCheck->Fill((int)((optorx.lv1() & 0xFF) - ((unsigned int)status.ec() & 0xFF)) & 0xFF);
           if ((static_cast<int>((optorx.lv1() & 0xFF) - status.ec()) != EC_difference_56_) &&
               (static_cast<uint8_t>((optorx.lv1() & 0xFF) - status.ec()) < 128))
-            EC_difference_56_ =
-                static_cast<int>(optorx.lv1() & 0xFF) - (static_cast<unsigned int>(status.ec()) & 0xFF);
+            EC_difference_56_ = static_cast<int>(optorx.lv1() & 0xFF) - (static_cast<unsigned int>(status.ec()) & 0xFF);
           if (EC_difference_56_ != 1 && EC_difference_56_ != -500 && std::abs(EC_difference_56_) < 127) {
             if (detId.channel() == 6 || detId.channel() == 7)
               potPlots_[detId_pot].HPTDCErrorFlags_2D->Fill(16, 2 * detId.plane() + (detId.channel() - 6));
             if (verbosity_)
               edm::LogProblem("CTPPSDiamondDQMSource")
-                  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x" << std::hex << optorx.lv1()
-                  << "\t\tVFAT EC: 0x" << static_cast<unsigned int>(status.ec()) << "\twith ID: " << std::dec
-                  << detId << "\tdiff: " << EC_difference_56_;
+                  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x" << std::hex << optorx.lv1() << "\t\tVFAT EC: 0x"
+                  << static_cast<unsigned int>(status.ec()) << "\twith ID: " << std::dec << detId
+                  << "\tdiff: " << EC_difference_56_;
           }
         } else if (detId.arm() == 0 && optorx.fedId() == CTPPS_FED_ID_45) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.lv1() & 0xFF) - status.ec()) & 0xFF);
           if ((static_cast<int>((optorx.lv1() & 0xFF) - status.ec()) != EC_difference_45_) &&
               (static_cast<uint8_t>((optorx.lv1() & 0xFF) - status.ec()) < 128))
-            EC_difference_45_ =
-                static_cast<int>(optorx.lv1() & 0xFF) - (static_cast<unsigned int>(status.ec()) & 0xFF);
+            EC_difference_45_ = static_cast<int>(optorx.lv1() & 0xFF) - (static_cast<unsigned int>(status.ec()) & 0xFF);
           if (EC_difference_45_ != 1 && EC_difference_45_ != -500 && std::abs(EC_difference_45_) < 127) {
             if (detId.channel() == 6 || detId.channel() == 7)
               potPlots_[detId_pot].HPTDCErrorFlags_2D->Fill(16, 2 * detId.plane() + (detId.channel() - 6));
             if (verbosity_)
               edm::LogProblem("CTPPSDiamondDQMSource")
-                  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x" << std::hex << optorx.lv1()
-                  << "\t\tVFAT EC: 0x" << static_cast<unsigned int>(status.ec()) << "\twith ID: " << std::dec
-                  << detId << "\tdiff: " << EC_difference_45_;
+                  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x" << std::hex << optorx.lv1() << "\t\tVFAT EC: 0x"
+                  << static_cast<unsigned int>(status.ec()) << "\twith ID: " << std::dec << detId
+                  << "\tdiff: " << EC_difference_45_;
           }
         }
       }
@@ -764,8 +761,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
 
         TH2F* hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
         TAxis* hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
-        int startBin =
-            hitHistoOOTTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+        int startBin = hitHistoOOTTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
         int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
           hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.ootIndex(),
@@ -776,8 +772,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
           // Only leading
           TH2F* hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis* hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
-          int startBin =
-              hitHistoOOTTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
+          int startBin = hitHistoOOTTmpYAxis->FindBin(rechit.x() - horizontalShiftOfDiamond_ - 0.5 * rechit.xWidth());
           int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for (int i = 0; i < numOfBins; ++i) {
             hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.ootIndex(),
@@ -1033,8 +1028,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         }
 
         for (auto& planeId : planesWitHits_set)
-          planePlots_[planeId].pixelTracksMapWithDiamonds.Fill(lt.x0() - horizontalShiftBwDiamondPixels_,
-                                                               lt.y0());
+          planePlots_[planeId].pixelTracksMapWithDiamonds.Fill(lt.x0() - horizontalShiftBwDiamondPixels_, lt.y0());
       }
     }
   }
@@ -1071,8 +1065,8 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
           }
           if (digi.leadingEdge() != 0 && digi.trailingEdge() != 0) {
             ++(channelPlots_[detId].CompleteCounter);
-            channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill(
-                HPTDC_BIN_WIDTH_NS * digi.leadingEdge(), HPTDC_BIN_WIDTH_NS * digi.trailingEdge());
+            channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill(HPTDC_BIN_WIDTH_NS * digi.leadingEdge(),
+                                                                            HPTDC_BIN_WIDTH_NS * digi.trailingEdge());
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -250,9 +250,9 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
       ID.setStation(stn);
       string stnd, stnTitle;
 
-      CTPPSDetId(ID.getStationId()).stationName(stnd, CTPPSDetId::nPath);
-      CTPPSDetId(ID.getStationId()).stationName(stnTitle, CTPPSDetId::nFull);
-      CTPPSDetId(ID.getStationId()).stationName(stnTitleShort, CTPPSDetId::nShort);
+      CTPPSDetId(ID.stationId()).stationName(stnd, CTPPSDetId::nPath);
+      CTPPSDetId(ID.stationId()).stationName(stnTitle, CTPPSDetId::nFull);
+      CTPPSDetId(ID.stationId()).stationName(stnTitleShort, CTPPSDetId::nShort);
 
       ibooker.setCurrentFolder(stnd);
       //--------- RPots ---
@@ -260,7 +260,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
       for (int rp = RPn_first; rp < RPn_last; rp++) {  // only installed pixel pots
         ID.setRP(rp);
         string rpd, rpTitle;
-        CTPPSDetId(ID.getRPId()).rpName(rpTitle, CTPPSDetId::nShort);
+        CTPPSDetId(ID.rpId()).rpName(rpTitle, CTPPSDetId::nShort);
         string rpBinName = armTitleShort + "_" + stnTitleShort + "_" + rpTitle;
         yah1st->SetBinLabel(getRPglobalBin(arm, stn), rpBinName.c_str());
         xah1trk->SetBinLabel(getRPglobalBin(arm, stn), rpBinName.c_str());
@@ -271,8 +271,8 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
         int indexP = getRPindex(arm, stn, rp);
         RPindexValid[indexP] = 1;
 
-        CTPPSDetId(ID.getRPId()).rpName(rpTitle, CTPPSDetId::nFull);
-        CTPPSDetId(ID.getRPId()).rpName(rpd, CTPPSDetId::nPath);
+        CTPPSDetId(ID.rpId()).rpName(rpTitle, CTPPSDetId::nFull);
+        CTPPSDetId(ID.rpId()).rpName(rpd, CTPPSDetId::nPath);
 
         ibooker.setCurrentFolder(rpd);
 
@@ -450,15 +450,15 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
 
       for (DetSet<CTPPSPixelLocalTrack>::const_iterator dit = ds_tr.begin(); dit != ds_tr.end(); ++dit) {
         ++pixRPTracks[rpInd];
-        int nh_tr = (dit->getNDF() + TrackFitDimension) / 2;
+        int nh_tr = (dit->ndf() + TrackFitDimension) / 2;
         for (int i = 0; i <= NplaneMAX; i++) {
           if (i == nh_tr)
             htrackHits[rpInd]->Fill(nh_tr, 1.);
           else
             htrackHits[rpInd]->Fill(i, 0.);
         }
-        float x0 = dit->getX0();
-        float y0 = dit->getY0();
+        float x0 = dit->x0();
+        float y0 = dit->y0();
         h2trackXY0[rpInd]->Fill(x0, y0);
         if (x0_MAX < x0)
           x0_MAX = x0;

--- a/DQM/CTPPS/plugins/ElasticPlotDQMSource.cc
+++ b/DQM/CTPPS/plugins/ElasticPlotDQMSource.cc
@@ -258,7 +258,7 @@ void ElasticPlotDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
 
   for (const auto &ds : *hits) {
     TotemRPDetId detId(ds.detId());
-    CTPPSDetId rpId = detId.getRPId();
+    CTPPSDetId rpId = detId.rpId();
 
     if (ds.size() > 5) {
       if (detId.isStripsCoordinateUDirection())
@@ -274,12 +274,12 @@ void ElasticPlotDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
     // count U and V patterns
     unsigned int n_pat_u = 0, n_pat_v = 0;
     for (auto &p : ds) {
-      if (!p.getFittable())
+      if (!p.fittable())
         continue;
 
-      if (p.getProjection() == TotemRPUVPattern::projU)
+      if (p.projection() == TotemRPUVPattern::projU)
         n_pat_u++;
-      else if (p.getProjection() == TotemRPUVPattern::projV)
+      else if (p.projection() == TotemRPUVPattern::projV)
         n_pat_v++;
     }
 
@@ -330,10 +330,10 @@ void ElasticPlotDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
         continue;
 
       if (cond_4rp)
-        dp.v_h2_y_vs_x_dgn_4rp[i]->Fill(tr_i->getX0(), tr_i->getY0());
+        dp.v_h2_y_vs_x_dgn_4rp[i]->Fill(tr_i->x0(), tr_i->y0());
 
       if (cond_2rp)
-        dp.v_h2_y_vs_x_dgn_2rp[i]->Fill(tr_i->getX0(), tr_i->getY0());
+        dp.v_h2_y_vs_x_dgn_2rp[i]->Fill(tr_i->x0(), tr_i->y0());
 
       for (unsigned int j = 0; j < 4; j++) {
         if (rp_track[dp.rpIds[j]] == nullptr)
@@ -341,7 +341,7 @@ void ElasticPlotDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
 
         dp.h2_track_corr_vert->Fill(i, j);
 
-        dp.v_h_y[i][j]->Fill(tr_i->getY0());
+        dp.v_h_y[i][j]->Fill(tr_i->y0());
       }
     }
   }

--- a/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
@@ -93,14 +93,14 @@ void TotemDAQTriggerDQMSource::analyze(edm::Event const &event, edm::EventSetup 
   // DAQ plots
   if (daqValid) {
     for (auto &it1 : *fedInfo) {
-      daq_event_bx_diff->Fill(it1.getBX() - event.bunchCrossing());
-      daq_event_bx_diff_vs_fed->Fill(it1.getFEDId(), it1.getBX() - event.bunchCrossing());
+      daq_event_bx_diff->Fill(it1.bx() - event.bunchCrossing());
+      daq_event_bx_diff_vs_fed->Fill(it1.fedId(), it1.bx() - event.bunchCrossing());
 
       for (auto &it2 : *fedInfo) {
-        if (it2.getFEDId() <= it1.getFEDId())
+        if (it2.fedId() <= it1.fedId())
           continue;
 
-        daq_bx_diff->Fill(it2.getBX() - it1.getBX());
+        daq_bx_diff->Fill(it2.bx() - it1.bx());
       }
     }
   }

--- a/DQM/CTPPS/plugins/TotemRPDQMHarvester.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMHarvester.cc
@@ -132,7 +132,7 @@ void TotemRPDQMHarvester::MakePlaneEfficiencyHistograms(unsigned int id,
   }
 
   // book new RP histogram, if not yet done
-  CTPPSDetId rpId = detId.getRPId();
+  CTPPSDetId rpId = detId.rpId();
   rpId.rpName(path, TotemRPDetId::nPath);
   const string rp_efficiency_name = "plane efficiency";
   MonitorElement *rp_efficiency = igetter.get(path + "/" + rp_efficiency_name);

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -341,7 +341,7 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
       if (!ft.isValid())
         continue;
 
-      double rp_z = geometry->getRPTranslation(rpId).z();
+      double rp_z = geometry->rpTranslation(rpId).z();
 
       for (unsigned int plNum = 0; plNum < 10; ++plNum) {
         TotemRPDetId plId = rpId;
@@ -564,9 +564,9 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
       plId_U.setPlane(1);
 
       double rp_x =
-          (geometry->getSensor(plId_V)->translation().x() + geometry->getSensor(plId_U)->translation().x()) / 2.;
+          (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2.;
       double rp_y =
-          (geometry->getSensor(plId_V)->translation().y() + geometry->getSensor(plId_U)->translation().y()) / 2.;
+          (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2.;
 
       // mean read-out direction of U and V planes
       CLHEP::Hep3Vector rod_U = geometry->localToGlobalDirection(plId_U, CLHEP::Hep3Vector(0., 1., 0.));

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -280,18 +280,18 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
 
     for (auto &s : ds) {
       if (s.isMissing()) {
-        plots.vfat_problem->Fill(plNum, s.getChipPosition());
-        plots.vfat_missing->Fill(plNum, s.getChipPosition());
+        plots.vfat_problem->Fill(plNum, s.chipPosition());
+        plots.vfat_missing->Fill(plNum, s.chipPosition());
       }
 
       if (s.isECProgressError() || s.isBCProgressError()) {
-        plots.vfat_problem->Fill(plNum, s.getChipPosition());
-        plots.vfat_ec_bc_error->Fill(plNum, s.getChipPosition());
+        plots.vfat_problem->Fill(plNum, s.chipPosition());
+        plots.vfat_ec_bc_error->Fill(plNum, s.chipPosition());
       }
 
       if (s.isIDMismatch() || s.isFootprintError() || s.isCRCError()) {
-        plots.vfat_problem->Fill(plNum, s.getChipPosition());
-        plots.vfat_corruption->Fill(plNum, s.getChipPosition());
+        plots.vfat_problem->Fill(plNum, s.chipPosition());
+        plots.vfat_corruption->Fill(plNum, s.chipPosition());
       }
     }
   }
@@ -309,7 +309,7 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
     auto &plots = plIt->second;
 
     for (DetSet<TotemRPDigi>::const_iterator dit = it->begin(); dit != it->end(); ++dit)
-      plots.digi_profile_cumulative->Fill(dit->getStripNumber());
+      plots.digi_profile_cumulative->Fill(dit->stripNumber());
   }
 
   // cluster plots
@@ -595,7 +595,7 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
 
     set<unsigned int> sectors;
     for (const auto &d : dp) {
-      unsigned int sector = d.getStripNumber() / 32;
+      unsigned int sector = d.stripNumber() / 32;
       sectors.insert(sector);
     }
 

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -563,10 +563,8 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
       TotemRPDetId plId_U(rpId);
       plId_U.setPlane(1);
 
-      double rp_x =
-          (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2.;
-      double rp_y =
-          (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2.;
+      double rp_x = (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2.;
+      double rp_y = (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2.;
 
       // mean read-out direction of U and V planes
       CLHEP::Hep3Vector rod_U = geometry->localToGlobalDirection(plId_U, CLHEP::Hep3Vector(0., 1., 0.));

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -536,7 +536,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 
         potPlots_[detId_pot].digiDistribution->Fill(detId.plane(), detId.channel());
 
-        for (auto it = digi.getSamplesBegin(); it != digi.getSamplesEnd(); ++it)
+        for (auto it = digi.samplesBegin(); it != digi.samplesEnd(); ++it)
           potPlots_[detId_pot].dataSamplesRaw->Fill(*it);
 
         float boardId = digi.getEventInfo().getHardwareBoardId() + 0.5 * digi.getEventInfo().getHardwareSampicId();
@@ -569,13 +569,13 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
       if (channelPlots_.find(detId) != channelPlots_.end()) {
         channelPlots_[detId].activityPerBX->Fill(event.bunchCrossing());
 
-        for (auto it = digi.getSamplesBegin(); it != digi.getSamplesEnd(); ++it)
+        for (auto it = digi.samplesBegin(); it != digi.samplesEnd(); ++it)
           channelPlots_[detId].dataSamplesRaw->Fill(*it);
         for (unsigned short i = 0; i < samplesForNoise_; ++i)
-          channelPlots_[detId].noiseSamples->Fill(SAMPIC_ADC_V * digi.getSampleAt(i));
+          channelPlots_[detId].noiseSamples->Fill(SAMPIC_ADC_V * digi.sampleAt(i));
 
         unsigned int cellOfMax =
-            std::max_element(digi.getSamplesBegin(), digi.getSamplesEnd()) - digi.getSamplesBegin();
+            std::max_element(digi.samplesBegin(), digi.samplesEnd()) - digi.samplesBegin();
         channelPlots_[detId].cellOfMax->Fill((int)cellOfMax);
 
         if (timeOfPreviousEvent_ != 0)
@@ -597,45 +597,45 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 
     for (const auto &rechit : rechits) {
       if (potPlots_.find(detId_pot) != potPlots_.end()) {
-        potPlots_[detId_pot].amplitude->Fill(rechit.getAmplitude());
+        potPlots_[detId_pot].amplitude->Fill(rechit.amplitude());
 
         TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
-        float yCorrected = rechit.getY();
+        float yCorrected = rechit.y();
         yCorrected += (detId.rp() == TOTEM_TIMING_TOP_RP_ID) ? verticalShiftTop_ : verticalShiftBot_;
         float x_shift = detId.plane();
-        x_shift += (rechit.getX() > 2) ? 0.25 : 0;
-        int startBin = hitHistoTmpYAxis->FindBin(yCorrected - 0.5 * rechit.getYWidth());
-        int numOfBins = rechit.getYWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+        x_shift += (rechit.x() > 2) ? 0.25 : 0;
+        int startBin = hitHistoTmpYAxis->FindBin(yCorrected - 0.5 * rechit.yWidth());
+        int numOfBins = rechit.yWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i) {
-          potPlots_[detId_pot].hitDistribution2d->Fill(detId.plane() + 0.25 * (rechit.getX() > 2),
+          potPlots_[detId_pot].hitDistribution2d->Fill(detId.plane() + 0.25 * (rechit.x() > 2),
                                                        hitHistoTmpYAxis->GetBinCenter(startBin + i));
           potPlots_[detId_pot].hitDistribution2d_lumisection->Fill(x_shift,
                                                                    hitHistoTmpYAxis->GetBinCenter(startBin + i));
         }
 
         //All plots with Time
-        if (rechit.getT() != TotemTimingRecHit::NO_T_AVAILABLE) {
+        if (rechit.t() != TotemTimingRecHit::NO_T_AVAILABLE) {
           for (int i = 0; i < numOfBins; ++i)
-            potPlots_[detId_pot].hitDistribution2dWithTime->Fill(detId.plane() + 0.25 * (rechit.getX() > 2),
+            potPlots_[detId_pot].hitDistribution2dWithTime->Fill(detId.plane() + 0.25 * (rechit.x() > 2),
                                                                  hitHistoTmpYAxis->GetBinCenter(startBin + i));
 
-          potPlots_[detId_pot].recHitTime->Fill(rechit.getT());
+          potPlots_[detId_pot].recHitTime->Fill(rechit.t());
           potPlots_[detId_pot].planesWithTimeSet.insert(detId.plane());
 
           // Plane Plots
           if (planePlots_.find(detId_plane) != planePlots_.end()) {
             // Visualization tricks
-            float x_shift = (rechit.getX() > 2) ? 15 : 0;
+            float x_shift = (rechit.x() > 2) ? 15 : 0;
             TH1F *hitProfileHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
-            int numOfBins = rechit.getYWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
+            int numOfBins = rechit.yWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
             if (detId.rp() == TOTEM_TIMING_TOP_RP_ID) {
-              float yCorrected = rechit.getY() + verticalShiftTop_ - 0.5 * rechit.getYWidth() + x_shift;
+              float yCorrected = rechit.y() + verticalShiftTop_ - 0.5 * rechit.yWidth() + x_shift;
               int startBin = hitProfileHistoTmp->FindBin(yCorrected);
               for (int i = 0; i < numOfBins; ++i)
                 hitProfileHistoTmp->Fill(hitProfileHistoTmp->GetBinCenter(startBin + i));
             } else {
-              float yCorrected = rechit.getY() + verticalShiftBot_ + 0.5 * rechit.getYWidth() + (15 - x_shift);
+              float yCorrected = rechit.y() + verticalShiftBot_ + 0.5 * rechit.yWidth() + (15 - x_shift);
               int startBin = hitProfileHistoTmp->FindBin(yCorrected);
               int totBins = hitProfileHistoTmp->GetNbinsX();
               for (int i = 0; i < numOfBins; ++i)
@@ -649,10 +649,10 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
           }
 
           if (channelPlots_.find(detId) != channelPlots_.end()) {
-            potPlots_[detId_pot].tirggerCellTime->Fill(rechit.getSampicThresholdTime());
-            channelPlots_[detId].tirggerCellTime->Fill(rechit.getSampicThresholdTime());
-            channelPlots_[detId].recHitTime->Fill(rechit.getT());
-            channelPlots_[detId].amplitude->Fill(rechit.getAmplitude());
+            potPlots_[detId_pot].tirggerCellTime->Fill(rechit.sampicThresholdTime());
+            channelPlots_[detId].tirggerCellTime->Fill(rechit.sampicThresholdTime());
+            channelPlots_[detId].recHitTime->Fill(rechit.t());
+            channelPlots_[detId].amplitude->Fill(rechit.amplitude());
           }
         }
       }
@@ -672,7 +672,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
     float y_shift = (detId.rp() == TOTEM_TIMING_TOP_RP_ID) ? 20 : 5;
 
     for (const auto &rechit : rechits) {
-      if (rechit.getT() != TotemTimingRecHit::NO_T_AVAILABLE && potPlots_.find(detId_pot) != potPlots_.end() &&
+      if (rechit.t() != TotemTimingRecHit::NO_T_AVAILABLE && potPlots_.find(detId_pot) != potPlots_.end() &&
           planePlots_.find(detId_plane) != planePlots_.end() && channelPlots_.find(detId) != channelPlots_.end()) {
         if (stripTracks.isValid()) {
           for (const auto &ds : *stripTracks) {
@@ -696,15 +696,15 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
 
             for (const auto &striplt : ds) {
               if (striplt.isValid() && stripId.arm() == detId.arm()) {
-                if (striplt.getTx() > maximumStripAngleForTomography_ ||
-                    striplt.getTy() > maximumStripAngleForTomography_)
+                if (striplt.tx() > maximumStripAngleForTomography_ ||
+                    striplt.ty() > maximumStripAngleForTomography_)
                   continue;
-                if (striplt.getTx() < minimumStripAngleForTomography_ ||
-                    striplt.getTy() < minimumStripAngleForTomography_)
+                if (striplt.tx() < minimumStripAngleForTomography_ ||
+                    striplt.ty() < minimumStripAngleForTomography_)
                   continue;
                 if (stripId.rp() - detId.rp() == (TOTEM_STRIP_MAX_RP_ID - TOTEM_TIMING_BOT_RP_ID)) {
-                  double x = striplt.getX0() - rp_x;
-                  double y = striplt.getY0() - rp_y;
+                  double x = striplt.x0() - rp_x;
+                  double y = striplt.y0() - rp_y;
                   if (stripId.station() == TOTEM_STATION_210) {
                     potPlots_[detId_pot].stripTomography210->Fill(x + detId.plane() * 50, y + y_shift);
                     channelPlots_[detId].stripTomography210->Fill(x, y + y_shift);

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -430,11 +430,11 @@ void TotemTimingDQMSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSet
   verticalShiftTop_ = 0;
   verticalShiftBot_ = 0;
   {
-    const DetGeomDesc *det_top = geom->getSensorNoThrow(detid_top);
+    const DetGeomDesc *det_top = geom->sensorNoThrow(detid_top);
     if (det_top) {
       verticalShiftTop_ = det_top->translation().y() + det_top->params().at(1);
     }
-    const DetGeomDesc *det_bot = geom->getSensorNoThrow(detid_bot);
+    const DetGeomDesc *det_bot = geom->sensorNoThrow(detid_bot);
     if (det_bot)
       verticalShiftBot_ = det_bot->translation().y() + det_bot->params().at(1);
   }
@@ -687,9 +687,9 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
             double rp_y = 0;
             try {
               rp_x =
-                  (geometry->getSensor(plId_V)->translation().x() + geometry->getSensor(plId_U)->translation().x()) / 2;
+                  (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2;
               rp_y =
-                  (geometry->getSensor(plId_V)->translation().y() + geometry->getSensor(plId_U)->translation().y()) / 2;
+                  (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2;
             } catch (const cms::Exception &) {
               continue;
             }

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -614,12 +614,12 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
         }
 
         //All plots with Time
-        if (rechit.t() != TotemTimingRecHit::NO_T_AVAILABLE) {
+        if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE) {
           for (int i = 0; i < numOfBins; ++i)
             potPlots_[detId_pot].hitDistribution2dWithTime->Fill(detId.plane() + 0.25 * (rechit.x() > 2),
                                                                  hitHistoTmpYAxis->GetBinCenter(startBin + i));
 
-          potPlots_[detId_pot].recHitTime->Fill(rechit.t());
+          potPlots_[detId_pot].recHitTime->Fill(rechit.time());
           potPlots_[detId_pot].planesWithTimeSet.insert(detId.plane());
 
           // Plane Plots
@@ -650,7 +650,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
           if (channelPlots_.find(detId) != channelPlots_.end()) {
             potPlots_[detId_pot].tirggerCellTime->Fill(rechit.sampicThresholdTime());
             channelPlots_[detId].tirggerCellTime->Fill(rechit.sampicThresholdTime());
-            channelPlots_[detId].recHitTime->Fill(rechit.t());
+            channelPlots_[detId].recHitTime->Fill(rechit.time());
             channelPlots_[detId].amplitude->Fill(rechit.amplitude());
           }
         }
@@ -671,7 +671,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
     float y_shift = (detId.rp() == TOTEM_TIMING_TOP_RP_ID) ? 20 : 5;
 
     for (const auto &rechit : rechits) {
-      if (rechit.t() != TotemTimingRecHit::NO_T_AVAILABLE && potPlots_.find(detId_pot) != potPlots_.end() &&
+      if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE && potPlots_.find(detId_pot) != potPlots_.end() &&
           planePlots_.find(detId_plane) != planePlots_.end() && channelPlots_.find(detId) != channelPlots_.end()) {
         if (stripTracks.isValid()) {
           for (const auto &ds : *stripTracks) {

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -574,8 +574,7 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
         for (unsigned short i = 0; i < samplesForNoise_; ++i)
           channelPlots_[detId].noiseSamples->Fill(SAMPIC_ADC_V * digi.sampleAt(i));
 
-        unsigned int cellOfMax =
-            std::max_element(digi.samplesBegin(), digi.samplesEnd()) - digi.samplesBegin();
+        unsigned int cellOfMax = std::max_element(digi.samplesBegin(), digi.samplesEnd()) - digi.samplesBegin();
         channelPlots_[detId].cellOfMax->Fill((int)cellOfMax);
 
         if (timeOfPreviousEvent_ != 0)
@@ -686,21 +685,17 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
             double rp_x = 0;
             double rp_y = 0;
             try {
-              rp_x =
-                  (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2;
-              rp_y =
-                  (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2;
+              rp_x = (geometry->sensor(plId_V)->translation().x() + geometry->sensor(plId_U)->translation().x()) / 2;
+              rp_y = (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2;
             } catch (const cms::Exception &) {
               continue;
             }
 
             for (const auto &striplt : ds) {
               if (striplt.isValid() && stripId.arm() == detId.arm()) {
-                if (striplt.tx() > maximumStripAngleForTomography_ ||
-                    striplt.ty() > maximumStripAngleForTomography_)
+                if (striplt.tx() > maximumStripAngleForTomography_ || striplt.ty() > maximumStripAngleForTomography_)
                   continue;
-                if (striplt.tx() < minimumStripAngleForTomography_ ||
-                    striplt.ty() < minimumStripAngleForTomography_)
+                if (striplt.tx() < minimumStripAngleForTomography_ || striplt.ty() < minimumStripAngleForTomography_)
                   continue;
                 if (stripId.rp() - detId.rp() == (TOTEM_STRIP_MAX_RP_ID - TOTEM_TIMING_BOT_RP_ID)) {
                   double x = striplt.x0() - rp_x;

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -539,12 +539,12 @@ void TotemTimingDQMSource::analyze(const edm::Event &event, const edm::EventSetu
         for (auto it = digi.samplesBegin(); it != digi.samplesEnd(); ++it)
           potPlots_[detId_pot].dataSamplesRaw->Fill(*it);
 
-        float boardId = digi.getEventInfo().getHardwareBoardId() + 0.5 * digi.getEventInfo().getHardwareSampicId();
-        potPlots_[detId_pot].digiSent->Fill(boardId, digi.getHardwareChannelId());
-        if (boardSet.find(digi.getEventInfo().getHardwareId()) == boardSet.end()) {
+        float boardId = digi.eventInfo().hardwareBoardId() + 0.5 * digi.eventInfo().hardwareSampicId();
+        potPlots_[detId_pot].digiSent->Fill(boardId, digi.hardwareChannelId());
+        if (boardSet.find(digi.eventInfo().hardwareId()) == boardSet.end()) {
           // This guarantees that every board is counted only once
-          boardSet.insert(digi.getEventInfo().getHardwareId());
-          std::bitset<16> chMap(digi.getEventInfo().getChannelMap());
+          boardSet.insert(digi.eventInfo().hardwareId());
+          std::bitset<16> chMap(digi.eventInfo().channelMap());
           for (int i = 0; i < 16; ++i) {
             if (chMap.test(i)) {
               potPlots_[detId_pot].digiAll->Fill(boardId, i);

--- a/DataFormats/CTPPSDetId/interface/CTPPSDetId.h
+++ b/DataFormats/CTPPSDetId/interface/CTPPSDetId.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  *
  * This is a part of TOTEM offline software.
- * Authors: 
- *	Jan Kašpar (jan.kaspar@gmail.com) 
+ * Authors:
+ *	Jan Kašpar (jan.kaspar@gmail.com)
  *
  ****************************************************************************/
 
@@ -24,7 +24,7 @@
  *   bits [24:24] => arm: 0 (sector 45), 1 (sector 56)
  *   bits [22:23] => station: 0 (210m), 1 (cylyndrical pots), 2 (220m)
  *   bits [19:21] => Roman Pot: 0 (near top), 1 (near bottom), 2 (near horizontal), 3 (far horizontal), 4 (far top), 5 (far bottom)
- *   bits [0:18] => available for derived classes 
+ *   bits [0:18] => available for derived classes
  *
  * The ...Name() methods implement the official naming scheme based on EDMS 906715.
 **/
@@ -71,11 +71,11 @@ public:
 
   //-------------------- id getters for higher-level objects --------------------
 
-  CTPPSDetId getArmId() const { return CTPPSDetId(rawId() & (~lowMaskArm)); }
+  CTPPSDetId armId() const { return CTPPSDetId(rawId() & (~lowMaskArm)); }
 
-  CTPPSDetId getStationId() const { return CTPPSDetId(rawId() & (~lowMaskStation)); }
+  CTPPSDetId stationId() const { return CTPPSDetId(rawId() & (~lowMaskStation)); }
 
-  CTPPSDetId getRPId() const { return CTPPSDetId(rawId() & (~lowMaskRP)); }
+  CTPPSDetId rpId() const { return CTPPSDetId(rawId() & (~lowMaskRP)); }
 
   //-------------------- name methods --------------------
 

--- a/DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h
+++ b/DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  * Author: Seyed Mohsen Etesami
- *  September 2016 
+ *  September 2016
  ****************************************************************************/
 
 #ifndef DataFormats_CTPPSDetId_CTPPSDiamondDetId
@@ -17,7 +17,7 @@
 /**
  *\brief Detector ID class for CTPPS Timing Diamond detectors.
  * Bits [19:31] : Assigend in CTPPSDetId Calss
- * Bits [17:18] : 2 bits for diamond plane 0,1,2,3 
+ * Bits [17:18] : 2 bits for diamond plane 0,1,2,3
  * Bits [12:16] : 5 bits for Diamond  channel numbers 1,2,3,..16
  * Bits [0:11]  : unspecified yet
  **/
@@ -58,7 +58,7 @@ public:
 
   //-------------------- id getters for higher-level objects --------------------
 
-  CTPPSDiamondDetId getPlaneId() const { return CTPPSDiamondDetId(rawId() & (~lowMaskPlane)); }
+  CTPPSDiamondDetId planeId() const { return CTPPSDiamondDetId(rawId() & (~lowMaskPlane)); }
 
   //-------------------- name methods --------------------
 

--- a/DataFormats/CTPPSDetId/interface/TotemRPDetId.h
+++ b/DataFormats/CTPPSDetId/interface/TotemRPDetId.h
@@ -1,9 +1,9 @@
 /****************************************************************************
  *
  * This is a part of TOTEM offline software.
- * Authors: 
+ * Authors:
  *	Hubert Niewiadomski
- *	Jan Kašpar (jan.kaspar@gmail.com) 
+ *	Jan Kašpar (jan.kaspar@gmail.com)
  *
  ****************************************************************************/
 
@@ -59,7 +59,7 @@ public:
 
   //-------------------- id getters for higher-level objects --------------------
 
-  TotemRPDetId getPlaneId() const { return TotemRPDetId(rawId() & (~lowMaskPlane)); }
+  TotemRPDetId planeId() const { return TotemRPDetId(rawId() & (~lowMaskPlane)); }
 
   //-------------------- strip orientation methods --------------------
 
@@ -70,9 +70,9 @@ public:
   //-------------------- conversions to the obsolete decimal representation --------------------
   // NOTE: only for backward compatibility, do not use otherwise!
 
-  inline uint32_t getRPDecimalId() const { return rp() + station() * 10 + arm() * 100; }
+  inline uint32_t rpDecimalId() const { return rp() + station() * 10 + arm() * 100; }
 
-  inline uint32_t getPlaneDecimalId() const { return plane() + getRPDecimalId() * 10; }
+  inline uint32_t planeDecimalId() const { return plane() + rpDecimalId() * 10; }
 
   //-------------------- name methods --------------------
 

--- a/DataFormats/CTPPSDetId/interface/TotemTimingDetId.h
+++ b/DataFormats/CTPPSDetId/interface/TotemTimingDetId.h
@@ -61,7 +61,7 @@ public:
 
   //-------------------- id getters for higher-level objects --------------------
 
-  TotemTimingDetId getPlaneId() const { return TotemTimingDetId(rawId() & (~lowMaskPlane)); }
+  TotemTimingDetId planeId() const { return TotemTimingDetId(rawId() & (~lowMaskPlane)); }
 
   //-------------------- name methods --------------------
 

--- a/DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h
+++ b/DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h
@@ -4,7 +4,7 @@
 /** \class CTPPSDiamondDigi
  *
  * Digi Class for CTPPS Timing Detector
- *  
+ *
  *
  * \author Seyed Mohsen Etesami
  * March 2016
@@ -25,15 +25,15 @@ public:
 
   /// Return digi values number
 
-  unsigned int getLeadingEdge() const { return ledgt; }
+  unsigned int leadingEdge() const { return ledgt; }
 
-  unsigned int getTrailingEdge() const { return tedgt; }
+  unsigned int trailingEdge() const { return tedgt; }
 
-  unsigned int getThresholdVoltage() const { return threvolt; }
+  unsigned int thresholdVoltage() const { return threvolt; }
 
-  bool getMultipleHit() const { return mhit; }
+  bool multipleHit() const { return mhit; }
 
-  HPTDCErrorFlags getHPTDCErrorFlags() const { return hptdcerror; }
+  HPTDCErrorFlags hptdcErrorFlags() const { return hptdcerror; }
 
   /// Set digi values
   inline void setLeadingEdge(unsigned int ledgt_) { ledgt = ledgt_; }
@@ -57,32 +57,32 @@ private:
 #include <iostream>
 
 inline bool operator<(const CTPPSDiamondDigi& one, const CTPPSDiamondDigi& other) {
-  if (one.getLeadingEdge() < other.getLeadingEdge())
+  if (one.leadingEdge() < other.leadingEdge())
     return true;
-  if (one.getLeadingEdge() > other.getLeadingEdge())
+  if (one.leadingEdge() > other.leadingEdge())
     return false;
-  if (one.getTrailingEdge() < other.getTrailingEdge())
+  if (one.trailingEdge() < other.trailingEdge())
     return true;
-  if (one.getTrailingEdge() > other.getTrailingEdge())
+  if (one.trailingEdge() > other.trailingEdge())
     return false;
-  if (one.getMultipleHit() < other.getMultipleHit())
+  if (one.multipleHit() < other.multipleHit())
     return true;
-  if (one.getMultipleHit() > other.getMultipleHit())
+  if (one.multipleHit() > other.multipleHit())
     return false;
-  if (one.getHPTDCErrorFlags().getErrorFlag() < other.getHPTDCErrorFlags().getErrorFlag())
+  if (one.hptdcErrorFlags().errorFlag() < other.hptdcErrorFlags().errorFlag())
     return true;
-  if (one.getHPTDCErrorFlags().getErrorFlag() > other.getHPTDCErrorFlags().getErrorFlag())
+  if (one.hptdcErrorFlags().errorFlag() > other.hptdcErrorFlags().errorFlag())
     return false;
-  if (one.getThresholdVoltage() < other.getThresholdVoltage())
+  if (one.thresholdVoltage() < other.thresholdVoltage())
     return true;
-  if (one.getThresholdVoltage() > other.getThresholdVoltage())
+  if (one.thresholdVoltage() > other.thresholdVoltage())
     return false;
   return false;
 }
 
 inline std::ostream& operator<<(std::ostream& o, const CTPPSDiamondDigi& digi) {
-  return o << " " << digi.getLeadingEdge() << " " << digi.getTrailingEdge() << " " << digi.getThresholdVoltage() << " "
-           << digi.getMultipleHit() << " " << digi.getHPTDCErrorFlags().getErrorFlag();
+  return o << " " << digi.leadingEdge() << " " << digi.trailingEdge() << " " << digi.thresholdVoltage() << " "
+           << digi.multipleHit() << " " << digi.hptdcErrorFlags().errorFlag();
 }
 
 #endif

--- a/DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h
+++ b/DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h
@@ -6,7 +6,7 @@
 /** \class HPTDCErrorFlags
  *
  * HPTDC error flags container
- *  
+ *
  * \author Seyed Mohsen Etesami
  * \author Laurent Forthomme
  * July 2016
@@ -16,62 +16,62 @@ class HPTDCErrorFlags {
 public:
   HPTDCErrorFlags(unsigned short flags = 0) : error_flags(flags) {}
 
-  bool getErrorId(unsigned short id) const {
+  bool errorId(unsigned short id) const {
     switch (id) {
       case 0:
-        return getInternalFatalChipError();
+        return internalFatalChipError();
       case 1:
-        return getEventLost();
+        return eventLost();
       case 2:
-        return getHitRejectedByEventSizeLimit();
+        return hitRejectedByEventSizeLimit();
       case 3:
-        return getHitErrorGroup3();
+        return hitErrorGroup3();
       case 4:
-        return getHitLostL1OverflowGroup3();
+        return hitLostL1OverflowGroup3();
       case 5:
-        return getHitLostROFifoOverflowGroup3();
+        return hitLostROFifoOverflowGroup3();
       case 6:
-        return getHitErrorGroup2();
+        return hitErrorGroup2();
       case 7:
-        return getHitLostL1OverflowGroup2();
+        return hitLostL1OverflowGroup2();
       case 8:
-        return getHitLostROFifoOverflowGroup2();
+        return hitLostROFifoOverflowGroup2();
       case 9:
-        return getHitErrorGroup1();
+        return hitErrorGroup1();
       case 10:
-        return getHitLostL1OverflowGroup1();
+        return hitLostL1OverflowGroup1();
       case 11:
-        return getHitLostROFifoOverflowGroup1();
+        return hitLostROFifoOverflowGroup1();
       case 12:
-        return getHitErrorGroup0();
+        return hitErrorGroup0();
       case 13:
-        return getHitLostL1OverflowGroup0();
+        return hitLostL1OverflowGroup0();
       case 14:
-        return getHitLostROFifoOverflowGroup0();
+        return hitLostROFifoOverflowGroup0();
       default:
         return true;
     }
   }
 
-  bool getInternalFatalChipError() const { return error_flags & 0x1; }
-  bool getEventLost() const { return (error_flags >> 1) & 0x1; }
-  bool getHitRejectedByEventSizeLimit() const { return (error_flags >> 2) & 0x1; }
-  bool getHitErrorGroup3() const { return (error_flags >> 3) & 0x1; }
-  bool getHitLostL1OverflowGroup3() const { return (error_flags >> 4) & 0x1; }
-  bool getHitLostROFifoOverflowGroup3() const { return (error_flags >> 5) & 0x1; }
-  bool getHitErrorGroup2() const { return (error_flags >> 6) & 0x1; }
-  bool getHitLostL1OverflowGroup2() const { return (error_flags >> 7) & 0x1; }
-  bool getHitLostROFifoOverflowGroup2() const { return (error_flags >> 8) & 0x1; }
-  bool getHitErrorGroup1() const { return (error_flags >> 9) & 0x1; }
-  bool getHitLostL1OverflowGroup1() const { return (error_flags >> 10) & 0x1; }
-  bool getHitLostROFifoOverflowGroup1() const { return (error_flags >> 11) & 0x1; }
-  bool getHitErrorGroup0() const { return (error_flags >> 12) & 0x1; }
-  bool getHitLostL1OverflowGroup0() const { return (error_flags >> 13) & 0x1; }
-  bool getHitLostROFifoOverflowGroup0() const { return (error_flags >> 14) & 0x1; }
+  bool internalFatalChipError() const { return error_flags & 0x1; }
+  bool eventLost() const { return (error_flags >> 1) & 0x1; }
+  bool hitRejectedByEventSizeLimit() const { return (error_flags >> 2) & 0x1; }
+  bool hitErrorGroup3() const { return (error_flags >> 3) & 0x1; }
+  bool hitLostL1OverflowGroup3() const { return (error_flags >> 4) & 0x1; }
+  bool hitLostROFifoOverflowGroup3() const { return (error_flags >> 5) & 0x1; }
+  bool hitErrorGroup2() const { return (error_flags >> 6) & 0x1; }
+  bool hitLostL1OverflowGroup2() const { return (error_flags >> 7) & 0x1; }
+  bool hitLostROFifoOverflowGroup2() const { return (error_flags >> 8) & 0x1; }
+  bool hitErrorGroup1() const { return (error_flags >> 9) & 0x1; }
+  bool hitLostL1OverflowGroup1() const { return (error_flags >> 10) & 0x1; }
+  bool hitLostROFifoOverflowGroup1() const { return (error_flags >> 11) & 0x1; }
+  bool hitErrorGroup0() const { return (error_flags >> 12) & 0x1; }
+  bool hitLostL1OverflowGroup0() const { return (error_flags >> 13) & 0x1; }
+  bool hitLostROFifoOverflowGroup0() const { return (error_flags >> 14) & 0x1; }
 
-  inline unsigned short getErrorFlag() const { return error_flags; }
+  inline unsigned short errorFlag() const { return error_flags; }
 
-  static std::string getHPTDCErrorName(const unsigned short id) {
+  static std::string hptdcErrorName(const unsigned short id) {
     switch (id) {
       case 0:
         return "InternalFatalChipError";

--- a/DataFormats/CTPPSDigi/interface/TotemFEDInfo.h
+++ b/DataFormats/CTPPSDigi/interface/TotemFEDInfo.h
@@ -16,34 +16,34 @@
  **/
 class TotemFEDInfo {
 public:
-  TotemFEDInfo(int _id = 0) : fedId(_id), header(0), orbitCounter(0), footer(0) {}
+  TotemFEDInfo(int id = 0) : fedId_(id), header(0), orbitCounter_(0), footer(0) {}
 
-  void setFEDId(int _f) { fedId = _f; }
-  int getFEDId() const { return fedId; }
+  void setFEDId(int f) { fedId_ = f; }
+  int fedId() const { return fedId_; }
 
   void setHeader(uint64_t _h) { header = _h; }
-  uint8_t getBOE() const { return (header >> 60) & 0xF; }
-  uint32_t getLV1() const { return (header >> 32) & 0xFFFFFF; }
-  uint16_t getBX() const { return (header >> 20) & 0xFFF; }
-  uint16_t getOptoRxId() const { return (header >> 8) & 0xFFF; }
-  uint8_t getFOV() const { return (header >> 4) & 0xF; }
-  uint8_t getH0() const { return (header >> 0) & 0xF; }
+  uint8_t boe() const { return (header >> 60) & 0xF; }
+  uint32_t lv1() const { return (header >> 32) & 0xFFFFFF; }
+  uint16_t bx() const { return (header >> 20) & 0xFFF; }
+  uint16_t optoRxId() const { return (header >> 8) & 0xFFF; }
+  uint8_t fov() const { return (header >> 4) & 0xF; }
+  uint8_t h0() const { return (header >> 0) & 0xF; }
 
-  void setOrbitCounter(uint32_t _oc) { orbitCounter = _oc; }
-  uint32_t getOrbitCounter() const { return orbitCounter; }
+  void setOrbitCounter(uint32_t oc) { orbitCounter_ = oc; }
+  uint32_t orbitCounter() const { return orbitCounter_; }
 
   void setFooter(uint64_t _f) { footer = _f; }
-  uint8_t getEOE() const { return (footer >> 60) & 0xF; }
-  uint16_t getFSize() const { return (footer >> 32) & 0x3FF; }
-  uint8_t getF0() const { return (footer >> 0) & 0xF; }
+  uint8_t eoe() const { return (footer >> 60) & 0xF; }
+  uint16_t fSize() const { return (footer >> 32) & 0x3FF; }
+  uint8_t f0() const { return (footer >> 0) & 0xF; }
 
 private:
   /// Id from FEDRawDataCollection.
-  int fedId;
+  int fedId_;
 
   /// Data from OptoRx headers and footer.
   uint64_t header;
-  uint32_t orbitCounter;
+  uint32_t orbitCounter_;
   uint64_t footer;
 };
 

--- a/DataFormats/CTPPSDigi/interface/TotemRPDigi.h
+++ b/DataFormats/CTPPSDigi/interface/TotemRPDigi.h
@@ -17,7 +17,7 @@ class TotemRPDigi {
 public:
   TotemRPDigi(unsigned short strip_no = 0) : strip_no_(strip_no){};
 
-  unsigned short getStripNumber() const { return strip_no_; }
+  unsigned short stripNumber() const { return strip_no_; }
 
 private:
   /// index of the activated strip
@@ -25,7 +25,7 @@ private:
 };
 
 inline bool operator<(const TotemRPDigi& one, const TotemRPDigi& other) {
-  return one.getStripNumber() < other.getStripNumber();
+  return one.stripNumber() < other.stripNumber();
 }
 
 #endif

--- a/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
@@ -132,12 +132,11 @@ inline bool operator<(const TotemTimingDigi& one, const TotemTimingDigi& other) 
 
 inline std::ostream& operator<<(std::ostream& os, const TotemTimingDigi& digi) {
   return os << "TotemTimingDigi:"
-            << "\nHardwareId:\t" << std::hex << digi.hardwareId() << "\nDB: " << std::dec
-            << digi.hardwareBoardId() << "\tSampic: " << digi.hardwareSampicId()
-            << "\tChannel: " << digi.hardwareChannelId() << "\nFPGATimestamp:\t" << std::dec
-            << digi.fpgaTimestamp() << "\nTimestampA:\t" << std::dec << digi.timestampA() << "\nTimestampB:\t"
-            << std::dec << digi.timestampB() << "\nCellInfo:\t" << std::hex << digi.cellInfo()
-            << "\nNumberOfSamples:\t" << std::dec << digi.numberOfSamples() << std::endl
+            << "\nHardwareId:\t" << std::hex << digi.hardwareId() << "\nDB: " << std::dec << digi.hardwareBoardId()
+            << "\tSampic: " << digi.hardwareSampicId() << "\tChannel: " << digi.hardwareChannelId()
+            << "\nFPGATimestamp:\t" << std::dec << digi.fpgaTimestamp() << "\nTimestampA:\t" << std::dec
+            << digi.timestampA() << "\nTimestampB:\t" << std::dec << digi.timestampB() << "\nCellInfo:\t" << std::hex
+            << digi.cellInfo() << "\nNumberOfSamples:\t" << std::dec << digi.numberOfSamples() << std::endl
             << digi.eventInfo() << std::endl;
 }
 

--- a/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
@@ -35,38 +35,38 @@ public:
   /// Return digi values number
 
   /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
-  inline unsigned int getHardwareId() const { return hwId_; }
+  inline unsigned int hardwareId() const { return hwId_; }
 
-  inline unsigned int getHardwareBoardId() const { return (hwId_ & 0xE0) >> 5; }
+  inline unsigned int hardwareBoardId() const { return (hwId_ & 0xE0) >> 5; }
 
-  inline unsigned int getHardwareSampicId() const { return (hwId_ & 0x10) >> 4; }
+  inline unsigned int hardwareSampicId() const { return (hwId_ & 0x10) >> 4; }
 
-  inline unsigned int getHardwareChannelId() const { return (hwId_ & 0x0F); }
+  inline unsigned int hardwareChannelId() const { return (hwId_ & 0x0F); }
 
-  inline unsigned int getFPGATimestamp() const { return fpgaTimestamp_; }
+  inline unsigned int fpgaTimestamp() const { return fpgaTimestamp_; }
 
-  inline unsigned int getTimestampA() const { return timestampA_; }
+  inline unsigned int timestampA() const { return timestampA_; }
 
-  inline unsigned int getTimestampB() const { return timestampB_; }
+  inline unsigned int timestampB() const { return timestampB_; }
 
-  inline unsigned int getCellInfo() const { return cellInfo_; }
+  inline unsigned int cellInfo() const { return cellInfo_; }
 
-  inline std::vector<uint8_t> getSamples() const { return samples_; }
+  inline std::vector<uint8_t> samples() const { return samples_; }
 
-  inline std::vector<uint8_t>::const_iterator getSamplesBegin() const { return samples_.cbegin(); }
+  inline std::vector<uint8_t>::const_iterator samplesBegin() const { return samples_.cbegin(); }
 
-  inline std::vector<uint8_t>::const_iterator getSamplesEnd() const { return samples_.cend(); }
+  inline std::vector<uint8_t>::const_iterator samplesEnd() const { return samples_.cend(); }
 
-  inline unsigned int getNumberOfSamples() const { return samples_.size(); }
+  inline unsigned int numberOfSamples() const { return samples_.size(); }
 
-  inline int getSampleAt(const unsigned int i) const {
+  inline int sampleAt(const unsigned int i) const {
     int sampleValue = -1;
     if (i < samples_.size())
       sampleValue = (int)samples_.at(i);
     return sampleValue;
   }
 
-  inline TotemTimingEventInfo getEventInfo() const { return totemTimingEventInfo_; }
+  inline TotemTimingEventInfo eventInfo() const { return totemTimingEventInfo_; }
 
   /// Set digi values
   /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
@@ -123,22 +123,22 @@ private:
 #include <iostream>
 
 inline bool operator<(const TotemTimingDigi& one, const TotemTimingDigi& other) {
-  if (one.getEventInfo() < other.getEventInfo())
+  if (one.eventInfo() < other.eventInfo())
     return true;
-  if (one.getHardwareId() < other.getHardwareId())
+  if (one.hardwareId() < other.hardwareId())
     return true;
   return false;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const TotemTimingDigi& digi) {
   return os << "TotemTimingDigi:"
-            << "\nHardwareId:\t" << std::hex << digi.getHardwareId() << "\nDB: " << std::dec
-            << digi.getHardwareBoardId() << "\tSampic: " << digi.getHardwareSampicId()
-            << "\tChannel: " << digi.getHardwareChannelId() << "\nFPGATimestamp:\t" << std::dec
-            << digi.getFPGATimestamp() << "\nTimestampA:\t" << std::dec << digi.getTimestampA() << "\nTimestampB:\t"
-            << std::dec << digi.getTimestampB() << "\nCellInfo:\t" << std::hex << digi.getCellInfo()
-            << "\nNumberOfSamples:\t" << std::dec << digi.getNumberOfSamples() << std::endl
-            << digi.getEventInfo() << std::endl;
+            << "\nHardwareId:\t" << std::hex << digi.hardwareId() << "\nDB: " << std::dec
+            << digi.hardwareBoardId() << "\tSampic: " << digi.hardwareSampicId()
+            << "\tChannel: " << digi.hardwareChannelId() << "\nFPGATimestamp:\t" << std::dec
+            << digi.fpgaTimestamp() << "\nTimestampA:\t" << std::dec << digi.timestampA() << "\nTimestampB:\t"
+            << std::dec << digi.timestampB() << "\nCellInfo:\t" << std::hex << digi.cellInfo()
+            << "\nNumberOfSamples:\t" << std::dec << digi.numberOfSamples() << std::endl
+            << digi.eventInfo() << std::endl;
 }
 
 #endif

--- a/DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h
@@ -36,31 +36,31 @@ public:
   /// Return digi values number
 
   /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
-  inline unsigned int getHardwareId() const { return hwId_; }
+  inline unsigned int hardwareId() const { return hwId_; }
 
-  inline unsigned int getHardwareBoardId() const { return (hwId_ & 0xE0) >> 5; }
+  inline unsigned int hardwareBoardId() const { return (hwId_ & 0xE0) >> 5; }
 
-  inline unsigned int getHardwareSampicId() const { return (hwId_ & 0x10) >> 4; }
+  inline unsigned int hardwareSampicId() const { return (hwId_ & 0x10) >> 4; }
 
-  inline unsigned int getHardwareChannelId() const { return (hwId_ & 0x0F); }
+  inline unsigned int hardwareChannelId() const { return (hwId_ & 0x0F); }
 
-  inline unsigned int getL1ATimestamp() const { return l1ATimestamp_; }
+  inline unsigned int l1ATimestamp() const { return l1ATimestamp_; }
 
-  inline unsigned int getBunchNumber() const { return bunchNumber_; }
+  inline unsigned int bunchNumber() const { return bunchNumber_; }
 
-  inline unsigned int getOrbitNumber() const { return orbitNumber_; }
+  inline unsigned int orbitNumber() const { return orbitNumber_; }
 
-  inline unsigned int getEventNumber() const { return eventNumber_; }
+  inline unsigned int eventNumber() const { return eventNumber_; }
 
-  inline uint16_t getChannelMap() const { return channelMap_; }
+  inline uint16_t channelMap() const { return channelMap_; }
 
-  inline unsigned int getL1ALatency() const { return l1ALatency_; }
+  inline unsigned int l1ALatency() const { return l1ALatency_; }
 
-  inline unsigned int getNumberOfSamples() const { return numberOfSamples_; }
+  inline unsigned int numberOfSamples() const { return numberOfSamples_; }
 
-  inline unsigned int getOffsetOfSamples() const { return offsetOfSamples_; }
+  inline unsigned int offsetOfSamples() const { return offsetOfSamples_; }
 
-  inline uint8_t getPLLInfo() const { return pllInfo_; }
+  inline uint8_t pllInfo() const { return pllInfo_; }
 
   /// Set digi values
   /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
@@ -115,25 +115,25 @@ private:
 #include <iostream>
 
 inline bool operator<(const TotemTimingEventInfo& one, const TotemTimingEventInfo& other) {
-  if (one.getEventNumber() < other.getEventNumber())
+  if (one.eventNumber() < other.eventNumber())
     return true;
-  if (one.getL1ATimestamp() < other.getL1ATimestamp())
+  if (one.l1ATimestamp() < other.l1ATimestamp())
     return true;
-  if (one.getHardwareId() < other.getHardwareId())
+  if (one.hardwareId() < other.hardwareId())
     return true;
   return false;
 }
 
 inline std::ostream& operator<<(std::ostream& o, const TotemTimingEventInfo& digi) {
-  std::bitset<16> bitsPLLInfo(digi.getPLLInfo());
+  std::bitset<16> bitsPLLInfo(digi.pllInfo());
   return o << "TotemTimingEventInfo:"
-           << "\nHardwareId:\t" << std::hex << digi.getHardwareId() << "\nDB: " << std::dec << digi.getHardwareBoardId()
-           << "\tSampic: " << digi.getHardwareSampicId() << "\tChannel: " << digi.getHardwareChannelId()
-           << "\nL1A Timestamp:\t" << std::dec << digi.getL1ATimestamp() << "\nL1A Latency:\t" << std::dec
-           << digi.getL1ALatency() << "\nBunch Number:\t" << std::dec << digi.getBunchNumber() << "\nOrbit Number:\t"
-           << std::dec << digi.getOrbitNumber() << "\nEvent Number:\t" << std::dec << digi.getEventNumber()
-           << "\nChannels fired:\t" << std::hex << digi.getChannelMap() << "\nNumber of Samples:\t" << std::dec
-           << digi.getNumberOfSamples() << "\nOffset of Samples:\t" << std::dec << digi.getOffsetOfSamples()
+           << "\nHardwareId:\t" << std::hex << digi.hardwareId() << "\nDB: " << std::dec << digi.hardwareBoardId()
+           << "\tSampic: " << digi.hardwareSampicId() << "\tChannel: " << digi.hardwareChannelId()
+           << "\nL1A Timestamp:\t" << std::dec << digi.l1ATimestamp() << "\nL1A Latency:\t" << std::dec
+           << digi.l1ALatency() << "\nBunch Number:\t" << std::dec << digi.bunchNumber() << "\nOrbit Number:\t"
+           << std::dec << digi.orbitNumber() << "\nEvent Number:\t" << std::dec << digi.eventNumber()
+           << "\nChannels fired:\t" << std::hex << digi.channelMap() << "\nNumber of Samples:\t" << std::dec
+           << digi.numberOfSamples() << "\nOffset of Samples:\t" << std::dec << digi.offsetOfSamples()
            << "\nPLL Info:\t" << bitsPLLInfo.to_string() << std::endl;
 }
 

--- a/DataFormats/CTPPSDigi/interface/TotemVFATStatus.h
+++ b/DataFormats/CTPPSDigi/interface/TotemVFATStatus.h
@@ -1,10 +1,10 @@
 /****************************************************************************
 *
 * This is a part of TOTEM offline software.
-* Authors: 
+* Authors:
 *   Maciej Wróbel (wroblisko@gmail.com)
 *   Jan Kašpar (jan.kaspar@gmail.com)
-*    
+*
 ****************************************************************************/
 
 #ifndef DataFormats_CTPPSDigi_TotemVFATStatus
@@ -20,12 +20,12 @@
  */
 class TotemVFATStatus {
 public:
-  TotemVFATStatus(uint8_t _cp = 0)
-      : chipPosition(_cp), status(0), numberOfClustersSpecified(false), numberOfClusters(0), eventCounter(0) {}
+  TotemVFATStatus(uint8_t cp = 0)
+      : chipPosition_(cp), status(0), numberOfClustersSpecified(false), numberOfClusters_(0), eventCounter(0) {}
 
   /// Chip position
-  inline uint8_t getChipPosition() const { return chipPosition; }
-  inline void setChipPosition(uint8_t _cp) { chipPosition = _cp; }
+  inline uint8_t chipPosition() const { return chipPosition_; }
+  inline void setChipPosition(uint8_t cp) { chipPosition_ = cp; }
 
   /// VFAT is present in mapping but no data is present int raw event
   inline bool isMissing() const { return status[0]; }
@@ -69,27 +69,27 @@ public:
   inline bool isNumberOfClustersSpecified() const { return numberOfClustersSpecified; }
   inline void setNumberOfClustersSpecified(bool v) { numberOfClustersSpecified = v; }
 
-  inline uint8_t getNumberOfClusters() const { return numberOfClusters; }
-  inline void setNumberOfClusters(uint8_t v) { numberOfClusters = v; }
+  inline uint8_t numberOfClusters() const { return numberOfClusters_; }
+  inline void setNumberOfClusters(uint8_t v) { numberOfClusters_ = v; }
 
   bool operator<(const TotemVFATStatus& cmp) const { return (status.to_ulong() < cmp.status.to_ulong()); }
 
   friend std::ostream& operator<<(std::ostream& s, const TotemVFATStatus& st);
 
   /// event Counter
-  inline uint8_t getEC() const { return eventCounter; }
+  inline uint8_t ec() const { return eventCounter; }
   inline void setEC(const uint8_t ec) { eventCounter = ec; }
 
 private:
   /// describes placement of the VFAT within the detector
-  uint8_t chipPosition;
+  uint8_t chipPosition_;
 
   /// the status bits
   std::bitset<8> status;
 
   /// the number of hit clusters before DAQ trimming
   bool numberOfClustersSpecified;
-  uint8_t numberOfClusters;
+  uint8_t numberOfClusters_;
 
   /// event counter in the VFAT frame
   uint8_t eventCounter;

--- a/DataFormats/CTPPSDigi/src/CTPPSDiamondDigi.cc
+++ b/DataFormats/CTPPSDigi/src/CTPPSDiamondDigi.cc
@@ -1,5 +1,5 @@
 /** \file
- * 
+ *
  *
  * \author Seyed Mohsen Etesami
  */
@@ -16,8 +16,8 @@ CTPPSDiamondDigi::CTPPSDiamondDigi() : ledgt(0), tedgt(0), threvolt(0), mhit(fal
 
 // Comparison
 bool CTPPSDiamondDigi::operator==(const CTPPSDiamondDigi& digi) const {
-  if (ledgt != digi.getLeadingEdge() || tedgt != digi.getTrailingEdge() || threvolt != digi.getThresholdVoltage() ||
-      mhit != digi.getMultipleHit() || hptdcerror.getErrorFlag() != digi.getHPTDCErrorFlags().getErrorFlag())
+  if (ledgt != digi.leadingEdge() || tedgt != digi.trailingEdge() || threvolt != digi.thresholdVoltage() ||
+      mhit != digi.multipleHit() || hptdcerror.errorFlag() != digi.hptdcErrorFlags().errorFlag())
     return false;
   else
     return true;

--- a/DataFormats/CTPPSDigi/src/classes_def.xml
+++ b/DataFormats/CTPPSDigi/src/classes_def.xml
@@ -14,11 +14,18 @@
   </class>
   <class name="edm::Wrapper<TotemTriggerCounters>"/>
 
-  <class name="TotemVFATStatus" ClassVersion="4">
-    <version ClassVersion="4" checksum="1562789855"/>
+  <class name="TotemVFATStatus" ClassVersion="5">
     <version ClassVersion="2" checksum="3003040825"/>
     <version ClassVersion="3" checksum="1439138260"/>
+    <version ClassVersion="4" checksum="1562789855"/>
+    <version ClassVersion="5" checksum="1998337285"/>
   </class>
+  <ioread sourceClass="TotemVFATStatus" version="[2-4]" targetClass="TotemVFATStatus" source="uint8_t chipPosition" target="chipPosition_">
+  <![CDATA[ chipPosition_ = onfile.chipPosition;]]>
+  </ioread>
+  <ioread sourceClass="TotemVFATStatus" version="[2-4]" targetClass="TotemVFATStatus" source="uint8_t numberOfClusters" target="numberOfClusters_">
+  <![CDATA[ numberOfClusters_ = onfile.numberOfClusters;]]>
+  </ioread>
   <class name="edm::DetSet<TotemVFATStatus>"/>
   <class name="std::vector<TotemVFATStatus>"/>
   <class name="std::vector<edm::DetSet<TotemVFATStatus> >"/>
@@ -29,9 +36,16 @@
   <class name="std::bitset<8>"/>
   <class name="edm::Wrapper<std::bitset<8> >"/>
 
-  <class name="TotemFEDInfo" ClassVersion="2">
+  <class name="TotemFEDInfo" ClassVersion="3">
     <version ClassVersion="2" checksum="2844972317"/>
+    <version ClassVersion="3" checksum="3276964679"/>
   </class>
+  <ioread sourceClass="TotemFEDInfo" version="[2]" targetClass="TotemFEDInfo" source="int fedId" target="fedId_">
+  <![CDATA[ fedId_ = onfile.fedId;]]>
+  </ioread>
+  <ioread sourceClass="TotemFEDInfo" version="[2]" targetClass="TotemFEDInfo" source="uint32_t orbitCounter" target="orbitCounter_">
+  <![CDATA[ orbitCounter_ = onfile.orbitCounter;]]>
+  </ioread>
   <class name="std::vector<TotemFEDInfo>"/>
   <class name="edm::Wrapper<std::vector<TotemFEDInfo>>"/>
 

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h
@@ -28,10 +28,10 @@ public:
   //--- temporal set'ters
 
   inline void setOOTIndex(int i) { ts_index_ = i; }
-  inline int getOOTIndex() const { return ts_index_; }
+  inline int ootIndex() const { return ts_index_; }
 
   inline void setMultipleHits(int i) { mh_ = i; }
-  inline int getMultipleHits() const { return mh_; }
+  inline int multipleHits() const { return mh_; }
 
 private:
   /// Time slice index

--- a/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h
@@ -39,19 +39,19 @@ public:
   static constexpr int TIMESLICE_WITHOUT_LEADING = -10;
 
   inline void setToT(float tot) { tot_ = tot; }
-  inline float getToT() const { return tot_; }
+  inline float toT() const { return tot_; }
 
   inline void setTPrecision(float tPrecision) { tPrecision_ = tPrecision; }
-  inline float getTPrecision() const { return tPrecision_; }
+  inline float tPrecision() const { return tPrecision_; }
 
   inline void setOOTIndex(int i) { tsIndex_ = i; }
-  inline int getOOTIndex() const { return tsIndex_; }
+  inline int ootIndex() const { return tsIndex_; }
 
   inline void setMultipleHits(bool mh) { mh_ = mh; }
-  inline bool getMultipleHits() const { return mh_; }
+  inline bool multipleHits() const { return mh_; }
 
   inline void setHPTDCErrorFlags(const HPTDCErrorFlags &err) { hptdcErr_ = err; }
-  inline HPTDCErrorFlags getHPTDCErrorFlags() const { return hptdcErr_; }
+  inline HPTDCErrorFlags hptdcErrorFlags() const { return hptdcErr_; }
 
 private:
   /// Time over threshold

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -19,20 +19,20 @@
 class CTPPSLocalTrackLite {
 public:
   CTPPSLocalTrackLite()
-      : rpId(0),
-        x(0.),
-        x_unc(-1.),
-        y(0.),
-        y_unc(-1.),
-        tx(999.),
-        tx_unc(-1.),
-        ty(999.),
-        ty_unc(-1.),
-        chiSquaredOverNDF(-1.),
-        pixelTrack_reco_info(CTPPSpixelLocalTrackReconstructionInfo::invalid),
-        numberOfPointsUsedForFit(0),
-        time(0.),
-        time_unc(-1.) {}
+      : rp_id_(0),
+        x_(0.),
+        x_unc_(-1.),
+        y_(0.),
+        y_unc_(-1.),
+        tx_(999.),
+        tx_unc_(-1.),
+        ty_(999.),
+        ty_unc_(-1.),
+        chi2_norm_(-1.),
+        pixel_track_reco_info_(CTPPSpixelLocalTrackReconstructionInfo::invalid),
+        num_points_fit_(0),
+        time_(0.),
+        time_unc_(-1.) {}
 
   CTPPSLocalTrackLite(uint32_t pid,
                       float px,
@@ -48,100 +48,106 @@ public:
                       unsigned short pNumberOfPointsUsedForFit,
                       float pt,
                       float ptu)
-      : rpId(pid),
-        x(px),
-        x_unc(pxu),
-        y(py),
-        y_unc(pyu),
-        tx(ptx),
-        tx_unc(ptxu),
-        ty(pty),
-        ty_unc(ptyu),
-        chiSquaredOverNDF(pchiSquaredOverNDF),
-        pixelTrack_reco_info(ppixelTrack_reco_info),
-        numberOfPointsUsedForFit(pNumberOfPointsUsedForFit),
-        time(pt),
-        time_unc(ptu) {}
+      : rp_id_(pid),
+        x_(px),
+        x_unc_(pxu),
+        y_(py),
+        y_unc_(pyu),
+        tx_(ptx),
+        tx_unc_(ptxu),
+        ty_(pty),
+        ty_unc_(ptyu),
+        chi2_norm_(pchiSquaredOverNDF),
+        pixel_track_reco_info_(ppixelTrack_reco_info),
+        num_points_fit_(pNumberOfPointsUsedForFit),
+        time_(pt),
+        time_unc_(ptu) {}
 
   /// returns the RP id
-  inline uint32_t getRPId() const { return rpId; }
+  inline uint32_t rpId() const { return rp_id_; }
 
   /// returns the horizontal track position
-  inline float getX() const { return x; }
+  inline float x() const { return x_; }
 
   /// returns the horizontal track position uncertainty
-  inline float getXUnc() const { return x_unc; }
+  inline float xUnc() const { return x_unc_; }
 
   /// returns the vertical track position
-  inline float getY() const { return y; }
+  inline float y() const { return y_; }
 
   /// returns the vertical track position uncertainty
-  inline float getYUnc() const { return y_unc; }
+  inline float yUnc() const { return y_unc_; }
 
   /// returns the track time
-  inline float getTime() const { return time; }
+  inline float time() const { return time_; }
 
   /// returns the track time uncertainty
-  inline float getTimeUnc() const { return time_unc; }
+  inline float timeUnc() const { return time_unc_; }
 
   /// returns the track horizontal angle
-  inline float getTx() const { return tx; }
+  inline float tx() const { return tx_; }
 
   /// returns the track horizontal angle uncertainty
-  inline float getTxUnc() const { return tx_unc; }
+  inline float txUnc() const { return tx_unc_; }
 
   /// returns the track vertical angle
-  inline float getTy() const { return ty; }
+  inline float ty() const { return ty_; }
 
   /// returns the track vertical angle uncertainty
-  inline float getTyUnc() const { return ty_unc; }
+  inline float tyUnc() const { return ty_unc_; }
 
   /// returns the track fit chi Squared over NDF
-  inline float getChiSquaredOverNDF() const { return chiSquaredOverNDF; }
+  inline float chiSquaredOverNDF() const { return chi2_norm_; }
 
   /// returns the track reconstruction info byte
-  inline CTPPSpixelLocalTrackReconstructionInfo getPixelTrackRecoInfo() const { return pixelTrack_reco_info; }
+  inline CTPPSpixelLocalTrackReconstructionInfo pixelTrackRecoInfo() const { return pixel_track_reco_info_; }
 
   /// returns the number of points used for fit
-  inline unsigned short getNumberOfPointsUsedForFit() const { return numberOfPointsUsedForFit; }
+  inline unsigned short numberOfPointsUsedForFit() const { return num_points_fit_; }
 
 protected:
   /// RP id
-  uint32_t rpId;
+  uint32_t rp_id_;
 
   /// local track parameterization
   /// x = x0 + tx*(z-z0), y = y0 + ty*(z-z0)
   /// x0, y0, z-z0 in mm
   /// z0: position of the reference scoring plane (in the middle of the RP)
 
-  /// horizontal hit position and uncertainty, mm
-  float x, x_unc;
-
-  /// vertical hit position and uncertainty, mm
-  float y, y_unc;
-
-  /// horizontal angle and uncertainty, x = x0 + tx*(z-z0)
-  float tx, tx_unc;
-
-  /// vertical angle and uncertainty, y = y0 + ty*(z-z0)
-  float ty, ty_unc;
-
-  /// fit chi^2 over NDF
-  float chiSquaredOverNDF;
+  /// horizontal hit position, mm
+  float x_;
+  /// uncertainty on horizontal hit position, mm
+  float x_unc_;
+  /// vertical hit position, mm
+  float y_;
+  /// uncertainty on vertical hit position, mm
+  float y_unc_;
+  /// horizontal angle, x = x0 + tx*(z-z0)
+  float tx_;
+  /// uncertainty on horizontal angle
+  float tx_unc_;
+  /// vertical angle, y = y0 + ty*(z-z0)
+  float ty_;
+  /// uncertainty on vertical angle
+  float ty_unc_;
+  /// fit \f$\chi^2\f$/NDF
+  float chi2_norm_;
 
   /// Track information byte for bx-shifted runs:
-  /// pixelTrack_reco_info = notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
-  /// pixelTrack_reco_info = allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
-  /// pixelTrack_reco_info = noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
-  /// pixelTrack_reco_info = mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
-  /// pixelTrack_reco_info = invalid          -> Dummy value. Assigned when pixelTrack_reco_info is not computed (i.e. non-pixel tracks)
-  CTPPSpixelLocalTrackReconstructionInfo pixelTrack_reco_info;
+  /// * notShiftedRun    -> Default value for tracks reconstructed in non-bx-shifted ROCs
+  /// * allShiftedPlanes -> Track reconstructed in a bx-shifted ROC with bx-shifted planes only
+  /// * noShiftedPlanes  -> Track reconstructed in a bx-shifted ROC with non-bx-shifted planes only
+  /// * mixedPlanes      -> Track reconstructed in a bx-shifted ROC both with bx-shifted and non-bx-shifted planes
+  /// * invalid          -> Dummy value. Assigned when pixelTrack_reco_info is not computed (i.e. non-pixel tracks)
+  CTPPSpixelLocalTrackReconstructionInfo pixel_track_reco_info_;
 
   /// number of points used for fit
-  unsigned short numberOfPointsUsedForFit;
+  unsigned short num_points_fit_;
 
-  /// time information and uncertainty, ns
-  float time, time_unc;
+  /// time information, ns
+  float time_;
+  /// uncertainty on time information, ns
+  float time_unc_;
 };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -115,21 +115,33 @@ public:
   }
 
   inline float x0() const { return track_params_vector_[(unsigned int)TrackPar::x0]; }
-  inline float x0Sigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::x0][(unsigned int)TrackPar::x0]); }
-  inline float x0Variance() const { return par_covariance_matrix_[(unsigned int)TrackPar::x0][(unsigned int)TrackPar::x0]; }
+  inline float x0Sigma() const {
+    return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::x0][(unsigned int)TrackPar::x0]);
+  }
+  inline float x0Variance() const {
+    return par_covariance_matrix_[(unsigned int)TrackPar::x0][(unsigned int)TrackPar::x0];
+  }
 
   inline float y0() const { return track_params_vector_[(unsigned int)TrackPar::y0]; }
-  inline float y0Sigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::y0][(unsigned int)TrackPar::y0]); }
-  inline float y0Variance() const { return par_covariance_matrix_[(unsigned int)TrackPar::y0][(unsigned int)TrackPar::y0]; }
+  inline float y0Sigma() const {
+    return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::y0][(unsigned int)TrackPar::y0]);
+  }
+  inline float y0Variance() const {
+    return par_covariance_matrix_[(unsigned int)TrackPar::y0][(unsigned int)TrackPar::y0];
+  }
 
   inline float z0() const { return z0_; }
   inline void setZ0(float z0) { z0_ = z0; }
 
   inline float tx() const { return track_params_vector_[(unsigned int)TrackPar::tx]; }
-  inline float txSigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::tx][(unsigned int)TrackPar::tx]); }
+  inline float txSigma() const {
+    return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::tx][(unsigned int)TrackPar::tx]);
+  }
 
   inline float ty() const { return track_params_vector_[(unsigned int)TrackPar::ty]; }
-  inline float tySigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::ty][(unsigned int)TrackPar::ty]); }
+  inline float tySigma() const {
+    return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::ty][(unsigned int)TrackPar::ty]);
+  }
 
   inline GlobalVector directionVector() const {
     GlobalVector vect(tx(), ty(), 1);
@@ -154,13 +166,15 @@ public:
   /// returns the point from which the track is passing by at the selected z
   inline GlobalPoint trackPoint(float z) const {
     float delta_z = z - z0_;
-    return GlobalPoint(track_params_vector_[(unsigned int)TrackPar::x0] + track_params_vector_[(unsigned int)TrackPar::tx] * delta_z,
-                       track_params_vector_[(unsigned int)TrackPar::y0] + track_params_vector_[(unsigned int)TrackPar::ty] * delta_z,
-                       z);
+    return GlobalPoint(
+        track_params_vector_[(unsigned int)TrackPar::x0] + track_params_vector_[(unsigned int)TrackPar::tx] * delta_z,
+        track_params_vector_[(unsigned int)TrackPar::y0] + track_params_vector_[(unsigned int)TrackPar::ty] * delta_z,
+        z);
   }
 
   inline GlobalPoint trackCentrePoint() {
-    return GlobalPoint(track_params_vector_[(unsigned int)TrackPar::x0], track_params_vector_[(unsigned int)TrackPar::y0], z0_);
+    return GlobalPoint(
+        track_params_vector_[(unsigned int)TrackPar::x0], track_params_vector_[(unsigned int)TrackPar::y0], z0_);
   }
 
   AlgebraicSymMatrix22 trackPointInterpolationCovariance(float z) const;

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h
@@ -49,29 +49,29 @@ public:
 
   virtual ~CTPPSPixelFittedRecHit() {}
 
-  inline const GlobalPoint& getGlobalCoordinates() const { return space_point_on_det_; }
-  inline float getXResidual() const { return residual_.x(); }
-  inline float getYResidual() const { return residual_.y(); }
+  inline const GlobalPoint& globalCoordinates() const { return space_point_on_det_; }
+  inline float xResidual() const { return residual_.x(); }
+  inline float yResidual() const { return residual_.y(); }
 
-  inline float getXPull() const { return pull_.x(); }
-  inline float getYPull() const { return pull_.y(); }
+  inline float xPull() const { return pull_.x(); }
+  inline float yPull() const { return pull_.y(); }
 
-  inline float getXPullNormalization() const { return residual_.x() / pull_.x(); }
-  inline float getYPullNormalization() const { return residual_.y() / pull_.y(); }
+  inline float xPullNormalization() const { return residual_.x() / pull_.x(); }
+  inline float yPullNormalization() const { return residual_.y() / pull_.y(); }
 
   inline void setIsUsedForFit(bool usedForFit) {
     if (usedForFit)
       isRealHit_ = true;
     isUsedForFit_ = usedForFit;
   }
-  inline bool getIsUsedForFit() const { return isUsedForFit_; }
+  inline bool isUsedForFit() const { return isUsedForFit_; }
 
   inline void setIsRealHit(bool realHit) {
     if (!realHit)
       isUsedForFit_ = false;
     isRealHit_ = realHit;
   }
-  inline bool getIsRealHit() const { return isRealHit_; }
+  inline bool isRealHit() const { return isRealHit_; }
 
 private:
   GlobalPoint space_point_on_det_;  ///< mm
@@ -83,7 +83,7 @@ private:
 
 class CTPPSPixelLocalTrack {
 public:
-  enum TrackPar { x0 = 0, y0 = 1, tx = 2, ty = 3 };
+  enum class TrackPar { x0 = 0, y0 = 1, tx = 2, ty = 3 };
 
   ///< parameter vector size
   static constexpr int dimension = 4;
@@ -107,60 +107,60 @@ public:
 
   ~CTPPSPixelLocalTrack() {}
 
-  inline const edm::DetSetVector<CTPPSPixelFittedRecHit>& getHits() const { return track_hits_vector_; }
+  inline const edm::DetSetVector<CTPPSPixelFittedRecHit>& hits() const { return track_hits_vector_; }
   inline void addHit(unsigned int detId, const CTPPSPixelFittedRecHit& hit) {
     track_hits_vector_.find_or_insert(detId).push_back(hit);
-    if (hit.getIsUsedForFit())
+    if (hit.isUsedForFit())
       ++numberOfPointsUsedForFit_;
   }
 
-  inline float getX0() const { return track_params_vector_[TrackPar::x0]; }
-  inline float getX0Sigma() const { return sqrt(par_covariance_matrix_[TrackPar::x0][TrackPar::x0]); }
-  inline float getX0Variance() const { return par_covariance_matrix_[TrackPar::x0][TrackPar::x0]; }
+  inline float x0() const { return track_params_vector_[(unsigned int)TrackPar::x0]; }
+  inline float x0Sigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::x0][(unsigned int)TrackPar::x0]); }
+  inline float x0Variance() const { return par_covariance_matrix_[(unsigned int)TrackPar::x0][(unsigned int)TrackPar::x0]; }
 
-  inline float getY0() const { return track_params_vector_[TrackPar::y0]; }
-  inline float getY0Sigma() const { return sqrt(par_covariance_matrix_[TrackPar::y0][TrackPar::y0]); }
-  inline float getY0Variance() const { return par_covariance_matrix_[TrackPar::y0][TrackPar::y0]; }
+  inline float y0() const { return track_params_vector_[(unsigned int)TrackPar::y0]; }
+  inline float y0Sigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::y0][(unsigned int)TrackPar::y0]); }
+  inline float y0Variance() const { return par_covariance_matrix_[(unsigned int)TrackPar::y0][(unsigned int)TrackPar::y0]; }
 
-  inline float getZ0() const { return z0_; }
+  inline float z0() const { return z0_; }
   inline void setZ0(float z0) { z0_ = z0; }
 
-  inline float getTx() const { return track_params_vector_[TrackPar::tx]; }
-  inline float getTxSigma() const { return sqrt(par_covariance_matrix_[TrackPar::tx][TrackPar::tx]); }
+  inline float tx() const { return track_params_vector_[(unsigned int)TrackPar::tx]; }
+  inline float txSigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::tx][(unsigned int)TrackPar::tx]); }
 
-  inline float getTy() const { return track_params_vector_[TrackPar::ty]; }
-  inline float getTySigma() const { return sqrt(par_covariance_matrix_[TrackPar::ty][TrackPar::ty]); }
+  inline float ty() const { return track_params_vector_[(unsigned int)TrackPar::ty]; }
+  inline float tySigma() const { return sqrt(par_covariance_matrix_[(unsigned int)TrackPar::ty][(unsigned int)TrackPar::ty]); }
 
-  inline GlobalVector getDirectionVector() const {
-    GlobalVector vect(getTx(), getTy(), 1);
+  inline GlobalVector directionVector() const {
+    GlobalVector vect(tx(), ty(), 1);
     return vect.unit();
   }
 
-  inline const ParameterVector& getParameterVector() const { return track_params_vector_; }
+  inline const ParameterVector& parameterVector() const { return track_params_vector_; }
 
-  inline const CovarianceMatrix& getCovarianceMatrix() const { return par_covariance_matrix_; }
+  inline const CovarianceMatrix& covarianceMatrix() const { return par_covariance_matrix_; }
 
-  inline float getChiSquared() const { return chiSquared_; }
+  inline float chiSquared() const { return chiSquared_; }
 
-  inline float getChiSquaredOverNDF() const {
+  inline float chiSquaredOverNDF() const {
     if (numberOfPointsUsedForFit_ <= dimension / 2)
       return -999.;
     else
       return chiSquared_ / (2 * numberOfPointsUsedForFit_ - dimension);
   }
 
-  inline int getNDF() const { return (2 * numberOfPointsUsedForFit_ - dimension); }
+  inline int ndf() const { return (2 * numberOfPointsUsedForFit_ - dimension); }
 
   /// returns the point from which the track is passing by at the selected z
-  inline GlobalPoint getTrackPoint(float z) const {
+  inline GlobalPoint trackPoint(float z) const {
     float delta_z = z - z0_;
-    return GlobalPoint(track_params_vector_[TrackPar::x0] + track_params_vector_[TrackPar::tx] * delta_z,
-                       track_params_vector_[TrackPar::y0] + track_params_vector_[TrackPar::ty] * delta_z,
+    return GlobalPoint(track_params_vector_[(unsigned int)TrackPar::x0] + track_params_vector_[(unsigned int)TrackPar::tx] * delta_z,
+                       track_params_vector_[(unsigned int)TrackPar::y0] + track_params_vector_[(unsigned int)TrackPar::ty] * delta_z,
                        z);
   }
 
-  inline GlobalPoint getTrackCentrePoint() {
-    return GlobalPoint(track_params_vector_[TrackPar::x0], track_params_vector_[TrackPar::y0], z0_);
+  inline GlobalPoint trackCentrePoint() {
+    return GlobalPoint(track_params_vector_[(unsigned int)TrackPar::x0], track_params_vector_[(unsigned int)TrackPar::y0], z0_);
   }
 
   AlgebraicSymMatrix22 trackPointInterpolationCovariance(float z) const;
@@ -171,10 +171,10 @@ public:
 
   bool operator<(const CTPPSPixelLocalTrack& r);
 
-  inline CTPPSpixelLocalTrackReconstructionInfo getRecoInfo() const { return recoInfo_; }
+  inline CTPPSpixelLocalTrackReconstructionInfo recoInfo() const { return recoInfo_; }
   inline void setRecoInfo(CTPPSpixelLocalTrackReconstructionInfo recoInfo) { recoInfo_ = recoInfo; }
 
-  inline unsigned short getNumberOfPointsUsedForFit() const { return numberOfPointsUsedForFit_; }
+  inline unsigned short numberOfPointsUsedForFit() const { return numberOfPointsUsedForFit_; }
 
 private:
   edm::DetSetVector<CTPPSPixelFittedRecHit> track_hits_vector_;

--- a/DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h
@@ -39,8 +39,8 @@ public:
         clusterSizeRow_(rowsize),
         clusterSizeCol_(colsize) {}
 
-  inline LocalPoint getPoint() const { return thePoint_; }
-  inline LocalError getError() const { return theError_; }
+  inline LocalPoint point() const { return thePoint_; }
+  inline LocalError error() const { return theError_; }
 
   inline bool isOnEdge() const { return isOnEdge_; }
   inline bool hasBadPixels() const { return hasBadPixels_; }
@@ -69,6 +69,6 @@ private:
   unsigned int clusterSizeCol_;
 };
 
-inline bool operator<(CTPPSPixelRecHit& a, CTPPSPixelRecHit& b) { return (a.getPoint().mag() < b.getPoint().mag()); };
+inline bool operator<(CTPPSPixelRecHit& a, CTPPSPixelRecHit& b) { return (a.point().mag() < b.point().mag()); };
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSTimingLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSTimingLocalTrack.h
@@ -55,13 +55,13 @@ public:
 
   //--- temporal get'ters
 
-  inline float t() const { return t_; }
-  inline float tSigma() const { return t_sigma_; }
+  inline float time() const { return t_; }
+  inline float timeSigma() const { return t_sigma_; }
 
   //--- temporal set'ters
 
-  inline void setT(float t) { t_ = t; }
-  inline void setTSigma(float t_sigma) { t_sigma_ = t_sigma; }
+  inline void setTime(float t) { t_ = t; }
+  inline void setTimeSigma(float t_sigma) { t_sigma_ = t_sigma; }
 
 private:
   //--- spatial information

--- a/DataFormats/CTPPSReco/interface/CTPPSTimingLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSTimingLocalTrack.h
@@ -28,17 +28,17 @@ public:
 
   //--- spatial get'ters
 
-  inline float getX0() const { return pos0_.x(); }
-  inline float getX0Sigma() const { return pos0_sigma_.x(); }
+  inline float x0() const { return pos0_.x(); }
+  inline float x0Sigma() const { return pos0_sigma_.x(); }
 
-  inline float getY0() const { return pos0_.y(); }
-  inline float getY0Sigma() const { return pos0_sigma_.y(); }
+  inline float y0() const { return pos0_.y(); }
+  inline float y0Sigma() const { return pos0_sigma_.y(); }
 
-  inline float getZ0() const { return pos0_.z(); }
-  inline float getZ0Sigma() const { return pos0_sigma_.z(); }
+  inline float z0() const { return pos0_.z(); }
+  inline float z0Sigma() const { return pos0_sigma_.z(); }
 
-  inline int getNumOfHits() const { return num_hits_; }
-  inline int getNumOfPlanes() const { return num_planes_; }
+  inline int hitsNumber() const { return num_hits_; }
+  inline int planesNumber() const { return num_planes_; }
 
   //--- spatial set'ters
 
@@ -55,8 +55,8 @@ public:
 
   //--- temporal get'ters
 
-  inline float getT() const { return t_; }
-  inline float getTSigma() const { return t_sigma_; }
+  inline float t() const { return t_; }
+  inline float tSigma() const { return t_sigma_; }
 
   //--- temporal set'ters
 

--- a/DataFormats/CTPPSReco/interface/CTPPSTimingLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSTimingLocalTrack.h
@@ -37,8 +37,8 @@ public:
   inline float z0() const { return pos0_.z(); }
   inline float z0Sigma() const { return pos0_sigma_.z(); }
 
-  inline int hitsNumber() const { return num_hits_; }
-  inline int planesNumber() const { return num_planes_; }
+  inline int numberOfHits() const { return num_hits_; }
+  inline int numberOfPlanes() const { return num_planes_; }
 
   //--- spatial set'ters
 

--- a/DataFormats/CTPPSReco/interface/CTPPSTimingRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSTimingRecHit.h
@@ -18,25 +18,25 @@ public:
       : x_(x), xWidth_(xWidth), y_(y), yWidth_(yWidth), z_(z), zWidth_(zWidth), t_(t) {}
 
   inline void setX(float x) { x_ = x; }
-  inline float getX() const { return x_; }
+  inline float x() const { return x_; }
 
   inline void setY(float y) { y_ = y; }
-  inline float getY() const { return y_; }
+  inline float y() const { return y_; }
 
   inline void setZ(float z) { z_ = z; }
-  inline float getZ() const { return z_; }
+  inline float z() const { return z_; }
 
   inline void setXWidth(float xWidth) { xWidth_ = xWidth; }
-  inline float getXWidth() const { return xWidth_; }
+  inline float xWidth() const { return xWidth_; }
 
   inline void setYWidth(float yWidth) { yWidth_ = yWidth; }
-  inline float getYWidth() const { return yWidth_; }
+  inline float yWidth() const { return yWidth_; }
 
   inline void setZWidth(float zWidth) { zWidth_ = zWidth; }
-  inline float getZWidth() const { return zWidth_; }
+  inline float zWidth() const { return zWidth_; }
 
   inline void setT(float t) { t_ = t; }
-  inline float getT() const { return t_; }
+  inline float t() const { return t_; }
 
 protected:
   float x_, xWidth_;
@@ -49,7 +49,7 @@ protected:
 
 inline bool operator<(const CTPPSTimingRecHit &l, const CTPPSTimingRecHit &r) {
   // only sort by leading edge time
-  return (l.getT() < r.getT());
+  return (l.t() < r.t());
 }
 
 #endif

--- a/DataFormats/CTPPSReco/interface/CTPPSTimingRecHit.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSTimingRecHit.h
@@ -35,8 +35,8 @@ public:
   inline void setZWidth(float zWidth) { zWidth_ = zWidth; }
   inline float zWidth() const { return zWidth_; }
 
-  inline void setT(float t) { t_ = t; }
-  inline float t() const { return t_; }
+  inline void setTime(float t) { t_ = t; }
+  inline float time() const { return t_; }
 
 protected:
   float x_, xWidth_;
@@ -49,7 +49,7 @@ protected:
 
 inline bool operator<(const CTPPSTimingRecHit &l, const CTPPSTimingRecHit &r) {
   // only sort by leading edge time
-  return (l.t() < r.t());
+  return (l.time() < r.time());
 }
 
 #endif

--- a/DataFormats/CTPPSReco/interface/TotemRPCluster.h
+++ b/DataFormats/CTPPSReco/interface/TotemRPCluster.h
@@ -19,15 +19,15 @@ class TotemRPCluster {
 public:
   TotemRPCluster(unsigned short str_beg = 0, unsigned short str_end = 0) : str_beg_(str_beg), str_end_(str_end) {}
 
-  inline uint16_t getStripBegin() const { return str_beg_; }
+  inline uint16_t stripBegin() const { return str_beg_; }
   inline void setStripBegin(unsigned short str_beg) { str_beg_ = str_beg; }
 
-  inline uint16_t getStripEnd() const { return str_end_; }
+  inline uint16_t stripEnd() const { return str_end_; }
   inline void setStripEnd(unsigned short str_end) { str_end_ = str_end; }
 
-  inline int getNumberOfStrips() const { return str_end_ - str_beg_ + 1; }
+  inline int numberOfStrips() const { return str_end_ - str_beg_ + 1; }
 
-  inline double getCenterStripPosition() const { return (str_beg_ + str_end_) / 2.; }
+  inline double centerStripPosition() const { return (str_beg_ + str_end_) / 2.; }
 
 private:
   uint16_t str_beg_;
@@ -37,12 +37,12 @@ private:
 //----------------------------------------------------------------------------------------------------
 
 inline bool operator<(const TotemRPCluster& l, const TotemRPCluster& r) {
-  if (l.getStripBegin() < r.getStripBegin())
+  if (l.stripBegin() < r.stripBegin())
     return true;
-  if (l.getStripBegin() > r.getStripBegin())
+  if (l.stripBegin() > r.stripBegin())
     return false;
 
-  if (l.getStripEnd() < r.getStripEnd())
+  if (l.stripEnd() < r.stripEnd())
     return true;
 
   return false;

--- a/DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h
+++ b/DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h
@@ -39,16 +39,16 @@ public:
 
     virtual ~FittedRecHit() {}
 
-    inline const TVector3 &getGlobalCoordinates() const { return space_point_on_det_; }
+    inline const TVector3 &globalCoordinates() const { return space_point_on_det_; }
     inline void setGlobalCoordinates(const TVector3 &space_point_on_det) { space_point_on_det_ = space_point_on_det; }
 
-    inline double getResidual() const { return residual_; }
+    inline double residual() const { return residual_; }
     inline void setResidual(double residual) { residual_ = residual; }
 
-    inline double getPull() const { return pull_; }
+    inline double pull() const { return pull_; }
     inline void setPull(double pull) { pull_ = pull; }
 
-    inline double getPullNormalization() const { return residual_ / pull_; }
+    inline double pullNormalization() const { return residual_ / pull_; }
 
   private:
     TVector3 space_point_on_det_;  ///< mm
@@ -72,55 +72,55 @@ public:
 
   virtual ~TotemRPLocalTrack() {}
 
-  inline const edm::DetSetVector<FittedRecHit> &getHits() const { return track_hits_vector_; }
+  inline const edm::DetSetVector<FittedRecHit> &hits() const { return track_hits_vector_; }
   inline void addHit(unsigned int detId, const FittedRecHit &hit) {
     track_hits_vector_.find_or_insert(detId).push_back(hit);
   }
 
-  inline double getX0() const { return track_params_vector_[0]; }
-  inline double getX0Sigma() const { return sqrt(CovarianceMatrixElement(0, 0)); }
-  inline double getX0Variance() const { return CovarianceMatrixElement(0, 0); }
+  inline double x0() const { return track_params_vector_[0]; }
+  inline double x0Sigma() const { return sqrt(CovarianceMatrixElement(0, 0)); }
+  inline double x0Variance() const { return CovarianceMatrixElement(0, 0); }
 
-  inline double getY0() const { return track_params_vector_[1]; }
-  inline double getY0Sigma() const { return sqrt(CovarianceMatrixElement(1, 1)); }
-  inline double getY0Variance() const { return CovarianceMatrixElement(1, 1); }
+  inline double y0() const { return track_params_vector_[1]; }
+  inline double y0Sigma() const { return sqrt(CovarianceMatrixElement(1, 1)); }
+  inline double y0Variance() const { return CovarianceMatrixElement(1, 1); }
 
-  inline double getZ0() const { return z0_; }
+  inline double z0() const { return z0_; }
   inline void setZ0(double z0) { z0_ = z0; }
 
-  inline double getTx() const { return track_params_vector_[2]; }
-  inline double getTxSigma() const { return sqrt(CovarianceMatrixElement(2, 2)); }
+  inline double tx() const { return track_params_vector_[2]; }
+  inline double txSigma() const { return sqrt(CovarianceMatrixElement(2, 2)); }
 
-  inline double getTy() const { return track_params_vector_[3]; }
-  inline double getTySigma() const { return sqrt(CovarianceMatrixElement(3, 3)); }
+  inline double ty() const { return track_params_vector_[3]; }
+  inline double tySigma() const { return sqrt(CovarianceMatrixElement(3, 3)); }
 
-  inline TVector3 getDirectionVector() const {
-    TVector3 vect(getTx(), getTy(), 1);
+  inline TVector3 directionVector() const {
+    TVector3 vect(tx(), ty(), 1);
     vect.SetMag(1.0);
     return vect;
   }
 
-  TVectorD getParameterVector() const;
+  TVectorD parameterVector() const;
   void setParameterVector(const TVectorD &track_params_vector);
 
-  TMatrixD getCovarianceMatrix() const;
+  TMatrixD covarianceMatrix() const;
   void setCovarianceMatrix(const TMatrixD &par_covariance_matrix);
 
-  inline double getChiSquared() const { return chiSquared_; }
+  inline double chiSquared() const { return chiSquared_; }
   inline void setChiSquared(double &chiSquared) { chiSquared_ = chiSquared; }
 
-  inline double getChiSquaredOverNDF() const { return chiSquared_ / (track_hits_vector_.size() - 4); }
+  inline double chiSquaredOverNDF() const { return chiSquared_ / (track_hits_vector_.size() - 4); }
 
-  inline unsigned short getNumberOfPointsUsedForFit() const { return track_hits_vector_.size(); }
+  inline unsigned short numberOfPointsUsedForFit() const { return track_hits_vector_.size(); }
 
   /// returns (x, y) vector
-  inline TVector2 getTrackPoint(double z) const {
+  inline TVector2 trackPoint(double z) const {
     double delta_z = z - z0_;
     return TVector2(track_params_vector_[0] + track_params_vector_[2] * delta_z,
                     track_params_vector_[1] + track_params_vector_[3] * delta_z);
   }
 
-  inline TVector3 getTrackCentrePoint() { return TVector3(track_params_vector_[0], track_params_vector_[1], z0_); }
+  inline TVector3 trackCentrePoint() { return TVector3(track_params_vector_[0], track_params_vector_[1], z0_); }
 
   TMatrixD trackPointInterpolationCovariance(double z) const;
 

--- a/DataFormats/CTPPSReco/interface/TotemRPRecHit.h
+++ b/DataFormats/CTPPSReco/interface/TotemRPRecHit.h
@@ -19,10 +19,10 @@ class TotemRPRecHit {
 public:
   TotemRPRecHit(double position = 0, double sigma = 0) : position_(position), sigma_(sigma) {}
 
-  inline double getPosition() const { return position_; }
+  inline double position() const { return position_; }
   inline void setPosition(double position) { position_ = position; }
 
-  inline double getSigma() const { return sigma_; }
+  inline double sigma() const { return sigma_; }
   inline void setSigma(double sigma) { sigma_ = sigma; }
 
 private:
@@ -36,12 +36,12 @@ private:
 //----------------------------------------------------------------------------------------------------
 
 inline bool operator<(const TotemRPRecHit &l, const TotemRPRecHit &r) {
-  if (l.getPosition() < r.getPosition())
+  if (l.position() < r.position())
     return true;
-  if (l.getPosition() > r.getPosition())
+  if (l.position() > r.position())
     return false;
 
-  if (l.getSigma() < r.getSigma())
+  if (l.sigma() < r.sigma())
     return true;
 
   return false;

--- a/DataFormats/CTPPSReco/interface/TotemRPUVPattern.h
+++ b/DataFormats/CTPPSReco/interface/TotemRPUVPattern.h
@@ -24,37 +24,37 @@ class TotemRPUVPattern {
 public:
   enum ProjectionType { projInvalid, projU, projV };
 
-  TotemRPUVPattern() : projection(projInvalid), a(0.), b(0.), w(0.), fittable(false) {}
+  TotemRPUVPattern() : projection_(projInvalid), a_(0.), b_(0.), w_(0.), fittable_(false) {}
 
-  ProjectionType getProjection() const { return projection; }
-  void setProjection(ProjectionType p_) { projection = p_; }
+  ProjectionType projection() const { return projection_; }
+  void setProjection(ProjectionType type) { projection_ = type; }
 
-  double getA() const { return a; }
-  void setA(double a_) { a = a_; }
+  double a() const { return a_; }
+  void setA(double a) { a_ = a; }
 
-  double getB() const { return b; }
-  void setB(double b_) { b = b_; }
+  double b() const { return b_; }
+  void setB(double b) { b_ = b; }
 
-  double getW() const { return w; }
-  void setW(double w_) { w = w_; }
+  double w() const { return w_; }
+  void setW(double w) { w_ = w; }
 
-  bool getFittable() const { return fittable; }
-  void setFittable(bool f_) { fittable = f_; }
+  bool fittable() const { return fittable_; }
+  void setFittable(bool fittable) { fittable_ = fittable; }
 
-  void addHit(edm::det_id_type detId, const TotemRPRecHit &hit) { hits.find_or_insert(detId).push_back(hit); }
+  void addHit(edm::det_id_type detId, const TotemRPRecHit &hit) { hits_.find_or_insert(detId).push_back(hit); }
 
-  const edm::DetSetVector<TotemRPRecHit> &getHits() const { return hits; }
+  const edm::DetSetVector<TotemRPRecHit> &hits() const { return hits_; }
 
   friend bool operator<(const TotemRPUVPattern &l, const TotemRPUVPattern &r);
 
 private:
-  ProjectionType projection;  ///< projection
-  double a;                   ///< slope in rad
-  double b;                   ///< intercept in mm
-  double w;                   ///< weight
-  bool fittable;              ///< whether this pattern is worth including in track fits
+  ProjectionType projection_;  ///< projection
+  double a_;                   ///< slope in rad
+  double b_;                   ///< intercept in mm
+  double w_;                   ///< weight
+  bool fittable_;              ///< whether this pattern is worth including in track fits
 
-  edm::DetSetVector<TotemRPRecHit> hits;  ///< hits associated with the pattern
+  edm::DetSetVector<TotemRPRecHit> hits_;  ///< hits associated with the pattern
 };
 
 //----------------------------------------------------------------------------------------------------

--- a/DataFormats/CTPPSReco/interface/TotemTimingRecHit.h
+++ b/DataFormats/CTPPSReco/interface/TotemTimingRecHit.h
@@ -13,7 +13,7 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSTimingRecHit.h"
 
 /// Reconstructed hit in Totem UFSDetectors.
-/// \note t: time computed using algorithm getTimingAlgorithm()
+/// \note t: time computed using algorithm timingAlgorithm()
 class TotemTimingRecHit : public CTPPSTimingRecHit {
 public:
   enum TimingAlgorithm { NOT_SET, CFD, SMART, SIMPLE };
@@ -42,18 +42,18 @@ public:
         mode_(mode) {}
 
   inline void setSampicThresholdTime(float stt) { sampicThresholdTime_ = stt; }
-  inline float getSampicThresholdTime() const { return sampicThresholdTime_; }
+  inline float sampicThresholdTime() const { return sampicThresholdTime_; }
 
   inline void setTPrecision(float tPrecision) { tPrecision_ = tPrecision; }
-  inline float getTPrecision() const { return tPrecision_; }
+  inline float tPrecision() const { return tPrecision_; }
 
   inline void setAmplitude(float amplitude) { amplitude_ = amplitude; }
-  inline float getAmplitude() const { return amplitude_; }
+  inline float amplitude() const { return amplitude_; }
 
   inline void setBaselineRMS(float brms) { baselineRMS_ = brms; }
-  inline float getBaselineRMS() const { return baselineRMS_; }
+  inline float baselineRMS() const { return baselineRMS_; }
 
-  inline TimingAlgorithm getTimingAlgorithm() const { return mode_; }
+  inline TimingAlgorithm timingAlgorithm() const { return mode_; }
 
 private:
   float sampicThresholdTime_, tPrecision_;

--- a/DataFormats/CTPPSReco/src/CTPPSDiamondLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSDiamondLocalTrack.cc
@@ -24,6 +24,6 @@ bool CTPPSDiamondLocalTrack::containsHit(const CTPPSDiamondRecHit& recHit, float
   if (!CTPPSTimingLocalTrack::containsHit(recHit, tolerance))
     return false;
 
-  return (recHit.getOOTIndex() == ts_index_ ||
-          recHit.getOOTIndex() == ts_index_ + CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING);
+  return (recHit.ootIndex() == ts_index_ ||
+          recHit.ootIndex() == ts_index_ + CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING);
 }

--- a/DataFormats/CTPPSReco/src/CTPPSTimingLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSTimingLocalTrack.cc
@@ -26,13 +26,13 @@ CTPPSTimingLocalTrack::CTPPSTimingLocalTrack(const math::XYZPoint& pos0,
 //--- interface member functions
 
 bool CTPPSTimingLocalTrack::containsHit(const CTPPSTimingRecHit& recHit, float tolerance, CheckDimension check) const {
-  float xTolerance = pos0_sigma_.x() + (0.5 * recHit.getXWidth()) + tolerance;
-  float yTolerance = pos0_sigma_.y() + (0.5 * recHit.getYWidth()) + tolerance;
-  float zTolerance = pos0_sigma_.z() + (0.5 * recHit.getZWidth()) + tolerance;
+  float xTolerance = pos0_sigma_.x() + (0.5 * recHit.xWidth()) + tolerance;
+  float yTolerance = pos0_sigma_.y() + (0.5 * recHit.yWidth()) + tolerance;
+  float zTolerance = pos0_sigma_.z() + (0.5 * recHit.zWidth()) + tolerance;
 
-  float xDiff = std::abs(pos0_.x() - recHit.getX());
-  float yDiff = std::abs(pos0_.y() - recHit.getY());
-  float zDiff = std::abs(pos0_.z() - recHit.getZ());
+  float xDiff = std::abs(pos0_.x() - recHit.x());
+  float yDiff = std::abs(pos0_.y() - recHit.y());
+  float zDiff = std::abs(pos0_.z() - recHit.z());
 
   switch (check) {
     case CheckDimension::x:
@@ -51,20 +51,20 @@ bool CTPPSTimingLocalTrack::containsHit(const CTPPSTimingRecHit& recHit, float t
 
 bool operator<(const CTPPSTimingLocalTrack& lhs, const CTPPSTimingLocalTrack& rhs) {
   // start to sort by temporal coordinate
-  if (lhs.getT() < rhs.getT())
+  if (lhs.t() < rhs.t())
     return true;
-  if (lhs.getT() > rhs.getT())
+  if (lhs.t() > rhs.t())
     return false;
   // then sort by x-position
-  if (lhs.getX0() < rhs.getX0())
+  if (lhs.x0() < rhs.x0())
     return true;
-  if (lhs.getX0() > rhs.getX0())
+  if (lhs.x0() > rhs.x0())
     return false;
   // ...and y-position
-  if (lhs.getY0() < rhs.getY0())
+  if (lhs.y0() < rhs.y0())
     return true;
-  if (lhs.getY0() > rhs.getY0())
+  if (lhs.y0() > rhs.y0())
     return false;
   // ...and z-position
-  return (lhs.getZ0() < rhs.getZ0());
+  return (lhs.z0() < rhs.z0());
 }

--- a/DataFormats/CTPPSReco/src/CTPPSTimingLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/CTPPSTimingLocalTrack.cc
@@ -51,9 +51,9 @@ bool CTPPSTimingLocalTrack::containsHit(const CTPPSTimingRecHit& recHit, float t
 
 bool operator<(const CTPPSTimingLocalTrack& lhs, const CTPPSTimingLocalTrack& rhs) {
   // start to sort by temporal coordinate
-  if (lhs.t() < rhs.t())
+  if (lhs.time() < rhs.time())
     return true;
-  if (lhs.t() > rhs.t())
+  if (lhs.time() > rhs.time())
     return false;
   // then sort by x-position
   if (lhs.x0() < rhs.x0())

--- a/DataFormats/CTPPSReco/src/TotemRPLocalTrack.cc
+++ b/DataFormats/CTPPSReco/src/TotemRPLocalTrack.cc
@@ -46,7 +46,7 @@ TotemRPLocalTrack::TotemRPLocalTrack(double z0,
 
 //----------------------------------------------------------------------------------------------------
 
-TVectorD TotemRPLocalTrack::getParameterVector() const {
+TVectorD TotemRPLocalTrack::parameterVector() const {
   TVectorD v(dimension);
 
   for (int i = 0; i < dimension; ++i)
@@ -64,7 +64,7 @@ void TotemRPLocalTrack::setParameterVector(const TVectorD &track_params_vector) 
 
 //----------------------------------------------------------------------------------------------------
 
-TMatrixD TotemRPLocalTrack::getCovarianceMatrix() const {
+TMatrixD TotemRPLocalTrack::covarianceMatrix() const {
   TMatrixD m(dimension, dimension);
 
   for (int i = 0; i < dimension; ++i)

--- a/DataFormats/CTPPSReco/src/TotemRPUVPattern.cc
+++ b/DataFormats/CTPPSReco/src/TotemRPUVPattern.cc
@@ -11,29 +11,29 @@
 //----------------------------------------------------------------------------------------------------
 
 bool operator<(const TotemRPUVPattern &l, const TotemRPUVPattern &r) {
-  if (l.projection < r.projection)
+  if (l.projection_ < r.projection_)
     return true;
-  if (l.projection > r.projection)
+  if (l.projection_ > r.projection_)
     return false;
 
-  if (l.a < r.a)
+  if (l.a_ < r.a_)
     return true;
-  if (l.a > r.a)
+  if (l.a_ > r.a_)
     return false;
 
-  if (l.b < r.b)
+  if (l.b_ < r.b_)
     return true;
-  if (l.b > r.b)
+  if (l.b_ > r.b_)
     return false;
 
-  if (l.w < r.w)
+  if (l.w_ < r.w_)
     return true;
-  if (l.w > r.w)
+  if (l.w_ > r.w_)
     return false;
 
-  if (l.fittable < r.fittable)
+  if (l.fittable_ < r.fittable_)
     return true;
-  if (l.fittable > r.fittable)
+  if (l.fittable_ > r.fittable_)
     return false;
 
   return false;

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -179,10 +179,53 @@
 
 <!-- common objects -->
 
-  <class name="CTPPSLocalTrackLite" ClassVersion="4">
+  <class name="CTPPSLocalTrackLite" ClassVersion="5">
     <version ClassVersion="3" checksum="3838813906"/>
     <version ClassVersion="4" checksum="2435718827"/>
+    <version ClassVersion="5" checksum="4235453685"/>
   </class>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="uint32_t rpId" target="rp_id_">
+  <![CDATA[ rp_id_ = onfile.rpId;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float x" target="x_">
+  <![CDATA[ x_ = onfile.x;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float x_unc" target="x_unc_">
+  <![CDATA[ x_unc_ = onfile.x_unc;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float y" target="y_">
+  <![CDATA[ y_ = onfile.y;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float y_unc" target="y_unc_">
+  <![CDATA[ y_unc_ = onfile.y_unc;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float tx" target="tx_">
+  <![CDATA[ tx_ = onfile.tx;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float tx_unc" target="tx_unc_">
+  <![CDATA[ tx_unc_ = onfile.tx_unc;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float ty" target="ty_">
+  <![CDATA[ ty_ = onfile.ty;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float ty_unc" target="ty_unc_">
+  <![CDATA[ ty_unc_ = onfile.ty_unc;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float chiSquaredOverNDF" target="chi2_norm_">
+  <![CDATA[ chi2_norm_ = onfile.chiSquaredOverNDF;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="CTPPSpixelLocalTrackReconstructionInfo pixelTrack_reco_info" target="pixel_track_reco_info_">
+  <![CDATA[ pixel_track_reco_info_ = onfile.pixelTrack_reco_info;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="unsigned short numberOfPointsUsedForFit" target="num_points_fit_">
+  <![CDATA[ num_points_fit_ = onfile.numberOfPointsUsedForFit;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float time" target="time_">
+  <![CDATA[ time_ = onfile.time;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float time_unc" target="time_unc_">
+  <![CDATA[ time_unc_ = onfile.time_unc;]]>
+  </ioread>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<std::vector<CTPPSLocalTrackLite>>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -162,9 +162,8 @@
     <version ClassVersion="3" checksum="4150373475"/>
     <version ClassVersion="4" checksum="298693321"/>
   </class>
-  <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit" target="numberOfPointsUsedForFit_">
-  <![CDATA[numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit;
-  ]]>
+  <ioread sourceClass="CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
+  <![CDATA[numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit_;]]>
   </ioread>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
   <class name="std::vector<CTPPSPixelLocalTrack>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -21,9 +21,25 @@
   <class name="std::vector<TotemRPRecHit>"/>
   <class name="std::vector<const TotemRPRecHit*>"/>
 
-  <class name="TotemRPUVPattern" ClassVersion="2">
+  <class name="TotemRPUVPattern" ClassVersion="3">
     <version ClassVersion="2" checksum="3530058029"/>
+    <version ClassVersion="3" checksum="1693481125"/>
   </class>
+  <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="double a" target="a_">
+  <![CDATA[ a_ = onfile.a;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="double b" target="b_">
+  <![CDATA[ b_ = onfile.b;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="double w" target="w_">
+  <![CDATA[ w_ = onfile.w;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="bool fittable" target="fittable_">
+  <![CDATA[ fittable_ = onfile.fittable;]]>
+  </ioread>
+  <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="edm::DetSetVector<TotemRPRecHit> hits" target="hits_">
+  <![CDATA[ hits_ = onfile.hits;]]>
+  </ioread>
   <class name="edm::DetSet<TotemRPUVPattern>"/>
   <class name="std::vector<TotemRPUVPattern>"/>
   <class name="std::vector<edm::DetSet<TotemRPUVPattern> >"/>
@@ -143,7 +159,7 @@
   <class name="edm::Wrapper<edm::DetSetVector<CTPPSPixelRecHit> >"/>
 
   <class name="CTPPSPixelLocalTrack" ClassVersion="4">
-    <version ClassVersion="3" checksum="4150373475"/>    
+    <version ClassVersion="3" checksum="4150373475"/>
     <version ClassVersion="4" checksum="298693321"/>
   </class>
   <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
@@ -164,7 +180,7 @@
 <!-- common objects -->
 
   <class name="CTPPSLocalTrackLite" ClassVersion="4">
-    <version ClassVersion="3" checksum="3838813906"/>    
+    <version ClassVersion="3" checksum="3838813906"/>
     <version ClassVersion="4" checksum="2435718827"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -26,19 +26,19 @@
     <version ClassVersion="3" checksum="1693481125"/>
   </class>
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="double a" target="a_">
-  <![CDATA[ a_ = onfile.a;]]>
+  <![CDATA[a_ = onfile.a;]]>
   </ioread>
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="double b" target="b_">
-  <![CDATA[ b_ = onfile.b;]]>
+  <![CDATA[b_ = onfile.b;]]>
   </ioread>
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="double w" target="w_">
-  <![CDATA[ w_ = onfile.w;]]>
+  <![CDATA[w_ = onfile.w;]]>
   </ioread>
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="bool fittable" target="fittable_">
-  <![CDATA[ fittable_ = onfile.fittable;]]>
+  <![CDATA[fittable_ = onfile.fittable;]]>
   </ioread>
   <ioread sourceClass="TotemRPUVPattern" version="[2]" targetClass="TotemRPUVPattern" source="edm::DetSetVector<TotemRPRecHit> hits" target="hits_">
-  <![CDATA[ hits_ = onfile.hits;]]>
+  <![CDATA[hits_ = onfile.hits;]]>
   </ioread>
   <class name="edm::DetSet<TotemRPUVPattern>"/>
   <class name="std::vector<TotemRPUVPattern>"/>
@@ -162,8 +162,8 @@
     <version ClassVersion="3" checksum="4150373475"/>
     <version ClassVersion="4" checksum="298693321"/>
   </class>
-  <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit_" target="numberOfPointsUsedForFit_">
-  <![CDATA[ numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit_;
+  <ioread sourceClass = "CTPPSPixelLocalTrack" version="[3]" targetClass="CTPPSPixelLocalTrack" source="int numberOfPointUsedForFit" target="numberOfPointsUsedForFit_">
+  <![CDATA[numberOfPointsUsedForFit_ = onfile.numberOfPointUsedForFit;
   ]]>
   </ioread>
   <class name="edm::DetSet<CTPPSPixelLocalTrack>"/>
@@ -184,47 +184,47 @@
     <version ClassVersion="4" checksum="2435718827"/>
     <version ClassVersion="5" checksum="4235453685"/>
   </class>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="uint32_t rpId" target="rp_id_">
-  <![CDATA[ rp_id_ = onfile.rpId;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="uint32_t rpId" target="rp_id_">
+  <![CDATA[rp_id_ = onfile.rpId;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float x" target="x_">
-  <![CDATA[ x_ = onfile.x;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float x" target="x_">
+  <![CDATA[x_ = onfile.x;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float x_unc" target="x_unc_">
-  <![CDATA[ x_unc_ = onfile.x_unc;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float x_unc" target="x_unc_">
+  <![CDATA[x_unc_ = onfile.x_unc;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float y" target="y_">
-  <![CDATA[ y_ = onfile.y;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float y" target="y_">
+  <![CDATA[y_ = onfile.y;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float y_unc" target="y_unc_">
-  <![CDATA[ y_unc_ = onfile.y_unc;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float y_unc" target="y_unc_">
+  <![CDATA[y_unc_ = onfile.y_unc;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float tx" target="tx_">
-  <![CDATA[ tx_ = onfile.tx;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float tx" target="tx_">
+  <![CDATA[tx_ = onfile.tx;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float tx_unc" target="tx_unc_">
-  <![CDATA[ tx_unc_ = onfile.tx_unc;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float tx_unc" target="tx_unc_">
+  <![CDATA[tx_unc_ = onfile.tx_unc;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float ty" target="ty_">
-  <![CDATA[ ty_ = onfile.ty;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float ty" target="ty_">
+  <![CDATA[ty_ = onfile.ty;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float ty_unc" target="ty_unc_">
-  <![CDATA[ ty_unc_ = onfile.ty_unc;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float ty_unc" target="ty_unc_">
+  <![CDATA[ty_unc_ = onfile.ty_unc;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float chiSquaredOverNDF" target="chi2_norm_">
-  <![CDATA[ chi2_norm_ = onfile.chiSquaredOverNDF;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float chiSquaredOverNDF" target="chi2_norm_">
+  <![CDATA[chi2_norm_ = onfile.chiSquaredOverNDF;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="CTPPSpixelLocalTrackReconstructionInfo pixelTrack_reco_info" target="pixel_track_reco_info_">
-  <![CDATA[ pixel_track_reco_info_ = onfile.pixelTrack_reco_info;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="CTPPSpixelLocalTrackReconstructionInfo pixelTrack_reco_info" target="pixel_track_reco_info_">
+  <![CDATA[pixel_track_reco_info_ = onfile.pixelTrack_reco_info;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="unsigned short numberOfPointsUsedForFit" target="num_points_fit_">
-  <![CDATA[ num_points_fit_ = onfile.numberOfPointsUsedForFit;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="unsigned short numberOfPointsUsedForFit" target="num_points_fit_">
+  <![CDATA[num_points_fit_ = onfile.numberOfPointsUsedForFit;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float time" target="time_">
-  <![CDATA[ time_ = onfile.time;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float time" target="time_">
+  <![CDATA[time_ = onfile.time;]]>
   </ioread>
-  <ioread sourceClass="TotemRPUVPattern" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float time_unc" target="time_unc_">
-  <![CDATA[ time_unc_ = onfile.time_unc;]]>
+  <ioread sourceClass="CTPPSLocalTrackLite" version="[3-4]" targetClass="CTPPSLocalTrackLite" source="float time_unc" target="time_unc_">
+  <![CDATA[time_unc_ = onfile.time_unc;]]>
   </ioread>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSTotemDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSTotemDataFormatter.cc
@@ -54,7 +54,7 @@ void CTPPSTotemDataFormatter::formatRawData(unsigned int lvl1_ID,
     for (auto const &it : detDigis) {
       m_DigiCounter++;
       const int nCH = 128;
-      int nStrip = it.getStripNumber();
+      int nStrip = it.stripNumber();
       int chipPosition = nStrip / nCH;
       int channel = nStrip - chipPosition * nCH;        //channel from DIGI
       uint32_t newrawId = rawId + 8192 * chipPosition;  //8192 - distance between chipIds

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -191,7 +191,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &input,
     // calculate ids
     TotemRPDetId chipId(record.info->symbolicID.symbolicID);
     uint8_t chipPosition = chipId.chip();
-    TotemRPDetId detId = chipId.getPlaneId();
+    TotemRPDetId detId = chipId.planeId();
 
     // update chipPosition in status
     record.status.setChipPosition(chipPosition);

--- a/Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h
@@ -58,12 +58,12 @@ public:
 
   ///\brief returns geometry of a detector
   /// performs necessary checks, returns NULL if fails
-  const DetGeomDesc* getSensor(unsigned int id) const;
-  const DetGeomDesc* getSensorNoThrow(unsigned int id) const noexcept;
+  const DetGeomDesc* sensor(unsigned int id) const;
+  const DetGeomDesc* sensorNoThrow(unsigned int id) const noexcept;
 
   /// returns geometry of a RP box
-  const DetGeomDesc* getRP(unsigned int id) const;
-  const DetGeomDesc* getRPNoThrow(unsigned int id) const noexcept;
+  const DetGeomDesc* rp(unsigned int id) const;
+  const DetGeomDesc* rpNoThrow(unsigned int id) const noexcept;
 
   //----- objects iterators
 
@@ -96,20 +96,20 @@ public:
 
   /// returns translation (position) of a detector
   /// \param id sensor id
-  CLHEP::Hep3Vector getSensorTranslation(unsigned int id) const;
+  CLHEP::Hep3Vector sensorTranslation(unsigned int id) const;
 
   /// returns position of a RP box
   /// \param id RP id
-  CLHEP::Hep3Vector getRPTranslation(unsigned int id) const;
+  CLHEP::Hep3Vector rpTranslation(unsigned int id) const;
 
   /// after checks returns set of station ids corresponding to the given arm id
-  const std::set<unsigned int>& getStationsInArm(unsigned int) const;
+  const std::set<unsigned int>& stationsInArm(unsigned int) const;
 
   /// after checks returns set of RP ids corresponding to the given station id
-  const std::set<unsigned int>& getRPsInStation(unsigned int) const;
+  const std::set<unsigned int>& rpsInStation(unsigned int) const;
 
   /// after checks returns set of sensor ids corresponding to the given RP id
-  const std::set<unsigned int>& getSensorsInRP(unsigned int) const;
+  const std::set<unsigned int>& sensorsInRP(unsigned int) const;
 
 protected:
   /// map: sensor id --> DetGeomDesc

--- a/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
@@ -45,9 +45,9 @@ void CTPPSGeometry::build(const DetGeomDesc* gD) {
   // build sets
   for (const auto& it : sensors_map_) {
     const CTPPSDetId detId(it.first);
-    const CTPPSDetId rpId = detId.getRPId();
-    const CTPPSDetId stId = detId.getStationId();
-    const CTPPSDetId armId = detId.getArmId();
+    const CTPPSDetId rpId = detId.rpId();
+    const CTPPSDetId stId = detId.stationId();
+    const CTPPSDetId armId = detId.armId();
 
     stations_in_arm_[armId].insert(armId);
     rps_in_station_[stId].insert(rpId);
@@ -77,8 +77,8 @@ bool CTPPSGeometry::addRP(unsigned int id, const DetGeomDesc*& gD) {
 
 //----------------------------------------------------------------------------------------------------
 
-const DetGeomDesc* CTPPSGeometry::getSensor(unsigned int id) const {
-  auto g = getSensorNoThrow(id);
+const DetGeomDesc* CTPPSGeometry::sensor(unsigned int id) const {
+  auto g = sensorNoThrow(id);
   if (nullptr == g) {
     throw cms::Exception("CTPPSGeometry") << "Not found detector with ID " << id << ", i.e. " << CTPPSDetId(id);
   }
@@ -87,7 +87,7 @@ const DetGeomDesc* CTPPSGeometry::getSensor(unsigned int id) const {
 
 //----------------------------------------------------------------------------------------------------
 
-const DetGeomDesc* CTPPSGeometry::getSensorNoThrow(unsigned int id) const noexcept {
+const DetGeomDesc* CTPPSGeometry::sensorNoThrow(unsigned int id) const noexcept {
   auto it = sensors_map_.find(id);
   if (it == sensors_map_.end()) {
     return nullptr;
@@ -97,8 +97,8 @@ const DetGeomDesc* CTPPSGeometry::getSensorNoThrow(unsigned int id) const noexce
 
 //----------------------------------------------------------------------------------------------------
 
-const DetGeomDesc* CTPPSGeometry::getRP(unsigned int id) const {
-  auto rp = getRPNoThrow(id);
+const DetGeomDesc* CTPPSGeometry::rp(unsigned int id) const {
+  auto rp = rpNoThrow(id);
   if (nullptr == rp) {
     throw cms::Exception("CTPPSGeometry") << "Not found RP device with ID " << id << ", i.e. " << CTPPSDetId(id);
   }
@@ -107,7 +107,7 @@ const DetGeomDesc* CTPPSGeometry::getRP(unsigned int id) const {
 
 //----------------------------------------------------------------------------------------------------
 
-const DetGeomDesc* CTPPSGeometry::getRPNoThrow(unsigned int id) const noexcept {
+const DetGeomDesc* CTPPSGeometry::rpNoThrow(unsigned int id) const noexcept {
   auto it = rps_map_.find(id);
   if (it == rps_map_.end()) {
     return nullptr;
@@ -117,7 +117,7 @@ const DetGeomDesc* CTPPSGeometry::getRPNoThrow(unsigned int id) const noexcept {
 }
 
 //----------------------------------------------------------------------------------------------------
-const std::set<unsigned int>& CTPPSGeometry::getStationsInArm(unsigned int id) const {
+const std::set<unsigned int>& CTPPSGeometry::stationsInArm(unsigned int id) const {
   auto it = stations_in_arm_.find(id);
   if (it == stations_in_arm_.end())
     throw cms::Exception("CTPPSGeometry") << "Arm with ID " << id << " not found.";
@@ -126,7 +126,7 @@ const std::set<unsigned int>& CTPPSGeometry::getStationsInArm(unsigned int id) c
 
 //----------------------------------------------------------------------------------------------------
 
-const std::set<unsigned int>& CTPPSGeometry::getRPsInStation(unsigned int id) const {
+const std::set<unsigned int>& CTPPSGeometry::rpsInStation(unsigned int id) const {
   auto it = rps_in_station_.find(id);
   if (it == rps_in_station_.end())
     throw cms::Exception("CTPPSGeometry") << "Station with ID " << id << " not found.";
@@ -135,7 +135,7 @@ const std::set<unsigned int>& CTPPSGeometry::getRPsInStation(unsigned int id) co
 
 //----------------------------------------------------------------------------------------------------
 
-const std::set<unsigned int>& CTPPSGeometry::getSensorsInRP(unsigned int id) const {
+const std::set<unsigned int>& CTPPSGeometry::sensorsInRP(unsigned int id) const {
   auto it = dets_in_rp_.find(id);
   if (it == dets_in_rp_.end())
     throw cms::Exception("CTPPSGeometry") << "RP with ID " << id << " not found.";
@@ -151,7 +151,7 @@ CLHEP::Hep3Vector CTPPSGeometry::localToGlobal(const DetGeomDesc* gd, const CLHE
 //----------------------------------------------------------------------------------------------------
 
 CLHEP::Hep3Vector CTPPSGeometry::localToGlobal(unsigned int id, const CLHEP::Hep3Vector& r) const {
-  return localToGlobal(getSensor(id), r);
+  return localToGlobal(sensor(id), r);
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -164,31 +164,31 @@ CLHEP::Hep3Vector CTPPSGeometry::globalToLocal(const DetGeomDesc* gd, const CLHE
 //----------------------------------------------------------------------------------------------------
 
 CLHEP::Hep3Vector CTPPSGeometry::globalToLocal(unsigned int id, const CLHEP::Hep3Vector& r) const {
-  return globalToLocal(getSensor(id), r);
+  return globalToLocal(sensor(id), r);
 }
 
 //----------------------------------------------------------------------------------------------------
 
 CLHEP::Hep3Vector CTPPSGeometry::localToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const {
-  return getSensor(id)->rotation() * dir;
+  return sensor(id)->rotation() * dir;
 }
 
 //----------------------------------------------------------------------------------------------------
 
 CLHEP::Hep3Vector CTPPSGeometry::globalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const {
-  return getSensor(id)->rotation().Inverse() * dir;
+  return sensor(id)->rotation().Inverse() * dir;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::getSensorTranslation(unsigned int id) const {
-  auto gd = getSensor(id);
+CLHEP::Hep3Vector CTPPSGeometry::sensorTranslation(unsigned int id) const {
+  auto gd = sensor(id);
   return CLHEP::Hep3Vector(gd->translation().x(), gd->translation().y(), gd->translation().z());
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::getRPTranslation(unsigned int id) const {
-  auto gd = getRP(id);
+CLHEP::Hep3Vector CTPPSGeometry::rpTranslation(unsigned int id) const {
+  auto gd = rp(id);
   return CLHEP::Hep3Vector(gd->translation().x(), gd->translation().y(), gd->translation().z());
 }

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -238,7 +238,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
     trackFinder_->setRomanPotId(romanPotId);
     trackFinder_->setHits(&hitOnPlaneMap);
     trackFinder_->setGeometry(&geometry);
-    trackFinder_->setZ0(geometry.getRPTranslation(romanPotId).z());
+    trackFinder_->setZ0(geometry.rpTranslation(romanPotId).z());
     trackFinder_->findTracks(iEvent.getRun().id().run());
     std::vector<CTPPSPixelLocalTrack> tmpTracksVector = trackFinder_->getLocalTracks();
 

--- a/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoCTPPS/PixelLocal/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -164,7 +164,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
     if (verbosity_ > 2)
       edm::LogInfo("CTPPSPixelLocalTrackProducer")
           << "Hits found in plane = " << recHitSet.detId() << " number = " << recHitSet.size();
-    CTPPSPixelDetId tmpRomanPotId = CTPPSPixelDetId(recHitSet.detId()).getRPId();
+    CTPPSPixelDetId tmpRomanPotId = CTPPSPixelDetId(recHitSet.detId()).rpId();
     uint32_t hitOnPlane = recHitSet.size();
 
     //Get the number of hits per pot
@@ -185,7 +185,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
   //remove rechit for pot with too many hits or containing planes with too many hits
   for (const auto &recHitSet : recHitVector) {
     const auto tmpDetectorId = CTPPSPixelDetId(recHitSet.detId());
-    const auto tmpRomanPotId = tmpDetectorId.getRPId();
+    const auto tmpRomanPotId = tmpDetectorId.rpId();
 
     if ((maxHitPerRomanPot_ >= 0 && mapHitPerPot[tmpRomanPotId] > (uint32_t)maxHitPerRomanPot_) ||
         find(listOfPotWithHighOccupancyPlanes.begin(), listOfPotWithHighOccupancyPlanes.end(), tmpRomanPotId) !=
@@ -210,7 +210,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
 
   for (const auto &pattern : patternVector) {
     CTPPSPixelDetId firstHitDetId = CTPPSPixelDetId(pattern.at(0).detId);
-    CTPPSPixelDetId romanPotId = firstHitDetId.getRPId();
+    CTPPSPixelDetId romanPotId = firstHitDetId.rpId();
 
     std::map<CTPPSPixelDetId, std::vector<RPixDetPatternFinder::PointInPlane>>
         hitOnPlaneMap;  //hit of the pattern organized by plane
@@ -218,7 +218,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
     //loop on all the hits of the pattern
     for (const auto &hit : pattern) {
       CTPPSPixelDetId hitDetId = CTPPSPixelDetId(hit.detId);
-      CTPPSPixelDetId tmpRomanPotId = hitDetId.getRPId();
+      CTPPSPixelDetId tmpRomanPotId = hitDetId.rpId();
 
       if (tmpRomanPotId != romanPotId) {  //check that the hits belong to the same tracking station
         throw cms::Exception("CTPPSPixelLocalTrackProducer")

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -310,7 +310,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
         math::Vector<3>::type maxGlobalPointDistance(
             maximumXLocalDistanceFromTrack_, maximumYLocalDistanceFromTrack_, 0.);
 
-        DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(tmpPlaneId)->rotation();
+        DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->sensor(tmpPlaneId)->rotation();
         AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
         theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0),
                                         tmpPlaneRotationMatrixMap(0, 1),
@@ -607,7 +607,7 @@ bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack
   math::Vector<3>::type pointOnPlane(tmpPointOnPlane.x(), tmpPointOnPlane.y(), tmpPointOnPlane.z());
   math::Vector<3>::type planeUnitVector(0., 0., 1.);
 
-  DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(planeId)->rotation();
+  DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->sensor(planeId)->rotation();
   AlgebraicMatrix33 tmpPlaneRotationMatrixMap;
   theRotationMatrix.GetComponents(tmpPlaneRotationMatrixMap(0, 0),
                                   tmpPlaneRotationMatrixMap(0, 1),

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -188,7 +188,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
           << "Number of combinations of trackMinNumberOfPoints_ planes " << mapOfAllMinRequiredPoint.size();
     for (const auto &pointsAndRef : mapOfAllMinRequiredPoint) {
       CTPPSPixelLocalTrack tmpTrack = fitTrack(pointsAndRef.second);
-      double tmpChiSquaredOverNDF = tmpTrack.getChiSquaredOverNDF();
+      double tmpChiSquaredOverNDF = tmpTrack.chiSquaredOverNDF();
       if (verbosity_ >= 2)
         edm::LogInfo("RPixPlaneCombinatoryTracking") << "ChiSquare of the present track " << tmpChiSquaredOverNDF;
       if (!tmpTrack.isValid() || tmpChiSquaredOverNDF > maximumChi2OverNDF_ || tmpChiSquaredOverNDF == 0.)
@@ -259,7 +259,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
       if (foundTrackWithCurrentNumberOfPlanes && tmpNumberOfPlanes < currentNumberOfPlanes)
         break;
       CTPPSPixelLocalTrack tmpTrack = fitTrack(pointsAndRef.second);
-      double tmpChiSquaredOverNDF = tmpTrack.getChiSquaredOverNDF();
+      double tmpChiSquaredOverNDF = tmpTrack.chiSquaredOverNDF();
       if (!tmpTrack.isValid() || tmpChiSquaredOverNDF > maximumChi2OverNDF_ || tmpChiSquaredOverNDF == 0.)
         continue;  //validity check
       if (tmpChiSquaredOverNDF < theMinChiSquaredOverNDF) {
@@ -272,7 +272,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
     }
 
     if (verbosity_ >= 1)
-      edm::LogInfo("RPixPlaneCombinatoryTracking") << "The best track has " << bestTrack.getNDF() / 2 + 2;
+      edm::LogInfo("RPixPlaneCombinatoryTracking") << "The best track has " << bestTrack.ndf() / 2 + 2;
 
     std::vector<uint32_t> listOfPlaneNotUsedForFit = listOfAllPlanes_;
     //remove the hits belonging to the tracks from the full list of hits
@@ -358,11 +358,11 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
     int pointOnTrack = 0;
 
     if (verbosity_ >= 1) {
-      for (const auto &planeHits : bestTrack.getHits()) {
+      for (const auto &planeHits : bestTrack.hits()) {
         for (const auto &fittedhit : planeHits) {
-          if (fittedhit.getIsUsedForFit())
+          if (fittedhit.isUsedForFit())
             ++pointForTracking;
-          if (fittedhit.getIsRealHit())
+          if (fittedhit.isRealHit())
             ++pointOnTrack;
         }
       }
@@ -441,13 +441,13 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
     unsigned short bxNonShiftedPlanesUsed = 0;
     unsigned short hitInShiftedROC = 0;
 
-    auto const &fittedHits = track.getHits();
+    auto const &fittedHits = track.hits();
     auto const &planeFlags = (shiftStatusInitialRun->second).at(romanPotId_);
 
     for (const auto &planeHits : fittedHits) {
       unsigned short plane = CTPPSPixelDetId(planeHits.detId()).plane();
       for (const auto &hit : planeHits) {
-        if (hit.getIsUsedForFit()) {
+        if (hit.isUsedForFit()) {
           if (pixelIndices.getROCId(hit.minPixelCol(), hit.minPixelRow()) == shiftedROC)
             hitInShiftedROC++;  // Count how many hits are in the shifted ROC
           if (planeFlags.at(plane))
@@ -482,7 +482,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
                                                            << "More than six points found for a track, skipping.";
       continue;
     }
-    if (track.getRecoInfo() == CTPPSpixelLocalTrackReconstructionInfo::invalid) {
+    if (track.recoInfo() == CTPPSpixelLocalTrackReconstructionInfo::invalid) {
       throw cms::Exception("RPixPlaneCombinatoryTracking") << "Error in RPixPlaneCombinatoryTracking::findTracks -> "
                                                            << "recoInfo has not been set properly.";
     }
@@ -493,7 +493,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
           << "\nFirst run with this bx-shift configuration: " << shiftStatusInitialRun->first
           << "\nTrack reconstructed with: " << bxShiftedPlanesUsed << " bx-shifted planes, " << bxNonShiftedPlanesUsed
           << " non-bx-shifted planes, " << hitInShiftedROC << " hits in the bx-shifted ROC"
-          << "\nrecoInfo = " << (unsigned short)track.getRecoInfo();
+          << "\nrecoInfo = " << (unsigned short)track.recoInfo();
       if (planeFlags != std::vector<bool>(6, false))
         edm::LogInfo("RPixPlaneCombinatoryTracking") << "The shifted ROC is ROC" << shiftedROC;
     }
@@ -594,11 +594,11 @@ CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList poi
 bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack *track,
                                                             CTPPSPixelDetId planeId,
                                                             GlobalPoint &planeLineIntercept) {
-  double z0 = track->getZ0();
-  CTPPSPixelLocalTrack::ParameterVector parameters = track->getParameterVector();
+  double z0 = track->z0();
+  CTPPSPixelLocalTrack::ParameterVector parameters = track->parameterVector();
 
   math::Vector<3>::type pointOnLine(parameters[0], parameters[1], z0);
-  GlobalVector tmpLineUnitVector = track->getDirectionVector();
+  GlobalVector tmpLineUnitVector = track->directionVector();
   math::Vector<3>::type lineUnitVector(tmpLineUnitVector.x(), tmpLineUnitVector.y(), tmpLineUnitVector.z());
 
   CLHEP::Hep3Vector tmpPointLocal(0., 0., 0.);

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -62,7 +62,7 @@ void RPixRoadFinder::findPattern() {
       if (verbosity_ > 2)
         edm::LogInfo("RPixRoadFinder") << "Hits = " << ds_rh2.data.size();
 
-      DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->getSensor(myid)->rotation();
+      DetGeomDesc::RotationMatrix theRotationMatrix = geometry_->sensor(myid)->rotation();
       AlgebraicMatrix33 theRotationTMatrix;
       theRotationMatrix.GetComponents(theRotationTMatrix(0, 0),
                                       theRotationTMatrix(0, 1),

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -98,7 +98,7 @@ void RPixRoadFinder::findPattern() {
     while (it_gh2 != temp_all_hits.end()) {
       bool same_pot = false;
       CTPPSPixelDetId tmpGh2Id = CTPPSPixelDetId(it_gh2->detId);
-      if (currDet.getRPId() == tmpGh2Id.getRPId())
+      if (currDet.rpId() == tmpGh2Id.rpId())
         same_pot = true;
       CLHEP::Hep3Vector subtraction = currPoint - it_gh2->globalPoint;
 

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -47,14 +47,14 @@ void RPixRoadFinder::findPattern() {
   for (const auto& ds_rh2 : *hitVector_) {
     const auto myid = CTPPSPixelDetId(ds_rh2.id);
     for (const auto& it_rh : ds_rh2.data) {
-      CLHEP::Hep3Vector localV(it_rh.getPoint().x(), it_rh.getPoint().y(), it_rh.getPoint().z());
+      CLHEP::Hep3Vector localV(it_rh.point().x(), it_rh.point().y(), it_rh.point().z());
       CLHEP::Hep3Vector globalV = geometry_->localToGlobal(ds_rh2.id, localV);
       math::Error<3>::type localError;
-      localError[0][0] = it_rh.getError().xx();
-      localError[0][1] = it_rh.getError().xy();
+      localError[0][0] = it_rh.error().xx();
+      localError[0][1] = it_rh.error().xy();
       localError[0][2] = 0.;
-      localError[1][0] = it_rh.getError().xy();
-      localError[1][1] = it_rh.getError().yy();
+      localError[1][0] = it_rh.error().xy();
+      localError[1][1] = it_rh.error().yy();
       localError[1][2] = 0.;
       localError[2][0] = 0.;
       localError[2][1] = 0.;

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -339,8 +339,8 @@ void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
             const auto &tr_i = hTracks->at(i);
             const auto &tr_j = hTracks->at(j);
 
-            const double z_i = hGeometry->getRPTranslation(tr_i.rpId()).z();
-            const double z_j = hGeometry->getRPTranslation(tr_j.rpId()).z();
+            const double z_i = hGeometry->rpTranslation(tr_i.rpId()).z();
+            const double z_j = hGeometry->rpTranslation(tr_j.rpId()).z();
 
             for (const auto &ti : timingSelection[arm_it.first]) {
               const auto &tr_ti = hTracks->at(ti);
@@ -350,7 +350,7 @@ void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
                 continue;
 
               // interpolation from tracking RPs
-              const double z_ti = -hGeometry->getRPTranslation(tr_ti.rpId())
+              const double z_ti = -hGeometry->rpTranslation(tr_ti.rpId())
                                        .z();  // the minus sign fixes a bug in the diamond geometry
               const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
               const double x_inter = f_i * tr_i.x() + f_j * tr_j.x();

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -350,8 +350,8 @@ void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
                 continue;
 
               // interpolation from tracking RPs
-              const double z_ti = -hGeometry->rpTranslation(tr_ti.rpId())
-                                       .z();  // the minus sign fixes a bug in the diamond geometry
+              const double z_ti =
+                  -hGeometry->rpTranslation(tr_ti.rpId()).z();  // the minus sign fixes a bug in the diamond geometry
               const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
               const double x_inter = f_i * tr_i.x() + f_j * tr_j.x();
               const double x_inter_unc_sq =

--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -130,8 +130,8 @@ double ProtonReconstructionAlgorithm::ChiSquareCalculator::operator()(const doub
     const double y = k_out.y - oit->second.y0;
 
     // calculate chi^2 contributions, convert track data mm --> cm
-    const double x_diff_norm = (x - track->x() * 1E-1) / (track->yUnc() * 1E-1);
-    const double y_diff_norm = (y - track->x() * 1E-1) / (track->yUnc() * 1E-1);
+    const double x_diff_norm = (x - track->x() * 1E-1) / (track->xUnc() * 1E-1);
+    const double y_diff_norm = (y - track->y() * 1E-1) / (track->yUnc() * 1E-1);
 
     // increase chi^2
     s2 += x_diff_norm * x_diff_norm + y_diff_norm * y_diff_norm;

--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -118,7 +118,7 @@ double ProtonReconstructionAlgorithm::ChiSquareCalculator::operator()(const doub
   double s2 = 0.;
 
   for (const auto &track : *tracks) {
-    const CTPPSDetId rpId(track->getRPId());
+    const CTPPSDetId rpId(track->rpId());
 
     // transport proton to the RP
     auto oit = m_rp_optics->find(rpId);
@@ -130,8 +130,8 @@ double ProtonReconstructionAlgorithm::ChiSquareCalculator::operator()(const doub
     const double y = k_out.y - oit->second.y0;
 
     // calculate chi^2 contributions, convert track data mm --> cm
-    const double x_diff_norm = (x - track->getX() * 1E-1) / (track->getXUnc() * 1E-1);
-    const double y_diff_norm = (y - track->getY() * 1E-1) / (track->getYUnc() * 1E-1);
+    const double x_diff_norm = (x - track->x() * 1E-1) / (track->yUnc() * 1E-1);
+    const double y_diff_norm = (y - track->x() * 1E-1) / (track->yUnc() * 1E-1);
 
     // increase chi^2
     s2 += x_diff_norm * x_diff_norm + y_diff_norm * y_diff_norm;
@@ -147,21 +147,21 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
                                                                           std::ostream &os) const {
   // make sure optics is available for all tracks
   for (const auto &it : tracks) {
-    auto oit = m_rp_optics_.find(it->getRPId());
+    auto oit = m_rp_optics_.find(it->rpId());
     if (oit == m_rp_optics_.end())
       throw cms::Exception("ProtonReconstructionAlgorithm")
-          << "Optics data not available for RP " << it->getRPId() << ", i.e. " << CTPPSDetId(it->getRPId()) << ".";
+          << "Optics data not available for RP " << it->rpId() << ", i.e. " << CTPPSDetId(it->rpId()) << ".";
   }
 
   // initial estimate of xi and th_x
   double xi_init = 0., th_x_init = 0.;
 
   if (useImprovedInitialEstimate_) {
-    double x_N = tracks[0]->getX() * 1E-1,  // conversion: mm --> cm
-        x_F = tracks[1]->getX() * 1E-1;
+    double x_N = tracks[0]->x() * 1E-1,  // conversion: mm --> cm
+        x_F = tracks[1]->x() * 1E-1;
 
-    const RPOpticsData &i_N = m_rp_optics_.find(tracks[0]->getRPId())->second,
-                       &i_F = m_rp_optics_.find(tracks[1]->getRPId())->second;
+    const RPOpticsData &i_N = m_rp_optics_.find(tracks[0]->rpId())->second,
+                       &i_F = m_rp_optics_.find(tracks[1]->rpId())->second;
 
     const double a = i_F.ch1 * i_N.la1 - i_N.ch1 * i_F.la1;
     const double b =
@@ -175,8 +175,8 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
   } else {
     double s_xi0 = 0., s_1 = 0.;
     for (const auto &track : tracks) {
-      auto oit = m_rp_optics_.find(track->getRPId());
-      double xi = oit->second.s_xi_vs_x_d->Eval(track->getX() * 1E-1 + oit->second.x0);  // conversion: mm --> cm
+      auto oit = m_rp_optics_.find(track->rpId());
+      double xi = oit->second.s_xi_vs_x_d->Eval(track->x() * 1E-1 + oit->second.x0);  // conversion: mm --> cm
 
       s_1 += 1.;
       s_xi0 += xi;
@@ -197,9 +197,9 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
     if (y_idx >= 2)
       break;
 
-    auto oit = m_rp_optics_.find(track->getRPId());
+    auto oit = m_rp_optics_.find(track->rpId());
 
-    y[y_idx] = track->getY() * 1E-1 - oit->second.s_y_d_vs_xi->Eval(xi_init);  // track y: mm --> cm
+    y[y_idx] = track->y() * 1E-1 - oit->second.s_y_d_vs_xi->Eval(xi_init);  // track y: mm --> cm
     v_y[y_idx] = oit->second.s_v_y_vs_xi->Eval(xi_init);
     L_y[y_idx] = oit->second.s_L_y_vs_xi->Eval(xi_init);
 
@@ -223,7 +223,7 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
   if (!std::isfinite(th_y_init))
     th_y_init = 0.;
 
-  unsigned int armId = CTPPSDetId((*tracks.begin())->getRPId()).arm();
+  unsigned int armId = CTPPSDetId((*tracks.begin())->rpId()).arm();
 
   if (verbosity_)
     os << "ProtonReconstructionAlgorithm::reconstructFromMultiRP(" << armId << ")" << std::endl
@@ -297,30 +297,30 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
 reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const CTPPSLocalTrackLiteRef &track,
                                                                            const LHCInfo &lhcInfo,
                                                                            std::ostream &os) const {
-  CTPPSDetId rpId(track->getRPId());
+  CTPPSDetId rpId(track->rpId());
 
   if (verbosity_)
     os << "reconstructFromSingleRP(" << rpId.arm() * 100 + rpId.station() * 10 + rpId.rp() << ")" << std::endl;
 
   // make sure optics is available for the track
-  auto oit = m_rp_optics_.find(track->getRPId());
+  auto oit = m_rp_optics_.find(track->rpId());
   if (oit == m_rp_optics_.end())
     throw cms::Exception("ProtonReconstructionAlgorithm")
-        << "Optics data not available for RP " << track->getRPId() << ", i.e. " << rpId << ".";
+        << "Optics data not available for RP " << track->rpId() << ", i.e. " << rpId << ".";
 
   // rough estimate of xi and th_y from each track
-  const double x_full = track->getX() * 1E-1 + oit->second.x0;  // conversion mm --> cm
+  const double x_full = track->x() * 1E-1 + oit->second.x0;  // conversion mm --> cm
   const double xi = oit->second.s_xi_vs_x_d->Eval(x_full);
   const double L_y = oit->second.s_L_y_vs_xi->Eval(xi);
-  const double th_y = track->getY() * 1E-1 / L_y;  // conversion mm --> cm
+  const double th_y = track->y() * 1E-1 / L_y;  // conversion mm --> cm
 
   const double ep_x = 1E-6;
   const double dxi_dx = (oit->second.s_xi_vs_x_d->Eval(x_full + ep_x) - xi) / ep_x;
-  const double xi_unc = abs(dxi_dx) * track->getXUnc() * 1E-1;  // conversion mm --> cm
+  const double xi_unc = abs(dxi_dx) * track->xUnc() * 1E-1;  // conversion mm --> cm
 
   const double ep_xi = 1E-4;
   const double dL_y_dxi = (oit->second.s_L_y_vs_xi->Eval(xi + ep_xi) - L_y) / ep_xi;
-  const double th_y_unc = th_y * sqrt(pow(track->getYUnc() / track->getY(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.));
+  const double th_y_unc = th_y * sqrt(pow(track->yUnc() / track->y(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.));
 
   if (verbosity_)
     os << "    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << th_y_unc << "." << std::endl;
@@ -328,7 +328,7 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const
   using FP = reco::ForwardProton;
 
   // save proton candidate
-  const double sign_z = (CTPPSDetId(track->getRPId()).arm() == 0) ? +1. : -1.;  // CMS convention
+  const double sign_z = (CTPPSDetId(track->rpId()).arm() == 0) ? +1. : -1.;  // CMS convention
   const FP::Point vertex(0., 0., 0.);
   const double cos_th = sqrt(1. - th_y * th_y);
   const double p = lhcInfo.energy() * (1. - xi);

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSTimingTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSTimingTrackRecognition.h
@@ -235,7 +235,7 @@ inline bool CTPPSTimingTrackRecognition<TRACK_TYPE, HIT_TYPE>::timeEval(const Hi
     if (hit.tPrecision() <= 0.)
       continue;
     const float weight = std::pow(hit.tPrecision(), -2);
-    mean_num += weight * hit.t();
+    mean_num += weight * hit.time();
     mean_denom += weight;
     valid_hits = true;  // at least one valid hit to account for
   }

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSTimingTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSTimingTrackRecognition.h
@@ -200,9 +200,9 @@ CTPPSTimingTrackRecognition<TRACK_TYPE, HIT_TYPE>::getHitSpatialRange(const HitV
   SpatialRange result;
 
   for (const auto& hit : hits) {
-    const float xBegin = hit.getX() - 0.5f * hit.getXWidth(), xEnd = hit.getX() + 0.5f * hit.getXWidth();
-    const float yBegin = hit.getY() - 0.5f * hit.getYWidth(), yEnd = hit.getY() + 0.5f * hit.getYWidth();
-    const float zBegin = hit.getZ() - 0.5f * hit.getZWidth(), zEnd = hit.getZ() + 0.5f * hit.getZWidth();
+    const float xBegin = hit.x() - 0.5f * hit.xWidth(), xEnd = hit.x() + 0.5f * hit.xWidth();
+    const float yBegin = hit.y() - 0.5f * hit.yWidth(), yEnd = hit.y() + 0.5f * hit.yWidth();
+    const float zBegin = hit.z() - 0.5f * hit.zWidth(), zEnd = hit.z() + 0.5f * hit.zWidth();
 
     if (!initialized) {
       result.xBegin = xBegin;
@@ -232,10 +232,10 @@ inline bool CTPPSTimingTrackRecognition<TRACK_TYPE, HIT_TYPE>::timeEval(const Hi
   float mean_num = 0.f, mean_denom = 0.f;
   bool valid_hits = false;
   for (const auto& hit : hits) {
-    if (hit.getTPrecision() <= 0.)
+    if (hit.tPrecision() <= 0.)
       continue;
-    const float weight = std::pow(hit.getTPrecision(), -2);
-    mean_num += weight * hit.getT();
+    const float weight = std::pow(hit.tPrecision(), -2);
+    mean_num += weight * hit.t();
     mean_denom += weight;
     valid_hits = true;  // at least one valid hit to account for
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -69,7 +69,7 @@ void CTPPSDiamondLocalTrackFitter::produce(edm::Event& iEvent, const edm::EventS
     const CTPPSDiamondDetId detid(vec.detId());
     for (const auto& hit : vec) {
       // skip hits without a leading edge
-      if (hit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING)
+      if (hit.ootIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING)
         continue;
 
       switch (detid.arm()) {

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -99,16 +99,16 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
         if (!trk.isValid())
           continue;
 
-        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
-        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
-        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
-        float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
-        float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
-        float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
-        float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
+        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.x0());
+        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.x0Sigma());
+        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.y0());
+        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.y0Sigma());
+        float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.tx());
+        float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.txSigma());
+        float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.ty());
+        float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.tySigma());
         float roundedChiSquaredOverNDF =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.chiSquaredOverNDF());
 
         pOut->emplace_back(rpId,  // detector info
                                   // spatial info
@@ -124,7 +124,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
                            // reconstruction info
                            roundedChiSquaredOverNDF,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
-                           trk.getNumberOfPointsUsedForFit(),
+                           trk.numberOfPointsUsedForFit(),
                            // timing info
                            0.,
                            0.);
@@ -146,16 +146,16 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
         if (!trk.isValid())
           continue;
 
-        const float abs_time = trk.getT() + trk.getOOTIndex() * HPTDC_TIME_SLICE_WIDTH;
+        const float abs_time = trk.t() + trk.ootIndex() * HPTDC_TIME_SLICE_WIDTH;
         if (abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_)
           continue;
 
-        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
-        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
-        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
+        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.x0());
+        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.x0Sigma());
+        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.y0());
+        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.y0Sigma());
         float roundedT = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
-        float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getTSigma());
+        float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.tSigma());
 
         pOut->emplace_back(rpId,  // detector info
                                   // spatial info
@@ -171,7 +171,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
                            // reconstruction info
                            0.,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
-                           trk.getNumOfPlanes(),
+                           trk.planesNumber(),
                            // timing info
                            roundedT,
                            roundedTSigma);
@@ -192,18 +192,18 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
         for (const auto &trk : rpv) {
           if (!trk.isValid())
             continue;
-          if (trk.getTx() > pixelTrackTxMin_ && trk.getTx() < pixelTrackTxMax_ && trk.getTy() > pixelTrackTyMin_ &&
-              trk.getTy() < pixelTrackTyMax_) {
-            float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
-            float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
-            float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-            float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
-            float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
-            float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
-            float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
-            float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
+          if (trk.tx() > pixelTrackTxMin_ && trk.tx() < pixelTrackTxMax_ && trk.ty() > pixelTrackTyMin_ &&
+              trk.ty() < pixelTrackTyMax_) {
+            float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.x0());
+            float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.x0Sigma());
+            float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.y0());
+            float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.y0Sigma());
+            float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.tx());
+            float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.txSigma());
+            float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.ty());
+            float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.tySigma());
             float roundedChiSquaredOverNDF =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.chiSquaredOverNDF());
 
             pOut->emplace_back(rpId,  // detector info
                                       // spatial info
@@ -218,8 +218,8 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
                                roundedTySigma,
                                // reconstruction info
                                roundedChiSquaredOverNDF,
-                               trk.getRecoInfo(),
-                               trk.getNumberOfPointsUsedForFit(),
+                               trk.recoInfo(),
+                               trk.numberOfPointsUsedForFit(),
                                // timing info
                                0.,
                                0.);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -171,7 +171,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
                            // reconstruction info
                            0.,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
-                           trk.planesNumber(),
+                           trk.numberOfPlanes(),
                            // timing info
                            roundedT,
                            roundedTSigma);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -145,7 +145,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
         if (!trk.isValid())
           continue;
 
-        const float abs_time = trk.t() + trk.ootIndex() * HPTDC_TIME_SLICE_WIDTH;
+        const float abs_time = trk.time() + trk.ootIndex() * HPTDC_TIME_SLICE_WIDTH;
         if (abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_)
           continue;
 
@@ -154,7 +154,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
         float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.y0());
         float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.y0Sigma());
         float roundedT = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
-        float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.tSigma());
+        float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.timeSigma());
 
         pOut->emplace_back(rpId,  // detector info
                                   // spatial info

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -107,8 +107,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSe
         float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.txSigma());
         float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.ty());
         float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.tySigma());
-        float roundedChiSquaredOverNDF =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.chiSquaredOverNDF());
+        float roundedChiSquaredOverNDF = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.chiSquaredOverNDF());
 
         pOut->emplace_back(rpId,  // detector info
                                   // spatial info

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPLocalTrackFitter.cc
@@ -151,7 +151,7 @@ void TotemRPLocalTrackFitter::produce(edm::Event &e, const edm::EventSetup &setu
     }
 
     // run fit
-    double z0 = geometry->getRPTranslation(rpId).z();
+    double z0 = geometry->rpTranslation(rpId).z();
 
     TotemRPLocalTrack track;
     fitter_.fitTrack(hits, z0, *geometry, track);

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPLocalTrackFitter.cc
@@ -103,11 +103,11 @@ void TotemRPLocalTrackFitter::produce(edm::Event &e, const edm::EventSetup &setu
       // here it would make sense to skip non-fittable patterns, but to keep the logic
       // equivalent to version 7_0_4, nothing is skipped
       /*
-      if (pattern.getFittable() == false)
+      if (pattern.fittable() == false)
         continue;
       */
 
-      switch (pattern.getProjection()) {
+      switch (pattern.projection()) {
         case TotemRPUVPattern::projU:
           n_U++;
           idx_U = pi;
@@ -133,18 +133,18 @@ void TotemRPLocalTrackFitter::produce(edm::Event &e, const edm::EventSetup &setu
     }
 
     // again, to follow the logic from version 7_0_4, skip the non-fittable patterns here
-    if (!rpv[idx_U].getFittable() || !rpv[idx_V].getFittable())
+    if (!rpv[idx_U].fittable() || !rpv[idx_V].fittable())
       continue;
 
     // combine U and V hits
     DetSetVector<TotemRPRecHit> hits;
-    for (auto &ids : rpv[idx_U].getHits()) {
+    for (auto &ids : rpv[idx_U].hits()) {
       auto &ods = hits.find_or_insert(ids.detId());
       for (auto &h : ids)
         ods.push_back(h);
     }
 
-    for (auto &ids : rpv[idx_V].getHits()) {
+    for (auto &ids : rpv[idx_V].hits()) {
       auto &ods = hits.find_or_insert(ids.detId());
       for (auto &h : ids)
         ods.push_back(h);
@@ -161,7 +161,7 @@ void TotemRPLocalTrackFitter::produce(edm::Event &e, const edm::EventSetup &setu
 
     if (verbosity_ > 5) {
       unsigned int n_hits = 0;
-      for (auto &hds : track.getHits())
+      for (auto &hds : track.hits())
         n_hits += hds.size();
 
       LogVerbatim("TotemRPLocalTrackFitter")

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
@@ -269,8 +269,7 @@ void TotemRPUVPatternFinder::produce(edm::Event &event, const edm::EventSetup &e
 
         LogVerbatim("TotemRPUVPatternFinder")
             << "\t\t\tproj = " << ((p.projection() == TotemRPUVPattern::projU) ? "U" : "V") << ", a = " << p.a()
-            << ", b = " << p.b() << ", w = " << p.w() << ", fittable = " << p.fittable()
-            << ", hits = " << n_hits;
+            << ", b = " << p.b() << ", w = " << p.w() << ", fittable = " << p.fittable() << ", hits = " << n_hits;
       }
     }
   }

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
@@ -1,8 +1,8 @@
 /****************************************************************************
 *
 * This is a part of TOTEM offline software.
-* Authors: 
-*   Jan Kašpar (jan.kaspar@gmail.com) 
+* Authors:
+*   Jan Kašpar (jan.kaspar@gmail.com)
 *
 ****************************************************************************/
 
@@ -143,13 +143,13 @@ void TotemRPUVPatternFinder::recognizeAndSelect(TotemRPUVPattern::ProjectionType
     p.setFittable(true);
 
     set<unsigned int> planes;
-    for (const auto &ds : p.getHits())
+    for (const auto &ds : p.hits())
       planes.insert(TotemRPDetId(ds.detId()).plane());
 
     if (planes.size() < planes_required)
       p.setFittable(false);
 
-    if (fabs(p.getA()) > max_a_toFit)
+    if (fabs(p.a()) > max_a_toFit)
       p.setFittable(false);
 
     patterns.push_back(p);
@@ -264,12 +264,12 @@ void TotemRPUVPatternFinder::produce(edm::Event &event, const edm::EventSetup &e
       LogVerbatim("TotemRPUVPatternFinder") << "\t\tpatterns:";
       for (const auto &p : patterns) {
         unsigned int n_hits = 0;
-        for (auto &hds : p.getHits())
+        for (auto &hds : p.hits())
           n_hits += hds.size();
 
         LogVerbatim("TotemRPUVPatternFinder")
-            << "\t\t\tproj = " << ((p.getProjection() == TotemRPUVPattern::projU) ? "U" : "V") << ", a = " << p.getA()
-            << ", b = " << p.getB() << ", w = " << p.getW() << ", fittable = " << p.getFittable()
+            << "\t\t\tproj = " << ((p.projection() == TotemRPUVPattern::projU) ? "U" : "V") << ", a = " << p.a()
+            << ", b = " << p.b() << ", w = " << p.w() << ", fittable = " << p.fittable()
             << ", hits = " << n_hits;
       }
     }

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
@@ -188,7 +188,7 @@ void TotemRPUVPatternFinder::produce(edm::Event &event, const edm::EventSetup &e
     unsigned int plane = detId.plane();
     bool uDir = detId.isStripsCoordinateUDirection();
 
-    CTPPSDetId rpId = detId.getRPId();
+    CTPPSDetId rpId = detId.rpId();
 
     RPData &data = rpData[rpId];
 

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
@@ -253,7 +253,7 @@ void TotemRPUVPatternFinder::produce(edm::Event &event, const edm::EventSetup &e
     DetSet<TotemRPUVPattern> &patterns = patternsVector.find_or_insert(rpId);
 
     // "typical" z0 for the RP
-    double z0 = geometry->getRP(rpId)->translation().z();
+    double z0 = geometry->rp(rpId)->translation().z();
 
     // u then v recognition
     recognizeAndSelect(TotemRPUVPattern::projU, z0, threshold_U, minPlanesPerProjectionToFit_U, data.hits_U, patterns);

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -51,7 +51,7 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert(detid);
 
     for (const auto& digi : vec) {
-      const int t_lead = digi.getLeadingEdge(), t_trail = digi.getTrailingEdge();
+      const int t_lead = digi.leadingEdge(), t_trail = digi.trailingEdge();
       // skip invalid digis
       if (t_lead == 0 && t_trail == 0)
         continue;
@@ -87,8 +87,8 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
           ch_t_precis,
           time_slice,
           // readout information
-          digi.getHPTDCErrorFlags(),
-          digi.getMultipleHit());
+          digi.hptdcErrorFlags(),
+          digi.multipleHit());
     }
   }
 }

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -30,7 +30,7 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
       continue;
 
     // retrieve the geometry element associated to this DetID
-    const DetGeomDesc* det = geom.getSensor(detid);
+    const DetGeomDesc* det = geom.sensor(detid);
 
     const float x_pos = det->translation().x(), y_pos = det->translation().y();
     float z_pos = 0.;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -26,10 +26,10 @@ void CTPPSDiamondTrackRecognition::clear() {
 //----------------------------------------------------------------------------------------------------
 
 void CTPPSDiamondTrackRecognition::addHit(const CTPPSDiamondRecHit& recHit) {
-  if (excludeSingleEdgeHits_ && recHit.getToT() <= 0.)
+  if (excludeSingleEdgeHits_ && recHit.toT() <= 0.)
     return;
   // store hit parameters
-  hitVectorMap_[recHit.getOOTIndex()].emplace_back(recHit);
+  hitVectorMap_[recHit.ootIndex()].emplace_back(recHit);
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -38,8 +38,8 @@ int CTPPSDiamondTrackRecognition::produceTracks(edm::DetSet<CTPPSDiamondLocalTra
   int numberOfTracks = 0;
   DimensionParameters param;
 
-  auto getX = [](const CTPPSDiamondRecHit& hit) { return hit.getX(); };
-  auto getXWidth = [](const CTPPSDiamondRecHit& hit) { return hit.getXWidth(); };
+  auto getX = [](const CTPPSDiamondRecHit& hit) { return hit.x(); };
+  auto getXWidth = [](const CTPPSDiamondRecHit& hit) { return hit.xWidth(); };
   auto setX = [](CTPPSDiamondLocalTrack& track, float x) { track.setPosition(math::XYZPoint(x, 0., 0.)); };
   auto setXSigma = [](CTPPSDiamondLocalTrack& track, float sigma) {
     track.setPositionSigma(math::XYZPoint(sigma, 0., 0.));
@@ -68,8 +68,8 @@ int CTPPSDiamondTrackRecognition::produceTracks(edm::DetSet<CTPPSDiamondLocalTra
     const float zSigma = 0.5f * (hitRange.zEnd - hitRange.zBegin);
 
     for (const auto& xTrack : xPartTracks) {
-      math::XYZPoint position(xTrack.getX0(), yRangeCenter, zRangeCenter);
-      math::XYZPoint positionSigma(xTrack.getX0Sigma(), ySigma, zSigma);
+      math::XYZPoint position(xTrack.x0(), yRangeCenter, zRangeCenter);
+      math::XYZPoint positionSigma(xTrack.x0Sigma(), ySigma, zSigma);
 
       const int multipleHits = (mhMap_.find(oot) != mhMap_.end()) ? mhMap_[oot] : 0;
       CTPPSDiamondLocalTrack newTrack(position, positionSigma, 0.f, 0.f, oot, multipleHits);
@@ -77,7 +77,7 @@ int CTPPSDiamondTrackRecognition::produceTracks(edm::DetSet<CTPPSDiamondLocalTra
       // find contributing hits
       HitVector componentHits;
       for (const auto& hit : hits)
-        if (newTrack.containsHit(hit, tolerance_) && (!excludeSingleEdgeHits_ || hit.getToT() > 0.))
+        if (newTrack.containsHit(hit, tolerance_) && (!excludeSingleEdgeHits_ || hit.toT() > 0.))
           componentHits.emplace_back(hit);
       // compute timing information
       float mean_time = 0.f, time_sigma = 0.f;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -83,8 +83,8 @@ int CTPPSDiamondTrackRecognition::produceTracks(edm::DetSet<CTPPSDiamondLocalTra
       float mean_time = 0.f, time_sigma = 0.f;
       bool valid_hits = timeEval(componentHits, mean_time, time_sigma);
       newTrack.setValid(valid_hits);
-      newTrack.setT(mean_time);
-      newTrack.setTSigma(time_sigma);
+      newTrack.setTime(mean_time);
+      newTrack.setTimeSigma(time_sigma);
 
       tracks.push_back(newTrack);
     }

--- a/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
@@ -1,8 +1,8 @@
 /****************************************************************************
 *
 * This is a part of TOTEM offline software.
-* Authors: 
-*   Jan Kašpar (jan.kaspar@gmail.com) 
+* Authors:
+*   Jan Kašpar (jan.kaspar@gmail.com)
 *
 ****************************************************************************/
 
@@ -97,9 +97,9 @@ void FastLineRecognition::getPatterns(const DetSetVector<TotemRPRecHit> &input,
       const TotemRPRecHit *hit = &h;
       const GeomData &gd = getGeomData(detId);
 
-      double p = hit->getPosition() + gd.s;
+      double p = hit->position() + gd.s;
       double z = gd.z - z0;
-      double w = sigma0 / hit->getSigma();
+      double w = sigma0 / hit->sigma();
 
       points.push_back(Point(detId, hit, p, z, w));
     }

--- a/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
@@ -72,7 +72,7 @@ FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id) 
 
   // calculate it
   CLHEP::Hep3Vector d = geometry->localToGlobalDirection(id, CLHEP::Hep3Vector(0., 1., 0.));
-  DetGeomDesc::Translation c = geometry->getSensor(TotemRPDetId(id))->translation();
+  DetGeomDesc::Translation c = geometry->sensor(TotemRPDetId(id))->translation();
   GeomData gd;
   gd.z = c.z();
   gd.s = d.x() * c.x() + d.y() * c.y();

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPClusterProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPClusterProducerAlgorithm.cc
@@ -41,7 +41,7 @@ int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId,
   int cur_strip;
 
   for (TotemRPDigiSet::const_iterator i = strip_digi_set_.begin(); i != strip_digi_set_.end(); ++i) {
-    cur_strip = i->getStripNumber();
+    cur_strip = i->stripNumber();
     bool non_continuity = (cur_strip != prev_strip + 1);
 
     if (iter_beg) {

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
@@ -32,7 +32,7 @@ TotemRPLocalTrackFitterAlgorithm::RPDetCoordinateAlgebraObjs
 TotemRPLocalTrackFitterAlgorithm::prepareReconstAlgebraData(unsigned int det_id, const CTPPSGeometry &tot_rp_geom) {
   RPDetCoordinateAlgebraObjs det_algebra_obj;
 
-  det_algebra_obj.centre_of_det_global_position_ = convert3vector(tot_rp_geom.getSensorTranslation(det_id));
+  det_algebra_obj.centre_of_det_global_position_ = convert3vector(tot_rp_geom.sensorTranslation(det_id));
 
   HepMC::ThreeVector rp_topology_stripaxis = rp_topology_.GetStripReadoutAxisDir();
   CLHEP::Hep3Vector rp_topology_stripaxis_clhep;

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
@@ -109,11 +109,11 @@ bool TotemRPLocalTrackFitterAlgorithm::fitTrack(const edm::DetSetVector<TotemRPR
     double delta_z = alg_obj->centre_of_det_global_position_.Z() - z_0;
     H(i, 2) = alg_obj->readout_direction_.X() * delta_z;
     H(i, 3) = alg_obj->readout_direction_.Y() * delta_z;
-    double var = applicable_hits[i].hit->getSigma();
+    double var = applicable_hits[i].hit->sigma();
     var *= var;
     V[i] = var;
     V_inv[i] = 1.0 / var;
-    U[i] = applicable_hits[i].hit->getPosition() - alg_obj->rec_u_0_;
+    U[i] = applicable_hits[i].hit->position() - alg_obj->rec_u_0_;
   }
 
   TMatrixD H_T_V_inv(TMatrixD::kTransposed, H);
@@ -141,10 +141,10 @@ bool TotemRPLocalTrackFitterAlgorithm::fitTrack(const edm::DetSetVector<TotemRPR
     RPDetCoordinateAlgebraObjs *alg_obj = applicable_hits[i].alg;
     TVector2 readout_dir = alg_obj->readout_direction_;
     double det_z = alg_obj->centre_of_det_global_position_.Z();
-    double sigma_str = applicable_hits[i].hit->getSigma();
+    double sigma_str = applicable_hits[i].hit->sigma();
     double sigma_str_2 = sigma_str * sigma_str;
-    TVector2 fited_det_xy_point = fitted_track.getTrackPoint(det_z);
-    double U_readout = applicable_hits[i].hit->getPosition() - alg_obj->rec_u_0_;
+    TVector2 fited_det_xy_point = fitted_track.trackPoint(det_z);
+    double U_readout = applicable_hits[i].hit->position() - alg_obj->rec_u_0_;
     double U_fited = (readout_dir *= fited_det_xy_point);
     double residual = U_fited - U_readout;
     TMatrixD V_T_Cov_X_Y(1, 2);

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPRecHitProducerAlgorithm.cc
@@ -16,6 +16,6 @@ void TotemRPRecHitProducerAlgorithm::buildRecoHits(const edm::DetSet<TotemRPClus
   for (edm::DetSet<TotemRPCluster>::const_iterator it = input.begin(); it != input.end(); ++it) {
     constexpr double nominal_sigma = 0.0191;
     output.push_back(
-        TotemRPRecHit(rp_topology_.GetHitPositionInReadoutDirection(it->getCenterStripPosition()), nominal_sigma));
+        TotemRPRecHit(rp_topology_.GetHitPositionInReadoutDirection(it->centerStripPosition()), nominal_sigma));
   }
 }

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingConversions.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingConversions.cc
@@ -19,28 +19,28 @@ TotemTimingConversions::TotemTimingConversions(bool mergeTimePeaks, const PPSTim
 //----------------------------------------------------------------------------------------------------
 
 float TotemTimingConversions::timeOfFirstSample(const TotemTimingDigi& digi) const {
-  unsigned int offsetOfSamples = digi.getEventInfo().getOffsetOfSamples();
+  unsigned int offsetOfSamples = digi.eventInfo().offsetOfSamples();
   if (offsetOfSamples == 0)
     offsetOfSamples = SAMPIC_DEFAULT_OFFSET;  // FW 0 is not sending this, FW > 0 yes
 
   unsigned int timestamp =
-      (digi.getCellInfo() <= SAMPIC_MAX_NUMBER_OF_SAMPLES / 2) ? digi.getTimestampA() : digi.getTimestampB();
+      (digi.cellInfo() <= SAMPIC_MAX_NUMBER_OF_SAMPLES / 2) ? digi.timestampA() : digi.timestampB();
 
-  int cell0TimeClock = timestamp + ((digi.getFPGATimestamp() - timestamp) & CELL0_MASK) -
-                       digi.getEventInfo().getL1ATimestamp() + digi.getEventInfo().getL1ALatency();
+  int cell0TimeClock = timestamp + ((digi.fpgaTimestamp() - timestamp) & CELL0_MASK) -
+                       digi.eventInfo().l1ATimestamp() + digi.eventInfo().l1ALatency();
 
   // time of first cell
   float cell0TimeInstant = SAMPIC_MAX_NUMBER_OF_SAMPLES * SAMPIC_SAMPLING_PERIOD_NS * cell0TimeClock;
 
   // time of triggered cell
   float firstCellTimeInstant =
-      (digi.getCellInfo() < offsetOfSamples)
-          ? cell0TimeInstant + digi.getCellInfo() * SAMPIC_SAMPLING_PERIOD_NS
-          : cell0TimeInstant - (SAMPIC_MAX_NUMBER_OF_SAMPLES - digi.getCellInfo()) * SAMPIC_SAMPLING_PERIOD_NS;
+      (digi.cellInfo() < offsetOfSamples)
+          ? cell0TimeInstant + digi.cellInfo() * SAMPIC_SAMPLING_PERIOD_NS
+          : cell0TimeInstant - (SAMPIC_MAX_NUMBER_OF_SAMPLES - digi.cellInfo()) * SAMPIC_SAMPLING_PERIOD_NS;
 
-  int db = digi.getHardwareBoardId();
-  int sampic = digi.getHardwareSampicId();
-  int channel = digi.getHardwareChannelId();
+  int db = digi.hardwareBoardId();
+  int sampic = digi.hardwareSampicId();
+  int channel = digi.hardwareChannelId();
   float t = firstCellTimeInstant + calibration_.timeOffset(db, sampic, channel);
   //NOTE: If no time offset is set, timeOffset returns 0
 
@@ -56,7 +56,7 @@ float TotemTimingConversions::timeOfFirstSample(const TotemTimingDigi& digi) con
 //----------------------------------------------------------------------------------------------------
 
 float TotemTimingConversions::triggerTime(const TotemTimingDigi& digi) const {
-  unsigned int offsetOfSamples = digi.getEventInfo().getOffsetOfSamples();
+  unsigned int offsetOfSamples = digi.eventInfo().offsetOfSamples();
   if (offsetOfSamples == 0)
     offsetOfSamples = 30;  // FW 0 is not sending this, FW > 0 yes
 
@@ -66,16 +66,16 @@ float TotemTimingConversions::triggerTime(const TotemTimingDigi& digi) const {
 //----------------------------------------------------------------------------------------------------
 
 float TotemTimingConversions::timePrecision(const TotemTimingDigi& digi) const {
-  int db = digi.getHardwareBoardId();
-  int sampic = digi.getHardwareSampicId();
-  int channel = digi.getHardwareChannelId();
+  int db = digi.hardwareBoardId();
+  int sampic = digi.hardwareSampicId();
+  int channel = digi.hardwareChannelId();
   return calibration_.timePrecision(db, sampic, channel);
 }
 
 //----------------------------------------------------------------------------------------------------
 
 std::vector<float> TotemTimingConversions::timeSamples(const TotemTimingDigi& digi) const {
-  std::vector<float> time(digi.getNumberOfSamples());
+  std::vector<float> time(digi.numberOfSamples());
   for (unsigned int i = 0; i < time.size(); ++i)
     time.at(i) = timeOfFirstSample(digi) + i * SAMPIC_SAMPLING_PERIOD_NS;
   return time;
@@ -87,14 +87,14 @@ std::vector<float> TotemTimingConversions::timeSamples(const TotemTimingDigi& di
 std::vector<float> TotemTimingConversions::voltSamples(const TotemTimingDigi& digi) const {
   std::vector<float> data;
   if (calibrationFunction_.numberOfVariables() != 1)
-    for (const auto& sample : digi.getSamples())
+    for (const auto& sample : digi.samples())
       data.emplace_back(SAMPIC_ADC_V * sample);
   else {
-    unsigned int db = digi.getHardwareBoardId();
-    unsigned int sampic = digi.getHardwareSampicId();
-    unsigned int channel = digi.getHardwareChannelId();
-    unsigned int cell = digi.getCellInfo();
-    for (const auto& sample : digi.getSamples()) {
+    unsigned int db = digi.hardwareBoardId();
+    unsigned int sampic = digi.hardwareSampicId();
+    unsigned int channel = digi.hardwareChannelId();
+    unsigned int cell = digi.cellInfo();
+    for (const auto& sample : digi.samples()) {
       // ring buffer on Sampic, so accounting for samples register boundary
       const unsigned short sample_cell = (cell++) % SAMPIC_MAX_NUMBER_OF_SAMPLES;
       auto parameters = calibration_.parameters(db, sampic, channel, sample_cell);

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingConversions.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingConversions.cc
@@ -26,8 +26,8 @@ float TotemTimingConversions::timeOfFirstSample(const TotemTimingDigi& digi) con
   unsigned int timestamp =
       (digi.cellInfo() <= SAMPIC_MAX_NUMBER_OF_SAMPLES / 2) ? digi.timestampA() : digi.timestampB();
 
-  int cell0TimeClock = timestamp + ((digi.fpgaTimestamp() - timestamp) & CELL0_MASK) -
-                       digi.eventInfo().l1ATimestamp() + digi.eventInfo().l1ALatency();
+  int cell0TimeClock = timestamp + ((digi.fpgaTimestamp() - timestamp) & CELL0_MASK) - digi.eventInfo().l1ATimestamp() +
+                       digi.eventInfo().l1ALatency();
 
   // time of first cell
   float cell0TimeInstant = SAMPIC_MAX_NUMBER_OF_SAMPLES * SAMPIC_SAMPLING_PERIOD_NS * cell0TimeClock;

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -42,7 +42,7 @@ void TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     float x_width = 0.f, y_width = 0.f, z_width = 0.f;
 
     // retrieve the geometry element associated to this DetID ( if present )
-    const DetGeomDesc* det = geom.getSensorNoThrow(detid);
+    const DetGeomDesc* det = geom.sensorNoThrow(detid);
 
     if (det) {
       x_pos = det->translation().x();

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
@@ -18,7 +18,7 @@ TotemTimingTrackRecognition::TotemTimingTrackRecognition(const edm::ParameterSet
 //----------------------------------------------------------------------------------------------------
 
 void TotemTimingTrackRecognition::addHit(const TotemTimingRecHit& recHit) {
-  if (recHit.getT() != TotemTimingRecHit::NO_T_AVAILABLE)
+  if (recHit.t() != TotemTimingRecHit::NO_T_AVAILABLE)
     hitVectorMap_[0].emplace_back(recHit);
 }
 
@@ -28,14 +28,14 @@ int TotemTimingTrackRecognition::produceTracks(edm::DetSet<TotemTimingLocalTrack
   int numberOfTracks = 0;
   DimensionParameters param;
 
-  auto getX = [](const TotemTimingRecHit& hit) { return hit.getX(); };
-  auto getXWidth = [](const TotemTimingRecHit& hit) { return hit.getXWidth(); };
+  auto getX = [](const TotemTimingRecHit& hit) { return hit.x(); };
+  auto getXWidth = [](const TotemTimingRecHit& hit) { return hit.xWidth(); };
   auto setX = [](TotemTimingLocalTrack& track, float x) { track.setPosition(math::XYZPoint(x, 0., 0.)); };
   auto setXSigma = [](TotemTimingLocalTrack& track, float sigma) {
     track.setPositionSigma(math::XYZPoint(sigma, 0., 0.));
   };
-  auto getY = [](const TotemTimingRecHit& hit) { return hit.getY(); };
-  auto getYWidth = [](const TotemTimingRecHit& hit) { return hit.getYWidth(); };
+  auto getY = [](const TotemTimingRecHit& hit) { return hit.y(); };
+  auto getYWidth = [](const TotemTimingRecHit& hit) { return hit.yWidth(); };
   auto setY = [](TotemTimingLocalTrack& track, float y) { track.setPosition(math::XYZPoint(0., y, 0.)); };
   auto setYSigma = [](TotemTimingLocalTrack& track, float sigma) {
     track.setPositionSigma(math::XYZPoint(0., sigma, 0.));
@@ -62,9 +62,9 @@ int TotemTimingTrackRecognition::produceTracks(edm::DetSet<TotemTimingLocalTrack
 
     for (const auto& xTrack : xPartTracks) {
       for (const auto& yTrack : yPartTracks) {
-        math::XYZPoint position(xTrack.getX0(), yTrack.getY0(), 0.5f * (hitRange.zBegin + hitRange.zEnd));
+        math::XYZPoint position(xTrack.x0(), yTrack.y0(), 0.5f * (hitRange.zBegin + hitRange.zEnd));
         math::XYZPoint positionSigma(
-            xTrack.getX0Sigma(), yTrack.getY0Sigma(), 0.5f * (hitRange.zEnd - hitRange.zBegin));
+            xTrack.x0Sigma(), yTrack.y0Sigma(), 0.5f * (hitRange.zEnd - hitRange.zBegin));
 
         TotemTimingLocalTrack newTrack(position, positionSigma, 0., 0.);
 

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
@@ -63,8 +63,7 @@ int TotemTimingTrackRecognition::produceTracks(edm::DetSet<TotemTimingLocalTrack
     for (const auto& xTrack : xPartTracks) {
       for (const auto& yTrack : yPartTracks) {
         math::XYZPoint position(xTrack.x0(), yTrack.y0(), 0.5f * (hitRange.zBegin + hitRange.zEnd));
-        math::XYZPoint positionSigma(
-            xTrack.x0Sigma(), yTrack.y0Sigma(), 0.5f * (hitRange.zEnd - hitRange.zBegin));
+        math::XYZPoint positionSigma(xTrack.x0Sigma(), yTrack.y0Sigma(), 0.5f * (hitRange.zEnd - hitRange.zBegin));
 
         TotemTimingLocalTrack newTrack(position, positionSigma, 0., 0.);
 

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
@@ -18,7 +18,7 @@ TotemTimingTrackRecognition::TotemTimingTrackRecognition(const edm::ParameterSet
 //----------------------------------------------------------------------------------------------------
 
 void TotemTimingTrackRecognition::addHit(const TotemTimingRecHit& recHit) {
-  if (recHit.t() != TotemTimingRecHit::NO_T_AVAILABLE)
+  if (recHit.time() != TotemTimingRecHit::NO_T_AVAILABLE)
     hitVectorMap_[0].emplace_back(recHit);
 }
 
@@ -77,8 +77,8 @@ int TotemTimingTrackRecognition::produceTracks(edm::DetSet<TotemTimingLocalTrack
         float mean_time = 0.f, time_sigma = 0.f;
         bool valid_hits = timeEval(componentHits, mean_time, time_sigma);
         newTrack.setValid(valid_hits);
-        newTrack.setT(mean_time);
-        newTrack.setTSigma(time_sigma);
+        newTrack.setTime(mean_time);
+        newTrack.setTimeSigma(time_sigma);
         // in a next iteration, we will be setting validity / numHits / numPlanes
         tracks.push_back(newTrack);
       }

--- a/SimPPS/RPDigiProducer/plugins/RPDigiProducer.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPDigiProducer.cc
@@ -215,7 +215,7 @@ edm::DetSet<TotemRPDigi> RPDigiProducer::convertRPStripDetSet(const edm::DetSet<
   for (std::vector<TotemRPDigi>::const_iterator stripIterator = rpstrip_detset.data.begin();
        stripIterator < rpstrip_detset.data.end();
        ++stripIterator) {
-    rpdigi_detset.push_back(TotemRPDigi(stripIterator->getStripNumber()));
+    rpdigi_detset.push_back(TotemRPDigi(stripIterator->stripNumber()));
   }
 
   return rpdigi_detset;

--- a/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.cc
@@ -43,7 +43,7 @@ RPDisplacementGenerator::RPDisplacementGenerator(const edm::ParameterSet &ps,
   // transform shift and rotation to the local coordinate frame
   ESHandle<CTPPSGeometry> geom;
   iSetup.get<VeryForwardRealGeometryRecord>().get(geom);
-  const DetGeomDesc *g = geom->getSensor(detId_);
+  const DetGeomDesc *g = geom->sensor(detId_);
   const DDRotationMatrix &R_l = g->rotation();
   rotation_ = R_l.Inverse() * R_m.Inverse() * R_l;
   shift_ = R_l.Inverse() * R_m.Inverse() * S_m;

--- a/SimPPS/RPDigiProducer/plugins/RPVFATSimulator.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPVFATSimulator.cc
@@ -38,7 +38,7 @@ void RPVFATSimulator::ConvertChargeToHits(const simromanpot::strip_charge_map &s
 
   if (verbosity_) {
     for (unsigned int i = 0; i < output_digi.size(); ++i) {
-      edm::LogInfo("RPVFATSimulator") << output_digi[i].getStripNumber() << "\n";
+      edm::LogInfo("RPVFATSimulator") << output_digi[i].stripNumber() << "\n";
     }
   }
 }

--- a/Validation/CTPPS/plugins/CTPPSAcceptancePlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSAcceptancePlotter.cc
@@ -220,7 +220,7 @@ void CTPPSAcceptancePlotter::analyze(const edm::Event &iEvent, const edm::EventS
   // process tracks
   map<unsigned int, bool> trackPresent;
   for (const auto &trk : *hTracks) {
-    CTPPSDetId rpId(trk.getRPId());
+    CTPPSDetId rpId(trk.rpId());
     unsigned int rpDecId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
     trackPresent[rpDecId] = true;
   }

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -343,7 +343,7 @@ void CTPPSDirectProtonSimulation::processProton(const HepMC::GenVertex* in_vtx,
       continue;
 
     // loop over all sensors in the RP
-    for (const auto& detIdInt : geometry.getSensorsInRP(rpId)) {
+    for (const auto& detIdInt : geometry.sensorsInRP(rpId)) {
       CTPPSDetId detId(detIdInt);
 
       // determine the track impact point (in global coordinates)

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulationValidator.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulationValidator.cc
@@ -89,11 +89,11 @@ void CTPPSDirectProtonSimulationValidator::analyze(const edm::Event& iEvent, con
 
   // process tracks
   for (const auto& simuTrack : *simuTracks) {
-    const CTPPSDetId rpId(simuTrack.getRPId());
+    const CTPPSDetId rpId(simuTrack.rpId());
     for (const auto& recoTrack : *recoTracks) {
-      if (simuTrack.getRPId() == recoTrack.getRPId()) {
+      if (simuTrack.rpId() == recoTrack.rpId()) {
         unsigned int rpDecId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
-        rpPlots_[rpDecId].fill(simuTrack.getX(), simuTrack.getY(), recoTrack.getX(), recoTrack.getY());
+        rpPlots_[rpDecId].fill(simuTrack.x(), simuTrack.y(), recoTrack.x(), recoTrack.y());
       }
     }
   }

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -139,7 +139,7 @@ private:
 
       unsigned int n_tracking_RPs = 0, n_timing_RPs = 0;
       for (const auto &tr : p.contributingLocalTracks()) {
-        CTPPSDetId detId(tr->getRPId());
+        CTPPSDetId detId(tr->rpId());
         if (detId.subdetId() == CTPPSDetId::sdTrackingStrip || detId.subdetId() == CTPPSDetId::sdTrackingPixel)
           n_tracking_RPs++;
         if (detId.subdetId() == CTPPSDetId::sdTimingDiamond || detId.subdetId() == CTPPSDetId::sdTimingFastSilicon)
@@ -376,7 +376,7 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
   const CTPPSLocalTrackLite *tr_R_F = nullptr;
 
   for (const auto &tr : *hTracks) {
-    CTPPSDetId rpId(tr.getRPId());
+    CTPPSDetId rpId(tr.rpId());
     unsigned int decRPId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
 
     if (decRPId == rpId_45_N_)
@@ -390,25 +390,25 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
   }
 
   if (tr_L_N && tr_L_F) {
-    p_x_L_diffNF_vs_x_L_N_->Fill(tr_L_N->getX(), tr_L_F->getX() - tr_L_N->getX());
-    p_y_L_diffNF_vs_y_L_N_->Fill(tr_L_N->getY(), tr_L_F->getY() - tr_L_N->getY());
+    p_x_L_diffNF_vs_x_L_N_->Fill(tr_L_N->x(), tr_L_F->x() - tr_L_N->x());
+    p_y_L_diffNF_vs_y_L_N_->Fill(tr_L_N->y(), tr_L_F->y() - tr_L_N->y());
   }
 
   if (tr_R_N && tr_R_F) {
-    p_x_R_diffNF_vs_x_R_N_->Fill(tr_R_N->getX(), tr_R_F->getX() - tr_R_N->getX());
-    p_y_R_diffNF_vs_y_R_N_->Fill(tr_R_N->getY(), tr_R_F->getY() - tr_R_N->getY());
+    p_x_R_diffNF_vs_x_R_N_->Fill(tr_R_N->x(), tr_R_F->x() - tr_R_N->x());
+    p_y_R_diffNF_vs_y_R_N_->Fill(tr_R_N->y(), tr_R_F->y() - tr_R_N->y());
   }
 
   // make single-RP-reco plots
   for (const auto &proton : *hRecoProtonsSingleRP) {
-    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->getRPId());
+    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
     unsigned int decRPId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
     singleRPPlots_[decRPId].fill(proton);
   }
 
   // make multi-RP-reco plots
   for (const auto &proton : *hRecoProtonsMultiRP) {
-    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->getRPId());
+    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
     unsigned int armId = rpId.arm();
     multiRPPlots_[armId].fill(proton);
   }
@@ -417,8 +417,8 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
   for (const auto &proton_s : *hRecoProtonsSingleRP) {
     for (const auto &proton_m : *hRecoProtonsMultiRP) {
       // only compare object from the same arm
-      CTPPSDetId rpId_s((*proton_s.contributingLocalTracks().begin())->getRPId());
-      CTPPSDetId rpId_m((*proton_m.contributingLocalTracks().begin())->getRPId());
+      CTPPSDetId rpId_s((*proton_s.contributingLocalTracks().begin())->rpId());
+      CTPPSDetId rpId_m((*proton_m.contributingLocalTracks().begin())->rpId());
 
       if (rpId_s.arm() != rpId_m.arm())
         continue;
@@ -436,7 +436,7 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
   const reco::ForwardProton *p_arm1_s_N = nullptr, *p_arm1_s_F = nullptr, *p_arm1_m = nullptr;
 
   for (const auto &proton : *hRecoProtonsSingleRP) {
-    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->getRPId());
+    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
     const unsigned int rpDecId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
 
     if (rpDecId == rpId_45_N_)
@@ -451,7 +451,7 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
   }
 
   for (const auto &proton : *hRecoProtonsMultiRP) {
-    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->getRPId());
+    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
     const unsigned int arm = rpId.arm();
 
     if (arm == 0)

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
@@ -275,7 +275,7 @@ void CTPPSProtonReconstructionSimulationValidator::analyze(const edm::Event &iEv
       if (rec_pr.method() == reco::ForwardProton::ReconstructionMethod::singleRP) {
         meth_idx = 0;
 
-        CTPPSDetId rpId((*rec_pr.contributingLocalTracks().begin())->getRPId());
+        CTPPSDetId rpId((*rec_pr.contributingLocalTracks().begin())->rpId());
         idx = 100 * rpId.arm() + 10 * rpId.station() + rpId.rp();
       }
 

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionValidator.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionValidator.cc
@@ -97,7 +97,7 @@ void CTPPSProtonReconstructionValidator::analyze(const edm::Event& iEvent, const
       continue;
 
     for (const auto& tr : pr.contributingLocalTracks()) {
-      CTPPSDetId rpId(tr->getRPId());
+      CTPPSDetId rpId(tr->rpId());
       unsigned int rpDecId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
 
       auto it = hOpticalFunctions->find(rpId);
@@ -111,8 +111,8 @@ void CTPPSProtonReconstructionValidator::analyze(const edm::Event& iEvent, const
       LHCInterpolatedOpticalFunctionsSet::Kinematics k_out;
       it->second.transport(k_in, k_out);
 
-      const double de_x = (k_out.x - k_out_beam.x) * 10. - tr->getX();  // conversions: cm --> mm
-      const double de_y = (k_out.y - k_out_beam.y) * 10. - tr->getY();  // conversions: cm --> mm
+      const double de_x = (k_out.x - k_out_beam.x) * 10. - tr->x();  // conversions: cm --> mm
+      const double de_y = (k_out.y - k_out_beam.y) * 10. - tr->y();  // conversions: cm --> mm
 
       rp_plots_[rpDecId].fill(de_x, de_y);
     }

--- a/Validation/CTPPS/plugins/CTPPSTrackDistributionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSTrackDistributionPlotter.cc
@@ -103,22 +103,22 @@ void CTPPSTrackDistributionPlotter::analyze(const edm::Event& iEvent, const edm:
 
   // process tracks
   for (const auto& trk : *tracks) {
-    CTPPSDetId rpId(trk.getRPId());
+    CTPPSDetId rpId(trk.rpId());
     unsigned int rpDecId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
-    rpPlots[rpDecId].fill(trk.getX(), trk.getY());
+    rpPlots[rpDecId].fill(trk.x(), trk.y());
   }
 
   for (const auto& t1 : *tracks) {
-    CTPPSDetId rpId1(t1.getRPId());
+    CTPPSDetId rpId1(t1.rpId());
 
     for (const auto& t2 : *tracks) {
-      CTPPSDetId rpId2(t2.getRPId());
+      CTPPSDetId rpId2(t2.rpId());
 
       if (rpId1.arm() != rpId2.arm())
         continue;
 
       if (rpId1.station() == 0 && rpId2.station() == 2)
-        armPlots[rpId1.arm()].fill(t1.getX(), t1.getY(), t2.getX(), t2.getY());
+        armPlots[rpId1.arm()].fill(t1.x(), t1.y(), t2.x(), t2.y());
     }
   }
 }


### PR DESCRIPTION
#### PR description:

This purely technical/aesthetic PR addresses the proposal in #25690 to drop all `get` prefixes in PPS data formats accessors.

#### PR validation:

Compiles fine, backward-compatible with previously produced samples.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

cc: @jan-kaspar @fabferro 