### PR TITLE
EventSetup consumes migration, SiStrip modules

### DIFF
--- a/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
@@ -9,8 +9,8 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h"
 
-class SiStripClusterInfo;
 class SiStripProcessedRawDigi;
 class TrackerTopology;
 
@@ -41,6 +41,7 @@ private:
 
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > theClustersToken_;
   edm::EDGetTokenT<edm::DetSetVector<SiStripProcessedRawDigi> > theDigisToken_;
+  SiStripClusterInfo siStripClusterInfo_;
 };
 
 #endif

--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -30,6 +30,7 @@
 
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
+#include "RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h"
 
 #include "TROOT.h"
 #include "TFile.h"
@@ -63,6 +64,8 @@ private:
 
   const edm::EDGetTokenT<LumiScalersCollection> scalerToken_;
   const edm::EDGetTokenT<edm::DetSetVector<SiStripRawDigi> > commonModeToken_;
+
+  SiStripClusterInfo siStripClusterInfo_;
 
   bool addLumi_;
   bool addCommonMode_;

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -686,7 +686,6 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
                     cluster_info.push_back(parameters.first.y());
                     cluster_info.push_back(sqrt(parameters.second.yy()));
                     cluster_info.push_back(siStripClusterInfo_.signalOverNoise());
-                    //cluster_info.push_back( siStripClusterInfo_.getSignalOverNoise() );
                     VCluster_info.push_back(cluster_info);
                     nClusters++;
                     LogDebug("SiStripHitEfficiency:HitEff") << "Have ID match. residual = " << VCluster_info.back()[0]

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -49,7 +49,6 @@
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
@@ -73,6 +72,7 @@ using namespace std;
 HitEff::HitEff(const edm::ParameterSet& conf)
     : scalerToken_(consumes<LumiScalersCollection>(conf.getParameter<edm::InputTag>("lumiScalers"))),
       commonModeToken_(mayConsume<edm::DetSetVector<SiStripRawDigi> >(conf.getParameter<edm::InputTag>("commonMode"))),
+      siStripClusterInfo_(consumesCollector()),
       combinatorialTracks_token_(
           consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("combinatorialTracks"))),
       trajectories_token_(consumes<std::vector<Trajectory> >(conf.getParameter<edm::InputTag>("trajectories"))),
@@ -162,6 +162,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
+
+  siStripClusterInfo_.initEvent(es);
 
   //  bool DEBUG = false;
 
@@ -672,7 +674,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
                                    yErr * yErr * xloc * xloc * uylfac * uylfac / uxlden / uxlden / uxlden / uxlden);
                     }
 
-                    SiStripClusterInfo clusterInfo = SiStripClusterInfo(*iter, es, ClusterId);
+                    siStripClusterInfo_.setCluster(*iter, ClusterId);
                     // signal to noise from SiStripClusterInfo not working in 225. I'll fix this after the interface
                     // redesign in 300 -ku
                     //float cluster_info[7] = {res, sigma, parameters.first.x(), sqrt(parameters.second.xx()), parameters.first.y(), sqrt(parameters.second.yy()), signal_to_noise};
@@ -683,8 +685,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
                     cluster_info.push_back(sqrt(parameters.second.xx()));
                     cluster_info.push_back(parameters.first.y());
                     cluster_info.push_back(sqrt(parameters.second.yy()));
-                    cluster_info.push_back(clusterInfo.signalOverNoise());
-                    //cluster_info.push_back( clusterInfo.getSignalOverNoise() );
+                    cluster_info.push_back(siStripClusterInfo_.signalOverNoise());
+                    //cluster_info.push_back( siStripClusterInfo_.getSignalOverNoise() );
                     VCluster_info.push_back(cluster_info);
                     nClusters++;
                     LogDebug("SiStripHitEfficiency:HitEff") << "Have ID match. residual = " << VCluster_info.back()[0]

--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -15,12 +15,12 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include <vector>
 
@@ -29,7 +29,18 @@
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-class SiStripDetCabling;
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+
 class SiStripCluster;
 class SiPixelCluster;
 class EventWithHistory;
@@ -124,7 +135,7 @@ public:
 private:
   void createMEs(const edm::EventSetup& es, DQMStore::IBooker& ibooker);
   void createLayerMEs(std::string label, int ndets, DQMStore::IBooker& ibooker);
-  void createModuleMEs(ModMEs& mod_single, uint32_t detid, DQMStore::IBooker& ibooker);
+  void createModuleMEs(ModMEs& mod_single, uint32_t detid, DQMStore::IBooker& ibooker, const SiStripDetCabling&);
   void createSubDetMEs(std::string label, DQMStore::IBooker& ibooker);
   int FindRegion(int nstrip, int npixel);
   void fillModuleMEs(ModMEs& mod_mes, ClusterProperties& cluster);
@@ -163,7 +174,6 @@ private:
   bool show_mechanical_structure_view, show_readout_view, show_control_view, select_all_detectors, reset_each_run;
   unsigned long long m_cacheID_;
 
-  edm::ESHandle<SiStripDetCabling> SiStripDetCabling_;
   std::vector<uint32_t> ModulesToBeExcluded_;
 
   edm::ParameterSet Parameters;
@@ -242,6 +252,15 @@ private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clusterProducerPixToken_;
   edm::EDGetTokenT<EventWithHistory> historyProducerToken_;
   edm::EDGetTokenT<APVCyclePhaseCollection> apvPhaseProducerToken_;
+
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyRunToken_;
+  edm::ESGetToken<TkDetMap, TrackerTopologyRcd> tkDetMapToken_;
+  edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> siStripDetCablingRunToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyEventToken_;
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> siStripNoisesToken_;
+  edm::ESGetToken<SiStripGain, SiStripGainRcd> siStripGainToken_;
+  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> siStripQualityToken_;
+  edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> siStripDetCablingEventToken_;
 
   bool applyClusterQuality_;
   double sToNLowerLimit_;

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -13,15 +13,13 @@
 #include <vector>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
 #include "TNamed.h"
 
-#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
-#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
 #include "DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h"
@@ -36,7 +34,6 @@
 #include "DPGAnalysis/SiStripTools/interface/EventWithHistory.h"
 
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <iostream>
 #include "TMath.h"
@@ -49,10 +46,16 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
       show_control_view(false),
       select_all_detectors(false),
       reset_each_run(false),
-      m_cacheID_(0)
-//  , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig,
-//  consumesCollector()))
-{
+      m_cacheID_(0),
+      qualityLabel_{conf_.getParameter<std::string>("StripQualityLabel")},
+      trackerTopologyRunToken_{esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()},
+      tkDetMapToken_{esConsumes<TkDetMap, TrackerTopologyRcd, edm::Transition::BeginRun>()},
+      siStripDetCablingRunToken_{esConsumes<SiStripDetCabling, SiStripDetCablingRcd, edm::Transition::BeginRun>()},
+      trackerTopologyEventToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
+      siStripNoisesToken_{esConsumes<SiStripNoises, SiStripNoisesRcd>()},
+      siStripGainToken_{esConsumes<SiStripGain, SiStripGainRcd>()},
+      siStripQualityToken_{esConsumes<SiStripQuality, SiStripQualityRcd>(edm::ESInputTag("", qualityLabel_))},
+      siStripDetCablingEventToken_{esConsumes<SiStripDetCabling, SiStripDetCablingRcd>()} {
   // initialize
   passBPTXfilter_ = true;
 
@@ -199,8 +202,6 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
   conf_.getParameter<edm::InputTag>("ClusterProducerStrip"); clusterProducerPix_
   = conf_.getParameter<edm::InputTag>("ClusterProducerPix");
   */
-  // SiStrip Quality Label
-  qualityLabel_ = conf_.getParameter<std::string>("StripQualityLabel");
   // cluster quality conditions
   edm::ParameterSet cluster_condition = conf_.getParameter<edm::ParameterSet>("ClusterConditions");
   applyClusterQuality_ = cluster_condition.getParameter<bool>("On");
@@ -248,21 +249,13 @@ void SiStripMonitorCluster::dqmBeginRun(const edm::Run& run, const edm::EventSet
 //--------------------------------------------------------------------------------------------
 void SiStripMonitorCluster::createMEs(const edm::EventSetup& es, DQMStore::IBooker& ibooker) {
   if (show_mechanical_structure_view) {
-    // Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    es.get<TrackerTopologyRcd>().get(tTopoHandle);
-    const TrackerTopology* const tTopo = tTopoHandle.product();
-    edm::ESHandle<TkDetMap> tkDetMapHandle;
-    es.get<TrackerTopologyRcd>().get(tkDetMapHandle);
-    const TkDetMap* tkDetMap = tkDetMapHandle.product();
-
-    // take from eventSetup the SiStripDetCabling object - here will use
-    // SiStripDetControl later on
-    es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
+    const TrackerTopology* const tTopo = &es.getData(trackerTopologyRunToken_);
+    const TkDetMap* tkDetMap = &es.getData(tkDetMapToken_);
+    const SiStripDetCabling& siStripDetCabling = es.getData(siStripDetCablingRunToken_);
 
     // get list of active detectors from SiStripDetCabling
     std::vector<uint32_t> activeDets;
-    SiStripDetCabling_->addActiveDetectorsRawIds(activeDets);
+    siStripDetCabling.addActiveDetectorsRawIds(activeDets);
 
     SiStripFolderOrganizer folder_organizer;
     folder_organizer.setSiStripFolderName(topFolderName_);
@@ -306,7 +299,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es, DQMStore::IBook
         folder_organizer.setDetectorFolder(detid, tTopo);  // pass the detid to this method
         if (reset_each_run)
           ResetModuleMEs(detid);
-        createModuleMEs(mod_single, detid, ibooker);
+        createModuleMEs(mod_single, detid, ibooker, siStripDetCabling);
         // append to ModuleMEsMap
         ModuleMEsMap.insert(std::make_pair(detid, mod_single));
       }
@@ -640,9 +633,7 @@ void SiStripMonitorCluster::bookHistograms(DQMStore::IBooker& ibooker, const edm
 //--------------------------------------------------------------------------------------------
 void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(trackerTopologyEventToken_);
 
   // Filter out events if Trigger Filtering is requested
   passBPTXfilter_ = (iEvent.isRealData() and genTriggerEventFlagBPTXfilter_->on())
@@ -667,16 +658,10 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
   int NPixClusters = 0, NStripClusters = 0, MultiplicityRegion = 0;
   bool isPixValid = false;
 
-  edm::ESHandle<SiStripNoises> noiseHandle;
-  iSetup.get<SiStripNoisesRcd>().get(noiseHandle);
-
-  edm::ESHandle<SiStripGain> gainHandle;
-  iSetup.get<SiStripGainRcd>().get(gainHandle);
-
-  edm::ESHandle<SiStripQuality> qualityHandle;
-  iSetup.get<SiStripQualityRcd>().get(qualityLabel_, qualityHandle);
-
-  iSetup.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
+  const SiStripNoises& siStripNoises = iSetup.getData(siStripNoisesToken_);
+  const SiStripGain& siStripGain = iSetup.getData(siStripGainToken_);
+  const SiStripQuality& siStripQuality = iSetup.getData(siStripQualityToken_);
+  const SiStripDetCabling& siStripDetCabling = iSetup.getData(siStripDetCablingEventToken_);
 
   // get collection of DetSetVector of clusters from Event
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > cluster_detsetvektor;
@@ -802,7 +787,7 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
       // All connections for a detid have same FED Id therefore one FEDID is
       // associated with a given detID. Vector of constant FedChannelConnection
       // objects to variable pointers.
-      std::vector<const FedChannelConnection*> fedConnections = SiStripDetCabling_->getConnections(detid);
+      std::vector<const FedChannelConnection*> fedConnections = siStripDetCabling.getConnections(detid);
 
       // Filling FED Id associated clusters map.
 
@@ -847,9 +832,9 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
 
       short total_clusterized_strips = 0;
 
-      SiStripNoises::Range detNoiseRange = noiseHandle->getRange(detid);
-      SiStripApvGain::Range detGainRange = gainHandle->getRange(detid);
-      SiStripQuality::Range qualityRange = qualityHandle->getRange(detid);
+      SiStripNoises::Range detNoiseRange = siStripNoises.getRange(detid);
+      SiStripApvGain::Range detGainRange = siStripGain.getRange(detid);
+      SiStripQuality::Range qualityRange = siStripQuality.getRange(detid);
 
       for (edmNew::DetSet<SiStripCluster>::const_iterator clusterIter = cluster_detset.begin();
            clusterIter != cluster_detset.end();
@@ -876,9 +861,9 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
         for (uint iamp = 0; iamp < ampls.size(); iamp++) {
           if (ampls[iamp] > 0) {  // nonzero amplitude
             cluster_signal += ampls[iamp];
-            if (!qualityHandle->IsStripBad(qualityRange, clusterIter->firstStrip() + iamp)) {
-              noise = noiseHandle->getNoise(clusterIter->firstStrip() + iamp, detNoiseRange) /
-                      gainHandle->getStripGain(clusterIter->firstStrip() + iamp, detGainRange);
+            if (!siStripQuality.IsStripBad(qualityRange, clusterIter->firstStrip() + iamp)) {
+              noise = siStripNoises.getNoise(clusterIter->firstStrip() + iamp, detNoiseRange) /
+                      siStripGain.getStripGain(clusterIter->firstStrip() + iamp, detGainRange);
             }
             noise2 += noise * noise;
             nrnonzeroamplitudes++;
@@ -953,7 +938,7 @@ void SiStripMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSe
             trendVar, std::abs(det_ring_pair.second), ncluster_ring[std::abs(det_ring_pair.second)]);
       }
 
-      short total_nr_strips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
+      short total_nr_strips = siStripDetCabling.nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
       float local_occupancy = static_cast<float>(total_clusterized_strips) / static_cast<float>(total_nr_strips);
       if (found_module_me and passDCSFilter_) {
         if (moduleswitchnrclusterizedstrip && mod_single.NrOfClusterizedStrips) {  // nr of clusterized strips
@@ -1132,7 +1117,10 @@ void SiStripMonitorCluster::ResetModuleMEs(uint32_t idet) {
 //
 // -- Create Module Level MEs
 //
-void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, DQMStore::IBooker& ibooker) {
+void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single,
+                                            uint32_t detid,
+                                            DQMStore::IBooker& ibooker,
+                                            const SiStripDetCabling& siStripDetCabling) {
   // use SistripHistoId for producing histogram id (and title)
   SiStripHistoId hidmanager;
   std::string hid;
@@ -1147,7 +1135,7 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
 
   // ClusterPosition
   if (moduleswitchclusposon) {
-    short total_nr_strips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
+    short total_nr_strips = siStripDetCabling.nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
     hid = hidmanager.createHistoId("ClusterPosition", "det", detid);
     mod_single.ClusterPosition = ibooker.book1D(hid, hid, total_nr_strips, 0.5, total_nr_strips + 0.5);
     mod_single.ClusterPosition->setAxisTitle("cluster position [strip number +0.5]");
@@ -1155,7 +1143,7 @@ void SiStripMonitorCluster::createModuleMEs(ModMEs& mod_single, uint32_t detid, 
 
   // ClusterDigiPosition
   if (moduleswitchclusdigiposon) {
-    short total_nr_strips = SiStripDetCabling_->nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
+    short total_nr_strips = siStripDetCabling.nApvPairs(detid) * 2 * 128;  // get correct # of avp pairs
     hid = hidmanager.createHistoId("ClusterDigiPosition", "det", detid);
     mod_single.ClusterDigiPosition = ibooker.book1D(hid, hid, total_nr_strips, 0.5, total_nr_strips + 0.5);
     mod_single.ClusterDigiPosition->setAxisTitle("digi in cluster position [strip number +0.5]");

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -1,10 +1,8 @@
-#include <FWCore/MessageLogger/interface/MessageLogger.h>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
@@ -17,9 +15,6 @@
 #include "DataFormats/TrackReco/interface/HitPattern.h"
 #include "DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h"
 
-#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-
 #include "DQM/SiStripCommon/interface/SiStripHistoId.h"
 #include "TMath.h"
 
@@ -28,6 +23,12 @@
 
 SiStripMonitorTrack::SiStripMonitorTrack(const edm::ParameterSet& conf)
     : conf_(conf),
+      siStripClusterInfo_(consumesCollector()),
+      trackerGeometryToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      siStripDetCablingToken_(esConsumes<SiStripDetCabling, SiStripDetCablingRcd, edm::Transition::BeginRun>()),
+      trackerTopologyRunToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      tkDetMapToken_(esConsumes<TkDetMap, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      trackerTopologyEventToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
       tracksCollection_in_EventTree(true),
       firstEvent(-1),
       genTriggerEventFlag_(new GenericTriggerEventFlag(
@@ -72,46 +73,37 @@ SiStripMonitorTrack::~SiStripMonitorTrack() {
 }
 
 //------------------------------------------------------------------------
-void SiStripMonitorTrack::dqmBeginRun(const edm::Run& run, const edm::EventSetup& es) {
-  //get geom
-  es.get<TrackerDigiGeometryRecord>().get(tkgeom_);
+void SiStripMonitorTrack::dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
+  tkgeom_ = &iSetup.getData(trackerGeometryToken_);
   LogDebug("SiStripMonitorTrack") << "[SiStripMonitorTrack::beginRun] There are " << tkgeom_->detUnits().size()
                                   << " detectors instantiated in the geometry" << std::endl;
-  es.get<SiStripDetCablingRcd>().get(SiStripDetCabling_);
-
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  tTopo_ = tTopoHandle.product();
-
-  edm::ESHandle<SiStripGain> gainHandle;
-  es.get<SiStripGainRcd>().get(gainHandle);
-  stripGain_ = gainHandle.product();
+  siStripDetCabling_ = &iSetup.getData(siStripDetCablingToken_);
 
   // Initialize the GenericTriggerEventFlag
   if (genTriggerEventFlag_->on())
-    genTriggerEventFlag_->initRun(run, es);
+    genTriggerEventFlag_->initRun(run, iSetup);
 }
 
 //------------------------------------------------------------------------
-void SiStripMonitorTrack::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) {
-  // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
+void SiStripMonitorTrack::bookHistograms(DQMStore::IBooker& ibooker,
+                                         const edm::Run& run,
+                                         const edm::EventSetup& iSetup) {
+  const TrackerTopology* trackerTopology = &iSetup.getData(trackerTopologyRunToken_);
+  const TkDetMap* tkDetMap = &iSetup.getData(tkDetMapToken_);
 
-  edm::ESHandle<TkDetMap> tkDetMapHandle;
-  es.get<TrackerTopologyRcd>().get(tkDetMapHandle);
-
-  book(ibooker, tTopoHandle.product(), tkDetMapHandle.product());
+  book(ibooker, trackerTopology, tkDetMap);
 }
 
 // ------------ method called to produce the data  ------------
-void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es) {
+void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
+  siStripClusterInfo_.initEvent(iSetup);
+
   // Filter out events if DCS checking is requested
-  if (dcsStatus_ && !dcsStatus_->getStatus(e, es))
+  if (dcsStatus_ && !dcsStatus_->getStatus(e, iSetup))
     return;
 
   // Filter out events if Trigger Filtering is requested
-  if (genTriggerEventFlag_->on() && !genTriggerEventFlag_->accept(e, es))
+  if (genTriggerEventFlag_->on() && !genTriggerEventFlag_->accept(e, iSetup))
     return;
 
   //initialization of global quantities
@@ -129,35 +121,21 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
     iSubDet->second.totNClustersOffTrack = 0;
   }
 
-  if (watchertTopo_.check(es)) {
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    es.get<TrackerTopologyRcd>().get(tTopoHandle);
-    tTopo_ = tTopoHandle.product();
-  }
-
-  if (watcherStripGain_.check(es)) {
-    edm::ESHandle<SiStripGain> gainHandle;
-    es.get<SiStripGainRcd>().get(gainHandle);
-    stripGain_ = gainHandle.product();
-  }
-
-  edm::ESHandle<SiStripQuality> qualityHandle;
-  es.get<SiStripQualityRcd>().get("", qualityHandle);
-  stripQuality_ = qualityHandle.product();
+  trackerTopology_ = &iSetup.getData(trackerTopologyEventToken_);
 
   //Perform track study
-  trackStudy(e, es);
+  trackStudy(e);
 
   //Perform Cluster Study (irrespectively to tracks)
 
-  AllClusters(e, es);  //analyzes the off Track Clusters
+  AllClusters(e);  //analyzes the off Track Clusters
 
   //Summary Counts of clusters
   std::map<std::string, MonitorElement*>::iterator iME;
   std::map<std::string, LayerMEs>::iterator iLayerME;
 
   if (!(topFolderName_.find("IsolatedBunches") != std::string::npos)) {
-    fillControlViewHistos(e, es);
+    fillControlViewHistos(e);
   }
 
   if (Trend_On_) {
@@ -216,7 +194,7 @@ void SiStripMonitorTrack::book(DQMStore::IBooker& ibooker, const TrackerTopology
   //******** TkHistoMaps
 
   std::vector<uint32_t> vdetId_;
-  SiStripDetCabling_->addActiveDetectorsRawIds(vdetId_);
+  siStripDetCabling_->addActiveDetectorsRawIds(vdetId_);
   const char* tec = "TEC";
   const char* tid = "TID";
   //Histos for each detector, layer and module
@@ -440,7 +418,7 @@ void SiStripMonitorTrack::bookModMEs(DQMStore::IBooker& ibooker, const uint32_t 
     theModMEs.ClusterStoNCorr = bookME1D(
         ibooker, "TH1ClusterStoNCorrMod", hidmanager.createHistoId("ClusterStoNCorr_OnTrack", name, id).c_str());
     // Cluster Position
-    short total_nr_strips = SiStripDetCabling_->nApvPairs(id) * 2 * 128;
+    short total_nr_strips = siStripDetCabling_->nApvPairs(id) * 2 * 128;
     theModMEs.ClusterPos = ibooker.book1D(hidmanager.createHistoId("ClusterPosition_OnTrack", name, id).c_str(),
                                           hidmanager.createHistoId("ClusterPosition_OnTrack", name, id).c_str(),
                                           total_nr_strips,
@@ -544,7 +522,7 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker& ibooker, const uint32_
   theLayerMEs.ClusterWidthOffTrack = handleBookMEs(ibooker, view, layer_id, hpar, hname);
 
   //Cluster Position
-  short total_nr_strips = SiStripDetCabling_->nApvPairs(mod_id) * 2 * 128;
+  short total_nr_strips = siStripDetCabling_->nApvPairs(mod_id) * 2 * 128;
   if (layer_id.find("TEC") != std::string::npos)
     total_nr_strips = 3 * 2 * 128;
 
@@ -677,7 +655,7 @@ void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker& ibooker, const uint32_t
   theRingMEs.ClusterWidthOffTrack = handleBookMEs(ibooker, view, ring_id, hpar, hname);
 
   //Cluster Position
-  short total_nr_strips = SiStripDetCabling_->nApvPairs(mod_id) * 2 * 128;
+  short total_nr_strips = siStripDetCabling_->nApvPairs(mod_id) * 2 * 128;
   if (ring_id.find("TEC") != std::string::npos)
     total_nr_strips = 3 * 2 * 128;
 
@@ -910,7 +888,6 @@ SiStripMonitorTrack::MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::
 void SiStripMonitorTrack::trajectoryStudy(const reco::Track& track,
                                           const edm::DetSetVector<SiStripDigi>& digilist,
                                           const edm::Event& ev,
-                                          const edm::EventSetup& es,
                                           bool track_ok) {
   auto const& trajParams = track.extra()->trajParams();
   assert(trajParams.size() == track.recHitsSize());
@@ -954,16 +931,16 @@ void SiStripMonitorTrack::trajectoryStudy(const reco::Track& track,
       const GeomDetUnit* monodet = gdet->monoDet();
       statedirection = monodet->toLocal(gtrkdirup);
       SiStripRecHit2D m = matchedhit->monoHit();
-      //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,trackref,es);
+      //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,trackref);
       if (statedirection.mag())
-        RecHitInfo<SiStripRecHit2D>(&m, statedirection, digilist, ev, es, track_ok);
+        RecHitInfo<SiStripRecHit2D>(&m, statedirection, digilist, ev, track_ok);
       //stereo side
       const GeomDetUnit* stereodet = gdet->stereoDet();
       statedirection = stereodet->toLocal(gtrkdirup);
       SiStripRecHit2D s = matchedhit->stereoHit();
-      //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,trackref,es);
+      //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,trackref);
       if (statedirection.mag())
-        RecHitInfo<SiStripRecHit2D>(&s, statedirection, digilist, ev, es, track_ok);
+        RecHitInfo<SiStripRecHit2D>(&s, statedirection, digilist, ev, track_ok);
     } else if (projhit) {
       LogTrace("SiStripMonitorTrack") << "\nProjected recHit found" << std::endl;
       //	type=Projected;
@@ -978,21 +955,21 @@ void SiStripMonitorTrack::trajectoryStudy(const reco::Track& track,
         det = gdet->monoDet();
         statedirection = det->toLocal(gtrkdirup);
         if (statedirection.mag())
-          RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, es, track_ok);
+          RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, track_ok);
       } else {
         LogTrace("SiStripMonitorTrack") << "\nProjected recHit found STEREO" << std::endl;
         //stereo side
         det = gdet->stereoDet();
         statedirection = det->toLocal(gtrkdirup);
         if (statedirection.mag())
-          RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, es, track_ok);
+          RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, track_ok);
       }
     } else if (hit2D) {
       if (statedirection.mag())
-        RecHitInfo<SiStripRecHit2D>(hit2D, statedirection, digilist, ev, es, track_ok);
+        RecHitInfo<SiStripRecHit2D>(hit2D, statedirection, digilist, ev, track_ok);
     } else if (hit1D) {
       if (statedirection.mag())
-        RecHitInfo<SiStripRecHit1D>(hit1D, statedirection, digilist, ev, es, track_ok);
+        RecHitInfo<SiStripRecHit1D>(hit1D, statedirection, digilist, ev, track_ok);
     } else {
       LogDebug("SiStripMonitorTrack") << " LocalMomentum: " << statedirection
                                       << "\nLocal x-z plane angle: " << atan2(statedirection.x(), statedirection.z());
@@ -1001,7 +978,6 @@ void SiStripMonitorTrack::trajectoryStudy(const reco::Track& track,
 }
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::hitStudy(const edm::Event& ev,
-                                   const edm::EventSetup& es,
                                    const edm::DetSetVector<SiStripDigi>& digilist,
                                    const ProjectedSiStripRecHit2D* projhit,
                                    const SiStripMatchedRecHit2D* matchedhit,
@@ -1022,14 +998,14 @@ void SiStripMonitorTrack::hitStudy(const edm::Event& ev,
     statedirection = monodet->toLocal(gtrkdirup);
     SiStripRecHit2D m = matchedhit->monoHit();
     if (statedirection.mag())
-      RecHitInfo<SiStripRecHit2D>(&m, statedirection, digilist, ev, es, track_ok);
+      RecHitInfo<SiStripRecHit2D>(&m, statedirection, digilist, ev, track_ok);
 
     //stereo side
     const GeomDetUnit* stereodet = gdet->stereoDet();
     statedirection = stereodet->toLocal(gtrkdirup);
     SiStripRecHit2D s = matchedhit->stereoHit();
     if (statedirection.mag())
-      RecHitInfo<SiStripRecHit2D>(&s, statedirection, digilist, ev, es, track_ok);
+      RecHitInfo<SiStripRecHit2D>(&s, statedirection, digilist, ev, track_ok);
   } else if (projhit) {  // type=Projected;
     LogTrace("SiStripMonitorTrack") << "\nProjected recHit found" << std::endl;
 
@@ -1045,30 +1021,30 @@ void SiStripMonitorTrack::hitStudy(const edm::Event& ev,
       det = gdet->monoDet();
       statedirection = det->toLocal(gtrkdirup);
       if (statedirection.mag())
-        RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, es, track_ok);
+        RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, track_ok);
     } else {
       LogTrace("SiStripMonitorTrack") << "\nProjected recHit found STEREO" << std::endl;
       //stereo side
       det = gdet->stereoDet();
       statedirection = det->toLocal(gtrkdirup);
       if (statedirection.mag())
-        RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, es, track_ok);
+        RecHitInfo<SiStripRecHit2D>(&(originalhit), statedirection, digilist, ev, track_ok);
     }
   } else if (hit2D) {  // type=2D
     statedirection = localMomentum;
     if (statedirection.mag())
-      RecHitInfo<SiStripRecHit2D>(hit2D, statedirection, digilist, ev, es, track_ok);
+      RecHitInfo<SiStripRecHit2D>(hit2D, statedirection, digilist, ev, track_ok);
   } else if (hit1D) {  // type=1D
     statedirection = localMomentum;
     if (statedirection.mag())
-      RecHitInfo<SiStripRecHit1D>(hit1D, statedirection, digilist, ev, es, track_ok);
+      RecHitInfo<SiStripRecHit1D>(hit1D, statedirection, digilist, ev, track_ok);
   } else {
     LogDebug("SiStripMonitorTrack") << " LocalMomentum: " << statedirection
                                     << "\nLocal x-z plane angle: " << atan2(statedirection.x(), statedirection.z());
   }
 }
 //------------------------------------------------------------------------
-void SiStripMonitorTrack::trackStudy(const edm::Event& ev, const edm::EventSetup& es) {
+void SiStripMonitorTrack::trackStudy(const edm::Event& ev) {
   using namespace std;
   using namespace edm;
   using namespace reco;
@@ -1087,7 +1063,7 @@ void SiStripMonitorTrack::trackStudy(const edm::Event& ev, const edm::EventSetup
   auto& digilist = digihandle.isValid() ? *(digihandle.product()) : dummy;
 
   if (trackCollectionHandle.isValid()) {
-    trackStudyFromTrajectory(trackCollectionHandle, digilist, ev, es);
+    trackStudyFromTrajectory(trackCollectionHandle, digilist, ev);
   } else {
     edm::LogError("SiStripMonitorTrack") << "also Track Collection is not valid !! " << TrackLabel_ << std::endl;
     return;
@@ -1110,12 +1086,7 @@ bool SiStripMonitorTrack::trackFilter(const reco::Track& track) {
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection> trackCollectionHandle,
                                               const edm::DetSetVector<SiStripDigi>& digilist,
-                                              const edm::Event& ev,
-                                              const edm::EventSetup& es) {
-  //  edm::ESHandle<TransientTrackBuilder> builder;
-  //  es.get<TransientTrackRecord>().get("TransientTrackBuilder",builder);
-  //  const TransientTrackBuilder* transientTrackBuilder = builder.product();
-
+                                              const edm::Event& ev) {
   //numTracks = trackCollectionHandle->size();
   reco::TrackCollection trackCollection = *trackCollectionHandle;
   for (reco::TrackCollection::const_iterator track = trackCollection.begin(), etrack = trackCollection.end();
@@ -1153,7 +1124,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection>
       //      reco::TrajectoryStateOnSurface stateOnSurface = transientTrack->stateOnSurface(globalPoint);
 
       LocalVector localMomentum;
-      hitStudy(ev, es, digilist, projhit, matchedhit, hit2D, hit1D, localMomentum, track_ok);
+      hitStudy(ev, digilist, projhit, matchedhit, hit2D, hit1D, localMomentum, track_ok);
     }
 
     // hit pattern of the track
@@ -1192,8 +1163,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection>
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<reco::TrackCollection> trackCollectionHandle,
                                                    const edm::DetSetVector<SiStripDigi>& digilist,
-                                                   const edm::Event& ev,
-                                                   const edm::EventSetup& es) {
+                                                   const edm::Event& ev) {
   //Perform track study
   int i = 0;
   reco::TrackCollection trackCollection = *trackCollectionHandle;
@@ -1211,9 +1181,9 @@ void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<reco::TrackCollec
     //      <<"\n\tFrom EXTRA : "
     //      <<"\n\t\touter PT "<< trackref->outerPt()<<std::endl;
 
-    //    trajectoryStudy(traj_iterator,trackref,es);
+    //    trajectoryStudy(traj_iterator,trackref);
     bool track_ok = trackFilter(*track);
-    trajectoryStudy(*track, digilist, ev, es, track_ok);
+    trajectoryStudy(*track, digilist, ev, track_ok);
   }
 }
 //------------------------------------------------------------------------
@@ -1222,7 +1192,6 @@ void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit,
                                      LocalVector LV,
                                      const edm::DetSetVector<SiStripDigi>& digilist,
                                      const edm::Event& ev,
-                                     const edm::EventSetup& es,
                                      bool track_ok) {
   if (!tkrecHit->isValid()) {
     LogTrace("SiStripMonitorTrack") << "\t\t Invalid Hit " << std::endl;
@@ -1255,18 +1224,18 @@ void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit,
     }
 
     const SiStripCluster* SiStripCluster_ = &*(tkrecHit->cluster());
-    SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_, es, detid);
+    siStripClusterInfo_.setCluster(*SiStripCluster_, detid);
 
-    const Det2MEs MEs = findMEs(tTopo_, detid);
-    if (clusterInfos(&SiStripClusterInfo_,
+    const Det2MEs MEs = findMEs(trackerTopology_, detid);
+    if (clusterInfos(&siStripClusterInfo_,
                      detid,
                      OnTrack,
                      track_ok,
                      LV,
                      MEs,
-                     tTopo_,
-                     stripGain_,
-                     stripQuality_,
+                     trackerTopology_,
+                     siStripClusterInfo_.siStripGain(),
+                     siStripClusterInfo_.siStripQuality(),
                      digilist,
                      clust_Pos1,
                      clust_Pos2)) {
@@ -1278,23 +1247,8 @@ void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit,
 }
 
 //------------------------------------------------------------------------
-void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetup& es) {
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
-  /*edm::ESHandle<TrackerGeometry> tracker;
-  es.get<TrackerDigiGeometryRecord>().get(tracker);
-  const TrackerGeometry *tkgeom = &(*tracker); */
-
-  edm::ESHandle<SiStripGain> gainHandle;
-  es.get<SiStripGainRcd>().get(gainHandle);
-  const SiStripGain* stripGain = gainHandle.product();
-
-  edm::ESHandle<SiStripQuality> qualityHandle;
-  es.get<SiStripQualityRcd>().get("", qualityHandle);
-  const SiStripQuality* stripQuality = qualityHandle.product();
+void SiStripMonitorTrack::AllClusters(const edm::Event& ev) {
+  const TrackerTopology* tTopo = trackerTopology_;
 
   edm::Handle<edm::DetSetVector<SiStripDigi>> digihandle;
   ev.getByToken(digiToken_, digihandle);
@@ -1325,7 +1279,7 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
            ClusIter != ClusEnd;
            ++ClusIter) {
         if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end()) {
-          SiStripClusterInfo SiStripClusterInfo_(*ClusIter, es, detid);
+          siStripClusterInfo_.setCluster(*ClusIter, detid);
 
           /*const StripGeomDetUnit * stripdet = (const StripGeomDetUnit*) tkgeom->idToDetUnit(detid);
     	  StripClusterParameterEstimator::LocalValues parameters=stripcpe.localParameters(*ClusIter, *stripdet);
@@ -1333,15 +1287,15 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 	  const Surface& surface = tracker->idToDet(detid)->surface();
 	  GlobalPoint gp = surface.toGlobal(lp);*/
 
-          clusterInfos(&SiStripClusterInfo_,
+          clusterInfos(&siStripClusterInfo_,
                        detid,
                        OffTrack,
                        /*track_ok*/ false,
                        LV,
                        MEs,
                        tTopo,
-                       stripGain,
-                       stripQuality,
+                       siStripClusterInfo_.siStripGain(),
+                       siStripClusterInfo_.siStripQuality(),
                        digilist,
                        0,
                        0);
@@ -1385,7 +1339,9 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
   return me;
 }
 
-bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm::EventSetup& es) {
+bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev) {
+  const TrackerTopology* tTopo = trackerTopology_;
+
   edm::Handle<reco::TrackCollection> tracks;
   ev.getByToken(trackToken_, tracks);  //takes the track collection
 
@@ -1410,28 +1366,24 @@ bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm:
         continue;
       }
 
-      edm::ESHandle<TrackerTopology> tTopoHandle;
-      es.get<TrackerTopologyRcd>().get(tTopoHandle);
-      const TrackerTopology* const tTopo = tTopoHandle.product();
-
       const SiStripRecHit1D* hit1D = dynamic_cast<const SiStripRecHit1D*>(theHit);
       const SiStripRecHit2D* hit2D = dynamic_cast<const SiStripRecHit2D*>(theHit);
 
       float sovn = -1.;
       if (hit1D && !hit2D) {
         const SiStripCluster* SiStripCluster_ = &*(hit1D->cluster());
-        SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_, es, thedetid);
-        sovn = SiStripClusterInfo_.signalOverNoise();
+        siStripClusterInfo_.setCluster(*SiStripCluster_, thedetid);
+        sovn = siStripClusterInfo_.signalOverNoise();
       }
 
       else if (!hit1D && hit2D) {
         const SiStripCluster* SiStripCluster_ = &*(hit2D->cluster());
-        SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_, es, thedetid);
-        sovn = SiStripClusterInfo_.signalOverNoise();
+        siStripClusterInfo_.setCluster(*SiStripCluster_, thedetid);
+        sovn = siStripClusterInfo_.signalOverNoise();
       }
 
       std::vector<const FedChannelConnection*> getFedChanConnections;
-      getFedChanConnections = SiStripDetCabling_->getConnections(thedetid);
+      getFedChanConnections = siStripDetCabling_->getConnections(thedetid);
 
       //      SiStripFolderOrganizer folder_organizer;
       //      std::string sistripsubdet = folder_organizer.getSubDetFolderAndTag(thedetid, tTopo).second;

--- a/DQM/TrackingMonitorSource/interface/StandaloneTrackMonitor.h
+++ b/DQM/TrackingMonitorSource/interface/StandaloneTrackMonitor.h
@@ -22,6 +22,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h"
 
 class TrackingRecHit;
 class SiStripCluster;
@@ -61,6 +62,7 @@ private:
   const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusterToken_;
 
   const std::string trackQuality_;
+  SiStripClusterInfo siStripClusterInfo_;
   const bool doPUCorrection_;
   const bool isMC_;
   const bool haveAllHistograms_;

--- a/RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/SiStripClusterInfo.h
@@ -1,22 +1,29 @@
 #ifndef SISTRIPCLUSTERIZER_SISTRIPCLUSTERINFO_H
 #define SISTRIPCLUSTERIZER_SISTRIPCLUSTERINFO_H
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include <algorithm>
-#include <numeric>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
-class SiStripNoises;
-class SiStripGain;
-class SiStripQuality;
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <utility>
+#include <vector>
 
 class SiStripClusterInfo {
 public:
-  SiStripClusterInfo(const SiStripCluster& cluster,
-                     const edm::EventSetup& es,
-                     const int detid,
-                     const std::string& qualityLabel = "");
+  SiStripClusterInfo(edm::ConsumesCollector&&, const std::string& qualityLabel = "");
+
+  void initEvent(const edm::EventSetup& iSetup);
+  void setCluster(const SiStripCluster& cluster, int detId);
 
   const SiStripCluster* cluster() const { return cluster_ptr; }
 
@@ -51,18 +58,23 @@ public:
   bool IsModuleBad() const;
   bool IsModuleUsable() const;
 
-  std::vector<SiStripCluster> reclusterize(const edm::ParameterSet&) const;
+  const SiStripGain* siStripGain() const { return siStripGain_; }
+  const SiStripQuality* siStripQuality() const { return siStripQuality_; }
 
 private:
   float calculate_noise(const std::vector<float>&) const;
 
-  const SiStripCluster* cluster_ptr;
-  const edm::EventSetup& es;
-  edm::ESHandle<SiStripNoises> noiseHandle;
-  edm::ESHandle<SiStripGain> gainHandle;
-  edm::ESHandle<SiStripQuality> qualityHandle;
-  std::string qualityLabel;
-  uint32_t detId_;
+  const SiStripCluster* cluster_ptr = nullptr;
+
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> siStripNoisesToken_;
+  edm::ESGetToken<SiStripGain, SiStripGainRcd> siStripGainToken_;
+  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> siStripQualityToken_;
+
+  const SiStripNoises* siStripNoises_ = nullptr;
+  const SiStripGain* siStripGain_ = nullptr;
+  const SiStripQuality* siStripQuality_ = nullptr;
+
+  uint32_t detId_ = 0;
 };
 
 #endif

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -154,6 +154,8 @@ namespace reco {
       edm::EDGetTokenT<reco::TrackCollection> tokenTracks;
       edm::EDGetTokenT<TrajTrackAssociationCollection> tokenTrajTrack;
 
+      SiStripClusterInfo siStripClusterInfo_;
+
       bool tagOverlaps_;
       int nOverlaps;
       int layerFromId(const DetId &id, const TrackerTopology *tTopo) const;
@@ -305,6 +307,7 @@ namespace reco {
           pxlTPLProbXYQ_(iConfig.getParameter<double>("PxlTemplateProbXYChargeCut")),
           pxlTPLqBin_(iConfig.getParameter<std::vector<int32_t> >("PxlTemplateqBinCut")),
           PXLcorrClusChargeCut_(iConfig.getParameter<double>("PxlCorrClusterChargeCut")),
+          siStripClusterInfo_(consumesCollector()),
           tagOverlaps_(iConfig.getParameter<bool>("tagOverlaps")) {
       if (useTrajectories_)
         tokenTrajTrack = consumes<TrajTrackAssociationCollection>(src_);
@@ -393,6 +396,7 @@ namespace reco {
       iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
       //iSetup.get<TransientRecHitRecord>().get("WithTrackAngle",theBuilder);
       // RHBuilder=   theBuilder.product();
+      siStripClusterInfo_.initEvent(iSetup);
 
       // prepare output collection
       size_t candcollsize;
@@ -813,14 +817,14 @@ namespace reco {
           }
 
           if (keepthishit) {
-            SiStripClusterInfo clusterInfo = SiStripClusterInfo(*cluster, iSetup, id.rawId());
+            siStripClusterInfo_.setCluster(*cluster, id.rawId());
             if ((subdetStoNlowcut_[subdet_cnt - 1] > 0) &&
-                (clusterInfo.signalOverNoise() < subdetStoNlowcut_[subdet_cnt - 1]))
+                (siStripClusterInfo_.signalOverNoise() < subdetStoNlowcut_[subdet_cnt - 1]))
               keepthishit = false;
             if ((subdetStoNhighcut_[subdet_cnt - 1] > 0) &&
-                (clusterInfo.signalOverNoise() > subdetStoNhighcut_[subdet_cnt - 1]))
+                (siStripClusterInfo_.signalOverNoise() > subdetStoNhighcut_[subdet_cnt - 1]))
               keepthishit = false;
-            //if(!keepthishit)std::cout<<"Hit rejected because of bad S/N: "<<clusterInfo.signalOverNoise()<<std::endl;
+            //if(!keepthishit)std::cout<<"Hit rejected because of bad S/N: "<<siStripClusterInfo_.signalOverNoise()<<std::endl;
           }
 
         }  //end if  subdetStoN_[subdet_cnt]&&...


### PR DESCRIPTION
#### PR description:

EventSetup consumes migration for SiStripMonitorTrack, and SiStripMonitorCluster. This required modifying the SiStripClusterInfo helper class.

Modified all the other clients of SiStripClusterInfo also to keep working with the changes in the helper class, but I didn't finish the migration for those other modules because I am not sure which are actually still used. But the part using SiStripClusterInfo is migrated now.

Note that I deleted the reclusterize function from SiStripClusterInfo. Nothing in the repository used that function and it seemed an odd place to run clusterization from anyway. I deleted it because the reclusterize function used EventSetup and removing that postpones the EventSetup consumes migration of that algorithm until we migrate the module that actually runs it.

#### PR validation:

Relies on existing tests. There is no new functionality. All results should be identical if I've done this correctly.
