### PR TITLE
Remove ParameterSet::Bool as unused

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -37,7 +37,6 @@ namespace edm {
   public:
     template <typename T>
     friend class ParameterDescription;
-    enum Bool { False = 0, True = 1, Unknown = 2 };
 
     // default-construct
     ParameterSet();
@@ -1044,8 +1043,5 @@ namespace edm {
 
   template <>
   std::vector<std::string> ParameterSet::getParameterNamesForType<VParameterSet>(bool trackiness) const;
-
-  ParameterSet::Bool operator&&(ParameterSet::Bool a, ParameterSet::Bool b);
-
 }  // namespace edm
 #endif

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -2180,15 +2180,4 @@ namespace edm {
           << "The required ParameterSetVector '" << name << "' was not specified.\n";
     return result->vpset();
   }
-
-  //----------------------------------------------------------------------------------
-  ParameterSet::Bool operator&&(ParameterSet::Bool a, ParameterSet::Bool b) {
-    if (a == ParameterSet::False || b == ParameterSet::False) {
-      return ParameterSet::False;
-    } else if (a == ParameterSet::Unknown || b == ParameterSet::Unknown) {
-      return ParameterSet::Unknown;
-    }
-    return ParameterSet::True;
-  }
-
 }  // namespace edm


### PR DESCRIPTION
#### PR description:

I came across the ternary boolean, and since it appears to be unused, this PR suggests to remove it.

#### PR validation:

Code compiles.