### PR TITLE
ECAL Logs Cleanup

### DIFF
--- a/DQM/EcalMonitorTasks/interface/RecoSummaryTask.h
+++ b/DQM/EcalMonitorTasks/interface/RecoSummaryTask.h
@@ -46,10 +46,10 @@ namespace ecaldqm {
         break;
       case kEBReducedRecHit:
       case kEEReducedRecHit:
-	if(_p && fillRecoFlagReduced_)
-	  runOnReducedRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
-	return fillRecoFlagReduced_;
-	break;
+        if (_p && fillRecoFlagReduced_)
+          runOnReducedRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
+        return fillRecoFlagReduced_;
+        break;
       case kEBBasicCluster:
       case kEEBasicCluster:
         if (_p)

--- a/DQM/EcalMonitorTasks/interface/RecoSummaryTask.h
+++ b/DQM/EcalMonitorTasks/interface/RecoSummaryTask.h
@@ -33,6 +33,7 @@ namespace ecaldqm {
     float rechitThresholdEE_;
     EcalRecHitCollection const* ebHits_;
     EcalRecHitCollection const* eeHits_;
+    bool fillRecoFlagReduced_;
   };
 
   inline bool RecoSummaryTask::analyze(void const* _p, Collections _collection) {
@@ -45,10 +46,10 @@ namespace ecaldqm {
         break;
       case kEBReducedRecHit:
       case kEEReducedRecHit:
-        if (_p)
-          runOnReducedRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
-        return true;
-        break;
+	if(_p && fillRecoFlagReduced_)
+	  runOnReducedRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
+	return fillRecoFlagReduced_;
+	break;
       case kEBBasicCluster:
       case kEEBasicCluster:
         if (_p)

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -52,7 +52,7 @@ EcalDQMonitorTask::EcalDQMonitorTask(edm::ParameterSet const& _ps)
       },
       "initialization");
 
-  edm::ParameterSet const& collectionTags(_ps.getUntrackedParameterSet("collectionTags"));
+  edm::ParameterSet const& collectionTags(_ps.getParameterSet("collectionTags"));
 
   for (unsigned iCol(0); iCol < ecaldqm::nCollections; iCol++) {
     if (hasTaskToRun[iCol])
@@ -90,7 +90,7 @@ void EcalDQMonitorTask::fillDescriptions(edm::ConfigurationDescriptions& _descs)
 
   edm::ParameterSetDescription collectionTags;
   collectionTags.addWildcardUntracked<edm::InputTag>("*");
-  desc.addUntracked("collectionTags", collectionTags);
+  desc.add("collectionTags", collectionTags);
 
   desc.addUntracked<bool>("allowMissingCollections", true);
   desc.addUntracked<double>("resetInterval", 0.);

--- a/DQM/EcalMonitorTasks/python/CollectionTags_cfi.py
+++ b/DQM/EcalMonitorTasks/python/CollectionTags_cfi.py
@@ -1,6 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalDQMCollectionTags = cms.untracked.PSet(
+# Dec 2019: ecalDQMCollectionTags was changed from an untracked PSet to a tracked PSet.
+# The reason is that this PSet is part of the offline DQM configuration for both pp
+# and HI runs. For HI runs, there is a function in the the config builder that
+# replaces all inputTags named "rawDataCollector" to "rawDataMapperByLabel", which
+# is necessary for HI runs. As of Dec 2019, this function was called "MassReplaceInputTag".
+# This only works if the collection tags below are part of a tracked PSet.
+
+ecalDQMCollectionTags = cms.PSet(
     Source = cms.untracked.InputTag("rawDataCollector"),
     EcalRawData = cms.untracked.InputTag("ecalDigis"),
     EBGainErrors = cms.untracked.InputTag("ecalDigis", "EcalIntegrityGainErrors"),

--- a/DQM/EcalMonitorTasks/python/RecoSummaryTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/RecoSummaryTask_cfi.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 ecalRecoSummaryTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         rechitThresholdEB = cms.untracked.double(0.8),
-        rechitThresholdEE = cms.untracked.double(1.2)
+        rechitThresholdEE = cms.untracked.double(1.2),
+        fillRecoFlagReduced = cms.untracked.bool(True)
     ),
     MEs = cms.untracked.PSet(
         EnergyMax = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
+++ b/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
@@ -12,11 +12,15 @@
 
 namespace ecaldqm {
   RecoSummaryTask::RecoSummaryTask()
-      : DQWorkerTask(), rechitThresholdEB_(0.), rechitThresholdEE_(0.), ebHits_(nullptr), eeHits_(nullptr) {}
+    : DQWorkerTask(), rechitThresholdEB_(0.), rechitThresholdEE_(0.), ebHits_(nullptr), eeHits_(nullptr), fillRecoFlagReduced_(true) {}
 
   void RecoSummaryTask::setParams(edm::ParameterSet const& _params) {
     rechitThresholdEB_ = _params.getUntrackedParameter<double>("rechitThresholdEB");
     rechitThresholdEE_ = _params.getUntrackedParameter<double>("rechitThresholdEE");
+    fillRecoFlagReduced_ = _params.getUntrackedParameter<bool>("fillRecoFlagReduced");
+    if (!fillRecoFlagReduced_) {
+      MEs_.erase(std::string("RecoFlagReduced"));
+    }
   }
 
   void RecoSummaryTask::addDependencies(DependencySet& _dependencies) {

--- a/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
+++ b/DQM/EcalMonitorTasks/src/RecoSummaryTask.cc
@@ -12,7 +12,12 @@
 
 namespace ecaldqm {
   RecoSummaryTask::RecoSummaryTask()
-    : DQWorkerTask(), rechitThresholdEB_(0.), rechitThresholdEE_(0.), ebHits_(nullptr), eeHits_(nullptr), fillRecoFlagReduced_(true) {}
+      : DQWorkerTask(),
+        rechitThresholdEB_(0.),
+        rechitThresholdEE_(0.),
+        ebHits_(nullptr),
+        eeHits_(nullptr),
+        fillRecoFlagReduced_(true) {}
 
   void RecoSummaryTask::setParams(edm::ParameterSet const& _params) {
     rechitThresholdEB_ = _params.getUntrackedParameter<double>("rechitThresholdEB");

--- a/DQMOffline/Ecal/python/ecal_dqm_source_offline_HI_cff.py
+++ b/DQMOffline/Ecal/python/ecal_dqm_source_offline_HI_cff.py
@@ -30,6 +30,8 @@ ecal_dqm_source_offline = cms.Sequence(
     ecalMultiftAnalyzer
 )
 
+ecalMonitorTask.workerParameters.TrigPrimTask.params.runOnEmul = False
+ecalMonitorTask.collectionTags.Source = 'rawDataMapperByLabel'
 ecalMonitorTask.collectionTags.EBBasicCluster = 'islandBasicClusters:islandBarrelBasicClusters'
 ecalMonitorTask.collectionTags.EEBasicCluster = 'islandBasicClusters:islandEndcapBasicClusters'
 ecalMonitorTask.collectionTags.EBSuperCluster = 'correctedIslandBarrelSuperClusters'

--- a/DQMOffline/Ecal/python/ecal_dqm_source_offline_cff.py
+++ b/DQMOffline/Ecal/python/ecal_dqm_source_offline_cff.py
@@ -20,3 +20,5 @@ ecal_dqm_source_offline = cms.Sequence(
     ecalzmasstask +
     ecalPileUpDepMonitor
 )
+
+ecalMonitorTask.workerParameters.TrigPrimTask.params.runOnEmul = False

--- a/DQMOffline/Ecal/python/ecal_dqm_source_offline_cosmic_cff.py
+++ b/DQMOffline/Ecal/python/ecal_dqm_source_offline_cosmic_cff.py
@@ -16,7 +16,10 @@ ecal_dqm_source_offline = cms.Sequence(
 )
 
 ecalMonitorTask.workerParameters.TrigPrimTask.params.runOnEmul = False
+ecalMonitorTask.workerParameters.RecoSummaryTask.params.fillRecoFlagReduced = False
 ecalMonitorTask.collectionTags.EBBasicCluster = 'cosmicBasicClusters:CosmicBarrelBasicClusters'
 ecalMonitorTask.collectionTags.EEBasicCluster = 'cosmicBasicClusters:CosmicEndcapBasicClusters'
 ecalMonitorTask.collectionTags.EBSuperCluster = 'cosmicSuperClusters:CosmicBarrelSuperClusters'
 ecalMonitorTask.collectionTags.EESuperCluster = 'cosmicSuperClusters:CosmicEndcapSuperClusters'
+ecalMonitorTask.collectionTags.EBUncalibRecHit = 'ecalWeightUncalibRecHit:EcalUncalibRecHitsEB'
+ecalMonitorTask.collectionTags.EEUncalibRecHit = 'ecalWeightUncalibRecHit:EcalUncalibRecHitsEE'


### PR DESCRIPTION
Disabled a few plots from the offline workflows (that were not meant to be filled), stopping them from filling up the logs with warnings. These changes have no effect on DQM other than a significant reduction in these warnings.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->
Due to diverse reasons, offline DQM logs are currently filled up with false alarms from ECAL DQM. Some plots that are only meant to be filled online (HLT emulation) produce a warning when an offline DQM process tries to fill them. Also, the collections passed to ECAL DQM are slightly different in different running conditions (offline, HI, pp collisions), and this is expected because of the slightly different rechit algos run with each process. Plots that are not meaningful for cosmics runs also produce similar warnings.

This PR fixes most problems with unnecessary warnings in the logs due to ECAL DQM. This is done by introducing a new flag that is set differently in the offline cfg file or by reusing already existing flags, and also by including the correct collection names in the cfg files.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

We ran the standard suite of tests: `runTheMatrix.py --nproc=4 --nThreads=10 -l limited -i all --ibeos`, and noted that all warnings related to ECAL DQM disappear from the logs.

#### if this PR is a backport please specify the original PR:
Not a backport.
