### PR TITLE
Update Run3 Tracker (Pixel and Strips) conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,13 +68,13 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_11_20_20_35_10', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2019_11_20_20_40_41',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_11_20_20_46_21', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_11_20_20_47_22', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v2'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -72,7 +72,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for P666hase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2019_10_31_12_19_14',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_10_31_12_16_57', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_11_04_22_24_44', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_10_31_12_18_03', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,13 +68,13 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
-    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_10_31_12_09_00', # GT containing realistic conditions for Phase1 2021
+    # GlobalTag for MC production (cosmics) with realistic conditions for P666hase1 2021,  Strip tracker in DECO mode
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2019_10_31_12_19_14',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v5', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_10_31_12_16_57', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v5', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_10_31_12_18_03', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v2'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -69,7 +69,7 @@ autoCond = {
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
     'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_10_31_12_09_00', # GT containing realistic conditions for Phase1 2021
-    # GlobalTag for MC production (cosmics) with realistic conditions for P666hase1 2021,  Strip tracker in DECO mode
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2019_10_31_12_19_14',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_11_04_22_24_44', # GT containing realistic conditions for Phase1 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,13 +68,13 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_10_31_12_09_00', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2019_11_20_20_35_10', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2019_10_31_12_19_14',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2019_11_20_20_40_41',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_11_04_22_24_44', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2019_11_20_20_46_21', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_10_31_12_18_03', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2019_11_20_20_47_22', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v2'
 }

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -42,7 +42,7 @@ def _modifyPixelDigitizerForRun3( digitizer ):
 
     digitizer.ThresholdInElectrons_FPix = cms.double(1600.0)
     digitizer.ThresholdInElectrons_BPix = cms.double(1600.0)
-    digitizer.ThresholdInElectrons_BPix_L1 = cms.double(1300.0)
+    digitizer.ThresholdInElectrons_BPix_L1 = cms.double(2000.0)
     digitizer.ThresholdInElectrons_BPix_L2 = cms.double(1600.0)
 
 SiPixelSimBlock = cms.PSet(


### PR DESCRIPTION
#### PR description:

The aim of this PR is to update the conditions used for the simulation of Run3 (all three years: 2021, 2023, 2024), correcting few mistakes, inaccuracies observed in the previous round of MC production in 10.6.X.
Namely:
   * the Pixel digitizer threshold is updated in BPix L1 from the unrealistic (too optimistic) threshold of 1300e to 2000e (more in line with lab measurement, see details [here](https://indico.cern.ch/event/841666/contributions/3586406/)).
   * the Pixel CPE conditions are all updated taking into account the updated digi threshold.
   * the Strip conditions are updated using the latest updates introduced for 2018 simulation introduced in PR #28234.
   * the Strip noise extrapolation has been re-done using the updated value for 2018, which yields better Data/MC agreement for 2018 simulation.

#### PR validation:

Extensive validation through production of dedicated private samples has been carried out within the Tracker DPG. A full report has been gathered [here](https://indico.cern.ch/event/841678/?showDate=all&showSession=6#33-feedback-on-the-new-run-3-c).
In addition the alignment performance of the previous misalignment scenario has been checked using samples produced with the updated conditions, and a compelling reason to update it has not been found (report is available [here](https://indico.cern.ch/event/841678/?showDate=all&showSession=0#36-run-iii-studies-virtual)).

#### if this PR is a backport please specify the original PR:

This PR is not a backport, though possibly updated GTs in 10.6.X will be requested as well for further samples production.
Cc:
@tsusa @tvami @pieterdavid @robervalwalsh @connorpa @adewit 
