### PR TITLE
Fix LuminosityBlockSummaryCache & concurrent lumis

### DIFF
--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -118,6 +118,7 @@ namespace edm {
 
       virtual void preallocStreams(unsigned int);
       virtual void preallocLumis(unsigned int);
+      virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -124,6 +124,7 @@ namespace edm {
 
       virtual void preallocStreams(unsigned int);
       virtual void preallocLumis(unsigned int);
+      virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -127,6 +127,7 @@ namespace edm {
 
       virtual void preallocStreams(unsigned int);
       virtual void preallocLumis(unsigned int);
+      virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -184,18 +184,21 @@ namespace edm {
         ~LuminosityBlockSummaryCacheHolder() noexcept(false) override{};
 
       private:
+        void preallocLumisSummary(unsigned int iNLumis) final { caches_.reset(new std::shared_ptr<C>[iNLumis]); }
+
         friend class EndLuminosityBlockSummaryProducer<T, C>;
 
         void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) final {
-          cache_ = globalBeginLuminosityBlockSummary(lb, c);
+          caches_[lb.index()] = globalBeginLuminosityBlockSummary(lb, c);
         }
 
         void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) final {
           std::lock_guard<std::mutex> guard(mutex_);
-          streamEndLuminosityBlockSummary(id, lb, c, cache_.get());
+          streamEndLuminosityBlockSummary(id, lb, c, caches_[lb.index()].get());
         }
         void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) final {
-          globalEndLuminosityBlockSummary(lb, c, cache_.get());
+          globalEndLuminosityBlockSummary(lb, c, caches_[lb.index()].get());
+          maybeClearCache(lb);
         }
 
         virtual std::shared_ptr<C> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
@@ -207,8 +210,10 @@ namespace edm {
 
         virtual void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, C*) const = 0;
 
+        virtual void maybeClearCache(LuminosityBlock const& lb) { caches_[lb.index()].reset(); }
+
         //When threaded we will have a container for N items where N is # of simultaneous Lumis
-        std::shared_ptr<C> cache_;
+        std::unique_ptr<std::shared_ptr<C>[]> caches_;
         std::mutex mutex_;
       };
 
@@ -292,10 +297,14 @@ namespace edm {
 
       private:
         void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) final {
-          globalEndLuminosityBlockProduce(lb, c, LuminosityBlockSummaryCacheHolder<T, S>::cache_.get());
+          globalEndLuminosityBlockProduce(lb, c, LuminosityBlockSummaryCacheHolder<T, S>::caches_[lb.index()].get());
+          LuminosityBlockSummaryCacheHolder<T, S>::caches_[lb.index()].reset();
         }
 
         virtual void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, S const*) const = 0;
+
+        // Do nothing because the cache is cleared in doEndLuminosityBlockProduce_
+        void maybeClearCache(LuminosityBlock const&) final {}
       };
 
       template <typename T>

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -123,6 +123,7 @@ namespace edm {
 
       virtual void preallocStreams(unsigned int);
       virtual void preallocLumis(unsigned int);
+      virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -123,6 +123,7 @@ namespace edm {
 
       virtual void preallocStreams(unsigned int);
       virtual void preallocLumis(unsigned int);
+      virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -126,6 +126,7 @@ namespace edm {
 
       virtual void preallocStreams(unsigned int);
       virtual void preallocLumis(unsigned int);
+      virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);
       virtual void doBeginStream_(StreamID id);
       virtual void doEndStream_(StreamID id);

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -61,6 +61,7 @@ namespace edm {
     void EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       preallocStreams(iPrealloc.numberOfStreams());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+      preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
     }
 
@@ -168,6 +169,7 @@ namespace edm {
 
     void EDAnalyzerBase::preallocStreams(unsigned int) {}
     void EDAnalyzerBase::preallocLumis(unsigned int) {}
+    void EDAnalyzerBase::preallocLumisSummary(unsigned int) {}
     void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id) {}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -85,6 +85,7 @@ namespace edm {
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+      preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
     }
 
@@ -204,6 +205,7 @@ namespace edm {
 
     void EDFilterBase::preallocStreams(unsigned int) {}
     void EDFilterBase::preallocLumis(unsigned int) {}
+    void EDFilterBase::preallocLumisSummary(unsigned int) {}
     void EDFilterBase::preallocate(PreallocationConfiguration const&) {}
     void EDFilterBase::doBeginStream_(StreamID id) {}
     void EDFilterBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -90,6 +90,7 @@ namespace edm {
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+      preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
     }
 
@@ -212,6 +213,7 @@ namespace edm {
 
     void EDProducerBase::preallocStreams(unsigned int) {}
     void EDProducerBase::preallocLumis(unsigned int) {}
+    void EDProducerBase::preallocLumisSummary(unsigned int) {}
     void EDProducerBase::preallocate(PreallocationConfiguration const&) {}
     void EDProducerBase::doBeginStream_(StreamID id) {}
     void EDProducerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -62,6 +62,7 @@ namespace edm {
     void EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       preallocStreams(iPrealloc.numberOfStreams());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+      preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
     }
 
@@ -169,6 +170,7 @@ namespace edm {
 
     void EDAnalyzerBase::preallocStreams(unsigned int) {}
     void EDAnalyzerBase::preallocLumis(unsigned int) {}
+    void EDAnalyzerBase::preallocLumisSummary(unsigned int) {}
     void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}
     void EDAnalyzerBase::doBeginStream_(StreamID id) {}
     void EDAnalyzerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -67,6 +67,7 @@ namespace edm {
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+      preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
     }
 
@@ -186,6 +187,7 @@ namespace edm {
 
     void EDFilterBase::preallocStreams(unsigned int) {}
     void EDFilterBase::preallocLumis(unsigned int) {}
+    void EDFilterBase::preallocLumisSummary(unsigned int) {}
     void EDFilterBase::preallocate(PreallocationConfiguration const&) {}
     void EDFilterBase::doBeginStream_(StreamID id) {}
     void EDFilterBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -67,6 +67,7 @@ namespace edm {
       previousParentageIds_.reset(new ParentageID[nStreams]);
       preallocStreams(nStreams);
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
+      preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
     }
 
@@ -186,6 +187,7 @@ namespace edm {
 
     void EDProducerBase::preallocStreams(unsigned int) {}
     void EDProducerBase::preallocLumis(unsigned int) {}
+    void EDProducerBase::preallocLumisSummary(unsigned int) {}
     void EDProducerBase::preallocate(PreallocationConfiguration const&) {}
     void EDProducerBase::doBeginStream_(StreamID id) {}
     void EDProducerBase::doEndStream_(StreamID id) {}

--- a/FWCore/Framework/test/modules_2_concurrent_lumis_cfg.py
+++ b/FWCore/Framework/test/modules_2_concurrent_lumis_cfg.py
@@ -1,0 +1,66 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource", numberEventsInLuminosityBlock = cms.untracked.uint32(2))
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32( 20 ) )
+
+process.options = cms.untracked.PSet( numberOfThreads = cms.untracked.uint32(4),
+                                      numberOfStreams = cms.untracked.uint32(0),
+                                      numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(2))
+
+process.prod = cms.EDProducer("BusyWaitIntProducer",
+                              ivalue = cms.int32(1),
+                              iterations = cms.uint32(50*1000*20) )
+
+process.LumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
+    transitions = cms.int32(60)
+    ,cachevalue = cms.int32(2)
+)
+
+process.LumiSumLumiProd = cms.EDProducer("edmtest::global::LumiSummaryLumiProducer",
+    transitions = cms.int32(70)
+    ,cachevalue = cms.int32(2)
+)
+
+process.LumiSumIntFilter = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
+    transitions = cms.int32(84)
+    ,cachevalue = cms.int32(2)
+)
+
+process.LumiSumIntAnalyzer = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
+    transitions = cms.int32(84)
+    ,cachevalue = cms.int32(2)
+)
+
+process.LimitedLumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
+    transitions = cms.int32(60)
+    ,cachevalue = cms.int32(2)
+    ,concurrencyLimit = cms.untracked.uint32(1)
+)
+
+process.LimitedLumiSumLumiProd = cms.EDProducer("edmtest::limited::LumiSummaryLumiProducer",
+    transitions = cms.int32(70)
+    ,cachevalue = cms.int32(2)
+    ,concurrencyLimit = cms.untracked.uint32(1)
+)
+
+process.LimitedLumiSumIntFilter = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
+    transitions = cms.int32(84)
+    ,cachevalue = cms.int32(2)
+    ,concurrencyLimit = cms.untracked.uint32(1)
+)
+
+process.LimitedLumiSumIntAnalyzer = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
+    transitions = cms.int32(84)
+    ,cachevalue = cms.int32(2)
+    ,concurrencyLimit = cms.untracked.uint32(1)
+)
+
+process.p = cms.Path(process.prod * process.LumiSumIntProd * process.LumiSumLumiProd * process.LumiSumIntFilter * process.LumiSumIntAnalyzer * process.LimitedLumiSumIntProd * process.LimitedLumiSumLumiProd * process.LimitedLumiSumIntFilter * process.LimitedLumiSumIntAnalyzer)
+
+process.add_(cms.Service("ConcurrentModuleTimer",
+                         modulesToExclude = cms.untracked.vstring("TriggerResults","p"),
+                         excludeSource = cms.untracked.bool(True)))
+

--- a/FWCore/Framework/test/run_global_stream_one.sh
+++ b/FWCore/Framework/test/run_global_stream_one.sh
@@ -29,4 +29,7 @@ touch empty_file
 
 (cmsRun ${LOCAL_TEST_DIR}/test_limited_concurrent_module_cfg.py 2>&1) | tail -n 3 | grep -v ' 0 ' | grep -v 'e-' | diff - empty_file || die "Failure using test_limited_concurrent_module_cfg.py" $?
 
+echo cmsRun modules_2_concurrent_lumis_cfg.py
+cmsRun ${LOCAL_TEST_DIR}/modules_2_concurrent_lumis_cfg.py || die "cmsRun modules_2_concurrent_lumis_cfg.py" $?
+
 popd

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -347,7 +347,7 @@ namespace edmtest {
                                                                      edm::EventSetup const&) const override {
         ++m_count;
         auto gCache = std::make_shared<UnsafeCache>();
-        ++(gCache->lumi);
+        gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
         return gCache;
       }
 
@@ -357,34 +357,107 @@ namespace edmtest {
       }
 
       void streamEndLuminosityBlockSummary(edm::StreamID iID,
-                                           edm::LuminosityBlock const&,
+                                           edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
         ++m_count;
-        if (gCache->lumi == 0) {
-          throw cms::Exception("out of sequence")
-              << "streamEndLuminosityBlockSummary after globalEndLuminosityBlockSummary in Stream " << iID.value();
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue")
+              << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
         }
         auto sCache = streamCache(iID);
         gCache->value += sCache->value;
         sCache->value = 0;
       }
 
-      void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+      void globalEndLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
         ++m_count;
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue") << "globalEndLuminosityBlockSummary unexpected lumi number";
+        }
         if (gCache->value != cvalue_) {
           throw cms::Exception("cache value")
               << "LumiSummaryIntProducer cache value " << gCache->value << " but it was supposed to be " << cvalue_;
         }
-        --(gCache->lumi);
       }
 
       ~LumiSummaryIntProducer() {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "LumiSummaryIntProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+      }
+    };
+
+    class LumiSummaryLumiProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>,
+                                                                   edm::LuminosityBlockSummaryCache<UnsafeCache>,
+                                                                   edm::EndLuminosityBlockProducer> {
+    public:
+      explicit LumiSummaryLumiProducer(edm::ParameterSet const& p)
+          : trans_(p.getParameter<int>("transitions")), cvalue_(p.getParameter<int>("cachevalue")) {
+        produces<unsigned int>();
+      }
+      const unsigned int trans_;
+      const unsigned int cvalue_;
+      mutable std::atomic<unsigned int> m_count{0};
+
+      std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override { return std::make_unique<UnsafeCache>(); }
+
+      std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
+                                                                     edm::EventSetup const&) const override {
+        ++m_count;
+        auto gCache = std::make_shared<UnsafeCache>();
+        gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
+        return gCache;
+      }
+
+      void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        auto sCache = streamCache(iID);
+        ++(sCache->value);
+      }
+
+      void streamEndLuminosityBlockSummary(edm::StreamID iID,
+                                           edm::LuminosityBlock const& iLB,
+                                           edm::EventSetup const&,
+                                           UnsafeCache* gCache) const override {
+        ++m_count;
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue")
+              << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
+        }
+        auto sCache = streamCache(iID);
+        gCache->value += sCache->value;
+        sCache->value = 0;
+      }
+
+      void globalEndLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
+                                           edm::EventSetup const&,
+                                           UnsafeCache* gCache) const override {
+        ++m_count;
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue") << "globalEndLuminosityBlockSummary unexpected lumi number";
+        }
+        if (gCache->value != cvalue_) {
+          throw cms::Exception("cache value")
+              << "LumiSummaryLumiProducer cache value " << gCache->value << " but it was supposed to be " << cvalue_;
+        }
+      }
+
+      void globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLB,
+                                           edm::EventSetup const&,
+                                           UnsafeCache const* gCache) const override {
+        ++m_count;
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue") << "globalEndLuminosityBlockProduce unexpected lumi number";
+        }
+      }
+
+      ~LumiSummaryLumiProducer() {
+        if (m_count != trans_) {
+          throw cms::Exception("transitions")
+              << "LumiSummaryLumiProducer transitions " << m_count << " but it was supposed to be " << trans_;
         }
       }
     };
@@ -560,6 +633,7 @@ DEFINE_FWK_MODULE(edmtest::global::RunIntProducer);
 DEFINE_FWK_MODULE(edmtest::global::LumiIntProducer);
 DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntProducer);
 DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::LumiSummaryLumiProducer);
 DEFINE_FWK_MODULE(edmtest::global::TestBeginRunProducer);
 DEFINE_FWK_MODULE(edmtest::global::TestEndRunProducer);
 DEFINE_FWK_MODULE(edmtest::global::TestBeginLumiBlockProducer);

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -36,8 +36,9 @@ namespace edmtest {
       };
 
       struct UnsafeCache {
-        UnsafeCache() : value(0) {}
+        UnsafeCache() : value(0), lumi(0) {}
         unsigned int value;
+        unsigned int lumi;
       };
 
     }  //end anonymous namespace
@@ -267,10 +268,12 @@ namespace edmtest {
         return std::make_unique<UnsafeCache>();
       }
 
-      std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+      std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                                                      edm::EventSetup const&) const override {
         ++m_count;
-        return std::make_shared<UnsafeCache>();
+        auto gCache = std::make_shared<UnsafeCache>();
+        gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
+        return gCache;
       }
 
       void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {
@@ -279,18 +282,25 @@ namespace edmtest {
       }
 
       void streamEndLuminosityBlockSummary(edm::StreamID iID,
-                                           edm::LuminosityBlock const& iLumiBlock,
+                                           edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
         ++m_count;
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue")
+              << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
+        }
         gCache->value += (streamCache(iID))->value;
         (streamCache(iID))->value = 0;
       }
 
-      void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+      void globalEndLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
         ++m_count;
+        if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("UnexpectedValue") << "globalEndLuminosityBlockSummary unexpected lumi number";
+        }
         if (gCache->value != cvalue_) {
           throw cms::Exception("cache value")
               << "LumiSummaryIntAnalyzer cache value " << gCache->value << " but it was supposed to be " << cvalue_;


### PR DESCRIPTION
#### PR description:

Fix a bug affecting LuminosityBlockSummaryCache only when processing more than 1 lumi concurrently. Nothing in production runs with more than 1 concurrent lumis yet, so I am guessing the impact of this bug has been small. Outside of Core tests, the only modules in the CMSSW repository using this cache at this point in time are HLTriggerJSONMonitoring and L1TriggerJSONMonitoring.

This fixes the problem reported by Srecko Morovic on the Framework hyper news on 10/31/19.

#### PR validation:

Added a new Core unit test to verify correct behavior. This test would have detected the original problem reported.
