### PR TITLE
Adding dqmHarvestingFakeHLT for HI

### DIFF
--- a/Configuration/StandardSequences/python/HarvestingHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/HarvestingHeavyIons_cff.py
@@ -7,6 +7,7 @@ from Validation.RecoHI.HarvestingHI_cff import *
 
 dqmHarvesting = cms.Path(DQMOfflineHeavyIons_SecondStep*DQMOfflineHeavyIons_Certification)
 dqmHarvestingPOG = cms.Path(DQMOfflineHeavyIons_SecondStep_PrePOG)
+dqmHarvestingFakeHLT =  cms.Path(DQMOfflineHeavyIons_SecondStep_FakeHLT*DQMOfflineHeavyIons_Certification)
 
 validationHarvesting = cms.Path(postValidationHI)
 validationHarvestingHI = cms.Path(postValidationHI) ## for backwards compatibility?

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
@@ -80,5 +80,5 @@ DQMOfflineHeavyIons_SecondStep = cms.Sequence(
                                                DQMMessageLoggerClientSeq )
 
 DQMOfflineHeavyIons_SecondStep_FakeHLT = cms.Sequence( DQMOfflineHeavyIons_SecondStep )
-DQMOffline_SecondStep_FakeHLT.remove( DQMOfflineHeavyIons_SecondStepTrigger )
+DQMOfflineHeavyIons_SecondStep_FakeHLT.remove( DQMOfflineHeavyIons_SecondStepTrigger )
 

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_SecondStep_cff.py
@@ -78,3 +78,7 @@ DQMOfflineHeavyIons_SecondStep = cms.Sequence(
                                                DQMOfflineHeavyIons_SecondStep_PreDPG *
                                                DQMOfflineHeavyIons_SecondStep_PrePOG *
                                                DQMMessageLoggerClientSeq )
+
+DQMOfflineHeavyIons_SecondStep_FakeHLT = cms.Sequence( DQMOfflineHeavyIons_SecondStep )
+DQMOffline_SecondStep_FakeHLT.remove( DQMOfflineHeavyIons_SecondStepTrigger )
+


### PR DESCRIPTION
#### PR description:

This PR adds dqmHarvestingFakeHLT  for HI to fix Harvesting in wf140.53
Error in logs recently spotted
https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-e133d3/4085/runTheMatrix-results/140.53_RunHI2011+RunHI2011+RECOHID11+HARVESTDHI/step3_RunHI2011+RunHI2011+RECOHID11+HARVESTDHI.log
Only affecting Run1 HI workflows
Run2 HI workflows run pp harvesting

#### PR validation:

Tested with  runTheMatrix.py -l 140.53 -i all --ibeos

#### if this PR is a backport please specify the original PR:

Not needed