### PR TITLE
Global tags for Run 2 UL reprocessing

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v8',
+    'run1_data'         :   '110X_dataRun2_v9',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v8',
+    'run2_data'         :   '110X_dataRun2_v9',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v8',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v7',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -62,9 +62,9 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v4',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,10 +32,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '110X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v8',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v8',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v8',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v9',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v9',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -15,7 +15,9 @@ autoCond = {
     'run2_mc_l1stage1'  :   '110X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v3',
-    #GlobalTag for MC production with optimistic alignment and calibrations for Run2
+    #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
+    'run2_mc_pre_vfp'           :   '110X_mcRun2_asymptotic_preVFP_v1',
+    #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
     'run2_mc'           :   '110X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v4',

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,9 +16,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '110X_mcRun2_asymptotic_v4',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v3',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,10 +30,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '110X_dataRun2_relval_v9',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v7',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v8',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v7',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v7',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v8',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v8',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2886,14 +2886,12 @@ steps['REMINIAOD_data2016'] = merge([{'-s' : 'PAT,DQM:@miniAODDQM',
                                       '--data' : '',
                                       '--scenario' : 'pp',
                                       '--eventcontent' : 'MINIAOD,DQM',
-                                      '--datatier' : 'MINIAOD,DQMIO',
-                                      '--customise_unsch' : 'PhysicsTools/PatAlgos/slimming/customizeMiniAOD_HcalFixLegacy2016.customizeAll'
+                                      '--datatier' : 'MINIAOD,DQMIO'
                                       },stepMiniAODDefaults])
 
 steps['REMINIAOD_data2016_HIPM'] = merge([{'--era' : 'Run2_2016_HIPM,run2_miniAOD_80XLegacy'},steps['REMINIAOD_data2016']])
 
 stepReMiniAODData17 = merge([{'--era' : 'Run2_2017,run2_miniAOD_94XFall17'},steps['REMINIAOD_data2016']])
-stepReMiniAODData17 = remove(stepReMiniAODData17,'--customise_unsch')
 steps['REMINIAOD_data2017'] = stepReMiniAODData17
 
 # Not sure whether the customisations are in the dict as "--customise" or "--era" so try to


### PR DESCRIPTION
#### PR description:

This autoCond update finalizes the global tags for the Run 2 UL reprocessing, including cosmic GTs (the 2017 cosmic GT has already been updated in PR #28079). A separate GT will be used for the early 2016 MC scenario (the "pre-VFP" era) and a new autoCond entry `auto:run2_mc_pre_vfp` has been created.

The offline GTs remove an record of type `HcalRespCorrsRcd` with label "bugged". As this record will be obsolete with the UL reprocessing, commit c2349b328da639ad160f44dd6cfc435f7e6c68ad removes a customization from 2016 workflows that makes use of this labeled record. @abdoulline @mariadalfonso @mazarkin  

**GT diffs**

**2016 pp collision MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v4/110X_mcRun2_asymptotic_v5

**2016 pp collision MC for "pre-VFP" era (new autoCond key)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v4/110X_mcRun2_asymptotic_preVFP_v1

which differs from the standard 2016 pp collision MC GT as follows;

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_v5/110X_mcRun2_asymptotic_preVFP_v1


**2016 cosmic MC**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2cosmics_startup_deco_v3/110X_mcRun2cosmics_startup_deco_v4

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v8/110X_dataRun2_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v8/110X_dataRun2_relval_v9

**Prompt-like data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HEfail_v7/110X_dataRun2_PromptLike_HEfail_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_v7/110X_dataRun2_PromptLike_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_PromptLike_HI_v7/110X_dataRun2_PromptLike_HI_v9

**2018 cosmic GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_deco_v4/110X_upgrade2018cosmics_realistic_deco_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_peak_v5/110X_upgrade2018cosmics_realistic_peak_v6
#### PR validation:

Details of subsystem validation of the conditions can be found at [1]-[15] below. In additional, a technical test was performed: `runTheMatrix.py -l limited,7.2,7.4,7.21,7.22 --ibeos`

8 July 2019:
HCAL [1]: https://indico.cern.ch/event/832785/contributions/3489397/attachments/1876358/3089810/Hcal_UL_2016_2018_July8_v1.pdf, followup at https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4188.html 

22 July 2019:
Pixel [2]: https://indico.cern.ch/event/835589/contributions/3513525/attachments/1887574/3114665/20190729_AlCaDB_UL16.pdf; See also https://github.com/cms-sw/cmssw/pull/27600 

8 Aug 2018:
HCAL negative energy filter [3]: PPD meeting

2 Sep 2019:
PF [3]:
https://indico.cern.ch/event/843260/#39-sign-off-pf-calibration-for 
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4215/1/1.html

30 Sep 2019:
PPS [4]:
https://indico.cern.ch/event/848325/#2-ul-2016-sign-off-pps-alignme
Tracker alignment + APE [5]:
https://indico.cern.ch/event/848325/#3-ul-2016-sign-off-tracker-ali
https://hypernews.cern.ch/HyperNews/CMS/get/tk-alignment/1875.html

7 Oct 2019
Tracker alignment + APE HN announcement [6]:
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4228/1.html

21 Oct 2019:
Beamspot [7]:
https://indico.cern.ch/event/854617/#7-beamspot-for-ultra-legacy-20
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4234.html
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4234/1.html

28 Oct 2019:
PPS details[8] 
https://indico.cern.ch/event/854618/#3-ul-2016-sign-off-update-pps 
SiStrip G2 calibration[9]
https://indico.cern.ch/event/854618/#4-updated-sistrip-g2-calibrati 
Tracker MC misalignment scenario[10]
https://indico.cern.ch/event/854618/#11-tracker-mc-misalignment-sce 

4 Nov 2019:
PPS, update of runs 303817-303819 of 2017E , virtual presentation [11]:
https://indico.cern.ch/event/859478/#4-ul-2016-2018-updated-pps-ali

11 Nov 2019:
ECAL [12]:
https://indico.cern.ch/event/859480/#2-ul-2016-sign-off-ecal-data-a
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4241.html
https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4241/1.html
Muon + GRP[13]:
https://indico.cern.ch/event/859480/#3-ul-2016-sign-off-muongpr

18 Nov 2019:
EGamma, partial sign-off, data tags and PR still needed [14]:
https://indico.cern.ch/event/862728/#3-ul-2016-sign-off-egamma-mc-a 

21 Nov 2019:
EGamma final sign-off [15]:
https://indico.cern.ch/event/860471/#12-ul-16-egm-regression-sign-o

#### if this PR is a backport please specify the original PR:

This PR is not a backport but all updates will be backported to 10_6_X.
