### PR TITLE
Remove global declarations in classes.h in CaloAnalysis

### DIFF
--- a/SimDataFormats/CaloAnalysis/src/classes.h
+++ b/SimDataFormats/CaloAnalysis/src/classes.h
@@ -2,25 +2,3 @@
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
-
-namespace SimDataFormats {
-  namespace CaloAnalysis {
-    SimCluster sc;
-    SimClusterCollection vsc;
-    edm::Wrapper<SimClusterCollection> wvsc;
-
-    SimClusterRef scr;
-    SimClusterRefVector scrv;
-    SimClusterRefProd scrp;
-    SimClusterContainer scc;
-
-    CaloParticle cp;
-    CaloParticleCollection vcp;
-    edm::Wrapper<CaloParticleCollection> wvcp;
-
-    CaloParticleRef cpr;
-    CaloParticleRefVector cprv;
-    CaloParticleRefProd cprp;
-    CaloParticleContainer cpc;
-  }  // namespace CaloAnalysis
-}  // namespace SimDataFormats


### PR DESCRIPTION
#### PR description:

The declaration of a variable of a given type is no longer necessary to generate a ROOT dictionary.

This was found by the static analyzer.

#### PR validation:

The code compiles and the resultant .rootmap file is identical to the original.