### PR TITLE
Use corrected PF cluster correction tags for 2018 design MC scenario

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -54,7 +54,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '110X_upgrade2018_design_v2',
+    'phase1_2018_design'       :  '110X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:

PR #28014 corrected a bug in the EGamma PF cluster corrections that led to an incorrect energy scale. However, the 2018 design scenario was inadvertently not updated. Details can be found at [1]. The correction has already been made in the 10_6_X autoCond update in PR #28053.

**Global tag diff**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_design_v2/110X_upgrade2018_design_v3

[1] https://indico.cern.ch/event/842863/contributions/3562026/attachments/1906927/3149650/updates_2018ULPFCorrections.pdf

#### PR validation:

Please see [1] for details of the physics validation. In addition, a technical test was performed: `runTheMatrix.py -l 11224.0`

[1] https://indico.cern.ch/event/842863/contributions/3562026/attachments/1906927/3149650/updates_2018ULPFCorrections.pdf

#### if this PR is a backport please specify the original PR:

This PR is not a backport but the changes are already present in 10_6_X PR #28053.
