### PR TITLE
fix geometry type in TrackingTools/KalmanUpdators unit test

### DIFF
--- a/TrackingTools/KalmanUpdators/test/KFUpdator_t.cpp
+++ b/TrackingTools/KalmanUpdators/test/KFUpdator_t.cpp
@@ -46,9 +46,9 @@ Matrix5 buildCovariance(float y) {
 
 // A fake Det class
 
-class MyDet : public GeomDet {
+class MyDet : public TrackerGeomDet {
 public:
-  MyDet(BoundPlane* bp, DetId id) : GeomDet(bp) { setDetId(id); }
+  MyDet(BoundPlane* bp, DetId id) : TrackerGeomDet(bp) { setDetId(id); }
 
   virtual std::vector<const GeomDet*> components() const { return std::vector<const GeomDet*>(); }
 


### PR DESCRIPTION
#### PR description:

KFUpdator_t uses the wrong type for the local geometry, which violates an assumption made by the BaseTrackerRecHit.  This is the same error as one of the errors in PR #28531

#### PR validation:

Reran unit test in an ASAN build and verified that the heap-buffer-overflow error was fixed.