### PR TITLE
Added missing library to DataFormats/ParticleFlowReco

### DIFF
--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="DataFormats/VertexReco"/>
 <use   name="DataFormats/Candidate"/>
 <use   name="FWCore/Utilities"/>
+<use   name="Geometry/CaloGeometry"/>
 <use   name="rootcore"/>
 <use   name="rootmath"/>
 <use   name="vdt_headers"/>


### PR DESCRIPTION
#### PR description:

Linking to Geometry/CaloGeometry is required to make UBSAN work.

#### PR validation:

Code now links under CMSSW_11_1_UBSAN_X_2019-12-06-2300.