### PR TITLE
make HB TDC conversion configurable

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -48,8 +48,8 @@ public:
 
 private:
   int _verbosity;
-  int tdc_1;
-  int tdc_2;
+  int tdc1_;
+  int tdc2_;
   std::string electronicsMapLabel_;
 
   edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame> > tok_QIE10DigiCollection_;
@@ -63,8 +63,8 @@ private:
 
 HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
     : _verbosity(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
-      tdc_1(iConfig.getParameter<int>("tdc1")),
-      tdc_2(iConfig.getParameter<int>("tdc2")),
+      tdc1_(iConfig.getParameter<int>("tdc1")),
+      tdc2_(iConfig.getParameter<int>("tdc2")),
       electronicsMapLabel_(iConfig.getParameter<std::string>("ElectronicsMap")),
       tok_QIE10DigiCollection_(
           consumes<HcalDataFrameContainer<QIE10DataFrame> >(iConfig.getParameter<edm::InputTag>("QIE10"))),
@@ -150,7 +150,7 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
 
       //   convert to hb qie data if hb
       if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel)
-        qiedf = convertHB(qiedf, tdc_1, tdc_2);
+        qiedf = convertHB(qiedf, tdc1_, tdc2_);
 
       if (!uhtrs.exist(uhtrIndex)) {
         uhtrs.newUHTR(uhtrIndex, presamples);

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -48,6 +48,8 @@ public:
 
 private:
   int _verbosity;
+  int tdc_1;
+  int tdc_2;
   std::string electronicsMapLabel_;
 
   edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame> > tok_QIE10DigiCollection_;
@@ -61,6 +63,8 @@ private:
 
 HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
     : _verbosity(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
+      tdc_1(iConfig.getParameter<int>("tdc1")),
+      tdc_2(iConfig.getParameter<int>("tdc2")),
       electronicsMapLabel_(iConfig.getParameter<std::string>("ElectronicsMap")),
       tok_QIE10DigiCollection_(
           consumes<HcalDataFrameContainer<QIE10DataFrame> >(iConfig.getParameter<edm::InputTag>("QIE10"))),
@@ -146,7 +150,7 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
 
       //   convert to hb qie data if hb
       if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel)
-        qiedf = convertHB(qiedf);
+        qiedf = convertHB(qiedf, tdc_1, tdc_2);
 
       if (!uhtrs.exist(uhtrIndex)) {
         uhtrs.newUHTR(uhtrIndex, presamples);
@@ -274,6 +278,8 @@ void HcalDigiToRawuHTR::fillDescriptions(edm::ConfigurationDescriptions& descrip
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.addUntracked<int>("Verbosity", 0);
+  desc.add<int>("tdc1", 4);
+  desc.add<int>("tdc2", 20);
   desc.add<std::string>("ElectronicsMap", "");
   desc.add<edm::InputTag>("QIE10", edm::InputTag("simHcalDigis", "HFQIE10DigiCollection"));
   desc.add<edm::InputTag>("QIE11", edm::InputTag("simHcalDigis", "HBHEQIE11DigiCollection"));

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -50,6 +50,7 @@ private:
   int _verbosity;
   int tdc1_;
   int tdc2_;
+  static constexpr int tdcmax_ = 49;
   std::string electronicsMapLabel_;
 
   edm::EDGetTokenT<HcalDataFrameContainer<QIE10DataFrame> > tok_QIE10DigiCollection_;
@@ -75,6 +76,8 @@ HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig)
       tok_TPDigiCollection_(consumes<HcalTrigPrimDigiCollection>(iConfig.getParameter<edm::InputTag>("TP"))),
       premix_(iConfig.getParameter<bool>("premix")) {
   produces<FEDRawDataCollection>("");
+  if (!(tdc1_ >= 0 && tdc1_ <= tdc2_ && tdc2_ <= tdcmax_))
+    edm::LogWarning("HcalDigiToRawuHTR") << " incorrect TDC ranges " << tdc1_ << ", " << tdc2_ << ", " << tdcmax_;
 }
 
 HcalDigiToRawuHTR::~HcalDigiToRawuHTR() {}
@@ -150,7 +153,7 @@ void HcalDigiToRawuHTR::produce(edm::StreamID id, edm::Event& iEvent, const edm:
 
       //   convert to hb qie data if hb
       if (HcalDetId(detid.rawId()).subdet() == HcalSubdetector::HcalBarrel)
-        qiedf = convertHB(qiedf, tdc1_, tdc2_);
+        qiedf = convertHB(qiedf, tdc1_, tdc2_, tdcmax_);
 
       if (!uhtrs.exist(uhtrIndex)) {
         uhtrs.newUHTR(uhtrIndex, presamples);

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -616,7 +616,7 @@ public:
 
 // converts HE QIE digies to HB data format
 
-QIE11DataFrame convertHB(QIE11DataFrame qiehe) {
+QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2) {
   QIE11DataFrame qiehb = qiehe;
   int adc, tdc;
   bool soi;
@@ -633,13 +633,13 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe) {
     tdc = qiehe[is].tdc();
     soi = qiehe[is].soi();
 
-    if (tdc >= 0 && tdc <= 24)
+    if (tdc >= 0 && tdc <= tdc1)
       tdc = 0;
-    else if (tdc >= 25 && tdc <= 49)
+    else if (tdc > tdc1 && tdc <= tdc2)
       tdc = 1;
-    else if (tdc == 63)
+    else if (tdc2 < 49 && tdc > tdc2 && tdc <= 49)
       tdc = 2;
-    else if (tdc == 62)
+    else
       tdc = 3;
 
     qiehb.setSample(is, adc, tdc, soi);

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -616,7 +616,7 @@ public:
 
 // converts HE QIE digies to HB data format
 
-QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2) {
+QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2, int tdcmax) {
   QIE11DataFrame qiehb = qiehe;
   int adc, tdc;
   bool soi;
@@ -637,7 +637,7 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2) {
       tdc = 0;
     else if (tdc > tdc1 && tdc <= tdc2)
       tdc = 1;
-    else if (tdc2 < 49 && tdc > tdc2 && tdc <= 49)
+    else if (tdc2 < tdcmax && tdc > tdc2 && tdc <= tdcmax)
       tdc = 2;
     else
       tdc = 3;

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -637,7 +637,7 @@ QIE11DataFrame convertHB(QIE11DataFrame qiehe, int tdc1, int tdc2, int tdcmax) {
       tdc = 0;
     else if (tdc > tdc1 && tdc <= tdc2)
       tdc = 1;
-    else if (tdc2 < tdcmax && tdc > tdc2 && tdc <= tdcmax)
+    else if (tdc > tdc2 && tdc <= tdcmax)
       tdc = 2;
     else
       tdc = 3;


### PR DESCRIPTION
#### PR description:

- Adding 2 configurable variables to HcalDigiToRawuHTR class and passing them to convertHB() method in PackerHelp.h to allow easy management of HB tdc bits from job config. 

- Expect no impact on regular workflows.

- Default values of configurables tdc1/tdc2 are current "guesstimates" from the first-pass look at LLP physics and will be studied (once in the release) and adjusted later on, first with some private MC mini-productions, then central samples will be requested.
