### PR TITLE
Make HLTHighLevel a stream module

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTHighLevel.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTHighLevel.cc
@@ -41,7 +41,6 @@ HLTHighLevel::HLTHighLevel(const edm::ParameterSet& iConfig)
       andOr_(iConfig.getParameter<bool>("andOr")),
       throw_(iConfig.getParameter<bool>("throw")),
       eventSetupPathsKey_(iConfig.getParameter<std::string>("eventSetupPathsKey")),
-      watchAlCaRecoTriggerBitsRcd_(nullptr),
       HLTPatterns_(iConfig.getParameter<std::vector<std::string> >("HLTPaths")),
       HLTPathsByName_(),
       HLTPathsByIndex_() {
@@ -57,12 +56,8 @@ HLTHighLevel::HLTHighLevel(const edm::ParameterSet& iConfig)
           << HLTPatterns_.size() << " HLTPaths and\n"
           << " eventSetupPathsKey " << eventSetupPathsKey_ << ", choose either of them.";
     }
-    watchAlCaRecoTriggerBitsRcd_ = new edm::ESWatcher<AlCaRecoTriggerBitsRcd>;
+    watchAlCaRecoTriggerBitsRcd_.emplace();
   }
-}
-
-HLTHighLevel::~HLTHighLevel() {
-  delete watchAlCaRecoTriggerBitsRcd_;  // safe on null pointer...
 }
 
 //

--- a/HLTrigger/HLTfilters/plugins/HLTHighLevel.h
+++ b/HLTrigger/HLTfilters/plugins/HLTHighLevel.h
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
@@ -30,6 +31,8 @@ namespace edm {
   class ConfigurationDescriptions;
   class TriggerResults;
 }  // namespace edm
+
+class AlCaRecoTriggerBits;
 class AlCaRecoTriggerBitsRcd;
 
 //
@@ -76,6 +79,8 @@ private:
   const std::string eventSetupPathsKey_;
   /// Watcher to be created and used if 'eventSetupPathsKey_' non empty:
   std::optional<edm::ESWatcher<AlCaRecoTriggerBitsRcd>> watchAlCaRecoTriggerBitsRcd_;
+  /// ESGetToken to read AlCaRecoTriggerBits
+  edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> alcaRecotriggerBitsToken_;
 
   /// input patterns that will be expanded into trigger names
   std::vector<std::string> HLTPatterns_;

--- a/HLTrigger/HLTfilters/plugins/HLTHighLevel.h
+++ b/HLTrigger/HLTfilters/plugins/HLTHighLevel.h
@@ -15,10 +15,11 @@
 // C++ headers
 #include <vector>
 #include <string>
+#include <optional>
 
 // CMSSW headers
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Common/interface/TriggerNames.h"
@@ -35,10 +36,9 @@ class AlCaRecoTriggerBitsRcd;
 // class declaration
 //
 
-class HLTHighLevel : public edm::EDFilter {
+class HLTHighLevel : public edm::stream::EDFilter<> {
 public:
   explicit HLTHighLevel(const edm::ParameterSet &);
-  ~HLTHighLevel() override;
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   bool filter(edm::Event &, const edm::EventSetup &) override;
@@ -75,7 +75,7 @@ private:
   /// not empty => use read paths from AlCaRecoTriggerBitsRcd via this key
   const std::string eventSetupPathsKey_;
   /// Watcher to be created and used if 'eventSetupPathsKey_' non empty:
-  edm::ESWatcher<AlCaRecoTriggerBitsRcd> *watchAlCaRecoTriggerBitsRcd_;
+  std::optional<edm::ESWatcher<AlCaRecoTriggerBitsRcd>> watchAlCaRecoTriggerBitsRcd_;
 
   /// input patterns that will be expanded into trigger names
   std::vector<std::string> HLTPatterns_;


### PR DESCRIPTION
#### PR description:

In the context of https://github.com/cms-sw/cmssw/issues/25090, this PR makes HLTHighLevel a stream EDFilter instead of legacy, and in addition
- replaces a raw pointer with `std::optional`
- uses ESGetToken to access `AlCaRecoTriggerBits` from the EventSetup

#### PR validation:

Limited matrix runs.