### PR TITLE
Added new beamspot with fixed emittance for 2017 pp @ 5 TeV

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -53,6 +53,7 @@ VtxSmeared = {
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
     'Nominal5TeVpp2015Collision':    'IOMC.EventVertexGenerators.VtxSmearedNominal5TeVpp2015Collision_cfi',
     'Realistic5TeVppCollision2017':    'IOMC.EventVertexGenerators.VtxSmearedRealistic5TeVppCollision2017_cfi',
+    'Fixed_EmitRealistic5TeVppCollision2017':    'IOMC.EventVertexGenerators.VtxSmearedFixed_EmitRealistic5TeVppCollision2017_cfi',
     'Realistic25ns13TeV2016Collision':    'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeV2016Collision_cfi',
     'Realistic100ns13TeVCollisionBetaStar90m' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90m_cfi',
     'Realistic100ns13TeVCollisionBetaStar90mLowBunches' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic100ns13TeVCollisionBetaStar90mLowBunches_cfi',

--- a/IOMC/EventVertexGenerators/python/VtxSmearedFixed_EmitRealistic5TeVppCollision2017_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedFixed_EmitRealistic5TeVppCollision2017_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Fixed_EmitRealistic5TeVppCollision2017VtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Fixed_EmitRealistic5TeVppCollision2017VtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -594,6 +594,21 @@ Realistic5TeVppCollision2017VtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.619)
 )
 
+# Fixed Emittance (X2) in Beam spot extracted from data for 2017 pp run @ 5 TeV
+Fixed_EmitRealistic5TeVppCollision2017VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(311),
+    Emittance = cms.double(7.6e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.82),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(-0.0228),
+    Y0 = cms.double(0.0795),
+    Z0 = cms.double(0.619)
+)
+
+
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),


### PR DESCRIPTION
#### PR description:

This PR adds a new beamspot option for MC. This beamspot is a modification of that previously used for MC for 2017 pp data @ 5 TeV. It was known for some time that the original beam smearing did not match that in data but it was felt that the difference was small enough not to matter. However, now that we have the much larger 2018 PbPb dataset, new analyses may be possible that are sensitive to the difference in beam smearing in pp. Therefore, it was decided to add a more accurate beam smearing option in CMSSW. This is being put in CMSSW_9_4_X since this is the only CMSSW version used for analyzing that 2017 pp data.

#### PR validation:

This exact code has already been used successfully to generate numerous private MC samples with the new beamspot option. We now want the ability to generate official samples and so need this code in an official CMSSW release.

#### Back port information

This is a backport of PR #28580 which is now merged into master.