### PR TITLE
[Do Not Merge] use scram runtime instead of cmsenv alias

### DIFF
--- a/Documentation/ReferenceManualScripts/scripts/generate_reference_manual
+++ b/Documentation/ReferenceManualScripts/scripts/generate_reference_manual
@@ -1,6 +1,6 @@
 #!/bin/tcsh
 
-cmsenv
+eval `scram run -csh`
 
 set PWDv    = `pwd`
 set SOURCE  = $CMSSW_BASE/src


### PR DESCRIPTION
Do not merge this PR, it is open for testing cms-bot new `test parameters` 