### PR TITLE
Do not register SiPixelOfflineCalibAnalysisBase as a plugin

### DIFF
--- a/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
+++ b/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
@@ -300,5 +300,3 @@ void SiPixelOfflineCalibAnalysisBase::addTF1ToDQMMonitoringElement(MonitorElemen
   }
   return;
 }
-//define this as a plug-in
-DEFINE_FWK_MODULE(SiPixelOfflineCalibAnalysisBase);


### PR DESCRIPTION
#### PR description:

The class is intended as a base class for other modules and needs
to be linked with.
This avoids a multiple plugin error seen in the IBs.

#### PR validation:

The code compiles.