### PR TITLE
PPS: configurable timing-tracking cut

### DIFF
--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -67,6 +67,9 @@ private:
     bool th_y_cut_apply;
     double th_y_cut_value;
 
+    double ti_tr_min;
+    double ti_tr_max;
+
     void load(const edm::ParameterSet &ps) {
       x_cut_apply = ps.getParameter<bool>("x_cut_apply");
       x_cut_value = ps.getParameter<double>("x_cut_value");
@@ -76,6 +79,9 @@ private:
       xi_cut_value = ps.getParameter<double>("xi_cut_value");
       th_y_cut_apply = ps.getParameter<bool>("th_y_cut_apply");
       th_y_cut_value = ps.getParameter<double>("th_y_cut_value");
+
+      ti_tr_min = ps.getParameter<double>("ti_tr_min");
+      ti_tr_max = ps.getParameter<double>("ti_tr_max");
     }
 
     static edm::ParameterSetDescription getDefaultParameters() {
@@ -89,6 +95,9 @@ private:
       desc.add<double>("xi_cut_value", 0.013)->setComment("threshold of track-association cut in xi");
       desc.add<bool>("th_y_cut_apply", true)->setComment("whether to apply track-association cut in th_y");
       desc.add<double>("th_y_cut_value", 20E-6)->setComment("threshold of track-association cut in th_y, rad");
+
+      desc.add<double>("ti_tr_min", -1.)->setComment("minimum value for timing-tracking association cut");
+      desc.add<double>("ti_tr_max", +1.)->setComment("maximum value for timing-tracking association cut");
 
       return desc;
     }
@@ -362,8 +371,9 @@ void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
 
               const double de_x = tr_ti.x() - x_inter;
               const double de_x_unc = sqrt(tr_ti.xUnc() * tr_ti.xUnc() + x_inter_unc_sq);
+              const double r = (de_x_unc > 0.) ? de_x / de_x_unc : 1E100;
 
-              const bool matching = (std::abs(de_x) <= de_x_unc);
+              const bool matching = (ac.ti_tr_min < r && r < ac.ti_tr_max);
 
               if (verbosity_)
                 ssLog << "ti=" << ti << ", i=" << i << ", j=" << j << " | z_ti=" << z_ti << ", z_i=" << z_i


### PR DESCRIPTION
#### PR description:

This PR allows to configure (in python) the cuts for association between timing-RP and tracking-RP local tracks. Previously, these cuts were effectively hard-coded. This is a follow up of an observation presented e.g. in [Proton POG meeting 26 Nov 2019](https://indico.cern.ch/event/865518/contributions/3648775/attachments/1951600/3240029/kaspar_dpg_timing_eff.pdf) (slide 5), showing that the current cuts a little too strict. In order to maintain the backward compatibility, this PR keeps the default cut values as before.

#### PR validation:

The plot below compares proton reconstruction results for different periods (rows) and different CMSSW versions/settiings (colours). Comparing blue (before this PR) with red dashed (this PR, default cuts) shows that there is no difference in results. Comparing red dashed (default cuts) with green (enlarged cuts) shows that more reco-proton objects include non-zero number of timing-RP tracks.

![make_cmp](https://user-images.githubusercontent.com/17830858/70791259-0f2b8900-1d97-11ea-8210-9dd68eb6e9fb.png)
