### PR TITLE
Fix use of object after destructor in HcalHardcodeCalibrations

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -239,7 +239,8 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations(const edm::ParameterSet& iCon
       findingRecord<HcalZSThresholdsRcd>();
     }
     if ((objectName == "RespCorrs") || (objectName == "ResponseCorrection") || all) {
-      auto& c = setWhatProduced(this, &HcalHardcodeCalibrations::produceRespCorrs).setConsumes(topoTokens_[kRespCorrs]);
+      auto c = setWhatProduced(this, &HcalHardcodeCalibrations::produceRespCorrs);
+      c.setConsumes(topoTokens_[kRespCorrs]);
       if (he_recalibration) {
         c.setConsumes(heDarkeningToken_, edm::ESInputTag("", "HE"));
       }


### PR DESCRIPTION
#### PR description:

The temporarily created ESConsumesCollector is held by reference but goes away on that line (since the compiler does not know it must extend the lifetime of the object returned by setWhatProduced).

The problem was found by the address sanitizer.

#### PR validation:

The code compiles.