### PR TITLE
Add phase2 modifier to the photonValidationSequence_cff and add the p…

### DIFF
--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -6,6 +6,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'bTagOnlyValidation' : ['prebTagSequenceMC','bTagPlotsMCbcl','bTagCollectorSequenceMCbcl'],
                    'JetMETOnlyValidation' : ['globalPrevalidationJetMETOnly','globalValidationJetMETonly','postValidation_JetMET'],
                    'electronOnlyValidation' : ['', 'electronValidationSequence', 'electronPostValidationSequence'],
+                   'photonOnlyValidation' : ['', 'photonValidationSequence', 'photonPostProcessor'],
                    'tauOnlyValidation' : ['produceDenoms', 'pfTauRunDQMValidation', 'runTauEff'],
                    'hcalOnlyValidation' : ['globalPrevalidationHCAL','globalValidationHCAL','postValidation_HCAL'],
                    'baseValidation' : ['baseCommonPreValidation','baseCommonValidation','postValidation_common'],
@@ -18,7 +19,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'ecalValidation_phase2' : ['', 'validationECALPhase2', ''],
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'bTagOnlyValidation', 'tauOnlyValidation', 'hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalOnlyValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])

--- a/Validation/RecoEgamma/python/photonValidationSequence_cff.py
+++ b/Validation/RecoEgamma/python/photonValidationSequence_cff.py
@@ -48,12 +48,19 @@ oldpfPhotonValidation.rBin = 48
 oldpfPhotonValidation.eoverpMin = 0.
 oldpfPhotonValidation.eoverpMax = 5.
 
-
+import Validation.RecoEgamma.tkConvValidator_cfi
 
 
 
 # selectors go in separate "pre-" sequence
 photonPrevalidationSequence = cms.Sequence(tpSelection*tpSelecForFakeRate*tpSelecForEfficiency)
 photonValidationSequence = cms.Sequence(trackAssociatorByHitsForPhotonValidation*photonValidation*pfPhotonValidation*trackAssociatorByHitsForConversionValidation*tkConversionValidation)
+
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify( photonValidation, useTP = cms.bool(False) )
+phase2_common.toModify( pfPhotonValidation, useTP = cms.bool(False) )
+phase2_common.toModify( oldpfPhotonValidation, useTP = cms.bool(False) )
+phase2_common.toModify( tkConversionValidation, useTP = cms.bool(False) )
 
 


### PR DESCRIPTION
…hotonValidationSequence_cff in the autoValidation.py

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

This PR allows the photon validation to be run for Phase 2 Relvals. 

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Succesfully tested with runTheMatrix.py --what upgrade -b 'UPSG_Std_2026D41noPU' -l 20452.0 --label 2026D41noPU -m 5000 -t 8 --noCafVeto --command="--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 -n 100"  >& localRun.log &




#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
