### PR TITLE
drop EI from AOD data tier

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -491,7 +491,6 @@ AODEventContent.outputCommands.extend(EvtScalersAOD.outputCommands)
 AODEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
 AODEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 AODEventContent.outputCommands.extend(CommonEventContent.outputCommands)
-AODEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
 ctpps_2016.toModify(AODEventContent, outputCommands = AODEventContent.outputCommands + RecoCTPPSAOD.outputCommands)
 
 RAWAODEventContent.outputCommands.extend(AODEventContent.outputCommands)


### PR DESCRIPTION
EI products take almost 2% of AOD.
These were introduced before we had miniAOD as a standard reference.

@rappoccio @arizzi @gpetruc @peruzzim @fgolf 
in case you know of any use case from your current/past PAT/miniAOD knowledge base.

@mbluj @swozniewski pfTausDiscriminationByDecayModeFinding and pfTausDiscriminationByIsolation are kept only via CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
Is there any use case for these products?

