### PR TITLE
Run3-sim48 First step to remove access of DDCompactView in SimG4CMS/Calo for ECAL

### DIFF
--- a/CondFormats/GeometryObjects/interface/EcalSimulationParameters.h
+++ b/CondFormats/GeometryObjects/interface/EcalSimulationParameters.h
@@ -1,0 +1,27 @@
+#ifndef CondFormats_GeometryObjects_EcalSimulationParameters_h
+#define CondFormats_GeometryObjects_EcalSimulationParameters_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+class EcalSimulationParameters {
+public:
+  EcalSimulationParameters(void) = default;
+  ~EcalSimulationParameters(void) = default;
+
+  int nxtalEta_;
+  int nxtalPhi_;
+  int phiBaskets_;
+  std::vector<int> etaBaskets_;
+  int ncrys_;
+  int nmods_;
+  bool useWeight_;
+  std::string depth1Name_;
+  std::string depth2Name_;
+  std::vector<std::string> lvNames_;
+  std::vector<std::string> matNames_;
+  std::vector<double> dzs_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/GeometryObjects/src/T_EventSetup_EcalParameters.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_EcalParameters.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(EcalSimulationParameters);

--- a/CondFormats/GeometryObjects/src/classes.h
+++ b/CondFormats/GeometryObjects/src/classes.h
@@ -10,4 +10,5 @@
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "CondFormats/GeometryObjects/interface/HcalSimulationParameters.h"
 #include "CondFormats/GeometryObjects/interface/CaloSimulationParameters.h"
+#include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
 #include "CondFormats/GeometryObjects/interface/PHGCalParameters.h"

--- a/CondFormats/GeometryObjects/src/classes_def.xml
+++ b/CondFormats/GeometryObjects/src/classes_def.xml
@@ -192,5 +192,20 @@
    <field name="fCaloNames_"            mapping="blob"/>
    <field name="fLevels_"               mapping="blob"/>
  </class>
+ <class name="EcalSimulationParameters" class_version="0"> 
+   <field name="nxtalEta_"              mapping="blob"/>
+   <field name="nxtalPhi_"              mapping="blob"/>
+   <field name="phiBaskets_"            mapping="blob"/>
+   <field name="etaBaskets_"            mapping="blob"/>
+   <field name="ncrys_"                 mapping="blob"/>
+   <field name="nmods_"                 mapping="blob"/>
+   <field name="useWeight_"             mapping="blob"/>
+   <field name="depth1Name_"            mapping="blob"/>
+   <field name="depth2Name_"            mapping="blob"/>
+   <field name="lvNames_"               mapping="blob"/>
+   <field name="matNames_"              mapping="blob"/>
+   <field name="dzs_"                   mapping="blob"/>
+ </class>
 
 </lcgdict> 
+

--- a/Geometry/EcalCommonData/BuildFile.xml
+++ b/Geometry/EcalCommonData/BuildFile.xml
@@ -1,5 +1,7 @@
 <use   name="DataFormats/EcalDetId"/>
 <use   name="Geometry/CaloGeometry"/>
+<use   name="DetectorDescription/Core"/>
+<use   name="DetectorDescription/DDCMS"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry-dump.xml
+++ b/Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry-dump.xml
@@ -62,6 +62,5 @@
     <Include ref='Geometry/EcalCommonData/data/eefixed.xml'/>
     <Include ref='Geometry/EcalCommonData/data/escon.xml'/>
     <Include ref='Geometry/EcalCommonData/data/esalgo/2021/v1/esalgo.xml'/>
-    <Include ref='Geometry/EcalSimData/data/ecalsens.xml'/>
   </IncludeSection>
 </DDDefinition>

--- a/Geometry/EcalCommonData/interface/EcalSimParametersFromDD.h
+++ b/Geometry/EcalCommonData/interface/EcalSimParametersFromDD.h
@@ -1,0 +1,37 @@
+#ifndef EcalCommonData_EcalSimParametersFromDD_h
+#define EcalCommonData_EcalSimParametersFromDD_h
+
+#include "DetectorDescription/Core/interface/DDsvalues.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <string>
+#include <vector>
+
+class DDFilteredView;
+class EcalSimulationParameters;
+
+template <typename T>
+void myPrint(std::string value, const std::vector<T>& vec) {
+  edm::LogVerbatim("HCalGeom") << "EcalSimParametersFromDD: " << vec.size() << " entries for " << value << ":";
+  unsigned int i(0);
+  for (const auto& e : vec) {
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << e;
+    ++i;
+  }
+}
+
+class EcalSimParametersFromDD {
+public:
+  EcalSimParametersFromDD() = default;
+
+  bool build(const DDCompactView*, const std::string& name, EcalSimulationParameters&);
+  bool build(const cms::DDCompactView*, const std::string& name, EcalSimulationParameters&);
+
+private:
+  bool buildParameters(const EcalSimulationParameters&);
+  std::vector<std::string> getStringArray(const std::string&, const DDsvalues_type&);
+  std::vector<double> getDDDArray(const std::string&, const DDsvalues_type&);
+};
+
+#endif

--- a/Geometry/EcalCommonData/interface/EcalSimParametersFromDD.h
+++ b/Geometry/EcalCommonData/interface/EcalSimParametersFromDD.h
@@ -11,16 +11,6 @@
 class DDFilteredView;
 class EcalSimulationParameters;
 
-template <typename T>
-void myPrint(std::string value, const std::vector<T>& vec) {
-  edm::LogVerbatim("HCalGeom") << "EcalSimParametersFromDD: " << vec.size() << " entries for " << value << ":";
-  unsigned int i(0);
-  for (const auto& e : vec) {
-    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << e;
-    ++i;
-  }
-}
-
 class EcalSimParametersFromDD {
 public:
   EcalSimParametersFromDD() = default;

--- a/Geometry/EcalCommonData/plugins/BuildFile.xml
+++ b/Geometry/EcalCommonData/plugins/BuildFile.xml
@@ -1,6 +1,10 @@
 <library   file="*.cc" name="GeometryEcalCommonDataPlugins">
   <use   name="DetectorDescription/Core"/>
+  <use   name="DetectorDescription/DDCMS"/>
   <use   name="Geometry/EcalCommonData"/>
+  <use   name="Geometry/Records"/>
+  <use   name="Geometry/EcalCommonData"/>
+  <use   name="CondFormats/GeometryObjects"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
 

--- a/Geometry/EcalCommonData/plugins/EcalSimParametersESModule.cc
+++ b/Geometry/EcalCommonData/plugins/EcalSimParametersESModule.cc
@@ -30,9 +30,8 @@ private:
   const std::string name_;
 };
 
-EcalSimParametersESModule::EcalSimParametersESModule(const edm::ParameterSet& ps) : 
-  fromDD4Hep_(ps.getParameter<bool>("fromDD4Hep")),
-  name_(ps.getParameter<std::string>("name")) {
+EcalSimParametersESModule::EcalSimParametersESModule(const edm::ParameterSet& ps)
+    : fromDD4Hep_(ps.getParameter<bool>("fromDD4Hep")), name_(ps.getParameter<std::string>("name")) {
   auto cc = setWhatProduced(this, name_);
   cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
   cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());

--- a/Geometry/EcalCommonData/plugins/EcalSimParametersESModule.cc
+++ b/Geometry/EcalCommonData/plugins/EcalSimParametersESModule.cc
@@ -1,0 +1,76 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/EcalCommonData/interface/EcalSimParametersFromDD.h"
+
+#include <memory>
+
+//#define EDM_ML_DEBUG
+
+class EcalSimParametersESModule : public edm::ESProducer {
+public:
+  EcalSimParametersESModule(const edm::ParameterSet&);
+
+  using ReturnType = std::unique_ptr<EcalSimulationParameters>;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  ReturnType produce(const IdealGeometryRecord&);
+
+private:
+  edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvTokenDDD_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> cpvTokenDD4Hep_;
+  const bool fromDD4Hep_;
+  const std::string name_;
+};
+
+EcalSimParametersESModule::EcalSimParametersESModule(const edm::ParameterSet& ps) : 
+  fromDD4Hep_(ps.getParameter<bool>("fromDD4Hep")),
+  name_(ps.getParameter<std::string>("name")) {
+  auto cc = setWhatProduced(this, name_);
+  cpvTokenDD4Hep_ = cc.consumesFrom<cms::DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+  cpvTokenDDD_ = cc.consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag());
+
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersESModule::EcalSimParametersESModule called with dd4hep: "
+                               << fromDD4Hep_ << " for " << name_;
+#endif
+}
+
+void EcalSimParametersESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("fromDD4Hep", false);
+  desc.add<std::string>("name", "EcalHitsEB");
+  descriptions.add("ecalSimulationParametersEB", desc);
+}
+
+EcalSimParametersESModule::ReturnType EcalSimParametersESModule::produce(const IdealGeometryRecord& iRecord) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersESModule::produce(const IdealGeometryRecord& iRecord)";
+#endif
+
+  auto ptp = std::make_unique<EcalSimulationParameters>();
+  EcalSimParametersFromDD builder;
+  if (fromDD4Hep_) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("EcalGeom") << "EcalSimParametersESModule::Try to access cms::DDCompactView";
+#endif
+    edm::ESTransientHandle<cms::DDCompactView> cpv = iRecord.getTransientHandle(cpvTokenDD4Hep_);
+    builder.build(&(*cpv), name_, *ptp);
+  } else {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("EcalGeom") << "EcalSimParametersESModule::Try to access DDCompactView";
+#endif
+    edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvTokenDDD_);
+    builder.build(&(*cpv), name_, *ptp);
+  }
+  return ptp;
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(EcalSimParametersESModule);

--- a/Geometry/EcalCommonData/python/ecalSimulationParametersAnalyzer_cff.py
+++ b/Geometry/EcalCommonData/python/ecalSimulationParametersAnalyzer_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from Geometry.EcalCommonData.ecalSimulationParametersAnalyzerEB_cfi import *
+
+ecalSimulationParametersAnalyzerEE = ecalSimulationParametersAnalyzerEB.clone(
+    name  = "EcalHitsEE")
+
+ecalSimulationParametersAnalyzerES = ecalSimulationParametersAnalyzerEB.clone(
+    name  = "EcalHitsES")

--- a/Geometry/EcalCommonData/python/ecalSimulationParameters_cff.py
+++ b/Geometry/EcalCommonData/python/ecalSimulationParameters_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+from Geometry.EcalCommonData.ecalSimulationParametersEB_cfi import *
+
+from Configuration.Eras.Modifier_dd4hep_cff import dd4hep
+
+dd4hep.toModify(ecalSimulationParametersEB,
+                fromDD4Hep = cms.bool(True)
+)
+
+ecalSimulationParametersEE = ecalSimulationParametersEB.clone(
+    name  = cms.string("EcalHitsEE"))
+
+ecalSimulationParametersES = ecalSimulationParametersEB.clone(
+    name  = cms.string("EcalHitsES"))

--- a/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
+++ b/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
@@ -1,0 +1,209 @@
+#include "Geometry/EcalCommonData/interface/EcalSimParametersFromDD.h"
+#include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDFilter.h"
+#include "DetectorDescription/Core/interface/DDValue.h"
+#include "DetectorDescription/Core/interface/DDutils.h"
+#include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+#include <iostream>
+#include <iomanip>
+
+//#define EDM_ML_DEBUG
+
+bool EcalSimParametersFromDD::build(const DDCompactView* cpv, const std::string& name, EcalSimulationParameters& php) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom")
+    << "Inside EcalSimParametersFromDD::build(const DDCompactView*, const std::string&, EcalSimulationParameters&)";
+#endif
+  // Get the filtered view
+  std::string attribute = "ReadOutName";
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, name, 0)};
+  DDFilteredView fv(*cpv, filter);
+  bool dodet = fv.firstChild();
+  DDsvalues_type sv(fv.mergedSpecifics());
+
+  //First the specpars
+  php.useWeight_ = true;
+  std::vector<double> tempD = getDDDArray("EnergyWeight", sv);
+  if (!tempD.empty()) {
+    if (tempD[0] < 0.1)
+      php.useWeight_ = false;
+  }
+  tempD = getDDDArray("nxtalEta", sv);
+  if (tempD.empty())
+    php.nxtalEta_ = 0;
+  else
+    php.nxtalEta_ = static_cast<int>(tempD[0]);
+  tempD = getDDDArray("nxtalPhi", sv);
+  if (tempD.empty())
+    php.nxtalPhi_ = 0;
+  else
+    php.nxtalPhi_ = static_cast<int>(tempD[0]);
+  tempD = getDDDArray("PhiBaskets", sv);
+  if (tempD.empty())
+    php.phiBaskets_ = 0;
+  else
+    php.phiBaskets_ = static_cast<int>(tempD[0]);
+  php.etaBaskets_ = dbl_to_int(getDDDArray("EtaBaskets", sv));
+  tempD = getDDDArray("ncrys", sv);
+  if (tempD.empty())
+    php.ncrys_ = 0;
+  else
+    php.ncrys_ = static_cast<int>(tempD[0]);
+   tempD = getDDDArray("nmods", sv);
+  if (tempD.empty())
+    php.nmods_ = 0;
+  else
+    php.nmods_ = static_cast<int>(tempD[0]);
+
+  std::vector<std::string> tempS = getStringArray("Depth1Name", sv);
+  if (!tempS.empty())
+    php.depth1Name_ = tempS[0];
+  else
+    php.depth1Name_ = " ";
+  tempS = getStringArray("Depth2Name", sv);
+  if (!tempS.empty())
+    php.depth2Name_ = tempS[0];
+  else
+    php.depth2Name_ = " ";
+
+  //Then the logical volumes
+  while (dodet) {
+    if (std::find(php.lvNames_.begin(), php.lvNames_.end(), fv.logicalPart().name().name()) == php.lvNames_.end()) {
+      php.matNames_.emplace_back(fv.logicalPart().material().name().name());
+      php.lvNames_.emplace_back(fv.logicalPart().name().name());
+      const DDSolid& sol = fv.logicalPart().solid();
+      const std::vector<double>& paras = sol.parameters();
+      double dz = (sol.shape() == DDSolidShape::ddtrap) ? (2 * paras[0]) : 0.0;
+      php.dzs_.emplace_back(dz);
+    }
+    dodet = fv.next();
+  }
+  return this->buildParameters(php);
+}
+
+bool EcalSimParametersFromDD::build(const cms::DDCompactView* cpv, const std::string& name, EcalSimulationParameters& php) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom")
+    << "Inside EcalSimParametersFromDD::build(const cms::DDCompactView*, const std::string, EcalSimulationParameters&)";
+#endif
+  // Get the filtered view
+  std::string attribute = "ReadOutName";
+  cms::DDFilteredView fv(cpv->detector(), cpv->detector()->worldVolume());
+
+  //First the specpars
+  char specName[10];
+  if (name == "EcalHitsEE") 
+    sprintf (specName, "ecal_ee");
+  else if (name == "EcalHitsES")
+    sprintf (specName, "ecal_sf");
+  else
+    sprintf (specName, "ecal_eb");
+  
+  php.useWeight_ = true;
+  std::vector<double> tempD = fv.get<std::vector<double> >(specName, "EnergyWeight");
+  if (!tempD.empty()) {
+    if (tempD[0] < 0.1)
+      php.useWeight_ = false;
+  }
+  tempD = fv.get<std::vector<double> >(specName, "nxtalEta");
+  if (tempD.empty())
+    php.nxtalEta_ = 0;
+  else
+    php.nxtalEta_ = static_cast<int>(tempD[0]);
+  tempD = fv.get<std::vector<double> >(specName, "nxtalPhi");
+  if (tempD.empty())
+    php.nxtalPhi_ = 0;
+  else
+    php.nxtalPhi_ = static_cast<int>(tempD[0]);
+  tempD = fv.get<std::vector<double> >(specName, "PhiBaskets");
+  if (tempD.empty())
+    php.phiBaskets_ = 0;
+  else
+    php.phiBaskets_ = static_cast<int>(tempD[0]);
+  php.etaBaskets_ = dbl_to_int(fv.get<std::vector<double> >(specName, "EtaBaskets"));
+  tempD = fv.get<std::vector<double> >(specName, "ncrys");
+  if (tempD.empty())
+    php.ncrys_ = 0;
+  else
+    php.ncrys_ = static_cast<int>(tempD[0]);
+  tempD = fv.get<std::vector<double> >(specName, "nmods");
+  if (tempD.empty())
+    php.nmods_ = 0;
+  else
+    php.nmods_ = static_cast<int>(tempD[0]);
+
+  std::vector<std::string> tempS = fv.get<std::vector<std::string> >(specName, "Depth1Name");
+  if (!tempS.empty())
+    php.depth1Name_ = tempS[0];
+  else
+    php.depth1Name_ = " ";
+  tempS = fv.get<std::vector<std::string> >(specName, "Depth2Name");
+  if (!tempS.empty())
+    php.depth2Name_ = tempS[0];
+  else
+    php.depth2Name_ = " ";
+
+  //Then the logical volumes
+  cms::DDSpecParRefs refs;
+  const cms::DDSpecParRegistry& mypar = cpv->specpars();
+   mypar.filter(refs, attribute, name);
+  fv.mergedSpecifics(refs);
+  bool dodet = fv.firstChild();
+  while (dodet) {
+    if (std::find(php.lvNames_.begin(), php.lvNames_.end(), fv.name()) == php.lvNames_.end()) {
+      php.matNames_.emplace_back(fv.materialName());
+      php.lvNames_.emplace_back(fv.name());
+      const std::vector<double>& paras = fv.parameters();
+      double dz = (fv.isATrapezoid()) ? (2 * paras[0]) : 0.0;
+      php.dzs_.emplace_back(dz);
+    }
+    dodet = fv.nextSibling();
+  }
+
+  return this->buildParameters(php);
+}
+
+bool EcalSimParametersFromDD::buildParameters(const EcalSimulationParameters& php) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:: nxtalEta:" << php.nxtalEta_ << " nxtalPhi:" << php.nxtalPhi_ << " phiBaskets:" << php.phiBaskets_ << " ncrys:" << php.ncrys_ << " nmods: " << php.nmods_ << " useWeight:" << php.useWeight_ << " DeothNames:" << php.depth1Name_ << ":" << php.depth2Name_;
+  myPrint("etaBaskets", php.etaBaskets_);
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:: " << php.lvNames_.size() << " lvNames, " << php.matNames_.size() << " matNames and " << php.dzs_.size() << "dzs";
+#endif
+
+  return true;
+}
+
+std::vector<double> EcalSimParametersFromDD::getDDDArray(const std::string& str, const DDsvalues_type& sv) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:getDDDArray called for " << str;
+#endif
+  DDValue value(str);
+  if (DDfetch(&sv, value)) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("EcalGeom") << value;
+#endif
+    const std::vector<double>& fvec = value.doubles();
+    return fvec;
+  } else {
+    std::vector<double> fvec;
+    return fvec;
+  }
+}
+
+std::vector<std::string> EcalSimParametersFromDD::getStringArray(const std::string& str, const DDsvalues_type& sv) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:getStringArray called for " << str;
+#endif
+  DDValue value(str);
+  if (DDfetch(&sv, value)) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("EcalGeom") << value;
+#endif
+    const std::vector<std::string>& fvec = value.strings();
+    return fvec;
+  } else {
+    std::vector<std::string> fvec;
+    return fvec;
+  }
+}

--- a/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
+++ b/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
@@ -12,10 +12,10 @@
 
 template <typename T>
 void myPrint(std::string value, const std::vector<T>& vec) {
-  edm::LogVerbatim("HCalGeom") << "EcalSimParametersFromDD: " << vec.size() << " entries for " << value << ":";
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD: " << vec.size() << " entries for " << value << ":";
   unsigned int i(0);
   for (const auto& e : vec) {
-    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << e;
+    edm::LogVerbatim("EcalGeom") << " (" << i << ") " << e;
     ++i;
   }
 }

--- a/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
+++ b/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
@@ -13,7 +13,7 @@
 bool EcalSimParametersFromDD::build(const DDCompactView* cpv, const std::string& name, EcalSimulationParameters& php) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalGeom")
-    << "Inside EcalSimParametersFromDD::build(const DDCompactView*, const std::string&, EcalSimulationParameters&)";
+      << "Inside EcalSimParametersFromDD::build(const DDCompactView*, const std::string&, EcalSimulationParameters&)";
 #endif
   // Get the filtered view
   std::string attribute = "ReadOutName";
@@ -50,7 +50,7 @@ bool EcalSimParametersFromDD::build(const DDCompactView* cpv, const std::string&
     php.ncrys_ = 0;
   else
     php.ncrys_ = static_cast<int>(tempD[0]);
-   tempD = getDDDArray("nmods", sv);
+  tempD = getDDDArray("nmods", sv);
   if (tempD.empty())
     php.nmods_ = 0;
   else
@@ -82,10 +82,12 @@ bool EcalSimParametersFromDD::build(const DDCompactView* cpv, const std::string&
   return this->buildParameters(php);
 }
 
-bool EcalSimParametersFromDD::build(const cms::DDCompactView* cpv, const std::string& name, EcalSimulationParameters& php) {
+bool EcalSimParametersFromDD::build(const cms::DDCompactView* cpv,
+                                    const std::string& name,
+                                    EcalSimulationParameters& php) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("EcalGeom")
-    << "Inside EcalSimParametersFromDD::build(const cms::DDCompactView*, const std::string, EcalSimulationParameters&)";
+  edm::LogVerbatim("EcalGeom") << "Inside EcalSimParametersFromDD::build(const cms::DDCompactView*, const std::string, "
+                                  "EcalSimulationParameters&)";
 #endif
   // Get the filtered view
   std::string attribute = "ReadOutName";
@@ -93,13 +95,13 @@ bool EcalSimParametersFromDD::build(const cms::DDCompactView* cpv, const std::st
 
   //First the specpars
   char specName[10];
-  if (name == "EcalHitsEE") 
-    sprintf (specName, "ecal_ee");
+  if (name == "EcalHitsEE")
+    sprintf(specName, "ecal_ee");
   else if (name == "EcalHitsES")
-    sprintf (specName, "ecal_sf");
+    sprintf(specName, "ecal_sf");
   else
-    sprintf (specName, "ecal_eb");
-  
+    sprintf(specName, "ecal_eb");
+
   php.useWeight_ = true;
   std::vector<double> tempD = fv.get<std::vector<double> >(specName, "EnergyWeight");
   if (!tempD.empty()) {
@@ -147,7 +149,7 @@ bool EcalSimParametersFromDD::build(const cms::DDCompactView* cpv, const std::st
   //Then the logical volumes
   cms::DDSpecParRefs refs;
   const cms::DDSpecParRegistry& mypar = cpv->specpars();
-   mypar.filter(refs, attribute, name);
+  mypar.filter(refs, attribute, name);
   fv.mergedSpecifics(refs);
   bool dodet = fv.firstChild();
   while (dodet) {
@@ -166,9 +168,13 @@ bool EcalSimParametersFromDD::build(const cms::DDCompactView* cpv, const std::st
 
 bool EcalSimParametersFromDD::buildParameters(const EcalSimulationParameters& php) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:: nxtalEta:" << php.nxtalEta_ << " nxtalPhi:" << php.nxtalPhi_ << " phiBaskets:" << php.phiBaskets_ << " ncrys:" << php.ncrys_ << " nmods: " << php.nmods_ << " useWeight:" << php.useWeight_ << " DeothNames:" << php.depth1Name_ << ":" << php.depth2Name_;
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:: nxtalEta:" << php.nxtalEta_
+                               << " nxtalPhi:" << php.nxtalPhi_ << " phiBaskets:" << php.phiBaskets_
+                               << " ncrys:" << php.ncrys_ << " nmods: " << php.nmods_ << " useWeight:" << php.useWeight_
+                               << " DeothNames:" << php.depth1Name_ << ":" << php.depth2Name_;
   myPrint("etaBaskets", php.etaBaskets_);
-  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:: " << php.lvNames_.size() << " lvNames, " << php.matNames_.size() << " matNames and " << php.dzs_.size() << "dzs";
+  edm::LogVerbatim("EcalGeom") << "EcalSimParametersFromDD:: " << php.lvNames_.size() << " lvNames, "
+                               << php.matNames_.size() << " matNames and " << php.dzs_.size() << "dzs";
 #endif
 
   return true;

--- a/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
+++ b/Geometry/EcalCommonData/src/EcalSimParametersFromDD.cc
@@ -10,6 +10,16 @@
 
 //#define EDM_ML_DEBUG
 
+template <typename T>
+void myPrint(std::string value, const std::vector<T>& vec) {
+  edm::LogVerbatim("HCalGeom") << "EcalSimParametersFromDD: " << vec.size() << " entries for " << value << ":";
+  unsigned int i(0);
+  for (const auto& e : vec) {
+    edm::LogVerbatim("HCalGeom") << " (" << i << ") " << e;
+    ++i;
+  }
+}
+
 bool EcalSimParametersFromDD::build(const DDCompactView* cpv, const std::string& name, EcalSimulationParameters& php) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalGeom")

--- a/Geometry/EcalCommonData/test/BuildFile.xml
+++ b/Geometry/EcalCommonData/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<use   name="Geometry/EcalCommonData"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="FWCore/Utilities"/>
+<use   name="Geometry/Records"/>
+<use   name="CondFormats/GeometryObjects"/>
+<library   file="*.cc" name="testEcalCommonDataAnalyzer">
+ <flags   EDM_PLUGIN="1"/>
+</library>

--- a/Geometry/EcalCommonData/test/EcalSimParametersAnalyzer.cc
+++ b/Geometry/EcalCommonData/test/EcalSimParametersAnalyzer.cc
@@ -19,7 +19,8 @@ private:
   std::string name_;
 };
 
-EcalSimParametersAnalyzer::EcalSimParametersAnalyzer(const edm::ParameterSet& ic) : name_(ic.getUntrackedParameter<std::string>("name")) {
+EcalSimParametersAnalyzer::EcalSimParametersAnalyzer(const edm::ParameterSet& ic)
+    : name_(ic.getUntrackedParameter<std::string>("name")) {
   simparToken_ = esConsumes<EcalSimulationParameters, IdealGeometryRecord>(edm::ESInputTag{"", name_});
 }
 
@@ -50,7 +51,8 @@ void EcalSimParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm:
       std::cout << it << ", ";
       ++kount;
       if (kount == 8) {
-	std::cout << "\n"; kount = 0;
+        std::cout << "\n";
+        kount = 0;
       }
     }
     kount = 0;
@@ -59,7 +61,8 @@ void EcalSimParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm:
       std::cout << it << ", ";
       ++kount;
       if (kount == 7) {
-	std::cout << "\n"; kount = 0;
+        std::cout << "\n";
+        kount = 0;
       }
     }
     kount = 0;
@@ -68,7 +71,8 @@ void EcalSimParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm:
       std::cout << it << ", ";
       ++kount;
       if (kount == 20) {
-	std::cout << "\n"; kount = 0;
+        std::cout << "\n";
+        kount = 0;
       }
     }
     std::cout << std::endl;

--- a/Geometry/EcalCommonData/test/EcalSimParametersAnalyzer.cc
+++ b/Geometry/EcalCommonData/test/EcalSimParametersAnalyzer.cc
@@ -1,0 +1,78 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CondFormats/GeometryObjects/interface/EcalSimulationParameters.h"
+#include "Geometry/Records/interface/HcalParametersRcd.h"
+#include <iostream>
+
+class EcalSimParametersAnalyzer : public edm::one::EDAnalyzer<> {
+public:
+  explicit EcalSimParametersAnalyzer(const edm::ParameterSet&);
+
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  edm::ESGetToken<EcalSimulationParameters, IdealGeometryRecord> simparToken_;
+  std::string name_;
+};
+
+EcalSimParametersAnalyzer::EcalSimParametersAnalyzer(const edm::ParameterSet& ic) : name_(ic.getUntrackedParameter<std::string>("name")) {
+  simparToken_ = esConsumes<EcalSimulationParameters, IdealGeometryRecord>(edm::ESInputTag{"", name_});
+}
+
+void EcalSimParametersAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("name", "EcalHitsEB");
+  descriptions.add("ecalSimulationParametersAnalyzerEB", desc);
+}
+
+void EcalSimParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  const auto& parS = iSetup.getData(simparToken_);
+  const EcalSimulationParameters* parsim = &parS;
+  if (parsim != nullptr) {
+    std::cout << "\n nxtalEta_: " << parsim->nxtalEta_;
+    std::cout << "\n nxtalPhi_: " << parsim->nxtalPhi_;
+    std::cout << "\n phiBaskets_: " << parsim->phiBaskets_;
+    std::cout << "\n etaBaskets_: ";
+    for (const auto& it : parsim->etaBaskets_)
+      std::cout << it << ", ";
+    std::cout << "\n ncrys_: " << parsim->ncrys_;
+    std::cout << "\n nmods_: " << parsim->nmods_;
+    std::cout << "\n useWeight_: " << parsim->useWeight_;
+    std::cout << "\n depth1Name_: " << parsim->depth1Name_;
+    std::cout << "\n depth2Name_: " << parsim->depth2Name_;
+    std::cout << "\n lvNames_: " << parsim->lvNames_.size() << " occurences\n";
+    int kount(0);
+    for (const auto& it : parsim->lvNames_) {
+      std::cout << it << ", ";
+      ++kount;
+      if (kount == 8) {
+	std::cout << "\n"; kount = 0;
+      }
+    }
+    kount = 0;
+    std::cout << "\n matNames_: " << parsim->matNames_.size() << " occurences\n";
+    for (const auto& it : parsim->matNames_) {
+      std::cout << it << ", ";
+      ++kount;
+      if (kount == 7) {
+	std::cout << "\n"; kount = 0;
+      }
+    }
+    kount = 0;
+    std::cout << "\n dzs_: " << parsim->dzs_.size() << " occurences\n";
+    for (const auto& it : parsim->dzs_) {
+      std::cout << it << ", ";
+      ++kount;
+      if (kount == 20) {
+	std::cout << "\n"; kount = 0;
+      }
+    }
+    std::cout << std::endl;
+  }
+}
+
+DEFINE_FWK_MODULE(EcalSimParametersAnalyzer);

--- a/Geometry/EcalCommonData/test/python/dumpECDD4Hep_cfg.py
+++ b/Geometry/EcalCommonData/test/python/dumpECDD4Hep_cfg.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DumpECDD4Hep")
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 5
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('EcalGeom')
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml'),
+                                            appendToDataLabel = cms.string('DDEcal')
+                                            )
+
+process.testDump = cms.EDAnalyzer("DDTestDumpFile",
+                                  outputFileName = cms.untracked.string('ecalDD4Hep.root'),
+                                  DDDetector = cms.ESInputTag('','DDEcal')
+                                  )
+
+process.p = cms.Path(process.testDump)

--- a/Geometry/EcalCommonData/test/python/dumpECDD4Hep_cfg.py
+++ b/Geometry/EcalCommonData/test/python/dumpECDD4Hep_cfg.py
@@ -13,7 +13,7 @@ if hasattr(process,'MessageLogger'):
     process.MessageLogger.categories.append('EcalGeom')
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml'),
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry-dump.xml'),
                                             appendToDataLabel = cms.string('DDEcal')
                                             )
 

--- a/Geometry/EcalCommonData/test/python/dumpECDDD_cfg.py
+++ b/Geometry/EcalCommonData/test/python/dumpECDDD_cfg.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DumpECDDD")
+
+process.load("Geometry.EcalCommonData.EcalOnly_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.categories.append('G4cerr')
+    process.MessageLogger.categories.append('G4cout')
+    process.MessageLogger.categories.append('EcalGeom')
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.add_(cms.ESProducer("TGeoMgrFromDdd",
+        verbose = cms.untracked.bool(False),
+        level   = cms.untracked.int32(14)
+))
+
+
+process.dump = cms.EDAnalyzer("DumpSimGeometry",
+                              outputFileName = cms.untracked.string('ecalDDD.root')
+)
+
+process.p = cms.Path(process.dump)

--- a/Geometry/EcalCommonData/test/python/runEcalSimParameterDD4Hep_cfg.py
+++ b/Geometry/EcalCommonData/test/python/runEcalSimParameterDD4Hep_cfg.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("EcalSimParametersTest")
+
+process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 5
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('ECalGeom')
+    process.MessageLogger.categories.append('ECalSim')
+    process.MessageLogger.categories.append('Geometry')
+
+process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/EcalCommonData/data/dd4hep/cms-ecal-geometry.xml'),
+                                            appendToDataLabel = cms.string('')
+                                            )
+
+process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                                appendToDataLabel = cms.string('')
+)
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.ecalSimulationParametersEB.fromDD4Hep = cms.bool(True)
+process.ecalSimulationParametersEE.fromDD4Hep = cms.bool(True)
+process.ecalSimulationParametersES.fromDD4Hep = cms.bool(True)
+
+process.load('Geometry.EcalCommonData.ecalSimulationParametersAnalyzer_cff')
+
+process.Timing = cms.Service("Timing")
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
+
+process.p1 = cms.Path(process.ecalSimulationParametersAnalyzerEB+process.ecalSimulationParametersAnalyzerEE+process.ecalSimulationParametersAnalyzerES)

--- a/Geometry/EcalCommonData/test/python/runEcalSimParameterDDD_cfg.py
+++ b/Geometry/EcalCommonData/test/python/runEcalSimParameterDDD_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("EcalSimulationParametersTest")
+
+process.load('Geometry.EcalCommonData.EcalOnly_cfi')
+process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.categories.append('EcalGeom')
+    process.MessageLogger.categories.append('EcalSim')
+
+process.load('Geometry.EcalCommonData.ecalSimulationParametersAnalyzer_cff')
+
+process.Timing = cms.Service("Timing")
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
+
+process.p1 = cms.Path(process.ecalSimulationParametersAnalyzerEB+process.ecalSimulationParametersAnalyzerEE+process.ecalSimulationParametersAnalyzerES)

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -284,8 +284,8 @@ uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4Logical
     G4ThreeVector localPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
     edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " << hitPoint->GetPosition() << ":"
                                 << (hitPoint->GetPosition()).rho() << " Local " << localPoint << " Crystal Length "
-                                << crystalLength << " Radl " << radl << " crystalDepth " << crystalDepth << " Index " << thisX0 << " : "
-                                << getLayerIDForTimeSim();
+                                << crystalLength << " Radl " << radl << " crystalDepth " << crystalDepth << " Index "
+                                << thisX0 << " : " << getLayerIDForTimeSim();
 #endif
   }
   return thisX0;

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -250,13 +250,13 @@ uint16_t ECalSD::getDepth(const G4Step* aStep) {
   crystalLength = (ite == xtalLMap.end()) ? 230.0 : std::abs(ite->second);
   crystalDepth = (ite == xtalLMap.end()) ? 0.0 : (std::abs(0.5 * (ite->second) + currentLocalPoint.z()));
   depth = any(useDepth1, lv) ? 1 : (any(useDepth2, lv) ? 2 : 0);
-
+  uint16_t depth1(0), depth2(0);
   if (storeRL) {
-    uint16_t depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 : PCaloHit::kEcalDepthRefz);
-    uint16_t depth2 = getRadiationLength(hitPoint, lv);
+    depth1 = (ite == xtalLMap.end()) ? 0 : (((ite->second) >= 0) ? 0 : PCaloHit::kEcalDepthRefz);
+    depth2 = getRadiationLength(hitPoint, lv);
     depth |= (((depth2 & PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset) | depth1);
   } else if (storeLayerTimeSim) {
-    uint16_t depth2 = getLayerIDForTimeSim();
+    depth2 = getLayerIDForTimeSim();
     depth |= ((depth2 & PCaloHit::kEcalDepthMask) << PCaloHit::kEcalDepthOffset);
   }
 #ifdef EDM_ML_DEBUG
@@ -281,9 +281,10 @@ uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4Logical
     g2L_[kk]->Fill(rz, thisX0);
 #endif
 #ifdef EDM_ML_DEBUG
+    G4ThreeVector localPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
     edm::LogVerbatim("EcalSim") << lv->GetName() << " Global " << hitPoint->GetPosition() << ":"
                                 << (hitPoint->GetPosition()).rho() << " Local " << localPoint << " Crystal Length "
-                                << crlength << " Radl " << radl << " DetZ " << detz << " Index " << thisX0 << " : "
+                                << crystalLength << " Radl " << radl << " crystalDepth " << crystalDepth << " Index " << thisX0 << " : "
                                 << getLayerIDForTimeSim();
 #endif
   }


### PR DESCRIPTION
#### PR description:

Create objects for ECAL which are needed at SIM step from specpar etc so that SIM step does not require access to DDCompactView and can use this object. The change in SIM step to be done in the next step 

#### PR validation:

Tested with standard workflows

#### if this PR is a backport please specify the original PR:

Nothing special