### PR TITLE
[HBHE] Update MahiDebugger and fix nP in NNLS (v2)

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -77,17 +77,14 @@ struct MahiDebugInfo {
   float mahiEnergy;
   float chiSq;
   float arrivalTime;
-
-  float pEnergy;
-  float nEnergy;
   float pedEnergy;
+  float ootEnergy[7];
 
   float count[MaxSVSize];
   float inputTS[MaxSVSize];
   int inputTDC[MaxSVSize];
   float itPulse[MaxSVSize];
-  float pPulse[MaxSVSize];
-  float nPulse[MaxSVSize];
+  float ootPulse[7][MaxSVSize];
 };
 
 class MahiFit {

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -547,15 +547,15 @@ void MahiFit::phase1Debug(const HBHEChannelInfo& channelData, MahiDebugInfo& mdi
       }
     } else if (nnlsWork_.bxs.coeff(iBX) == pedestalBX_) {
       mdi.pedEnergy = nnlsWork_.ampVec.coeff(iBX);
-    } else if (nnlsWork_.bxs.coeff(iBX) == -1) {
-      mdi.pEnergy = nnlsWork_.ampVec.coeff(iBX);
+    } else if (nnlsWork_.bxs.coeff(iBX)>=-3 && nnlsWork_.bxs.coeff(iBX) <= 4) {
+      int ootIndex = nnlsWork_.bxs.coeff(iBX);
+      if (ootIndex > 0)
+        ootIndex += 2;
+      else
+        ootIndex += 3;
+      mdi.ootEnergy[ootIndex] = nnlsWork_.ampVec.coeff(iBX);
       for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {
-        mdi.pPulse[iTS] = nnlsWork_.pulseMat.col(iBX).coeff(iTS);
-      }
-    } else if (nnlsWork_.bxs.coeff(iBX) == 1) {
-      mdi.nEnergy = nnlsWork_.ampVec.coeff(iBX);
-      for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {
-        mdi.nPulse[iTS] = nnlsWork_.pulseMat.col(iBX).coeff(iTS);
+        mdi.ootPulse[ootIndex][iTS] = nnlsWork_.pulseMat.col(iBX).coeff(iTS);
       }
     }
   }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -545,7 +545,7 @@ void MahiFit::phase1Debug(const HBHEChannelInfo& channelData, MahiDebugInfo& mdi
       }
     } else if (nnlsWork_.bxs.coeff(iBX) == pedestalBX_) {
       mdi.pedEnergy = nnlsWork_.ampVec.coeff(iBX);
-    } else if (nnlsWork_.bxs.coeff(iBX)>=-3 && nnlsWork_.bxs.coeff(iBX) <= 4) {
+    } else if (nnlsWork_.bxs.coeff(iBX) >= -3 && nnlsWork_.bxs.coeff(iBX) <= 4) {
       int ootIndex = nnlsWork_.bxs.coeff(iBX);
       if (ootIndex > 0)
         ootIndex += 2;

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -351,8 +351,6 @@ void MahiFit::nnls() const {
   double wmax = 0.0;
   double threshold = nnlsThresh_;
 
-  nnlsWork_.nP = 0;
-
   while (true) {
     if (iter > 0 || nnlsWork_.nP == 0) {
       if (nnlsWork_.nP == std::min(npulse, nsamples))
@@ -615,6 +613,7 @@ void MahiFit::resetWorkspace() const {
   nnlsWork_.tsOffset = 0;
   nnlsWork_.bxOffset = 0;
   nnlsWork_.maxoffset = 0;
+  nnlsWork_.nP = 0;
 
   // NOT SURE THIS IS NEEDED
   nnlsWork_.amplitudes.setZero();


### PR DESCRIPTION
This is a cleaner version of https://github.com/cms-sw/cmssw/pull/28193.

All comments from Slava in https://github.com/cms-sw/cmssw/pull/28193 have been implemented. 

For convenience, I copy the description for https://github.com/cms-sw/cmssw/pull/28193 below: 

------

This PR consists of two changes.

(1) update on MahiDebugger

The current version of it only stores info for BX=-1,0,1 pulses and baseline because mahi ran with 3 pulses + baseline. Now it runs with 8 pulses, so the debugger should be updated accordingly. This has no impact on the reconstruction because changes are only in the debugger.

(2) Bug fix in initializing nP variable

Currently, nnlsWork_.nP is reset to 0 at every iteration. This turned out to make the fit unstable sometimes (particularly, the BX=+1 pulse became anomalously large). The initialization is now done at the beginning of MahiFit::phase1Apply. The comparison before and after this update is shown in [1] (Fix #2 in the slides corresponds to this update).

Here I summarize the changes after the update:

Overall impact on intime energy is small (p4)
There are changes in BX=-1 and BX=+1 pulses (p5 and p6, respectively). Based on the pulse displays (p21-32), the fit looks much better (BX=+1 pulse looks much more reasonable).
the chi2 became smaller (p12 and 13)
All these results have led us to conclude that the fix improves the behavior of the fit. This PR is for Run3.

[1] https://indico.cern.ch/event/855229/contributions/3597588/attachments/1924959/3188179/Hcal_mahi.pdf