### PR TITLE
Run3-hcx238 Tidy up Hcal related agorithms and corresonding test examples

### DIFF
--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -71,6 +71,12 @@ namespace geant_units {
     }
 
     template <class NumType>
+    inline constexpr NumType convertCm2ToMm2(NumType centimeters)  // Centimeters^2 -> Milliimeters^2
+    {
+      return (centimeters * 100.);
+    }
+
+    template <class NumType>
     inline constexpr NumType convertMm3ToM3(NumType mm3)  // Cubic millimeters -> cubic meters
     {
       return (mm3 / 1.e9);

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalTBCable-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalTBCable-algorithm.xml
@@ -20,7 +20,7 @@
   <close_geometry/>
 
   <IncludeSection>
-    <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/materials/2021/v1/materials.xml"/>
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/HcalTestBeamData/data/TBHcal.xml"/>

--- a/Geometry/HcalAlgo/data/cms-test-ddhcalTBZpos-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-ddhcalTBZpos-algorithm.xml
@@ -20,7 +20,7 @@
   <close_geometry/>
 
   <IncludeSection>
-    <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/materials/2021/v1/materials.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalforwardmaterial.xml"/>
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
@@ -31,8 +31,9 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << " mother " << deltaZ << " along Z, " << convertRadToDeg(deltaPhi)
                                << " along phi and with " << rStart.size() << " different bundle types";
   for (unsigned int i = 0; i < areaSection.size(); ++i)
-    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Child[" << i << "] Area " << convertCm2ToMm2(areaSection[i]) << " R at Start "
-                                 << convertCmToMm(rStart[i]) << " R at End " << convertCmToMm(rEnd[i]);
+    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Child[" << i << "] Area " << convertCm2ToMm2(areaSection[i])
+                                 << " R at Start " << convertCmToMm(rStart[i]) << " R at End "
+                                 << convertCmToMm(rEnd[i]);
   edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: NameSpace " << ns.name() << " Tilt Angle "
                                << convertRadToDeg(tilt) << " Bundle type at different positions";
   for (unsigned int i = 0; i < bundle.size(); ++i) {
@@ -67,7 +68,7 @@ static long algorithm(dd4hep::Detector& /* description */,
     double dEnd = areaSection[i] / (2 * dPhi * r0);
     std::string name = childPrefix + std::to_string(i);
     dd4hep::Solid solid = dd4hep::ConeSegment(
-					      name, 0.5 * deltaZ, rStart[i] - dStart, rStart[i] + dStart, r0 - dEnd, r0 + dEnd, -0.5 * dPhi, 0.5 * dPhi);
+        name, 0.5 * deltaZ, rStart[i] - dStart, rStart[i] + dStart, r0 - dEnd, r0 + dEnd, -0.5 * dPhi, 0.5 * dPhi);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Creating a new solid " << name << " a cons with dZ " << deltaZ
                                  << " rStart " << rStart[i] - dStart << ":" << rStart[i] + dStart << " rEnd "

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
@@ -1,11 +1,11 @@
-#include "DD4hep/DetFactoryHelper.h"
-#include "DataFormats/Math/interface/CMSUnits.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DD4hep/DetFactoryHelper.h"
 
 //#define EDM_ML_DEBUG
 
-using namespace cms_units::operators;
+using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
@@ -31,8 +31,8 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << " mother " << deltaZ << " along Z, " << convertRadToDeg(deltaPhi)
                                << " along phi and with " << rStart.size() << " different bundle types";
   for (unsigned int i = 0; i < areaSection.size(); ++i)
-    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Child[" << i << "] Area " << areaSection[i] << " R at Start "
-                                 << rStart[i] << " R at End " << rEnd[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Child[" << i << "] Area " << convertCm2ToMm2(areaSection[i]) << " R at Start "
+                                 << convertCmToMm(rStart[i]) << " R at End " << convertCmToMm(rEnd[i]);
   edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: NameSpace " << ns.name() << " Tilt Angle "
                                << convertRadToDeg(tilt) << " Bundle type at different positions";
   for (unsigned int i = 0; i < bundle.size(); ++i) {
@@ -47,9 +47,10 @@ static long algorithm(dd4hep::Detector& /* description */,
   // Create the rotation matrices
   double dPhi = deltaPhi / numberPhi;
   std::vector<dd4hep::Rotation3D> rotation;
+  dd4hep::Rotation3D rot;
   for (int i = 0; i < numberPhi; ++i) {
     double phi = -0.5 * deltaPhi + (i + 0.5) * dPhi;
-    dd4hep::Rotation3D rot = cms::makeRotation3D(90._deg, phi, 90._deg, (90._deg + phi), 0, 0);
+    rot = dd4hep::RotationZ(phi);
 #ifdef EDM_ML_DEBUG
     double phideg = convertRadToDeg(phi);
     edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Creating a new rotation " << 90 << "," << phideg << "," << 90
@@ -66,8 +67,7 @@ static long algorithm(dd4hep::Detector& /* description */,
     double dEnd = areaSection[i] / (2 * dPhi * r0);
     std::string name = childPrefix + std::to_string(i);
     dd4hep::Solid solid = dd4hep::ConeSegment(
-        0.5 * deltaZ, rStart[i] - dStart, rStart[i] + dStart, r0 - dEnd, r0 + dEnd, -0.5 * dPhi, 0.5 * dPhi);
-    ns.addSolidNS(name, solid);
+					      name, 0.5 * deltaZ, rStart[i] - dStart, rStart[i] + dStart, r0 - dEnd, r0 + dEnd, -0.5 * dPhi, 0.5 * dPhi);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Creating a new solid " << name << " a cons with dZ " << deltaZ
                                  << " rStart " << rStart[i] - dStart << ":" << rStart[i] + dStart << " rEnd "
@@ -75,7 +75,6 @@ static long algorithm(dd4hep::Detector& /* description */,
                                  << convertRadToDeg(0.5 * dPhi);
 #endif
     dd4hep::Volume log(name, solid, matter);
-    ns.addVolumeNS(log);
     logs.emplace_back(log);
   }
 
@@ -83,18 +82,16 @@ static long algorithm(dd4hep::Detector& /* description */,
   int copy = 0;
   int nY = static_cast<int>(bundle.size()) / numberPhi;
   for (unsigned int i = 0; i < bundle.size(); i++) {
-    dd4hep::Position tran(0, 0, 0);
     int ir = static_cast<int>(i) / nY;
     if (ir >= numberPhi)
       ir = numberPhi - 1;
     int ib = bundle[i];
     copy++;
     if (ib >= 0 && ib < (int)(logs.size())) {
-      mother.placeVolume(logs[ib], copy, dd4hep::Transform3D(rotation[ir], tran));
+      mother.placeVolume(logs[ib], copy, rotation[ir]);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: " << logs[ib].name() << " number " << copy
-                                   << " positioned in " << mother.name() << " at (0, 0, 0)" << tran << " with "
-                                   << rotation[ir];
+                                   << " positioned in " << mother.name() << " at (0, 0, 0) with " << rotation[ir];
 #endif
     }
   }

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
@@ -57,9 +57,12 @@ static long algorithm(dd4hep::Detector& /* description */,
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: General material " << genMat << "\tSectors " << nsectors << ", "
                                << nsectortot << "\tHalves " << nhalf << "\tRin " << convertCmToMm(rin);
   for (unsigned int i = 0; i < theta.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t" << i << " Theta " << convertRadToDeg(theta[i]) << " rmax " << convertCmToMm(rmax[i]) << " zoff " << convertCmToMm(zoff[i]);
-  edm::LogVerbatim("HCalGeom") << "\tCable mockup made of " << absMat << "\tThick " << convertCmToMm(thick) << "\tLength and width "
-                               << convertCmToMm(length1) << ", " << convertCmToMm(width1) << " and " << convertCmToMm(length2) << ", " << convertCmToMm(width2) << " Gap " << convertCmToMm(gap2);
+    edm::LogVerbatim("HCalGeom") << "\t" << i << " Theta " << convertRadToDeg(theta[i]) << " rmax "
+                                 << convertCmToMm(rmax[i]) << " zoff " << convertCmToMm(zoff[i]);
+  edm::LogVerbatim("HCalGeom") << "\tCable mockup made of " << absMat << "\tThick " << convertCmToMm(thick)
+                               << "\tLength and width " << convertCmToMm(length1) << ", " << convertCmToMm(width1)
+                               << " and " << convertCmToMm(length2) << ", " << convertCmToMm(width2) << " Gap "
+                               << convertCmToMm(gap2);
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Parent " << args.parentName() << " idName " << idName
                                << " NameSpace " << idNameSpace << " for solids";
 #endif
@@ -84,7 +87,8 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << nsectortot << " sectors from " << convertRadToDeg(-alpha) << " to "
                                << convertRadToDeg(-alpha + dphi) << " and with " << pgonZ.size() << " sections";
   for (unsigned int i = 0; i < pgonZ.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << convertCmToMm(pgonZ[i]) << "\tRmin = " << convertCmToMm(pgonRmin[i]) << "\tRmax = " << convertCmToMm(pgonRmax[i]);
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << convertCmToMm(pgonZ[i]) << "\tRmin = " << convertCmToMm(pgonRmin[i])
+                                 << "\tRmax = " << convertCmToMm(pgonRmax[i]);
 #endif
 
   dd4hep::Volume parent = ns.volume(args.parentName());
@@ -112,7 +116,8 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << " with 1 sector from " << convertRadToDeg(-alpha) << " to " << convertRadToDeg(alpha)
                                << " and with " << pgonZ.size() << " sections";
   for (unsigned int i = 0; i < pgonZ.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << convertCmToMm(pgonZ[i]) << "\tRmin = " << convertCmToMm(pgonRmin[i]) << "\tRmax = " << convertCmToMm(pgonRmax[i]);
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << convertCmToMm(pgonZ[i]) << "\tRmin = " << convertCmToMm(pgonRmin[i])
+                                 << "\tRmax = " << convertCmToMm(pgonRmax[i]);
 #endif
 
   for (int ii = 0; ii < nsectortot; ++ii) {
@@ -145,8 +150,9 @@ static long algorithm(dd4hep::Detector& /* description */,
   dd4hep::Volume glog(solid.name(), solid, matter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Trap made of " << genMat
-                               << " of dimensions " << convertCmToMm(dz) << ", 0, 0, " << convertCmToMm(dy) << ", " << convertCmToMm(dx1) << ", " << convertCmToMm(dx1) << ", 0, "
-                               << convertCmToMm(dy) << ", " << convertCmToMm(dx2) << ", " << convertCmToMm(dx2) << ", 0";
+                               << " of dimensions " << convertCmToMm(dz) << ", 0, 0, " << convertCmToMm(dy) << ", "
+                               << convertCmToMm(dx1) << ", " << convertCmToMm(dx1) << ", 0, " << convertCmToMm(dy)
+                               << ", " << convertCmToMm(dx2) << ", " << convertCmToMm(dx2) << ", 0";
 #endif
 
   rot = cms::makeRotation3D(90._deg, 270._deg, (180._deg - theta[2]), 0, (90._deg - theta[2]), 0);
@@ -159,7 +165,8 @@ static long algorithm(dd4hep::Detector& /* description */,
   seclogic.placeVolume(glog, 1, dd4hep::Transform3D(rot, r1));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << glog.name() << " number 1 positioned in " << seclogic.name()
-                               << " at (" << convertCmToMm(0.5 * (rinl + routl)) << ", 0, " << convertCmToMm(0.5 * (pgonZ[1] + pgonZ[2])) << " with rotation: " << rot;
+                               << " at (" << convertCmToMm(0.5 * (rinl + routl)) << ", 0, "
+                               << convertCmToMm(0.5 * (pgonZ[1] + pgonZ[2])) << " with rotation: " << rot;
 #endif
   //Now the cable of type 1
   name = idName + "Cable1";
@@ -170,7 +177,8 @@ static long algorithm(dd4hep::Detector& /* description */,
   dd4hep::Volume cablog1(solid.name(), solid, absmatter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Box made of " << absMat << " of dimension "
-							   << convertCmToMm(0.5 * width1) << ", " << convertCmToMm(0.5 * thick) << ", " << convertCmToMm(0.5 * length1);
+                               << convertCmToMm(0.5 * width1) << ", " << convertCmToMm(0.5 * thick) << ", "
+                               << convertCmToMm(0.5 * length1);
 #endif
 
   dd4hep::Rotation3D rot2 = cms::makeRotation3D((90._deg + phi), 0.0, 90._deg, 90._deg, phi, 0.0);
@@ -182,7 +190,8 @@ static long algorithm(dd4hep::Detector& /* description */,
   glog.placeVolume(cablog1, 1, dd4hep::Transform3D(rot2, r2));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() << " number 1 positioned in " << glog.name()
-							   << " at (" << convertCmToMm(xmid - 0.5 * width1 * cos(phi)) << ", 0, 0) with rotation: " << rot2;
+                               << " at (" << convertCmToMm(xmid - 0.5 * width1 * cos(phi))
+                               << ", 0, 0) with rotation: " << rot2;
 #endif
   dd4hep::Rotation3D rot3 = cms::makeRotation3D((90._deg - phi), 0, 90._deg, 90._deg, -phi, 0);
 #ifdef EDM_ML_DEBUG
@@ -193,7 +202,8 @@ static long algorithm(dd4hep::Detector& /* description */,
   glog.placeVolume(cablog1, 2, dd4hep::Transform3D(rot3, r3));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() << " number 2 positioned in " << glog.name()
-							   << " at (" << convertCmToMm(xmid - 0.5 * width1 * cos(phi)) << ", 0, 0) with rotation: " << rot3;
+                               << " at (" << convertCmToMm(xmid - 0.5 * width1 * cos(phi))
+                               << ", 0, 0) with rotation: " << rot3;
 #endif
   //Now the cable of type 2
   name = idName + "Cable2";
@@ -201,18 +211,19 @@ static long algorithm(dd4hep::Detector& /* description */,
   dd4hep::Volume cablog2(solid.name(), solid, absmatter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Box made of " << absMat << " of dimension "
-							   << convertCmToMm(0.5 * width2) << ", " << convertCmToMm(0.5 * thick) << ", " << convertCmToMm(0.5 * length2);
+                               << convertCmToMm(0.5 * width2) << ", " << convertCmToMm(0.5 * thick) << ", "
+                               << convertCmToMm(0.5 * length2);
 #endif
 
   glog.placeVolume(cablog2, 1, dd4hep::Position(0.5 * (width2 + gap2), 0, 0));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() << " number 1 positioned in " << glog.name()
-							   << " at (" << convertCmToMm(0.5 * (width2 + gap2)) << ", 0, 0) with no rotation";
+                               << " at (" << convertCmToMm(0.5 * (width2 + gap2)) << ", 0, 0) with no rotation";
 #endif
   glog.placeVolume(cablog2, 2, dd4hep::Position(-0.5 * (width2 + gap2), 0, 0));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() << " number 2 positioned in " << glog.name()
-							   << " at " << convertCmToMm(-0.5 * (width2 + gap2)) << ", 0, 0) with no rotation";
+                               << " at " << convertCmToMm(-0.5 * (width2 + gap2)) << ", 0, 0) with no rotation";
 
   edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalTBCableAlgo construction";
 #endif

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
@@ -1,11 +1,11 @@
-#include "DD4hep/DetFactoryHelper.h"
-#include "DataFormats/Math/interface/CMSUnits.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DD4hep/DetFactoryHelper.h"
 
 //#define EDM_ML_DEBUG
 
-using namespace cms_units::operators;
+using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
@@ -55,11 +55,11 @@ static long algorithm(dd4hep::Detector& /* description */,
   std::string idName = args.value<std::string>("MotherName");             //Name of the "parent" volume.
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: General material " << genMat << "\tSectors " << nsectors << ", "
-                               << nsectortot << "\tHalves " << nhalf << "\tRin " << rin;
+                               << nsectortot << "\tHalves " << nhalf << "\tRin " << convertCmToMm(rin);
   for (unsigned int i = 0; i < theta.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t" << i << " Theta " << theta[i] << " rmax " << rmax[i] << " zoff " << zoff[i];
-  edm::LogVerbatim("HCalGeom") << "\tCable mockup made of " << absMat << "\tThick " << thick << "\tLength and width "
-                               << length1 << ", " << width1 << " and " << length2 << ", " << width2 << " Gap " << gap2;
+    edm::LogVerbatim("HCalGeom") << "\t" << i << " Theta " << convertRadToDeg(theta[i]) << " rmax " << convertCmToMm(rmax[i]) << " zoff " << convertCmToMm(zoff[i]);
+  edm::LogVerbatim("HCalGeom") << "\tCable mockup made of " << absMat << "\tThick " << convertCmToMm(thick) << "\tLength and width "
+                               << convertCmToMm(length1) << ", " << convertCmToMm(width1) << " and " << convertCmToMm(length2) << ", " << convertCmToMm(width2) << " Gap " << convertCmToMm(gap2);
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Parent " << args.parentName() << " idName " << idName
                                << " NameSpace " << idNameSpace << " for solids";
 #endif
@@ -76,8 +76,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   std::vector<double> pgonRmin = {rin, rin, rstep0, rmax[2]};
   std::vector<double> pgonRmax = {rin, rstep1, rmax[2], rmax[2]};
 
-  dd4hep::Solid solid = dd4hep::Polyhedra(nsectortot, -alpha, dphi, pgonZ, pgonRmin, pgonRmax);
-  ns.addSolidNS(ns.prepend(idName), solid);
+  dd4hep::Solid solid = dd4hep::Polyhedra(ns.prepend(idName), nsectortot, -alpha, dphi, pgonZ, pgonRmin, pgonRmax);
   dd4hep::Material matter = ns.material(genMat);
   dd4hep::Volume genlogic(solid.name(), solid, matter);
 #ifdef EDM_ML_DEBUG
@@ -85,54 +84,52 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << nsectortot << " sectors from " << convertRadToDeg(-alpha) << " to "
                                << convertRadToDeg(-alpha + dphi) << " and with " << pgonZ.size() << " sections";
   for (unsigned int i = 0; i < pgonZ.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << convertCmToMm(pgonZ[i]) << "\tRmin = " << convertCmToMm(pgonRmin[i]) << "\tRmax = " << convertCmToMm(pgonRmax[i]);
 #endif
 
   dd4hep::Volume parent = ns.volume(args.parentName());
-  dd4hep::Position r0(0.0, 0.0, 0.0);
   dd4hep::Rotation3D rot;
-  parent.placeVolume(genlogic, 1, dd4hep::Transform3D(rot, r0));
+  parent.placeVolume(genlogic, 1);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << genlogic.name() << " number 1 positioned in "
-                               << parent.name() << " at " << r0 << " with " << rot;
+                               << parent.name() << " at (0, 0, 0) with no rotation";
 #endif
   if (nhalf != 1) {
     rot = cms::makeRotation3D(90._deg, 180._deg, 90._deg, 90._deg, 180._deg, 0);
-    parent.placeVolume(genlogic, 2, dd4hep::Transform3D(rot, r0));
+    parent.placeVolume(genlogic, 2, rot);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << genlogic.name() << " number 2 positioned in "
-                                 << parent.name() << " at " << r0 << " with " << rot;
+                                 << parent.name() << " at (0, 0, 0) with rotation: " << rot;
 #endif
   }
 
   //Construct sector (from -alpha to +alpha)
   std::string name = idName + "Module";
-  solid = dd4hep::Polyhedra(1, -alpha, 2 * alpha, pgonZ, pgonRmin, pgonRmax);
-  ns.addSolidNS(ns.prepend(name), solid);
+  solid = dd4hep::Polyhedra(ns.prepend(name), 1, -alpha, 2 * alpha, pgonZ, pgonRmin, pgonRmax);
   dd4hep::Volume seclogic(solid.name(), solid, matter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Polyhedra made of " << genMat
                                << " with 1 sector from " << convertRadToDeg(-alpha) << " to " << convertRadToDeg(alpha)
                                << " and with " << pgonZ.size() << " sections";
   for (unsigned int i = 0; i < pgonZ.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << convertCmToMm(pgonZ[i]) << "\tRmin = " << convertCmToMm(pgonRmin[i]) << "\tRmax = " << convertCmToMm(pgonRmax[i]);
 #endif
 
   for (int ii = 0; ii < nsectortot; ++ii) {
     double phi = ii * 2 * alpha;
     dd4hep::Rotation3D rotation;
     if (phi != 0) {
-      rotation = cms::makeRotation3D(90._deg, phi, 90._deg, (90._deg + phi), 0, 0);
+      rotation = dd4hep::RotationZ(phi);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a new rotation "
                                    << "\t90," << convertRadToDeg(phi) << ",90," << (90 + convertRadToDeg(phi))
                                    << ", 0, 0";
 #endif
     }
-    genlogic.placeVolume(seclogic, ii + 1, dd4hep::Transform3D(rotation, r0));
+    genlogic.placeVolume(seclogic, ii + 1, rotation);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << seclogic.name() << " number " << ii + 1
-                                 << " positioned in " << genlogic.name() << " at " << r0 << " with " << rotation;
+                                 << " positioned in " << genlogic.name() << " at (0, 0, 0) with rotation: " << rotation;
 #endif
   }
 
@@ -144,13 +141,12 @@ static long algorithm(dd4hep::Detector& /* description */,
   double dy = 0.50 * thick;
   double dz = 0.50 * (routl - rinl);
   name = idName + "Trap";
-  solid = dd4hep::Trap(dz, 0, 0, dy, dx1, dx1, 0, dy, dx2, dx2, 0);
-  ns.addSolidNS(ns.prepend(name), solid);
+  solid = dd4hep::Trap(ns.prepend(name), dz, 0, 0, dy, dx1, dx1, 0, dy, dx2, dx2, 0);
   dd4hep::Volume glog(solid.name(), solid, matter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Trap made of " << genMat
-                               << " of dimensions " << dz << ", 0, 0, " << dy << ", " << dx1 << ", " << dx1 << ", 0, "
-                               << dy << ", " << dx2 << ", " << dx2 << ", 0";
+                               << " of dimensions " << convertCmToMm(dz) << ", 0, 0, " << convertCmToMm(dy) << ", " << convertCmToMm(dx1) << ", " << convertCmToMm(dx1) << ", 0, "
+                               << convertCmToMm(dy) << ", " << convertCmToMm(dx2) << ", " << convertCmToMm(dx2) << ", 0";
 #endif
 
   rot = cms::makeRotation3D(90._deg, 270._deg, (180._deg - theta[2]), 0, (90._deg - theta[2]), 0);
@@ -163,19 +159,18 @@ static long algorithm(dd4hep::Detector& /* description */,
   seclogic.placeVolume(glog, 1, dd4hep::Transform3D(rot, r1));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << glog.name() << " number 1 positioned in " << seclogic.name()
-                               << " at " << r1 << " with " << rot;
+                               << " at (" << convertCmToMm(0.5 * (rinl + routl)) << ", 0, " << convertCmToMm(0.5 * (pgonZ[1] + pgonZ[2])) << " with rotation: " << rot;
 #endif
   //Now the cable of type 1
   name = idName + "Cable1";
   double phi = atan((dx2 - dx1) / (2 * dz));
   double xmid = 0.5 * (dx1 + dx2) - 1.0;
-  solid = dd4hep::Box(0.5 * width1, 0.5 * thick, 0.5 * length1);
-  ns.addSolidNS(ns.prepend(name), solid);
+  solid = dd4hep::Box(ns.prepend(name), 0.5 * width1, 0.5 * thick, 0.5 * length1);
   dd4hep::Material absmatter = ns.material(absMat);
   dd4hep::Volume cablog1(solid.name(), solid, absmatter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Box made of " << absMat << " of dimension "
-                               << 0.5 * width1 << ", " << 0.5 * thick << ", " << 0.5 * length1;
+							   << convertCmToMm(0.5 * width1) << ", " << convertCmToMm(0.5 * thick) << ", " << convertCmToMm(0.5 * length1);
 #endif
 
   dd4hep::Rotation3D rot2 = cms::makeRotation3D((90._deg + phi), 0.0, 90._deg, 90._deg, phi, 0.0);
@@ -187,7 +182,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   glog.placeVolume(cablog1, 1, dd4hep::Transform3D(rot2, r2));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() << " number 1 positioned in " << glog.name()
-                               << " at " << r2 << " with " << rot2;
+							   << " at (" << convertCmToMm(xmid - 0.5 * width1 * cos(phi)) << ", 0, 0) with rotation: " << rot2;
 #endif
   dd4hep::Rotation3D rot3 = cms::makeRotation3D((90._deg - phi), 0, 90._deg, 90._deg, -phi, 0);
 #ifdef EDM_ML_DEBUG
@@ -198,30 +193,26 @@ static long algorithm(dd4hep::Detector& /* description */,
   glog.placeVolume(cablog1, 2, dd4hep::Transform3D(rot3, r3));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() << " number 2 positioned in " << glog.name()
-                               << " at " << r3 << " with " << rot3;
+							   << " at (" << convertCmToMm(xmid - 0.5 * width1 * cos(phi)) << ", 0, 0) with rotation: " << rot3;
 #endif
   //Now the cable of type 2
   name = idName + "Cable2";
-  solid = dd4hep::Box(0.5 * width2, 0.5 * thick, 0.5 * length2);
-  ns.addSolidNS(ns.prepend(name), solid);
+  solid = dd4hep::Box(ns.prepend(name), 0.5 * width2, 0.5 * thick, 0.5 * length2);
   dd4hep::Volume cablog2(solid.name(), solid, absmatter);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Box made of " << absMat << " of dimension "
-                               << 0.5 * width2 << ", " << 0.5 * thick << ", " << 0.5 * length2;
+							   << convertCmToMm(0.5 * width2) << ", " << convertCmToMm(0.5 * thick) << ", " << convertCmToMm(0.5 * length2);
 #endif
 
-  dd4hep::Rotation3D rot4;
-  dd4hep::Position r4(0.5 * (width2 + gap2), 0, 0);
-  glog.placeVolume(cablog2, 1, dd4hep::Transform3D(rot4, r4));
+  glog.placeVolume(cablog2, 1, dd4hep::Position(0.5 * (width2 + gap2), 0, 0));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() << " number 1 positioned in " << glog.name()
-                               << " at " << r4 << " with " << rot4;
+							   << " at (" << convertCmToMm(0.5 * (width2 + gap2)) << ", 0, 0) with no rotation";
 #endif
-  dd4hep::Position r5(-0.5 * (width2 + gap2), 0, 0);
-  glog.placeVolume(cablog2, 2, dd4hep::Transform3D(rot4, r5));
+  glog.placeVolume(cablog2, 2, dd4hep::Position(-0.5 * (width2 + gap2), 0, 0));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() << " number 2 positioned in " << glog.name()
-                               << " at " << r5 << "with " << r4;
+							   << " at " << convertCmToMm(-0.5 * (width2 + gap2)) << ", 0, 0) with no rotation";
 
   edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalTBCableAlgo construction";
 #endif

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
@@ -1,10 +1,10 @@
 #include "DD4hep/DetFactoryHelper.h"
-#include "DataFormats/Math/interface/CMSUnits.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#define EDM_ML_DEBUG
-using namespace cms_units::operators;
+using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
@@ -28,9 +28,9 @@ static long algorithm(dd4hep::Detector& /* description */,
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parameters for position"
                                << "ing--"
-                               << " Eta " << eta << "\tTheta " << convertRadToDeg(theta) << "\tShifts " << shiftX
-                               << ", " << shiftY << " along x, y "
-                               << "axes; \tZoffest " << zoffset << "\tRadial Distance " << dist << "\tTilt angle "
+                               << " Eta " << eta << "\tTheta " << convertRadToDeg(theta) << "\tShifts " << convertCmToMm(shiftX)
+                               << ", " << convertCmToMm(shiftY) << " along x, y "
+                               << "axes; \tZoffest " << convertCmToMm(zoffset) << "\tRadial Distance " << convertCmToMm(dist) << "\tTilt angle "
                                << convertRadToDeg(tilt) << "\tcopyNumber " << copyNumber;
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parent " << args.parentName() << "\tChild " << childName
                                << " NameSpace " << idNameSpace;
@@ -51,12 +51,12 @@ static long algorithm(dd4hep::Detector& /* description */,
     edm::LogVerbatim("HCalGeom") << "DDHCalZposAlgo: Creating a rotation \t90, " << convertRadToDeg(tilt) << ",90,"
                                  << (90 + convertRadToDeg(tilt)) << ", 0, 0";
 #endif
-    rot = cms::makeRotation3D(90._deg, tilt, 90._deg, (90._deg + tilt), 0.0, 0.0);
+    rot = dd4hep::RotationZ(tilt);
   }
   mother.placeVolume(child, copyNumber, dd4hep::Transform3D(rot, tran));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: " << child.name() << " number " << copyNumber << " positioned in "
-                               << mother.name() << " at " << tran << " with " << rot;
+                               << mother.name() << " at (" << convertCmToMm(x) << ", " << convertCmToMm(y) << ", " << convertCmToMm(z) << ") with " << rot;
 #endif
 
   return 1;

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
@@ -28,10 +28,11 @@ static long algorithm(dd4hep::Detector& /* description */,
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parameters for position"
                                << "ing--"
-                               << " Eta " << eta << "\tTheta " << convertRadToDeg(theta) << "\tShifts " << convertCmToMm(shiftX)
-                               << ", " << convertCmToMm(shiftY) << " along x, y "
-                               << "axes; \tZoffest " << convertCmToMm(zoffset) << "\tRadial Distance " << convertCmToMm(dist) << "\tTilt angle "
-                               << convertRadToDeg(tilt) << "\tcopyNumber " << copyNumber;
+                               << " Eta " << eta << "\tTheta " << convertRadToDeg(theta) << "\tShifts "
+                               << convertCmToMm(shiftX) << ", " << convertCmToMm(shiftY) << " along x, y "
+                               << "axes; \tZoffest " << convertCmToMm(zoffset) << "\tRadial Distance "
+                               << convertCmToMm(dist) << "\tTilt angle " << convertRadToDeg(tilt) << "\tcopyNumber "
+                               << copyNumber;
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parent " << args.parentName() << "\tChild " << childName
                                << " NameSpace " << idNameSpace;
 #endif
@@ -56,7 +57,8 @@ static long algorithm(dd4hep::Detector& /* description */,
   mother.placeVolume(child, copyNumber, dd4hep::Transform3D(rot, tran));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: " << child.name() << " number " << copyNumber << " positioned in "
-                               << mother.name() << " at (" << convertCmToMm(x) << ", " << convertCmToMm(y) << ", " << convertCmToMm(z) << ") with " << rot;
+                               << mother.name() << " at (" << convertCmToMm(x) << ", " << convertCmToMm(y) << ", "
+                               << convertCmToMm(z) << ") with " << rot;
 #endif
 
   return 1;


### PR DESCRIPTION
#### PR description:

Tidy up 3 algorithms for defining geometry of hadron calorimeter and the test beam setups. Also update the test examples. Also add an extra method for converting areas in cm^2 to mm^2.

#### PR validation:

Tested with example configurations in Geometry/HcalAlgo/test/python

#### if this PR is a backport please specify the original PR:

Nothing special