### PR TITLE
Add a flag to disable matching in SiStripRecHitConverter

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -49,7 +49,7 @@ private:
   bool isMasked(const SiStripCluster& cluster, bool bad128StripBlocks[6]) const;
   bool useModule(const uint32_t id) const;
 
-  bool useQuality, maskBad128StripBlocks;
+  bool useQuality, maskBad128StripBlocks, doMatching;
   uint32_t tracker_cache_id, cpe_cache_id, quality_cache_id;
   edm::ESInputTag cpeTag, matcherTag, qualityTag;
   edm::ESHandle<TrackerGeometry> tracker;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -14,6 +14,7 @@
 
 namespace edm {
   class ParameterSet;
+  class ParameterSetDescription;
   class EventSetup;
 }  // namespace edm
 
@@ -42,6 +43,8 @@ public:
   void initialize(const edm::EventSetup&);
   void run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output);
   void run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output, LocalVector trackdirection);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
 private:
   void match(products& output, LocalVector trackdirection) const;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -1,7 +1,7 @@
 #ifndef SiStripRecHitConverterAlgorithm_h
 #define SiStripRecHitConverterAlgorithm_h
 
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
@@ -13,10 +13,14 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
 namespace edm {
+  class ConsumesCollector;
   class ParameterSet;
   class ParameterSetDescription;
   class EventSetup;
 }  // namespace edm
+class TrackerDigiGeometryRecord;
+class TkStripCPERecord;
+class SiStripQualityRcd;
 
 class SiStripRecHitConverterAlgorithm {
 public:
@@ -39,7 +43,7 @@ public:
     }
   };
 
-  SiStripRecHitConverterAlgorithm(const edm::ParameterSet&);
+  SiStripRecHitConverterAlgorithm(const edm::ParameterSet&, edm::ConsumesCollector);
   void initialize(const edm::EventSetup&);
   void run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output);
   void run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output, LocalVector trackdirection);
@@ -53,11 +57,14 @@ private:
   bool useModule(const uint32_t id) const;
 
   bool useQuality, maskBad128StripBlocks, doMatching;
-  edm::ESInputTag cpeTag, matcherTag, qualityTag;
-  edm::ESHandle<TrackerGeometry> tracker;
-  edm::ESHandle<StripClusterParameterEstimator> parameterestimator;
-  edm::ESHandle<SiStripRecHitMatcher> matcher;
-  edm::ESHandle<SiStripQuality> quality;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken;
+  edm::ESGetToken<StripClusterParameterEstimator, TkStripCPERecord> cpeToken;
+  edm::ESGetToken<SiStripRecHitMatcher, TkStripCPERecord> matcherToken;
+  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualityToken;
+  const TrackerGeometry* tracker = nullptr;
+  const StripClusterParameterEstimator* parameterestimator = nullptr;
+  const SiStripRecHitMatcher* matcher = nullptr;
+  const SiStripQuality* quality = nullptr;
 
   typedef SiStripRecHit2DCollection::FastFiller Collector;
 };

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -53,7 +53,6 @@ private:
   bool useModule(const uint32_t id) const;
 
   bool useQuality, maskBad128StripBlocks, doMatching;
-  uint32_t tracker_cache_id, cpe_cache_id, quality_cache_id;
   edm::ESInputTag cpeTag, matcherTag, qualityTag;
   edm::ESHandle<TrackerGeometry> tracker;
   edm::ESHandle<StripClusterParameterEstimator> parameterestimator;

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
@@ -5,15 +5,18 @@ SiStripRecHitConverter::SiStripRecHitConverter(edm::ParameterSet const& conf)
     : recHitConverterAlgorithm(conf),
       matchedRecHitsTag(conf.getParameter<std::string>("matchedRecHits")),
       rphiRecHitsTag(conf.getParameter<std::string>("rphiRecHits")),
-      stereoRecHitsTag(conf.getParameter<std::string>("stereoRecHits")) {
+      stereoRecHitsTag(conf.getParameter<std::string>("stereoRecHits")),
+      doMatching(conf.getParameter<bool>("doMatching")) {
   clusterProducer =
       consumes<edmNew::DetSetVector<SiStripCluster> >(conf.getParameter<edm::InputTag>("ClusterProducer"));
 
-  produces<SiStripMatchedRecHit2DCollection>(matchedRecHitsTag);
   produces<SiStripRecHit2DCollection>(rphiRecHitsTag);
   produces<SiStripRecHit2DCollection>(stereoRecHitsTag);
-  produces<SiStripRecHit2DCollection>(rphiRecHitsTag + "Unmatched");
-  produces<SiStripRecHit2DCollection>(stereoRecHitsTag + "Unmatched");
+  if (doMatching) {
+    produces<SiStripMatchedRecHit2DCollection>(matchedRecHitsTag);
+    produces<SiStripRecHit2DCollection>(rphiRecHitsTag + "Unmatched");
+    produces<SiStripRecHit2DCollection>(stereoRecHitsTag + "Unmatched");
+  }
 }
 
 void SiStripRecHitConverter::produce(edm::Event& e, const edm::EventSetup& es) {
@@ -28,9 +31,11 @@ void SiStripRecHitConverter::produce(edm::Event& e, const edm::EventSetup& es) {
                                      << output.rphi->dataSize() << "  clusters in mono detectors\n"
                                      << output.stereo->dataSize() << "  clusters in partners stereo detectors\n";
 
-  e.put(std::move(output.matched), matchedRecHitsTag);
   e.put(std::move(output.rphi), rphiRecHitsTag);
   e.put(std::move(output.stereo), stereoRecHitsTag);
-  e.put(std::move(output.rphiUnmatched), rphiRecHitsTag + "Unmatched");
-  e.put(std::move(output.stereoUnmatched), stereoRecHitsTag + "Unmatched");
+  if (doMatching) {
+    e.put(std::move(output.matched), matchedRecHitsTag);
+    e.put(std::move(output.rphiUnmatched), rphiRecHitsTag + "Unmatched");
+    e.put(std::move(output.stereoUnmatched), stereoRecHitsTag + "Unmatched");
+  }
 }

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
@@ -1,5 +1,7 @@
 #include "RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 SiStripRecHitConverter::SiStripRecHitConverter(edm::ParameterSet const& conf)
     : recHitConverterAlgorithm(conf),
@@ -17,6 +19,21 @@ SiStripRecHitConverter::SiStripRecHitConverter(edm::ParameterSet const& conf)
     produces<SiStripRecHit2DCollection>(rphiRecHitsTag + "Unmatched");
     produces<SiStripRecHit2DCollection>(stereoRecHitsTag + "Unmatched");
   }
+}
+
+void SiStripRecHitConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("ClusterProducer", edm::InputTag("siStripClusters"));
+  desc.add<std::string>("rphiRecHits", "rphiRecHit");
+  desc.add<std::string>("stereoRecHits", "stereoRecHit");
+  desc.add<std::string>("matchedRecHits", "matchedRecHit");
+
+  SiStripRecHitConverterAlgorithm::fillPSetDescription(desc);
+
+  // unused? could be removed after parameter gets removed from HLT menu?
+  desc.addOptionalUntracked<int>("VerbosityLevel");
+
+  descriptions.addWithDefaultLabel(desc);
 }
 
 void SiStripRecHitConverter::produce(edm::Event& e, const edm::EventSetup& es) {

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
@@ -1,10 +1,11 @@
 #include "RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 SiStripRecHitConverter::SiStripRecHitConverter(edm::ParameterSet const& conf)
-    : recHitConverterAlgorithm(conf),
+    : recHitConverterAlgorithm(conf, consumesCollector()),
       matchedRecHitsTag(conf.getParameter<std::string>("matchedRecHits")),
       rphiRecHitsTag(conf.getParameter<std::string>("rphiRecHits")),
       stereoRecHitsTag(conf.getParameter<std::string>("stereoRecHits")),

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h
@@ -10,6 +10,8 @@ public:
   explicit SiStripRecHitConverter(const edm::ParameterSet&);
   void produce(edm::Event&, const edm::EventSetup&) override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   SiStripRecHitConverterAlgorithm recHitConverterAlgorithm;
   std::string matchedRecHitsTag, rphiRecHitsTag, stereoRecHitsTag;

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.h
@@ -14,5 +14,6 @@ private:
   SiStripRecHitConverterAlgorithm recHitConverterAlgorithm;
   std::string matchedRecHitsTag, rphiRecHitsTag, stereoRecHitsTag;
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusterProducer;
+  bool doMatching;
 };
 #endif

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitConverter_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitConverter_cfi.py
@@ -1,15 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-siStripMatchedRecHits = cms.EDProducer("SiStripRecHitConverter",
-    ClusterProducer    = cms.InputTag('siStripClusters'),
-    StripCPE            = cms.ESInputTag('StripCPEfromTrackAngleESProducer:StripCPEfromTrackAngle'),
-    Matcher             = cms.ESInputTag('SiStripRecHitMatcherESProducer:StandardMatcher'),
-    siStripQualityLabel = cms.ESInputTag(''),
-    useSiStripQuality = cms.bool(False),
-    MaskBadAPVFibers  = cms.bool(False),
-    rphiRecHits    = cms.string('rphiRecHit'),
-    stereoRecHits  = cms.string('stereoRecHit'),
-    matchedRecHits = cms.string('matchedRecHit'),
-    VerbosityLevel = cms.untracked.int32(1),
-    doMatching = cms.bool(True),
-)
+from RecoLocalTracker.SiStripRecHitConverter.siStripRecHitConverter_cfi import siStripRecHitConverter as _siStripRecHitConverter
+
+siStripMatchedRecHits = _siStripRecHitConverter.clone()

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitConverter_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitConverter_cfi.py
@@ -10,5 +10,6 @@ siStripMatchedRecHits = cms.EDProducer("SiStripRecHitConverter",
     rphiRecHits    = cms.string('rphiRecHit'),
     stereoRecHits  = cms.string('stereoRecHit'),
     matchedRecHits = cms.string('matchedRecHit'),
-    VerbosityLevel = cms.untracked.int32(1)
+    VerbosityLevel = cms.untracked.int32(1),
+    doMatching = cms.bool(True),
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/src/ES_SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/ES_SiStripRecHitMatcher.cc
@@ -1,0 +1,3 @@
+#include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(SiStripRecHitMatcher);

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -16,9 +16,6 @@ SiStripRecHitConverterAlgorithm::SiStripRecHitConverterAlgorithm(const edm::Para
     : useQuality(conf.getParameter<bool>("useSiStripQuality")),
       maskBad128StripBlocks(conf.getParameter<bool>("MaskBadAPVFibers")),
       doMatching(conf.getParameter<bool>("doMatching")),
-      tracker_cache_id(0),
-      cpe_cache_id(0),
-      quality_cache_id(0),
       cpeTag(conf.getParameter<edm::ESInputTag>("StripCPE")),
       matcherTag(conf.getParameter<edm::ESInputTag>("Matcher")),
       qualityTag(conf.getParameter<edm::ESInputTag>("siStripQualityLabel")) {}
@@ -33,22 +30,13 @@ void SiStripRecHitConverterAlgorithm::fillPSetDescription(edm::ParameterSetDescr
 }
 
 void SiStripRecHitConverterAlgorithm::initialize(const edm::EventSetup& es) {
-  uint32_t tk_cache_id = es.get<TrackerDigiGeometryRecord>().cacheIdentifier();
-  uint32_t c_cache_id = es.get<TkStripCPERecord>().cacheIdentifier();
-  uint32_t q_cache_id = es.get<SiStripQualityRcd>().cacheIdentifier();
-
-  if (tk_cache_id != tracker_cache_id) {
-    es.get<TrackerDigiGeometryRecord>().get(tracker);
-    tracker_cache_id = tk_cache_id;
-  }
-  if (c_cache_id != cpe_cache_id) {
+  es.get<TrackerDigiGeometryRecord>().get(tracker);
+  if (doMatching) {
     es.get<TkStripCPERecord>().get(matcherTag, matcher);
-    es.get<TkStripCPERecord>().get(cpeTag, parameterestimator);
-    cpe_cache_id = c_cache_id;
   }
-  if (useQuality && q_cache_id != quality_cache_id) {
+  es.get<TkStripCPERecord>().get(cpeTag, parameterestimator);
+  if (useQuality) {
     es.get<SiStripQualityRcd>().get(qualityTag, quality);
-    quality_cache_id = q_cache_id;
   }
 }
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -11,8 +11,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/typelookup.h"
-TYPELOOKUP_DATA_REG(SiStripRecHitMatcher);
 
 SiStripRecHitConverterAlgorithm::SiStripRecHitConverterAlgorithm(const edm::ParameterSet& conf)
     : useQuality(conf.getParameter<bool>("useSiStripQuality")),

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -16,6 +16,7 @@ TYPELOOKUP_DATA_REG(SiStripRecHitMatcher);
 SiStripRecHitConverterAlgorithm::SiStripRecHitConverterAlgorithm(const edm::ParameterSet& conf)
     : useQuality(conf.getParameter<bool>("useSiStripQuality")),
       maskBad128StripBlocks(conf.existsAs<bool>("MaskBadAPVFibers") && conf.getParameter<bool>("MaskBadAPVFibers")),
+      doMatching(conf.getParameter<bool>("doMatching")),
       tracker_cache_id(0),
       cpe_cache_id(0),
       quality_cache_id(0),
@@ -73,7 +74,9 @@ void SiStripRecHitConverterAlgorithm::run(edm::Handle<edmNew::DetSetVector<SiStr
     if (collector.empty())
       collector.abort();
   }
-  match(output, trackdirection);
+  if (doMatching) {
+    match(output, trackdirection);
+  }
 }
 
 namespace {

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -9,13 +9,14 @@
 #include "DataFormats/Common/interface/Ref.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 TYPELOOKUP_DATA_REG(SiStripRecHitMatcher);
 
 SiStripRecHitConverterAlgorithm::SiStripRecHitConverterAlgorithm(const edm::ParameterSet& conf)
     : useQuality(conf.getParameter<bool>("useSiStripQuality")),
-      maskBad128StripBlocks(conf.existsAs<bool>("MaskBadAPVFibers") && conf.getParameter<bool>("MaskBadAPVFibers")),
+      maskBad128StripBlocks(conf.getParameter<bool>("MaskBadAPVFibers")),
       doMatching(conf.getParameter<bool>("doMatching")),
       tracker_cache_id(0),
       cpe_cache_id(0),
@@ -23,6 +24,15 @@ SiStripRecHitConverterAlgorithm::SiStripRecHitConverterAlgorithm(const edm::Para
       cpeTag(conf.getParameter<edm::ESInputTag>("StripCPE")),
       matcherTag(conf.getParameter<edm::ESInputTag>("Matcher")),
       qualityTag(conf.getParameter<edm::ESInputTag>("siStripQualityLabel")) {}
+
+void SiStripRecHitConverterAlgorithm::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<bool>("useSiStripQuality", false);
+  desc.add<bool>("MaskBadAPVFibers", false);
+  desc.add<bool>("doMatching", true);
+  desc.add<edm::ESInputTag>("StripCPE", edm::ESInputTag("StripCPEfromTrackAngleESProducer", "StripCPEfromTrackAngle"));
+  desc.add<edm::ESInputTag>("Matcher", edm::ESInputTag("SiStripRecHitMatcherESProducer", "StandardMatcher"));
+  desc.add<edm::ESInputTag>("siStripQualityLabel", edm::ESInputTag());
+}
 
 void SiStripRecHitConverterAlgorithm::initialize(const edm::EventSetup& es) {
   uint32_t tk_cache_id = es.get<TrackerDigiGeometryRecord>().cacheIdentifier();


### PR DESCRIPTION
#### PR description:

This PR proposes to add a configuration parameter `doMatching` (defaults to `True`) to `SiStripRecHitConverter` to allow disabling the strip matching. The motivation is to test mkFit within a customized HLT menu: mkFit needs all rphi+stereo hits as an input, but not the matched ones, and matching is rather expensive (as a reminder the current tracking creates the hit objects on the fly). In order to support the new parameter in existing HI HLT menus, I implemented `fillDescriptions()`. 

While at it, I decided to migrate the `SiStripRecHitConverter` to use ESGetToken. As a preparatory steps I did two modernizations: moved `TYPELOOKUP_DATA_REG` to its own file as suggested in the [EventSetup instructions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToRegisterESData), and removed the use of cached IDs as they're not really useful for just getting the EventSetup products.

#### PR validation:

Limited matrix runs.