### PR TITLE
[GCC9] fix warning by adding the missing break for RecoParticleFlow/PFProducer

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -197,7 +197,7 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       switch (elements[0].type()) {
         case reco::PFBlockElement::SC:
           edm::LogError("PFEGammaProducer") << "PFBLOCKALGO BUG!!!! Found a SuperCluster in a block by itself!";
-          [[fallthrough]];
+          break;
         case reco::PFBlockElement::PS1:
         case reco::PFBlockElement::PS2:
         case reco::PFBlockElement::ECAL:

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -197,6 +197,7 @@ void PFEGammaProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       switch (elements[0].type()) {
         case reco::PFBlockElement::SC:
           edm::LogError("PFEGammaProducer") << "PFBLOCKALGO BUG!!!! Found a SuperCluster in a block by itself!";
+          [[fallthrough]];
         case reco::PFBlockElement::PS1:
         case reco::PFBlockElement::PS2:
         case reco::PFBlockElement::ECAL:


### PR DESCRIPTION
This should fix the GCC9 compilation warning, added missing break