### PR TITLE
Add a possibility to display a GDML file

### DIFF
--- a/Fireworks/Core/src/FWGeometryTableViewManager.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewManager.cc
@@ -94,12 +94,13 @@ void FWGeometryTableViewManager::setGeoManagerFromFile() {
   TFile* file = FWGeometry::findFile(m_fileName.c_str());
   fwLog(fwlog::kInfo) << "Geometry table file: " << m_fileName.c_str() << std::endl;
   try {
-    if (!file)
-      throw std::runtime_error("No root file.");
-
-    file->ls();
-
-    s_geoManager = (TGeoManager*)file->Get(m_TGeoName.c_str());
+    if (!file) {
+      // Try it as a GDML file
+      s_geoManager = TGeoManager::Import(m_fileName.c_str(), m_TGeoName.c_str());
+    } else {
+      file->ls();
+      s_geoManager = (TGeoManager*)file->Get(m_TGeoName.c_str());
+    }
     if (!s_geoManager)
       throw std::runtime_error("Can't find TGeoManager object in selected file.");
 


### PR DESCRIPTION
#### PR description:

A GDML file produced by G4 GDML writer can be viewed in cmsShow. For example:

```
cmsShow -c g4Geom.fwc --sim-geom-file=cmsG4Geometry.gdml --tgeo-name=world-volume
```
![Screen Shot 2019-11-05 at 12 06 08](https://user-images.githubusercontent.com/1390682/68214997-bff77900-ffde-11e9-83a0-5fdb07a764dd.png)

@civanch - FYI

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
