### PR TITLE
Use TFile::GetUUID() for job report GUID in DQMRootOutputModule

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -36,7 +36,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/Utilities/interface/Digest.h"
-#include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
@@ -334,7 +333,7 @@ void DQMRootOutputModule::openFile(edm::FileBlock const&) {
                                    std::string(),
                                    "DQMRootOutputModule",
                                    description().moduleLabel(),
-                                   edm::createGlobalIdentifier(),
+                                   m_file->GetUUID().AsString(),
                                    std::string(),
                                    branchHash.digest().toString(),
                                    std::vector<std::string>());

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -328,12 +328,14 @@ void DQMRootOutputModule::openFile(edm::FileBlock const&) {
 
   edm::Service<edm::JobReport> jr;
   cms::Digest branchHash;
+  std::string guid{m_file->GetUUID().AsString()};
+  std::transform(guid.begin(), guid.end(), guid.begin(), (int (*)(int))std::toupper);
   m_jrToken = jr->outputFileOpened(m_fileName,
                                    m_logicalFileName,
                                    std::string(),
                                    "DQMRootOutputModule",
                                    description().moduleLabel(),
-                                   m_file->GetUUID().AsString(),
+                                   std::move(guid),
                                    std::string(),
                                    branchHash.digest().toString(),
                                    std::vector<std::string>());

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -632,13 +632,15 @@ std::unique_ptr<edm::FileBlock> DQMRootSource::readFile_() {
     ++m_presentIndexItr;
 
   edm::Service<edm::JobReport> jr;
+  std::string guid{m_file->GetUUID().AsString()};
+  std::transform(guid.begin(), guid.end(), guid.begin(), (int (*)(int))std::toupper);
   m_jrToken = jr->inputFileOpened(m_presentlyOpenFileName,
                                   m_catalog.logicalFileNames()[m_fileIndex - 1],
                                   std::string(),
                                   std::string(),
                                   "DQMRootSource",
                                   "source",
-                                  m_file->GetUUID().AsString(),  //edm::createGlobalIdentifier(),
+                                  std::move(guid),
                                   std::vector<std::string>());
 
   return std::unique_ptr<edm::FileBlock>(new edm::FileBlock);

--- a/DQMServices/FwkIO/test/check_guid_file1.py
+++ b/DQMServices/FwkIO/test/check_guid_file1.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import re
+import sys
+import ROOT
+
+fname_root = "dqm_file1.root"
+fname_report = "dqm_file1_jobreport.xml"
+
+f = ROOT.TFile.Open(fname_root)
+guid_file = f.GetUUID().AsString()
+f.Close()
+
+guid_report = None
+with open(fname_report) as f:
+    guid_re = re.compile("<GUID>(?P<guid>.*)</GUID>")
+    for line in f:
+        m = guid_re.search(line)
+        if m:
+            guid_report = m.group("guid")
+            break
+
+if guid_report is None:
+    print("Did not find GUID from %s" % fname_report)
+    sys.exit(1)
+if guid_file != guid_report:
+    print("GUID from file %s differs from GUID from job report %s" % (guid_file, guid_report))
+    sys.exit(1)
+
+print("SUCCEEDED")

--- a/DQMServices/FwkIO/test/check_guid_file1.py
+++ b/DQMServices/FwkIO/test/check_guid_file1.py
@@ -7,7 +7,7 @@ fname_root = "dqm_file1.root"
 fname_report = "dqm_file1_jobreport.xml"
 
 f = ROOT.TFile.Open(fname_root)
-guid_file = f.GetUUID().AsString()
+guid_file = f.GetUUID().AsString().upper()
 f.Close()
 
 guid_report = None

--- a/DQMServices/FwkIO/test/run_tests.sh
+++ b/DQMServices/FwkIO/test/run_tests.sh
@@ -78,8 +78,14 @@ pushd ${LOCAL_TMP_DIR}
   #merging
   testConfig=create_file1_cfg.py
   rm -f dqm_file1.root
+  rm -f dqm_file1_jobreport.xml
   echo ${testConfig} ------------------------------------------------------------
-  cmsRun -p ${LOCAL_TEST_DIR}/${testConfig} || die "cmsRun ${testConfig}" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/${testConfig} -j dqm_file1_jobreport.xml || die "cmsRun ${testConfig}" $?
+
+  # test GUID here
+  checkFile=check_guid_file1.py
+  echo ${checkFile} ------------------------------------------------------------
+  python ${LOCAL_TEST_DIR}/${checkFile} || die "python ${checkFile}" $?
 
   testConfig=create_file2_cfg.py
   rm -f dqm_file2.root


### PR DESCRIPTION
#### PR description:

`DQMRootSource` uses `TFile::GetUUID()` to report the GUID of the file to the framework job report, while `DQMRootOutputModule` uses `edm::createGlobalIdentifier()` but without saving it to the file, leading to inconsistency with file names and GUIDs in the job reports (see #28534).

As the simplest fix this PR proposes to use the `TFile::GetUUID()` also in `DQMRootOutputModule` for the job report.

Fixes #28534. 

#### PR validation:

Unit tests run.