### PR TITLE
Fix DDCMS unit tests by restoring missing ROOT element table

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -535,8 +535,21 @@ void Converter<DDLElementaryMaterial>::operator()(xml_h element) const {
     int atomicNumber = xmat.attr<int>(DD_CMU(atomicNumber));
     double atomicWeight = xmat.attr<double>(DD_CMU(atomicWeight)) / (dd4hep::g / dd4hep::mole);
     TGeoElementTable* tab = mgr.GetElementTable();
+    int nElem = tab->GetNelements();
+    printout(ns.context()->debug_materials ? ALWAYS : DEBUG, "DD4CMS", "+++ Element table size = %d", nElem);
+
+    if (nElem <= 1) {  // Restore the element table DD4hep destroyed.
+      tab->TGeoElementTable::~TGeoElementTable();
+      new (tab) TGeoElementTable();
+      tab->BuildDefaultElements();
+    }
     TGeoMixture* mix = new TGeoMixture(nam.c_str(), 1, density);
     TGeoElement* elt = tab->FindElement(xmat.nameStr().c_str());
+    printout(ns.context()->debug_materials ? ALWAYS : DEBUG,
+             "DD4CMS",
+             "+++ Searching for material %-48s  elt_ptr = %ld",
+             xmat.nameStr().c_str(),
+             elt);
 
     printout(ns.context()->debug_materials ? ALWAYS : DEBUG,
              "DD4CMS",
@@ -554,12 +567,19 @@ void Converter<DDLElementaryMaterial>::operator()(xml_h element) const {
       // A is Mass of a mole in Geant4 units for atoms with atomic shell
       printout(ns.context()->debug_materials ? ALWAYS : DEBUG,
                "DD4CMS",
-               "    ROOT definition of %-50s Atomic weight %.3f, Atomic number %u, Number of nucleons %u",
+               "    ROOT definition of %-50s Atomic weight %g, Atomic number %u, Number of nucleons %u",
                elt->GetName(),
-               (elt->A()),
+               elt->A(),
                elt->Z(),
                elt->N());
-      if (atomicNumber != elt->Z() || atomicWeight != elt->A())
+      printout(ns.context()->debug_materials ? ALWAYS : DEBUG,
+               "DD4CMS",
+               "+++ Compared to XML values: Atomic weight %g, Atomic number %u",
+               atomicWeight,
+               atomicNumber);
+      static const double weightTolerance = 0.001;
+      if (atomicNumber != elt->Z() ||
+          (std::abs(atomicWeight - elt->A()) > (weightTolerance * (atomicWeight + elt->A()))))
         newMatDef = true;
     }
 

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -577,7 +577,7 @@ void Converter<DDLElementaryMaterial>::operator()(xml_h element) const {
                "+++ Compared to XML values: Atomic weight %g, Atomic number %u",
                atomicWeight,
                atomicNumber);
-      static const double weightTolerance = 0.001;
+      static const double weightTolerance = 1.0e-6;
       if (atomicNumber != elt->Z() ||
           (std::abs(atomicWeight - elt->A()) > (weightTolerance * (atomicWeight + elt->A()))))
         newMatDef = true;


### PR DESCRIPTION
#### PR description:

The latest version of DD4hep CMS is trying to integrate includes a change that eliminates the ROOT default element table CMS was using. DDCMS unit tests fail when this table is missing.

There are various options for CMS to rebuild this table, but the simplest one is to just make a call to have ROOT rebuild it. We can consider other solutions in coming months.

This PR fixes issue #28476 and enables external PR 5376 (new DD4hep version) to go forward.

#### PR validation:

This fix has been tested with the new version of DD4hep to verify it works.

No backport.