### PR TITLE
Removed use of global histograms in DTVDriftCalibration

### DIFF
--- a/CalibMuon/DTCalibration/interface/DTTMax.h
+++ b/CalibMuon/DTCalibration/interface/DTTMax.h
@@ -14,6 +14,7 @@
 #include "DataFormats/DTRecHit/interface/DTRecHit1D.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "Histogram.h"
 
 #include <string>
 #include <vector>
@@ -39,7 +40,8 @@ public:
          const DTSuperLayer& isl,
          GlobalVector dir,
          GlobalPoint pos,
-         const DTTTrigBaseSync& sync);
+         const DTTTrigBaseSync& sync,
+         dtcalibration::Histograms& hist);
 
   /// Destructor
   virtual ~DTTMax();

--- a/CalibMuon/DTCalibration/interface/Histogram.h
+++ b/CalibMuon/DTCalibration/interface/Histogram.h
@@ -1,60 +1,63 @@
-#ifndef Histogram_H
-#define Histogram_H
+#ifndef CalibMuon_DTCalibration_Histogram_H
+#define CalibMuon_DTCalibration_Histogram_H
 
 #include "TH1.h"
 #include "TH2.h"
 #include "TString.h"
 
-TH1F* hT123Bad;
-TH1F* hT123LRL;
-TH1F* hT123LLR;
-TH1F* hT123LRR;
-TH1F* hT124Bad;
-TH1F* hT124LRR1gt4;
-TH1F* hT124LRR1lt4;
-TH1F* hT124LLR;
-TH1F* hT124LLLR;
-TH1F* hT124LLLL;
-TH1F* hT124LRLL;
-TH1F* hT124LRLR;
-TH1F* hT134Bad;
-TH1F* hT134LLR1gt4;
-TH1F* hT134LLR1lt4;
-TH1F* hT134LRR;
-TH1F* hT134LRLR;
-TH1F* hT134LRLL;
-TH1F* hT134LLLL;
-TH1F* hT134LLLR;
-TH1F* hT234Bad;
-TH1F* hT234LRL;
-TH1F* hT234LLR;
-TH1F* hT234LRR;
+namespace dtcalibration {
+  struct Histograms {
+    TH1F* hT123Bad;
+    TH1F* hT123LRL;
+    TH1F* hT123LLR;
+    TH1F* hT123LRR;
+    TH1F* hT124Bad;
+    TH1F* hT124LRR1gt4;
+    TH1F* hT124LRR1lt4;
+    TH1F* hT124LLR;
+    TH1F* hT124LLLR;
+    TH1F* hT124LLLL;
+    TH1F* hT124LRLL;
+    TH1F* hT124LRLR;
+    TH1F* hT134Bad;
+    TH1F* hT134LLR1gt4;
+    TH1F* hT134LLR1lt4;
+    TH1F* hT134LRR;
+    TH1F* hT134LRLR;
+    TH1F* hT134LRLL;
+    TH1F* hT134LLLL;
+    TH1F* hT134LLLR;
+    TH1F* hT234Bad;
+    TH1F* hT234LRL;
+    TH1F* hT234LLR;
+    TH1F* hT234LRR;
 
-void bookHistos() {
-  hT123LRL = new TH1F("hT123LRL", "Tmax123 LRL", 2000, -1000., 1000.);
-  hT123LLR = new TH1F("hT123LLR", "Tmax123 LLR", 2000, -1000., 1000.);
-  hT123LRR = new TH1F("hT123LRR", "Tmax123 LRR", 2000, -1000., 1000.);
-  hT123Bad = new TH1F("hT123Bad", "Bad Tmax123", 10, -5., 5.);
-  hT124LRR1gt4 = new TH1F("hT124LRR1gt4", "Tmax124 LRR x1>x4", 2000, -1000., 1000.);
-  hT124LRR1lt4 = new TH1F("hT124LRR1lt4", "Tmax124 LRR x1<x4", 2000, -1000., 1000.);
-  hT124LLR = new TH1F("hT124LLR", "Tmax124 LLR", 2000, -1000., 1000.);
-  hT124LLLR = new TH1F("hT124LLLR", "Tmax124 LLL Dir.R", 2000, -1000., 1000.);
-  hT124LLLL = new TH1F("hT124LLLL", "Tmax124 LLL Dir.L", 2000, -1000., 1000.);
-  hT124LRLL = new TH1F("hT124LRLL", "Tmax124 LRL Dir.L", 2000, -1000., 1000.);
-  hT124LRLR = new TH1F("hT124LRLR", "Tmax124 LRL Dir.R", 2000, -1000., 1000.);
-  hT124Bad = new TH1F("hT124Bad", "Bad Tmax124", 10, -5., 5.);
-  hT134LLR1gt4 = new TH1F("hT134LLR1gt4", "Tmax134 LLR x1>x4", 2000, -1000., 1000.);
-  hT134LLR1lt4 = new TH1F("hT134LLR1lt4", "Tmax134 LLR x1<x4", 2000, -1000., 1000.);
-  hT134LRR = new TH1F("hT134LRR", "Tmax134", 2000, -1000., 1000.);
-  hT134LRLR = new TH1F("hT134LRLR", "Tmax134 LRL Dir.R", 2000, -1000., 1000.);
-  hT134LRLL = new TH1F("hT134LRLL", "Tmax134 LRL Dir.L", 2000, -1000., 1000.);
-  hT134LLLL = new TH1F("hT134LLLL", "Tmax134 LLL Dir.L", 2000, -1000., 1000.);
-  hT134LLLR = new TH1F("hT134LLLR", "Tmax134 LLL Dir.R", 2000, -1000., 1000.);
-  hT134Bad = new TH1F("hT134Bad", "Bad Tmax134", 10, -5., 5.);
-  hT234LRL = new TH1F("hT234LRL", "Tmax234 LRL", 2000, -1000., 1000.);
-  hT234LLR = new TH1F("hT234LLR", "Tmax234 LLR", 2000, -1000., 1000.);
-  hT234LRR = new TH1F("hT234LRR", "Tmax234 LRR", 2000, -1000., 1000.);
-  hT234Bad = new TH1F("hT234Bad", "Bad Tmax234", 10, -5., 5.);
-}
-
+    void bookHistos() {
+      hT123LRL = new TH1F("hT123LRL", "Tmax123 LRL", 2000, -1000., 1000.);
+      hT123LLR = new TH1F("hT123LLR", "Tmax123 LLR", 2000, -1000., 1000.);
+      hT123LRR = new TH1F("hT123LRR", "Tmax123 LRR", 2000, -1000., 1000.);
+      hT123Bad = new TH1F("hT123Bad", "Bad Tmax123", 10, -5., 5.);
+      hT124LRR1gt4 = new TH1F("hT124LRR1gt4", "Tmax124 LRR x1>x4", 2000, -1000., 1000.);
+      hT124LRR1lt4 = new TH1F("hT124LRR1lt4", "Tmax124 LRR x1<x4", 2000, -1000., 1000.);
+      hT124LLR = new TH1F("hT124LLR", "Tmax124 LLR", 2000, -1000., 1000.);
+      hT124LLLR = new TH1F("hT124LLLR", "Tmax124 LLL Dir.R", 2000, -1000., 1000.);
+      hT124LLLL = new TH1F("hT124LLLL", "Tmax124 LLL Dir.L", 2000, -1000., 1000.);
+      hT124LRLL = new TH1F("hT124LRLL", "Tmax124 LRL Dir.L", 2000, -1000., 1000.);
+      hT124LRLR = new TH1F("hT124LRLR", "Tmax124 LRL Dir.R", 2000, -1000., 1000.);
+      hT124Bad = new TH1F("hT124Bad", "Bad Tmax124", 10, -5., 5.);
+      hT134LLR1gt4 = new TH1F("hT134LLR1gt4", "Tmax134 LLR x1>x4", 2000, -1000., 1000.);
+      hT134LLR1lt4 = new TH1F("hT134LLR1lt4", "Tmax134 LLR x1<x4", 2000, -1000., 1000.);
+      hT134LRR = new TH1F("hT134LRR", "Tmax134", 2000, -1000., 1000.);
+      hT134LRLR = new TH1F("hT134LRLR", "Tmax134 LRL Dir.R", 2000, -1000., 1000.);
+      hT134LRLL = new TH1F("hT134LRLL", "Tmax134 LRL Dir.L", 2000, -1000., 1000.);
+      hT134LLLL = new TH1F("hT134LLLL", "Tmax134 LLL Dir.L", 2000, -1000., 1000.);
+      hT134LLLR = new TH1F("hT134LLLR", "Tmax134 LLL Dir.R", 2000, -1000., 1000.);
+      hT134Bad = new TH1F("hT134Bad", "Bad Tmax134", 10, -5., 5.);
+      hT234LRL = new TH1F("hT234LRL", "Tmax234 LRL", 2000, -1000., 1000.);
+      hT234LLR = new TH1F("hT234LLR", "Tmax234 LLR", 2000, -1000., 1000.);
+      hT234LRR = new TH1F("hT234LRR", "Tmax234 LRR", 2000, -1000., 1000.);
+      hT234Bad = new TH1F("hT234Bad", "Bad Tmax234", 10, -5., 5.);
+    }
+  };
+}  // namespace dtcalibration
 #endif

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.cc
@@ -35,10 +35,6 @@
 #include "TF1.h"
 #include "TROOT.h"
 
-// Declare histograms.
-TH1F* hChi2;
-extern void bookHistos();
-
 using namespace std;
 using namespace edm;
 using namespace dttmaxenums;
@@ -70,7 +66,7 @@ DTVDriftCalibration::DTVDriftCalibration(const ParameterSet& pset)
   h2DSegmRPhi = new h2DSegm("SLRPhi");
   h2DSegmRZ = new h2DSegm("SLRZ");
   h4DSegmAllCh = new h4DSegm("AllCh");
-  bookHistos();
+  histograms_.bookHistos();
 
   findVDriftAndT0 = pset.getUntrackedParameter<bool>("fitAndWrite", false);
 
@@ -229,7 +225,8 @@ void DTVDriftCalibration::analyze(const Event& event, const EventSetup& eventSet
                      *(chamber->superLayer(slIdAndHits->first)),
                      chamber->toGlobal((*segment).localDirection()),
                      chamber->toGlobal((*segment).localPosition()),
-                     *theSync);
+                     *theSync,
+                     histograms_);
 
         if (theGranularity == bySL) {
           vector<const TMax*> tMaxes = slSeg.getTMax(slId);

--- a/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftCalibration.h
@@ -51,6 +51,8 @@ private:
   // The class containing TMax information
   typedef DTTMax::TMax TMax;
 
+  dtcalibration::Histograms histograms_;
+
   // class to create/manage histos for each partition (SL)
   class cellInfo {
   public:
@@ -70,6 +72,7 @@ private:
     hTMaxCell* histos;
   };
 
+  TH1F* hChi2;
   h2DSegm* h2DSegmRZ;
   h2DSegm* h2DSegmRPhi;
   h4DSegm* h4DSegmAllCh;

--- a/CalibMuon/DTCalibration/src/DTTMax.cc
+++ b/CalibMuon/DTCalibration/src/DTTMax.cc
@@ -9,7 +9,7 @@
 #include "Geometry/DTGeometry/interface/DTSuperLayer.h"
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 // Declare histograms for debugging purposes
-#include "CalibMuon/DTCalibration/interface/Histogram.h"
+//#include "CalibMuon/DTCalibration/interface/Histogram.h"
 
 #include <map>
 #include <iostream>
@@ -43,7 +43,8 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits,
                const DTSuperLayer& isl,
                GlobalVector dir,
                GlobalPoint pos,
-               const DTTTrigBaseSync& sync)
+               const DTTTrigBaseSync& sync,
+               dtcalibration::Histograms& hist)
     : theInfoLayers(4, (InfoLayer*)nullptr),  //FIXME
       theTMaxes(4, (TMax*)nullptr) {
   // debug parameter for verbose output
@@ -152,19 +153,19 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits,
       if (type == "LRL" || type == "RLR") {
         t0Factor = 2;
         t = (t1 + t3) / 2. + t2;
-        hT123LRL->Fill(t);
+        hist.hT123LRL->Fill(t);
       } else if ((type == "LLR" && theSegDir == R) || (type == "RRL" && theSegDir == L)) {
         t0Factor = 1;
         t = (t3 - t1) / 2. + t2;
-        hT123LLR->Fill(t);
+        hist.hT123LLR->Fill(t);
       } else if ((type == "LRR" && theSegDir == R) || (type == "RLL" && theSegDir == L)) {
         t0Factor = 1;
         t = (t1 - t3) / 2. + t2;
-        hT123LRR->Fill(t);
+        hist.hT123LRR->Fill(t);
       } else {
         t = -1.;
         sigma = noR;
-        hT123Bad->Fill(t);
+        hist.hT123Bad->Fill(t);
       }
       theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
       if (debug)
@@ -178,43 +179,43 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits,
       if ((theSegType == "LRLR" && type == "LRR" && x1 > x4) || (theSegType == "RLRL" && type == "RLL" && x1 < x4)) {
         t0Factor = 2;
         t = 1.5 * t2 + t1 - t4 / 2.;
-        hT124LRR1gt4->Fill(t);
+        hist.hT124LRR1gt4->Fill(t);
       } else if ((type == "LLR" && theSegDir == R && (fabs(x2 - x4) < delta) && x1 < x2) ||
                  (type == "RRL" && theSegDir == L && (fabs(x2 - x4) < delta) && x1 > x2)) {
         t0Factor = 1;
         t = 1.5 * t2 - t1 + t4 / 2.;
-        hT124LLR->Fill(t);
+        hist.hT124LLR->Fill(t);
       } else if ((type == "LLL" && theSegDir == R && (fabs(x2 - x4) < delta) && x1 < x2) ||
                  (type == "RRR" && theSegDir == L && (fabs(x2 - x4) < delta) && x1 > x2)) {
         t0Factor = 0;
         t = 1.5 * t2 - t1 - t4 / 2.;
-        hT124LLLR->Fill(t);
+        hist.hT124LLLR->Fill(t);
       } else if ((type == "LLL" && theSegDir == L && (fabs(x2 - x4) < delta)) ||
                  (type == "RRR" && theSegDir == R && (fabs(x2 - x4) < delta))) {
         t0Factor = 0;
         t = -1.5 * t2 + t1 + t4 / 2.;
-        hT124LLLL->Fill(t);
+        hist.hT124LLLL->Fill(t);
       } else if ((type == "LRL" && theSegDir == L && (fabs(x2 - x4) < delta)) ||
                  (type == "RLR" && theSegDir == R && (fabs(x2 - x4) < delta))) {
         t0Factor = 3;
         t = 1.5 * t2 + t1 + t4 / 2.;
-        hT124LRLL->Fill(t);
+        hist.hT124LRLL->Fill(t);
       } else if ((type == "LRL" && theSegDir == R && (fabs(x1 - x4) < (halfCell + delta))) ||
                  (type == "RLR" && theSegDir == L && (fabs(x1 - x4) < (halfCell + delta)))) {
         t0Factor = 99;  // it's actually 1.5, but this value it's not used
         t = 3. / 4. * t2 + t1 / 2. + t4 / 4.;
         sigma = r78;
-        hT124LRLR->Fill(t);
+        hist.hT124LRLR->Fill(t);
       } else if ((type == "LRR" && theSegDir == R && x1 < x4 && (fabs(x1 - x4) < (halfCell + delta))) ||
                  (type == "RLL" && theSegDir == L && x1 > x4 && (fabs(x1 - x4) < (halfCell + delta)))) {
         t0Factor = 1;
         t = 3. / 4. * t2 + t1 / 2. - t4 / 4.;
         sigma = r78;
-        hT124LRR1lt4->Fill(t);
+        hist.hT124LRR1lt4->Fill(t);
       } else {
         t = -1.;
         sigma = noR;
-        hT124Bad->Fill(t);
+        hist.hT124Bad->Fill(t);
       }
       theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
       if (debug)
@@ -228,43 +229,43 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits,
       if ((type == "LLR" && x1 > x4 && theSegType == "LRLR") || (type == "RRL" && x1 < x4 && theSegType == "RLRL")) {
         t0Factor = 2;
         t = 1.5 * t3 + t4 - t1 / 2.;
-        hT134LLR1gt4->Fill(t);
+        hist.hT134LLR1gt4->Fill(t);
       } else if ((type == "LLR" && x1 < x4 && (fabs(x1 - x4) < (halfCell + delta))) ||
                  (type == "RRL" && x1 > x4 && (fabs(x1 - x4) < (halfCell + delta)))) {
         t0Factor = 1;
         t = 3. / 4. * t3 + t4 / 2. - t1 / 4.;
         sigma = r78;
-        hT134LLR1lt4->Fill(t);
+        hist.hT134LLR1lt4->Fill(t);
       } else if ((type == "LRR" && theSegDir == R && x1 < x4 && (fabs(x1 - x3) < delta)) ||
                  (type == "RLL" && theSegDir == L && x1 > x4 && (fabs(x1 - x3) < delta))) {
         t0Factor = 1;
         t = 1.5 * t3 - t4 + t1 / 2.;
-        hT134LRR->Fill(t);
+        hist.hT134LRR->Fill(t);
       } else if ((type == "LRL" && theSegDir == R && (fabs(x1 - x3) < delta)) ||
                  (type == "RLR" && theSegDir == L && (fabs(x1 - x3) < delta))) {
         t0Factor = 3;
         t = 1.5 * t3 + t4 + t1 / 2.;
-        hT134LRLR->Fill(t);
+        hist.hT134LRLR->Fill(t);
       } else if ((type == "LRL" && theSegDir == L && (fabs(x1 - x3) < (2. * halfCell + delta))) ||
                  (type == "RLR" && theSegDir == R && (fabs(x1 - x3) < (2. * halfCell + delta)))) {
         t0Factor = 99;  // it's actually 1.5, but this value it's not used
         t = 3. / 4. * t3 + t4 / 2. + t1 / 4.;
         sigma = r78;
-        hT134LRLL->Fill(t);
+        hist.hT134LRLL->Fill(t);
       } else if ((type == "LLL" && theSegDir == L && x1 > x4 && (fabs(x1 - x3) < delta)) ||
                  (type == "RRR" && theSegDir == R && x1 < x4 && (fabs(x1 - x3) < delta))) {
         t0Factor = 0;
         t = 1.5 * t3 - t4 - t1 / 2.;
-        hT134LLLL->Fill(t);
+        hist.hT134LLLL->Fill(t);
       } else if ((type == "LLL" && theSegDir == R && (fabs(x1 - x3) < delta)) ||
                  (type == "RRR" && theSegDir == L && (fabs(x1 - x3) < delta))) {
         t0Factor = 0;
         t = -1.5 * t3 + t4 + t1 / 2.;
-        hT134LLLR->Fill(t);
+        hist.hT134LLLR->Fill(t);
       } else {
         t = -1;
         sigma = noR;
-        hT134Bad->Fill(t);
+        hist.hT134Bad->Fill(t);
       }
       theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
       if (debug)
@@ -278,19 +279,19 @@ DTTMax::DTTMax(const vector<DTRecHit1D>& hits,
       if ((type == "LRL") || (type == "RLR")) {
         t0Factor = 2;
         t = (t2 + t4) / 2. + t3;
-        hT234LRL->Fill(t);
+        hist.hT234LRL->Fill(t);
       } else if ((type == "LRR" && theSegDir == R) || (type == "RLL" && theSegDir == L)) {
         t0Factor = 1;
         t = (t2 - t4) / 2. + t3;
-        hT234LRR->Fill(t);
+        hist.hT234LRR->Fill(t);
       } else if ((type == "LLR" && theSegDir == R) || (type == "RRL" && theSegDir == L)) {
         t0Factor = 1;
         t = (t4 - t2) / 2. + t3;
-        hT234LLR->Fill(t);
+        hist.hT234LLR->Fill(t);
       } else {
         t = -1;
         sigma = noR;
-        hT234Bad->Fill(t);
+        hist.hT234Bad->Fill(t);
       }
       theTMaxes[cGroup] = new TMax(t, cGroup, type, sigma, t0Factor, hSubGroup);
       if (debug)


### PR DESCRIPTION
#### PR description:

Moved the histograms to a class that is shared between the two
uses of the histograms.

This was found by the static analyzer.
#### PR validation:

The code compiles.