### PR TITLE
Return ClusterParam by unique_ptr in PixelCPE

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -147,7 +147,7 @@ public:
 #endif
 
     DetParam const& theDetParam = detParam(det);
-    ClusterParam* theClusterParam = createClusterParam(cl);
+    std::unique_ptr<ClusterParam> theClusterParam = createClusterParam(cl);
     setTheClu(theDetParam, *theClusterParam);
     computeAnglesFromDetPosition(theDetParam, *theClusterParam);
 
@@ -156,7 +156,6 @@ public:
     LocalError le = localError(theDetParam, *theClusterParam);
     SiPixelRecHitQuality::QualWordType rqw = rawQualityWord(*theClusterParam);
     auto tuple = std::make_tuple(lp, le, rqw);
-    delete theClusterParam;
 
     //std::cout<<" in PixelCPEBase:localParameters(all) - "<<lp.x()<<" "<<lp.y()<<std::endl;  //dk
     return tuple;
@@ -174,7 +173,7 @@ public:
 #endif
 
     DetParam const& theDetParam = detParam(det);
-    ClusterParam* theClusterParam = createClusterParam(cl);
+    std::unique_ptr<ClusterParam> theClusterParam = createClusterParam(cl);
     setTheClu(theDetParam, *theClusterParam);
     computeAnglesFromTrajectory(theDetParam, *theClusterParam, ltp);
 
@@ -183,14 +182,13 @@ public:
     LocalError le = localError(theDetParam, *theClusterParam);
     SiPixelRecHitQuality::QualWordType rqw = rawQualityWord(*theClusterParam);
     auto tuple = std::make_tuple(lp, le, rqw);
-    delete theClusterParam;
 
     //std::cout<<" in PixelCPEBase:localParameters(on track) - "<<lp.x()<<" "<<lp.y()<<std::endl;  //dk
     return tuple;
   }
 
 private:
-  virtual ClusterParam* createClusterParam(const SiPixelCluster& cl) const = 0;
+  virtual std::unique_ptr<ClusterParam> createClusterParam(const SiPixelCluster& cl) const = 0;
 
   //--------------------------------------------------------------------------
   // This is where the action happens.

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -64,7 +64,7 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
-  ClusterParam *createClusterParam(const SiPixelCluster &cl) const override;
+  std::unique_ptr<ClusterParam> createClusterParam(const SiPixelCluster &cl) const override;
 
   // Calculate local position.  (Calls TemplateReco)
   LocalPoint localPosition(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -89,7 +89,7 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
-  ClusterParam *createClusterParam(const SiPixelCluster &cl) const override;
+  std::unique_ptr<ClusterParam> createClusterParam(const SiPixelCluster &cl) const override;
 
   LocalPoint localPosition(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;
   LocalError localError(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -63,7 +63,7 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription &desc);
 
 private:
-  ClusterParam *createClusterParam(const SiPixelCluster &cl) const override;
+  std::unique_ptr<ClusterParam> createClusterParam(const SiPixelCluster &cl) const override;
 
   // We only need to implement measurementPosition, since localPosition() from
   // PixelCPEBase will call it and do the transformation

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -162,8 +162,8 @@ PixelCPEClusterRepair::~PixelCPEClusterRepair() {
     x.destroy();
 }
 
-PixelCPEBase::ClusterParam* PixelCPEClusterRepair::createClusterParam(const SiPixelCluster& cl) const {
-  return new ClusterParamTemplate(cl);
+std::unique_ptr<PixelCPEBase::ClusterParam> PixelCPEClusterRepair::createClusterParam(const SiPixelCluster& cl) const {
+  return std::make_unique<ClusterParamTemplate>(cl);
 }
 
 //------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -143,8 +143,8 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const& conf,
   }
 }
 
-PixelCPEBase::ClusterParam* PixelCPEGeneric::createClusterParam(const SiPixelCluster& cl) const {
-  return new ClusterParamGeneric(cl);
+std::unique_ptr<PixelCPEBase::ClusterParam> PixelCPEGeneric::createClusterParam(const SiPixelCluster& cl) const {
+  return std::make_unique<ClusterParamGeneric>(cl);
 }
 
 //-----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -99,8 +99,8 @@ PixelCPETemplateReco::~PixelCPETemplateReco() {
     x.destroy();
 }
 
-PixelCPEBase::ClusterParam* PixelCPETemplateReco::createClusterParam(const SiPixelCluster& cl) const {
-  return new ClusterParamTemplate(cl);
+std::unique_ptr<PixelCPEBase::ClusterParam> PixelCPETemplateReco::createClusterParam(const SiPixelCluster& cl) const {
+  return std::make_unique<ClusterParamTemplate>(cl);
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

Returning by `unique_ptr` makes the ownership clear, guarantees deletion, and silences static analyzer warnings.

#### PR validation:

Code compiles.