### PR TITLE
Adjust CondFormats/Serialization for boost 1.72.0

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -114,16 +114,21 @@
 #elif BOOST_VERSION < 104800
 #include <boost/spirit/home/support/detail/integer/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#else
+#elif BOOST_VERSION < 106700
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
+#else
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/spirit/home/support/detail/endian/endian.hpp>
 #endif
 
 // namespace alias
 #if BOOST_VERSION < 103800
 namespace fp = boost::math;
-#else
+#elif BOOST_VERSION < 106700
 namespace fp = boost::spirit::math;
+#else
+namespace fp = boost::math;
 #endif
 
 // namespace alias endian
@@ -132,6 +137,7 @@ namespace endian = boost::detail;
 #else
 namespace endian = boost::spirit::detail;
 #endif
+
 
 #ifndef BOOST_NO_STD_WSTRING
 // used for wstring to utf8 conversion

--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -63,7 +63,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and ¡kos MarÛy.
+ *       Contributions we made by Johan Rade and √Åkos Mar√≥y.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -119,7 +119,7 @@
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
 #else
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/spirit/home/support/detail/endian/endian.hpp>
+#include <boost/predef/other/endian.h>
 #endif
 
 // namespace alias

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -66,7 +66,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and ¡kos MarÛy.
+ *       Contributions we made by Johan Rade and √Åkos Mar√≥y.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -126,8 +126,8 @@
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
 #else
+#include <boost/predef/other/endian.h>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/spirit/home/support/detail/endian/endian.hpp>
 #endif
 
 // namespace alias fp_classify
@@ -396,7 +396,7 @@ namespace eos {
           break;
         case FP_SUBNORMAL:
           assert(std::numeric_limits<T>::has_denorm);  // pass
-        case FP_ZERO:                                  // note that floats can be ±0.0
+        case FP_ZERO:                                  // note that floats can be ¬±0.0
         case FP_NORMAL:
           traits::get_bits(t, bits);
           break;

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -122,16 +122,21 @@
 #elif BOOST_VERSION < 104800
 #include <boost/spirit/home/support/detail/integer/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#else
+#elif BOOST_VERSION < 106700
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
+#else
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/spirit/home/support/detail/endian/endian.hpp>
 #endif
 
 // namespace alias fp_classify
 #if BOOST_VERSION < 103800
 namespace fp = boost::math;
-#else
+#elif BOOST_VERSION < 106700
 namespace fp = boost::spirit::math;
+#else
+namespace fp = boost::math;
 #endif
 
 // namespace alias endian


### PR DESCRIPTION
#### PR description:

Add the least for our code to work with boost 1.71.0. 
Aims to check indirect dependencies and ping package responsible check the differences

#### PR validation:

Builds CondFormats/Serialization. Unit tests run successfully 

#### Note

Deprecations warning is thrown at build saying 

```
In file included from /build/mrodozov/fix_boost/build_tool_conf/slc7_amd64_gcc820/external/boost/1.71.0/include/boost/detail/endian.hpp:9,
                 from /build/mrodozov/fix_boost/build_tool_conf/slc7_amd64_gcc820/external/boost/1.71.0/include/boost/archive/impl/basic_binary_iarchive.ipp:25,
                 from /build/mrodozov/fix_boost/CMSSW_11_1_X_2019-12-11-1100/src/CondFormats/Serialization/src/templateInstantiations.cc:7:
/build/mrodozov/fix_boost/build_tool_conf/slc7_amd64_gcc820/external/boost/1.71.0/include/boost/predef/detail/endian_compat.h:11:161: note: #pragma message: The use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Please include <boost/predef/other/endian.h> and use BOOST_ENDIAN_*_BYTE instead
 #pragma message("The use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Please include <boost/predef/other/endian.h> and use BOOST_ENDIAN_*_BYTE instead")
```

meaning additional code adjustments are expected. 
