### PR TITLE
Use CmsRun python module for Validation/Geometry tests

### DIFF
--- a/Validation/Geometry/test/genTrackerPlots.sh
+++ b/Validation/Geometry/test/genTrackerPlots.sh
@@ -9,7 +9,7 @@ mkdir $TEST_DIR && cd $TEST_DIR
 cmsRun ${VGEO_DIR}/test/single_neutrino_cfg.py nEvents=1000 >$TEST_DIR/single_neutrino_cfg.log 2>&1
 
 for geom in {'Extended2015','Extended2017Plan1'}; do
-    cmsRun ${VGEO_DIR}/test/runP_Tracker_cfg.py geom=$geom label=Tracker >$TEST_DIR/runP_Tracker_cfg.log 2>&1
+    python ${VGEO_DIR}/test/runP_Tracker.py geom=$geom label=Tracker >$TEST_DIR/runP_Tracker_cfg.log 2>&1
 done
 
 python ${VGEO_DIR}/test/MaterialBudget.py -s -d Tracker -g 'Extended2017Plan1'

--- a/Validation/Geometry/test/runMaterialDumpAnalyser.sh
+++ b/Validation/Geometry/test/runMaterialDumpAnalyser.sh
@@ -128,7 +128,7 @@ fi
 
 for t in BeamPipe Tracker PixBar PixFwdMinus PixFwdPlus TIB TOB TIDB TIDF TEC TkStrct InnerServices; do
   if [ ! -e matbdg_${t}.root ]; then
-    cmsRun runP_Tracker_cfg.py geom=${geometry} label=$t >& /dev/null &
+    python runP_Tracker.py geom=${geometry} label=$t >& /dev/null &
   fi
 done
 

--- a/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseI.sh
+++ b/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseI.sh
@@ -134,7 +134,7 @@ fi
 
 for t in BeamPipe Tracker PixBar PixFwdMinus PixFwdPlus TIB TOB TIDB TIDF TEC TkStrct InnerServices; do
   if [ ! -e matbdg_${t}.root ]; then
-    cmsRun runP_Tracker_cfg.py geom=${geometry} label=$t >& /dev/null &
+    python runP_Tracker.py geom=${geometry} label=$t >& /dev/null &
   fi
 done
 

--- a/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh
+++ b/Validation/Geometry/test/runMaterialDumpAnalyser_PhaseII.sh
@@ -136,7 +136,7 @@ fi
 
 for t in BeamPipe Tracker Phase2PixelBarrel Phase2OTBarrel Phase2PixelEndcap Phase2OTForward; do
   if [ ! -e matbdg_${t}.root ]; then
-    cmsRun runP_Tracker_cfg.py geom=${geometry} label=$t >& /dev/null &
+    python runP_Tracker.py geom=${geometry} label=$t >& /dev/null &
   fi
 done
 

--- a/Validation/Geometry/test/runP_Tracker.py
+++ b/Validation/Geometry/test/runP_Tracker.py
@@ -1,11 +1,13 @@
 # In order to produce everything that you need in one go, use the command:
 #
-# for t in {'BeamPipe','Tracker','PixBar','PixFwdMinus','PixFwdPlus','TIB','TOB','TIDB','TIDF','TEC','TkStrct','InnerServices'}; do cmsRun runP_Tracker_cfg.py geom=XYZ label=$t >& /dev/null &; done
+# for t in {'BeamPipe','Tracker','PixBar','PixFwdMinus','PixFwdPlus','TIB','TOB','TIDB','TIDF','TEC','TkStrct','InnerServices'}; do python runP_Tracker.py geom=XYZ label=$t >& /dev/null &; done
 
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 import sys, re
+
+from FWCore.PythonFramework.CmsRun import CmsRun
 
 process = cms.Process("PROD")
 
@@ -19,7 +21,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
  The default component to be monitored is the Tracker. If other
  components need to be studied, they must be supplied, one at a time,
- at the command line, e.g.: cmsRun runP_Tracker_cfg.py
+ at the command line, e.g.: python runP_Tracker.py
  label="XYZ"
 
 """
@@ -134,3 +136,6 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
         TextFile = cms.string('None')
     )
 ))
+
+cmsRun = CmsRun(process)
+cmsRun.run()


### PR DESCRIPTION
#### PR description:

The tests had been crashing in future looking IBs because ROOT
was doing cleanup once the ROOT python module is removed. This
caused a problem when using the module within a _cfg.py file as
cmsRun shutsdown python before doing the event processing.

Switching to using the CmsRun python module instead of running the
cmsRun executable avoids the problem as the CmsRun python module
does not shutdown (or spinup) python internally.

#### PR validation:

The tests now pass when run under CMSSW_11_1_ROOT618_X_2019-12-11-2300.