### PR TITLE
Many classes in EgammaElectronAlgos turned into pure functions

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
@@ -7,7 +7,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-namespace EgAmbiguityTools {
+namespace electronAlgos {
   // for clusters
   float sharedEnergy(reco::CaloCluster const& clu1,
                      reco::CaloCluster const& clu2,
@@ -26,6 +26,6 @@ namespace EgAmbiguityTools {
   bool isBetter(reco::GsfElectron const&, reco::GsfElectron const&);
   bool isInnerMost(reco::GsfElectron const&, reco::GsfElectron const&);
 
-}  // namespace EgAmbiguityTools
+}  // namespace electronAlgos
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
@@ -24,7 +24,7 @@ namespace egamma {
 
   // electrons comparison
   bool isBetterElectron(reco::GsfElectron const&, reco::GsfElectron const&);
-  bool isInnerMostElectron(reco::GsfElectron const&, reco::GsfElectron const&);
+  bool isInnermostElectron(reco::GsfElectron const&, reco::GsfElectron const&);
 
 }  // namespace egamma
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
@@ -7,7 +7,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-namespace electronAlgos {
+namespace egamma {
   // for clusters
   float sharedEnergy(reco::CaloCluster const& clu1,
                      reco::CaloCluster const& clu2,
@@ -23,9 +23,9 @@ namespace electronAlgos {
   int sharedDets(reco::GsfTrackRef const&, reco::GsfTrackRef const&);
 
   // electrons comparison
-  bool isBetter(reco::GsfElectron const&, reco::GsfElectron const&);
-  bool isInnerMost(reco::GsfElectron const&, reco::GsfElectron const&);
+  bool isBetterElectron(reco::GsfElectron const&, reco::GsfElectron const&);
+  bool isInnerMostElectron(reco::GsfElectron const&, reco::GsfElectron const&);
 
-}  // namespace electronAlgos
+}  // namespace egamma
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h
@@ -9,8 +9,8 @@
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-namespace electronAlgos {
-  reco::GsfElectron::Classification classify(reco::GsfElectron const&);
+namespace egamma {
+  reco::GsfElectron::Classification classifyElectron(reco::GsfElectron const&);
 }
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h
@@ -7,24 +7,10 @@
 // See GsfElectron::Classification
 //===================================================================
 
-//#include "ElectronPhoton/EgammaAnalysis/interface/EgammaCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-class ElectronClassification {
-public:
-  ElectronClassification() {}
-
-  void classify(reco::GsfElectron&);
-  void refineWithPflow(reco::GsfElectron&);
-
-private:
-  //  void classify(const reco::GsfElectron &);
-
-  //  bool isInCrack(float eta) const;
-  //  bool isInEtaGaps(float eta) const;
-  //  bool isInPhiGaps(float phi) const;
-
-  //  reco::GsfElectron::Classification electronClass_;
-};
+namespace electronAlgos {
+  reco::GsfElectron::Classification classify(reco::GsfElectron const&);
+}
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h
@@ -7,14 +7,14 @@
 
 class EcalClusterFunctionBaseClass;
 
-namespace electronAlgos {
+namespace egamma {
 
-  float classBasedParameterizationEnergy(reco::GsfElectron const &,
-                                         reco::BeamSpot const &,
-                                         EcalClusterFunctionBaseClass const &crackCorrectionFunction);
-  double classBasedParameterizationUncertainty(reco::GsfElectron const &);
-  double simpleParameterizationUncertainty(reco::GsfElectron const &);
+  float classBasedElectronEnergy(reco::GsfElectron const &,
+                                 reco::BeamSpot const &,
+                                 EcalClusterFunctionBaseClass const &crackCorrectionFunction);
+  double classBasedElectronEnergyUncertainty(reco::GsfElectron const &);
+  double simpleElectronEnergyUncertainty(reco::GsfElectron const &);
 
-}  // namespace electronAlgos
+}  // namespace egamma
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h
@@ -7,30 +7,14 @@
 
 class EcalClusterFunctionBaseClass;
 
-class ElectronEnergyCorrector {
-public:
-  ElectronEnergyCorrector(EcalClusterFunctionBaseClass *crackCorrectionFunction)
-      : crackCorrectionFunction_(crackCorrectionFunction) {}
+namespace electronAlgos {
 
-  void classBasedParameterizationEnergy(reco::GsfElectron &, const reco::BeamSpot &bs);
-  void classBasedParameterizationUncertainty(reco::GsfElectron &);
-  void simpleParameterizationUncertainty(reco::GsfElectron &);
+  float classBasedParameterizationEnergy(reco::GsfElectron const &,
+                                         reco::BeamSpot const &,
+                                         EcalClusterFunctionBaseClass const &crackCorrectionFunction);
+  double classBasedParameterizationUncertainty(reco::GsfElectron const &);
+  double simpleParameterizationUncertainty(reco::GsfElectron const &);
 
-private:
-  double fEtaBarrelBad(double scEta) const;
-  double fEtaBarrelGood(double scEta) const;
-  double fEtaEndcapBad(double scEta) const;
-  double fEtaEndcapGood(double scEta) const;
-
-  // new corrections (N. Chanon et al.)
-  float fEta(float energy, float eta, int algorithm) const;
-  //float fBrem (float e,  float eta, int algorithm) const ;
-  //float fEtEta(float et, float eta, int algorithm) const ;
-  float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl) const;
-  float fEt(float et, int algorithm, reco::GsfElectron::Classification cl) const;
-  float fEnergy(float e, int algorithm, reco::GsfElectron::Classification cl) const;
-
-  EcalClusterFunctionBaseClass *crackCorrectionFunction_;
-};
+}  // namespace electronAlgos
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h
@@ -12,7 +12,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-namespace electronAlgos {
+namespace egamma {
 
   struct ElectronMomentum {
     const math::XYZTLorentzVector momentum;
@@ -20,7 +20,7 @@ namespace electronAlgos {
     const float finalError;
   };
 
-  ElectronMomentum correctMomentum(reco::GsfElectron const&, TrajectoryStateOnSurface const&);
-}  // namespace electronAlgos
+  ElectronMomentum correctElectronMomentum(reco::GsfElectron const&, TrajectoryStateOnSurface const&);
+}  // namespace egamma
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h
@@ -8,38 +8,19 @@
 //adapted to CMSSW by U.Berthon, dec 2006
 //===================================================================
 
-/*! \file ElectronMomentumCorrector.h
-  Egamma class for Correction of electrons energy.
-*/
-
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-class ElectronMomentumCorrector {
-public:
-  //  ElectronMomentumCorrector(){newMomentum_=CLHEP::HepLorentzVector();}
-  // ElectronMomentumCorrector(){ newMomentum_= math::XYZTLorentzVector();}
-  ElectronMomentumCorrector() {}
-  //virtual
-  ~ElectronMomentumCorrector() {}
+namespace electronAlgos {
 
-  //virtual
-  void correct(reco::GsfElectron &, TrajectoryStateOnSurface &);
+  struct ElectronMomentum {
+    const math::XYZTLorentzVector momentum;
+    const float trackError;
+    const float finalError;
+  };
 
-  //DC: USED ??
-  ////  CLHEP::HepLorentzVector getBestMomentum() const {return newMomentum_;}
-  //math::XYZTLorentzVector getBestMomentum() const {return newMomentum_;}
-  //float getSCEnergyError() const {return errorEnergy_;}
-  //float getTrackMomentumError() const {return errorTrackMomentum_;}
-
-private:
-  float energyError(float E, float *par) const;
-
-  //  CLHEP::HepLorentzVector newMomentum_;
-  //math::XYZTLorentzVector newMomentum_;
-  //float errorEnergy_;
-  //float errorTrackMomentum_;
-};
+  ElectronMomentum correctMomentum(reco::GsfElectron const&, TrajectoryStateOnSurface const&);
+}  // namespace electronAlgos
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h
@@ -7,31 +7,12 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-class EnergyUncertaintyElectronSpecific {
-public:
-  //EnergyUncertaintyElectronSpecific( const edm::ParameterSet& config);
-  EnergyUncertaintyElectronSpecific();
-  ~EnergyUncertaintyElectronSpecific();
+namespace electronAlgos {
 
-  void init(const edm::EventSetup& theEventSetup);
-  //void calculate( edm::Event& evt, reco::Electron &, int subdet,const reco::VertexCollection& vtxcol,const edm::EventSetup& iSetup) ;
-  //double applyCrackCorrection(const reco::SuperCluster &cl, EcalClusterFunctionBaseClass* crackCorrectionFunction);
+  double computeEnergyUncertainty(reco::GsfElectron::Classification c, double eta, double brem, double energy);
 
-  double computeElectronEnergyUncertainty(reco::GsfElectron::Classification c, double eta, double brem, double energy);
-
-private:
-  double computeElectronEnergyUncertainty_golden(double eta, double brem, double energy);
-  double computeElectronEnergyUncertainty_bigbrem(double eta, double brem, double energy);
-  double computeElectronEnergyUncertainty_showering(double eta, double brem, double energy);
-  double computeElectronEnergyUncertainty_cracks(double eta, double brem, double energy);
-  double computeElectronEnergyUncertainty_badtrack(double eta, double brem, double energy);
-};
+}
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h
@@ -9,9 +9,9 @@
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-namespace electronAlgos {
+namespace egamma {
 
-  double computeEnergyUncertainty(reco::GsfElectron::Classification c, double eta, double brem, double energy);
+  double electronEnergyUncertainty(reco::GsfElectron::Classification c, double eta, double brem, double energy);
 
 }
 

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -81,7 +81,7 @@ public:
     bool pureTrackerDrivenEcalErrorFromSimpleParameterization;
     // ambiguity solving
     bool applyAmbResolution;              // if not true, ambiguity solving is not applied
-    unsigned ambSortingStrategy;          // 0:isBetter, 1:isInnerMost
+    unsigned ambSortingStrategy;          // 0:isBetter, 1:isInnermost
     unsigned ambClustersOverlapStrategy;  // 0:sc adresses, 1:bc shared energy
     // if true, trackerDriven electrons are added
     bool addPflowElectrons;

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
@@ -5,13 +5,13 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-namespace gsfElectronTools {
+namespace electronAlgos {
 
   // From Puneeth Kalavase : returns the CTF track that has the highest fraction
   // of shared hits in Pixels and the inner strip tracker with the electron Track
   std::pair<reco::TrackRef, float> getClosestCtfToGsf(reco::GsfTrackRef const&,
                                                       edm::Handle<reco::TrackCollection> const& ctfTracksH);
 
-}  // namespace gsfElectronTools
+}  // namespace electronAlgos
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
@@ -5,13 +5,13 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-namespace electronAlgos {
+namespace egamma {
 
   // From Puneeth Kalavase : returns the CTF track that has the highest fraction
   // of shared hits in Pixels and the inner strip tracker with the electron Track
   std::pair<reco::TrackRef, float> getClosestCtfToGsf(reco::GsfTrackRef const&,
                                                       edm::Handle<reco::TrackCollection> const& ctfTracksH);
 
-}  // namespace electronAlgos
+}  // namespace egamma
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
@@ -11,13 +11,13 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-namespace electronAlgos {
+namespace egamma {
 
-  bool isBetter(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
+  bool isBetterElectron(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
     return (std::abs(e1.eSuperClusterOverP() - 1) < std::abs(e2.eSuperClusterOverP() - 1));
   }
 
-  bool isInnerMost(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
+  bool isInnerMostElectron(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
     // retreive first valid hit
     int gsfHitCounter1 = 0;
     for (auto const& elHit : e1.gsfTrack()->recHits()) {
@@ -41,7 +41,7 @@ namespace electronAlgos {
     } else if (HitPattern::getLayer(gsfHit1) != HitPattern::getLayer(gsfHit2)) {
       return (HitPattern::getLayer(gsfHit1) < HitPattern::getLayer(gsfHit2));
     } else {
-      return isBetter(e1, e2);
+      return isBetterElectron(e1, e2);
     }
   }
 
@@ -177,4 +177,4 @@ namespace electronAlgos {
     return energyShared;
   }
 
-}  // namespace electronAlgos
+}  // namespace egamma

--- a/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
@@ -11,7 +11,7 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-namespace EgAmbiguityTools {
+namespace electronAlgos {
 
   bool isBetter(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
     return (std::abs(e1.eSuperClusterOverP() - 1) < std::abs(e2.eSuperClusterOverP() - 1));
@@ -177,4 +177,4 @@ namespace EgAmbiguityTools {
     return energyShared;
   }
 
-}  // namespace EgAmbiguityTools
+}  // namespace electronAlgos

--- a/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
@@ -17,7 +17,7 @@ namespace egamma {
     return (std::abs(e1.eSuperClusterOverP() - 1) < std::abs(e2.eSuperClusterOverP() - 1));
   }
 
-  bool isInnerMostElectron(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
+  bool isInnermostElectron(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
     // retreive first valid hit
     int gsfHitCounter1 = 0;
     for (auto const& elHit : e1.gsfTrack()->recHits()) {

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronClassification.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronClassification.cc
@@ -9,7 +9,7 @@
 
 using namespace reco;
 
-GsfElectron::Classification electronAlgos::classify(GsfElectron const& electron) {
+GsfElectron::Classification egamma::classifyElectron(GsfElectron const& electron) {
   if (!electron.isEB() && !electron.isEE()) {
     edm::LogWarning("") << "ElectronClassification::init(): Undefined electron, eta = " << electron.eta() << "!!!!";
     return GsfElectron::UNKNOWN;

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronClassification.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronClassification.cc
@@ -1,8 +1,5 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h"
-
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //===================================================================
 // Author: Federico Ferri - INFN Milano, Bicocca university
@@ -12,43 +9,28 @@
 
 using namespace reco;
 
-void ElectronClassification::classify(GsfElectron& electron) {
-  if ((!electron.isEB()) && (!electron.isEE())) {
+GsfElectron::Classification electronAlgos::classify(GsfElectron const& electron) {
+  if (!electron.isEB() && !electron.isEE()) {
     edm::LogWarning("") << "ElectronClassification::init(): Undefined electron, eta = " << electron.eta() << "!!!!";
-    electron.setClassification(GsfElectron::UNKNOWN);
-    return;
+    return GsfElectron::UNKNOWN;
   }
 
   if (electron.isEBEEGap() || electron.isEBEtaGap() || electron.isEERingGap()) {
-    electron.setClassification(GsfElectron::GAP);
-    return;
+    return GsfElectron::GAP;
   }
 
-  //float pin  = electron.trackMomentumAtVtx().R() ;
   float fbrem = electron.trackFbrem();
   int nbrem = electron.numberOfBrems();
 
-  if (nbrem == 0 && fbrem < 0.5)  // part (pin - scEnergy)/pin < 0.1 removed - M.D.
-  {
-    electron.setClassification(GsfElectron::GOLDEN);
-  } else if (nbrem == 0 && fbrem >= 0.5)  // part (pin - scEnergy)/pin < 0.1 removed - M.D.
-  {
-    electron.setClassification(GsfElectron::BIGBREM);
-  } else {
-    electron.setClassification(GsfElectron::SHOWERING);
-  }
-}
-
-void ElectronClassification::refineWithPflow(GsfElectron& electron) {
-  if ((!electron.isEB()) && (!electron.isEE())) {
-    return;
+  if (electron.superClusterFbrem() - fbrem >= 0.15) {
+    return GsfElectron::BADTRACK;
   }
 
-  if (electron.isEBEEGap() || electron.isEBEtaGap() || electron.isEERingGap()) {
-    return;
+  if (nbrem == 0 && fbrem < 0.5) {
+    return GsfElectron::GOLDEN;
   }
-
-  if ((electron.superClusterFbrem() - electron.trackFbrem()) >= 0.15) {
-    electron.setClassification(GsfElectron::BADTRACK);
+  if (nbrem == 0 && fbrem >= 0.5) {
+    return GsfElectron::BIGBREM;
   }
+  return GsfElectron::SHOWERING;
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
@@ -1,4 +1,3 @@
-
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
@@ -16,16 +15,258 @@
  *
  ****************************************************************************/
 
-float fEta(float energy, float eta, int algorithm);
-float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl);
-float fEt(float ET, int algorithm, reco::GsfElectron::Classification cl);
-float fEnergy(float E, int algorithm, reco::GsfElectron::Classification cl);
-double fEtaBarrelGood(double scEta);
-double fEtaBarrelBad(double scEta);
-double fEtaEndcapGood(double scEta);
-double fEtaEndcapBad(double scEta);
+namespace {
 
-float energyError(float E, float* par) { return sqrt(pow(par[0] / sqrt(E), 2) + pow(par[1] / E, 2) + pow(par[2], 2)); }
+  inline float energyError(float E, float* par) {
+    return sqrt(pow(par[0] / sqrt(E), 2) + pow(par[1] / E, 2) + pow(par[2], 2));
+  }
+
+  // main correction function
+  // new corrections: taken from EcalClusterCorrectionObjectSpecific.cc (N. Chanon et al.)
+  // this is to prepare for class based corrections, for the time being the parameters are the same as for the SC corrections
+  // code fully duplicated here, to be improved; electron means algorithm==0 and mode==0
+
+  float fEta(float energy, float eta, int algorithm) {
+    // corrections for electrons
+    if (algorithm != 0) {
+      edm::LogWarning("ElectronEnergyCorrector::fEta") << "algorithm should be 0 for electrons !";
+      return energy;
+    }
+    //std::cout << "fEta function" << std::endl;
+
+    // this correction is setup only for EB
+    if (algorithm != 0)
+      return energy;
+
+    float ieta = fabs(eta) * (5 / 0.087);
+    // bypass the DB reading for the time being
+    //float p0 = (params_->params())[0];  // should be 40.2198
+    //float p1 = (params_->params())[1];  // should be -3.03103e-6
+    float p0 = 40.2198;
+    float p1 = -3.03103e-6;
+
+    //std::cout << "ieta=" << ieta << std::endl;
+
+    float correctedEnergy = energy;
+    if (ieta < p0)
+      correctedEnergy = energy;
+    else
+      correctedEnergy = energy / (1.0 + p1 * (ieta - p0) * (ieta - p0));
+    //std::cout << "ECEC fEta = " << correctedEnergy << std::endl;
+    return correctedEnergy;
+  }
+
+  float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl) {
+    // corrections for electrons
+    if (algorithm != 0) {
+      edm::LogWarning("ElectronEnergyCorrector::fBremEta") << "algorithm should be 0 for electrons !";
+      return 1.;
+    }
+
+    const float etaCrackMin = 1.44;
+    const float etaCrackMax = 1.56;
+
+    //STD
+    const int nBinsEta = 14;
+    float leftEta[nBinsEta] = {0.02, 0.25, 0.46, 0.81, 0.91, 1.01, 1.16, etaCrackMax, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4};
+    float rightEta[nBinsEta] = {0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4, 2.5};
+
+    // eta = 0
+    if (TMath::Abs(eta) < leftEta[0]) {
+      eta = 0.02;
+    }
+
+    // outside acceptance
+    if (TMath::Abs(eta) >= rightEta[nBinsEta - 1]) {
+      eta = 2.49;
+    }  //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
+
+    int tmpEta = -1;
+    for (int iEta = 0; iEta < nBinsEta; ++iEta) {
+      if (leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < rightEta[iEta]) {
+        tmpEta = iEta;
+      }
+    }
+
+    float xcorr[nBinsEta][reco::GsfElectron::GAP + 1] = {{1.00227, 1.00227, 1.00227, 1.00227, 1.00227},
+                                                         {1.00252, 1.00252, 1.00252, 1.00252, 1.00252},
+                                                         {1.00225, 1.00225, 1.00225, 1.00225, 1.00225},
+                                                         {1.00159, 1.00159, 1.00159, 1.00159, 1.00159},
+                                                         {0.999475, 0.999475, 0.999475, 0.999475, 0.999475},
+                                                         {0.997203, 0.997203, 0.997203, 0.997203, 0.997203},
+                                                         {0.993886, 0.993886, 0.993886, 0.993886, 0.993886},
+                                                         {0.971262, 0.971262, 0.971262, 0.971262, 0.971262},
+                                                         {0.975922, 0.975922, 0.975922, 0.975922, 0.975922},
+                                                         {0.979087, 0.979087, 0.979087, 0.979087, 0.979087},
+                                                         {0.98495, 0.98495, 0.98495, 0.98495, 0.98495},
+                                                         {0.98781, 0.98781, 0.98781, 0.98781, 0.98781},
+                                                         {0.989546, 0.989546, 0.989546, 0.989546, 0.989546},
+                                                         {0.989638, 0.989638, 0.989638, 0.989638, 0.989638}};
+
+    float par0[nBinsEta][reco::GsfElectron::GAP + 1] = {{0.994949, 1.00718, 1.00718, 1.00556, 1.00718},
+                                                        {1.009, 1.00713, 1.00713, 1.00248, 1.00713},
+                                                        {0.999395, 1.00641, 1.00641, 1.00293, 1.00641},
+                                                        {0.988662, 1.00761, 1.001, 0.99972, 1.00761},
+                                                        {0.998443, 1.00682, 1.001, 1.00282, 1.00682},
+                                                        {1.00285, 1.0073, 1.001, 1.00396, 1.0073},
+                                                        {0.993053, 1.00462, 1.01341, 1.00184, 1.00462},
+                                                        {1.10561, 0.972798, 1.02835, 0.995218, 0.972798},
+                                                        {0.893741, 0.981672, 0.98982, 1.01712, 0.981672},
+                                                        {0.911123, 0.98251, 1.03466, 1.00824, 0.98251},
+                                                        {0.981931, 0.986123, 0.954295, 1.0202, 0.986123},
+                                                        {0.905634, 0.990124, 0.928934, 0.998492, 0.990124},
+                                                        {0.919343, 0.990187, 0.967526, 0.963923, 0.990187},
+                                                        {0.844783, 0.99372, 0.923808, 0.953001, 0.99372}};
+
+    float par1[nBinsEta][reco::GsfElectron::GAP + 1] = {
+        {0.0111034, -0.00187886, -0.00187886, -0.00289304, -0.00187886},
+        {-0.00969012, -0.00227574, -0.00227574, -0.00182187, -0.00227574},
+        {0.00389454, -0.00259935, -0.00259935, -0.00211059, -0.00259935},
+        {0.017095, -0.00433692, -0.00302335, -0.00241385, -0.00433692},
+        {-0.00049009, -0.00551324, -0.00302335, -0.00532352, -0.00551324},
+        {-0.00252723, -0.00799669, -0.00302335, -0.00823109, -0.00799669},
+        {0.00332567, -0.00870057, -0.0170581, -0.011482, -0.00870057},
+        {-0.213285, -0.000771577, -0.036007, -0.0187526, -0.000771577},
+        {0.1741, -0.00202028, -0.0233995, -0.0302066, -0.00202028},
+        {0.152794, 0.00441308, -0.0468563, -0.0158817, 0.00441308},
+        {0.0351465, 0.00832913, 0.0358028, -0.0233262, 0.00832913},
+        {0.185781, 0.00742879, 0.08858, 0.00568078, 0.00742879},
+        {0.153088, 0.0094608, 0.0489979, 0.0491897, 0.0094608},
+        {0.296681, 0.00560406, 0.106492, 0.0652007, 0.00560406}};
+
+    float par2[nBinsEta][reco::GsfElectron::GAP + 1] = {{-0.00330844, 0, 0, 5.62441e-05, 0},
+                                                        {0.00329373, 0, 0, -0.000113883, 0},
+                                                        {-0.00104661, 0, 0, -0.000152794, 0},
+                                                        {-0.0060409, 0, -0.000257724, -0.000202099, 0},
+                                                        {-0.000742866, 0, -0.000257724, -2.06003e-05, 0},
+                                                        {-0.00205425, 0, -0.000257724, 3.84179e-05, 0},
+                                                        {-0.00350757, 0, 0.000590483, 0.000323723, 0},
+                                                        {0.0794596, -0.00276696, 0.00205854, 0.000356716, -0.00276696},
+                                                        {-0.092436, -0.00471028, 0.00062096, 0.00088347, -0.00471028},
+                                                        {-0.0855029, -0.00809139, 0.00284102, -0.00366903, -0.00809139},
+                                                        {-0.0306209, -0.00944584, -0.0145892, -0.00176969, -0.00944584},
+                                                        {-0.0996414, -0.00960462, -0.0328264, -0.00983844, -0.00960462},
+                                                        {-0.0784107, -0.010172, -0.0256722, -0.0215133, -0.010172},
+                                                        {-0.145815, -0.00943169, -0.0414525, -0.027087, -0.00943169}};
+
+    float sigmaPhiSigmaEtaMin[reco::GsfElectron::GAP + 1] = {0.8, 0.8, 0.8, 0.8, 0.8};
+    float sigmaPhiSigmaEtaMax[reco::GsfElectron::GAP + 1] = {5., 5., 5., 5., 5.};
+    float sigmaPhiSigmaEtaFit[reco::GsfElectron::GAP + 1] = {1.2, 1.2, 1.2, 1.2, 1.2};
+
+    // extra protections
+    // fix sigmaPhiSigmaEta boundaries
+    if (sigmaPhiSigmaEta < sigmaPhiSigmaEtaMin[cl]) {
+      sigmaPhiSigmaEta = sigmaPhiSigmaEtaMin[cl];
+    }
+    if (sigmaPhiSigmaEta > sigmaPhiSigmaEtaMax[cl]) {
+      sigmaPhiSigmaEta = sigmaPhiSigmaEtaMax[cl];
+    }
+
+    // In eta cracks/gaps
+    if (tmpEta == -1)  // need to interpolate
+    {
+      float tmpInter = 1;
+      for (int iEta = 0; iEta < nBinsEta - 1; ++iEta) {
+        if (rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < leftEta[iEta + 1]) {
+          if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
+            tmpInter =
+                (par0[iEta][cl] + sigmaPhiSigmaEta * par1[iEta][cl] +
+                 sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta][cl] + par0[iEta + 1][cl] +
+                 sigmaPhiSigmaEta * par1[iEta + 1][cl] + sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta + 1][cl]) /
+                2.;
+          } else
+            tmpInter = (xcorr[iEta][cl] + xcorr[iEta + 1][cl]) / 2.;
+        }
+      }
+      return tmpInter;
+    }
+
+    if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
+      return par0[tmpEta][cl] + sigmaPhiSigmaEta * par1[tmpEta][cl] +
+             sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[tmpEta][cl];
+    } else {
+      return xcorr[tmpEta][cl];
+    }
+
+    return 1.;
+  }
+
+  float fEt(float ET, int algorithm, reco::GsfElectron::Classification cl) {
+    if (algorithm == 0)  //Electrons EB
+    {
+      const float parClassIndep[5] = {0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776};
+      const float par[reco::GsfElectron::GAP + 1][5] = {
+          {0.974327, 0.996127, 5.99401e-05, 0.159813, -3.80392},
+          {0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776},
+          {0.940666, 0.988894, 0.00017474, 0.25603, -4.58153},
+          {0.969526, 0.98572, 0.000193842, 4.21548, -1.37159},
+          {parClassIndep[0], parClassIndep[1], parClassIndep[2], parClassIndep[3], parClassIndep[4]}};
+      if (ET > 200) {
+        ET = 200;
+      }
+      if (ET > 100) {
+        return (parClassIndep[1] + ET * parClassIndep[2]) * (1 - parClassIndep[3] * exp(ET / parClassIndep[4]));
+      }
+      if (ET >= 10) {
+        return (par[cl][1] + ET * par[cl][2]) * (1 - par[cl][3] * exp(ET / par[cl][4]));
+      }
+      if (ET >= 5) {
+        return par[cl][0];
+      }
+      return 1.;
+    } else if (algorithm == 1)  //Electrons EE
+    {
+      float par[reco::GsfElectron::GAP + 1][5] = {{0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                  {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                  {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                  {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                  {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461}};
+      if (ET > 200) {
+        ET = 200;
+      }
+      if (ET < 5) {
+        return 1.;
+      }
+      if (5 <= ET && ET < 10) {
+        return par[cl][0];
+      }
+      if (10 <= ET && ET <= 200) {
+        return (par[cl][1] + ET * par[cl][2]) * (1 - par[cl][3] * exp(ET / par[cl][4]));
+      }
+    } else {
+      edm::LogWarning("ElectronEnergyCorrector::fEt") << "algorithm should be 0 or 1 for electrons !";
+    }
+    return 1.;
+  }
+
+  float fEnergy(float E, int algorithm, reco::GsfElectron::Classification cl) {
+    if (algorithm == 0)  // Electrons EB
+    {
+      return 1.;
+    } else if (algorithm == 1)  // Electrons EE
+    {
+      float par0[reco::GsfElectron::GAP + 1] = {400, 400, 400, 400, 400};
+      float par1[reco::GsfElectron::GAP + 1] = {0.999545, 0.982475, 0.986217, 0.996763, 0.982475};
+      float par2[reco::GsfElectron::GAP + 1] = {1.26568e-05, 4.95413e-05, 5.02161e-05, 2.8485e-06, 4.95413e-05};
+      float par3[reco::GsfElectron::GAP + 1] = {0.0696757, 0.16886, 0.115317, 0.12098, 0.16886};
+      float par4[reco::GsfElectron::GAP + 1] = {-54.3468, -30.1517, -26.3805, -62.0538, -30.1517};
+
+      if (E > par0[cl]) {
+        E = par0[cl];
+      }
+      if (E < 0) {
+        return 1.;
+      }
+      if (0 <= E && E <= par0[cl]) {
+        return (par1[cl] + E * par2[cl]) * (1 - par3[cl] * exp(E / par4[cl]));
+      }
+    } else {
+      edm::LogWarning("ElectronEnergyCorrector::fEnergy") << "algorithm should be 0 or 1 for electrons !";
+    }
+    return 1.;
+  }
+
+}  // namespace
 
 double electronAlgos::classBasedParameterizationUncertainty(reco::GsfElectron const& electron) {
   double ecalEnergy = electron.correctedEcalEnergy();
@@ -106,300 +347,4 @@ float electronAlgos::classBasedParameterizationEnergy(reco::GsfElectron const& e
   newEnergy *= crackcor;
 
   return newEnergy;
-}
-
-// main correction function
-// new corrections: taken from EcalClusterCorrectionObjectSpecific.cc (N. Chanon et al.)
-// this is to prepare for class based corrections, for the time being the parameters are the same as for the SC corrections
-// code fully duplicated here, to be improved; electron means algorithm==0 and mode==0
-
-float fEta(float energy, float eta, int algorithm) {
-  // corrections for electrons
-  if (algorithm != 0) {
-    edm::LogWarning("ElectronEnergyCorrector::fEta") << "algorithm should be 0 for electrons !";
-    return energy;
-  }
-  //std::cout << "fEta function" << std::endl;
-
-  // this correction is setup only for EB
-  if (algorithm != 0)
-    return energy;
-
-  float ieta = fabs(eta) * (5 / 0.087);
-  // bypass the DB reading for the time being
-  //float p0 = (params_->params())[0];  // should be 40.2198
-  //float p1 = (params_->params())[1];  // should be -3.03103e-6
-  float p0 = 40.2198;
-  float p1 = -3.03103e-6;
-
-  //std::cout << "ieta=" << ieta << std::endl;
-
-  float correctedEnergy = energy;
-  if (ieta < p0)
-    correctedEnergy = energy;
-  else
-    correctedEnergy = energy / (1.0 + p1 * (ieta - p0) * (ieta - p0));
-  //std::cout << "ECEC fEta = " << correctedEnergy << std::endl;
-  return correctedEnergy;
-}
-
-float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl) {
-  // corrections for electrons
-  if (algorithm != 0) {
-    edm::LogWarning("ElectronEnergyCorrector::fBremEta") << "algorithm should be 0 for electrons !";
-    return 1.;
-  }
-
-  const float etaCrackMin = 1.44;
-  const float etaCrackMax = 1.56;
-
-  //STD
-  const int nBinsEta = 14;
-  float leftEta[nBinsEta] = {0.02, 0.25, 0.46, 0.81, 0.91, 1.01, 1.16, etaCrackMax, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4};
-  float rightEta[nBinsEta] = {0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4, 2.5};
-
-  // eta = 0
-  if (TMath::Abs(eta) < leftEta[0]) {
-    eta = 0.02;
-  }
-
-  // outside acceptance
-  if (TMath::Abs(eta) >= rightEta[nBinsEta - 1]) {
-    eta = 2.49;
-  }  //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
-
-  int tmpEta = -1;
-  for (int iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < rightEta[iEta]) {
-      tmpEta = iEta;
-    }
-  }
-
-  float xcorr[nBinsEta][reco::GsfElectron::GAP + 1] = {{1.00227, 1.00227, 1.00227, 1.00227, 1.00227},
-                                                       {1.00252, 1.00252, 1.00252, 1.00252, 1.00252},
-                                                       {1.00225, 1.00225, 1.00225, 1.00225, 1.00225},
-                                                       {1.00159, 1.00159, 1.00159, 1.00159, 1.00159},
-                                                       {0.999475, 0.999475, 0.999475, 0.999475, 0.999475},
-                                                       {0.997203, 0.997203, 0.997203, 0.997203, 0.997203},
-                                                       {0.993886, 0.993886, 0.993886, 0.993886, 0.993886},
-                                                       {0.971262, 0.971262, 0.971262, 0.971262, 0.971262},
-                                                       {0.975922, 0.975922, 0.975922, 0.975922, 0.975922},
-                                                       {0.979087, 0.979087, 0.979087, 0.979087, 0.979087},
-                                                       {0.98495, 0.98495, 0.98495, 0.98495, 0.98495},
-                                                       {0.98781, 0.98781, 0.98781, 0.98781, 0.98781},
-                                                       {0.989546, 0.989546, 0.989546, 0.989546, 0.989546},
-                                                       {0.989638, 0.989638, 0.989638, 0.989638, 0.989638}};
-
-  float par0[nBinsEta][reco::GsfElectron::GAP + 1] = {{0.994949, 1.00718, 1.00718, 1.00556, 1.00718},
-                                                      {1.009, 1.00713, 1.00713, 1.00248, 1.00713},
-                                                      {0.999395, 1.00641, 1.00641, 1.00293, 1.00641},
-                                                      {0.988662, 1.00761, 1.001, 0.99972, 1.00761},
-                                                      {0.998443, 1.00682, 1.001, 1.00282, 1.00682},
-                                                      {1.00285, 1.0073, 1.001, 1.00396, 1.0073},
-                                                      {0.993053, 1.00462, 1.01341, 1.00184, 1.00462},
-                                                      {1.10561, 0.972798, 1.02835, 0.995218, 0.972798},
-                                                      {0.893741, 0.981672, 0.98982, 1.01712, 0.981672},
-                                                      {0.911123, 0.98251, 1.03466, 1.00824, 0.98251},
-                                                      {0.981931, 0.986123, 0.954295, 1.0202, 0.986123},
-                                                      {0.905634, 0.990124, 0.928934, 0.998492, 0.990124},
-                                                      {0.919343, 0.990187, 0.967526, 0.963923, 0.990187},
-                                                      {0.844783, 0.99372, 0.923808, 0.953001, 0.99372}};
-
-  float par1[nBinsEta][reco::GsfElectron::GAP + 1] = {{0.0111034, -0.00187886, -0.00187886, -0.00289304, -0.00187886},
-                                                      {-0.00969012, -0.00227574, -0.00227574, -0.00182187, -0.00227574},
-                                                      {0.00389454, -0.00259935, -0.00259935, -0.00211059, -0.00259935},
-                                                      {0.017095, -0.00433692, -0.00302335, -0.00241385, -0.00433692},
-                                                      {-0.00049009, -0.00551324, -0.00302335, -0.00532352, -0.00551324},
-                                                      {-0.00252723, -0.00799669, -0.00302335, -0.00823109, -0.00799669},
-                                                      {0.00332567, -0.00870057, -0.0170581, -0.011482, -0.00870057},
-                                                      {-0.213285, -0.000771577, -0.036007, -0.0187526, -0.000771577},
-                                                      {0.1741, -0.00202028, -0.0233995, -0.0302066, -0.00202028},
-                                                      {0.152794, 0.00441308, -0.0468563, -0.0158817, 0.00441308},
-                                                      {0.0351465, 0.00832913, 0.0358028, -0.0233262, 0.00832913},
-                                                      {0.185781, 0.00742879, 0.08858, 0.00568078, 0.00742879},
-                                                      {0.153088, 0.0094608, 0.0489979, 0.0491897, 0.0094608},
-                                                      {0.296681, 0.00560406, 0.106492, 0.0652007, 0.00560406}};
-
-  float par2[nBinsEta][reco::GsfElectron::GAP + 1] = {{-0.00330844, 0, 0, 5.62441e-05, 0},
-                                                      {0.00329373, 0, 0, -0.000113883, 0},
-                                                      {-0.00104661, 0, 0, -0.000152794, 0},
-                                                      {-0.0060409, 0, -0.000257724, -0.000202099, 0},
-                                                      {-0.000742866, 0, -0.000257724, -2.06003e-05, 0},
-                                                      {-0.00205425, 0, -0.000257724, 3.84179e-05, 0},
-                                                      {-0.00350757, 0, 0.000590483, 0.000323723, 0},
-                                                      {0.0794596, -0.00276696, 0.00205854, 0.000356716, -0.00276696},
-                                                      {-0.092436, -0.00471028, 0.00062096, 0.00088347, -0.00471028},
-                                                      {-0.0855029, -0.00809139, 0.00284102, -0.00366903, -0.00809139},
-                                                      {-0.0306209, -0.00944584, -0.0145892, -0.00176969, -0.00944584},
-                                                      {-0.0996414, -0.00960462, -0.0328264, -0.00983844, -0.00960462},
-                                                      {-0.0784107, -0.010172, -0.0256722, -0.0215133, -0.010172},
-                                                      {-0.145815, -0.00943169, -0.0414525, -0.027087, -0.00943169}};
-
-  float sigmaPhiSigmaEtaMin[reco::GsfElectron::GAP + 1] = {0.8, 0.8, 0.8, 0.8, 0.8};
-  float sigmaPhiSigmaEtaMax[reco::GsfElectron::GAP + 1] = {5., 5., 5., 5., 5.};
-  float sigmaPhiSigmaEtaFit[reco::GsfElectron::GAP + 1] = {1.2, 1.2, 1.2, 1.2, 1.2};
-
-  // extra protections
-  // fix sigmaPhiSigmaEta boundaries
-  if (sigmaPhiSigmaEta < sigmaPhiSigmaEtaMin[cl]) {
-    sigmaPhiSigmaEta = sigmaPhiSigmaEtaMin[cl];
-  }
-  if (sigmaPhiSigmaEta > sigmaPhiSigmaEtaMax[cl]) {
-    sigmaPhiSigmaEta = sigmaPhiSigmaEtaMax[cl];
-  }
-
-  // In eta cracks/gaps
-  if (tmpEta == -1)  // need to interpolate
-  {
-    float tmpInter = 1;
-    for (int iEta = 0; iEta < nBinsEta - 1; ++iEta) {
-      if (rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < leftEta[iEta + 1]) {
-        if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
-          tmpInter =
-              (par0[iEta][cl] + sigmaPhiSigmaEta * par1[iEta][cl] +
-               sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta][cl] + par0[iEta + 1][cl] +
-               sigmaPhiSigmaEta * par1[iEta + 1][cl] + sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta + 1][cl]) /
-              2.;
-        } else
-          tmpInter = (xcorr[iEta][cl] + xcorr[iEta + 1][cl]) / 2.;
-      }
-    }
-    return tmpInter;
-  }
-
-  if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
-    return par0[tmpEta][cl] + sigmaPhiSigmaEta * par1[tmpEta][cl] +
-           sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[tmpEta][cl];
-  } else {
-    return xcorr[tmpEta][cl];
-  }
-
-  return 1.;
-}
-
-float fEt(float ET, int algorithm, reco::GsfElectron::Classification cl) {
-  if (algorithm == 0)  //Electrons EB
-  {
-    const float parClassIndep[5] = {0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776};
-    const float par[reco::GsfElectron::GAP + 1][5] = {
-        {0.974327, 0.996127, 5.99401e-05, 0.159813, -3.80392},
-        {0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776},
-        {0.940666, 0.988894, 0.00017474, 0.25603, -4.58153},
-        {0.969526, 0.98572, 0.000193842, 4.21548, -1.37159},
-        {parClassIndep[0], parClassIndep[1], parClassIndep[2], parClassIndep[3], parClassIndep[4]}};
-    if (ET > 200) {
-      ET = 200;
-    }
-    if (ET > 100) {
-      return (parClassIndep[1] + ET * parClassIndep[2]) * (1 - parClassIndep[3] * exp(ET / parClassIndep[4]));
-    }
-    if (ET >= 10) {
-      return (par[cl][1] + ET * par[cl][2]) * (1 - par[cl][3] * exp(ET / par[cl][4]));
-    }
-    if (ET >= 5) {
-      return par[cl][0];
-    }
-    return 1.;
-  } else if (algorithm == 1)  //Electrons EE
-  {
-    float par[reco::GsfElectron::GAP + 1][5] = {{0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
-                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
-                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
-                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
-                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461}};
-    if (ET > 200) {
-      ET = 200;
-    }
-    if (ET < 5) {
-      return 1.;
-    }
-    if (5 <= ET && ET < 10) {
-      return par[cl][0];
-    }
-    if (10 <= ET && ET <= 200) {
-      return (par[cl][1] + ET * par[cl][2]) * (1 - par[cl][3] * exp(ET / par[cl][4]));
-    }
-  } else {
-    edm::LogWarning("ElectronEnergyCorrector::fEt") << "algorithm should be 0 or 1 for electrons !";
-  }
-  return 1.;
-}
-
-float fEnergy(float E, int algorithm, reco::GsfElectron::Classification cl) {
-  if (algorithm == 0)  // Electrons EB
-  {
-    return 1.;
-  } else if (algorithm == 1)  // Electrons EE
-  {
-    float par0[reco::GsfElectron::GAP + 1] = {400, 400, 400, 400, 400};
-    float par1[reco::GsfElectron::GAP + 1] = {0.999545, 0.982475, 0.986217, 0.996763, 0.982475};
-    float par2[reco::GsfElectron::GAP + 1] = {1.26568e-05, 4.95413e-05, 5.02161e-05, 2.8485e-06, 4.95413e-05};
-    float par3[reco::GsfElectron::GAP + 1] = {0.0696757, 0.16886, 0.115317, 0.12098, 0.16886};
-    float par4[reco::GsfElectron::GAP + 1] = {-54.3468, -30.1517, -26.3805, -62.0538, -30.1517};
-
-    if (E > par0[cl]) {
-      E = par0[cl];
-    }
-    if (E < 0) {
-      return 1.;
-    }
-    if (0 <= E && E <= par0[cl]) {
-      return (par1[cl] + E * par2[cl]) * (1 - par3[cl] * exp(E / par4[cl]));
-    }
-  } else {
-    edm::LogWarning("ElectronEnergyCorrector::fEnergy") << "algorithm should be 0 or 1 for electrons !";
-  }
-  return 1.;
-}
-
-//==========================================================================
-//
-//==========================================================================
-
-double fEtaBarrelGood(double scEta) {
-  // f(eta) for the first 3 classes (0, 10 and 20) (estimated from 1Mevt single e sample)
-  // Ivica's new corrections 01/06
-  float p0 = 1.00149e+00;
-  float p1 = -2.06622e-03;
-  float p2 = -1.08793e-02;
-  float p3 = 1.54392e-02;
-  float p4 = -1.02056e-02;
-  double x = (double)std::abs(scEta);
-  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
-}
-
-double fEtaBarrelBad(double scEta) {
-  // f(eta) for the class = 30 (estimated from 1Mevt single e sample)
-  // Ivica's new corrections 01/06
-  float p0 = 9.99063e-01;
-  float p1 = -2.63341e-02;
-  float p2 = 5.16054e-02;
-  float p3 = -4.95976e-02;
-  float p4 = 3.62304e-03;
-  double x = (double)std::abs(scEta);
-  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
-}
-
-double fEtaEndcapGood(double scEta) {
-  // f(eta) for the first 3 classes (100, 110 and 120)
-  // Ivica's new corrections 01/06
-  float p0 = -8.51093e-01;
-  float p1 = 3.54266e+00;
-  float p2 = -2.59288e+00;
-  float p3 = 8.58945e-01;
-  float p4 = -1.07844e-01;
-  double x = (double)std::abs(scEta);
-  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
-}
-
-double fEtaEndcapBad(double scEta) {
-  // f(eta) for the class = 130-134
-  // Ivica's new corrections 01/06
-  float p0 = -4.25221e+00;
-  float p1 = 1.01936e+01;
-  float p2 = -7.48247e+00;
-  float p3 = 2.45520e+00;
-  float p4 = -3.02872e-01;
-  double x = (double)std::abs(scEta);
-  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
@@ -268,14 +268,14 @@ namespace {
 
 }  // namespace
 
-double electronAlgos::classBasedParameterizationUncertainty(reco::GsfElectron const& electron) {
+double egamma::classBasedElectronEnergyUncertainty(reco::GsfElectron const& electron) {
   double ecalEnergy = electron.correctedEcalEnergy();
   double eleEta = electron.superCluster()->eta();
   double brem = electron.superCluster()->etaWidth() / electron.superCluster()->phiWidth();
-  return electronAlgos::computeEnergyUncertainty(electron.classification(), eleEta, brem, ecalEnergy);
+  return egamma::electronEnergyUncertainty(electron.classification(), eleEta, brem, ecalEnergy);
 }
 
-double electronAlgos::simpleParameterizationUncertainty(reco::GsfElectron const& electron) {
+double egamma::simpleElectronEnergyUncertainty(reco::GsfElectron const& electron) {
   double error = 999.;
   double ecalEnergy = electron.correctedEcalEnergy();
 
@@ -293,9 +293,9 @@ double electronAlgos::simpleParameterizationUncertainty(reco::GsfElectron const&
   return error;
 }
 
-float electronAlgos::classBasedParameterizationEnergy(reco::GsfElectron const& electron,
-                                                      reco::BeamSpot const& bs,
-                                                      EcalClusterFunctionBaseClass const& crackCorrectionFunction) {
+float egamma::classBasedElectronEnergy(reco::GsfElectron const& electron,
+                                       reco::BeamSpot const& bs,
+                                       EcalClusterFunctionBaseClass const& crackCorrectionFunction) {
   auto elClass = electron.classification();
 
   // new corrections from N. Chanon et al., taken from EcalClusterCorrectionObjectSpecific.cc

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
@@ -164,11 +164,12 @@ electronAlgos::ElectronMomentum electronAlgos::correctMomentum(reco::GsfElectron
   // final set
   //=======================================================================================
 
-  math::XYZTLorentzVector oldMomentum = electron.p4();
-  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector(oldMomentum.x() * finalMomentum / oldMomentum.t(),
-                                                                oldMomentum.y() * finalMomentum / oldMomentum.t(),
-                                                                oldMomentum.z() * finalMomentum / oldMomentum.t(),
-                                                                finalMomentum);
+  auto const& oldMomentum = electron.p4();
 
-  return {newMomentum, errorTrackMomentum, finalMomentumError};
+  return {{oldMomentum.x() * finalMomentum / oldMomentum.t(),
+           oldMomentum.y() * finalMomentum / oldMomentum.t(),
+           oldMomentum.z() * finalMomentum / oldMomentum.t(),
+           finalMomentum},
+          errorTrackMomentum,
+          finalMomentumError};
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
@@ -4,8 +4,6 @@
 #include "TrackingTools/GsfTools/interface/GaussianSumUtilities1D.h"
 #include "TrackingTools/GsfTools/interface/MultiGaussianStateTransform.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 /****************************************************************************
  *
  * Class based E-p combination for the final electron momentum. It relies on
@@ -22,20 +20,9 @@
  *
  ****************************************************************************/
 
-void ElectronMomentumCorrector::correct(reco::GsfElectron& electron, TrajectoryStateOnSurface& vtxTsos) {
-  if (electron.p4Error(reco::GsfElectron::P4_COMBINATION) != 999.) {
-    edm::LogWarning("ElectronMomentumCorrector::correct") << "already done";
-    return;
-  }
-
-  //math::XYZTLorentzVector newMomentum = electron.p4() ; // default
+electronAlgos::ElectronMomentum electronAlgos::correctMomentum(reco::GsfElectron const& electron,
+                                                               TrajectoryStateOnSurface const& vtxTsos) {
   int elClass = electron.classification();
-
-  // irrelevant classification
-  if ((elClass <= reco::GsfElectron::UNKNOWN) || (elClass > reco::GsfElectron::GAP)) {
-    edm::LogWarning("ElectronMomentumCorrector::correct") << "unexpected classification";
-    return;
-  }
 
   //=======================================================================================
   // cluster energy
@@ -117,39 +104,6 @@ void ElectronMomentumCorrector::correct(reco::GsfElectron& electron, TrajectoryS
                              (scEnergy * errorTrackMomentum / trackMomentum / trackMomentum) *
                                  (scEnergy * errorTrackMomentum / trackMomentum / trackMomentum));
 
-    //    if ( eOverP  > 1 + 2.5*errorEOverP )
-    //     {
-    //      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
-    //      if ((elClass==reco::GsfElectron::GOLDEN) && electron.isEB() && (eOverP<1.15))
-    //        {
-    //          if (scEnergy<15) {finalMomentum = trackMomentum ; finalMomentumError = errorTrackMomentum;}
-    //        }
-    //     }
-    //    else if ( eOverP < 1 - 2.5*errorEOverP )
-    //     {
-    //      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
-    //      if (elClass==reco::GsfElectron::SHOWERING)
-    //       {
-    //	      if (electron.isEB())
-    //	       {
-    //		      if (scEnergy<18)
-    //		       { finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum; }
-    //	       }
-    //	      else if (electron.isEE())
-    //	       {
-    //          if (scEnergy<13)
-    //           {finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum;}
-    //	       }
-    //	      else
-    //	       { edm::LogWarning("ElectronMomentumCorrector::correct")<<"nor barrel neither endcap electron ?!" ; }
-    //	     }
-    //	    else if (electron.isGap())
-    //	     {
-    //	      if (scEnergy<60)
-    //	       { finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum ; }
-    //	     }
-    //      }
-
     bool eleIsNotInCombination = false;
     if ((eOverP > 1 + 2.5 * errorEOverP) || (eOverP < 1 - 2.5 * errorEOverP) || (eOverP < 0.8) || (eOverP > 1.3)) {
       eleIsNotInCombination = true;
@@ -216,5 +170,5 @@ void ElectronMomentumCorrector::correct(reco::GsfElectron& electron, TrajectoryS
                                                                 oldMomentum.z() * finalMomentum / oldMomentum.t(),
                                                                 finalMomentum);
 
-  electron.correctMomentum(newMomentum, errorTrackMomentum, finalMomentumError);
+  return {newMomentum, errorTrackMomentum, finalMomentumError};
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
@@ -20,8 +20,8 @@
  *
  ****************************************************************************/
 
-electronAlgos::ElectronMomentum electronAlgos::correctMomentum(reco::GsfElectron const& electron,
-                                                               TrajectoryStateOnSurface const& vtxTsos) {
+egamma::ElectronMomentum egamma::correctElectronMomentum(reco::GsfElectron const& electron,
+                                                         TrajectoryStateOnSurface const& vtxTsos) {
   int elClass = electron.classification();
 
   //=======================================================================================

--- a/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
@@ -397,19 +397,18 @@ namespace {
 
 }  // namespace
 
-double electronAlgos::computeEnergyUncertainty(reco::GsfElectron::Classification c,
-                                               double eta,
-                                               double brem,
-                                               double energy) {
-  if (c == reco::GsfElectron::GOLDEN)
+using reco::GsfElectron;
+
+double egamma::electronEnergyUncertainty(GsfElectron::Classification c, double eta, double brem, double energy) {
+  if (c == GsfElectron::GOLDEN)
     return computeEnergyUncertaintyGolden(eta, brem, energy);
-  if (c == reco::GsfElectron::BIGBREM)
+  if (c == GsfElectron::BIGBREM)
     return computeEnergyUncertaintyBigbrem(eta, brem, energy);
-  if (c == reco::GsfElectron::SHOWERING)
+  if (c == GsfElectron::SHOWERING)
     return computeEnergyUncertaintyShowering(eta, brem, energy);
-  if (c == reco::GsfElectron::BADTRACK)
+  if (c == GsfElectron::BADTRACK)
     return computeEnergyUncertaintyBadTrack(eta, brem, energy);
-  if (c == reco::GsfElectron::GAP)
+  if (c == GsfElectron::GAP)
     return computeEnergyUncertaintyCracks(eta, brem, energy);
   throw cms::Exception("GsfElectronAlgo|InternalError") << "unknown classification";
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
@@ -1,34 +1,6 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h"
-#include "TMath.h"
 
-#include <iostream>
-
-EnergyUncertaintyElectronSpecific::EnergyUncertaintyElectronSpecific() {}
-
-EnergyUncertaintyElectronSpecific::~EnergyUncertaintyElectronSpecific() {}
-
-void EnergyUncertaintyElectronSpecific::init(const edm::EventSetup& theEventSetup) {}
-
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty(reco::GsfElectron::Classification c,
-                                                                           double eta,
-                                                                           double brem,
-                                                                           double energy) {
-  if (c == reco::GsfElectron::GOLDEN)
-    return computeElectronEnergyUncertainty_golden(eta, brem, energy);
-  if (c == reco::GsfElectron::BIGBREM)
-    return computeElectronEnergyUncertainty_bigbrem(eta, brem, energy);
-  if (c == reco::GsfElectron::SHOWERING)
-    return computeElectronEnergyUncertainty_showering(eta, brem, energy);
-  if (c == reco::GsfElectron::BADTRACK)
-    return computeElectronEnergyUncertainty_badtrack(eta, brem, energy);
-  if (c == reco::GsfElectron::GAP)
-    return computeElectronEnergyUncertainty_cracks(eta, brem, energy);
-  throw cms::Exception("GsfElectronAlgo|InternalError") << "unknown classification";
-}
-
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_golden(double eta,
-                                                                                  double brem,
-                                                                                  double energy) {
+double computeEnergyUncertaintyGolden(double eta, double brem, double energy) {
   double et = energy / cosh(eta);
 
   constexpr int nBinsEta = 5;
@@ -92,12 +64,12 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_golde
     iBremSl = nBinsBrem - 1;
 
   if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_golden";
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyGolden";
     return 0;
   }
 
   if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_golden";
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyGolden";
     return 0;
   }
 
@@ -113,9 +85,7 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_golde
   return (uncertainty * energy);
 }
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_bigbrem(double eta,
-                                                                                   double brem,
-                                                                                   double energy) {
+double computeEnergyUncertaintyBigbrem(double eta, double brem, double energy) {
   const double et = energy / cosh(eta);
 
   constexpr int nBinsEta = 4;
@@ -154,12 +124,12 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_bigbr
     iBremSl = nBinsBrem - 1;
 
   if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_bigbrem";
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyBigbrem";
     return 0;
   }
 
   if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_bigbrem";
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyBigbrem";
     return 0;
   }
 
@@ -177,9 +147,7 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_bigbr
 
   return (uncertainty * energy);
 }
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_badtrack(double eta,
-                                                                                    double brem,
-                                                                                    double energy) {
+double computeEnergyUncertaintyBadTrack(double eta, double brem, double energy) {
   const double et = energy / cosh(eta);
 
   constexpr int nBinsEta = 4;
@@ -218,12 +186,12 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_badtr
     iBremSl = nBinsBrem - 1;
 
   if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_badtrack";
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyBadTrack";
     return 0;
   }
 
   if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_badtrack";
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyBadTrack";
     return 0;
   }
 
@@ -242,9 +210,7 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_badtr
   return (uncertainty * energy);
 }
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_showering(double eta,
-                                                                                     double brem,
-                                                                                     double energy) {
+double computeEnergyUncertaintyShowering(double eta, double brem, double energy) {
   const double et = energy / cosh(eta);
 
   constexpr int nBinsEta = 4;
@@ -307,12 +273,12 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_showe
     iBremSl = nBinsBrem - 1;
 
   if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_showering";
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyShowering";
     return 0;
   }
 
   if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_showering";
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyShowering";
     return 0;
   }
 
@@ -331,9 +297,7 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_showe
   return (uncertainty * energy);
 }
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_cracks(double eta,
-                                                                                  double brem,
-                                                                                  double energy) {
+double computeEnergyUncertaintyCracks(double eta, double brem, double energy) {
   const double et = energy / cosh(eta);
 
   constexpr int nBinsEta = 5;
@@ -407,12 +371,12 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_crack
     iBremSl = nBinsBrem - 1;
 
   if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_cracks";
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyCracks";
     return 0;
   }
 
   if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_cracks";
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyCracks";
     return 0;
   }
 
@@ -426,4 +390,21 @@ double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_crack
     uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
 
   return (uncertainty * energy);
+}
+
+double electronAlgos::computeEnergyUncertainty(reco::GsfElectron::Classification c,
+                                               double eta,
+                                               double brem,
+                                               double energy) {
+  if (c == reco::GsfElectron::GOLDEN)
+    return computeEnergyUncertaintyGolden(eta, brem, energy);
+  if (c == reco::GsfElectron::BIGBREM)
+    return computeEnergyUncertaintyBigbrem(eta, brem, energy);
+  if (c == reco::GsfElectron::SHOWERING)
+    return computeEnergyUncertaintyShowering(eta, brem, energy);
+  if (c == reco::GsfElectron::BADTRACK)
+    return computeEnergyUncertaintyBadTrack(eta, brem, energy);
+  if (c == reco::GsfElectron::GAP)
+    return computeEnergyUncertaintyCracks(eta, brem, energy);
+  throw cms::Exception("GsfElectronAlgo|InternalError") << "unknown classification";
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
@@ -1,396 +1,401 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h"
 
-double computeEnergyUncertaintyGolden(double eta, double brem, double energy) {
-  double et = energy / cosh(eta);
+namespace {
 
-  constexpr int nBinsEta = 5;
-  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.4, 0.8, 1.5, 2.0, 2.5};
+  double computeEnergyUncertaintyGolden(double eta, double brem, double energy) {
+    double et = energy / cosh(eta);
 
-  constexpr int nBinsBrem = 6;
-  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.0, 1.1, 1.2, 1.3, 1.5, 8.0};
+    constexpr int nBinsEta = 5;
+    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.4, 0.8, 1.5, 2.0, 2.5};
 
-  constexpr float par0[nBinsEta][nBinsBrem] = {{0.00567891, 0.0065673, 0.00574742, 0.00542964, 0.00523293, 0.00547518},
+    constexpr int nBinsBrem = 6;
+    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.0, 1.1, 1.2, 1.3, 1.5, 8.0};
 
-                                               {0.00552517, 0.00611188, 0.0062729, 0.00574846, 0.00447373, 0.00595789},
+    constexpr float par0[nBinsEta][nBinsBrem] = {
+        {0.00567891, 0.0065673, 0.00574742, 0.00542964, 0.00523293, 0.00547518},
 
-                                               {0.00356679, 0.00503827, 0.00328016, 0.00592303, 0.00512479, 0.00484166},
+        {0.00552517, 0.00611188, 0.0062729, 0.00574846, 0.00447373, 0.00595789},
 
-                                               {0.0109195, 0.0102361, 0.0101576, 0.0120683, 0.0155326, 0.0225035},
+        {0.00356679, 0.00503827, 0.00328016, 0.00592303, 0.00512479, 0.00484166},
 
-                                               {0.0109632, 0.0103342, 0.0103486, 0.00862762, 0.0111448, 0.0146648}};
+        {0.0109195, 0.0102361, 0.0101576, 0.0120683, 0.0155326, 0.0225035},
 
-  static_assert(par0[0][0] == 0.00567891f);
-  static_assert(par0[0][1] == 0.0065673f);
-  static_assert(par0[1][3] == 0.00574846f);
+        {0.0109632, 0.0103342, 0.0103486, 0.00862762, 0.0111448, 0.0146648}};
 
-  constexpr float par1[nBinsEta][nBinsBrem] = {{0.238685, 0.193642, 0.249171, 0.259997, 0.310505, 0.390506},
+    static_assert(par0[0][0] == 0.00567891f);
+    static_assert(par0[0][1] == 0.0065673f);
+    static_assert(par0[1][3] == 0.00574846f);
 
-                                               {0.288736, 0.312303, 0.294717, 0.294491, 0.379178, 0.38164},
+    constexpr float par1[nBinsEta][nBinsBrem] = {{0.238685, 0.193642, 0.249171, 0.259997, 0.310505, 0.390506},
 
-                                               {0.456456, 0.394912, 0.541713, 0.401744, 0.483151, 0.657995},
+                                                 {0.288736, 0.312303, 0.294717, 0.294491, 0.379178, 0.38164},
 
-                                               {1.13803, 1.39866, 1.51353, 1.48587, 1.49732, 1.82363},
+                                                 {0.456456, 0.394912, 0.541713, 0.401744, 0.483151, 0.657995},
 
-                                               {0.458212, 0.628761, 0.659144, 0.929563, 1.06724, 1.6427}};
+                                                 {1.13803, 1.39866, 1.51353, 1.48587, 1.49732, 1.82363},
 
-  constexpr float par2[nBinsEta][nBinsBrem] = {{2.12035, 3.41493, 1.7401, 1.46234, 0.233226, -2.78168},
+                                                 {0.458212, 0.628761, 0.659144, 0.929563, 1.06724, 1.6427}};
 
-                                               {1.30552, 0.137905, 0.653793, 0.790746, -1.42584, -2.34653},
+    constexpr float par2[nBinsEta][nBinsBrem] = {{2.12035, 3.41493, 1.7401, 1.46234, 0.233226, -2.78168},
 
-                                               {0.610716, 0.778879, -1.58577, 1.45098, -0.0985911, -3.47167},
-                                               {-3.48281, -6.4736, -8.03308, -7.55974, -7.98843, -10.1027},
+                                                 {1.30552, 0.137905, 0.653793, 0.790746, -1.42584, -2.34653},
 
-                                               {0.995183, -2.42889, -2.14073, -6.27768, -7.68512, -13.3504}};
+                                                 {0.610716, 0.778879, -1.58577, 1.45098, -0.0985911, -3.47167},
+                                                 {-3.48281, -6.4736, -8.03308, -7.55974, -7.98843, -10.1027},
 
-  Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
-      iEtaSl = iEta;
+                                                 {0.995183, -2.42889, -2.14073, -6.27768, -7.68512, -13.3504}};
+
+    Int_t iEtaSl = -1;
+    for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+      if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
+        iEtaSl = iEta;
+      }
     }
-  }
 
-  Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
-    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
-      iBremSl = iBrem;
+    Int_t iBremSl = -1;
+    for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+      if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
+        iBremSl = iBrem;
+      }
     }
-  }
 
-  if (fabs(eta) > 2.5)
-    iEtaSl = nBinsEta - 1;
-  if (brem < BremBins[0])
-    iBremSl = 0;
-  if (brem > BremBins[nBinsBrem - 1])
-    iBremSl = nBinsBrem - 1;
+    if (fabs(eta) > 2.5)
+      iEtaSl = nBinsEta - 1;
+    if (brem < BremBins[0])
+      iBremSl = 0;
+    if (brem > BremBins[nBinsBrem - 1])
+      iBremSl = nBinsBrem - 1;
 
-  if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyGolden";
-    return 0;
-  }
-
-  if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyGolden";
-    return 0;
-  }
-
-  float uncertainty = 0;
-  if (et < 5)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]);
-  if (et > 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]);
-
-  if (et > 5 && et < 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
-
-  return (uncertainty * energy);
-}
-
-double computeEnergyUncertaintyBigbrem(double eta, double brem, double energy) {
-  const double et = energy / cosh(eta);
-
-  constexpr int nBinsEta = 4;
-  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.5, 2.0, 2.5};
-
-  constexpr int nBinsBrem = 1;
-  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
-
-  constexpr float par0[nBinsEta][nBinsBrem] = {{0.00593389}, {0.00266954}, {0.00500623}, {0.00841038}};
-
-  constexpr float par1[nBinsEta][nBinsBrem] = {{0.178275}, {0.811415}, {2.34018}, {1.06851}};
-
-  constexpr float par2[nBinsEta][nBinsBrem] = {{-7.28273}, {-1.66063}, {-11.0129}, {-4.1259}};
-
-  constexpr float par3[nBinsEta][nBinsBrem] = {{13.2632}, {1.03555}, {-0.200323}, {-0.0646195}};
-
-  Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
-      iEtaSl = iEta;
+    if (iEtaSl == -1) {
+      edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyGolden";
+      return 0;
     }
-  }
 
-  Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
-    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
-      iBremSl = iBrem;
+    if (iBremSl == -1) {
+      edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyGolden";
+      return 0;
     }
+
+    float uncertainty = 0;
+    if (et < 5)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]);
+    if (et > 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]);
+
+    if (et > 5 && et < 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
+
+    return (uncertainty * energy);
   }
 
-  if (fabs(eta) > 2.5)
-    iEtaSl = nBinsEta - 1;
-  if (brem < BremBins[0])
-    iBremSl = 0;
-  if (brem > BremBins[nBinsBrem - 1])
-    iBremSl = nBinsBrem - 1;
+  double computeEnergyUncertaintyBigbrem(double eta, double brem, double energy) {
+    const double et = energy / cosh(eta);
 
-  if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyBigbrem";
-    return 0;
-  }
+    constexpr int nBinsEta = 4;
+    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.5, 2.0, 2.5};
 
-  if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyBigbrem";
-    return 0;
-  }
+    constexpr int nBinsBrem = 1;
+    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
 
-  float uncertainty = 0;
-  if (et < 5)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
-  if (et > 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
+    constexpr float par0[nBinsEta][nBinsBrem] = {{0.00593389}, {0.00266954}, {0.00500623}, {0.00841038}};
 
-  if (et > 5 && et < 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
+    constexpr float par1[nBinsEta][nBinsBrem] = {{0.178275}, {0.811415}, {2.34018}, {1.06851}};
 
-  return (uncertainty * energy);
-}
-double computeEnergyUncertaintyBadTrack(double eta, double brem, double energy) {
-  const double et = energy / cosh(eta);
+    constexpr float par2[nBinsEta][nBinsBrem] = {{-7.28273}, {-1.66063}, {-11.0129}, {-4.1259}};
 
-  constexpr int nBinsEta = 4;
-  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.7, 1.3, 1.8, 2.5};
+    constexpr float par3[nBinsEta][nBinsBrem] = {{13.2632}, {1.03555}, {-0.200323}, {-0.0646195}};
 
-  constexpr int nBinsBrem = 1;
-  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
-
-  constexpr float par0[nBinsEta][nBinsBrem] = {{0.00601311}, {0.0059814}, {0.00953032}, {0.00728618}};
-
-  constexpr float par1[nBinsEta][nBinsBrem] = {{0.390988}, {1.02668}, {2.27491}, {2.08268}};
-
-  constexpr float par2[nBinsEta][nBinsBrem] = {{-4.11919}, {-2.87477}, {-7.61675}, {-8.66756}};
-
-  constexpr float par3[nBinsEta][nBinsBrem] = {{4.61671}, {0.163447}, {-0.335786}, {-1.27831}};
-
-  Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
-      iEtaSl = iEta;
+    Int_t iEtaSl = -1;
+    for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+      if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
+        iEtaSl = iEta;
+      }
     }
-  }
 
-  Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
-    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
-      iBremSl = iBrem;
+    Int_t iBremSl = -1;
+    for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+      if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
+        iBremSl = iBrem;
+      }
     }
-  }
 
-  if (fabs(eta) > 2.5)
-    iEtaSl = nBinsEta - 1;
-  if (brem < BremBins[0])
-    iBremSl = 0;
-  if (brem > BremBins[nBinsBrem - 1])
-    iBremSl = nBinsBrem - 1;
+    if (fabs(eta) > 2.5)
+      iEtaSl = nBinsEta - 1;
+    if (brem < BremBins[0])
+      iBremSl = 0;
+    if (brem > BremBins[nBinsBrem - 1])
+      iBremSl = nBinsBrem - 1;
 
-  if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyBadTrack";
-    return 0;
-  }
-
-  if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyBadTrack";
-    return 0;
-  }
-
-  float uncertainty = 0;
-  if (et < 5)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
-  if (et > 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
-
-  if (et > 5 && et < 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
-
-  return (uncertainty * energy);
-}
-
-double computeEnergyUncertaintyShowering(double eta, double brem, double energy) {
-  const double et = energy / cosh(eta);
-
-  constexpr int nBinsEta = 4;
-  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.2, 1.7, 2.5};
-
-  constexpr int nBinsBrem = 5;
-  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.8, 2.2, 3.0, 4.0, 8.0};
-
-  constexpr float par0[nBinsEta][nBinsBrem] = {{0.0049351, 0.00566155, 0.0051397, 0.00468481, 0.00444475},
-
-                                               {0.00201762, 0.00431475, 0.00501004, 0.00632666, 0.00636704},
-
-                                               {-0.00729396, 0.00539783, 0.00608149, 0.00465335, 0.00642685},
-
-                                               {0.0149449, 0.0216691, 0.0255957, 0.0206101, 0.0180508}};
-
-  constexpr float par1[nBinsEta][nBinsBrem] = {{0.579925, 0.496137, 0.551947, 0.63011, 0.684261},
-
-                                               {0.914762, 0.824483, 0.888521, 0.960241, 1.25728},
-
-                                               {3.24295, 1.72935, 1.80606, 2.13562, 2.07592},
-
-                                               {1.00448, 1.18393, 0.00775295, 2.59246, 3.1099}};
-
-  constexpr float par2[nBinsEta][nBinsBrem] = {{-9.33987, -5.52543, -7.30079, -6.7722, -4.67614},
-
-                                               {-4.48042, -5.02885, -4.77311, -3.36742, -5.53561},
-
-                                               {-17.1458, -5.92807, -6.67563, -10.1105, -7.50257},
-
-                                               {-2.09368, -4.56674, -44.2722, -13.1702, -13.6208}};
-
-  constexpr float par3[nBinsEta][nBinsBrem] = {{1.62129, 1.19101, 1.89701, 1.81614, 1.64415},
-
-                                               {-1.50473, -0.153502, -0.355145, -1.16499, -0.864123},
-
-                                               {-4.69711, -2.18733, -0.922401, -0.230781, -2.91515},
-
-                                               {0.455037, -0.601872, 241.516, -2.35024, -2.11069}};
-
-  Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
-      iEtaSl = iEta;
+    if (iEtaSl == -1) {
+      edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyBigbrem";
+      return 0;
     }
-  }
 
-  Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
-    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
-      iBremSl = iBrem;
+    if (iBremSl == -1) {
+      edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyBigbrem";
+      return 0;
     }
+
+    float uncertainty = 0;
+    if (et < 5)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+    if (et > 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
+
+    if (et > 5 && et < 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
+
+    return (uncertainty * energy);
   }
+  double computeEnergyUncertaintyBadTrack(double eta, double brem, double energy) {
+    const double et = energy / cosh(eta);
 
-  if (fabs(eta) > 2.5)
-    iEtaSl = nBinsEta - 1;
-  if (brem < BremBins[0])
-    iBremSl = 0;
-  if (brem > BremBins[nBinsBrem - 1])
-    iBremSl = nBinsBrem - 1;
+    constexpr int nBinsEta = 4;
+    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.7, 1.3, 1.8, 2.5};
 
-  if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyShowering";
-    return 0;
-  }
+    constexpr int nBinsBrem = 1;
+    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
 
-  if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyShowering";
-    return 0;
-  }
+    constexpr float par0[nBinsEta][nBinsBrem] = {{0.00601311}, {0.0059814}, {0.00953032}, {0.00728618}};
 
-  float uncertainty = 0;
-  if (et < 5)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
-  if (et > 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
+    constexpr float par1[nBinsEta][nBinsBrem] = {{0.390988}, {1.02668}, {2.27491}, {2.08268}};
 
-  if (et > 5 && et < 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
-                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
+    constexpr float par2[nBinsEta][nBinsBrem] = {{-4.11919}, {-2.87477}, {-7.61675}, {-8.66756}};
 
-  return (uncertainty * energy);
-}
+    constexpr float par3[nBinsEta][nBinsBrem] = {{4.61671}, {0.163447}, {-0.335786}, {-1.27831}};
 
-double computeEnergyUncertaintyCracks(double eta, double brem, double energy) {
-  const double et = energy / cosh(eta);
-
-  constexpr int nBinsEta = 5;
-  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.42, 0.78, 1.2, 1.52, 1.65};
-
-  constexpr int nBinsBrem = 6;
-  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.2, 1.5, 2.1, 3., 4, 8.0};
-
-  constexpr float par0[nBinsEta][nBinsBrem] = {
-      {0.0139815, 0.00550839, 0.0108292, 0.00596201, -0.00498136, 0.000621696},
-
-      {0.00467498, 0.00808463, 0.00546665, 0.00506318, 0.00608425, -4.45641e-06},
-
-      {0.00971734, 0.00063951, -0.0121618, -0.00604365, 0.00492161, -0.00143907},
-
-      {-0.0844907, -0.0592498, -0.0828631, -0.0740798, -0.0698045, -0.0699518},
-
-      {-0.0999971, -0.0999996, -0.0989356, -0.0999965, -0.0833049, -0.020072}};
-
-  constexpr float par1[nBinsEta][nBinsBrem] = {{0.569273, 0.674654, 0.523128, 1.02501, 1.75645, 0.955191},
-
-                                               {0.697951, 0.580628, 0.814515, 0.819975, 0.829616, 1.18952},
-
-                                               {3.79446, 2.47472, 5.12931, 3.42497, 1.84123, 2.3773},
-
-                                               {19.9999, 10.4079, 16.6273, 15.9316, 15.4883, 14.7306},
-
-                                               {15.9122, 18.5882, 19.9996, 19.9999, 18.2281, 8.1587}};
-
-  constexpr float par2[nBinsEta][nBinsBrem] = {{-4.31243, -3.071, -2.56702, -7.74555, -21.3726, -6.2189},
-
-                                               {-6.56009, -3.66067, -7.8275, -6.01641, -7.85456, -8.27071},
-
-                                               {-49.9996, -25.0724, -49.985, -28.1932, -10.6485, -15.4014},
-
-                                               {-39.9444, -25.1133, -49.9999, -50, -49.9998, -49.9998},
-
-                                               {-30.1268, -42.6113, -46.6999, -47.074, -49.9995, -25.2897}};
-
-  static_assert(par0[0][3] == 0.00596201f);
-  static_assert(par1[0][3] == 1.02501f);
-  static_assert(par2[0][3] == -7.74555f);
-
-  static_assert(par0[2][4] == 0.00492161f);
-  static_assert(par1[2][4] == 1.84123f);
-  static_assert(par2[2][4] == -10.6485f);
-
-  static_assert(par0[4][3] == -0.0999965f);
-  static_assert(par1[4][3] == 19.9999f);
-  static_assert(par2[4][3] == -47.074f);
-
-  Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
-    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
-      iEtaSl = iEta;
+    Int_t iEtaSl = -1;
+    for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+      if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
+        iEtaSl = iEta;
+      }
     }
-  }
 
-  Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
-    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
-      iBremSl = iBrem;
+    Int_t iBremSl = -1;
+    for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+      if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
+        iBremSl = iBrem;
+      }
     }
+
+    if (fabs(eta) > 2.5)
+      iEtaSl = nBinsEta - 1;
+    if (brem < BremBins[0])
+      iBremSl = 0;
+    if (brem > BremBins[nBinsBrem - 1])
+      iBremSl = nBinsBrem - 1;
+
+    if (iEtaSl == -1) {
+      edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyBadTrack";
+      return 0;
+    }
+
+    if (iBremSl == -1) {
+      edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyBadTrack";
+      return 0;
+    }
+
+    float uncertainty = 0;
+    if (et < 5)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+    if (et > 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
+
+    if (et > 5 && et < 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
+
+    return (uncertainty * energy);
   }
 
-  if (fabs(eta) > 2.5)
-    iEtaSl = nBinsEta - 1;
-  if (brem < BremBins[0])
-    iBremSl = 0;
-  if (brem > BremBins[nBinsBrem - 1])
-    iBremSl = nBinsBrem - 1;
+  double computeEnergyUncertaintyShowering(double eta, double brem, double energy) {
+    const double et = energy / cosh(eta);
 
-  if (iEtaSl == -1) {
-    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyCracks";
-    return 0;
+    constexpr int nBinsEta = 4;
+    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.2, 1.7, 2.5};
+
+    constexpr int nBinsBrem = 5;
+    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.8, 2.2, 3.0, 4.0, 8.0};
+
+    constexpr float par0[nBinsEta][nBinsBrem] = {{0.0049351, 0.00566155, 0.0051397, 0.00468481, 0.00444475},
+
+                                                 {0.00201762, 0.00431475, 0.00501004, 0.00632666, 0.00636704},
+
+                                                 {-0.00729396, 0.00539783, 0.00608149, 0.00465335, 0.00642685},
+
+                                                 {0.0149449, 0.0216691, 0.0255957, 0.0206101, 0.0180508}};
+
+    constexpr float par1[nBinsEta][nBinsBrem] = {{0.579925, 0.496137, 0.551947, 0.63011, 0.684261},
+
+                                                 {0.914762, 0.824483, 0.888521, 0.960241, 1.25728},
+
+                                                 {3.24295, 1.72935, 1.80606, 2.13562, 2.07592},
+
+                                                 {1.00448, 1.18393, 0.00775295, 2.59246, 3.1099}};
+
+    constexpr float par2[nBinsEta][nBinsBrem] = {{-9.33987, -5.52543, -7.30079, -6.7722, -4.67614},
+
+                                                 {-4.48042, -5.02885, -4.77311, -3.36742, -5.53561},
+
+                                                 {-17.1458, -5.92807, -6.67563, -10.1105, -7.50257},
+
+                                                 {-2.09368, -4.56674, -44.2722, -13.1702, -13.6208}};
+
+    constexpr float par3[nBinsEta][nBinsBrem] = {{1.62129, 1.19101, 1.89701, 1.81614, 1.64415},
+
+                                                 {-1.50473, -0.153502, -0.355145, -1.16499, -0.864123},
+
+                                                 {-4.69711, -2.18733, -0.922401, -0.230781, -2.91515},
+
+                                                 {0.455037, -0.601872, 241.516, -2.35024, -2.11069}};
+
+    Int_t iEtaSl = -1;
+    for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+      if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
+        iEtaSl = iEta;
+      }
+    }
+
+    Int_t iBremSl = -1;
+    for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+      if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
+        iBremSl = iBrem;
+      }
+    }
+
+    if (fabs(eta) > 2.5)
+      iEtaSl = nBinsEta - 1;
+    if (brem < BremBins[0])
+      iBremSl = 0;
+    if (brem > BremBins[nBinsBrem - 1])
+      iBremSl = nBinsBrem - 1;
+
+    if (iEtaSl == -1) {
+      edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyShowering";
+      return 0;
+    }
+
+    if (iBremSl == -1) {
+      edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyShowering";
+      return 0;
+    }
+
+    float uncertainty = 0;
+    if (et < 5)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+    if (et > 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
+
+    if (et > 5 && et < 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                    par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
+
+    return (uncertainty * energy);
   }
 
-  if (iBremSl == -1) {
-    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyCracks";
-    return 0;
+  double computeEnergyUncertaintyCracks(double eta, double brem, double energy) {
+    const double et = energy / cosh(eta);
+
+    constexpr int nBinsEta = 5;
+    constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.42, 0.78, 1.2, 1.52, 1.65};
+
+    constexpr int nBinsBrem = 6;
+    constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.2, 1.5, 2.1, 3., 4, 8.0};
+
+    constexpr float par0[nBinsEta][nBinsBrem] = {
+        {0.0139815, 0.00550839, 0.0108292, 0.00596201, -0.00498136, 0.000621696},
+
+        {0.00467498, 0.00808463, 0.00546665, 0.00506318, 0.00608425, -4.45641e-06},
+
+        {0.00971734, 0.00063951, -0.0121618, -0.00604365, 0.00492161, -0.00143907},
+
+        {-0.0844907, -0.0592498, -0.0828631, -0.0740798, -0.0698045, -0.0699518},
+
+        {-0.0999971, -0.0999996, -0.0989356, -0.0999965, -0.0833049, -0.020072}};
+
+    constexpr float par1[nBinsEta][nBinsBrem] = {{0.569273, 0.674654, 0.523128, 1.02501, 1.75645, 0.955191},
+
+                                                 {0.697951, 0.580628, 0.814515, 0.819975, 0.829616, 1.18952},
+
+                                                 {3.79446, 2.47472, 5.12931, 3.42497, 1.84123, 2.3773},
+
+                                                 {19.9999, 10.4079, 16.6273, 15.9316, 15.4883, 14.7306},
+
+                                                 {15.9122, 18.5882, 19.9996, 19.9999, 18.2281, 8.1587}};
+
+    constexpr float par2[nBinsEta][nBinsBrem] = {{-4.31243, -3.071, -2.56702, -7.74555, -21.3726, -6.2189},
+
+                                                 {-6.56009, -3.66067, -7.8275, -6.01641, -7.85456, -8.27071},
+
+                                                 {-49.9996, -25.0724, -49.985, -28.1932, -10.6485, -15.4014},
+
+                                                 {-39.9444, -25.1133, -49.9999, -50, -49.9998, -49.9998},
+
+                                                 {-30.1268, -42.6113, -46.6999, -47.074, -49.9995, -25.2897}};
+
+    static_assert(par0[0][3] == 0.00596201f);
+    static_assert(par1[0][3] == 1.02501f);
+    static_assert(par2[0][3] == -7.74555f);
+
+    static_assert(par0[2][4] == 0.00492161f);
+    static_assert(par1[2][4] == 1.84123f);
+    static_assert(par2[2][4] == -10.6485f);
+
+    static_assert(par0[4][3] == -0.0999965f);
+    static_assert(par1[4][3] == 19.9999f);
+    static_assert(par2[4][3] == -47.074f);
+
+    Int_t iEtaSl = -1;
+    for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+      if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
+        iEtaSl = iEta;
+      }
+    }
+
+    Int_t iBremSl = -1;
+    for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+      if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
+        iBremSl = iBrem;
+      }
+    }
+
+    if (fabs(eta) > 2.5)
+      iEtaSl = nBinsEta - 1;
+    if (brem < BremBins[0])
+      iBremSl = 0;
+    if (brem > BremBins[nBinsBrem - 1])
+      iBremSl = nBinsBrem - 1;
+
+    if (iEtaSl == -1) {
+      edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeEnergyUncertaintyCracks";
+      return 0;
+    }
+
+    if (iBremSl == -1) {
+      edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeEnergyUncertaintyCracks";
+      return 0;
+    }
+
+    float uncertainty = 0;
+    if (et < 5)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]);
+    if (et > 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]);
+
+    if (et > 5 && et < 100)
+      uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
+
+    return (uncertainty * energy);
   }
 
-  float uncertainty = 0;
-  if (et < 5)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]);
-  if (et > 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]);
-
-  if (et > 5 && et < 100)
-    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
-
-  return (uncertainty * energy);
-}
+}  // namespace
 
 double electronAlgos::computeEnergyUncertainty(reco::GsfElectron::Classification c,
                                                double eta,

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -648,8 +648,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
                                      const gsfAlgoHelpers::HeavyObjectCache* hoc) {
   // eventually check ctf track
   if (generalData_.strategyCfg.ctfTracksCheck && electronData.ctfTrackRef.isNull()) {
-    electronData.ctfTrackRef =
-        electronAlgos::getClosestCtfToGsf(electronData.gsfTrackRef, eventData.currentCtfTracks).first;
+    electronData.ctfTrackRef = egamma::getClosestCtfToGsf(electronData.gsfTrackRef, eventData.currentCtfTracks).first;
   }
 
   // charge ID
@@ -873,7 +872,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   // classification and corrections
   //====================================================
   // classification
-  const auto elClass = electronAlgos::classify(ele);
+  const auto elClass = egamma::classifyElectron(ele);
   ele.setClassification(elClass);
 
   bool unexpectedClassification = elClass == GsfElectron::UNKNOWN || elClass > GsfElectron::GAP;
@@ -892,18 +891,18 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
       if (ele.core()->ecalDrivenSeed()) {
         if (generalData_.strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization && !unexpectedClassification) {
           if (ele.isEcalEnergyCorrected()) {
-            edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy") << "already done";
+            edm::LogWarning("ElectronEnergyCorrector::classBasedElectronEnergy") << "already done";
           } else {
-            ele.setCorrectedEcalEnergy(electronAlgos::classBasedParameterizationEnergy(
-                ele, *eventData.beamspot, *generalData_.crackCorrectionFunction));
+            ele.setCorrectedEcalEnergy(
+                egamma::classBasedElectronEnergy(ele, *eventData.beamspot, *generalData_.crackCorrectionFunction));
           }
         }
         if (generalData_.strategyCfg.ecalDrivenEcalErrorFromClassBasedParameterization) {
-          ele.setCorrectedEcalEnergyError(electronAlgos::classBasedParameterizationUncertainty(ele));
+          ele.setCorrectedEcalEnergyError(egamma::classBasedElectronEnergyUncertainty(ele));
         }
       } else {
         if (generalData_.strategyCfg.pureTrackerDrivenEcalErrorFromSimpleParameterization) {
-          ele.setCorrectedEcalEnergyError(electronAlgos::simpleParameterizationUncertainty(ele));
+          ele.setCorrectedEcalEnergyError(egamma::simpleElectronEnergyUncertainty(ele));
         }
       }
     }
@@ -915,7 +914,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
     if (ele.p4Error(reco::GsfElectron::P4_COMBINATION) != 999.) {
       edm::LogWarning("ElectronMomentumCorrector::correct") << "already done";
     } else {
-      auto p = electronAlgos::correctMomentum(ele, electronData.vtxTSOS);
+      auto p = egamma::correctElectronMomentum(ele, electronData.vtxTSOS);
       ele.correctMomentum(p.momentum, p.trackError, p.finalError);
     }
   }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -649,7 +649,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   // eventually check ctf track
   if (generalData_.strategyCfg.ctfTracksCheck && electronData.ctfTrackRef.isNull()) {
     electronData.ctfTrackRef =
-        gsfElectronTools::getClosestCtfToGsf(electronData.gsfTrackRef, eventData.currentCtfTracks).first;
+        electronAlgos::getClosestCtfToGsf(electronData.gsfTrackRef, eventData.currentCtfTracks).first;
   }
 
   // charge ID
@@ -873,11 +873,15 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   // classification and corrections
   //====================================================
   // classification
-  ElectronClassification theClassifier;
-  theClassifier.classify(ele);
-  theClassifier.refineWithPflow(ele);
+  const auto elClass = electronAlgos::classify(ele);
+  ele.setClassification(elClass);
+
+  bool unexpectedClassification = elClass == GsfElectron::UNKNOWN || elClass > GsfElectron::GAP;
+  if (unexpectedClassification) {
+    edm::LogWarning("GsfElectronAlgo") << "unexpected classification";
+  }
+
   // ecal energy
-  ElectronEnergyCorrector theEnCorrector(generalData_.crackCorrectionFunction.get());
   if (generalData_.strategyCfg.useEcalRegression)  // new
   {
     generalData_.regHelper.applyEcalRegression(
@@ -886,15 +890,20 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   {
     if (!EcalTools::isHGCalDet((DetId::Detector)region)) {
       if (ele.core()->ecalDrivenSeed()) {
-        if (generalData_.strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization) {
-          theEnCorrector.classBasedParameterizationEnergy(ele, *eventData.beamspot);
+        if (generalData_.strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization && !unexpectedClassification) {
+          if (ele.isEcalEnergyCorrected()) {
+            edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy") << "already done";
+          } else {
+            ele.setCorrectedEcalEnergy(electronAlgos::classBasedParameterizationEnergy(
+                ele, *eventData.beamspot, *generalData_.crackCorrectionFunction));
+          }
         }
         if (generalData_.strategyCfg.ecalDrivenEcalErrorFromClassBasedParameterization) {
-          theEnCorrector.classBasedParameterizationUncertainty(ele);
+          ele.setCorrectedEcalEnergyError(electronAlgos::classBasedParameterizationUncertainty(ele));
         }
       } else {
         if (generalData_.strategyCfg.pureTrackerDrivenEcalErrorFromSimpleParameterization) {
-          theEnCorrector.simpleParameterizationUncertainty(ele);
+          ele.setCorrectedEcalEnergyError(electronAlgos::simpleParameterizationUncertainty(ele));
         }
       }
     }
@@ -902,9 +911,13 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
 
   // momentum
   // Keep the default correction running first. The track momentum error is computed in there
-  if (ele.core()->ecalDrivenSeed()) {
-    ElectronMomentumCorrector theMomCorrector;
-    theMomCorrector.correct(ele, electronData.vtxTSOS);
+  if (ele.core()->ecalDrivenSeed() && !unexpectedClassification) {
+    if (ele.p4Error(reco::GsfElectron::P4_COMBINATION) != 999.) {
+      edm::LogWarning("ElectronMomentumCorrector::correct") << "already done";
+    } else {
+      auto p = electronAlgos::correctMomentum(ele, electronData.vtxTSOS);
+      ele.correctMomentum(p.momentum, p.trackError, p.finalError);
+    }
   }
   if (generalData_.strategyCfg.useCombinationRegression)  // new
   {

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
@@ -6,7 +6,7 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h"
 
-namespace gsfElectronTools {
+namespace electronAlgos {
 
   using namespace reco;
 
@@ -98,4 +98,4 @@ namespace gsfElectronTools {
     return make_pair(ctfTrackRef, maxFracShared);
   }
 
-}  // namespace gsfElectronTools
+}  // namespace electronAlgos

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
@@ -6,7 +6,7 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h"
 
-namespace electronAlgos {
+namespace egamma {
 
   using namespace reco;
 
@@ -98,4 +98,4 @@ namespace electronAlgos {
     return make_pair(ctfTrackRef, maxFracShared);
   }
 
-}  // namespace electronAlgos
+}  // namespace egamma

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -462,9 +462,9 @@ void GsfElectronBaseProducer::setAmbiguityData(reco::GsfElectronCollection& elec
   auto const& endcapRecHits = event.get(inputCfg_.endcapRecHitCollection);
 
   if (strategyCfg_.ambSortingStrategy == 0) {
-    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isBetter);
+    std::sort(electrons.begin(), electrons.end(), electronAlgos::isBetter);
   } else if (strategyCfg_.ambSortingStrategy == 1) {
-    std::sort(electrons.begin(), electrons.end(), EgAmbiguityTools::isInnerMost);
+    std::sort(electrons.begin(), electrons.end(), electronAlgos::isInnerMost);
   } else {
     throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")
         << "value of strategyCfg_.ambSortingStrategy is : " << strategyCfg_.ambSortingStrategy;
@@ -523,12 +523,11 @@ void GsfElectronBaseProducer::setAmbiguityData(reco::GsfElectronCollection& elec
         } else if (strategyCfg_.ambClustersOverlapStrategy == 1) {
           float eMin = 1.;
           float threshold = eMin * cosh(EleRelPoint(scRef1->position(), beamspot.position()).eta());
-          sameCluster =
-              ((EgAmbiguityTools::sharedEnergy(*eleClu1, *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
-               (EgAmbiguityTools::sharedEnergy(*scRef1->seed(), *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
-               (EgAmbiguityTools::sharedEnergy(*eleClu1, *scRef2->seed(), barrelRecHits, endcapRecHits) >= threshold) ||
-               (EgAmbiguityTools::sharedEnergy(*scRef1->seed(), *scRef2->seed(), barrelRecHits, endcapRecHits) >=
-                threshold));
+          using electronAlgos::sharedEnergy;
+          sameCluster = ((sharedEnergy(*eleClu1, *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
+                         (sharedEnergy(*scRef1->seed(), *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
+                         (sharedEnergy(*eleClu1, *scRef2->seed(), barrelRecHits, endcapRecHits) >= threshold) ||
+                         (sharedEnergy(*scRef1->seed(), *scRef2->seed(), barrelRecHits, endcapRecHits) >= threshold));
         } else {
           throw cms::Exception("GsfElectronAlgo|UnknownAmbiguityClustersOverlapStrategy")
               << "value of strategyCfg_.ambClustersOverlapStrategy is : " << strategyCfg_.ambClustersOverlapStrategy;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -464,7 +464,7 @@ void GsfElectronBaseProducer::setAmbiguityData(reco::GsfElectronCollection& elec
   if (strategyCfg_.ambSortingStrategy == 0) {
     std::sort(electrons.begin(), electrons.end(), egamma::isBetterElectron);
   } else if (strategyCfg_.ambSortingStrategy == 1) {
-    std::sort(electrons.begin(), electrons.end(), egamma::isInnerMostElectron);
+    std::sort(electrons.begin(), electrons.end(), egamma::isInnermostElectron);
   } else {
     throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")
         << "value of strategyCfg_.ambSortingStrategy is : " << strategyCfg_.ambSortingStrategy;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -462,18 +462,18 @@ void GsfElectronBaseProducer::setAmbiguityData(reco::GsfElectronCollection& elec
   auto const& endcapRecHits = event.get(inputCfg_.endcapRecHitCollection);
 
   if (strategyCfg_.ambSortingStrategy == 0) {
-    std::sort(electrons.begin(), electrons.end(), electronAlgos::isBetter);
+    std::sort(electrons.begin(), electrons.end(), egamma::isBetterElectron);
   } else if (strategyCfg_.ambSortingStrategy == 1) {
-    std::sort(electrons.begin(), electrons.end(), electronAlgos::isInnerMost);
+    std::sort(electrons.begin(), electrons.end(), egamma::isInnerMostElectron);
   } else {
     throw cms::Exception("GsfElectronAlgo|UnknownAmbiguitySortingStrategy")
         << "value of strategyCfg_.ambSortingStrategy is : " << strategyCfg_.ambSortingStrategy;
   }
 
   // init
-  for (auto e1 = electrons.begin(); e1 != electrons.end(); ++e1) {
-    e1->clearAmbiguousGsfTracks();
-    e1->setAmbiguous(false);
+  for (auto& electron : electrons) {
+    electron.clearAmbiguousGsfTracks();
+    electron.setAmbiguous(false);
   }
 
   // get ambiguous from GsfPfRecTracks
@@ -523,7 +523,7 @@ void GsfElectronBaseProducer::setAmbiguityData(reco::GsfElectronCollection& elec
         } else if (strategyCfg_.ambClustersOverlapStrategy == 1) {
           float eMin = 1.;
           float threshold = eMin * cosh(EleRelPoint(scRef1->position(), beamspot.position()).eta());
-          using electronAlgos::sharedEnergy;
+          using egamma::sharedEnergy;
           sameCluster = ((sharedEnergy(*eleClu1, *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
                          (sharedEnergy(*scRef1->seed(), *eleClu2, barrelRecHits, endcapRecHits) >= threshold) ||
                          (sharedEnergy(*eleClu1, *scRef2->seed(), barrelRecHits, endcapRecHits) >= threshold) ||

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.cc
@@ -46,6 +46,6 @@ void GsfElectronCoreBaseProducer::initEvent(edm::Event& event, const edm::EventS
 void GsfElectronCoreBaseProducer::fillElectronCore(reco::GsfElectronCore* eleCore) {
   const GsfTrackRef& gsfTrackRef = eleCore->gsfTrack();
 
-  std::pair<TrackRef, float> ctfpair = electronAlgos::getClosestCtfToGsf(gsfTrackRef, ctfTracksH_);
+  std::pair<TrackRef, float> ctfpair = egamma::getClosestCtfToGsf(gsfTrackRef, ctfTracksH_);
   eleCore->setCtfTrack(ctfpair.first, ctfpair.second);
 }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronCoreBaseProducer.cc
@@ -46,6 +46,6 @@ void GsfElectronCoreBaseProducer::initEvent(edm::Event& event, const edm::EventS
 void GsfElectronCoreBaseProducer::fillElectronCore(reco::GsfElectronCore* eleCore) {
   const GsfTrackRef& gsfTrackRef = eleCore->gsfTrack();
 
-  std::pair<TrackRef, float> ctfpair = gsfElectronTools::getClosestCtfToGsf(gsfTrackRef, ctfTracksH_);
+  std::pair<TrackRef, float> ctfpair = electronAlgos::getClosestCtfToGsf(gsfTrackRef, ctfTracksH_);
   eleCore->setCtfTrack(ctfpair.first, ctfpair.second);
 }


### PR DESCRIPTION
#### PR description:

This is one of the occasional PRs to make the EGamma algos follow a bit more a functional paradigm for better multithread-friendlieness and code readability.

I propose to convert the member functions of all the classes in `EgammaElectronAlgos` that don't have member variables into free functions that should all live in the same namespce (I suggest here the name `electronAlgos`, I think one namespace for each former class would be a bit excessive, but I don't think CMS has any guidelines for that so that's maybe a thing to discuss). Functions that were previously private are simply not declared in the public header file.

All these functions were then adapted such that they are pure, i.e. they don't mutate their inputs and always have an output of a defined type. This means that when the GsfElectrons are created, they are actually only mutated in the GsfElectronAlgo itself and never in the various helper functions that it calls.

Optimally, the formerly private functions should live in the anonymous namespace, but I was a bit reluctant to do that because it would cause huge chunks of code to shift indentation without actual changes. Is there maybe a way to put functions in the anonymous namespace without enclosing them with `namespace { }` and therefore causing an additional layer of indentation?

This PR does not clash with https://github.com/cms-sw/cmssw/pull/28262.

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR:

No backport intended.
