### PR TITLE
Take python exceptions from builtins

### DIFF
--- a/PhysicsTools/PythonAnalysis/python/cmstools.py
+++ b/PhysicsTools/PythonAnalysis/python/cmstools.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 from builtins import range
 import re
 import ROOT
-import exceptions
 import six
 import sys
 ### define tab completion
@@ -174,7 +173,7 @@ class EventBranch(object):
         return self._buffer
 
 
-class cmserror(exceptions.Exception):
+class cmserror(Exception):
     def __init__(self, message):
           length = len(message)+7   #7=len("ERROR: ")
           print("="*length)

--- a/RecoLocalCalo/EcalRecProducers/test/compare_csv.py
+++ b/RecoLocalCalo/EcalRecProducers/test/compare_csv.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import sys
-import exceptions
 
 def compare(fn1, fn2):
     f1, f2 = open(fn1, "r"), open(fn2, "r")
@@ -22,7 +21,7 @@ def compare(fn1, fn2):
                 diff.append((diff_f, k1, k2, "l1: " + l1, "l2: " + l2, ))
 
                 print("diffrence[f%d]: %s -> %s" % (i, k1, k2))
-            except exceptions.ValueError:
+            except ValueError:
                 print("non float-type difference[f%d]: %s -> %s" % (i, k1, k2))
 
     for key, item in sorted(diff_cols.items()):


### PR DESCRIPTION
#### PR description:

Today I wanted to use the `edmDumpEventContent` script with python3, which can be easily done by automatically updating the code with `python-modernize` except for one hiccup: the `import exceptions` line in *PhysicsTools/PythonAnalysis/python/cmstools.py*. Following the information in this post [1], the exceptions can be just taken from the builtins instead of the exceptions module in python 2 as well, which makes the code python 3 compatible. There was also another spot in CMSSW where the former `exceptions` module was imported, so I changed this one too.

[1] https://stackoverflow.com/questions/27030933/python-2s-exceptions-module-is-missing-in-python3-where-did-its-contents-go

#### PR validation:

I can use `edmDumpEventContent` with python 3 when I take this PR and run `python-modernize -n -w .` on top of it.

#### if this PR is a backport please specify the original PR:

No backport intended.
