### PR TITLE
Update to correct modeling of neutral density filter in HB and HE

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,15 +66,15 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v2'
 }


### PR DESCRIPTION
#### PR description:

The modeling of the neutral density filters in HB and HE has been updated [1]. The geometry update includes the requested change to the full 2021 geometry [2]. The geometry updates changes light yields in depth=1, which are compensated by tuned HcalRespCorrs and HcalGains.

The GT diffs are as follows:

**2021 design MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_design_v4/110X_mcRun3_2021_design_v5
**2021 realistic MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_v4/110X_mcRun3_2021_realistic_v5
**2021 realistic cosmic MC, with tracker in deco mode**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021cosmics_realistic_deco_v2/110X_mcRun3_2021cosmics_realistic_deco_v3
**2023 realistic MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_v4/110X_mcRun3_2023_realistic_v5
**2024 realistic MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2024_realistic_v4/110X_mcRun3_2024_realistic_v5

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4235.html
[2] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4206/1.html

#### PR validation:

Validation by HCAL experts with a single-pion scan shows that the energy scale remains practically unchanged, except at low energy, where the observed small changes are consistent with expectations. See [1] for details. In addition, a technical test was performed: `runTheMatrix.py -l 12024.0,11634.0,8.2,12434.0,12834.0`.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4235.html

#### if this PR is a backport please specify the original PR:

This is not a backport and should not be backported.