### PR TITLE
HCAL: implementation of TDC simulation functionality for Phase1 HB/HE

### DIFF
--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -102,8 +102,8 @@ public:
 
   // set flavor
   constexpr void setFlavor(int flavor) {
-    m_data[0] &= 0x9FFF; // inversion of flavor mask
-    m_data[0] |= ((flavor&MASK_FLAVOR) << OFFSET_FLAVOR);
+    m_data[0] &= 0x9FFF;  // inversion of flavor mask
+    m_data[0] |= ((flavor & MASK_FLAVOR) << OFFSET_FLAVOR);
   }
 
   constexpr void setCapid0(int cap0) {

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -65,6 +65,7 @@ public:
 
   /// Get the detector id
   constexpr DetId detid() const { return DetId(m_data.id()); }
+  constexpr HcalDetId hcaldetid() const { return HcalDetId(m_data.id()); } 
   constexpr edm::DataFrame::id_type id() const { return m_data.id(); }
   /// more accessors
   constexpr edm::DataFrame::size_type size() const { return m_data.size(); }
@@ -99,6 +100,13 @@ public:
   }
   /// get the sample
   constexpr inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(m_data, i + HEADER_WORDS); }
+
+  // set flavor
+  constexpr void setFlavor(int flavor) {
+    m_data[0] &= 0x9FFF; // inversion of flavor mask
+    m_data[0] |= ((flavor&MASK_FLAVOR) << OFFSET_FLAVOR);
+  }
+
   constexpr void setCapid0(int cap0) {
     if (flavor() == FLAVOR_HB) {
       for (int i = 0; i < samples(); i++) {

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -65,7 +65,6 @@ public:
 
   /// Get the detector id
   constexpr DetId detid() const { return DetId(m_data.id()); }
-  constexpr HcalDetId hcaldetid() const { return HcalDetId(m_data.id()); } 
   constexpr edm::DataFrame::id_type id() const { return m_data.id(); }
   /// more accessors
   constexpr edm::DataFrame::size_type size() const { return m_data.size(); }

--- a/DataFormats/HcalDigi/src/QIE11DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE11DataFrame.cc
@@ -3,8 +3,8 @@
 
 std::ostream& operator<<(std::ostream& s, const QIE11DataFrame& digi) {
   if (digi.detid().det() == DetId::Hcal) {
-    s << "DetID=" << HcalGenericDetId(digi.detid()) << " flavor=" << digi.flavor(); 
- } else {
+    s << "DetID=" << HcalGenericDetId(digi.detid()) << " flavor=" << digi.flavor();
+  } else {
     s << "DetId(" << digi.detid().rawId() << ")";
   }
   s << " " << digi.samples() << " samples";

--- a/DataFormats/HcalDigi/src/QIE11DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE11DataFrame.cc
@@ -3,8 +3,8 @@
 
 std::ostream& operator<<(std::ostream& s, const QIE11DataFrame& digi) {
   if (digi.detid().det() == DetId::Hcal) {
-    s << HcalGenericDetId(digi.detid());
-  } else {
+    s << "DetID=" << HcalGenericDetId(digi.detid()) << " flavor=" << digi.flavor(); 
+ } else {
     s << "DetId(" << digi.detid().rawId() << ")";
   }
   s << " " << digi.samples() << " samples";

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -118,7 +118,7 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
       int presamples = qiedf.presamples();
 
       /* Defining a custom index that will encode only
-	 the information about the crate and slot of a 
+	 the information about the crate and slot of a
 	 given channel:   crate: bits 0-7
 	 slot:  bits 8-12 */
 
@@ -143,6 +143,9 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
       int slotId = eid.slot();
       int uhtrIndex = ((slotId & 0xF) << 8) | (crateId & 0xFF);
       int presamples = qiedf.presamples();
+
+      //   convert to hb qie data if hb
+      if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel) qiedf = convertHB2HE(qiedf);
 
       if (!uhtrs.exist(uhtrIndex)) {
         uhtrs.newUHTR(uhtrIndex, presamples);

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -145,7 +145,8 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
       int presamples = qiedf.presamples();
 
       //   convert to hb qie data if hb
-      if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel) qiedf = convertHB2HE(qiedf);
+      if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel)
+        qiedf = convertHB2HE(qiedf);
 
       if (!uhtrs.exist(uhtrIndex)) {
         uhtrs.newUHTR(uhtrIndex, presamples);

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -146,12 +146,13 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
 
       //   convert to hb qie data if hb
       if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel)
-        qiedf = convertHB2HE(qiedf);
+        qiedf = convertHB(qiedf);
 
       if (!uhtrs.exist(uhtrIndex)) {
         uhtrs.newUHTR(uhtrIndex, presamples);
       }
       uhtrs.addChannel(uhtrIndex, qiedf, readoutMap, _verbosity);
+      // if(HcalDetId(qiedf.detid()).ieta()==1&&HcalDetId(qiedf.detid()).iphi()==1) std::cout<<qiedf<<std::endl;
     }
   }
   // - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -152,7 +152,6 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
         uhtrs.newUHTR(uhtrIndex, presamples);
       }
       uhtrs.addChannel(uhtrIndex, qiedf, readoutMap, _verbosity);
-      // if(HcalDetId(qiedf.detid()).ieta()==1&&HcalDetId(qiedf.detid()).iphi()==1) std::cout<<qiedf<<std::endl;
     }
   }
   // - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -129,7 +129,7 @@ namespace QIE11HeaderSpec0 {
   static const int MASK_FLAVOR = 0x7;
   static const int OFFSET_HEADER_BIT = 15;
   static const int MASK_HEADER_BIT = 0x1;
-}  // namespace QIE11HeaderSpec
+}  // namespace QIE11HeaderSpec0
 
 namespace QIE11HeaderSpec3 {
   static const int OFFSET_FIBERCHAN = 0;
@@ -144,7 +144,7 @@ namespace QIE11HeaderSpec3 {
   static const int MASK_FLAVOR = 0x7;
   static const int OFFSET_HEADER_BIT = 15;
   static const int MASK_HEADER_BIT = 0x1;
-}
+}  // namespace QIE11HeaderSpec3
 
 namespace TPHeaderSpec {
   static const int OFFSET_TOWER = 0;
@@ -418,14 +418,18 @@ public:
 
     int fiber = eid.fiberIndex();
     int fiberchan = eid.fiberChanId();
-  // capacitor id for the first sample
+    // capacitor id for the first sample
 
     // Flavor is added
 
     int flavor = qiedf[0].flavor();
     int capid0;
-    if (qiedf.samples() == 0) capid0=0;
-    if (flavor == 3) capid0 = qiedf[1].capid(); else capid0 = qiedf[0].capid();
+    if (qiedf.samples() == 0)
+      capid0 = 0;
+    if (flavor == 3)
+      capid0 = qiedf[1].capid();
+    else
+      capid0 = qiedf[0].capid();
 
     // adding only cases for flavor 3
 
@@ -625,37 +629,42 @@ public:
 
 // converts HE QIE digies to HB data format
 
-  QIE11DataFrame convertHB2HE(QIE11DataFrame qiehe) {
-    QIE11DataFrame qiehb = qiehe;
-    int adc_, tdc_, capid_;
-    bool soi_;
-    int is=0;
+QIE11DataFrame convertHB2HE(QIE11DataFrame qiehe) {
+  QIE11DataFrame qiehb = qiehe;
+  int adc_, tdc_, capid_;
+  bool soi_;
+  int is = 0;
 
-    //  flavor for HB digies is hardcoded here
-    static const int hbflavor = 3;
+  //  flavor for HB digies is hardcoded here
+  static const int hbflavor = 3;
 
-    //  iterator over samples
-    for (edm::DataFrame::const_iterator it = qiehe.begin(); it != qiehe.end(); ++it) {
-      if (it == qiehe.begin()) continue;
-      adc_ = qiehe[is].adc();
-      tdc_ = qiehe[is].tdc();
-      soi_ = qiehe[is].soi();
+  //  iterator over samples
+  for (edm::DataFrame::const_iterator it = qiehe.begin(); it != qiehe.end(); ++it) {
+    if (it == qiehe.begin())
+      continue;
+    adc_ = qiehe[is].adc();
+    tdc_ = qiehe[is].tdc();
+    soi_ = qiehe[is].soi();
 
-      if(tdc_>=0&&tdc_<=24) tdc_=0;
-      else if(tdc_>=25&&tdc_<=49) tdc_=1;
-      else if(tdc_==63) tdc_=2;
-      else if(tdc_==62) tdc_=3;
+    if (tdc_ >= 0 && tdc_ <= 24)
+      tdc_ = 0;
+    else if (tdc_ >= 25 && tdc_ <= 49)
+      tdc_ = 1;
+    else if (tdc_ == 63)
+      tdc_ = 2;
+    else if (tdc_ == 62)
+      tdc_ = 3;
 
-      qiehb.setSample(is,adc_,tdc_,soi_);
-      is++;
-    };
+    qiehb.setSample(is, adc_, tdc_, soi_);
+    is++;
+  };
 
-    // puting flavor is safe here because flavor is stored in the same bits for all flavors
-    qiehb.setFlavor(hbflavor);
-    capid_ = qiehe[0].capid();
-    qiehb.setCapid0(capid_);
+  // puting flavor is safe here because flavor is stored in the same bits for all flavors
+  qiehb.setFlavor(hbflavor);
+  capid_ = qiehe[0].capid();
+  qiehb.setCapid0(capid_);
 
-    return qiehb;
-  }
+  return qiehb;
+}
 
 #endif

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -351,14 +351,14 @@ public:
 
     int fiber = eid.fiberIndex() + 1;
     int fiberchan = eid.fiberChanId();
-    int fiberErr = qieSample.er();
-    int capid0 = qieSample.capid();
 
     header |= (fiberchan & QIE8HeaderSpec::MASK_FIBERCHAN) << QIE8HeaderSpec::OFFSET_FIBERCHAN;
     header |= ((fiber - 1) & QIE8HeaderSpec::MASK_FIBER) << QIE8HeaderSpec::OFFSET_FIBER;
     if (flavor == 7) {
       header |= (15 & QIE8HeaderSpec::MASK_TECHNICAL_DATA_TYPE) << QIE8HeaderSpec::OFFSET_TECHNICAL_DATA_TYPE;
     } else {
+      int fiberErr = qieSample.er();
+      int capid0 = qieSample.capid();
       header |= (capid0 & QIE8HeaderSpec::MASK_CAPID) << QIE8HeaderSpec::OFFSET_CAPID;
       header |= (fiberErr & QIE8HeaderSpec::MASK_FIBERERR) << QIE8HeaderSpec::OFFSET_FIBERERR;
     }
@@ -418,13 +418,9 @@ public:
 
     int fiber = eid.fiberIndex();
     int fiberchan = eid.fiberChanId();
-    // capacitor id for the first sample
-
     int flavor = qiedf[0].flavor();
-    int capid0;
-    if (qiedf.samples() == 0)
-      capid0 = 0;
-    else if (flavor == 3) {
+
+    if (flavor == 3) {
       header |= (fiberchan & QIE11HeaderSpec3::MASK_FIBERCHAN) << QIE11HeaderSpec3::OFFSET_FIBERCHAN;
       header |= (fiber & QIE11HeaderSpec3::MASK_FIBER) << QIE11HeaderSpec3::OFFSET_FIBER;
       header |= (0x0 & QIE11HeaderSpec3::MASK_MP) << QIE11HeaderSpec3::OFFSET_MP;
@@ -432,7 +428,7 @@ public:
       header |= (flavor & QIE11HeaderSpec3::MASK_FLAVOR) << QIE11HeaderSpec3::OFFSET_FLAVOR;  //flavor
       header |= (0x1 & QIE11HeaderSpec3::MASK_HEADER_BIT) << QIE11HeaderSpec3::OFFSET_HEADER_BIT;
     } else {
-      capid0 = qiedf[0].capid();
+      int capid0 = qiedf[0].capid();
       header |= (fiberchan & QIE11HeaderSpec0::MASK_FIBERCHAN) << QIE11HeaderSpec0::OFFSET_FIBERCHAN;
       header |= (fiber & QIE11HeaderSpec0::MASK_FIBER) << QIE11HeaderSpec0::OFFSET_FIBER;
       header |= (capid0 & QIE11HeaderSpec0::MASK_CAPID) << QIE11HeaderSpec0::OFFSET_CAPID;
@@ -622,7 +618,7 @@ public:
 
 QIE11DataFrame convertHB(QIE11DataFrame qiehe) {
   QIE11DataFrame qiehb = qiehe;
-  int adc, tdc, capid;
+  int adc, tdc;
   bool soi;
   int is = 0;
 
@@ -652,7 +648,7 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe) {
 
   // puting flavor is safe here because flavor is stored in the same bits for all flavors
   qiehb.setFlavor(hbflavor);
-  capid = qiehe[0].capid();
+  int capid = qiehe[0].capid();
   qiehb.setCapid0(capid);
 
   return qiehb;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
@@ -9,6 +9,7 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalCoderFactory.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSimParameterMap.h"
 
 class HBHEDataFrame;
 class HODataFrame;
@@ -23,7 +24,7 @@ namespace CLHEP {
 
 class HcalElectronicsSim {
 public:
-  HcalElectronicsSim(HcalAmplifier* amplifier, const HcalCoderFactory* coderFactory, bool PreMix);
+  HcalElectronicsSim(const HcalSimParameterMap* parameterMap, HcalAmplifier* amplifier, const HcalCoderFactory* coderFactory, bool PreMix);
   ~HcalElectronicsSim();
 
   void setDbService(const HcalDbService* service);
@@ -73,6 +74,7 @@ private:
   template <class Digi>
   void premix(CaloSamples& frame, Digi& result, double preMixFactor, unsigned preMixBits);
 
+  const HcalSimParameterMap* theParameterMap;
   HcalAmplifier* theAmplifier;
   const HcalCoderFactory* theCoderFactory;
   HcalTDC theTDC;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h
@@ -24,7 +24,10 @@ namespace CLHEP {
 
 class HcalElectronicsSim {
 public:
-  HcalElectronicsSim(const HcalSimParameterMap* parameterMap, HcalAmplifier* amplifier, const HcalCoderFactory* coderFactory, bool PreMix);
+  HcalElectronicsSim(const HcalSimParameterMap* parameterMap,
+                     HcalAmplifier* amplifier,
+                     const HcalCoderFactory* coderFactory,
+                     bool PreMix);
   ~HcalElectronicsSim();
 
   void setDbService(const HcalDbService* service);

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h
@@ -41,6 +41,7 @@ public:
   int pixels(const DetId& detId) const;
   bool doSiPMSmearing() const { return theSiPMSmearing; }
 
+  double threshold_currentTDC() const { return threshold_currentTDC_; }
   double sipmTau() const { return theSiPMTau; }
   double sipmDarkCurrentuA(const DetId& detId) const;
   double sipmCrossTalk(const DetId& detId) const;
@@ -59,6 +60,7 @@ private:
   bool doTimeSmear_;
   HcalTimeSmearSettings theSmearSettings;
   double theSiPMTau;
+  double threshold_currentTDC_;
 };
 
 #endif

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
@@ -1,4 +1,4 @@
-// -*- mode: c++ -*- 
+// -*- mode: c++ -*-
 #ifndef HcalSimAlgos_HcalTDC_h
 #define HcalSimAlgos_HcalTDC_h
 
@@ -15,17 +15,16 @@ namespace CLHEP {
 }
 
 class HcalTDC {
-
 public:
   HcalTDC(double threshold_currentTDC = 0.);
   ~HcalTDC();
 
   /// adds timing information to the digi
   /// template <class Digi>
-  void timing(const CaloSamples & lf, QIE11DataFrame & digi) const;
+  void timing(const CaloSamples& lf, QIE11DataFrame& digi) const;
 
   /// the Producer will probably update this every event
-  void setDbService(const HcalDbService * service);
+  void setDbService(const HcalDbService* service);
 
   void setThresholdDAC(unsigned int DAC) { theDAC = DAC; }
   unsigned int getThresholdDAC() { return theDAC; }
@@ -33,7 +32,7 @@ public:
 
 private:
   HcalTDCParameters theTDCParameters;
-  const HcalDbService * theDbService;
+  const HcalDbService* theDbService;
 
   unsigned int theDAC;
   double threshold_currentTDC_;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
@@ -6,6 +6,7 @@
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h"
 #include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 class HcalDbService;
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h
@@ -1,10 +1,11 @@
-// -*- mode: c++ -*-
+// -*- mode: c++ -*- 
 #ifndef HcalSimAlgos_HcalTDC_h
 #define HcalSimAlgos_HcalTDC_h
 
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalTDCParameters.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 
 class HcalDbService;
 
@@ -13,29 +14,28 @@ namespace CLHEP {
 }
 
 class HcalTDC {
+
 public:
-  HcalTDC(unsigned int thresholdDAC = 12);
+  HcalTDC(double threshold_currentTDC = 0.);
   ~HcalTDC();
 
   /// adds timing information to the digi
-  template <class Digi>
-  void timing(const CaloSamples& lf, Digi& digi, CLHEP::HepRandomEngine*) const;
+  /// template <class Digi>
+  void timing(const CaloSamples & lf, QIE11DataFrame & digi) const;
 
   /// the Producer will probably update this every event
-  void setDbService(const HcalDbService* service);
+  void setDbService(const HcalDbService * service);
 
   void setThresholdDAC(unsigned int DAC) { theDAC = DAC; }
   unsigned int getThresholdDAC() { return theDAC; }
+  double getThreshold() const { return threshold_currentTDC_; };
 
 private:
-  double getThreshold(const HcalGenericDetId& detId, CLHEP::HepRandomEngine*) const;
-  double getHysteresisThreshold(double nominal) const;
-
   HcalTDCParameters theTDCParameters;
-  const HcalDbService* theDbService;
+  const HcalDbService * theDbService;
 
   unsigned int theDAC;
-
+  double threshold_currentTDC_;
   double const lsb;
 };
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -10,7 +10,10 @@
 #include "CLHEP/Random/RandFlat.h"
 #include <cmath>
 
-HcalElectronicsSim::HcalElectronicsSim(const HcalSimParameterMap* parameterMap, HcalAmplifier* amplifier, const HcalCoderFactory* coderFactory, bool PreMixing)
+HcalElectronicsSim::HcalElectronicsSim(const HcalSimParameterMap* parameterMap,
+                                       HcalAmplifier* amplifier,
+                                       const HcalCoderFactory* coderFactory,
+                                       bool PreMixing)
     : theParameterMap(parameterMap),
       theAmplifier(amplifier),
       theCoderFactory(coderFactory),
@@ -140,7 +143,7 @@ void HcalElectronicsSim::analogToDigital(
 void HcalElectronicsSim::analogToDigital(
     CLHEP::HepRandomEngine* engine, CaloSamples& lf, QIE11DataFrame& result, double preMixFactor, unsigned preMixBits) {
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
-  if (!PreMixDigis) { 
+  if (!PreMixDigis) {
     const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
     HcalTDC theTDC((pars.threshold_currentTDC()));
     theTDC.timing(lf, result);

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -1,4 +1,6 @@
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalElectronicsSim.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalTDC.h"
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDigi/interface/HODataFrame.h"
 #include "DataFormats/HcalDigi/interface/HFDataFrame.h"
@@ -8,8 +10,9 @@
 #include "CLHEP/Random/RandFlat.h"
 #include <cmath>
 
-HcalElectronicsSim::HcalElectronicsSim(HcalAmplifier* amplifier, const HcalCoderFactory* coderFactory, bool PreMixing)
-    : theAmplifier(amplifier),
+HcalElectronicsSim::HcalElectronicsSim(const HcalSimParameterMap* parameterMap, HcalAmplifier* amplifier, const HcalCoderFactory* coderFactory, bool PreMixing)
+    : theParameterMap(parameterMap),
+      theAmplifier(amplifier),
       theCoderFactory(coderFactory),
       theStartingCapId(0),
       theStartingCapIdIsRandom(true),
@@ -137,6 +140,11 @@ void HcalElectronicsSim::analogToDigital(
 void HcalElectronicsSim::analogToDigital(
     CLHEP::HepRandomEngine* engine, CaloSamples& lf, QIE11DataFrame& result, double preMixFactor, unsigned preMixBits) {
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
+  if (!PreMixDigis) { 
+    const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
+    HcalTDC theTDC((pars.threshold_currentTDC()));
+    theTDC.timing(lf, result);
+  }
 }
 
 void HcalElectronicsSim::newEvent(CLHEP::HepRandomEngine* engine) {

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSimParameters.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSimParameters.cc
@@ -46,7 +46,8 @@ HcalSimParameters::HcalSimParameters(const edm::ParameterSet& p)
       theSamplingFactors(p.getParameter<std::vector<double> >("samplingFactors")),
       theSiPMSmearing(p.getParameter<bool>("doSiPMSmearing")),
       doTimeSmear_(p.getParameter<bool>("timeSmearing")),
-      theSiPMTau(p.getParameter<double>("sipmTau")) {
+      theSiPMTau(p.getParameter<double>("sipmTau")),
+      threshold_currentTDC_(p.getParameter<double>("threshold_currentTDC")) {
   defaultTimeSmearing();
 
   edm::LogInfo("HcalSimParameters:") << " doSiPMsmearing    = " << theSiPMSmearing;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -5,31 +5,26 @@
 
 #include "CLHEP/Random/RandGaussQ.h"
 
-HcalTDC::HcalTDC(unsigned int thresholdDAC)
-    : theTDCParameters(), theDbService(nullptr), theDAC(thresholdDAC), lsb(3.74) {}
 
-HcalTDC::~HcalTDC() {}
+HcalTDC::HcalTDC(double threshold_currentTDC) : theTDCParameters(), 
+					      theDbService(nullptr),
+					      threshold_currentTDC_(threshold_currentTDC),
+					      lsb(3.74) {}
 
-template <class Digi>
-void HcalTDC::timing(const CaloSamples& lf, Digi& digi, CLHEP::HepRandomEngine* engine) const {
-  float const TDC_Threshold(getThreshold(digi.id(), engine));
-  float const TDC_Threshold_hyst(TDC_Threshold);
-  bool risingReady(true), fallingReady(false);
+HcalTDC::~HcalTDC() {
+}
+
+//template <class Digi>
+void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame & digi) const {
+
+  float const TDC_Threshold(getThreshold());
+  bool risingReady(true);
   int tdcBins = theTDCParameters.nbins();
-  // start with a loop over 10 samples
-  bool hasTDCValues = true;
-  if (lf.preciseSize() == 0)
-    hasTDCValues = false;
+  bool hasTDCValues=true;
+  if (lf.preciseSize()==0 ) hasTDCValues=false;
 
-  // "AC" hysteresis from Tom:  There cannot be a second transition
-  // within the QIE within 3ns
-  int const rising_ac_hysteresis(5);
-  int lastRisingEdge(0);
+  //std::cout << "TDC threshold: " << TDC_Threshold << std::endl; 
 
-  // if (hasTDCValues)
-  //   std::cout << digi.id()
-  // 	      << " threshold: " << TDC_Threshold
-  // 	      << '\n';
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
     /*
     If in a given 25ns bunch/time sample, the pulse is above
@@ -45,83 +40,62 @@ void HcalTDC::timing(const CaloSamples& lf, Digi& digi, CLHEP::HepRandomEngine* 
     TDC_FallingEdge=62.
     */
     // special codes
-    int TDC_RisingEdge = (risingReady) ? theTDCParameters.noTransitionCode() : theTDCParameters.alreadyTransitionCode();
-    int TDC_FallingEdge =
-        (fallingReady) ? theTDCParameters.alreadyTransitionCode() : theTDCParameters.noTransitionCode();
+    int TDC_RisingEdge = (risingReady) ? 
+      theTDCParameters.noTransitionCode() :
+      theTDCParameters.alreadyTransitionCode();
     int preciseBegin = ibin * tdcBins;
     int preciseEnd = preciseBegin + tdcBins;
-    if (hasTDCValues) {
-      // std::cout << " alreadyOn: " << alreadyOn << '\n';
-      for (int i = preciseBegin; i < preciseEnd; ++i) {
-        // 	std::cout << " preciseBin: " << i
-        // 			    << " preciseAt(i): " << lf.preciseAt(i);
-        if ((fallingReady) && (i % 3 == 0) && (lf.preciseAt(i) < TDC_Threshold)) {
-          fallingReady = false;
-          TDC_FallingEdge = i - preciseBegin;
-          // std::cout << " falling ";
-        }
-        if ((risingReady) && (lf.preciseAt(i) > TDC_Threshold)) {
-          risingReady = false;
-          TDC_RisingEdge = i - preciseBegin;
-          lastRisingEdge = 0;
-          // std::cout << " rising ";
-        }
-        // std::cout << '\n';
 
-        //This is the place for hysteresis code.  Need to to arm the
-        //tdc by setting the risingReady or fallingReady to true.
+    if ( hasTDCValues) {
+      for(int i = preciseBegin; i < preciseEnd; ++i) { //find the TDC time value in each TS 
 
-        if ((!fallingReady) && (lf.preciseAt(i) > TDC_Threshold)) {
-          fallingReady = true;
-          if (TDC_FallingEdge == theTDCParameters.alreadyTransitionCode())
-            TDC_FallingEdge = theTDCParameters.noTransitionCode();
-        }
-        if ((!risingReady) && (lastRisingEdge > rising_ac_hysteresis) && (lf.preciseAt(i) < TDC_Threshold_hyst)) {
-          risingReady = true;
-          if (TDC_RisingEdge == theTDCParameters.alreadyTransitionCode())
-            TDC_RisingEdge = theTDCParameters.noTransitionCode();
-        }
-        ++lastRisingEdge;
-      }
+    	  //std::cout << " preciseBin: " << i << " preciseAt(i): " << lf.preciseAt(i) << std::endl;
+
+          if( (!risingReady) && (i==preciseBegin) && (i!=0) ) {
+	    if( ((lf.preciseAt(i+1) - lf.preciseAt(i-1)) > TDC_Threshold) ){
+	      TDC_RisingEdge = theTDCParameters.alreadyTransitionCode();
+              break;
+            } else risingReady = true;
+          }
+
+          if(risingReady){
+            if( i!=399 && i!=0 && (lf.preciseAt(i+1) - lf.preciseAt(i-1)) > TDC_Threshold){
+	      risingReady = false;
+	      TDC_RisingEdge = i-preciseBegin;
+            } else if(i==0 && (lf.preciseAt(i+1) - lf.preciseAt(i))/0.5 > TDC_Threshold){
+              risingReady = false;
+              TDC_RisingEdge = i-preciseBegin;
+            } else if(i==(preciseEnd-1)) TDC_RisingEdge = theTDCParameters.noTransitionCode();
+          }
+
+          if( (!risingReady) && (i==(preciseEnd-1)) && (i!=399) ){
+            if( ((lf.preciseAt(i+1) - lf.preciseAt(i-1)) < TDC_Threshold) ) {
+              risingReady = true;
+            } 
+          }
+      } //end of looping precise bins
     }
+
     // change packing to allow for special codes
-    int packedTDC = TDC_RisingEdge + (tdcBins * 2) * TDC_FallingEdge;
-    digi.setSample(ibin, digi.adc(ibin), packedTDC, true);
-    // if ( hasTDCValues) {
-    //   std::cout << " sample: " << ibin
-    // 		<< " adc: " << digi.adc(ibin)
-    // 		<< " fC: " << digi[ibin].nominal_fC()
-    // 		<< " risingEdge: " << TDC_RisingEdge
-    // 		<< " fallingEdge: " << TDC_FallingEdge
-    // 		<< " packedTDC: " << packedTDC
-    // 		<< std::endl;
-    // }
-  }  // loop over bunch crossing bins
+    int packedTDC = TDC_RisingEdge;
+    digi.setSample(ibin, digi[ibin].adc(), packedTDC, digi[ibin].soi());
+
+    /*if ( hasTDCValues) {
+	if(digi.hcaldetid().ieta()==1&&digi.hcaldetid().iphi()==1){
+            std::cout << " Depth: " << digi.hcaldetid().depth() 
+		<< " sample: " << ibin << " adc: " << digi[ibin].adc() 
+		<< " capid: " << digi[ibin].capid() 
+		<< " risingEdge: " << TDC_RisingEdge 
+		<< " packedTDC: " << packedTDC 
+		<< " tdc: " << digi[ibin].tdc() 
+		<< " flavor(HE=0/HB=3): " << digi.flavor() 
+		<< " SubDet(HE=2/HB=1): " << digi.hcaldetid().subdet() 
+		<< std::endl;
+        }
+    }*/
+  } // loop over bunch crossing bins
 }
 
-double HcalTDC::getThreshold(const HcalGenericDetId& detId, CLHEP::HepRandomEngine* engine) const {
-  // subtract off pedestal and noise once
-  double pedestal = theDbService->getHcalCalibrations(detId).pedestal(0);
-  double pedestalWidth = theDbService->getHcalCalibrationWidths(detId).pedestal(0);
-  // here the TDCthreshold_ is a multiple of the least significant bit
-  // for the TDC portion of the QIE.  The nominal reference is 40 uA which is
-  // divided by an 8 bit DAC.  This means the least significant bit is 0.135 uA
-  // in the TDC circuit or 3.74 uA at the input current.
-
-  // the pedestal is assumed to be evenly distributed in time with some
-  // random variation.
-
-  return lsb * theDAC - CLHEP::RandGaussQ::shoot(engine, pedestal, pedestalWidth) / theTDCParameters.deltaT() /
-                            theTDCParameters.nbins();
+void HcalTDC::setDbService(const HcalDbService * service) {
+  theDbService = service;
 }
-
-double HcalTDC::getHysteresisThreshold(double nominal) const {
-  // the TDC will "re-arm" when it crosses the threshold minus 2.5 mV.
-  // the lsb is 44kOhm * (3.74 uA / 24) = 6.86 mV.  2.5 mV is 0.36 lsb.
-  // with the this means that the hysteresis it isn't far from the nominal
-  // threshold
-
-  return nominal - 0.365 * lsb;
-}
-
-void HcalTDC::setDbService(const HcalDbService* service) { theDbService = service; }

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -42,8 +42,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
     if (hasTDCValues) {
       for (int i = preciseBegin; i < preciseEnd; ++i) {  //find the TDC time value in each TS
 
-        //std::cout << " preciseBin: " << i << " preciseAt(i): " << lf.preciseAt(i) << std::endl;
-
         if ((!risingReady) && (i == preciseBegin) && (i != 0)) {
           if (((lf.preciseAt(i + 1) - lf.preciseAt(i - 1)) > TDC_Threshold)) {
             TDC_RisingEdge = theTDCParameters.alreadyTransitionCode();
@@ -75,20 +73,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
     int packedTDC = TDC_RisingEdge;
     digi.setSample(ibin, digi[ibin].adc(), packedTDC, digi[ibin].soi());
 
-    /*if ( hasTDCValues) {
-	if(HcalDetId(digi.detid()).ieta()==1&&HcalDetId(digi.detid()).iphi()==1){
-            std::cout << " Depth: " << HcalDetId(digi.detid()).depth() 
-		<< " sample: " << ibin << " adc: " << digi[ibin].adc() 
-		<< " capid: " << digi[ibin].capid() 
-		<< " risingEdge: " << TDC_RisingEdge 
-		<< " packedTDC: " << packedTDC 
-		<< " tdc: " << digi[ibin].tdc() 
-		<< " flavor(HE=0/HB=3): " << digi.flavor() 
-		<< " SubDet(HE=2/HB=1): " << HcalDetId(digi.detid()).subdet() 
-		<< std::endl;
-        }
-    }*/
-    // if(HcalDetId(digi.detid()).ieta()==1&&HcalDetId(digi.detid()).iphi()==1) std::cout<<digi<<std::endl;
   }  // loop over bunch crossing bins
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -18,8 +18,6 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
   if (lf.preciseSize() == 0)
     hasTDCValues = false;
 
-  //std::cout << "TDC threshold: " << TDC_Threshold << std::endl;
-
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
     /*
     If in a given 25ns bunch/time sample, the pulse is above

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -4,25 +4,21 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CLHEP/Random/RandGaussQ.h"
 
+HcalTDC::HcalTDC(double threshold_currentTDC)
+    : theTDCParameters(), theDbService(nullptr), threshold_currentTDC_(threshold_currentTDC), lsb(3.74) {}
 
-HcalTDC::HcalTDC(double threshold_currentTDC) : theTDCParameters(), 
-					      theDbService(nullptr),
-					      threshold_currentTDC_(threshold_currentTDC),
-					      lsb(3.74) {}
-
-HcalTDC::~HcalTDC() {
-}
+HcalTDC::~HcalTDC() {}
 
 //template <class Digi>
-void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame & digi) const {
-
+void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
   float const TDC_Threshold(getThreshold());
   bool risingReady(true);
   int tdcBins = theTDCParameters.nbins();
-  bool hasTDCValues=true;
-  if (lf.preciseSize()==0 ) hasTDCValues=false;
+  bool hasTDCValues = true;
+  if (lf.preciseSize() == 0)
+    hasTDCValues = false;
 
-  //std::cout << "TDC threshold: " << TDC_Threshold << std::endl; 
+  //std::cout << "TDC threshold: " << TDC_Threshold << std::endl;
 
   for (int ibin = 0; ibin < lf.size(); ++ibin) {
     /*
@@ -39,40 +35,40 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame & digi) const {
     TDC_FallingEdge=62.
     */
     // special codes
-    int TDC_RisingEdge = (risingReady) ? 
-      theTDCParameters.noTransitionCode() :
-      theTDCParameters.alreadyTransitionCode();
+    int TDC_RisingEdge = (risingReady) ? theTDCParameters.noTransitionCode() : theTDCParameters.alreadyTransitionCode();
     int preciseBegin = ibin * tdcBins;
     int preciseEnd = preciseBegin + tdcBins;
 
-    if ( hasTDCValues) {
-      for(int i = preciseBegin; i < preciseEnd; ++i) { //find the TDC time value in each TS 
+    if (hasTDCValues) {
+      for (int i = preciseBegin; i < preciseEnd; ++i) {  //find the TDC time value in each TS
 
-    	  //std::cout << " preciseBin: " << i << " preciseAt(i): " << lf.preciseAt(i) << std::endl;
+        //std::cout << " preciseBin: " << i << " preciseAt(i): " << lf.preciseAt(i) << std::endl;
 
-          if( (!risingReady) && (i==preciseBegin) && (i!=0) ) {
-	    if( ((lf.preciseAt(i+1) - lf.preciseAt(i-1)) > TDC_Threshold) ){
-	      TDC_RisingEdge = theTDCParameters.alreadyTransitionCode();
-              break;
-            } else risingReady = true;
+        if ((!risingReady) && (i == preciseBegin) && (i != 0)) {
+          if (((lf.preciseAt(i + 1) - lf.preciseAt(i - 1)) > TDC_Threshold)) {
+            TDC_RisingEdge = theTDCParameters.alreadyTransitionCode();
+            break;
+          } else
+            risingReady = true;
+        }
+
+        if (risingReady) {
+          if (i != 399 && i != 0 && (lf.preciseAt(i + 1) - lf.preciseAt(i - 1)) > TDC_Threshold) {
+            risingReady = false;
+            TDC_RisingEdge = i - preciseBegin;
+          } else if (i == 0 && (lf.preciseAt(i + 1) - lf.preciseAt(i)) / 0.5 > TDC_Threshold) {
+            risingReady = false;
+            TDC_RisingEdge = i - preciseBegin;
+          } else if (i == (preciseEnd - 1))
+            TDC_RisingEdge = theTDCParameters.noTransitionCode();
+        }
+
+        if ((!risingReady) && (i == (preciseEnd - 1)) && (i != 399)) {
+          if (((lf.preciseAt(i + 1) - lf.preciseAt(i - 1)) < TDC_Threshold)) {
+            risingReady = true;
           }
-
-          if(risingReady){
-            if( i!=399 && i!=0 && (lf.preciseAt(i+1) - lf.preciseAt(i-1)) > TDC_Threshold){
-	      risingReady = false;
-	      TDC_RisingEdge = i-preciseBegin;
-            } else if(i==0 && (lf.preciseAt(i+1) - lf.preciseAt(i))/0.5 > TDC_Threshold){
-              risingReady = false;
-              TDC_RisingEdge = i-preciseBegin;
-            } else if(i==(preciseEnd-1)) TDC_RisingEdge = theTDCParameters.noTransitionCode();
-          }
-
-          if( (!risingReady) && (i==(preciseEnd-1)) && (i!=399) ){
-            if( ((lf.preciseAt(i+1) - lf.preciseAt(i-1)) < TDC_Threshold) ) {
-              risingReady = true;
-            } 
-          }
-      } //end of looping precise bins
+        }
+      }  //end of looping precise bins
     }
 
     // change packing to allow for special codes
@@ -92,9 +88,7 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame & digi) const {
 		<< std::endl;
         }
     }*/
-  } // loop over bunch crossing bins
+  }  // loop over bunch crossing bins
 }
 
-void HcalTDC::setDbService(const HcalDbService * service) {
-  theDbService = service;
-}
+void HcalTDC::setDbService(const HcalDbService* service) { theDbService = service; }

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -76,18 +76,19 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame& digi) const {
     digi.setSample(ibin, digi[ibin].adc(), packedTDC, digi[ibin].soi());
 
     /*if ( hasTDCValues) {
-	if(HcalDetId(hcaldetid()).ieta()==1&&HcalDetId(hcaldetid()).iphi()==1){
-            std::cout << " Depth: " << digi.hcaldetid().depth() 
+	if(HcalDetId(digi.detid()).ieta()==1&&HcalDetId(digi.detid()).iphi()==1){
+            std::cout << " Depth: " << HcalDetId(digi.detid()).depth() 
 		<< " sample: " << ibin << " adc: " << digi[ibin].adc() 
 		<< " capid: " << digi[ibin].capid() 
 		<< " risingEdge: " << TDC_RisingEdge 
 		<< " packedTDC: " << packedTDC 
 		<< " tdc: " << digi[ibin].tdc() 
 		<< " flavor(HE=0/HB=3): " << digi.flavor() 
-		<< " SubDet(HE=2/HB=1): " << digi.hcaldetid().subdet() 
+		<< " SubDet(HE=2/HB=1): " << HcalDetId(digi.detid()).subdet() 
 		<< std::endl;
         }
     }*/
+    // if(HcalDetId(digi.detid()).ieta()==1&&HcalDetId(digi.detid()).iphi()==1) std::cout<<digi<<std::endl;
   }  // loop over bunch crossing bins
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTDC.cc
@@ -2,7 +2,6 @@
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include "CLHEP/Random/RandGaussQ.h"
 
 
@@ -81,7 +80,7 @@ void HcalTDC::timing(const CaloSamples& lf, QIE11DataFrame & digi) const {
     digi.setSample(ibin, digi[ibin].adc(), packedTDC, digi[ibin].soi());
 
     /*if ( hasTDCValues) {
-	if(digi.hcaldetid().ieta()==1&&digi.hcaldetid().iphi()==1){
+	if(HcalDetId(hcaldetid()).ieta()==1&&HcalDetId(hcaldetid()).iphi()==1){
             std::cout << " Depth: " << digi.hcaldetid().depth() 
 		<< " sample: " << ibin << " adc: " << digi[ibin].adc() 
 		<< " capid: " << digi[ibin].capid() 

--- a/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalDigitizerTest.cc
@@ -230,7 +230,7 @@ void HcalDigitizerTest::analyze(const edm::Event& iEvent, const edm::EventSetup&
   bool PM2 = false;
   HcalAmplifier amplifier(&parameterMap, addNoise, PM1, PM2);
   HcalCoderFactory coderFactory(HcalCoderFactory::NOMINAL);
-  HcalElectronicsSim electronicsSim(&amplifier, &coderFactory, PM1);
+  HcalElectronicsSim electronicsSim(&parameterMap, &amplifier, &coderFactory, PM1);
   amplifier.setDbService(&calibratorHandle);
   amplifier.setTimeSlew(hcalTimeSlew_delay_);
   parameterMap.setDbService(&calibratorHandle);

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -21,6 +21,7 @@ hcalSimParameters = cms.PSet(
         timePhase = cms.double(14.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
+        threshold_currentTDC = cms.double(18.7),
     ),
     hf2 = cms.PSet(
         readoutFrameSize = cms.int32(4),
@@ -33,6 +34,7 @@ hcalSimParameters = cms.PSet(
         timePhase = cms.double(13.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
+        threshold_currentTDC = cms.double(18.7),
     ),
     ho = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -50,6 +52,7 @@ hcalSimParameters = cms.PSet(
         siPMCode = cms.int32(2),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(5.),
+        threshold_currentTDC = cms.double(18.7),
     ),
     hb = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -67,6 +70,7 @@ hcalSimParameters = cms.PSet(
         timeSmearing = cms.bool(True),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
+        threshold_currentTDC = cms.double(18.7),
     ),
     he = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -83,6 +87,7 @@ hcalSimParameters = cms.PSet(
         timeSmearing = cms.bool(True),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
+        threshold_currentTDC = cms.double(18.7),
     ),
     zdc = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -95,6 +100,7 @@ hcalSimParameters = cms.PSet(
         timePhase = cms.double(-4.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
+        threshold_currentTDC = cms.double(18.7),
     ),
 )
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -129,18 +129,22 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
 
   theCoderFactory = std::make_unique<HcalCoderFactory>(HcalCoderFactory::DB);
 
-  theHBHEElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theHBHEAmplifier.get(), theCoderFactory.get(), PreMix1);
-  theHFElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theHFAmplifier.get(), theCoderFactory.get(), PreMix1);
-  theHOElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theHOAmplifier.get(), theCoderFactory.get(), PreMix1);
-  theZDCElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theZDCAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theHBHEElectronicsSim =
+      std::make_unique<HcalElectronicsSim>(&theParameterMap, theHBHEAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theHFElectronicsSim =
+      std::make_unique<HcalElectronicsSim>(&theParameterMap, theHFAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theHOElectronicsSim =
+      std::make_unique<HcalElectronicsSim>(&theParameterMap, theHOAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theZDCElectronicsSim =
+      std::make_unique<HcalElectronicsSim>(&theParameterMap, theZDCAmplifier.get(), theCoderFactory.get(), PreMix1);
   theHFQIE10ElectronicsSim =
-      std::make_unique<HcalElectronicsSim>(&theParameterMap, 
-					   theHFQIE10Amplifier.get(),
+      std::make_unique<HcalElectronicsSim>(&theParameterMap,
+                                           theHFQIE10Amplifier.get(),
                                            theCoderFactory.get(),
                                            PreMix1);  // should this use a different coder factory?
   theHBHEQIE11ElectronicsSim =
-      std::make_unique<HcalElectronicsSim>(&theParameterMap, 
-					   theHBHEQIE11Amplifier.get(),
+      std::make_unique<HcalElectronicsSim>(&theParameterMap,
+                                           theHBHEQIE11Amplifier.get(),
                                            theCoderFactory.get(),
                                            PreMix1);  // should this use a different coder factory?
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -129,16 +129,18 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
 
   theCoderFactory = std::make_unique<HcalCoderFactory>(HcalCoderFactory::DB);
 
-  theHBHEElectronicsSim = std::make_unique<HcalElectronicsSim>(theHBHEAmplifier.get(), theCoderFactory.get(), PreMix1);
-  theHFElectronicsSim = std::make_unique<HcalElectronicsSim>(theHFAmplifier.get(), theCoderFactory.get(), PreMix1);
-  theHOElectronicsSim = std::make_unique<HcalElectronicsSim>(theHOAmplifier.get(), theCoderFactory.get(), PreMix1);
-  theZDCElectronicsSim = std::make_unique<HcalElectronicsSim>(theZDCAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theHBHEElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theHBHEAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theHFElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theHFAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theHOElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theHOAmplifier.get(), theCoderFactory.get(), PreMix1);
+  theZDCElectronicsSim = std::make_unique<HcalElectronicsSim>(&theParameterMap, theZDCAmplifier.get(), theCoderFactory.get(), PreMix1);
   theHFQIE10ElectronicsSim =
-      std::make_unique<HcalElectronicsSim>(theHFQIE10Amplifier.get(),
+      std::make_unique<HcalElectronicsSim>(&theParameterMap, 
+					   theHFQIE10Amplifier.get(),
                                            theCoderFactory.get(),
                                            PreMix1);  // should this use a different coder factory?
   theHBHEQIE11ElectronicsSim =
-      std::make_unique<HcalElectronicsSim>(theHBHEQIE11Amplifier.get(),
+      std::make_unique<HcalElectronicsSim>(&theParameterMap, 
+					   theHBHEQIE11Amplifier.get(),
                                            theCoderFactory.get(),
                                            PreMix1);  // should this use a different coder factory?
 

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -17,6 +17,7 @@
 #include "SimCalorimetry/HcalTestBeam/interface/HcalTBSimParameterMap.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSimParameters.h"
 
 #include <string>
 #include <vector>
@@ -62,6 +63,7 @@ private:
   typedef CaloTDigitizer<HODigitizerTraits> HODigitizer;
 
   HcalTBSimParameterMap *theParameterMap;
+  HcalSimParameterMap *paraMap;
   CaloVShape *theHcalShape;
   CaloVShape *theHcalIntegratedShape;
 

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -23,6 +23,7 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
                                        edm::ProducerBase &mixMod,
                                        edm::ConsumesCollector &iC)
     : theParameterMap(new HcalTBSimParameterMap(ps)),
+      paraMap(new HcalSimParameterMap(ps)),
       theHcalShape(new HcalShape()),
       theHcalIntegratedShape(new CaloShapeIntegrator(theHcalShape)),
       theHBHEResponse(new CaloHitResponse(theParameterMap, theHcalIntegratedShape)),
@@ -53,7 +54,7 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet &ps,
   bool dummy2 = false;  // extra arguments for premixing
   theAmplifier = new HcalAmplifier(theParameterMap, doNoise, dummy1, dummy2);
   theCoderFactory = new HcalCoderFactory(HcalCoderFactory::DB);
-  theElectronicsSim = new HcalElectronicsSim(theAmplifier, theCoderFactory, dummy1);
+  theElectronicsSim = new HcalElectronicsSim(paraMap, theAmplifier, theCoderFactory, dummy1);
 
   double minFCToDelay = ps.getParameter<double>("minFCToDelay");
   bool doTimeSlew = ps.getParameter<bool>("doTimeSlew");


### PR DESCRIPTION
#### PR description:
1,Update of the HB/HE TDC simulation
    The current version of HcalTDC.cc was developed but obsolete and never used in simulation production. The algorithm in it is rewritten to provide TDC timing according to the specifications of QIE11 running at p5, and the timing method is now used when simulating hcal electronics to get the TDC time
2, Modification of MC Digis packing (PackerHelp.h and HCalDigiToRawuHTR.cc)
    Convert the data format according to uHTR specifications for HB 
3, Making TDC current cut a configurable (HcalElectronicsSim.cc and some other files)
    Passed a new variable to the constructor to allow for tuning of TDC current threshold from python configuration files.

#### PR validation:

(1) pion-gun results are identical w/wo the TDC branch in 11_0_0_pre11: [results here](https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/Run3/11_0_0_pre11_run3_TDC_vs_11_0_0_pre11_run3_SinglePi/)

(2) TDC has been tested privately and yields expected results; eg. page 5 [here](https://indico.cern.ch/event/856715/contributions/3606082/attachments/1929084/3194540/TDC_in_Simulation.pdf)

(3) runTheMatrix.py -s test is OK.

