### PR TITLE
Register consumes from the EventSetup in GsfElectronAlgo

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -59,14 +59,13 @@ public:
     std::unique_ptr<const ElectronMVAEstimator> iElectronMVAEstimator;
   };
 
-  struct InputTagsConfiguration {
+  struct Tokens {
     edm::EDGetTokenT<reco::GsfElectronCollection> previousGsfElectrons;
     edm::EDGetTokenT<reco::GsfElectronCollection> pflowGsfElectronsTag;
     edm::EDGetTokenT<reco::GsfElectronCoreCollection> gsfElectronCores;
     edm::EDGetTokenT<CaloTowerCollection> hcalTowersTag;
     edm::EDGetTokenT<reco::SuperClusterCollection> barrelSuperClusters;
     edm::EDGetTokenT<reco::SuperClusterCollection> endcapSuperClusters;
-    //edm::EDGetTokenT tracks ;
     edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitCollection;
     edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitCollection;
     edm::EDGetTokenT<reco::ElectronSeedCollection> seedsTag;
@@ -75,10 +74,6 @@ public:
     edm::EDGetTokenT<reco::GsfPFRecTrackCollection> gsfPfRecTracksTag;
     edm::EDGetTokenT<reco::VertexCollection> vtxCollectionTag;
     edm::EDGetTokenT<reco::ConversionCollection> conversions;
-
-    //IsoVals (PF and EcalDriven)
-    edm::ParameterSet pfIsoVals;
-    edm::ParameterSet edIsoVals;
   };
 
   struct StrategyConfiguration {
@@ -187,7 +182,7 @@ public:
     bool useNumCrystals;
   };
 
-  GsfElectronAlgo(const InputTagsConfiguration&,
+  GsfElectronAlgo(const Tokens&,
                   const StrategyConfiguration&,
                   const CutsConfiguration& cutsCfg,
                   const CutsConfiguration& cutsCfgPflow,
@@ -195,8 +190,8 @@ public:
                   const ElectronHcalHelper::Configuration& hcalCfgPflow,
                   const IsolationConfiguration&,
                   const EcalRecHitsConfiguration&,
-                  std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
-                  std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
+                  std::unique_ptr<EcalClusterFunctionBaseClass>&& superClusterErrorFunction,
+                  std::unique_ptr<EcalClusterFunctionBaseClass>&& crackCorrectionFunction,
                   const RegressionHelper::Configuration& regCfg,
                   const edm::ParameterSet& tkIsol03Cfg,
                   const edm::ParameterSet& tkIsol04Cfg,
@@ -215,7 +210,7 @@ private:
 
   struct Configuration {
     // configurables
-    const InputTagsConfiguration input;
+    const Tokens tokens;
     const StrategyConfiguration strategy;
     const CutsConfiguration cuts;
     const CutsConfiguration cutsPflow;
@@ -243,15 +238,13 @@ private:
   void setCutBasedPreselectionFlag(reco::GsfElectron& ele, const reco::BeamSpot&) const;
 
   template <bool full5x5>
-  void calculateShowerShape(const reco::SuperClusterRef&,
-                            ElectronHcalHelper const& hcalHelper,
-                            reco::GsfElectron::ShowerShape&,
-                            EventData const& eventData,
-                            CaloTopology const& topology,
-                            CaloGeometry const& geometry) const;
-  void calculateSaturationInfo(const reco::SuperClusterRef&,
-                               reco::GsfElectron::SaturationInfo&,
-                               EventData const& eventData) const;
+  reco::GsfElectron::ShowerShape calculateShowerShape(const reco::SuperClusterRef&,
+                                                      ElectronHcalHelper const& hcalHelper,
+                                                      EventData const& eventData,
+                                                      CaloTopology const& topology,
+                                                      CaloGeometry const& geometry) const;
+  reco::GsfElectron::SaturationInfo calculateSaturationInfo(const reco::SuperClusterRef&,
+                                                            EventData const& eventData) const;
 
   // Pixel match variables
   void setPixelMatchInfomation(reco::GsfElectron&) const;

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -220,19 +220,12 @@ private:
   // general data and helpers
   struct GeneralData {
     // configurables
-    const InputTagsConfiguration inputCfg;
-    const StrategyConfiguration strategyCfg;
-    const CutsConfiguration cutsCfg;
-    const CutsConfiguration cutsCfgPflow;
-    const IsolationConfiguration isoCfg;
-    const EcalRecHitsConfiguration recHitsCfg;
-
-    // additional configuration and helpers
-    ElectronHcalHelper hcalHelper;
-    ElectronHcalHelper hcalHelperPflow;
-    std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction;
-    std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction;
-    RegressionHelper regHelper;
+    const InputTagsConfiguration input;
+    const StrategyConfiguration strategy;
+    const CutsConfiguration cuts;
+    const CutsConfiguration cutsPflow;
+    const IsolationConfiguration iso;
+    const EcalRecHitsConfiguration recHits;
   };
 
   //===================================================================
@@ -317,19 +310,6 @@ private:
     GlobalVector vtxMomWithConstraint;
   };
 
-  GeneralData generalData_;
-
-  EleTkIsolFromCands tkIsol03Calc_;
-  EleTkIsolFromCands tkIsol04Calc_;
-  EleTkIsolFromCands tkIsolHEEP03Calc_;
-  EleTkIsolFromCands tkIsolHEEP04Calc_;
-
-  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
-  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
-  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopologyToken_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
-  const edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> ecalSeveretyLevelAlgoToken_;
-
   void checkSetup(edm::EventSetup const& eventSetup);
   EventData beginEvent(edm::Event const& event,
                        CaloGeometry const& caloGeometry,
@@ -363,6 +343,27 @@ private:
 
   // Pixel match variables
   void setPixelMatchInfomation(reco::GsfElectron&);
+
+  // constant class members
+  const GeneralData cfg_;
+
+  const EleTkIsolFromCands tkIsol03Calc_;
+  const EleTkIsolFromCands tkIsol04Calc_;
+  const EleTkIsolFromCands tkIsolHEEP03Calc_;
+  const EleTkIsolFromCands tkIsolHEEP04Calc_;
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopologyToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  const edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> ecalSeveretyLevelAlgoToken_;
+
+  // additional configuration and helpers
+  ElectronHcalHelper hcalHelper_;
+  ElectronHcalHelper hcalHelperPflow_;
+  std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction_;
+  std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
+  RegressionHelper regHelper_;
 };
 
 #endif  // GsfElectronAlgo_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -213,12 +213,7 @@ public:
 private:
   // internal structures
 
-  //===================================================================
-  // GsfElectronAlgo::GeneralData
-  //===================================================================
-
-  // general data and helpers
-  struct GeneralData {
+  struct Configuration {
     // configurables
     const InputTagsConfiguration input;
     const StrategyConfiguration strategy;
@@ -228,87 +223,8 @@ private:
     const EcalRecHitsConfiguration recHits;
   };
 
-  //===================================================================
-  // GsfElectronAlgo::EventData
-  //===================================================================
-
-  struct EventData {
-    // utilities
-    void retreiveOriginalTrackCollections(const reco::TrackRef&, const reco::GsfTrackRef&);
-
-    // general
-    edm::Event const* event;
-    const reco::BeamSpot* beamspot;
-
-    // input collections
-    edm::Handle<reco::GsfElectronCollection> previousElectrons;
-    edm::Handle<reco::GsfElectronCollection> pflowElectrons;
-    edm::Handle<reco::GsfElectronCoreCollection> coreElectrons;
-    edm::Handle<EcalRecHitCollection> barrelRecHits;
-    edm::Handle<EcalRecHitCollection> endcapRecHits;
-    edm::Handle<reco::TrackCollection> currentCtfTracks;
-    edm::Handle<reco::ElectronSeedCollection> seeds;
-    edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks;
-    edm::Handle<reco::VertexCollection> vertices;
-    edm::Handle<reco::ConversionCollection> conversions;
-
-    // isolation helpers
-    EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04;
-    EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04;
-    EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc;
-    EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc;
-    EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04;
-    EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04;
-
-    //Isolation Value Maps for PF and EcalDriven electrons
-    typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsolationValueMaps;
-    IsolationValueMaps pfIsolationValues;
-    IsolationValueMaps edIsolationValues;
-
-    edm::Handle<reco::TrackCollection> originalCtfTracks;
-    edm::Handle<reco::GsfTrackCollection> originalGsfTracks;
-
-    bool originalCtfTrackCollectionRetreived = false;
-    bool originalGsfTrackCollectionRetreived = false;
-  };
-
-  //===================================================================
-  // GsfElectronAlgo::ElectronData
-  //===================================================================
-
-  struct ElectronData {
-    // Refs to subproducts
-    const reco::GsfElectronCoreRef coreRef;
-    const reco::GsfTrackRef gsfTrackRef;
-    const reco::SuperClusterRef superClusterRef;
-    reco::TrackRef ctfTrackRef;
-    float shFracInnerHits;
-    const reco::BeamSpot beamSpot;
-
-    // constructors
-    ElectronData(const reco::GsfElectronCoreRef& core, const reco::BeamSpot& bs);
-
-    // utilities
-    void computeCharge(int& charge, reco::GsfElectron::ChargeInfo& info);
-    reco::CaloClusterPtr getEleBasicCluster(MultiTrajectoryStateTransform const&);
-    bool calculateTSOS(MultiTrajectoryStateTransform const&, GsfConstraintAtVertex const&);
-    void calculateMode();
-    reco::Candidate::LorentzVector calculateMomentum();
-
-    // TSOS
-    TrajectoryStateOnSurface innTSOS;
-    TrajectoryStateOnSurface outTSOS;
-    TrajectoryStateOnSurface vtxTSOS;
-    TrajectoryStateOnSurface sclTSOS;
-    TrajectoryStateOnSurface seedTSOS;
-    TrajectoryStateOnSurface eleTSOS;
-    TrajectoryStateOnSurface constrainedVtxTSOS;
-
-    // mode
-    GlobalVector innMom, seedMom, eleMom, sclMom, vtxMom, outMom;
-    GlobalPoint innPos, seedPos, elePos, sclPos, vtxPos, outPos;
-    GlobalVector vtxMomWithConstraint;
-  };
+  struct EventData;
+  struct ElectronData;
 
   void checkSetup(edm::EventSetup const& eventSetup);
   EventData beginEvent(edm::Event const& event,
@@ -324,8 +240,7 @@ private:
                       double magneticFieldInTesla,
                       const HeavyObjectCache*);
 
-  void setMVAepiBasedPreselectionFlag(reco::GsfElectron& ele);
-  void setCutBasedPreselectionFlag(reco::GsfElectron& ele, const reco::BeamSpot&);
+  void setCutBasedPreselectionFlag(reco::GsfElectron& ele, const reco::BeamSpot&) const;
 
   template <bool full5x5>
   void calculateShowerShape(const reco::SuperClusterRef&,
@@ -333,19 +248,16 @@ private:
                             reco::GsfElectron::ShowerShape&,
                             EventData const& eventData,
                             CaloTopology const& topology,
-                            CaloGeometry const& geometry);
+                            CaloGeometry const& geometry) const;
   void calculateSaturationInfo(const reco::SuperClusterRef&,
                                reco::GsfElectron::SaturationInfo&,
-                               EventData const& eventData);
-
-  // associations
-  const reco::SuperClusterRef getTrSuperCluster(const reco::GsfTrackRef& trackRef);
+                               EventData const& eventData) const;
 
   // Pixel match variables
-  void setPixelMatchInfomation(reco::GsfElectron&);
+  void setPixelMatchInfomation(reco::GsfElectron&) const;
 
   // constant class members
-  const GeneralData cfg_;
+  const Configuration cfg_;
 
   const EleTkIsolFromCands tkIsol03Calc_;
   const EleTkIsolFromCands tkIsol04Calc_;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -372,7 +372,8 @@ GsfElectronBaseProducer::GsfElectronBaseProducer(const edm::ParameterSet& cfg, c
       cfg.getParameter<edm::ParameterSet>("trkIsol03Cfg"),
       cfg.getParameter<edm::ParameterSet>("trkIsol04Cfg"),
       cfg.getParameter<edm::ParameterSet>("trkIsolHEEP03Cfg"),
-      cfg.getParameter<edm::ParameterSet>("trkIsolHEEP04Cfg"));
+      cfg.getParameter<edm::ParameterSet>("trkIsolHEEP04Cfg"),
+      consumesCollector());
 }
 
 GsfElectronBaseProducer::~GsfElectronBaseProducer() = default;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -253,8 +253,8 @@ GsfElectronBaseProducer::GsfElectronBaseProducer(const edm::ParameterSet& cfg, c
       consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("endcapRecHitCollectionTag"));
   pfMVA_ = consumes<edm::ValueMap<float>>(cfg.getParameter<edm::InputTag>("pfMvaTag"));
   inputCfg_.ctfTracks = consumes<reco::TrackCollection>(cfg.getParameter<edm::InputTag>("ctfTracksTag"));
-  inputCfg_.seedsTag = consumes<reco::ElectronSeedCollection>(
-      cfg.getParameter<edm::InputTag>("seedsTag"));  // used to check config consistency with seeding
+  // used to check config consistency with seeding
+  inputCfg_.seedsTag = consumes<reco::ElectronSeedCollection>(cfg.getParameter<edm::InputTag>("seedsTag"));
   inputCfg_.beamSpotTag = consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("beamSpotTag"));
   inputCfg_.gsfPfRecTracksTag =
       consumes<reco::GsfPFRecTrackCollection>(cfg.getParameter<edm::InputTag>("gsfPfRecTracksTag"));
@@ -263,16 +263,14 @@ GsfElectronBaseProducer::GsfElectronBaseProducer(const edm::ParameterSet& cfg, c
     inputCfg_.conversions = consumes<reco::ConversionCollection>(cfg.getParameter<edm::InputTag>("conversionsTag"));
 
   if (cfg.getParameter<bool>("useIsolationValues")) {
-    inputCfg_.pfIsoVals = cfg.getParameter<edm::ParameterSet>("pfIsolationValues");
-    for (const std::string& name : inputCfg_.pfIsoVals.getParameterNamesForType<edm::InputTag>()) {
-      edm::InputTag tag = inputCfg_.pfIsoVals.getParameter<edm::InputTag>(name);
-      mayConsume<edm::ValueMap<double>>(tag);
+    pfIsoVals_ = cfg.getParameter<edm::ParameterSet>("pfIsolationValues");
+    for (const std::string& name : pfIsoVals_.getParameterNamesForType<edm::InputTag>()) {
+      mayConsume<edm::ValueMap<double>>(pfIsoVals_.getParameter<edm::InputTag>(name));
     }
 
-    inputCfg_.edIsoVals = cfg.getParameter<edm::ParameterSet>("edIsolationValues");
-    for (const std::string& name : inputCfg_.edIsoVals.getParameterNamesForType<edm::InputTag>()) {
-      edm::InputTag tag = inputCfg_.edIsoVals.getParameter<edm::InputTag>(name);
-      mayConsume<edm::ValueMap<double>>(tag);
+    edIsoVals_ = cfg.getParameter<edm::ParameterSet>("edIsolationValues");
+    for (const std::string& name : edIsoVals_.getParameterNamesForType<edm::InputTag>()) {
+      mayConsume<edm::ValueMap<double>>(edIsoVals_.getParameter<edm::InputTag>(name));
     }
   }
 
@@ -316,18 +314,14 @@ GsfElectronBaseProducer::GsfElectronBaseProducer(const edm::ParameterSet& cfg, c
 
   // Ecal rec hits configuration
   GsfElectronAlgo::EcalRecHitsConfiguration recHitsCfg;
-  const std::vector<std::string> flagnamesbarrel =
-      cfg.getParameter<std::vector<std::string>>("recHitFlagsToBeExcludedBarrel");
+  auto const& flagnamesbarrel = cfg.getParameter<std::vector<std::string>>("recHitFlagsToBeExcludedBarrel");
   recHitsCfg.recHitFlagsToBeExcludedBarrel = StringToEnumValue<EcalRecHit::Flags>(flagnamesbarrel);
-  const std::vector<std::string> flagnamesendcaps =
-      cfg.getParameter<std::vector<std::string>>("recHitFlagsToBeExcludedEndcaps");
+  auto const& flagnamesendcaps = cfg.getParameter<std::vector<std::string>>("recHitFlagsToBeExcludedEndcaps");
   recHitsCfg.recHitFlagsToBeExcludedEndcaps = StringToEnumValue<EcalRecHit::Flags>(flagnamesendcaps);
-  const std::vector<std::string> severitynamesbarrel =
-      cfg.getParameter<std::vector<std::string>>("recHitSeverityToBeExcludedBarrel");
+  auto const& severitynamesbarrel = cfg.getParameter<std::vector<std::string>>("recHitSeverityToBeExcludedBarrel");
   recHitsCfg.recHitSeverityToBeExcludedBarrel =
       StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesbarrel);
-  const std::vector<std::string> severitynamesendcaps =
-      cfg.getParameter<std::vector<std::string>>("recHitSeverityToBeExcludedEndcaps");
+  auto const& severitynamesendcaps = cfg.getParameter<std::vector<std::string>>("recHitSeverityToBeExcludedEndcaps");
   recHitsCfg.recHitSeverityToBeExcludedEndcaps =
       StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesendcaps);
   //recHitsCfg.severityLevelCut = cfg.getParameter<int>("severityLevelCut") ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -51,7 +51,7 @@ protected:
   const edm::OrphanHandle<reco::GsfElectronCollection>& orphanHandle() const { return orphanHandle_; }
 
   // configurables
-  GsfElectronAlgo::InputTagsConfiguration inputCfg_;
+  GsfElectronAlgo::Tokens inputCfg_;
   GsfElectronAlgo::StrategyConfiguration strategyCfg_;
   const GsfElectronAlgo::CutsConfiguration cutsCfg_;
   const GsfElectronAlgo::CutsConfiguration cutsCfgPflow_;
@@ -60,6 +60,10 @@ protected:
 
   // used to make some provenance checks
   edm::EDGetTokenT<edm::ValueMap<float>> pfMVA_;
+
+  //IsoVals (PF and EcalDriven)
+  edm::ParameterSet pfIsoVals_;
+  edm::ParameterSet edIsoVals_;
 
 private:
   bool isPreselected(reco::GsfElectron const& ele) const;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -108,10 +108,10 @@ void GsfElectronProducer::addPflowInfo(reco::GsfElectronCollection& electrons, e
 
   //Fill in the Isolation Value Maps for PF and EcalDriven electrons
   std::vector<edm::InputTag> inputTagIsoVals;
-  if (!inputCfg_.pfIsoVals.empty()) {
-    inputTagIsoVals.push_back(inputCfg_.pfIsoVals.getParameter<edm::InputTag>("pfSumChargedHadronPt"));
-    inputTagIsoVals.push_back(inputCfg_.pfIsoVals.getParameter<edm::InputTag>("pfSumPhotonEt"));
-    inputTagIsoVals.push_back(inputCfg_.pfIsoVals.getParameter<edm::InputTag>("pfSumNeutralHadronEt"));
+  if (!pfIsoVals_.empty()) {
+    inputTagIsoVals.push_back(pfIsoVals_.getParameter<edm::InputTag>("pfSumChargedHadronPt"));
+    inputTagIsoVals.push_back(pfIsoVals_.getParameter<edm::InputTag>("pfSumPhotonEt"));
+    inputTagIsoVals.push_back(pfIsoVals_.getParameter<edm::InputTag>("pfSumNeutralHadronEt"));
 
     pfIsolationValues.resize(inputTagIsoVals.size());
 
@@ -120,11 +120,11 @@ void GsfElectronProducer::addPflowInfo(reco::GsfElectronCollection& electrons, e
     }
   }
 
-  if (!inputCfg_.edIsoVals.empty()) {
+  if (!edIsoVals_.empty()) {
     inputTagIsoVals.clear();
-    inputTagIsoVals.push_back(inputCfg_.edIsoVals.getParameter<edm::InputTag>("edSumChargedHadronPt"));
-    inputTagIsoVals.push_back(inputCfg_.edIsoVals.getParameter<edm::InputTag>("edSumPhotonEt"));
-    inputTagIsoVals.push_back(inputCfg_.edIsoVals.getParameter<edm::InputTag>("edSumNeutralHadronEt"));
+    inputTagIsoVals.push_back(edIsoVals_.getParameter<edm::InputTag>("edSumChargedHadronPt"));
+    inputTagIsoVals.push_back(edIsoVals_.getParameter<edm::InputTag>("edSumPhotonEt"));
+    inputTagIsoVals.push_back(edIsoVals_.getParameter<edm::InputTag>("edSumNeutralHadronEt"));
 
     edIsolationValues.resize(inputTagIsoVals.size());
 


### PR DESCRIPTION
#### PR description:

As explained in https://github.com/cms-sw/cmssw/pull/28223 and in @Dr15Jones email, it's better to register the consumes from the EventSetup also for ED producers. I wanted to do this for some time in the GsfElectronAlgo anyway, because in this way I can get rid of the manual caching with the `unsigned long long cacheID` member variables, trusting the framework to handle this efficiently on its own and bringing us a good step closer to an algo with no mutable member variables. The remaining class members were also reorganized a bit to further reduce the mutable state and make it clearer what is still mutable: the HcalHelper, the RegressionHelper and the EcalClusterFunctions.

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR:

No backport intended.
