### PR TITLE
GEMMasking :: FixBug

### DIFF
--- a/RecoLocalMuon/GEMRecHit/interface/GEMClusterizer.h
+++ b/RecoLocalMuon/GEMRecHit/interface/GEMClusterizer.h
@@ -6,12 +6,13 @@
 
 #include "RecoLocalMuon/GEMRecHit/interface/GEMClusterContainer.h"
 #include "RecoLocalMuon/GEMRecHit/interface/GEMCluster.h"
+#include "RecoLocalMuon/GEMRecHit/interface/GEMEtaPartitionMask.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 
 class GEMClusterizer {
 public:
   GEMClusterizer(){};
   ~GEMClusterizer(){};
-  GEMClusterContainer doAction(const GEMDigiCollection::Range& digiRange);
+  GEMClusterContainer doAction(const GEMDigiCollection::Range& digiRange, const EtaPartitionMask& mask);
 };
 #endif

--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
@@ -108,13 +108,13 @@ void GEMRecHitProducer::beginRun(const edm::Run& r, const edm::EventSetup& setup
       for (const auto& tomask : theGEMMaskedStripsObj->getMaskVec()) {
         if (tomask.rawId == rawId) {
           const int bit = tomask.strip;
-          mask.set(bit - 1);
+          mask.set(bit);
         }
       }
       for (const auto& tomask : theGEMDeadStripsObj->getDeadVec()) {
         if (tomask.rawId == rawId) {
           const int bit = tomask.strip;
-          mask.set(bit - 1);
+          mask.set(bit);
         }
       }
       // add to masking map if masking present in etaPartition

--- a/RecoLocalMuon/GEMRecHit/src/GEMClusterizer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMClusterizer.cc
@@ -1,6 +1,6 @@
 #include "RecoLocalMuon/GEMRecHit/interface/GEMClusterizer.h"
 
-GEMClusterContainer GEMClusterizer::doAction(const GEMDigiCollection::Range& digiRange) {
+GEMClusterContainer GEMClusterizer::doAction(const GEMDigiCollection::Range& digiRange, const EtaPartitionMask& mask) {
   GEMClusterContainer initialCluster, finalCluster;
   // Return empty container for null input
   if (std::distance(digiRange.second, digiRange.first) == 0)
@@ -8,6 +8,8 @@ GEMClusterContainer GEMClusterizer::doAction(const GEMDigiCollection::Range& dig
 
   // Start from single digi recHits
   for (auto digi = digiRange.first; digi != digiRange.second; ++digi) {
+    if (mask.test(digi->strip()))
+      continue;
     GEMCluster cl(digi->strip(), digi->strip(), digi->bx());
     initialCluster.insert(cl);
   }

--- a/RecoLocalMuon/GEMRecHit/src/GEMMaskReClusterizer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMMaskReClusterizer.cc
@@ -31,4 +31,4 @@ GEMClusterContainer GEMMaskReClusterizer::doAction(const GEMDetId& id,
   return finClusters;
 }
 
-bool GEMMaskReClusterizer::get(const EtaPartitionMask& mask, int strip) const { return mask.test(strip - 1); }
+bool GEMMaskReClusterizer::get(const EtaPartitionMask& mask, int strip) const { return mask.test(strip); }

--- a/RecoLocalMuon/GEMRecHit/src/GEMMaskReClusterizer.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMMaskReClusterizer.cc
@@ -2,7 +2,6 @@
  *  \author J.C. Sanabria -- UniAndes, Bogota
  */
 #include "RecoLocalMuon/GEMRecHit/interface/GEMCluster.h"
-#include "RecoLocalMuon/GEMRecHit/interface/GEMClusterizer.h"
 #include "RecoLocalMuon/GEMRecHit/interface/GEMMaskReClusterizer.h"
 
 GEMClusterContainer GEMMaskReClusterizer::doAction(const GEMDetId& id,

--- a/RecoLocalMuon/GEMRecHit/src/GEMRecHitBaseAlgo.cc
+++ b/RecoLocalMuon/GEMRecHit/src/GEMRecHitBaseAlgo.cc
@@ -23,7 +23,7 @@ edm::OwnVector<GEMRecHit> GEMRecHitBaseAlgo::reconstruct(const GEMEtaPartition& 
   edm::OwnVector<GEMRecHit> result;
 
   GEMClusterizer clizer;
-  GEMClusterContainer tcls = clizer.doAction(digiRange);
+  GEMClusterContainer tcls = clizer.doAction(digiRange, mask);
   GEMMaskReClusterizer mrclizer;
   GEMClusterContainer cls = mrclizer.doAction(gemId, tcls, mask);
 


### PR DESCRIPTION
#### PR description:

* GEM strip numbering start from 0. But we used the strip number starting from 1. It has fixed for the GEM masking method.
* GEM masking should be applied at initial clusterization to conceal digis from maskedStrips. It has applied now.
 
#### PR validation:

* Code style has fixed with scram build code-format command.
* runTheMatrix.py is runnable.
* The result has not changed for GEM.

@jshlee @watson-ij 