### PR TITLE
Modernize SinglePhotonJetPlusHOFilter

### DIFF
--- a/DPGAnalysis/Skims/python/SinglePhotonJetPlusHOFilter_cff.py
+++ b/DPGAnalysis/Skims/python/SinglePhotonJetPlusHOFilter_cff.py
@@ -1,13 +1,11 @@
 import FWCore.ParameterSet.Config as cms 
 
-SinglePhotonJetPlusHOFilterSkim = cms.EDFilter("SinglePhotonJetPlusHOFilter",
+from DPGAnalysis.Skims.singlePhotonJetPlusHOFilter_cfi import singlePhotonJetPlusHOFilter as _singlePhotonJetPlusHOFilter
+
+SinglePhotonJetPlusHOFilterSkim = _singlePhotonJetPlusHOFilter.clone(
     Photons = cms.InputTag("photons"),
     PFJets = cms.InputTag("ak4PFJets"),
     particleFlowClusterHO = cms.InputTag("particleFlowClusterHO"),
-    Ptcut = cms.untracked.double(90.0), 
-    Etacut = cms.untracked.double(1.5),
-    HOcut = cms.untracked.double(5.0), 
-    Pho_Ptcut = cms.untracked.double(120.0)
 ) 
 
 SinglePhotonJetPlusHOFilterSequence = cms.Sequence(SinglePhotonJetPlusHOFilterSkim)

--- a/DPGAnalysis/Skims/src/SinglePhotonJetPlusHOFilter.cc
+++ b/DPGAnalysis/Skims/src/SinglePhotonJetPlusHOFilter.cc
@@ -18,16 +18,11 @@ Skimming of SinglePhoton data set for the study of HO absolute weight calculatio
 
 // system include files
 #include <memory>
-#include <string>
-
-#include <iostream>
-#include <fstream>
 
 // class declaration
 //
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,115 +32,70 @@ Skimming of SinglePhoton data set for the study of HO absolute weight calculatio
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-using namespace std;
-using namespace edm;
-using namespace reco;
-
-class SinglePhotonJetPlusHOFilter : public edm::EDFilter {
+class SinglePhotonJetPlusHOFilter : public edm::global::EDFilter<> {
 public:
   explicit SinglePhotonJetPlusHOFilter(const edm::ParameterSet&);
-  ~SinglePhotonJetPlusHOFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
-  int Nevt;
-  int Njetp;
-  int Npass;
-  double jtptthr;
-  double jtetath;
-  double hothres;
-  double pho_Ptcut;
-  bool isOthHistFill;
+  const double jtptthr_;
+  const double jtetath_;
+  const double hothres_;
+  const double pho_Ptcut_;
 
-  edm::EDGetTokenT<reco::PFJetCollection> tok_PFJets_;
-  edm::EDGetTokenT<reco::PFClusterCollection> tok_hoht_;
-  edm::EDGetTokenT<edm::View<reco::Photon> > tok_photons_;
+  const edm::EDGetTokenT<reco::PFJetCollection> tok_PFJets_;
+  const edm::EDGetTokenT<reco::PFClusterCollection> tok_hoht_;
+  const edm::EDGetTokenT<edm::View<reco::Photon> > tok_photons_;
 };
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-SinglePhotonJetPlusHOFilter::SinglePhotonJetPlusHOFilter(const edm::ParameterSet& iConfig) {
-  tok_PFJets_ = consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("PFJets"));
-  tok_hoht_ = consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("particleFlowClusterHO"));
-  tok_photons_ = consumes<edm::View<reco::Photon> >(iConfig.getParameter<edm::InputTag>("Photons"));
-
-  //now do what ever initialization is needed
-  jtptthr = iConfig.getUntrackedParameter<double>("Ptcut", 90.0);
-  jtetath = iConfig.getUntrackedParameter<double>("Etacut", 1.5);
-  hothres = iConfig.getUntrackedParameter<double>("HOcut", 5);
-  pho_Ptcut = iConfig.getUntrackedParameter<double>("Pho_Ptcut", 120);
-
-  Nevt = 0;
-  Njetp = 0;
-  Npass = 0;
-}
-
-SinglePhotonJetPlusHOFilter::~SinglePhotonJetPlusHOFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
+SinglePhotonJetPlusHOFilter::SinglePhotonJetPlusHOFilter(const edm::ParameterSet& iConfig)
+    : jtptthr_{iConfig.getParameter<double>("Ptcut")},
+      jtetath_{iConfig.getParameter<double>("Etacut")},
+      hothres_{iConfig.getParameter<double>("HOcut")},
+      pho_Ptcut_{iConfig.getParameter<double>("Pho_Ptcut")},
+      tok_PFJets_{consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("PFJets"))},
+      tok_hoht_{consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("particleFlowClusterHO"))},
+      tok_photons_{consumes<edm::View<reco::Photon> >(iConfig.getParameter<edm::InputTag>("Photons"))} {}
 
 // ------------ method called on each new Event  ------------
-bool SinglePhotonJetPlusHOFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool SinglePhotonJetPlusHOFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace std;
   using namespace edm;
   using namespace reco;
 
-  Nevt++;
-
-  edm::Handle<reco::PFJetCollection> PFJets;
-  iEvent.getByToken(tok_PFJets_, PFJets);
   bool passed = false;
   vector<pair<double, double> > jetdirection;
   vector<double> jetspt;
-  if (PFJets.isValid()) {
-    for (unsigned jet = 0; jet < PFJets->size(); jet++) {
-      if (((*PFJets)[jet].pt() < jtptthr) || (abs((*PFJets)[jet].eta()) > jtetath))
+  if (auto PFJets = iEvent.getHandle(tok_PFJets_)) {
+    for (const auto& jet : *PFJets) {
+      if ((jet.pt() < jtptthr_) || (abs(jet.eta()) > jtetath_))
         continue;
 
-      std::pair<double, double> etaphi((*PFJets)[jet].eta(), (*PFJets)[jet].phi());
-      jetdirection.push_back(etaphi);
-      jetspt.push_back((*PFJets)[jet].pt());
+      jetdirection.emplace_back(jet.eta(), jet.phi());
+      jetspt.push_back(jet.pt());
       passed = true;
     }
   }
   if (!passed)
     return passed;
 
-  edm::Handle<edm::View<reco::Photon> > photons;
-  iEvent.getByToken(tok_photons_, photons);
   bool pho_passed = false;
   vector<pair<double, double> > phodirection;
   vector<double> phopT;
-
-  if (photons.isValid()) {
-    edm::View<reco::Photon>::const_iterator gamma1;
-    for (gamma1 = photons->begin(); gamma1 != photons->end(); gamma1++) {
-      if (gamma1->pt() < pho_Ptcut)
+  if (auto photons = iEvent.getHandle(tok_photons_)) {
+    for (const auto& gamma1 : *photons) {
+      if (gamma1.pt() < pho_Ptcut_)
         continue;
-      std::pair<double, double> etaphi_pho(gamma1->eta(), gamma1->phi());
-      phodirection.push_back(etaphi_pho);
-      phopT.push_back(gamma1->pt());
+      phodirection.emplace_back(gamma1.eta(), gamma1.phi());
+      phopT.push_back(gamma1.pt());
 
       pho_passed = true;
     }
@@ -153,33 +103,31 @@ bool SinglePhotonJetPlusHOFilter::filter(edm::Event& iEvent, const edm::EventSet
 
   if (!pho_passed)
     return false;
-  Njetp++;
-  bool isJetDir = false;
 
-  edm::Handle<PFClusterCollection> hoht;
-  iEvent.getByToken(tok_hoht_, hoht);
-  if (hoht.isValid()) {
-    if (!(*hoht).empty()) {
-      for (unsigned ijet = 0; ijet < jetdirection.size(); ijet++) {
+  bool isJetDir = false;
+  if (auto hhoht = iEvent.getHandle(tok_hoht_)) {
+    const auto& hoht = *hhoht;
+    if (!hoht.empty()) {
+      for (const auto& jet : jetdirection) {
         bool matched = false;
-        for (unsigned iph = 0; iph < phodirection.size(); iph++) {
-          if (abs(deltaPhi(phodirection[iph].second, jetdirection[ijet].second)) > 2.0) {
+        for (const auto& ph : phodirection) {
+          if (abs(deltaPhi(ph.second, jet.second)) > 2.0) {
             matched = true;
             break;
           }
         }
         if (matched) {
-          for (PFClusterCollection::const_iterator ij = (*hoht).begin(); ij != (*hoht).end(); ij++) {
-            double hoenr = (*ij).energy();
-            if (hoenr < hothres)
+          for (const auto& ij : hoht) {
+            double hoenr = ij.energy();
+            if (hoenr < hothres_)
               continue;
 
-            const math::XYZPoint& cluster_pos = ij->position();
+            const math::XYZPoint& cluster_pos = ij.position();
 
             double hoeta = cluster_pos.eta();
             double hophi = cluster_pos.phi();
 
-            double delta = deltaR2(jetdirection[ijet].first, jetdirection[ijet].second, hoeta, hophi);
+            double delta = deltaR2(jet.first, jet.second, hoeta, hophi);
             if (delta < 0.5) {
               isJetDir = true;
               break;
@@ -193,10 +141,6 @@ bool SinglePhotonJetPlusHOFilter::filter(edm::Event& iEvent, const edm::EventSet
     }
   }
 
-  if (isJetDir) {
-    Npass++;
-  }
-
   return isJetDir;
 }
 
@@ -205,16 +149,15 @@ void SinglePhotonJetPlusHOFilter::fillDescriptions(edm::ConfigurationDescription
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<double>("Ptcut", 90.0);
+  desc.add<double>("Etacut", 1.5);
+  desc.add<double>("HOcut", 5);
+  desc.add<double>("Pho_Ptcut", 120);
+  desc.add<edm::InputTag>("PFJets");
+  desc.add<edm::InputTag>("particleFlowClusterHO");
+  desc.add<edm::InputTag>("Photons");
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(SinglePhotonJetPlusHOFilter);
-
-/*
-
-End of SinglePhotonJetPlusHOFilter with event 100 Jetpassed 16 passed 3
-
-
-*/


### PR DESCRIPTION
### PR description:

In the context of #25090 this PR modernizes `SinglePhotonJetPlusHOFilter` by

- Remove unnecessary counters
- Make members `const`, initialize in initializer list, use naming convention
- Remove unnecessary includes
- Make the module global
- Use range-for
- Get event data with `getHandle()`
- Make parameters tracked
- Implement `fillDescriptions()`

#### PR validation:

Limited matrix runs.