### PR TITLE
Prevent directory traversal in cmsswConfigtrace.py

### DIFF
--- a/DQMOffline/Configuration/scripts/cmsswConfigtrace.py
+++ b/DQMOffline/Configuration/scripts/cmsswConfigtrace.py
@@ -545,7 +545,7 @@ def serve_main():
     (re.compile('/workflow/(.*)$'), showworkflow),
     (re.compile('/info/(.*):(\d+)$'), showinfo),
     (re.compile('/why/(\d+)$'), showwhy),
-    (re.compile('/(.+)$'), showfile),
+    (re.compile('/([^.]*[.]?[^.]+[.]?[^.]*)$'), showfile),
     (re.compile('/$'), index),
   ]
 


### PR DESCRIPTION
#### PR description:
Detected by CERN's Automatic computer security monitoring on my instance at http://cmsswconfigexplore.cern.ch:1234/

#### PR validation:

Prevents requests containing `..`. no workflows are affected.