### PR TITLE
EventSetup consumes migration for TrackingMonitor

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -11,6 +11,7 @@ Monitoring source for general quantities related to tracks.
 #include <fstream>
 #include <unordered_map>
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -26,6 +27,12 @@ Monitoring source for general quantities related to tracks.
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
 class BeamSpot;
 class TrackAnalyzer {
@@ -78,6 +85,10 @@ private:
   edm::EDGetTokenT<reco::VertexCollection> pvToken_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
   edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;
+
   float lumi_factor_per_bx_;
 
   edm::ParameterSet const* conf_;

--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -48,14 +48,14 @@ public:
                const TrajectorySeed& seed,
                const SeedStopInfo& stopInfo,
                const reco::BeamSpot& bs,
-               const edm::ESHandle<MagneticField>& theMF,
-               const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder);
+               const MagneticField& theMF,
+               const TransientTrackingRecHitBuilder& theTTRHBuilder);
   void analyze(const edm::Event& iEvent,
                const edm::EventSetup& iSetup,
                const TrackCandidate& candidate,
                const reco::BeamSpot& bs,
-               const edm::ESHandle<MagneticField>& theMF,
-               const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder);
+               const MagneticField& theMF,
+               const TransientTrackingRecHitBuilder& theTTRHBuilder);
   void analyze(const edm::View<reco::Track>& trackCollection,
                const std::vector<const MVACollection*>& mvaCollections,
                const std::vector<const QualityMaskCollection*>& qualityMaskCollections);

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -14,9 +14,9 @@ Monitoring source for general quantities related to tracks.
 #include <memory>
 #include <fstream>
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,6 @@ Monitoring source for general quantities related to tracks.
 
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
@@ -47,6 +46,11 @@ Monitoring source for general quantities related to tracks.
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionsSeedingLayerSets.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 class TrackAnalyzer;
 class TrackBuildingAnalyzer;
@@ -110,6 +114,9 @@ private:
 
   std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection> > > mvaQualityTokens_;
   edm::EDGetTokenT<edm::View<reco::Track> > mvaTrackToken_;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderToken_;
 
   std::string Quality_;
   std::string AlgoName_;
@@ -191,7 +198,6 @@ private:
   MonitorElement* NumberOfTracks_lumiFlag;
 
   std::string builderName;
-  edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
 
   bool doTrackerSpecific_;
   bool doLumiAnalysis;

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -269,7 +269,7 @@ void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker& iboo
     }
   }
 
-  TrackerGeometry const& trackerGeometry = iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometryToken_);
+  TrackerGeometry const& trackerGeometry = iSetup.getData(trackerGeometryToken_);
 
   // Values are not ordered randomly, but the order is taken from
   // http://cmslxr.fnal.gov/dxr/CMSSW/source/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h#15
@@ -1126,7 +1126,7 @@ void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSe
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
   iEvent.getByToken(pixelClustersToken_, pixelClusters);
   if (pixelClusters.isValid()) {
-    TrackerTopology const& tTopo = iSetup.get<TrackerTopologyRcd>().get(trackerTopologyToken_);
+    TrackerTopology const& tTopo = iSetup.getData(trackerTopologyToken_);
 
     // Count the number of clusters with at least a minimum
     // number of pixels per cluster and at least a minimum charge.
@@ -1351,7 +1351,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       yPointOfClosestApproachVsZ0wrtPV->Fill(track.dz(pv.position()), (track.vy() - pv.position().y()));
 
       if (doSIPPlots_) {
-        TransientTrackBuilder const& theB = iSetup.get<TransientTrackRecord>().get(transientTrackBuilderToken_);
+        TransientTrackBuilder const& theB = iSetup.getData(transientTrackBuilderToken_);
         reco::TransientTrack transTrack = theB.build(track);
 
         GlobalVector dir(track.px(), track.py(), track.pz());
@@ -1958,7 +1958,7 @@ void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco
     etaerror = track.etaError();
 
   } else {
-    TransientTrackBuilder const& theB = iSetup.get<TransientTrackRecord>().get(transientTrackBuilderToken_);
+    TransientTrackBuilder const& theB = iSetup.getData(transientTrackBuilderToken_);
     reco::TransientTrack TransTrack = theB.build(track);
 
     TrajectoryStateOnSurface TSOS;

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -6,15 +6,14 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQM/TrackingMonitor/interface/TrackAnalyzer.h"
 #include <string>
@@ -85,6 +84,17 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig, edm::ConsumesColl
   pvToken_ = iC.consumes<reco::VertexCollection>(primaryVertexInputTag);
   pixelClustersToken_ = iC.mayConsume<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterInputTag);
   lumiscalersToken_ = iC.mayConsume<LumiScalersCollection>(scalInputTag);
+
+  if (doAllPlots_ || doEffFromHitPatternVsPU_ || doEffFromHitPatternVsBX_ || doEffFromHitPatternVsLUMI_) {
+    trackerGeometryToken_ = iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>();
+  }
+  trackerTopologyToken_ = iC.esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  if (doSIPPlots_ ||
+      ((doMeasurementStatePlots_ || doAllPlots_) && (stateName_ == "All" || stateName_ == "OuterSurface" ||
+                                                     stateName_ == "InnerSurface" || stateName_ == "ImpactPoint"))) {
+    transientTrackBuilderToken_ =
+        iC.esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"));
+  }
 
   if (useBPixLayer1_)
     lumi_factor_per_bx_ = GetLumi::FREQ_ORBIT * GetLumi::SECONDS_PER_LS / GetLumi::XSEC_PIXEL_CLUSTER;
@@ -259,8 +269,7 @@ void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker& iboo
     }
   }
 
-  edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
+  TrackerGeometry const& trackerGeometry = iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometryToken_);
 
   // Values are not ordered randomly, but the order is taken from
   // http://cmslxr.fnal.gov/dxr/CMSSW/source/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h#15
@@ -275,7 +284,7 @@ void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker& iboo
   // We set sub_det to be a 1-based index since to it is the sub-sub-structure in the HitPattern
   char title[50];
   for (unsigned int det = 1; det < sizeof(dets) / sizeof(char*); ++det) {
-    for (unsigned int sub_det = 1; sub_det <= trackerGeometry->numberOfLayers(det); ++sub_det) {
+    for (unsigned int sub_det = 1; sub_det <= trackerGeometry.numberOfLayers(det); ++sub_det) {
       for (unsigned int cat = 0; cat < sizeof(hit_category) / sizeof(char*); ++cat) {
         memset(title, 0, sizeof(title));
         snprintf(title, sizeof(title), "Hits%s_%s_%s_Subdet%d", name.c_str(), hit_category[cat], dets[det], sub_det);
@@ -1103,7 +1112,6 @@ void TrackAnalyzer::setNumberOfGoodVertices(const edm::Event& iEvent) {
 
 void TrackAnalyzer::setBX(const edm::Event& iEvent) { bx_ = iEvent.bunchCrossing(); }
 
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // as done by pixelLumi http://cmslxr.fnal.gov/source/DQM/PixelLumi/plugins/PixelLumiDQM.cc
 
@@ -1118,9 +1126,7 @@ void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSe
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
   iEvent.getByToken(pixelClustersToken_, pixelClusters);
   if (pixelClusters.isValid()) {
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-    const TrackerTopology* const tTopo = tTopoHandle.product();
+    TrackerTopology const& tTopo = iSetup.get<TrackerTopologyRcd>().get(trackerTopologyToken_);
 
     // Count the number of clusters with at least a minimum
     // number of pixels per cluster and at least a minimum charge.
@@ -1131,9 +1137,9 @@ void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSe
     for (; pixCluDet != pixelClusters->end(); ++pixCluDet) {
       DetId detid = pixCluDet->detId();
       size_t subdetid = detid.subdetId();
-      //      std::cout << tTopo->print(detid) << std::endl;
+      //      std::cout << tTopo.print(detid) << std::endl;
       if (subdetid == (int)PixelSubdetector::PixelBarrel)
-        if (tTopo->layer(detid) == 1)
+        if (tTopo.layer(detid) == 1)
           continue;
 
       edmNew::DetSet<SiPixelCluster>::const_iterator pixClu = pixCluDet->begin();
@@ -1345,9 +1351,8 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       yPointOfClosestApproachVsZ0wrtPV->Fill(track.dz(pv.position()), (track.vy() - pv.position().y()));
 
       if (doSIPPlots_) {
-        edm::ESHandle<TransientTrackBuilder> theB;
-        iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
-        reco::TransientTrack transTrack = theB->build(track);
+        TransientTrackBuilder const& theB = iSetup.get<TransientTrackRecord>().get(transientTrackBuilderToken_);
+        reco::TransientTrack transTrack = theB.build(track);
 
         GlobalVector dir(track.px(), track.py(), track.pz());
         std::pair<bool, Measurement1D> ip3d = IPTools::signedImpactParameter3D(transTrack, dir, pv);
@@ -1375,7 +1380,6 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   if (doTrackerSpecific_ || doAllPlots_) {
     fillHistosForTrackerSpecific(track);
   }
-
   if (doMeasurementStatePlots_ || doAllPlots_) {
     if (stateName_ == "All") {
       fillHistosForState(iSetup, track, std::string("OuterSurface"));
@@ -1954,9 +1958,8 @@ void TrackAnalyzer::fillHistosForState(const edm::EventSetup& iSetup, const reco
     etaerror = track.etaError();
 
   } else {
-    edm::ESHandle<TransientTrackBuilder> theB;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
-    reco::TransientTrack TransTrack = theB->build(track);
+    TransientTrackBuilder const& theB = iSetup.get<TransientTrackRecord>().get(transientTrackBuilderToken_);
+    reco::TransientTrack TransTrack = theB.build(track);
 
     TrajectoryStateOnSurface TSOS;
 

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -497,15 +497,15 @@ void TrackBuildingAnalyzer::analyze(const edm::Event& iEvent,
                                     const TrajectorySeed& candidate,
                                     const SeedStopInfo& stopInfo,
                                     const reco::BeamSpot& bs,
-                                    const edm::ESHandle<MagneticField>& theMF,
-                                    const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder) {
+                                    const MagneticField& theMF,
+                                    const TransientTrackingRecHitBuilder& theTTRHBuilder) {
   TSCBLBuilderNoMaterial tscblBuilder;
 
   //get parameters and errors from the candidate state
-  auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(theTTRHBuilder.product()))->geometry();
+  auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(&theTTRHBuilder))->geometry();
   auto const& candSS = candidate.startingState();
   TrajectoryStateOnSurface state =
-      trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), theMF.product());
+      trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), &theMF);
   TrajectoryStateClosestToBeamLine tsAtClosestApproachSeed =
       tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
   if (!(tsAtClosestApproachSeed.isValid())) {
@@ -573,15 +573,15 @@ void TrackBuildingAnalyzer::analyze(const edm::Event& iEvent,
                                     const edm::EventSetup& iSetup,
                                     const TrackCandidate& candidate,
                                     const reco::BeamSpot& bs,
-                                    const edm::ESHandle<MagneticField>& theMF,
-                                    const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder) {
+                                    const MagneticField& theMF,
+                                    const TransientTrackingRecHitBuilder& theTTRHBuilder) {
   TSCBLBuilderNoMaterial tscblBuilder;
 
   //get parameters and errors from the candidate state
-  auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(theTTRHBuilder.product()))->geometry();
+  auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(&theTTRHBuilder))->geometry();
   auto const& candSS = candidate.trajectoryStateOnDet();
   TrajectoryStateOnSurface state =
-      trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), theMF.product());
+      trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), &theMF);
   TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
       tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
   if (!(tsAtClosestApproachTrackCand.isValid())) {

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -891,7 +891,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     // fill the TrackCandidate info
     if (doTkCandPlots) {
       // magnetic field
-      MagneticField const& theMF = iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldToken_);
+      MagneticField const& theMF = iSetup.getData(magneticFieldToken_);
 
       // get the candidate collection
       edm::Handle<TrackCandidateCollection> theTCHandle;
@@ -913,8 +913,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         if (seedHandle.isValid() && !seedCollection.empty())
           FractionCandidatesOverSeeds->Fill(double(theTCCollection.size()) / double(seedCollection.size()));
 
-        TransientTrackingRecHitBuilder const& theTTRHBuilder =
-            iSetup.get<TransientRecHitRecord>().get(transientTrackingRecHitBuilderToken_);
+        TransientTrackingRecHitBuilder const& theTTRHBuilder = iSetup.getData(transientTrackingRecHitBuilderToken_);
         for (TrackCandidateCollection::const_iterator cand = theTCCollection.begin(); cand != theTCCollection.end();
              ++cand) {
           theTrackBuildingAnalyzer->analyze(iEvent, iSetup, *cand, bs, theMF, theTTRHBuilder);
@@ -977,15 +976,14 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           if (seedStopInfo.size() == seedCollection.size()) {
             //here duplication of mag field and be informations is needed to allow seed and track cand histos to be independent
             // magnetic field
-            MagneticField const& theMF = iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldToken_);
+            MagneticField const& theMF = iSetup.getData(magneticFieldToken_);
 
             // get the beam spot
             edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
             iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
             const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
-            TransientTrackingRecHitBuilder const& theTTRHBuilder =
-                iSetup.get<TransientRecHitRecord>().get(transientTrackingRecHitBuilderToken_);
+            TransientTrackingRecHitBuilder const& theTTRHBuilder = iSetup.getData(transientTrackingRecHitBuilderToken_);
             for (size_t i = 0; i < seedCollection.size(); ++i) {
               theTrackBuildingAnalyzer->analyze(
                   iEvent, iSetup, seedCollection[i], seedStopInfo[i], bs, theMF, theTTRHBuilder);

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -9,7 +9,6 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -20,12 +19,9 @@
 #include "DQM/TrackingMonitor/interface/VertexMonitor.h"
 #include "DQM/TrackingMonitor/interface/TrackingMonitor.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -106,9 +102,11 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
       doTrackerSpecific_(iConfig.getParameter<bool>("doTrackerSpecific")),
       doLumiAnalysis(iConfig.getParameter<bool>("doLumiAnalysis")),
       doProfilesVsLS_(iConfig.getParameter<bool>("doProfilesVsLS")),
+      doAllSeedPlots(iConfig.getParameter<bool>("doSeedParameterHistos")),
       doAllPlots(iConfig.getParameter<bool>("doAllPlots")),
       doGeneralPropertiesPlots_(iConfig.getParameter<bool>("doGeneralPropertiesPlots")),
       doHitPropertiesPlots_(iConfig.getParameter<bool>("doHitPropertiesPlots")),
+      doTkCandPlots(iConfig.getParameter<bool>("doTrackCandHistos")),
       doPUmonitoring_(iConfig.getParameter<bool>("doPUmonitoring")),
       genTriggerEventFlag_(new GenericTriggerEventFlag(
           iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"), consumesCollector(), *this)),
@@ -174,6 +172,20 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   edm::InputTag pixelClusterInputTag_ = iConfig.getParameter<edm::InputTag>("pixelCluster");
   stripClustersToken_ = mayConsume<edmNew::DetSetVector<SiStripCluster> >(stripClusterInputTag_);
   pixelClustersToken_ = mayConsume<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterInputTag_);
+
+  runTrackBuildingAnalyzerForSeed =
+      (doAllSeedPlots || iConfig.getParameter<bool>("doSeedPTHisto") || iConfig.getParameter<bool>("doSeedETAHisto") ||
+       iConfig.getParameter<bool>("doSeedPHIHisto") || iConfig.getParameter<bool>("doSeedPHIVsETAHisto") ||
+       iConfig.getParameter<bool>("doSeedThetaHisto") || iConfig.getParameter<bool>("doSeedQHisto") ||
+       iConfig.getParameter<bool>("doSeedDxyHisto") || iConfig.getParameter<bool>("doSeedDzHisto") ||
+       iConfig.getParameter<bool>("doSeedNRecHitsHisto") || iConfig.getParameter<bool>("doSeedNVsPhiProf") ||
+       iConfig.getParameter<bool>("doSeedNVsEtaProf"));
+
+  if (doTkCandPlots || doAllSeedPlots || runTrackBuildingAnalyzerForSeed) {
+    magneticFieldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
+    transientTrackingRecHitBuilderToken_ =
+        esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(edm::ESInputTag("", builderName));
+  }
 
   doFractionPlot_ = true;
   if (alltrackProducer.label() == trackProducer.label())
@@ -572,19 +584,9 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 
   ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
 
-  doAllSeedPlots = conf->getParameter<bool>("doSeedParameterHistos");
   doSeedNumberPlot = conf->getParameter<bool>("doSeedNumberHisto");
   doSeedLumiAnalysis_ = conf->getParameter<bool>("doSeedLumiAnalysis");
   doSeedVsClusterPlot = conf->getParameter<bool>("doSeedVsClusterHisto");
-  //    if (doAllPlots) doAllSeedPlots=true;
-
-  runTrackBuildingAnalyzerForSeed =
-      (doAllSeedPlots || conf->getParameter<bool>("doSeedPTHisto") || conf->getParameter<bool>("doSeedETAHisto") ||
-       conf->getParameter<bool>("doSeedPHIHisto") || conf->getParameter<bool>("doSeedPHIVsETAHisto") ||
-       conf->getParameter<bool>("doSeedThetaHisto") || conf->getParameter<bool>("doSeedQHisto") ||
-       conf->getParameter<bool>("doSeedDxyHisto") || conf->getParameter<bool>("doSeedDzHisto") ||
-       conf->getParameter<bool>("doSeedNRecHitsHisto") || conf->getParameter<bool>("doSeedNVsPhiProf") ||
-       conf->getParameter<bool>("doSeedNVsEtaProf"));
 
   edm::InputTag seedProducer = conf->getParameter<edm::InputTag>("SeedProducer");
 
@@ -645,9 +647,6 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
     NumberOfTrackingRegions->setAxisTitle("Number of TrackingRegions per Event", 1);
     NumberOfTrackingRegions->setAxisTitle("Number of Events", 2);
   }
-
-  doTkCandPlots = conf->getParameter<bool>("doTrackCandHistos");
-  //    if (doAllPlots) doTkCandPlots=true;
 
   if (doTkCandPlots) {
     ibooker.setCurrentFolder(MEFolderName + "/TrackBuilding");
@@ -892,8 +891,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     // fill the TrackCandidate info
     if (doTkCandPlots) {
       // magnetic field
-      edm::ESHandle<MagneticField> theMF;
-      iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+      MagneticField const& theMF = iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldToken_);
 
       // get the candidate collection
       edm::Handle<TrackCandidateCollection> theTCHandle;
@@ -915,7 +913,8 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         if (seedHandle.isValid() && !seedCollection.empty())
           FractionCandidatesOverSeeds->Fill(double(theTCCollection.size()) / double(seedCollection.size()));
 
-        iSetup.get<TransientRecHitRecord>().get(builderName, theTTRHBuilder);
+        TransientTrackingRecHitBuilder const& theTTRHBuilder =
+            iSetup.get<TransientRecHitRecord>().get(transientTrackingRecHitBuilderToken_);
         for (TrackCandidateCollection::const_iterator cand = theTCCollection.begin(); cand != theTCCollection.end();
              ++cand) {
           theTrackBuildingAnalyzer->analyze(iEvent, iSetup, *cand, bs, theMF, theTTRHBuilder);
@@ -978,15 +977,15 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           if (seedStopInfo.size() == seedCollection.size()) {
             //here duplication of mag field and be informations is needed to allow seed and track cand histos to be independent
             // magnetic field
-            edm::ESHandle<MagneticField> theMF;
-            iSetup.get<IdealMagneticFieldRecord>().get(theMF);
+            MagneticField const& theMF = iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldToken_);
 
             // get the beam spot
             edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
             iEvent.getByToken(bsSrcToken_, recoBeamSpotHandle);
             const reco::BeamSpot& bs = *recoBeamSpotHandle;
 
-            iSetup.get<TransientRecHitRecord>().get(builderName, theTTRHBuilder);
+            TransientTrackingRecHitBuilder const& theTTRHBuilder =
+                iSetup.get<TransientRecHitRecord>().get(transientTrackingRecHitBuilderToken_);
             for (size_t i = 0; i < seedCollection.size(); ++i) {
               theTrackBuildingAnalyzer->analyze(
                   iEvent, iSetup, seedCollection[i], seedStopInfo[i], bs, theMF, theTTRHBuilder);


### PR DESCRIPTION
#### PR description:

EventSetup consumes migration for TrackingMonitor.

(Note there are many more of these coming on other modules with similar style. Let me know if you have any problems with how this is being done.)

#### PR validation:

Relies on existing tests. There is not any new functionality. Results should stay exactly the same.
