### PR TITLE
[HGCAL trigger] Fix getLinksInModule

### DIFF
--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -496,8 +496,7 @@ unsigned HGCalTriggerGeometryV9Imp2::getLinksInModule(const unsigned module_id) 
   // Scintillator
   if (module_det_id.det() == DetId::HGCalHSc) {
     links = hSc_links_per_module_;
-  }
-  if (module_det_id.det() == DetId::Forward && module_det_id.subdetId() == ForwardSubdetector::HFNose) {
+  } else if (module_det_id.det() == DetId::Forward && module_det_id.subdetId() == ForwardSubdetector::HFNose) {
     links = 1;
   }
   // TO ADD HFNOSE : getLinksInModule


### PR DESCRIPTION
#### PR description:

Fix `if` condition in `getLinksInModule()`. It affected only cases where the number of links per module is needed, which is not used for the default algorithmic chain.

#### PR validation:
Validated in a case  where this function is called.
