### PR TITLE
Hcal: A fix for DQM TDC inconsistency for 2017 workflows

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -145,8 +145,10 @@ void HcalElectronicsSim::analogToDigital(
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
   if (!PreMixDigis) {
     const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
-    HcalTDC theTDC((pars.threshold_currentTDC()));
-    theTDC.timing(lf, result);
+    if (pars.threshold_currentTDC() > 0) {
+      HcalTDC theTDC((pars.threshold_currentTDC()));
+      theTDC.timing(lf, result);
+    }
   }
 }
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -145,7 +145,7 @@ void HcalElectronicsSim::analogToDigital(
   analogToDigitalImpl(engine, lf, result, preMixFactor, preMixBits);
   if (!PreMixDigis) {
     const HcalSimParameters& pars = static_cast<const HcalSimParameters&>(theParameterMap->simParameters(lf.id()));
-    if (pars.threshold_currentTDC() > 0) {
+    if (pars.threshold_currentTDC() > 0.) {
       HcalTDC theTDC((pars.threshold_currentTDC()));
       theTDC.timing(lf, result);
     }

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -21,7 +21,7 @@ hcalSimParameters = cms.PSet(
         timePhase = cms.double(14.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
-        threshold_currentTDC = cms.double(18.7),
+        threshold_currentTDC = cms.double(-999.),
     ),
     hf2 = cms.PSet(
         readoutFrameSize = cms.int32(4),
@@ -34,7 +34,7 @@ hcalSimParameters = cms.PSet(
         timePhase = cms.double(13.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
-        threshold_currentTDC = cms.double(18.7),
+        threshold_currentTDC = cms.double(-999.),
     ),
     ho = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -52,7 +52,7 @@ hcalSimParameters = cms.PSet(
         siPMCode = cms.int32(2),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(5.),
-        threshold_currentTDC = cms.double(18.7),
+        threshold_currentTDC = cms.double(-999.),
     ),
     hb = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -70,7 +70,7 @@ hcalSimParameters = cms.PSet(
         timeSmearing = cms.bool(True),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
-        threshold_currentTDC = cms.double(18.7),
+        threshold_currentTDC = cms.double(-999.),
     ),
     he = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -87,7 +87,7 @@ hcalSimParameters = cms.PSet(
         timeSmearing = cms.bool(True),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
-        threshold_currentTDC = cms.double(18.7),
+        threshold_currentTDC = cms.double(-999.),
     ),
     zdc = cms.PSet(
         readoutFrameSize = cms.int32(10),
@@ -100,7 +100,7 @@ hcalSimParameters = cms.PSet(
         timePhase = cms.double(-4.0),
         doSiPMSmearing = cms.bool(False),
         sipmTau = cms.double(0.),
-        threshold_currentTDC = cms.double(18.7),
+        threshold_currentTDC = cms.double(-999.),
     ),
 )
 
@@ -149,7 +149,8 @@ from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 run2_HE_2018.toModify( hcalSimParameters,
     he = dict(
                readoutFrameSize = cms.int32(8), 
-               binOfMaximum     = cms.int32(4)
+               binOfMaximum     = cms.int32(4),
+               threshold_currentTDC = cms.double(18.7)
               )
 )
 
@@ -158,6 +159,7 @@ from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify( hcalSimParameters,
     hb = dict(
         doSiPMSmearing = cms.bool(True),
+        threshold_currentTDC = cms.double(18.7),
         sipmTau = cms.double(10.),
     )
 )


### PR DESCRIPTION
#### PR description:

A fix for DQM TDC inconsistency of non-reproducibility of LETDCTime for 2017 workflows, caused by threshold settings in https://github.com/cms-sw/cmssw/pull/28330. 