### PR TITLE
call close with the option to shutdown workers

### DIFF
--- a/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
@@ -6,8 +6,7 @@ using namespace std;
 
 #include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
-void proof_thing2_sel()
-{
+void proof_thing2_sel() {
   if (gSystem->Getenv("TMPDIR")) {
     std::string t(gSystem->Getenv("TMPDIR"));
     if (t.size() > 80)
@@ -18,8 +17,8 @@ void proof_thing2_sel()
   }
 
   //Setup the proof server
-  TProof *myProof=TProof::Open( "", "workers=2" );
-  
+  TProof *myProof = TProof::Open("", "workers=2");
+
   // This makes sure the TSelector library and dictionary are properly
   // installed in the remote PROOF servers
 
@@ -28,17 +27,18 @@ void proof_thing2_sel()
   //myProof->Exec( ".x proof_remote.C" );
 
   // So inline it...
-  myProof->Exec("gSystem->Load(\"libFWCoreFWLite\"); "
-               "FWLiteEnabler::enable(); "
-               "gSystem->Load(\"libFWCoreTFWLiteSelectorTest\");");
-  
+  myProof->Exec(
+      "gSystem->Load(\"libFWCoreFWLite\"); "
+      "FWLiteEnabler::enable(); "
+      "gSystem->Load(\"libFWCoreTFWLiteSelectorTest\");");
+
   //This creates the 'data set' which defines what files we need to process
   // NOTE: the files given must be accessible by the remote systems
-  TDSet c( "TTree", "Events");
+  TDSet c("TTree", "Events");
   c.Add("testTFWLiteSelector.root");
-  
+
   //This makes the actual processing happen
-  c.Process( "tfwliteselectortest::ThingsTSelector2" );
+  c.Process("tfwliteselectortest::ThingsTSelector2");
 
   myProof->Close("S");
 }

--- a/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
@@ -39,4 +39,6 @@ void proof_thing2_sel()
   
   //This makes the actual processing happen
   c.Process( "tfwliteselectortest::ThingsTSelector2" );
+
+  myProof->Close("S");
 }

--- a/FWCore/TFWLiteSelector/test/proof_thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing_sel.C
@@ -6,8 +6,7 @@ using namespace std;
 
 #include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
-void proof_thing_sel()
-{
+void proof_thing_sel() {
   if (gSystem->Getenv("TMPDIR")) {
     std::string t = gSystem->Getenv("TMPDIR");
     if (t.size() > 80)
@@ -18,7 +17,7 @@ void proof_thing_sel()
   }
 
   //Setup the proof server
-  TProof *myProof=TProof::Open( "", "workers=2" );
+  TProof *myProof = TProof::Open("", "workers=2");
 
   // This makes sure the TSelector library and dictionary are properly
   // installed in the remote PROOF servers
@@ -28,17 +27,18 @@ void proof_thing_sel()
   //myProof->Exec(".x proof_remote.C");
 
   // So inline it...
-  myProof->Exec("gSystem->Load(\"libFWCoreFWLite\"); "
-               "FWLiteEnabler::enable(); "
-               "gSystem->Load(\"libFWCoreTFWLiteSelectorTest\");");
+  myProof->Exec(
+      "gSystem->Load(\"libFWCoreFWLite\"); "
+      "FWLiteEnabler::enable(); "
+      "gSystem->Load(\"libFWCoreTFWLiteSelectorTest\");");
 
   // This creates the 'data set' which defines what files we need to process
   // NOTE: the files given must be accessible by the remote systems
-  TDSet c( "TTree", "Events");
+  TDSet c("TTree", "Events");
   c.Add("testTFWLiteSelector.root");
-  
+
   //This makes the actual processing happen
-  c.Process( "tfwliteselectortest::ThingsTSelector" );
+  c.Process("tfwliteselectortest::ThingsTSelector");
 
   myProof->Close("S");
 }

--- a/FWCore/TFWLiteSelector/test/proof_thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing_sel.C
@@ -39,4 +39,6 @@ void proof_thing_sel()
   
   //This makes the actual processing happen
   c.Process( "tfwliteselectortest::ThingsTSelector" );
+
+  myProof->Close("S");
 }


### PR DESCRIPTION
#### PR description:

On close, ROOT defaults to detaching "remote sessions", which apparently includes workers on the local node.  This has been observed to occupy resources on the build servers.  This PR calls `TProof::Close("S")`, which should tell the workers to shutdown rather than detach.

#### PR validation:

Ran the standard tests and observed that no worker processes were left behind.  This PR should have no impact on anything outside the scope of the TFWLiteSelector unit tests.
