### PR TITLE
Fix alias in PreMixing configuration for APV simulation

### DIFF
--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -70,4 +70,4 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(simCastorDigis, mix = None)
 fastSim.toModify(simSiPixelDigis, mix = None)
 fastSim.toModify(simSiStripDigis, mix = None)
-fastSim.toModify(simAPVsaturation, mix = None)
+fastSim.toModify(simAPVsaturation, mixData = None)

--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -65,6 +65,9 @@ run3_common.toModify(simCastorDigis, mix = None)
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(simSiPixelDigis, mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))])
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(simAPVsaturation, mixData = None)
+
 # no castor,pixel,strip digis in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(simCastorDigis, mix = None)


### PR DESCRIPTION
#### PR description:

The integration of #28355 has caused a massive relval failure in CMSSW_11_0_X_2019-11-21-2300 due to a problem in the configuration of alias for PreMixing. This PR suggests a fix, to ve confirmed and validated by experts @mmusich @makortel .

#### PR validation:

The failing configurations (250400.0) now run. This does not fix yet 20634.99 .