### PR TITLE
fix coordinates swap into SiStrip gains payload inspector

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -1324,22 +1324,22 @@ namespace {
 
         if (subid == StripSubdetector::TIB) {
           ratios["TIB"]->Fill(ratio);
-          scatters["TIB"]->Fill(lastmap[index], firstmap[index]);
+          scatters["TIB"]->Fill(firstmap[index], lastmap[index]);
         }
 
         if (subid == StripSubdetector::TOB) {
           ratios["TOB"]->Fill(ratio);
-          scatters["TOB"]->Fill(lastmap[index], firstmap[index]);
+          scatters["TOB"]->Fill(firstmap[index], lastmap[index]);
         }
 
         if (subid == StripSubdetector::TID) {
           ratios["TID"]->Fill(ratio);
-          scatters["TID"]->Fill(lastmap[index], firstmap[index]);
+          scatters["TID"]->Fill(firstmap[index], lastmap[index]);
         }
 
         if (subid == StripSubdetector::TEC) {
           ratios["TEC"]->Fill(ratio);
-          scatters["TEC"]->Fill(lastmap[index], firstmap[index]);
+          scatters["TEC"]->Fill(firstmap[index], lastmap[index]);
         }
       }
 


### PR DESCRIPTION
#### PR description:

Trivial bug-fix. Coordinates in a scatter plot were inverted. 

#### PR validation:

Unit test still run.
   * Original plot:
![image](https://user-images.githubusercontent.com/5082376/69950473-a8cf7c80-14f3-11ea-90d4-e98e1fe71941.png)
   * Fixed plot:
![image](https://user-images.githubusercontent.com/5082376/69950524-bbe24c80-14f3-11ea-823e-582de27ea1c4.png)



#### if this PR is a backport please specify the original PR:

NA
