### PR TITLE
Delay constructing transition wrappers

### DIFF
--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -33,6 +33,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/PrincipalGetAdapter.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
@@ -94,7 +95,12 @@ namespace edm {
     ///\return The id for the particular Stream processing the Event
     StreamID streamID() const { return streamID_; }
 
-    LuminosityBlock const& getLuminosityBlock() const { return *luminosityBlock_; }
+    LuminosityBlock const& getLuminosityBlock() const {
+      if (not luminosityBlock_) {
+        fillLuminosityBlock();
+      }
+      return *luminosityBlock_;
+    }
 
     Run const& getRun() const;
 
@@ -255,6 +261,8 @@ namespace edm {
 
     EventPrincipal const& eventPrincipal() const;
 
+    void fillLuminosityBlock() const;
+
     ProductID makeProductID(BranchDescription const& desc) const;
 
     //override used by EventBase class
@@ -298,7 +306,7 @@ namespace edm {
     ProductPtrVec putProducts_;
 
     EventAuxiliary const& aux_;
-    std::shared_ptr<LuminosityBlock const> const luminosityBlock_;
+    mutable std::optional<LuminosityBlock> luminosityBlock_;
 
     // gotBranchIDs_ must be mutable because it records all 'gets',
     // which do not logically modify the PrincipalGetAdapter. gotBranchIDs_ is

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -22,6 +22,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Common/interface/LuminosityBlockBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/PrincipalGetAdapter.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
@@ -33,6 +34,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include <string>
 #include <typeinfo>
 #include <vector>
+#include <optional>
 
 namespace edm {
   class ModuleCallingContext;
@@ -100,7 +102,12 @@ namespace edm {
     template <typename PROD>
     void getManyByType(std::vector<Handle<PROD>>& results) const;
 
-    Run const& getRun() const { return *run_; }
+    Run const& getRun() const {
+      if (not run_) {
+        fillRun();
+      }
+      return run_.value();
+    }
 
     ///Put a new product.
     template <typename PROD>
@@ -157,6 +164,8 @@ namespace edm {
     ProductPtrVec& putProducts() { return putProducts_; }
     ProductPtrVec const& putProducts() const { return putProducts_; }
 
+    void fillRun() const;
+
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any
     // alternative is not great either.  Putting it into the
@@ -171,7 +180,7 @@ namespace edm {
     PrincipalGetAdapter provRecorder_;
     ProductPtrVec putProducts_;
     LuminosityBlockAuxiliary const& aux_;
-    std::shared_ptr<Run const> const run_;
+    mutable std::optional<Run> run_;
     ModuleCallingContext const* moduleCallingContext_;
 
     static const std::string emptyString_;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -141,8 +141,10 @@ namespace edm {
     //size_t size() const;
 
     void setConsumer(EDConsumerBase const* iConsumer) { consumer_ = iConsumer; }
+    EDConsumerBase const* getConsumer() const { return consumer_; }
 
     void setSharedResourcesAcquirer(SharedResourcesAcquirer* iSra) { resourcesAcquirer_ = iSra; }
+    SharedResourcesAcquirer* getSharedResourcesAcquirer() const { return resourcesAcquirer_; }
 
     void setProducer(ProducerBase const* iProd) { prodBase_ = iProd; }
 
@@ -172,6 +174,7 @@ namespace edm {
 
     BranchDescription const& getBranchDescription(unsigned int iPutTokenIndex) const;
     ProductID const& getProductID(unsigned int iPutTokenIndex) const;
+    ModuleDescription const& moduleDescription() const { return md_; }
 
     std::vector<edm::ProductResolverIndex> const& putTokenIndexToProductResolverIndex() const;
 


### PR DESCRIPTION
#### PR description:

Do not create the edm::Run or edm::LuminosityBlock objects until they are requested.

#### PR validation:

The framework unit tests pass.