### PR TITLE
[SiPixelAli PCL] Update the pede options to avoid issues with too many binaries open

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
@@ -42,8 +42,9 @@ SiPixelAliPedeAlignmentProducer.algoConfig.pedeSteerer.method = 'inversion  5  0
 SiPixelAliPedeAlignmentProducer.algoConfig.pedeSteerer.options = cms.vstring(
     #'regularisation 1.0 0.05', # non-stated pre-sigma 50 mrad or 500 mum
      'entries 500',
-     'chisqcut  30.0  4.5', #,
-     'threads 1 1' #,
+     'chisqcut  30.0  4.5',
+     'threads 1 1',
+     'closeandreopen'
      #'outlierdownweighting 3','dwfractioncut 0.1'
      #'outlierdownweighting 5','dwfractioncut 0.2'
     )

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -43,8 +43,9 @@ SiPixelAliPedeAlignmentProducer.algoConfig.pedeSteerer.method = 'inversion  5  0
 SiPixelAliPedeAlignmentProducer.algoConfig.pedeSteerer.options = cms.vstring(
     #'regularisation 1.0 0.05', # non-stated pre-sigma 50 mrad or 500 mum
      'entries 500',
-     'chisqcut  30.0  4.5', #,
-     'threads 1 1' #,
+     'chisqcut  30.0  4.5',
+     'threads 1 1',
+     'closeandreopen'
      #'outlierdownweighting 3','dwfractioncut 0.1'
      #'outlierdownweighting 5','dwfractioncut 0.2'
     )


### PR DESCRIPTION
#### PR description:
During Run-2 pp operations it was noticed that occasionally the PCL alignment workflow was stalled for very long runs (typically exceeding 1000 LS long), examples are [run 317182](https://tinyurl.com/yxoeyh2r) and [run 317320](https://tinyurl.com/y3j4yjdq). 
In those relatively rare cases no measurement was available despite the large amount of tracks available.
Inspection of log files revealed that the issue lied in the inability of the pede routine to open the input binary files and access the data within them:
```
STOP FILETC: open error
%MSG-e MillePedeFileReader: AlignmentProducerAsAnalyzer:SiPixelAliPedeAlignmentProducer@endJob 10-Jun-2018 13:58:10 CEST PostGlobalEndRun
Could not read millepede result-file.
%MSG
%MSG-e MillePedeFileReader:  MillePedeDQMModule:SiPixelAliDQMModule@endJob 10-Jun-2018 13:58:10 CEST PostGlobalEndRun
Could not read millepede result-file.
%MSG 
```
The issues has been traced back in the meanwhile in having a too large amount of pede binary files open at the same time.
This issue has been solved in recent pede releases (cf. http://www.desy.de/~kleinwrt/MP2/doc/html/index.html), by providing the option [closeandreopen](http://www.desy.de/~kleinwrt/MP2/doc/html/option_page.html#cmd-closeandreopen) (from the pede manual: sets flag `keepOpen` to zero to enable closing and reopening of binary files to limit the number of concurrently open files). 
Such an option is available starting from the 19.04.12 revision and is available either in the privately distributed pede executable at `/afs/cern.ch/user/c/ckleinw/bin/rev183/pede`or in the official MillePede release `V04-06-00`  (which has been requested here: https://github.com/cms-sw/cmsdist/pull/5309)
This PR updates the configuration of `SiPixelAliPedeAlignmentProducer`in order to use the `closeandreopen` option and is a companion of  https://github.com/cms-sw/cmsdist/pull/5309 (**N.B. the two should be tested together**). 

#### PR validation:

The previously failing PCL workflow for run 317320 re-generated via:

```
cmsDriver.py pedeStep --data --conditions 106X_dataRun3_Express_v2 --scenario pp --era Run2_2018 -s ALCAHARVEST:SiPixelAli --dasquery='file dataset=/StreamExpress/Run2018B-PromptCalibProdSiPixelAli-Express-v1/ALCAPROMPT run=317320' -n -1 
```
with the modifications proposed in this PR + adding the line:
```
process.SiPixelAliPedeAlignmentProducer.algoConfig.pedeSteerer.pedeCommand = "/afs/cern.ch/user/c/ckleinw/bin/rev183/pede"
```
in the configuration (equivalent to have `V04-06-00`as default executable) runs to completion (takes about 3h to complete).

![image](https://user-images.githubusercontent.com/5082376/67793064-7fe24480-fa7a-11e9-9fca-fee8bc5c188b.png)

#### if this PR is a backport please specify the original PR:

This PR is not a backport.
cc:
@adewit @connorpa @dmeuser
