### PR TITLE
E/g HLT Pixel match Speedups: 11_0_X

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -259,6 +259,8 @@ private:
   std::string detLayerGeomLabel_;
 
   bool useRecoVertex_;
+  bool enableHitSkipping_;
+  bool requireExactMatchCount_;
   std::vector<std::unique_ptr<MatchingCuts> > matchingCuts_;
 
   //these two varibles determine how hits we require

--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -197,7 +197,7 @@ private:
                                       const GlobalPoint& candPos,
                                       const GlobalPoint& vprim,
                                       const float energy,
-                                      const int charge);
+                                      const TrajectoryStateOnSurface& initialTrajState);
 
   static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,
                                         const GlobalPoint& hitPos,
@@ -226,6 +226,10 @@ private:
                                                         const GlobalPoint& point,
                                                         const PropagatorWithMaterial& propagator);
 
+  TrajectoryStateOnSurface makeTrajStateOnSurface(const GlobalPoint& pos,
+                                                  const GlobalPoint& vtx,
+                                                  const float energy,
+                                                  const int charge) const;
   void clearCache();
 
   bool passesMatchSel(const SCHitMatch& hit, const size_t hitNr) const;
@@ -245,6 +249,12 @@ private:
 
   size_t getNrHitsRequired(const int nrValidLayers) const;
 
+  //parameterised b-fields may not be valid for entire detector, just tracker volume
+  //however need we ecal so we auto select based on the position
+  const MagneticField& getMagField(const GlobalPoint& point) const {
+    return useParamMagFieldIfDefined_ && magFieldParam_->isDefined(point) ? *magFieldParam_ : *magField_;
+  }
+
 private:
   static constexpr float kElectronMass_ = 0.000511;
   static constexpr float kPhiCut_ = -0.801144;  //cos(2.5)
@@ -252,15 +262,18 @@ private:
   std::unique_ptr<PropagatorWithMaterial> backwardPropagator_;
   unsigned long long cacheIDMagField_;
   edm::ESHandle<MagneticField> magField_;
+  edm::ESHandle<MagneticField> magFieldParam_;
   edm::Handle<MeasurementTrackerEvent> measTkEvt_;
   edm::ESHandle<NavigationSchool> navSchool_;
   edm::ESHandle<DetLayerGeometry> detLayerGeom_;
+  std::string paramMagFieldLabel_;
   std::string navSchoolLabel_;
   std::string detLayerGeomLabel_;
 
   bool useRecoVertex_;
   bool enableHitSkipping_;
   bool requireExactMatchCount_;
+  bool useParamMagFieldIfDefined_;
   std::vector<std::unique_ptr<MatchingCuts> > matchingCuts_;
 
   //these two varibles determine how hits we require

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -56,7 +56,7 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   edm::ParameterSetDescription desc;
   desc.add<bool>("useRecoVertex", false);
   desc.add<bool>("enableHitSkipping", false);
-  desc.add<bool>("requireExactMatchCount", false);
+  desc.add<bool>("requireExactMatchCount", true);
   desc.add<std::string>("navSchool", "SimpleNavigationSchool");
   desc.add<std::string>("detLayerGeom", "hltESPGlobalDetLayerGeometry");
   desc.add<std::vector<int> >("minNrHitsValidLayerBins", {4});

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
@@ -125,12 +125,12 @@ void ElectronNHitSeedProducer::produce(edm::Event& iEvent, const edm::EventSetup
   matcher_.setMeasTkEvtHandle(getHandle(iEvent, measTkEvtToken_));
 
   auto eleSeeds = std::make_unique<reco::ElectronSeedCollection>();
-
   auto initialSeedsHandle = getHandle(iEvent, initialSeedsToken_);
 
   auto beamSpotHandle = getHandle(iEvent, beamSpotToken_);
   GlobalPoint primVtxPos = convertToGP(beamSpotHandle->position());
 
+  // Loop over all super-cluster collections (typically barrel and forward are supplied separately)
   for (const auto& superClustersToken : superClustersTokens_) {
     auto superClustersHandle = getHandle(iEvent, superClustersToken);
     for (auto& superClusRef : *superClustersHandle) {


### PR DESCRIPTION
#### PR description:

This PR speeds up the E/gamma HLT pixel matching. It uses work done by Calib Fangmeier to allow the pixel matching to run on triplet cleaned doublets which at a small efficiency cost will greatly increase speed (the path needs to enable this so its of for now). 

Additionally it does some optimization where expensive variables are now computed outside a loop, it also uses parametric b field for speed where appropriate and finally adds a minimum et cut for superclusters to pixel match. 

This benefits Run2/Run3 configs but the real reason is for PhaseII 200PU where the e/gamma hlt pixel matching was taking ~30mins an event. It now takes ~2seconds and could be further optimised.

No / very small changes are expected for existing HLT workflows although the timing is reduced. 

I validated this on an electron gun sample for 2021 MC conditions (the samples used for the Run3 projections) using /dev/CMSSW_11_0_0/GRun/V10

![image](https://user-images.githubusercontent.com/5021403/68960414-6bb77a80-07d0-11ea-8e2d-15c676af96a0.png)

Timing:
TimeReport   0.015958     0.032457     0.032457  hltEgammaElectronPixelSeeds
goes to
TimeReport   0.007012     0.014263     0.014263  hltEgammaElectronPixelSeeds

Doing a full timing study  on 2018 data I see a drop from 240ms to 236ms with the drops happening in electron paths as expected.


