### PR TITLE
Improve SiPixAli PCL DQM output

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -82,6 +82,8 @@ public:  //====================================================================
 
   const AlignPCLThresholds::threshold_map getThresholdMap() const { return theThresholds_.get()->getThreshold_Map(); }
 
+  const int binariesAmount() const { return binariesAmount_; }
+
   const mpPCLresults getResults() const {
     return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_, exitMessage_, updateBits_);
   }
@@ -140,6 +142,9 @@ private:
   // 3rd bit: exceeds maximum errors
   // 4th bit: is below the significance
   std::bitset<4> updateBits_;
+
+  // pede binaries available
+  int binariesAmount_{0};
 
   int Nrec_{0};
   int exitCode_{-1};

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -19,19 +19,36 @@ private:
   bool m_isDBUpdateVetoed;
   int m_nRecords;
   int m_exitCode;
+  std::string m_exitMessage;
+  std::bitset<4> m_updateBits;
 
 public:
-  mpPCLresults(bool isDBUpdated, bool isDBUpdateVetoed, int nRecords, int exitCode)
-      : m_isDBUpdated(isDBUpdated), m_isDBUpdateVetoed(isDBUpdateVetoed), m_nRecords(nRecords), m_exitCode(exitCode) {}
+  mpPCLresults(bool isDBUpdated,
+               bool isDBUpdateVetoed,
+               int nRecords,
+               int exitCode,
+               std::string exitMessage,
+               std::bitset<4> updateBits)
+      : m_isDBUpdated(isDBUpdated),
+        m_isDBUpdateVetoed(isDBUpdateVetoed),
+        m_nRecords(nRecords),
+        m_exitCode(exitCode),
+        m_exitMessage(exitMessage),
+        m_updateBits(updateBits) {}
 
   const bool getDBUpdated() { return m_isDBUpdated; }
   const bool getDBVetoed() { return m_isDBUpdateVetoed; }
+  const bool exceedsThresholds() { return m_updateBits.test(0); }
+  const bool exceedsCutoffs() { return m_updateBits.test(1); }
+  const bool exceedsMaxError() { return m_updateBits.test(2); }
+  const bool belowSignificance() { return m_updateBits.test(3); }
   const int getNRecords() { return m_nRecords; }
   const int getExitCode() { return m_exitCode; }
+  const std::string getExitMessage() { return m_exitMessage; }
 
   void print() {
     std::cout << " is DB updated: " << m_isDBUpdated << " is DB update vetoed: " << m_isDBUpdateVetoed
-              << " nRecords: " << m_nRecords << " exitCode: " << m_exitCode << std::endl;
+              << " nRecords: " << m_nRecords << " exitCode: " << m_exitCode << " (" << m_exitMessage << ")" <<std::endl;
   }
 };
 
@@ -64,7 +81,9 @@ public:  //====================================================================
 
   const AlignPCLThresholds::threshold_map getThresholdMap() const { return theThresholds_.get()->getThreshold_Map(); }
 
-  const mpPCLresults getResults() const { return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_); }
+  const mpPCLresults getResults() const {
+    return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_, exitMessage_, updateBits_);
+  }
 
 private:
   //========================= PRIVATE ENUMS ====================================
@@ -113,8 +132,17 @@ private:
 
   bool updateDB_{false};
   bool vetoUpdateDB_{false};
+
+  // stores in a compact format the 4 decisions:
+  // 1st bit: exceeds maximum thresholds
+  // 2nd bit: exceeds cutoffs (significant movement)
+  // 3rd bit: exceeds maximum errors
+  // 4th bit: is below the significance
+  std::bitset<4> updateBits_;
+
   int Nrec_{0};
   int exitCode_{-1};
+  std::string exitMessage_{""};
 
   std::array<double, 6> Xobs_ = {{0., 0., 0., 0., 0., 0.}};
   std::array<double, 6> XobsErr_ = {{0., 0., 0., 0., 0., 0.}};

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -8,6 +8,7 @@
 
 /*** core framework functionality ***/
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 /*** Alignment ***/
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
@@ -47,9 +48,9 @@ public:
   const std::string getExitMessage() { return m_exitMessage; }
 
   void print() {
-    std::cout << " is DB updated: " << m_isDBUpdated << " is DB update vetoed: " << m_isDBUpdateVetoed
-              << " nRecords: " << m_nRecords << " exitCode: " << m_exitCode << " (" << m_exitMessage << ")"
-              << std::endl;
+    edm::LogInfo("MillePedeFileReader") << " is DB updated: " << m_isDBUpdated
+                                        << " is DB update vetoed: " << m_isDBUpdateVetoed << " nRecords: " << m_nRecords
+                                        << " exitCode: " << m_exitCode << " (" << m_exitMessage << ")" << std::endl;
   }
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -48,7 +48,8 @@ public:
 
   void print() {
     std::cout << " is DB updated: " << m_isDBUpdated << " is DB update vetoed: " << m_isDBUpdateVetoed
-              << " nRecords: " << m_nRecords << " exitCode: " << m_exitCode << " (" << m_exitMessage << ")" <<std::endl;
+              << " nRecords: " << m_nRecords << " exitCode: " << m_exitCode << " (" << m_exitMessage << ")"
+              << std::endl;
   }
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -13,6 +13,28 @@
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
 
+struct mpPCLresults {
+private:
+  bool m_isDBUpdated;
+  bool m_isDBUpdateVetoed;
+  int m_nRecords;
+  int m_exitCode;
+
+public:
+  mpPCLresults(bool isDBUpdated, bool isDBUpdateVetoed, int nRecords, int exitCode)
+      : m_isDBUpdated(isDBUpdated), m_isDBUpdateVetoed(isDBUpdateVetoed), m_nRecords(nRecords), m_exitCode(exitCode) {}
+
+  const bool getDBUpdated() { return m_isDBUpdated; }
+  const bool getDBVetoed() { return m_isDBUpdateVetoed; }
+  const int getNRecords() { return m_nRecords; }
+  const int getExitCode() { return m_exitCode; }
+
+  void print() {
+    std::cout << " is DB updated: " << m_isDBUpdated << " is DB update vetoed: " << m_isDBUpdateVetoed
+              << " nRecords: " << m_nRecords << " exitCode: " << m_exitCode << std::endl;
+  }
+};
+
 class MillePedeFileReader {
   //========================== PUBLIC METHODS ==================================
 public:  //====================================================================
@@ -42,6 +64,8 @@ public:  //====================================================================
 
   const AlignPCLThresholds::threshold_map getThresholdMap() const { return theThresholds_.get()->getThreshold_Map(); }
 
+  const mpPCLresults getResults() const { return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_); }
+
 private:
   //========================= PRIVATE ENUMS ====================================
   //============================================================================
@@ -59,6 +83,7 @@ private:
   //========================= PRIVATE METHODS ==================================
   //============================================================================
 
+  void readMillePedeEndFile();
   void readMillePedeLogFile();
   void readMillePedeResultFile();
   PclHLS getHLS(const Alignable*);
@@ -74,6 +99,7 @@ private:
   const std::shared_ptr<const AlignPCLThresholds> theThresholds_;
 
   // file-names
+  const std::string millePedeEndFile_;
   const std::string millePedeLogFile_;
   const std::string millePedeResFile_;
 
@@ -88,6 +114,7 @@ private:
   bool updateDB_{false};
   bool vetoUpdateDB_{false};
   int Nrec_{0};
+  int exitCode_{-1};
 
   std::array<double, 6> Xobs_ = {{0., 0., 0., 0., 0., 0.}};
   std::array<double, 6> XobsErr_ = {{0., 0., 0., 0., 0., 0.}};

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -69,8 +69,8 @@ void MillePedeDQMModule ::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGetter
   auto theResults = mpReader_->getResults();
 
   booker.cd();
-  booker.setCurrentFolder("AlCaReco/SiPixelAli/");
-  exitCodes = booker.bookString("PedeExitCode",theResults.getExitMessage());
+  booker.setCurrentFolder("AlCa.co/SiPixelAli/");
+  exitCodes. booker.bookString("PedeExitCode", theResults.getExitMessage());
   booker.cd();
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -52,8 +52,7 @@ void MillePedeDQMModule ::bookHistograms(DQMStore::IBooker& booker) {
   h_zPos = booker.book1D("Zpos", "Alignment fit #DeltaZ;;#mum", 36, 0., 36.);
   h_zRot = booker.book1D("Zrot", "Alignment fit #Delta#theta_{Z};;#murad", 36, 0., 36.);
 
-  statusResults = booker.book2D("statusResults", "Status of pede minimization;;", 4, 0., 4., 1, 0., 1.);
-
+  statusResults = booker.book2D("statusResults", "Status of SiPixelAli PCL workflow;;", 6, 0., 6., 1, 0., 1.);
   booker.cd();
 }
 
@@ -67,6 +66,12 @@ void MillePedeDQMModule ::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGetter
   }
   fillExpertHistos();
   fillStatusHisto(statusResults);
+  auto theResults = mpReader_->getResults();
+
+  booker.cd();
+  booker.setCurrentFolder("AlCaReco/SiPixelAli/");
+  exitCodes = booker.bookString("PedeExitCode",theResults.getExitMessage());
+  booker.cd();
 }
 
 //=============================================================================
@@ -114,13 +119,17 @@ void MillePedeDQMModule ::fillStatusHisto(MonitorElement* statusHisto) {
   auto theResults = mpReader_->getResults();
   theResults.print();
   histo_status->SetBinContent(1, 1, theResults.getDBUpdated());
-  histo_status->GetXaxis()->SetBinLabel(1, "is DB updated?");
-  histo_status->SetBinContent(2, 1, theResults.getDBVetoed());
-  histo_status->GetXaxis()->SetBinLabel(2, "is DB update vetoed?");
-  histo_status->SetBinContent(3, 1, theResults.getNRecords());
-  histo_status->GetXaxis()->SetBinLabel(3, "n. records");
-  histo_status->SetBinContent(4, 1, theResults.getExitCode());
-  histo_status->GetXaxis()->SetBinLabel(4, "pede exit code");
+  histo_status->GetXaxis()->SetBinLabel(1, "DB updated");
+  histo_status->SetBinContent(2, 1, theResults.exceedsCutoffs());
+  histo_status->GetXaxis()->SetBinLabel(2, "significant movement");
+  histo_status->SetBinContent(3, 1, theResults.getDBVetoed());
+  histo_status->GetXaxis()->SetBinLabel(3, "DB update vetoed");
+  histo_status->SetBinContent(4, 1, !theResults.exceedsThresholds());
+  histo_status->GetXaxis()->SetBinLabel(4, "within max movement");
+  histo_status->SetBinContent(5, 1, !theResults.exceedsMaxError());
+  histo_status->GetXaxis()->SetBinLabel(5, "within max error");
+  histo_status->SetBinContent(6, 1, !theResults.belowSignificance());
+  histo_status->GetXaxis()->SetBinLabel(6, "above significance");
 }
 
 void MillePedeDQMModule ::fillExpertHistos() {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -52,6 +52,8 @@ void MillePedeDQMModule ::bookHistograms(DQMStore::IBooker& booker) {
   h_zPos = booker.book1D("Zpos", "Alignment fit #DeltaZ;;#mum", 36, 0., 36.);
   h_zRot = booker.book1D("Zrot", "Alignment fit #Delta#theta_{Z};;#murad", 36, 0., 36.);
 
+  statusResults = booker.book2D("statusResults", "Status of pede minimization;;", 4, 0., 4., 1, 0., 1.);
+
   booker.cd();
 }
 
@@ -64,6 +66,7 @@ void MillePedeDQMModule ::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGetter
                                        << "Try to read MillePede results before initializing MillePedeFileReader";
   }
   fillExpertHistos();
+  fillStatusHisto(statusResults);
 }
 
 //=============================================================================
@@ -104,6 +107,20 @@ void MillePedeDQMModule ::beginRun(const edm::Run&, const edm::EventSetup& setup
 
   mpReader_ = std::make_unique<MillePedeFileReader>(
       mpReaderConfig_, pedeLabeler, std::shared_ptr<const AlignPCLThresholds>(myThresholds));
+}
+
+void MillePedeDQMModule ::fillStatusHisto(MonitorElement* statusHisto) {
+  TH2F* histo_status = statusHisto->getTH2F();
+  auto theResults = mpReader_->getResults();
+  theResults.print();
+  histo_status->SetBinContent(1, 1, theResults.getDBUpdated());
+  histo_status->GetXaxis()->SetBinLabel(1, "is DB updated?");
+  histo_status->SetBinContent(2, 1, theResults.getDBVetoed());
+  histo_status->GetXaxis()->SetBinLabel(2, "is DB update vetoed?");
+  histo_status->SetBinContent(3, 1, theResults.getNRecords());
+  histo_status->GetXaxis()->SetBinLabel(3, "n. records");
+  histo_status->SetBinContent(4, 1, theResults.getExitCode());
+  histo_status->GetXaxis()->SetBinLabel(4, "pede exit code");
 }
 
 void MillePedeDQMModule ::fillExpertHistos() {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -53,6 +53,9 @@ void MillePedeDQMModule ::bookHistograms(DQMStore::IBooker& booker) {
   h_zRot = booker.book1D("Zrot", "Alignment fit #Delta#theta_{Z};;#murad", 36, 0., 36.);
 
   statusResults = booker.book2D("statusResults", "Status of SiPixelAli PCL workflow;;", 6, 0., 6., 1, 0., 1.);
+  binariesAvalaible = booker.bookInt("BinariesFound");
+  exitCode = booker.bookString("PedeExitCode", "");
+
   booker.cd();
 }
 
@@ -66,12 +69,10 @@ void MillePedeDQMModule ::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGetter
   }
   fillExpertHistos();
   fillStatusHisto(statusResults);
+  binariesAvalaible->Fill(mpReader_->binariesAmount());
   auto theResults = mpReader_->getResults();
-
-  booker.cd();
-  booker.setCurrentFolder("AlCa.co/SiPixelAli/");
-  exitCodes. booker.bookString("PedeExitCode", theResults.getExitMessage());
-  booker.cd();
+  std::string exitCodeStr = theResults.getExitMessage();
+  exitCode->Fill(exitCodeStr);
 }
 
 //=============================================================================

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -50,6 +50,8 @@ private:  //===================================================================
 
   void bookHistograms(DQMStore::IBooker&);
 
+  void fillStatusHisto(MonitorElement* statusHisto);
+
   void fillExpertHistos();
 
   void fillExpertHisto(MonitorElement* histo,
@@ -81,6 +83,8 @@ private:  //===================================================================
   MonitorElement* h_yRot;
   MonitorElement* h_zPos;
   MonitorElement* h_zRot;
+
+  MonitorElement* statusResults;
 };
 
 // define this as a plug-in

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -85,7 +85,8 @@ private:  //===================================================================
   MonitorElement* h_zRot;
 
   MonitorElement* statusResults;
-  MonitorElement* exitCodes;
+  MonitorElement* binariesAvalaible;
+  MonitorElement* exitCode;
 };
 
 // define this as a plug-in

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -85,6 +85,7 @@ private:  //===================================================================
   MonitorElement* h_zRot;
 
   MonitorElement* statusResults;
+  MonitorElement* exitCodes;
 };
 
 // define this as a plug-in

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 MillePedeFileReader = cms.PSet(
+  millePedeEndFile = cms.string('millepede.end'),
   millePedeLogFile = cms.string('millepede.log'),
-  millePedeResFile = cms.string('millepede.res'),
+  millePedeResFile = cms.string('millepede.res')
   )

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -60,6 +60,7 @@ void MillePedeFileReader ::readMillePedeEndFile() {
     }
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede end-file.";
+    exitMessage_ = "no exit code found";
   }
 }
 
@@ -73,6 +74,7 @@ void MillePedeFileReader ::readMillePedeLogFile() {
 
     while (getline(logFile, line)) {
       std::string Nrec_string = "NREC =";
+      std::string Binaries_string = "C_binary";
 
       if (line.find(Nrec_string) != std::string::npos) {
         std::istringstream iss(line);
@@ -85,8 +87,11 @@ void MillePedeFileReader ::readMillePedeLogFile() {
           updateDB_ = false;
         }
       }
-    }
 
+      if (line.find(Binaries_string) != std::string::npos) {
+        binariesAmount_ += 1;
+      }
+    }
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede log-file.";
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -5,9 +5,6 @@
 #include <cmath>  // include floating-point std::abs functions
 #include <fstream>
 
-/*** core framework functionality ***/
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 /*** Alignment ***/
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -49,12 +49,14 @@ void MillePedeFileReader ::readMillePedeEndFile() {
       exitMessage_ = line;
       std::istringstream iss(line);
       iss >> exitCode_ >> trash;
-      edm::LogInfo("MillePedeFileReader") << " Pede exit code is: " << exitCode_ << " (" << exitMessage_ << ")" << std::endl;
+      edm::LogInfo("MillePedeFileReader")
+          << " Pede exit code is: " << exitCode_ << " (" << exitMessage_ << ")" << std::endl;
     } else {
       exitMessage_ = line;
       std::istringstream iss(line);
       iss >> exitCode_ >> trash;
-      edm::LogInfo("MillePedeFileReader") << " Pede exit code is: " << exitCode_ << " (" << exitMessage_ << ")"<< std::endl;
+      edm::LogInfo("MillePedeFileReader")
+          << " Pede exit code is: " << exitCode_ << " (" << exitMessage_ << ")" << std::endl;
     }
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede end-file.";

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -46,13 +46,15 @@ void MillePedeFileReader ::readMillePedeEndFile() {
     std::string trash;
     if (line.find("-1") != std::string::npos) {
       getline(endFile, line);
+      exitMessage_ = line;
       std::istringstream iss(line);
       iss >> exitCode_ >> trash;
-      edm::LogInfo("MillePedeFileReader") << " Pede exit code is: " << exitCode_ << std::endl;
+      edm::LogInfo("MillePedeFileReader") << " Pede exit code is: " << exitCode_ << " (" << exitMessage_ << ")" << std::endl;
     } else {
+      exitMessage_ = line;
       std::istringstream iss(line);
       iss >> exitCode_ >> trash;
-      edm::LogInfo("MillePedeFileReader") << " Pede exit code is:" << exitCode_ << std::endl;
+      edm::LogInfo("MillePedeFileReader") << " Pede exit code is: " << exitCode_ << " (" << exitMessage_ << ")"<< std::endl;
     }
   } else {
     edm::LogError("MillePedeFileReader") << "Could not read millepede end-file.";
@@ -191,18 +193,23 @@ void MillePedeFileReader ::readMillePedeResultFile() {
           edm::LogWarning("MillePedeFileReader") << "Aborting payload creation."
                                                  << " Exceeding maximum thresholds for movement: " << std::abs(ObsMove)
                                                  << " for" << detLabel << "(" << coord << ")";
+          updateBits_.set(0);
           vetoUpdateDB_ = true;
           continue;
 
         } else if (std::abs(ObsMove) > cutoffs_[detLabel][alignableIndex]) {
+          updateBits_.set(1);
+
           if (std::abs(ObsErr) > errors_[detLabel][alignableIndex]) {
             edm::LogWarning("MillePedeFileReader") << "Aborting payload creation."
                                                    << " Exceeding maximum thresholds for error: " << std::abs(ObsErr)
                                                    << " for" << detLabel << "(" << coord << ")";
+            updateBits_.set(2);
             vetoUpdateDB_ = true;
             continue;
           } else {
             if (std::abs(ObsMove / ObsErr) < significances_[detLabel][alignableIndex]) {
+              updateBits_.set(3);
               continue;
             }
           }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -20,10 +20,12 @@ MillePedeFileReader ::MillePedeFileReader(const edm::ParameterSet& config,
                                           const std::shared_ptr<const AlignPCLThresholds>& theThresholds)
     : pedeLabeler_(pedeLabeler),
       theThresholds_(theThresholds),
+      millePedeEndFile_(config.getParameter<std::string>("millePedeEndFile")),
       millePedeLogFile_(config.getParameter<std::string>("millePedeLogFile")),
       millePedeResFile_(config.getParameter<std::string>("millePedeResFile")) {}
 
 void MillePedeFileReader ::read() {
+  readMillePedeEndFile();
   readMillePedeLogFile();
   readMillePedeResultFile();
 }
@@ -33,6 +35,29 @@ bool MillePedeFileReader ::storeAlignments() { return (updateDB_ && !vetoUpdateD
 //=============================================================================
 //===   PRIVATE METHOD IMPLEMENTATION                                       ===
 //=============================================================================
+void MillePedeFileReader ::readMillePedeEndFile() {
+  std::ifstream endFile;
+  endFile.open(millePedeEndFile_.c_str());
+
+  if (endFile.is_open()) {
+    edm::LogInfo("MillePedeFileReader") << "Reading millepede end-file";
+    std::string line;
+    getline(endFile, line);
+    std::string trash;
+    if (line.find("-1") != std::string::npos) {
+      getline(endFile, line);
+      std::istringstream iss(line);
+      iss >> exitCode_ >> trash;
+      edm::LogInfo("MillePedeFileReader") << " Pede exit code is: " << exitCode_ << std::endl;
+    } else {
+      std::istringstream iss(line);
+      iss >> exitCode_ >> trash;
+      edm::LogInfo("MillePedeFileReader") << " Pede exit code is:" << exitCode_ << std::endl;
+    }
+  } else {
+    edm::LogError("MillePedeFileReader") << "Could not read millepede end-file.";
+  }
+}
 
 void MillePedeFileReader ::readMillePedeLogFile() {
   std::ifstream logFile;


### PR DESCRIPTION
#### PR description:

As part of the effort done to avoid exotic error states with the SiPixelAli PCL workflow (see PRs https://github.com/cms-sw/cmssw/pull/28306 and https://github.com/cms-sw/cmsdist/pull/5309) we profited to introduce few new `MonitorElement`s to display the status of the alignment fit.
The introduced plots are: 
  * number of binaries used
  * complete exit code of the pede execution
  * summary table about the decisions taken leading to the upload of the updated alignment

#### PR validation:

The SiPixelAli PCL workflow for run [317212](https://tinyurl.com/y23yd34r) has been re-run with the changes proposes here, using the command:
```
cmsDriver.py pedeStep --data --conditions 106X_dataRun3_Express_v2 --scenario pp --era Run2_2018 -s ALCAHARVEST:SiPixelAli --dasquery=file dataset=/StreamExpress/Run2018B-PromptCalibProdSiPixelAli-Express-v1/ALCAPROMPT run= 317212' -n -1
```
which run to completion, producing the desired output plots.
Here is a screenshot of the output DQM file uploaded to a private development DQM GUI:

![image](https://user-images.githubusercontent.com/5082376/67882964-7f61b080-fb43-11e9-8b66-ea07860a9d3b.png)




#### if this PR is a backport please specify the original PR:
This PR is not a backport.
cc:
@adewit @connorpa @dmeuser
