### PR TITLE
Clean-up Geant4 Physics Lists

### DIFF
--- a/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
@@ -4,8 +4,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
 
     FLAVOR = process.generator.hscpFlavor.value()
-    MASS_POINT = process.generator.massPoint.value()
-    SLHA_FILE = process.generator.SLHAFileForPythia8.value()
     PROCESS_FILE = process.generator.processFile.value()
     PARTICLE_FILE = process.generator.particleFile.value()
     USE_REGGE = process.generator.useregge.value()

--- a/SimG4Core/CustomPhysics/python/Exotica_MT_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_MT_SIM_cfi.py
@@ -4,8 +4,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
 
     FLAVOR = process.generator.hscpFlavor.value()
-    MASS_POINT = process.generator.massPoint.value()
-    SLHA_FILE = process.generator.slhaFile.value()
     PROCESS_FILE = process.generator.processFile.value()
     PARTICLE_FILE = process.generator.particleFile.value()
     USE_REGGE = process.generator.useregge.value()

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -9,6 +9,7 @@
 #include "G4HadronElasticPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
+#include "G4EmParameters.hh"
 
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
@@ -17,13 +18,16 @@ FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) 
   bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
   bool tracking = p.getParameter<bool>("TrackingCut");
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-                              << "FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
-                              << hadPhys << " and tracking cut " << tracking;
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
+  edm::LogVerbatim("PhysicsList") 
+    << "You are using the simulation engine: "
+    << "FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+    << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
     RegisterPhysics(new G4EmStandardPhysics_option3(ver));
+    G4EmParameters::Instance()->SetMscStepLimitType(fUseSafetyPlus);
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -19,10 +19,10 @@ FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) 
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
   bool tracking = p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
-  edm::LogVerbatim("PhysicsList") 
-    << "You are using the simulation engine: "
-    << "FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
-    << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: "
+                                  << "FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                                  << hadPhys << " and tracking cut " << tracking
+                                  << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
@@ -9,6 +9,7 @@
 #include "G4HadronElasticPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
 #include "G4HadronicProcessStore.hh"
+#include "G4EmParameters.hh"
 
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
@@ -18,13 +19,15 @@ QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet& p) : Physi
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
   bool tracking = p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
-  edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-                              << "QGSP_FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
-                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
+  edm::LogVerbatim("PhysicsList") 
+    << "You are using the simulation engine: "
+    << "QGSP_FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+    << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
     RegisterPhysics(new G4EmStandardPhysics_option3(ver));
+    G4EmParameters::Instance()->SetMscStepLimitType(fUseSafetyPlus);
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
@@ -19,10 +19,10 @@ QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet& p) : Physi
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
   bool tracking = p.getParameter<bool>("TrackingCut");
   double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
-  edm::LogVerbatim("PhysicsList") 
-    << "You are using the simulation engine: "
-    << "QGSP_FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
-    << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
+  edm::LogVerbatim("PhysicsList") << "You are using the simulation engine: "
+                                  << "QGSP_FTFP_BERT_EMY \n Flags for EM Physics " << emPhys
+                                  << ", for Hadronic Physics " << hadPhys << " and tracking cut " << tracking
+                                  << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -194,12 +194,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       G4UrbanMscModel* msc1 = new G4UrbanMscModel();
       G4WentzelVIModel* msc2 = new G4WentzelVIModel();
       G4UrbanMscModel* msc3 = new G4UrbanMscModel();
-      //---VI: these line should be moved down
-      msc3->SetLocked(true);
-      //---
       msc1->SetHighEnergyLimit(highEnergyLimit);
       msc2->SetLowEnergyLimit(highEnergyLimit);
       msc3->SetHighEnergyLimit(highEnergyLimit);
+      msc3->SetLocked(true);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
       if (aRegion) {
@@ -311,11 +309,9 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       if (nullptr == pb) {
         pb = new G4hBremsstrahlung();
         pp = new G4hPairProduction();
-        //--- VI: these lines should be moved out of the brackets
-        pmsc = new G4hMultipleScattering();
-        pmsc->SetEmModel(new G4WentzelVIModel());
-        //---
       }
+      pmsc = new G4hMultipleScattering();
+      pmsc->SetEmModel(new G4WentzelVIModel());
 
       ph->RegisterProcess(pmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);


### PR DESCRIPTION
#### PR description:

This PR includes few modifications in view of coming new Geant4:
1) CMSSW EM physics configuration has minor inaccuracy, which is now fixed, this may bring change of histories and regression discrepancy in part of tests. This fix was pending for long and now a good time to implement.
2) FTFP_BERT_EMY physics list provide crashes in CMS geometry, which were recently understood and more safe parameters for Geant4 tracking are proposed
3) Custom physics configuration historically have parameters , which are not used, so they are removed

#### PR validation:
private

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
