### PR TITLE
Jet energy resolution smearing with systematic uncertainties split up

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -26,7 +26,17 @@
 #include <TFormula.h>
 #endif
 
-enum class Variation { NOMINAL = 0, DOWN = 1, UP = 2 };
+enum class Variation { NOMINAL = 0, DOWN = 1, UP = 2,
+                       DOWN2 = 3, UP2 = 4,
+                       DOWN3 = 5, UP3 = 6,
+                       DOWN4 = 7, UP4 = 8,
+                       DOWN5 = 9, UP5 = 10,
+                       DOWN6 = 11, UP6 = 12,
+                       DOWN7 = 13, UP7 = 14,
+                       DOWN8 = 15, UP8 = 16,
+                       DOWN9 = 17, UP9 = 18,
+                       DOWN10 = 19, UP10 = 20
+                     };
 
 template <typename T>
 T clip(const T& n, const T& lower, const T& upper) {

--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -26,17 +26,7 @@
 #include <TFormula.h>
 #endif
 
-enum class Variation { NOMINAL = 0, DOWN = 1, UP = 2,
-                       DOWN2 = 3, UP2 = 4,
-                       DOWN3 = 5, UP3 = 6,
-                       DOWN4 = 7, UP4 = 8,
-                       DOWN5 = 9, UP5 = 10,
-                       DOWN6 = 11, UP6 = 12,
-                       DOWN7 = 13, UP7 = 14,
-                       DOWN8 = 15, UP8 = 16,
-                       DOWN9 = 17, UP9 = 18,
-                       DOWN10 = 19, UP10 = 20
-                     };
+enum class Variation { NOMINAL = 0, DOWN = 1, UP = 2 };
 
 template <typename T>
 T clip(const T& n, const T& lower, const T& upper) {
@@ -167,6 +157,10 @@ namespace JME {
 
       size_t nVariables() const { return m_variables.size(); }
 
+      const std::vector<std::string>& getParametersName() const { return m_parameters_name; }
+
+      size_t nParameters() const { return m_parameters_name.size(); }
+
       std::string getFormulaString() const { return m_formula_str; }
 
 #ifndef STANDALONE
@@ -188,6 +182,7 @@ namespace JME {
 #endif
       std::vector<Binning> m_bins COND_TRANSIENT;
       std::vector<Binning> m_variables COND_TRANSIENT;
+      std::vector<std::string> m_parameters_name COND_TRANSIENT;
 
       COND_SERIALIZABLE;
     };

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -164,19 +164,34 @@ namespace JME {
     std::string formula_str_lower = m_formula_str;
     std::transform(formula_str_lower.begin(), formula_str_lower.end(), formula_str_lower.begin(), ::tolower);
 
-    if (formula_str_lower == "none")
+    if (formula_str_lower == "none") {
       m_formula_str = "";
+
+      if ((tokens.size() > n_bins + n_variables + 3) && (std::atoi(tokens[n_bins + n_variables + 3].c_str()))) {
+        size_t n_parameters = std::stoul(tokens[n_bins + n_variables + 3]);
+
+        if (tokens.size() < (1 + n_bins + 1 + n_variables + 1 + 1 + n_parameters)) {
+          throwException(edm::errors::ConfigFileReadError, "Invalid file format. Please check.");
+        }
+
+        for (size_t i = 0; i < n_parameters; i++) {
+          m_formula_str += tokens[n_bins + n_variables + 4 + i] + " ";
+        }
+      }
+    }
 
     init();
   }
 
   void JetResolutionObject::Definition::init() {
-    if (!m_formula_str.empty())
+    if ((!m_formula_str.empty()) && (m_formula_str.find(' ') == std::string::npos))
 #ifndef STANDALONE
       m_formula = std::make_shared<reco::FormulaEvaluator>(m_formula_str);
 #else
       m_formula = std::make_shared<TFormula>("jet_resolution_formula", m_formula_str.c_str());
 #endif
+    else
+      m_parameters_name = getTokens(m_formula_str);
     for (const auto& bin : m_bins_name) {
       const auto& b = JetParameters::binning_to_string.right.find(bin);
       if (b == JetParameters::binning_to_string.right.cend()) {

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -185,14 +185,14 @@ namespace JME {
 
   void JetResolutionObject::Definition::init() {
     if (!m_formula_str.empty()) {
-     if (m_formula_str.find(' ') == std::string::npos)
+      if (m_formula_str.find(' ') == std::string::npos)
 #ifndef STANDALONE
-      m_formula = std::make_shared<reco::FormulaEvaluator>(m_formula_str);
+        m_formula = std::make_shared<reco::FormulaEvaluator>(m_formula_str);
 #else
-      m_formula = std::make_shared<TFormula>("jet_resolution_formula", m_formula_str.c_str());
+        m_formula = std::make_shared<TFormula>("jet_resolution_formula", m_formula_str.c_str());
 #endif
-     else
-      m_parameters_name = getTokens(m_formula_str);
+      else
+        m_parameters_name = getTokens(m_formula_str);
     }
     for (const auto& bin : m_bins_name) {
       const auto& b = JetParameters::binning_to_string.right.find(bin);

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -184,14 +184,16 @@ namespace JME {
   }
 
   void JetResolutionObject::Definition::init() {
-    if ((!m_formula_str.empty()) && (m_formula_str.find(' ') == std::string::npos))
+    if (!m_formula_str.empty()) {
+     if (m_formula_str.find(' ') == std::string::npos)
 #ifndef STANDALONE
       m_formula = std::make_shared<reco::FormulaEvaluator>(m_formula_str);
 #else
       m_formula = std::make_shared<TFormula>("jet_resolution_formula", m_formula_str.c_str());
 #endif
-    else
+     else
       m_parameters_name = getTokens(m_formula_str);
+    }
     for (const auto& bin : m_bins_name) {
       const auto& b = JetParameters::binning_to_string.right.find(bin);
       if (b == JetParameters::binning_to_string.right.cend()) {

--- a/JetMETCorrections/Modules/interface/JetResolution.h
+++ b/JetMETCorrections/Modules/interface/JetResolution.h
@@ -49,7 +49,9 @@ namespace JME {
     static const JetResolutionScaleFactor get(const edm::EventSetup&, const std::string&);
 #endif
 
-    float getScaleFactor(const JetParameters& parameters, Variation variation = Variation::NOMINAL) const;
+    float getScaleFactor(const JetParameters& parameters,
+                         Variation variation = Variation::NOMINAL,
+                         std::string uncertaintySource = "") const;
 
     void dump() const { m_object->dump(); }
 

--- a/JetMETCorrections/Modules/src/JetResolution.cc
+++ b/JetMETCorrections/Modules/src/JetResolution.cc
@@ -75,7 +75,8 @@ namespace JME {
         std::string s;
         for (const auto& piece : parameter_names)
           s += piece + " ";
-        throw cms::Exception("InvalidParameter") << "Invalid value for 'uncertaintySource' parameter. Only " + s + " are supported.\n";
+        throw cms::Exception("InvalidParameter")
+            << "Invalid value for 'uncertaintySource' parameter. Only " + s + " are supported.\n";
       }
     }
     return parameters_values[parameter];

--- a/JetMETCorrections/Modules/src/JetResolution.cc
+++ b/JetMETCorrections/Modules/src/JetResolution.cc
@@ -54,13 +54,31 @@ namespace JME {
 #endif
 
   float JetResolutionScaleFactor::getScaleFactor(const JetParameters& parameters,
-                                                 Variation variation /* = Variation::NOMINAL*/) const {
+                                                 Variation variation /* = Variation::NOMINAL*/,
+                                                 std::string uncertaintySource /* = ""*/) const {
     const JetResolutionObject::Record* record = m_object->getRecord(parameters);
     if (!record)
       return 1;
 
     const std::vector<float>& parameters_values = record->getParametersValues();
-    return parameters_values[static_cast<size_t>(variation)];
+    const std::vector<std::string>& parameter_names = m_object->getDefinition().getParametersName();
+    size_t parameter = static_cast<size_t>(variation);
+    if (!uncertaintySource.empty()) {
+      if (variation == Variation::DOWN)
+        parameter =
+            std::distance(parameter_names.begin(),
+                          std::find(parameter_names.begin(), parameter_names.end(), uncertaintySource + "Down"));
+      else if (variation == Variation::UP)
+        parameter = std::distance(parameter_names.begin(),
+                                  std::find(parameter_names.begin(), parameter_names.end(), uncertaintySource + "Up"));
+      if (parameter >= parameter_names.size()) {
+        std::string s;
+        for (const auto& piece : parameter_names)
+          s += piece + " ";
+        throw "Invalid value for 'uncertaintySource' parameter. Only " + s + " are supported.";
+      }
+    }
+    return parameters_values[parameter];
   }
 
 }  // namespace JME

--- a/JetMETCorrections/Modules/src/JetResolution.cc
+++ b/JetMETCorrections/Modules/src/JetResolution.cc
@@ -75,7 +75,7 @@ namespace JME {
         std::string s;
         for (const auto& piece : parameter_names)
           s += piece + " ";
-        throw "Invalid value for 'uncertaintySource' parameter. Only " + s + " are supported.";
+        throw cms::Exception("InvalidParameter") << "Invalid value for 'uncertaintySource' parameter. Only " + s + " are supported.\n";
       }
     }
     return parameters_values[parameter];

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -131,19 +131,16 @@ public:
       m_nomVar = 1;
       if (variation == 0)
         m_systematic_variation = Variation::NOMINAL;
-      else if (variation == 1)
-        m_systematic_variation = Variation::UP;
-      else if (variation == -1)
-        m_systematic_variation = Variation::DOWN;
       else if (variation == 101) {
         m_systematic_variation = Variation::NOMINAL;
         m_nomVar = 1;
       } else if (variation == -101) {
         m_systematic_variation = Variation::NOMINAL;
         m_nomVar = -1;
-      } else
-        throw edm::Exception(edm::errors::ConfigFileReadError,
-                             "Invalid value for 'variation' parameter. Only -1, 0, 1 or 101, -101 are supported.");
+      } else if (variation < 0)
+        m_systematic_variation = Variation(-variation*2-1); // Variation::DOWN*
+      else if (variation > 0)
+        m_systematic_variation = Variation(variation*2); // Variation::UP*
     }
 
     produces<JetCollection>();

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -128,8 +128,7 @@ public:
         m_genJetMatcher = std::make_shared<pat::GenJetMatcher>(cfg, consumesCollector());
 
       std::int32_t variation = cfg.getParameter<std::int32_t>("variation");
-      if (cfg.exists("uncertaintySource"))
-        m_uncertaintySource = cfg.getParameter<std::string>("uncertaintySource");
+      m_uncertaintySource = cfg.getParameter<std::string>("uncertaintySource");
       m_nomVar = 1;
       if (variation == 0)
         m_systematic_variation = Variation::NOMINAL;

--- a/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
+++ b/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
@@ -108,12 +108,15 @@ process.load("JetMETCorrections.Modules.JetResolutionESProducer_cfi")
 #
 #process.es_prefer_jer = cms.ESPrefer('PoolDBESSource', 'jer')
 
+# example for smearing the jet resolution
 process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
        src = cms.InputTag('slimmedJets'),
        enabled = cms.bool(True),
        rho = cms.InputTag("fixedGridRhoFastjetAll"),
        algo = cms.string('AK4PFchs'),
        algopt = cms.string('AK4PFchs_pt'),
+       #resolutionFile = cms.FileInPath('Autumn18_V7_MC_PtResolution_AK4PFchs.txt'),
+       #scaleFactorFile = cms.FileInPath('combined_SFs_uncertSources.txt'),
 
        genJets = cms.InputTag('slimmedGenJets'),
        dRMax = cms.double(0.2),
@@ -122,11 +125,27 @@ process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
        debug = cms.untracked.bool(False),
    # Systematic variation
    # 0: Nominal
-   # -1: -1 sigma (down variation)
-   # 1: +1 sigma (up variation)
+   # -1: -1 sigma total (down variation)
+   # 1: +1 sigma total (up variation)
+   # -2: -2 sigma stat-only (down variation)
+   # 2: +2 sigma stat-only (up variation)
+   # -3, 3, -4, 4,... systematic variations down and up
    variation = cms.int32(0),  # If not specified, default to 0
        )
-
 process.p=cms.Path(process.slimmedJetsSmeared)
+
+# example for computing total uncertainties on jet resolution
+process.slimmedJetsSmearedDown=process.slimmedJetsSmeared.clone(variation=cms.int32(-1))
+process.p+=process.slimmedJetsSmearedDown
+process.slimmedJetsSmearedUp=process.slimmedJetsSmeared.clone(variation=cms.int32(1))
+process.p+=process.slimmedJetsSmearedUp
+
+# example for cumputing statistical and systematic uncertainties on jet resolution separately
+#for i in range(2,7):
+#  setattr(process,"slimmedJetsSmearedDown"+str(i),process.slimmedJetsSmeared.clone(variation=cms.int32(-i)))
+#  process.p+=getattr(process,"slimmedJetsSmearedDown"+str(i))
+#for i in range(2,7):
+#  setattr(process,"slimmedJetsSmearedUp"+str(i),process.slimmedJetsSmeared.clone(variation=cms.int32(i)))
+#  process.p+=getattr(process,"slimmedJetsSmearedUp"+str(i))
 
 process.schedule=cms.Schedule(process.p,process.MINIAODSIMoutput_step)

--- a/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
+++ b/PhysicsTools/PatUtils/test/runJERsmearingOnMiniAOD.py
@@ -125,12 +125,10 @@ process.slimmedJetsSmeared = cms.EDProducer('SmearedPATJetProducer',
        debug = cms.untracked.bool(False),
    # Systematic variation
    # 0: Nominal
-   # -1: -1 sigma total (down variation)
-   # 1: +1 sigma total (up variation)
-   # -2: -2 sigma stat-only (down variation)
-   # 2: +2 sigma stat-only (up variation)
-   # -3, 3, -4, 4,... systematic variations down and up
+   # -1: -1 sigma (down variation)
+   # 1: +1 sigma (up variation)
    variation = cms.int32(0),  # If not specified, default to 0
+   uncertaintySource = cms.string(""), # If not specified, default to Total
        )
 process.p=cms.Path(process.slimmedJetsSmeared)
 
@@ -141,11 +139,10 @@ process.slimmedJetsSmearedUp=process.slimmedJetsSmeared.clone(variation=cms.int3
 process.p+=process.slimmedJetsSmearedUp
 
 # example for cumputing statistical and systematic uncertainties on jet resolution separately
-#for i in range(2,7):
-#  setattr(process,"slimmedJetsSmearedDown"+str(i),process.slimmedJetsSmeared.clone(variation=cms.int32(-i)))
-#  process.p+=getattr(process,"slimmedJetsSmearedDown"+str(i))
-#for i in range(2,7):
-#  setattr(process,"slimmedJetsSmearedUp"+str(i),process.slimmedJetsSmeared.clone(variation=cms.int32(i)))
-#  process.p+=getattr(process,"slimmedJetsSmearedUp"+str(i))
+#for source in ["Stat","Jec","Gaus","Rest","Time"]:
+#  setattr(process,"slimmedJetsSmeared"+source+"Down",process.slimmedJetsSmeared.clone(uncertaintySource=source,variation=cms.int32(-1)))
+#  process.p+=getattr(process,"slimmedJetsSmeared"+source+"Down")
+#  setattr(process,"slimmedJetsSmeared"+source+"Up",process.slimmedJetsSmeared.clone(uncertaintySource=source,variation=cms.int32(1)))
+#  process.p+=getattr(process,"slimmedJetsSmeared"+source+"Up")
 
 process.schedule=cms.Schedule(process.p,process.MINIAODSIMoutput_step)


### PR DESCRIPTION
#### PR description:

Jet energy resolution data/MC scale factors now come with systematic uncertainties broken up into sources. An example is here:
https://github.com/cms-jet/JRDatabase/blob/master/textFiles/Autumn18_V7b_MC/Autumn18_V7b_MC_SF_AK4PFchs.txt
https://github.com/cms-jet/JRDatabase/blob/master/SQLiteFiles/Autumn18_V7b_MC.db
This PR provides an interface to access these uncertainties via:
float getScaleFactor(const JetParameters& parameters, Variation variation = Variation::NOMINAL, std::string uncertaintySource = "") const;
The condition dataformat is modified, however, the persitent part is untoched, so this code also works on old conditions.

#### PR validation:

It was checked that all uncertainty sources can be accessed with the new interface with the test file runJERsmearingOnMiniAOD.py.
It was checked that the total uncertainty can be accessed as before in old conditions.

Links to discussion in JetMET:
https://indico.cern.ch/event/864045/#2-updates-on-2018-jer-and-disc
https://indico.cern.ch/event/859946/#5-update-on-jer-scale-factors

#### Backports:

Backports to all Analysis/NanoAOD releases would be needed, i.e. 10_2_X and 10_6_X.