### PR TITLE
Added consumes to RecoLocalFastTime packages

### DIFF
--- a/RecoLocalFastTime/FTLClusterizer/plugins/MTDCPEESProducer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/plugins/MTDCPEESProducer.cc
@@ -26,11 +26,12 @@ public:
 
 private:
   edm::ParameterSet pset_;
+  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> ddToken_;
 };
 
 MTDCPEESProducer::MTDCPEESProducer(const edm::ParameterSet& p) {
   pset_ = p;
-  setWhatProduced(this, "MTDCPEBase");
+  setWhatProduced(this, "MTDCPEBase").setConsumes(ddToken_);
 }
 
 // Configuration descriptions
@@ -40,10 +41,7 @@ void MTDCPEESProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
 }
 
 std::unique_ptr<MTDClusterParameterEstimator> MTDCPEESProducer::produce(const MTDCPERecord& iRecord) {
-  edm::ESHandle<MTDGeometry> pDD;
-  iRecord.getRecord<MTDDigiGeometryRecord>().get(pDD);
-
-  return std::make_unique<MTDCPEBase>(pset_, *pDD.product());
+  return std::make_unique<MTDCPEBase>(pset_, iRecord.get(ddToken_));
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
@@ -29,12 +29,14 @@ public:
   std::unique_ptr<MTDTimeCalib> produce(const MTDTimeCalibRecord&);
 
 private:
+  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> ddToken_;
+  edm::ESGetToken<MTDTopology, MTDTopologyRcd> topoToken_;
   edm::ParameterSet pset_;
 };
 
 MTDTimeCalibESProducer::MTDTimeCalibESProducer(const edm::ParameterSet& p) {
   pset_ = p;
-  setWhatProduced(this, "MTDTimeCalib");
+  setWhatProduced(this, "MTDTimeCalib").setConsumes(ddToken_).setConsumes(topoToken_);
 }
 
 // Configuration descriptions
@@ -49,13 +51,7 @@ void MTDTimeCalibESProducer::fillDescriptions(edm::ConfigurationDescriptions& de
 }
 
 std::unique_ptr<MTDTimeCalib> MTDTimeCalibESProducer::produce(const MTDTimeCalibRecord& iRecord) {
-  edm::ESHandle<MTDGeometry> pDD;
-  iRecord.getRecord<MTDDigiGeometryRecord>().get(pDD);
-
-  edm::ESHandle<MTDTopology> pTopo;
-  iRecord.getRecord<MTDTopologyRcd>().get(pTopo);
-
-  return std::make_unique<MTDTimeCalib>(pset_, pDD.product(), pTopo.product());
+  return std::make_unique<MTDTimeCalib>(pset_, &iRecord.get(ddToken_), &iRecord.get(topoToken_));
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"


### PR DESCRIPTION
#### PR description:

Also uses ESGetToken to obtained the data.

#### PR validation:

Ran workflows 20434.0, 21234.0, and 22034.0