### PR TITLE
[GCC9] fix base class initialization warning for RecoTracker/TkHitPairs

### DIFF
--- a/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
@@ -11,7 +11,8 @@ CombinedHitPairGenerator::CombinedHitPairGenerator(const edm::ParameterSet& cfg,
 }
 
 CombinedHitPairGenerator::CombinedHitPairGenerator(const CombinedHitPairGenerator& cb)
-    : theSeedingLayerToken(cb.theSeedingLayerToken),
+    : HitPairGenerator(cb),
+      theSeedingLayerToken(cb.theSeedingLayerToken),
       theGenerator(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, cb.theMaxElement)) {
   theMaxElement = cb.theMaxElement;
 }


### PR DESCRIPTION
This should fix the GCC9 compilation warning. 