### PR TITLE
[GCC9] Fix for empty else body in L1TriggerConfig/L1GtConfigProducers

### DIFF
--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc
@@ -729,8 +729,7 @@ bool L1GtVhdlWriterCore::processAlgorithmMap(std::vector<std::map<int, std::stri
       algorithmsChip2[pin] = logicalExpr;
       if (debugMode_)
         algorithmsChip2[pin] += ("-- " + logicalExprCopy);
-    } else
-      ;
+    }
 
     algoIter++;
   }


### PR DESCRIPTION
This should fix the GCC9 compilation warning.