### PR TITLE
add missing dictionary back to DataFormats/Math 

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -4,6 +4,7 @@
   <class name="edm::Wrapper<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag> >"/>
   <class name="edm::Wrapper<std::vector<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > > >"/>
   <class name="std::vector<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >"/>
+  <class name="edm::Wrapper<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > >"/>
 <selection>
   <class pattern="ROOT::Math::SMatrix<*>" />
   <class pattern="ROOT::Math::MatRepStd<*>" />


### PR DESCRIPTION
The full iB showed there was one dictionary missing for a unit test in TauAnalysis after removing the dictionary wildcards. I've added it back to DataFormats/Math 
