### PR TITLE
HBHE: speed up + mahi move double to float

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -3,9 +3,9 @@
 
 #include <Eigen/Dense>
 
-constexpr int MaxSVSize = 10;
-constexpr int MaxFSVSize = 19;
-constexpr int MaxPVSize = 10;
+constexpr int MaxSVSize = 8;
+constexpr int MaxFSVSize = 15;
+constexpr int MaxPVSize = 8;
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
 typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
@@ -17,10 +17,7 @@ typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, Max
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
-typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxSVSize> PulseSampleMatrix;
 
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
-typedef Eigen::LLT<PulseMatrix> PulseDecompLLT;
-typedef Eigen::LDLT<PulseMatrix> PulseDecompLDLT;
 
 #endif

--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -3,7 +3,7 @@
 
 #include <Eigen/Dense>
 
-constexpr int MaxSVSize = 8;
+constexpr int MaxSVSize = 10;
 constexpr int MaxFSVSize = 15;
 constexpr int MaxPVSize = 8;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -7,16 +7,16 @@ constexpr int MaxSVSize = 8;
 constexpr int MaxFSVSize = 15;
 constexpr int MaxPVSize = 8;
 
-typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
-typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
+typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
+typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
 typedef Eigen::Matrix<int, Eigen::Dynamic, 1, 0, MaxPVSize, 1> BXVector;
 
-typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, MaxFSVSize, 1> FullSampleVector;
-typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, MaxFSVSize> FullSampleMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxFSVSize, 1> FullSampleVector;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, MaxFSVSize> FullSampleMatrix;
 
-typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
-typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
-typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
 
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -3,20 +3,22 @@
 
 #include <Eigen/Dense>
 
+using FLOAT = double;
+
 constexpr int MaxSVSize = 10;
 constexpr int MaxFSVSize = 15;
 constexpr int MaxPVSize = 8;
 
-typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
-typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
 typedef Eigen::Matrix<int, Eigen::Dynamic, 1, 0, MaxPVSize, 1> BXVector;
 
-typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxFSVSize, 1> FullSampleVector;
-typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, MaxFSVSize> FullSampleMatrix;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, 1, 0, MaxFSVSize, 1> FullSampleVector;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, MaxFSVSize> FullSampleMatrix;
 
-typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
-typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
-typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
+typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
 
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/EigenMatrixTypes.h
@@ -3,22 +3,20 @@
 
 #include <Eigen/Dense>
 
-using FLOAT = double;
-
 constexpr int MaxSVSize = 10;
 constexpr int MaxFSVSize = 15;
 constexpr int MaxPVSize = 8;
 
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
+typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxSVSize, 1> SampleVector;
+typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxPVSize, 1> PulseVector;
 typedef Eigen::Matrix<int, Eigen::Dynamic, 1, 0, MaxPVSize, 1> BXVector;
 
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, 1, 0, MaxFSVSize, 1> FullSampleVector;
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, MaxFSVSize> FullSampleMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, 1, 0, MaxFSVSize, 1> FullSampleVector;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxFSVSize, MaxFSVSize> FullSampleMatrix;
 
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
-typedef Eigen::Matrix<FLOAT, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxSVSize> SampleMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxPVSize, MaxPVSize> PulseMatrix;
+typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, 0, MaxSVSize, MaxPVSize> SamplePulseMatrix;
 
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -127,16 +127,16 @@ public:
   const HcalTimeSlew* hcalTimeSlewDelay_ = nullptr;
 
 private:
-  double minimize() const;
+  const float minimize() const;
   void onePulseMinimize() const;
   void updateCov(const SampleMatrix & invCovMat) const;
-  void updatePulseShape(double itQ,
+  void updatePulseShape(const float itQ,
                         FullSampleVector& pulseShape,
                         FullSampleVector& pulseDeriv,
                         FullSampleMatrix& pulseCov) const;
 
   float calculateArrivalTime(unsigned int iBX) const;
-  double calculateChiSq() const;
+  float calculateChiSq() const;
   void nnls() const;
   void resetWorkspace() const;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -129,7 +129,7 @@ public:
 private:
   const float minimize() const;
   void onePulseMinimize() const;
-  void updateCov(const SampleMatrix & invCovMat) const;
+  void updateCov(const SampleMatrix& invCovMat) const;
   void updatePulseShape(const float itQ,
                         FullSampleVector& pulseShape,
                         FullSampleVector& pulseDeriv,

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -53,7 +53,6 @@ struct MahiNnlsWorkspace {
   PulseVector aTbVec;  // A-transpose b (vector)
 
   SampleDecompLLT covDecomp;
-  PulseDecompLDLT pulseDecomp;
 };
 
 struct MahiDebugInfo {
@@ -130,13 +129,13 @@ public:
 private:
   double minimize() const;
   void onePulseMinimize() const;
-  void updateCov() const;
+  void updateCov(const SampleMatrix & invCovMat) const;
   void updatePulseShape(double itQ,
                         FullSampleVector& pulseShape,
                         FullSampleVector& pulseDeriv,
                         FullSampleMatrix& pulseCov) const;
 
-  float calculateArrivalTime() const;
+  float calculateArrivalTime(unsigned int iBX) const;
   double calculateChiSq() const;
   void nnls() const;
   void resetWorkspace() const;
@@ -163,6 +162,7 @@ private:
   bool applyTimeSlew_;
   HcalTimeSlew::BiasSetting slewFlavor_;
   float tsDelay1GeV_ = 0.f;
+  float norm_ = 1.f;
 
   bool calculateArrivalTime_;
   float meanTime_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -152,7 +152,7 @@ private:
 
   // used to restrict returned time value to a 25 ns window centered
   // on the nominal arrival time
-  static constexpr float timeLimit_ = 12.5;
+  static constexpr float timeLimit_ = 12.5f;
 
   // Python-configurables
   bool dynamicPed_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -162,7 +162,7 @@ private:
   bool applyTimeSlew_;
   HcalTimeSlew::BiasSetting slewFlavor_;
   float tsDelay1GeV_ = 0.f;
-  float norm_ = (1. / std::sqrt(12));
+  float norm_ = (1.f / std::sqrt(12));
 
   bool calculateArrivalTime_;
   float meanTime_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -162,7 +162,7 @@ private:
   bool applyTimeSlew_;
   HcalTimeSlew::BiasSetting slewFlavor_;
   float tsDelay1GeV_ = 0.f;
-  float norm_ = 1.f;
+  float norm_ = (1. / std::sqrt(12));
 
   bool calculateArrivalTime_;
   float meanTime_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFunctor.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFunctor.h
@@ -9,7 +9,7 @@ namespace HcalConst {
   constexpr int maxPSshapeBin = 256;
   constexpr int nsPerBX = 25;
   constexpr float iniTimeShift = 92.5f;
-  constexpr double invertnsPerBx = 0.04;
+  constexpr float invertnsPerBx = 0.04f;
   constexpr int shiftTS = 4;
 
 }  // namespace HcalConst

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -92,10 +92,14 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo &channelData,
                                        const HcalTimeSlew *hcalTimeSlew_delay) const {
   unsigned int soi = channelData.soi();
 
-  std::vector<double> corrCharge; corrCharge.reserve(channelData.nSamples());
-  std::vector<double> inputCharge; inputCharge.reserve(channelData.nSamples());
-  std::vector<double> inputPedestal; inputPedestal.reserve(channelData.nSamples());
-  std::vector<double> inputNoise; inputNoise.reserve(channelData.nSamples());
+  std::vector<double> corrCharge;
+  corrCharge.reserve(channelData.nSamples());
+  std::vector<double> inputCharge;
+  inputCharge.reserve(channelData.nSamples());
+  std::vector<double> inputPedestal;
+  inputPedestal.reserve(channelData.nSamples());
+  std::vector<double> inputNoise;
+  inputNoise.reserve(channelData.nSamples());
 
   double gainCorr = 0;
   double respCorr = 0;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -92,10 +92,11 @@ void HcalDeterministicFit::phase1Apply(const HBHEChannelInfo &channelData,
                                        const HcalTimeSlew *hcalTimeSlew_delay) const {
   unsigned int soi = channelData.soi();
 
-  std::vector<double> corrCharge;
-  std::vector<double> inputCharge;
-  std::vector<double> inputPedestal;
-  std::vector<double> inputNoise;
+  std::vector<double> corrCharge; corrCharge.reserve(channelData.nSamples());
+  std::vector<double> inputCharge; inputCharge.reserve(channelData.nSamples());
+  std::vector<double> inputPedestal; inputPedestal.reserve(channelData.nSamples());
+  std::vector<double> inputNoise; inputNoise.reserve(channelData.nSamples());
+
   double gainCorr = 0;
   double respCorr = 0;
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -157,7 +157,8 @@ void MahiFit::doFit(std::array<float, 3>& correctedOutput, int nbx) const {
       nnlsWork_.pulseDerivMat.col(iBX) = SampleVector::Zero(nnlsWork_.tsSize);
     } else {
       pulseShapeArray.setZero(nnlsWork_.tsSize + nnlsWork_.maxoffset + nnlsWork_.bxOffset);
-      if (calculateArrivalTime_) pulseDerivArray.setZero(nnlsWork_.tsSize + nnlsWork_.maxoffset + nnlsWork_.bxOffset);
+      if (calculateArrivalTime_)
+        pulseDerivArray.setZero(nnlsWork_.tsSize + nnlsWork_.maxoffset + nnlsWork_.bxOffset);
       pulseCov.setZero(nnlsWork_.tsSize + nnlsWork_.maxoffset + nnlsWork_.bxOffset,
                        nnlsWork_.tsSize + nnlsWork_.maxoffset + nnlsWork_.bxOffset);
       nnlsWork_.pulseCovArray[iBX].setZero(nnlsWork_.tsSize, nnlsWork_.tsSize);
@@ -166,7 +167,8 @@ void MahiFit::doFit(std::array<float, 3>& correctedOutput, int nbx) const {
           nnlsWork_.amplitudes.coeff(nnlsWork_.tsOffset + offset), pulseShapeArray, pulseDerivArray, pulseCov);
 
       nnlsWork_.pulseMat.col(iBX) = pulseShapeArray.segment(nnlsWork_.maxoffset - offset, nnlsWork_.tsSize);
-      if (calculateArrivalTime_) nnlsWork_.pulseDerivMat.col(iBX) = pulseDerivArray.segment(nnlsWork_.maxoffset - offset, nnlsWork_.tsSize);
+      if (calculateArrivalTime_)
+        nnlsWork_.pulseDerivMat.col(iBX) = pulseDerivArray.segment(nnlsWork_.maxoffset - offset, nnlsWork_.tsSize);
       nnlsWork_.pulseCovArray[iBX] = pulseCov.block(
           nnlsWork_.maxoffset - offset, nnlsWork_.maxoffset - offset, nnlsWork_.tsSize, nnlsWork_.tsSize);
     }
@@ -274,7 +276,8 @@ void MahiFit::updatePulseShape(const float itQ,
 
   for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {
     pulseShape(iTS + nnlsWork_.maxoffset) = pulseN[iTS + delta];
-    if(calculateArrivalTime_) pulseDeriv(iTS + nnlsWork_.maxoffset) = (pulseM[iTS + delta] - pulseP[iTS + delta]) * invDt;
+    if (calculateArrivalTime_)
+      pulseDeriv(iTS + nnlsWork_.maxoffset) = (pulseM[iTS + delta] - pulseP[iTS + delta]) * invDt;
 
     pulseM[iTS + delta] -= pulseN[iTS + delta];
     pulseP[iTS + delta] -= pulseN[iTS + delta];
@@ -291,8 +294,7 @@ void MahiFit::updatePulseShape(const float itQ,
   }
 }
 
-void MahiFit::updateCov(const SampleMatrix & samplecov) const {
-
+void MahiFit::updateCov(const SampleMatrix& samplecov) const {
   SampleMatrix invCovMat = samplecov;
 
   for (unsigned int iBX = 0; iBX < nnlsWork_.nPulseTot; ++iBX) {
@@ -341,8 +343,7 @@ void MahiFit::nnls() const {
 
   nnlsWork_.invcovp = nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.pulseMat);
   nnlsWork_.aTaMat = nnlsWork_.invcovp.transpose() * nnlsWork_.invcovp;
-  nnlsWork_.aTbVec =
-    nnlsWork_.invcovp.transpose() * (nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
+  nnlsWork_.aTbVec = nnlsWork_.invcovp.transpose() * (nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
 
   int iter = 0;
   Index idxwmax = 0;
@@ -356,7 +357,8 @@ void MahiFit::nnls() const {
 
       const unsigned int nActive = npulse - nnlsWork_.nP;
       // exit if there are no more pulses to constrain
-      if (nActive == 0) break;
+      if (nActive == 0)
+        break;
 
       updateWork = nnlsWork_.aTbVec - nnlsWork_.aTaMat * nnlsWork_.ampVec;
 
@@ -387,8 +389,8 @@ void MahiFit::nnls() const {
 
       //check solution
       if (ampvecpermtest.head(nnlsWork_.nP).minCoeff() > 0.f) {
-	nnlsWork_.ampVec.head(nnlsWork_.nP) = ampvecpermtest.head(nnlsWork_.nP);
-	break;
+        nnlsWork_.ampVec.head(nnlsWork_.nP) = ampvecpermtest.head(nnlsWork_.nP);
+        break;
       }
 
       //update parameter vector
@@ -426,11 +428,11 @@ void MahiFit::nnls() const {
 }
 
 void MahiFit::onePulseMinimize() const {
-
   nnlsWork_.invcovp = nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.pulseMat);
 
   float aTaCoeff = (nnlsWork_.invcovp.transpose() * nnlsWork_.invcovp).coeff(0);
-  float aTbCoeff = (nnlsWork_.invcovp.transpose() * (nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes))).coeff(0);
+  float aTbCoeff =
+      (nnlsWork_.invcovp.transpose() * (nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes))).coeff(0);
 
   nnlsWork_.ampVec.coeffRef(0) = std::max(0.f, aTbCoeff / aTaCoeff);
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -1,3 +1,4 @@
+#define EIGEN_NO_DEBUG  // kill throws in eigen code
 #include "RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -211,8 +211,8 @@ const float MahiFit::minimize() const {
   invCovMat.setConstant(nnlsWork_.tsSize, nnlsWork_.tsSize, nnlsWork_.pedVal);
   invCovMat += nnlsWork_.noiseTerms.asDiagonal();
 
-  double oldChiSq = 9999;
-  double chiSq = oldChiSq;
+  float oldChiSq = 9999;
+  float chiSq = oldChiSq;
 
   for (int iter = 1; iter < nMaxItersMin_; ++iter) {
     updateCov(invCovMat);
@@ -286,7 +286,7 @@ void MahiFit::updatePulseShape(const float itQ,
 
   for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {
     for (unsigned int jTS = 0; jTS < iTS + 1; ++jTS) {
-      float const tmp = 0.5 * (pulseP[iTS + delta] * pulseP[jTS + delta] + pulseM[iTS + delta] * pulseM[jTS + delta]);
+      auto const tmp = 0.5 * (pulseP[iTS + delta] * pulseP[jTS + delta] + pulseM[iTS + delta] * pulseM[jTS + delta]);
 
       pulseCov(jTS + nnlsWork_.maxoffset, iTS + nnlsWork_.maxoffset) = tmp;
       if (iTS != jTS)
@@ -330,7 +330,7 @@ float MahiFit::calculateArrivalTime(unsigned int itIndex) const {
 
   SampleVector residuals = nnlsWork_.pulseMat * nnlsWork_.ampVec - nnlsWork_.amplitudes;
   PulseVector solution = nnlsWork_.pulseDerivMat.colPivHouseholderQr().solve(residuals);
-  float t = std::clamp(solution.coeff(itIndex), -timeLimit_, timeLimit_);
+  float t = std::clamp((float)solution.coeff(itIndex), -timeLimit_, timeLimit_);
 
   return t;
 }
@@ -347,8 +347,8 @@ void MahiFit::nnls() const {
 
   int iter = 0;
   Index idxwmax = 0;
-  float wmax = 0.0f;
-  float threshold = nnlsThresh_;
+  FLOAT wmax = 0.0f;
+  FLOAT threshold = nnlsThresh_;
 
   while (true) {
     if (iter > 0 || nnlsWork_.nP == 0) {
@@ -363,7 +363,7 @@ void MahiFit::nnls() const {
       updateWork = nnlsWork_.aTbVec - nnlsWork_.aTaMat * nnlsWork_.ampVec;
 
       Index idxwmaxprev = idxwmax;
-      float wmaxprev = wmax;
+      FLOAT wmaxprev = wmax;
       wmax = updateWork.tail(nActive).maxCoeff(&idxwmax);
 
       if (wmax < threshold || (idxwmax == idxwmaxprev && wmax == wmaxprev)) {
@@ -397,11 +397,11 @@ void MahiFit::nnls() const {
       Index minratioidx = 0;
 
       // no realizable optimization here (because it autovectorizes!)
-      float minratio = std::numeric_limits<float>::max();
+      FLOAT minratio = std::numeric_limits<FLOAT>::max();
       for (unsigned int ipulse = 0; ipulse < nnlsWork_.nP; ++ipulse) {
         if (ampvecpermtest.coeff(ipulse) <= 0.f) {
-          const float c_ampvec = nnlsWork_.ampVec.coeff(ipulse);
-          const float ratio = c_ampvec / (c_ampvec - ampvecpermtest.coeff(ipulse));
+          const FLOAT c_ampvec = nnlsWork_.ampVec.coeff(ipulse);
+          const FLOAT ratio = c_ampvec / (c_ampvec - ampvecpermtest.coeff(ipulse));
           if (ratio < minratio) {
             minratio = ratio;
             minratioidx = ipulse;
@@ -560,43 +560,43 @@ void MahiFit::solveSubmatrix(PulseMatrix& mat, PulseVector& invec, PulseVector& 
   using namespace Eigen;
   switch (nP) {  // pulse matrix is always square.
     case 10: {
-      Matrix<float, 10, 10> temp = mat;
+      Matrix<FLOAT, 10, 10> temp = mat;
       outvec.head<10>() = temp.ldlt().solve(invec.head<10>());
     } break;
     case 9: {
-      Matrix<float, 9, 9> temp = mat.topLeftCorner<9, 9>();
+      Matrix<FLOAT, 9, 9> temp = mat.topLeftCorner<9, 9>();
       outvec.head<9>() = temp.ldlt().solve(invec.head<9>());
     } break;
     case 8: {
-      Matrix<float, 8, 8> temp = mat.topLeftCorner<8, 8>();
+      Matrix<FLOAT, 8, 8> temp = mat.topLeftCorner<8, 8>();
       outvec.head<8>() = temp.ldlt().solve(invec.head<8>());
     } break;
     case 7: {
-      Matrix<float, 7, 7> temp = mat.topLeftCorner<7, 7>();
+      Matrix<FLOAT, 7, 7> temp = mat.topLeftCorner<7, 7>();
       outvec.head<7>() = temp.ldlt().solve(invec.head<7>());
     } break;
     case 6: {
-      Matrix<float, 6, 6> temp = mat.topLeftCorner<6, 6>();
+      Matrix<FLOAT, 6, 6> temp = mat.topLeftCorner<6, 6>();
       outvec.head<6>() = temp.ldlt().solve(invec.head<6>());
     } break;
     case 5: {
-      Matrix<float, 5, 5> temp = mat.topLeftCorner<5, 5>();
+      Matrix<FLOAT, 5, 5> temp = mat.topLeftCorner<5, 5>();
       outvec.head<5>() = temp.ldlt().solve(invec.head<5>());
     } break;
     case 4: {
-      Matrix<float, 4, 4> temp = mat.topLeftCorner<4, 4>();
+      Matrix<FLOAT, 4, 4> temp = mat.topLeftCorner<4, 4>();
       outvec.head<4>() = temp.ldlt().solve(invec.head<4>());
     } break;
     case 3: {
-      Matrix<float, 3, 3> temp = mat.topLeftCorner<3, 3>();
+      Matrix<FLOAT, 3, 3> temp = mat.topLeftCorner<3, 3>();
       outvec.head<3>() = temp.ldlt().solve(invec.head<3>());
     } break;
     case 2: {
-      Matrix<float, 2, 2> temp = mat.topLeftCorner<2, 2>();
+      Matrix<FLOAT, 2, 2> temp = mat.topLeftCorner<2, 2>();
       outvec.head<2>() = temp.ldlt().solve(invec.head<2>());
     } break;
     case 1: {
-      Matrix<float, 1, 1> temp = mat.topLeftCorner<1, 1>();
+      Matrix<FLOAT, 1, 1> temp = mat.topLeftCorner<1, 1>();
       outvec.head<1>() = temp.ldlt().solve(invec.head<1>());
     } break;
     default:

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -309,7 +309,7 @@ void MahiFit::updateCov(const SampleMatrix& samplecov) const {
       continue;
     else {
       auto const ampsq = amp * amp;
-      invCovMat += ampsq * nnlsWork_.pulseCovArray.at(offset + nnlsWork_.bxOffset);
+      invCovMat += ampsq * nnlsWork_.pulseCovArray[offset + nnlsWork_.bxOffset];
     }
   }
 
@@ -328,6 +328,7 @@ float MahiFit::calculateArrivalTime(unsigned int itIndex) const {
     nnlsWork_.pulseDerivMat.col(iBX) *= nnlsWork_.ampVec.coeff(iBX);
   }
 
+  //FIXME: avoid solve full equation for one element
   SampleVector residuals = nnlsWork_.pulseMat * nnlsWork_.ampVec - nnlsWork_.amplitudes;
   PulseVector solution = nnlsWork_.pulseDerivMat.colPivHouseholderQr().solve(residuals);
   float t = std::clamp((float)solution.coeff(itIndex), -timeLimit_, timeLimit_);
@@ -471,22 +472,26 @@ void MahiFit::resetPulseShapeTemplate(const HcalPulseShapes::Shape& ps, bool has
 }
 
 void MahiFit::nnlsUnconstrainParameter(Index idxp) const {
-  nnlsWork_.aTaMat.col(nnlsWork_.nP).swap(nnlsWork_.aTaMat.col(idxp));
-  nnlsWork_.aTaMat.row(nnlsWork_.nP).swap(nnlsWork_.aTaMat.row(idxp));
-  nnlsWork_.pulseMat.col(nnlsWork_.nP).swap(nnlsWork_.pulseMat.col(idxp));
-  Eigen::numext::swap(nnlsWork_.aTbVec.coeffRef(nnlsWork_.nP), nnlsWork_.aTbVec.coeffRef(idxp));
-  Eigen::numext::swap(nnlsWork_.ampVec.coeffRef(nnlsWork_.nP), nnlsWork_.ampVec.coeffRef(idxp));
-  Eigen::numext::swap(nnlsWork_.bxs.coeffRef(nnlsWork_.nP), nnlsWork_.bxs.coeffRef(idxp));
+  if (idxp != nnlsWork_.nP) {
+    nnlsWork_.aTaMat.col(nnlsWork_.nP).swap(nnlsWork_.aTaMat.col(idxp));
+    nnlsWork_.aTaMat.row(nnlsWork_.nP).swap(nnlsWork_.aTaMat.row(idxp));
+    nnlsWork_.pulseMat.col(nnlsWork_.nP).swap(nnlsWork_.pulseMat.col(idxp));
+    Eigen::numext::swap(nnlsWork_.aTbVec.coeffRef(nnlsWork_.nP), nnlsWork_.aTbVec.coeffRef(idxp));
+    Eigen::numext::swap(nnlsWork_.ampVec.coeffRef(nnlsWork_.nP), nnlsWork_.ampVec.coeffRef(idxp));
+    Eigen::numext::swap(nnlsWork_.bxs.coeffRef(nnlsWork_.nP), nnlsWork_.bxs.coeffRef(idxp));
+  }
   ++nnlsWork_.nP;
 }
 
 void MahiFit::nnlsConstrainParameter(Index minratioidx) const {
-  nnlsWork_.aTaMat.col(nnlsWork_.nP - 1).swap(nnlsWork_.aTaMat.col(minratioidx));
-  nnlsWork_.aTaMat.row(nnlsWork_.nP - 1).swap(nnlsWork_.aTaMat.row(minratioidx));
-  nnlsWork_.pulseMat.col(nnlsWork_.nP - 1).swap(nnlsWork_.pulseMat.col(minratioidx));
-  Eigen::numext::swap(nnlsWork_.aTbVec.coeffRef(nnlsWork_.nP - 1), nnlsWork_.aTbVec.coeffRef(minratioidx));
-  Eigen::numext::swap(nnlsWork_.ampVec.coeffRef(nnlsWork_.nP - 1), nnlsWork_.ampVec.coeffRef(minratioidx));
-  Eigen::numext::swap(nnlsWork_.bxs.coeffRef(nnlsWork_.nP - 1), nnlsWork_.bxs.coeffRef(minratioidx));
+  if (minratioidx != (nnlsWork_.nP - 1)) {
+    nnlsWork_.aTaMat.col(nnlsWork_.nP - 1).swap(nnlsWork_.aTaMat.col(minratioidx));
+    nnlsWork_.aTaMat.row(nnlsWork_.nP - 1).swap(nnlsWork_.aTaMat.row(minratioidx));
+    nnlsWork_.pulseMat.col(nnlsWork_.nP - 1).swap(nnlsWork_.pulseMat.col(minratioidx));
+    Eigen::numext::swap(nnlsWork_.aTbVec.coeffRef(nnlsWork_.nP - 1), nnlsWork_.aTbVec.coeffRef(minratioidx));
+    Eigen::numext::swap(nnlsWork_.ampVec.coeffRef(nnlsWork_.nP - 1), nnlsWork_.ampVec.coeffRef(minratioidx));
+    Eigen::numext::swap(nnlsWork_.bxs.coeffRef(nnlsWork_.nP - 1), nnlsWork_.bxs.coeffRef(minratioidx));
+  }
   --nnlsWork_.nP;
 }
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -348,8 +348,8 @@ void MahiFit::nnls() const {
 
   int iter = 0;
   Index idxwmax = 0;
-  FLOAT wmax = 0.0f;
-  FLOAT threshold = nnlsThresh_;
+  float wmax = 0.0f;
+  float threshold = nnlsThresh_;
 
   while (true) {
     if (iter > 0 || nnlsWork_.nP == 0) {
@@ -364,7 +364,7 @@ void MahiFit::nnls() const {
       updateWork = nnlsWork_.aTbVec - nnlsWork_.aTaMat * nnlsWork_.ampVec;
 
       Index idxwmaxprev = idxwmax;
-      FLOAT wmaxprev = wmax;
+      float wmaxprev = wmax;
       wmax = updateWork.tail(nActive).maxCoeff(&idxwmax);
 
       if (wmax < threshold || (idxwmax == idxwmaxprev && wmax == wmaxprev)) {
@@ -398,11 +398,11 @@ void MahiFit::nnls() const {
       Index minratioidx = 0;
 
       // no realizable optimization here (because it autovectorizes!)
-      FLOAT minratio = std::numeric_limits<FLOAT>::max();
+      float minratio = std::numeric_limits<float>::max();
       for (unsigned int ipulse = 0; ipulse < nnlsWork_.nP; ++ipulse) {
         if (ampvecpermtest.coeff(ipulse) <= 0.f) {
-          const FLOAT c_ampvec = nnlsWork_.ampVec.coeff(ipulse);
-          const FLOAT ratio = c_ampvec / (c_ampvec - ampvecpermtest.coeff(ipulse));
+          const float c_ampvec = nnlsWork_.ampVec.coeff(ipulse);
+          const float ratio = c_ampvec / (c_ampvec - ampvecpermtest.coeff(ipulse));
           if (ratio < minratio) {
             minratio = ratio;
             minratioidx = ipulse;
@@ -565,43 +565,43 @@ void MahiFit::solveSubmatrix(PulseMatrix& mat, PulseVector& invec, PulseVector& 
   using namespace Eigen;
   switch (nP) {  // pulse matrix is always square.
     case 10: {
-      Matrix<FLOAT, 10, 10> temp = mat;
+      Matrix<float, 10, 10> temp = mat;
       outvec.head<10>() = temp.ldlt().solve(invec.head<10>());
     } break;
     case 9: {
-      Matrix<FLOAT, 9, 9> temp = mat.topLeftCorner<9, 9>();
+      Matrix<float, 9, 9> temp = mat.topLeftCorner<9, 9>();
       outvec.head<9>() = temp.ldlt().solve(invec.head<9>());
     } break;
     case 8: {
-      Matrix<FLOAT, 8, 8> temp = mat.topLeftCorner<8, 8>();
+      Matrix<float, 8, 8> temp = mat.topLeftCorner<8, 8>();
       outvec.head<8>() = temp.ldlt().solve(invec.head<8>());
     } break;
     case 7: {
-      Matrix<FLOAT, 7, 7> temp = mat.topLeftCorner<7, 7>();
+      Matrix<float, 7, 7> temp = mat.topLeftCorner<7, 7>();
       outvec.head<7>() = temp.ldlt().solve(invec.head<7>());
     } break;
     case 6: {
-      Matrix<FLOAT, 6, 6> temp = mat.topLeftCorner<6, 6>();
+      Matrix<float, 6, 6> temp = mat.topLeftCorner<6, 6>();
       outvec.head<6>() = temp.ldlt().solve(invec.head<6>());
     } break;
     case 5: {
-      Matrix<FLOAT, 5, 5> temp = mat.topLeftCorner<5, 5>();
+      Matrix<float, 5, 5> temp = mat.topLeftCorner<5, 5>();
       outvec.head<5>() = temp.ldlt().solve(invec.head<5>());
     } break;
     case 4: {
-      Matrix<FLOAT, 4, 4> temp = mat.topLeftCorner<4, 4>();
+      Matrix<float, 4, 4> temp = mat.topLeftCorner<4, 4>();
       outvec.head<4>() = temp.ldlt().solve(invec.head<4>());
     } break;
     case 3: {
-      Matrix<FLOAT, 3, 3> temp = mat.topLeftCorner<3, 3>();
+      Matrix<float, 3, 3> temp = mat.topLeftCorner<3, 3>();
       outvec.head<3>() = temp.ldlt().solve(invec.head<3>());
     } break;
     case 2: {
-      Matrix<FLOAT, 2, 2> temp = mat.topLeftCorner<2, 2>();
+      Matrix<float, 2, 2> temp = mat.topLeftCorner<2, 2>();
       outvec.head<2>() = temp.ldlt().solve(invec.head<2>());
     } break;
     case 1: {
-      Matrix<FLOAT, 1, 1> temp = mat.topLeftCorner<1, 1>();
+      Matrix<float, 1, 1> temp = mat.topLeftCorner<1, 1>();
       outvec.head<1>() = temp.ldlt().solve(invec.head<1>());
     } break;
     default:

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFunctor.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFunctor.cc
@@ -75,8 +75,6 @@ namespace FitterFuncs {
                                     bool scalePulse) {
     // pulse shape components over a range of time 0 ns to 255 ns in 1 ns steps
     constexpr int ns_per_bx = HcalConst::nsPerBX;
-    constexpr int num_ns = HcalConst::nsPerBX * HcalConst::maxSamples;
-    constexpr int num_bx = num_ns / ns_per_bx;
     //Get the starting time
     int i_start = (-HcalConst::iniTimeShift - pulseTime - slew > 0
                        ? 0
@@ -97,7 +95,7 @@ namespace FitterFuncs {
       const int bin_start = (int)offset_start;                                               //bin off to integer
       const int bin_0_start = (offset_start < bin_start + 0.5 ? bin_start - 1 : bin_start);  //Round it
       const int iTS_start = i_start / ns_per_bx;                                             //Time Slice for time shift
-      const int distTo25ns_start = HcalConst::nsPerBX - 1 - i_start % ns_per_bx;             //Delta ns
+      const int distTo25ns_start = ns_per_bx - 1 - i_start % ns_per_bx;                      //Delta ns
       const double factor = offset_start - bin_0_start - 0.5;                                //Small correction?
 
       //Build the new pulse
@@ -107,13 +105,13 @@ namespace FitterFuncs {
                accVarLenIdxMinusOneVec[distTo25ns_start] + factor * diffVarItvlIdxMinusOneVec[distTo25ns_start]
                : accVarLenIdxZEROVec[distTo25ns_start] + factor * diffVarItvlIdxZEROVec[distTo25ns_start]);
       //Fill the rest of the bins
-      for (int iTS = iTS_start + 1; iTS < num_bx; ++iTS) {
+      for (int iTS = iTS_start + 1; iTS < HcalConst::maxSamples; ++iTS) {
         int bin_idx = distTo25ns_start + 1 + (iTS - iTS_start - 1) * ns_per_bx + bin_0_start;
         ntmpbin[iTS] = acc25nsVec[bin_idx] + factor * diff25nsItvlVec[bin_idx];
       }
       //Scale the pulse
       if (scalePulse) {
-        for (int i = iTS_start; i < num_bx; ++i) {
+        for (int i = iTS_start; i < HcalConst::maxSamples; ++i) {
           ntmpbin[i] *= pulseHeight;
         }
       }

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -55,8 +55,6 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
                                              const HcalRecoParam* params,
                                              const HcalCalibrations& calibs,
                                              const bool isData) {
-  HBHERecHit rh;
-
   const HcalDetId channelId(info.id());
 
   // Calculate "Method 0" quantities
@@ -111,6 +109,8 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
   }
 
   // Finally, construct the rechit
+  HBHERecHit rh;
+
   float rhE = m0E;
   float rht = m0t;
   float rhX = -1.f;

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -155,7 +155,7 @@ edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo() {
   desc.add<double>("tdcTimeShift", 0.0);
   desc.add<bool>("correctForPhaseContainment", true);
   desc.add<bool>("applyLegacyHBMCorrection", true);
-  desc.add<bool>("calculateArrivalTime", true);
+  desc.add<bool>("calculateArrivalTime", false);
 
   return desc;
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -418,8 +418,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     // in the database but can still come in the QIE11DataFrame
     // in the laser calibs, etc.
     const HcalSubdetector subdet = cell.subdet();
-    if (!(subdet == HcalSubdetector::HcalBarrel || subdet == HcalSubdetector::HcalEndcap ||
-          subdet == HcalSubdetector::HcalOuter))
+    if (!(subdet == HcalSubdetector::HcalBarrel || subdet == HcalSubdetector::HcalEndcap))
       continue;
 
     // Check if the database tells us to drop this channel
@@ -444,18 +443,23 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
     const HcalCoderDb coder(*channelCoder, *shape);
 
-    // needed for the dark current in the M2
-    const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
-    const double darkCurrent = siPMParameter.getDarkCurrent();
-    const double fcByPE = siPMParameter.getFCByPE();
-    const double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
+    const bool saveEffectivePeds = channelInfo->hasEffectivePedestals();
+    double darkCurrent = 0.;
+    double fcByPE = 0.;
+    double lambda = 0.;
+    if (!saveEffectivePeds || saveInfos_) {
+      // needed for the dark current in the M2 in alternative of the effectivePed
+      const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
+      darkCurrent = siPMParameter.getDarkCurrent();
+      fcByPE = siPMParameter.getFCByPE();
+      lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
+    }
 
     // ADC to fC conversion
     CaloSamples cs;
     coder.adc2fC(frame, cs);
 
     // Prepare to iterate over time slices
-    const bool saveEffectivePeds = channelInfo->hasEffectivePedestals();
     const int nRead = cs.size();
     const int maxTS = std::min(nRead, static_cast<int>(HBHEChannelInfo::MAXSAMPLES));
     const int soi = tsFromDB_ ? param_ts->firstSample() : frame.presamples();

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -444,14 +444,13 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     const HcalCoderDb coder(*channelCoder, *shape);
 
     const bool saveEffectivePeds = channelInfo->hasEffectivePedestals();
+    const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
+    const double fcByPE = siPMParameter.getFCByPE();
     double darkCurrent = 0.;
-    double fcByPE = 0.;
     double lambda = 0.;
     if (!saveEffectivePeds || saveInfos_) {
       // needed for the dark current in the M2 in alternative of the effectivePed
-      const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
       darkCurrent = siPMParameter.getDarkCurrent();
-      fcByPE = siPMParameter.getFCByPE();
       lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter.getType());
     }
 


### PR DESCRIPTION
This PR gain 45% in CPU speed up in the minimize function see igprof results below.

Validation plots provided in double and floats
http://dalfonso.web.cern.ch/dalfonso/HCAL/HCAL_PR28366.pdf
Impact on the INtime energy is negligible, small changes on the arrivalTime.

To keep in mind in the future, the maxSV size should be moved 10 -->8 once the 2018menu is removed.

-- release tag: CMSSW_11_0_X_2019-11-07-2300  --

```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           81.6  .........      54.70 / 54.97        MahiFit::phase1Apply(HBHEChannelInfo const&, float&, float&, bool&, float&) const [18]
[19]       81.6      54.70       2.76 / 51.93      MahiFit::doFit(std::array<float, 3ul>&, int) const
           60.0  .........      40.23 / 40.23        MahiFit::minimize() const [20]
            9.8  .........       6.56 / 6.56         MahiFit::calculateArrivalTime() const [25]
            7.5  .........       5.05 / 5.05         MahiFit::updatePulseShape(double, Eigen::Matrix<double, -1, 1, 0, 19, 1>&, Eigen::Matrix<double, -1, 1, 0, 19, 1>&, Eigen::Matrix<double, -1, -1, 0, 19, 19>&) const [28]


- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           60.0  .........      40.23 / 54.70        MahiFit::doFit(std::array<float, 3ul>&, int) const [19]
[20]       60.0      40.23       0.31 / 39.91      MahiFit::minimize() const
           30.8  .........      20.61 / 20.61        MahiFit::nnls() const [21]
           16.0  .........      10.74 / 10.74        MahiFit::updateCov() const [23]
            7.7  .........       5.15 / 5.15         MahiFit::onePulseMinimize() const [27]
            5.0  .........       3.38 / 3.38         MahiFit::calculateChiSq() const [33]

```
 

-- this PR at commit d6a2dd12edaed949ae9723cd936e1af691856b65   --

```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           74.1  .........      33.31 / 33.56        MahiFit::phase1Apply(HBHEChannelInfo const&, float&, float&, bool&, float&) const [18]
[19]       74.1      33.31       1.74 / 31.56      MahiFit::doFit(std::array<float, 3ul>&, int) const
           49.8  .........      22.38 / 22.38        MahiFit::minimize() const [20]
           11.0  .........       4.95 / 4.95         MahiFit::updatePulseShape(float, Eigen::Matrix<float, -1, 1, 0, 15, 1>&, Eigen::Matrix<float, -1, 1, 0, 15, 1>&, Eigen::Matrix<float, -1, -1, 0, 15, 15>&) const [25]
            9.4  .........       4.22 / 4.22         MahiFit::calculateArrivalTime(unsigned int) const [26]

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           49.8  .........      22.38 / 33.31        MahiFit::doFit(std::array<float, 3ul>&, int) const [19]
[20]       49.8      22.38       0.32 / 22.06      MahiFit::minimize() const
           23.2  .........      10.42 / 10.42        MahiFit::nnls() const [21]
           14.7  .........       6.59 / 6.59         MahiFit::updateCov(Eigen::Matrix<float, -1, -1, 0, 10, 10> const&) const [22]
            6.5  .........       2.93 / 2.93         MahiFit::onePulseMinimize() const [29]
            4.7  .........       2.11 / 2.11         MahiFit::calculateChiSq() const [34]

```

Tests above done on fu-c2a02-37-03 2 CPUs:
  0: Intel(R) Xeon(R) Gold 6130 CPU @ 2.10GHz (16 cores, 32 threads)
  1: Intel(R) Xeon(R) Gold 6130 CPU @ 2.10GHz (16 cores, 32 threads)

