### PR TITLE
DQM: Reduce TH1 Usage

### DIFF
--- a/Calibration/HcalCalibAlgos/test/ValidationHcalIsoTrackAlCaReco.cc
+++ b/Calibration/HcalCalibAlgos/test/ValidationHcalIsoTrackAlCaReco.cc
@@ -386,13 +386,13 @@ void ValidationHcalIsoTrackAlCaReco::beginJob() {
       dbe_->book2D("hOccupancyFull", "number of tracks per tower, full energy range", 48, -25, 25, 73, 0, 73);
   hOccupancyFull->setAxisTitle("ieta", 1);
   hOccupancyFull->setAxisTitle("iphi", 2);
-  hOccupancyFull->getTH2F()->SetOption("colz");
+  hOccupancyFull->setOption("colz");
   hOccupancyFull->getTH2F()->SetStats(kFALSE);
   hOccupancyHighEn =
       dbe_->book2D("hOccupancyHighEn", "number of tracks per tower, high energy tracks", 48, -25, 25, 73, 0, 73);
   hOccupancyHighEn->setAxisTitle("ieta", 1);
   hOccupancyHighEn->setAxisTitle("iphi", 2);
-  hOccupancyHighEn->getTH2F()->SetOption("colz");
+  hOccupancyHighEn->setOption("colz");
   hOccupancyHighEn->getTH2F()->SetStats(kFALSE);
 
   hOffL3TrackMatch = dbe_->book1D("hOffL3TrackMatch", "Distance from L3 object to offline track", 200, 0, 0.5);

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -243,7 +243,7 @@ void BeamMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const& iRu
 
   h_vx_vy = iBooker.book2D(
       "trk_vx_vy", "Vertex (PCA) position of selected tracks", vxBin_, vxMin_, vxMax_, vxBin_, vxMin_, vxMax_);
-  h_vx_vy->getTH2F()->SetOption("COLZ");
+  h_vx_vy->setOption("COLZ");
   //   h_vx_vy->getTH1()->SetCanExtend(TH1::kAllAxes);
   h_vx_vy->setAxisTitle("x coordinate of input track at PCA (cm)", 1);
   h_vx_vy->setAxisTitle("y coordinate of input track at PCA (cm)", 2);

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -360,14 +360,14 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
   HPTDCErrorFlags_2D->setBinLabel(16, "Wrong EC");
 
   int tmpIndex = 0;
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 0 TDC 18");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 0 TDC 17");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 0 TDC 16");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 0 TDC 15");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 1 TDC 18");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 1 TDC 17");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 1 TDC 16");
-  HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 1 TDC 15");
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 0 TDC 18", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 0 TDC 17", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 0 TDC 16", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 0 TDC 15", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 1 TDC 18", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 1 TDC 17", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 1 TDC 16", /* axis */ 2);
+  HPTDCErrorFlags_2D->setBinLabel(++tmpIndex, "DB 1 TDC 15", /* axis */ 2);
 
   MHComprensive =
       ibooker.book2D("MH in channels", title + " MH (%) in channels;plane number;ch number", 10, -0.5, 4.5, 14, -1, 13);

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -347,17 +347,17 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
 
   leadingWithoutTrailingCumulativePot =
       ibooker.book1D("event category", title + " leading edges without trailing;;%", 3, 0.5, 3.5);
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel(1, "Leading only");
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel(2, "Trailing only");
-  leadingWithoutTrailingCumulativePot->getTH1F()->GetXaxis()->SetBinLabel(3, "Both");
+  leadingWithoutTrailingCumulativePot->setBinLabel(1, "Leading only");
+  leadingWithoutTrailingCumulativePot->setBinLabel(2, "Trailing only");
+  leadingWithoutTrailingCumulativePot->setBinLabel(3, "Both");
 
   ECCheck = ibooker.book1D("optorxEC(8bit) - vfatEC", title + " EC Error;optorxEC-vfatEC", 50, -25, 25);
 
   HPTDCErrorFlags_2D = ibooker.book2D("HPTDC Errors", title + " HPTDC Errors", 16, -0.5, 16.5, 9, -0.5, 8.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
-    HPTDCErrorFlags_2D->getTH2F()->GetXaxis()->SetBinLabel(error_index,
+    HPTDCErrorFlags_2D->setBinLabel(error_index,
                                                            HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
-  HPTDCErrorFlags_2D->getTH2F()->GetXaxis()->SetBinLabel(16, "Wrong EC");
+  HPTDCErrorFlags_2D->setBinLabel(16, "Wrong EC");
 
   int tmpIndex = 0;
   HPTDCErrorFlags_2D->getTH2F()->GetYaxis()->SetBinLabel(++tmpIndex, "DB 0 TDC 18");
@@ -428,9 +428,9 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, un
   CTPPSDiamondDetId(id).channelName(title, CTPPSDiamondDetId::nFull);
 
   leadingWithoutTrailing = ibooker.book1D("event category", title + " Event Category;;%", 3, 0.5, 3.5);
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel(1, "Leading only");
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel(2, "Trailing only");
-  leadingWithoutTrailing->getTH1F()->GetXaxis()->SetBinLabel(3, "Full");
+  leadingWithoutTrailing->setBinLabel(1, "Leading only");
+  leadingWithoutTrailing->setBinLabel(2, "Trailing only");
+  leadingWithoutTrailing->setBinLabel(3, "Full");
 
   activity_per_bx[0] =
       ibooker.book1D("activity per BX 0 25", title + " Activity per BX 0 - 25 ns;Event.BX", 500, -1.5, 498. + 0.5);
@@ -441,9 +441,9 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, un
 
   HPTDCErrorFlags = ibooker.book1D("hptdc_Errors", title + " HPTDC Errors", 16, -0.5, 16.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
-    HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel(error_index,
+    HPTDCErrorFlags->setBinLabel(error_index,
                                                         HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
-  HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel(16, "MH  (%)");
+  HPTDCErrorFlags->setBinLabel(16, "MH  (%)");
 
   leadingEdgeCumulative_both =
       ibooker.book1D("leading edge (le and te)", title + " leading edge (recHits); leading edge (ns)", 75, 0, 75);

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -355,8 +355,7 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
 
   HPTDCErrorFlags_2D = ibooker.book2D("HPTDC Errors", title + " HPTDC Errors", 16, -0.5, 16.5, 9, -0.5, 8.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
-    HPTDCErrorFlags_2D->setBinLabel(error_index,
-                                                           HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
+    HPTDCErrorFlags_2D->setBinLabel(error_index, HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
   HPTDCErrorFlags_2D->setBinLabel(16, "Wrong EC");
 
   int tmpIndex = 0;
@@ -441,8 +440,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, un
 
   HPTDCErrorFlags = ibooker.book1D("hptdc_Errors", title + " HPTDC Errors", 16, -0.5, 16.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
-    HPTDCErrorFlags->setBinLabel(error_index,
-                                                        HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
+    HPTDCErrorFlags->setBinLabel(error_index, HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
   HPTDCErrorFlags->setBinLabel(16, "MH  (%)");
 
   leadingEdgeCumulative_both =

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -355,7 +355,7 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots(DQMStore::IBooker& ibooker, unsigned i
 
   HPTDCErrorFlags_2D = ibooker.book2D("HPTDC Errors", title + " HPTDC Errors", 16, -0.5, 16.5, 9, -0.5, 8.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
-    HPTDCErrorFlags_2D->setBinLabel(error_index, HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
+    HPTDCErrorFlags_2D->setBinLabel(error_index, HPTDCErrorFlags::hptdcErrorName(error_index - 1));
   HPTDCErrorFlags_2D->setBinLabel(16, "Wrong EC");
 
   int tmpIndex = 0;
@@ -440,7 +440,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, un
 
   HPTDCErrorFlags = ibooker.book1D("hptdc_Errors", title + " HPTDC Errors", 16, -0.5, 16.5);
   for (unsigned short error_index = 1; error_index < 16; ++error_index)
-    HPTDCErrorFlags->setBinLabel(error_index, HPTDCErrorFlags::hptdcErrorName(error_index - 1).c_str());
+    HPTDCErrorFlags->setBinLabel(error_index, HPTDCErrorFlags::hptdcErrorName(error_index - 1));
   HPTDCErrorFlags->setBinLabel(16, "MH  (%)");
 
   leadingEdgeCumulative_both =

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -282,19 +282,19 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
         string st3 = ";PlaneIndex(=pixelPot*PlaneMAX + plane)";
         h2HitsMultipl[arm][stn] =
             ibooker.book2DD(st, st + st2 + st3 + ";multiplicity", NPlaneBins, 0, NPlaneBins, hitMultMAX, 0, hitMultMAX);
-        h2HitsMultipl[arm][stn]->getTH2D()->SetOption("colz");
+        h2HitsMultipl[arm][stn]->setOption("colz");
 
         st = "cluster size in planes";
         h2CluSize[arm][stn] = ibooker.book2D(
             st, st + st2 + st3 + ";Cluster size", NPlaneBins, 0, NPlaneBins, ClusterSizeMax + 1, 0, ClusterSizeMax + 1);
-        h2CluSize[arm][stn]->getTH2F()->SetOption("colz");
+        h2CluSize[arm][stn]->setOption("colz");
 
         const float x0Maximum = 70.;
         const float y0Maximum = 15.;
         st = "track intercept point";
         h2trackXY0[indexP] = ibooker.book2D(
             st, st + st2 + ";x0;y0", int(x0Maximum) * 2, 0., x0Maximum, int(y0Maximum) * 4, -y0Maximum, y0Maximum);
-        h2trackXY0[indexP]->getTH2F()->SetOption("colz");
+        h2trackXY0[indexP]->setOption("colz");
 
         st = "number of tracks per event";
         htrackMult[indexP] = ibooker.bookProfile(st,
@@ -377,7 +377,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
           st = "hits position";
           h2xyHits[indexP][p] =
               ibooker.book2DD(st, st1 + ";pix col;pix row", pixRowMAX, 0, pixRowMAX, pixRowMAX, 0, pixRowMAX);
-          h2xyHits[indexP][p]->getTH2D()->SetOption("colz");
+          h2xyHits[indexP][p]->setOption("colz");
 
           st = "adc average value";
           hp2xyADC[indexP][p] = ibooker.bookProfile2D(

--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -105,15 +105,15 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   sprintf(s, "CASTOR BadChannelsMap");
   h2status = ibooker.book2D(s, s, 14, 0., 14., 16, 0., 16.);
-  h2status->getTH2F()->GetXaxis()->SetTitle("Module Z");
+  h2status->setAxisTitle("Module Z");
   h2status->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
-  h2status->getTH2F()->SetOption("colz");
+  h2status->setOption("colz");
 
   sprintf(s, "CASTOR TSmax Significance Map");
   h2TSratio = ibooker.book2D(s, s, 14, 0., 14., 16, 0., 16.);
-  h2TSratio->getTH2F()->GetXaxis()->SetTitle("Module Z");
+  h2TSratio->setAxisTitle("Module Z");
   h2TSratio->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
-  h2TSratio->getTH2F()->SetOption("colz");
+  h2TSratio->setOption("colz");
 
   sprintf(s, "CASTOR TSmax Significance All chan");
   hTSratio = ibooker.book1D(s, s, 105, 0., 1.05);
@@ -122,11 +122,11 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   hdigisize = ibooker.book1DD(s, s, 20, 0., 20.);
   sprintf(s, "ModuleZ(fC)_allTS");
   hModule = ibooker.book1D(s, s, 14, 0., 14.);
-  hModule->getTH1F()->GetXaxis()->SetTitle("ModuleZ");
+  hModule->setAxisTitle("ModuleZ");
   hModule->getTH1F()->GetYaxis()->SetTitle("QIE(fC)");
   sprintf(s, "Sector #phi(fC)_allTS");
   hSector = ibooker.book1D(s, s, 16, 0., 16.);
-  hSector->getTH1F()->GetXaxis()->SetTitle("Sector #phi");
+  hSector->setAxisTitle("Sector #phi");
   hSector->getTH1F()->GetYaxis()->SetTitle("QIE(fC)");
 
   st = "Castor cells avr digi(fC) per event Map TS vs Channel";
@@ -136,21 +136,21 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   st = "Castor cells avr digiRMS(fC) per event Map TS vs Channel";
   h2QrmsTSvsCh = ibooker.book2D(st, st + ";" + string(sTileIndex) + ";TS", 224, 0., 224., 10, 0., 10.);
-  h2QrmsTSvsCh->getTH2F()->SetOption("colz");
+  h2QrmsTSvsCh->setOption("colz");
 
   sprintf(s, "CASTOR data quality");
   h2qualityMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
-  h2qualityMap->getTH2F()->GetXaxis()->SetTitle("module Z");
+  h2qualityMap->setAxisTitle("module Z");
   h2qualityMap->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
-  h2qualityMap->getTH2F()->SetOption("colz");
+  h2qualityMap->setOption("colz");
 
   hReport = ibooker.bookFloat("CASTOR reportSummary");
 
   sprintf(s, "QmeanfC_map(allTS)");
   h2QmeanMap = ibooker.book2D(s, s, 14, 0., 14., 16, 0., 16.);
-  h2QmeanMap->getTH2F()->GetXaxis()->SetTitle("Module Z");
+  h2QmeanMap->setAxisTitle("Module Z");
   h2QmeanMap->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
-  h2QmeanMap->getTH2F()->SetOption("textcolz");
+  h2QmeanMap->setOption("textcolz");
 
   const int NEtow = 20;
   float EhadTow[NEtow + 1];
@@ -173,18 +173,18 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   sprintf(s, "CASTOR_Tower_EMvsEhad(fC)");
   h2towEMvsHAD = ibooker.book2D(s, s, NEtow, EhadTow, NEtow, EMTow);
-  h2towEMvsHAD->getTH2F()->GetXaxis()->SetTitle("Ehad [fC]");
+  h2towEMvsHAD->setAxisTitle("Ehad [fC]");
   h2towEMvsHAD->getTH2F()->GetYaxis()->SetTitle("EM [fC]");
-  h2towEMvsHAD->getTH2F()->SetOption("colz");
+  h2towEMvsHAD->setOption("colz");
 
   sprintf(s, "CASTOR_TowerTotalEnergy(fC)");
   htowE = ibooker.book1D(s, s, NEtow + 1, ETower);
-  htowE->getTH1F()->GetXaxis()->SetTitle("fC");
+  htowE->setAxisTitle("fC");
 
   for (int ts = 0; ts <= 1; ts++) {
     sprintf(s, "QIErms_TS=%d", ts);
     hQIErms[ts] = ibooker.book1D(s, s, 1000, 0., 100.);
-    hQIErms[ts]->getTH1F()->GetXaxis()->SetTitle("QIErms(fC)");
+    hQIErms[ts]->setAxisTitle("QIErms(fC)");
   }
 
   for (int ind = 0; ind < 224; ind++)
@@ -296,19 +296,19 @@ void CastorDigiMonitor::processEvent(edm::Event const &event,
         sum += a;
         double Qmean = QmeanTS[ind - 1][ts - 1] / ievt_;
         double Qrms = QrmsTS[ind - 1][ts - 1] / ievt_ - Qmean * Qmean;
-        h2QrmsTSvsCh->getTH2F()->SetBinContent(ind, ts, sqrt(Qrms));
+        h2QrmsTSvsCh->setBinContent(ind, ts, sqrt(Qrms));
       }
       ModuleSum[mod] += sum;
       SectorSum[sec] += sum;
       float isum = float(int(sum * 10. + 0.5)) / 10.;
       if (ChannelStatus[mod][sec] != StatusBadChannel)
-        h2QmeanMap->getTH2F()->SetBinContent(mod + 1, sec + 1, isum);
+        h2QmeanMap->setBinContent(mod + 1, sec + 1, isum);
     }  // end for(int mod=0; mod<14; mod++) for(int sec=0;...
 
   for (int mod = 0; mod < 14; mod++)
-    hModule->getTH1F()->SetBinContent(mod + 1, ModuleSum[mod]);
+    hModule->setBinContent(mod + 1, ModuleSum[mod]);
   for (int sec = 0; sec < 16; sec++)
-    hSector->getTH1F()->SetBinContent(sec + 1, SectorSum[sec]);
+    hSector->setBinContent(sec + 1, SectorSum[sec]);
 
   int nGoodCh = 0;
   hTSratio->Reset();
@@ -322,7 +322,7 @@ void CastorDigiMonitor::processEvent(edm::Event const &event,
       float ChanStatus = 0.;
       if (Qrms < Qrms_DEAD)
         ChanStatus = 1.;
-      h2status->getTH2F()->SetBinContent(mod + 1, sec + 1, ChanStatus);
+      h2status->setBinContent(mod + 1, sec + 1, ChanStatus);
 
       float am = 0.;
       for (int ts = 0; ts < TS_MAX - 1; ts++) {
@@ -341,7 +341,7 @@ void CastorDigiMonitor::processEvent(edm::Event const &event,
         r = 1. - (sum - am) / (TS_MAX - 2) / am * 2.;
       // if(r<0.|| r>1.) cout<<"ievt="<<ievt<<" r="<<r<<" amax= "<<am<<"
       // sum="<<sum<<endl;
-      h2TSratio->getTH2F()->SetBinContent(mod + 1, sec + 1, r);
+      h2TSratio->setBinContent(mod + 1, sec + 1, r);
       hTSratio->Fill(r);
 
       float statusTS = 1.0;
@@ -352,7 +352,7 @@ void CastorDigiMonitor::processEvent(edm::Event const &event,
       float gChanStatus = statusTS;
       if (ChanStatus > 0.)
         gChanStatus = repChanBAD;  // RMS
-      h2qualityMap->getTH2F()->SetBinContent(mod + 1, sec + 1, gChanStatus);
+      h2qualityMap->setBinContent(mod + 1, sec + 1, gChanStatus);
       if (gChanStatus > repChanBAD)
         ++nGoodCh;
     }

--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -106,13 +106,13 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "CASTOR BadChannelsMap");
   h2status = ibooker.book2D(s, s, 14, 0., 14., 16, 0., 16.);
   h2status->setAxisTitle("Module Z");
-  h2status->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
+  h2status->setAxisTitle("Sector #phi", /* axis */ 2);
   h2status->setOption("colz");
 
   sprintf(s, "CASTOR TSmax Significance Map");
   h2TSratio = ibooker.book2D(s, s, 14, 0., 14., 16, 0., 16.);
   h2TSratio->setAxisTitle("Module Z");
-  h2TSratio->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
+  h2TSratio->setAxisTitle("Sector #phi", /* axis */ 2);
   h2TSratio->setOption("colz");
 
   sprintf(s, "CASTOR TSmax Significance All chan");
@@ -123,11 +123,11 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "ModuleZ(fC)_allTS");
   hModule = ibooker.book1D(s, s, 14, 0., 14.);
   hModule->setAxisTitle("ModuleZ");
-  hModule->getTH1F()->GetYaxis()->SetTitle("QIE(fC)");
+  hModule->setAxisTitle("QIE(fC)", /* axis */ 2);
   sprintf(s, "Sector #phi(fC)_allTS");
   hSector = ibooker.book1D(s, s, 16, 0., 16.);
   hSector->setAxisTitle("Sector #phi");
-  hSector->getTH1F()->GetYaxis()->SetTitle("QIE(fC)");
+  hSector->setAxisTitle("QIE(fC)", /* axis */ 2);
 
   st = "Castor cells avr digi(fC) per event Map TS vs Channel";
   h2QmeantsvsCh =
@@ -141,7 +141,7 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "CASTOR data quality");
   h2qualityMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
   h2qualityMap->setAxisTitle("module Z");
-  h2qualityMap->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
+  h2qualityMap->setAxisTitle("Sector #phi", /* axis */ 2);
   h2qualityMap->setOption("colz");
 
   hReport = ibooker.bookFloat("CASTOR reportSummary");
@@ -149,7 +149,7 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "QmeanfC_map(allTS)");
   h2QmeanMap = ibooker.book2D(s, s, 14, 0., 14., 16, 0., 16.);
   h2QmeanMap->setAxisTitle("Module Z");
-  h2QmeanMap->getTH2F()->GetYaxis()->SetTitle("Sector #phi");
+  h2QmeanMap->setAxisTitle("Sector #phi", /* axis */ 2);
   h2QmeanMap->setOption("textcolz");
 
   const int NEtow = 20;
@@ -174,7 +174,7 @@ void CastorDigiMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "CASTOR_Tower_EMvsEhad(fC)");
   h2towEMvsHAD = ibooker.book2D(s, s, NEtow, EhadTow, NEtow, EMTow);
   h2towEMvsHAD->setAxisTitle("Ehad [fC]");
-  h2towEMvsHAD->getTH2F()->GetYaxis()->SetTitle("EM [fC]");
+  h2towEMvsHAD->setAxisTitle("EM [fC]", /* axis */ 2);
   h2towEMvsHAD->setOption("colz");
 
   sprintf(s, "CASTOR_TowerTotalEnergy(fC)");

--- a/DQM/CastorMonitor/src/CastorLEDMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorLEDMonitor.cc
@@ -30,8 +30,8 @@ void CastorLEDMonitor::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run
   h2qMap->setOption("colz");
   sprintf(s, "CastorLED_QmeanMap");
   h2meanMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
-  h2meanMap->setAxisTitle("moduleZ");
-  h2meanMap->getTH2F()->GetYaxis()->SetTitle("sectorPhi");
+  h2meanMap->setAxisTitle("moduleZ", /* axis */ 1);
+  h2meanMap->setAxisTitle("sectorPhi", /* axis */ 2);
   h2meanMap->setOption("colz");
 
   ievt_ = 0;
@@ -75,7 +75,7 @@ void CastorLEDMonitor::processEvent(const CastorDigiCollection &castorDigis, con
   if (ievt_ % 100 == 0) {
     for (int mod = 1; mod <= 14; mod++)
       for (int sec = 1; sec <= 16; sec++) {
-        double a = h2qMap->getTH2F()->GetBinContent(mod, sec);
+        double a = h2qMap->getBinContent(mod, sec);
         h2meanMap->setBinContent(mod, sec, a / double(ievt_));
       }
   }

--- a/DQM/CastorMonitor/src/CastorLEDMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorLEDMonitor.cc
@@ -27,12 +27,12 @@ void CastorLEDMonitor::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run
 
   sprintf(s, "CastorLEDqMap(cumulative)");
   h2qMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
-  h2qMap->getTH2F()->SetOption("colz");
+  h2qMap->setOption("colz");
   sprintf(s, "CastorLED_QmeanMap");
   h2meanMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
-  h2meanMap->getTH2F()->GetXaxis()->SetTitle("moduleZ");
+  h2meanMap->setAxisTitle("moduleZ");
   h2meanMap->getTH2F()->GetYaxis()->SetTitle("sectorPhi");
-  h2meanMap->getTH2F()->SetOption("colz");
+  h2meanMap->setOption("colz");
 
   ievt_ = 0;
   return;
@@ -76,7 +76,7 @@ void CastorLEDMonitor::processEvent(const CastorDigiCollection &castorDigis, con
     for (int mod = 1; mod <= 14; mod++)
       for (int sec = 1; sec <= 16; sec++) {
         double a = h2qMap->getTH2F()->GetBinContent(mod, sec);
-        h2meanMap->getTH2F()->SetBinContent(mod, sec, a / double(ievt_));
+        h2meanMap->setBinContent(mod, sec, a / double(ievt_));
       }
   }
 

--- a/DQM/CastorMonitor/src/CastorMonitorModule.cc
+++ b/DQM/CastorMonitor/src/CastorMonitorModule.cc
@@ -75,24 +75,22 @@ void CastorMonitorModule::bookHistograms(DQMStore::IBooker &ibooker,
   char s[60];
   sprintf(s, "CastorEventProducts");
   CastorEventProduct = ibooker.book1DD(s, s, 6, -0.5, 5.5);
-  CastorEventProduct->getTH1D()->GetYaxis()->SetTitle("Events");
-  TAxis *xa = CastorEventProduct->getTH1D()->GetXaxis();
-  xa->SetBinLabel(1, "FEDs/3");
-  xa->SetBinLabel(2, "RawData");
-  xa->SetBinLabel(3, "Digi");
-  xa->SetBinLabel(4, "RecHits");
-  xa->SetBinLabel(5, "Towers");
-  xa->SetBinLabel(6, "Jets");
+  CastorEventProduct->setAxisTitle("Events", /* axis */ 2);
+  CastorEventProduct->setBinLabel(1, "FEDs/3");
+  CastorEventProduct->setBinLabel(2, "RawData");
+  CastorEventProduct->setBinLabel(3, "Digi");
+  CastorEventProduct->setBinLabel(4, "RecHits");
+  CastorEventProduct->setBinLabel(5, "Towers");
+  CastorEventProduct->setBinLabel(6, "Jets");
 
   sprintf(s, "CASTORUnpackReport");
   hunpkrep = ibooker.bookProfile(s, s, 6, -0.5, 5.5, 100, 0, 1.e10, "");
-  xa = hunpkrep->getTProfile()->GetXaxis();
-  xa->SetBinLabel(1, "N_FEDs");
-  xa->SetBinLabel(2, "SPIGOT_Err");
-  xa->SetBinLabel(3, "empty");
-  xa->SetBinLabel(4, "busy");
-  xa->SetBinLabel(5, "OvF");
-  xa->SetBinLabel(6, "BadDigis");
+  hunpkrep->setBinLabel(1, "N_FEDs");
+  hunpkrep->setBinLabel(2, "SPIGOT_Err");
+  hunpkrep->setBinLabel(3, "empty");
+  hunpkrep->setBinLabel(4, "busy");
+  hunpkrep->setBinLabel(5, "OvF");
+  hunpkrep->setBinLabel(6, "BadDigis");
   return;
 }
 

--- a/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
@@ -46,9 +46,9 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   sprintf(s, "Castor Energy by Sectors #Phi");
   h2RHvsSec = ibooker.book2D(s, s, N_Sec, xSec, nySec, ySec);
-  h2RHvsSec->getTH2F()->GetXaxis()->SetTitle("sector #Phi");
+  h2RHvsSec->setAxisTitle("sector #Phi");
   h2RHvsSec->getTH2F()->GetYaxis()->SetTitle("RecHit / GeV");
-  h2RHvsSec->getTH2F()->SetOption("colz");
+  h2RHvsSec->setOption("colz");
 
   const int nxCh = 224;
   const int nyE = 18;
@@ -65,11 +65,11 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   string st = "Castor Cell Energy Map (cell-wise)";
   h2RHchan = ibooker.book2D(st, st + ";moduleZ*16 + sector #Phi;RecHit / GeV", nxCh, xCh, nyE, yErh);
-  h2RHchan->getTH2F()->SetOption("colz");
+  h2RHchan->setOption("colz");
 
   sprintf(s, "Castor Cell Energy");
   hallchan = ibooker.book1D(s, s, nyE, yErh);
-  hallchan->getTH1F()->GetXaxis()->SetTitle("GeV");
+  hallchan->setAxisTitle("GeV");
 
   st = "Castor cell avr Energy per event Map Z-Phi";
   h2RHoccmap = ibooker.bookProfile2D(st, st + ";module Z;sector Phi", 14, 0, 14, 16, 0, 16, 0., 1.e10, "");
@@ -77,16 +77,16 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   sprintf(s, "CastorRecHitEntriesMap");
   h2RHentriesMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
-  h2RHentriesMap->getTH2F()->GetXaxis()->SetTitle("moduleZ");
+  h2RHentriesMap->setAxisTitle("moduleZ");
   h2RHentriesMap->getTH2F()->GetYaxis()->SetTitle("sector #Phi");
-  h2RHentriesMap->getTH2F()->SetOption("colz");
+  h2RHentriesMap->setOption("colz");
 
   sprintf(s, "CastorRecHitTime");
   hRHtime = ibooker.book1D(s, s, 301, -101., 200.);
 
   sprintf(s, "CASTORTowerDepth");
   hTowerDepth = ibooker.book1D(s, s, 130, -15500., -14200.);
-  hTowerDepth->getTH1F()->GetXaxis()->SetTitle("mm");
+  hTowerDepth->setAxisTitle("mm");
 
   sprintf(s, "CASTORTowerMultiplicity");
   hTowerMultipl = ibooker.book1D(s, s, 20, 0., 20.);
@@ -112,13 +112,13 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
 
   sprintf(s, "CASTORTowerEMvsEhad");
   h2TowerEMhad = ibooker.book2D(s, s, NEtow, EhadTow, NEtow, EMTow);
-  h2TowerEMhad->getTH2F()->GetXaxis()->SetTitle("Ehad / GeV");
+  h2TowerEMhad->setAxisTitle("Ehad / GeV");
   h2TowerEMhad->getTH2F()->GetYaxis()->SetTitle("EM / GeV");
-  h2TowerEMhad->getTH2F()->SetOption("colz");
+  h2TowerEMhad->setOption("colz");
 
   sprintf(s, "CASTORTowerTotalEnergy");
   hTowerE = ibooker.book1D(s, s, NEtow + 1, ETower);
-  hTowerE->getTH1F()->GetXaxis()->SetTitle("GeV");
+  hTowerE->setAxisTitle("GeV");
 
   sprintf(s, "CASTORJetsMultiplicity");
   hJetsMultipl = ibooker.book1D(s, s, 16, 0., 16.);

--- a/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
@@ -47,7 +47,7 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "Castor Energy by Sectors #Phi");
   h2RHvsSec = ibooker.book2D(s, s, N_Sec, xSec, nySec, ySec);
   h2RHvsSec->setAxisTitle("sector #Phi");
-  h2RHvsSec->getTH2F()->GetYaxis()->SetTitle("RecHit / GeV");
+  h2RHvsSec->setAxisTitle("RecHit / GeV", /* axis */ 2);
   h2RHvsSec->setOption("colz");
 
   const int nxCh = 224;
@@ -78,7 +78,7 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "CastorRecHitEntriesMap");
   h2RHentriesMap = ibooker.book2D(s, s, 14, 0, 14, 16, 0, 16);
   h2RHentriesMap->setAxisTitle("moduleZ");
-  h2RHentriesMap->getTH2F()->GetYaxis()->SetTitle("sector #Phi");
+  h2RHentriesMap->setAxisTitle("sector #Phi", /* axis */ 2);
   h2RHentriesMap->setOption("colz");
 
   sprintf(s, "CastorRecHitTime");
@@ -113,7 +113,7 @@ void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
   sprintf(s, "CASTORTowerEMvsEhad");
   h2TowerEMhad = ibooker.book2D(s, s, NEtow, EhadTow, NEtow, EMTow);
   h2TowerEMhad->setAxisTitle("Ehad / GeV");
-  h2TowerEMhad->getTH2F()->GetYaxis()->SetTitle("EM / GeV");
+  h2TowerEMhad->setAxisTitle("EM / GeV", /* axis */ 2);
   h2TowerEMhad->setOption("colz");
 
   sprintf(s, "CASTORTowerTotalEnergy");

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -381,16 +381,16 @@ void L1TStage2CaloLayer1::endLuminosityBlock(const edm::LuminosityBlock& lumi, c
   maxEvtMismatchHCALCurrentLumi_ = 0;
 
   // Simple way to embed current lumi to auto-scale axis limits in render plugin
-  ecalLinkErrorByLumi_->getTH1F()->SetBinContent(0, id);
-  ecalMismatchByLumi_->getTH1F()->SetBinContent(0, id);
-  hcalLinkErrorByLumi_->getTH1F()->SetBinContent(0, id);
-  hcalMismatchByLumi_->getTH1F()->SetBinContent(0, id);
-  maxEvtLinkErrorsByLumiECAL_->getTH1F()->SetBinContent(0, id);
-  maxEvtLinkErrorsByLumiHCAL_->getTH1F()->SetBinContent(0, id);
-  maxEvtLinkErrorsByLumi_->getTH1F()->SetBinContent(0, id);
-  maxEvtMismatchByLumiECAL_->getTH1F()->SetBinContent(0, id);
-  maxEvtMismatchByLumiHCAL_->getTH1F()->SetBinContent(0, id);
-  maxEvtMismatchByLumi_->getTH1F()->SetBinContent(0, id);
+  ecalLinkErrorByLumi_->setBinContent(0, id);
+  ecalMismatchByLumi_->setBinContent(0, id);
+  hcalLinkErrorByLumi_->setBinContent(0, id);
+  hcalMismatchByLumi_->setBinContent(0, id);
+  maxEvtLinkErrorsByLumiECAL_->setBinContent(0, id);
+  maxEvtLinkErrorsByLumiHCAL_->setBinContent(0, id);
+  maxEvtLinkErrorsByLumi_->setBinContent(0, id);
+  maxEvtMismatchByLumiECAL_->setBinContent(0, id);
+  maxEvtMismatchByLumiHCAL_->setBinContent(0, id);
+  maxEvtMismatchByLumi_->setBinContent(0, id);
 }
 
 void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) {
@@ -481,10 +481,10 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm::
                                      20,
                                      0,
                                      20);
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(1, "Ecal TP Et Mismatch");
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(2, "Ecal TP Fine Grain Bit Mismatch");
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(3, "Hcal TP Et Mismatch");
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(4, "Hcal TP Feature Bit Mismatch");
+  last20Mismatches_->setBinLabel(1, "Ecal TP Et Mismatch");
+  last20Mismatches_->setBinLabel(2, "Ecal TP Fine Grain Bit Mismatch");
+  last20Mismatches_->setBinLabel(3, "Hcal TP Et Mismatch");
+  last20Mismatches_->setBinLabel(4, "Hcal TP Feature Bit Mismatch");
   for (size_t i = 0; i < last20MismatchArray_.size(); ++i)
     last20MismatchArray_[i] = {"-" + std::to_string(i), 0};
   for (size_t i = 1; i <= 20; ++i)

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -343,10 +343,10 @@ void L1TStage2CaloLayer1::updateMismatch(const edm::Event& e, int mismatchType) 
 
 void L1TStage2CaloLayer1::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {
   // Ugly way to loop backwards through the last 20 mismatches
-  auto h = last20Mismatches_->getTH2F();
+  auto h = last20Mismatches_;
   for (size_t ibin = 1, imatch = lastMismatchIndex_; ibin <= 20; ibin++, imatch = (imatch + 19) % 20) {
-    h->GetYaxis()->SetBinLabel(ibin, last20MismatchArray_.at(imatch).first.c_str());
-    for (int itype = 0; itype < h->GetNbinsX(); ++itype) {
+    h->setBinLabel(ibin, last20MismatchArray_.at(imatch).first.c_str(), /* axis */ 2);
+    for (int itype = 0; itype < h->getNbinsX(); ++itype) {
       int binContent = (last20MismatchArray_.at(imatch).second >> itype) & 1;
       last20Mismatches_->setBinContent(itype + 1, ibin, binContent);
     }
@@ -488,7 +488,7 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm::
   for (size_t i = 0; i < last20MismatchArray_.size(); ++i)
     last20MismatchArray_[i] = {"-" + std::to_string(i), 0};
   for (size_t i = 1; i <= 20; ++i)
-    last20Mismatches_->getTH2F()->GetYaxis()->SetBinLabel(i, ("-" + std::to_string(i)).c_str());
+    last20Mismatches_->setBinLabel(i, ("-" + std::to_string(i)).c_str(), /* axis */ 2);
 
   const int nLumis = 2000;
   ecalLinkErrorByLumi_ = ibooker.book1D(

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -345,7 +345,7 @@ void L1TStage2CaloLayer1::beginLuminosityBlock(const edm::LuminosityBlock&, cons
   // Ugly way to loop backwards through the last 20 mismatches
   auto h = last20Mismatches_;
   for (size_t ibin = 1, imatch = lastMismatchIndex_; ibin <= 20; ibin++, imatch = (imatch + 19) % 20) {
-    h->setBinLabel(ibin, last20MismatchArray_.at(imatch).first.c_str(), /* axis */ 2);
+    h->setBinLabel(ibin, last20MismatchArray_.at(imatch).first, /* axis */ 2);
     for (int itype = 0; itype < h->getNbinsX(); ++itype) {
       int binContent = (last20MismatchArray_.at(imatch).second >> itype) & 1;
       last20Mismatches_->setBinContent(itype + 1, ibin, binContent);
@@ -488,7 +488,7 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm::
   for (size_t i = 0; i < last20MismatchArray_.size(); ++i)
     last20MismatchArray_[i] = {"-" + std::to_string(i), 0};
   for (size_t i = 1; i <= 20; ++i)
-    last20Mismatches_->setBinLabel(i, ("-" + std::to_string(i)).c_str(), /* axis */ 2);
+    last20Mismatches_->setBinLabel(i, "-" + std::to_string(i), /* axis */ 2);
 
   const int nLumis = 2000;
   ecalLinkErrorByLumi_ = ibooker.book1D(

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -1964,8 +1964,8 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
   for (unsigned int i = 0; i < 108; ++i) {
     char fed[10];
     sprintf(fed, "%d", crateFED[i]);
-    fedVectorMonitorRUN_->getTH2F()->GetXaxis()->SetBinLabel(i + 1, fed);
-    fedVectorMonitorLS_->getTH2F()->GetXaxis()->SetBinLabel(i + 1, fed);
+    fedVectorMonitorRUN_->setBinLabel(i + 1, fed);
+    fedVectorMonitorLS_->setBinLabel(i + 1, fed);
   }
   fedVectorMonitorRUN_->getTH2F()->GetYaxis()->SetBinLabel(1, "OUT");
   fedVectorMonitorRUN_->getTH2F()->GetYaxis()->SetBinLabel(2, "IN");

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -202,7 +202,7 @@ void L1TdeStage2CaloLayer1::updateMismatch(const edm::Event& e, int mismatchType
 void L1TdeStage2CaloLayer1::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {
   // Ugly way to loop backwards through the last 20 mismatches
   for (size_t ibin = 1, imatch = lastMismatchIndex_; ibin <= 20; ibin++, imatch = (imatch + 19) % 20) {
-    last20Mismatches_->getTH2F()->GetYaxis()->SetBinLabel(ibin, last20MismatchArray_.at(imatch).first.c_str());
+    last20Mismatches_->setBinLabel(ibin, last20MismatchArray_.at(imatch).first.c_str(), /* axis */ 2);
     for (int itype = 0; itype < 4; ++itype) {
       int binContent = (last20MismatchArray_.at(imatch).second >> itype) & 1;
       last20Mismatches_->setBinContent(itype + 1, ibin, binContent);
@@ -241,7 +241,7 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm
                                     NSummaryColumns,
                                     0.,
                                     double(NSummaryColumns));
-  dataEmulSummary_->getTH1F()->GetYaxis()->SetTitle("Fraction events with mismatch");
+  dataEmulSummary_->setAxisTitle("Fraction events with mismatch", /* axis */ 2);
   dataEmulSummary_->setBinLabel(1 + EtMismatch, "Et");
   dataEmulSummary_->setBinLabel(1 + ErMismatch, "Et ratio");
   dataEmulSummary_->setBinLabel(1 + FbMismatch, "Feature bit");
@@ -301,5 +301,5 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm
   for (size_t i = 0; i < last20MismatchArray_.size(); ++i)
     last20MismatchArray_[i] = {"-" + std::to_string(i), 0};
   for (size_t i = 1; i <= 20; ++i)
-    last20Mismatches_->getTH2F()->GetYaxis()->SetBinLabel(i, ("-" + std::to_string(i)).c_str());
+    last20Mismatches_->setBinLabel(i, ("-" + std::to_string(i)).c_str(), /* axis */ 2);
 }

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -174,7 +174,7 @@ void L1TdeStage2CaloLayer1::analyze(const edm::Event& event, const edm::EventSet
     dataEmulNumerator_[TowerCountMismatch] += 1;
 
   for (size_t i = 0; i < NSummaryColumns; ++i) {
-    dataEmulSummary_->getTH1F()->SetBinContent(1 + i, dataEmulNumerator_[i] / dataEmulDenominator_);
+    dataEmulSummary_->setBinContent(1 + i, dataEmulNumerator_[i] / dataEmulDenominator_);
   }
   // GetEntries() increments every SetBinContent() call
   dataEmulSummary_->getTH1F()->SetEntries(dataEmulDenominator_);
@@ -213,9 +213,9 @@ void L1TdeStage2CaloLayer1::beginLuminosityBlock(const edm::LuminosityBlock&, co
 void L1TdeStage2CaloLayer1::endLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&) {
   auto id = static_cast<double>(lumi.id().luminosityBlock());  // uint64_t
   // Simple way to embed current lumi to auto-scale axis limits in render plugin
-  etMismatchByLumi_->getTH1F()->SetBinContent(0, id);
-  erMismatchByLumi_->getTH1F()->SetBinContent(0, id);
-  fbMismatchByLumi_->getTH1F()->SetBinContent(0, id);
+  etMismatchByLumi_->setBinContent(0, id);
+  erMismatchByLumi_->setBinContent(0, id);
+  fbMismatchByLumi_->setBinContent(0, id);
 }
 
 void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) {
@@ -242,10 +242,10 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm
                                     0.,
                                     double(NSummaryColumns));
   dataEmulSummary_->getTH1F()->GetYaxis()->SetTitle("Fraction events with mismatch");
-  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1 + EtMismatch, "Et");
-  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1 + ErMismatch, "Et ratio");
-  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1 + FbMismatch, "Feature bit");
-  dataEmulSummary_->getTH1F()->GetXaxis()->SetBinLabel(1 + TowerCountMismatch, "CaloTower readout");
+  dataEmulSummary_->setBinLabel(1 + EtMismatch, "Et");
+  dataEmulSummary_->setBinLabel(1 + ErMismatch, "Et ratio");
+  dataEmulSummary_->setBinLabel(1 + FbMismatch, "Feature bit");
+  dataEmulSummary_->setBinLabel(1 + TowerCountMismatch, "CaloTower readout");
   mismatchesPerBxMod9_ = ibooker.book1D(
       "mismatchesPerBxMod9", "CaloLayer1 data-emulator mismatch per bx%9;Bunch crossing mod 9;Counts", 9, -0.5, 8.5);
 
@@ -294,10 +294,10 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm
 
   last20Mismatches_ =
       ibooker.book2D("last20Mismatches", "Log of last 20 mismatches (use json tool to copy/paste)", 4, 0, 4, 20, 0, 20);
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(1, "Et Mismatch");
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(2, "Et ratio Mismatch");
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(3, "Feature bit Mismatch");
-  last20Mismatches_->getTH2F()->GetXaxis()->SetBinLabel(4, "-");
+  last20Mismatches_->setBinLabel(1, "Et Mismatch");
+  last20Mismatches_->setBinLabel(2, "Et ratio Mismatch");
+  last20Mismatches_->setBinLabel(3, "Feature bit Mismatch");
+  last20Mismatches_->setBinLabel(4, "-");
   for (size_t i = 0; i < last20MismatchArray_.size(); ++i)
     last20MismatchArray_[i] = {"-" + std::to_string(i), 0};
   for (size_t i = 1; i <= 20; ++i)

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -202,7 +202,7 @@ void L1TdeStage2CaloLayer1::updateMismatch(const edm::Event& e, int mismatchType
 void L1TdeStage2CaloLayer1::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {
   // Ugly way to loop backwards through the last 20 mismatches
   for (size_t ibin = 1, imatch = lastMismatchIndex_; ibin <= 20; ibin++, imatch = (imatch + 19) % 20) {
-    last20Mismatches_->setBinLabel(ibin, last20MismatchArray_.at(imatch).first.c_str(), /* axis */ 2);
+    last20Mismatches_->setBinLabel(ibin, last20MismatchArray_.at(imatch).first, /* axis */ 2);
     for (int itype = 0; itype < 4; ++itype) {
       int binContent = (last20MismatchArray_.at(imatch).second >> itype) & 1;
       last20Mismatches_->setBinContent(itype + 1, ibin, binContent);
@@ -301,5 +301,5 @@ void L1TdeStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker, const edm
   for (size_t i = 0; i < last20MismatchArray_.size(); ++i)
     last20MismatchArray_[i] = {"-" + std::to_string(i), 0};
   for (size_t i = 1; i <= 20; ++i)
-    last20Mismatches_->setBinLabel(i, ("-" + std::to_string(i)).c_str(), /* axis */ 2);
+    last20Mismatches_->setBinLabel(i, "-" + std::to_string(i), /* axis */ 2);
 }

--- a/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
@@ -200,7 +200,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     hname = "dataEmulSummary_" + bxt.str();
     htitle = "uGT Data/Emulator Mismatches --" + bxn.str();
     m_SummaryHistograms[hname] = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
-    m_SummaryHistograms[hname]->getTH1F()->GetYaxis()->SetTitle("Events");
+    m_SummaryHistograms[hname]->setAxisTitle("Events", /* axis */ 2);
     m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchDataNoEmul,
                                                                    "Data, NoEmul -- Initial Decisions");
     m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchEmulNoData,
@@ -214,7 +214,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
       hname = "normalizationHisto";
       htitle = "Normalization histogram for uGT Data/Emulator Mismatches ratios";
       m_normalizationHisto = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
-      m_normalizationHisto->getTH1F()->GetYaxis()->SetTitle("Events");
+      m_normalizationHisto->setAxisTitle("Events", /* axis */ 2);
       m_normalizationHisto->setBinLabel(1 + NInitalMismatchDataNoEmul,
                                                                "Data, NoEmul -- Initial Decisions");
       m_normalizationHisto->setBinLabel(1 + NInitalMismatchEmulNoData,
@@ -232,7 +232,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
                                                   numLS_,
                                                   0.,
                                                   double(numLS_));
-    initDecisionMismatches_vs_LS->getTH1F()->GetYaxis()->SetTitle("Events with Initial Decision Mismatch");
+    initDecisionMismatches_vs_LS->setAxisTitle("Events with Initial Decision Mismatch", /* axis */ 2);
     initDecisionMismatches_vs_LS->setAxisTitle("Luminosity Segment");
 
     hname = "DataNoEmul_" + bxt.str();
@@ -250,7 +250,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
                                                    numLS_,
                                                    0.,
                                                    double(numLS_));
-    finalDecisionMismatches_vs_LS->getTH1F()->GetYaxis()->SetTitle("Events with Final Decision Mismatch");
+    finalDecisionMismatches_vs_LS->setAxisTitle("Events with Final Decision Mismatch", /* axis */ 2);
     finalDecisionMismatches_vs_LS->setAxisTitle("Luminosity Segment");
 
     hname = "DataNoEmul_" + bxt.str();
@@ -271,7 +271,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     // 	(*it).second->setBinLabel(1+i, name.c_str());
     // }
     (*it).second->setAxisTitle("Trigger Bit");
-    (*it).second->getTH1F()->GetYaxis()->SetTitle("Events with Initial Decision Mismatch");
+    (*it).second->setAxisTitle("Events with Initial Decision Mismatch", /* axis */ 2);
   }
 
   for (std::map<std::string, MonitorElement*>::iterator it = m_HistNamesFinal.begin(); it != m_HistNamesFinal.end();
@@ -282,7 +282,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     // 	(*it).second->setBinLabel(1+i, name.c_str());
     // }
     (*it).second->setAxisTitle("Trigger Bit (Unprescaled)");
-    (*it).second->getTH1F()->GetYaxis()->SetTitle("Events with Final Decision Mismatch");
+    (*it).second->setAxisTitle("Events with Final Decision Mismatch", /* axis */ 2);
   }
 }
 

--- a/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
@@ -201,13 +201,13 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     htitle = "uGT Data/Emulator Mismatches --" + bxn.str();
     m_SummaryHistograms[hname] = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
     m_SummaryHistograms[hname]->getTH1F()->GetYaxis()->SetTitle("Events");
-    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1 + NInitalMismatchDataNoEmul,
+    m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchDataNoEmul,
                                                                    "Data, NoEmul -- Initial Decisions");
-    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1 + NInitalMismatchEmulNoData,
+    m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchEmulNoData,
                                                                    "Emulator, No Data -- Initial Decisions");
-    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1 + NFinalMismatchDataNoEmul,
+    m_SummaryHistograms[hname]->setBinLabel(1 + NFinalMismatchDataNoEmul,
                                                                    "Data, NoEmul -- Final Decisions");
-    m_SummaryHistograms[hname]->getTH1F()->GetXaxis()->SetBinLabel(1 + NFinalMismatchEmulNoData,
+    m_SummaryHistograms[hname]->setBinLabel(1 + NFinalMismatchEmulNoData,
                                                                    "Emulator, No Data -- Final Decisions");
 
     if (i == 0) {
@@ -215,13 +215,13 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
       htitle = "Normalization histogram for uGT Data/Emulator Mismatches ratios";
       m_normalizationHisto = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
       m_normalizationHisto->getTH1F()->GetYaxis()->SetTitle("Events");
-      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1 + NInitalMismatchDataNoEmul,
+      m_normalizationHisto->setBinLabel(1 + NInitalMismatchDataNoEmul,
                                                                "Data, NoEmul -- Initial Decisions");
-      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1 + NInitalMismatchEmulNoData,
+      m_normalizationHisto->setBinLabel(1 + NInitalMismatchEmulNoData,
                                                                "Emulator, No Data -- Initial Decisions");
-      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1 + NFinalMismatchDataNoEmul,
+      m_normalizationHisto->setBinLabel(1 + NFinalMismatchDataNoEmul,
                                                                "Data, NoEmul -- Final Decisions");
-      m_normalizationHisto->getTH1F()->GetXaxis()->SetBinLabel(1 + NFinalMismatchEmulNoData,
+      m_normalizationHisto->setBinLabel(1 + NFinalMismatchEmulNoData,
                                                                "Emulator, No Data -- Final Decisions");
     }
 
@@ -233,7 +233,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
                                                   0.,
                                                   double(numLS_));
     initDecisionMismatches_vs_LS->getTH1F()->GetYaxis()->SetTitle("Events with Initial Decision Mismatch");
-    initDecisionMismatches_vs_LS->getTH1F()->GetXaxis()->SetTitle("Luminosity Segment");
+    initDecisionMismatches_vs_LS->setAxisTitle("Luminosity Segment");
 
     hname = "DataNoEmul_" + bxt.str();
     htitle = "uGT data-emul mismatch -- Data fired but not Emulator --" + bxn.str();
@@ -251,7 +251,7 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
                                                    0.,
                                                    double(numLS_));
     finalDecisionMismatches_vs_LS->getTH1F()->GetYaxis()->SetTitle("Events with Final Decision Mismatch");
-    finalDecisionMismatches_vs_LS->getTH1F()->GetXaxis()->SetTitle("Luminosity Segment");
+    finalDecisionMismatches_vs_LS->setAxisTitle("Luminosity Segment");
 
     hname = "DataNoEmul_" + bxt.str();
     htitle = "uGT data-emul mismatch -- Data fired but not Emulator --" + bxn.str();
@@ -268,9 +268,9 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     // for (unsigned int i = 0; i < prescales.size(); i++) {
     //   auto const& name = prescales.at(i).first;
     //   if (name != "NULL")
-    // 	(*it).second->getTH1F()->GetXaxis()->SetBinLabel(1+i, name.c_str());
+    // 	(*it).second->setBinLabel(1+i, name.c_str());
     // }
-    (*it).second->getTH1F()->GetXaxis()->SetTitle("Trigger Bit");
+    (*it).second->setAxisTitle("Trigger Bit");
     (*it).second->getTH1F()->GetYaxis()->SetTitle("Events with Initial Decision Mismatch");
   }
 
@@ -279,9 +279,9 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     // for (unsigned int i = 0; i < prescales.size(); i++) {
     //   auto const& name = prescales.at(i).first;
     //   if (name != "NULL")
-    // 	(*it).second->getTH1F()->GetXaxis()->SetBinLabel(1+i, name.c_str());
+    // 	(*it).second->setBinLabel(1+i, name.c_str());
     // }
-    (*it).second->getTH1F()->GetXaxis()->SetTitle("Trigger Bit (Unprescaled)");
+    (*it).second->setAxisTitle("Trigger Bit (Unprescaled)");
     (*it).second->getTH1F()->GetYaxis()->SetTitle("Events with Final Decision Mismatch");
   }
 }

--- a/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
@@ -201,28 +201,20 @@ void L1TdeStage2uGT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& 
     htitle = "uGT Data/Emulator Mismatches --" + bxn.str();
     m_SummaryHistograms[hname] = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
     m_SummaryHistograms[hname]->setAxisTitle("Events", /* axis */ 2);
-    m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchDataNoEmul,
-                                                                   "Data, NoEmul -- Initial Decisions");
-    m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchEmulNoData,
-                                                                   "Emulator, No Data -- Initial Decisions");
-    m_SummaryHistograms[hname]->setBinLabel(1 + NFinalMismatchDataNoEmul,
-                                                                   "Data, NoEmul -- Final Decisions");
-    m_SummaryHistograms[hname]->setBinLabel(1 + NFinalMismatchEmulNoData,
-                                                                   "Emulator, No Data -- Final Decisions");
+    m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchDataNoEmul, "Data, NoEmul -- Initial Decisions");
+    m_SummaryHistograms[hname]->setBinLabel(1 + NInitalMismatchEmulNoData, "Emulator, No Data -- Initial Decisions");
+    m_SummaryHistograms[hname]->setBinLabel(1 + NFinalMismatchDataNoEmul, "Data, NoEmul -- Final Decisions");
+    m_SummaryHistograms[hname]->setBinLabel(1 + NFinalMismatchEmulNoData, "Emulator, No Data -- Final Decisions");
 
     if (i == 0) {
       hname = "normalizationHisto";
       htitle = "Normalization histogram for uGT Data/Emulator Mismatches ratios";
       m_normalizationHisto = ibooker.book1D(hname, htitle, NSummaryColumns, 0., double(NSummaryColumns));
       m_normalizationHisto->setAxisTitle("Events", /* axis */ 2);
-      m_normalizationHisto->setBinLabel(1 + NInitalMismatchDataNoEmul,
-                                                               "Data, NoEmul -- Initial Decisions");
-      m_normalizationHisto->setBinLabel(1 + NInitalMismatchEmulNoData,
-                                                               "Emulator, No Data -- Initial Decisions");
-      m_normalizationHisto->setBinLabel(1 + NFinalMismatchDataNoEmul,
-                                                               "Data, NoEmul -- Final Decisions");
-      m_normalizationHisto->setBinLabel(1 + NFinalMismatchEmulNoData,
-                                                               "Emulator, No Data -- Final Decisions");
+      m_normalizationHisto->setBinLabel(1 + NInitalMismatchDataNoEmul, "Data, NoEmul -- Initial Decisions");
+      m_normalizationHisto->setBinLabel(1 + NInitalMismatchEmulNoData, "Emulator, No Data -- Initial Decisions");
+      m_normalizationHisto->setBinLabel(1 + NFinalMismatchDataNoEmul, "Data, NoEmul -- Final Decisions");
+      m_normalizationHisto->setBinLabel(1 + NFinalMismatchEmulNoData, "Emulator, No Data -- Final Decisions");
     }
 
     // book initial decisions histograms

--- a/DQM/L1TMonitorClient/src/L1TGMTClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TGMTClient.cc
@@ -43,7 +43,7 @@ void L1TGMTClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& iget
   if (eff_eta_dtcsc != nullptr) {
     eff_eta_dtcsc->setAxisTitle("eta", 1);
     if (eff_eta_dtcsc->getTH1F()->GetSumw2N() == 0)
-      eff_eta_dtcsc->getTH1F()->Sumw2();
+      eff_eta_dtcsc->enableSumw2();
   }
 
   eff_eta_rpc = bookClone1DVB(ibooker, igetter, "eff_eta_rpc", "efficiency RPC vs eta", "eta_DTCSC_and_RPC");
@@ -51,7 +51,7 @@ void L1TGMTClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& iget
   if (eff_eta_rpc != nullptr) {
     eff_eta_rpc->setAxisTitle("eta", 1);
     if (eff_eta_rpc->getTH1F()->GetSumw2N() == 0)
-      eff_eta_rpc->getTH1F()->Sumw2();
+      eff_eta_rpc->enableSumw2();
   }
 
   eff_phi_dtcsc = bookClone1D(ibooker, igetter, "eff_phi_dtcsc", "efficiency DTCSC vs phi", "phi_DTCSC_and_RPC");
@@ -59,7 +59,7 @@ void L1TGMTClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& iget
   if (eff_phi_dtcsc != nullptr) {
     eff_phi_dtcsc->setAxisTitle("phi (deg)", 1);
     if (eff_phi_dtcsc->getTH1F()->GetSumw2N() == 0)
-      eff_phi_dtcsc->getTH1F()->Sumw2();
+      eff_phi_dtcsc->enableSumw2();
   }
 
   eff_phi_rpc = bookClone1D(ibooker, igetter, "eff_phi_rpc", "efficiency RPC vs phi", "phi_DTCSC_and_RPC");
@@ -67,7 +67,7 @@ void L1TGMTClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& iget
   if (eff_phi_rpc != nullptr) {
     eff_phi_rpc->setAxisTitle("phi (deg)", 1);
     if (eff_phi_rpc->getTH1F()->GetSumw2N() == 0)
-      eff_phi_rpc->getTH1F()->Sumw2();
+      eff_phi_rpc->enableSumw2();
   }
 
   eff_etaphi_dtcsc =
@@ -77,7 +77,7 @@ void L1TGMTClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& iget
     eff_etaphi_dtcsc->setAxisTitle("eta", 1);
     eff_etaphi_dtcsc->setAxisTitle("phi (deg)", 2);
     if (eff_etaphi_dtcsc->getTH2F()->GetSumw2N() == 0)
-      eff_etaphi_dtcsc->getTH2F()->Sumw2();
+      eff_etaphi_dtcsc->enableSumw2();
   }
 
   eff_etaphi_rpc =
@@ -87,7 +87,7 @@ void L1TGMTClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& iget
     eff_etaphi_rpc->setAxisTitle("eta", 1);
     eff_etaphi_rpc->setAxisTitle("phi (deg)", 2);
     if (eff_etaphi_rpc->getTH2F()->GetSumw2N() == 0)
-      eff_etaphi_rpc->getTH2F()->Sumw2();
+      eff_etaphi_rpc->enableSumw2();
   }
 
   processHistograms(ibooker, igetter);

--- a/DQM/Physics/src/QcdPhotonsDQM.cc
+++ b/DQM/Physics/src/QcdPhotonsDQM.cc
@@ -222,7 +222,7 @@ void QcdPhotonsDQM::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
 
   auto setSumw2 = [](MonitorElement* me) {
     if (me->getTH1F()->GetSumw2N() == 0) {
-      me->getTH1F()->Sumw2();
+      me->enableSumw2();
     }
   };
 

--- a/DQM/RPCMonitorClient/src/RPCMonitorLinkSynchro.cc
+++ b/DQM/RPCMonitorClient/src/RPCMonitorLinkSynchro.cc
@@ -58,7 +58,7 @@ void RPCMonitorLinkSynchro::bookHistograms(DQMStore::IBooker& ibooker,
   for (unsigned int i = 0; i < 3; ++i) {
     me_notComplete[i]->getTH2F()->GetXaxis()->SetNdivisions(512);
     me_notComplete[i]->getTH2F()->GetYaxis()->SetNdivisions(505);
-    me_notComplete[i]->getTH2F()->SetXTitle("rmb");
+    me_notComplete[i]->setAxisTitle("rmb");
     me_notComplete[i]->getTH2F()->SetYTitle("link");
     me_notComplete[i]->getTH2F()->SetStats(false);
   }

--- a/DQM/RPCMonitorClient/src/RPCMonitorRaw.cc
+++ b/DQM/RPCMonitorClient/src/RPCMonitorRaw.cc
@@ -57,11 +57,11 @@ void RPCMonitorRaw::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& i
 
   me_mapGoodEvents = ibooker.book2D("mapGoodRecords", "mapGoodRecords", 36, -0.5, 35.5, 3, 789.5, 792.5);
   me_mapGoodEvents->getTH2F()->SetNdivisions(3, "y");
-  me_mapGoodEvents->getTH2F()->SetXTitle("rmb");
+  me_mapGoodEvents->setAxisTitle("rmb");
   me_mapGoodEvents->getTH2F()->SetYTitle("fed");
   me_mapGoodEvents->getTH2F()->SetStats(false);
   me_mapBadEvents = ibooker.book2D("mapErrorRecords", "mapErrorRecords", 36, -0.5, 35.5, 3, 789.5, 792.5);
-  me_mapBadEvents->getTH2F()->SetXTitle("fed");
+  me_mapBadEvents->setAxisTitle("fed");
   me_mapBadEvents->getTH2F()->SetYTitle("rmb");
   me_mapBadEvents->getTH2F()->SetNdivisions(3, "y");
   me_mapBadEvents->getTH2F()->SetStats(false);

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -210,7 +210,7 @@ void TkHistoMap::setBinContent(DetId detid, float value) {
     tkHistoMap_[layer]->getTProfile2D()->SetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix, xybin.iy),
                                                        value);
   } else if (tkHistoMap_[layer]->kind() == MonitorElement::Kind::TH2F) {
-    tkHistoMap_[layer]->getTH2F()->SetBinContent(xybin.ix, xybin.iy, value);
+    tkHistoMap_[layer]->setBinContent(xybin.ix, xybin.iy, value);
   }
 
 #ifdef debug_TkHistoMap

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -1142,7 +1142,7 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
     hid = hidmanager.createHistoId("NumberOfClusters", "det", detid);
     mod_single.NumberOfClusters = bookME1D("TH1nClusters", hid.c_str(), ibooker);
     mod_single.NumberOfClusters->setAxisTitle("number of clusters in one detector module");
-    mod_single.NumberOfClusters->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+    mod_single.NumberOfClusters->setStatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
 
   // ClusterPosition
@@ -1383,21 +1383,21 @@ void SiStripMonitorCluster::createSubDetMEs(std::string label, DQMStore::IBooker
     HistoName = "ClusterCharge__" + label;
     subdetMEs.SubDetClusterChargeTH1 = bookME1D("TH1ClusterCharge", HistoName.c_str(), ibooker);
     subdetMEs.SubDetClusterChargeTH1->setAxisTitle("Cluster charge [ADC counts]");
-    subdetMEs.SubDetClusterChargeTH1->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+    subdetMEs.SubDetClusterChargeTH1->setStatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
   // cluster width
   if (subdetswitchcluswidthon) {
     HistoName = "ClusterWidth__" + label;
     subdetMEs.SubDetClusterWidthTH1 = bookME1D("TH1ClusterWidth", HistoName.c_str(), ibooker);
     subdetMEs.SubDetClusterWidthTH1->setAxisTitle("Cluster width [strips]");
-    subdetMEs.SubDetClusterWidthTH1->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+    subdetMEs.SubDetClusterWidthTH1->setStatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
   // Total Number of Cluster - 1D
   if (subdetswitchtotclusth1on) {
     HistoName = "TotalNumberOfCluster__" + label;
     subdetMEs.SubDetTotClusterTH1 = bookME1D("TH1TotalNumberOfClusters", HistoName.c_str(), ibooker);
     subdetMEs.SubDetTotClusterTH1->setAxisTitle("Total number of clusters in subdetector");
-    subdetMEs.SubDetTotClusterTH1->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+    subdetMEs.SubDetTotClusterTH1->setStatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
   // Total Number of Cluster vs Time - Profile
   if (subdetswitchtotclusprofon) {

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -1019,7 +1019,7 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
     hid = hidmanager.createHistoId("NumberOfDigis", "det", detid);
     mod_single.NumberOfDigis = ibooker.book1D(hid, hid, 21, -0.5, 20.5);
     mod_single.NumberOfDigis->setAxisTitle("number of digis in one detector module");
-    mod_single.NumberOfDigis->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+    mod_single.NumberOfDigis->setStatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
 
   //nr. of digis per strip in module
@@ -1028,7 +1028,7 @@ void SiStripMonitorDigi::createModuleMEs(DQMStore::IBooker& ibooker, ModMEs& mod
     short nstrips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;
     mod_single.NumberOfDigisPerStrip = ibooker.book1D(hid, hid, nstrips, -0.5, nstrips + 0.5);
     mod_single.NumberOfDigisPerStrip->setAxisTitle("number of (digis > 0) per strip");
-    mod_single.NumberOfDigisPerStrip->getTH1()->StatOverflows(kTRUE);  // over/underflows in Mean calculation
+    mod_single.NumberOfDigisPerStrip->setStatOverflows(kTRUE);  // over/underflows in Mean calculation
   }
   //#ADCs for hottest strip
   if (moduleswitchadchotteston) {

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -724,7 +724,7 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string&
   axisName = "Number of on-track clusters in " + name;
   theSubDetMEs.nClustersOnTrack = bookME1D(ibooker, "TH1nClustersOn", completeName.c_str());
   theSubDetMEs.nClustersOnTrack->setAxisTitle(axisName);
-  theSubDetMEs.nClustersOnTrack->getTH1()->StatOverflows(kTRUE);
+  theSubDetMEs.nClustersOnTrack->setStatOverflows(kTRUE);
 
   // TotalNumber of Cluster OffTrack
   completeName = "Summary_TotalNumberOfClusters_OffTrack" + subdet_tag;
@@ -750,7 +750,7 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker& ibooker, std::string&
     theSubDetMEs.nClustersOffTrack->setAxisRange(0.0, xmaximum, 1);
   }
 
-  theSubDetMEs.nClustersOffTrack->getTH1()->StatOverflows(kTRUE);
+  theSubDetMEs.nClustersOffTrack->setStatOverflows(kTRUE);
 
   // Cluster Gain
   completeName = "Summary_ClusterGain" + subdet_tag;

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -2033,13 +2033,13 @@ void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco
                         tkmes.TrackEtaPhiInvertedoutofphase->getTH2F()->GetBinContent(ii, jj);
 
           if (Sum1 == 0 || Sum2 == 0) {
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->getTH2F()->SetBinContent(ii, jj, 1);
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->getTH2F()->SetBinContent(ii, jj, 1);
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, 1);
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, 1);
           } else {
             double ratio1 = Sub1 / Sum1;
             double ratio2 = Sub2 / Sum2;
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->getTH2F()->SetBinContent(ii, jj, ratio1);
-            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->getTH2F()->SetBinContent(ii, jj, ratio2);
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap->setBinContent(ii, jj, ratio1);
+            tkmes.TkEtaPhi_RelativeDifference_byFoldingmap_op->setBinContent(ii, jj, ratio2);
           }
         }
       }

--- a/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyClient.cc
@@ -69,7 +69,7 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
   histName = "effX_";
   effX = ibooker_.book1D(histName + algoName_, histName + algoName_, effXBin, effXMin, effXMax);
   if (effX->getTH1F())
-    effX->getTH1F()->Sumw2();
+    effX->enableSumw2();
   effX->setAxisTitle("");
 
   //
@@ -80,7 +80,7 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
   histName = "effY_";
   effY = ibooker_.book1D(histName + algoName_, histName + algoName_, effYBin, effYMin, effYMax);
   if (effY->getTH1F())
-    effY->getTH1F()->Sumw2();
+    effY->enableSumw2();
   effY->setAxisTitle("");
 
   //
@@ -91,7 +91,7 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
   histName = "effZ_";
   effZ = ibooker_.book1D(histName + algoName_, histName + algoName_, effZBin, effZMin, effZMax);
   if (effZ->getTH1F())
-    effZ->getTH1F()->Sumw2();
+    effZ->enableSumw2();
   effZ->setAxisTitle("");
 
   //
@@ -102,7 +102,7 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
   histName = "effEta_";
   effEta = ibooker_.book1D(histName + algoName_, histName + algoName_, effEtaBin, effEtaMin, effEtaMax);
   if (effEta->getTH1F())
-    effEta->getTH1F()->Sumw2();
+    effEta->enableSumw2();
   effEta->setAxisTitle("");
 
   //
@@ -113,7 +113,7 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
   histName = "effPhi_";
   effPhi = ibooker_.book1D(histName + algoName_, histName + algoName_, effPhiBin, effPhiMin, effPhiMax);
   if (effPhi->getTH1F())
-    effPhi->getTH1F()->Sumw2();
+    effPhi->enableSumw2();
   effPhi->setAxisTitle("");
 
   //
@@ -124,7 +124,7 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
   histName = "effD0_";
   effD0 = ibooker_.book1D(histName + algoName_, histName + algoName_, effD0Bin, effD0Min, effD0Max);
   if (effD0->getTH1F())
-    effD0->getTH1F()->Sumw2();
+    effD0->enableSumw2();
   effD0->setAxisTitle("");
 
   //
@@ -139,19 +139,19 @@ void TrackEfficiencyClient::bookMEs(DQMStore::IBooker& ibooker_)
                                         effCompatibleLayersMin,
                                         effCompatibleLayersMax);
   if (effCompatibleLayers->getTH1F())
-    effCompatibleLayers->getTH1F()->Sumw2();
+    effCompatibleLayers->enableSumw2();
   effCompatibleLayers->setAxisTitle("");
 
   histName = "MuonEffPtPhi_LowPt";
   effPtPhiLowPt = ibooker_.book2D(histName + algoName_, histName + algoName_, 20, -2.4, 2.4, 20, -3.25, 3.25);
   if (effPtPhiLowPt->getTH2F())
-    effPtPhiLowPt->getTH2F()->Sumw2();
+    effPtPhiLowPt->enableSumw2();
   effPtPhiLowPt->setAxisTitle("");
 
   histName = "MuonEffPtPhi_HighPt";
   effPtPhiHighPt = ibooker_.book2D(histName + algoName_, histName + algoName_, 20, -2.4, 2.4, 20, -3.25, 3.25);
   if (effPtPhiHighPt->getTH2F())
-    effPtPhiHighPt->getTH2F()->Sumw2();
+    effPtPhiHighPt->enableSumw2();
   effPtPhiHighPt->setAxisTitle("");
 }
 

--- a/DQM/TrackingMonitorClient/plugins/TrackingDQMClientHeavyIons.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingDQMClientHeavyIons.cc
@@ -51,23 +51,23 @@ void TrackingDQMClientHeavyIons::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore:
   DCAStats->getTH2F()->GetYaxis()->SetBinLabel(2, "RMS, #sigma");
   DCAStats->getTH2F()->GetYaxis()->SetBinLabel(3, "Skewness ,#gamma_{1}");
   DCAStats->getTH2F()->GetYaxis()->SetBinLabel(4, "Kurtosis, #gamma_{2}");
-  DCAStats->getTH2F()->GetXaxis()->SetBinLabel(1, "Longitudinal");
-  DCAStats->getTH2F()->GetXaxis()->SetBinLabel(2, "Transverse");
-  DCAStats->getTH2F()->SetOption("text");
+  DCAStats->setBinLabel(1, "Longitudinal");
+  DCAStats->setBinLabel(2, "Transverse");
+  DCAStats->setOption("text");
 
   histName = "LongDCASig_HeavyIonTk";
   ME* element = igetter.get(TopFolder_ + "/" + histName);
   //Longitudinal First
-  DCAStats->getTH2F()->SetBinContent(1, 1, element->getTH1F()->GetMean());      //mean
-  DCAStats->getTH2F()->SetBinContent(1, 2, element->getTH1F()->GetRMS());       //rms
-  DCAStats->getTH2F()->SetBinContent(1, 3, element->getTH1F()->GetSkewness());  //skewness
-  DCAStats->getTH2F()->SetBinContent(1, 4, element->getTH1F()->GetKurtosis());  //kurtosis
+  DCAStats->setBinContent(1, 1, element->getTH1F()->GetMean());      //mean
+  DCAStats->setBinContent(1, 2, element->getTH1F()->GetRMS());       //rms
+  DCAStats->setBinContent(1, 3, element->getTH1F()->GetSkewness());  //skewness
+  DCAStats->setBinContent(1, 4, element->getTH1F()->GetKurtosis());  //kurtosis
   //Transverse
   histName = "TransDCASig_HeavyIonTk";
   ME* element1 = igetter.get(TopFolder_ + "/" + histName);
   //Longitudinal First
-  DCAStats->getTH2F()->SetBinContent(2, 1, element1->getTH1F()->GetMean());      //mean
-  DCAStats->getTH2F()->SetBinContent(2, 2, element1->getTH1F()->GetRMS());       //rms
-  DCAStats->getTH2F()->SetBinContent(2, 3, element1->getTH1F()->GetSkewness());  //skewness
-  DCAStats->getTH2F()->SetBinContent(2, 4, element1->getTH1F()->GetKurtosis());  //kurtosis
+  DCAStats->setBinContent(2, 1, element1->getTH1F()->GetMean());      //mean
+  DCAStats->setBinContent(2, 2, element1->getTH1F()->GetRMS());       //rms
+  DCAStats->setBinContent(2, 3, element1->getTH1F()->GetSkewness());  //skewness
+  DCAStats->setBinContent(2, 4, element1->getTH1F()->GetKurtosis());  //kurtosis
 }

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -66,13 +66,13 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1(DQMStor
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
   if (!titleX.empty()) {
-    me->getTH1F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH1F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1()->StatOverflows(kTRUE);
@@ -92,15 +92,15 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1withSumw
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
   if (me->getTH1F()->GetSumw2N() == 0)
-    me->getTH1F()->Sumw2();
+    me->enableSumw2();
   if (!titleX.empty()) {
-    me->getTH1F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH1F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1()->StatOverflows(kTRUE);
@@ -123,13 +123,13 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2(DQMStor
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
   if (!titleX.empty()) {
-    me->getTH2F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH2F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1()->StatOverflows(kTRUE);
@@ -152,15 +152,15 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2withSumw
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
   if (me->getTH2F()->GetSumw2N() == 0)
-    me->getTH2F()->Sumw2();
+    me->enableSumw2();
   if (!titleX.empty()) {
-    me->getTH2F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH2F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1()->StatOverflows(kTRUE);

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -69,7 +69,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1(DQMStor
     me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
-    me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
+    me->setAxisTitle(titleY.c_str(), 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -97,7 +97,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1withSumw
     me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
-    me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
+    me->setAxisTitle(titleY.c_str(), 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -126,7 +126,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2(DQMStor
     me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
-    me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
+    me->setAxisTitle(titleY.c_str(), 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -157,7 +157,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2withSumw
     me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
-    me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
+    me->setAxisTitle(titleY.c_str(), 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -185,7 +185,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookP1(DQMStor
     me->getTProfile()->GetXaxis()->SetTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
-    me->getTProfile()->GetYaxis()->SetTitle(titleY.c_str());
+    me->setAxisTitle(titleY.c_str(), 2);
   }
   if (TString(option) != "") {
     me->getTProfile()->SetOption(option);

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -75,7 +75,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1(DQMStor
     me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
-    me->getTH1()->StatOverflows(kTRUE);
+    me->setStatOverflows(kTRUE);
   }
   return me;
 }
@@ -103,7 +103,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1withSumw
     me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
-    me->getTH1()->StatOverflows(kTRUE);
+    me->setStatOverflows(kTRUE);
   }
   return me;
 }
@@ -132,7 +132,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2(DQMStor
     me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
-    me->getTH1()->StatOverflows(kTRUE);
+    me->setStatOverflows(kTRUE);
   }
   return me;
 }
@@ -163,7 +163,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2withSumw
     me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
-    me->getTH1()->StatOverflows(kTRUE);
+    me->setStatOverflows(kTRUE);
   }
   return me;
 }
@@ -191,7 +191,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookP1(DQMStor
     me->getTProfile()->SetOption(option);
   }
   if (bookStatOverflowFlag_) {
-    me->getTH1()->StatOverflows(kTRUE);
+    me->setStatOverflows(kTRUE);
   }
   return me;
 }

--- a/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
@@ -66,10 +66,10 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1(DQMStor
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
-    me->setAxisTitle(titleY.c_str(), 2);
+    me->setAxisTitle(titleY, 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -94,10 +94,10 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH1withSumw
   if (me->getTH1F()->GetSumw2N() == 0)
     me->enableSumw2();
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
-    me->setAxisTitle(titleY.c_str(), 2);
+    me->setAxisTitle(titleY, 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -123,10 +123,10 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2(DQMStor
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
-    me->setAxisTitle(titleY.c_str(), 2);
+    me->setAxisTitle(titleY, 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -154,10 +154,10 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookH2withSumw
   if (me->getTH2F()->GetSumw2N() == 0)
     me->enableSumw2();
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
-    me->setAxisTitle(titleY.c_str(), 2);
+    me->setAxisTitle(titleY, 2);
   }
   if (TString(option) != "") {
     me->setOption(option);
@@ -185,7 +185,7 @@ ElectronDqmAnalyzerBase::MonitorElement *ElectronDqmAnalyzerBase::bookP1(DQMStor
     me->getTProfile()->GetXaxis()->SetTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
-    me->setAxisTitle(titleY.c_str(), 2);
+    me->setAxisTitle(titleY, 2);
   }
   if (TString(option) != "") {
     me->getTProfile()->SetOption(option);

--- a/DQMOffline/EGamma/src/ElectronDqmHarvesterBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmHarvesterBase.cc
@@ -203,13 +203,13 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH1(DQMSt
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
   if (!titleX.empty()) {
-    me->getTH1F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH1F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1F()->StatOverflows(kTRUE);
@@ -228,15 +228,15 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH1withSu
                                                                                     Option_t *option) {
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
-  me->getTH1F()->Sumw2();
+  me->enableSumw2();
   if (!titleX.empty()) {
-    me->getTH1F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH1F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1F()->StatOverflows(kTRUE);
@@ -259,13 +259,13 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH2(DQMSt
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
   if (!titleX.empty()) {
-    me->getTH2F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH2F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1F()->StatOverflows(kTRUE);
@@ -287,15 +287,15 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH2withSu
                                                                                     Option_t *option) {
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
-  me->getTH2F()->Sumw2();
+  me->enableSumw2();
   if (!titleX.empty()) {
-    me->getTH2F()->GetXaxis()->SetTitle(titleX.c_str());
+    me->setAxisTitle(titleX.c_str());
   }
   if (!titleY.empty()) {
     me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
   }
   if (TString(option) != "") {
-    me->getTH2F()->SetOption(option);
+    me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
     me->getTH1F()->StatOverflows(kTRUE);

--- a/DQMOffline/EGamma/src/ElectronDqmHarvesterBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmHarvesterBase.cc
@@ -203,7 +203,7 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH1(DQMSt
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
     me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
@@ -230,7 +230,7 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH1withSu
   MonitorElement *me = iBooker.book1D(newName(name), title, nchX, lowX, highX);
   me->enableSumw2();
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
     me->getTH1F()->GetYaxis()->SetTitle(titleY.c_str());
@@ -259,7 +259,7 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH2(DQMSt
   iBooker.setCurrentFolder(outputInternalPath_);
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
     me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());
@@ -289,7 +289,7 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH2withSu
   MonitorElement *me = iBooker.book2D(newName(name), title, nchX, lowX, highX, nchY, lowY, highY);
   me->enableSumw2();
   if (!titleX.empty()) {
-    me->setAxisTitle(titleX.c_str());
+    me->setAxisTitle(titleX);
   }
   if (!titleY.empty()) {
     me->getTH2F()->GetYaxis()->SetTitle(titleY.c_str());

--- a/DQMOffline/JetMET/src/CaloTowerAnalyzer.cc
+++ b/DQMOffline/JetMET/src/CaloTowerAnalyzer.cc
@@ -92,39 +92,39 @@ void CaloTowerAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run cons
   hCT_Nevents = ibooker.book1D("METTask_CT_Nevents", "", 1, 0, 1);
   //--Data integrated over all events and stored by CaloTower(ieta,iphi)
   hCT_et_ieta_iphi = ibooker.book2D("METTask_CT_et_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_et_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_et_ieta_iphi->setOption("colz");
   hCT_et_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_et_ieta_iphi->setAxisTitle("ephi", 2);
 
   hCT_emEt_ieta_iphi = ibooker.book2D("METTask_CT_emEt_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_emEt_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_emEt_ieta_iphi->setOption("colz");
   hCT_emEt_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_emEt_ieta_iphi->setAxisTitle("ephi", 2);
   hCT_hadEt_ieta_iphi = ibooker.book2D("METTask_CT_hadEt_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_hadEt_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_hadEt_ieta_iphi->setOption("colz");
   hCT_hadEt_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_hadEt_ieta_iphi->setAxisTitle("ephi", 2);
   hCT_outerEt_ieta_iphi = ibooker.book2D("METTask_CT_outerEt_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_outerEt_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_outerEt_ieta_iphi->setOption("colz");
   hCT_outerEt_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_outerEt_ieta_iphi->setAxisTitle("ephi", 2);
   hCT_Occ_ieta_iphi = ibooker.book2D("METTask_CT_Occ_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_Occ_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_Occ_ieta_iphi->setOption("colz");
   hCT_Occ_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_Occ_ieta_iphi->setAxisTitle("ephi", 2);
 
   hCT_Occ_EM_Et_ieta_iphi = ibooker.book2D("METTask_CT_Occ_EM_Et_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_Occ_EM_Et_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_Occ_EM_Et_ieta_iphi->setOption("colz");
   hCT_Occ_EM_Et_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_Occ_EM_Et_ieta_iphi->setAxisTitle("ephi", 2);
 
   hCT_Occ_HAD_Et_ieta_iphi = ibooker.book2D("METTask_CT_Occ_HAD_Et_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_Occ_HAD_Et_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_Occ_HAD_Et_ieta_iphi->setOption("colz");
   hCT_Occ_HAD_Et_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_Occ_HAD_Et_ieta_iphi->setAxisTitle("ephi", 2);
 
   hCT_Occ_Outer_Et_ieta_iphi = ibooker.book2D("METTask_CT_Occ_Outer_Et_ieta_iphi", "", 83, -41, 42, 72, 1, 73);
-  hCT_Occ_Outer_Et_ieta_iphi->getTH2F()->SetOption("colz");
+  hCT_Occ_Outer_Et_ieta_iphi->setOption("colz");
   hCT_Occ_Outer_Et_ieta_iphi->setAxisTitle("ieta", 1);
   hCT_Occ_Outer_Et_ieta_iphi->setAxisTitle("ephi", 2);
 

--- a/DQMOffline/JetMET/src/DataCertificationJetMET.cc
+++ b/DQMOffline/JetMET/src/DataCertificationJetMET.cc
@@ -652,14 +652,14 @@ void DataCertificationJetMET::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGe
 
   if (reportSummaryMap && reportSummaryMap->getRootObject()) {
     reportSummaryMap->getTH2F()->SetStats(kFALSE);
-    reportSummaryMap->getTH2F()->SetOption("colz");
+    reportSummaryMap->setOption("colz");
     reportSummaryMap->setBinLabel(1, "CaloTower");
     reportSummaryMap->setBinLabel(2, "MET");
     reportSummaryMap->setBinLabel(3, "Jet");
   }
   if (CertificationSummaryMap && CertificationSummaryMap->getRootObject()) {
     CertificationSummaryMap->getTH2F()->SetStats(kFALSE);
-    CertificationSummaryMap->getTH2F()->SetOption("colz");
+    CertificationSummaryMap->setOption("colz");
     CertificationSummaryMap->setBinLabel(1, "CaloTower");
     CertificationSummaryMap->setBinLabel(2, "MET");
     CertificationSummaryMap->setBinLabel(3, "Jet");

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -367,7 +367,7 @@ void JetAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRu
   map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "NJets_profile", mNJets_profile));
 
   mPhiVSEta = ibooker.book2D("PhiVSEta", "PhiVSEta", 50, etaMin_, etaMax_, 24, phiMin_, phiMax_);
-  mPhiVSEta->getTH2F()->SetOption("colz");
+  mPhiVSEta->setOption("colz");
   mPhiVSEta->setAxisTitle("#eta", 1);
   mPhiVSEta->setAxisTitle("#phi", 2);
   map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "PhiVSEta", mPhiVSEta));

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -1150,11 +1150,11 @@ void METAnalyzer::bookMonitorElement(std::string DirName,
         hMExLS = ibooker.book2D("MExLS", "MEx_LS", 200, -200, 200, 250, 0., 2500.);
         hMExLS->setAxisTitle("MEx [GeV]", 1);
         hMExLS->setAxisTitle("Lumi Section", 2);
-        hMExLS->getTH2F()->SetOption("colz");
+        hMExLS->setOption("colz");
         hMEyLS = ibooker.book2D("MEyLS", "MEy_LS", 200, -200, 200, 250, 0., 2500.);
         hMEyLS->setAxisTitle("MEy [GeV]", 1);
         hMEyLS->setAxisTitle("Lumi Section", 2);
-        hMEyLS->getTH2F()->SetOption("colz");
+        hMEyLS->setOption("colz");
         map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "MExLS", hMExLS));
         map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "MEyLS", hMEyLS));
       }

--- a/DQMOffline/L1Trigger/src/L1TFillWithinLimits.cc
+++ b/DQMOffline/L1Trigger/src/L1TFillWithinLimits.cc
@@ -10,20 +10,18 @@ namespace dqmoffline {
  * @param
  */
     void fillWithinLimits(MonitorElement* mon, double value, double weight) {
-      TH1* hist = mon->getTH1F();
-      double min(hist->GetXaxis()->GetXmin());
-      double max(hist->GetXaxis()->GetXmax());
+      double min(mon->getAxisMin(1));
+      double max(mon->getAxisMax(1));
 
       double fillValue = getFillValueWithinLimits(value, min, max);
       mon->Fill(fillValue, weight);
     }
     void fill2DWithinLimits(MonitorElement* mon, double valueX, double valueY, double weight) {
-      TH1* hist = mon->getTH2F();
-      double minX(hist->GetXaxis()->GetXmin());
-      double minY(hist->GetYaxis()->GetXmin());
+      double minX(mon->getAxisMin(1));
+      double minY(mon->getAxisMin(2));
 
-      double maxX(hist->GetXaxis()->GetXmax());
-      double maxY(hist->GetYaxis()->GetXmax());
+      double maxX(mon->getAxisMax(1));
+      double maxY(mon->getAxisMax(2));
 
       double fillValueX = getFillValueWithinLimits(valueX, minX, maxX);
       double fillValueY = getFillValueWithinLimits(valueY, minY, maxY);

--- a/DQMOffline/PFTau/plugins/PFClient.cc
+++ b/DQMOffline/PFTau/plugins/PFClient.cc
@@ -355,7 +355,7 @@ void PFClient::createEfficiencyPlots(DQMStore::IBooker &ibooker,
     }
     */
     // Binomial errors "B" asked by Florian
-    /*me1_forEff->Sumw2(); me2_forEff->Sumw2();*/ me_eff->getTH1F()->Sumw2();
+    /*me1_forEff->Sumw2(); me2_forEff->Sumw2();*/ me_eff->enableSumw2();
     me_eff->getTH1F()->Divide(me1_forEff, me2_forEff, 1, 1, "B");
   }
 }

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -321,20 +321,20 @@ FlavourHistograms<T>::FlavourHistograms(const std::string& baseNameTitle_,
   // statistics if requested
   if (theStatistics) {
     if (theHisto_all)
-      theHisto_all->getTH1F()->Sumw2();
+      theHisto_all->enableSumw2();
     if (mcPlots_) {
       if (mcPlots_ > 2) {
-        theHisto_d->getTH1F()->Sumw2();
-        theHisto_u->getTH1F()->Sumw2();
-        theHisto_s->getTH1F()->Sumw2();
-        theHisto_g->getTH1F()->Sumw2();
-        theHisto_dus->getTH1F()->Sumw2();
+        theHisto_d->enableSumw2();
+        theHisto_u->enableSumw2();
+        theHisto_s->enableSumw2();
+        theHisto_g->enableSumw2();
+        theHisto_dus->enableSumw2();
       }
-      theHisto_c->getTH1F()->Sumw2();
-      theHisto_b->getTH1F()->Sumw2();
-      theHisto_ni->getTH1F()->Sumw2();
-      theHisto_dusg->getTH1F()->Sumw2();
-      theHisto_pu->getTH1F()->Sumw2();
+      theHisto_c->enableSumw2();
+      theHisto_b->enableSumw2();
+      theHisto_ni->enableSumw2();
+      theHisto_dusg->enableSumw2();
+      theHisto_pu->enableSumw2();
     }
   }
   // defaults for other data members
@@ -517,7 +517,7 @@ void FlavourHistograms<T>::plot(TPad* theCanvas /* = 0 */) {
       lineStyle[1] = 2;
   }
 
-  histo[0]->getTH1F()->GetXaxis()->SetTitle(theBaseNameDescription.c_str());
+  histo[0]->setAxisTitle(theBaseNameDescription.c_str());
   histo[0]->getTH1F()->GetYaxis()->SetTitle("Arbitrary Units");
   histo[0]->getTH1F()->GetYaxis()->SetTitleOffset(1.25);
 

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
@@ -580,23 +580,23 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D(TString baseNameTitle_,
   // statistics if requested
   if (theStatistics) {
     if (theHisto_all)
-      theHisto_all->getTH2F()->Sumw2();
+      theHisto_all->enableSumw2();
     if (createProfile)
       if (theProfile_all)
         theProfile_all->getTProfile()->Sumw2();
     if (mcPlots_) {
       if (mcPlots_ > 2) {
-        theHisto_d->getTH2F()->Sumw2();
-        theHisto_u->getTH2F()->Sumw2();
-        theHisto_s->getTH2F()->Sumw2();
-        theHisto_g->getTH2F()->Sumw2();
-        theHisto_dus->getTH2F()->Sumw2();
+        theHisto_d->enableSumw2();
+        theHisto_u->enableSumw2();
+        theHisto_s->enableSumw2();
+        theHisto_g->enableSumw2();
+        theHisto_dus->enableSumw2();
       }
-      theHisto_c->getTH2F()->Sumw2();
-      theHisto_b->getTH2F()->Sumw2();
-      theHisto_ni->getTH2F()->Sumw2();
-      theHisto_dusg->getTH2F()->Sumw2();
-      theHisto_pu->getTH2F()->Sumw2();
+      theHisto_c->enableSumw2();
+      theHisto_b->enableSumw2();
+      theHisto_ni->enableSumw2();
+      theHisto_dusg->enableSumw2();
+      theHisto_pu->enableSumw2();
 
       if (createProfile) {
         if (mcPlots_ > 2) {
@@ -829,7 +829,7 @@ void FlavourHistograms2D<T, G>::plot(TPad *theCanvas /* = 0 */) {
     markerStyle[3] = 23;
   }
 
-  histo[0]->getTH2F()->GetXaxis()->SetTitle(theBaseNameDescription.c_str());
+  histo[0]->setAxisTitle(theBaseNameDescription.c_str());
   histo[0]->getTH2F()->GetYaxis()->SetTitle("Arbitrary Units");
   histo[0]->getTH2F()->GetYaxis()->SetTitleOffset(1.25);
 

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
@@ -829,7 +829,7 @@ void FlavourHistograms2D<T, G>::plot(TPad *theCanvas /* = 0 */) {
     markerStyle[3] = 23;
   }
 
-  histo[0]->setAxisTitle(theBaseNameDescription.c_str());
+  histo[0]->setAxisTitle(theBaseNameDescription);
   histo[0]->getTH2F()->GetYaxis()->SetTitle("Arbitrary Units");
   histo[0]->getTH2F()->GetYaxis()->SetTitleOffset(1.25);
 

--- a/DQMOffline/RecoB/interface/TrackIPHistograms.h
+++ b/DQMOffline/RecoB/interface/TrackIPHistograms.h
@@ -115,10 +115,10 @@ TrackIPHistograms<T>::TrackIPHistograms(const std::string& baseNameTitle_,
         baseNameTitle_ + "QualHighPur", baseNameDescription_ + " High Purity Quality", nBins_, lowerBound_, upperBound_);
 
     if (statistics_) {
-      theQual_undefined->getTH1F()->Sumw2();
-      theQual_loose->getTH1F()->Sumw2();
-      theQual_tight->getTH1F()->Sumw2();
-      theQual_highpur->getTH1F()->Sumw2();
+      theQual_undefined->enableSumw2();
+      theQual_loose->enableSumw2();
+      theQual_tight->enableSumw2();
+      theQual_highpur->enableSumw2();
     }
   }
 }

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -136,9 +136,9 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   type[0] = iBooker.book1D("otherType", "Vertex type (other Vtx)", 3, -0.5, 2.5);
   type[1] = iBooker.book1D("tagType", "Vertex type (tagged Vtx)", 3, -0.5, 2.5);
   for (int i = 0; i < 2; ++i) {
-    type[i]->getTH1F()->GetXaxis()->SetBinLabel(1, "Valid, real");
-    type[i]->getTH1F()->GetXaxis()->SetBinLabel(2, "Valid, fake");
-    type[i]->getTH1F()->GetXaxis()->SetBinLabel(3, "Invalid");
+    type[i]->setBinLabel(1, "Valid, real");
+    type[i]->setBinLabel(2, "Valid, fake");
+    type[i]->setBinLabel(3, "Invalid");
   }
 
   //  get the store
@@ -154,10 +154,10 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   bsBeamWidthX = iBooker.book1D("bsBeamWidthX", "BeamSpot BeamWidthX", 100, 0., 100.);
   bsBeamWidthY = iBooker.book1D("bsBeamWidthY", "BeamSpot BeamWidthY", 100, 0., 100.);
   bsType = iBooker.book1D("bsType", "BeamSpot type", 4, -1.5, 2.5);
-  bsType->getTH1F()->GetXaxis()->SetBinLabel(1, "Unknown");
-  bsType->getTH1F()->GetXaxis()->SetBinLabel(2, "Fake");
-  bsType->getTH1F()->GetXaxis()->SetBinLabel(3, "LHC");
-  bsType->getTH1F()->GetXaxis()->SetBinLabel(4, "Tracker");
+  bsType->setBinLabel(1, "Unknown");
+  bsType->setBinLabel(2, "Fake");
+  bsType->setBinLabel(3, "LHC");
+  bsType->setBinLabel(4, "Tracker");
 
   //  get the store
   dqmLabel = TopFolderName_ + "/" + AlignmentLabel_;

--- a/DQMOffline/RecoB/src/EffPurFromHistos2D.cc
+++ b/DQMOffline/RecoB/src/EffPurFromHistos2D.cc
@@ -369,7 +369,7 @@ void EffPurFromHistos2D::compute(DQMStore::IBooker& ibook, vector<double> fixedE
         (prov.book1D(hX + fixedEfficiency + hE, hX + fixedEfficiency + hE, nBinOutputX, startOutputX, endOutputX)));
     X_vs_Y_eff_at_fixedZeff[ieff]->setEfficiencyFlag();
 
-    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetXTitle("Light mistag");
+    X_vs_Y_eff_at_fixedZeff[ieff]->setAxisTitle("Light mistag");
     X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetYTitle("B mistag");
     if (!doCTagPlots_)
       X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetYTitle("C mistag");

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -721,7 +721,7 @@ void HLTMuonMatchAndPlot::book1D(DQMStore::IBooker& iBooker, string name, const 
   hists_[name] = iBooker.book1D(name, title, nBins, edges);
   if (hists_[name])
     if (hists_[name]->getTH1F()->GetSumw2N())
-      hists_[name]->getTH1F()->Sumw2();
+      hists_[name]->enableSumw2();
 
   if (edges)
     delete[] edges;
@@ -749,7 +749,7 @@ void HLTMuonMatchAndPlot::book2D(DQMStore::IBooker& iBooker,
   hists_[name] = iBooker.book2D(name.c_str(), title.c_str(), nBinsX, edgesX, nBinsY, edgesY);
   if (hists_[name])
     if (hists_[name]->getTH2F()->GetSumw2N())
-      hists_[name]->getTH2F()->Sumw2();
+      hists_[name]->enableSumw2();
 
   if (edgesX)
     delete[] edgesX;

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -106,7 +106,7 @@ void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker& iBooker) {
           "L3TrigTauEtaPhiEffNum", "L3 efficiency in eta-phi plane", etabins_, -2.5, 2.5, phibins_, -3.2, 3.2);
       hL3TrigTauEtaPhiEffDenom_ = iBooker.book2D(
           "L3TrigTauEtaPhiEffDenom", "L3 denominator in eta-phi plane", etabins_, -2.5, 2.5, phibins_, -3.2, 3.2);
-      hL3TrigTauEtaPhiEffDenom_->getTH2F()->SetOption("COL");
+      hL3TrigTauEtaPhiEffDenom_->setOption("COL");
     }
 
     if (hltPath_.hasL2Electrons()) {

--- a/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
@@ -65,7 +65,7 @@ void HLTTauDQMTagAndProbePlotter::bookHistograms(DQMStore::IBooker& iBooker,
         iBooker.book2D(xvariable + "EtaPhiEffNum", "", nbinsEta_, etamin_, etamax_, nbinsPhi_, phimin_, phimax_);
     h_den_etaphi =
         iBooker.book2D(xvariable + "EtaPhiEffDenom", "", nbinsEta_, etamin_, etamax_, nbinsPhi_, phimin_, phimax_);
-    h_den_etaphi->getTH2F()->SetOption("COL");
+    h_den_etaphi->setOption("COL");
   }
 
   h_num_phi = iBooker.book1D(xvariable + "PhiEffNum", "", nbinsPhi_, phimin_, phimax_);

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -192,27 +192,27 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
     static const boost::regex prefix(current_path + "/path ");
     std::string path = boost::regex_replace(subsubdir, prefix, "");
 
-    paths_time->getTH1F()->GetXaxis()->SetBinLabel(ibin, path.c_str());
-    paths_thread->getTH1F()->GetXaxis()->SetBinLabel(ibin, path.c_str());
-    paths_allocated->getTH1F()->GetXaxis()->SetBinLabel(ibin, path.c_str());
-    paths_deallocated->getTH1F()->GetXaxis()->SetBinLabel(ibin, path.c_str());
+    paths_time->setBinLabel(ibin, path.c_str());
+    paths_thread->setBinLabel(ibin, path.c_str());
+    paths_allocated->setBinLabel(ibin, path.c_str());
+    paths_deallocated->setBinLabel(ibin, path.c_str());
 
     if ((me = getter.get(subsubdir + "/path time_real"))) {
       mean = me->getMean();
-      paths_time->getTH1F()->SetBinContent(ibin, mean);
+      paths_time->setBinContent(ibin, mean);
     }
     if ((me = getter.get(subsubdir + "/path time_thread"))) {
       mean = me->getMean();
-      paths_thread->getTH1F()->SetBinContent(ibin, mean);
+      paths_thread->setBinContent(ibin, mean);
     }
     if ((me = getter.get(subsubdir + "/path allocated"))) {
       mean = me->getMean();
-      paths_allocated->getTH1F()->SetBinContent(ibin, mean);
+      paths_allocated->setBinContent(ibin, mean);
     }
 
     if ((me = getter.get(subsubdir + "/path deallocated"))) {
       mean = me->getMean();
-      paths_deallocated->getTH1F()->SetBinContent(ibin, mean);
+      paths_deallocated->setBinContent(ibin, mean);
     }
 
     ibin++;

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -192,10 +192,10 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
     static const boost::regex prefix(current_path + "/path ");
     std::string path = boost::regex_replace(subsubdir, prefix, "");
 
-    paths_time->setBinLabel(ibin, path.c_str());
-    paths_thread->setBinLabel(ibin, path.c_str());
-    paths_allocated->setBinLabel(ibin, path.c_str());
-    paths_deallocated->setBinLabel(ibin, path.c_str());
+    paths_time->setBinLabel(ibin, path);
+    paths_thread->setBinLabel(ibin, path);
+    paths_allocated->setBinLabel(ibin, path);
+    paths_deallocated->setBinLabel(ibin, path);
 
     if ((me = getter.get(subsubdir + "/path time_real"))) {
       mean = me->getMean();

--- a/Validation/HcalDigis/src/ZDCDigiStudy.cc
+++ b/Validation/HcalDigis/src/ZDCDigiStudy.cc
@@ -173,12 +173,12 @@ void ZDCDigiStudy::bookHistograms(DQMStore::IBooker& ib, edm::Run const& run, ed
     meZdcfCPEMvHAD = ib.book2D("PEMvPHAD", "PZDC_EMvHAD", 200, -25, 12000, 200, -25, 15000);
     meZdcfCPEMvHAD->setAxisTitle("SumEM_fC", 2);
     meZdcfCPEMvHAD->setAxisTitle("SumHAD_fC", 1);
-    meZdcfCPEMvHAD->getTH2F()->SetOption("colz");
+    meZdcfCPEMvHAD->setOption("colz");
     ////////////////////////////////24///////////////////////////////////////////
     meZdcfCNEMvHAD = ib.book2D("NEMvNHAD", "NZDC_EMvHAD", 1000, -25, 12000, 1000, -25, 15000);
     meZdcfCNEMvHAD->setAxisTitle("SumEM_fC", 2);
     meZdcfCNEMvHAD->setAxisTitle("SumHAD_fC", 1);
-    meZdcfCNEMvHAD->getTH2F()->SetOption("colz");
+    meZdcfCNEMvHAD->setOption("colz");
     ///////////////////////////////////////////////////////////////////////////////
   }
 }

--- a/Validation/HcalHits/src/ZdcSimHitStudy.cc
+++ b/Validation/HcalHits/src/ZdcSimHitStudy.cc
@@ -371,7 +371,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_Pi0F->setAxisTitle("Eta", 1);
     genpart_Pi0F->setAxisTitle("Phi (radians)", 2);
     genpart_Pi0F->setAxisTitle("Energy (GeV)", 3);
-    genpart_Pi0F->getTH2F()->SetOption("lego2z,prof");
+    genpart_Pi0F->setOption("lego2z,prof");
     genpart_Pi0F->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_Pi0F->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -380,7 +380,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_Pi0F_counts->setAxisTitle("#eta", 1);
     genpart_Pi0F_counts->setAxisTitle("#phi (radians)", 2);
     genpart_Pi0F_counts->setAxisTitle("Energy (GeV)", 3);
-    genpart_Pi0F_counts->getTH2F()->SetOption("lego2z,prof");
+    genpart_Pi0F_counts->setOption("lego2z,prof");
     genpart_Pi0F_counts->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_Pi0F_counts->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -390,7 +390,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_NeutF->setAxisTitle("Eta", 1);
     genpart_NeutF->setAxisTitle("Phi (radians)", 2);
     genpart_NeutF->setAxisTitle("Energy (GeV)", 3);
-    genpart_NeutF->getTH2F()->SetOption("lego2z,prof");
+    genpart_NeutF->setOption("lego2z,prof");
     genpart_NeutF->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_NeutF->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -399,7 +399,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_NeutF_counts->setAxisTitle("#eta", 1);
     genpart_NeutF_counts->setAxisTitle("#phi (radians)", 2);
     genpart_NeutF_counts->setAxisTitle("Energy (GeV)", 3);
-    genpart_NeutF_counts->getTH2F()->SetOption("lego2z,prof");
+    genpart_NeutF_counts->setOption("lego2z,prof");
     genpart_NeutF_counts->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_NeutF_counts->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -409,7 +409,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_GammaF->setAxisTitle("Eta", 1);
     genpart_GammaF->setAxisTitle("Phi (radians)", 2);
     genpart_GammaF->setAxisTitle("Energy (GeV)", 3);
-    genpart_GammaF->getTH2F()->SetOption("lego2z,prof");
+    genpart_GammaF->setOption("lego2z,prof");
     genpart_GammaF->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_GammaF->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -418,7 +418,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_GammaF_counts->setAxisTitle("#eta", 1);
     genpart_GammaF_counts->setAxisTitle("#phi (radians)", 2);
     genpart_GammaF_counts->setAxisTitle("Energy (GeV)", 3);
-    genpart_GammaF_counts->getTH2F()->SetOption("lego2z,prof");
+    genpart_GammaF_counts->setOption("lego2z,prof");
     genpart_GammaF_counts->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_GammaF_counts->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -446,7 +446,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_Pi0B->setAxisTitle("Eta", 1);
     genpart_Pi0B->setAxisTitle("Phi (radians)", 2);
     genpart_Pi0B->setAxisTitle("Energy (GeV)", 3);
-    genpart_Pi0B->getTH2F()->SetOption("lego2z,prof");
+    genpart_Pi0B->setOption("lego2z,prof");
     genpart_Pi0B->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_Pi0B->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -455,7 +455,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_Pi0B_counts->setAxisTitle("#eta", 1);
     genpart_Pi0B_counts->setAxisTitle("#phi (radians)", 2);
     genpart_Pi0B_counts->setAxisTitle("Energy (GeV)", 3);
-    genpart_Pi0B_counts->getTH2F()->SetOption("lego2z,prof");
+    genpart_Pi0B_counts->setOption("lego2z,prof");
     genpart_Pi0B_counts->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_Pi0B_counts->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -465,7 +465,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_NeutB->setAxisTitle("Eta", 1);
     genpart_NeutB->setAxisTitle("Phi (radians)", 2);
     genpart_NeutB->setAxisTitle("Energy (GeV)", 3);
-    genpart_NeutB->getTH2F()->SetOption("lego2z,prof");
+    genpart_NeutB->setOption("lego2z,prof");
     genpart_NeutB->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_NeutB->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -474,7 +474,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_NeutB_counts->setAxisTitle("#eta", 1);
     genpart_NeutB_counts->setAxisTitle("#phi (radians)", 2);
     genpart_NeutB_counts->setAxisTitle("Energy (GeV)", 3);
-    genpart_NeutB_counts->getTH2F()->SetOption("lego2z,prof");
+    genpart_NeutB_counts->setOption("lego2z,prof");
     genpart_NeutB_counts->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_NeutB_counts->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -483,7 +483,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_GammaB->setAxisTitle("Eta", 1);
     genpart_GammaB->setAxisTitle("Phi (radians)", 2);
     genpart_GammaB->setAxisTitle("Energy (GeV)", 3);
-    genpart_GammaB->getTH2F()->SetOption("lego2z,prof");
+    genpart_GammaB->setOption("lego2z,prof");
     genpart_GammaB->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_GammaB->getTH2F()->SetTitleOffset(1.4, "y");
 
@@ -492,7 +492,7 @@ void ZdcSimHitStudy::bookHistograms(DQMStore::IBooker &ib, edm::Run const &run, 
     genpart_GammaB_counts->setAxisTitle("#eta", 1);
     genpart_GammaB_counts->setAxisTitle("#phi (radians)", 2);
     genpart_GammaB_counts->setAxisTitle("Energy (GeV)", 3);
-    genpart_GammaB_counts->getTH2F()->SetOption("lego2z,prof");
+    genpart_GammaB_counts->setOption("lego2z,prof");
     genpart_GammaB_counts->getTH2F()->SetTitleOffset(1.4, "x");
     genpart_GammaB_counts->getTH2F()->SetTitleOffset(1.4, "y");
 

--- a/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
+++ b/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
@@ -167,7 +167,7 @@ recoBSVTagInfoValidationAnalyzer::recoBSVTagInfoValidationAnalyzer(const edm::Pa
 
   // Set the proper categories names
   for (Int_t i = 0; i < numberVertexClassifier_; ++i)
-    HistIndex_["VertexClassifier"]->getTH1F()->GetXaxis()->SetBinLabel(i + 1, VertexCategories::Names[i]);
+    HistIndex_["VertexClassifier"]->setBinLabel(i + 1, VertexCategories::Names[i]);
 
   // book histograms
   bookRecoToSim("rs_All");

--- a/Validation/SiOuterTrackerV/src/OuterTrackerMCHarvester.cc
+++ b/Validation/SiOuterTrackerV/src/OuterTrackerMCHarvester.cc
@@ -117,7 +117,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       // Calculate the efficiency
       me_effic_eta->getTH1F()->Divide(numerator, denominator, 1., 1., "B");
-      me_effic_eta->getTH1F()->GetXaxis()->SetTitle("tracking particle #eta");
+      me_effic_eta->setAxisTitle("tracking particle #eta");
       me_effic_eta->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_eta->getTH1F()->SetMaximum(1.0);
       me_effic_eta->getTH1F()->SetMinimum(0.0);
@@ -146,7 +146,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       // Calculate the efficiency
       me_effic_pt->getTH1F()->Divide(numerator2, denominator2, 1., 1., "B");
-      me_effic_pt->getTH1F()->GetXaxis()->SetTitle("Tracking particle p_{T} [GeV]");
+      me_effic_pt->setAxisTitle("Tracking particle p_{T} [GeV]");
       me_effic_pt->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_pt->getTH1F()->SetMaximum(1.0);
       me_effic_pt->getTH1F()->SetMinimum(0.0);
@@ -175,7 +175,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       // Calculate the efficiency
       me_effic_pt_zoom->getTH1F()->Divide(numerator2_zoom, denominator2_zoom, 1., 1., "B");
-      me_effic_pt_zoom->getTH1F()->GetXaxis()->SetTitle("Tracking particle p_{T} [GeV]");
+      me_effic_pt_zoom->setAxisTitle("Tracking particle p_{T} [GeV]");
       me_effic_pt_zoom->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_pt_zoom->getTH1F()->SetMaximum(1.0);
       me_effic_pt_zoom->getTH1F()->SetMinimum(0.0);
@@ -204,7 +204,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       // Calculate the efficiency
       me_effic_d0->getTH1F()->Divide(numerator5, denominator5, 1., 1., "B");
-      me_effic_d0->getTH1F()->GetXaxis()->SetTitle("Tracking particle d_{0} [cm]");
+      me_effic_d0->setAxisTitle("Tracking particle d_{0} [cm]");
       me_effic_d0->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_d0->getTH1F()->SetMaximum(1.0);
       me_effic_d0->getTH1F()->SetMinimum(0.0);
@@ -233,7 +233,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       // Calculate the efficiency
       me_effic_VtxR->getTH1F()->Divide(numerator6, denominator6, 1., 1., "B");
-      me_effic_VtxR->getTH1F()->GetXaxis()->SetTitle("Tracking particle VtxR [cm]");
+      me_effic_VtxR->setAxisTitle("Tracking particle VtxR [cm]");
       me_effic_VtxR->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_VtxR->getTH1F()->SetMaximum(1.0);
       me_effic_VtxR->getTH1F()->SetMinimum(0.0);
@@ -262,7 +262,7 @@ void OuterTrackerMCHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IG
 
       // Calculate the efficiency
       me_effic_VtxZ->getTH1F()->Divide(numerator7, denominator7, 1., 1., "B");
-      me_effic_VtxZ->getTH1F()->GetXaxis()->SetTitle("Tracking particle VtxZ [cm]");
+      me_effic_VtxZ->setAxisTitle("Tracking particle VtxZ [cm]");
       me_effic_VtxZ->getTH1F()->GetYaxis()->SetTitle("Efficiency");
       me_effic_VtxZ->getTH1F()->SetMaximum(1.0);
       me_effic_VtxZ->getTH1F()->SetMinimum(0.0);


### PR DESCRIPTION
#### PR description:

This PR includes a few cherry-picks from the "new DQMStore" branch that remove unnecessary calls to `getTH1` and friends. While there is no specific reason to do this now, `getTH1` is unsafe in general and will become illegal at some point (for certain situations, at least).

For now, this is just general cleanup of the DQM codebase.

Some new APIs in the `MonitorElement` are required for this, since those are present in #28092, it is included here. This PR should wait until #28092 is merged.

I excluded the changes regarding `SetCanExtend`, since I am not really sure if and where it is safe to remove these calls. This will need to be figured out later.

#### PR validation:
No changes expected.
