### PR TITLE
Make cond::persistency::KeyList const thread-safe

### DIFF
--- a/CondCore/CondDB/interface/KeyList.h
+++ b/CondCore/CondDB/interface/KeyList.h
@@ -54,7 +54,7 @@ namespace cond {
       /** Retrieve the item associated with the key directly from the DB.
           The function is non-const since it is not thread-safe. */
       template <typename T>
-      std::shared_ptr<T> getUsingKey(unsigned long long key) {
+      std::shared_ptr<T> getUsingKey(unsigned long long key) const {
         auto item = loadFromDB(key);
         return deserialize<T>(item.first, item.second.first, item.second.second);
       }
@@ -63,9 +63,9 @@ namespace cond {
       size_t size() const { return m_data.size(); }
 
     private:
-      std::pair<std::string, std::pair<cond::Binary, cond::Binary>> loadFromDB(unsigned long long key);
-      // the db session
-      IOVProxy m_proxy;
+      std::pair<std::string, std::pair<cond::Binary, cond::Binary>> loadFromDB(unsigned long long key) const;
+      // the db session, protected by a mutex
+      mutable IOVProxy m_proxy;
       // the key selection:
       std::vector<unsigned long long> m_keys;
       std::vector<std::pair<std::string, std::pair<cond::Binary, cond::Binary>>> m_data;

--- a/CondCore/CondDB/interface/KeyList.h
+++ b/CondCore/CondDB/interface/KeyList.h
@@ -1,3 +1,4 @@
+
 #ifndef CondCore_CondDB_KeyList_h
 #define CondCore_CondDB_KeyList_h
 
@@ -31,35 +32,43 @@ namespace cond {
 
     class KeyList {
     public:
+      ///Called by PoolDBESSource
       void init(IOVProxy iovProxy);
       void init(KeyList const&);
 
-      void load(const std::vector<unsigned long long>& keys);
+      /// determines which keys to use to read from the DB. Should only be used by PoolDBESSource
+      void setKeys(const std::vector<unsigned long long>& keys);
 
+      ///Retrieves the pre-fetched data. The index is the same order as the keys used in setKeys.
       template <typename T>
-      std::shared_ptr<T> get(size_t n) const {
+      std::shared_ptr<T> getUsingIndex(size_t n) const {
         if (n >= size())
-          throwException("Index outside the bounds of the key array.", "KeyList::get");
-        if (!m_objects[n]) {
-          auto i = m_data.find(n);
-          if (i != m_data.end()) {
-            m_objects[n] = deserialize<T>(i->second.first, i->second.second.first, i->second.second.second);
-            m_data.erase(n);
-          } else {
-            throwException("Payload for index " + std::to_string(n) + " has not been found.", "KeyList::get");
-          }
+          throwException("Index outside the bounds of the key array.", "KeyList::getUsingIndex");
+        if (m_keys[n] == 0 or m_data[n].first.empty()) {
+          throwException("Payload for index " + std::to_string(n) + " has not been found.", "KeyList::getUsingIndex");
         }
-        return std::static_pointer_cast<T>(m_objects[n]);
+        auto const& i = m_data[n];
+        return deserialize<T>(i.first, i.second.first, i.second.second);
       }
 
-      size_t size() const { return m_objects.size(); }
+      /** Retrieve the item associated with the key directly from the DB.
+          The function is non-const since it is not thread-safe. */
+      template <typename T>
+      std::shared_ptr<T> getUsingKey(unsigned long long key) {
+        auto item = loadFromDB(key);
+        return deserialize<T>(item.first, item.second.first, item.second.second);
+      }
+
+      ///Number of keys based on container passed to setKeys.
+      size_t size() const { return m_data.size(); }
 
     private:
+      std::pair<std::string, std::pair<cond::Binary, cond::Binary>> loadFromDB(unsigned long long key);
       // the db session
       IOVProxy m_proxy;
       // the key selection:
-      mutable std::map<size_t, std::pair<std::string, std::pair<cond::Binary, cond::Binary> > > m_data;
-      mutable std::vector<std::shared_ptr<void> > m_objects;
+      std::vector<unsigned long long> m_keys;
+      std::vector<std::pair<std::string, std::pair<cond::Binary, cond::Binary>>> m_data;
     };
 
   }  // namespace persistency

--- a/CondCore/CondDB/interface/KeyListProxy.h
+++ b/CondCore/CondDB/interface/KeyListProxy.h
@@ -42,7 +42,7 @@ namespace cond {
     protected:
       void loadPayload() override {
         super::loadPayload();
-        m_keyList.load(super::operator()());
+        m_keyList.setKeys(super::operator()());
       }
 
     private:

--- a/CondCore/CondDB/src/KeyList.cc
+++ b/CondCore/CondDB/src/KeyList.cc
@@ -36,7 +36,7 @@ namespace cond {
       s.transaction().commit();
     }
 
-    std::pair<std::string, std::pair<cond::Binary, cond::Binary> > KeyList::loadFromDB(unsigned long long key) {
+    std::pair<std::string, std::pair<cond::Binary, cond::Binary> > KeyList::loadFromDB(unsigned long long key) const {
       std::pair<std::string, std::pair<cond::Binary, cond::Binary> > item;
       if (key == 0) {
         return item;

--- a/CondCore/CondDB/src/KeyList.cc
+++ b/CondCore/CondDB/src/KeyList.cc
@@ -8,35 +8,54 @@ namespace cond {
     void KeyList::init(IOVProxy iovProxy) {
       m_proxy = iovProxy;
       m_data.clear();
-      m_objects.clear();
+      m_keys.clear();
     }
 
     void KeyList::init(KeyList const& originalKeyList) { init(originalKeyList.m_proxy); }
 
-    void KeyList::load(const std::vector<unsigned long long>& keys) {
+    void KeyList::setKeys(const std::vector<unsigned long long>& keys) {
       std::shared_ptr<SessionImpl> simpl = m_proxy.session();
       if (!simpl.get())
-        cond::throwException("The KeyList has not been initialized.", "KeyList::load");
+        cond::throwException("The KeyList has not been initialized.", "KeyList::setKeys");
       Session s(simpl);
       s.transaction().start(true);
+      m_keys = keys;
+      std::sort(m_keys.begin(), m_keys.end(), std::less<unsigned long long>());
       m_data.clear();
-      m_objects.resize(keys.size());
-      for (size_t i = 0; i < keys.size(); ++i) {
-        m_objects[i].reset();
-        if (keys[i] != 0) {
-          auto p = m_proxy.find(keys[i]);
+      m_data.resize(keys.size(), std::make_pair("", std::make_pair(cond::Binary(), cond::Binary())));
+      for (size_t i = 0; i < m_keys.size(); ++i) {
+        if (m_keys[i] != 0) {
+          auto p = m_proxy.find(m_keys[i]);
           if (p != m_proxy.end()) {
-            auto item =
-                m_data.insert(std::make_pair(i, std::make_pair("", std::make_pair(cond::Binary(), cond::Binary()))));
-            if (!s.fetchPayloadData((*p).payloadId,
-                                    item.first->second.first,
-                                    item.first->second.second.first,
-                                    item.first->second.second.second))
-              cond::throwException("The Iov contains a broken payload reference.", "KeyList::load");
+            auto& item = m_data[i];
+            if (!s.fetchPayloadData((*p).payloadId, item.first, item.second.first, item.second.second))
+              cond::throwException("The Iov contains a broken payload reference.", "KeyList::setKeys");
           }
         }
       }
       s.transaction().commit();
     }
+
+    std::pair<std::string, std::pair<cond::Binary, cond::Binary> > KeyList::loadFromDB(unsigned long long key) {
+      std::pair<std::string, std::pair<cond::Binary, cond::Binary> > item;
+      if (key == 0) {
+        return item;
+      }
+      std::shared_ptr<SessionImpl> simpl = m_proxy.session();
+      if (!simpl.get())
+        cond::throwException("The KeyList has not been initialized.", "KeyList::loadFromDB");
+      Session s(simpl);
+      s.transaction().start(true);
+      auto p = m_proxy.find(key);
+      if (p != m_proxy.end()) {
+        if (!s.fetchPayloadData((*p).payloadId, item.first, item.second.first, item.second.second))
+          cond::throwException("The Iov contains a broken payload reference.", "KeyList::loadFromDB");
+      } else {
+        throwException("Payload for key " + std::to_string(key) + " has not been found.", "KeyList::loadFromDB");
+      }
+      s.transaction().commit();
+      return item;
+    }
+
   }  // namespace persistency
 }  // namespace cond

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -10,6 +10,7 @@
 #include "RelationalAccess/ISessionProxy.h"
 //
 #include <memory>
+#include <mutex>
 // temporarely
 
 namespace coral {
@@ -70,6 +71,9 @@ namespace cond {
       std::unique_ptr<IIOVSchema> iovSchemaHandle;
       std::unique_ptr<IGTSchema> gtSchemaHandle;
       std::unique_ptr<IRunInfoSchema> runInfoSchemaHandle;
+    private:
+      std::recursive_mutex transactionMutex;
+      std::unique_lock<std::recursive_mutex> transactionLock;
     };
 
   }  // namespace persistency

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -71,6 +71,7 @@ namespace cond {
       std::unique_ptr<IIOVSchema> iovSchemaHandle;
       std::unique_ptr<IGTSchema> gtSchemaHandle;
       std::unique_ptr<IRunInfoSchema> runInfoSchemaHandle;
+
     private:
       std::recursive_mutex transactionMutex;
       std::unique_lock<std::recursive_mutex> transactionLock;

--- a/CondCore/PopCon/interface/PopConAnalyzer.h
+++ b/CondCore/PopCon/interface/PopConAnalyzer.h
@@ -23,6 +23,8 @@ namespace popcon {
 
     ~PopConAnalyzer() override {}
 
+  protected:
+    SourceHandler& source() { return m_source;}
   private:
     void beginJob() override {}
     void endJob() override { write(); }

--- a/CondCore/PopCon/interface/PopConAnalyzer.h
+++ b/CondCore/PopCon/interface/PopConAnalyzer.h
@@ -24,7 +24,8 @@ namespace popcon {
     ~PopConAnalyzer() override {}
 
   protected:
-    SourceHandler& source() { return m_source;}
+    SourceHandler& source() { return m_source; }
+
   private:
     void beginJob() override {}
     void endJob() override { write(); }

--- a/CondTools/DT/interface/DTKeyedConfigCache.h
+++ b/CondTools/DT/interface/DTKeyedConfigCache.h
@@ -31,9 +31,9 @@ public:
   DTKeyedConfigCache();
   virtual ~DTKeyedConfigCache();
 
-  int get(cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj);
+  int get(const cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj);
 
-  void getData(cond::persistency::KeyList& keyList, int cfgId, std::vector<std::string>& list);
+  void getData(const cond::persistency::KeyList& keyList, int cfgId, std::vector<std::string>& list);
 
   void purge();
 

--- a/CondTools/DT/interface/DTKeyedConfigHandler.h
+++ b/CondTools/DT/interface/DTKeyedConfigHandler.h
@@ -59,7 +59,7 @@ public:
   void getNewObjects() override;
   std::string id() const override;
 
-  void setList(cond::persistency::KeyList* list);
+  void setList(const cond::persistency::KeyList* list);
 
 private:
   bool copyData;
@@ -80,7 +80,7 @@ private:
   void chkConfigList();
   static bool sameConfigList(const std::vector<DTConfigKey>& cfgl, const std::vector<DTConfigKey>& cfgr);
 
-  cond::persistency::KeyList* keyList = nullptr;
+  const cond::persistency::KeyList* keyList = nullptr;
 };
 
 #endif  // DTKeyedConfigHandler_H

--- a/CondTools/DT/interface/DTKeyedConfigHandler.h
+++ b/CondTools/DT/interface/DTKeyedConfigHandler.h
@@ -59,7 +59,7 @@ public:
   void getNewObjects() override;
   std::string id() const override;
 
-  static void setList(cond::persistency::KeyList* list);
+  void setList(cond::persistency::KeyList* list);
 
 private:
   bool copyData;
@@ -80,7 +80,7 @@ private:
   void chkConfigList();
   static bool sameConfigList(const std::vector<DTConfigKey>& cfgl, const std::vector<DTConfigKey>& cfgr);
 
-  static cond::persistency::KeyList* keyList;
+  cond::persistency::KeyList* keyList = nullptr;
 };
 
 #endif  // DTKeyedConfigHandler_H

--- a/CondTools/DT/interface/DTUserKeyedConfigHandler.h
+++ b/CondTools/DT/interface/DTUserKeyedConfigHandler.h
@@ -59,7 +59,7 @@ public:
   void getNewObjects() override;
   std::string id() const override;
 
-  static void setList(cond::persistency::KeyList* list);
+  void setList(cond::persistency::KeyList* list);
 
 private:
   int dataRun;
@@ -79,7 +79,7 @@ private:
   bool userDiscardedKey(int key);
   static bool sameConfigList(const std::vector<DTConfigKey>& cfgl, const std::vector<DTConfigKey>& cfgr);
 
-  static cond::persistency::KeyList* keyList;
+  cond::persistency::KeyList* keyList = nullptr;
 };
 
 #endif  // DTUserKeyedConfigHandler_H

--- a/CondTools/DT/interface/DTUserKeyedConfigHandler.h
+++ b/CondTools/DT/interface/DTUserKeyedConfigHandler.h
@@ -59,7 +59,7 @@ public:
   void getNewObjects() override;
   std::string id() const override;
 
-  void setList(cond::persistency::KeyList* list);
+  void setList(const cond::persistency::KeyList* list);
 
 private:
   int dataRun;
@@ -79,7 +79,7 @@ private:
   bool userDiscardedKey(int key);
   static bool sameConfigList(const std::vector<DTConfigKey>& cfgl, const std::vector<DTConfigKey>& cfgr);
 
-  cond::persistency::KeyList* keyList = nullptr;
+  const cond::persistency::KeyList* keyList = nullptr;
 };
 
 #endif  // DTUserKeyedConfigHandler_H

--- a/CondTools/DT/plugins/DTKeyedConfigDBDump.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigDBDump.cc
@@ -60,20 +60,14 @@ void DTKeyedConfigDBDump::analyze(const edm::Event& e, const edm::EventSetup& c)
   std::cout << "got context" << std::endl;
   cond::persistency::KeyList const& kl = *klh.product();
   cond::persistency::KeyList* kp = const_cast<cond::persistency::KeyList*>(&kl);
-  std::vector<unsigned long long> nkeys;
-  nkeys.push_back(999999999);
-  std::cout << "now load" << std::endl;
-  kp->load(nkeys);
-  std::cout << "now get" << std::endl;
-  std::shared_ptr<DTKeyedConfig> pkc = kp->get<DTKeyedConfig>(0);
+  std::cout << "now load and get" << std::endl;
+  auto pkc = kp->getUsingKey<DTKeyedConfig>(999999999);
   std::cout << "now check" << std::endl;
   if (pkc.get())
     std::cout << pkc->getId() << " " << *(pkc->dataBegin()) << std::endl;
   else
     std::cout << "not found" << std::endl;
   std::cout << std::endl;
-  std::vector<unsigned long long> nvoid;
-  kp->load(nvoid);
   return;
 }
 

--- a/CondTools/DT/plugins/DTKeyedConfigDBDump.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigDBDump.cc
@@ -59,7 +59,7 @@ void DTKeyedConfigDBDump::analyze(const edm::Event& e, const edm::EventSetup& c)
   c.get<DTKeyedConfigListRcd>().get(klh);
   std::cout << "got context" << std::endl;
   cond::persistency::KeyList const& kl = *klh.product();
-  cond::persistency::KeyList* kp = const_cast<cond::persistency::KeyList*>(&kl);
+  cond::persistency::KeyList const* kp = &kl;
   std::cout << "now load and get" << std::endl;
   auto pkc = kp->getUsingKey<DTKeyedConfig>(999999999);
   std::cout << "now check" << std::endl;

--- a/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
@@ -29,7 +29,7 @@ public:
       if (kelem.get())
         std::cout << kelem->getId() << std::endl;
     }
-    source().setList(const_cast<cond::persistency::KeyList*>(&kl));
+    source().setList(&kl);
   }
 
 private:

--- a/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
@@ -24,13 +24,12 @@ public:
     s.get<DTKeyedConfigListRcd>().get(klh);
     std::cout << "got context" << std::endl;
     cond::persistency::KeyList const& kl = *klh.product();
-    cond::persistency::KeyList* list = const_cast<cond::persistency::KeyList*>(&kl);
-    for (size_t i = 0; i < list->size(); i++) {
-      std::shared_ptr<DTKeyedConfig> kelem = list->get<DTKeyedConfig>(i);
+    for (size_t i = 0; i < kl.size(); i++) {
+      std::shared_ptr<DTKeyedConfig> kelem = kl.getUsingIndex<DTKeyedConfig>(i);
       if (kelem.get())
         std::cout << kelem->getId() << std::endl;
     }
-    DTKeyedConfigHandler::setList(list);
+    DTKeyedConfigHandler::setList(const_cast<cond::persistency::KeyList*>(&kl));
   }
 
 private:

--- a/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTKeyedConfigPopConAnalyzer.cc
@@ -29,7 +29,7 @@ public:
       if (kelem.get())
         std::cout << kelem->getId() << std::endl;
     }
-    DTKeyedConfigHandler::setList(const_cast<cond::persistency::KeyList*>(&kl));
+    source().setList(const_cast<cond::persistency::KeyList*>(&kl));
   }
 
 private:

--- a/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
@@ -20,13 +20,12 @@ public:
     s.get<DTKeyedConfigListRcd>().get(klh);
     std::cout << "got context" << std::endl;
     cond::persistency::KeyList const& kl = *klh.product();
-    cond::persistency::KeyList* list = const_cast<cond::persistency::KeyList*>(&kl);
-    for (size_t i = 0; i < list->size(); i++) {
-      std::shared_ptr<DTKeyedConfig> kentry = list->get<DTKeyedConfig>(i);
+    for (size_t i = 0; i < kl.size(); i++) {
+      std::shared_ptr<DTKeyedConfig> kentry = kl.getUsingIndex<DTKeyedConfig>(i);
       if (kentry.get())
         std::cout << kentry->getId() << std::endl;
     }
-    DTUserKeyedConfigHandler::setList(list);
+    DTUserKeyedConfigHandler::setList(const_cast<cond::persistency::KeyList*>(&kl));
   }
 
 private:

--- a/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
@@ -25,7 +25,7 @@ public:
       if (kentry.get())
         std::cout << kentry->getId() << std::endl;
     }
-    source().setList(const_cast<cond::persistency::KeyList*>(&kl));
+    source().setList(&kl);
   }
 
 private:

--- a/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
+++ b/CondTools/DT/plugins/DTUserKeyedConfigPopConAnalyzer.cc
@@ -25,7 +25,7 @@ public:
       if (kentry.get())
         std::cout << kentry->getId() << std::endl;
     }
-    DTUserKeyedConfigHandler::setList(const_cast<cond::persistency::KeyList*>(&kl));
+    source().setList(const_cast<cond::persistency::KeyList*>(&kl));
   }
 
 private:

--- a/CondTools/DT/src/DTKeyedConfigCache.cc
+++ b/CondTools/DT/src/DTKeyedConfigCache.cc
@@ -75,13 +75,10 @@ int DTKeyedConfigCache::get(cond::persistency::KeyList& keyList, int cfgId, cons
     }
   }
 
-  std::vector<unsigned long long> checkedKeys;
   std::shared_ptr<DTKeyedConfig> kBrick;
-  checkedKeys.push_back(cfgId);
   bool brickFound = false;
   try {
-    keyList.load(checkedKeys);
-    kBrick = keyList.get<DTKeyedConfig>(0);
+    kBrick = keyList.getUsingKey<DTKeyedConfig>(cfgId);
     if (kBrick.get())
       brickFound = (kBrick->getId() == cfgId);
   } catch (std::exception const& e) {

--- a/CondTools/DT/src/DTKeyedConfigCache.cc
+++ b/CondTools/DT/src/DTKeyedConfigCache.cc
@@ -39,7 +39,7 @@ DTKeyedConfigCache::DTKeyedConfigCache() : cachedBrickNumber(0), cachedStringNum
 //--------------
 DTKeyedConfigCache::~DTKeyedConfigCache() { purge(); }
 
-int DTKeyedConfigCache::get(cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj) {
+int DTKeyedConfigCache::get(const cond::persistency::KeyList& keyList, int cfgId, const DTKeyedConfig*& obj) {
   bool cacheFound = false;
   int cacheAge = 999999999;
   std::map<int, counted_brick>::iterator cache_iter = brickMap.begin();
@@ -112,7 +112,7 @@ int DTKeyedConfigCache::get(cond::persistency::KeyList& keyList, int cfgId, cons
   return 999;
 }
 
-void DTKeyedConfigCache::getData(cond::persistency::KeyList& keyList, int cfgId, std::vector<std::string>& list) {
+void DTKeyedConfigCache::getData(const cond::persistency::KeyList& keyList, int cfgId, std::vector<std::string>& list) {
   const DTKeyedConfig* obj = nullptr;
   get(keyList, cfgId, obj);
   if (obj == nullptr)

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -602,4 +602,4 @@ bool DTKeyedConfigHandler::sameConfigList(const std::vector<DTConfigKey>& cfgl, 
   return true;
 }
 
-void DTKeyedConfigHandler::setList(cond::persistency::KeyList* list) { keyList = list; }
+void DTKeyedConfigHandler::setList(const cond::persistency::KeyList* list) { keyList = list; }

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -41,7 +41,6 @@
 //-------------------
 // Initializations --
 //-------------------
-cond::persistency::KeyList* DTKeyedConfigHandler::keyList = nullptr;
 
 //----------------
 // Constructors --

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -509,7 +509,6 @@ void DTKeyedConfigHandler::chkConfigList() {
   coral::ICursor& brickConfigCursor = brickConfigQuery->execute();
   DTKeyedConfig* brickData = nullptr;
   std::vector<int> missingList;
-  std::vector<unsigned long long> checkedKeys;
   while (brickConfigCursor.next()) {
     const coral::AttributeList& row = brickConfigCursor.currentRow();
     int brickConfigId = row["BRKID"].data<int>();
@@ -526,11 +525,9 @@ void DTKeyedConfigHandler::chkConfigList() {
       continue;
     std::string brickConfigName = row["BRKNAME"].data<std::string>();
     std::cout << "brick " << brickConfigId << " : " << brickConfigName << std::endl;
-    checkedKeys.push_back(brickConfigId);
     bool brickFound = false;
     try {
-      keyList->load(checkedKeys);
-      std::shared_ptr<DTKeyedConfig> brickCheck = keyList->get<DTKeyedConfig>(0);
+      std::shared_ptr<DTKeyedConfig> brickCheck = keyList->getUsingKey<DTKeyedConfig>(brickConfigId);
       if (brickCheck.get())
         brickFound = (brickCheck->getId() == brickConfigId);
     } catch (std::exception const&) {
@@ -539,9 +536,7 @@ void DTKeyedConfigHandler::chkConfigList() {
       std::cout << "brick " << brickConfigId << " missing, copy request" << std::endl;
       missingList.push_back(brickConfigId);
     }
-    checkedKeys.clear();
   }
-  keyList->load(checkedKeys);
 
   std::vector<int>::const_iterator brickIter = missingList.begin();
   std::vector<int>::const_iterator brickIend = missingList.end();

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -41,7 +41,6 @@
 //-------------------
 // Initializations --
 //-------------------
-cond::persistency::KeyList* DTUserKeyedConfigHandler::keyList = nullptr;
 
 //----------------
 // Constructors --

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -332,14 +332,12 @@ void DTUserKeyedConfigHandler::chkConfigList(const std::map<int, bool>& userBric
       continue;
     std::string brickConfigName = row["BRKNAME"].data<std::string>();
     std::cout << "brick " << brickConfigId << " : " << brickConfigName << std::endl;
-    checkedKeys.push_back(brickConfigId);
     bool brickFound = false;
     try {
-      std::cout << "load brick " << checkedKeys[0] << std::endl;
+      std::cout << "load brick " << brickConfigId << std::endl;
       std::cout << "key list " << keyList << std::endl;
-      keyList->load(checkedKeys);
       std::cout << "get brick..." << std::endl;
-      std::shared_ptr<DTKeyedConfig> brickCheck = keyList->get<DTKeyedConfig>(0);
+      std::shared_ptr<DTKeyedConfig> brickCheck = keyList->getUsingKey<DTKeyedConfig>(brickConfigId);
       if (brickCheck.get()) {
         brickFound = (brickCheck->getId() == brickConfigId);
       }
@@ -349,9 +347,7 @@ void DTUserKeyedConfigHandler::chkConfigList(const std::map<int, bool>& userBric
       std::cout << "brick " << brickConfigId << " missing, copy request" << std::endl;
       missingList.push_back(brickConfigId);
     }
-    checkedKeys.clear();
   }
-  keyList->load(checkedKeys);
 
   std::vector<int>::const_iterator brickIter = missingList.begin();
   std::vector<int>::const_iterator brickIend = missingList.end();

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -424,4 +424,4 @@ bool DTUserKeyedConfigHandler::userDiscardedKey(int key) {
   return true;
 }
 
-void DTUserKeyedConfigHandler::setList(cond::persistency::KeyList* list) { keyList = list; }
+void DTUserKeyedConfigHandler::setList(const cond::persistency::KeyList* list) { keyList = list; }

--- a/CondTools/DT/test/stubs/DTKeyedConfigDump.cc
+++ b/CondTools/DT/test/stubs/DTKeyedConfigDump.cc
@@ -47,7 +47,7 @@ namespace edmtest {
     const DTKeyedConfig** allBricks = new const DTKeyedConfig*[100000];
     int nBricks = 0;
 
-    auto& keyList = const_cast<cond::persistency::KeyList&>(context.getData(keyListToken_));
+    auto const& keyList = context.getData(keyListToken_);
     // loop over chambers
     DTCCBConfig::ccb_config_map configKeys(conf.configKeyMap());
     DTCCBConfig::ccb_config_iterator iter = configKeys.begin();

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -373,12 +373,7 @@ int DTConfigDBProducer::readDTCCBConfig(const DTConfigManagerRcd &iRecord, DTCon
   if (ccb_conf.configKeyMap().size() != 250)  // check the number of chambers!!!
     return -1;
 
-  // This const_cast and usage of KeyList is a problem
-  // that will need to be addressed in the future.
-  // I'm not fixing now, because I want to finish what I am
-  // fixing. One thing at a time. (This was already in the
-  // the DTKeyedConfigCache which copied to make this file)
-  auto &keyList = const_cast<cond::persistency::KeyList &>(keyRecord.get(m_keyListToken));
+  auto const &keyList = keyRecord.get(m_keyListToken);
 
   // read data from CCBConfig
   while (iter != iend) {


### PR DESCRIPTION
#### PR description:

KeyList change
- Avoid need for updating an internal cache to avoid thread-safety issues. This was accomplished by avoiding the _load()_ then _get()_ call chain and instead have specialized functions which combine both.
- internal keys are only set by CondDBESSource Proxy.
- All uses can not call `const` interfaces.

SessionImpl change
- Need to use a mutex since the `SessionImpl` can be called concurrently from both CondDBESSource and from a user of the KeyList obtained from the EventSetup.

#### PR validation:

Ran workflow 25.0 from the IB using 4 threads and the jobs completed successfully.