### PR TITLE
[PY3] run dablooms tests for python2 only

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -40,4 +40,4 @@
 <iftool name="py2-cx-oracle">
   <test name="testCxOracle" command="python -c 'import cx_Oracle'"/>
 </iftool>
-<test name="testPYDablooms" command="python -c 'import pydablooms'"/>
+<test name="testPYDablooms" command="$(LOCALTOP)/src/PhysicsTools/PythonAnalysis/test/test-pydablooms"/>

--- a/PhysicsTools/PythonAnalysis/test/test-pydablooms
+++ b/PhysicsTools/PythonAnalysis/test/test-pydablooms
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import sys
+if sys.version_info[0]>2:
+  print("Dabloom is not available for Python 3")
+else:
+  import pydablooms
+  


### PR DESCRIPTION
PyDabloom is only avaiolable for python2. Building it for python3 fails. Looks like this project is not moving to python3 any time soon, there is no development since Feb 2016 ( https://github.com/bitly/dablooms ). We use dablooms for Utilities/StaticAnalyzers only ( https://github.com/cms-sw/cmssw/blob/master/Utilities/StaticAnalyzers/BuildFile.xml#L2 ). @gartung can you please check if we can drop this dependency?

For now, I have disabled this unit test for python3 IBs.