### PR TITLE
Add thread safety macro CMS_SA_ALLOW == [[cms::sa_allow]]

### DIFF
--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -307,6 +307,8 @@ namespace edm {
     ProductPtrVec putProducts_;
 
     EventAuxiliary const& aux_;
+    // measurable performance gain by only creating LuminosityBlock when needed
+    // mutables are allowed in this case because edm::Event is only accessed by one thread
     CMS_SA_ALLOW mutable std::optional<LuminosityBlock> luminosityBlock_;
 
     // gotBranchIDs_ must be mutable because it records all 'gets',

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -41,6 +41,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <memory>
 #include <string>
@@ -306,15 +307,15 @@ namespace edm {
     ProductPtrVec putProducts_;
 
     EventAuxiliary const& aux_;
-    mutable std::optional<LuminosityBlock> luminosityBlock_;
+    CMS_SA_ALLOW mutable std::optional<LuminosityBlock> luminosityBlock_;
 
     // gotBranchIDs_ must be mutable because it records all 'gets',
     // which do not logically modify the PrincipalGetAdapter. gotBranchIDs_ is
     // merely a cache reflecting what has been retrieved from the
     // Principal class.
     typedef std::unordered_set<BranchID::value_type> BranchIDSet;
-    mutable BranchIDSet gotBranchIDs_;
-    mutable std::vector<bool> gotBranchIDsFromPrevious_;
+    CMS_SA_ALLOW mutable BranchIDSet gotBranchIDs_;
+    CMS_SA_ALLOW mutable std::vector<bool> gotBranchIDsFromPrevious_;
     std::vector<BranchID>* previousBranchIDs_ = nullptr;
     std::vector<BranchID>* gotBranchIDsFromAcquire_ = nullptr;
 
@@ -322,7 +323,7 @@ namespace edm {
     void addToGotBranchIDs(BranchID const& branchID) const;
 
     // We own the retrieved Views, and have to destroy them.
-    mutable std::vector<std::shared_ptr<ViewBase>> gotViews_;
+    CMS_SA_ALLOW mutable std::vector<std::shared_ptr<ViewBase>> gotViews_;
 
     StreamID streamID_;
     ModuleCallingContext const* moduleCallingContext_;

--- a/FWCore/Utilities/interface/thread_safety_macros.h
+++ b/FWCore/Utilities/interface/thread_safety_macros.h
@@ -2,9 +2,11 @@
 #define FWCore_Utilites_thread_safe_macros_h
 #if !defined __ROOTCLING__ && !defined __INTEL_COMPILER && !defined __NVCC__
 #define CMS_THREAD_SAFE [[cms::thread_safe]]
+#define CMS_SA_ALLOW [[cms::sa_allow]]
 #define CMS_THREAD_GUARD(_var_) [[cms::thread_guard(#_var_)]]
 #else
 #define CMS_THREAD_SAFE
+#define CMS_SA_ALLOW
 #define CMS_THREAD_GUARD(_var_)
 #endif
 #endif

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
@@ -14,7 +14,7 @@ namespace clangcms {
   void MutableMemberChecker::checkASTDecl(const clang::FieldDecl *D,
                                           clang::ento::AnalysisManager &Mgr,
                                           clang::ento::BugReporter &BR) const {
-    if (D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>())
+    if (D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>() || D->hasAttr<CMSSaAllowAttr>())
       return;
     if (D->isMutable() && D->getDeclContext()->isRecord()) {
       clang::QualType t = D->getType();


### PR DESCRIPTION
CMS_SA_ALLOW will be put in front of statements that the clang static analyzer module should skip.

[[cms::sa_allow]]  attribute will be added to clang in an external PR.
