### PR TITLE
Make classes.h in JetMETObjects conform to CondFormats conventions

### DIFF
--- a/CondFormats/JetMETObjects/src/classes.h
+++ b/CondFormats/JetMETObjects/src/classes.h
@@ -2,28 +2,32 @@
 
 #include <vector>
 
-JetCorrectorParameters corr;
-JetCorrectorParameters::Definitions def;
-JetCorrectorParameters::Record record;
-std::vector<JetCorrectorParameters> corrv;
-std::vector<JetCorrectorParameters::Record> recordv;
-JetCorrectorParametersCollection coll;
-JetCorrectorParametersCollection::pair_type pair_type;
-JetCorrectorParametersCollection::collection_type colltype;
-std::vector<JetCorrectorParametersCollection> collv;
-FFTJetCorrectorParameters fftcorr;
-QGLikelihoodCategory qgcat;
-QGLikelihoodObject qgobj;
-QGLikelihoodObject::Entry qgentry;
-std::vector<QGLikelihoodObject::Entry> qgentryv;
-QGLikelihoodSystematicsObject qgsystobj;
-QGLikelihoodSystematicsObject::Entry qgsystentry;
-std::vector<QGLikelihoodSystematicsObject::Entry> qgsystentryv;
-METCorrectorParameters METcorr;
-MEtXYcorrectParameters MEtXYcorr;
-JME::JetResolutionObject jerobj;
-JME::JetResolutionObject::Definition jerdef;
-JME::JetResolutionObject::Record jerrecord;
-JME::JetResolutionObject::Range jerrange;
-std::vector<JME::JetResolutionObject::Record> jerrecordvec;
-std::vector<JME::JetResolutionObject::Range> jerrangevec;
+namespace CondFormats_JetMETObjects {
+  struct dictionary {
+    JetCorrectorParameters corr;
+    JetCorrectorParameters::Definitions def;
+    JetCorrectorParameters::Record record;
+    std::vector<JetCorrectorParameters> corrv;
+    std::vector<JetCorrectorParameters::Record> recordv;
+    JetCorrectorParametersCollection coll;
+    JetCorrectorParametersCollection::pair_type pair_type;
+    JetCorrectorParametersCollection::collection_type colltype;
+    std::vector<JetCorrectorParametersCollection> collv;
+    FFTJetCorrectorParameters fftcorr;
+    QGLikelihoodCategory qgcat;
+    QGLikelihoodObject qgobj;
+    QGLikelihoodObject::Entry qgentry;
+    std::vector<QGLikelihoodObject::Entry> qgentryv;
+    QGLikelihoodSystematicsObject qgsystobj;
+    QGLikelihoodSystematicsObject::Entry qgsystentry;
+    std::vector<QGLikelihoodSystematicsObject::Entry> qgsystentryv;
+    METCorrectorParameters METcorr;
+    MEtXYcorrectParameters MEtXYcorr;
+    JME::JetResolutionObject jerobj;
+    JME::JetResolutionObject::Definition jerdef;
+    JME::JetResolutionObject::Record jerrecord;
+    JME::JetResolutionObject::Range jerrange;
+    std::vector<JME::JetResolutionObject::Record> jerrecordvec;
+    std::vector<JME::JetResolutionObject::Range> jerrangevec;
+  };
+}  // namespace CondFormats_JetMETObjects


### PR DESCRIPTION

#### PR description:
Avoid declaring unnecessary global objects by following the conventions
used in other CondFormats packages for the structure of classes.h.

This was found by the static analyzer.
#### PR validation:

The code compiles.