### PR TITLE
Revert "BTL simulation: OOT effects"

### DIFF
--- a/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
+++ b/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
@@ -29,12 +29,12 @@ public:
   };
   class Data {
   public:
-    constexpr static unsigned energyOffset = 14;
-    constexpr static unsigned energyMask = 0x3;
-    constexpr static unsigned sampleOffset = 10;
+    constexpr static unsigned energyOffset = 15;
+    constexpr static unsigned energyMask = 0x1;
+    constexpr static unsigned sampleOffset = 11;
     constexpr static unsigned sampleMask = 0xf;
     constexpr static unsigned dataOffset = 0;
-    constexpr static unsigned dataMask = 0x3ff;
+    constexpr static unsigned dataMask = 0x7ff;
 
     Data() : data_(0) {}
     Data(unsigned short ei, unsigned short si, unsigned short d)

--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -60,7 +60,7 @@ private:
   const float DarkCountRate_;
   const float SigmaElectronicNoise_;
   const float SigmaClock_;
-  const bool smearTimeForOOTtails_;
+
   const float Npe_to_pC_;
   const float Npe_to_V_;
 
@@ -80,7 +80,6 @@ private:
   const float sinPhi_;
 
   const float ScintillatorDecayTime2_;
-  const float ScintillatorDecayTimeInv_;
   const float SPTR2_;
   const float DCRxRiseTime_;
   const float SigmaElectronicNoise2_;

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -69,7 +69,7 @@ namespace mtd_digitizer {
     constexpr uint16_t base = 1 << PMTDSimAccumulator::Data::sampleOffset;
 
     simResult.reserve(simData.size());
-    // mimicking the digitization
+    // mimicing the digitization
     for (const auto& elem : simData) {
       // store only non-zero
       for (size_t iEn = 0; iEn < nEnergies; ++iEn) {
@@ -77,7 +77,7 @@ namespace mtd_digitizer {
         for (size_t iSample = 0; iSample < nSamples; ++iSample) {
           if (samples[iSample] > minCharge) {
             unsigned short packed;
-            if (iEn == 1 || iEn == 3) {
+            if (iEn == 1) {
               // assuming linear range for tof of 0..26
               packed = samples[iSample] / PREMIX_MAX_TOF * base;
             } else {
@@ -108,13 +108,13 @@ namespace mtd_digitizer {
       size_t iSample = detIdIndexHitInfo.sampleIndex();
 
       float value;
-      if (iEn == 1 || iEn == 3) {
+      if (iEn == 1) {
         value = static_cast<float>(detIdIndexHitInfo.data()) / base * PREMIX_MAX_TOF;
       } else {
         value = logintpack::unpack16log(detIdIndexHitInfo.data(), minPackChargeLog, maxPackChargeLog, base);
       }
 
-      if (iEn == 0 || iEn == 2) {
+      if (iEn == 0) {
         hit_info[iEn][iSample] += value;
       } else if (hit_info[iEn][iSample] == 0) {
         // For iEn==1 the digitizers just set the TOF of the first SimHit

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -15,11 +15,8 @@ namespace mtd_digitizer {
   typedef std::array<MTDSimData_t, nSamples> MTDSimHitData;
 
   struct MTDCellInfo {
-    // for the BTL tile geometry and ETL:
-    //     1st array=energy, 2nd array=time-of-flight
-    // for the BTL bar geometry:
-    //     3rd array=energy (right side), 4th array=time-of-flight (right side)
-    std::array<MTDSimHitData, 4> hit_info;
+    //1st array=energy, 2nd array=time-of-flight
+    std::array<MTDSimHitData, 2> hit_info;
   };
 
   // Maximum value of time-of-flight for premixing packing
@@ -39,9 +36,6 @@ namespace mtd_digitizer {
   // use a wider integer now since we have to add row and column in an
   // intermediate det id for ETL
   typedef std::unordered_map<MTDCellId, MTDCellInfo> MTDSimHitDataAccumulator;
-
-  constexpr int kNumberOfBX = 15;
-  constexpr int kInTimeBX = 9;
 
 }  // namespace mtd_digitizer
 

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -33,7 +33,6 @@ _barrel_tile_MTDDigitizer = cms.PSet(
         SigmaElectronicNoise       = cms.double(1.),    # [p.e.]
         SigmaClock                 = cms.double(0.015), # [ns]
         CorrelationCoefficient     = cms.double(1.),
-        SmearTimeForOOTtails       = cms.bool(True),
         Npe_to_pC                  = cms.double(0.016), # [pC] 
         Npe_to_V                   = cms.double(0.0064),# [V] 
 

--- a/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
@@ -84,43 +84,36 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
     // --- Get the simHit energy and convert it from MeV to photo-electrons
     float Npe = 1000. * hit.energyLoss() * LightYield_ * LightCollEff_ * PDE_;
 
-    // --- Calculate the light propagation time to the crystal bases (labeled L and R)
+    // --- Get the simHit time of arrival
+    float toa = std::get<2>(hitRef);
+
+    if (toa > bxTime_ || toa < 0)  //just consider BX==0
+      continue;
+
+    // --- Accumulate the energy of simHits in the same crystal for the BX==0
+    // this is to simulate the charge integration in a 25 ns window
+    (simHitIt->second).hit_info[0][0] += Npe;
+    (simHitIt->second).hit_info[0][1] += Npe;
+
     double distR = 0.5 * topo.pitch().second - 0.1 * hit.localPosition().y();
     double distL = 0.5 * topo.pitch().second + 0.1 * hit.localPosition().y();
 
-    // This is for the layouts with bars along phi
+    // This is for the layout with bars along phi
     if (topo_->getMTDTopologyMode() == (int)BTLDetId::CrysLayout::bar ||
         topo_->getMTDTopologyMode() == (int)BTLDetId::CrysLayout::barphiflat) {
       distR = 0.5 * topo.pitch().first - 0.1 * hit.localPosition().x();
       distL = 0.5 * topo.pitch().first + 0.1 * hit.localPosition().x();
     }
 
-    double tR = std::get<2>(hitRef) + LightCollSlopeR_ * distR;
-    double tL = std::get<2>(hitRef) + LightCollSlopeL_ * distL;
+    double tR = toa + LightCollSlopeR_ * distR;
+    double tL = toa + LightCollSlopeL_ * distL;
 
-    // --- Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    const int iBXR = std::floor(tR / bxTime_) + mtd_digitizer::kInTimeBX;
-    const int iBXL = std::floor(tL / bxTime_) + mtd_digitizer::kInTimeBX;
+    // --- Store the time of the first SimHit
+    if ((simHitIt->second).hit_info[1][0] == 0 || tR < (simHitIt->second).hit_info[1][0])
+      (simHitIt->second).hit_info[1][0] = tR;
 
-    // --- Right side
-    if (iBXR > 0 && iBXR < mtd_digitizer::kNumberOfBX) {
-      // Accumulate the energy of simHits in the same crystal
-      (simHitIt->second).hit_info[0][iBXR] += Npe;
-
-      // Store the time of the first SimHit in the i-th BX
-      if ((simHitIt->second).hit_info[1][iBXR] == 0 || tR < (simHitIt->second).hit_info[1][iBXR])
-        (simHitIt->second).hit_info[1][iBXR] = tR;
-    }
-
-    // --- Left side
-    if (iBXL > 0 && iBXL < mtd_digitizer::kNumberOfBX) {
-      // Accumulate the energy of simHits in the same crystal
-      (simHitIt->second).hit_info[2][iBXL] += Npe;
-
-      // Store the time of the first SimHit in the i-th BX
-      if ((simHitIt->second).hit_info[3][iBXL] == 0 || tL < (simHitIt->second).hit_info[3][iBXL])
-        (simHitIt->second).hit_info[3][iBXL] = tL;
-    }
+    if ((simHitIt->second).hit_info[1][1] == 0 || tL < (simHitIt->second).hit_info[1][1])
+      (simHitIt->second).hit_info[1][1] = tL;
 
   }  // hitRef loop
 }

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -23,7 +23,6 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset)
       DarkCountRate_(pset.getParameter<double>("DarkCountRate")),
       SigmaElectronicNoise_(pset.getParameter<double>("SigmaElectronicNoise")),
       SigmaClock_(pset.getParameter<double>("SigmaClock")),
-      smearTimeForOOTtails_(pset.getParameter<bool>("SmearTimeForOOTtails")),
       Npe_to_pC_(pset.getParameter<double>("Npe_to_pC")),
       Npe_to_V_(pset.getParameter<double>("Npe_to_V")),
       adcNbits_(pset.getParameter<uint32_t>("adcNbits")),
@@ -38,7 +37,6 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset)
       cosPhi_(0.5 * (sqrt(1. + CorrCoeff_) + sqrt(1. - CorrCoeff_))),
       sinPhi_(0.5 * CorrCoeff_ / cosPhi_),
       ScintillatorDecayTime2_(ScintillatorDecayTime_ * ScintillatorDecayTime_),
-      ScintillatorDecayTimeInv_(1. / ScintillatorDecayTime_),
       SPTR2_(SinglePhotonTimeResolution_ * SinglePhotonTimeResolution_),
       DCRxRiseTime_(DarkCountRate_ * ScintillatorRiseTime_),
       SigmaElectronicNoise2_(SigmaElectronicNoise_ * SigmaElectronicNoise_),
@@ -50,20 +48,17 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
   MTDSimHitData chargeColl, toa1, toa2;
 
   for (MTDSimHitDataAccumulator::const_iterator it = input.begin(); it != input.end(); it++) {
-    // --- Digitize only the in-time bucket:
-    const unsigned int iBX = mtd_digitizer::kInTimeBX;
-
     chargeColl.fill(0.f);
     toa1.fill(0.f);
     toa2.fill(0.f);
-    for (size_t iside = 0; iside < 2; iside++) {
+    for (size_t i = 0; i < it->second.hit_info[0].size(); i++) {
       // --- Fluctuate the total number of photo-electrons
-      float Npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][iBX]);
+      float Npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[0][i]);
       if (Npe < EnergyThreshold_)
         continue;
 
       // --- Get the time of arrival and add a channel time offset
-      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + ChannelTimeOffset_;
+      float finalToA1 = (it->second).hit_info[1][i] + ChannelTimeOffset_;
 
       if (smearChannelTimeOffset_ > 0.) {
         float timeSmearing = CLHEP::RandGaussQ::shoot(hre, 0., smearChannelTimeOffset_);
@@ -81,26 +76,6 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
       float finalToA2 = finalToA1 + times[1];
       finalToA1 += times[0];
-
-      // --- Estimate the time uncertainty due to photons from earlier OOT hits in the current BTL cell
-      if (smearTimeForOOTtails_) {
-        float rate_oot = 0.;
-        // Loop on earlier OOT hits
-        for (unsigned int ibx = 0; ibx < mtd_digitizer::kInTimeBX; ++ibx) {
-          if ((it->second).hit_info[2 * iside][ibx] > 0.) {
-            float npe_oot = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][ibx]);
-            rate_oot += npe_oot * exp((it->second).hit_info[1 + 2 * iside][ibx] * ScintillatorDecayTimeInv_) *
-                        ScintillatorDecayTimeInv_;
-          }
-        }  // ibx loop
-
-        if (rate_oot > 0.) {
-          float sigma_oot = sqrt(rate_oot * ScintillatorRiseTime_) * ScintillatorDecayTime_ / Npe;
-          float smearing_oot = CLHEP::RandGaussQ::shoot(hre, 0., sigma_oot);
-          finalToA1 += smearing_oot;
-          finalToA2 += smearing_oot;
-        }
-      }  // if smearTimeForOOTtails_
 
       // --- Uncertainty due to the fluctuations of the n-th photon arrival time:
       if (testBeamMIPTimeRes_ > 0.) {
@@ -140,19 +115,17 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       finalToA1 += cosPhi_ * smearing_thr1_uncorr + sinPhi_ * smearing_thr2_uncorr;
       finalToA2 += sinPhi_ * smearing_thr1_uncorr + cosPhi_ * smearing_thr2_uncorr;
 
-      chargeColl[iside] = Npe * Npe_to_pC_;  // the p.e. number is here converted to pC
+      chargeColl[i] = Npe * Npe_to_pC_;  // the p.e. number is here converted to pC
 
-      toa1[iside] = finalToA1;
-      toa2[iside] = finalToA2;
-
-    }  // iside loop
+      toa1[i] = finalToA1;
+      toa2[i] = finalToA2;
+    }
 
     //run the shaper to create a new data frame
     BTLDataFrame rawDataFrame(it->first.detid_);
     runTrivialShaper(rawDataFrame, chargeColl, toa1, toa2, it->first.row_, it->first.column_);
     updateOutput(output, rawDataFrame);
-
-  }  // MTDSimHitDataAccumulator loop
+  }
 }
 
 void BTLElectronicsSim::runTrivialShaper(BTLDataFrame& dataFrame,

--- a/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
@@ -84,16 +84,14 @@ void BTLTileDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_
     if (smearLightCollTime_ > 0.)
       toa += CLHEP::RandGaussQ::shoot(hre, 0., smearLightCollTime_);
 
-    // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
-    const int iBX = std::floor(toa / bxTime_) + mtd_digitizer::kInTimeBX;
-    if (iBX < 0 || iBX >= mtd_digitizer::kNumberOfBX)
+    if (toa > bxTime_ || toa < 0)  //just consider BX==0
       continue;
 
-    (simHitIt->second).hit_info[0][iBX] += Npe;
+    (simHitIt->second).hit_info[0][0] += Npe;
 
-    // --- Store the time of the first SimHit in the i-th BX
-    if ((simHitIt->second).hit_info[1][iBX] == 0 || toa < (simHitIt->second).hit_info[1][iBX])
-      (simHitIt->second).hit_info[1][iBX] = toa;
+    // --- Store the time of the first SimHit
+    if ((simHitIt->second).hit_info[1][0] == 0 || toa < (simHitIt->second).hit_info[1][0])
+      (simHitIt->second).hit_info[1][0] = toa;
 
   }  // hitRef loop
 }


### PR DESCRIPTION
Temporarily reverts cms-sw/cmssw#28433 as it is causing in CMSSW_11_0_X_2019-11-28-1100 a crash in the premixing test wf 20634.99 under investigation.