### PR TITLE
test D49 in short matrix

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -45,4 +45,4 @@ Several detector combinations have been generated:
 * D48 = T16+C9+M3+I10+O3+F2
 * D49 = T15+C9+M4+I10+O4+F2
 
-D35 is the baseline for the MTD TDR, and D41 is the baseline for the L1T TDR.
+D35 is the MTD TDR baseline, D41 is the L1T TDR baseline, and D49 is the HLT TDR baseline.

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
                      20034.0, #2026D35 ttbar (MTD TDR baseline)
                      20434.0, #2026D41 ttbar (L1T TDR baseline)
                      21234.0, #2026D44 (exercise HF nose)
-                     22034.0, #2026D46 ttbar (exercise V11 HGCal)
+                     23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix
                      ],


### PR DESCRIPTION
#### PR description:

Since D49 is (preliminarily) selected as the baseline geometry for the HLT TDR, it should be tested for every PR in the short matrix (not just in IBs).

D49 is also marked as the baseline in the geometry readme.