### PR TITLE
CP5 tune variations in 71X

### DIFF
--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneDownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneDownSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5TuneUpSettingsBlock = cms.PSet(
-    pythia8CP5TuneUpSettings = cms.vstring(
+pythia8CP5TuneDownSettingsBlock = cms.PSet(
+    pythia8CP5TuneDownSettings = cms.vstring(
     'Tune:pp 14',
         'Tune:ee 7',
         'MultipartonInteractions:ecmPow=0.03344',

--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneDownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneDownSettings_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CP5SettingsBlock = cms.PSet(
+    pythia8CP5Settings = cms.vstring(
+    'Tune:pp 14',
+        'Tune:ee 7',
+        'MultipartonInteractions:ecmPow=0.03344',
+        'PDF:pSet=20',
+        'MultipartonInteractions:bProfile=2',
+		'MultipartonInteractions:pT0Ref=1.46',
+        'MultipartonInteractions:coreRadius=0.6879',
+        'MultipartonInteractions:coreFraction=0.7253',
+        'ColourReconnection:range=4.691',
+        'SigmaTotal:zeroAXB=off',
+        'SpaceShower:alphaSorder=2',
+        'SpaceShower:alphaSvalue=0.118',
+        'SigmaProcess:alphaSvalue=0.118',
+        'SigmaProcess:alphaSorder=2',
+        'MultipartonInteractions:alphaSvalue=0.118',
+        'MultipartonInteractions:alphaSorder=2',
+        'TimeShower:alphaSorder=2',
+        'TimeShower:alphaSvalue=0.118',
+        )
+)

--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneDownSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneDownSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5SettingsBlock = cms.PSet(
-    pythia8CP5Settings = cms.vstring(
+pythia8CP5TuneUpSettingsBlock = cms.PSet(
+    pythia8CP5TuneUpSettings = cms.vstring(
     'Tune:pp 14',
         'Tune:ee 7',
         'MultipartonInteractions:ecmPow=0.03344',

--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneUpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneUpSettings_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CP5SettingsBlock = cms.PSet(
+    pythia8CP5Settings = cms.vstring(
+    'Tune:pp 14',
+        'Tune:ee 7',
+        'MultipartonInteractions:ecmPow=0.03344',
+        'PDF:pSet=20',
+        'MultipartonInteractions:bProfile=2',
+        'MultipartonInteractions:pT0Ref=1.407',
+        'MultipartonInteractions:coreRadius=0.6671',
+        'MultipartonInteractions:coreFraction=0.4281',
+        'ColourReconnection:range=4.881',
+        'SigmaTotal:zeroAXB=off',
+        'SpaceShower:alphaSorder=2',
+        'SpaceShower:alphaSvalue=0.118',
+        'SigmaProcess:alphaSvalue=0.118',
+        'SigmaProcess:alphaSorder=2',
+        'MultipartonInteractions:alphaSvalue=0.118',
+        'MultipartonInteractions:alphaSorder=2',
+        'TimeShower:alphaSorder=2',
+        'TimeShower:alphaSvalue=0.118',
+        )
+)

--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneUpSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5TuneUpSettings_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-pythia8CP5SettingsBlock = cms.PSet(
-    pythia8CP5Settings = cms.vstring(
+pythia8CP5TuneUpSettingsBlock = cms.PSet(
+    pythia8CP5TuneUpSettings = cms.vstring(
     'Tune:pp 14',
         'Tune:ee 7',
         'MultipartonInteractions:ecmPow=0.03344',


### PR DESCRIPTION
#### PR description:

Backport of CP5 UE tune variation configuration files (#24527 and #24528). 
This is needed for RunIISummer15wmLHEGS requests with up and down varied CP5 tunes. 

#### PR validation:
Small tests were performed, creating ttbar events with these tune variations. 
