### PR TITLE
mark mutable atomic_value_ptr members as CMS_THREAD_SAFE in [V]ParamererSetEntry

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSetEntry.h
+++ b/FWCore/ParameterSet/interface/ParameterSetEntry.h
@@ -8,6 +8,7 @@
   */
 
 #include "FWCore/Utilities/interface/atomic_value_ptr.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
 namespace cms {
@@ -57,7 +58,7 @@ namespace edm {
     bool isTracked_;
     // can be internally reconstituted from the ID, in an
     // ostensibly const function
-    mutable atomic_value_ptr<ParameterSet> thePSet_;
+    CMS_THREAD_SAFE mutable atomic_value_ptr<ParameterSet> thePSet_;
 
     ParameterSetID theID_;
   };

--- a/FWCore/ParameterSet/interface/VParameterSetEntry.h
+++ b/FWCore/ParameterSet/interface/VParameterSetEntry.h
@@ -10,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetEntry.h"
 #include "FWCore/Utilities/interface/value_ptr.h"
 #include "FWCore/Utilities/interface/atomic_value_ptr.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <iosfwd>
 #include <string>
@@ -55,7 +56,7 @@ namespace edm {
 
   private:
     bool tracked_;
-    mutable atomic_value_ptr<std::vector<ParameterSet> > theVPSet_;
+    CMS_THREAD_SAFE mutable atomic_value_ptr<std::vector<ParameterSet> > theVPSet_;
     value_ptr<std::vector<ParameterSetID> > theIDs_;
   };
 }  // namespace edm


### PR DESCRIPTION
based on what's apparently false-positive reports of thread unsafety by the static analyzer.

I expect that this PR will substantially reduce the total count of warnings (IIUC, this count is replicated from every include and use case of [V]ParameterSetEntry)
