### PR TITLE
Faster formatting of header for MessageLogger

### DIFF
--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -147,7 +147,8 @@ namespace edm {
       // stream info is first in the container
       // concurrent lumi info is next
       // concurrent run info is last
-      std::vector<std::string> transitionInfoCache_;
+      // The longest possible string needing to be cached is 51 chars
+      std::vector<std::array<char, 64>> transitionInfoCache_;
       unsigned int lumiInfoBegin_ = 0;
       unsigned int runInfoBegin_ = 0;
 

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -97,6 +97,11 @@
 
 #include <sstream>
 #include <limits>
+#include <algorithm>
+#include <type_traits>
+#include <cstring>
+#include <charconv>
+#include <cassert>
 
 using namespace edm;
 using namespace edm::service;
@@ -114,6 +119,31 @@ namespace {
       "@streamEndRun",
       "@endStream",
   };
+
+  char* fill_buffer(char* p, char*) { return p; }
+
+  template <typename T, typename... U>
+  char* fill_buffer(char* first, char* last, T value, U... u) {
+    if constexpr (std::is_arithmetic<T>::value) {
+      auto v = std::to_chars(first, last, value);
+      assert(v.ec == std::errc{});
+      return fill_buffer(v.ptr, last, std::forward<U>(u)...);
+    } else {
+      auto l = strlen(value);
+      assert(first + l < last);
+      std::copy(value, value + l, first);
+      return fill_buffer(first + l, last, std::forward<U>(u)...);
+    }
+  }
+
+  template <typename... T>
+  std::string_view fill_buffer(std::array<char, 64>& buffer, T... t) {
+    auto e = fill_buffer(buffer.begin(), buffer.end(), std::forward<T>(t)...);
+    assert(e < buffer.end());
+    *e = 0;
+    return std::string_view(buffer.begin(), e - buffer.begin() + 1);
+  }
+
 }  // namespace
 
 namespace edm {
@@ -368,7 +398,7 @@ namespace edm {
       // std::cerr << "establishModule( " << desc.moduleName() << ")\n";
       // Change Log 17
       auto const desc = mod.moduleDescription();
-      messageDrop->runEvent = transitionInfoCache_[transitionIndex];
+      messageDrop->runEvent = transitionInfoCache_[transitionIndex].begin();
       messageDrop->setModuleWithPhase(desc->moduleName(), desc->moduleLabel(), desc->id(), whichPhase);
       messageDrop->streamID = transitionIndex;
       if (transitionIndex >= lumiInfoBegin_) {
@@ -655,12 +685,11 @@ namespace edm {
     void MessageLogger::postFile(std::string const&, bool) { unEstablish("AfterFile"); }
 
     void MessageLogger::preEvent(StreamContext const& iContext) {
-      std::ostringstream ost;
-      auto const& id = iContext.eventID();
-      ost << "Run: " << id.run() << " Event: " << id.event();  // change log 2
       assert(iContext.streamID().value() < transitionInfoCache_.size());
-      transitionInfoCache_[iContext.streamID().value()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto& buffer = transitionInfoCache_[iContext.streamID().value()];
+      auto const& id = iContext.eventID();
+      auto v = fill_buffer(buffer, "Run: ", id.run(), " Event: ", id.event());
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreEventProcessing");  // changelog 17
           // Note - module name had not been set here  Similarly in other places where
           // RunEvent carries the new information; we add setSinglet for module name.
@@ -673,11 +702,10 @@ namespace edm {
 
     void MessageLogger::preStreamBeginRun(StreamContext const& iContext)  // change log 14
     {
-      std::ostringstream ost;
-      ost << "Run: " << iContext.eventID().run() << " Stream: " << iContext.streamID().value();
-      ;
-      transitionInfoCache_[iContext.streamID().value()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto& buffer = transitionInfoCache_[iContext.streamID().value()];
+      auto v = fill_buffer(buffer, "Run: ", iContext.eventID().run(), " Stream: ", iContext.streamID().value());
+
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreStreamBeginRun");  // changelog 17
     }
     void MessageLogger::postStreamBeginRun(StreamContext const&) {
@@ -687,11 +715,10 @@ namespace edm {
     }
 
     void MessageLogger::preStreamEndRun(StreamContext const& iContext) {
-      std::ostringstream ost;
-      ost << "End Run: " << iContext.eventID().run() << " Stream: " << iContext.streamID().value();
-      ;
-      transitionInfoCache_[iContext.streamID().value()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto& buffer = transitionInfoCache_[iContext.streamID().value()];
+      auto v = fill_buffer(buffer, "End Run: ", iContext.eventID().run(), " Stream: ", iContext.streamID().value());
+
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreStreamEndRun");  // changelog 17
     }
 
@@ -701,11 +728,11 @@ namespace edm {
     }
 
     void MessageLogger::preStreamBeginLumi(StreamContext const& iContext) {
-      std::ostringstream ost;
+      auto& buffer = transitionInfoCache_[iContext.streamID().value()];
       auto const& id = iContext.eventID();
-      ost << "Run: " << id.run() << " Lumi: " << id.luminosityBlock() << " Stream: " << iContext.streamID().value();
-      transitionInfoCache_[iContext.streamID().value()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto v = fill_buffer(
+          buffer, "Run: ", id.run(), " Lumi: ", id.luminosityBlock(), " Stream: ", iContext.streamID().value());
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreStreamBeginLumi");  // changelog 17
     }
 
@@ -715,12 +742,12 @@ namespace edm {
     }
 
     void MessageLogger::preStreamEndLumi(StreamContext const& iContext) {
-      std::ostringstream ost;
+      auto& buffer = transitionInfoCache_[iContext.streamID().value()];
       auto const& id = iContext.eventID();
-      ost << "Run: " << id.run() << " Lumi: " << id.luminosityBlock() << " Stream: " << iContext.streamID().value();
-      ;
-      transitionInfoCache_[iContext.streamID().value()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto v = fill_buffer(
+          buffer, "Run: ", id.run(), " Lumi: ", id.luminosityBlock(), " Stream: ", iContext.streamID().value());
+
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreStreamEndLumi");  // changelog 17
     }
     void MessageLogger::postStreamEndLumi(StreamContext const&) {
@@ -730,10 +757,9 @@ namespace edm {
 
     void MessageLogger::preGlobalBeginRun(GlobalContext const& iContext)  // change log 14
     {
-      std::ostringstream ost;
-      ost << "Run: " << iContext.luminosityBlockID().run();
-      transitionInfoCache_[runInfoBegin_ + iContext.runIndex()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto& buffer = transitionInfoCache_[runInfoBegin_ + iContext.runIndex()];
+      auto v = fill_buffer(buffer, "Run: ", iContext.luminosityBlockID().run());
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreGlobalBeginRun");  // changelog 17
     }
     void MessageLogger::postGlobalBeginRun(GlobalContext const&) {
@@ -745,7 +771,7 @@ namespace edm {
     void MessageLogger::prePathEvent(StreamContext const& stream, PathContext const& iPath)  // change log 14
     {
       auto messageDrop = edm::MessageDrop::instance();
-      messageDrop->runEvent = transitionInfoCache_[stream.streamID().value()];
+      messageDrop->runEvent = transitionInfoCache_[stream.streamID().value()].begin();
       messageDrop->setPath("PreProcPath ", iPath.pathName());
       // change log 17
     }
@@ -755,10 +781,9 @@ namespace edm {
     }
 
     void MessageLogger::preGlobalEndRun(GlobalContext const& iContext) {
-      std::ostringstream ost;
-      ost << "End Run: " << iContext.luminosityBlockID().run();
-      transitionInfoCache_[runInfoBegin_ + iContext.runIndex()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto& buffer = transitionInfoCache_[runInfoBegin_ + iContext.runIndex()];
+      auto v = fill_buffer(buffer, "End Run: ", iContext.luminosityBlockID().run());
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreGlobalEndRun");  // changelog 17
     }
 
@@ -768,11 +793,10 @@ namespace edm {
     }
 
     void MessageLogger::preGlobalBeginLumi(GlobalContext const& iContext) {
-      std::ostringstream ost;
+      auto& buffer = transitionInfoCache_[lumiInfoBegin_ + iContext.luminosityBlockIndex()];
       auto const& id = iContext.luminosityBlockID();
-      ost << "Run: " << id.run() << " Lumi: " << id.luminosityBlock();
-      transitionInfoCache_[lumiInfoBegin_ + iContext.luminosityBlockIndex()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto v = fill_buffer(buffer, "Run: ", id.run(), " Lumi: ", id.luminosityBlock());
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreGlobalBeginLumi");  // changelog 17
     }
 
@@ -782,11 +806,10 @@ namespace edm {
     }
 
     void MessageLogger::preGlobalEndLumi(GlobalContext const& iContext) {
-      std::ostringstream ost;
+      auto& buffer = transitionInfoCache_[lumiInfoBegin_ + iContext.luminosityBlockIndex()];
       auto const& id = iContext.luminosityBlockID();
-      ost << "Run: " << id.run() << " Lumi: " << id.luminosityBlock();
-      transitionInfoCache_[lumiInfoBegin_ + iContext.luminosityBlockIndex()] = ost.str();
-      edm::MessageDrop::instance()->runEvent = ost.str();
+      auto v = fill_buffer(buffer, "Run: ", id.run(), " Lumi: ", id.luminosityBlock());
+      edm::MessageDrop::instance()->runEvent = v;
       edm::MessageDrop::instance()->setSinglet("PreGlobalEndLumi");  // changelog 17
     }
     void MessageLogger::postGlobalEndLumi(GlobalContext const&) {


### PR DESCRIPTION
#### PR description:

Switch to using a fixed sized buffer and calls to std::to_chars to create the string that holds the transition id (i.e. run, luminosityblock and event ids) for messages.

igProf shows this is now 50x faster.

#### PR validation:

The FWCore/Framework and FWCore/MessageService unit tests all pass.