### PR TITLE
Remove redundant disabling of copy constructor/assignment from EgHLTOfflineClient

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTOfflineClient.h
+++ b/DQMOffline/Trigger/interface/EgHLTOfflineClient.h
@@ -67,10 +67,6 @@ private:
   bool isSetup_;
   std::string hltTag_;
 
-  //disabling copying/assignment (in theory this is copyable but lets not just in case)
-  EgHLTOfflineClient(const EgHLTOfflineClient& rhs) {}
-  EgHLTOfflineClient& operator=(const EgHLTOfflineClient& rhs) { return *this; }
-
 public:
   explicit EgHLTOfflineClient(const edm::ParameterSet&);
   ~EgHLTOfflineClient() override;


### PR DESCRIPTION
#### PR description:

The base class (`edm::one::EDProducer`) already disables these operations. Silences a warning by gcc 9.

#### PR validation:

Code compiles.