### PR TITLE
Use PREMIX in the name of the .97 workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3304,13 +3304,20 @@ for step in upgradeStepDict.keys():
             for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
                 k=frag[:-4]+'_'+key+'_'+step
                 if (step in upgradeStepDict or step.replace("PUPRMX", "PU")) and key in upgradeStepDict[step]:
-                    steps[k]=merge([ {'cfg':frag},howMuch,upgradeStepDict[step][key]])
+                    stepKey = k
+                    # Include premixing stage1 only for SingleNu, use special step name
+                    if 'Premix' in step:
+                        if not 'SingleNu' in k:
+                            continue
+                        stepKey = 'PREMIX_'+key+'_'+step
+
+                    steps[stepKey]=merge([ {'cfg':frag},howMuch,upgradeStepDict[step][key]])
                     #get inputs in case of -i...but no need to specify in great detail
                     #however, there can be a conflict of beam spots but this is lost in the dataset name
                     #so please be careful
                     s=frag[:-4]+'_'+key
-                    if 'FastSim' not in k and 'Premix' not in step and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and defaultDataSets[key] != '': # exclude upgradeKeys without input dataset
-                        steps[k+'INPUT']={'INPUT':InputInfo(dataSet='/RelVal'+info.dataset+'/%s/GEN-SIM'%(baseDataSetReleaseBetter[s],),location='STD')}
+                    if 'FastSim' not in stepKey and 'Premix' not in step and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and defaultDataSets[key] != '': # exclude upgradeKeys without input dataset
+                        steps[stepKey+'INPUT']={'INPUT':InputInfo(dataSet='/RelVal'+info.dataset+'/%s/GEN-SIM'%(baseDataSetReleaseBetter[s],),location='STD')}
    else:
         for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
             k=step+'_'+key

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3309,6 +3309,7 @@ for step in upgradeStepDict.keys():
                         if not 'SingleNu' in frag:
                             continue
                         stepKey = 'PREMIX_'+key+'_'+step
+                        howMuch = Kby(100,100)
                         steps[stepKey]=merge([ {'--evt_type':frag},howMuch,upgradeStepDict[step][key]])
                     else:
                         steps[k]=merge([ {'cfg':frag},howMuch,upgradeStepDict[step][key]])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3304,20 +3304,20 @@ for step in upgradeStepDict.keys():
             for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
                 k=frag[:-4]+'_'+key+'_'+step
                 if (step in upgradeStepDict or step.replace("PUPRMX", "PU")) and key in upgradeStepDict[step]:
-                    stepKey = k
-                    # Include premixing stage1 only for SingleNu, use special step name
                     if 'Premix' in step:
-                        if not 'SingleNu' in k:
+                        # Include premixing stage1 only for SingleNu, use special step name
+                        if not 'SingleNu' in frag:
                             continue
                         stepKey = 'PREMIX_'+key+'_'+step
-
-                    steps[stepKey]=merge([ {'cfg':frag},howMuch,upgradeStepDict[step][key]])
-                    #get inputs in case of -i...but no need to specify in great detail
-                    #however, there can be a conflict of beam spots but this is lost in the dataset name
-                    #so please be careful
-                    s=frag[:-4]+'_'+key
-                    if 'FastSim' not in stepKey and 'Premix' not in step and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and defaultDataSets[key] != '': # exclude upgradeKeys without input dataset
-                        steps[stepKey+'INPUT']={'INPUT':InputInfo(dataSet='/RelVal'+info.dataset+'/%s/GEN-SIM'%(baseDataSetReleaseBetter[s],),location='STD')}
+                        steps[stepKey]=merge([ {'--evt_type':frag},howMuch,upgradeStepDict[step][key]])
+                    else:
+                        steps[k]=merge([ {'cfg':frag},howMuch,upgradeStepDict[step][key]])
+                        #get inputs in case of -i...but no need to specify in great detail
+                        #however, there can be a conflict of beam spots but this is lost in the dataset name
+                        #so please be careful
+                        s=frag[:-4]+'_'+key
+                        if 'FastSim' not in k and s+'INPUT' not in steps and s in baseDataSetReleaseBetter and defaultDataSets[key] != '': # exclude upgradeKeys without input dataset
+                            steps[k+'INPUT']={'INPUT':InputInfo(dataSet='/RelVal'+info.dataset+'/%s/GEN-SIM'%(baseDataSetReleaseBetter[s],),location='STD')}
    else:
         for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
             k=step+'_'+key

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -78,7 +78,9 @@ for year in upgradeKeys:
             if inclPremix:
                 # premixing stage1, only for NuGun
                 if info.dataset=="NuGun":
-                    workflows[numWF+upgradeWFs['Premix'].offset] = [info.dataset, stepList['Premix']]
+                    # The first element of the list sets the dataset name(?)
+                    datasetName = 'PREMIXUP' + key[2:].replace("PU", "").replace("Design", "") + '_PU25'
+                    workflows[numWF+upgradeWFs['Premix'].offset] = [datasetName, stepList['Premix']]
 
                 # premixing stage2
                 slist = []

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -56,7 +56,7 @@ for year in upgradeKeys:
                         s = s + 'PU' # later processing requires to have PU here
                         # Hardcode nu gun fragment below in order to use it for combined stage1+stage2
                         # Anyway all other fragments are irrelevant for premixing stage1
-                        stepList[specialType].append(stepMaker(key,"SingleNuE10_cf",s,specialWF.suffix))
+                        stepList[specialType].append(stepMaker(key,'PREMIX',s,specialWF.suffix))
                     elif (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to the discussion in https://github.com/cms-sw/cmssw/pull/27753#issuecomment-557797983 to use PREMIX as the dataset name for the pileup library for the premix workflows coming from the upgrade matrix. The PR is marked as RFC because I'm not sure if the changes here are sufficient.

#### PR validation:

Workflow 20661.97 runs.
