### PR TITLE
Include dedx collections in fastsim output

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -251,9 +251,6 @@ void FastTrackDeDxProducer::processHit(const FastTrackerRecHit& recHit,
     return;
   if (!thit.hasPositionAndError())
     return;
-  auto const& clus = thit.firstClusterRef();
-  if (!clus.isValid())
-    return;
 
   if (recHit.isPixel()) {
     if (!usePixel)

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -118,8 +118,8 @@ void FastTrackDeDxProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
   desc.add<bool>("UsePixel", false);
   desc.add<bool>("UseStrip", true);
-  desc.add<double>("MeVperADCPixel", 3.61e-06 * 265);
-  desc.add<double>("MeVperADCStrip", 3.61e-06);
+  desc.add<double>("MeVperADCStrip", 3.61e-06 * 265);
+  desc.add<double>("MeVperADCPixel", 3.61e-06);
   desc.add<bool>("ShapeTest", true);
   desc.add<bool>("UseCalibration", false);
   desc.add<string>("calibrationPath", "");
@@ -248,6 +248,8 @@ void FastTrackDeDxProducer::processHit(const FastTrackerRecHit& recHit,
 
   auto const& thit = static_cast<BaseTrackerRecHit const&>(recHit);
   if (!thit.isValid())
+    return;
+  if (!thit.hasPositionAndError())
     return;
   auto const& clus = thit.firstClusterRef();
   if (!clus.isValid())

--- a/RecoTracker/Configuration/python/RecoTracker_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_cff.py
@@ -38,6 +38,4 @@ trackingGlobalRecoTask = cms.Task(ckftracksTask, trackExtrapolator)
 trackingGlobalReco = cms.Sequence(trackingGlobalRecoTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-ckftracks_fast = cms.Sequence(doAlldEdXEstimators)
-_fastSim_trackingGlobalReco = cms.Sequence(ckftracks_fast*trackExtrapolator)
-fastSim.toReplaceWith(trackingGlobalReco,_fastSim_trackingGlobalReco)
+fastSim.toReplaceWith(trackingGlobalRecoTask, cms.Task(doAlldEdXEstimatorsTask, trackExtrapolator))

--- a/RecoTracker/Configuration/python/RecoTracker_cff.py
+++ b/RecoTracker/Configuration/python/RecoTracker_cff.py
@@ -38,5 +38,6 @@ trackingGlobalRecoTask = cms.Task(ckftracksTask, trackExtrapolator)
 trackingGlobalReco = cms.Sequence(trackingGlobalRecoTask)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-_fastSim_trackingGlobalReco = cms.Sequence(trackExtrapolator)
+ckftracks_fast = cms.Sequence(doAlldEdXEstimators)
+_fastSim_trackingGlobalReco = cms.Sequence(ckftracks_fast*trackExtrapolator)
 fastSim.toReplaceWith(trackingGlobalReco,_fastSim_trackingGlobalReco)

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -46,6 +46,20 @@ dedxHarmonic2 = cms.EDProducer("DeDxEstimatorProducer",
     calibrationPath = cms.string(""),
 )
 
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+
+# explicit python dependency
+import FastSimulation.SimplifiedGeometryPropagator.FastTrackDeDxProducer_cfi
+
+# do this before defining dedxPixelHarmonic2 so it automatically comes out right
+fastSim.toReplaceWith(dedxHarmonic2,
+    FastSimulation.SimplifiedGeometryPropagator.FastTrackDeDxProducer_cfi.FastTrackDeDxProducer.clone(
+        ShapeTest = False,
+        simHit2RecHitMap = cms.InputTag("fastMatchedTrackerRecHits","simHit2RecHitMap"),
+        simHits = cms.InputTag("fastSimProducer","TrackerHits"),
+    )
+)
+
 dedxPixelHarmonic2 = dedxHarmonic2.clone(UseStrip = False, UsePixel = True)
 
 dedxPixelAndStripHarmonic2T085 = dedxHarmonic2.clone(
@@ -78,3 +92,9 @@ dedxDiscrimASmi.estimator = cms.string('asmirnovDiscrim')
 
 doAlldEdXEstimatorsTask = cms.Task(dedxTruncated40 , dedxHarmonic2 , dedxPixelHarmonic2 , dedxPixelAndStripHarmonic2T085 , dedxHitInfo)
 doAlldEdXEstimators = cms.Sequence(doAlldEdXEstimatorsTask)
+
+doFastdEdXEstimatorsTask = cms.Task(dedxHarmonic2, dedxPixelHarmonic2)
+doFastdEdXEstimators = cms.Sequence(doFastdEdXEstimatorsTask)
+
+fastSim.toReplaceWith(doAlldEdXEstimatorsTask, doFastdEdXEstimatorsTask)
+fastSim.toReplaceWith(doAlldEdXEstimators, doFastdEdXEstimators)

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -93,8 +93,4 @@ dedxDiscrimASmi.estimator = cms.string('asmirnovDiscrim')
 doAlldEdXEstimatorsTask = cms.Task(dedxTruncated40 , dedxHarmonic2 , dedxPixelHarmonic2 , dedxPixelAndStripHarmonic2T085 , dedxHitInfo)
 doAlldEdXEstimators = cms.Sequence(doAlldEdXEstimatorsTask)
 
-doFastdEdXEstimatorsTask = cms.Task(dedxHarmonic2, dedxPixelHarmonic2)
-doFastdEdXEstimators = cms.Sequence(doFastdEdXEstimatorsTask)
-
-fastSim.toReplaceWith(doAlldEdXEstimatorsTask, doFastdEdXEstimatorsTask)
-fastSim.toReplaceWith(doAlldEdXEstimators, doFastdEdXEstimators)
+fastSim.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(dedxHarmonic2, dedxPixelHarmonic2))


### PR DESCRIPTION
#### PR description:

The `FastTrackDeDxProducer` is now included in the FastSim reconstruction sequence with two versions (strip tracker and pixel).

The sizes of the new output collections from a test config are (using `edmEventSize`):
```
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
recoDeDxDataedmValueMap_dedxHarmonic2__RECO. 11165.7 1507.67
recoDeDxDataedmValueMap_dedxPixelHarmonic2__RECO. 11192.3 1399.33
```

Similar collections are already included in regular RECO/AOD output, so this should be an acceptable increase for FastSim RECO/AOD output.

This PR also fixes a condition in the producer that was modified in the backport PR #28235, but erroneously not modified in master.

#### PR validation:

Ran a private test config without errors and observed the desired collections in the output.

attn: @sbein @ssekmen @scarletnorberg