### PR TITLE
Fix D51 and D52 reco geometry configurations after #28500

### DIFF
--- a/Configuration/Geometry/python/GeometryExtended2026D51Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D51Reco_cff.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Geometry.GeometryExtended2026D51_cff import *
 
 # tracker
-from Geometry.CommonDetUnit.globalTrackingGeometry_cfi import *
+from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D52Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D52Reco_cff.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Geometry.GeometryExtended2026D52_cff import *
 
 # tracker
-from Geometry.CommonDetUnit.globalTrackingGeometry_cfi import *
+from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -291,7 +291,7 @@ trackerDict = {
             'from SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkT14_cff import *',
         ],
         "reco" : [
-            'from Geometry.CommonDetUnit.globalTrackingGeometry_cfi import *',
+            'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cfi import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
@@ -326,7 +326,7 @@ trackerDict = {
             'from SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkT14_cff import *',
         ],
         "reco" : [
-            'from Geometry.CommonDetUnit.globalTrackingGeometry_cfi import *',
+            'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cfi import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',


### PR DESCRIPTION
#### PR description:

The code reorganization implied by #28500 was not taken into account in #28503 that was developed and integrated in parallel. This causes the newly added test workflows 23634.0 and 24034.0 to crash. This PR fixes the reco geometry configuration.

#### PR validation:

```
18:23 cmsdev25 2854> less runall-report-step123-.log 
23634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D51_GenSimHLBeamSpotFull14+DigiFullTrigger_2026D51+RecoFullGlobal_2026D51+HARVESTFullGlobal_2026D51 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  4 18:18:04 2019-date Wed Dec  4 18:03:23 2019; exit: 0 0 0 0
24034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D52_GenSimHLBeamSpotFull14+DigiFullTrigger_2026D52+RecoFullGlobal_2026D52+HARVESTFullGlobal_2026D52 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Dec  4 18:18:04 2019-date Wed Dec  4 18:03:23 2019; exit: 0 0 0 0
2 2 2 2 tests passed, 0 0 0 0 failed
```