### PR TITLE
add Wrapper<LorentzVector> dictionary

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -1,4 +1,5 @@
 <lcgdict>
+  <class name="edm::Wrapper<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >"/>
   <class name="edm::ValueMap<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >"/>
   <class name="edm::Wrapper<edm::ValueMap<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > > >"/>
   <class name="edm::Wrapper<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag> >"/>


### PR DESCRIPTION
after integration of #28541 there is a failure in some cases to read the single stored LorentzVector.
One example is in https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_1_X_2019-12-05-1100/unitTestLogs/TauAnalysis/MCEmbeddingTools#/

