### PR TITLE
quark and gluons Py8EGun

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -57,16 +57,16 @@ namespace gen {
         particleID = std::fabs(particleID);
       }
       if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
-      (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
+        (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
       else if (std::abs(particleID) == 21)  // gluons
-      (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
+        (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
       // other
       else {
-      (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
-      int eventSize = (fMasterGen->event).size() - 1;
-      // -log(flat) = exponential distribution
-      double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
-      (fMasterGen->event)[eventSize].tau(tauTmp);
+        (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
+        int eventSize = (fMasterGen->event).size() - 1;
+        // -log(flat) = exponential distribution
+        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+        (fMasterGen->event)[eventSize].tau(tauTmp);
       }
 
       // Here also need to add anti-particle (if any)
@@ -79,15 +79,15 @@ namespace gen {
         } else if (std::abs(particleID) == 21) {  // gluons
           (fMasterGen->event).append(21, 23, 102, 101, -px, -py, -pz, ee, mass);
         } else {
-        if ((fMasterGen->particleData).isParticle(-particleID)) {
-          (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
-        } else {
-          (fMasterGen->event).append(particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
-        }
-        int eventSize = (fMasterGen->event).size() - 1;
-        // -log(flat) = exponential distribution
-        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
-        (fMasterGen->event)[eventSize].tau(tauTmp);
+          if ((fMasterGen->particleData).isParticle(-particleID)) {
+            (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          } else {
+            (fMasterGen->event).append(particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          }
+          int eventSize = (fMasterGen->event).size() - 1;
+          // -log(flat) = exponential distribution
+          double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+          (fMasterGen->event)[eventSize].tau(tauTmp);
         }
       }
     }

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -56,26 +56,39 @@ namespace gen {
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
+      (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
+      else if (std::abs(particleID) == 21)  // gluons
+      (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
+      // other
+      else {
       (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
       int eventSize = (fMasterGen->event).size() - 1;
       // -log(flat) = exponential distribution
       double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
       (fMasterGen->event)[eventSize].tau(tauTmp);
+      }
 
       // Here also need to add anti-particle (if any)
       // otherwise just add a 2nd particle of the same type
       // (for example, gamma)
       //
       if (fAddAntiParticle) {
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+          (fMasterGen->event).append(-particleID, 23, 0, 101, -px, -py, -pz, ee, mass);
+        } else if (std::abs(particleID) == 21) {  // gluons
+          (fMasterGen->event).append(21, 23, 102, 101, -px, -py, -pz, ee, mass);
+        } else {
         if ((fMasterGen->particleData).isParticle(-particleID)) {
           (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
         } else {
           (fMasterGen->event).append(particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
         }
-        eventSize = (fMasterGen->event).size() - 1;
+        int eventSize = (fMasterGen->event).size() - 1;
         // -log(flat) = exponential distribution
-        tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
         (fMasterGen->event)[eventSize].tau(tauTmp);
+        }
       }
     }
 


### PR DESCRIPTION
#### PR description:

Added a feature to the Py8EGun: now the gun can use also quark or gluons. This feature was already present in the Py8PtGun, but not in the EGun. 
This feature is required for the MC production for the training of DeeoCore Algorithm in forward region. see this jira ticked for details: [(https://its.cern.ch/jira/browse/PDMVRELVALS-65#add-comment)]. After the merge **this feature must be backported to CMSSW_10_2_5** for the production of the MC. 

#### PR validation:

Tested using a standard path which use the Py8Gun, properly modified to produce gluons and quarks.

