### PR TITLE
Make SiStripDCSFilter a stream module

### DIFF
--- a/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
@@ -19,7 +19,6 @@ class SiStripDCSStatus {
 public:
   SiStripDCSStatus(edm::ConsumesCollector&& iC) : SiStripDCSStatus(iC){};
   SiStripDCSStatus(edm::ConsumesCollector& iC);
-  ~SiStripDCSStatus();
 
   bool getStatus(edm::Event const& e, edm::EventSetup const& eSetup);
 
@@ -27,7 +26,6 @@ private:
   void initialise(edm::Event const& e, edm::EventSetup const& eSetup);
 
   bool TIBTIDinDAQ, TOBinDAQ, TECFinDAQ, TECBinDAQ;
-  bool statusTIBTID, statusTOB, statusTECF, statusTECB;
   bool trackerAbsent;
   bool rawdataAbsent;
   bool initialised;

--- a/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
@@ -5,9 +5,15 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+class TrackerTopology;
+class TrackerTopologyRcd;
+class SiStripFedCabling;
+class SiStripFedCablingRcd;
 
 class SiStripDCSStatus {
 public:
@@ -28,6 +34,8 @@ private:
 
   edm::EDGetTokenT<DcsStatusCollection> dcsStatusToken_;
   edm::EDGetTokenT<FEDRawDataCollection> rawDataToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCablingToken_;
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
@@ -1,38 +1,25 @@
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h"
 
-#include <iostream>
 //
 // -- Class Deleration
 //
 
-class SiStripDCSFilter : public edm::EDFilter {
+class SiStripDCSFilter : public edm::stream::EDFilter<> {
 public:
   SiStripDCSFilter(const edm::ParameterSet&);
-  ~SiStripDCSFilter() override;
 
 private:
   bool filter(edm::Event&, edm::EventSetup const&) override;
-  SiStripDCSStatus* dcsStatus_;
+  SiStripDCSStatus dcsStatus_;
 };
 
 //
 // -- Constructor
 //
-SiStripDCSFilter::SiStripDCSFilter(const edm::ParameterSet& pset) {
-  dcsStatus_ = new SiStripDCSStatus(consumesCollector());
-}
-//
-// -- Destructor
-//
-SiStripDCSFilter::~SiStripDCSFilter() {
-  if (dcsStatus_)
-    delete dcsStatus_;
-}
+SiStripDCSFilter::SiStripDCSFilter(const edm::ParameterSet& pset) : dcsStatus_{consumesCollector()} {}
 
-bool SiStripDCSFilter::filter(edm::Event& evt, edm::EventSetup const& es) { return (dcsStatus_->getStatus(evt, es)); }
+bool SiStripDCSFilter::filter(edm::Event& evt, edm::EventSetup const& es) { return (dcsStatus_.getStatus(evt, es)); }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiStripDCSFilter);

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -36,10 +36,6 @@ SiStripDCSStatus::SiStripDCSStatus(edm::ConsumesCollector& iC)
   fedCablingToken_ = iC.esConsumes<SiStripFedCabling, SiStripFedCablingRcd>();
 }
 //
-// -- Destructor
-//
-SiStripDCSStatus::~SiStripDCSStatus() {}
-//
 // -- Get State
 //
 bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSetup) {
@@ -55,10 +51,10 @@ bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSe
   if ((*dcsStatus).empty())
     return retVal;
 
-  statusTIBTID = true;
-  statusTOB = true;
-  statusTECF = true;
-  statusTECB = true;
+  bool statusTIBTID = true;
+  bool statusTOB = true;
+  bool statusTECF = true;
+  bool statusTECB = true;
 
   bool dcsTIBTID = ((*dcsStatus)[0].ready(DcsStatus::TIBTID));
   bool dcsTOB = ((*dcsStatus)[0].ready(DcsStatus::TOB));


### PR DESCRIPTION
#### PR description:

In the context of #25090, this PR makes SiStripDCSFilter a stream EDFilter instead of legacy, and in addition
* uses ESGetToken
* removes unnecessary members of SiSTripDCSStatus class

#### PR validation:

Limited matrix runs.