### PR TITLE
A fix for missing SelectEvents configuration option

### DIFF
--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -81,7 +81,6 @@ oldo = process._Process__outputmodules["FEVToutput"]
 del process._Process__outputmodules["FEVToutput"]
 
 process.FEVToutput = cms.OutputModule("JsonWritingTimeoutPoolOutputModule",
-    SelectEvents = oldo.SelectEvents,
     splitLevel = oldo.splitLevel,
     outputCommands = oldo.outputCommands,
     fileName = oldo.fileName,
@@ -91,6 +90,9 @@ process.FEVToutput = cms.OutputModule("JsonWritingTimeoutPoolOutputModule",
     # output path must exist!
     outputPath = cms.untracked.string(outDir),
 )
+
+if hasattr(oldo, 'SelectEvents'):
+    process.FEVToutput.SelectEvents = oldo.SelectEvents
 
 process.DQMMonitoringService = cms.Service("DQMMonitoringService")
 


### PR DESCRIPTION
#### PR description:

A fix for the crash in the second instance of the Event Display when SelectEvents property might be missing.

#### PR validation:

PR was validated locally.

#### if this PR is a backport please specify the original PR:

Backport of #28208. Replaces #27530
