### PR TITLE
(DAQ) Revert to untracked parameters and new configuration

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -189,20 +189,22 @@ namespace evf {
 
     std::string base_dir_;
     std::string bu_base_dir_;
-    bool directorBu_;
     unsigned int run_;
     bool useFileBroker_;
+    bool fileBrokerHostFromCfg_;
     std::string fileBrokerHost_;
     std::string fileBrokerPort_;
     bool fileBrokerKeepAlive_;
     bool fileBrokerUseLocalLock_;
-    unsigned int startFromLS_ = 1;
+    unsigned int fuLockPollInterval_;
     bool outputAdler32Recheck_;
     bool requireTSPSet_;
     std::string selectedTransferMode_;
-    std::string hltSourceDirectory_;
-    unsigned int fuLockPollInterval_;
     std::string mergeTypePset_;
+    bool directorBU_;
+    std::string hltSourceDirectory_;
+
+    unsigned int startFromLS_ = 1;
 
     std::string hostname_;
     std::string run_string_;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -43,7 +43,7 @@ namespace evf {
         run_(pset.getUntrackedParameter<unsigned int>("runNumber")),
         useFileBroker_(pset.getUntrackedParameter<bool>("useFileBroker")),
         fileBrokerHostFromCfg_(pset.getUntrackedParameter<bool>("fileBrokerHostFromCfg", true)),
-        fileBrokerHost_(pset.getUntrackedParameter<std::string>("fileBrokerHost","InValid")),
+        fileBrokerHost_(pset.getUntrackedParameter<std::string>("fileBrokerHost", "InValid")),
         fileBrokerPort_(pset.getUntrackedParameter<std::string>("fileBrokerPort", "8080")),
         fileBrokerKeepAlive_(pset.getUntrackedParameter<bool>("fileBrokerKeepAlive", true)),
         fileBrokerUseLocalLock_(pset.getUntrackedParameter<bool>("fileBrokerUseLocalLock", true)),
@@ -329,7 +329,7 @@ namespace evf {
         ->setComment("Use BU file service to grab input data instead of NFS file locking");
     desc.addUntracked<bool>("fileBrokerHostFromCfg", true)
         ->setComment("Allow service to discover BU address from hltd configuration");
-    desc.addUntracked<std::string>("fileBrokerHost","InValid")->setComment("BU file service host.");
+    desc.addUntracked<std::string>("fileBrokerHost", "InValid")->setComment("BU file service host.");
     desc.addUntracked<std::string>("fileBrokerPort", "8080")->setComment("BU file service port");
     desc.addUntracked<bool>("fileBrokerKeepAlive", true)
         ->setComment("Use keep alive to avoid using large number of sockets");

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -42,7 +42,7 @@ namespace evf {
         bu_base_dir_(pset.getUntrackedParameter<std::string>("buBaseDir")),
         run_(pset.getUntrackedParameter<unsigned int>("runNumber")),
         useFileBroker_(pset.getUntrackedParameter<bool>("useFileBroker")),
-        fileBrokerHostFromCfg_(pset.getUntrackedParameter<bool>("fileBrokerHostFromCfg",true)),
+        fileBrokerHostFromCfg_(pset.getUntrackedParameter<bool>("fileBrokerHostFromCfg", true)),
         fileBrokerHost_(pset.getUntrackedParameter<std::string>("fileBrokerHost")),
         fileBrokerPort_(pset.getUntrackedParameter<std::string>("fileBrokerPort", "8080")),
         fileBrokerKeepAlive_(pset.getUntrackedParameter<bool>("fileBrokerKeepAlive", true)),
@@ -106,21 +106,20 @@ namespace evf {
     if (useFileBroker_) {
       if (fileBrokerHostFromCfg_) {
         //find BU data address from hltd configuration
-        fileBrokerHost_=std::string();
+        fileBrokerHost_ = std::string();
         struct stat buf;
         if (stat("/etc/appliance/bus.config", &buf) == 0) {
           std::ifstream busconfig("/etc/appliance/bus.config", std::ifstream::in);
           std::getline(busconfig, fileBrokerHost_);
         }
         if (fileBrokerHost_.empty())
-            throw cms::Exception("EvFDaqDirector") << "No file service or BU data address information";
-      }
-      else if (fileBrokerHost_.empty())
-        throw cms::Exception("EvFDaqDirector") << "fileBrokerHostFromCfg must be set to true if no fileBrokerHost is given";
+          throw cms::Exception("EvFDaqDirector") << "No file service or BU data address information";
+      } else if (fileBrokerHost_.empty())
+        throw cms::Exception("EvFDaqDirector")
+            << "fileBrokerHostFromCfg must be set to true if no fileBrokerHost is given";
 
       resolver_ = std::make_unique<boost::asio::ip::tcp::resolver>(io_service_);
-      query_ =
-          std::make_unique<boost::asio::ip::tcp::resolver::query>(fileBrokerHost_, fileBrokerPort_);
+      query_ = std::make_unique<boost::asio::ip::tcp::resolver::query>(fileBrokerHost_, fileBrokerPort_);
       endpoint_iterator_ = std::make_unique<boost::asio::ip::tcp::resolver::iterator>(resolver_->resolve(*query_));
       socket_ = std::make_unique<boost::asio::ip::tcp::socket>(io_service_);
     }
@@ -328,7 +327,7 @@ namespace evf {
     desc.addUntracked<unsigned int>("runNumber", 0)->setComment("Run Number in ramdisk to open");
     desc.addUntracked<bool>("useFileBroker", false)
         ->setComment("Use BU file service to grab input data instead of NFS file locking");
-    desc.addUntracked<bool>("fileBrokerHostFromCfg",true)
+    desc.addUntracked<bool>("fileBrokerHostFromCfg", true)
         ->setComment("Allow service to discover BU address from hltd configuration");
     desc.addUntracked<std::string>("fileBrokerHost")->setComment("BU file service host.");
     desc.addUntracked<std::string>("fileBrokerPort", "8080")->setComment("BU file service port");
@@ -344,9 +343,8 @@ namespace evf {
         ->setComment("Require complete transferSystem PSet in the process configuration");
     desc.addUntracked<std::string>("selectedTransferMode", "")
         ->setComment("Selected transfer mode (choice in Lvl0 propagated as Python parameter");
-    desc.addUntracked<bool>("directorIsBU",false)->setComment("BU director mode used for testing");
-    desc.addUntracked<std::string>("hltSourceDirectory", "")
-        ->setComment("BU director mode source directory");
+    desc.addUntracked<bool>("directorIsBU", false)->setComment("BU director mode used for testing");
+    desc.addUntracked<std::string>("hltSourceDirectory", "")->setComment("BU director mode source directory");
     desc.addUntracked<std::string>("mergingPset", "")
         ->setComment("Name of merging PSet to look for merging type definitions for streams");
     descriptions.add("EvFDaqDirector", desc);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -43,7 +43,7 @@ namespace evf {
         run_(pset.getUntrackedParameter<unsigned int>("runNumber")),
         useFileBroker_(pset.getUntrackedParameter<bool>("useFileBroker")),
         fileBrokerHostFromCfg_(pset.getUntrackedParameter<bool>("fileBrokerHostFromCfg", true)),
-        fileBrokerHost_(pset.getUntrackedParameter<std::string>("fileBrokerHost")),
+        fileBrokerHost_(pset.getUntrackedParameter<std::string>("fileBrokerHost","InValid")),
         fileBrokerPort_(pset.getUntrackedParameter<std::string>("fileBrokerPort", "8080")),
         fileBrokerKeepAlive_(pset.getUntrackedParameter<bool>("fileBrokerKeepAlive", true)),
         fileBrokerUseLocalLock_(pset.getUntrackedParameter<bool>("fileBrokerUseLocalLock", true)),
@@ -114,9 +114,9 @@ namespace evf {
         }
         if (fileBrokerHost_.empty())
           throw cms::Exception("EvFDaqDirector") << "No file service or BU data address information";
-      } else if (fileBrokerHost_.empty())
+      } else if (fileBrokerHost_.empty() || fileBrokerHost_ == "InValid")
         throw cms::Exception("EvFDaqDirector")
-            << "fileBrokerHostFromCfg must be set to true if no fileBrokerHost is given";
+            << "fileBrokerHostFromCfg must be set to true if fileBrokerHost parameter is not valid or empty";
 
       resolver_ = std::make_unique<boost::asio::ip::tcp::resolver>(io_service_);
       query_ = std::make_unique<boost::asio::ip::tcp::resolver::query>(fileBrokerHost_, fileBrokerPort_);
@@ -329,7 +329,7 @@ namespace evf {
         ->setComment("Use BU file service to grab input data instead of NFS file locking");
     desc.addUntracked<bool>("fileBrokerHostFromCfg", true)
         ->setComment("Allow service to discover BU address from hltd configuration");
-    desc.addUntracked<std::string>("fileBrokerHost")->setComment("BU file service host.");
+    desc.addUntracked<std::string>("fileBrokerHost","InValid")->setComment("BU file service host.");
     desc.addUntracked<std::string>("fileBrokerPort", "8080")->setComment("BU file service port");
     desc.addUntracked<bool>("fileBrokerKeepAlive", true)
         ->setComment("Use keep alive to avoid using large number of sockets");

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -101,12 +101,12 @@ process.source = cms.Source("EmptySource",
 )
 
 process.EvFDaqDirector = cms.Service("EvFDaqDirector",
-    runNumber = cms.uint32(options.runNumber),
-    baseDir = cms.string(options.fffBaseDir+"/"+options.buBaseDir),
-    buBaseDir = cms.string(options.fffBaseDir+"/"+options.buBaseDir),
-    directorIsBu = cms.untracked.bool(True),
-    useFileBroker = cms.bool(False),
-    fileBrokerHost = cms.string("")
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(True),
+    useFileBroker = cms.untracked.bool(False),
+    fileBrokerHost = cms.untracked.string("")
 )
 
 #throttle when running with no limit

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -66,13 +66,13 @@ process.FastMonitoringService = cms.Service("FastMonitoringService",
 )
 
 process.EvFDaqDirector = cms.Service("EvFDaqDirector",
-    useFileBroker = cms.bool(False),
-    fileServiceHost = cms.untracked.string("htcp40.cern.ch"),
-    runNumber = cms.uint32(options.runNumber),
-    baseDir = cms.string(options.fffBaseDir+"/"+options.fuBaseDir),
-    buBaseDir = cms.string(options.fffBaseDir+"/"+options.buBaseDir),
-    directorIsBu = cms.untracked.bool(False),
-    fileBrokerHost_ = cms.string("")
+    useFileBroker = cms.untracked.bool(False),
+    fileBrokerHostFromCfg = cms.untracked.bool(True),
+    fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(False),
 )
 
 try:

--- a/EventFilter/Utilities/test/start_multiLS_FU.py
+++ b/EventFilter/Utilities/test/start_multiLS_FU.py
@@ -67,13 +67,12 @@ process.FastMonitoringService = cms.Service("FastMonitoringService",
 )
 
 process.EvFDaqDirector = cms.Service("EvFDaqDirector",
-    useFileBroker = cms.bool(False),
-    fileServiceHost = cms.untracked.string("htcp40.cern.ch"),
-    runNumber = cms.uint32(options.runNumber),
-    baseDir = cms.string(options.fffBaseDir+"/"+options.fuBaseDir),
-    buBaseDir = cms.string(options.fffBaseDir+"/"+options.buBaseDir),
-    directorIsBu = cms.untracked.bool(False),
-    fileBrokerHost_ = cms.string("")
+    useFileBroker = cms.untracked.bool(False),
+    fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(False)
 )
 
 try:


### PR DESCRIPTION
#### PR description:
Reverting to untracked parameters in EvFDaqDirector as discussed in #28151
Including also these changes:
- new parameter is added to control if fileBrokeHost parameter can be changed within the process by looking at hltd configuration (which is current behavior).
- default value is removed from fileBrokerHost, so it must always be present for the configuration to run successfully.
- other parameters in the service have also been regrouped, and one was renamed.

#### PR validation:

Tested in DAQ "VM" test cluster with several relevant combinations of parameters. RunBUFU.sh in EventFilter/Utilities/test also runs fine.
