### PR TITLE
EventSetup consumes migration, 3 DQMOffline modules

### DIFF
--- a/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
+++ b/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
@@ -2,7 +2,6 @@
 #define _DQMOFFLINE_HCAL_CALOTOWERSANALYZER_H_
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -11,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -22,7 +22,9 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
@@ -41,11 +43,11 @@ public:
   CaloTowersAnalyzer(edm::ParameterSet const &conf);
   ~CaloTowersAnalyzer() override;
 
-  void analyze(edm::Event const &e, edm::EventSetup const &c) override;
+  void analyze(edm::Event const &, edm::EventSetup const &) override;
   void beginJob() override;
   void endJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c) override;
+  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
 
 private:
   double dR(double eta1, double phi1, double eta2, double phi2);
@@ -58,6 +60,7 @@ private:
   typedef math::RhoEtaPhiVector Vector;
 
   edm::EDGetTokenT<CaloTowerCollection> tok_towers_;
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> hcalDDDRecConstantsToken_;
 
   int isub;
   int nevent;
@@ -67,9 +70,6 @@ private:
   // eta limits to calcualte MET, SET (not to include HF if not needed)
   double etaMax[3];
   double etaMin[3];
-
-  // Geometry from DB
-  const HcalDDDRecConstants *hcons;
 
   int iphi_bins_;
   float iphi_min_, iphi_max_;

--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -2,7 +2,6 @@
 #define _DQMOFFLINE_HCAL_HCALRECHITSANALYZER_H_
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -11,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 
@@ -28,7 +28,10 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include <algorithm>
@@ -57,11 +60,11 @@ class HcalRecHitsAnalyzer : public DQMEDAnalyzer {
 public:
   HcalRecHitsAnalyzer(edm::ParameterSet const &conf);
 
-  void analyze(edm::Event const &ev, edm::EventSetup const &c) override;
+  void analyze(edm::Event const &ev, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  // virtual void beginRun(edm::Run const& run, edm::EventSetup const& c)
+  // virtual void beginRun(edm::Run const& run, edm::EventSetup const&)
   // override;
-  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c) override;
+  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &) override;
 
 private:
   virtual void fillRecHitsTmp(int subdet_, edm::Event const &ev);
@@ -80,7 +83,6 @@ private:
   std::string mc_;
   bool famos_;
 
-  const HcalDDDRecConstants *hcons;
   int maxDepthHB_, maxDepthHE_, maxDepthHO_, maxDepthHF_, maxDepthAll_;
 
   int nChannels_[5];  // 0:any, 1:HB, 2:HE
@@ -98,6 +100,13 @@ private:
   edm::EDGetTokenT<EBRecHitCollection> tok_EB_;
   edm::EDGetTokenT<EERecHitCollection> tok_EE_;
 
+  edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> hcalDDDRecConstantsToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryRunToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryEventToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalTopologyToken_;
+  edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> hcalChannelQualityToken_;
+  edm::ESGetToken<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd> hcalSeverityLevelComputerToken_;
+
   // choice of subdetector in config : noise/HB/HE/HO/HF/ALL (0/1/2/3/4/5)
   int subdet_;
 
@@ -107,11 +116,11 @@ private:
   int imc;
 
   // Hcal topology
-  const HcalTopology *theHcalTopology;
+  const HcalTopology *theHcalTopology = nullptr;
   // for checking the status of ECAL and HCAL channels stored in the DB
-  const HcalChannelQuality *theHcalChStatus;
+  const HcalChannelQuality *theHcalChStatus = nullptr;
   // calculator of severety level for HCAL
-  const HcalSeverityLevelComputer *theHcalSevLvlComputer;
+  const HcalSeverityLevelComputer *theHcalSevLvlComputer = nullptr;
   int hcalSevLvl(const CaloRecHit *hit);
 
   std::vector<int> hcalHBSevLvlVec, hcalHESevLvlVec, hcalHFSevLvlVec, hcalHOSevLvlVec;
@@ -258,7 +267,7 @@ private:
   MonitorElement *meNumEcalRecHitsConeHB;
   MonitorElement *meNumEcalRecHitsConeHE;
 
-  edm::ESHandle<CaloGeometry> geometry;
+  CaloGeometry const *geometry = nullptr;
 
   // Status word histos
   MonitorElement *RecHit_StatusWord_HB;

--- a/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
+++ b/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
@@ -2,8 +2,10 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
-CaloTowersAnalyzer::CaloTowersAnalyzer(edm::ParameterSet const &conf) {
+CaloTowersAnalyzer::CaloTowersAnalyzer(edm::ParameterSet const &conf)
+    : hcalDDDRecConstantsToken_{esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>()} {
   tok_towers_ = consumes<CaloTowerCollection>(conf.getUntrackedParameter<edm::InputTag>("CaloTowerCollectionLabel"));
   // DQM ROOT output
 
@@ -15,18 +17,16 @@ CaloTowersAnalyzer::CaloTowersAnalyzer(edm::ParameterSet const &conf) {
 }
 
 void CaloTowersAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup &es) {
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  es.get<HcalRecNumberingRecord>().get(pHRNDC);
-  hcons = &(*pHRNDC);
+  HcalDDDRecConstants const &hcons = es.getData(hcalDDDRecConstantsToken_);
 
   // Get Phi segmentation from geometry, use the max phi number so that all iphi
   // values are included.
 
-  int NphiMax = hcons->getNPhi(0);
+  int NphiMax = hcons.getNPhi(0);
 
-  NphiMax = (hcons->getNPhi(1) > NphiMax ? hcons->getNPhi(1) : NphiMax);
-  NphiMax = (hcons->getNPhi(2) > NphiMax ? hcons->getNPhi(2) : NphiMax);
-  NphiMax = (hcons->getNPhi(3) > NphiMax ? hcons->getNPhi(3) : NphiMax);
+  NphiMax = (hcons.getNPhi(1) > NphiMax ? hcons.getNPhi(1) : NphiMax);
+  NphiMax = (hcons.getNPhi(2) > NphiMax ? hcons.getNPhi(2) : NphiMax);
+  NphiMax = (hcons.getNPhi(3) > NphiMax ? hcons.getNPhi(3) : NphiMax);
 
   // Center the iphi bins on the integers
   iphi_min_ = 0.5;
@@ -35,10 +35,10 @@ void CaloTowersAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup 
 
   // Retain classic behavior, all plots have same ieta range.
 
-  int iEtaMax = (hcons->getEtaRange(0).second > hcons->getEtaRange(1).second ? hcons->getEtaRange(0).second
-                                                                             : hcons->getEtaRange(1).second);
-  iEtaMax = (iEtaMax > hcons->getEtaRange(2).second ? iEtaMax : hcons->getEtaRange(2).second);
-  iEtaMax = (iEtaMax > hcons->getEtaRange(3).second ? iEtaMax : hcons->getEtaRange(3).second);
+  int iEtaMax = (hcons.getEtaRange(0).second > hcons.getEtaRange(1).second ? hcons.getEtaRange(0).second
+                                                                           : hcons.getEtaRange(1).second);
+  iEtaMax = (iEtaMax > hcons.getEtaRange(2).second ? iEtaMax : hcons.getEtaRange(2).second);
+  iEtaMax = (iEtaMax > hcons.getEtaRange(3).second ? iEtaMax : hcons.getEtaRange(3).second);
 
   // Give an empty bin around the subdet ieta range to make it clear that all
   // ieta rings have been included
@@ -455,7 +455,7 @@ void CaloTowersAnalyzer::endJob() {}
 
 void CaloTowersAnalyzer::beginJob() { nevent = 0; }
 
-void CaloTowersAnalyzer::analyze(edm::Event const &event, edm::EventSetup const &c) {
+void CaloTowersAnalyzer::analyze(edm::Event const &event, edm::EventSetup const &) {
   nevent++;
 
   edm::Handle<CaloTowerCollection> towers;

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -1,10 +1,17 @@
 #include "DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const &conf)
-    : topFolderName_(conf.getParameter<std::string>("TopFolderName")) {
+    : topFolderName_(conf.getParameter<std::string>("TopFolderName")),
+      hcalDDDRecConstantsToken_{esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord, edm::Transition::BeginRun>()},
+      caloGeometryRunToken_{esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>()},
+      caloGeometryEventToken_{esConsumes<CaloGeometry, CaloGeometryRecord>()},
+      hcalTopologyToken_{esConsumes<HcalTopology, HcalRecNumberingRecord>()},
+      hcalChannelQualityToken_{esConsumes<HcalChannelQuality, HcalChannelQualityRcd>(edm::ESInputTag("", "withTopo"))},
+      hcalSeverityLevelComputerToken_{esConsumes<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd>()} {
   // DQM ROOT output
   outputFile_ = conf.getUntrackedParameter<std::string>("outputFile", "myfile.root");
 
@@ -63,24 +70,19 @@ HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const &conf)
   imc = 0;
 }
 
-void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup &es) {
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  es.get<HcalRecNumberingRecord>().get(pHRNDC);
-  hcons = &(*pHRNDC);
-  maxDepthHB_ = hcons->getMaxDepth(0);
-  maxDepthHE_ = hcons->getMaxDepth(1);
-  maxDepthHF_ = std::max(hcons->getMaxDepth(2), 1);
-  maxDepthHO_ = hcons->getMaxDepth(3);
+void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup &iSetup) {
+  HcalDDDRecConstants const &hcons = iSetup.getData(hcalDDDRecConstantsToken_);
+  maxDepthHB_ = hcons.getMaxDepth(0);
+  maxDepthHE_ = hcons.getMaxDepth(1);
+  maxDepthHF_ = std::max(hcons.getMaxDepth(2), 1);
+  maxDepthHO_ = hcons.getMaxDepth(3);
 
-  edm::ESHandle<CaloGeometry> geometry;
+  CaloGeometry const &geo = iSetup.getData(caloGeometryRunToken_);
 
-  es.get<CaloGeometryRecord>().get(geometry);
-
-  const CaloGeometry *geo = geometry.product();
-  const HcalGeometry *gHB = static_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
-  const HcalGeometry *gHE = static_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
-  const HcalGeometry *gHO = static_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, HcalOuter));
-  const HcalGeometry *gHF = static_cast<const HcalGeometry *>(geo->getSubdetectorGeometry(DetId::Hcal, HcalForward));
+  const HcalGeometry *gHB = static_cast<const HcalGeometry *>(geo.getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
+  const HcalGeometry *gHE = static_cast<const HcalGeometry *>(geo.getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
+  const HcalGeometry *gHO = static_cast<const HcalGeometry *>(geo.getSubdetectorGeometry(DetId::Hcal, HcalOuter));
+  const HcalGeometry *gHF = static_cast<const HcalGeometry *>(geo.getSubdetectorGeometry(DetId::Hcal, HcalForward));
 
   nChannels_[1] = gHB->getHxSize(1);
   nChannels_[2] = std::max(int(gHE->getHxSize(2)), 1);
@@ -103,11 +105,11 @@ void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup
   // Get Phi segmentation from geometry, use the max phi number so that all iphi
   // values are included.
 
-  int NphiMax = hcons->getNPhi(0);
+  int NphiMax = hcons.getNPhi(0);
 
-  NphiMax = (hcons->getNPhi(1) > NphiMax ? hcons->getNPhi(1) : NphiMax);
-  NphiMax = (hcons->getNPhi(2) > NphiMax ? hcons->getNPhi(2) : NphiMax);
-  NphiMax = (hcons->getNPhi(3) > NphiMax ? hcons->getNPhi(3) : NphiMax);
+  NphiMax = (hcons.getNPhi(1) > NphiMax ? hcons.getNPhi(1) : NphiMax);
+  NphiMax = (hcons.getNPhi(2) > NphiMax ? hcons.getNPhi(2) : NphiMax);
+  NphiMax = (hcons.getNPhi(3) > NphiMax ? hcons.getNPhi(3) : NphiMax);
 
   // Center the iphi bins on the integers
   iphi_min_ = 0.5;
@@ -116,10 +118,10 @@ void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup
 
   // Retain classic behavior, all plots have same ieta range.
 
-  int iEtaMax = (hcons->getEtaRange(0).second > hcons->getEtaRange(1).second ? hcons->getEtaRange(0).second
-                                                                             : hcons->getEtaRange(1).second);
-  iEtaMax = (iEtaMax > hcons->getEtaRange(2).second ? iEtaMax : hcons->getEtaRange(2).second);
-  iEtaMax = (iEtaMax > hcons->getEtaRange(3).second ? iEtaMax : hcons->getEtaRange(3).second);
+  int iEtaMax = (hcons.getEtaRange(0).second > hcons.getEtaRange(1).second ? hcons.getEtaRange(0).second
+                                                                           : hcons.getEtaRange(1).second);
+  iEtaMax = (iEtaMax > hcons.getEtaRange(2).second ? iEtaMax : hcons.getEtaRange(2).second);
+  iEtaMax = (iEtaMax > hcons.getEtaRange(3).second ? iEtaMax : hcons.getEtaRange(3).second);
 
   // Give an empty bin around the subdet ieta range to make it clear that all
   // ieta rings have been included
@@ -130,7 +132,7 @@ void HcalRecHitsAnalyzer::dqmBeginRun(const edm::Run &run, const edm::EventSetup
 
 void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
                                          edm::Run const & /* iRun*/,
-                                         edm::EventSetup const & /* iSetup */)
+                                         edm::EventSetup const &)
 
 {
   Char_t histo[200];
@@ -542,7 +544,7 @@ void HcalRecHitsAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
   }
 }
 
-void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c) {
+void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &iSetup) {
   using namespace edm;
 
   // cuts for each subdet_ector mimiking  "Scheme B"
@@ -568,23 +570,17 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &c
   double etaHot = 99999.;
   double phiHot = 99999.;
 
-  //   previously was:  c.get<IdealGeometryRecord>().get (geometry);
-  c.get<CaloGeometryRecord>().get(geometry);
+  //   previously was:  iSetup.get<IdealGeometryRecord>().get (geometry);
+  geometry = &iSetup.getData(caloGeometryEventToken_);
 
   // HCAL Topology **************************************************
-  edm::ESHandle<HcalTopology> topo;
-  c.get<HcalRecNumberingRecord>().get(topo);
-  theHcalTopology = topo.product();
+  theHcalTopology = &iSetup.getData(hcalTopologyToken_);
 
   // HCAL channel status map ****************************************
-  edm::ESHandle<HcalChannelQuality> hcalChStatus;
-  c.get<HcalChannelQualityRcd>().get("withTopo", hcalChStatus);
-  theHcalChStatus = hcalChStatus.product();
+  theHcalChStatus = &iSetup.getData(hcalChannelQualityToken_);
 
   // Assignment of severity levels **********************************
-  edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
-  c.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
-  theHcalSevLvlComputer = hcalSevLvlComputerHndl.product();
+  theHcalSevLvlComputer = &iSetup.getData(hcalSeverityLevelComputerToken_);
 
   // Fill working vectors of HCAL RecHits quantities (all of these are drawn)
   fillRecHitsTmp(subdet_, ev);

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -92,6 +92,9 @@ BPHMonitor::BPHMonitor(const edm::ParameterSet& iConfig)
       trSelection_(iConfig.getParameter<std::string>("muoSelection")),
       trSelection_ref(iConfig.getParameter<std::string>("trSelection_ref")),
       DMSelection_ref(iConfig.getParameter<std::string>("DMSelection_ref")) {
+  if (!tnp_) {
+    magneticFieldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
+  }
   muPhi_.numerator = nullptr;
   muPhi_.denominator = nullptr;
   muEta_.numerator = nullptr;
@@ -472,8 +475,6 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   edm::Handle<edm::TriggerResults> handleTriggerTrigRes;
 
-  edm::ESHandle<MagneticField> bFieldHandle;
-
   const std::string& hltpath = getTriggerName(hltpaths_den[0]);
   const std::string& hltpath1 = getTriggerName(hltpaths_num[0]);
 
@@ -552,11 +553,11 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
         }
 
         // dimuon vertex reconstruction
-        iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
+        MagneticField const& magneticField = iSetup.getData(magneticFieldToken_);
         const reco::BeamSpot& vertexBeamSpot = *beamSpot;
         std::vector<reco::TransientTrack> j_tks;
-        reco::TransientTrack mu1TT(m.track(), &(*bFieldHandle));
-        reco::TransientTrack mu2TT(m1.track(), &(*bFieldHandle));
+        reco::TransientTrack mu1TT(m.track(), &magneticField);
+        reco::TransientTrack mu2TT(m1.track(), &magneticField);
         j_tks.push_back(mu1TT);
         j_tks.push_back(mu2TT);
         KalmanVertexFitter jkvf;
@@ -928,7 +929,7 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
                 pB = p1 + p2 + p3;
                 if (pB.mass() > maxmassJpsiTk || pB.mass() < minmassJpsiTk)
                   continue;
-                reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
+                reco::TransientTrack trTT(itrk1, &magneticField);
                 std::vector<reco::TransientTrack> t_tks;
                 t_tks.push_back(mu1TT);
                 t_tks.push_back(mu2TT);
@@ -1005,7 +1006,7 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
                 pB = p2 + p3;
                 if (pB.mass() > maxmassJpsiTk || pB.mass() < minmassJpsiTk)
                   continue;
-                reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
+                reco::TransientTrack trTT(itrk1, &magneticField);
                 std::vector<reco::TransientTrack> t_tks;
                 t_tks.push_back(mu2TT);
                 t_tks.push_back(trTT);
@@ -1103,10 +1104,10 @@ void BPHMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
                   pB = p1 + p2 + p3 + p4;
                   if (pB.mass() > maxmassJpsiTk || pB.mass() < minmassJpsiTk)
                     continue;
-                  reco::TransientTrack mu1TT(m.track(), &(*bFieldHandle));
-                  reco::TransientTrack mu2TT(m1.track(), &(*bFieldHandle));
-                  reco::TransientTrack trTT(itrk1, &(*bFieldHandle));
-                  reco::TransientTrack tr1TT(itrk2, &(*bFieldHandle));
+                  reco::TransientTrack mu1TT(m.track(), &magneticField);
+                  reco::TransientTrack mu2TT(m1.track(), &magneticField);
+                  reco::TransientTrack trTT(itrk1, &magneticField);
+                  reco::TransientTrack tr1TT(itrk2, &magneticField);
                   std::vector<reco::TransientTrack> t_tks;
                   t_tks.push_back(mu1TT);
                   t_tks.push_back(mu2TT);

--- a/DQMOffline/Trigger/plugins/BPHMonitor.h
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.h
@@ -6,6 +6,7 @@
 #include <map>
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -13,7 +14,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
@@ -80,24 +80,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void fillHistoPSetDescription(edm::ParameterSetDescription& pset);
   static void fillHistoLSPSetDescription(edm::ParameterSetDescription& pset);
-
-  void case11_selection(const float& dimuonCL,
-                        const float& jpsi_cos,
-                        const GlobalPoint& displacementFromBeamspotJpsi,
-                        const GlobalError& jerr,
-                        const edm::Handle<reco::TrackCollection>& trHandle,
-                        const std::string& hltpath,
-                        const edm::Handle<trigger::TriggerEvent>& handleTriggerEvent,
-                        const reco::Muon& m,
-                        const reco::Muon& m1,
-                        const edm::ESHandle<MagneticField>& bFieldHandle,
-                        const reco::BeamSpot& vertexBeamSpot,
-                        MonitorElement* phi1,
-                        MonitorElement* eta1,
-                        MonitorElement* pT1,
-                        MonitorElement* phi2,
-                        MonitorElement* eta2,
-                        MonitorElement* pT2);
 
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
@@ -169,6 +151,9 @@ private:
   edm::EDGetTokenT<reco::TrackCollection> trToken_;
   edm::EDGetTokenT<reco::PhotonCollection> phToken_;
   edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
+
   MEbinning phi_binning_;
   MEbinning pt_binning_;
   MEbinning dMu_pt_binning_;


### PR DESCRIPTION
#### PR description:

Does the EventSetup consumes migration for CaloTowersAnalyzer, HcalRecHitsAnalyzer,
and BPHMonitor.

#### PR validation:

Relies on existing tests. There is not any new functionality. Results should stay exactly the same.
