### PR TITLE
Hcal geometry: comment debug printouts 

### DIFF
--- a/Geometry/HcalCommonData/src/CaloDDDSimulationConstants.cc
+++ b/Geometry/HcalCommonData/src/CaloDDDSimulationConstants.cc
@@ -1,7 +1,7 @@
 #include "Geometry/HcalCommonData/interface/CaloDDDSimulationConstants.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 CaloDDDSimulationConstants::CaloDDDSimulationConstants(const CaloSimulationParameters* csp) : calospar_(csp) {
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

This PR addresses https://github.com/cms-sw/cmssw/pull/28539#issuecomment-567635421 and restores the synchronization with 11_0_X adding a fix that comments debug printouts in Hcal geometry, ported to 11_0_X by #28539 but only partially applied in master in #28506.

#### PR validation:

Code compiles, the only effect is to switch off simple ```LogInfo``` statements.