### PR TITLE
[PY3] unit test fixed for Aligenmnet

### DIFF
--- a/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
+++ b/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
@@ -12,7 +12,10 @@ import math
 import bisect
 import random
 import signal
-import cPickle
+if sys.version_info[0]>2:
+  import _pickle as cPickle
+else:
+  import cPickle
 import difflib
 import argparse
 import functools
@@ -363,14 +366,14 @@ class FileListCreator(object):
         for d in self._datasets: print_msg("\t"+d)
         print_msg("This may take a while...")
 
-        result = pool.map_async(get_events_per_dataset, self._datasets).get(sys.maxsize)
+        result = pool.map_async(get_events_per_dataset, self._datasets).get(3600)
         self._events_in_dataset = sum(result)
 
-        result = pool.map_async(get_max_run, self._datasets).get(sys.maxsize)
+        result = pool.map_async(get_max_run, self._datasets).get(3600)
         self._max_run = max(result)
 
-        result = sum(pool.map_async(get_file_info, self._datasets).get(sys.maxint), [])
-        files = pool.map_async(_make_file_info, result).get(sys.maxint)
+        result = sum(pool.map_async(get_file_info, self._datasets).get(3600), [])
+        files = pool.map_async(_make_file_info, result).get(3600)
         self._file_info = sorted(fileinfo for fileinfo in files)
 
         self.rereco = any(len(fileinfo.runs)>1 for fileinfo in self._file_info)

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/iniparser.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/iniparser.py
@@ -5,7 +5,7 @@
 # parseParameter will override the config values.
 ##
 
-import ConfigParser
+import configparser as ConfigParser
 import logging
 import os
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
@@ -4,12 +4,15 @@ from __future__ import print_function
 import os
 import re
 import sys
-import cPickle
+if sys.version_info[0]>2:
+  import _pickle as cPickle
+else:
+  import cPickle
 import argparse
 import itertools
 import subprocess
 import collections
-import ConfigParser
+import configparser as ConfigParser
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.tools as mps_tools
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.Mpslibclass as mpslib
 import Alignment.MillePedeAlignmentAlgorithm.mpsvalidate.iniparser as mpsv_iniparser

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_create_file_lists.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_create_file_lists.py
@@ -9,4 +9,4 @@ print("(in Alignment/CommonAlignment/scripts).")
 print("=======================================")
 print()
 import subprocess
-execfile(subprocess.check_output(["which", "tkal_create_file_lists.py"]).rstrip())
+exec(open(subprocess.check_output(["which", "tkal_create_file_lists.py"], universal_newlines=True).rstrip()).read())

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -20,7 +20,10 @@ import os
 import sys
 import glob
 import shutil
-import cPickle
+if sys.version_info[0]>2:
+  import _pickle as cPickle
+else:
+  import cPickle
 import subprocess
 import re
 import argparse


### PR DESCRIPTION
These changes are needed to fix unit tests for Alignment for python3
- cPickle in python3 now comes from _pickle
- set time out to 3600 s (1h) instead of sys.maxsize which is like forever
- ConfigParser in python is renamed to configparser