### PR TITLE
Option to write out all ALCTs and CLCTs

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
@@ -71,6 +71,7 @@ public:
              const GEMPadDigiClusterCollection* gemPadClusters,
              CSCALCTDigiCollection& oc_alct,
              CSCCLCTDigiCollection& oc_clct,
+             CSCCLCTDigiCollection& oc_clct_all,
              CSCALCTPreTriggerDigiCollection& oc_alctpretrigger,
              CSCCLCTPreTriggerDigiCollection& oc_clctpretrigger,
              CSCCLCTPreTriggerCollection& oc_pretrig,

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
@@ -70,6 +70,7 @@ public:
              const GEMPadDigiCollection* gemPads,
              const GEMPadDigiClusterCollection* gemPadClusters,
              CSCALCTDigiCollection& oc_alct,
+             CSCALCTDigiCollection& oc_alct_all,
              CSCCLCTDigiCollection& oc_clct,
              CSCCLCTDigiCollection& oc_clct_all,
              CSCALCTPreTriggerDigiCollection& oc_alctpretrigger,

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -193,11 +193,11 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
 
   // Put collections in event.
   ev.put(std::move(oc_alct));
-  if (writeOutAllALCTs_){
+  if (writeOutAllALCTs_) {
     ev.put(std::move(oc_alct_all), "All");
   }
   ev.put(std::move(oc_clct));
-  if (writeOutAllCLCTs_){
+  if (writeOutAllCLCTs_) {
     ev.put(std::move(oc_clct_all), "All");
   }
   if (savePreTriggers_) {

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -50,6 +50,8 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
 
   writeOutAllCLCTs_ = conf.getParameter<bool>("writeOutAllCLCTs");
 
+  writeOutAllALCTs_ = conf.getParameter<bool>("writeOutAllALCTs");
+
   savePreTriggers_ = conf.getParameter<bool>("savePreTriggers");
 
   // check whether you need to run the integrated local triggers
@@ -68,6 +70,9 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   // for experimental simulation studies
   if (writeOutAllCLCTs_) {
     produces<CSCCLCTDigiCollection>("ALL");
+  }
+  if (writeOutAllALCTs_) {
+    produces<CSCALCTDigiCollection>("ALL");
   }
   produces<CSCCLCTPreTriggerDigiCollection>();
   produces<CSCCLCTPreTriggerCollection>();
@@ -142,6 +147,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   // Create empty collections of ALCTs, CLCTs, and correlated LCTs upstream
   // and downstream of MPC.
   std::unique_ptr<CSCALCTDigiCollection> oc_alct(new CSCALCTDigiCollection);
+  std::unique_ptr<CSCALCTDigiCollection> oc_alct_all(new CSCALCTDigiCollection);
   std::unique_ptr<CSCCLCTDigiCollection> oc_clct(new CSCCLCTDigiCollection);
   std::unique_ptr<CSCCLCTDigiCollection> oc_clct_all(new CSCCLCTDigiCollection);
   std::unique_ptr<CSCCLCTPreTriggerDigiCollection> oc_clctpretrigger(new CSCCLCTPreTriggerDigiCollection);
@@ -172,6 +178,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
                             gemPads,
                             gemPadClusters,
                             *oc_alct,
+                            *oc_alct_all,
                             *oc_clct,
                             *oc_clct_all,
                             *oc_alctpretrigger,
@@ -186,6 +193,9 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
 
   // Put collections in event.
   ev.put(std::move(oc_alct));
+  if (writeOutAllALCTs_){
+    ev.put(std::move(oc_alct_all), "ALL");
+  }
   ev.put(std::move(oc_clct));
   if (writeOutAllCLCTs_){
     ev.put(std::move(oc_clct_all), "ALL");

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -69,10 +69,10 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   produces<CSCCLCTDigiCollection>();
   // for experimental simulation studies
   if (writeOutAllCLCTs_) {
-    produces<CSCCLCTDigiCollection>("ALL");
+    produces<CSCCLCTDigiCollection>("All");
   }
   if (writeOutAllALCTs_) {
-    produces<CSCALCTDigiCollection>("ALL");
+    produces<CSCALCTDigiCollection>("All");
   }
   produces<CSCCLCTPreTriggerDigiCollection>();
   produces<CSCCLCTPreTriggerCollection>();
@@ -194,11 +194,11 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   // Put collections in event.
   ev.put(std::move(oc_alct));
   if (writeOutAllALCTs_){
-    ev.put(std::move(oc_alct_all), "ALL");
+    ev.put(std::move(oc_alct_all), "All");
   }
   ev.put(std::move(oc_clct));
   if (writeOutAllCLCTs_){
-    ev.put(std::move(oc_clct_all), "ALL");
+    ev.put(std::move(oc_clct_all), "All");
   }
   if (savePreTriggers_) {
     ev.put(std::move(oc_alctpretrigger));

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -48,6 +48,8 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
                             : edm::InputTag("");
   checkBadChambers_ = conf.getParameter<bool>("checkBadChambers");
 
+  writeOutAllCLCTs_ = conf.getParameter<bool>("writeOutAllCLCTs");
+
   savePreTriggers_ = conf.getParameter<bool>("savePreTriggers");
 
   // check whether you need to run the integrated local triggers
@@ -63,6 +65,10 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   // register what this produces
   produces<CSCALCTDigiCollection>();
   produces<CSCCLCTDigiCollection>();
+  // for experimental simulation studies
+  if (writeOutAllCLCTs_) {
+    produces<CSCCLCTDigiCollection>("ALL");
+  }
   produces<CSCCLCTPreTriggerDigiCollection>();
   produces<CSCCLCTPreTriggerCollection>();
   produces<CSCALCTPreTriggerDigiCollection>();
@@ -137,6 +143,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   // and downstream of MPC.
   std::unique_ptr<CSCALCTDigiCollection> oc_alct(new CSCALCTDigiCollection);
   std::unique_ptr<CSCCLCTDigiCollection> oc_clct(new CSCCLCTDigiCollection);
+  std::unique_ptr<CSCCLCTDigiCollection> oc_clct_all(new CSCCLCTDigiCollection);
   std::unique_ptr<CSCCLCTPreTriggerDigiCollection> oc_clctpretrigger(new CSCCLCTPreTriggerDigiCollection);
   std::unique_ptr<CSCALCTPreTriggerDigiCollection> oc_alctpretrigger(new CSCALCTPreTriggerDigiCollection);
   std::unique_ptr<CSCCLCTPreTriggerCollection> oc_pretrig(new CSCCLCTPreTriggerCollection);
@@ -166,6 +173,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
                             gemPadClusters,
                             *oc_alct,
                             *oc_clct,
+                            *oc_clct_all,
                             *oc_alctpretrigger,
                             *oc_clctpretrigger,
                             *oc_pretrig,
@@ -179,6 +187,9 @@ void CSCTriggerPrimitivesProducer::produce(edm::StreamID iID, edm::Event& ev, co
   // Put collections in event.
   ev.put(std::move(oc_alct));
   ev.put(std::move(oc_clct));
+  if (writeOutAllCLCTs_){
+    ev.put(std::move(oc_clct_all), "ALL");
+  }
   if (savePreTriggers_) {
     ev.put(std::move(oc_alctpretrigger));
     ev.put(std::move(oc_clctpretrigger));

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -74,6 +74,10 @@ private:
   // switch to for enabling checking against the list of bad chambers
   bool checkBadChambers_;
 
+  // write out all CLCTs
+  // only relevant when CSCConstants::MAX_CLCTS_PER_PROCESSOR is > 2
+  bool writeOutAllCLCTs_;
+
   // Write out pre-triggers
   bool savePreTriggers_;
 

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -78,6 +78,10 @@ private:
   // only relevant when CSCConstants::MAX_CLCTS_PER_PROCESSOR is > 2
   bool writeOutAllCLCTs_;
 
+  // write out all ALCTs
+  // only relevant when CSCConstants::MAX_ALCTS_PER_PROCESSOR is > 2
+  bool writeOutAllALCTs_;
+
   // Write out pre-triggers
   bool savePreTriggers_;
 

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -19,6 +19,8 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
     # Write out all CLCTs
     writeOutAllCLCTs = cms.bool(False),
+
+    # Write out all ALCTs
     writeOutAllALCTs = cms.bool(False),
 
     # Write out pre-triggers

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -19,6 +19,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
     # Write out all CLCTs
     writeOutAllCLCTs = cms.bool(False),
+    writeOutAllALCTs = cms.bool(False),
 
     # Write out pre-triggers
     savePreTriggers = cms.bool(False),

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -17,6 +17,9 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
     # If True, output collections will only be built for good chambers
     checkBadChambers = cms.bool(True),
 
+    # Write out all CLCTs
+    writeOutAllCLCTs = cms.bool(False),
+
     # Write out pre-triggers
     savePreTriggers = cms.bool(False),
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -118,6 +118,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         const GEMPadDigiCollection* gemPads,
                                         const GEMPadDigiClusterCollection* gemClusters,
                                         CSCALCTDigiCollection& oc_alct,
+                                        CSCALCTDigiCollection& oc_alct_all,
                                         CSCCLCTDigiCollection& oc_clct,
                                         CSCCLCTDigiCollection& oc_clct_all,
                                         CSCALCTPreTriggerDigiCollection& oc_alctpretrigger,
@@ -174,6 +175,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11->readoutLCTs1a();
               const std::vector<CSCALCTDigi>& alctV = tmb11->alctProc->readoutALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all = tmb11->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11->clctProc->readoutCLCTsME1b();
               const std::vector<CSCCLCTDigi>& clctV_all = tmb11->clctProc->getCLCTs();
               const std::vector<int> preTriggerBXs = tmb11->clctProc->preTriggerBXs();
@@ -195,6 +197,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // put collections in event
               put(lctV, oc_lct, detid, " ME1b LCT digi");
               put(alctV, oc_alct, detid, " ME1b ALCT digi");
+              put(alctV_all, oc_alct_all, detid, " ME1b ALCT digi");
               put(clctV, oc_clct, detid, " ME1b CLCT digi");
               put(clctV_all, oc_clct_all, detid, " ME1b CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " ME1b CLCT pre-trigger digi");
@@ -236,6 +239,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb11GEM->readoutLCTs1b();
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11GEM->readoutLCTs1a();
               const std::vector<CSCALCTDigi>& alctV = tmb11GEM->alctProc->readoutALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all = tmb11GEM->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
               const std::vector<CSCCLCTDigi>& clctV_all = tmb11GEM->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = tmb11GEM->clctProc->preTriggerBXs();
@@ -253,6 +257,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // put collections in event
               put(lctV, oc_lct, detid, " ME1b LCT digi");
               put(alctV, oc_alct, detid, " ME1b ALCT digi");
+              put(alctV_all, oc_alct_all, detid, " ME1b ALCT digi");
               put(clctV, oc_clct, detid, " ME1b CLCT digi");
               put(clctV_all, oc_clct_all, detid, " ME1b CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " ME1b CLCT pre-trigger digi");
@@ -290,6 +295,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb21GEM->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alctProc->readoutALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all = tmb21GEM->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clctProc->readoutCLCTs();
               const std::vector<CSCCLCTDigi>& clctV_all = tmb21GEM->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = tmb21GEM->clctProc->preTriggerBXs();
@@ -304,6 +310,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // put collections in event
               put(lctV, oc_lct, detid, " ME21 LCT digi");
               put(alctV, oc_alct, detid, " ME21 ALCT digi");
+              put(alctV_all, oc_alct_all, detid, " ME21 ALCT digi");
               put(clctV, oc_clct, detid, " ME21 CLCT digi");
               put(clctV_all, oc_clct_all, detid, " ME21 CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " ME21 CLCT pre-trigger digi");
@@ -321,6 +328,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = utmb->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = utmb->alctProc->readoutALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all = utmb->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = utmb->clctProc->readoutCLCTs();
               const std::vector<CSCCLCTDigi>& clctV_all = utmb->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = utmb->clctProc->preTriggerBXs();
@@ -334,6 +342,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // put collections in event
               put(lctV, oc_lct, detid, " LCT digi");
               put(alctV, oc_alct, detid, " ALCT digi");
+              put(alctV_all, oc_alct_all, detid, " ALCT digi");
               put(clctV, oc_clct, detid, " CLCT digi");
               put(clctV_all, oc_clct_all, detid, tmb->getCSCName() + " CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " CLCT pre-trigger digi");
@@ -349,6 +358,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // get the collections
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = tmb->alctProc->readoutALCTs();
+              const std::vector<CSCALCTDigi>& alctV_all = tmb->alctProc->getALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb->clctProc->readoutCLCTs();
               const std::vector<CSCCLCTDigi>& clctV_all = tmb->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
@@ -362,6 +372,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // put collections in event
               put(lctV, oc_lct, detid, tmb->getCSCName() + " LCT digi");
               put(alctV, oc_alct, detid, tmb->getCSCName() + " ALCT digi");
+              put(alctV_all, oc_alct_all, detid, tmb->getCSCName() + " ALCT digi");
               put(clctV, oc_clct, detid, tmb->getCSCName() + " CLCT digi");
               put(clctV_all, oc_clct_all, detid, tmb->getCSCName() + " CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, tmb->getCSCName() + " CLCT pre-trigger digi");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -119,6 +119,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         const GEMPadDigiClusterCollection* gemClusters,
                                         CSCALCTDigiCollection& oc_alct,
                                         CSCCLCTDigiCollection& oc_clct,
+                                        CSCCLCTDigiCollection& oc_clct_all,
                                         CSCALCTPreTriggerDigiCollection& oc_alctpretrigger,
                                         CSCCLCTPreTriggerDigiCollection& oc_pretrigger,
                                         CSCCLCTPreTriggerCollection& oc_pretrig,
@@ -174,6 +175,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11->readoutLCTs1a();
               const std::vector<CSCALCTDigi>& alctV = tmb11->alctProc->readoutALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11->clctProc->readoutCLCTsME1b();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb11->clctProc->getCLCTs();
               const std::vector<int> preTriggerBXs = tmb11->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11->clctProc->preTriggerDigisME1b();
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11->clctProc->readoutCLCTsME1a();
@@ -190,11 +192,11 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               if (!(lctV.empty() && alctV.empty() && clctV.empty()) and infoV > 1) {
                 LogTrace("L1CSCTrigger") << "CSCTriggerPrimitivesBuilder results in " << detid;
               }
-
               // put collections in event
               put(lctV, oc_lct, detid, " ME1b LCT digi");
               put(alctV, oc_alct, detid, " ME1b ALCT digi");
               put(clctV, oc_clct, detid, " ME1b CLCT digi");
+              put(clctV_all, oc_clct_all, detid, " ME1b CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " ME1b CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " ME1b CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ME1b ALCT pre-trigger digi");
@@ -235,6 +237,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV1a = tmb11GEM->readoutLCTs1a();
               const std::vector<CSCALCTDigi>& alctV = tmb11GEM->alctProc->readoutALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb11GEM->clctProc->readoutCLCTsME1b();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb11GEM->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = tmb11GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb11GEM->clctProc->preTriggerDigisME1b();
               const std::vector<CSCCLCTDigi>& clctV1a = tmb11GEM->clctProc->readoutCLCTsME1a();
@@ -251,6 +254,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(lctV, oc_lct, detid, " ME1b LCT digi");
               put(alctV, oc_alct, detid, " ME1b ALCT digi");
               put(clctV, oc_clct, detid, " ME1b CLCT digi");
+              put(clctV_all, oc_clct_all, detid, " ME1b CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " ME1b CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " ME1b CLCT pre-trigger BX");
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
@@ -287,6 +291,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb21GEM->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = tmb21GEM->alctProc->readoutALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb21GEM->clctProc->readoutCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb21GEM->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = tmb21GEM->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb21GEM->clctProc->preTriggerDigis();
               const std::vector<GEMCoPadDigi>& copads = tmb21GEM->coPadProcessor->readoutCoPads();
@@ -300,6 +305,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(lctV, oc_lct, detid, " ME21 LCT digi");
               put(alctV, oc_alct, detid, " ME21 ALCT digi");
               put(clctV, oc_clct, detid, " ME21 CLCT digi");
+              put(clctV_all, oc_clct_all, detid, " ME21 CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " ME21 CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " ME21 CLCT pre-trigger BX");
               put(copads, oc_gemcopad, gemId, " GEM coincidence pad");
@@ -316,6 +322,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = utmb->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = utmb->alctProc->readoutALCTs();
               const std::vector<CSCCLCTDigi>& clctV = utmb->clctProc->readoutCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = utmb->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = utmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = utmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = utmb->alctProc->preTriggerDigis();
@@ -328,6 +335,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(lctV, oc_lct, detid, " LCT digi");
               put(alctV, oc_alct, detid, " ALCT digi");
               put(clctV, oc_clct, detid, " CLCT digi");
+              put(clctV_all, oc_clct_all, detid, tmb->getCSCName() + " CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, " CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, " CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, " ALCT pre-trigger digi");
@@ -342,6 +350,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               const std::vector<CSCCorrelatedLCTDigi>& lctV = tmb->readoutLCTs();
               const std::vector<CSCALCTDigi>& alctV = tmb->alctProc->readoutALCTs();
               const std::vector<CSCCLCTDigi>& clctV = tmb->clctProc->readoutCLCTs();
+              const std::vector<CSCCLCTDigi>& clctV_all = tmb->clctProc->getCLCTs();
               const std::vector<int>& preTriggerBXs = tmb->clctProc->preTriggerBXs();
               const std::vector<CSCCLCTPreTriggerDigi>& pretriggerV = tmb->clctProc->preTriggerDigis();
               const std::vector<CSCALCTPreTriggerDigi>& alctpretriggerV = tmb->alctProc->preTriggerDigis();
@@ -354,6 +363,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               put(lctV, oc_lct, detid, tmb->getCSCName() + " LCT digi");
               put(alctV, oc_alct, detid, tmb->getCSCName() + " ALCT digi");
               put(clctV, oc_clct, detid, tmb->getCSCName() + " CLCT digi");
+              put(clctV_all, oc_clct_all, detid, tmb->getCSCName() + " CLCT digi");
               put(pretriggerV, oc_pretrigger, detid, tmb->getCSCName() + " CLCT pre-trigger digi");
               put(preTriggerBXs, oc_pretrig, detid, tmb->getCSCName() + " CLCT pre-trigger BX");
               put(alctpretriggerV, oc_alctpretrigger, detid, tmb->getCSCName() + " ALCT pre-trigger digi");


### PR DESCRIPTION
#### PR description:

Current CSC trigger simulation only allows for max 2 ALCTs and max 2 CLCTs per chamber. MC studies are ongoing that investigate possibilities to trigger on exotic signatures which produce >2 ALCTs or >2 CLCTs. Such signatures may include long-lived particles that decay to multiple muons.

This PR introduces an option in the CSC trigger to write out specific ALCT and CLCT collections with the label "All" for such exotica studies. These collections are only useful when `MAX_ALCTS_PER_PROCESSOR` and `MAX_CLCTS_PER_PROCESSOR` is greater than 2. By default the option is turned off, so there is no change in the trigger performance.

#### PR validation:

Tested it with a 2026 runTheMatrix command.

#### if this PR is a backport please specify the original PR:

N/A

@tahuang1991 