### PR TITLE
[PY3] Set PYTHONHOME to python2 to fix PyDevParameterSet unittest

### DIFF
--- a/FWCore/PyDevParameterSet/test/BuildFile.xml
+++ b/FWCore/PyDevParameterSet/test/BuildFile.xml
@@ -4,4 +4,7 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/PyDevParameterSet"/>
   <use   name="FWCore/Utilities"/>
+  <ifrelease name="_PY3_">
+    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
+  </ifrelease>
 </bin>


### PR DESCRIPTION
This shoudl fix the PY3 IB unit test for  FWCore/PyDevParameterSet. For PY3 IBs , PyDevParameterSet is linked to python2 but `python` executable points to `python3` this make pybind11 to fail as it tries to look for python2 shared libs under python3/lib path. 

This change will only set  PYTHONHOME to python2 path for PY3 IBs. 