### PR TITLE
Redefine (in)valid GEM digis and pads

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMDigi.h
@@ -4,7 +4,7 @@
 /** \class GEMDigi
  *
  * Digi for GEM
- *  
+ *
  * \author Vadim Khotilovich
  *
  */
@@ -20,6 +20,7 @@ public:
   bool operator==(const GEMDigi& digi) const;
   bool operator!=(const GEMDigi& digi) const;
   bool operator<(const GEMDigi& digi) const;
+  bool isValid() const;
 
   // return the strip number. counts from 0.
   int strip() const { return strip_; }

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -5,7 +5,7 @@
  *
  * Cluster of maximal 8 adjacent GEM pad digis
  * with the same BX
- *  
+ *
  * \author Sven Dildick
  *
  */
@@ -22,6 +22,7 @@ public:
   bool operator==(const GEMPadDigiCluster& digi) const;
   bool operator!=(const GEMPadDigiCluster& digi) const;
   bool operator<(const GEMPadDigiCluster& digi) const;
+  bool isValid() const;
 
   const std::vector<uint16_t>& pads() const { return v_; }
   int bx() const { return bx_; }

--- a/DataFormats/GEMDigi/src/GEMDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMDigi.cc
@@ -1,15 +1,9 @@
-/** \file
- * 
- *
- * \author Vadim Khotilovich
- */
-
 #include "DataFormats/GEMDigi/interface/GEMDigi.h"
 #include <iostream>
 
 GEMDigi::GEMDigi(int strip, int bx) : strip_(strip), bx_(bx) {}
 
-GEMDigi::GEMDigi() : strip_(0), bx_(0) {}
+GEMDigi::GEMDigi() : strip_(65535), bx_(-99) {}
 
 // Comparison
 bool GEMDigi::operator==(const GEMDigi& digi) const { return strip_ == digi.strip() and bx_ == digi.bx(); }
@@ -24,6 +18,8 @@ bool GEMDigi::operator<(const GEMDigi& digi) const {
   else
     return digi.bx() < bx_;
 }
+
+bool GEMDigi::isValid() const { return bx_ != -99 and strip_ != 65535; }
 
 std::ostream& operator<<(std::ostream& o, const GEMDigi& digi) {
   return o << " GEMDigi strip = " << digi.strip() << " bx = " << digi.bx();

--- a/DataFormats/GEMDigi/src/GEMPadDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigi.cc
@@ -1,17 +1,9 @@
-/** \file
- *
- *  $Date: 2013/01/18 04:21:50 $
- *  $Revision: 1.1 $
- *
- * \author Vadim Khotilovich
- */
-
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include <iostream>
 
 GEMPadDigi::GEMPadDigi(int pad, int bx) : pad_(pad), bx_(bx) {}
 
-GEMPadDigi::GEMPadDigi() : pad_(0), bx_(0) {}
+GEMPadDigi::GEMPadDigi() : pad_(65535), bx_(-99) {}
 
 // Comparison
 bool GEMPadDigi::operator==(const GEMPadDigi& digi) const { return pad_ == digi.pad() and bx_ == digi.bx(); }
@@ -27,7 +19,7 @@ bool GEMPadDigi::operator<(const GEMPadDigi& digi) const {
     return digi.bx() < bx_;
 }
 
-bool GEMPadDigi::isValid() const { return pad_ != 0; }
+bool GEMPadDigi::isValid() const { return bx_ != -99 and pad_ != 65535; }
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi) {
   return o << " GEMPadDigi Pad = " << digi.pad() << " bx = " << digi.bx();

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -3,7 +3,7 @@
 
 GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads, int bx) : v_(pads), bx_(bx) {}
 
-GEMPadDigiCluster::GEMPadDigiCluster() : v_(std::vector<uint16_t>()), bx_(0) {}
+GEMPadDigiCluster::GEMPadDigiCluster() : v_(std::vector<uint16_t>()), bx_(-99) {}
 
 // Comparison
 bool GEMPadDigiCluster::operator==(const GEMPadDigiCluster& digi) const {
@@ -22,6 +22,8 @@ bool GEMPadDigiCluster::operator<(const GEMPadDigiCluster& digi) const {
   else
     return digi.bx() < bx_;
 }
+
+bool GEMPadDigiCluster::isValid() const { return !v_.empty() and bx_ != -99; }
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi) {
   o << " bx: " << digi.bx() << " pads: ";


### PR DESCRIPTION
#### PR description:

PR #24356 reset the begin pad as 0 instead of 1. This broke a function in the GEM-CSC trigger. To fix it, I redefine when strips, pads and clusters are valid. Default strips/pads are now initialized with bx -99 and strip/pad number 2^16-1. 

#### PR validation:

I checked that it runs with WF 22034. 

#### if this PR is a backport please specify the original PR:

N/A