### PR TITLE
Fix undefined behavior in L1GtPatternWriter

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternWriter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtPatternWriter.cc
@@ -114,8 +114,8 @@ L1GtPatternWriter::~L1GtPatternWriter() { close(); }
 
 uint32_t L1GtPatternWriter::mask(uint32_t length) {
   if (length < 32) {
-    return ~((~0) << length);
+    return ~((~0U) << length);
   } else {
-    return ~0;
+    return ~0U;
   }
 }


### PR DESCRIPTION
#### PR description:

Bit shifting a negative number is undef. The starting number is now an unsigned value instead. This fixes a gcc 9 warning.

#### PR validation:

The warning is no longer present in gcc9 builds.
Using compiler explorer to test the change, the same value is returned for both gcc and clang after the change.
https://godbolt.org/z/oHP_EL