### PR TITLE
Fix undefined behavior in DigiConverterFP420

### DIFF
--- a/SimRomanPot/SimFP420/src/DigiConverterFP420.cc
+++ b/SimRomanPot/SimFP420/src/DigiConverterFP420.cc
@@ -21,7 +21,7 @@ DigiConverterFP420::DigiConverterFP420(float in, int verbosity) {
   if (adcBits > largestBits || adcBits < 1)
     adcBits = largestBits;
 
-  theMaxADC = ~(~0 << adcBits);
+  theMaxADC = ~(~0U << adcBits);
   //      std::cout << "theMaxADC= "<< theMaxADC  << std::endl; // = 1023
   if (verbos > 0) {
     std::cout << " ***DigiConverterFP420: constructor" << std::endl;


### PR DESCRIPTION
#### PR description:

Bit shifting a negative number is undef. The starting number is now an unsigned value instead. This fixes a gcc 9 warning.

#### PR validation:

The warning is no longer present in gcc9 builds.
Using compiler explorer to test the change, the same value is returned for both gcc and clang after the change.
https://godbolt.org/z/oHP_EL