### PR TITLE
Remove track jets from AOD

### DIFF
--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -101,8 +101,6 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            'keep *_ak4PFJets_*_*',
                                            'keep *_JetPlusTrackZSPCorJetAntiKt4_*_*',    
-                                           'keep *_ak4TrackJets_*_*',
-                                           'keep recoRecoChargedRefCandidates_trackRefsForJets_*_*',                                             
                                            'keep *_caloTowers_*_*', 
                                            'keep *_CastorTowerReco_*_*',                                           
                                            'keep *_ak4JetTracksAssociatorAtVertex_*_*',


### PR DESCRIPTION
#### PR description:

This PR removes AK4 track jets and the track p4 candidates used for them from AOD. 

#### PR validation:

Ran matrix workflows, the output of AOD drops these as expected. 

#### if this PR is a backport please specify the original PR:

No backport needed. 