### PR TITLE
Fix gcc 9 warning in HLTrigger/HLTfilters

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
@@ -1371,8 +1371,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event& iEvent, trigger::TriggerFilterObj
               }
               includeTauJet = false;
             }
-          }
-          break;
+          } break;
           case HfRingEtSums: {
             if (includeIsoTauJet) {
               edm::Handle<l1extra::L1JetParticleCollection> l1IsoTauJet;

--- a/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
@@ -1372,7 +1372,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event& iEvent, trigger::TriggerFilterObj
               includeTauJet = false;
             }
           }
-
+            [[fallthrough]];
           case HfRingEtSums: {
             if (includeIsoTauJet) {
               edm::Handle<l1extra::L1JetParticleCollection> l1IsoTauJet;

--- a/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTLevel1GTSeed.cc
@@ -1372,7 +1372,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event& iEvent, trigger::TriggerFilterObj
               includeTauJet = false;
             }
           }
-            [[fallthrough]];
+          break;
           case HfRingEtSums: {
             if (includeIsoTauJet) {
               edm::Handle<l1extra::L1JetParticleCollection> l1IsoTauJet;


### PR DESCRIPTION
#### PR description:
Fixes this 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_11_0_X_2019-10-24-2300/HLTrigger/HLTfilters
#### PR validation:

Compiles without the warning

