### PR TITLE
update severely outdated default values in Scouting producers

### DIFF
--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -242,7 +242,7 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
 void HLTScoutingPFProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("pfJetCollection", edm::InputTag("hltAK4PFJets"));
-  desc.add<edm::InputTag>("pfJetTagCollection", edm::InputTag("hltCombinedSecondaryVertexBJetTagsPF"));
+  desc.add<edm::InputTag>("pfJetTagCollection", edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsPF"));
   desc.add<edm::InputTag>("pfCandidateCollection", edm::InputTag("hltParticleFlow"));
   desc.add<edm::InputTag>("vertexCollection", edm::InputTag("hltPixelVertices"));
   desc.add<edm::InputTag>("metCollection", edm::InputTag("hltPFMETProducer"));

--- a/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.cc
+++ b/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.cc
@@ -228,16 +228,16 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event& iEvent, edm
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void HLTScoutingMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("ChargedCandidates", edm::InputTag("hltL3MuonCandidates"));
-  desc.add<edm::InputTag>("Tracks", edm::InputTag("hltL3Muons"));
-  desc.add<edm::InputTag>("EcalPFClusterIsoMap", edm::InputTag("hltMuonEcalPFClusterIsoForMuons"));
-  desc.add<edm::InputTag>("HcalPFClusterIsoMap", edm::InputTag("hltMuonHcalPFClusterIsoForMuons"));
-  desc.add<edm::InputTag>("TrackIsoMap", edm::InputTag("hltMuonTkRelIsolationCut0p09Map:combinedRelativeIsoDeposits"));
-  desc.add<edm::InputTag>("displacedvertexCollection", edm::InputTag("hltDisplacedmumuVtxProducerDoubleMu3NoVtx"));
-  desc.add<double>("muonPtCut", 4.0);
+  desc.add<edm::InputTag>("ChargedCandidates", edm::InputTag("hltIterL3MuonCandidates"));
+  desc.add<edm::InputTag>("Tracks", edm::InputTag("hltPixelTracks"));
+  desc.add<edm::InputTag>("EcalPFClusterIsoMap", edm::InputTag("hltMuonEcalMFPFClusterIsoForMuons"));
+  desc.add<edm::InputTag>("HcalPFClusterIsoMap", edm::InputTag("hltMuonHcalRegPFClusterIsoForMuons"));
+  desc.add<edm::InputTag>("TrackIsoMap", edm::InputTag("hltMuonTkRelIsolationCut0p07Map:combinedRelativeIsoDeposits"));
+  desc.add<edm::InputTag>("displacedvertexCollection", edm::InputTag("hltPixelVertices"));
+  desc.add<double>("muonPtCut", 3.0);
   desc.add<double>("muonEtaCut", 2.4);
   desc.add<double>("minVtxProbCut", 0.001);
-  desc.add<edm::InputTag>("InputLinks", edm::InputTag("hltL3MuonsIterL3LinksNoVtx"));
+  desc.add<edm::InputTag>("InputLinks", edm::InputTag("hltL3MuonsIterL3Links"));
 
   descriptions.add("hltScoutingMuonProducer", desc);
 }


### PR DESCRIPTION
#### PR description:

I am updating default parameters in the scouting producers. While also being configured in the HLT menus, similar parameters have led to not store muons in muon scouting streams

#### PR validation:

I ran OnLine_HLT_GRun.py with the updated input to the Scouting packers, and saw that Muons Isolation, Muons in PFScouting and the btagger for PFJets is now correctly computed.