### PR TITLE
BTL simulation: OOT effects

### DIFF
--- a/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
+++ b/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
@@ -29,12 +29,12 @@ public:
   };
   class Data {
   public:
-    constexpr static unsigned energyOffset = 15;
-    constexpr static unsigned energyMask = 0x1;
-    constexpr static unsigned sampleOffset = 11;
+    constexpr static unsigned energyOffset = 14;
+    constexpr static unsigned energyMask = 0x3;
+    constexpr static unsigned sampleOffset = 10;
     constexpr static unsigned sampleMask = 0xf;
     constexpr static unsigned dataOffset = 0;
-    constexpr static unsigned dataMask = 0x7ff;
+    constexpr static unsigned dataMask = 0x3ff;
 
     Data() : data_(0) {}
     Data(unsigned short ei, unsigned short si, unsigned short d)

--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -60,7 +60,7 @@ private:
   const float DarkCountRate_;
   const float SigmaElectronicNoise_;
   const float SigmaClock_;
-
+  const bool smearTimeForOOTtails_;
   const float Npe_to_pC_;
   const float Npe_to_V_;
 

--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -80,6 +80,7 @@ private:
   const float sinPhi_;
 
   const float ScintillatorDecayTime2_;
+  const float ScintillatorDecayTimeInv_;
   const float SPTR2_;
   const float DCRxRiseTime_;
   const float SigmaElectronicNoise2_;

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -69,7 +69,7 @@ namespace mtd_digitizer {
     constexpr uint16_t base = 1 << PMTDSimAccumulator::Data::sampleOffset;
 
     simResult.reserve(simData.size());
-    // mimicing the digitization
+    // mimicking the digitization
     for (const auto& elem : simData) {
       // store only non-zero
       for (size_t iEn = 0; iEn < nEnergies; ++iEn) {
@@ -77,7 +77,7 @@ namespace mtd_digitizer {
         for (size_t iSample = 0; iSample < nSamples; ++iSample) {
           if (samples[iSample] > minCharge) {
             unsigned short packed;
-            if (iEn == 1) {
+            if (iEn == 1 || iEn == 3) {
               // assuming linear range for tof of 0..26
               packed = samples[iSample] / PREMIX_MAX_TOF * base;
             } else {
@@ -108,13 +108,13 @@ namespace mtd_digitizer {
       size_t iSample = detIdIndexHitInfo.sampleIndex();
 
       float value;
-      if (iEn == 1) {
+      if (iEn == 1 || iEn == 3) {
         value = static_cast<float>(detIdIndexHitInfo.data()) / base * PREMIX_MAX_TOF;
       } else {
         value = logintpack::unpack16log(detIdIndexHitInfo.data(), minPackChargeLog, maxPackChargeLog, base);
       }
 
-      if (iEn == 0) {
+      if (iEn == 0 || iEn == 2) {
         hit_info[iEn][iSample] += value;
       } else if (hit_info[iEn][iSample] == 0) {
         // For iEn==1 the digitizers just set the TOF of the first SimHit

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -40,6 +40,9 @@ namespace mtd_digitizer {
   // intermediate det id for ETL
   typedef std::unordered_map<MTDCellId, MTDCellInfo> MTDSimHitDataAccumulator;
 
+  constexpr int kNumberOfBX = 15;
+  constexpr int kInTimeBX = 9;
+
 }  // namespace mtd_digitizer
 
 namespace std {

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -15,8 +15,11 @@ namespace mtd_digitizer {
   typedef std::array<MTDSimData_t, nSamples> MTDSimHitData;
 
   struct MTDCellInfo {
-    //1st array=energy, 2nd array=time-of-flight
-    std::array<MTDSimHitData, 2> hit_info;
+    // for the BTL tile geometry and ETL:
+    //     1st array=energy, 2nd array=time-of-flight
+    // for the BTL bar geometry:
+    //     3rd array=energy (right side), 4th array=time-of-flight (right side)
+    std::array<MTDSimHitData, 4> hit_info;
   };
 
   // Maximum value of time-of-flight for premixing packing

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -33,6 +33,7 @@ _barrel_tile_MTDDigitizer = cms.PSet(
         SigmaElectronicNoise       = cms.double(1.),    # [p.e.]
         SigmaClock                 = cms.double(0.015), # [ns]
         CorrelationCoefficient     = cms.double(1.),
+        SmearTimeForOOTtails       = cms.bool(True),
         Npe_to_pC                  = cms.double(0.016), # [pC] 
         Npe_to_V                   = cms.double(0.0064),# [V] 
 

--- a/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
@@ -99,11 +99,11 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
     double tL = std::get<2>(hitRef) + LightCollSlopeL_ * distL;
 
     // --- Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    const int iBXR = std::floor(tR / bxTime_) + 9;
-    const int iBXL = std::floor(tL / bxTime_) + 9;
+    const int iBXR = std::floor(tR / bxTime_) + mtd_digitizer::kInTimeBX;
+    const int iBXL = std::floor(tL / bxTime_) + mtd_digitizer::kInTimeBX;
 
     // --- Right side
-    if (iBXR > 0 && iBXR < 15) {
+    if (iBXR > 0 && iBXR < mtd_digitizer::kNumberOfBX) {
       // Accumulate the energy of simHits in the same crystal
       (simHitIt->second).hit_info[0][iBXR] += Npe;
 
@@ -113,7 +113,7 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
     }
 
     // --- Left side
-    if (iBXL > 0 && iBXL < 15) {
+    if (iBXL > 0 && iBXL < mtd_digitizer::kNumberOfBX) {
       // Accumulate the energy of simHits in the same crystal
       (simHitIt->second).hit_info[2][iBXL] += Npe;
 

--- a/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
@@ -84,36 +84,45 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
     // --- Get the simHit energy and convert it from MeV to photo-electrons
     float Npe = 1000. * hit.energyLoss() * LightYield_ * LightCollEff_ * PDE_;
 
-    // --- Get the simHit time of arrival
-    float toa = std::get<2>(hitRef);
-
-    if (toa > bxTime_ || toa < 0)  //just consider BX==0
-      continue;
-
-    // --- Accumulate the energy of simHits in the same crystal for the BX==0
-    // this is to simulate the charge integration in a 25 ns window
-    (simHitIt->second).hit_info[0][0] += Npe;
-    (simHitIt->second).hit_info[0][1] += Npe;
-
+    // --- Calculate the light propagation time to the crystal bases (labeled L and R)
     double distR = 0.5 * topo.pitch().second - 0.1 * hit.localPosition().y();
     double distL = 0.5 * topo.pitch().second + 0.1 * hit.localPosition().y();
 
-    // This is for the layout with bars along phi
+    // This is for the layouts with bars along phi
     if (topo_->getMTDTopologyMode() == (int)BTLDetId::CrysLayout::bar ||
         topo_->getMTDTopologyMode() == (int)BTLDetId::CrysLayout::barphiflat) {
       distR = 0.5 * topo.pitch().first - 0.1 * hit.localPosition().x();
       distL = 0.5 * topo.pitch().first + 0.1 * hit.localPosition().x();
     }
 
-    double tR = toa + LightCollSlopeR_ * distR;
-    double tL = toa + LightCollSlopeL_ * distL;
+    double tR = std::get<2>(hitRef) + LightCollSlopeR_ * distR;
+    double tL = std::get<2>(hitRef) + LightCollSlopeL_ * distL;
 
-    // --- Store the time of the first SimHit
-    if ((simHitIt->second).hit_info[1][0] == 0 || tR < (simHitIt->second).hit_info[1][0])
-      (simHitIt->second).hit_info[1][0] = tR;
+    // --- Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
+    //const int iBXL = std::floor( tL/bxTime_ ) + 9;
+    //const int iBXR = std::floor( tR/bxTime_ ) + 9;
+    const int iBXR = std::floor(std::get<2>(hitRef) / bxTime_) + 9;  // >>>>>> TO BE CHANGED
+    const int iBXL = std::floor(std::get<2>(hitRef) / bxTime_) + 9;  // >>>>>> TO BE CHANGED
 
-    if ((simHitIt->second).hit_info[1][1] == 0 || tL < (simHitIt->second).hit_info[1][1])
-      (simHitIt->second).hit_info[1][1] = tL;
+    // --- Right side
+    if (iBXR > 0 && iBXR < 15) {
+      // Accumulate the energy of simHits in the same crystal
+      (simHitIt->second).hit_info[0][iBXR] += Npe;
+
+      // Store the time of the first SimHit in the i-th BX
+      if ((simHitIt->second).hit_info[1][iBXR] == 0 || tR < (simHitIt->second).hit_info[1][iBXR])
+        (simHitIt->second).hit_info[1][iBXR] = tR;
+    }
+
+    // --- Left side
+    if (iBXL > 0 && iBXL < 15) {
+      // Accumulate the energy of simHits in the same crystal
+      (simHitIt->second).hit_info[2][iBXL] += Npe;
+
+      // Store the time of the first SimHit in the i-th BX
+      if ((simHitIt->second).hit_info[3][iBXL] == 0 || tL < (simHitIt->second).hit_info[3][iBXL])
+        (simHitIt->second).hit_info[3][iBXL] = tL;
+    }
 
   }  // hitRef loop
 }

--- a/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
@@ -99,10 +99,8 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
     double tL = std::get<2>(hitRef) + LightCollSlopeL_ * distL;
 
     // --- Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    //const int iBXL = std::floor( tL/bxTime_ ) + 9;
-    //const int iBXR = std::floor( tR/bxTime_ ) + 9;
-    const int iBXR = std::floor(std::get<2>(hitRef) / bxTime_) + 9;  // >>>>>> TO BE CHANGED
-    const int iBXL = std::floor(std::get<2>(hitRef) / bxTime_) + 9;  // >>>>>> TO BE CHANGED
+    const int iBXR = std::floor(tR / bxTime_) + 9;
+    const int iBXL = std::floor(tL / bxTime_) + 9;
 
     // --- Right side
     if (iBXR > 0 && iBXR < 15) {

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -23,6 +23,7 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset)
       DarkCountRate_(pset.getParameter<double>("DarkCountRate")),
       SigmaElectronicNoise_(pset.getParameter<double>("SigmaElectronicNoise")),
       SigmaClock_(pset.getParameter<double>("SigmaClock")),
+      smearTimeForOOTtails_(pset.getParameter<bool>("SmearTimeForOOTtails")),
       Npe_to_pC_(pset.getParameter<double>("Npe_to_pC")),
       Npe_to_V_(pset.getParameter<double>("Npe_to_V")),
       adcNbits_(pset.getParameter<uint32_t>("adcNbits")),
@@ -48,17 +49,20 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
   MTDSimHitData chargeColl, toa1, toa2;
 
   for (MTDSimHitDataAccumulator::const_iterator it = input.begin(); it != input.end(); it++) {
+    // --- Digitize only the in-time bucket (BX=9):
+    const unsigned int iBX = 9;
+
     chargeColl.fill(0.f);
     toa1.fill(0.f);
     toa2.fill(0.f);
-    for (size_t i = 0; i < it->second.hit_info[0].size(); i++) {
+    for (size_t iside = 0; iside < 2; iside++) {
       // --- Fluctuate the total number of photo-electrons
-      float Npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[0][i]);
+      float Npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][iBX]);
       if (Npe < EnergyThreshold_)
         continue;
 
       // --- Get the time of arrival and add a channel time offset
-      float finalToA1 = (it->second).hit_info[1][i] + ChannelTimeOffset_;
+      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + ChannelTimeOffset_;
 
       if (smearChannelTimeOffset_ > 0.) {
         float timeSmearing = CLHEP::RandGaussQ::shoot(hre, 0., smearChannelTimeOffset_);
@@ -76,6 +80,26 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
       float finalToA2 = finalToA1 + times[1];
       finalToA1 += times[0];
+
+      // --- Estimate the time uncertainty due to photons from earlier OOT hits in the current BTL cell
+      if (smearTimeForOOTtails_) {
+        float rate_oot = 0.;
+        // Loop on earlier OOT hits
+        for (unsigned int ibx = 0; ibx < 9; ++ibx) {
+          if ((it->second).hit_info[2 * iside][ibx] > 0.) {
+            float npe_oot = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][ibx]);
+            rate_oot += npe_oot * exp((it->second).hit_info[1 + 2 * iside][ibx] / ScintillatorDecayTime_) /
+                        ScintillatorDecayTime_;
+          }
+        }  // ibx loop
+
+        if (rate_oot > 0.) {
+          float sigma_oot = sqrt(rate_oot * ScintillatorRiseTime_) * ScintillatorDecayTime_ / Npe;
+          float smearing_oot = CLHEP::RandGaussQ::shoot(hre, 0., sigma_oot);
+          finalToA1 += smearing_oot;
+          finalToA2 += smearing_oot;
+        }
+      }  // if smearTimeForOOTtails_
 
       // --- Uncertainty due to the fluctuations of the n-th photon arrival time:
       if (testBeamMIPTimeRes_ > 0.) {
@@ -115,17 +139,19 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       finalToA1 += cosPhi_ * smearing_thr1_uncorr + sinPhi_ * smearing_thr2_uncorr;
       finalToA2 += sinPhi_ * smearing_thr1_uncorr + cosPhi_ * smearing_thr2_uncorr;
 
-      chargeColl[i] = Npe * Npe_to_pC_;  // the p.e. number is here converted to pC
+      chargeColl[iside] = Npe * Npe_to_pC_;  // the p.e. number is here converted to pC
 
-      toa1[i] = finalToA1;
-      toa2[i] = finalToA2;
-    }
+      toa1[iside] = finalToA1;
+      toa2[iside] = finalToA2;
+
+    }  // iside loop
 
     //run the shaper to create a new data frame
     BTLDataFrame rawDataFrame(it->first.detid_);
     runTrivialShaper(rawDataFrame, chargeColl, toa1, toa2, it->first.row_, it->first.column_);
     updateOutput(output, rawDataFrame);
-  }
+
+  }  // MTDSimHitDataAccumulator loop
 }
 
 void BTLElectronicsSim::runTrivialShaper(BTLDataFrame& dataFrame,

--- a/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
@@ -85,8 +85,8 @@ void BTLTileDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_
       toa += CLHEP::RandGaussQ::shoot(hre, 0., smearLightCollTime_);
 
     // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    const int iBX = std::floor(toa / bxTime_) + 9;
-    if (iBX < 0 || iBX > 14)
+    const int iBX = std::floor(toa / bxTime_) + mtd_digitizer::kInTimeBX;
+    if (iBX < 0 || iBX >= mtd_digitizer::kNumberOfBX)
       continue;
 
     (simHitIt->second).hit_info[0][iBX] += Npe;

--- a/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
@@ -84,14 +84,16 @@ void BTLTileDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_
     if (smearLightCollTime_ > 0.)
       toa += CLHEP::RandGaussQ::shoot(hre, 0., smearLightCollTime_);
 
-    if (toa > bxTime_ || toa < 0)  //just consider BX==0
+    // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
+    const int iBX = std::floor(toa / bxTime_) + 9;
+    if (iBX < 0 || iBX > 14)
       continue;
 
-    (simHitIt->second).hit_info[0][0] += Npe;
+    (simHitIt->second).hit_info[0][iBX] += Npe;
 
-    // --- Store the time of the first SimHit
-    if ((simHitIt->second).hit_info[1][0] == 0 || toa < (simHitIt->second).hit_info[1][0])
-      (simHitIt->second).hit_info[1][0] = toa;
+    // --- Store the time of the first SimHit in the i-th BX
+    if ((simHitIt->second).hit_info[1][iBX] == 0 || toa < (simHitIt->second).hit_info[1][iBX])
+      (simHitIt->second).hit_info[1][iBX] = toa;
 
   }  // hitRef loop
 }


### PR DESCRIPTION
#### PR description:

This PR modifies the BTL digitization to include the effects on time resolution due to the photon tails of earlier OOT hits in the same crystal. It implements the model proposed by A. Ledovskoy ([slides](https://indico.cern.ch/event/782676/contributions/3289163/attachments/1783938/2903520/190123_mtd_ledovskoy.pdf)). (@pmeridian @parbol )

The size of MTDSimHitData had to be increased in order for the information of previous BXs 
for both bar sides to be available in the BTLElectronicSim. The premixing configuration has been updated accordingly. (@makortel )


#### PR validation:

The new code has been tested in CMSSW_11_0_X_2019-11-18-2300 with the TTbar WF 22234 (PU200):

**step 2:**

MemoryReport> Peak virtual size 6280.26 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 4296.21 deltaVsize = 0 rss = 3077.83 delta = 0
[3] run: 1 lumi: 1 event: 3  vsize = 5128.21 deltaVsize = 832 rss = 3166.95 delta = 89.1211
[88] run: 1 lumi: 1 event: 88  vsize = 6280.26 deltaVsize = 640 rss = 3146.59 delta = -20.3594
[12] run: 1 lumi: 1 event: 12  vsize = 5640.25 deltaVsize = 512.008 rss = 3204.43 delta = 37.4727
[90] run: 1 lumi: 1 event: 90  vsize = 6280.26 deltaVsize = 0 rss = 3078.7 delta = -67.8984
[89] run: 1 lumi: 1 event: 89  vsize = 6280.26 deltaVsize = 0 rss = 3203.86 delta = 57.2656
[88] run: 1 lumi: 1 event: 88  vsize = 6280.26 deltaVsize = 640 rss = 3146.59 delta = -34.625
TimeReport> Time report complete in 10911.9 seconds
Time Summary: 
 - Min event:   80.4885
 - Max event:   128.658
 - Avg event:   107.631
 - Total loop:  10882.3
 - Total init:  29.3701
 - Total job:   10911.9
 - EventSetup Lock:   0.00013113
 - EventSetup Get:   83.4706
 Event Throughput: 0.00918923 ev/s
 CPU Summary: 
 - Total loop:  9314.68
 - Total init:  13.381
 - Total extra: 0
 - Total job:   9328.3

 
**step 3**

 MemoryReport> Peak virtual size 10161.6 Mbytes
 Key events increasing vsize: 
[8] run: 1 lumi: 1 event: 8  vsize = 9139.4 deltaVsize = 32.0586 rss = 6650.14 delta = 89.9492
[3] run: 1 lumi: 1 event: 3  vsize = 9107.34 deltaVsize = 900.121 rss = 6560.19 delta = 155.914
[42] run: 1 lumi: 1 event: 42  vsize = 10161.6 deltaVsize = 1022.13 rss = 6870.45 delta = 310.262
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[44] run: 1 lumi: 1 event: 44  vsize = 10161.6 deltaVsize = 0 rss = 6714.96 delta = -155.488
[43] run: 1 lumi: 1 event: 43  vsize = 10161.6 deltaVsize = 0 rss = 6831.04 delta = -39.4141
[42] run: 1 lumi: 1 event: 42  vsize = 10161.6 deltaVsize = 1022.13 rss = 6870.45 delta = 68.0742
TimeReport> Time report complete in 24287.1 seconds
 Time Summary: 
 - Min event:   145.066
 - Max event:   412.86
 - Avg event:   237.186
 - Total loop:  24138
 - Total init:  138.612
 - Total job:   24287.1
 - EventSetup Lock:   0.000231981
 - EventSetup Get:   95.3623
 Event Throughput: 0.00414284 ev/s
 CPU Summary: 
 - Total loop:  20984.7
 - Total init:  101.39
 - Total extra: 0
 - Total job:   21096.3
