### PR TITLE
Added Service callbacks for Run and Lumi writing

### DIFF
--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -513,6 +513,8 @@ ModuleCallingContext state = Running
 ++++++ starting: global end lumi for module: label = 'get' id = 3
 ++++++ finished: global end lumi for module: label = 'get' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndRun
@@ -543,6 +545,8 @@ ModuleCallingContext state = Running
 ++++++ starting: global end run for module: label = 'get' id = 3
 ++++++ finished: global end run for module: label = 'get' id = 3
 ++++ finished: global end run 1 : time = 1000030
+++++ starting: global write run 1 : time = 1000030
+++++ finished: global write run 1 : time = 1000030
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'get' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -163,6 +163,8 @@
 ++++++ starting: global end lumi for module: label = 'getTwo' id = 6
 ++++++ finished: global end lumi for module: label = 'getTwo' id = 6
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: end run for module: stream = 0 label = 'two' id = 5
@@ -175,6 +177,8 @@
 ++++++ starting: global end run for module: label = 'getTwo' id = 6
 ++++++ finished: global end run for module: label = 'getTwo' id = 6
 ++++ finished: global end run 1 : time = 1000030
+++++ starting: global write run 1 : time = 1000030
+++++ finished: global write run 1 : time = 1000030
 ++++ starting: end stream for module: stream = 0 label = 'one' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'one' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'getOne' id = 4

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -906,8 +906,34 @@ GlobalContext: transition = EndLuminosityBlock
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = WriteLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++++ starting: write lumi for module: label = 'out' id = 8
 ++++++ finished: write lumi for module: label = 'out' id = 8
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = WriteLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = WriteLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = WriteLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -998,8 +1024,34 @@ GlobalContext: transition = EndRun
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++ starting: global write run 1 : time = 15000001
+GlobalContext: transition = WriteRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++++ starting: write run for module: label = 'out' id = 8
 ++++++ finished: write run for module: label = 'out' id = 8
+++++ finished: global write run 1 : time = 15000001
+GlobalContext: transition = WriteRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
+++++ starting: global write run 1 : time = 0
+GlobalContext: transition = WriteRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
+++++ finished: global write run 1 : time = 0
+GlobalContext: transition = WriteRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
+
 ++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
 ++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 4
 ++++ starting: end stream for module: stream = 0 label = 'a1' id = 5

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -685,8 +685,20 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = WriteLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++++ starting: write lumi for module: label = 'out' id = 5
 ++++++ finished: write lumi for module: label = 'out' id = 5
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = WriteLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -739,8 +751,20 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++ starting: global write run 1 : time = 15000001
+GlobalContext: transition = WriteRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++++ starting: write run for module: label = 'out' id = 5
 ++++++ finished: write run for module: label = 'out' id = 5
+++++ finished: global write run 1 : time = 15000001
+GlobalContext: transition = WriteRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
+
 ++++ starting: close input file: lfn = file:testGetBy1.root usedFallBack = 0
 ++++ finished: close input file: lfn = file:testGetBy1.root usedFallBack = 0
 ++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1068,10 +1068,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
+++++ starting: global write lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
@@ -1846,10 +1858,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
@@ -2300,10 +2324,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
 ++++ starting: end run: stream = 0 run = 1 time = 0
@@ -2366,10 +2402,22 @@
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end run 1 : time = 0
+++++ starting: global write run 1 : time = 50000001
+++++ finished: global write run 1 : time = 50000001
+++++ starting: global write run 1 : time = 0
+++++ finished: global write run 1 : time = 0
+++++ starting: global write run 1 : time = 0
+++++ finished: global write run 1 : time = 0
+++++ starting: global write run 1 : time = 0
+++++ finished: global write run 1 : time = 0
+++++ starting: global write run 1 : time = 0
+++++ starting: global write run 1 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 37
 ++++++ finished: write run for module: label = 'out' id = 37
+++++ finished: global write run 1 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24
+++++ finished: global write run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 2 : time = 55000001
@@ -3208,10 +3256,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
@@ -3986,10 +4046,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
@@ -4440,10 +4512,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
 ++++ starting: end run: stream = 0 run = 2 time = 0
@@ -4506,10 +4590,22 @@
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end run 2 : time = 0
+++++ starting: global write run 2 : time = 100000001
+++++ finished: global write run 2 : time = 100000001
+++++ starting: global write run 2 : time = 0
+++++ finished: global write run 2 : time = 0
+++++ starting: global write run 2 : time = 0
+++++ finished: global write run 2 : time = 0
+++++ starting: global write run 2 : time = 0
+++++ finished: global write run 2 : time = 0
+++++ starting: global write run 2 : time = 0
+++++ starting: global write run 2 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 37
 ++++++ finished: write run for module: label = 'out' id = 37
+++++ finished: global write run 2 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24
+++++ finished: global write run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 3 : time = 105000001
@@ -5348,10 +5444,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
@@ -6126,10 +6234,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
@@ -6580,10 +6700,22 @@
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: write lumi for module: label = 'out' id = 37
 ++++++ finished: write lumi for module: label = 'out' id = 37
+++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
+++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
 ++++ starting: end run: stream = 0 run = 3 time = 0
@@ -6646,10 +6778,22 @@
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global end run 3 : time = 0
+++++ starting: global write run 3 : time = 150000001
+++++ finished: global write run 3 : time = 150000001
+++++ starting: global write run 3 : time = 0
+++++ finished: global write run 3 : time = 0
+++++ starting: global write run 3 : time = 0
+++++ finished: global write run 3 : time = 0
+++++ starting: global write run 3 : time = 0
+++++ finished: global write run 3 : time = 0
+++++ starting: global write run 3 : time = 0
+++++ starting: global write run 3 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 37
 ++++++ finished: write run for module: label = 'out' id = 37
+++++ finished: global write run 3 : time = 0
 ++++++ starting: write run for module: label = 'out' id = 24
 ++++++ finished: write run for module: label = 'out' id = 24
+++++ finished: global write run 3 : time = 0
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 6

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -292,6 +292,18 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_1(watchPostGlobalEndRun)
 
+    typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalWriteRun;
+    PreGlobalWriteRun preGlobalWriteRunSignal_;
+    void watchPreGlobalWriteRun(PreGlobalWriteRun::slot_type const& iSlot) { preGlobalWriteRunSignal_.connect(iSlot); }
+    AR_WATCH_USING_METHOD_1(watchPreGlobalWriteRun)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PostGlobalWriteRun;
+    PostGlobalWriteRun postGlobalWriteRunSignal_;
+    void watchPostGlobalWriteRun(PostGlobalWriteRun::slot_type const& iSlot) {
+      postGlobalWriteRunSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostGlobalWriteRun)
+
     typedef signalslot::Signal<void(StreamContext const&)> PreStreamBeginRun;
     PreStreamBeginRun preStreamBeginRunSignal_;
     void watchPreStreamBeginRun(PreStreamBeginRun::slot_type const& iSlot) { preStreamBeginRunSignal_.connect(iSlot); }
@@ -341,6 +353,20 @@ namespace edm {
       postGlobalEndLumiSignal_.connect_front(iSlot);
     }
     AR_WATCH_USING_METHOD_1(watchPostGlobalEndLumi)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalWriteLumi;
+    PreGlobalEndLumi preGlobalWriteLumiSignal_;
+    void watchPreGlobalWriteLumi(PreGlobalWriteLumi::slot_type const& iSlot) {
+      preGlobalWriteLumiSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPreGlobalWriteLumi)
+
+    typedef signalslot::Signal<void(GlobalContext const&)> PostGlobalWriteLumi;
+    PostGlobalEndLumi postGlobalWriteLumiSignal_;
+    void watchPostGlobalWriteLumi(PostGlobalEndLumi::slot_type const& iSlot) {
+      postGlobalWriteLumiSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_1(watchPostGlobalWriteLumi)
 
     typedef signalslot::Signal<void(StreamContext const&)> PreStreamBeginLumi;
     PreStreamBeginLumi preStreamBeginLumiSignal_;

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -134,6 +134,9 @@ namespace edm {
     preGlobalEndRunSignal_.connect(std::cref(iOther.preGlobalEndRunSignal_));
     postGlobalEndRunSignal_.connect(std::cref(iOther.postGlobalEndRunSignal_));
 
+    preGlobalWriteRunSignal_.connect(std::cref(iOther.preGlobalWriteRunSignal_));
+    postGlobalWriteRunSignal_.connect(std::cref(iOther.postGlobalWriteRunSignal_));
+
     preStreamBeginRunSignal_.connect(std::cref(iOther.preStreamBeginRunSignal_));
     postStreamBeginRunSignal_.connect(std::cref(iOther.postStreamBeginRunSignal_));
 
@@ -145,6 +148,9 @@ namespace edm {
 
     preGlobalEndLumiSignal_.connect(std::cref(iOther.preGlobalEndLumiSignal_));
     postGlobalEndLumiSignal_.connect(std::cref(iOther.postGlobalEndLumiSignal_));
+
+    preGlobalWriteLumiSignal_.connect(std::cref(iOther.preGlobalWriteLumiSignal_));
+    postGlobalWriteLumiSignal_.connect(std::cref(iOther.postGlobalWriteLumiSignal_));
 
     preStreamBeginLumiSignal_.connect(std::cref(iOther.preStreamBeginLumiSignal_));
     postStreamBeginLumiSignal_.connect(std::cref(iOther.postStreamBeginLumiSignal_));
@@ -308,6 +314,9 @@ namespace edm {
     copySlotsToFrom(preGlobalEndRunSignal_, iOther.preGlobalEndRunSignal_);
     copySlotsToFromReverse(postGlobalEndRunSignal_, iOther.postGlobalEndRunSignal_);
 
+    copySlotsToFrom(preGlobalWriteRunSignal_, iOther.preGlobalWriteRunSignal_);
+    copySlotsToFromReverse(postGlobalWriteRunSignal_, iOther.postGlobalWriteRunSignal_);
+
     copySlotsToFrom(preStreamBeginRunSignal_, iOther.preStreamBeginRunSignal_);
     copySlotsToFromReverse(postStreamBeginRunSignal_, iOther.postStreamBeginRunSignal_);
 
@@ -319,6 +328,9 @@ namespace edm {
 
     copySlotsToFrom(preGlobalEndLumiSignal_, iOther.preGlobalEndLumiSignal_);
     copySlotsToFromReverse(postGlobalEndLumiSignal_, iOther.postGlobalEndLumiSignal_);
+
+    copySlotsToFrom(preGlobalWriteLumiSignal_, iOther.preGlobalWriteLumiSignal_);
+    copySlotsToFromReverse(postGlobalWriteLumiSignal_, iOther.postGlobalWriteLumiSignal_);
 
     copySlotsToFrom(preStreamBeginLumiSignal_, iOther.preStreamBeginLumiSignal_);
     copySlotsToFromReverse(postStreamBeginLumiSignal_, iOther.postStreamBeginLumiSignal_);

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -102,6 +102,9 @@ namespace edm {
       void preGlobalEndRun(GlobalContext const&);
       void postGlobalEndRun(GlobalContext const&);
 
+      void preGlobalWriteRun(GlobalContext const&);
+      void postGlobalWriteRun(GlobalContext const&);
+
       void preStreamBeginRun(StreamContext const&);
       void postStreamBeginRun(StreamContext const&);
 
@@ -113,6 +116,9 @@ namespace edm {
 
       void preGlobalEndLumi(GlobalContext const&);
       void postGlobalEndLumi(GlobalContext const&);
+
+      void preGlobalWriteLumi(GlobalContext const&);
+      void postGlobalWriteLumi(GlobalContext const&);
 
       void preStreamBeginLumi(StreamContext const&);
       void postStreamBeginLumi(StreamContext const&);
@@ -261,6 +267,9 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
   iRegistry.watchPreGlobalEndRun(this, &Tracer::preGlobalEndRun);
   iRegistry.watchPostGlobalEndRun(this, &Tracer::postGlobalEndRun);
 
+  iRegistry.watchPreGlobalWriteRun(this, &Tracer::preGlobalWriteRun);
+  iRegistry.watchPostGlobalWriteRun(this, &Tracer::postGlobalWriteRun);
+
   iRegistry.watchPreStreamBeginRun(this, &Tracer::preStreamBeginRun);
   iRegistry.watchPostStreamBeginRun(this, &Tracer::postStreamBeginRun);
 
@@ -272,6 +281,9 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
 
   iRegistry.watchPreGlobalEndLumi(this, &Tracer::preGlobalEndLumi);
   iRegistry.watchPostGlobalEndLumi(this, &Tracer::postGlobalEndLumi);
+
+  iRegistry.watchPreGlobalWriteLumi(this, &Tracer::preGlobalWriteLumi);
+  iRegistry.watchPostGlobalWriteLumi(this, &Tracer::postGlobalWriteLumi);
 
   iRegistry.watchPreStreamBeginLumi(this, &Tracer::preStreamBeginLumi);
   iRegistry.watchPostStreamBeginLumi(this, &Tracer::postStreamBeginLumi);
@@ -647,6 +659,26 @@ void Tracer::postGlobalEndRun(GlobalContext const& gc) {
   }
 }
 
+void Tracer::preGlobalWriteRun(GlobalContext const& gc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  out << indention_ << indention_ << " starting: global write run " << gc.luminosityBlockID().run()
+      << " : time = " << gc.timestamp().value();
+  if (dumpNonModuleContext_) {
+    out << "\n" << gc;
+  }
+}
+
+void Tracer::postGlobalWriteRun(GlobalContext const& gc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  out << indention_ << indention_ << " finished: global write run " << gc.luminosityBlockID().run()
+      << " : time = " << gc.timestamp().value();
+  if (dumpNonModuleContext_) {
+    out << "\n" << gc;
+  }
+}
+
 void Tracer::preStreamBeginRun(StreamContext const& sc) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
@@ -721,6 +753,26 @@ void Tracer::postGlobalEndLumi(GlobalContext const& gc) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);
   out << indention_ << indention_ << " finished: global end lumi: run = " << gc.luminosityBlockID().run()
+      << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
+  if (dumpNonModuleContext_) {
+    out << "\n" << gc;
+  }
+}
+
+void Tracer::preGlobalWriteLumi(GlobalContext const& gc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  out << indention_ << indention_ << " starting: global write lumi: run = " << gc.luminosityBlockID().run()
+      << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
+  if (dumpNonModuleContext_) {
+    out << "\n" << gc;
+  }
+}
+
+void Tracer::postGlobalWriteLumi(GlobalContext const& gc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  out << indention_ << indention_ << " finished: global write lumi: run = " << gc.luminosityBlockID().run()
       << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if (dumpNonModuleContext_) {
     out << "\n" << gc;


### PR DESCRIPTION
#### PR description:

The new signals are used to announce when starting and ending of the OutputModule write phases occur for Runs and LuminosityBlocks.

#### PR validation:

All framework unit tests pass.