### PR TITLE
Avoid use of container after std::move

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -446,8 +446,8 @@ int TSGForOI::makeSeedsFromHits(const TrackerTopology* tTopo,
     seedHits.push_back(*it->recHit()->hit());
     PTrajectoryStateOnDet const& pstate =
         trajectoryStateTransform::persistentState(updatedTSOS, it->recHit()->geographicalId().rawId());
-    TrajectorySeed seed(pstate, std::move(seedHits), oppositeToMomentum);
     LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: number of seedHits: " << seedHits.size() << endl;
+    TrajectorySeed seed(pstate, std::move(seedHits), oppositeToMomentum);
     out.push_back(seed);
     found++;
     numSeedsMade++;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.cc
@@ -416,9 +416,9 @@ void TSGForOIFromL2::makeSeedsFromHits(const GeometricSearchDet& layer,
     seedHits.push_back(*it->recHit()->hit());
     PTrajectoryStateOnDet const& pstate =
         trajectoryStateTransform::persistentState(updatedTSOS, it->recHit()->geographicalId().rawId());
-    TrajectorySeed seed(pstate, std::move(seedHits), oppositeToMomentum);
     LogTrace("TSGForOIFromL2") << "TSGForOIFromL2::makeSeedsFromHits: Number of seedHits: " << seedHits.size()
                                << std::endl;
+    TrajectorySeed seed(pstate, std::move(seedHits), oppositeToMomentum);
     out.push_back(seed);
     found++;
     numSeedsMade++;


### PR DESCRIPTION

#### PR description:

Moved log message to before the use of std::move.
This was found by the static analyzer.

#### PR validation:

THe code compiles.