### PR TITLE
Switch off the signal scaling for the HGC CEH_Sci sector

### DIFF
--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -85,7 +85,11 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
     int PartID = particles[ip];
     const HepPDT::ParticleData* PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID)));
     double mass = PData->mass().value();
-    double mom = sqrt(fEn * fEn - mass * mass);
+    double mom2 = fEn * fEn - mass * mass;
+    double mom = 0.;
+    if (mom2 > 0.) {
+      mom = sqrt(mom2);
+    }
     double px = 0.;
     double py = 0.;
     double pz = mom;

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -220,8 +220,8 @@ hgchebackDigitizer = cms.PSet(
     digiCfg = cms.PSet(
         #0 empty digitizer, 1 calice digitizer, 2 realistic digitizer
         algo          = cms.uint32(2),
-        scaleByTileArea= cms.bool(True),
-        scaleBySipmArea= cms.bool(True),
+        scaleByTileArea= cms.bool(False),
+        scaleBySipmArea= cms.bool(False),
         sipmMap       = cms.string("SimCalorimetry/HGCalSimProducers/data/sipmParams_geom-10.txt"),
         noise         = cms.PSet(refToPSet_ = cms.string("HGCAL_noise_heback")), #scales both for scint raddam and sipm dark current
         keV2MIP       = cms.double(1./675.0),


### PR DESCRIPTION
this PR contains two changes:

- switches off the flags that take care of scaling the signal in the CEH_Sci sector according to the tile and the sipm areas. while this will be eventually turned on again, at the moment there isn't yet a mechanism that re-applies the same factors at recHit level to ensure a calibrated response. Therefore prefer to keep this scaling off until such a mechanism is available.

- adds a protection to the CloseByParticleGun to avoid un-physical cases


@cseez @rovere @apsallid @pfs @franzoni 