### PR TITLE
make sure to run WriteStreamerFile before ReadStreamerFile

### DIFF
--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -11,6 +11,7 @@
     <use   name="FWCore/Services"/>
     <use   name="FWCore/ParameterSetReader"/>
     <flags   TEST_RUNNER_ARGS="all"/>
+    <flags   PRE_TEST="WriteStreamerFile"/>
   </bin>
   <bin   file="WriteStreamerFile.cpp">
     <use   name="IOPool/Streamer"/>


### PR DESCRIPTION
#### PR description:

Unit test `ReadStreamerFile` reads a data files which is generated by `WriteStreamerFile` . This PR makes sure that `scram` runs `WriteStreamerFile` before `ReadStreamerFile`

FYI @Dr15Jones 

#### PR validation:

build and run locally ( for CentOs8)

[a]
```
===== Test "WriteStreamerFile" ====
Trying to Write a Streamer file
Trying to Write Out The Init message into Streamer File: teststreamfile.dat
Writing Event# : 2000 To Streamer file
Writing Event# : 2001 To Streamer file
Writing Event# : 2002 To Streamer file
Writing Event# : 2003 To Streamer file
Writing Event# : 2004 To Streamer file
Writing Event# : 2005 To Streamer file
Writing Event# : 2006 To Streamer file
Writing Event# : 2007 To Streamer file
Writing Event# : 2008 To Streamer file
Writing Event# : 2009 To Streamer file

---> test WriteStreamerFile succeeded
 
^^^^ End Test WriteStreamerFile ^^^^
Package IOPool/Streamer: Running test ReadStreamerFile
 
===== Test "ReadStreamerFile" ====
27-Nov-2019 16:05:03 CET  Initiating request to open file teststreamfile.dat
27-Nov-2019 16:05:03 CET  Successfully opened file teststreamfile.dat
Trying to Read The Init message from Streamer File: teststreamfile.dat
27-Nov-2019 16:05:03 CET  Closed file teststreamfile.dat
27-Nov-2019 16:05:03 CET  Initiating request to open file file:teststreamfile.dat
27-Nov-2019 16:05:03 CET  Successfully opened file file:teststreamfile.dat
Trying to Read The Init message from Streamer File: teststreamfile.dat
27-Nov-2019 16:05:03 CET  Closed file file:teststreamfile.dat
27-Nov-2019 16:05:03 CET  Initiating request to open file file:teststreamfile.dat
27-Nov-2019 16:05:03 CET  Successfully opened file file:teststreamfile.dat
File Boundary has just been crossed, a new file is read
A new INIT Message is available
Event from next file is also avialble
 TOTAL Events Read: 20
27-Nov-2019 16:05:03 CET  Closed file file:teststreamfile.dat
Exception caught:  An exception of category 'LogicalFileNameNotFound' occurred.
Exception Message:
StreamerInputFile::openStreamerFile()
Logical file name 'teststreamfile.dat' was not found in the file catalog.
If you wanted a local file, you forgot the 'file:' prefix
before the file name in your configuration file.


ReadStreamerFile TEST DONE


---> test ReadStreamerFile succeeded

```