### PR TITLE
record for xtal-dependent seeding thresholds

### DIFF
--- a/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
+++ b/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
@@ -1,0 +1,6 @@
+#ifndef CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
+#define CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class EcalPFSeedingThresholdsRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalPFSeedingThresholdsRcd> {};
+#endif

--- a/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
+++ b/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
@@ -2,5 +2,6 @@
 #define CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-class EcalPFSeedingThresholdsRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalPFSeedingThresholdsRcd> {};
+class EcalPFSeedingThresholdsRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalPFSeedingThresholdsRcd> {
+};
 #endif

--- a/CondFormats/DataRecord/src/EcalPFSeedingThresholdsRcd.cc
+++ b/CondFormats/DataRecord/src/EcalPFSeedingThresholdsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalPFSeedingThresholdsRcd);

--- a/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
+++ b/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
@@ -1,0 +1,15 @@
+#ifndef CondFormats_EcalObjects_EcalPFSeedingThresholds_H
+#define CondFormats_EcalObjects_EcalPFSeedingThresholds_H
+/**
+ * Author: Maria Giulia Ratti, ETH Zurich
+ * Created: 05 Sep 2019
+ * $Id: EcalPFSeedingThresholds.h, 2019/09/05 20:21:42 mratti Exp $
+ **/
+#include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
+
+typedef float EcalPFSeedingThreshold;
+typedef EcalFloatCondObjectContainer EcalPFSeedingThresholdsMap;
+typedef EcalPFSeedingThresholdsMap EcalPFSeedingThresholds;
+
+
+#endif

--- a/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
+++ b/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
@@ -11,5 +11,4 @@ typedef float EcalPFSeedingThreshold;
 typedef EcalFloatCondObjectContainer EcalPFSeedingThresholdsMap;
 typedef EcalPFSeedingThresholdsMap EcalPFSeedingThresholds;
 
-
 #endif


### PR DESCRIPTION
#### PR description:

A new feature is planned in PF reconstruction, whereby seeding is made using xtal-dependent thresholds.  This PR is to introduce the new record that provides the thresholds, so that the DB can be populated and the new feature introduced later.

#### PR Validation:
N/A
