### PR TITLE
Fix a crash in edm::checkForModuleDependencyCorrectness() in case of Path with Task but no direct modules

### DIFF
--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -333,6 +333,12 @@ namespace edm {
         }
       }
     }
-    graph::throwIfImproperDependencies(edgeToPathMap, pathIndexToModuleIndexOrder, pathNames, moduleIndexToNames);
+    // Don't bother if there are no modules in any paths (the
+    // dependence check crashes if the configuration has only Paths
+    // with Tasks with modules, but nothing to trigger any work to
+    // run)
+    if (not moduleIndexToPathIndex.empty()) {
+      graph::throwIfImproperDependencies(edgeToPathMap, pathIndexToModuleIndexOrder, pathNames, moduleIndexToNames);
+    }
   }
 }  // namespace edm

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -321,6 +321,10 @@
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test transition_test.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
+<bin   name="TestFWCoreFrameworkEmptyPath" file="TestDriver.cpp">
+  <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_emptyPath.sh"/>
+  <use   name="FWCore/Utilities"/>
+</bin>
 <bin file="test_catch2_main.cc,test_catch2notTP_*.cc" name="TestFWCoreFrameworkCatch2notTP">
   <use name="catch2"/>
   <use   name="FWCore/Framework"/>

--- a/FWCore/Framework/test/test_emptyEndPathWithTask_cfg.py
+++ b/FWCore/Framework/test/test_emptyEndPathWithTask_cfg.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.intProducer1 = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1"))
+
+process.ep = cms.EndPath(cms.Task(process.intProducer1, process.intProducer2))

--- a/FWCore/Framework/test/test_emptyPath.sh
+++ b/FWCore/Framework/test/test_emptyPath.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${LOCAL_TEST_DIR}/test_emptyPathWithTask_cfg.py
+F2=${LOCAL_TEST_DIR}/test_emptyEndPathWithTask_cfg.py
+
+(cmsRun $F1 ) || die "Failure using $F1" $?
+(cmsRun $F2 ) || die "Failure using $F2" $?
+
+

--- a/FWCore/Framework/test/test_emptyPathWithTask_cfg.py
+++ b/FWCore/Framework/test/test_emptyPathWithTask_cfg.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.intProducer1 = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer1"))
+
+process.p = cms.Path(cms.Task(process.intProducer1, process.intProducer2))


### PR DESCRIPTION
#### PR description:

Fixes #27427.

#### PR validation:

Unit tests run
