### PR TITLE
Fix dependency and use root tools instead of explicit lib names

### DIFF
--- a/Fireworks/Calo/BuildFile.xml
+++ b/Fireworks/Calo/BuildFile.xml
@@ -12,8 +12,8 @@
 <use name="boost_system"/>
 <use name="rootgpad"/>
 <use name="rootphysics"/>
-<lib name="Eve"/>
-<lib name="Geom"/>
+<use name="rooteve"/>
+<use name="rootgeom"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Calo/plugins/BuildFile.xml
+++ b/Fireworks/Calo/plugins/BuildFile.xml
@@ -15,8 +15,8 @@
  <use name="Fireworks/Core"/>
  <use name="Fireworks/Tracks"/>
  <use name="rootinteractive"/>
- <lib name="Eve"/>
- <lib name="RGL"/>
- <lib name="Geom"/>
+ <use name="rooteve"/>
+ <use name="rootrgl"/>
+ <use name="rootgeom"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Candidates/BuildFile.xml
+++ b/Fireworks/Candidates/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="boost_system"/>
 <use name="Fireworks/Core"/>
 <use name="Fireworks/Calo"/>
-<lib name="Eve"/>
+<use name="rooteve"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Candidates/plugins/BuildFile.xml
+++ b/Fireworks/Candidates/plugins/BuildFile.xml
@@ -2,7 +2,7 @@
  <use name="DataFormats/Candidate"/>
  <use name="Fireworks/Candidates"/>
  <use name="Fireworks/Core"/>
- <lib name="Eve"/>
- <lib name="RGL"/>
+ <use name="rooteve"/>
+ <use name="rootrgl"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -31,12 +31,7 @@
 <use name="rootgeom"/>
 <use name="rootgeompainter"/>
 <use name="rootguihtml"/>
-<architecture name="!osx10">
-<lib name="GX11"/>
-</architecture>
-<architecture name="osx10">
-<lib name="GCocoa"/>
-</architecture>
+<use name="rootx11"/>
 <use name="rootrgl"/>
 <use name="rootglew"/>
 <use name="rootgui"/>

--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -26,20 +26,20 @@
 <use name="rootgraphics"/>
 <use name="sigcpp"/>
 <use name="rootged"/>
-<lib name="Thread"/>
-<lib name="Eve"/>
-<lib name="Geom"/>
-<lib name="GeomPainter"/>
-<lib name="GuiHtml"/>
+<use name="rootthread"/>
+<use name="rooteve"/>
+<use name="rootgeom"/>
+<use name="rootgeompainter"/>
+<use name="rootguihtml"/>
 <architecture name="!osx10">
 <lib name="GX11"/>
 </architecture>
 <architecture name="osx10">
 <lib name="GCocoa"/>
 </architecture>
-<lib name="RGL"/>
-<lib name="GLEW"/>
-<lib name="Gui"/>
+<use name="rootrgl"/>
+<use name="rootglew"/>
+<use name="rootgui"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Core/bin/BuildFile.xml
+++ b/Fireworks/Core/bin/BuildFile.xml
@@ -2,7 +2,7 @@
  <use name="FWCore/MessageLogger"/>
  <use name="Fireworks/Core"/>
  <use name="rootinteractive"/>
- <lib name="Eve"/>
+ <use name="rooteve"/>
 </bin>
 <bin name="cmsShowSendReport" file="cmsShowSendReport.cc">
  <use name="zlib"/>

--- a/Fireworks/Electrons/BuildFile.xml
+++ b/Fireworks/Electrons/BuildFile.xml
@@ -1,8 +1,8 @@
 <use name="DataFormats/EgammaReco"/>
 <use name="Fireworks/Core"/>
 <use name="rootcore"/>
-<lib name="Eve"/>
-<lib name="Geom"/>
+<use name="rooteve"/>
+<use name="rootgeom"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Electrons/plugins/BuildFile.xml
+++ b/Fireworks/Electrons/plugins/BuildFile.xml
@@ -10,7 +10,7 @@
  <use name="Fireworks/Tracks"/>
  <use name="rootinteractive"/>
  <use name="rootphysics"/>
- <lib name="Eve"/>
- <lib name="RGL"/>
+ <use name="rooteve"/>
+ <use name="rootrgl"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Eve/BuildFile.xml
+++ b/Fireworks/Eve/BuildFile.xml
@@ -4,9 +4,9 @@
 <use name="CondFormats/RunInfo"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
-<lib name="Geom"/>
-<lib name="Gui"/>
-<lib name="Eve"/>
+<use name="rootgeom"/>
+<use name="rootgui"/>
+<use name="rooteve"/>
 <export>
 <lib name="1"/>
 </export>

--- a/Fireworks/Eve/plugins/BuildFile.xml
+++ b/Fireworks/Eve/plugins/BuildFile.xml
@@ -1,8 +1,8 @@
 <library file="EveServicePlugin.cc"
          name="FireworksEveEveServicePlugin">
         <use name="Fireworks/Eve"/>
-        <lib name="Eve"/>
-        <lib name="Geom"/>
+        <use name="rooteve"/>
+        <use name="rootgeom"/>
 	<flags EDM_PLUGIN="1"/>
 </library>
 
@@ -12,7 +12,8 @@
   <use name="Fireworks/Geometry"/>
   <use name="Fireworks/Eve"/>
   <use name="Fireworks/Tracks"/>
-  <lib name="Eve"/>
-  <lib name="Geom"/>
+  <use name="rooteve"/>
+  <use name="rootgeom"/>
+  <use name="rootrgl"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/FWInterface/BuildFile.xml
+++ b/Fireworks/FWInterface/BuildFile.xml
@@ -14,7 +14,7 @@
 <use name="rooteve"/>
 <use name="rootrgl"/>
 <use name="rootguihtml"/>
-<lib name="GX11"/>
+<use name="rootx11"/>
 <use name="boost_python"/>
 <use name="FWCore/PythonParameterSet"/>
 <export>

--- a/Fireworks/FWInterface/BuildFile.xml
+++ b/Fireworks/FWInterface/BuildFile.xml
@@ -10,10 +10,10 @@
 <use name="Fireworks/Geometry"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
-<lib name="Geom"/>
-<lib name="Eve"/>
-<lib name="RGL"/>
-<lib name="GuiHtml"/>
+<use name="rootgeom"/>
+<use name="rooteve"/>
+<use name="rootrgl"/>
+<use name="rootguihtml"/>
 <lib name="GX11"/>
 <use name="boost_python"/>
 <use name="FWCore/PythonParameterSet"/>

--- a/Fireworks/FWInterface/plugins/BuildFile.xml
+++ b/Fireworks/FWInterface/plugins/BuildFile.xml
@@ -10,7 +10,7 @@
  <use name="SimDataFormats/TrackingAnalysis"/>
  <use name="SimGeneral/TrackingAnalysis"/>
 <use name="rootcore"/>
-<lib name="Geom"/>
-<lib name="Eve"/>
+<use name="rootgeom"/>
+<use name="rooteve"/>
 
 <library name="FireworksFWInterfacePlugin" file="*.cc"/>

--- a/Fireworks/GenParticle/plugins/BuildFile.xml
+++ b/Fireworks/GenParticle/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
  <use name="Fireworks/Candidates"/>
  <use name="Fireworks/Core"/>
  <use name="rootcore"/>
- <lib name="EG"/>
- <lib name="Eve"/>
+ <use name="rooteg"/>
+ <use name="rooteve"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Geometry/BuildFile.xml
+++ b/Fireworks/Geometry/BuildFile.xml
@@ -20,9 +20,9 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="Fireworks/Core"/>
 <use name="rootcore"/>
-<lib name="Geom"/>
-<lib name="Eve"/>
-<lib name="Physics"/>
+<use name="rootgeom"/>
+<use name="rooteve"/>
+<use name="rootphysics"/>
 <export>
 <lib name="1"/>
 </export>

--- a/Fireworks/Geometry/plugins/BuildFile.xml
+++ b/Fireworks/Geometry/plugins/BuildFile.xml
@@ -2,9 +2,10 @@
 	<use name="FWCore/Framework"/>
 	<use name="Fireworks/Geometry"/>
 	<use name="Fireworks/Eve"/>
-        <lib name="Eve"/>
-        <lib name="Geom"/>
-        <lib name="Physics"/>
+        <use name="rooteve"/>
+        <use name="rootgeom"/>
+        <use name="rootphysics"/>
+        <use name="rootrgl"/>
 	<use name="MagneticField/Engine"/>
 	<use name="MagneticField/Records"/>
 	<flags EDM_PLUGIN="1"/>
@@ -14,8 +15,8 @@
 	<use name="Geometry/Records"/>
 	<use name="Fireworks/Geometry"/>
 	<use name="rootgpad"/>
-	<lib name="Eve"/>
-	<lib name="Geom"/>
+        <use name="rooteve"/>
+        <use name="rootgeom"/>
 	<flags EDM_PLUGIN="1"/>
 </library>
 
@@ -24,7 +25,7 @@
         <use name="FWCore/Framework"/>
         <use name="FWCore/PluginManager"/>
         <use name="FWCore/ParameterSet"/>
-        <lib name="Geom"/>
+        <use name="rootgeom"/>
 	<flags EDM_PLUGIN="1"/>
 </library>
 
@@ -41,8 +42,8 @@
 
 <library file="DumpFWRecoGeometry.cc" name="FireworksGeometryDumpFWRecoGeometryPlugin">
 	<use name="Fireworks/Geometry"/>
-        <lib name="Eve"/>
-	<lib name="Geom"/>
+        <use name="rooteve"/>
+        <use name="rootgeom"/>
 	<use name="rootcore"/>
         <use name="FWCore/Framework"/>
         <use name="FWCore/PluginManager"/>
@@ -58,8 +59,8 @@
 
 <library file="DumpFWTGeoRecoGeometry.cc" name="FireworksGeometryDumpFWTGeoRecoGeometryPlugin">
 	<use name="Fireworks/Geometry"/>
-        <lib name="Eve"/>
-	<lib name="Geom"/>
+        <use name="rooteve"/>
+        <use name="rootgeom"/>
 	<use name="rootcore"/>
         <use name="FWCore/Framework"/>
         <use name="FWCore/PluginManager"/>
@@ -84,7 +85,7 @@
         <use name="Fireworks/Core"/>
         <use name="Fireworks/Tracks"/> 
         <use name="rootcore"/>
-        <lib name="Geom"/>
+        <use name="rootgeom"/>
 	<flags EDM_PLUGIN="1"/>
 </library>
 

--- a/Fireworks/Muons/BuildFile.xml
+++ b/Fireworks/Muons/BuildFile.xml
@@ -4,9 +4,9 @@
 <use name="Fireworks/Candidates"/>
 <use name="Fireworks/Core"/>
 <use name="Fireworks/Tracks"/>
-<lib name="Eve"/>
-<lib name="Geom"/>
-<lib name="GeomPainter"/>
+<use name="rooteve"/>
+<use name="rootgeom"/>
+<use name="rootgeompainter"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Muons/plugins/BuildFile.xml
+++ b/Fireworks/Muons/plugins/BuildFile.xml
@@ -16,8 +16,8 @@
  <use name="Fireworks/Muons"/>
  <use name="rootinteractive"/>
 
- <lib name="Eve"/>
- <lib name="Geom"/>
- <lib name="RGL"/>
+ <use name="rooteve"/>
+ <use name="rootgeom"/>
+ <use name="rootrgl"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/ParticleFlow/BuildFile.xml
+++ b/Fireworks/ParticleFlow/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="Fireworks/Candidates"/>
 <use name="Fireworks/Tracks"/>
 <use name="Fireworks/Calo"/>
-<lib name="Eve"/>
+<use name="rooteve"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/ParticleFlow/plugins/BuildFile.xml
+++ b/Fireworks/ParticleFlow/plugins/BuildFile.xml
@@ -6,7 +6,7 @@
  <use name="DataFormats/PatCandidates"/>
  <use name="DataFormats/TrackReco"/>
  <use name="Fireworks/ParticleFlow"/>
- <lib name="Eve"/>
- <lib name="RGL"/>
+ <use name="rooteve"/>
+ <use name="rootrgl"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/SimData/plugins/BuildFile.xml
+++ b/Fireworks/SimData/plugins/BuildFile.xml
@@ -6,8 +6,8 @@
  <use name="SimDataFormats/Vertex"/>
  <use name="SimDataFormats/TrackingAnalysis"/>
  <use name="SimDataFormats/CaloAnalysis"/>
- <lib name="Eve"/>
- <lib name="EG"/>
- <lib name="Geom"/>
+ <use name="rooteve"/>
+ <use name="rooteg"/>
+ <use name="rootgeom"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Tracks/BuildFile.xml
+++ b/Fireworks/Tracks/BuildFile.xml
@@ -13,7 +13,7 @@
 <use name="Fireworks/Core"/>
 <use name="rootmath"/>
 <use name="rootphysics"/>
-<lib name="Eve"/>
+<use name="rooteve"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Tracks/plugins/BuildFile.xml
+++ b/Fireworks/Tracks/plugins/BuildFile.xml
@@ -16,8 +16,8 @@
  <use name="rootinteractive"/>
  <use name="rootphysics"/>
 
- <lib name="Eve"/>
- <lib name="Geom"/>
- <lib name="RGL"/>
+ <use name="rooteve"/>
+ <use name="rootgeom"/>
+ <use name="rootrgl"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/Fireworks/Vertices/BuildFile.xml
+++ b/Fireworks/Vertices/BuildFile.xml
@@ -2,11 +2,11 @@
 <use name="Fireworks/Core"/>
 <use name="rootcore"/>
 <use name="opengl"/>
-<lib name="Eve"/>
-<lib name="Geom"/>
-<lib name="Physics"/>
-<lib name="RGL"/>
-<lib name="Core"/>
+<use name="rooteve"/>
+<use name="rootgeom"/>
+<use name="rootphysics"/>
+<use name="rootrgl"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Fireworks/Vertices/plugins/BuildFile.xml
+++ b/Fireworks/Vertices/plugins/BuildFile.xml
@@ -5,8 +5,8 @@
  <use name="Fireworks/Vertices"/>
  <use name="Fireworks/Candidates"/>
  <use name="roothistmatrix"/>
- <lib name="Eve"/>
- <lib name="Geom"/>
- <lib name="Core"/>
+ <use name="rooteve"/>
+ <use name="rootgeom"/>
+ <use name="rootcling"/>
  <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

- Added dependency on `rootrgl` to fix UBSAN IBs errors
```
ld: Fireworks/Geometry/plugins/FireworksDisplayGeomPlugin/DisplayGeom.cc.o:(.data.rel+0xdd8): undefined reference to `typeinfo for TGLSceneBase'
ld: Fireworks/Eve/plugins/FireworksEveDummyEvelyserPlugin/DummyEvelyser.cc.o:(.data.rel+0x2318): undefined reference to `typeinfo for TGLSceneBase'
```
- Use root tools instead of explicit library names in BuildFiles.