### PR TITLE
[CC8] unit test fixed, no need to use static ServiceToken and Registry

### DIFF
--- a/CondCore/CondDB/test/testConnectionPool.cpp
+++ b/CondCore/CondDB/test/testConnectionPool.cpp
@@ -122,8 +122,8 @@ int main(int argc, char** argv) {
   edm::ParameterSet pSet;
   pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
   psets.push_back(pSet);
-  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-  static const edm::ServiceRegistry::Operate operate(services);
+  const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  const edm::ServiceRegistry::Operate operate(services);
 
   std::array<std::string, 2> connectionStrings{
       {"frontier://FrontierPrep/CMS_CONDITIONS",

--- a/CondCore/CondDB/test/testFrontier.cpp
+++ b/CondCore/CondDB/test/testFrontier.cpp
@@ -22,8 +22,8 @@ int main(int argc, char** argv) {
   edm::ParameterSet pSet;
   pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
   psets.push_back(pSet);
-  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-  static const edm::ServiceRegistry::Operate operate(services);
+  const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  const edm::ServiceRegistry::Operate operate(services);
 
   std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
   std::cout << "# Connecting with db in " << connectionString << std::endl;


### PR DESCRIPTION
#### PR description:

These unit tests are failing in CC8 IBs. Using non-static ServiceToken and Registry fixes these.
@Dr15Jones , could it be that there is some double delete going on in ServiceToken/Registry? The error we get is
```
==== Test "testFrontier" ====
# Connecting with db in frontier://FrontierProd/CMS_CONDITIONS
Loaded size=90714
free(): corrupted unsorted chunks
/bin/sh: line 1: 18858 Aborted                 testFrontier

---&gt; test testFrontier had ERRORS
```

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

#### PR validation:

Locally build/run and all unit tests of this package now runs successfully for CentOS8
```
Singularity> cat logs/cc8_amd64_gcc8/testing.log | grep '^---> test '
---> test testReadWritePayloads succeeded
---> test testRunInfo succeeded
---> test testGroupSelection succeeded
---> test testFrontier succeeded
---> test testConditionDatabase_2 succeeded
---> test testPayloadProxy succeeded
---> test testRootStreaming succeeded
---> test testConditionDatabase_0 succeeded
---> test testConnectionPool had ERRORS
---> test testConditionDatabase_1 succeeded
---> test condTestRegression succeeded
```