### PR TITLE
[HGCAL trigger] Remove HFNose from tower maps

### DIFF
--- a/L1Trigger/L1THGCal/src/backend/HGCalTowerMap2DImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalTowerMap2DImpl.cc
@@ -32,7 +32,13 @@ void HGCalTowerMap2DImpl::buildTowerMap2D(const std::vector<edm::Ptr<l1t::HGCalT
   std::unordered_map<int, l1t::HGCalTowerMap> towerMapsTmp = newTowerMaps();
 
   for (auto tc : triggerCellsPtrs) {
+    if (triggerTools_.isNose(tc->detId()))
+      continue;
     unsigned layer = triggerTools_.layerWithOffset(tc->detId());
+    if (towerMapsTmp.find(layer) == towerMapsTmp.end()) {
+      throw cms::Exception("Out of range")
+          << "HGCalTowerMap2dImpl: Found trigger cell in layer " << layer << " for which there is no tower map\n";
+    }
     // FIXME: should actually sum the energy not the Et...
     double calibPt = tc->pt();
     if (useLayerWeights_)


### PR DESCRIPTION
#### PR description:
Fix crash in HFNose workflows coming from HFNose layers being mixed with HGCAL layers in the tower maps (see #28598).
Simply remove HFNose trigger cells from the tower maps (no HFNose towers have been used or are needed so far).

#### PR validation:
Tested with workflow 21234.0 
