### PR TITLE
replace wildcards of cmssw class dictionaries to avoid duplicates

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -1,13 +1,15 @@
 <lcgdict>
+  <class name="edm::ValueMap<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >"/>
+  <class name="edm::Wrapper<edm::ValueMap<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > > >"/>
+  <class name="edm::Wrapper<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag> >"/>
+  <class name="edm::Wrapper<std::vector<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > > >"/>
+  <class name="std::vector<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >"/>
 <selection>
   <class pattern="ROOT::Math::SMatrix<*>" />
   <class pattern="ROOT::Math::MatRepStd<*>" />
   <class pattern="ROOT::Math::RowOffsets<*>" />
   <class pattern="ROOT::Math::SVector<*>" />
   <class pattern="std::vector<ROOT::Math::SMatrix<*>>" />
-  <class pattern="edm::Wrapper<*>" />
-  <class pattern="edm::RefVector<*>" />
-  <class pattern="edm::ValueMap<*>" />
   <class pattern="std::vector<std::pair<ROOT::Math::PositionVector3D<*>,float> >"/>
 </selection>
 <exclusion>


### PR DESCRIPTION
as discussed in the core meeting yesterday, the wildcards in DataFormats/Math are giving duplicate  dictionary definitions for some classes when using root modules. The use of wildcards for cmssw classes is not desired by the fwk group. This PR removes them and replaces them with what's needed to run matrix workflows (I tested a few)