### PR TITLE
Fix gcc9 warning in DetectorDescription/DDCMS (missing struct initial…

### DIFF
--- a/DetectorDescription/DDCMS/interface/Filter.h
+++ b/DetectorDescription/DDCMS/interface/Filter.h
@@ -28,7 +28,7 @@ namespace cms {
     std::vector<std::string_view> keys;
     std::unique_ptr<Filter> next;
     struct Filter* up;
-    const DDSpecPar* spec;
+    const DDSpecPar* spec = {};
   };
 
   namespace dd {

--- a/DetectorDescription/DDCMS/interface/Filter.h
+++ b/DetectorDescription/DDCMS/interface/Filter.h
@@ -28,7 +28,7 @@ namespace cms {
     std::vector<std::string_view> keys;
     std::unique_ptr<Filter> next;
     struct Filter* up;
-    const DDSpecPar* spec = {};
+    const DDSpecPar* spec = nullptr;
   };
 
   namespace dd {


### PR DESCRIPTION


#### PR description:
Fixes 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_11_0_X_2019-10-24-2300/DetectorDescription/DDCMS

#### PR validation:
Compiles without a warning

