### PR TITLE
Keeping sumPt from MET Significance calculation

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -70,6 +70,10 @@ namespace pat {
     void setMETSignificance(const double& metSig);
     // get the MET significance
     double metSignificance() const;
+    // set the MET sumPt for MET Significance
+    void setMETSumPt(const double& sumPt);
+    // get the MET sumPt
+    double metSumPt() const;
 
     // ---- methods for uncorrected MET ----
     // Methods not yet defined
@@ -317,6 +321,8 @@ namespace pat {
 
     // MET significance
     double metSig_;
+    // MET sumPt for MET Significance
+    double sumPt_;
 
     const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
 

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -70,10 +70,10 @@ namespace pat {
     void setMETSignificance(const double& metSig);
     // get the MET significance
     double metSignificance() const;
-    // set the MET sumPt for MET Significance
-    void setMETSumPt(const double& sumPt);
-    // get the MET sumPt
-    double metSumPt() const;
+    // set the MET sumPtUnclustered for MET Significance
+    void setMETSumPtUnclustered(const double& sumPtUnclustered);
+    // get the MET sumPtUnclustered
+    double metSumPtUnclustered() const;
 
     // ---- methods for uncorrected MET ----
     // Methods not yet defined
@@ -321,8 +321,8 @@ namespace pat {
 
     // MET significance
     double metSig_;
-    // MET sumPt for MET Significance
-    double sumPt_;
+    // MET sumPtUnclustered for MET Significance
+    double sumPtUnclustered_;
 
     const PackedMETUncertainty findMETTotalShift(MET::METCorrectionLevel cor, MET::METUncertainty shift) const;
 

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -21,6 +21,7 @@ MET::MET(const reco::MET &aMET) : PATObject<reco::MET>(aMET) {
     this->operator=(*pm);
 
   metSig_ = 0.;
+  sumPt_ = 0.;
   initCorMap();
 }
 
@@ -37,6 +38,7 @@ MET::MET(const edm::RefToBase<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRe
     this->operator=(*pm);
 
   metSig_ = 0.;
+  sumPt_ = 0.;
   initCorMap();
 }
 
@@ -53,6 +55,7 @@ MET::MET(const edm::Ptr<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRef) {
     this->operator=(*pm);
 
   metSig_ = 0.;
+  sumPt_ = 0.;
   initCorMap();
 }
 
@@ -63,6 +66,7 @@ MET::MET(MET const &iOther)
       caloMET_(iOther.caloMET_),
       pfMET_(iOther.pfMET_),
       metSig_(iOther.metSig_),
+      sumPt_(iOther.sumPt_),
       uncertaintiesRaw_(iOther.uncertaintiesRaw_),          //74X reading compatibility
       uncertaintiesType1_(iOther.uncertaintiesType1_),      //74X compatibility
       uncertaintiesType1p2_(iOther.uncertaintiesType1p2_),  //74X compatibility
@@ -80,6 +84,7 @@ MET::MET(const reco::MET &corMET, const MET &srcMET)
       caloMET_(srcMET.caloMET_),
       pfMET_(srcMET.pfMET_),
       metSig_(srcMET.metSig_),
+      sumPt_(srcMET.sumPt_),
       caloPackedMet_(srcMET.caloPackedMet_) {
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
 
@@ -100,6 +105,7 @@ MET &MET::operator=(MET const &iOther) {
   uncertainties_ = iOther.uncertainties_;
   corrections_ = iOther.corrections_;
   metSig_ = iOther.metSig_;
+  sumPt_ = iOther.sumPt_;
   caloPackedMet_ = iOther.caloPackedMet_;
 
   return *this;
@@ -118,6 +124,10 @@ void MET::setGenMET(const reco::GenMET &gm) {
 void MET::setMETSignificance(const double &metSig) { metSig_ = metSig; }
 
 double MET::metSignificance() const { return metSig_; }
+
+void MET::setMETSumPt(const double &sumPt) { sumPt_ = sumPt; }
+
+double MET::metSumPt() const { return sumPt_; }
 
 void MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRaw;

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -21,7 +21,7 @@ MET::MET(const reco::MET &aMET) : PATObject<reco::MET>(aMET) {
     this->operator=(*pm);
 
   metSig_ = 0.;
-  sumPt_ = 0.;
+  sumPtUnclustered_ = 0.;
   initCorMap();
 }
 
@@ -38,7 +38,7 @@ MET::MET(const edm::RefToBase<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRe
     this->operator=(*pm);
 
   metSig_ = 0.;
-  sumPt_ = 0.;
+  sumPtUnclustered_ = 0.;
   initCorMap();
 }
 
@@ -55,7 +55,7 @@ MET::MET(const edm::Ptr<reco::MET> &aMETRef) : PATObject<reco::MET>(aMETRef) {
     this->operator=(*pm);
 
   metSig_ = 0.;
-  sumPt_ = 0.;
+  sumPtUnclustered_ = 0.;
   initCorMap();
 }
 
@@ -66,7 +66,7 @@ MET::MET(MET const &iOther)
       caloMET_(iOther.caloMET_),
       pfMET_(iOther.pfMET_),
       metSig_(iOther.metSig_),
-      sumPt_(iOther.sumPt_),
+      sumPtUnclustered_(iOther.sumPtUnclustered_),
       uncertaintiesRaw_(iOther.uncertaintiesRaw_),          //74X reading compatibility
       uncertaintiesType1_(iOther.uncertaintiesType1_),      //74X compatibility
       uncertaintiesType1p2_(iOther.uncertaintiesType1p2_),  //74X compatibility
@@ -84,7 +84,7 @@ MET::MET(const reco::MET &corMET, const MET &srcMET)
       caloMET_(srcMET.caloMET_),
       pfMET_(srcMET.pfMET_),
       metSig_(srcMET.metSig_),
-      sumPt_(srcMET.sumPt_),
+      sumPtUnclustered_(srcMET.sumPtUnclustered_),
       caloPackedMet_(srcMET.caloPackedMet_) {
   setSignificanceMatrix(srcMET.getSignificanceMatrix());
 
@@ -105,7 +105,7 @@ MET &MET::operator=(MET const &iOther) {
   uncertainties_ = iOther.uncertainties_;
   corrections_ = iOther.corrections_;
   metSig_ = iOther.metSig_;
-  sumPt_ = iOther.sumPt_;
+  sumPtUnclustered_ = iOther.sumPtUnclustered_;
   caloPackedMet_ = iOther.caloPackedMet_;
 
   return *this;
@@ -125,9 +125,9 @@ void MET::setMETSignificance(const double &metSig) { metSig_ = metSig; }
 
 double MET::metSignificance() const { return metSig_; }
 
-void MET::setMETSumPt(const double &sumPt) { sumPt_ = sumPt; }
+void MET::setMETSumPtUnclustered(const double &sumPtUnclustered) { sumPtUnclustered_ = sumPtUnclustered; }
 
-double MET::metSumPt() const { return sumPt_; }
+double MET::metSumPtUnclustered() const { return sumPtUnclustered_; }
 
 void MET::initCorMap() {
   std::vector<MET::METCorrectionType> tmpRaw;

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -272,9 +272,10 @@
   <ioread sourceClass = "pat::Jet" version="[1-]" targetClass="pat::Jet" source="" target="daughtersTemp_">
     <![CDATA[daughtersTemp_.reset();]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="15">
-    <version ClassVersion="15" checksum="428901429"/>
+  <class name="pat::MET"  ClassVersion="16">
+    <version ClassVersion="16" checksum="2931227204"/>
     <field name="corMap_" transient="true"/>
+   <version ClassVersion="15" checksum="428901429"/>
    <version ClassVersion="14" checksum="1795935545"/>
    <version ClassVersion="13" checksum="2368359386"/>
    <version ClassVersion="12" checksum="1474251442"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -272,10 +272,9 @@
   <ioread sourceClass = "pat::Jet" version="[1-]" targetClass="pat::Jet" source="" target="daughtersTemp_">
     <![CDATA[daughtersTemp_.reset();]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="17">
-    <version ClassVersion="17" checksum="2416242778"/>
+  <class name="pat::MET"  ClassVersion="16">
+    <version ClassVersion="16" checksum="2416242778"/>
     <field name="corMap_" transient="true"/>
-   <version ClassVersion="16" checksum="2931227204"/>
    <version ClassVersion="15" checksum="428901429"/>
    <version ClassVersion="14" checksum="1795935545"/>
    <version ClassVersion="13" checksum="2368359386"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -272,9 +272,10 @@
   <ioread sourceClass = "pat::Jet" version="[1-]" targetClass="pat::Jet" source="" target="daughtersTemp_">
     <![CDATA[daughtersTemp_.reset();]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="16">
-    <version ClassVersion="16" checksum="2931227204"/>
+  <class name="pat::MET"  ClassVersion="17">
+    <version ClassVersion="17" checksum="2416242778"/>
     <field name="corMap_" transient="true"/>
+   <version ClassVersion="16" checksum="2931227204"/>
    <version ClassVersion="15" checksum="428901429"/>
    <version ClassVersion="14" checksum="1795935545"/>
    <version ClassVersion="13" checksum="2368359386"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -94,7 +94,7 @@ void PATMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
     //add the MET significance
     if (calculateMETSignificance_) {
-      double sumPt=0;
+      double sumPt = 0;
       const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup, sumPt);
       amet.setSignificanceMatrix(sigcov);
       double metSig = metSigAlgo_->getSignificance(sigcov, amet);
@@ -157,8 +157,10 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   iDesc.add<edm::InputTag>("muonSource", edm::InputTag("muons"));
 }
 
-const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup, double &sumPt) const {
-//const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
+const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event,
+                                                         const edm::EventSetup& iSetup,
+                                                         double& sumPt) const {
+  //const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
   std::vector<edm::Handle<reco::CandidateView> > leptons;
   for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
        srcLeptons_i != lepTokens_.end();

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -160,7 +160,6 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event,
                                                          const edm::EventSetup& iSetup,
                                                          double& sumPt) const {
-  //const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
   std::vector<edm::Handle<reco::CandidateView> > leptons;
   for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
        srcLeptons_i != lepTokens_.end();

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -94,10 +94,12 @@ void PATMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
     //add the MET significance
     if (calculateMETSignificance_) {
-      const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup);
+      double sumPt=0;
+      const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup, sumPt);
       amet.setSignificanceMatrix(sigcov);
       double metSig = metSigAlgo_->getSignificance(sigcov, amet);
       amet.setMETSignificance(metSig);
+      amet.setMETSumPt(sumPt);
     }
 
     if (efficiencyLoader_.enabled()) {
@@ -155,7 +157,8 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   iDesc.add<edm::InputTag>("muonSource", edm::InputTag("muons"));
 }
 
-const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
+const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup, double &sumPt) const {
+//const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const {
   std::vector<edm::Handle<reco::CandidateView> > leptons;
   for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
        srcLeptons_i != lepTokens_.end();
@@ -181,7 +184,7 @@ const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event
 
   //Compute the covariance matrix and fill it
   reco::METCovMatrix cov = metSigAlgo_->getCovariance(
-      *inputJets, leptons, inputCands, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
+      *inputJets, leptons, inputCands, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
 
   return cov;
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.cc
@@ -94,12 +94,12 @@ void PATMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
     //add the MET significance
     if (calculateMETSignificance_) {
-      double sumPt = 0;
-      const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup, sumPt);
+      double sumPtUnclustered = 0;
+      const reco::METCovMatrix& sigcov = getMETCovMatrix(iEvent, iSetup, sumPtUnclustered);
       amet.setSignificanceMatrix(sigcov);
       double metSig = metSigAlgo_->getSignificance(sigcov, amet);
       amet.setMETSignificance(metSig);
-      amet.setMETSumPt(sumPt);
+      amet.setMETSumPtUnclustered(sumPtUnclustered);
     }
 
     if (efficiencyLoader_.enabled()) {
@@ -159,7 +159,7 @@ void PATMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 
 const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event,
                                                          const edm::EventSetup& iSetup,
-                                                         double& sumPt) const {
+                                                         double& sumPtUnclustered) const {
   std::vector<edm::Handle<reco::CandidateView> > leptons;
   for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
        srcLeptons_i != lepTokens_.end();
@@ -185,7 +185,7 @@ const reco::METCovMatrix PATMETProducer::getMETCovMatrix(const edm::Event& event
 
   //Compute the covariance matrix and fill it
   reco::METCovMatrix cov = metSigAlgo_->getCovariance(
-      *inputJets, leptons, inputCands, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
+      *inputJets, leptons, inputCands, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPtUnclustered);
 
   return cov;
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -72,7 +72,9 @@ namespace pat {
     std::string jetResPhiType_;
     std::string jetSFType_;
 
-    const reco::METCovMatrix getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup, double &sumPt) const;
+    const reco::METCovMatrix getMETCovMatrix(const edm::Event& event,
+                                             const edm::EventSetup& iSetup,
+                                             double& sumPt) const;
   };
 
 }  // namespace pat

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -72,7 +72,7 @@ namespace pat {
     std::string jetResPhiType_;
     std::string jetSFType_;
 
-    const reco::METCovMatrix getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup) const;
+    const reco::METCovMatrix getMETCovMatrix(const edm::Event& event, const edm::EventSetup& iSetup, double &sumPt) const;
   };
 
 }  // namespace pat

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -74,7 +74,7 @@ namespace pat {
 
     const reco::METCovMatrix getMETCovMatrix(const edm::Event& event,
                                              const edm::EventSetup& iSetup,
-                                             double& sumPt) const;
+                                             double& sumPtUnclustered) const;
   };
 
 }  // namespace pat

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -44,7 +44,8 @@ namespace metsig {
                                      JME::JetResolution& resPtObj,
                                      JME::JetResolution& resPhiObj,
                                      JME::JetResolutionScaleFactor& resSFObj,
-                                     bool isRealData);
+                                     bool isRealData,
+                                     double &sumPt);
 
     static double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met);
 

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -45,7 +45,7 @@ namespace metsig {
                                      JME::JetResolution& resPhiObj,
                                      JME::JetResolutionScaleFactor& resSFObj,
                                      bool isRealData,
-                                     double &sumPt);
+                                     double& sumPt);
 
     static double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met);
 

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -45,7 +45,7 @@ namespace metsig {
                                      JME::JetResolution& resPhiObj,
                                      JME::JetResolutionScaleFactor& resSFObj,
                                      bool isRealData,
-                                     double& sumPt);
+                                     double& sumPtUnclustered);
 
     static double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met);
 

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -51,7 +51,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
                                                           JME::JetResolution& resPhiObj,
                                                           JME::JetResolutionScaleFactor& resSFObj,
                                                           bool isRealData,
-                                                          double &sumPt) {
+                                                          double& sumPt) {
   //pfcandidates
   const edm::View<reco::Candidate>* pfCandidates = pfCandidatesH.product();
 
@@ -89,7 +89,6 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
 
   // calculate sumPt
   for (size_t i = 0; i < pfCandidates->size(); ++i) {
-
     // check if candidate exists in a lepton or jet
     bool cleancand = true;
     if (footprint.find(pfCandidates->ptrAt(i)) == footprint.end()) {

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -50,7 +50,8 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
                                                           JME::JetResolution& resPtObj,
                                                           JME::JetResolution& resPhiObj,
                                                           JME::JetResolutionScaleFactor& resSFObj,
-                                                          bool isRealData) {
+                                                          bool isRealData,
+                                                          double &sumPt) {
   //pfcandidates
   const edm::View<reco::Candidate>* pfCandidates = pfCandidatesH.product();
 
@@ -87,8 +88,8 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
   }
 
   // calculate sumPt
-  double sumPt = 0;
   for (size_t i = 0; i < pfCandidates->size(); ++i) {
+
     // check if candidate exists in a lepton or jet
     bool cleancand = true;
     if (footprint.find(pfCandidates->ptrAt(i)) == footprint.end()) {

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -51,7 +51,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
                                                           JME::JetResolution& resPhiObj,
                                                           JME::JetResolutionScaleFactor& resSFObj,
                                                           bool isRealData,
-                                                          double& sumPt) {
+                                                          double& sumPtUnclustered) {
   //pfcandidates
   const edm::View<reco::Candidate>* pfCandidates = pfCandidatesH.product();
 
@@ -63,7 +63,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
   // for lepton and jet subtraction
   std::unordered_set<reco::CandidatePtr, ptr_hash> footprint;
 
-  // subtract leptons out of sumPt
+  // subtract leptons out of sumPtUnclustered
   for (const auto& lep_i : leptons) {
     for (const auto& lep : *lep_i) {
       if (lep.pt() > 10) {
@@ -75,7 +75,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
       }
     }
   }
-  // subtract jets out of sumPt
+  // subtract jets out of sumPtUnclustered
   for (const auto& jet : jets) {
     // disambiguate jets and leptons
     if (!cleanJet(jet, leptons))
@@ -87,7 +87,7 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
     }
   }
 
-  // calculate sumPt
+  // calculate sumPtUnclustered
   for (size_t i = 0; i < pfCandidates->size(); ++i) {
     // check if candidate exists in a lepton or jet
     bool cleancand = true;
@@ -99,14 +99,14 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
           break;
         }
       }
-      // if not, add to sumPt
+      // if not, add to sumPtUnclustered
       if (cleancand) {
-        sumPt += (*pfCandidates)[i].pt();
+        sumPtUnclustered += (*pfCandidates)[i].pt();
       }
     }
   }
 
-  // add jets to metsig covariance matrix and subtract them from sumPt
+  // add jets to metsig covariance matrix and subtract them from sumPtUnclustered
   for (const auto& jet : jets) {
     // disambiguate jets and leptons
     if (!cleanJet(jet, leptons))
@@ -152,18 +152,18 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
       cov_yy += dph * dph * c * c + dpt * dpt * s * s;
 
     } else {
-      // add the (corrected) jet to the sumPt
-      sumPt += jpt;
+      // add the (corrected) jet to the sumPtUnclustered
+      sumPtUnclustered += jpt;
     }
   }
 
   //protection against unphysical events
-  if (sumPt < 0)
-    sumPt = 0;
+  if (sumPtUnclustered < 0)
+    sumPtUnclustered = 0;
 
   // add pseudo-jet to metsig covariance matrix
-  cov_xx += pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPt;
-  cov_yy += pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPt;
+  cov_xx += pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPtUnclustered;
+  cov_yy += pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPtUnclustered;
 
   reco::METCovMatrix cov;
   cov(0, 0) = cov_xx;

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -79,8 +79,9 @@ namespace cms {
     //
     // compute the significance
     //
+    double sumPt=0;
     const reco::METCovMatrix cov = metSigAlgo_->getCovariance(
-        *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
+        *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
     double sig = metSigAlgo_->getSignificance(cov, met);
 
     auto significance = std::make_unique<double>();

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -79,7 +79,7 @@ namespace cms {
     //
     // compute the significance
     //
-    double sumPt=0;
+    double sumPt = 0;
     const reco::METCovMatrix cov = metSigAlgo_->getCovariance(
         *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
     double sig = metSigAlgo_->getSignificance(cov, met);

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -79,9 +79,9 @@ namespace cms {
     //
     // compute the significance
     //
-    double sumPt = 0;
+    double sumPtUnclustered = 0;
     const reco::METCovMatrix cov = metSigAlgo_->getCovariance(
-        *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
+        *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPtUnclustered);
     double sig = metSigAlgo_->getSignificance(cov, met);
 
     auto significance = std::make_unique<double>();

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -94,7 +94,7 @@ namespace cms {
     event.getByToken(rhoToken_, rho);
 
     //Compute the covariance matrix and fill it
-    double sumPt;
+    double sumPt = 0;
     reco::METCovMatrix cov = metSigAlgo_->getCovariance(
         *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
 

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -94,8 +94,9 @@ namespace cms {
     event.getByToken(rhoToken_, rho);
 
     //Compute the covariance matrix and fill it
+    double sumPt;
     reco::METCovMatrix cov = metSigAlgo_->getCovariance(
-        *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
+        *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
 
     return cov;
   }

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -94,9 +94,9 @@ namespace cms {
     event.getByToken(rhoToken_, rho);
 
     //Compute the covariance matrix and fill it
-    double sumPt = 0;
+    double sumPtUnclustered = 0;
     reco::METCovMatrix cov = metSigAlgo_->getCovariance(
-        *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPt);
+        *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData(), sumPtUnclustered);
 
     return cov;
   }


### PR DESCRIPTION
#### PR description:

The sum of the unclustered energy is one of the inputs to MET significance, but is currently not stored in miniAOD, making recomputation of the significance and the MET covariance matrix difficult. With this PR, the calculated sum of the pTs of the unclustered particles is stored, and can be accessed with metSumPt(), similar to metSignificance().
This makes a later calculation, e.g. in nanoAOD as proposed in [this PR](https://github.com/cms-nanoAOD/cmssw/pull/443), redundant.

#### PR validation:

All tests have been run, and were passed.
