### PR TITLE
Add enforceGUIDInFileName option to PoolSource (7_1_X)

### DIFF
--- a/FWCore/Framework/python/test/cmsExceptionsFatalOption_cff.py
+++ b/FWCore/Framework/python/test/cmsExceptionsFatalOption_cff.py
@@ -30,5 +30,6 @@ Rethrow = cms.untracked.vstring(
   'ProductDoesNotSupportViews',
   'ProductDoesNotSupportPtr',
   'NotFound',
-  'FormatIncompatibility'
+  'FormatIncompatibility',
+  'FileNameInconsistentWithGUID',
 )

--- a/FWCore/MessageLogger/scripts/edmFjrDump
+++ b/FWCore/MessageLogger/scripts/edmFjrDump
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import xml.etree.ElementTree as ET
+import argparse
+
+def printGUID(root):
+    for f in root.findall("File"):
+        print(f.find("GUID").text)
+
+def printExitCode(root):
+    error = root.find("FrameworkError")
+    if error is None:
+        print("0")
+        return
+    print(error.get("ExitStatus"))
+
+def main(opts):
+    tree = ET.parse(opts.file)
+    root = tree.getroot()
+    if opts.guid:
+        printGUID(root)
+    if opts.exitCode:
+        printExitCode(root)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Extract some values from the Framework Job Report")
+    parser.add_argument("file", type=str,
+                        help="Framework Job Report XML file")
+    parser.add_argument("--guid", action="store_true",
+                        help="GUID of the output file")
+    parser.add_argument("--exitCode", action="store_true",
+                        help="Job exit code")
+
+    opts = parser.parse_args()
+    main(opts)

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -19,8 +19,7 @@ namespace edm {
   namespace errors {
 
     // If you add a new entry to the set of values, make sure to
-    // update the translation map in EDMException.cc, the actions
-    // table in FWCore/Framework/src/Actions.cc, and the configuration
+    // update the translation map in EDMException.cc, and the configuration
     // fragment FWCore/Framework/python/test/cmsExceptionsFatalOption_cff.py.
 
     enum ErrorCodes {

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -65,6 +65,8 @@ namespace edm {
        ExceededResourceVSize = 8030,
        ExceededResourceRSS = 8031,
        ExceededResourceTime = 8032,
+
+       FileNameInconsistentWithGUID = 8034,
       
        EventGenerationFailure = 8501,
 

--- a/FWCore/Utilities/interface/stemFromPath.h
+++ b/FWCore/Utilities/interface/stemFromPath.h
@@ -1,0 +1,17 @@
+#ifndef FWCore_Utilities_stemFromPath_h
+#define FWCore_Utilities_stemFromPath_h
+
+#include <string>
+
+namespace edm {
+  // This functions extracts the stem of a file from the path (= file
+  // name without the extension).
+  //
+  // The reason to have our own function instead of
+  // std/boost::filesystem is that tehcnically these paths are not
+  // filesystem paths, but paths in CMS LFN/PFN space that (may) have
+  // different rules.
+  std::string stemFromPath(const std::string& path);
+}  // namespace edm
+
+#endif

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -42,6 +42,7 @@ namespace edm {
       EDM_MAP_ENTRY_NONS(trans_, ExceededResourceVSize);
       EDM_MAP_ENTRY_NONS(trans_, ExceededResourceRSS);
       EDM_MAP_ENTRY_NONS(trans_, ExceededResourceTime);
+      EDM_MAP_ENTRY_NONS(trans_, FileNameInconsistentWithGUID);
       EDM_MAP_ENTRY_NONS(trans_, EventGenerationFailure);
     }
   }

--- a/FWCore/Utilities/src/stemFromPath.cc
+++ b/FWCore/Utilities/src/stemFromPath.cc
@@ -1,0 +1,20 @@
+#include "FWCore/Utilities/interface/stemFromPath.h"
+
+namespace edm {
+  std::string stemFromPath(const std::string& path) {
+    auto begin = path.rfind("/");
+    if (begin == std::string::npos) {
+      begin = path.rfind(":");
+      if (begin == std::string::npos) {
+        // shouldn't really happen?
+        begin = 0;
+      } else {
+        begin += 1;
+      }
+    } else {
+      begin += 1;
+    }
+    auto end = path.find(".", begin);
+    return path.substr(begin, end - begin);
+  }
+}  // namespace edm

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -38,6 +38,8 @@
 <bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
+<bin    file="test_stemFromPath.cc" name="testFWCoreUtilitiesStem">
+</bin>
 
 <bin   file="InputTag_t.cpp">
   <use name="tbb"/>

--- a/FWCore/Utilities/test/test_stemFromPath.cc
+++ b/FWCore/Utilities/test/test_stemFromPath.cc
@@ -1,0 +1,16 @@
+#include "FWCore/Utilities/interface/stemFromPath.h"
+
+#include <cassert>
+
+int main() {
+  assert(edm::stemFromPath("foo.root") == "foo");
+  assert(edm::stemFromPath("/foo.root") == "foo");
+  assert(edm::stemFromPath("/bar/foo.root") == "foo");
+  assert(edm::stemFromPath("/bar///....//...///foo.root") == "foo");
+  assert(edm::stemFromPath("/bar/foo.xyzzy") == "foo");
+  assert(edm::stemFromPath("/bar/xyzzy.foo.root") == "xyzzy");
+  assert(edm::stemFromPath("file:foo.root") == "foo");
+  assert(edm::stemFromPath("file:/path/to/bar.txt") == "bar");
+  assert(edm::stemFromPath("root://server.somewhere:port/whatever?param=path/to/bar.txt") == "bar");
+  return 0;
+}

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -37,6 +37,7 @@
 #include "FWCore/Utilities/interface/FriendlyName.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Utilities/interface/ReleaseVersion.h"
+#include "FWCore/Utilities/interface/stemFromPath.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
 //used for backward compatibility
@@ -1080,20 +1081,7 @@ namespace edm {
          "'Events' tree is corrupted or not present\n" << "in the input file.\n";
     }
     if (enforceGUIDInFileName_) {
-      auto begin = file_.rfind("/");
-      if (begin == std::string::npos) {
-        begin = file_.rfind(":");
-        if (begin == std::string::npos) {
-          // shouldn't really happen?
-          begin = 0;
-        } else {
-          begin += 1;
-        }
-      } else {
-        begin += 1;
-      }
-      auto end = file_.find(".", begin);
-      auto guidFromName = file_.substr(begin, end - begin);
+      auto guidFromName = stemFromPath(file_);
       if (guidFromName != fid_.fid()) {
         throw edm::Exception(edm::errors::FileNameInconsistentWithGUID)
             << "GUID " << guidFromName << " extracted from file name " << file_

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -161,7 +161,8 @@ namespace edm {
                      bool bypassVersionCheck,
                      bool labelRawDataLikeMC,
                      bool usingGoToEvent,
-                     bool enablePrefetching) :
+                     bool enablePrefetching,
+                     bool enforceGUIDInFileName) :
       file_(fileName),
       logicalFile_(logicalFileName),
       processConfiguration_(processConfiguration),
@@ -181,6 +182,7 @@ namespace edm {
       savedRunAuxiliary_(),
       skipAnyEvents_(skipAnyEvents),
       noEventSort_(noEventSort),
+      enforceGUIDInFileName_(enforceGUIDInFileName),
       whyNotFastClonable_(0),
       hasNewlyDroppedBranch_(),
       branchListIndexesUnchanged_(false),
@@ -1076,6 +1078,27 @@ namespace edm {
     if(!eventTree_.isValid()) {
       throw Exception(errors::EventCorruption) <<
          "'Events' tree is corrupted or not present\n" << "in the input file.\n";
+    }
+    if (enforceGUIDInFileName_) {
+      auto begin = file_.rfind("/");
+      if (begin == std::string::npos) {
+        begin = file_.rfind(":");
+        if (begin == std::string::npos) {
+          // shouldn't really happen?
+          begin = 0;
+        } else {
+          begin += 1;
+        }
+      } else {
+        begin += 1;
+      }
+      auto end = file_.find(".", begin);
+      auto guidFromName = file_.substr(begin, end - begin);
+      if (guidFromName != fid_.fid()) {
+        throw edm::Exception(edm::errors::FileNameInconsistentWithGUID)
+            << "GUID " << guidFromName << " extracted from file name " << file_
+            << " is inconsistent with the GUID read from the file " << fid_.fid();
+      }
     }
 
     if(fileFormatVersion().hasIndexIntoFile()) {

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -81,7 +81,8 @@ namespace edm {
              bool bypassVersionCheck,
              bool labelRawDataLikeMC,
              bool usingGoToEvent,
-             bool enablePrefetching);
+             bool enablePrefetching,
+             bool enforceGUIDInFileName);
     ~RootFile();
 
     RootFile(RootFile const&) = delete; // Disallow copying and moving
@@ -192,6 +193,7 @@ namespace edm {
     boost::shared_ptr<RunAuxiliary> savedRunAuxiliary_; // backward compatibility
     bool skipAnyEvents_;
     bool noEventSort_;
+    bool enforceGUIDInFileName_;
     int whyNotFastClonable_;
     std::array<bool, NumBranchTypes> hasNewlyDroppedBranch_;
     bool branchListIndexesUnchanged_;

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -66,6 +66,7 @@ namespace edm {
     labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC", true)),
     usingGoToEvent_(false),
     enablePrefetching_(false),
+    enforceGUIDInFileName_(pset.getUntrackedParameter<bool>("enforceGUIDInFileName", false)),
     usedFallback_(false) {
 
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
@@ -268,7 +269,8 @@ namespace edm {
           bypassVersionCheck_,
           labelRawDataLikeMC_,
           usingGoToEvent_,
-          enablePrefetching_));
+          enablePrefetching_,
+          enforceGUIDInFileName_));
 
       assert(rootFile_);
       fileIterLastOpened_ = fileIter_;
@@ -807,6 +809,10 @@ namespace edm {
                      "'permissive': Branches in each input file may be any subset of those in the first file.");
     desc.addUntracked<bool>("labelRawDataLikeMC", true)
         ->setComment("If True: replace module label for raw data to match MC. Also use 'LHC' as process.");
+    desc.addUntracked<bool>("enforceGUIDInFileName", false)
+      ->setComment(
+            "True:  file name part is required to be equal to the GUID of the file\n"
+            "False: file name can be anything");
 
     ProductSelectorRules::fillDescription(desc, "inputCommands");
     EventSkipperByID::fillDescription(desc);

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -120,6 +120,7 @@ namespace edm {
     bool labelRawDataLikeMC_;
     bool usingGoToEvent_;
     bool enablePrefetching_;
+    bool enforceGUIDInFileName_;
     bool usedFallback_;
   }; // class RootInputFileSequence
 }

--- a/IOPool/Input/test/PoolGUIDTest_cfg.py
+++ b/IOPool/Input/test/PoolGUIDTest_cfg.py
@@ -1,0 +1,31 @@
+# Configuration file for PoolInputTest
+
+import FWCore.ParameterSet.Config as cms
+import sys
+
+argv = []
+foundpy = False
+for a in sys.argv:
+    if foundpy:
+        argv.append(a)
+    if ".py" in a:
+        foundpy = True
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
+
+process.source = cms.Source("PoolSource",
+    setRunNumber = cms.untracked.uint32(621),
+    fileNames = cms.untracked.vstring(argv[0]),
+    enforceGUIDInFileName = cms.untracked.bool(True)
+)
+
+process.p = cms.Path(process.OtherThing*process.Analysis)
+
+

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -6,8 +6,13 @@ pushd ${LOCAL_TMP_DIR}
 
 cmsRun -j PoolInputTest_jobreport.xml --parameter-set ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py || die 'Failure using PrePoolInputTest_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:PoolInputTest.root && die 'PoolGUIDTest_cfg.py PoolInputTest.root did not throw an exception' 1
-GUID_NAME=$(fgrep GUID PoolInputTest_jobreport.xml | sed -E 's/<.?GUID>//g').root
+cmsRun  -j PoolGuidTest_jobreport.xml ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:PoolInputTest.root && die 'PoolGUIDTest_cfg.py PoolInputTest.root did not throw an exception' 1
+GUID_EXIT_CODE=$(edmFjrDump --exitCode PoolGuidTest_jobreport.xml)
+if [ "x${GUID_EXIT_CODE}" != "x8034" ]; then
+    echo "Inconsistent GUID test reported exit code ${GUID_EXIT_CODE} which is different from the expected 8034"
+    exit 1
+fi
+GUID_NAME=$(edmFjrDump --guid PoolInputTest_jobreport.xml).root
 cp PoolInputTest.root ${GUID_NAME}
 cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:${GUID_NAME} || die 'Failure using PoolGUIDTest_cfg.py ${GUID_NAME}' $?
 

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -4,7 +4,12 @@ function die { echo $1: status $2 ;  exit $2; }
 
 pushd ${LOCAL_TMP_DIR}
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py || die 'Failure using PrePoolInputTest_cfg.py' $?
+cmsRun -j PoolInputTest_jobreport.xml --parameter-set ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py || die 'Failure using PrePoolInputTest_cfg.py' $?
+
+cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:PoolInputTest.root && die 'PoolGUIDTest_cfg.py PoolInputTest.root did not throw an exception' 1
+GUID_NAME=$(fgrep GUID PoolInputTest_jobreport.xml | sed -E 's/<.?GUID>//g').root
+cp PoolInputTest.root ${GUID_NAME}
+cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:${GUID_NAME} || die 'Failure using PoolGUIDTest_cfg.py ${GUID_NAME}' $?
 
 cp PoolInputTest.root PoolInputOther.root
 


### PR DESCRIPTION
#### PR description:

Quoting original PR

> This PR adds an option to `PoolSource` ~~and `EmbeddedRootSource`~~ to enforce that the file name (without extension) corresponds the GUID of the file. The added configuration parameter is `enforceGUIDInFileName = cms.untracked.bool`, and is set to `false` by default to preserve the current behavior. In case of a mismatch a new error code 8034 (`FileNameInconsistentWithGUID`) is returned.
> 
> The motivation for such an option comes from https://github.com/dmwm/WMCore/issues/9432.

#### PR validation:

Unit tests run.

#### if this PR is a backport please specify the original PR:

Backport of #28561. There some differences wrt. original PR: `stemFromPath()` operates on `std::string` instead of `std::string_view`, its unit test does not use catch2, and the set of clients of `RootFile` class is different (because of #9397).