### PR TITLE
DQM: Remove dqmEndRun in DQMEDAnalyzer

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -75,7 +75,6 @@ protected:
   std::shared_ptr<dds::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock&,
                                                          const edm::EventSetup&) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override;
 
 private:
   // Constants
@@ -1191,10 +1190,6 @@ void CTPPSDiamondDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock&
     hitHistoTmp->Divide(&(plot.second.pixelTracksMapWithDiamonds), &(potPlots_[detId_pot].pixelTracksMap));
   }
 }
-
-//----------------------------------------------------------------------------------------------------
-
-void CTPPSDiamondDQMSource::dqmEndRun(const edm::Run&, const edm::EventSetup&) {}
 
 //----------------------------------------------------------------------------------------------------
 

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -38,7 +38,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   unsigned int verbosity;
@@ -637,15 +636,6 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
     return;
   if (verbosity)
     LogPrint("CTPPSPixelDQMSource") << "analyze event " << nEvents;
-}
-
-//-----------------------------------------------------------------------------
-void CTPPSPixelDQMSource::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  if (!verbosity)
-    return;
-  LogPrint("CTPPSPixelDQMSource") << "end of Run " << run.run() << ": " << nEvents << " events\n"
-                                  << "multHitsMax= " << multHitsMax << "   cluSizeMax= " << cluSizeMax
-                                  << "\nx0: " << x0_MIN << "/" << x0_MAX << "y0: " << y0_MIN << "/" << y0_MAX << "\n";
 }
 
 //---------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -58,7 +58,6 @@ protected:
   std::shared_ptr<totemds::Cache> globalBeginLuminosityBlock(const edm::LuminosityBlock &,
                                                              const edm::EventSetup &) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
-  void dqmEndRun(const edm::Run &, const edm::EventSetup &) override;
 
 private:
   // Constants
@@ -778,11 +777,5 @@ void TotemTimingDQMSource::globalEndLuminosityBlock(const edm::LuminosityBlock &
     }
   }
 }
-
-//----------------------------------------------------------------------------------------------------
-
-void TotemTimingDQMSource::dqmEndRun(const edm::Run &, const edm::EventSetup &) {}
-
-//----------------------------------------------------------------------------------------------------
 
 DEFINE_FWK_MODULE(TotemTimingDQMSource);

--- a/DQM/CastorMonitor/interface/CastorMonitorModule.h
+++ b/DQM/CastorMonitor/interface/CastorMonitorModule.h
@@ -15,7 +15,7 @@
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 #include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -39,13 +39,6 @@
 #include "DataFormats/CastorReco/interface/CastorCluster.h"
 #include "DataFormats/CastorReco/interface/CastorJet.h"
 #include "DataFormats/CastorReco/interface/CastorTower.h"
-#include "DataFormats/JetReco/interface/BasicJet.h"
-#include "DataFormats/JetReco/interface/BasicJetCollection.h"
-#include "DataFormats/JetReco/interface/CastorJetID.h"
-#include "DataFormats/JetReco/interface/Jet.h"
-#include "RecoJets/JetProducers/interface/CastorJetIDHelper.h"
-#include "RecoJets/JetProducers/plugins/CastorJetIDProducer.h"
-
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
@@ -69,7 +62,7 @@
 #include <sys/time.h>
 #include <vector>
 
-class CastorMonitorModule : public DQMEDAnalyzer {
+class CastorMonitorModule : public DQMOneEDAnalyzer<> {
 public:
   CastorMonitorModule(const edm::ParameterSet &ps);
   ~CastorMonitorModule() override;

--- a/DQM/HLTEvF/plugins/HLTObjectMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectMonitor.cc
@@ -94,7 +94,6 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& i, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
-  void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
   vector<hltPlot*> plotList;
   //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
@@ -790,11 +789,6 @@ void HLTObjectMonitor::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& 
 }
 
 // ------------ method called when ending the processing of a run  ------------
-
-void HLTObjectMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
-  if (debugPrint)
-    std::cout << "Calling endRun. " << std::endl;
-}
 
 void HLTObjectMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) {
   ////////////////////////////////

--- a/DQM/HLTEvF/plugins/HLTObjectMonitorProtonLead.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectMonitorProtonLead.cc
@@ -93,7 +93,6 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& i, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
-  void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
   vector<hltPlot*> plotList;
   //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
@@ -607,11 +606,6 @@ void HLTObjectMonitorProtonLead::dqmBeginRun(edm::Run const& iRun, edm::EventSet
 }
 
 // ------------ method called when ending the processing of a run  ------------
-
-void HLTObjectMonitorProtonLead::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
-  if (debugPrint)
-    std::cout << "Calling endRun. " << std::endl;
-}
 
 void HLTObjectMonitorProtonLead::bookHistograms(DQMStore::IBooker& ibooker,
                                                 edm::Run const& iRun,

--- a/DQM/L1TMonitor/interface/BxTiming.h
+++ b/DQM/L1TMonitor/interface/BxTiming.h
@@ -36,7 +36,6 @@ public:
   ~BxTiming() override;
 
 protected:
-  void dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
 

--- a/DQM/L1TMonitor/interface/L1ExtraDQM.h
+++ b/DQM/L1TMonitor/interface/L1ExtraDQM.h
@@ -66,12 +66,12 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "boost/lexical_cast.hpp"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 // forward declarations
 
 // class declaration
-class L1ExtraDQM : public DQMEDAnalyzer {
+class L1ExtraDQM : public DQMOneEDAnalyzer<> {
 public:
   // constructor(s)
   explicit L1ExtraDQM(const edm::ParameterSet&);

--- a/DQM/L1TMonitor/interface/L1GtHwValidation.h
+++ b/DQM/L1TMonitor/interface/L1GtHwValidation.h
@@ -105,7 +105,6 @@ private:
 
 protected:
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   //virtual void analyze(DQMStore::IBooker &ibooker, const edm::Event&, const edm::EventSetup&);
 
 private:

--- a/DQM/L1TMonitor/interface/L1TCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTF.h
@@ -66,8 +66,6 @@ public:
 protected:
   // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-  //virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/DQM/L1TMonitor/interface/L1TCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTPG.h
@@ -49,7 +49,6 @@ public:
 protected:
   // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/DQM/L1TMonitor/interface/L1TDEMON.h
+++ b/DQM/L1TMonitor/interface/L1TDEMON.h
@@ -31,9 +31,7 @@ public:
   ~L1TDEMON() override;
 
 protected:
-  //virtual void beginJob(void) ;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:

--- a/DQM/L1TMonitor/interface/L1TGCT.h
+++ b/DQM/L1TMonitor/interface/L1TGCT.h
@@ -128,7 +128,6 @@ protected:
   // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/DQM/L1TMonitor/interface/L1TGMT.h
+++ b/DQM/L1TMonitor/interface/L1TGMT.h
@@ -51,9 +51,6 @@ protected:
   // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  // BeginJob
-
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/DQM/L1TMonitor/interface/L1THIonImp.h
+++ b/DQM/L1TMonitor/interface/L1THIonImp.h
@@ -27,7 +27,6 @@ protected:
   // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
   //virtual std::vector<int> SortMinBiasBit(std::vector<int>, std::vector<int>);
   virtual std::vector<int> SortMinBiasBit(uint16_t, uint16_t);

--- a/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
+++ b/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
@@ -25,7 +25,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 

--- a/DQM/L1TMonitor/interface/L1TPUM.h
+++ b/DQM/L1TMonitor/interface/L1TPUM.h
@@ -30,7 +30,6 @@ public:
 protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
 private:
   edm::EDGetTokenT<L1CaloRegionCollection> regionSource_;

--- a/DQM/L1TMonitor/interface/L1TStage2BMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2BMTF.h
@@ -60,7 +60,6 @@ public:
   // member functions
 protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
 
   // data members

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -85,7 +85,6 @@ public:
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) override;
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
   void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h
@@ -25,7 +25,6 @@ public:
 
 protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
 
 private:

--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -19,7 +19,6 @@ public:
   ~L1TStage2EMTF() override;
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -19,7 +19,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2OMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2OMTF.h
@@ -41,7 +41,6 @@ public:
   // member functions
 protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
 
   // data members

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -19,7 +19,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -21,7 +21,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
@@ -19,7 +19,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TdeCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTF.h
@@ -65,7 +65,6 @@ private:
 protected:
   void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
 public:
   explicit L1TdeCSCTF(edm::ParameterSet const& pset);

--- a/DQM/L1TMonitor/interface/L1TdeGCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeGCT.h
@@ -30,7 +30,6 @@ public:
   ~L1TdeGCT() override;
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;

--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h
@@ -34,7 +34,6 @@ public:
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) override;
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
   void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
 

--- a/DQM/L1TMonitor/interface/L1TdeStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2EMTF.h
@@ -16,7 +16,6 @@ public:
   ~L1TdeStage2EMTF() override;
 
 protected:
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 

--- a/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
@@ -41,7 +41,6 @@ public:
 protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
 private:
   // Input and config info

--- a/DQM/L1TMonitor/src/BxTiming.cc
+++ b/DQM/L1TMonitor/src/BxTiming.cc
@@ -259,8 +259,6 @@ void BxTiming::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm:
   }
 }
 
-void BxTiming::dqmBeginRun(edm::Run const &r, edm::EventSetup const &iSetup) {}
-
 // ------------ method called to for each event  ------------
 void BxTiming::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   if (verbose())

--- a/DQM/L1TMonitor/src/L1GtHwValidation.cc
+++ b/DQM/L1TMonitor/src/L1GtHwValidation.cc
@@ -143,8 +143,6 @@ L1GtHwValidation::~L1GtHwValidation() {
 
 // member functions
 
-void L1GtHwValidation::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& evSetup) {}
-
 void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
                                       const edm::Run& iRun,
                                       const edm::EventSetup& evSetup) {

--- a/DQM/L1TMonitor/src/L1TCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TCSCTF.cc
@@ -105,8 +105,6 @@ L1TCSCTF::~L1TCSCTF() {
         delete srLUTs_[i][j][s];  //free the array of pointers
 }
 
-void L1TCSCTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TCSCTF::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   m_scalesCacheID = -999;
   m_ptScaleCacheID = -999;

--- a/DQM/L1TMonitor/src/L1TCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TCSCTPG.cc
@@ -45,8 +45,6 @@ void L1TCSCTPG::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun,
   csctpgbx = ibooker.book1D("CSC TPG bx", "CSC TPG bx", 20, -0.5, 19.5);
 }
 
-void L1TCSCTPG::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TCSCTPG::analyze(const Event& e, const EventSetup& c) {
   nev_++;
   if (verbose_)

--- a/DQM/L1TMonitor/src/L1TDEMON.cc
+++ b/DQM/L1TMonitor/src/L1TDEMON.cc
@@ -258,8 +258,6 @@ void L1TDEMON::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::
     std::cout << "L1TDEMON::bookHistograms()  end.\n" << std::flush;
 }
 
-void L1TDEMON::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 // ------------ method called to for each event  ------------
 void L1TDEMON::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if (!hasRecord_)

--- a/DQM/L1TMonitor/src/L1TGCT.cc
+++ b/DQM/L1TMonitor/src/L1TGCT.cc
@@ -254,8 +254,6 @@ void L1TGCT::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::Ev
   //}
 }
 
-void L1TGCT::dqmBeginRun(edm::Run const& iRrun, edm::EventSetup const& evSetup) {}
-
 void L1TGCT::analyze(const edm::Event& e, const edm::EventSetup& c) {
   nev_++;
   if (verbose_) {

--- a/DQM/L1TMonitor/src/L1TGMT.cc
+++ b/DQM/L1TMonitor/src/L1TGMT.cc
@@ -33,8 +33,6 @@ L1TGMT::L1TGMT(const ParameterSet& ps)
 
 L1TGMT::~L1TGMT() {}
 
-void L1TGMT::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TGMT::analyze(const Event& e, const EventSetup& c) {
   if (verbose_)
     cout << "L1TGMT: analyze...." << endl;

--- a/DQM/L1TMonitor/src/L1THIonImp.cc
+++ b/DQM/L1TMonitor/src/L1THIonImp.cc
@@ -221,8 +221,6 @@ void L1THIonImp::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm
       "Minimum Bias Trigger Data vs Emul", "Minimum Bias Trigger Data vs Emul", 6, -0.5, 5.5, 6, -0.5, 5.5);
 }
 
-void L1THIonImp::dqmBeginRun(edm::Run const& iRrun, edm::EventSetup const& evSetup) {}
-
 void L1THIonImp::analyze(const edm::Event& e, const edm::EventSetup& c) {
   edm::Handle<L1GctEmCandCollection> l1IsoEm;
   edm::Handle<L1GctEmCandCollection> l1NonIsoEm;

--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -71,8 +71,6 @@ void L1TMP7ZeroSupp::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   descriptions.add("l1tMP7ZeroSupp", desc);
 }
 
-void L1TMP7ZeroSupp::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TMP7ZeroSupp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   // overall summary
   ibooker.setCurrentFolder(monitorDir_);

--- a/DQM/L1TMonitor/src/L1TPUM.cc
+++ b/DQM/L1TMonitor/src/L1TPUM.cc
@@ -32,8 +32,6 @@ L1TPUM::L1TPUM(const edm::ParameterSet& ps)
 
 L1TPUM::~L1TPUM() {}
 
-void L1TPUM::dqmBeginRun(const edm::Run&, const edm::EventSetup&) {}
-
 void L1TPUM::analyze(const edm::Event& event, const edm::EventSetup& es) {
   edm::Handle<L1CaloRegionCollection> regionCollection;
   event.getByToken(regionSource_, regionCollection);

--- a/DQM/L1TMonitor/src/L1TStage2BMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2BMTF.cc
@@ -22,8 +22,6 @@ L1TStage2BMTF::L1TStage2BMTF(const edm::ParameterSet& ps)
 
 L1TStage2BMTF::~L1TStage2BMTF() {}
 
-void L1TStage2BMTF::dqmBeginRun(const edm::Run& iRrun, const edm::EventSetup& eveSetup) {}
-
 void L1TStage2BMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& iRun, const edm::EventSetup& eveSetup) {
   std::string histoPrefix = "bmtf";
   if (kalman) {

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -36,8 +36,6 @@ L1TStage2CaloLayer1::L1TStage2CaloLayer1(const edm::ParameterSet& ps)
 
 L1TStage2CaloLayer1::~L1TStage2CaloLayer1() {}
 
-void L1TStage2CaloLayer1::dqmBeginRun(const edm::Run&, const edm::EventSetup&) {}
-
 void L1TStage2CaloLayer1::analyze(const edm::Event& event, const edm::EventSetup& es) {
   // Monitorables stored in Layer 1 raw data but
   // not accessible from existing persistent data formats

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer2.cc
@@ -343,5 +343,3 @@ void L1TStage2CaloLayer2::analyze(const edm::Event& e, const edm::EventSetup& c)
     }
   }
 }
-
-void L1TStage2CaloLayer2::dqmBeginRun(edm::Run const& iRrun, edm::EventSetup const& evSetup) {}

--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -15,8 +15,6 @@ L1TStage2EMTF::L1TStage2EMTF(const edm::ParameterSet& ps)
 
 L1TStage2EMTF::~L1TStage2EMTF() {}
 
-void L1TStage2EMTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   // Monitor Dir
   ibooker.setCurrentFolder(monitorDir);

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -43,8 +43,6 @@ void L1TStage2MuonComp::fillDescriptions(edm::ConfigurationDescriptions& descrip
   descriptions.add("l1tStage2MuonComp", desc);
 }
 
-void L1TStage2MuonComp::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   // Subsystem Monitoring and Muon Output
   ibooker.setCurrentFolder(monitorDir);

--- a/DQM/L1TMonitor/src/L1TStage2OMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2OMTF.cc
@@ -16,8 +16,6 @@ L1TStage2OMTF::L1TStage2OMTF(const edm::ParameterSet& ps)
 
 L1TStage2OMTF::~L1TStage2OMTF() {}
 
-void L1TStage2OMTF::dqmBeginRun(const edm::Run& iRrun, const edm::EventSetup& eveSetup) {}
-
 void L1TStage2OMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& iRun, const edm::EventSetup& eveSetup) {
   ibooker.setCurrentFolder(monitorDir);
 

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -45,8 +45,6 @@ void L1TStage2RegionalMuonCandComp::fillDescriptions(edm::ConfigurationDescripti
   descriptions.add("l1tStage2RegionalMuonCandComp", desc);
 }
 
-void L1TStage2RegionalMuonCandComp::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker,
                                                    const edm::Run&,
                                                    const edm::EventSetup&) {

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -32,8 +32,6 @@ void L1TStage2uGMT::fillDescriptions(edm::ConfigurationDescriptions& description
   descriptions.add("l1tStage2uGMT", desc);
 }
 
-void L1TStage2uGMT::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   if (!emul) {
     // BMTF Input

--- a/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
@@ -20,8 +20,6 @@ void L1TStage2uGMTMuon::fillDescriptions(edm::ConfigurationDescriptions& descrip
   descriptions.add("l1tStage2uGMTMuon", desc);
 }
 
-void L1TStage2uGMTMuon::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   // Subsystem Monitoring and Muon Output
   ibooker.setCurrentFolder(monitorDir);

--- a/DQM/L1TMonitor/src/L1TdeCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTF.cc
@@ -82,8 +82,6 @@ L1TdeCSCTF::L1TdeCSCTF(ParameterSet const& pset) {
 	*/
   my_dtrc = std::make_unique<CSCTFDTReceiver>();
 }
-void L1TdeCSCTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TdeCSCTF::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   //Histograms booking
 

--- a/DQM/L1TMonitor/src/L1TdeGCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeGCT.cc
@@ -34,8 +34,6 @@ L1TdeGCT::L1TdeGCT(const edm::ParameterSet& iConfig) {
 
 L1TdeGCT::~L1TdeGCT() {}
 
-void L1TdeGCT::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const& evSetup) {}
-
 void L1TdeGCT::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   int rnkNBins = 63;
   double rnkMinim = 0.5;

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -34,8 +34,6 @@ L1TdeStage2CaloLayer1::L1TdeStage2CaloLayer1(const edm::ParameterSet& ps)
 
 L1TdeStage2CaloLayer1::~L1TdeStage2CaloLayer1() {}
 
-void L1TdeStage2CaloLayer1::dqmBeginRun(const edm::Run&, const edm::EventSetup&) {}
-
 void L1TdeStage2CaloLayer1::analyze(const edm::Event& event, const edm::EventSetup& es) {
   edm::Handle<CaloTowerBxCollection> dataTowers;
   event.getByToken(dataSource_, dataTowers);

--- a/DQM/L1TMonitor/src/L1TdeStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2EMTF.cc
@@ -10,8 +10,6 @@ L1TdeStage2EMTF::L1TdeStage2EMTF(const edm::ParameterSet& ps)
 
 L1TdeStage2EMTF::~L1TdeStage2EMTF() {}
 
-void L1TdeStage2EMTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void L1TdeStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
   ibooker.setCurrentFolder(monitorDir);
 

--- a/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
@@ -40,8 +40,6 @@ L1TdeStage2uGT::L1TdeStage2uGT(const edm::ParameterSet& ps)
 
 L1TdeStage2uGT::~L1TdeStage2uGT() {}
 
-void L1TdeStage2uGT::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& evtSetup) {}
-
 void L1TdeStage2uGT::analyze(const edm::Event& event, const edm::EventSetup& es) {
   edm::Handle<GlobalAlgBlkBxCollection> dataCollection;
   event.getByToken(dataSource_, dataCollection);

--- a/DQM/Physics/src/EwkElecDQM.h
+++ b/DQM/Physics/src/EwkElecDQM.h
@@ -15,7 +15,7 @@
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 namespace reco {
@@ -24,7 +24,7 @@ namespace reco {
   class BeamSpot;
 }  // namespace reco
 
-class EwkElecDQM : public DQMEDAnalyzer {
+class EwkElecDQM : public DQMOneEDAnalyzer<> {
 public:
   EwkElecDQM(const edm::ParameterSet&);
 

--- a/DQM/Physics/src/EwkMuDQM.cc
+++ b/DQM/Physics/src/EwkMuDQM.cc
@@ -240,8 +240,6 @@ void EwkMuDQM::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::
   phEta_ = ibooker.book1D("phEta", chtitle, 100, -2.5, 2.5);
 }
 
-void EwkMuDQM::dqmEndRun(const Run& r, const EventSetup& iSet) {}
-
 void EwkMuDQM::analyze(const Event& ev, const EventSetup& iSet) {
   // Muon collection
   Handle<View<Muon> > muonCollection;

--- a/DQM/Physics/src/EwkMuDQM.h
+++ b/DQM/Physics/src/EwkMuDQM.h
@@ -34,7 +34,6 @@ protected:
   //Book histograms
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override;
 
   void init_histograms();
 

--- a/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
+++ b/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
@@ -182,20 +182,6 @@ bool EwkMuLumiMonitorDQM::IsMuMatchedToHLTMu(const reco::Muon& mu,
   return (nPass > 0);
 }
 
-void EwkMuLumiMonitorDQM::dqmEndRun(const Run& r, const EventSetup&) {
-  LogVerbatim("") << "\n>>>>>> Z/W SELECTION SUMMARY BEGIN >>>>>>>>>>>>>>>";
-  LogVerbatim("") << "Total numer of events analyzed: " << nall << " [events]";
-  LogVerbatim("") << "Total numer of events selected: " << nsel << " [events]";
-
-  LogVerbatim("") << "Passing HLT criteria:           " << nhlt << " [events] ";
-  LogVerbatim("") << "Passing 2 HLT match criteria:           " << n2hlt << " [events] ";
-  LogVerbatim("") << "Passing 1 HLT match criteria:           " << n1hlt << " [events] ";
-  LogVerbatim("") << "Passing Not Iso criteria:           " << nNotIso << " [events] ";
-  LogVerbatim("") << "Passing GlbSta criteria:           " << nGlbSta << " [events] ";
-  LogVerbatim("") << "Passing W criteria:           " << nTMass << " [events] ";
-  LogVerbatim("") << ">>>>>> Z/W SELECTION SUMMARY END   >>>>>>>>>>>>>>>\n";
-}
-
 void EwkMuLumiMonitorDQM::analyze(const Event& ev, const EventSetup&) {
   nall++;
   bool hlt_sel = false;

--- a/DQM/Physics/src/EwkMuLumiMonitorDQM.h
+++ b/DQM/Physics/src/EwkMuLumiMonitorDQM.h
@@ -40,7 +40,6 @@ public:
   //Book histograms
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override;
 
   void init_histograms();
   double muIso(const reco::Muon&);

--- a/DQM/Physics/src/EwkTauDQM.h
+++ b/DQM/Physics/src/EwkTauDQM.h
@@ -15,7 +15,7 @@
  *          Christian Veelken
  */
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include <string>
@@ -24,7 +24,7 @@
 class EwkElecTauHistManager;
 class EwkMuTauHistManager;
 
-class EwkTauDQM : public DQMEDAnalyzer {
+class EwkTauDQM : public DQMOneEDAnalyzer<> {
 public:
   EwkTauDQM(const edm::ParameterSet&);
   ~EwkTauDQM() override;

--- a/DQM/Physics/src/HiggsDQM.cc
+++ b/DQM/Physics/src/HiggsDQM.cc
@@ -570,18 +570,6 @@ void HiggsDQM::analyze(const edm::Event& e, const edm::EventSetup& eSetup) {
     LogDebug("HiggsDQM") << "WARNING: " << nMu + nEle << " leptons in this event: run=" << e.id().run()
                          << ", event=" << e.id().event() << "\n";
 }
-//
-// -- End Run
-//
-void HiggsDQM::dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) {
-  //  cout<<"Entering HiggsDQM::endRun: "<<endl;
-
-  // edm::LogVerbatim ("HiggsDQM") <<"[HiggsDQM]: End of Run, saving  DQM output
-  // ";
-  // int iRun = run.run();
-
-  //  cout<<"...leaving HiggsDQM::endRun. "<<endl;
-}
 
 // Local Variables:
 // show-trailing-whitespace: t

--- a/DQM/Physics/src/HiggsDQM.h
+++ b/DQM/Physics/src/HiggsDQM.h
@@ -48,7 +48,6 @@ protected:
   //Book histograms
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
 private:
   double Distance(const reco::Candidate& c1, const reco::Candidate& c2);

--- a/DQM/PixelLumi/plugins/PixelLumiDQM.cc
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.cc
@@ -375,12 +375,6 @@ void PixelLumiDQM::bookHistograms(DQMStore::IBooker &ibooker,
   }
 }
 
-// ------------ Method called when ending the processing of a run.  ------------
-void PixelLumiDQM::dqmBeginRun(edm::Run const &, edm::EventSetup const &) {}
-
-// ------------ Method called when ending the processing of a run.  ------------
-void PixelLumiDQM::dqmEndRun(edm::Run const &, edm::EventSetup const &) {}
-
 // ------------ Method called when starting to process a luminosity block.
 // ------------
 void PixelLumiDQM::beginLuminosityBlock(edm::LuminosityBlock const &lumiBlock, edm::EventSetup const &) {

--- a/DQM/PixelLumi/plugins/PixelLumiDQM.h
+++ b/DQM/PixelLumi/plugins/PixelLumiDQM.h
@@ -59,8 +59,6 @@ public:
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
-  void dqmEndRun(edm::Run const &, edm::EventSetup const &) override;
   void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
   void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
 

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -72,8 +72,6 @@ private:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
-
   //update the cabling if necessary
   void updateCabling(const edm::EventSetup& eventSetup);
 
@@ -180,8 +178,6 @@ void SiStripCMMonitorPlugin::bookHistograms(DQMStore::IBooker& ibooker,
   if (fillAllDetailedHistograms_)
     cmHists_.bookAllFEDHistograms(ibooker);
 }
-
-void SiStripCMMonitorPlugin::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
 
 // ------------ method called to for each event  ------------
 void SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -44,13 +44,13 @@
 
 #include "DQM/SiStripMonitorHardware/interface/FEDErrors.hh"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
 //
 // Class declaration
 //
 
-class SiStripFEDCheckPlugin : public DQMEDAnalyzer {
+class SiStripFEDCheckPlugin : public DQMOneEDAnalyzer<> {
 public:
   explicit SiStripFEDCheckPlugin(const edm::ParameterSet&);
   ~SiStripFEDCheckPlugin() override;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorPedestals.h
@@ -41,7 +41,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iomanip>
@@ -51,7 +51,7 @@
 class ApvAnalysisFactory;
 class SiStripDetCabling;
 
-class SiStripMonitorPedestals : public DQMEDAnalyzer {
+class SiStripMonitorPedestals : public DQMOneEDAnalyzer<> {
 public:
   explicit SiStripMonitorPedestals(const edm::ParameterSet &);
   ~SiStripMonitorPedestals() override;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
@@ -31,7 +31,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iostream>
@@ -43,7 +43,7 @@ class SiStripDetCabling;
 class SiStripQuality;
 class TrackerTopology;
 
-class SiStripMonitorQuality : public DQMEDAnalyzer {
+class SiStripMonitorQuality : public DQMOneEDAnalyzer<> {
 public:
   explicit SiStripMonitorQuality(const edm::ParameterSet &);
   ~SiStripMonitorQuality() override;

--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
@@ -35,7 +35,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <iostream>
@@ -45,7 +45,7 @@
 
 class SiStripDetCabling;
 
-class SiStripMonitorRawData : public DQMEDAnalyzer {
+class SiStripMonitorRawData : public DQMOneEDAnalyzer<> {
 public:
   explicit SiStripMonitorRawData(const edm::ParameterSet &);
   ~SiStripMonitorRawData() override;

--- a/DQM/TrackingMonitor/interface/LogMessageMonitor.h
+++ b/DQM/TrackingMonitor/interface/LogMessageMonitor.h
@@ -61,9 +61,6 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
-  //      virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
-
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------

--- a/DQM/TrackingMonitor/src/LogMessageMonitor.cc
+++ b/DQM/TrackingMonitor/src/LogMessageMonitor.cc
@@ -269,17 +269,6 @@ void LogMessageMonitor::endJob() {
   }
 }
 
-/*
-// ------------ method called when starting to processes a run  ------------
-void 
-LogMessageMonitor::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
-{
-
-}
-*/
-// ------------ method called when ending the processing of a run  ------------
-void LogMessageMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {}
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void LogMessageMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation

--- a/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.h
+++ b/DQMOffline/CalibCalo/src/DQMHcalPhiSymAlCaReco.h
@@ -13,12 +13,12 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-class DQMHcalPhiSymAlCaReco : public DQMEDAnalyzer {
+class DQMHcalPhiSymAlCaReco : public DQMOneEDAnalyzer<> {
 public:
   DQMHcalPhiSymAlCaReco(const edm::ParameterSet &);
   ~DQMHcalPhiSymAlCaReco() override;

--- a/DQMOffline/JetMET/interface/DQMPFCandidateAnalyzer.h
+++ b/DQMOffline/JetMET/interface/DQMPFCandidateAnalyzer.h
@@ -77,9 +77,6 @@ public:
   /// Initialize run-based parameters
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
-  /// Finish up a run
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override;
-
 private:
   // ----------member data ---------------------------
   static bool jetSortingRule(reco::Jet x, reco::Jet y) { return x.pt() > y.pt(); }

--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -95,9 +95,6 @@ public:
   /// Initialize run-based parameters
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
-  /// Finish up a run
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override;
-
 private:
   // ----------member data ---------------------------
   static bool jetSortingRule(reco::Jet x, reco::Jet y) { return x.pt() > y.pt(); }

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -73,7 +73,7 @@
 #include "DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h"
 #include "PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h"
 #include "PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
@@ -86,7 +86,7 @@
 #include <map>
 #include <string>
 
-class METAnalyzer : public DQMEDAnalyzer {
+class METAnalyzer : public DQMOneEDAnalyzer<> {
 public:
   /// Constructor
   METAnalyzer(const edm::ParameterSet&);

--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -86,7 +86,7 @@
 #include <map>
 #include <string>
 
-class METAnalyzer : public DQMOneEDAnalyzer<> {
+class METAnalyzer : public DQMOneLumiEDAnalyzer<> {
 public:
   /// Constructor
   METAnalyzer(const edm::ParameterSet&);

--- a/DQMOffline/JetMET/src/DQMPFCandidateAnalyzer.cc
+++ b/DQMOffline/JetMET/src/DQMPFCandidateAnalyzer.cc
@@ -663,9 +663,6 @@ void DQMPFCandidateAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventS
 }
 
 // ***********************************************************
-void DQMPFCandidateAnalyzer::dqmEndRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
-
-// ***********************************************************
 void DQMPFCandidateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Vertex information
   Handle<VertexCollection> vertexHandle;

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -2240,9 +2240,6 @@ void JetAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 }
 
 // ***********************************************************
-void JetAnalyzer::dqmEndRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
-
-// ***********************************************************
 void JetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //set general folders first --> change later on for different folders
   if (jetCleaningFlag_) {

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -12,7 +12,7 @@
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 //DQM
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMOffline/L1Trigger/interface/HistDefinition.h"
 
@@ -35,7 +35,7 @@
 // stage2 collections:
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 
-class L1TEGammaOffline : public DQMEDAnalyzer {
+class L1TEGammaOffline : public DQMOneEDAnalyzer<> {
 public:
   L1TEGammaOffline(const edm::ParameterSet& ps);
   ~L1TEGammaOffline() override;

--- a/DQMOffline/L1Trigger/interface/L1TRate_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TRate_Offline.h
@@ -55,7 +55,6 @@ protected:
 
   void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
   void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
 
   // Private methods
   //private:

--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -86,7 +86,6 @@ protected:
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
   void endJob() override;
 
 private:

--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -85,10 +85,8 @@ public:
 
 protected:
   void dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
-  /* void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override; */
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
   void endJob() override;
 
   const reco::Vertex getPrimaryVertex(edm::Handle<reco::VertexCollection> const& vertex,

--- a/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
@@ -210,9 +210,6 @@ void L1TRate_Offline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
 }
 
 //_____________________________________________________________________
-
-void L1TRate_Offline::dqmBeginRun(edm::Run const&, edm::EventSetup const&) {}
-//_____________________________________________________________________
 void L1TRate_Offline::beginLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) {
   if (m_verbose) {
     cout << "[L1TRate_Offline:] Called beginLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock() << endl;

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -534,10 +534,6 @@ void L1TStage2CaloLayer2Offline::fillJetEfficiencies(const double& recoEt, const
 //
 // -------------------------------------- endRun --------------------------------------------
 //
-void L1TStage2CaloLayer2Offline::dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) {
-  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::endRun" << std::endl;
-}
-
 //
 // -------------------------------------- book histograms --------------------------------------------
 //

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -320,10 +320,6 @@ void L1TTauOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup) 
 //
 // -------------------------------------- endRun --------------------------------------------
 //
-void L1TTauOffline::dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) {
-  edm::LogInfo("L1TTauOffline") << "L1TTauOffline::endRun" << std::endl;
-}
-
 //
 // -------------------------------------- book histograms --------------------------------------------
 //

--- a/DQMOffline/Trigger/plugins/HLTMuonOfflineAnalyzer.cc
+++ b/DQMOffline/Trigger/plugins/HLTMuonOfflineAnalyzer.cc
@@ -44,7 +44,6 @@ private:
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void dqmEndRun(const edm::Run &, const edm::EventSetup &) override;
 
   // Extra Methods
   std::vector<std::string> moduleLabels(const std::string &);
@@ -142,10 +141,6 @@ void HLTMuonOfflineAnalyzer::bookHistograms(DQMStore::IBooker &iBooker,
 
 void HLTMuonOfflineAnalyzer::analyze(const Event &iEvent, const EventSetup &iSetup) {
   plotterContainer_.analyze(iEvent, iSetup);
-}
-
-void HLTMuonOfflineAnalyzer::dqmEndRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
-  //   plotterContainer_.endRun(iRun, iSetup);
 }
 
 //define this as a plug-in

--- a/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
@@ -34,7 +34,6 @@ public:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const& run, edm::EventSetup const& c) override;
-  void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override {}
 
 private:
   std::vector<HLTDQMTagAndProbeEff<TagType, TagCollType, ProbeType, ProbeCollType> > tagAndProbeEffs_;

--- a/DQMOffline/Trigger/plugins/HigPhotonJetHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HigPhotonJetHLTOfflineSource.cc
@@ -14,8 +14,7 @@
 #include <iostream>
 
 // user include files
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -43,7 +42,7 @@
 #include <TH2F.h>
 
 //  Define the interface
-class HigPhotonJetHLTOfflineSource : public DQMEDAnalyzer {
+class HigPhotonJetHLTOfflineSource : public DQMOneEDAnalyzer<> {
 public:
   explicit HigPhotonJetHLTOfflineSource(const edm::ParameterSet&);
 

--- a/DQMOffline/Trigger/plugins/LepHTMonitor.cc
+++ b/DQMOffline/Trigger/plugins/LepHTMonitor.cc
@@ -203,10 +203,6 @@ LepHTMonitor::LepHTMonitor(const edm::ParameterSet &ps)
 
 LepHTMonitor::~LepHTMonitor() { edm::LogInfo("LepHTMonitor") << "Destructor LepHTMonitor::~LepHTMonitor\n"; }
 
-void LepHTMonitor::dqmBeginRun(const edm::Run &run, const edm::EventSetup &e) {
-  edm::LogInfo("LepHTMonitor") << "LepHTMonitor::beginRun\n";
-}
-
 void LepHTMonitor::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &iRun, const edm::EventSetup &iSetup) {
   edm::LogInfo("LepHTMonitor") << "LepHTMonitor::bookHistograms\n";
   //book at beginRun
@@ -552,10 +548,6 @@ void LepHTMonitor::analyze(const edm::Event &e, const edm::EventSetup &eSetup) {
         h_pfHTTurnOn_num_->Fill(pfHT);
     }
   }
-}
-
-void LepHTMonitor::dqmEndRun(const edm::Run &run, const edm::EventSetup &eSetup) {
-  edm::LogInfo("LepHTMonitor") << "LepHTMonitor::endRun\n";
 }
 
 //define this as a plug-in

--- a/DQMOffline/Trigger/plugins/LepHTMonitor.h
+++ b/DQMOffline/Trigger/plugins/LepHTMonitor.h
@@ -56,10 +56,8 @@ public:
   ~LepHTMonitor() override;
 
 protected:
-  void dqmBeginRun(const edm::Run& run, const edm::EventSetup& e) override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) override;
   void analyze(const edm::Event& e, const edm::EventSetup& eSetup) override;
-  void dqmEndRun(const edm::Run& run, const edm::EventSetup& eSetup) override;
 
 private:
   //variables from config file

--- a/DQMOffline/Trigger/plugins/TagAndProbeBtagTriggerMonitor.cc
+++ b/DQMOffline/Trigger/plugins/TagAndProbeBtagTriggerMonitor.cc
@@ -165,7 +165,6 @@ void TagAndProbeBtagTriggerMonitor::analyze(edm::Event const& iEvent, edm::Event
     }      // at least two offline jets
   }        // accept trigger
 }
-void TagAndProbeBtagTriggerMonitor::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {}
 
 // Define this as a plug-in
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/DQMOffline/Trigger/plugins/TagAndProbeBtagTriggerMonitor.h
+++ b/DQMOffline/Trigger/plugins/TagAndProbeBtagTriggerMonitor.h
@@ -49,7 +49,6 @@ public:
 
 protected:
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  void dqmBeginRun(edm::Run const& run, edm::EventSetup const& iSetup) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -43,14 +43,11 @@ public:
         this->getCanSaveByLumi());
   }
 
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) final {
-    dqmBeginLuminosityBlock(lumi, setup);
-  }
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) final {}
 
   void accumulate(edm::Event const& event, edm::EventSetup const& setup) final { analyze(event, setup); }
 
   void endLuminosityBlockProduce(edm::LuminosityBlock& lumi, edm::EventSetup const& setup) final {
-    dqmEndLuminosityBlock(lumi, setup);
     edm::Service<DQMStore>()->cloneLumiHistograms(lumi.run(), lumi.luminosityBlock(), this->moduleDescription().id());
     lumi.emplace(lumiToken_);
   }
@@ -60,7 +57,6 @@ public:
   void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final{};
 
   void endRunProduce(edm::Run& run, edm::EventSetup const& setup) final {
-    dqmEndRun(run, setup);
     edm::Service<DQMStore>()->cloneRunHistograms(run.run(), this->moduleDescription().id());
     run.emplace<DQMToken>(runToken_);
   }
@@ -72,10 +68,7 @@ public:
   // methods to be implemented by the user, in order of invocation
   virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) {}
   virtual void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) = 0;
-  virtual void dqmBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
   virtual void analyze(edm::Event const&, edm::EventSetup const&) {}
-  virtual void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-  virtual void dqmEndRun(edm::Run const&, edm::EventSetup const&) {}
 
 protected:
   edm::EDPutTokenT<DQMToken> runToken_;

--- a/DQMServices/Examples/interface/DQMExample_Step1.h
+++ b/DQMServices/Examples/interface/DQMExample_Step1.h
@@ -52,7 +52,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/DQMServices/Examples/src/DQMExample_Step1.cc
+++ b/DQMServices/Examples/src/DQMExample_Step1.cc
@@ -282,10 +282,6 @@ void DQMExample_Step1::analyze(edm::Event const &e, edm::EventSetup const &eSetu
 // -------------------------------------- endRun
 // --------------------------------------------
 //
-void DQMExample_Step1::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("DQMExample_Step1") << "DQMExample_Step1::endRun" << std::endl;
-}
-
 //
 // -------------------------------------- book histograms
 // --------------------------------------------

--- a/HLTriggerOffline/Egamma/interface/EmDQM.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQM.h
@@ -3,7 +3,7 @@
 
 // Base Class Headers
 #include "CommonTools/Utils/interface/PtComparator.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -63,7 +63,7 @@ private:
   EmDQM *dqm;
 };
 
-class EmDQM : public DQMEDAnalyzer {
+class EmDQM : public DQMOneEDAnalyzer<> {
 public:
   friend class HistoFiller<reco::ElectronCollection>;
   friend class HistoFiller<reco::RecoEcalCandidateCollection>;

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaValidator.h
@@ -18,7 +18,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h"
@@ -34,7 +34,7 @@ struct EVTColContainer;
 /// of one single analysis. Each of those, in turn, books a
 /// vector if HLTExoticaPlotters to make plots for each
 /// HLT path
-class HLTExoticaValidator : public DQMEDAnalyzer {
+class HLTExoticaValidator : public DQMOneEDAnalyzer<> {
 public:
   /// Constructor and destructor
   HLTExoticaValidator(const edm::ParameterSet &);

--- a/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
+++ b/HLTriggerOffline/Higgs/interface/HLTHiggsValidator.h
@@ -39,7 +39,6 @@ private:
   void bookHistograms(DQMStore::IBooker &, const edm::Run &, const edm::EventSetup &) override;
   void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
   void analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) override;
-  void dqmEndRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
   //! Input from configuration file
   edm::ParameterSet _pset;

--- a/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsValidator.cc
@@ -64,14 +64,5 @@ void HLTHiggsValidator::analyze(const edm::Event& iEvent, const edm::EventSetup&
   }
 }
 
-void HLTHiggsValidator::dqmEndRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  // vector<HLTMuonPlotter>::iterator iter;
-  // for(std::vector<HLTHiggsPlotter>::iterator iter = _analyzers.begin();
-  //                 iter != analyzers_.end(); ++iter)
-  // {
-  //         iter->endRun(iRun, iSetup);
-  // }
-}
-
 //define this as a plug-in
 //DEFINE_FWK_MODULE(HLTHiggsValidator);

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -42,7 +42,6 @@ private:
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void dqmEndRun(const edm::Run &, const edm::EventSetup &) override;
 
   // Extra Methods
   std::vector<std::string> moduleLabels(std::string);
@@ -179,13 +178,6 @@ void HLTMuonValidator::analyze(const Event &iEvent, const EventSetup &iSetup) {
   for (iter = analyzers_.begin(); iter != analyzers_.end(); ++iter) {
     iter->analyze(iEvent, iSetup);
   }
-}
-
-void HLTMuonValidator::dqmEndRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
-  // vector<HLTMuonPlotter>::iterator iter;
-  // for (iter = analyzers_.begin(); iter != analyzers_.end(); ++iter) {
-  //   iter->endRun(iRun, iSetup);
-  // }
 }
 
 // define this as a plug-in

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DiJet_MET.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DiJet_MET.h
@@ -39,7 +39,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleEle_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleEle_Hadronic.h
@@ -36,7 +36,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleMuon_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_DoubleMuon_Hadronic.h
@@ -33,7 +33,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_ElecFakes.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_ElecFakes.h
@@ -39,7 +39,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Electron_BJet.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Electron_BJet.h
@@ -36,7 +36,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_InclusiveHT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_InclusiveHT.h
@@ -29,10 +29,8 @@ public:
   ~SUSY_HLT_InclusiveHT() override;
 
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuEle_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuEle_Hadronic.h
@@ -40,7 +40,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuonFakes.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_MuonFakes.h
@@ -39,7 +39,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_BJet.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_BJet.h
@@ -33,7 +33,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_Hadronic.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Muon_Hadronic.h
@@ -39,7 +39,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonHT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonHT.h
@@ -32,10 +32,8 @@ public:
   ~SUSY_HLT_PhotonHT() override;
 
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_PhotonMET.h
@@ -32,10 +32,8 @@ public:
   ~SUSY_HLT_PhotonMET() override;
 
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Razor.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_Razor.h
@@ -46,10 +46,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h
@@ -54,7 +54,6 @@ protected:
   void dqmBeginRun(const edm::Run &run, const edm::EventSetup &e) override;
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) override;
   void analyze(const edm::Event &e, const edm::EventSetup &eSetup) override;
-  void dqmEndRun(const edm::Run &run, const edm::EventSetup &eSetup) override;
 
 private:
   // variables from config file

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_VBF_Mu.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_VBF_Mu.h
@@ -39,7 +39,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
@@ -41,7 +41,6 @@ protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
   // histos booking function

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_DiJet_MET.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_DiJet_MET.cc
@@ -219,10 +219,6 @@ void SUSY_HLT_DiJet_MET::analyze(edm::Event const &e, edm::EventSetup const &eSe
   phiJet.clear();
 }
 
-void SUSY_HLT_DiJet_MET::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_DiJet_MET") << "SUSY_HLT_DiJet_MET::endRun" << std::endl;
-}
-
 void SUSY_HLT_DiJet_MET::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_DoubleEle_Hadronic.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_DoubleEle_Hadronic.cc
@@ -229,10 +229,6 @@ void SUSY_HLT_DoubleEle_Hadronic::analyze(edm::Event const &e, edm::EventSetup c
   }
 }
 
-void SUSY_HLT_DoubleEle_Hadronic::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_DoubleEle_Hadronic") << "SUSY_HLT_DoubleEle_Hadronic::endRun" << std::endl;
-}
-
 void SUSY_HLT_DoubleEle_Hadronic::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_DoubleMuon_Hadronic.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_DoubleMuon_Hadronic.cc
@@ -219,10 +219,6 @@ void SUSY_HLT_DoubleMuon_Hadronic::analyze(edm::Event const &e, edm::EventSetup 
   }
 }
 
-void SUSY_HLT_DoubleMuon_Hadronic::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_DoubleMuon_Hadronic") << "SUSY_HLT_DoubleMuon_Hadronic::endRun" << std::endl;
-}
-
 void SUSY_HLT_DoubleMuon_Hadronic::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_ElecFakes.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_ElecFakes.cc
@@ -101,10 +101,6 @@ void SUSY_HLT_ElecFakes::analyze(edm::Event const &e, edm::EventSetup const &eSe
   }
 }
 
-void SUSY_HLT_ElecFakes::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_ElecFakes") << "SUSY_HLT_ElecFakes::endRun" << std::endl;
-}
-
 void SUSY_HLT_ElecFakes::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Electron_BJet.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Electron_BJet.cc
@@ -116,10 +116,6 @@ void SUSY_HLT_Electron_BJet::analyze(edm::Event const &e, edm::EventSetup const 
   }
 }
 
-void SUSY_HLT_Electron_BJet::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_Electron_BJet") << "SUSY_HLT_Electron_BJet::endRun" << std::endl;
-}
-
 void SUSY_HLT_Electron_BJet::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_InclusiveHT.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_InclusiveHT.cc
@@ -24,10 +24,6 @@ SUSY_HLT_InclusiveHT::~SUSY_HLT_InclusiveHT() {
   edm::LogInfo("SUSY_HLT_InclusiveHT") << "Destructor SUSY_HLT_InclusiveHT::~SUSY_HLT_InclusiveHT " << std::endl;
 }
 
-void SUSY_HLT_InclusiveHT::dqmBeginRun(edm::Run const &, edm::EventSetup const &) {
-  edm::LogInfo("SUSY_HLT_InclusiveHT") << "SUSY_HLT_InclusiveHT::beginRun" << std::endl;
-}
-
 void SUSY_HLT_InclusiveHT::bookHistograms(DQMStore::IBooker &ibooker_, edm::Run const &, edm::EventSetup const &) {
   edm::LogInfo("SUSY_HLT_InclusiveHT") << "SUSY_HLT_InclusiveHT::bookHistograms" << std::endl;
   // book at beginRun
@@ -167,10 +163,6 @@ void SUSY_HLT_InclusiveHT::analyze(edm::Event const &e, edm::EventSetup const &e
     h_pfMetTurnOn_den->Fill(pfMETCollection->begin()->et());
     h_pfHTTurnOn_den->Fill(pfHT);
   }
-}
-
-void SUSY_HLT_InclusiveHT::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_InclusiveHT") << "SUSY_HLT_InclusiveHT::endRun" << std::endl;
 }
 
 void SUSY_HLT_InclusiveHT::bookHistos(DQMStore::IBooker &ibooker_) {

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_MuEle_Hadronic.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_MuEle_Hadronic.cc
@@ -274,10 +274,6 @@ void SUSY_HLT_MuEle_Hadronic::analyze(edm::Event const &e, edm::EventSetup const
   }
 }
 
-void SUSY_HLT_MuEle_Hadronic::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_MuEle_Hadronic") << "SUSY_HLT_MuEle_Hadronic::endRun" << std::endl;
-}
-
 void SUSY_HLT_MuEle_Hadronic::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_MuonFakes.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_MuonFakes.cc
@@ -99,10 +99,6 @@ void SUSY_HLT_MuonFakes::analyze(edm::Event const &e, edm::EventSetup const &eSe
   //  }
 }
 
-void SUSY_HLT_MuonFakes::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_MuonFakes") << "SUSY_HLT_MuonFakes::endRun" << std::endl;
-}
-
 void SUSY_HLT_MuonFakes::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Muon_BJet.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Muon_BJet.cc
@@ -111,10 +111,6 @@ void SUSY_HLT_Muon_BJet::analyze(edm::Event const &e, edm::EventSetup const &eSe
   }
 }
 
-void SUSY_HLT_Muon_BJet::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_Muon_BJet") << "SUSY_HLT_Muon_BJet::endRun" << std::endl;
-}
-
 void SUSY_HLT_Muon_BJet::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Muon_Hadronic.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Muon_Hadronic.cc
@@ -258,10 +258,6 @@ void SUSY_HLT_Muon_Hadronic::analyze(edm::Event const &e, edm::EventSetup const 
   }
 }
 
-void SUSY_HLT_Muon_Hadronic::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_Muon_Hadronic") << "SUSY_HLT_Muon_Hadronic::endRun" << std::endl;
-}
-
 void SUSY_HLT_Muon_Hadronic::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_PhotonHT.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_PhotonHT.cc
@@ -24,10 +24,6 @@ SUSY_HLT_PhotonHT::~SUSY_HLT_PhotonHT() {
   edm::LogInfo("SUSY_HLT_PhotonHT") << "Destructor SUSY_HLT_PhotonHT::~SUSY_HLT_PhotonHT " << std::endl;
 }
 
-void SUSY_HLT_PhotonHT::dqmBeginRun(edm::Run const &, edm::EventSetup const &) {
-  edm::LogInfo("SUSY_HLT_PhotonHT") << "SUSY_HLT_PhotonHT::beginRun" << std::endl;
-}
-
 void SUSY_HLT_PhotonHT::bookHistograms(DQMStore::IBooker &ibooker_, edm::Run const &, edm::EventSetup const &) {
   edm::LogInfo("SUSY_HLT_PhotonHT") << "SUSY_HLT_PhotonHT::bookHistograms" << std::endl;
   // book at beginRun
@@ -129,10 +125,6 @@ void SUSY_HLT_PhotonHT::analyze(edm::Event const &e, edm::EventSetup const &eSet
     if (!pfMETCollection->empty() && recoPhotonPt >= ptThrOffline_)
       h_htTurnOn_den->Fill(recoPhotonPt);
   }
-}
-
-void SUSY_HLT_PhotonHT::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_PhotonHT") << "SUSY_HLT_PhotonHT::endRun" << std::endl;
 }
 
 void SUSY_HLT_PhotonHT::bookHistos(DQMStore::IBooker &ibooker_) {

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_PhotonMET.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_PhotonMET.cc
@@ -21,10 +21,6 @@ SUSY_HLT_PhotonMET::~SUSY_HLT_PhotonMET() {
   edm::LogInfo("SUSY_HLT_PhotonMET") << "Destructor SUSY_HLT_PhotonMET::~SUSY_HLT_PhotonMET " << std::endl;
 }
 
-void SUSY_HLT_PhotonMET::dqmBeginRun(edm::Run const &, edm::EventSetup const &) {
-  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::beginRun" << std::endl;
-}
-
 void SUSY_HLT_PhotonMET::bookHistograms(DQMStore::IBooker &ibooker_, edm::Run const &, edm::EventSetup const &) {
   edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::bookHistograms" << std::endl;
   // book at beginRun
@@ -101,10 +97,6 @@ void SUSY_HLT_PhotonMET::analyze(edm::Event const &e, edm::EventSetup const &eSe
         h_photonTurnOn_num->Fill(recoPhotonPt);
     }
   }
-}
-
-void SUSY_HLT_PhotonMET::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_PhotonMET") << "SUSY_HLT_PhotonMET::endRun" << std::endl;
 }
 
 void SUSY_HLT_PhotonMET::bookHistos(DQMStore::IBooker &ibooker_) {

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Razor.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_Razor.cc
@@ -22,10 +22,6 @@ SUSY_HLT_Razor::~SUSY_HLT_Razor() {
   edm::LogInfo("SUSY_HLT_Razor") << "Destructor SUSY_HLT_Razor::~SUSY_HLT_Razor " << std::endl;
 }
 
-void SUSY_HLT_Razor::dqmBeginRun(edm::Run const &, edm::EventSetup const &) {
-  edm::LogInfo("SUSY_HLT_Razor") << "SUSY_HLT_Razor::beginRun" << std::endl;
-}
-
 void SUSY_HLT_Razor::bookHistograms(DQMStore::IBooker &ibooker_, edm::Run const &, edm::EventSetup const &) {
   edm::LogInfo("SUSY_HLT_Razor") << "SUSY_HLT_Razor::bookHistograms" << std::endl;
   // book at beginRun
@@ -216,10 +212,6 @@ void SUSY_HLT_Razor::analyze(edm::Event const &e, edm::EventSetup const &eSetup)
     h_calo_mr_vs_mr->Fill(MR, caloMR);
     h_calo_rsq_vs_rsq->Fill(Rsq, caloRsq);
   }
-}
-
-void SUSY_HLT_Razor::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_Razor") << "SUSY_HLT_Razor::endRun" << std::endl;
 }
 
 void SUSY_HLT_Razor::bookHistos(DQMStore::IBooker &ibooker_) {

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_SingleLepton.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_SingleLepton.cc
@@ -741,9 +741,5 @@ void SUSY_HLT_SingleLepton::analyze(const edm::Event &e, const edm::EventSetup &
   }
 }
 
-void SUSY_HLT_SingleLepton::dqmEndRun(const edm::Run &run, const edm::EventSetup &eSetup) {
-  edm::LogInfo("SUSY_HLT_SingleLepton") << "SUSY_HLT_SingleLepton::endRun\n";
-}
-
 // define this as a plug-in
 DEFINE_FWK_MODULE(SUSY_HLT_SingleLepton);

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_VBF_Mu.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_VBF_Mu.cc
@@ -355,10 +355,6 @@ void SUSY_HLT_VBF_Mu::analyze(edm::Event const &e, edm::EventSetup const &eSetup
   }
 }
 
-void SUSY_HLT_VBF_Mu::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_VBF_Mu") << "SUSY_HLT_VBF_Mu::endRun" << std::endl;
-}
-
 void SUSY_HLT_VBF_Mu::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/SUSY_HLT_VBF_Mu");

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_alphaT.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_alphaT.cc
@@ -235,10 +235,6 @@ void SUSY_HLT_alphaT::analyze(edm::Event const &e, edm::EventSetup const &eSetup
   }
 }
 
-void SUSY_HLT_alphaT::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  edm::LogInfo("SUSY_HLT_alphaT") << "SUSY_HLT_alphaT::endRun" << std::endl;
-}
-
 void SUSY_HLT_alphaT::bookHistos(DQMStore::IBooker &ibooker_) {
   ibooker_.cd();
   ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);

--- a/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
@@ -43,7 +43,6 @@ public:
 protected:
   //Book histograms
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override {}
 
 private:
   class Plot {

--- a/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
+++ b/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
@@ -52,7 +52,6 @@ class TBeamTest : public DQMEDAnalyzer {
 public:
   explicit TBeamTest(const edm::ParameterSet&);
   ~TBeamTest() override;
-  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
@@ -106,12 +105,6 @@ TBeamTest::~TBeamTest() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
   edm::LogInfo("TBeamTest") << ">>> Destroy TBeamTest ";
-}
-//
-// -- DQM Begin Run
-//
-void TBeamTest::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::LogInfo("TBeamTest") << "Initialize TBeamTest ";
 }
 //
 // -- Analyze

--- a/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
+++ b/Validation/EcalDigis/interface/EcalMixingModuleValidation.h
@@ -8,8 +8,8 @@
  *
 */
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -19,7 +19,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -61,7 +60,6 @@
 #include <fstream>
 #include <vector>
 #include <map>
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 namespace edm {
   class StreamID;
@@ -71,7 +69,7 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class EcalMixingModuleValidation : public DQMEDAnalyzer {
+class EcalMixingModuleValidation : public DQMOneEDAnalyzer<> {
   typedef std::map<uint32_t, float, std::less<uint32_t> > MapType;
 
 public:

--- a/Validation/EcalDigis/interface/EcalSelectiveReadoutValidation.h
+++ b/Validation/EcalDigis/interface/EcalSelectiveReadoutValidation.h
@@ -7,7 +7,7 @@
  *
  */
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 
@@ -31,7 +31,7 @@ class EEDetId;
 class EcalElectronicsMapping;
 class EcalTrigTowerConstituentsMap;
 
-class EcalSelectiveReadoutValidation : public DQMEDAnalyzer {
+class EcalSelectiveReadoutValidation : public DQMOneEDAnalyzer<> {
   typedef EcalRecHitCollection RecHitCollection;
   typedef EcalRecHit RecHit;
 

--- a/Validation/EventGenerator/interface/BPhysicsSpectrum.h
+++ b/Validation/EventGenerator/interface/BPhysicsSpectrum.h
@@ -37,7 +37,6 @@ public:
   ~BPhysicsSpectrum() override;
 
   void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run &r, const edm::EventSetup &c) override;
   void analyze(edm::Event const &, edm::EventSetup const &) override;
 
 private:

--- a/Validation/EventGenerator/interface/BPhysicsValidation.h
+++ b/Validation/EventGenerator/interface/BPhysicsValidation.h
@@ -37,7 +37,6 @@ public:
   ~BPhysicsValidation() override;
 
   void bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run &r, const edm::EventSetup &c) override;
   void analyze(edm::Event const &, edm::EventSetup const &) override;
 
 private:

--- a/Validation/EventGenerator/plugins/BPhysicsSpectrum.cc
+++ b/Validation/EventGenerator/plugins/BPhysicsSpectrum.cc
@@ -22,8 +22,6 @@ BPhysicsSpectrum::BPhysicsSpectrum(const edm::ParameterSet& iPSet)
 
 BPhysicsSpectrum::~BPhysicsSpectrum() {}
 
-void BPhysicsSpectrum::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void BPhysicsSpectrum::bookHistograms(DQMStore::IBooker& i, edm::Run const&, edm::EventSetup const&) {
   DQMHelper dqm(&i);
   i.setCurrentFolder("Generator/BPhysics");

--- a/Validation/EventGenerator/plugins/BPhysicsValidation.cc
+++ b/Validation/EventGenerator/plugins/BPhysicsValidation.cc
@@ -25,8 +25,6 @@ BPhysicsValidation::BPhysicsValidation(const edm::ParameterSet& iPSet)
 
 BPhysicsValidation::~BPhysicsValidation() {}
 
-void BPhysicsValidation::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
-
 void BPhysicsValidation::bookHistograms(DQMStore::IBooker& i, edm::Run const&, edm::EventSetup const&) {
   DQMHelper dqm(&i);
   i.setCurrentFolder("Generator/BPhysics");

--- a/Validation/HcalDigis/interface/ZDCDigiStudy.h
+++ b/Validation/HcalDigis/interface/ZDCDigiStudy.h
@@ -21,7 +21,7 @@
 #define SimG4CMS_ZDCDigiStudy_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -42,7 +42,7 @@
 #include <string>
 #include <memory>
 
-class ZDCDigiStudy : public DQMEDAnalyzer {
+class ZDCDigiStudy : public DQMOneEDAnalyzer<> {
 public:
   ZDCDigiStudy(const edm::ParameterSet& ps);
   ~ZDCDigiStudy() override;

--- a/Validation/HcalHits/interface/ZdcSimHitStudy.h
+++ b/Validation/HcalHits/interface/ZdcSimHitStudy.h
@@ -61,7 +61,6 @@ public:
   ~ZdcSimHitStudy() override;
 
 protected:
-  void dqmEndRun(const edm::Run &run, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;

--- a/Validation/HcalHits/src/ZdcSimHitStudy.cc
+++ b/Validation/HcalHits/src/ZdcSimHitStudy.cc
@@ -866,5 +866,3 @@ int ZdcSimHitStudy::FillHitValHist(int side, int section, int channel, double en
   }
   return 0;
 }
-
-void ZdcSimHitStudy::dqmEndRun(const edm::Run &run, const edm::EventSetup &c) {}

--- a/Validation/RecoEgamma/plugins/PhotonValidator.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.h
@@ -29,7 +29,7 @@
 //DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 //
 #include <map>
@@ -55,7 +55,7 @@ class TTree;
 class SimVertex;
 class SimTrack;
 
-class PhotonValidator : public DQMEDAnalyzer {
+class PhotonValidator : public DQMOneEDAnalyzer<> {
 public:
   //
   explicit PhotonValidator(const edm::ParameterSet&);

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.cc
@@ -193,8 +193,6 @@ void PhotonValidatorMiniAOD::bookHistograms(DQMStore::IBooker &iBooker,
   h_phoIso_[2] = iBooker.book1D(histname + "Endcap_miniAOD", "PF photonIso:  Endcap", etBin, etMin, 20.);
 }
 
-void PhotonValidatorMiniAOD::dqmEndRun(edm::Run const &r, edm::EventSetup const &theEventSetup) {}
-
 void PhotonValidatorMiniAOD::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // ********************************************************************************
   using namespace edm;
@@ -366,5 +364,3 @@ void PhotonValidatorMiniAOD::analyze(const edm::Event &iEvent, const edm::EventS
 
   }  // end loop over gen photons
 }
-
-void PhotonValidatorMiniAOD::dqmBeginRun(edm::Run const &r, edm::EventSetup const &theEventSetup) {}

--- a/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h
+++ b/Validation/RecoEgamma/plugins/PhotonValidatorMiniAOD.h
@@ -51,8 +51,6 @@ public:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   //  virtual void beginJob();
-  void dqmBeginRun(edm::Run const& r, edm::EventSetup const& theEventSetup) override;
-  void dqmEndRun(edm::Run const& r, edm::EventSetup const& es) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:

--- a/Validation/RecoEgamma/plugins/TkConvValidator.h
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.h
@@ -24,7 +24,7 @@
 //DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 //
 #include <map>
@@ -46,7 +46,7 @@ class SimTrack;
  **
  ***/
 
-class TkConvValidator : public DQMEDAnalyzer {
+class TkConvValidator : public DQMOneEDAnalyzer<> {
 public:
   //
   explicit TkConvValidator(const edm::ParameterSet&);

--- a/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
+++ b/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
@@ -17,18 +17,12 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+#
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 namespace reco {
@@ -42,7 +36,7 @@ class TrackAssociatorBase;
 // class decleration
 //
 
-class GlobalMuonMatchAnalyzer : public DQMEDAnalyzer {
+class GlobalMuonMatchAnalyzer : public DQMOneEDAnalyzer<> {
 public:
   explicit GlobalMuonMatchAnalyzer(const edm::ParameterSet &);
   ~GlobalMuonMatchAnalyzer() override;

--- a/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h
@@ -8,13 +8,10 @@
  */
 
 // Base Class Headers
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
-
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
@@ -26,7 +23,6 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
 namespace edm {
   class ParameterSet;
@@ -41,7 +37,7 @@ class KFUpdator;
 class MeasurementEstimator;
 class HResolution1DRecHit;
 
-class MuonTrackResidualAnalyzer : public DQMEDAnalyzer {
+class MuonTrackResidualAnalyzer : public DQMOneEDAnalyzer<> {
 public:
   enum EtaRange { all, barrel, endcap };
 

--- a/Validation/RecoMuon/src/RecoMuonValidator.h
+++ b/Validation/RecoMuon/src/RecoMuonValidator.h
@@ -1,8 +1,8 @@
 #ifndef Validation_RecoMuon_RecoMuonValidator_H
 #define Validation_RecoMuon_RecoMuonValidator_H
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 
@@ -20,16 +20,14 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
 #include "SimDataFormats/Associations/interface/MuonToTrackingParticleAssociator.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 // for selection cut
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 class MuonServiceProxy;
 class TrackAssociatorBase;
 
-class RecoMuonValidator : public DQMEDAnalyzer {
+class RecoMuonValidator : public DQMOneEDAnalyzer<> {
 public:
   RecoMuonValidator(const edm::ParameterSet& pset);
   ~RecoMuonValidator() override;

--- a/Validation/RecoParticleFlow/plugins/OffsetAnalyzerDQM.cc
+++ b/Validation/RecoParticleFlow/plugins/OffsetAnalyzerDQM.cc
@@ -21,8 +21,6 @@ public:
 protected:
   //Book histograms
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override {}
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override {}
   int getEtaIndex(float eta);
 
 private:

--- a/Validation/RecoParticleFlow/plugins/PFJetAnalyzerDQM.cc
+++ b/Validation/RecoParticleFlow/plugins/PFJetAnalyzerDQM.cc
@@ -26,8 +26,6 @@ public:
 protected:
   //Book histograms
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override {}
-  void dqmEndRun(const edm::Run&, const edm::EventSetup&) override {}
 
 private:
   class Plot1DInBin {

--- a/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.cc
@@ -87,10 +87,6 @@ Phase2TrackerValidateDigi::~Phase2TrackerValidateDigi() {
 //
 // -- DQM Begin Run
 //
-void Phase2TrackerValidateDigi::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::LogInfo("Phase2TrackerValidateDigi") << "Initialize Phase2TrackerValidateDigi ";
-}
-//
 // -- Analyze
 //
 void Phase2TrackerValidateDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.h
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.h
@@ -30,7 +30,6 @@ public:
   explicit Phase2TrackerValidateDigi(const edm::ParameterSet&);
   ~Phase2TrackerValidateDigi() override;
   void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
-  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   struct DigiMEs {


### PR DESCRIPTION
#### PR description:
Another step forward on the way towards `edm::stream` modules, I decided that we cannot support `endRun` operations in `DQMEDAnalyzer`. Same goes for begin/end lumi, but they are less common. I allow `dqmBeginRun`, since it logically makes sense and is also mostly save (It's hard to do anything illegal with DQM objects before `bookHistograms`).

The full API is still available in `DQMOneEDAnalyzer`, and the few modules having non-trivial `endRun` today where migrated to it. However, the majority was just debug printouts, which I simply removed.

This is separate PR (separate form the coming bigger changes, PR #28622 ), to make the changes affecting subsystem code more visible and allow a validation independent from the coming bigger PR.

#### PR validation:

Compiles, and no changes to *file* output are expected.  There will be less log output in some configurations.

Some "summary" printouts where removed; these might be useful, but should not be part of DQM modules.
