### PR TITLE
Fix gcc 9 warning in L1Trigger/GlobalTriggerAnalyzer

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternWriter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternWriter.cc
@@ -114,8 +114,8 @@ L1GtPatternWriter::~L1GtPatternWriter() { close(); }
 
 uint32_t L1GtPatternWriter::mask(uint32_t length) {
   if (length < 32) {
-    constexpr unsigned left_op = 0;
-    return ~(~left_op << length);
+    constexpr unsigned left_op = ~0;
+    return ~(left_op << length);
   } else {
     return ~0;
   }

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternWriter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternWriter.cc
@@ -114,7 +114,8 @@ L1GtPatternWriter::~L1GtPatternWriter() { close(); }
 
 uint32_t L1GtPatternWriter::mask(uint32_t length) {
   if (length < 32) {
-    return ~((~0) << length);
+    constexpr unsigned left_op = 0;
+    return ~(~left_op << length);
   } else {
     return ~0;
   }


### PR DESCRIPTION
#### PR description:

Fixes gcc9 warning in L1Trigger/GlobalTriggerAnalyzer

#### PR validation:

Compiles without the warning
I could've put only 

`return ~((~(unsigned)0) << length);`

decided to be more expresive 