### PR TITLE
Skip building onnx code on PowerPC. The external is not supported

### DIFF
--- a/PhysicsTools/ONNXRuntime/BuildFile.xml
+++ b/PhysicsTools/ONNXRuntime/BuildFile.xml
@@ -1,3 +1,6 @@
+<ifarchitecture name="_ppc64le_">
+<flags SKIP_FILES="%"/>
+</ifarchitecture>
 <use name="onnxruntime"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>

--- a/PhysicsTools/ONNXRuntime/test/BuildFile.xml
+++ b/PhysicsTools/ONNXRuntime/test/BuildFile.xml
@@ -1,3 +1,6 @@
+<ifarchitecture name="_ppc64le_">
+<flags SKIP_FILES="%"/>
+</ifarchitecture>
 <bin name="testONNXRuntime" file="testRunner.cpp, testONNXRuntime.cc">
     <use name="boost_filesystem" />
     <use name="cppunit" />

--- a/RecoBTag/ONNXRuntime/plugins/BuildFile.xml
+++ b/RecoBTag/ONNXRuntime/plugins/BuildFile.xml
@@ -1,3 +1,6 @@
+<ifarchitecture name="_ppc64le_">
+<flags SKIP_FILES="%"/>
+</ifarchitecture>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <library file="*.cc" name="RecoBTagONNXRuntimePlugins">


### PR DESCRIPTION
#### PR description:

Skip building code that requires onnxruntime external. The external doesn't build on PowerPC. 
Externals states the arch is not yet supported. Actual error is here:
https://github.com/cms-externals/onnxruntime/blob/cms/v1.0.0/onnxruntime/core/mlas/lib/mlasi.h#L714
and there are other errors but that's where it starts failing.

#### PR validation:

Builds & run tests. 

