### PR TITLE
Add enforceGUIDInFileName option to PoolSource and EmbeddedRootSource (11_0_X)

### DIFF
--- a/FWCore/Framework/python/test/cmsExceptionsFatalOption_cff.py
+++ b/FWCore/Framework/python/test/cmsExceptionsFatalOption_cff.py
@@ -30,5 +30,6 @@ Rethrow = cms.untracked.vstring(
   'ProductDoesNotSupportViews',
   'ProductDoesNotSupportPtr',
   'NotFound',
-  'FormatIncompatibility'
+  'FormatIncompatibility',
+  'FileNameInconsistentWithGUID',
 )

--- a/FWCore/MessageLogger/scripts/edmFjrDump
+++ b/FWCore/MessageLogger/scripts/edmFjrDump
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import xml.etree.ElementTree as ET
+import argparse
+
+def printGUID(root):
+    for f in root.findall("File"):
+        print(f.find("GUID").text)
+
+def printExitCode(root):
+    error = root.find("FrameworkError")
+    if error is None:
+        print("0")
+        return
+    print(error.get("ExitStatus"))
+
+def main(opts):
+    tree = ET.parse(opts.file)
+    root = tree.getroot()
+    if opts.guid:
+        printGUID(root)
+    if opts.exitCode:
+        printExitCode(root)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Extract some values from the Framework Job Report")
+    parser.add_argument("file", type=str,
+                        help="Framework Job Report XML file")
+    parser.add_argument("--guid", action="store_true",
+                        help="GUID of the output file")
+    parser.add_argument("--exitCode", action="store_true",
+                        help="Job exit code")
+
+    opts = parser.parse_args()
+    main(opts)

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -66,6 +66,8 @@ namespace edm {
 
       FileWriteError = 8033,
 
+      FileNameInconsistentWithGUID = 8034,
+
       EventGenerationFailure = 8501,
 
       CaughtSignal = 9000

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -16,8 +16,7 @@ namespace edm {
   namespace errors {
 
     // If you add a new entry to the set of values, make sure to
-    // update the translation map in EDMException.cc, the actions
-    // table in FWCore/Framework/src/Actions.cc, and the configuration
+    // update the translation map in EDMException.cc, and the configuration
     // fragment FWCore/Framework/python/test/cmsExceptionsFatalOption_cff.py.
 
     enum ErrorCodes {

--- a/FWCore/Utilities/interface/stemFromPath.h
+++ b/FWCore/Utilities/interface/stemFromPath.h
@@ -1,0 +1,20 @@
+#ifndef FWCore_Utilities_stemFromPath_h
+#define FWCore_Utilities_stemFromPath_h
+
+#include <string>
+#include <string_view>
+
+namespace edm {
+  // This functions extracts the stem of a file from the path (= file
+  // name without the extension). The returned value is a string_view
+  // to the input string. Caller should ensure that the input string
+  // object lives long enough.
+  //
+  // The reason to have our own function instead of
+  // std/boost::filesystem is that tehcnically these paths are not
+  // filesystem paths, but paths in CMS LFN/PFN space that (may) have
+  // different rules.
+  std::string_view stemFromPath(const std::string& path);
+}  // namespace edm
+
+#endif

--- a/FWCore/Utilities/interface/stemFromPath.h
+++ b/FWCore/Utilities/interface/stemFromPath.h
@@ -1,7 +1,6 @@
 #ifndef FWCore_Utilities_stemFromPath_h
 #define FWCore_Utilities_stemFromPath_h
 
-#include <string>
 #include <string_view>
 
 namespace edm {
@@ -14,7 +13,7 @@ namespace edm {
   // std/boost::filesystem is that tehcnically these paths are not
   // filesystem paths, but paths in CMS LFN/PFN space that (may) have
   // different rules.
-  std::string_view stemFromPath(const std::string& path);
+  std::string_view stemFromPath(std::string_view path);
 }  // namespace edm
 
 #endif

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -42,6 +42,7 @@ namespace edm {
                                                               FILLENTRY(ExceededResourceRSS),
                                                               FILLENTRY(ExceededResourceTime),
                                                               FILLENTRY(FileWriteError),
+                                                              FILLENTRY(FileNameInconsistentWithGUID),
                                                               FILLENTRY(EventGenerationFailure),
                                                               FILLENTRY(CaughtSignal)};
     static const std::string kUnknownCode("unknownCode");

--- a/FWCore/Utilities/src/stemFromPath.cc
+++ b/FWCore/Utilities/src/stemFromPath.cc
@@ -1,11 +1,11 @@
 #include "FWCore/Utilities/interface/stemFromPath.h"
 
 namespace edm {
-  std::string_view stemFromPath(const std::string& path) {
+  std::string_view stemFromPath(std::string_view path) {
     auto begin = path.rfind("/");
-    if (begin == std::string::npos) {
+    if (begin == std::string_view::npos) {
       begin = path.rfind(":");
-      if (begin == std::string::npos) {
+      if (begin == std::string_view::npos) {
         // shouldn't really happen?
         begin = 0;
       } else {
@@ -15,6 +15,6 @@ namespace edm {
       begin += 1;
     }
     auto end = path.find(".", begin);
-    return std::string_view(path).substr(begin, end - begin);
+    return path.substr(begin, end - begin);
   }
 }  // namespace edm

--- a/FWCore/Utilities/src/stemFromPath.cc
+++ b/FWCore/Utilities/src/stemFromPath.cc
@@ -1,0 +1,20 @@
+#include "FWCore/Utilities/interface/stemFromPath.h"
+
+namespace edm {
+  std::string_view stemFromPath(const std::string& path) {
+    auto begin = path.rfind("/");
+    if (begin == std::string::npos) {
+      begin = path.rfind(":");
+      if (begin == std::string::npos) {
+        // shouldn't really happen?
+        begin = 0;
+      } else {
+        begin += 1;
+      }
+    } else {
+      begin += 1;
+    }
+    auto end = path.find(".", begin);
+    return std::string_view(path).substr(begin, end - begin);
+  }
+}  // namespace edm

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -36,7 +36,6 @@
 </bin>
 <bin    file="test_catch2_*.cc" name="testFWCoreUtilitiesCatch2">
   <use name="catch2"/>
-  <use name="FWCore/Utilities"/>
 </bin>
 
 <bin   file="InputTag_t.cpp">

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -34,6 +34,10 @@
 <bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,esinputtag.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp,indexset.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
+<bin    file="test_catch2_*.cc" name="testFWCoreUtilitiesCatch2">
+  <use name="catch2"/>
+  <use name="FWCore/Utilities"/>
+</bin>
 
 <bin   file="InputTag_t.cpp">
   <use name="tbb"/>

--- a/FWCore/Utilities/test/test_catch2_main.cc
+++ b/FWCore/Utilities/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/FWCore/Utilities/test/test_catch2_stemFromPath.cc
+++ b/FWCore/Utilities/test/test_catch2_stemFromPath.cc
@@ -1,0 +1,15 @@
+#include "FWCore/Utilities/interface/stemFromPath.h"
+
+#include "catch.hpp"
+
+TEST_CASE("Test stemFromPath", "[sources]") {
+  CHECK(edm::stemFromPath("foo.root") == "foo");
+  CHECK(edm::stemFromPath("/foo.root") == "foo");
+  CHECK(edm::stemFromPath("/bar/foo.root") == "foo");
+  CHECK(edm::stemFromPath("/bar///....//...///foo.root") == "foo");
+  CHECK(edm::stemFromPath("/bar/foo.xyzzy") == "foo");
+  CHECK(edm::stemFromPath("/bar/xyzzy.foo.root") == "xyzzy");
+  CHECK(edm::stemFromPath("file:foo.root") == "foo");
+  CHECK(edm::stemFromPath("file:/path/to/bar.txt") == "bar");
+  CHECK(edm::stemFromPath("root://server.somewhere:port/whatever?param=path/to/bar.txt") == "bar");
+}

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -42,7 +42,8 @@ namespace edm {
         // and should be deleted from the code.
         initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0U)),
         treeCacheSize_(pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize)),
-        enablePrefetching_(false) {
+        enablePrefetching_(false),
+        enforceGUIDInFileName_(pset.getUntrackedParameter<bool>("enforceGUIDInFileName", false)) {
     if (noFiles()) {
       throw Exception(errors::NoSecondaryFiles)
           << "RootEmbeddedFileSequence no input files specified for secondary input source.\n";
@@ -138,7 +139,8 @@ namespace edm {
                                       currentIndexIntoFile,
                                       orderedProcessHistoryIDs_,
                                       input_.bypassVersionCheck(),
-                                      enablePrefetching_);
+                                      enablePrefetching_,
+                                      enforceGUIDInFileName_);
   }
 
   void RootEmbeddedFileSequence::skipEntries(unsigned int offset) {
@@ -336,5 +338,9 @@ namespace edm {
             "Skip the first 'skipEvents' events. Used only if 'sequential' is True and 'sameLumiBlock' is False");
     desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
         ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
+    desc.addUntracked<bool>("enforceGUIDInFileName", false)
+        ->setComment(
+            "True:  file name part is required to be equal to the GUID of the file\n"
+            "False: file name can be anything");
   }
 }  // namespace edm

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -70,6 +70,7 @@ namespace edm {
     int initialNumberOfEventsToSkip_;
     unsigned int treeCacheSize_;
     bool enablePrefetching_;
+    bool enforceGUIDInFileName_;
   };  // class RootEmbeddedFileSequence
 }  // namespace edm
 #endif

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -43,6 +43,7 @@
 #include "FWCore/Utilities/interface/FriendlyName.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Utilities/interface/ReleaseVersion.h"
+#include "FWCore/Utilities/interface/stemFromPath.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 
@@ -1142,20 +1143,7 @@ namespace edm {
                                                << "in the input file.\n";
     }
     if (enforceGUIDInFileName_) {
-      auto begin = file_.rfind("/");
-      if (begin == std::string::npos) {
-        begin = file_.rfind(":");
-        if (begin == std::string::npos) {
-          // shouldn't really happen?
-          begin = 0;
-        } else {
-          begin += 1;
-        }
-      } else {
-        begin += 1;
-      }
-      auto end = file_.find(".", begin);
-      auto guidFromName = std::string_view(file_).substr(begin, end - begin);
+      auto guidFromName = stemFromPath(file_);
       if (guidFromName != fid_.fid()) {
         throw edm::Exception(edm::errors::FileNameInconsistentWithGUID)
             << "GUID " << guidFromName << " extracted from file name " << file_

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -91,7 +91,8 @@ namespace edm {
              bool bypassVersionCheck,
              bool labelRawDataLikeMC,
              bool usingGoToEvent,
-             bool enablePrefetching);
+             bool enablePrefetching,
+             bool enforceGUIDInFileName);
 
     RootFile(std::string const& fileName,
              ProcessConfiguration const& processConfiguration,
@@ -113,7 +114,8 @@ namespace edm {
              std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
              bool bypassVersionCheck,
              bool labelRawDataLikeMC,
-             bool enablePrefetching)
+             bool enablePrefetching,
+             bool enforceGUIDInFileName)
         : RootFile(fileName,
                    processConfiguration,
                    logicalFileName,
@@ -142,7 +144,8 @@ namespace edm {
                    bypassVersionCheck,
                    labelRawDataLikeMC,
                    false,
-                   enablePrefetching) {}
+                   enablePrefetching,
+                   enforceGUIDInFileName) {}
 
     RootFile(std::string const& fileName,
              ProcessConfiguration const& processConfiguration,
@@ -159,7 +162,8 @@ namespace edm {
              std::vector<std::shared_ptr<IndexIntoFile>>::size_type currentIndexIntoFile,
              std::vector<ProcessHistoryID>& orderedProcessHistoryIDs,
              bool bypassVersionCheck,
-             bool enablePrefetching)
+             bool enablePrefetching,
+             bool enforceGUIDInFileName)
         : RootFile(fileName,
                    processConfiguration,
                    logicalFileName,
@@ -188,7 +192,8 @@ namespace edm {
                    bypassVersionCheck,
                    false,
                    false,
-                   enablePrefetching) {}
+                   enablePrefetching,
+                   enforceGUIDInFileName) {}
 
     ~RootFile();
 
@@ -325,6 +330,7 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<RunAuxiliary>> savedRunAuxiliary_;
     bool skipAnyEvents_;
     bool noEventSort_;
+    bool enforceGUIDInFileName_;
     int whyNotFastClonable_;
     std::array<bool, NumBranchTypes> hasNewlyDroppedBranch_;
     bool branchListIndexesUnchanged_;

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -32,7 +32,8 @@ namespace edm {
         treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize") : 0U),
         duplicateChecker_(new DuplicateChecker(pset)),
         usingGoToEvent_(false),
-        enablePrefetching_(false) {
+        enablePrefetching_(false),
+        enforceGUIDInFileName_(pset.getUntrackedParameter<bool>("enforceGUIDInFileName")) {
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
     Service<SiteLocalConfig> pSLC;
     if (pSLC.isAvailable()) {
@@ -137,7 +138,8 @@ namespace edm {
                                       input_.bypassVersionCheck(),
                                       input_.labelRawDataLikeMC(),
                                       usingGoToEvent_,
-                                      enablePrefetching_);
+                                      enablePrefetching_,
+                                      enforceGUIDInFileName_);
   }
 
   bool RootPrimaryFileSequence::nextFile() {
@@ -322,6 +324,10 @@ namespace edm {
         ->setComment(
             "'strict':     Branches in each input file must match those in the first file.\n"
             "'permissive': Branches in each input file may be any subset of those in the first file.");
+    desc.addUntracked<bool>("enforceGUIDInFileName", false)
+        ->setComment(
+            "True:  file name part is required to be equal to the GUID of the file\n"
+            "False: file name can be anything");
 
     EventSkipperByID::fillDescription(desc);
     DuplicateChecker::fillDescription(desc);

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -77,6 +77,7 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<DuplicateChecker>> duplicateChecker_;
     bool usingGoToEvent_;
     bool enablePrefetching_;
+    bool enforceGUIDInFileName_;
   };  // class RootPrimaryFileSequence
 }  // namespace edm
 #endif

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -21,7 +21,11 @@ namespace edm {
   RootSecondaryFileSequence::RootSecondaryFileSequence(ParameterSet const& pset,
                                                        PoolSource& input,
                                                        InputFileCatalog const& catalog)
-      : RootInputFileSequence(pset, catalog), input_(input), orderedProcessHistoryIDs_(), enablePrefetching_(false) {
+      : RootInputFileSequence(pset, catalog),
+        input_(input),
+        orderedProcessHistoryIDs_(),
+        enablePrefetching_(false),
+        enforceGUIDInFileName_(pset.getUntrackedParameter<bool>("enforceGUIDInFileName")) {
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
     Service<SiteLocalConfig> pSLC;
     if (pSLC.isAvailable()) {
@@ -85,7 +89,8 @@ namespace edm {
                                       orderedProcessHistoryIDs_,
                                       input_.bypassVersionCheck(),
                                       input_.labelRawDataLikeMC(),
-                                      enablePrefetching_);
+                                      enablePrefetching_,
+                                      enforceGUIDInFileName_);
   }
 
   void RootSecondaryFileSequence::initAssociationsFromSecondary(std::set<BranchID> const& associationsFromSecondary) {

--- a/IOPool/Input/src/RootSecondaryFileSequence.h
+++ b/IOPool/Input/src/RootSecondaryFileSequence.h
@@ -45,6 +45,7 @@ namespace edm {
     std::vector<BranchID> associationsFromSecondary_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
     bool enablePrefetching_;
+    bool enforceGUIDInFileName_;
   };  // class RootSecondaryFileSequence
 }  // namespace edm
 #endif

--- a/IOPool/Input/test/PoolGUIDTest_cfg.py
+++ b/IOPool/Input/test/PoolGUIDTest_cfg.py
@@ -1,0 +1,31 @@
+# Configuration file for PoolInputTest
+
+import FWCore.ParameterSet.Config as cms
+import sys
+
+argv = []
+foundpy = False
+for a in sys.argv:
+    if foundpy:
+        argv.append(a)
+    if ".py" in a:
+        foundpy = True
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
+
+process.source = cms.Source("PoolSource",
+    setRunNumber = cms.untracked.uint32(621),
+    fileNames = cms.untracked.vstring(argv[0]),
+    enforceGUIDInFileName = cms.untracked.bool(True)
+)
+
+process.p = cms.Path(process.OtherThing*process.Analysis)
+
+

--- a/IOPool/Input/test/PoolGUIDTest_cfg.py
+++ b/IOPool/Input/test/PoolGUIDTest_cfg.py
@@ -14,9 +14,7 @@ for a in sys.argv:
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
+process.maxEvents.input = -1
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
 

--- a/IOPool/Input/test/PrePoolInputTest_cfg.py
+++ b/IOPool/Input/test/PrePoolInputTest_cfg.py
@@ -3,26 +3,34 @@
 # Configuration file for PrePoolInputTest 
 
 import FWCore.ParameterSet.Config as cms
-from sys import argv
+import sys
+
+argv = []
+foundpy = False
+for a in sys.argv:
+    if foundpy:
+        argv.append(a)
+    if ".py" in a:
+        foundpy = True
 
 process = cms.Process("TESTPROD")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(int(argv[3]))
+    input = cms.untracked.int32(int(argv[1]))
 )
 
 process.Thing = cms.EDProducer("ThingProducer")
 
 process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(argv[2])
+    fileName = cms.untracked.string(argv[0])
 )
 
 process.source = cms.Source("EmptySource",
-    firstRun = cms.untracked.uint32(int(argv[4])),
-    numberEventsInRun = cms.untracked.uint32(int(argv[5])),
-    firstLuminosityBlock = cms.untracked.uint32(int(argv[6])),
-    numberEventsInLuminosityBlock = cms.untracked.uint32(int(argv[7]))
+    firstRun = cms.untracked.uint32(int(argv[2])),
+    numberEventsInRun = cms.untracked.uint32(int(argv[3])),
+    firstLuminosityBlock = cms.untracked.uint32(int(argv[4])),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(int(argv[5]))
 )
 
 process.p = cms.Path(process.Thing)

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -4,7 +4,13 @@ function die { echo $1: status $2 ;  exit $2; }
 
 pushd ${LOCAL_TMP_DIR}
 
-cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py PoolInputTest.root 11 561 7 6 3 || die 'Failure using PrePoolInputTest_cfg.py' $?
+cmsRun -j PoolInputTest_jobreport.xml ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py PoolInputTest.root 11 561 7 6 3 || die 'Failure using PrePoolInputTest_cfg.py' $?
+
+cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:PoolInputTest.root && die 'PoolGUIDTest_cfg.py PoolInputTest.root did not throw an exception' 1
+GUID_NAME=$(fgrep GUID PoolInputTest_jobreport.xml | sed -E 's/<.?GUID>//g').root
+cp PoolInputTest.root ${GUID_NAME}
+cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:${GUID_NAME} || die 'Failure using PoolGUIDTest_cfg.py ${GUID_NAME}' $?
+
 
 cp PoolInputTest.root PoolInputOther.root
 

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -6,8 +6,13 @@ pushd ${LOCAL_TMP_DIR}
 
 cmsRun -j PoolInputTest_jobreport.xml ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py PoolInputTest.root 11 561 7 6 3 || die 'Failure using PrePoolInputTest_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:PoolInputTest.root && die 'PoolGUIDTest_cfg.py PoolInputTest.root did not throw an exception' 1
-GUID_NAME=$(fgrep GUID PoolInputTest_jobreport.xml | sed -E 's/<.?GUID>//g').root
+cmsRun  -j PoolGuidTest_jobreport.xml ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:PoolInputTest.root && die 'PoolGUIDTest_cfg.py PoolInputTest.root did not throw an exception' 1
+GUID_EXIT_CODE=$(edmFjrDump --exitCode PoolGuidTest_jobreport.xml)
+if [ "x${GUID_EXIT_CODE}" != "x8034" ]; then
+    echo "Inconsistent GUID test reported exit code ${GUID_EXIT_CODE} which is different from the expected 8034"
+    exit 1
+fi
+GUID_NAME=$(edmFjrDump --guid PoolInputTest_jobreport.xml).root
 cp PoolInputTest.root ${GUID_NAME}
 cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:${GUID_NAME} || die 'Failure using PoolGUIDTest_cfg.py ${GUID_NAME}' $?
 


### PR DESCRIPTION
#### PR description:

Quoting original PR

> This PR adds an option to `PoolSource` and `EmbeddedRootSource` to enforce that the file name (without extension) corresponds the GUID of the file. The added configuration parameter is `enforceGUIDInFileName = cms.untracked.bool`, and is set to `false` by default to preserve the current behavior. In case of a mismatch a new error code 8034 (`FileNameInconsistentWithGUID`) is returned.
> 
> The motivation for such an option comes from https://github.com/dmwm/WMCore/issues/9432.

#### PR validation:

(Relevant) tests in #28561 worked, no problems in IBs.

#### if this PR is a backport please specify the original PR:

Backport of  #28561 (using ~~exactly the same branch~~ otherwise exactly the same branch but adding a commit cleaning up `FWCore/Utilities/test/BuildFile.xml`).