### PR TITLE
Phase 2 tracker: template CPE

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
@@ -77,12 +77,12 @@ struct SiPixelGenErrorStore {  //!< template storage structure
   SiPixelGenErrorHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
   float cotbetaY[60];
-  float cotbetaX[5];
-  float cotalphaX[29];
+  float cotbetaX[60];
+  float cotalphaX[60];
   //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
   SiPixelGenErrorEntry enty[60];
   //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
-  SiPixelGenErrorEntry entx[5][29];
+  SiPixelGenErrorEntry entx[60][60];
 #else
   float* cotbetaY;
   float* cotbetaX;

--- a/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
@@ -81,7 +81,7 @@ struct SiPixelGenErrorStore {  //!< template storage structure
   float cotbetaY[TEMP_ENTRY_SIZEY];
   float cotbetaX[TEMP_ENTRY_SIZEX_B];
   float cotalphaX[TEMP_ENTRY_SIZEX_A];
-  //!< 60 y templates spanning cluster lengths from 0px to +18px 
+  //!< 60 y templates spanning cluster lengths from 0px to +18px
   SiPixelGenErrorEntry enty[TEMP_ENTRY_SIZEY];
   //!< 60 x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 60 slices
   SiPixelGenErrorEntry entx[TEMP_ENTRY_SIZEX_B][TEMP_ENTRY_SIZEX_A];
@@ -89,8 +89,8 @@ struct SiPixelGenErrorStore {  //!< template storage structure
   float* cotbetaY;
   float* cotbetaX;
   float* cotalphaX;
-  boost::multi_array<SiPixelGenErrorEntry, 1> enty;  //!< use 1d entry to store [60] entries 
-  //!< use 2d entry to store [60][60] entries 
+  boost::multi_array<SiPixelGenErrorEntry, 1> enty;  //!< use 1d entry to store [60] entries
+  //!< use 2d entry to store [60][60] entries
   boost::multi_array<SiPixelGenErrorEntry, 2> entx;
 #endif
 };

--- a/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelGenError.h
@@ -17,6 +17,8 @@
 #ifndef SiPixelGenError_h
 #define SiPixelGenError_h 1
 
+#include "SiPixelTemplateDefs.h"
+
 #include <vector>
 #include <cassert>
 #include "boost/multi_array.hpp"
@@ -76,19 +78,19 @@ struct SiPixelGenErrorHeader {  //!< template header structure
 struct SiPixelGenErrorStore {  //!< template storage structure
   SiPixelGenErrorHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
-  float cotbetaY[60];
-  float cotbetaX[60];
-  float cotalphaX[60];
-  //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
-  SiPixelGenErrorEntry enty[60];
-  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
-  SiPixelGenErrorEntry entx[60][60];
+  float cotbetaY[TEMP_ENTRY_SIZEY];
+  float cotbetaX[TEMP_ENTRY_SIZEX_B];
+  float cotalphaX[TEMP_ENTRY_SIZEX_A];
+  //!< 60 y templates spanning cluster lengths from 0px to +18px 
+  SiPixelGenErrorEntry enty[TEMP_ENTRY_SIZEY];
+  //!< 60 x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 60 slices
+  SiPixelGenErrorEntry entx[TEMP_ENTRY_SIZEX_B][TEMP_ENTRY_SIZEX_A];
 #else
   float* cotbetaY;
   float* cotbetaX;
   float* cotalphaX;
-  boost::multi_array<SiPixelGenErrorEntry, 1> enty;  //!< use 1d entry to store [60] barrel entries or [28] fpix entries
-  //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
+  boost::multi_array<SiPixelGenErrorEntry, 1> enty;  //!< use 1d entry to store [60] entries 
+  //!< use 2d entry to store [60][60] entries 
   boost::multi_array<SiPixelGenErrorEntry, 2> entx;
 #endif
 };

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -207,12 +207,12 @@ struct SiPixelTemplateStore {  //!< template storage structure
   SiPixelTemplateHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
   float cotbetaY[60];
-  float cotbetaX[5];
-  float cotalphaX[29];
+  float cotbetaX[60];
+  float cotalphaX[60];
   //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
   SiPixelTemplateEntry enty[60];
   //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
-  SiPixelTemplateEntry entx[5][29];
+  SiPixelTemplateEntry entx[60][60];
   void destroy(){};
 #else
   float* cotbetaY = nullptr;

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -206,20 +206,20 @@ struct SiPixelTemplateHeader {  //!< template header structure
 struct SiPixelTemplateStore {  //!< template storage structure
   SiPixelTemplateHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
-  float cotbetaY[60];
-  float cotbetaX[60];
-  float cotalphaX[60];
-  //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
-  SiPixelTemplateEntry enty[60];
-  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
-  SiPixelTemplateEntry entx[60][60];
+  float cotbetaY[TEMP_ENTRY_SIZEY];
+  float cotbetaX[TEMP_ENTRY_SIZEX_B];
+  float cotalphaX[TEMP_ENTRY_SIZEX_A];
+  //!< 60 y templates spanning cluster lengths from 0px to +18px
+  SiPixelTemplateEntry enty[TEMP_ENTRY_SIZEY];
+  //!< 60 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 60 slices
+  SiPixelTemplateEntry entx[TEMP_ENTRY_SIZEX_B][TEMP_ENTRY_SIZEX_A];
   void destroy(){};
 #else
   float* cotbetaY = nullptr;
   float* cotbetaX = nullptr;
   float* cotalphaX = nullptr;
-  boost::multi_array<SiPixelTemplateEntry, 1> enty;  //!< use 1d entry to store [60] barrel entries or [28] fpix entries
-  //!< use 2d entry to store [5][29] barrel entries or [3][29] fpix entries
+  boost::multi_array<SiPixelTemplateEntry, 1> enty;  //!< use 1d entry to store [60] entries
+  //!< use 2d entry to store [60][60] entries
   boost::multi_array<SiPixelTemplateEntry, 2> entx;
   void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
     if (cotbetaY != nullptr)

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
@@ -40,5 +40,7 @@
 #define T2HY 10          // = T2YSIZE/2
 #define T2HYP1 T2HY + 1  // = T2YSIZE/2+1
 #define T2HX 3           // = T2XSIZE/2
-
+#define TEMP_ENTRY_SIZEX_A 60
+#define TEMP_ENTRY_SIZEX_B 60
+#define TEMP_ENTRY_SIZEY 60
 #endif

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -13,39 +13,45 @@ allTags={}
 
 
 allTags["LA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v1_mc'  ,SiPixelLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v1_mc' ,SiPixelLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v1_mc' ,SiPixelLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v2_mc'  ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T16' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T16_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
 }
 
 allTags["LAWidth"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc'  ,SiPixelLARecord,connectionString, "forWidth", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc' ,SiPixelLARecord,connectionString, "forWidth", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc' ,SiPixelLARecord,connectionString, "forWidth", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_mc_forWidthEmpty'  ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T16' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T16_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),
 }
 
 allTags["LAfromAlignment"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc'  ,SiPixelLARecord,connectionString, "fromAlignment", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_mc_forWidthEmpty'  ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T16' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T16_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ), 
 }
 
 allTags["SimLA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v1_mc'  ,SiPixelSimLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v2_mc'  ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T16' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T16_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),
 }
 
 allTags["GenError"] = {
-    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v0_mc_100x25'  ,SiPixelGenErrorRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v0_mc_100x25' ,SiPixelGenErrorRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v0_mc_100x25' ,SiPixelGenErrorRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v2_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T16' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T16_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),
 }
 
 allTags["Template"] = {
-    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v0_mc_100x25'  ,SiPixelTemplatesRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v0_mc_100x25' ,SiPixelTemplatesRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v0_mc_100x25' ,SiPixelTemplatesRecord,connectionString, "" , "2019-09-16 20:00:00.000"] ), ), # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v2_mc'  ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v2_mc' ,SiPixelTemplatesRecord,connectionString, "" , "2019-11-05 20:00:00.000"] ), ), # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T16' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T16_v2_mc' ,SiPixelTemplatesRecord,connectionString, "" , "2019-11-05 20:00:00.000"] ), ),
 }
 
 ##
@@ -68,7 +74,7 @@ allTags["Template2Dden"] = {
 activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template"]
 
 # list of geometries supported
-activeDets = ["T6","T14","T15"]
+activeDets = ["T6","T14","T15","T16"]
 phase2GTs = {}
 for det in activeDets:
     appendedTags = ()

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -13,38 +13,44 @@ allTags={}
 
 
 allTags["LA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v0_mc'  ,SiPixelLARecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v0_mc' ,SiPixelLARecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v0_mc' ,SiPixelLARecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v1_mc'  ,SiPixelLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v1_mc' ,SiPixelLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v1_mc' ,SiPixelLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
 }
 
 allTags["LAWidth"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc'  ,SiPixelLARecord,connectionString, "forWidth", "2019-07-15 12:00:00.000"] ), ),
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc' ,SiPixelLARecord,connectionString, "forWidth", "2019-07-15 12:00:00.000"] ), ),
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc' ,SiPixelLARecord,connectionString, "forWidth", "2019-07-15 12:00:00.000"] ), ),
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc'  ,SiPixelLARecord,connectionString, "forWidth", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc' ,SiPixelLARecord,connectionString, "forWidth", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc' ,SiPixelLARecord,connectionString, "forWidth", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+}
+
+allTags["LAfromAlignment"] = {
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T6_v0_mc'  ,SiPixelLARecord,connectionString, "fromAlignment", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T14_v0_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_forWidth_T15_v0_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2019-09-16 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
 }
 
 allTags["SimLA"] = {
-    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v0_mc'  ,SiPixelSimLARecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v0_mc' ,SiPixelSimLARecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v0_mc' ,SiPixelSimLARecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
+    'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v1_mc'  ,SiPixelSimLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
+}
+
+allTags["GenError"] = {
+    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v0_mc_100x25'  ,SiPixelGenErrorRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v0_mc_100x25' ,SiPixelGenErrorRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v0_mc_100x25' ,SiPixelGenErrorRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+}
+
+allTags["Template"] = {
+    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v0_mc_100x25'  ,SiPixelTemplatesRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v0_mc_100x25' ,SiPixelTemplatesRecord,connectionString, "", "2019-09-16 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v0_mc_100x25' ,SiPixelTemplatesRecord,connectionString, "" , "2019-09-16 20:00:00.000"] ), ), # cell is 25um (local-x) x 100um (local-y) , VBias=350V
 }
 
 ##
 ## All of the following conditions are not yet in active use, but will be activated in GT along the way
 ##
-
-allTags["GenError"] = {
-    'T6'  : ( ','.join( [ 'SiPixelGenErrorDBOject_phase2_T6_v0_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T14' : ( ','.join( [ 'SiPixelGenErrorDBOject_phase2_T14_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBOject_phase2_T15_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-}
-
-allTags["Template"] = {
-    'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v0_mc'  ,SiPixelTemplatesRecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v0_mc' ,SiPixelTemplatesRecord,connectionString, "", "2019-07-15 12:00:00.000"] ), ),
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v0_mc' ,SiPixelTemplatesRecord,connectionString, "" , "2019-07-15 12:00:00.000"] ), ),
-}
 
 allTags["Template2Dnum"] = {
     'T6'  : ( ','.join( [ 'SiPixel2DTemplateDBObject_phase2_T6_v0_num'  ,SiPixel2DTemplatesRecord,connectionString, "numerator", "2019-07-15 12:00:00.000"] ), ),
@@ -59,7 +65,7 @@ allTags["Template2Dden"] = {
 }
 
 # list of active tags to be replaced
-activeKeys = ["LA","LAWidth","SimLA"]
+activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template"]
 
 # list of geometries supported
 activeDets = ["T6","T14","T15"]
@@ -70,7 +76,7 @@ for det in activeDets:
        appendedTags += allTags[key][det]
     phase2GTs["phase2_realistic_"+det] = ('phase2_realistic', appendedTags)
 
-# method called in autoAlCa
+# method called in autoCond
 def autoCondPhase2(autoCond):
     for key,val in six.iteritems(phase2GTs):
         if len(val)==1 :

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -25,9 +25,9 @@ allTags["LAWidth"] = {
 }
 
 allTags["LAfromAlignment"] = {
-    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_mc_forWidthEmpty'  ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
-    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
-    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_mc_forWidthEmpty'  ,SiPixelLARecord,connectionString, "fromAlignment", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "fromAlignment", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
+    'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "fromAlignment", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
 }
 
 allTags["SimLA"] = {

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -16,42 +16,36 @@ allTags["LA"] = {
     'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_v2_mc'  ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.106/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T16' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T16_v2_mc' ,SiPixelLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
 }
 
 allTags["LAWidth"] = {
     'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_mc_forWidthEmpty'  ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
-    'T16' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T16_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),
 }
 
 allTags["LAfromAlignment"] = {
     'T6'  : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T6_mc_forWidthEmpty'  ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
     'T14' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T14_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
     'T15' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T15_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ),  # uH=0.0/T (not in use)
-    'T16' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T16_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2019-11-05 20:00:00.000"] ), ), 
 }
 
 allTags["SimLA"] = {
     'T6'  : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T6_v2_mc'  ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T14' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T14_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T15' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ), #uH = 0.0431/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T16' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T16_v2_mc' ,SiPixelSimLARecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),
 }
 
 allTags["GenError"] = {
     'T6'  : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T6_v2_mc'  ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T14' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T14_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T16' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T16_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),
 }
 
 allTags["Template"] = {
     'T6'  : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T6_v2_mc'  ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T14' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T14_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2019-11-05 20:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v2_mc' ,SiPixelTemplatesRecord,connectionString, "" , "2019-11-05 20:00:00.000"] ), ), # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T16' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T16_v2_mc' ,SiPixelTemplatesRecord,connectionString, "" , "2019-11-05 20:00:00.000"] ), ),
 }
 
 ##
@@ -74,7 +68,7 @@ allTags["Template2Dden"] = {
 activeKeys = ["LA","LAWidth","SimLA","LAfromAlignment","GenError","Template"]
 
 # list of geometries supported
-activeDets = ["T6","T14","T15","T16"]
+activeDets = ["T6","T14","T15"]
 phase2GTs = {}
 for det in activeDets:
     appendedTags = ()

--- a/DQM/TrackingMonitor/python/trackingRecoMaterialAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/trackingRecoMaterialAnalyzer_cfi.py
@@ -20,9 +20,6 @@ materialDumperAnalyzer = DQMEDAnalyzer('TrackingRecoMaterialAnalyser',
                                         PropagatorOpposite = cms.string("RungeKuttaTrackerPropagatorOpposite")
 )
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(materialDumperAnalyzer, TrackerRecHitBuilder='WithTrackAngle')
-
 materialDumper = cms.Sequence(materialDumperAnalyzer)
 materialDumper_step = cms.Path(materialDumper)
 

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -43,10 +43,6 @@ _fastSim_lowPtGsfElectronSeeds.PreIdLabel = cms.vstring("","HCAL")
 _fastSim_lowPtGsfElectronSeeds.PreGsfLabel = cms.string("")
 fastSim.toReplaceWith(lowPtGsfElectronSeeds,_fastSim_lowPtGsfElectronSeeds)
 
-# Modifiers for Phase2
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(lowPtGsfElectronSeeds, TTRHBuilder  = 'WithTrackAngle')
-
 # Modifiers for BParking
 from Configuration.Eras.Modifier_bParking_cff import bParking
 bParking.toModify(lowPtGsfElectronSeeds, ModelThresholds = thresholds("VL") )

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -3,10 +3,3 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.SiPixelRecHits._templates2_default_cfi import _templates2_default
 templates2 = _templates2_default.clone()
 
-# This customization will be removed once we get the templates for phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(templates2,
-  LoadTemplatesFromDB = False,
-  DoLorentz = False,
-)
-

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -8,14 +8,3 @@ PixelCPEGenericESProducer = _generic_default.clone()
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(PixelCPEGenericESProducer, IrradiationBiasCorrection = True)
 
-# This customization will be removed once we get the templates for phase2 pixel
-# FIXME::Is the Upgrade variable actually used?
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(PixelCPEGenericESProducer, 
-  UseErrorsFromTemplates = False,
-  LoadTemplatesFromDB = False,
-  TruncatePixelCharge = False,
-  IrradiationBiasCorrection = False,
-  DoCosmics = False,
-  Upgrade = cms.bool(True)
-)

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPETemplateReco_cfi.py
@@ -3,10 +3,3 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.SiPixelRecHits._templates_default_cfi import _templates_default
 templates = _templates_default.clone()
 
-# This customization will be removed once we get the templates for phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(templates,
-  LoadTemplatesFromDB = False,
-  DoLorentz = False,
-)
-

--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -55,7 +55,3 @@ displacedTracksTask = cms.Task(
     )
 displacedTracksSequence = cms.Sequence(displacedTracksTask)
 
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(duplicateDisplacedTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -53,11 +53,6 @@ GlobalMuonRefitter = cms.PSet(
     RefitFlag = cms.bool( True )
 )
 
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(GlobalMuonRefitter, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME
-
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 # FastSim doesn't use Runge Kute for propagation
 fastSim.toModify(GlobalMuonRefitter, Propagator = "SmartPropagatorAny")

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -79,11 +79,3 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         ),
 )
 
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(GlobalTrajectoryBuilderCommon, # FIXME
-    TrackerRecHitBuilder = 'WithTrackAngle',
-    TrackTransformer = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
-    GlbRefitterParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
-)

--- a/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
+++ b/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
@@ -19,8 +19,3 @@ TrackerKinkFinderParametersBlock = cms.PSet(
     )
 )
 
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(TrackerKinkFinderParametersBlock, TrackerKinkFinderParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle')) # FIXME
-

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -88,8 +88,3 @@ MuonTrackLoaderForCosmic = cms.PSet(
     )
 )
 
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(MuonTrackLoaderForGLB, TrackLoaderParameters = dict(TTRHBuilder = 'WithTrackAngle')) # FIXME
-

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
@@ -49,11 +49,6 @@ trackerDrivenElectronSeeds = cms.EDProducer("GoodSeedProducer",
     Min_dr = cms.double(0.2)
 )
 
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(trackerDrivenElectronSeeds, TTRHBuilder  = 'WithTrackAngle') # FIXME
-
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 for e in [pp_on_XeXe_2017, pp_on_AA_2018]:

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -30,10 +30,6 @@ duplicateTrackClassifier.mva.maxChi2n = [10.,1.0,0.4]  # [9999.,9999.,9999.]
 duplicateTrackClassifier.mva.minLayers = [0,0,0]
 duplicateTrackClassifier.mva.min3DLayers = [0,0,0]
 duplicateTrackClassifier.mva.maxLostLayers = [99,99,99]
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(duplicateTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
 
 generalTracks = DuplicateListMerger.clone()
 generalTracks.originalSource = cms.InputTag("preDuplicateMergingGeneralTracks")

--- a/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
@@ -21,9 +21,3 @@ inOutSeedsFromTrackerMuons = cms.EDProducer("MuonReSeeder",
     RefitRPCHits = cms.bool(True),
     Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
 )
-
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(inOutSeedsFromTrackerMuons, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME
-

--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -26,9 +26,3 @@ TrackProducer = cms.EDProducer("TrackProducer",
     MeasurementTracker = cms.string(''),
     MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent'),                   
 )
-
-# This customization will be removed once we get the templates for
-# phase2 pixel
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(TrackProducer, TTRHBuilder = 'WithTrackAngle') # FIXME
-


### PR DESCRIPTION
#### PR description:

This PR integrates the template method for the pixel hit reconstruction in the Cluster Parameter Estimators (CPEs) for Phase 2. The templates have been produced for 5 different geometries in a "temporary" configuration that has been described in detail here [1]. The PR introduces the following changes:

1.  Provide phase 2 conditions for geometries: T5, T6, T14, T15, T16 with latest DB conditions.
2.  Remove phase 2 customizations forcing CPE generic method.
3. Increase array sizes to allow for larger angle space of the phase 2 templates.

@mmusich @tsusa @OzAmram @tvami

#### PR validation:

Tested with phase 2 workflows: `runTheMatrix.py --what upgrade -l 20007.0,20407.0,20807.0,21607.0,22007.0,22807.0,22834.0  -t 4 -j 8`.

The template method for pixel hit residuals has been also tested running the reconstruction step for 100K events and results will be shown here [2]. Since the templates have been produced under "temporary" conditions, we do not expect a big change in the resolution results obtained with this method.

[1] https://indico.cern.ch/event/838960/contributions/3630543/attachments/1941870/3220114/CMS_phase2tem_Nov5.pdf
[2] https://indico.cern.ch/event/838961/

#### if this PR is a backport please specify the original PR:

NA