### PR TITLE
fix loop bounds off-by-one errors in TrackerAlignment_PayloadInspector

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -132,7 +132,7 @@ namespace {
 
       std::vector<int> boundaries;
       AlignmentPI::partitions currentPart = AlignmentPI::BPix;
-      for (unsigned int i = 0; i <= ref_ali.size(); i++) {
+      for (unsigned int i = 0; i < ref_ali.size(); i++) {
         if (ref_ali[i].rawId() == target_ali[i].rawId()) {
           counter++;
           int subid = DetId(ref_ali[i].rawId()).subdetId();
@@ -359,7 +359,7 @@ namespace {
       }
 
       int loopedComponents(0);
-      for (unsigned int i = 0; i <= ref_ali.size(); i++) {
+      for (unsigned int i = 0; i < ref_ali.size(); i++) {
         if (ref_ali[i].rawId() == target_ali[i].rawId()) {
           loopedComponents++;
           int subid = DetId(ref_ali[i].rawId()).subdetId();


### PR DESCRIPTION
#### PR description:

Adress sanitizer (ASAN) unit tests found two off-by-one errors in the TrackerAlignment_PayloadInspector.  Both errors read one place past the end of the vectors being compared.

#### PR validation:

Reran unit tests in an ASAN build and verified that the heap-buffer-overflow errors were fixed.