### PR TITLE
Fix two bugs in CommonTools/Utils unit tests found by ASAN

### DIFF
--- a/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
+++ b/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
@@ -20,7 +20,7 @@ int main() {
   using MyExpr = reco::MaskCollection<eetest::CandForTest>;
 
   std::vector<Cand> oriC;
-  oriC.reserve(10); // pre-allocate so it doesn't reallocate
+  oriC.reserve(10);  // pre-allocate so it doesn't reallocate
   MyExpr::Collection c;
   for (int i = 5; i < 15; ++i) {
     oriC.emplace_back(Cand(i, 1, 1));

--- a/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
+++ b/CommonTools/Utils/test/ExpressionEvaluatorUnitTest.cpp
@@ -20,6 +20,7 @@ int main() {
   using MyExpr = reco::MaskCollection<eetest::CandForTest>;
 
   std::vector<Cand> oriC;
+  oriC.reserve(10); // pre-allocate so it doesn't reallocate
   MyExpr::Collection c;
   for (int i = 5; i < 15; ++i) {
     oriC.emplace_back(Cand(i, 1, 1));

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -15,9 +15,9 @@
 
 // A fake Det class
 
-class MyDet : public GeomDet {
+class MyDet : public TrackerGeomDet {
 public:
-  MyDet(BoundPlane *bp) : GeomDet(bp) {}
+  MyDet(BoundPlane *bp) : TrackerGeomDet(bp) {}
 
   virtual DetId geographicalId() const { return DetId(); }
   virtual std::vector<const GeomDet *> components() const { return std::vector<const GeomDet *>(); }


### PR DESCRIPTION
#### PR description:

ASAN found two fairly trivial bugs in the CommonTools/Utils unit tests.  One bug used the wrong type for the local geometry, which violated an assumption made by the BaseTrackerRecHit here:

https://github.com/cms-sw/cmssw/blob/30a2ff8ff13aaa416259453b54ad0b62588edc91/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h#L29

The second bug takes a reference to a vector element which can be invalidated if the vector resizes.  This fix preallocates the vector so that it does not resize.

#### PR validation:

Tests were re-run in an ASAN build and verified that the bugs were fixed.  No effect on anything outside the package unit tests.
