### PR TITLE
Define new CLCT digi format for Run-3

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -119,7 +119,7 @@ public:
   /// Print content of digi.
   void print() const;
 
-private:
+protected:
   uint16_t valid_;
   uint16_t quality_;
   uint16_t pattern_;

--- a/DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h
@@ -1,0 +1,66 @@
+#ifndef CSCDigi_CSCCLCTRun3Digi_h
+#define CSCDigi_CSCCLCTRun3Digi_h
+
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+#include <vector>
+
+class CSCCLCTRun3Digi : public CSCCLCTDigi {
+public:
+  typedef std::vector<std::vector<uint16_t>> ComparatorContainer;
+
+  /// Constructors
+  CSCCLCTRun3Digi(const int valid,
+                  const int quality,
+                  const int pattern,
+                  const int striptype,
+                  const int bend,
+                  const int strip,
+                  const int cfeb,
+                  const int bx,
+                  const int compCode,
+                  const int trknmb = 0,
+                  const int fullbx = 0);
+  /// default
+  CSCCLCTRun3Digi();
+
+  /// clear this CLCT
+  void clear();
+
+  /// Convert strip_ and cfeb_ to keyStrip. Each CFEB has up to
+  /// 32 half-strips or 64 quart-strips.
+  /// There are up to 7 cfebs.  The "strip_" variable is one
+  /// of 32 half-strips or 64 quart-strips on the
+  /// keylayer of a single CFEB, so that:
+  /// - half-strip  = (cfeb * 32 + strip)
+  /// - quart-strip = (cfeb * 64 + strip).
+  /// Return the corresponding half-strip/quart-strip number
+  /// depending on whether the fit to comparator digis was done.
+  int getKeyStrip(bool doFit = true) const;
+
+  // 12-bit comparator code
+  int getCompCode() const { return compCode_; }
+
+  void setCompCode(const int16_t code) { compCode_ = code; }
+
+  // comparator hits in this CLCT
+  ComparatorContainer getHits() const { return hits_; }
+
+  void setHits(const ComparatorContainer& hits) { hits_ = hits; }
+
+  /// True if the two LCTs have exactly the same members (except the number).
+  bool operator==(const CSCCLCTRun3Digi&) const;
+
+  /// Print content of digi.
+  void print() const;
+
+private:
+  // 12-bit comparator code
+  uint16_t compCode_;
+
+  // which hits are in this CLCT?
+  ComparatorContainer hits_;
+};
+
+std::ostream& operator<<(std::ostream& o, const CSCCLCTRun3Digi& digi);
+
+#endif

--- a/DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h
@@ -40,7 +40,7 @@ public:
   // 12-bit comparator code
   int getCompCode() const { return compCode_; }
 
-  void setCompCode(const int16_t code) { compCode_ = code; }
+  void setCompCode(const uint16_t code) { compCode_ = code; }
 
   // comparator hits in this CLCT
   ComparatorContainer getHits() const { return hits_; }

--- a/DataFormats/CSCDigi/interface/CSCCLCTRun3DigiCollection.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTRun3DigiCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_CSCCLCTDigi_CSCCLCTRun3DigiCollection_h
+#define DataFormats_CSCCLCTDigi_CSCCLCTRun3DigiCollection_h
+
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+
+typedef MuonDigiCollection<CSCDetId, CSCCLCTRun3Digi> CSCCLCTRun3DigiCollection;
+
+#endif

--- a/DataFormats/CSCDigi/src/CSCCLCTRun3Digi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTRun3Digi.cc
@@ -1,0 +1,77 @@
+#include "DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iomanip>
+#include <iostream>
+
+/// Constructors
+CSCCLCTRun3Digi::CSCCLCTRun3Digi(const int valid,
+                                 const int quality,
+                                 const int pattern,
+                                 const int striptype,
+                                 const int bend,
+                                 const int strip,
+                                 const int cfeb,
+                                 const int bx,
+                                 const int compCode,
+                                 const int trknmb,
+                                 const int fullbx)
+    : CSCCLCTDigi(valid, quality, pattern, striptype, bend, strip, cfeb, bx, trknmb, fullbx), compCode_(compCode) {}
+
+/// Default
+CSCCLCTRun3Digi::CSCCLCTRun3Digi() : CSCCLCTDigi(), compCode_(0) {
+  hits_.resize(6);
+  for (auto& p : hits_) {
+    p.resize(11);
+  }
+}
+
+/// Clears this CLCT.
+void CSCCLCTRun3Digi::clear() {
+  CSCCLCTDigi::clear();
+  compCode_ = 0;
+  hits_.clear();
+}
+
+int CSCCLCTRun3Digi::getKeyStrip(bool doFit) const {
+  if (!doFit)
+    return CSCCLCTDigi::getKeyStrip();
+  int keyStrip = cfeb_ * 64 + strip_;
+  return keyStrip;
+}
+
+bool CSCCLCTRun3Digi::operator==(const CSCCLCTRun3Digi& rhs) const {
+  // Exact equality.
+  bool returnValue = false;
+  if (isValid() == rhs.isValid() && getQuality() == rhs.getQuality() && getPattern() == rhs.getPattern() &&
+      getKeyStrip() == rhs.getKeyStrip() && getStripType() == rhs.getStripType() && getBend() == getBend() &&
+      getBX() == rhs.getBX() && getCompCode() == rhs.getCompCode()) {
+    returnValue = true;
+  }
+  return returnValue;
+}
+
+/// Debug
+void CSCCLCTRun3Digi::print() const {
+  if (isValid()) {
+    char stripType = (getStripType() == 0) ? 'D' : 'H';
+    char bend = (getBend() == 0) ? 'L' : 'R';
+
+    edm::LogVerbatim("CSCDigi") << " CSC CLCT #" << std::setw(1) << getTrknmb() << ": Valid = " << std::setw(1)
+                                << isValid() << " Key Strip = " << std::setw(3) << getKeyStrip()
+                                << " Strip = " << std::setw(2) << getStrip() << " Quality = " << std::setw(1)
+                                << getQuality() << " Pattern = " << std::setw(1) << getPattern()
+                                << " Bend = " << std::setw(1) << bend << " Strip type = " << std::setw(1) << stripType
+                                << " CFEB ID = " << std::setw(1) << getCFEB() << " BX = " << std::setw(1) << getBX()
+                                << " Full BX= " << std::setw(1) << getFullBX() << " Comp Code= " << std::setw(1)
+                                << getCompCode();
+  } else {
+    edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
+  }
+}
+
+std::ostream& operator<<(std::ostream& o, const CSCCLCTRun3Digi& digi) {
+  return o << "CSC CLCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " Quality = " << digi.getQuality()
+           << " Pattern = " << digi.getPattern() << " StripType = " << digi.getStripType()
+           << " Bend = " << digi.getBend() << " Strip = " << digi.getStrip() << " KeyStrip = " << digi.getKeyStrip()
+           << " CFEB = " << digi.getCFEB() << " BX = " << digi.getBX() << " Comp Code " << digi.getCompCode();
+}

--- a/DataFormats/CSCDigi/src/classes.h
+++ b/DataFormats/CSCDigi/src/classes.h
@@ -8,6 +8,8 @@
 #include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTRun3Digi.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTRun3DigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"

--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -22,6 +22,9 @@
    <class name="CSCCLCTDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="3910057547"/>
    </class>
+   <class name="CSCCLCTRun3Digi" ClassVersion="10">
+    <version ClassVersion="10" checksum="1923373329"/>
+    </class>
    <class name="CSCCLCTPreTriggerDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="1207676078"/>
    </class>
@@ -60,6 +63,7 @@
    <class name="std::vector<CSCCorrelatedLCTDigi>"/>
    <class name="std::vector<GEMCSCLCTDigi>"/>
    <class name="std::vector<CSCCLCTDigi>"/>
+   <class name="std::vector<CSCCLCTRun3Digi>"/>
    <class name="std::vector<CSCCLCTPreTriggerDigi>"/>
    <class name="std::vector<CSCALCTDigi>"/>
    <class name="std::vector<CSCALCTPreTriggerDigi>"/>
@@ -78,6 +82,7 @@
    <class name="std::map<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<GEMCSCLCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTDigi> >"/>
+   <class name="std::map<CSCDetId,std::vector<CSCCLCTRun3Digi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCCLCTPreTriggerDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTDigi> >"/>
    <class name="std::map<CSCDetId,std::vector<CSCALCTPreTriggerDigi> >"/>
@@ -97,6 +102,7 @@
    <class name="std::pair<CSCDetId,std::vector<CSCCorrelatedLCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<GEMCSCLCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTDigi> >"/>
+   <class name="std::pair<CSCDetId,std::vector<CSCCLCTRun3Digi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTriggerDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCALCTDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCALCTPreTriggerDigi> >"/>
@@ -117,6 +123,7 @@
    <class name="MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,GEMCSCLCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCLCTDigi>"/>
+   <class name="MuonDigiCollection<CSCDetId,CSCCLCTRun3Digi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCCLCTPreTriggerDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCALCTDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCALCTPreTriggerDigi>"/>
@@ -136,6 +143,7 @@
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,GEMCSCLCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTDigi> >" splitLevel="0"/>
+   <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTRun3Digi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCCLCTPreTriggerDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTDigi> >" splitLevel="0"/>
    <class name="edm::Wrapper<MuonDigiCollection<CSCDetId,CSCALCTPreTriggerDigi> >" splitLevel="0"/>


### PR DESCRIPTION
#### PR description:

During Run-3 the CSC DPG group is planning to run the CSC trigger with new CLCT patterns based on a 12-bit comparator code. These new CLCTs will be of type `CSCCLCTRun3Digi` to differentiate with the legacy `CSCCLCTDigi` used in Run-1 and Run-2. An introduction to the new CLCT patterns can be found here: https://indico.cern.ch/event/778315/contributions/3238278/subcontributions/268636/attachments/1770627/2876988/181213-CCStatus_WNASH.pdf. A related PR is #28600.

#### PR validation:

The code compiles. `CSCCLCTRun3Digis` are not yet produced in CMSSW. This will be done in a future PR. There should be no change in any standard sequence.

#### if this PR is a backport please specify the original PR:

N/A

@ptcox @tahuang1991 