### PR TITLE
EventSetup consumes migration for L1GtUtils, L1TGlobalUtil, HLTPrescaleProvider

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -268,7 +268,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
   std::string prdnam = iConfig.getUntrackedParameter<std::string>("producerName", "");
   edm::InputTag algTag = iConfig.getParameter<edm::InputTag>("algInputTag");
   edm::InputTag extTag = iConfig.getParameter<edm::InputTag>("extInputTag");
-  l1GtUtils_ = new l1t::L1TGlobalUtil(iConfig, consumesCollector(), *this, algTag, extTag);
+  l1GtUtils_ = new l1t::L1TGlobalUtil(iConfig, consumesCollector(), *this, algTag, extTag, l1t::UseEventSetupIn::Event);
   // define tokens for access
   tok_trigEvt_ = consumes<trigger::TriggerEvent>(triggerEvent_);
   tok_trigRes_ = consumes<edm::TriggerResults>(theTriggerResultsLabel_);

--- a/Calibration/HcalCalibAlgos/python/gammaJetAnalysis_cfi.py
+++ b/Calibration/HcalCalibAlgos/python/gammaJetAnalysis_cfi.py
@@ -37,5 +37,8 @@ GammaJetAnalysis = cms.EDAnalyzer('GammaJetAnalysis',
                                   doGenJets           = cms.bool(True),
                                   debug               = cms.untracked.int32(0),
                                   debugHLTTrigNames   = cms.untracked.int32(2),
-                                  workOnAOD           = cms.int32(0)
+                                  workOnAOD           = cms.int32(0),
+                                  stageL1Trigger = cms.uint32(1)
                                   )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(GammaJetAnalysis, stageL1Trigger = 2)

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
@@ -290,7 +290,7 @@ HcalIsoTrackStudy::HcalIsoTrackStudy(const edm::ParameterSet& iConfig)
   std::string prdnam = iConfig.getUntrackedParameter<std::string>("producerName", "");
   edm::InputTag algTag = iConfig.getParameter<edm::InputTag>("algInputTag");
   edm::InputTag extTag = iConfig.getParameter<edm::InputTag>("extInputTag");
-  l1GtUtils_ = new l1t::L1TGlobalUtil(iConfig, consumesCollector(), *this, algTag, extTag);
+  l1GtUtils_ = new l1t::L1TGlobalUtil(iConfig, consumesCollector(), *this, algTag, extTag, l1t::UseEventSetupIn::Event);
   // define tokens for access
   tok_trigEvt_ = consumes<trigger::TriggerEvent>(triggerEvent_);
   tok_trigRes_ = consumes<edm::TriggerResults>(theTriggerResultsLabel_);

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
@@ -143,7 +143,7 @@ private:
 
 static const bool useL1GtTriggerMenuLite(true);
 IsoTrackCalib::IsoTrackCalib(const edm::ParameterSet& iConfig)
-    : m_l1GtUtils(iConfig, consumesCollector(), useL1GtTriggerMenuLite, *this),
+    : m_l1GtUtils(iConfig, consumesCollector(), useL1GtTriggerMenuLite, *this, L1GtUtils::UseEventSetupIn::Event),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
       l1Names_(iConfig.getUntrackedParameter<std::vector<std::string> >("L1Seed")),
       theTrackQuality_(iConfig.getUntrackedParameter<std::string>("TrackQuality", "highPurity")),

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -550,7 +550,8 @@ void IsoTrig::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   desc.addUntracked<double>("vertexCutIsol", 101.0);
   desc.addUntracked<double>("tauUnbiasCone", 1.2);
   desc.addUntracked<double>("prelimCone", 1.0);
-  descriptions.add("isoTrigHB", desc);
+  desc.add<unsigned int>("stageL1Trigger", 1);
+  descriptions.add("isoTrigDefault", desc);
 }
 
 void IsoTrig::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {

--- a/Calibration/IsolatedParticles/python/isoTrig_cff.py
+++ b/Calibration/IsolatedParticles/python/isoTrig_cff.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-from Calibration.IsolatedParticles.isoTrigHB_cfi import *
+from Calibration.IsolatedParticles.isoTrigDefault_cfi import isoTrigDefault as _isoTrigDefault
 
-isoTrigHE = isoTrigHB.clone(
+isoTrigHB = _isoTrigDefault.clone()
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(isoTrigHB, stageL1Trigger = 2)
+
+isoTrigHE = _isoTrigDefault.clone(
   Triggers = cms.untracked.vstring('HLT_IsoTrackHE'))
+stage2L1Trigger.toModify(isoTrigHE, stageL1Trigger = 2)

--- a/CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h
+++ b/CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h
@@ -23,6 +23,10 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
+#include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 #include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
@@ -42,6 +46,8 @@ class GenericTriggerEventFlag {
   std::unique_ptr<l1t::L1TGlobalUtil> l1uGt_;
   HLTConfigProvider hltConfig_;
   bool hltConfigInit_;
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> l1GtTriggerMenuToken_;
+  edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> alCaRecoTriggerBitsToken_;
   // Configuration parameters
   bool andOr_;
   std::string dbLabel_;
@@ -169,6 +175,7 @@ public:
   std::string l1DBKey() { return l1DBKey_; }    // can be empty
   std::string hltDBKey() { return hltDBKey_; }  // can be empty
 
+  // Must be called only during beginRun
   std::vector<std::string> expressionsFromDB(const std::string& key, const edm::EventSetup& setup);
 };
 
@@ -185,7 +192,7 @@ GenericTriggerEventFlag::GenericTriggerEventFlag(const edm::ParameterSet& config
                                                  T& module,
                                                  l1t::UseEventSetupIn use)
     : GenericTriggerEventFlag(config, iC, true) {
-  if (config.exists("andOrL1")) {
+  if (on_ && config.exists("andOrL1")) {
     if (stage2_) {
       l1uGt_ = std::make_unique<l1t::L1TGlobalUtil>(config, iC, use);
     } else {

--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -4,15 +4,12 @@
 
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
-#include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
 
 #include <vector>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 // Constants' definitions
 static const bool useL1EventSetup(true);
@@ -132,6 +129,15 @@ GenericTriggerEventFlag::GenericTriggerEventFlag(const edm::ParameterSet& config
       watchDB_ = std::make_unique<edm::ESWatcher<AlCaRecoTriggerBitsRcd> >();
     }
   }
+
+  if (onL1_ && !stage2_) {
+    l1GtTriggerMenuToken_ = iC.esConsumes<L1GtTriggerMenu, L1GtTriggerMenuRcd, edm::Transition::BeginRun>();
+  }
+  if ((onGt_ && !gtDBKey_.empty()) || (onL1_ && !l1DBKey_.empty()) || (onHlt_ && !hltDBKey_.empty())) {
+    alCaRecoTriggerBitsToken_ = iC.esConsumes<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd, edm::Transition::BeginRun>(
+        edm::ESInputTag{"", dbLabel_});
+  }
+
   //check to see we arent trying to setup legacy / stage-1 from a constructor call
   //that does not support it
   if (config.exists("andOrL1") && stage2_ == false) {  //stage-1 setup
@@ -200,14 +206,13 @@ void GenericTriggerEventFlag::initRun(const edm::Run& run, const edm::EventSetup
         algoNames.push_back(ip.first);
     } else {
       l1Gt_->getL1GtRunCache(run, setup, useL1EventSetup, useL1GtTriggerMenuLite);
-      edm::ESHandle<L1GtTriggerMenu> handleL1GtTriggerMenu;
-      setup.get<L1GtTriggerMenuRcd>().get(handleL1GtTriggerMenu);
+      L1GtTriggerMenu const& l1GtTriggerMenu = setup.get<L1GtTriggerMenuRcd>().get(l1GtTriggerMenuToken_);
 
-      const AlgorithmMap l1GtPhys(handleL1GtTriggerMenu->gtAlgorithmMap());
+      const AlgorithmMap& l1GtPhys(l1GtTriggerMenu.gtAlgorithmMap());
       for (CItAlgo iAlgo = l1GtPhys.begin(); iAlgo != l1GtPhys.end(); ++iAlgo) {
         algoNames.push_back(iAlgo->second.algoName());
       }
-      const AlgorithmMap l1GtTech(handleL1GtTriggerMenu->gtTechnicalTriggerMap());
+      const AlgorithmMap& l1GtTech(l1GtTriggerMenu.gtTechnicalTriggerMap());
       for (CItAlgo iAlgo = l1GtTech.begin(); iAlgo != l1GtTech.end(); ++iAlgo) {
         algoNames.push_back(iAlgo->second.algoName());
       }
@@ -699,7 +704,6 @@ std::vector<std::string> GenericTriggerEventFlag::expressionsFromDB(const std::s
                                                                     const edm::EventSetup& setup) {
   if (key.empty())
     return std::vector<std::string>(1, emptyKeyError_);
-  edm::ESHandle<AlCaRecoTriggerBits> logicalExpressions;
   std::vector<edm::eventsetup::DataKey> labels;
   setup.get<AlCaRecoTriggerBitsRcd>().fillRegisteredDataKeys(labels);
   std::vector<edm::eventsetup::DataKey>::const_iterator iKey = labels.begin();
@@ -711,8 +715,8 @@ std::vector<std::string> GenericTriggerEventFlag::expressionsFromDB(const std::s
           << "Label " << dbLabel_ << " not found in DB for 'AlCaRecoTriggerBitsRcd'";
     return std::vector<std::string>(1, configError_);
   }
-  setup.get<AlCaRecoTriggerBitsRcd>().get(dbLabel_, logicalExpressions);
-  const std::map<std::string, std::string>& expressionMap = logicalExpressions->m_alcarecoToTrig;
+  AlCaRecoTriggerBits const& alCaRecoTriggerBits = setup.get<AlCaRecoTriggerBitsRcd>().get(alCaRecoTriggerBitsToken_);
+  const std::map<std::string, std::string>& expressionMap = alCaRecoTriggerBits.m_alcarecoToTrig;
   std::map<std::string, std::string>::const_iterator listIter = expressionMap.find(key);
   if (listIter == expressionMap.end()) {
     if (verbose_ > 0)
@@ -720,7 +724,7 @@ std::vector<std::string> GenericTriggerEventFlag::expressionsFromDB(const std::s
           << "No logical expressions found under key " << key << " in 'AlCaRecoTriggerBitsRcd'";
     return std::vector<std::string>(1, configError_);
   }
-  return logicalExpressions->decompose(listIter->second);
+  return alCaRecoTriggerBits.decompose(listIter->second);
 }
 
 bool GenericTriggerEventFlag::allHLTPathsAreValid() const {

--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -18,11 +18,13 @@
 static const bool useL1EventSetup(true);
 static const bool useL1GtTriggerMenuLite(false);
 
-GenericTriggerEventFlag::GenericTriggerEventFlag(const edm::ParameterSet& config, edm::ConsumesCollector& iC)
+GenericTriggerEventFlag::GenericTriggerEventFlag(const edm::ParameterSet& config,
+                                                 edm::ConsumesCollector& iC,
+                                                 l1t::UseEventSetupIn use)
     : GenericTriggerEventFlag(config, iC, false) {
   if (config.exists("andOrL1")) {
     if (stage2_) {
-      l1uGt_.reset(new l1t::L1TGlobalUtil(config, iC));
+      l1uGt_.reset(new l1t::L1TGlobalUtil(config, iC, use));
     }
   }
 }

--- a/Configuration/Skimming/python/PDWG_DiPhoton_SD_cff.py
+++ b/Configuration/Skimming/python/PDWG_DiPhoton_SD_cff.py
@@ -36,8 +36,11 @@ DiPhotonHltFilter.HLTPaths = ["HLT_Photon*_Photon*"]
 hltDiPhotonCaloIdIsoObjectProducer = cms.EDProducer("CandidateTriggerObjectProducer",
                                              triggerName = cms.string("HLT_Photon.*_CaloId.*_Iso.*_Photon.*_CaloId.*_Iso.*_.*"),
                                              triggerResults = cms.InputTag("TriggerResults","","HLT"),
-                                             triggerEvent   = cms.InputTag("hltTriggerSummaryAOD","","HLT")
+                                             triggerEvent   = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
+                                             stageL1Trigger = cms.uint32(1)
                                              )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(hltDiPhotonCaloIdIsoObjectProducer, stageL1Trigger = 2)
 
 TrailingPtCaloIdIsoPhotons = cms.EDFilter("CandViewRefSelector",
     filter = cms.bool(True),

--- a/DPGAnalysis/Skims/python/WElectronSkim_cff.py
+++ b/DPGAnalysis/Skims/python/WElectronSkim_cff.py
@@ -103,8 +103,11 @@ PassingHLT = cms.EDProducer("trgMatchGsfElectronProducer",
     InputProducer = cms.InputTag( ELECTRON_COLL ),                          
     hltTags = cms.untracked.string( HLTPath ),
     triggerEventTag = cms.untracked.InputTag("hltTriggerSummaryAOD","",HLTProcessName),
-    triggerResultsTag = cms.untracked.InputTag("TriggerResults","",HLTProcessName)   
+    triggerResultsTag = cms.untracked.InputTag("TriggerResults","",HLTProcessName),
+    stageL1Trigger = cms.uint32(1)
 )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(PassingHLT, stageL1Trigger = 2)
 
 ##    _____             ____        __ _       _ _   _             
 ##   |_   _|_ _  __ _  |  _ \  ___ / _(_)_ __ (_) |_(_) ___  _ __  

--- a/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2uGT.h
@@ -52,9 +52,10 @@ private:
   std::vector<std::string> triggerBlackList_;
   int numBx_;
   std::string histFolder_;
-  l1t::L1TGlobalUtil* gtUtil_;
+  l1t::L1TGlobalUtil gtUtil_;
   int numLS_;
   uint m_currentLumi;
+  uint m_currentRun;
 
   int firstBx, lastBx;
 

--- a/DQM/Physics/python/ewkElecDQM_cfi.py
+++ b/DQM/Physics/python/ewkElecDQM_cfi.py
@@ -3,6 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # DQM monitor module for EWK-WMuNu
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ewkElecDQM = DQMEDAnalyzer('EwkElecDQM',
+
+      stageL1Trigger = cms.uint32(1),
+
       # Input collections ->
       TrigTag = cms.untracked.InputTag("TriggerResults::HLT"),
 #      MuonTag = cms.untracked.InputTag("muons"),
@@ -61,3 +64,5 @@ ewkElecDQM = DQMEDAnalyzer('EwkElecDQM',
       PUMax = cms.untracked.uint32(60),
       PUBinCount = cms.untracked.uint32(12)  # Bin size PUMax/PUBinCount
 )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(ewkElecDQM, stageL1Trigger = 2)

--- a/DQM/Physics/python/ewkMuDQM_cfi.py
+++ b/DQM/Physics/python/ewkMuDQM_cfi.py
@@ -3,6 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # DQM monitor module for EWK-WMuNu
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ewkMuDQM = DQMEDAnalyzer('EwkMuDQM',
+
+      stageL1Trigger = cms.uint32(1),
+
       # Input collections ->
       TrigTag = cms.untracked.InputTag("TriggerResults::HLT"),
       MuonTag = cms.untracked.InputTag("muons"),
@@ -40,3 +43,5 @@ ewkMuDQM = DQMEDAnalyzer('EwkMuDQM',
       EJetMin = cms.untracked.double(40.),
       NJetMax = cms.untracked.int32(999999)
 )
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(ewkMuDQM, stageL1Trigger = 2)

--- a/DQM/TrackerCommon/interface/TriggerHelper.h
+++ b/DQM/TrackerCommon/interface/TriggerHelper.h
@@ -124,7 +124,9 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesColle
 template <typename T>
 TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &iC, T &module)
     : TriggerHelper(config) {
-  l1Gt_.reset(new L1GtUtils(config, iC, false, module));
+  if (onL1_ && (!l1DBKey_.empty() || !l1LogicalExpressions_.empty())) {
+    l1Gt_.reset(new L1GtUtils(config, iC, false, module, L1GtUtils::UseEventSetupIn::Event));
+  }
 }
 
 #endif

--- a/DQM/TrigXMonitor/src/HLTSeedL1LogicScalers.cc
+++ b/DQM/TrigXMonitor/src/HLTSeedL1LogicScalers.cc
@@ -23,7 +23,8 @@ HLTSeedL1LogicScalers::HLTSeedL1LogicScalers(const edm::ParameterSet& iConfig)
                   *this,
                   fL1GtRecordInputTag,
                   fL1GtDaqReadoutRecordInputTag,
-                  edm::InputTag()) {
+                  edm::InputTag(),
+                  L1GtUtils::UseEventSetupIn::Event) {
   // now do what ever initialization is needed
   LogDebug("HLTSeedL1LogicScalers") << "constructor";
 

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -205,8 +205,10 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
   edm::ParameterSet highptjetparms = pSet.getParameter<edm::ParameterSet>("highPtJetTrigger");
   edm::ParameterSet lowptjetparms = pSet.getParameter<edm::ParameterSet>("lowPtJetTrigger");
 
-  highPtJetEventFlag_ = new GenericTriggerEventFlag(highptjetparms, consumesCollector(), *this);
-  lowPtJetEventFlag_ = new GenericTriggerEventFlag(lowptjetparms, consumesCollector(), *this);
+  highPtJetEventFlag_ =
+      new GenericTriggerEventFlag(highptjetparms, consumesCollector(), *this, l1t::UseEventSetupIn::Run);
+  lowPtJetEventFlag_ =
+      new GenericTriggerEventFlag(lowptjetparms, consumesCollector(), *this, l1t::UseEventSetupIn::Run);
 
   highPtJetExpr_ = highptjetparms.getParameter<std::vector<std::string> >("hltPaths");
   lowPtJetExpr_ = lowptjetparms.getParameter<std::vector<std::string> >("hltPaths");

--- a/DQMOffline/Muon/src/MuonRecoOneHLT.cc
+++ b/DQMOffline/Muon/src/MuonRecoOneHLT.cc
@@ -19,8 +19,9 @@ MuonRecoOneHLT::MuonRecoOneHLT(
 
   ParameterSet muonparms = parameters.getParameter<edm::ParameterSet>("SingleMuonTrigger");
   ParameterSet dimuonparms = parameters.getParameter<edm::ParameterSet>("DoubleMuonTrigger");
-  _SingleMuonEventFlag = new GenericTriggerEventFlag(muonparms, consumesCollector(), *this);
-  _DoubleMuonEventFlag = new GenericTriggerEventFlag(dimuonparms, consumesCollector(), *this);
+  _SingleMuonEventFlag = new GenericTriggerEventFlag(muonparms, consumesCollector(), *this, l1t::UseEventSetupIn::Run);
+  _DoubleMuonEventFlag =
+      new GenericTriggerEventFlag(dimuonparms, consumesCollector(), *this, l1t::UseEventSetupIn::Run);
 
   // Trigger Expresions in case de connection to the DB fails
   singlemuonExpr_ = muonparms.getParameter<std::vector<std::string> >("hltPaths");

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -1234,6 +1234,7 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<double>("minprob", 0.005);
   desc.add<double>("mincos", 0.95);
   desc.add<double>("minDS", 3.);
+  desc.add<unsigned int>("stageL1Trigger", 1);
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   genericTriggerEventPSet.add<bool>("andOr");

--- a/DQMOffline/Trigger/python/BPHMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cfi.py
@@ -1,8 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Trigger.bphMonitoring_cfi import bphMonitoring
+from DQMOffline.Trigger.bphMonitoring_cfi import bphMonitoring as _bphMonitoring
 
-hltBPHmonitoring = bphMonitoring.clone()
+hltBPHmonitoring = _bphMonitoring.clone()
+
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(hltBPHmonitoring, stageL1Trigger = 2)
+
 #hltBPHmonitoring.options = cms.untracked.PSet(
 #    SkipEvent = cms.untracked.vstring('ProductNotFound')
 #)

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
@@ -48,7 +48,8 @@ void HLTEventAnalyzerAOD::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<std::string>("triggerName", "@");
   desc.add<edm::InputTag>("triggerResults", edm::InputTag("TriggerResults", "", "HLT"));
   desc.add<edm::InputTag>("triggerEvent", edm::InputTag("hltTriggerSummaryAOD", "", "HLT"));
-  descriptions.add("hltEventAnalyzerAOD", desc);
+  desc.add<unsigned int>("stageL1Trigger", 1);
+  descriptions.add("hltEventAnalyzerAODDefault", desc);
 }
 
 void HLTEventAnalyzerAOD::endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}

--- a/HLTrigger/HLTcore/python/hltEventAnalyzerAOD_cfi.py
+++ b/HLTrigger/HLTcore/python/hltEventAnalyzerAOD_cfi.py
@@ -1,0 +1,6 @@
+from HLTrigger.HLTcore.hltEventAnalyzerAODDefault_cfi import hltEventAnalyzerAODDefault as _hltEventAnalyzerAODDefault
+
+hltEventAnalyzerAOD = _hltEventAnalyzerAODDefault.clone();
+
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(hltEventAnalyzerAOD, stageL1Trigger = 2)

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
@@ -124,7 +124,7 @@ L1GtUtilsHelper::L1GtUtilsHelper(edm::ParameterSet const& pset,
                                  edm::InputTag const& l1GtRecordInputTag,
                                  edm::InputTag const& l1GtReadoutRecordInputTag,
                                  edm::InputTag const& l1GtTriggerMenuLiteInputTag)
-    : m_consumesCollector(std::move(iC)),
+    : m_consumesCollector(iC),
 
       // Set InputTags from arguments
       m_l1GtRecordInputTag(l1GtRecordInputTag),

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtils.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtils.cc
@@ -1,14 +1,14 @@
 /**
  * \class L1GtUtils
- * 
- * 
+ *
+ *
  * Description: various methods for L1 GT, to be called in an EDM analyzer, producer or filter.
  *
  * Implementation:
  *    <TODO: enter implementation details>
- *   
+ *
  * \author: Vasile Mihai Ghete - HEPHY Vienna
- * 
+ *
  *
  */
 
@@ -23,29 +23,10 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerRecord.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "CondFormats/L1TObjects/interface/L1GtStableParameters.h"
-#include "CondFormats/DataRecord/interface/L1GtStableParametersRcd.h"
-
-#include "CondFormats/L1TObjects/interface/L1GtPrescaleFactors.h"
-#include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
-#include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsTechTrigRcd.h"
-
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
-
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskVetoAlgoTrigRcd.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskVetoTechTrigRcd.h"
-
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // constructor(s)
-L1GtUtils::L1GtUtils()
+L1GtUtils::L1GtUtils(edm::ConsumesCollector& iC, UseEventSetupIn useEventSetupIn)
     :
 
       m_l1GtStableParCacheID(0ULL),
@@ -79,14 +60,46 @@ L1GtUtils::L1GtUtils()
       m_retrieveL1GtTriggerMenuLite(false)
 
 {
-  // empty
+  if (useEventSetupIn == UseEventSetupIn::Run || useEventSetupIn == UseEventSetupIn::RunAndEvent) {
+    m_L1GtStableParametersRunToken =
+        iC.esConsumes<L1GtStableParameters, L1GtStableParametersRcd, edm::Transition::BeginRun>();
+    m_L1GtPrescaleFactorsAlgoTrigRunToken =
+        iC.esConsumes<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd, edm::Transition::BeginRun>();
+    m_L1GtPrescaleFactorsTechTrigRunToken =
+        iC.esConsumes<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd, edm::Transition::BeginRun>();
+    m_L1GtTriggerMaskAlgoTrigRunToken =
+        iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd, edm::Transition::BeginRun>();
+    m_L1GtTriggerMaskTechTrigRunToken =
+        iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd, edm::Transition::BeginRun>();
+    m_L1GtTriggerMaskVetoAlgoTrigRunToken =
+        iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskVetoAlgoTrigRcd, edm::Transition::BeginRun>();
+    m_L1GtTriggerMaskVetoTechTrigRunToken =
+        iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskVetoTechTrigRcd, edm::Transition::BeginRun>();
+    m_L1GtTriggerMenuRunToken = iC.esConsumes<L1GtTriggerMenu, L1GtTriggerMenuRcd, edm::Transition::BeginRun>();
+  }
+  if (useEventSetupIn == UseEventSetupIn::Event || useEventSetupIn == UseEventSetupIn::RunAndEvent) {
+    m_L1GtStableParametersEventToken = iC.esConsumes<L1GtStableParameters, L1GtStableParametersRcd>();
+    m_L1GtPrescaleFactorsAlgoTrigEventToken = iC.esConsumes<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd>();
+    m_L1GtPrescaleFactorsTechTrigEventToken = iC.esConsumes<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd>();
+    m_L1GtTriggerMaskAlgoTrigEventToken = iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd>();
+    m_L1GtTriggerMaskTechTrigEventToken = iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd>();
+    m_L1GtTriggerMaskVetoAlgoTrigEventToken = iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskVetoAlgoTrigRcd>();
+    m_L1GtTriggerMaskVetoTechTrigEventToken = iC.esConsumes<L1GtTriggerMask, L1GtTriggerMaskVetoTechTrigRcd>();
+    m_L1GtTriggerMenuEventToken = iC.esConsumes<L1GtTriggerMenu, L1GtTriggerMenuRcd>();
+  }
 }
 
-L1GtUtils::L1GtUtils(edm::ParameterSet const& pset, edm::ConsumesCollector&& iC, bool useL1GtTriggerMenuLite)
-    : L1GtUtils(pset, iC, useL1GtTriggerMenuLite) {}
+L1GtUtils::L1GtUtils(edm::ParameterSet const& pset,
+                     edm::ConsumesCollector&& iC,
+                     bool useL1GtTriggerMenuLite,
+                     UseEventSetupIn useEventSetupIn)
+    : L1GtUtils(pset, iC, useL1GtTriggerMenuLite, useEventSetupIn) {}
 
-L1GtUtils::L1GtUtils(edm::ParameterSet const& pset, edm::ConsumesCollector& iC, bool useL1GtTriggerMenuLite)
-    : L1GtUtils() {
+L1GtUtils::L1GtUtils(edm::ParameterSet const& pset,
+                     edm::ConsumesCollector& iC,
+                     bool useL1GtTriggerMenuLite,
+                     UseEventSetupIn useEventSetupIn)
+    : L1GtUtils(iC, useEventSetupIn) {
   m_l1GtUtilsHelper.reset(new L1GtUtilsHelper(pset, iC, useL1GtTriggerMenuLite));
 }
 
@@ -105,11 +118,13 @@ const std::string L1GtUtils::triggerCategory(const TriggerCategory& trigCategory
     }
 
     break;
-    default: { return EmptyString; } break;
+    default: {
+      return EmptyString;
+    } break;
   }
 }
 
-void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup) {
+void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup, bool isRun) {
   //
   m_retrieveL1EventSetup = true;
 
@@ -119,12 +134,15 @@ void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup) {
   // get / update the stable parameters from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtStableParCacheID = evSetup.get<L1GtStableParametersRcd>().cacheIdentifier();
+  auto l1GtStableParametersRcd = evSetup.get<L1GtStableParametersRcd>();
+  unsigned long long l1GtStableParCacheID = l1GtStableParametersRcd.cacheIdentifier();
 
   if (m_l1GtStableParCacheID != l1GtStableParCacheID) {
-    edm::ESHandle<L1GtStableParameters> l1GtStablePar;
-    evSetup.get<L1GtStableParametersRcd>().get(l1GtStablePar);
-    m_l1GtStablePar = l1GtStablePar.product();
+    if (isRun) {
+      m_l1GtStablePar = &l1GtStableParametersRcd.get(m_L1GtStableParametersRunToken);
+    } else {
+      m_l1GtStablePar = &l1GtStableParametersRcd.get(m_L1GtStableParametersEventToken);
+    }
 
     // number of algorithm triggers
     m_numberAlgorithmTriggers = m_l1GtStablePar->gtNumberPhysTriggers();
@@ -144,24 +162,30 @@ void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup) {
   // get / update the prescale factors from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().cacheIdentifier();
+  auto l1GtPrescaleFactorsAlgoTrigRcd = evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>();
+  unsigned long long l1GtPfAlgoCacheID = l1GtPrescaleFactorsAlgoTrigRcd.cacheIdentifier();
 
   if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
-    edm::ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
-    evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
-    m_l1GtPfAlgo = l1GtPfAlgo.product();
+    if (isRun) {
+      m_l1GtPfAlgo = &l1GtPrescaleFactorsAlgoTrigRcd.get(m_L1GtPrescaleFactorsAlgoTrigRunToken);
+    } else {
+      m_l1GtPfAlgo = &l1GtPrescaleFactorsAlgoTrigRcd.get(m_L1GtPrescaleFactorsAlgoTrigEventToken);
+    }
 
     m_prescaleFactorsAlgoTrig = &(m_l1GtPfAlgo->gtPrescaleFactors());
 
     m_l1GtPfAlgoCacheID = l1GtPfAlgoCacheID;
   }
 
-  unsigned long long l1GtPfTechCacheID = evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().cacheIdentifier();
+  auto l1GtPrescaleFactorsTechTrigRcd = evSetup.get<L1GtPrescaleFactorsTechTrigRcd>();
+  unsigned long long l1GtPfTechCacheID = l1GtPrescaleFactorsTechTrigRcd.cacheIdentifier();
 
   if (m_l1GtPfTechCacheID != l1GtPfTechCacheID) {
-    edm::ESHandle<L1GtPrescaleFactors> l1GtPfTech;
-    evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().get(l1GtPfTech);
-    m_l1GtPfTech = l1GtPfTech.product();
+    if (isRun) {
+      m_l1GtPfTech = &l1GtPrescaleFactorsTechTrigRcd.get(m_L1GtPrescaleFactorsTechTrigRunToken);
+    } else {
+      m_l1GtPfTech = &l1GtPrescaleFactorsTechTrigRcd.get(m_L1GtPrescaleFactorsTechTrigEventToken);
+    }
 
     m_prescaleFactorsTechTrig = &(m_l1GtPfTech->gtPrescaleFactors());
 
@@ -171,48 +195,63 @@ void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup) {
   // get / update the trigger mask from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtTmAlgoCacheID = evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().cacheIdentifier();
+  auto l1GtTriggerMaskAlgoTrigRcd = evSetup.get<L1GtTriggerMaskAlgoTrigRcd>();
+  unsigned long long l1GtTmAlgoCacheID = l1GtTriggerMaskAlgoTrigRcd.cacheIdentifier();
 
   if (m_l1GtTmAlgoCacheID != l1GtTmAlgoCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
-    evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
-    m_l1GtTmAlgo = l1GtTmAlgo.product();
+    if (isRun) {
+      m_l1GtTmAlgo = &l1GtTriggerMaskAlgoTrigRcd.get(m_L1GtTriggerMaskAlgoTrigRunToken);
+    } else {
+      m_l1GtTmAlgo = &l1GtTriggerMaskAlgoTrigRcd.get(m_L1GtTriggerMaskAlgoTrigEventToken);
+    }
 
     m_triggerMaskAlgoTrig = &(m_l1GtTmAlgo->gtTriggerMask());
 
     m_l1GtTmAlgoCacheID = l1GtTmAlgoCacheID;
   }
 
-  unsigned long long l1GtTmTechCacheID = evSetup.get<L1GtTriggerMaskTechTrigRcd>().cacheIdentifier();
+  auto l1GtTriggerMaskTechTrigRcd = evSetup.get<L1GtTriggerMaskTechTrigRcd>();
+  unsigned long long l1GtTmTechCacheID = l1GtTriggerMaskTechTrigRcd.cacheIdentifier();
 
   if (m_l1GtTmTechCacheID != l1GtTmTechCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmTech;
-    evSetup.get<L1GtTriggerMaskTechTrigRcd>().get(l1GtTmTech);
-    m_l1GtTmTech = l1GtTmTech.product();
+    if (isRun) {
+      m_l1GtTmTech = &l1GtTriggerMaskTechTrigRcd.get(m_L1GtTriggerMaskTechTrigRunToken);
+    } else {
+      m_l1GtTmTech = &l1GtTriggerMaskTechTrigRcd.get(m_L1GtTriggerMaskTechTrigEventToken);
+    }
 
     m_triggerMaskTechTrig = &(m_l1GtTmTech->gtTriggerMask());
 
     m_l1GtTmTechCacheID = l1GtTmTechCacheID;
   }
 
-  unsigned long long l1GtTmVetoAlgoCacheID = evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().cacheIdentifier();
+  auto l1GtTriggerMaskVetoAlgoTrigRcd = evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>();
+  unsigned long long l1GtTmVetoAlgoCacheID = l1GtTriggerMaskVetoAlgoTrigRcd.cacheIdentifier();
 
   if (m_l1GtTmVetoAlgoCacheID != l1GtTmVetoAlgoCacheID) {
     edm::ESHandle<L1GtTriggerMask> l1GtTmVetoAlgo;
     evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().get(l1GtTmVetoAlgo);
     m_l1GtTmVetoAlgo = l1GtTmVetoAlgo.product();
+    if (isRun) {
+      m_l1GtTmVetoAlgo = &l1GtTriggerMaskVetoAlgoTrigRcd.get(m_L1GtTriggerMaskVetoAlgoTrigRunToken);
+    } else {
+      m_l1GtTmVetoAlgo = &l1GtTriggerMaskVetoAlgoTrigRcd.get(m_L1GtTriggerMaskVetoAlgoTrigEventToken);
+    }
 
     m_triggerMaskVetoAlgoTrig = &(m_l1GtTmVetoAlgo->gtTriggerMask());
 
     m_l1GtTmVetoAlgoCacheID = l1GtTmVetoAlgoCacheID;
   }
 
-  unsigned long long l1GtTmVetoTechCacheID = evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>().cacheIdentifier();
+  auto l1GtTriggerMaskVetoTechTrigRcd = evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>();
+  unsigned long long l1GtTmVetoTechCacheID = l1GtTriggerMaskVetoTechTrigRcd.cacheIdentifier();
 
   if (m_l1GtTmVetoTechCacheID != l1GtTmVetoTechCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmVetoTech;
-    evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>().get(l1GtTmVetoTech);
-    m_l1GtTmVetoTech = l1GtTmVetoTech.product();
+    if (isRun) {
+      m_l1GtTmVetoTech = &l1GtTriggerMaskVetoTechTrigRcd.get(m_L1GtTriggerMaskVetoTechTrigRunToken);
+    } else {
+      m_l1GtTmVetoTech = &l1GtTriggerMaskVetoTechTrigRcd.get(m_L1GtTriggerMaskVetoTechTrigEventToken);
+    }
 
     m_triggerMaskVetoTechTrig = &(m_l1GtTmVetoTech->gtTriggerMask());
 
@@ -222,12 +261,18 @@ void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup) {
   // get / update the trigger menu from the EventSetup
   // local cache & check on cacheIdentifier
 
-  unsigned long long l1GtMenuCacheID = evSetup.get<L1GtTriggerMenuRcd>().cacheIdentifier();
+  auto l1GtTriggerMenuRcd = evSetup.get<L1GtTriggerMenuRcd>();
+  unsigned long long l1GtMenuCacheID = l1GtTriggerMenuRcd.cacheIdentifier();
 
   if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
     edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
     evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
     m_l1GtMenu = l1GtMenu.product();
+    if (isRun) {
+      m_l1GtMenu = &l1GtTriggerMenuRcd.get(m_L1GtTriggerMenuRunToken);
+    } else {
+      m_l1GtMenu = &l1GtTriggerMenuRcd.get(m_L1GtTriggerMenuEventToken);
+    }
 
     m_algorithmMap = &(m_l1GtMenu->gtAlgorithmMap());
     m_algorithmAliasMap = &(m_l1GtMenu->gtAlgorithmAliasMap());
@@ -282,7 +327,8 @@ void L1GtUtils::getL1GtRunCache(const edm::Run& iRun,
   // if requested, retrieve and cache L1 event setup
   // keep the caching based on cacheIdentifier() for each record
   if (useL1EventSetup) {
-    retrieveL1EventSetup(evSetup);
+    bool isRun = true;
+    retrieveL1EventSetup(evSetup, isRun);
   }
 
   // cached per run
@@ -304,7 +350,8 @@ void L1GtUtils::getL1GtRunCache(const edm::Event& iEvent,
     // if requested, retrieve and cache L1 event setup
     // keep the caching based on cacheIdentifier() for each record
     if (useL1EventSetup) {
-      retrieveL1EventSetup(evSetup);
+      bool isRun = false;
+      retrieveL1EventSetup(evSetup, isRun);
     }
   }
 

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
@@ -7,7 +7,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 L1GtUtilsHelper::L1GtUtilsHelper(edm::ParameterSet const& pset, edm::ConsumesCollector& iC, bool useL1GtTriggerMenuLite)
-    : m_consumesCollector(std::move(iC)),
+    : m_consumesCollector(iC),
       m_l1GtRecordInputTag(pset.getParameter<edm::InputTag>("l1GtRecordInputTag")),
       m_l1GtReadoutRecordInputTag(pset.getParameter<edm::InputTag>("l1GtReadoutRecordInputTag")),
       m_l1GtTriggerMenuLiteInputTag(pset.getParameter<edm::InputTag>("l1GtTriggerMenuLiteInputTag")),

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
@@ -112,7 +112,7 @@ namespace l1t {
                                            T& module,
                                            edm::InputTag const& l1tAlgBlkInputTag,
                                            edm::InputTag const& l1tExtBlkInputTag)
-      : m_consumesCollector(std::move(iC)),
+      : m_consumesCollector(iC),
 
         // Set InputTags from arguments
         m_l1tAlgBlkInputTag(l1tAlgBlkInputTag),

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -22,6 +22,7 @@
 // system include files
 #include <fstream>
 #include <iomanip>
+#include <memory>
 
 // user include files
 //   base class
@@ -114,7 +115,7 @@ namespace l1t {
     int m_minBxVectors;
     int m_maxBxVectors;
 
-    L1TGlobalUtil* m_gtUtil;
+    std::unique_ptr<L1TGlobalUtil> m_gtUtil;
 
   private:
     int m_tvVersion;
@@ -154,7 +155,8 @@ namespace l1t {
     std::string preScaleFileName = iConfig.getParameter<std::string>("psFileName");
     unsigned int preScColumn = iConfig.getParameter<int>("psColumn");
 
-    m_gtUtil = new L1TGlobalUtil(iConfig, consumesCollector(), *this, uGtAlgInputTag, uGtExtInputTag);
+    m_gtUtil = std::make_unique<L1TGlobalUtil>(
+        iConfig, consumesCollector(), *this, uGtAlgInputTag, uGtExtInputTag, l1t::UseEventSetupIn::Event);
     m_gtUtil->OverridePrescalesAndMasks(preScaleFileName, preScColumn);
   }
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
@@ -67,7 +67,11 @@ L1TGlobalSummary::L1TGlobalSummary(const edm::ParameterSet& iConfig) {
   readPrescalesFromFile_ = iConfig.getParameter<bool>("ReadPrescalesFromFile");
   minBx_ = iConfig.getParameter<int>("MinBx");
   maxBx_ = iConfig.getParameter<int>("MaxBx");
-  gtUtil_ = new L1TGlobalUtil(iConfig, consumesCollector(), *this, algInputTag_, extInputTag_);
+  l1t::UseEventSetupIn useEventSetupIn = l1t::UseEventSetupIn::Run;
+  if (dumpTriggerResults_ || dumpTriggerSummary_) {
+    useEventSetupIn = l1t::UseEventSetupIn::RunAndEvent;
+  }
+  gtUtil_ = new L1TGlobalUtil(iConfig, consumesCollector(), *this, algInputTag_, extInputTag_, useEventSetupIn);
   finalOrCount = 0;
 
   if (readPrescalesFromFile_) {

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtilHelper.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtilHelper.cc
@@ -7,7 +7,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 l1t::L1TGlobalUtilHelper::L1TGlobalUtilHelper(edm::ParameterSet const& pset, edm::ConsumesCollector& iC)
-    : m_consumesCollector(std::move(iC)),
+    : m_consumesCollector(iC),
       m_l1tAlgBlkInputTag(pset.getParameter<edm::InputTag>("l1tAlgBlkInputTag")),
       m_l1tExtBlkInputTag(pset.getParameter<edm::InputTag>("l1tExtBlkInputTag")),
       m_findL1TAlgBlk(false),

--- a/L1Trigger/L1TNtuples/plugins/L1MenuTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1MenuTreeProducer.cc
@@ -72,7 +72,7 @@ private:
 
 L1MenuTreeProducer::L1MenuTreeProducer(const edm::ParameterSet& iConfig)
     :  //  l1MenuInputTag_(iConfig.getParameter<edm::InputTag>("L1MenuInputTag")),
-      l1GtUtils_(iConfig, consumesCollector(), true) {
+      l1GtUtils_(iConfig, consumesCollector(), true, L1GtUtils::UseEventSetupIn::Event) {
   l1Menu = new L1Analysis::L1AnalysisL1Menu();
   l1MenuData = l1Menu->getData();
 

--- a/PhysicsTools/PatAlgos/python/patTemplate_cfg.py
+++ b/PhysicsTools/PatAlgos/python/patTemplate_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
-process = cms.Process("PAT")
+process = cms.Process("PAT", stage2L1Trigger)
 
 ## MessageLogger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/triggerLayer1/triggerProducer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 patTrigger = cms.EDProducer( "PATTriggerProducer"
 , onlyStandAlone = cms.bool( False )
+, stageL1Trigger = cms.uint32(1)
 ,l1GtRecordInputTag = cms.InputTag("gtDigis")
 ,l1GtReadoutRecordInputTag = cms.InputTag("gtDigis")
 ,l1GtTriggerMenuLiteInputTag = cms.InputTag("gtDigis")
@@ -32,4 +33,5 @@ patTrigger = cms.EDProducer( "PATTriggerProducer"
 # , exludeCollections = cms.vstring()
 , packTriggerLabels = cms.bool(False)
 )
-
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(patTrigger, stageL1Trigger = 2)

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -61,8 +61,10 @@ TauTagValidation::TauTagValidation(const edm::ParameterSet& iConfig)
   turnOnTrigger_ = iConfig.exists("turnOnTrigger") && iConfig.getParameter<bool>("turnOnTrigger");
   genericTriggerEventFlag_ =
       (iConfig.exists("GenericTriggerSelection") && turnOnTrigger_)
-          ? new GenericTriggerEventFlag(
-                iConfig.getParameter<edm::ParameterSet>("GenericTriggerSelection"), consumesCollector(), *this)
+          ? new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("GenericTriggerSelection"),
+                                        consumesCollector(),
+                                        *this,
+                                        l1t::UseEventSetupIn::Run)
           : nullptr;
   if (genericTriggerEventFlag_ != nullptr)
     LogDebug(moduleLabel_) << "--> GenericTriggerSelection parameters found in " << moduleLabel_ << "."

--- a/Validation/RecoVertex/python/anotherprimaryvertexanalyzer_cfi.py
+++ b/Validation/RecoVertex/python/anotherprimaryvertexanalyzer_cfi.py
@@ -20,6 +20,8 @@ primaryvertexanalyzer = cms.EDAnalyzer('AnotherPrimaryVertexAnalyzer',
                                             prescaleWeightTriggerResults      = cms.InputTag( "TriggerResults::HLT" ),
                                             prescaleWeightL1GtTriggerMenuLite = cms.InputTag( "l1GtTriggerMenuLite" ),
                                             prescaleWeightHltPaths            = cms.vstring() 
-                                            )
+                                            ),
+                                       stageL1Trigger = cms.uint32(1)
                                       )
-
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(primaryvertexanalyzer, stageL1Trigger = 2)


### PR DESCRIPTION
#### PR description:

Migrate L1GtUtils, L1TGlobalUtil, HLTPrescaleProvider, and GenericTriggerEventFlag to make necessary consumes calls for the EventSetup objects they get. The clients of these classes are modified the minimal amount necessary to keep things working properly with those changes, but this does not include the full consumes migration of all those client modules. That will need to be done in future PRs.

There is some choice for L1GtUtils and L1TGlobalUtil whether to get data in beginRun or the Event or both. It defaults to beginRun and clients that already used that choice did not need modification.

HLTPrescaleProvider needs a configuration parameter now to tell it whether to use L1GtUtils or L1TGlobalUtil. We do not want it prefetching for both when EventSetup prefetching is enabled. The era mechanism will be used to control this choice unless someone manually sets the parameter.

This could easily break code outside the repository. If they use one of the 4 migrated classes and the constructor argument defaults are not what is required.

#### PR validation:

There is no new functionality here. All results should be the same. I just ran the full runTheMatrix tests.
