### PR TITLE
Fix thread safety issues in SwitchProducer ProductResolvers

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -30,7 +30,7 @@ namespace edm {
 
   void DataManagingProductResolver::throwProductDeletedException() const {
     ProductDeletedException exception;
-    exception << "ProductResolverBase::resolveProduct_: The product matching all criteria was already deleted\n"
+    exception << "DataManagingProductResolver::resolveProduct_: The product matching all criteria was already deleted\n"
               << "Looking for type: " << branchDescription().unwrappedTypeID() << "\n"
               << "Looking for module label: " << moduleLabel() << "\n"
               << "Looking for productInstanceName: " << productInstanceName() << "\n"
@@ -293,8 +293,10 @@ namespace edm {
   }
 
   void InputProductResolver::resetProductData_(bool deleteEarly) {
-    m_prefetchRequested = false;
-    m_waitingTasks.reset();
+    if (not deleteEarly) {
+      m_prefetchRequested = false;
+      m_waitingTasks.reset();
+    }
     DataManagingProductResolver::resetProductData_(deleteEarly);
   }
 
@@ -357,9 +359,11 @@ namespace edm {
   }
 
   void PuttableProductResolver::resetProductData_(bool deleteEarly) {
-    m_waitingTasks.reset();
+    if (not deleteEarly) {
+      prefetchRequested_ = false;
+      m_waitingTasks.reset();
+    }
     DataManagingProductResolver::resetProductData_(deleteEarly);
-    prefetchRequested_ = false;
   }
 
   void PuttableProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
@@ -448,8 +452,10 @@ namespace edm {
   }
 
   void UnscheduledProductResolver::resetProductData_(bool deleteEarly) {
-    prefetchRequested_ = false;
-    waitingTasks_.reset();
+    if (not deleteEarly) {
+      prefetchRequested_ = false;
+      waitingTasks_.reset();
+    }
     DataManagingProductResolver::resetProductData_(deleteEarly);
   }
 
@@ -648,8 +654,10 @@ namespace edm {
   void SwitchBaseProductResolver::resetProductData_(bool deleteEarly) {
     productData_.resetProductData();
     realProduct_.resetProductData_(deleteEarly);
-    prefetchRequested_ = false;
-    waitingTasks_.reset();
+    if (not deleteEarly) {
+      prefetchRequested_ = false;
+      waitingTasks_.reset();
+    }
   }
 
   void SwitchBaseProductResolver::unsafe_setWrapperAndProvenance() const {
@@ -1057,6 +1065,9 @@ namespace edm {
   inline unsigned int NoProcessProductResolver::unsetIndexValue() const { return ambiguous_.size() + kUnsetOffset; }
 
   void NoProcessProductResolver::resetProductData_(bool) {
+    // This function should never receive 'true'. On the other hand,
+    // nothing should break if a 'true' is passed, because
+    // NoProcessProductResolver just forwards the resolve
     const auto resetValue = unsetIndexValue();
     lastCheckIndex_ = resetValue;
     lastSkipCurrentCheckIndex_ = resetValue;

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -649,6 +649,7 @@ namespace edm {
     productData_.resetProductData();
     realProduct_.resetProductData_(deleteEarly);
     prefetchRequested_ = false;
+    waitingTasks_.reset();
   }
 
   void SwitchBaseProductResolver::updateProvenance() const {

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -697,9 +697,9 @@ namespace edm {
       // module has an exception while running
       auto waiting = make_waiting_task(tbb::task::allocate_root(), [this](std::exception_ptr const* iException) {
         if (nullptr != iException) {
-          updateProvenance();
           waitingTasks().doneWaiting(*iException);
         } else {
+          updateProvenance();
           unsafe_setWrapper();
           waitingTasks().doneWaiting(std::exception_ptr());
         }
@@ -759,8 +759,6 @@ namespace edm {
 
     bool expected = false;
     if (prefetchRequested().compare_exchange_strong(expected, true)) {
-      updateProvenance();
-
       //using a waiting task to do a callback guarantees that
       // the waitingTasks() list will be released from waiting even
       // if the module does not put this data product or the
@@ -769,6 +767,7 @@ namespace edm {
         if (nullptr != iException) {
           waitingTasks().doneWaiting(*iException);
         } else {
+          updateProvenance();
           unsafe_setWrapper();
           waitingTasks().doneWaiting(std::exception_ptr());
         }

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -665,6 +665,7 @@ namespace edm {
   void SwitchBaseProductResolver::resetProductData_(bool deleteEarly) {
     productData_.resetProductData();
     realProduct_.resetProductData_(deleteEarly);
+    prefetchRequested_ = false;
     if (not deleteEarly) {
       status_ = defaultStatus_;
     }

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -652,11 +652,9 @@ namespace edm {
     waitingTasks_.reset();
   }
 
-  void SwitchBaseProductResolver::updateProvenance() const {
+  void SwitchBaseProductResolver::unsafe_setWrapperAndProvenance() const {
+    // update provenance
     productData_.provenance().store()->insertIntoSet(ProductProvenance(branchDescription().branchID(), parentageID_));
-  }
-
-  void SwitchBaseProductResolver::unsafe_setWrapper() const {
     // Use the Wrapper of the pointed-to resolver, but the provenance of this resolver
     productData_.unsafe_setWrapper(realProduct().getProductData().sharedConstWrapper());
   }
@@ -699,8 +697,7 @@ namespace edm {
         if (nullptr != iException) {
           waitingTasks().doneWaiting(*iException);
         } else {
-          updateProvenance();
-          unsafe_setWrapper();
+          unsafe_setWrapperAndProvenance();
           waitingTasks().doneWaiting(std::exception_ptr());
         }
       });
@@ -719,7 +716,7 @@ namespace edm {
     status_ = ProductStatus::ResolveFailed;
     bool expected = false;
     if (prefetchRequested().compare_exchange_strong(expected, true)) {
-      unsafe_setWrapper();
+      unsafe_setWrapperAndProvenance();
       waitingTasks().doneWaiting(std::exception_ptr());
     }
   }
@@ -767,8 +764,7 @@ namespace edm {
         if (nullptr != iException) {
           waitingTasks().doneWaiting(*iException);
         } else {
-          updateProvenance();
-          unsafe_setWrapper();
+          unsafe_setWrapperAndProvenance();
           waitingTasks().doneWaiting(std::exception_ptr());
         }
       });

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -40,6 +40,7 @@ namespace edm {
 
     // Give AliasProductResolver and SwitchBaseProductResolver access by moving this method to public
     void resetProductData_(bool deleteEarly) override = 0;
+    virtual ProductData const& getProductData() const = 0;
   };
 
   class DataManagingProductResolver : public DataManagingOrAliasProductResolver {
@@ -66,12 +67,12 @@ namespace edm {
     //Handle the boilerplate code needed for resolveProduct_
     template <bool callResolver, typename FUNC>
     Resolution resolveProductImpl(FUNC resolver) const;
+    ProductData const& getProductData() const final { return productData_; }
     void setMergeableRunProductMetadataInProductData(MergeableRunProductMetadata const*);
 
   private:
     void throwProductDeletedException() const;
     void checkType(WrapperBase const& prod) const;
-    ProductData const& getProductData() const { return productData_; }
     virtual bool isFromCurrentProcess() const = 0;
     // merges the product with the pre-existing product
     void mergeProduct(std::unique_ptr<WrapperBase> edp, MergeableRunProductMetadata const*) const;
@@ -252,6 +253,7 @@ namespace edm {
     void setProductID_(ProductID const& pid) override;
     ProductProvenance const* productProvenancePtr_() const override;
     void resetProductData_(bool deleteEarly) override;
+    ProductData const& getProductData() const final { return realProduct_.getProductData(); }
     bool singleProduct_() const override;
 
     DataManagingOrAliasProductResolver& realProduct_;
@@ -275,6 +277,7 @@ namespace edm {
     DataManagingOrAliasProductResolver const& realProduct() const { return realProduct_; }
     std::atomic<bool>& prefetchRequested() const { return prefetchRequested_; }
     void updateProvenance() const;
+    void unsafe_setWrapper() const;
     void resetProductData_(bool deleteEarly) override;
 
   private:
@@ -297,6 +300,7 @@ namespace edm {
     void setProductProvenanceRetriever_(ProductProvenanceRetriever const* provRetriever) final;
     void setProductID_(ProductID const& pid) final;
     ProductProvenance const* productProvenancePtr_() const final { return provenance()->productProvenance(); }
+    ProductData const& getProductData() const final { return productData_; }
     bool singleProduct_() const final { return true; }
 
     // for "alias" view

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -276,8 +276,7 @@ namespace edm {
     Worker* worker() const { return worker_; }
     DataManagingOrAliasProductResolver const& realProduct() const { return realProduct_; }
     std::atomic<bool>& prefetchRequested() const { return prefetchRequested_; }
-    void updateProvenance() const;
-    void unsafe_setWrapper() const;
+    void unsafe_setWrapperAndProvenance() const;
     void resetProductData_(bool deleteEarly) override;
 
   private:

--- a/FWCore/Framework/test/test_consumeAfterEarlyDeletePath_cfg.py
+++ b/FWCore/Framework/test/test_consumeAfterEarlyDeletePath_cfg.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(3))
+
+process.options = cms.untracked.PSet(
+        canDeleteEarly = cms.untracked.vstring("edmtestDeleteEarly_maker__TEST"))
+
+
+process.maker = cms.EDProducer("DeleteEarlyProducer")
+
+process.reader = cms.EDAnalyzer("DeleteEarlyReader",
+                                tag = cms.untracked.InputTag("maker"),
+                                mightGet = cms.untracked.vstring("edmtestDeleteEarly_maker__TEST"))
+
+# the following consumes the DeleteEarly but does not read it nor say it needs it
+# it won't fail as such, but triggers a prefetch request to maker
+process.consumer2 = cms.EDAnalyzer("DeleteEarlyConsumer",
+                                    tag = cms.untracked.InputTag("maker"))
+
+process.p = cms.Path(process.maker+process.reader+process.consumer2)

--- a/FWCore/Framework/test/test_consumeAfterEarlyDeleteTask_cfg.py
+++ b/FWCore/Framework/test/test_consumeAfterEarlyDeleteTask_cfg.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(3))
+
+process.options = cms.untracked.PSet(
+        canDeleteEarly = cms.untracked.vstring("edmtestDeleteEarly_maker__TEST"))
+
+
+process.maker = cms.EDProducer("DeleteEarlyProducer")
+
+process.reader = cms.EDAnalyzer("DeleteEarlyReader",
+                                tag = cms.untracked.InputTag("maker"),
+                                mightGet = cms.untracked.vstring("edmtestDeleteEarly_maker__TEST"))
+
+# the following consumes the DeleteEarly but does not read it nor say it needs it
+# it won't fail as such, but triggers a prefetch request to maker
+process.consumer2 = cms.EDAnalyzer("DeleteEarlyConsumer",
+                                    tag = cms.untracked.InputTag("maker"))
+
+process.t = cms.Task(process.maker)
+process.p = cms.Path(process.reader+process.consumer2)
+process.p.associate(process.t)

--- a/FWCore/Framework/test/test_deleteEarly.sh
+++ b/FWCore/Framework/test/test_deleteEarly.sh
@@ -9,6 +9,8 @@ F3=${LOCAL_TEST_DIR}/test_readAfterEarlyDelete_fail_cfg.py
 F4=${LOCAL_TEST_DIR}/test_multiPathEarlyDelete_cfg.py
 F5=${LOCAL_TEST_DIR}/test_multiPathMultiModuleEarlyDelete_cfg.py
 F6=${LOCAL_TEST_DIR}/test_subProcessDeleteEarly_cfg.py
+F7=${LOCAL_TEST_DIR}/test_consumeAfterEarlyDeleteTask_cfg.py
+F8=${LOCAL_TEST_DIR}/test_consumeAfterEarlyDeletePath_cfg.py
 
 (cmsRun $F1 ) || die "Failure using $F1" $?
 (cmsRun $F2 ) || die "Failure using $F2" $?
@@ -16,5 +18,7 @@ F6=${LOCAL_TEST_DIR}/test_subProcessDeleteEarly_cfg.py
 (cmsRun $F4 ) || die "Failure using $F4" $?
 (cmsRun $F5 ) || die "Failure using $F5" $?
 (cmsRun $F6 ) || die "Failure using $F6" $?
+(cmsRun $F7 ) || die "Failure using $F7" $?
+(cmsRun $F8 ) || die "Failure using $F8" $?
 
 

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -17,18 +17,18 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}Task_cfg.py disableTest2 || die "cmsRun ${test}Task_cfg.py 2" $?
 
   echo "*************************************************"
-  echo "Merge outputs"
-  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerMerge1.root inputFiles=file:testSwitchProducerTask1.root inputFiles=file:testSwitchProducerTask2.root || die "Merge 1: order 1 2" $?
+  echo "Merge outputs (Task)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerTaskMerge1.root inputFiles=file:testSwitchProducerTask1.root inputFiles=file:testSwitchProducerTask2.root || die "Merge Task1: order 1 2" $?
   echo "*************************************************"
-  echo "Merge outputs in reverse order"
-  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerMerge2.root inputFiles=file:testSwitchProducerTask2.root inputFiles=file:testSwitchProducerTask1.root || die "Merge 2: order 2 1" $?
+  echo "Merge outputs in reverse order (Task)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerTaskMerge2.root inputFiles=file:testSwitchProducerTask2.root inputFiles=file:testSwitchProducerTask1.root || die "Merge Task2: order 2 1" $?
 
   echo "*************************************************"
-  echo "Test provenance of merged output"
-  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerMerge1.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py 1" $?
+  echo "Test provenance of merged output (Task)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerTaskMerge1.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py Task1" $?
   echo "*************************************************"
-  echo "Test provenance of reversely merged output"
-  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py 2" $?
+  echo "Test provenance of reversely merged output (Task)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py Task2" $?
 
   
   echo "*************************************************"
@@ -38,6 +38,20 @@ pushd ${LOCAL_TMP_DIR}
   echo "*************************************************"
   echo "SwitchProducer in a Path, case test2 disabled"
   cmsRun -n ${NUMTHREADS}  ${LOCAL_TEST_DIR}/${test}Path_cfg.py disableTest2 || die "cmsRun ${test}Path_cfg.py 2" $?
+
+  echo "*************************************************"
+  echo "Merge outputs (Path)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerPathMerge1.root inputFiles=file:testSwitchProducerPath1.root inputFiles=file:testSwitchProducerPath2.root || die "Merge Path1: order 1 2" $?
+  echo "*************************************************"
+  echo "Merge outputs in reverse order (Path)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerPathMerge2.root inputFiles=file:testSwitchProducerPath2.root inputFiles=file:testSwitchProducerPath1.root || die "Merge Path2: order 2 1" $?
+
+  echo "*************************************************"
+  echo "Test provenance of merged output (Path)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerPathMerge1.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py Path1" $?
+  echo "*************************************************"
+  echo "Test provenance of reversely merged output (Path)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerPathMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py Path2" $?
 
 
   echo "*************************************************"

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -4,15 +4,17 @@ test=testSwitchProducer
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
+NUMTHREADS=4
+
 pushd ${LOCAL_TMP_DIR}
 
   echo "*************************************************"
   echo "SwitchProducer in a Task"
-  cmsRun ${LOCAL_TEST_DIR}/${test}Task_cfg.py || die "cmsRun ${test}Task_cfg.py 1" $?
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}Task_cfg.py || die "cmsRun ${test}Task_cfg.py 1" $?
 
   echo "*************************************************"
   echo "SwitchProducer in a Task, case test2 disabled"
-  cmsRun ${LOCAL_TEST_DIR}/${test}Task_cfg.py disableTest2 || die "cmsRun ${test}Task_cfg.py 2" $?
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}Task_cfg.py disableTest2 || die "cmsRun ${test}Task_cfg.py 2" $?
 
   echo "*************************************************"
   echo "Merge outputs"
@@ -31,33 +33,33 @@ pushd ${LOCAL_TMP_DIR}
   
   echo "*************************************************"
   echo "SwitchProducer in a Path"
-  cmsRun ${LOCAL_TEST_DIR}/${test}Path_cfg.py || die "cmsRun ${test}Path_cfg.py 1" $?
+  cmsRun -n ${NUMTHREADS}  ${LOCAL_TEST_DIR}/${test}Path_cfg.py || die "cmsRun ${test}Path_cfg.py 1" $?
 
   echo "*************************************************"
   echo "SwitchProducer in a Path, case test2 disabled"
-  cmsRun ${LOCAL_TEST_DIR}/${test}Path_cfg.py disableTest2 || die "cmsRun ${test}Path_cfg.py 2" $?
+  cmsRun -n ${NUMTHREADS}  ${LOCAL_TEST_DIR}/${test}Path_cfg.py disableTest2 || die "cmsRun ${test}Path_cfg.py 2" $?
 
 
   echo "*************************************************"
   echo "SwitchProducer in a Path after a failing filter"
-  cmsRun ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py || die "cmsRun ${test}PathFilter_cfg.py 1" $?
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py || die "cmsRun ${test}PathFilter_cfg.py 1" $?
 
   echo "*************************************************"
   echo "SwitchProducer in a Path after a failing filter, case test2 disabled"
-  cmsRun ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py disableTest2 || die "cmsRun ${test}PathFilter_cfg.py 2" $?
+  cmsRun -n ${NUMTHREADS}  ${LOCAL_TEST_DIR}/${test}PathFilter_cfg.py disableTest2 || die "cmsRun ${test}PathFilter_cfg.py 2" $?
 
 
   echo "*************************************************"
   echo "Keeping SwitchProducer-with-EDAlias and the aliased-for product should fail"
-  cmsRun ${LOCAL_TEST_DIR}/${test}AliasOutput_cfg.py && die "cmsRun ${test}AliasOutput_cfg.py did not throw an exception" $?
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}AliasOutput_cfg.py && die "cmsRun ${test}AliasOutput_cfg.py did not throw an exception" $?
 
   echo "*************************************************"
   echo "Alias to non-existent product should fail only when a corresponding product is accessed"
-  cmsRun ${LOCAL_TEST_DIR}/${test}AliasToNonExistent_cfg.py && die "cmsRun ${test}AliasToNonExistent_cfg.py did not throw an exception" $?
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}AliasToNonExistent_cfg.py && die "cmsRun ${test}AliasToNonExistent_cfg.py did not throw an exception" $?
 
   echo "*************************************************"
   echo "SwitchProducer-with-EDAlias being before the aliased-for producer in a Path should fail"
-  cmsRun ${LOCAL_TEST_DIR}/${test}PathWrongOrder_cfg.py && die "cmsRun ${test}PathWrongOrder_cfg.py did not throw an exception" $?
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}PathWrongOrder_cfg.py && die "cmsRun ${test}PathWrongOrder_cfg.py did not throw an exception" $?
 
   echo "SwitchProducer tests succeeded"
   echo "*************************************************"

--- a/FWCore/Integration/test/testSwitchProducerPathFilter_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPathFilter_cfg.py
@@ -27,7 +27,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSwitchProducerPath%d.root' % (1 if enableTest2 else 2,)),
+    fileName = cms.untracked.string('testSwitchProducerPathFilter%d.root' % (1 if enableTest2 else 2,)),
     outputCommands = cms.untracked.vstring(
         'keep *_intProducer_*_*'
     )

--- a/FWCore/Integration/test/testSwitchProducerPath_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPath_cfg.py
@@ -27,9 +27,10 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSwitchProducerPathFilter%d.root' % (1 if enableTest2 else 2,)),
+    fileName = cms.untracked.string('testSwitchProducerPath%d.root' % (1 if enableTest2 else 2,)),
     outputCommands = cms.untracked.vstring(
         'keep *_intProducer_*_*',
+        'keep *_intProducerAlias_*_*',
         'keep *_intProducerDep1_*_*',
         'keep *_intProducerDep2_*_*',
         'keep *_intProducerDep3_*_*',
@@ -38,7 +39,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2))
-process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(3), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(31))))
+process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
 if enableTest2:
     process.intProducer1.throw = cms.untracked.bool(True)
 else:

--- a/FWCore/Integration/test/testSwitchProducerPath_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPath_cfg.py
@@ -29,7 +29,10 @@ process.maxEvents = cms.untracked.PSet(
 process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testSwitchProducerPathFilter%d.root' % (1 if enableTest2 else 2,)),
     outputCommands = cms.untracked.vstring(
-        'keep *_intProducer_*_*'
+        'keep *_intProducer_*_*',
+        'keep *_intProducerDep1_*_*',
+        'keep *_intProducerDep2_*_*',
+        'keep *_intProducerDep3_*_*',
     )
 )
 
@@ -53,7 +56,14 @@ process.intProducerAlias = SwitchProducerTest(
                                                  cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
-process.t = cms.Task(process.intProducer1, process.intProducer2, process.intProducer3)
+# Test multiple consumers of a SwitchProducer
+process.intProducerDep1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer"))
+process.intProducerDep2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer"))
+process.intProducerDep3 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer"))
+
+
+process.t = cms.Task(process.intProducer1, process.intProducer2, process.intProducer3,
+                     process.intProducerDep1, process.intProducerDep2, process.intProducerDep3)
 process.p = cms.Path(process.intProducer + process.intProducerAlias, process.t)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -33,6 +33,9 @@ process.out = cms.OutputModule("PoolOutputModule",
         'keep *_intProducerOther_*_*',
         'keep *_intProducerAlias_*_*',
         'keep *_intProducerAlias2_foo_*',
+        'keep *_intProducerDep1_*_*',
+        'keep *_intProducerDep2_*_*',
+        'keep *_intProducerDep3_*_*',
     )
 )
 
@@ -68,7 +71,13 @@ process.intProducerAlias2 = SwitchProducerTest(
                         intProducer3 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
+# Test multiple consumers of a SwitchProducer
+process.intProducerDep1 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer"))
+process.intProducerDep2 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer"))
+process.intProducerDep3 = cms.EDProducer("AddIntsProducer", labels = cms.vstring("intProducer"))
+
 process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducerAlias2,
+                     process.intProducerDep1, process.intProducerDep2, process.intProducerDep3,
                      process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
 process.p = cms.Path(process.t)
 


### PR DESCRIPTION
#### PR description:

This PR fixes three thread safety issues in SwitchProducer ProductResolvers that I realized while addressing #28680
- `SwitchBaseProductResolver::prefetchRequested_` is now re-set to `false` in `resetProductData_()`
   * Current behavior (without re-setting) could lead to starvation if there are many consumers (in Tasks) for the SwitchProducer products. This indeed happens with enhanced tests (multiple consumers, multiple threads)
- Call `ProductData::unsafe_setWrapper()` in the prefetching phase as suggested by @Dr15Jones in #28680 
   * The ordering of the tasks ensures that exactly one task is accessing the `ProductData` at the time of the call, after which the tasks for the product consumers are spawned.
- `SwitchBaseProductResolver::waitingTasks_` is reset in `resetProductData_()`
  * Current behavior (without reset) leads to product consumer tasks being spawned too early from 2nd event onwards

In addition this PR
- Moves `putProduct_()` from `SwitchBaseProductResolver` to `SwitchProducerProductResolver`
   * The `putProduct_()` should never be called from `SwitchAliasProductResolver` (and now throws an exception)
- Moves the call to `updateProvenance()` to a proper place in `SwitchProducerProductResolver`
   * The earlier placement looked suspicious (why update if got an exception), and the problem in the provenance tracking was confirmed by enhancing the tests to check the provenance information also for the test configuration where the SwitchProcucer is in a Path

Fixes #28680.

#### PR validation:

Code compiles, unit tests run.