### PR TITLE
Changes for new trained regression for UL 2016 - 110X 

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2016_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2016_cff.py
@@ -11,7 +11,8 @@ from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 from Configuration.Eras.Modifier_pixel_2016_cff import pixel_2016
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
+from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
 
 Run2_2016 = cms.ModifierChain(run2_common, run2_25ns_specific,
- stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
+ stage2L1Trigger, ctpps_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_muon_2016, run2_egamma_2016, run2_L1prefiring, pixel_2016, run2_jme_2016, strips_vfp30_2016)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2016
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
@@ -22,7 +23,7 @@ from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 
-Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016,run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016]),
-phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
-trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
+Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016]),
+                              phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
+                              trackingPhase1, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
-from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2016
+from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017

--- a/Configuration/Eras/python/Modifier_run2_ECAL_2016_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_ECAL_2016_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_ECAL_2016 =  cms.Modifier()

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -240,6 +240,9 @@ regressionModifier80X = \
 regressionModifier = regressionModifier94X.clone()
 
 
+from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
+run2_egamma_2016.toReplaceWith(regressionModifier,regressionModifier106XUL)
+
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 run2_egamma_2017.toReplaceWith(regressionModifier,regressionModifier106XUL)
 

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -241,13 +241,10 @@ regressionModifier = regressionModifier94X.clone()
 
 
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
-run2_egamma_2016.toReplaceWith(regressionModifier,regressionModifier106XUL)
-
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
-run2_egamma_2017.toReplaceWith(regressionModifier,regressionModifier106XUL)
-
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
-run2_egamma_2018.toReplaceWith(regressionModifier,regressionModifier106XUL)
+
+(run2_egamma_2016 | run2_egamma_2017 | run2_egamma_2018).toReplaceWith(regressionModifier,regressionModifier106XUL)
 
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cff.py
@@ -4,6 +4,10 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cfi import parti
 particleFlowClusterECAL.energyCorrector.applyMVACorrections = True
 particleFlowClusterECAL.energyCorrector.maxPtForMVAEvaluation = 90.
 
+from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
+run2_ECAL_2016.toModify(particleFlowClusterECAL,
+                        energyCorrector = dict(srfAwareCorrection = True, maxPtForMVAEvaluation = 300.))
+
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 run2_ECAL_2017.toModify(particleFlowClusterECAL,
                         energyCorrector = dict(srfAwareCorrection = True, maxPtForMVAEvaluation = 300.))

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cff.py
@@ -4,11 +4,10 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cfi import parti
 particleFlowClusterECAL.energyCorrector.applyMVACorrections = True
 particleFlowClusterECAL.energyCorrector.maxPtForMVAEvaluation = 90.
 
-from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
-run2_ECAL_2016.toModify(particleFlowClusterECAL,
-                        energyCorrector = dict(srfAwareCorrection = True, maxPtForMVAEvaluation = 300.))
 
+from Configuration.Eras.Modifier_run2_ECAL_2016_cff import run2_ECAL_2016
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
-run2_ECAL_2017.toModify(particleFlowClusterECAL,
+
+(run2_ECAL_2016 | run2_ECAL_2017).toModify(particleFlowClusterECAL,
                         energyCorrector = dict(srfAwareCorrection = True, maxPtForMVAEvaluation = 300.))
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECAL_cff.py
@@ -6,7 +6,6 @@ particleFlowClusterOOTECAL.inputECAL = cms.InputTag("particleFlowClusterOOTECALU
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(
-    particleFlowClusterOOTECAL.energyCorrector, 
-    recHitsEBLabel = "reducedEcalRecHitsEB",
-    recHitsEELabel = "reducedEcalRecHitsEE"
+    particleFlowClusterOOTECAL,
+    energyCorrector = dict(applyMVACorrections = True, maxPtForMVAEvaluation = 90., srfAwareCorrection = False, recHitsEBLabel = "reducedEcalRecHitsEB", recHitsEELabel = "reducedEcalRecHitsEE")
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECAL_cff.py
@@ -5,7 +5,9 @@ particleFlowClusterOOTECAL = particleFlowClusterECAL.clone()
 particleFlowClusterOOTECAL.inputECAL = cms.InputTag("particleFlowClusterOOTECALUncorrected")
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-run2_miniAOD_80XLegacy.toModify(
-    particleFlowClusterOOTECAL,
-    energyCorrector = dict(applyMVACorrections = True, maxPtForMVAEvaluation = 90., srfAwareCorrection = False, recHitsEBLabel = "reducedEcalRecHitsEB", recHitsEELabel = "reducedEcalRecHitsEE")
-)
+run2_miniAOD_80XLegacy.toModify(particleFlowClusterOOTECAL,
+                                energyCorrector = dict( 
+                                    maxPtForMVAEvaluation = 90., srfAwareCorrection = False, 
+                                    recHitsEBLabel = "reducedEcalRecHitsEB", recHitsEELabel = "reducedEcalRecHitsEE"
+                                )
+                            )


### PR DESCRIPTION
***This is exactly the same as #28422. A new PR is created instead of continuing from there since the there were problems with the history and hence further merging***

These changes are essential for making the 2016 UL regression work. After discussion with Sam, I have made these changes (since 2016 uses the old PF cluster regression strategy and old ele/pho regressions codes).
We had to create Modifier_run2_ECAL_2016_cff.py so that the training strategy of 2017 and 2018 could be used here as well.

