### PR TITLE
A fix for importing dependencies in DQM bin by bin tool

### DIFF
--- a/DQMServices/FileIO/scripts/visDQMUpload.py
+++ b/DQMServices/FileIO/scripts/visDQMUpload.py
@@ -17,7 +17,7 @@ from stat import *
 try:
   from Monitoring.DQM import visDQMUtils
 except:
-  import DQMServices.FileIO.visDQMUtils
+  from DQMServices.FileIO import visDQMUtils
 
 HTTPS = httplib.HTTPS
 if sys.version_info[:3] >= (2, 4, 0):


### PR DESCRIPTION
#### PR description:

This is a follow up to #28494 as as import within visDQMUpload were failing.

#### PR validation:

PR was validated locally.
