### PR TITLE
Support of plot-specific input paramters for Payload Inspector

### DIFF
--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -11,6 +11,8 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/python/list.hpp>
+#include <boost/python/dict.hpp>
 
 namespace cond {
 
@@ -159,6 +161,12 @@ namespace cond {
       // required in the browser
       bool isTwoTags() const;
 
+      // required in the browser
+      boost::python::list inputParams() const;
+
+      // required in the browser
+      void setInputParamValues( const boost::python::dict& values );
+
       // returns the json file with the plot data
       std::string data() const;
 
@@ -189,6 +197,8 @@ namespace cond {
 
       void setTwoTags(bool flag);
 
+      void addInputParam( const std::string& paramName );
+
       // access to the fetch function of the configured reader, to be used in the processData implementations
       template <typename PayloadType>
       std::shared_ptr<PayloadType> fetchPayload(const cond::Hash& payloadHash) {
@@ -197,8 +207,7 @@ namespace cond {
 
       cond::Tag_t getTagInfo(const std::string& tag);
 
-      // access to the timeType of the tag in process
-      //cond::TimeType tagTimeType() const;
+      const std::map<std::string,std::string>& inputParamValues() const;
 
       // access to the underlying db session
       cond::persistency::Session dbSession();
@@ -207,12 +216,14 @@ namespace cond {
       PlotAnnotations m_plotAnnotations;
       std::string m_tag0 = "";
       std::string m_tag1 = "";
+      std::set<std::string> m_inputParams;
 
     private:
       cond::persistency::Session m_dbSession;
       //cond::TimeType m_tagTimeType;
 
       std::string m_data = "";
+      std::map<std::string,std::string> m_inputParamValues;
     };
 
     // Concrete plot-types implementations

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -165,7 +165,7 @@ namespace cond {
       boost::python::list inputParams() const;
 
       // required in the browser
-      void setInputParamValues( const boost::python::dict& values );
+      void setInputParamValues(const boost::python::dict& values);
 
       // returns the json file with the plot data
       std::string data() const;
@@ -197,7 +197,7 @@ namespace cond {
 
       void setTwoTags(bool flag);
 
-      void addInputParam( const std::string& paramName );
+      void addInputParam(const std::string& paramName);
 
       // access to the fetch function of the configured reader, to be used in the processData implementations
       template <typename PayloadType>
@@ -207,7 +207,7 @@ namespace cond {
 
       cond::Tag_t getTagInfo(const std::string& tag);
 
-      const std::map<std::string,std::string>& inputParamValues() const;
+      const std::map<std::string, std::string>& inputParamValues() const;
 
       // access to the underlying db session
       cond::persistency::Session dbSession();
@@ -223,7 +223,7 @@ namespace cond {
       //cond::TimeType m_tagTimeType;
 
       std::string m_data = "";
-      std::map<std::string,std::string> m_inputParamValues;
+      std::map<std::string, std::string> m_inputParamValues;
     };
 
     // Concrete plot-types implementations

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -20,6 +20,33 @@ namespace {
     float getFromPayload(cond::BasicPayload& payload) override { return payload.m_data0; }
   };
 
+class BasicPayload_data0_withInput : public cond::payloadInspector::HistoryPlot<cond::BasicPayload, float> {
+  public:
+    BasicPayload_data0_withInput() : cond::payloadInspector::HistoryPlot<cond::BasicPayload, float>("Example Trend", "data0") {
+      cond::payloadInspector::PlotBase::addInputParam("Offset");
+      cond::payloadInspector::PlotBase::addInputParam("Factor");
+      cond::payloadInspector::PlotBase::addInputParam("Scale");
+    }
+    ~BasicPayload_data0_withInput() override = default;
+    float getFromPayload(cond::BasicPayload& payload) override { 
+      float v = payload.m_data0;
+      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto ip = paramValues.find( "Factor");
+      if( ip != paramValues.end() ){
+	v = v*boost::lexical_cast<float>( ip->second );
+      }
+      ip = paramValues.find( "Offset");
+      if( ip != paramValues.end() ){
+	v = v+ boost::lexical_cast<float>( ip->second );
+      }
+      ip = paramValues.find( "Scale");
+      if( ip != paramValues.end() ){
+	v = v*boost::lexical_cast<float>( ip->second );
+      }
+      return v; 
+    }
+  };
+
   class BasicPayload_data1 : public cond::payloadInspector::RunHistoryPlot<cond::BasicPayload, float> {
   public:
     BasicPayload_data1()
@@ -259,6 +286,7 @@ namespace {
 
 PAYLOAD_INSPECTOR_MODULE(BasicPayload) {
   PAYLOAD_INSPECTOR_CLASS(BasicPayload_data0);
+  PAYLOAD_INSPECTOR_CLASS(BasicPayload_data0_withInput);
   PAYLOAD_INSPECTOR_CLASS(BasicPayload_data1);
   PAYLOAD_INSPECTOR_CLASS(BasicPayload_data2);
   PAYLOAD_INSPECTOR_CLASS(BasicPayload_data3);

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -29,12 +29,12 @@ namespace {
       cond::payloadInspector::PlotBase::addInputParam("Scale");
     }
     ~BasicPayload_data0_withInput() override = default;
-    float getFromPayload(cond::BasicPayload& payload) override { 
+    float getFromPayload(cond::BasicPayload& payload) override {
       float v = payload.m_data0;
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("Factor");
       if (ip != paramValues.end()){
-	v = v * boost::lexical_cast<float>(ip->second);
+    	v = v * boost::lexical_cast<float>(ip->second);
       }
       ip = paramValues.find("Offset");
       if (ip != paramValues.end()){

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -20,9 +20,10 @@ namespace {
     float getFromPayload(cond::BasicPayload& payload) override { return payload.m_data0; }
   };
 
-class BasicPayload_data0_withInput : public cond::payloadInspector::HistoryPlot<cond::BasicPayload, float> {
+  class BasicPayload_data0_withInput : public cond::payloadInspector::HistoryPlot<cond::BasicPayload, float> {
   public:
-    BasicPayload_data0_withInput() : cond::payloadInspector::HistoryPlot<cond::BasicPayload, float>("Example Trend", "data0") {
+    BasicPayload_data0_withInput()
+        : cond::payloadInspector::HistoryPlot<cond::BasicPayload, float>("Example Trend", "data0") {
       cond::payloadInspector::PlotBase::addInputParam("Offset");
       cond::payloadInspector::PlotBase::addInputParam("Factor");
       cond::payloadInspector::PlotBase::addInputParam("Scale");
@@ -31,17 +32,17 @@ class BasicPayload_data0_withInput : public cond::payloadInspector::HistoryPlot<
     float getFromPayload(cond::BasicPayload& payload) override { 
       float v = payload.m_data0;
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
-      auto ip = paramValues.find( "Factor");
-      if( ip != paramValues.end() ){
-	v = v*boost::lexical_cast<float>( ip->second );
+      auto ip = paramValues.find("Factor");
+      if (ip != paramValues.end()){
+	v = v * boost::lexical_cast<float>(ip->second);
       }
-      ip = paramValues.find( "Offset");
-      if( ip != paramValues.end() ){
-	v = v+ boost::lexical_cast<float>( ip->second );
+      ip = paramValues.find("Offset");
+      if (ip != paramValues.end()){
+	v = v + boost::lexical_cast<float>(ip->second);
       }
-      ip = paramValues.find( "Scale");
-      if( ip != paramValues.end() ){
-	v = v*boost::lexical_cast<float>( ip->second );
+      ip = paramValues.find("Scale");
+      if (ip != paramValues.end()){
+	v = v * boost::lexical_cast<float>(ip->second);
       }
       return v; 
     }

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -34,17 +34,17 @@ namespace {
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("Factor");
       if (ip != paramValues.end()) {
-    	v = v * boost::lexical_cast<float>(ip->second);
+        v = v * boost::lexical_cast<float>(ip->second);
       }
       ip = paramValues.find("Offset");
       if (ip != paramValues.end()) {
-	v = v + boost::lexical_cast<float>(ip->second);
+        v = v + boost::lexical_cast<float>(ip->second);
       }
       ip = paramValues.find("Scale");
       if (ip != paramValues.end()) {
-	v = v * boost::lexical_cast<float>(ip->second);
+        v = v * boost::lexical_cast<float>(ip->second);
       }
-      return v; 
+      return v;
     }
   };
 

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -33,15 +33,15 @@ namespace {
       float v = payload.m_data0;
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("Factor");
-      if (ip != paramValues.end()){
+      if (ip != paramValues.end()) {
     	v = v * boost::lexical_cast<float>(ip->second);
       }
       ip = paramValues.find("Offset");
-      if (ip != paramValues.end()){
+      if (ip != paramValues.end()) {
 	v = v + boost::lexical_cast<float>(ip->second);
       }
       ip = paramValues.find("Scale");
-      if (ip != paramValues.end()){
+      if (ip != paramValues.end()) {
 	v = v * boost::lexical_cast<float>(ip->second);
       }
       return v; 

--- a/CondCore/Utilities/plugins/Module_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/Module_PayloadInspector.cc
@@ -1,5 +1,6 @@
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include <boost/python.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
 BOOST_PYTHON_MODULE(pluginModule_PayloadInspector) {
   boost::python::class_<cond::payloadInspector::ModuleVersion>("ModuleVersion")
@@ -12,5 +13,7 @@ BOOST_PYTHON_MODULE(pluginModule_PayloadInspector) {
       .def("title", &cond::payloadInspector::PlotBase::title)
       .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov)
       .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)
+      .def("inputParams", &cond::payloadInspector::PlotBase::inputParams)
+      .def("setInputParamValues", &cond::payloadInspector::PlotBase::setInputParamValues)
       .def("data", &cond::payloadInspector::PlotBase::data);
 }

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -5,6 +5,8 @@
 
 #include <sstream>
 #include <iostream>
+#include <boost/python/extract.hpp>
+#include <boost/python/tuple.hpp>
 
 namespace cond {
 
@@ -22,7 +24,12 @@ namespace cond {
 
     constexpr const char* const ModuleVersion::label;
 
-    PlotBase::PlotBase() : m_plotAnnotations(), m_data("") {}
+    PlotBase::PlotBase() : m_plotAnnotations(), m_inputParams(), m_data(""), m_inputParamValues(){}
+
+    void PlotBase::addInputParam( const std::string& paramName ){
+      // maybe add a check for existing params - returning an Exception when found...
+      m_inputParams.insert( paramName );
+    }
 
     std::string PlotBase::payloadType() const { return m_plotAnnotations.get(PlotAnnotations::PAYLOAD_TYPE_K); }
 
@@ -33,6 +40,23 @@ namespace cond {
     bool PlotBase::isSingleIov() const { return m_plotAnnotations.singleIov; }
 
     bool PlotBase::isTwoTags() const { return m_plotAnnotations.twoTags; }
+
+    boost::python::list PlotBase::inputParams() const {
+      boost::python::list tmp;
+      for ( auto ip: m_inputParams ){
+	tmp.append( ip );
+      }
+      return tmp;
+    }
+
+    void PlotBase::setInputParamValues( const boost::python::dict& values ){
+      for( auto ip : m_inputParams ){
+	if( values.has_key( ip ) ){
+	  std::string val = boost::python::extract<std::string>( values.get( ip ) ); 
+	  m_inputParamValues.insert( std::make_pair( ip, val ) );
+	}
+      }
+    }
 
     std::string PlotBase::data() const { return m_data; }
 
@@ -62,30 +86,6 @@ namespace cond {
       // fixme...
       return true;
     }
-
-    /**
-    bool PlotBase::process( const std::string& connectionString,  const std::string& tag, cond::Time_t begin, cond::Time_t end ){
-      init();
-
-      std::vector<edm::ParameterSet> psets;
-      edm::ParameterSet pSet;
-      pSet.addParameter("@service_type",std::string("SiteLocalConfigService"));
-      psets.push_back(pSet);
-      static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-      static const edm::ServiceRegistry::Operate operate(services);
-
-      m_tag0 = tag;
-      cond::persistency::ConnectionPool connection;
-      m_dbSession = connection.createSession( connectionString );
-      m_dbSession.transaction().start();
-      std::vector<std::tuple<cond::Time_t,cond::Hash> > iovs;
-      m_dbSession.getIovRange( tag, begin, end, iovs );
-      m_data = processData( iovs );
-      m_dbSession.transaction().commit();
-      // fixme...                                                                                                                                                   
-      return true;
-    }
-    **/
 
     bool PlotBase::processTwoTags(const std::string& connectionString,
                                   const std::string& tag0,
@@ -127,14 +127,14 @@ namespace cond {
         m_plotAnnotations.singleIov = flag;
     }
 
-    //cond::TimeType PlotBase::tagTimeType() const {
-    //  return m_tagTimeType;
-    //}
-
     cond::Tag_t PlotBase::getTagInfo(const std::string& tag) {
       cond::Tag_t info;
       m_dbSession.getTagInfo(tag, info);
       return info;
+    }
+
+    const std::map<std::string,std::string>& PlotBase::inputParamValues() const {
+      return m_inputParamValues;
     }
 
     cond::persistency::Session PlotBase::dbSession() { return m_dbSession; }

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -24,11 +24,11 @@ namespace cond {
 
     constexpr const char* const ModuleVersion::label;
 
-    PlotBase::PlotBase() : m_plotAnnotations(), m_inputParams(), m_data(""), m_inputParamValues(){}
+    PlotBase::PlotBase() : m_plotAnnotations(), m_inputParams(), m_data(""), m_inputParamValues() {}
 
-    void PlotBase::addInputParam( const std::string& paramName ){
+    void PlotBase::addInputParam(const std::string& paramName){
       // maybe add a check for existing params - returning an Exception when found...
-      m_inputParams.insert( paramName );
+      m_inputParams.insert(paramName);
     }
 
     std::string PlotBase::payloadType() const { return m_plotAnnotations.get(PlotAnnotations::PAYLOAD_TYPE_K); }
@@ -43,17 +43,17 @@ namespace cond {
 
     boost::python::list PlotBase::inputParams() const {
       boost::python::list tmp;
-      for ( auto ip: m_inputParams ){
-	tmp.append( ip );
+      for (auto ip: m_inputParams){
+	tmp.append(ip);
       }
       return tmp;
     }
 
     void PlotBase::setInputParamValues( const boost::python::dict& values ){
       for( auto ip : m_inputParams ){
-	if( values.has_key( ip ) ){
-	  std::string val = boost::python::extract<std::string>( values.get( ip ) ); 
-	  m_inputParamValues.insert( std::make_pair( ip, val ) );
+	if (values.has_key(ip)){
+	  std::string val = boost::python::extract<std::string>(values.get(ip)); 
+	  m_inputParamValues.insert(std::make_pair(ip, val));
 	}
       }
     }
@@ -133,9 +133,7 @@ namespace cond {
       return info;
     }
 
-    const std::map<std::string,std::string>& PlotBase::inputParamValues() const {
-      return m_inputParamValues;
-    }
+    const std::map<std::string, std::string>& PlotBase::inputParamValues() const { return m_inputParamValues; }
 
     cond::persistency::Session PlotBase::dbSession() { return m_dbSession; }
 

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -44,17 +44,17 @@ namespace cond {
     boost::python::list PlotBase::inputParams() const {
       boost::python::list tmp;
       for (auto ip : m_inputParams) {
-	tmp.append(ip);
+        tmp.append(ip);
       }
       return tmp;
     }
 
     void PlotBase::setInputParamValues(const boost::python::dict& values) {
-      for( auto ip : m_inputParams ) {
-	if (values.has_key(ip)) {
-	  std::string val = boost::python::extract<std::string>(values.get(ip)); 
-	  m_inputParamValues.insert(std::make_pair(ip, val));
-	}
+      for (auto ip : m_inputParams) {
+        if (values.has_key(ip)) {
+          std::string val = boost::python::extract<std::string>(values.get(ip));
+          m_inputParamValues.insert(std::make_pair(ip, val));
+        }
       }
     }
 

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -26,7 +26,7 @@ namespace cond {
 
     PlotBase::PlotBase() : m_plotAnnotations(), m_inputParams(), m_data(""), m_inputParamValues() {}
 
-    void PlotBase::addInputParam(const std::string& paramName){
+    void PlotBase::addInputParam(const std::string& paramName) {
       // maybe add a check for existing params - returning an Exception when found...
       m_inputParams.insert(paramName);
     }
@@ -43,15 +43,15 @@ namespace cond {
 
     boost::python::list PlotBase::inputParams() const {
       boost::python::list tmp;
-      for (auto ip: m_inputParams){
+      for (auto ip: m_inputParams) {
 	tmp.append(ip);
       }
       return tmp;
     }
 
-    void PlotBase::setInputParamValues( const boost::python::dict& values ){
-      for( auto ip : m_inputParams ){
-	if (values.has_key(ip)){
+    void PlotBase::setInputParamValues( const boost::python::dict& values ) {
+      for( auto ip : m_inputParams ) {
+	if (values.has_key(ip)) {
 	  std::string val = boost::python::extract<std::string>(values.get(ip)); 
 	  m_inputParamValues.insert(std::make_pair(ip, val));
 	}

--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -43,13 +43,13 @@ namespace cond {
 
     boost::python::list PlotBase::inputParams() const {
       boost::python::list tmp;
-      for (auto ip: m_inputParams) {
+      for (auto ip : m_inputParams) {
 	tmp.append(ip);
       }
       return tmp;
     }
 
-    void PlotBase::setInputParamValues( const boost::python::dict& values ) {
+    void PlotBase::setInputParamValues(const boost::python::dict& values) {
       for( auto ip : m_inputParams ) {
 	if (values.has_key(ip)) {
 	  std::string val = boost::python::extract<std::string>(values.get(ip)); 


### PR DESCRIPTION
#### PR description:

The developer level interface of the Payload Inspector has been extended to support plot-specific input parameters

#### PR validation:

The new functionality has been tested with the test options of the getPayloadData script
More validation is expected after the deployment on the development service

