### PR TITLE
HCAL update of RelVal histos

### DIFF
--- a/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
+++ b/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
@@ -366,7 +366,7 @@ void CaloTowersAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     // MET and SET
     //-------------------------------------------------------------------------------------------
     sprintf(histo, "CaloTowersTask_energy_HCAL_HF");
-    meEnergyHcal_HF = ibooker.book1D(histo, histo, 5005, -20., 1000000.);
+    meEnergyHcal_HF = ibooker.book1D(histo, histo, 5001, -20., 1000000.);
 
     sprintf(histo, "CaloTowersTask_energy_ECAL_HF");
     meEnergyEcal_HF = ibooker.book1D(histo, histo, 3501, -20., 70000.);

--- a/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
+++ b/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
@@ -366,19 +366,19 @@ void CaloTowersAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     // MET and SET
     //-------------------------------------------------------------------------------------------
     sprintf(histo, "CaloTowersTask_energy_HCAL_HF");
-    meEnergyHcal_HF = ibooker.book1D(histo, histo, 6040, -200, 30000);
+    meEnergyHcal_HF = ibooker.book1D(histo, histo, 1001, -100., 1000000.);
 
     sprintf(histo, "CaloTowersTask_energy_ECAL_HF");
-    meEnergyEcal_HF = ibooker.book1D(histo, histo, 2440, -200, 12000);
+    meEnergyEcal_HF = ibooker.book1D(histo, histo, 701, -100., 70000.);
 
     sprintf(histo, "CaloTowersTask_number_of_fired_towers_HF");
-    meNumFiredTowers_HF = ibooker.book1D(histo, histo, 1000, 0, 2000);
+    meNumFiredTowers_HF = ibooker.book1D(histo, histo, 1000, 0., 2000.);
 
     sprintf(histo, "CaloTowersTask_MET_HF");
     MET_HF = ibooker.book1D(histo, histo, 500, 0., 500.);
 
     sprintf(histo, "CaloTowersTask_SET_HF");
-    SET_HF = ibooker.book1D(histo, histo, 2000, 0., 2000.);
+    SET_HF = ibooker.book1D(histo, histo, 500, 0., 5000.);
     //-------------------------------------------------------------------------------------------
 
     // Timing histos and profiles -- all six are necessary

--- a/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
+++ b/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
@@ -366,10 +366,10 @@ void CaloTowersAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     // MET and SET
     //-------------------------------------------------------------------------------------------
     sprintf(histo, "CaloTowersTask_energy_HCAL_HF");
-    meEnergyHcal_HF = ibooker.book1D(histo, histo, 1001, -100., 1000000.);
+    meEnergyHcal_HF = ibooker.book1D(histo, histo, 5005, -20., 1000000.);
 
     sprintf(histo, "CaloTowersTask_energy_ECAL_HF");
-    meEnergyEcal_HF = ibooker.book1D(histo, histo, 701, -100., 70000.);
+    meEnergyEcal_HF = ibooker.book1D(histo, histo, 3501, -20., 70000.);
 
     sprintf(histo, "CaloTowersTask_number_of_fired_towers_HF");
     meNumFiredTowers_HF = ibooker.book1D(histo, histo, 1000, 0., 2000.);

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -496,19 +496,19 @@ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     meRecHitsCleanedEnergyHO = ibooker.book1DD(histo, histo, 2010, -10., 2000.);
 
     sprintf(histo, "HcalRecHitTask_timing_HO");
-    meTimeHO = ibooker.book1DD(histo, histo, 70, -48., 92.);
+    meTimeHO = ibooker.book1DD(histo, histo, 80, -80., 80.);
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_HO");
-    meTE_HO = ibooker.book2D(histo, histo, 60, -5., 55., 70, -48., 92.);
+    meTE_HO = ibooker.book2D(histo, histo, 60, -5., 55., 80, -80., 80.);
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_High_HO");
-    meTE_High_HO = ibooker.book2D(histo, histo, 100, -5., 995., 70, -48., 92.);
+    meTE_High_HO = ibooker.book2D(histo, histo, 100, -5., 995., 80, -80., 80.);
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_HO");
-    meTEprofileHO = ibooker.bookProfile(histo, histo, 60, -5., 55., -48., 92., " ");
+    meTEprofileHO = ibooker.bookProfile(histo, histo, 60, -5., 55., -80., 80., " ");
 
     sprintf(histo, "HcalRecHitTask_timing_vs_energy_profile_High_HO");
-    meTEprofileHO_High = ibooker.bookProfile(histo, histo, 100, -5., 995., -48., 92., " ");
+    meTEprofileHO_High = ibooker.bookProfile(histo, histo, 100, -5., 995., -80., 80., " ");
   }
 
   // ********************** HF ************************************

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -77,8 +77,6 @@ globalValidation = cms.Sequence(   trackerHitsValidation
                                  + hcalSimHitsValidationSequence
                                  + hcaldigisValidationSequence
                                  + hcalSimHitStudy
-                                 + hcalRecHitsValidationSequence
-                                 + calotowersValidationSequence
                                  + validSimHit+muondtdigianalyzer
                                  + cscDigiValidation
                                  + validationMuonRPCDigis

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -178,7 +178,6 @@ void HcalDigisValidation::booking(DQMStore::IBooker& ib, const std::string bsubd
   // Adjust/Optimize binning (JR Dittmann, 16-JUL-2015)
 
   HistLim Ndigis(2600, 0., 2600.);
-  HistLim ndigis(520, -20., 1020.);
   HistLim sime(200, 0., 1.0);
 
   HistLim digiAmp(360, -100., 7100.);

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -264,7 +264,7 @@ void HcalDigisValidation::booking(DQMStore::IBooker& ib, const std::string bsubd
       book1D(ib, histo, digiAmp);
 
     sprintf(histo, "HcalDigiTask_number_of_amplitudes_above_10fC_%s", sub);
-    book1D(ib, histo, ndigis);
+    book1D(ib, histo, Ndigis);
 
     for (int depth = 1; depth <= maxDepth_[isubdet]; depth++) {
       sprintf(histo, "HcalDigiTask_ADC0_adc_depth%d_%s", depth, sub);


### PR DESCRIPTION
#### PR description:

(1) Update/extension of several histo limits/binning to cope with increasing Run3 and Run4 energy flow.  E.g. already in 2021 MC  had.component of HF energy distribution "leaks" above actual upper histo limit:
 https://cmsweb.cern.ch/dqm/relval/plotfairy/overlay?obj=archive%2F1%2FRelValTTbar_14TeV%2FCMSSW_10_6_1_patch1%2DPU_106X_mcRun3_2021_realistic_v3%2Dv1%2FDQMIO%2FCaloTowersD%2FCaloTowersTask%2FCaloTowersTask_energy_HCAL_HF;obj=archive%2F1%2FRelValTTbar_14TeV%2FCMSSW_11_0_0_pre11%2DPU_110X_mcRun3_2021_realistic_v5%2Dv1%2FDQMIO%2FCaloTowersD%2FCaloTowersTask%2FCaloTowersTask_energy_HCAL_HF;w=600;h=600;ref=ratiooverlay

(2) Removal of redundant HcalRecHitsV and CaloTowersV  (coming from Validation/...) components (analysers/folders)  from globalValidation. 
MC DQM contains their "siblings" HcalRecHitsD and CaloTowerD (from DQMOffline/Hcal) anyway.

#### PR validation:
runTheMatrix.py -s  is OK
