### PR TITLE
disable unit test for ppc64le due to lack of tfcompiler

### DIFF
--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -22,10 +22,10 @@
     <use name="PhysicsTools/TensorFlow" />
 </bin>
 
-
+<ifarchitecture name="!_ppc64le_">
 <bin file="tfadd_t.cpp">
   <flags DNN_NAME="test_graph_tfadd"/>
   <use name="tensorflow-runtime"/>
   <use name="tensorflow-xla_compiled_cpu_function"/> 
 </bin>
-
+</ifarchitecture>


### PR DESCRIPTION
#### PR description:

We do not have `tfcompiler` build for `ppc64le` this causes build errors in `ppc64le` IBs 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_ppc64le_gcc820/CMSSW_11_1_X_2019-12-02-2300/PhysicsTools/TensorFlow

This PR proposes to not build this unit test on ppc64le.