### PR TITLE
Handle mutable warnings from static analyzer in Core code

### DIFF
--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -10,7 +10,7 @@
  Description: Factory for building the Factories for the various 'plug-in' components needed for the EventSetup
 
  Usage:
-    <usage>
+    NOTE: it is not safe to call this class across threads, even if only calling const member functions.
 
 */
 //
@@ -31,6 +31,7 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 namespace edm {
@@ -110,7 +111,8 @@ namespace edm {
       const ComponentFactory& operator=(const ComponentFactory&);  // stop default
 
       // ---------- member data --------------------------------
-      mutable MakerMap makers_;
+      //Creating a new component is not done across threads
+      CMS_SA_ALLOW mutable MakerMap makers_;
     };
 
   }  // namespace eventsetup

--- a/FWCore/Framework/interface/SharedResourcesAcquirer.h
+++ b/FWCore/Framework/interface/SharedResourcesAcquirer.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include "FWCore/Concurrency/interface/SerialTaskQueueChain.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // user include files
 
@@ -54,7 +55,8 @@ namespace edm {
 
   private:
     // ---------- member data --------------------------------
-    mutable SerialTaskQueueChain m_queues;
+    //The class is thread safe even for non const functions
+    CMS_THREAD_SAFE mutable SerialTaskQueueChain m_queues;
   };
 }  // namespace edm
 

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edm {
   typedef edmplugin::PluginFactory<Maker*()> MakerPluginFactory;
@@ -23,6 +24,7 @@ namespace edm {
 
     static Factory const* get();
 
+    //This function is not const-thread safe
     std::shared_ptr<maker::ModuleHolder> makeModule(const MakeModuleParams&,
                                                     signalslot::Signal<void(const ModuleDescription&)>& pre,
                                                     signalslot::Signal<void(const ModuleDescription&)>& post) const;
@@ -33,7 +35,8 @@ namespace edm {
     Factory();
     Maker* findMaker(const MakeModuleParams& p) const;
     static Factory const singleInstance_;
-    mutable MakerMap makers_;
+    //It is not safe to create modules across threads
+    CMS_SA_ALLOW mutable MakerMap makers_;
   };
 
 }  // namespace edm

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -153,7 +153,7 @@ private:
     using edm::one::OutputModuleBase::doPreallocate;
     RunCacheOutputModule(edm::ParameterSet const& iPSet)
         : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::RunCache<DummyCache>>(iPSet) {}
-    mutable unsigned int m_count = 0;
+    mutable std::atomic<unsigned int> m_count = 0;
     void write(edm::EventForOutput const&) override { ++m_count; }
     void writeRun(edm::RunForOutput const&) override { ++m_count; }
     void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }
@@ -171,7 +171,7 @@ private:
     using edm::one::OutputModuleBase::doPreallocate;
     LumiCacheOutputModule(edm::ParameterSet const& iPSet)
         : edm::one::OutputModuleBase(iPSet), edm::one::OutputModule<edm::LuminosityBlockCache<DummyCache>>(iPSet) {}
-    mutable unsigned int m_count = 0;
+    mutable std::atomic<unsigned int> m_count = 0;
     void write(edm::EventForOutput const&) override { ++m_count; }
     void writeRun(edm::RunForOutput const&) override { ++m_count; }
     void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override { ++m_count; }

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -141,7 +141,7 @@ namespace edmtest {
     public:
       explicit RunCacheAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {}
       const unsigned int trans_;
-      mutable unsigned int m_count = 0;
+      mutable std::atomic<unsigned int> m_count = 0;
 
       void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {
         ++m_count;
@@ -185,7 +185,7 @@ namespace edmtest {
     public:
       explicit LumiBlockCacheAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {}
       const unsigned int trans_;
-      mutable unsigned int m_count = 0;
+      mutable std::atomic<unsigned int> m_count = 0;
 
       void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {
         ++m_count;

--- a/FWCore/Framework/test/stubs/TestOneFilters.cc
+++ b/FWCore/Framework/test/stubs/TestOneFilters.cc
@@ -142,7 +142,7 @@ namespace edmtest {
     public:
       explicit RunCacheFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {}
       const unsigned int trans_;
-      mutable unsigned int m_count = 0;
+      mutable std::atomic<unsigned int> m_count = 0;
 
       bool filter(edm::Event& iEvent, edm::EventSetup const&) override {
         ++m_count;
@@ -188,7 +188,7 @@ namespace edmtest {
     public:
       explicit LumiBlockCacheFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {}
       const unsigned int trans_;
-      mutable unsigned int m_count = 0;
+      mutable std::atomic<unsigned int> m_count = 0;
 
       bool filter(edm::Event& iEvent, edm::EventSetup const&) override {
         ++m_count;

--- a/FWCore/Framework/test/stubs/TestOneProducers.cc
+++ b/FWCore/Framework/test/stubs/TestOneProducers.cc
@@ -144,7 +144,7 @@ namespace edmtest {
         produces<int>();
       }
       const unsigned int trans_;
-      mutable unsigned int m_count = 0;
+      mutable std::atomic<unsigned int> m_count = 0;
 
       void produce(edm::Event& iEvent, edm::EventSetup const&) override {
         ++m_count;
@@ -190,7 +190,7 @@ namespace edmtest {
         produces<int>();
       }
       const unsigned int trans_;
-      mutable unsigned int m_count = 0;
+      mutable std::atomic<unsigned int> m_count = 0;
 
       void produce(edm::Event& iEvent, edm::EventSetup const&) override {
         ++m_count;

--- a/FWCore/MessageLogger/src/MessageDrop.cc
+++ b/FWCore/MessageLogger/src/MessageDrop.cc
@@ -144,7 +144,8 @@ namespace edm {
     private:
       const char* typePtr_;
       std::string path_;
-      mutable std::string cache_;
+      //This class is only used within a thread local object
+      CMS_SA_ALLOW mutable std::string cache_;
     };
 
     class StringProducerSinglet : public StringProducer {

--- a/FWCore/ParameterSet/interface/PluginDescription.h
+++ b/FWCore/ParameterSet/interface/PluginDescription.h
@@ -87,6 +87,7 @@ Each user plugin must define a static member function:
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // user include files
 #include <string>
@@ -245,7 +246,8 @@ namespace edm {
     }
 
     // ---------- member data --------------------------------
-    mutable std::shared_ptr<ParameterSetDescription> cache_;
+    //Validation of plugins is only done on one thread at a time
+    CMS_SA_ALLOW mutable std::shared_ptr<ParameterSetDescription> cache_;
     std::string typeLabel_;
     std::string defaultType_;
     bool typeLabelIsTracked_;

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -28,6 +28,7 @@
 #include "tbb/concurrent_vector.h"
 
 #include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 // user include files
 #include "FWCore/PluginManager/interface/PluginInfo.h"
 
@@ -69,8 +70,9 @@ namespace edmplugin {
     ///returns the name of the category to which this plugin factory belongs
     virtual const std::string& category() const = 0;
 
+    //The signal is only modified during a shared library load which is protected by a mutex by the operating system
     ///signal containing plugin category, and  plugin info for newly added plugin
-    mutable edm::signalslot::Signal<void(const std::string&, const PluginInfo&)> newPluginAdded_;
+    CMS_THREAD_SAFE mutable edm::signalslot::Signal<void(const std::string&, const PluginInfo&)> newPluginAdded_;
 
     // ---------- static member functions --------------------
 

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -26,6 +26,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeIDBase.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // system include files
 #include <memory>
@@ -49,7 +50,8 @@ namespace edm {
         edm::propagate_const<std::shared_ptr<ServiceMakerBase>> maker_;
         ParameterSet* pset_;
         ActivityRegistry* registry_;  // We do not use propagate_const because the registry itself is mutable
-        mutable bool wasAdded_;
+        //Services construction is not allowed to occur across threads
+        CMS_SA_ALLOW mutable bool wasAdded_;
       };
       typedef std::map<TypeIDBase, std::shared_ptr<ServiceWrapperBase>> Type2Service;
       typedef std::map<TypeIDBase, MakerHolder> Type2Maker;

--- a/FWCore/Utilities/interface/Digest.h
+++ b/FWCore/Utilities/interface/Digest.h
@@ -51,10 +51,10 @@ namespace cms {
     void append(std::string const& s);
     void append(const char* data, size_t size);
 
-    MD5Result digest() const;
+    MD5Result digest();
 
   private:
-    mutable md5_state_t state_;
+    md5_state_t state_;
   };
 }  // namespace cms
 

--- a/FWCore/Utilities/interface/Exception.h
+++ b/FWCore/Utilities/interface/Exception.h
@@ -39,6 +39,7 @@
 #include <type_traits>
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace cms {
 
@@ -85,6 +86,7 @@ namespace cms {
     Exception& operator=(Exception const& other);
 
     // The signature for what() must be identical to that of std::exception::what().
+    // This function is NOT const thread safe
     char const* what() const noexcept override;
 
     virtual std::string explainSelf() const;
@@ -180,7 +182,8 @@ namespace cms {
     // data members
     std::ostringstream ost_;
     std::string category_;
-    mutable std::string what_;
+    //The exception class should not be accessed across threads
+    CMS_SA_ALLOW mutable std::string what_;
     std::list<std::string> context_;
     std::list<std::string> additionalInfo_;
     bool alreadyPrinted_;

--- a/FWCore/Utilities/src/Digest.cc
+++ b/FWCore/Utilities/src/Digest.cc
@@ -168,7 +168,7 @@ namespace cms {
     md5_append(&state_, const_cast<md5_byte_t*>(data), size);
   }
 
-  MD5Result Digest::digest() const {
+  MD5Result Digest::digest() {
     MD5Result aDigest;
     md5_finish(&state_, aDigest.bytes);
     return aDigest;

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -11,6 +11,7 @@ RootDelayedReader.h // used by ROOT input sources
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Utilities/interface/InputType.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "RootTree.h"
 
 #include <map>
@@ -84,7 +85,8 @@ namespace edm {
     //If a fatal exception happens we need to make a copy so we can
     // rethrow that exception on other threads. This avoids TTree
     // non-exception safety problems on later calls to TTree.
-    mutable std::exception_ptr lastException_;
+    //All uses of the ROOT file are serialized
+    CMS_SA_ALLOW mutable std::exception_ptr lastException_;
   };  // class RootDelayedReader
   //------------------------------------------------------------
 }  // namespace edm

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -44,6 +44,7 @@
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Utilities/interface/ReleaseVersion.h"
 #include "FWCore/Utilities/interface/stemFromPath.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
 
@@ -2008,7 +2009,8 @@ namespace edm {
 
     RootTree* rootTree_;
     ProductProvenanceVector infoVector_;
-    mutable ProductProvenanceVector* pInfoVector_;
+    //All access to a ROOT file is serialized
+    CMS_SA_ALLOW mutable ProductProvenanceVector* pInfoVector_;
     DaqProvenanceHelper const* daqProvenanceHelper_;
     std::shared_ptr<std::recursive_mutex> mutex_;
     SharedResourcesAcquirer acquirer_;
@@ -2073,7 +2075,8 @@ namespace edm {
 
     edm::propagate_const<RootTree*> rootTree_;
     std::vector<EventEntryInfo> infoVector_;
-    mutable std::vector<EventEntryInfo>* pInfoVector_;
+    //All access to ROOT file are serialized
+    CMS_SA_ALLOW mutable std::vector<EventEntryInfo>* pInfoVector_;
     EntryDescriptionMap const& entryDescriptionMap_;
     DaqProvenanceHelper const* daqProvenanceHelper_;
     std::shared_ptr<std::recursive_mutex> mutex_;

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -13,6 +13,7 @@ RootTree.h // used by ROOT input sources
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputType.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "Rtypes.h"
 #include "TBranch.h"
@@ -58,8 +59,9 @@ namespace edm {
       BranchDescription const branchDescription_;
       TBranch* productBranch_;
       TBranch* provenanceBranch_;  // For backward compatibility
-      mutable TClass* classCache_;
-      mutable Int_t offsetToWrapperBase_;
+      //All access to a ROOT file is serialized
+      CMS_SA_ALLOW mutable TClass* classCache_;
+      CMS_SA_ALLOW mutable Int_t offsetToWrapperBase_;
     };
 
     class BranchMap {
@@ -216,10 +218,11 @@ namespace edm {
     // So, we make sure to it is detached before closing the TFile so there is no double delete.
     std::shared_ptr<TTreeCache> treeCache_;
     std::shared_ptr<TTreeCache> rawTreeCache_;
-    mutable std::shared_ptr<TTreeCache> triggerTreeCache_;
-    mutable std::shared_ptr<TTreeCache> rawTriggerTreeCache_;
-    mutable std::unordered_set<TBranch*> trainedSet_;
-    mutable std::unordered_set<TBranch*> triggerSet_;
+    //All access to a ROOT file is serialized
+    CMS_SA_ALLOW mutable std::shared_ptr<TTreeCache> triggerTreeCache_;
+    CMS_SA_ALLOW mutable std::shared_ptr<TTreeCache> rawTriggerTreeCache_;
+    CMS_SA_ALLOW mutable std::unordered_set<TBranch*> trainedSet_;
+    CMS_SA_ALLOW mutable std::unordered_set<TBranch*> triggerSet_;
     EntryNumber entries_;
     EntryNumber entryNumber_;
     std::unique_ptr<std::vector<EntryNumber> > entryNumberForIndex_;
@@ -227,8 +230,8 @@ namespace edm {
     BranchMap branches_;
     bool trainNow_;
     EntryNumber switchOverEntry_;
-    mutable EntryNumber rawTriggerSwitchOverEntry_;
-    mutable bool performedSwitchOver_;
+    CMS_SA_ALLOW mutable EntryNumber rawTriggerSwitchOverEntry_;
+    CMS_SA_ALLOW mutable bool performedSwitchOver_;
     unsigned int learningEntries_;
     unsigned int cacheSize_;
     unsigned long treeAutoFlush_;

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -96,9 +96,18 @@ namespace edm {
 
       bool operator<(OutputItem const& rh) const { return *branchDescription_ < *rh.branchDescription_; }
 
+      BranchDescription const* branchDescription() const { return branchDescription_; }
+      EDGetToken token() const { return token_; }
+      void const* const product() const { return product_; }
+      void const*& product() { return product_; }
+      void setProduct(void const* iProduct) { product_ = iProduct; }
+      int splitLevel() const { return splitLevel_; }
+      int basketSize() const { return basketSize_; }
+
+    private:
       BranchDescription const* branchDescription_;
       EDGetToken token_;
-      mutable void const* product_;
+      void const* product_;
       int splitLevel_;
       int basketSize_;
     };
@@ -120,6 +129,8 @@ namespace edm {
     };
 
     OutputItemListArray const& selectedOutputItemList() const { return selectedOutputItemList_; }
+
+    OutputItemListArray& selectedOutputItemList() { return selectedOutputItemList_; }
 
     BranchChildren const& branchChildren() const { return branchChildren_; }
 


### PR DESCRIPTION
#### PR description:

Went through the usage of mutable in most of the Core code. Either removed the need for the mutable or added the appropriate thread-safety attribute.

#### PR validation:

Code compiles.