### PR TITLE
rename tmp file to avoid race condition between PyDevParameterSet & PythonParameterSet

### DIFF
--- a/FWCore/PyDevParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PyDevParameterSet/test/makepset_t.cppunit.cc
@@ -232,7 +232,7 @@ void testmakepset::fileinpathAux() {
 
     CPPUNIT_ASSERT(!fullpath.empty());
 
-    tmpout = fullpath.substr(0, fullpath.find("FWCore/PyDevParameterSet/test/fip.txt")) + "tmp.py";
+    tmpout = fullpath.substr(0, fullpath.find("FWCore/PyDevParameterSet/test/fip.txt")) + "PyDevtmp.py";
 
     edm::FileInPath topo = innerps.getParameter<edm::FileInPath>("topo");
     // if the file is local, then just disable this check as then it is expected to fail
@@ -271,7 +271,7 @@ void testmakepset::fileinpathAux() {
       "import FWCore.ParameterSet.Config as cms\n"
       "process = cms.Process('PROD')\n"
       "process.main = cms.PSet(\n"
-      "    fip2 = cms.FileInPath('tmp.py')\n"
+      "    fip2 = cms.FileInPath('PyDevtmp.py')\n"
       ")\n"
       "process.source = cms.Source('EmptySource')\n";
 
@@ -288,7 +288,7 @@ void testmakepset::fileinpathAux() {
   if (localArea) {
     CPPUNIT_ASSERT(fip2.location() == edm::FileInPath::Local);
   }
-  CPPUNIT_ASSERT(fip2.relativePath() == "tmp.py");
+  CPPUNIT_ASSERT(fip2.relativePath() == "PyDevtmp.py");
   std::string fullpath2 = fip2.fullPath();
   std::cerr << "fullPath is: " << fip2.fullPath() << std::endl;
   std::cerr << "copy of fullPath is: " << fullpath2 << std::endl;


### PR DESCRIPTION
#### PR description:

This change makes sure that unit tests in PyDevParameterSet and PythonParameterSet generates different file name. Currently they both generate and delete `$CMSSW_BASE/src/tmp.py` which causes one of these tests to randomly fail
