### PR TITLE
pedestal subtraction for PCC luminosity

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -353,8 +353,8 @@ void CorrPCCProducer::calculateCorrections (std::vector<float> uncorrected, std:
       }
     }
     if(nped>0){
-      pedestal=pedestal/nped;
       pedestal_unc=sqrt(pedestal)/nped;
+      pedestal=pedestal/nped;
     }
     for(size_t i=0; i<LumiConstants::numBX; i++){
       corrected_tmp_.at(i)=corrected_tmp_.at(i)-pedestal;

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -127,6 +127,9 @@ class CorrPCCProducer : public DQMEDAnalyzer {
         double type2_a_;//amplitude for the type 2 correction 
         double type2_b_;//decay width for the type 2 correction
 
+        float pedestal;
+        float pedestal_unc;
+        TGraphErrors *pedestalGraph;
 
         LumiCorrections* pccCorrections;
 
@@ -175,6 +178,12 @@ CorrPCCProducer::CorrPCCProducer(const edm::ParameterSet& iConfig)
     type1FracGraph->SetMarkerStyle(8);
     type1resGraph->SetMarkerStyle(8);
     type2resGraph->SetMarkerStyle(8);
+
+    pedestalGraph= new TGraphErrors();
+    pedestalGraph->SetName("Pedestal");
+    pedestalGraph->GetYaxis()->SetTitle("pedestal value (counts) per lumi section");
+    pedestalGraph->GetXaxis()->SetTitle("Unique LS ID");
+    pedestalGraph->SetMarkerStyle(8);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -330,14 +339,33 @@ void CorrPCCProducer::calculateCorrections (std::vector<float> uncorrected, std:
         }
     }
 
+    float lumiMax = getMaximum(corrected_tmp_);
+    float threshold = lumiMax*0.2;
+
+    //here subtract the pedestal
+    pedestal=0.;
+    pedestal_unc=0.;
+    int nped=0;
+    for(size_t i=0; i<LumiConstants::numBX; i++){
+      if(corrected_tmp_.at(i)<threshold){
+	pedestal+=corrected_tmp_.at(i);
+	nped++;
+      }
+    }
+    if(nped>0){
+      pedestal=pedestal/nped;
+      pedestal_unc=sqrt(pedestal)/nped;
+    }
+    for(size_t i=0; i<LumiConstants::numBX; i++){
+      corrected_tmp_.at(i)=corrected_tmp_.at(i)-pedestal;
+    }
+
     evaluateCorrectionResiduals(corrected_tmp_);
 
     float integral_uncorr_clusters=0;
     float integral_corr_clusters = 0;
 
     //Calculate Per-BX correction factor and overall correction factor
-    float lumiMax = getMaximum(corrected_tmp_);
-    float threshold = lumiMax*0.2;
     for (size_t ibx=0; ibx<corrected_tmp_.size(); ibx++){
         if(corrected_tmp_.at(ibx)>threshold){
             integral_uncorr_clusters+=uncorrected.at(ibx);
@@ -584,6 +612,8 @@ void CorrPCCProducer::endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSe
         type1FracGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0,mean_type1_residual_unc);
         type1resGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0, mean_type1_residual_unc);
         type2resGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0, mean_type2_residual_unc);
+        pedestalGraph->SetPoint(iBlock,thisIOV+approxLumiBlockSize_/2.0,pedestal);
+	pedestalGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0,pedestal_unc);
 
         edm::LogInfo("INFO") <<"iBlock type1Frac mean_type1_residual mean_type2_residual mean_type1_residual_unc mean_type2_residual_unc "<<iBlock<<" "<<type1Frac<<" "<<mean_type1_residual<<" "<<mean_type2_residual<<" "<<mean_type1_residual_unc<<" "<<mean_type2_residual_unc;
 
@@ -592,6 +622,8 @@ void CorrPCCProducer::endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSe
         mean_type2_residual=0.0;
         mean_type1_residual_unc=0;
         mean_type2_residual_unc=0;
+	pedestal=0.;
+	pedestal_unc=0.;
 
         iBlock++;    
 
@@ -645,11 +677,14 @@ void CorrPCCProducer::endJob(){
     type1FracGraph->Write();
     type1resGraph->Write();
     type2resGraph->Write();
+    pedestalGraph->Write();
     histoFile->Write();
     histoFile->Close();
+
     delete type1FracGraph;
     delete type1resGraph;
     delete type2resGraph;
+    delete pedestalGraph;
 }
 
 DEFINE_FWK_MODULE(CorrPCCProducer);

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -129,7 +129,7 @@ class CorrPCCProducer : public DQMEDAnalyzer {
 
         float pedestal;
         float pedestal_unc;
-        TGraphErrors *pedestalGraph;
+        TGraphErrors* pedestalGraph;
 
         LumiCorrections* pccCorrections;
 
@@ -179,7 +179,7 @@ CorrPCCProducer::CorrPCCProducer(const edm::ParameterSet& iConfig)
     type1resGraph->SetMarkerStyle(8);
     type2resGraph->SetMarkerStyle(8);
 
-    pedestalGraph= new TGraphErrors();
+    pedestalGraph = new TGraphErrors();
     pedestalGraph->SetName("Pedestal");
     pedestalGraph->GetYaxis()->SetTitle("pedestal value (counts) per lumi section");
     pedestalGraph->GetXaxis()->SetTitle("Unique LS ID");
@@ -340,24 +340,24 @@ void CorrPCCProducer::calculateCorrections (std::vector<float> uncorrected, std:
     }
 
     float lumiMax = getMaximum(corrected_tmp_);
-    float threshold = lumiMax*0.2;
+    float threshold = lumiMax * 0.2;
 
     //here subtract the pedestal
-    pedestal=0.;
-    pedestal_unc=0.;
-    int nped=0;
-    for(size_t i=0; i<LumiConstants::numBX; i++){
-      if(corrected_tmp_.at(i)<threshold){
-	pedestal+=corrected_tmp_.at(i);
+    pedestal = 0.;
+    pedestal_unc = 0.;
+    int nped = 0;
+    for (size_t i = 0; i < LumiConstants::numBX; i++) {
+      if (corrected_tmp_.at(i) < threshold) {
+	pedestal += corrected_tmp_.at(i);
 	nped++;
       }
     }
-    if(nped>0){
-      pedestal_unc=sqrt(pedestal)/nped;
-      pedestal=pedestal/nped;
+    if (nped > 0) {
+      pedestal_unc = sqrt(pedestal) / nped;
+      pedestal = pedestal / nped;
     }
-    for(size_t i=0; i<LumiConstants::numBX; i++){
-      corrected_tmp_.at(i)=corrected_tmp_.at(i)-pedestal;
+    for (size_t i = 0; i < LumiConstants::numBX; i++) {
+      corrected_tmp_.at(i) = corrected_tmp_.at(i) - pedestal;
     }
 
     evaluateCorrectionResiduals(corrected_tmp_);
@@ -612,8 +612,8 @@ void CorrPCCProducer::endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSe
         type1FracGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0,mean_type1_residual_unc);
         type1resGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0, mean_type1_residual_unc);
         type2resGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0, mean_type2_residual_unc);
-        pedestalGraph->SetPoint(iBlock,thisIOV+approxLumiBlockSize_/2.0,pedestal);
-	pedestalGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0,pedestal_unc);
+        pedestalGraph->SetPoint(iBlock, thisIOV + approxLumiBlockSize_ / 2.0, pedestal);
+	pedestalGraph->SetPointError(iBlock, approxLumiBlockSize_ / 2.0, pedestal_unc);
 
         edm::LogInfo("INFO") <<"iBlock type1Frac mean_type1_residual mean_type2_residual mean_type1_residual_unc mean_type2_residual_unc "<<iBlock<<" "<<type1Frac<<" "<<mean_type1_residual<<" "<<mean_type2_residual<<" "<<mean_type1_residual_unc<<" "<<mean_type2_residual_unc;
 
@@ -622,8 +622,8 @@ void CorrPCCProducer::endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSe
         mean_type2_residual=0.0;
         mean_type1_residual_unc=0;
         mean_type2_residual_unc=0;
-	pedestal=0.;
-	pedestal_unc=0.;
+	pedestal = 0.;
+	pedestal_unc = 0.;
 
         iBlock++;    
 


### PR DESCRIPTION
#### PR description:
PCC luminosity is corrected for  pedestal noise, mainly affecting low inst. lumi runs.
See presentation here (slide 4):
https://indico.cern.ch/event/845626/contributions/3551341/attachments/1901149/3138360/PCC_2017G.pdf

The code also includes a TGraph to check the pedestal value vs lumi section similar to the type1,2 corrections.

#### PR validation:
The code has been tested in local installation of 10_2_2, used for 2018 PCC luminosity. 

### 
The code should be ported forward to the master.
