### PR TITLE
[HGCAL trigger] Revert const back to constexpr

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalClusteringImpl.h
@@ -16,7 +16,7 @@ bool distanceSorter(pair<edm::Ptr<l1t::HGCalTriggerCell>, float> i, pair<edm::Pt
 
 class HGCalClusteringImpl {
 private:
-  static const unsigned kNSides_ = 2;
+  static constexpr unsigned kNSides_ = 2;
 
 public:
   HGCalClusteringImpl(const edm::ParameterSet& conf);

--- a/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h
+++ b/L1Trigger/L1THGCal/interface/concentrator/HGCalConcentratorBestChoiceImpl.h
@@ -19,10 +19,10 @@ public:
 
 private:
   std::vector<unsigned> nData_;
-  static const unsigned kNDataSize_ = 128;
-  static const uint32_t kWaferOffset_ = 4;
-  static const uint32_t kWaferMask_ = 0x7;
-  static const uint32_t kLinkMask_ = 0xF;
+  static constexpr unsigned kNDataSize_ = 128;
+  static constexpr uint32_t kWaferOffset_ = 4;
+  static constexpr uint32_t kWaferMask_ = 0x7;
+  static constexpr uint32_t kLinkMask_ = 0xF;
 
   HGCalTriggerTools triggerTools_;
 };


### PR DESCRIPTION
Revert to `constexpr` instead of `const`, following comment in #28385 