### PR TITLE
Enforce proper produce calls for Begin and End Transitions

### DIFF
--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -163,9 +163,11 @@ namespace edm {
       return BranchAliasSetter{typeLabelList_.back(), EDPutToken{index}};
     }
 
-    virtual bool hasAbilityToProduceInRuns() const { return false; }
+    virtual bool hasAbilityToProduceInBeginRuns() const { return false; }
+    virtual bool hasAbilityToProduceInEndRuns() const { return false; }
 
-    virtual bool hasAbilityToProduceInLumis() const { return false; }
+    virtual bool hasAbilityToProduceInBeginLumis() const { return false; }
+    virtual bool hasAbilityToProduceInEndLumis() const { return false; }
 
   private:
     TypeLabelList typeLabelList_;

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -51,9 +51,11 @@ namespace edm {
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -46,9 +46,11 @@ namespace edm {
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/limited/EDFilter.h
+++ b/FWCore/Framework/interface/limited/EDFilter.h
@@ -57,9 +57,11 @@ namespace edm {
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/limited/EDProducer.h
+++ b/FWCore/Framework/interface/limited/EDProducer.h
@@ -52,9 +52,11 @@ namespace edm {
       bool wantsStreamRuns() const final { return WantsStreamRunTransitions<T...>::value; }
       bool wantsStreamLuminosityBlocks() const final { return WantsStreamLuminosityBlockTransitions<T...>::value; }
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -157,10 +157,31 @@ namespace edm {
   };
 
   template <typename... VArgs>
+  struct HasAbilityToProduceInBeginRuns {
+    static constexpr bool value = CheckAbility<module::Abilities::kBeginRunProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs>
+  struct HasAbilityToProduceInEndRuns {
+    static constexpr bool value = CheckAbility<module::Abilities::kEndRunProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs>
   struct HasAbilityToProduceInLumis {
     static constexpr bool value = CheckAbility<module::Abilities::kBeginLuminosityBlockProducer, VArgs...>::kHasIt or
                                   CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
   };
+
+  template <typename... VArgs>
+  struct HasAbilityToProduceInBeginLumis {
+    static constexpr bool value = CheckAbility<module::Abilities::kBeginLuminosityBlockProducer, VArgs...>::kHasIt;
+  };
+
+  template <typename... VArgs>
+  struct HasAbilityToProduceInEndLumis {
+    static constexpr bool value = CheckAbility<module::Abilities::kEndLuminosityBlockProducer, VArgs...>::kHasIt;
+  };
+
 }  // namespace edm
 
 #endif

--- a/FWCore/Framework/interface/one/EDFilter.h
+++ b/FWCore/Framework/interface/one/EDFilter.h
@@ -42,9 +42,11 @@ namespace edm {
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       // ---------- static member functions --------------------
 

--- a/FWCore/Framework/interface/one/EDProducer.h
+++ b/FWCore/Framework/interface/one/EDProducer.h
@@ -46,9 +46,11 @@ namespace edm {
       bool wantsGlobalRuns() const final { return WantsGlobalRunTransitions<T...>::value; }
       bool wantsGlobalLuminosityBlocks() const final { return WantsGlobalLuminosityBlockTransitions<T...>::value; }
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       SerialTaskQueue* globalRunsQueue() final { return globalRunsQueue_.queue(); }
       SerialTaskQueue* globalLuminosityBlocksQueue() final { return globalLuminosityBlocksQueue_.queue(); }

--- a/FWCore/Framework/interface/stream/EDFilter.h
+++ b/FWCore/Framework/interface/stream/EDFilter.h
@@ -58,9 +58,11 @@ namespace edm {
 
       // ---------- member functions ---------------------------
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
     private:
       EDFilter(const EDFilter&) = delete;  // stop default

--- a/FWCore/Framework/interface/stream/EDProducer.h
+++ b/FWCore/Framework/interface/stream/EDProducer.h
@@ -52,9 +52,11 @@ namespace edm {
 
       typedef AbilityChecker<T...> HasAbility;
 
-      bool hasAbilityToProduceInRuns() const final { return HasAbilityToProduceInRuns<T...>::value; }
+      bool hasAbilityToProduceInBeginRuns() const final { return HasAbilityToProduceInBeginRuns<T...>::value; }
+      bool hasAbilityToProduceInEndRuns() const final { return HasAbilityToProduceInEndRuns<T...>::value; }
 
-      bool hasAbilityToProduceInLumis() const final { return HasAbilityToProduceInLumis<T...>::value; }
+      bool hasAbilityToProduceInBeginLumis() const final { return HasAbilityToProduceInBeginLumis<T...>::value; }
+      bool hasAbilityToProduceInEndLumis() const final { return HasAbilityToProduceInEndLumis<T...>::value; }
 
       EDProducer() = default;
       //virtual ~EDProducer();

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -42,15 +42,14 @@ namespace edm {
     std::set<std::tuple<BranchType, std::type_index, std::string>> registeredProducts;
 
     for (TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
-      if (p->transition_ == Transition::BeginRun || p->transition_ == Transition::EndRun) {
-        if (not iProd->hasAbilityToProduceInRuns()) {
-          throwProducesWithoutAbility("Run", p->typeID_.userClassName());
-        }
-      } else if (p->transition_ == Transition::BeginLuminosityBlock ||
-                 p->transition_ == Transition::EndLuminosityBlock) {
-        if (not iProd->hasAbilityToProduceInLumis()) {
-          throwProducesWithoutAbility("LuminosityBlock", p->typeID_.userClassName());
-        }
+      if (p->transition_ == Transition::BeginRun && not iProd->hasAbilityToProduceInBeginRuns()) {
+        throwProducesWithoutAbility("BeginRun", p->typeID_.userClassName());
+      } else if (p->transition_ == Transition::EndRun && not iProd->hasAbilityToProduceInEndRuns()) {
+        throwProducesWithoutAbility("EndRun", p->typeID_.userClassName());
+      } else if (p->transition_ == Transition::BeginLuminosityBlock && not iProd->hasAbilityToProduceInBeginLumis()) {
+        throwProducesWithoutAbility("BeginLuminosityBlock", p->typeID_.userClassName());
+      } else if (p->transition_ == Transition::EndLuminosityBlock && not iProd->hasAbilityToProduceInEndLumis()) {
+        throwProducesWithoutAbility("EndLuminosityBlock", p->typeID_.userClassName());
       }
       if (!checkDictionary(missingDictionaries, p->typeID_)) {
         checkDictionaryOfWrappedType(missingDictionaries, p->typeID_);

--- a/FWCore/Sources/interface/PuttableSourceBase.h
+++ b/FWCore/Sources/interface/PuttableSourceBase.h
@@ -40,9 +40,9 @@ namespace edm {
     using ProducerBase::resolvePutIndicies;
     void registerProducts() final;
 
-    bool hasAbilityToProduceInRuns() const final { return true; }
+    bool hasAbilityToProduceInBeginRuns() const final { return true; }
 
-    bool hasAbilityToProduceInLumis() const final { return true; }
+    bool hasAbilityToProduceInBeginLumis() const final { return true; }
 
   protected:
     //If inheriting class overrides, they need to call this function as well


### PR DESCRIPTION
When calling `produce` we now check that if non-event transition is chosen, then the `begin` and `end` part of the transition must match the type of producer making the call.

#### PR description:

Framework code compiles and all framework tests pass.