### PR TITLE
No actual use for EcalClusterShapeFunction in HiEgammaAlgos

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h
@@ -15,7 +15,6 @@
 #include "RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h"
 #include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
@@ -1,4 +1,5 @@
 #include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -29,7 +29,6 @@
 #include "RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h"
 #include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"

--- a/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
@@ -35,7 +35,6 @@
 class PhotonProducer : public edm::stream::EDProducer<> {
 public:
   PhotonProducer(const edm::ParameterSet& ps);
-  ~PhotonProducer() override;
 
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
@@ -47,7 +46,6 @@ private:
                             const EcalRecHitCollection* ecalBarrelHits,
                             const EcalRecHitCollection* ecalEndcapHits,
                             const edm::Handle<CaloTowerCollection>& hcalTowersHandle,
-                            //math::XYZPoint & vtx,
                             reco::VertexCollection& pvVertices,
                             reco::PhotonCollection& outputCollection,
                             int& iSC,
@@ -60,9 +58,6 @@ private:
   edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHits_;
   edm::EDGetTokenT<CaloTowerCollection> hcalTowers_;
   edm::EDGetTokenT<reco::VertexCollection> vertexProducer_;
-
-  std::string conversionProducer_;
-  std::string conversionCollection_;
 
   //AA
   //Flags and severities to be excluded from calculations
@@ -81,27 +76,21 @@ private:
   bool runMIPTagger_;
 
   bool validConversions_;
-  std::string pixelSeedProducer_;
 
   bool usePrimaryVertex_;
-  edm::ParameterSet conf_;
 
   PositionCalc posCalculator_;
 
-  edm::ESHandle<CaloGeometry> theCaloGeom_;
-  edm::ESHandle<CaloTopology> theCaloTopo_;
-
   bool validPixelSeeds_;
-  PhotonIsolationCalculator* thePhotonIsolationCalculator_;
+  PhotonIsolationCalculator photonIsolationCalculator_;
 
   //MIP
-  PhotonMIPHaloTagger* thePhotonMIPHaloTagger_;
+  PhotonMIPHaloTagger photonMIPHaloTagger_;
 
   std::vector<double> preselCutValuesBarrel_;
   std::vector<double> preselCutValuesEndcap_;
 
-  EcalClusterFunctionBaseClass* energyCorrectionF;
-  PhotonEnergyCorrector* thePhotonEnergyCorrector_;
+  PhotonEnergyCorrector photonEnergyCorrector_;
   std::string candidateP4type_;
 };
 #endif

--- a/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h
@@ -28,8 +28,6 @@
 #include "RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h"
 #include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -32,8 +32,6 @@
 #include "RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -37,8 +37,6 @@
 #include "RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <vector>
 #include <memory>
 
@@ -31,24 +30,21 @@
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 
-PhotonProducer::PhotonProducer(const edm::ParameterSet& config)
-    :
-
-      conf_(config) {
+PhotonProducer::PhotonProducer(const edm::ParameterSet& config) : photonEnergyCorrector_(config, consumesCollector()) {
   // use onfiguration file to setup input/output collection names
 
-  photonCoreProducer_ = consumes<reco::PhotonCoreCollection>(conf_.getParameter<edm::InputTag>("photonCoreProducer"));
-  barrelEcalHits_ = consumes<EcalRecHitCollection>(conf_.getParameter<edm::InputTag>("barrelEcalHits"));
-  endcapEcalHits_ = consumes<EcalRecHitCollection>(conf_.getParameter<edm::InputTag>("endcapEcalHits"));
-  vertexProducer_ = consumes<reco::VertexCollection>(conf_.getParameter<edm::InputTag>("primaryVertexProducer"));
-  hcalTowers_ = consumes<CaloTowerCollection>(conf_.getParameter<edm::InputTag>("hcalTowers"));
-  hOverEConeSize_ = conf_.getParameter<double>("hOverEConeSize");
-  highEt_ = conf_.getParameter<double>("highEt");
+  photonCoreProducer_ = consumes<reco::PhotonCoreCollection>(config.getParameter<edm::InputTag>("photonCoreProducer"));
+  barrelEcalHits_ = consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalHits"));
+  endcapEcalHits_ = consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("endcapEcalHits"));
+  vertexProducer_ = consumes<reco::VertexCollection>(config.getParameter<edm::InputTag>("primaryVertexProducer"));
+  hcalTowers_ = consumes<CaloTowerCollection>(config.getParameter<edm::InputTag>("hcalTowers"));
+  hOverEConeSize_ = config.getParameter<double>("hOverEConeSize");
+  highEt_ = config.getParameter<double>("highEt");
   // R9 value to decide converted/unconverted
-  minR9Barrel_ = conf_.getParameter<double>("minR9Barrel");
-  minR9Endcap_ = conf_.getParameter<double>("minR9Endcap");
-  usePrimaryVertex_ = conf_.getParameter<bool>("usePrimaryVertex");
-  runMIPTagger_ = conf_.getParameter<bool>("runMIPTagger");
+  minR9Barrel_ = config.getParameter<double>("minR9Barrel");
+  minR9Endcap_ = config.getParameter<double>("minR9Endcap");
+  usePrimaryVertex_ = config.getParameter<bool>("usePrimaryVertex");
+  runMIPTagger_ = config.getParameter<bool>("runMIPTagger");
 
   candidateP4type_ = config.getParameter<std::string>("candidateP4type");
 
@@ -83,58 +79,48 @@ PhotonProducer::PhotonProducer(const edm::ParameterSet& config)
 
   // Parameters for the position calculation:
   //  std::map<std::string,double> providedParameters;
-  // providedParameters.insert(std::make_pair("LogWeighted",conf_.getParameter<bool>("posCalc_logweight")));
-  //providedParameters.insert(std::make_pair("T0_barl",conf_.getParameter<double>("posCalc_t0_barl")));
-  //providedParameters.insert(std::make_pair("T0_endc",conf_.getParameter<double>("posCalc_t0_endc")));
-  //providedParameters.insert(std::make_pair("T0_endcPresh",conf_.getParameter<double>("posCalc_t0_endcPresh")));
-  //providedParameters.insert(std::make_pair("W0",conf_.getParameter<double>("posCalc_w0")));
-  //providedParameters.insert(std::make_pair("X0",conf_.getParameter<double>("posCalc_x0")));
+  // providedParameters.insert(std::make_pair("LogWeighted",config.getParameter<bool>("posCalc_logweight")));
+  //providedParameters.insert(std::make_pair("T0_barl",config.getParameter<double>("posCalc_t0_barl")));
+  //providedParameters.insert(std::make_pair("T0_endc",config.getParameter<double>("posCalc_t0_endc")));
+  //providedParameters.insert(std::make_pair("T0_endcPresh",config.getParameter<double>("posCalc_t0_endcPresh")));
+  //providedParameters.insert(std::make_pair("W0",config.getParameter<double>("posCalc_w0")));
+  //providedParameters.insert(std::make_pair("X0",config.getParameter<double>("posCalc_x0")));
   //posCalculator_ = PositionCalc(providedParameters);
   // cut values for pre-selection
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("minSCEtBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("maxHoverEBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("ecalRecHitSumEtOffsetBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("ecalRecHitSumEtSlopeBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("hcalTowerSumEtOffsetBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("hcalTowerSumEtSlopeBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("nTrackSolidConeBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("nTrackHollowConeBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("trackPtSumSolidConeBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("trackPtSumHollowConeBarrel"));
-  preselCutValuesBarrel_.push_back(conf_.getParameter<double>("sigmaIetaIetaCutBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("minSCEtBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("maxHoverEBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("ecalRecHitSumEtOffsetBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("ecalRecHitSumEtSlopeBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("hcalTowerSumEtOffsetBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("hcalTowerSumEtSlopeBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("nTrackSolidConeBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("nTrackHollowConeBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("trackPtSumSolidConeBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("trackPtSumHollowConeBarrel"));
+  preselCutValuesBarrel_.push_back(config.getParameter<double>("sigmaIetaIetaCutBarrel"));
   //
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("minSCEtEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("maxHoverEEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("ecalRecHitSumEtOffsetEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("ecalRecHitSumEtSlopeEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("hcalTowerSumEtOffsetEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("hcalTowerSumEtSlopeEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("nTrackSolidConeEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("nTrackHollowConeEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("trackPtSumSolidConeEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("trackPtSumHollowConeEndcap"));
-  preselCutValuesEndcap_.push_back(conf_.getParameter<double>("sigmaIetaIetaCutEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("minSCEtEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("maxHoverEEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("ecalRecHitSumEtOffsetEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("ecalRecHitSumEtSlopeEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("hcalTowerSumEtOffsetEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("hcalTowerSumEtSlopeEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("nTrackSolidConeEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("nTrackHollowConeEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("trackPtSumSolidConeEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("trackPtSumHollowConeEndcap"));
+  preselCutValuesEndcap_.push_back(config.getParameter<double>("sigmaIetaIetaCutEndcap"));
   //
 
-  thePhotonEnergyCorrector_ = new PhotonEnergyCorrector(conf_, consumesCollector());
-  thePhotonIsolationCalculator_ = new PhotonIsolationCalculator();
-  edm::ParameterSet isolationSumsCalculatorSet = conf_.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet");
-  thePhotonIsolationCalculator_->setup(
+  edm::ParameterSet isolationSumsCalculatorSet = config.getParameter<edm::ParameterSet>("isolationSumsCalculatorSet");
+  photonIsolationCalculator_.setup(
       isolationSumsCalculatorSet, flagsexclEB_, flagsexclEE_, severitiesexclEB_, severitiesexclEE_, consumesCollector());
 
-  thePhotonMIPHaloTagger_ = new PhotonMIPHaloTagger();
-  edm::ParameterSet mipVariableSet = conf_.getParameter<edm::ParameterSet>("mipVariableSet");
-  thePhotonMIPHaloTagger_->setup(mipVariableSet, consumesCollector());
+  edm::ParameterSet mipVariableSet = config.getParameter<edm::ParameterSet>("mipVariableSet");
+  photonMIPHaloTagger_.setup(mipVariableSet, consumesCollector());
 
   // Register the product
   produces<reco::PhotonCollection>(PhotonCollection_);
-}
-
-PhotonProducer::~PhotonProducer() {
-  delete thePhotonEnergyCorrector_;
-  delete thePhotonIsolationCalculator_;
-  delete thePhotonMIPHaloTagger_;
-  //delete energyCorrectionF;
 }
 
 void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
@@ -185,16 +171,9 @@ void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEve
   Handle<CaloTowerCollection> hcalTowersHandle;
   theEvent.getByToken(hcalTowers_, hcalTowersHandle);
 
-  // get the geometry from the event setup:
-  theEventSetup.get<CaloGeometryRecord>().get(theCaloGeom_);
-
-  //
-  // update energy correction function
-  //  energyCorrectionF->init(theEventSetup);
-
   edm::ESHandle<CaloTopology> pTopology;
-  theEventSetup.get<CaloTopologyRecord>().get(theCaloTopo_);
-  const CaloTopology* topology = theCaloTopo_.product();
+  theEventSetup.get<CaloTopologyRecord>().get(pTopology);
+  const CaloTopology* topology = pTopology.product();
 
   // Get the primary event vertex
   Handle<reco::VertexCollection> vertexHandle;
@@ -210,8 +189,6 @@ void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEve
     if (validVertex)
       vertexCollection = *(vertexHandle.product());
   }
-  //  math::XYZPoint vtx(0.,0.,0.);
-  //if (vertexCollection.size()>0) vtx = vertexCollection.begin()->position();
 
   int iSC = 0;  // index in photon collection
   // Loop over barrel and endcap SC collections and fill the  photon collection
@@ -223,7 +200,6 @@ void PhotonProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEve
                          &barrelRecHits,
                          &endcapRecHits,
                          hcalTowersHandle,
-                         //vtx,
                          vertexCollection,
                          outputPhotonCollection,
                          iSC,
@@ -242,30 +218,32 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
                                           const EcalRecHitCollection* ecalBarrelHits,
                                           const EcalRecHitCollection* ecalEndcapHits,
                                           const edm::Handle<CaloTowerCollection>& hcalTowersHandle,
-                                          // math::XYZPoint & vtx,
                                           reco::VertexCollection& vertexCollection,
                                           reco::PhotonCollection& outputPhotonCollection,
                                           int& iSC,
                                           const EcalSeverityLevelAlgo* sevLv) {
-  const CaloGeometry* geometry = theCaloGeom_.product();
+  // get the geometry from the event setup:
+  edm::ESHandle<CaloGeometry> caloGeomHandle;
+  es.get<CaloGeometryRecord>().get(caloGeomHandle);
+
+  const CaloGeometry* geometry = caloGeomHandle.product();
   const CaloSubdetectorGeometry* subDetGeometry = nullptr;
-  const CaloSubdetectorGeometry* geometryES = theCaloGeom_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  const CaloSubdetectorGeometry* geometryES = caloGeomHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   const EcalRecHitCollection* hits = nullptr;
   std::vector<double> preselCutValues;
   float minR9 = 0;
 
-  thePhotonEnergyCorrector_->init(es);
+  photonEnergyCorrector_.init(es);
 
   std::vector<int> flags_, severitiesexcl_;
 
   for (unsigned int lSC = 0; lSC < photonCoreHandle->size(); lSC++) {
     reco::PhotonCoreRef coreRef(reco::PhotonCoreRef(photonCoreHandle, lSC));
     reco::SuperClusterRef scRef = coreRef->superCluster();
-    //    const reco::SuperCluster* pClus=&(*scRef);
     iSC++;
 
     int subdet = scRef->seed()->hitsAndFractions()[0].first.subdetId();
-    subDetGeometry = theCaloGeom_->getSubdetectorGeometry(DetId::Ecal, subdet);
+    subDetGeometry = caloGeomHandle->getSubdetectorGeometry(DetId::Ecal, subdet);
 
     if (subdet == EcalBarrel) {
       preselCutValues = preselCutValuesBarrel_;
@@ -301,8 +279,6 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     std::vector<CaloTowerDetId> TowersBehindClus = towerIsoBehindClus.towersOf(*scRef);
     float hcalDepth1OverEcalBc = towerIsoBehindClus.getDepth1HcalESum(TowersBehindClus) / scRef->energy();
     float hcalDepth2OverEcalBc = towerIsoBehindClus.getDepth2HcalESum(TowersBehindClus) / scRef->energy();
-    //    std::cout << " PhotonProducer calculation of HoE with towers in a cone " << HoE1  << "  " << HoE2 << std::endl;
-    //std::cout << " PhotonProducer calcualtion of HoE with towers behind the BCs " << hcalDepth1OverEcalBc  << "  " << hcalDepth2OverEcalBc << std::endl;
 
     // recalculate position of seed BasicCluster taking shower depth for unconverted photon
     math::XYZPoint unconvPos =
@@ -352,19 +328,16 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
       vtx = vertexCollection.begin()->position();
     // compute momentum vector of photon from primary vertex and cluster position
     math::XYZVector direction = caloPosition - vtx;
-    //math::XYZVector momentum = direction.unit() * photonEnergy ;
     math::XYZVector momentum = direction.unit();
 
     // Create dummy candidate with unit momentum and zero energy to allow setting of all variables. The energy is set for last.
     math::XYZTLorentzVectorD p4(momentum.x(), momentum.y(), momentum.z(), photonEnergy);
     reco::Photon newCandidate(p4, caloPosition, coreRef, vtx);
-    //std::cout << " standard p4 before " << newCandidate.p4() << " energy " << newCandidate.energy() <<  std::endl;
-    //std::cout << " type " <<newCandidate.getCandidateP4type() <<  " standard p4 after " << newCandidate.p4() << " energy " << newCandidate.energy() << std::endl;
 
     // Calculate fiducial flags and isolation variable. Blocked are filled from the isolationCalculator
     reco::Photon::FiducialFlags fiducialFlags;
     reco::Photon::IsolationVariables isolVarR03, isolVarR04;
-    thePhotonIsolationCalculator_->calculate(&newCandidate, evt, es, fiducialFlags, isolVarR04, isolVarR03);
+    photonIsolationCalculator_.calculate(&newCandidate, evt, es, fiducialFlags, isolVarR04, isolVarR03);
     newCandidate.setFiducialVolumeFlags(fiducialFlags);
     newCandidate.setIsolationVariables(isolVarR04, isolVarR03);
 
@@ -398,7 +371,7 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
     /// get ecal photon specific corrected energy
     /// plus values from regressions     and store them in the Photon
     // Photon candidate takes by default (set in photons_cfi.py)  a 4-momentum derived from the ecal photon-specific corrections.
-    thePhotonEnergyCorrector_->calculate(evt, newCandidate, subdet, vertexCollection, es);
+    photonEnergyCorrector_.calculate(evt, newCandidate, subdet, vertexCollection, es);
     if (candidateP4type_ == "fromEcalEnergy") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
@@ -407,15 +380,10 @@ void PhotonProducer::fillPhotonCollection(edm::Event& evt,
       newCandidate.setCandidateP4type(reco::Photon::regression1);
     }
 
-    //       std::cout << " final p4 " << newCandidate.p4() << " energy " << newCandidate.energy() <<  std::endl;
-
-    // std::cout << " PhotonProducer from candidate HoE with towers in a cone " << newCandidate.hadronicOverEm()  << "  " <<  newCandidate.hadronicDepth1OverEm()  << " " <<  newCandidate.hadronicDepth2OverEm()  << std::endl;
-    //    std::cout << " PhotonProducer from candidate  of HoE with towers behind the BCs " <<  newCandidate.hadTowOverEm()  << "  " << newCandidate.hadTowDepth1OverEm() << " " << newCandidate.hadTowDepth2OverEm() << std::endl;
-
     // fill MIP Vairables for Halo: Block for MIP are filled from PhotonMIPHaloTagger
     reco::Photon::MIPVariables mipVar;
     if (subdet == EcalBarrel && runMIPTagger_) {
-      thePhotonMIPHaloTagger_->MIPcalculate(&newCandidate, evt, es, mipVar);
+      photonMIPHaloTagger_.MIPcalculate(&newCandidate, evt, es, mipVar);
       newCandidate.setMIPVariables(mipVar);
     }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -29,8 +29,6 @@
 
 #include "RecoEgamma/EgammaPhotonProducers/interface/PhotonProducer.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 
 PhotonProducer::PhotonProducer(const edm::ParameterSet& config)

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -36,8 +36,6 @@
 #include "RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"

--- a/RecoHI/HiEgammaAlgos/interface/HiEgammaSCEnergyCorrectionAlgo.h
+++ b/RecoHI/HiEgammaAlgos/interface/HiEgammaSCEnergyCorrectionAlgo.h
@@ -12,8 +12,6 @@
 
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
@@ -26,50 +24,40 @@ public:
   enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 };
 
   // public member functions
-  HiEgammaSCEnergyCorrectionAlgo(float noise,
-                                 reco::CaloCluster::AlgoId theAlgo,
-                                 const edm::ParameterSet &pSet,
-                                 VerbosityLevel verbosity = pERROR);
-  ~HiEgammaSCEnergyCorrectionAlgo() {}
+  HiEgammaSCEnergyCorrectionAlgo(float noise, const edm::ParameterSet &pSet, VerbosityLevel verbosity = pERROR);
 
   // take a SuperCluster and return a corrected SuperCluster
   reco::SuperCluster applyCorrection(const reco::SuperCluster &cl,
                                      const EcalRecHitCollection &rhc,
-                                     reco::CaloCluster::AlgoId theAlgo,
-                                     const CaloSubdetectorGeometry *geometry,
-                                     const CaloTopology *topology,
-                                     EcalClusterFunctionBaseClass *EnergyCorrectionClass);
-
-  // function to set the verbosity level
-  void setVerbosity(VerbosityLevel verbosity) { verbosity_ = verbosity; }
+                                     reco::CaloCluster::AlgoId algoId,
+                                     const CaloSubdetectorGeometry &geometry,
+                                     const CaloTopology &topology) const;
 
 private:
   // correction factor as a function of number of crystals,
   // BasicCluster algo and location in the detector
-  float fNCrystals(int nCry, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
-  float fBrem(float widthRatio, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
-  float fEta(float eta, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
-  float fEtEta(float et, float eta, reco::CaloCluster::AlgoId theAlgo, EcalSubdetector theBase) const;
+  float fNCrystals(int nCry, reco::CaloCluster::AlgoId algoId, EcalSubdetector theBase) const;
+  float fBrem(float widthRatio, reco::CaloCluster::AlgoId algoId, EcalSubdetector theBase) const;
+  float fEta(float eta, reco::CaloCluster::AlgoId algoId, EcalSubdetector theBase) const;
+  float fEtEta(float et, float eta, reco::CaloCluster::AlgoId algoId, EcalSubdetector theBase) const;
 
   // Return the number of crystals in a BasicCluster above
   // 2sigma noise level
   int nCrystalsGT2Sigma(reco::BasicCluster const &seed, EcalRecHitCollection const &rhc) const;
 
-  float sigmaElectronicNoise_;
+  const float sigmaElectronicNoise_;
 
   //  the verbosity level
-  VerbosityLevel verbosity_;
-
-  reco::CaloCluster::AlgoId theAlgo_;
+  const VerbosityLevel verbosity_;
 
   // parameters
-  std::vector<double> p_fEta_;
-  std::vector<double> p_fBremTh_, p_fBrem_;
-  std::vector<double> p_fEtEta_;
+  const std::vector<double> p_fEta_;
+  const std::vector<double> p_fBremTh_, p_fBrem_;
+  const std::vector<double> p_fEtEta_;
 
-  double minR9Barrel_;
-  double minR9Endcap_;
-  double maxR9_;
+  const double minR9Barrel_;
+  const double minR9Endcap_;
+  const double maxR9_;
 };
 
 #endif /*RecoECAL_ECALClusters_HiEgammaSCEnergyCorrectionAlgo_h_*/

--- a/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
+++ b/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
@@ -30,8 +30,6 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 
 #include "RecoHI/HiEgammaAlgos/interface/HiEgammaSCEnergyCorrectionAlgo.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
@@ -43,8 +41,6 @@ public:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  std::unique_ptr<EcalClusterFunctionBaseClass> EnergyCorrection_;
-
   // the debug level
   HiEgammaSCEnergyCorrectionAlgo::VerbosityLevel verbosity_;
 


### PR DESCRIPTION
#### PR description:

In https://github.com/cms-sw/cmssw/pull/28332 we were wondering where the EcalClusterFunctions are actually used and if the inheritance/factory pattern is really necessary. This prompted me to check for their usage, and there is a misleading piece of code in the HI reco where a EcalClusterShapeFunction is created and passed around, but never actually used. It's probably better to remove this. On the way I also removed a few more unneeded includes of `EcalClusterFunctionBaseClass.h` and `EcalClusterFunctionFactory.h`, placed a few `const` and replaced a variable called `theAlgo` with `algoId`, to not get it confused for a member variable.

#### PR validation:

CMSSW compiles and local matrix tests pass.

#### if this PR is a backport please specify the original PR:

No backport intended.