### PR TITLE
[GCC9] fix implicit-fallthrough warning for TrackingTools/TrackAssociator

### DIFF
--- a/TrackingTools/TrackAssociator/src/TrackDetMatchInfo.cc
+++ b/TrackingTools/TrackAssociator/src/TrackDetMatchInfo.cc
@@ -353,7 +353,7 @@ DetId TrackDetMatchInfo::findMaxDeposition(EnergyType type) {
           id = (*hit)->id();
         }
       }
-    }
+    } break;
     default:
       throw cms::Exception("FatalError")
           << "Maximal energy deposition: unkown or not implemented energy type requested, type:" << type;

--- a/TrackingTools/TrackAssociator/src/TrackDetMatchInfo.cc
+++ b/TrackingTools/TrackAssociator/src/TrackDetMatchInfo.cc
@@ -329,7 +329,8 @@ DetId TrackDetMatchInfo::findMaxDeposition(EnergyType type) {
     } break;
     case TowerTotal:
     case TowerEcal:
-    case TowerHcal: {
+    case TowerHcal:
+    case TowerHO: {
       for (std::vector<const CaloTower*>::const_iterator hit = towers.begin(); hit != towers.end(); hit++) {
         double energy = 0;
         switch (type) {


### PR DESCRIPTION
This should fix the GCC9 compilation warning
