### PR TITLE
remove MTD 'fastsim' modules

### DIFF
--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -36,9 +36,7 @@ _phase2_tktiming_RecoVertexEventContent = [ 'keep *_offlinePrimaryVertices4D__*'
 
 _phase2_tktiming_layer_RecoVertexEventContent = [ 'keep *_offlinePrimaryVertices4DnoPID__*',
                                             'keep *_offlinePrimaryVertices4DnoPIDWithBS__*',
-                                            'keep *_tofPID_*_*',
-                                            'keep *_offlinePrimaryVertices4Dfastsim__*',
-                                            'keep *_offlinePrimaryVertices4DfastsimWithBS__*']
+                                            'keep *_tofPID_*_*']
 
 def _phase2_tktiming_AddNewContent(mod):
     temp = mod.outputCommands + _phase2_tktiming_RecoVertexEventContent

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -46,11 +46,6 @@ from RecoVertex.Configuration.RecoVertex_phase2_timing_cff import (tpClusterProd
                                                                   offlinePrimaryVertices4DwithPID ,
                                                                   offlinePrimaryVertices4DwithPIDWithBS,
                                                                   tofPID,
-                                                                  unsortedOfflinePrimaryVertices4Dfastsim,
-                                                                  trackWithVertexRefSelectorBeforeSorting4Dfastsim ,
-                                                                  trackRefsForJetsBeforeSorting4Dfastsim ,
-                                                                  offlinePrimaryVertices4Dfastsim,
-                                                                  offlinePrimaryVertices4DfastsimWithBS,
                                                                   unsortedOfflinePrimaryVertices4D,
                                                                   trackWithVertexRefSelectorBeforeSorting4D,
                                                                   trackRefsForJetsBeforeSorting4D,
@@ -75,11 +70,6 @@ _phase2_tktiming_layer_vertexrecoTask = cms.Task( _phase2_tktiming_vertexrecoTas
                                             offlinePrimaryVertices4DnoPID ,
                                             offlinePrimaryVertices4DnoPIDWithBS,
                                             tofPID,
-                                            unsortedOfflinePrimaryVertices4Dfastsim,
-                                            trackWithVertexRefSelectorBeforeSorting4Dfastsim ,
-                                            trackRefsForJetsBeforeSorting4Dfastsim ,
-                                            offlinePrimaryVertices4Dfastsim,
-                                            offlinePrimaryVertices4DfastsimWithBS,
                                             )
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing

--- a/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
@@ -44,15 +44,6 @@ offlinePrimaryVertices4DwithPID=offlinePrimaryVertices4D.clone(vertices="unsorte
                                                      trackTimeResoTag="tofPID:sigmat0safe")
 offlinePrimaryVertices4DwithPIDWithBS=offlinePrimaryVertices4DwithPID.clone(vertices="unsortedOfflinePrimaryVertices4DwithPID:WithBS")
 
-unsortedOfflinePrimaryVertices4Dfastsim = unsortedOfflinePrimaryVertices4D.clone()
-trackWithVertexRefSelectorBeforeSorting4Dfastsim = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices4Dfastsim",
-                                                                                    ptMax=9e99,
-                                                                                    ptErrorCut=9e99)
-trackRefsForJetsBeforeSorting4Dfastsim = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting4Dfastsim")
-offlinePrimaryVertices4Dfastsim=offlinePrimaryVertices4D.clone(vertices="unsortedOfflinePrimaryVertices4Dfastsim",
-                                                            particles="trackRefsForJetsBeforeSorting4Dfastsim")
-offlinePrimaryVertices4DfastsimWithBS=offlinePrimaryVertices4Dfastsim.clone(vertices="unsortedOfflinePrimaryVertices4Dfastsim:WithBS")
-
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import tpClusterProducer
 from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import quickTrackAssociatorByHits
 from SimTracker.TrackAssociation.trackTimeValueMapProducer_cfi import trackTimeValueMapProducer


### PR DESCRIPTION
#### PR description:

This PR removes CPU-heavy 4D vertexing modules that use the MTD 'fastsim' time smearing (not to be confused with the actual CMS fast simulation, to which it has no relation). These are no longer required for any purpose, but still consume ~10% of Phase 2 reconstruction CPU time in 200PU.

This PR should be followed up by a reassessment of the usage of `TrackTimeValueMapProducer`, which provides the time smearing inputs (and, in principle, is no longer actually used anywhere).

#### PR validation:

Ran workflow 20434.0 successfully.