### PR TITLE
Fix GCC9 warning in NavigationSchoolAnalyzer

### DIFF
--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -84,6 +84,7 @@ void NavigationSchoolAnalyzer::print(std::ostream& os, const DetLayer* dl) {
         break;
       case GeomDetEnumerators::RPCEndcap:
         side = (unsigned int)((RPCDetId(tag->geographicalId().rawId()).region() / 2. + 1) * 2.);
+        [[fallthrough]];
       case GeomDetEnumerators::RPCBarrel:
         LorW = RPCDetId(tag->geographicalId().rawId()).station();
         break;


### PR DESCRIPTION
#### PR description:

This PR fixes a GCC 9 warning by adding the `[[fallthrough]]` attribute to denote an intentional fallthrough.

#### PR validation:

Code compiles with GCC 9 without warnings.