### PR TITLE
102X backport of isolated particle level photons

### DIFF
--- a/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/particleLevel_cfi.py
@@ -21,4 +21,9 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     fatJetConeSize = cms.double(0.8),
     fatJetMinPt    = cms.double(200.),
     fatJetMaxEta   = cms.double(2.4),
+
+    phoIsoConeSize = cms.double(0.4),
+    phoMaxRelIso = cms.double(0.5),
+    phoMinPt = cms.double(10),
+    phoMaxEta = cms.double(2.5),
 )

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -44,6 +44,11 @@ particleLevel = cms.EDProducer("ParticleLevelProducer",
     fatJetConeSize = cms.double(0.8),
     fatJetMinPt    = cms.double(170.),
     fatJetMaxEta   = cms.double(999.),
+
+    phoIsoConeSize = cms.double(0.4),
+    phoMaxRelIso = cms.double(0.5),
+    phoMinPt = cms.double(10),
+    phoMaxEta = cms.double(2.5),
 )
 
 rivetProducerHTXS = cms.EDProducer('HTXSRivetProducer',


### PR DESCRIPTION
#### PR description:

Replaces the current photon collection in the Rivet particle level producer with a collection of isolated photons. The photon pt cut, photon eta cut, isolation cone size, and isolation cut are configurable.

#### PR validation:

I have run this producer on a recent TTBar and HGG relval sample, and found that the producer produces the expected number of isolated photons in each case.

#### if this PR is a backport please specify the original PR:

https://github.com/cms-sw/cmssw/pull/28371
