### PR TITLE
Return HitRZCompatibility and TrackingRegion by unique_ptr in TrackingRegion

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
@@ -119,7 +119,7 @@ void HitPairGeneratorFromLayerPairForPhotonConversion::hitPairs(const Conversion
     if (phiRange.empty()) continue;
     */
 
-    const HitRZCompatibility* checkRZ = region.checkRZ(innerLayerObj.detLayer(), ohit, es);
+    std::unique_ptr<const HitRZCompatibility> checkRZ = region.checkRZ(innerLayerObj.detLayer(), ohit, es);
     if (!checkRZ) {
 #ifdef mydebug_Seed
       ss << "*******\nNo valid checkRZ\n*******" << std::endl;
@@ -180,10 +180,6 @@ void HitPairGeneratorFromLayerPairForPhotonConversion::hitPairs(const Conversion
           result.resize(oldSize);
 #ifdef mydebug_Seed
           edm::LogError("TooManySeeds") << "number of pairs exceed maximum, no pairs produced";
-#endif
-          delete checkRZ;
-
-#ifdef mydebug_Seed
           std::cout << ss.str();
 #endif
           return;
@@ -191,7 +187,6 @@ void HitPairGeneratorFromLayerPairForPhotonConversion::hitPairs(const Conversion
         result.push_back(OrderedHitPair(*ih, ohit));
       }
     }
-    delete checkRZ;
   }
 
 #ifdef mydebug_Seed

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -83,18 +83,18 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
-  HitRZCompatibility* checkRZ(const DetLayer* layer,
-                              const Hit& outerHit,
-                              const edm::EventSetup& iSetup,
-                              const DetLayer* outerlayer = nullptr,
-                              float lr = 0,
-                              float gz = 0,
-                              float dr = 0,
-                              float dz = 0) const override {
+  std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
+                                              const Hit& outerHit,
+                                              const edm::EventSetup& iSetup,
+                                              const DetLayer* outerlayer = nullptr,
+                                              float lr = 0,
+                                              float gz = 0,
+                                              float dr = 0,
+                                              float dz = 0) const override {
     return nullptr;
   }
 
-  CosmicTrackingRegion* clone() const override { return new CosmicTrackingRegion(*this); }
+  std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<CosmicTrackingRegion>(*this); }
 
   std::string name() const override { return "CosmicTrackingRegion"; }
 

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -131,7 +131,7 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
     if (phiRange.empty())
       continue;
 
-    const HitRZCompatibility* checkRZ =
+    std::unique_ptr<const HitRZCompatibility> checkRZ =
         region.checkRZ(&innerHitDetLayer,
                        ohit,
                        iSetup,
@@ -157,15 +157,15 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
       bool ok[e - b];
       switch (checkRZ->algo()) {
         case (HitRZCompatibility::zAlgo):
-          std::get<0>(kernels).set(checkRZ);
+          std::get<0>(kernels).set(checkRZ.get());
           std::get<0>(kernels)(b, e, innerHitsMap, ok);
           break;
         case (HitRZCompatibility::rAlgo):
-          std::get<1>(kernels).set(checkRZ);
+          std::get<1>(kernels).set(checkRZ.get());
           std::get<1>(kernels)(b, e, innerHitsMap, ok);
           break;
         case (HitRZCompatibility::etaAlgo):
-          std::get<2>(kernels).set(checkRZ);
+          std::get<2>(kernels).set(checkRZ.get());
           std::get<2>(kernels)(b, e, innerHitsMap, ok);
           break;
       }
@@ -175,13 +175,11 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
         if (theMaxElement != 0 && result.size() >= theMaxElement) {
           result.clear();
           edm::LogError("TooManyPairs") << "number of pairs exceed maximum, no pairs produced";
-          delete checkRZ;
           return;
         }
         result.add(b + i, io);
       }
     }
-    delete checkRZ;
   }
   LogDebug("HitPairGeneratorFromLayerPair") << " total number of pairs provided back: " << result.size();
   result.shrink_to_fit();

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -43,16 +43,16 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
-  HitRZCompatibility* checkRZ(const DetLayer* layer,
-                              const Hit& outerHit,
-                              const edm::EventSetup& iSetup,
-                              const DetLayer* outerlayer = nullptr,
-                              float lr = 0,
-                              float gz = 0,
-                              float dr = 0,
-                              float dz = 0) const override;
+  std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
+                                              const Hit& outerHit,
+                                              const edm::EventSetup& iSetup,
+                                              const DetLayer* outerlayer = nullptr,
+                                              float lr = 0,
+                                              float gz = 0,
+                                              float dr = 0,
+                                              float dz = 0) const override;
 
-  GlobalTrackingRegion* clone() const override { return new GlobalTrackingRegion(*this); }
+  std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<GlobalTrackingRegion>(*this); }
 
   std::string name() const override { return "GlobalTrackingRegion"; }
   std::string print() const override;

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -175,27 +175,29 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
-  HitRZCompatibility* checkRZ(const DetLayer* layer,
-                              const Hit& outerHit,
-                              const edm::EventSetup& iSetup,
-                              const DetLayer* outerlayer = nullptr,
-                              float lr = 0,
-                              float gz = 0,
-                              float dr = 0,
-                              float dz = 0) const override {
+  std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
+                                              const Hit& outerHit,
+                                              const edm::EventSetup& iSetup,
+                                              const DetLayer* outerlayer = nullptr,
+                                              float lr = 0,
+                                              float gz = 0,
+                                              float dr = 0,
+                                              float dz = 0) const override {
     return checkRZOld(layer, outerHit, iSetup, outerlayer);
   }
 
-  RectangularEtaPhiTrackingRegion* clone() const override { return new RectangularEtaPhiTrackingRegion(*this); }
+  std::unique_ptr<TrackingRegion> clone() const override {
+    return std::make_unique<RectangularEtaPhiTrackingRegion>(*this);
+  }
 
   std::string name() const override { return "RectangularEtaPhiTrackingRegion"; }
   std::string print() const override;
 
 private:
-  HitRZCompatibility* checkRZOld(const DetLayer* layer,
-                                 const Hit& outerHit,
-                                 const edm::EventSetup& iSetup,
-                                 const DetLayer* outerlayer) const;
+  std::unique_ptr<HitRZCompatibility> checkRZOld(const DetLayer* layer,
+                                                 const Hit& outerHit,
+                                                 const edm::EventSetup& iSetup,
+                                                 const DetLayer* outerlayer) const;
 
   std::unique_ptr<MeasurementEstimator> estimator(const BarrelDetLayer* layer,
                                                   const edm::EventSetup& iSetup) const dso_internal;

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -22,11 +22,9 @@
 #include <utility>
 
 #include <sstream>
-
+#include <memory>
 #include <vector>
 #include <string>
-
-#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 class DetLayer;
 class HitRZCompatibility;
@@ -86,30 +84,30 @@ public:
 
   /// utility to check eta/theta hit compatibility with region constraints
   /// and outer hit constraint
-  virtual HitRZCompatibility* checkRZ(const DetLayer* layer,
-                                      const Hit& outerHit,
-                                      const edm::EventSetup& iSetup,
-                                      const DetLayer* outerlayer = nullptr,
-                                      float lr = 0,
-                                      float gz = 0,
-                                      float dr = 0,
-                                      float dz = 0) const = 0;
+  virtual std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
+                                                      const Hit& outerHit,
+                                                      const edm::EventSetup& iSetup,
+                                                      const DetLayer* outerlayer = nullptr,
+                                                      float lr = 0,
+                                                      float gz = 0,
+                                                      float dr = 0,
+                                                      float dz = 0) const = 0;
 
   /// get hits from layer compatible with region constraints
   virtual Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
 
   /// clone region with new vertex position
-  TrackingRegion* restrictedRegion(const GlobalPoint& originPos,
-                                   const float& originRBound,
-                                   const float& originZBound) const {
-    TrackingRegion* restr = clone();
+  std::unique_ptr<TrackingRegion> restrictedRegion(const GlobalPoint& originPos,
+                                                   const float& originRBound,
+                                                   const float& originZBound) const {
+    auto restr = clone();
     restr->theVertexPos = originPos;
     restr->theVertexRBound = originRBound;
     restr->theVertexZBound = originZBound;
     return restr;
   }
 
-  virtual TrackingRegion* clone() const = 0;
+  virtual std::unique_ptr<TrackingRegion> clone() const = 0;
 
   virtual std::string name() const { return "TrackingRegion"; }
   virtual std::string print() const {

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -68,10 +68,10 @@ void RectangularEtaPhiTrackingRegion::initEtaRange(const GlobalVector& dir, cons
   theMeanLambda = std::sinh(theEtaRange.mean());
 }
 
-HitRZCompatibility* RectangularEtaPhiTrackingRegion::checkRZOld(const DetLayer* layer,
-                                                                const Hit& outerHit,
-                                                                const edm::EventSetup& iSetup,
-                                                                const DetLayer* outerlayer) const {
+std::unique_ptr<HitRZCompatibility> RectangularEtaPhiTrackingRegion::checkRZOld(const DetLayer* layer,
+                                                                                const Hit& outerHit,
+                                                                                const edm::EventSetup& iSetup,
+                                                                                const DetLayer* outerlayer) const {
   bool isBarrel = (layer->location() == GeomDetEnumerators::barrel);
   GlobalPoint ohit = outerHit->globalPosition();
   float outerred_r = std::sqrt(sqr(ohit.x() - origin().x()) + sqr(ohit.y() - origin().y()));
@@ -87,7 +87,7 @@ HitRZCompatibility* RectangularEtaPhiTrackingRegion::checkRZOld(const DetLayer* 
                                              : (outer.z() - zMinOrigin) / (outer.r() + originRBound());
     float cotRight = std::max(vcotMin, theLambdaRange.min());
     float cotLeft = std::min(vcotMax, theLambdaRange.max());
-    return new HitEtaCheck(isBarrel, outer, cotLeft, cotRight);
+    return std::make_unique<HitEtaCheck>(isBarrel, outer, cotLeft, cotRight);
   }
 
   float outerZscatt = 0;
@@ -129,11 +129,11 @@ HitRZCompatibility* RectangularEtaPhiTrackingRegion::checkRZOld(const DetLayer* 
   if (isBarrel) {
     auto sinThetaInv = std::sqrt(1.f + sqr(cotTheta));
     auto corr = innerScatt * sinThetaInv;
-    return new HitZCheck(rzConstraint, HitZCheck::Margin(corr, corr));
+    return std::make_unique<HitZCheck>(rzConstraint, HitZCheck::Margin(corr, corr));
   } else {
     auto cosThetaInv = std::sqrt(1.f + sqr(1.f / cotTheta));
     auto corr = innerScatt * cosThetaInv;
-    return new HitRCheck(rzConstraint, HitRCheck::Margin(corr, corr));
+    return std::make_unique<HitRCheck>(rzConstraint, HitRCheck::Margin(corr, corr));
   }
 }
 


### PR DESCRIPTION
#### PR description:

Returning by `unique_ptr` makes the ownership clear, guarantees deletion, and silences static analyzer warnings.

#### PR validation:

Code compiles.