### PR TITLE
Prevent segfault if dd4hep::Solid is not valid

### DIFF
--- a/DetectorDescription/DDCMS/src/DDNamespace.cc
+++ b/DetectorDescription/DDCMS/src/DDNamespace.cc
@@ -153,11 +153,14 @@ dd4hep::Volume DDNamespace::addVolumeNS(dd4hep::Volume vol) const {
   dd4hep::Material m = vol.material();
   vol->SetName(n.c_str());
   m_context->volumes[n] = vol;
+  const char* solidName = "Invalid solid";
+  if (s.isValid())         // Protect against seg fault
+    solidName = s.name();  // If Solid is not valid, s.name() will seg fault.
   dd4hep::printout(m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG,
                    "DD4CMS",
-                   "+++ Add volume:%-38s Solid:%-26s[%-16s] Material:%s",
+                   "+++ Add volumeNS:%-38s Solid:%-26s[%-16s] Material:%s",
                    vol.name(),
-                   s.name(),
+                   solidName,
                    s.type(),
                    m.name());
   return vol;
@@ -170,12 +173,15 @@ dd4hep::Volume DDNamespace::addVolume(dd4hep::Volume vol) const {
   dd4hep::Material m = vol.material();
   //vol->SetName(n.c_str());
   m_context->volumes[n] = vol;
+  const char* solidName = "Invalid solid";
+  if (s.isValid())         // Protect against seg fault
+    solidName = s.name();  // If Solid is not valid, s.name() will seg fault.
   dd4hep::printout(m_context->debug_volumes ? dd4hep::ALWAYS : dd4hep::DEBUG,
                    "DD4CMS",
                    "+++ Add volume:%-38s as [%s] Solid:%-26s[%-16s] Material:%s",
                    vol.name(),
                    n.c_str(),
-                   s.name(),
+                   solidName,
                    s.type(),
                    m.name());
   return vol;


### PR DESCRIPTION
#### PR description:

A test script for reading geometry XML files terminated with a segmentation fault when it created an incomplete `dd4hep::Solid` object and then tried to output the `Solid::name()` in a debug statement. This `dd4hep::Solid::name()` method tries to de-reference a null pointer, causing a segfault, when the object is invalid.
To fix this problem, a call to `Solid::isValid()` is added to ensure that the object is valid before trying to get its name.
The DD4hep team will be changing the behavior of `Solid::name()` to raising an exception instead of segfaulting in the case of an invalid object, but the approach in this PR of checking for validity is our preferred solution to the problem

#### PR validation:

The script with the segfault was tested with this fix to ensure that the bug is gone. This fix should not change any standard workflows.

No backport needed.