### PR TITLE
[CC8] Unit test fixed; fixes needed for Perl 5.26

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_script.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_script.pl
@@ -30,7 +30,7 @@ $cmsCafPool = 0;
 
 # parse the arguments
 while (@ARGV) {
-  $arg = shift(ARGV);
+  $arg = shift(@ARGV);
   if ($arg =~ /\A-/) {  # check for option
     if ($arg =~ "h") {
       $helpwanted = 1;

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setupm.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_setupm.pl
@@ -22,7 +22,7 @@ my $ignoredisabledjobs = -1;
 ## parse the arguments
 my $i = 0;
 while (@ARGV) {
-  $arg = shift(ARGV);
+  $arg = shift(@ARGV);
   if ($arg =~ /\A-/) {  # check for option 
     if ($arg =~ "h") {
       $helpwanted = 1;

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_split.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_split.pl
@@ -23,7 +23,7 @@ $totalGen = 0;
 
 # parse the arguments
 while (@ARGV) {
-  $arg = shift(ARGV);
+  $arg = shift(@ARGV);
   if ($arg =~ /\A-/) {  # check for option 
     if ($arg =~ "h") {
       $helpwanted = 1;


### PR DESCRIPTION
#### PR description:
Unit test in CC8 IBs is failing with error [a]. CC8 contains a newer version of PERL 5.26 which fails if an array is not passed to `shift` function.

[a]
```
mps_split.pl CMSSW_11_0_X_2019-11-13-2300/tmp/2019-11-14_06.22.11.046735392_27535/MPproduction/dummy_input_file_list.txt 1 5 &gt; jobData/job001/theSplit
Type of arg 1 to shift must be array (not constant item) at CMSSW_11_0_X_2019-11-11-2300/bin/cc8_amd64_gcc8/mps_split.pl line 26, near "ARGV)"
```