### PR TITLE
esConsumes migration, 4 more modules

### DIFF
--- a/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
+++ b/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
@@ -5,9 +5,11 @@
 #include <vector>
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
-class MagneticField;
 class Trajectory;
 
 namespace edm {
@@ -104,7 +106,6 @@ public:
     std::vector<AVHitStruct> hits;
   };
 
-  TrackerValidationVariables();
   TrackerValidationVariables(const edm::ParameterSet& config, edm::ConsumesCollector&& iC);
   ~TrackerValidationVariables();
 
@@ -120,6 +121,7 @@ public:
 private:
   edm::EDGetTokenT<std::vector<Trajectory>> trajCollectionToken_;
   edm::EDGetTokenT<std::vector<reco::Track>> tracksToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.h
@@ -8,9 +8,19 @@
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityFromDbRcd.h"
+
 // Pixel quality harvester
 #include "CalibTracker/SiPixelQuality/interface/SiPixelStatusManager.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 // PixelDQM Framework
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
 // PixelPhase1 HelperClass
@@ -34,9 +44,9 @@ public:
   // Operations
   void beginJob() override;
   void endJob() override;
-  void bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&, edm::EventSetup const& iSetup) final;
+  void bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&, const edm::EventSetup&) final;
   void dqmEndRun(const edm::Run&, const edm::EventSetup&) final;
-  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) final;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup&) final;
 
   void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
   void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
@@ -72,6 +82,11 @@ private:
 
   // pixel online to offline pixel row/column
   std::map<int, std::map<int, std::pair<int, int> > > pixelO2O_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapToken_;
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityFromDbRcd> siPixelQualityToken_;
 
   //Helper functions
   std::vector<std::string> substructures;

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -15,6 +15,8 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
 // Pixel data format
 #include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
@@ -26,6 +28,7 @@ ________________________________________________________________**/
 #include "DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 class SiPixelStatusProducer
@@ -37,10 +40,10 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
-  void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) final;
-  void accumulate(edm::Event const&, const edm::EventSetup& iSetup) final;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup&) final;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup&) final;
+  void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) final;
+  void accumulate(edm::Event const&, const edm::EventSetup&) final;
 
   virtual void onlineRocColRow(const DetId& detId, int offlineRow, int offlineCol, int& roc, int& row, int& col) final;
 
@@ -59,14 +62,18 @@ private:
   // condition watchers
   // CablingMaps
   edm::ESWatcher<SiPixelFedCablingMapRcd> siPixelFedCablingMapWatcher_;
-  edm::ESHandle<SiPixelFedCablingMap> fCablingMap;
-  const SiPixelFedCablingMap* fCablingMap_;
+  const SiPixelFedCablingMap* fCablingMap_ = nullptr;
 
   // TrackerDIGIGeo
   edm::ESWatcher<TrackerDigiGeometryRecord> trackerDIGIGeoWatcher_;
-  edm::ESHandle<TrackerGeometry> fTG;
+  const TrackerGeometry* trackerGeometry_ = nullptr;
+
   // TrackerTopology
   edm::ESWatcher<TrackerTopologyRcd> trackerTopoWatcher_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapToken_;
 
   // SiPixel offline<->online conversion
   // -- map (for each detid) of the map from offline col/row to the online roc/col/row

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h
@@ -3,22 +3,22 @@
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
 #include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "CondFormats/SiPixelObjects/interface/ElectronicIndex.h"
 #include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include <cstdint>
 
-class SiPixelFedCablingMap;
+#include <cstdint>
+#include <map>
+#include <vector>
+
+class TrackerGeometry;
 
 class SiPixelFrameReverter {
 public:
-  SiPixelFrameReverter(const edm::EventSetup&, const SiPixelFedCabling* map);
+  SiPixelFrameReverter(const SiPixelFedCabling* map);
 
-  void buildStructure(edm::EventSetup const&);
+  void buildStructure(const TrackerGeometry*);
 
   // Function to test if detId exists
   bool hasDetUnit(uint32_t detId) const { return (DetToFedMap.find(detId) != DetToFedMap.end()); }

--- a/CondFormats/SiPixelObjects/interface/SiPixelQuality.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelQuality.h
@@ -22,10 +22,6 @@
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
 #include "CondFormats/SiStripObjects/interface/SiStripDetVOff.h"
 
-namespace edm {
-  class EventSetup;
-}
-
 class TrackerGeometry;
 
 class SiPixelQuality {
@@ -93,11 +89,7 @@ public:
   bool IsModuleBad(const uint32_t& detid) const;                   //returns True if module disabled
   bool IsModuleUsable(const uint32_t& detid) const;                //returns True if module NOT disabled
   bool IsRocBad(const uint32_t& detid, const short& rocNb) const;  //returns True if ROC is disabled
-  bool IsAreaBad(uint32_t detid,
-                 sipixelobjects::GlobalPixel global,
-                 const edm::EventSetup& es,
-                 const SiPixelFedCabling* map) const;
-  short getBadRocs(const uint32_t& detid) const;  //returns bad Rocs for given DetId
+  short getBadRocs(const uint32_t& detid) const;                   //returns bad Rocs for given DetId
   //each bad roc correspond to a bit to 1: num=
   //0 <-> all good rocs
   //1 <-> only roc 0 bad

--- a/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFrameReverter.cc
@@ -1,5 +1,4 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
 #include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDLink.h"
@@ -12,30 +11,17 @@
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 // Geometry
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include <sstream>
 
 using namespace std;
 using namespace sipixelobjects;
 
-SiPixelFrameReverter::SiPixelFrameReverter(const edm::EventSetup& iSetup, const SiPixelFedCabling* map)
-    : map_(map), DetToFedMap(map->det2PathMap()) {
-  // Build map
-  // buildStructure(iSetup);
-}
+SiPixelFrameReverter::SiPixelFrameReverter(const SiPixelFedCabling* map) : map_(map), DetToFedMap(map->det2PathMap()) {}
 
-void SiPixelFrameReverter::buildStructure(const edm::EventSetup& iSetup) {
+void SiPixelFrameReverter::buildStructure(const TrackerGeometry* trackerGeometry) {
   // Create map connecting each detId to appropriate SiPixelFrameConverter
-
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-
-  for (auto it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
+  for (auto it = trackerGeometry->dets().begin(); it != trackerGeometry->dets().end(); it++) {
     if (dynamic_cast<PixelGeomDetUnit const*>((*it)) != nullptr) {
       DetId detId = (*it)->geographicalId();
       uint32_t id = detId();

--- a/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelQuality.cc
@@ -121,18 +121,6 @@ bool SiPixelQuality::IsRocBad(const uint32_t& detid, const short& rocNb) const {
   return false;
 }
 
-bool SiPixelQuality::IsAreaBad(uint32_t detid,
-                               sipixelobjects::GlobalPixel global,
-                               const edm::EventSetup& es,
-                               const SiPixelFedCabling* map) const {
-  SiPixelFrameReverter reverter(es, map);
-  int rocfromarea = -1;
-  rocfromarea = reverter.findRocInDet(detid, global);
-
-  return SiPixelQuality::IsRocBad(detid, rocfromarea);
-  return false;
-}
-
 //ask for bad ROCS
 
 short SiPixelQuality::getBadRocs(const uint32_t& detid) const {

--- a/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
+++ b/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
@@ -18,6 +18,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -44,7 +45,9 @@ public:
   // this should always be faster). Most ops turned out to be not needed.
   typedef std::vector<std::pair<Column, Value>> Values;
 
-  GeometryInterface(const edm::ParameterSet&, edm::ConsumesCollector&&);
+  GeometryInterface(const edm::ParameterSet&,
+                    edm::ConsumesCollector&&,
+                    edm::Transition transition = edm::Transition::BeginRun);
 
   bool loaded() { return is_loaded; };
 

--- a/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
+++ b/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
@@ -13,8 +13,17 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <functional>
 #include <map>
@@ -35,7 +44,7 @@ public:
   // this should always be faster). Most ops turned out to be not needed.
   typedef std::vector<std::pair<Column, Value>> Values;
 
-  GeometryInterface(const edm::ParameterSet& conf) : iConfig(conf){};
+  GeometryInterface(const edm::ParameterSet&, edm::ConsumesCollector&&);
 
   bool loaded() { return is_loaded; };
 
@@ -115,13 +124,29 @@ public:
   std::string formatValue(Column, Value);
 
 private:
-  void loadFromTopology(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig);
-  void loadFromSiPixelCoordinates(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig);
-  void loadTimebased(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig);
-  void loadModuleLevel(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig);
-  void loadFEDCabling(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig);
+  void loadFromTopology(const TrackerGeometry&, const TrackerTopology&, const edm::ParameterSet&);
+  void loadFromSiPixelCoordinates(const TrackerGeometry&,
+                                  const TrackerTopology&,
+                                  const SiPixelFedCablingMap&,
+                                  const edm::ParameterSet&);
+  void loadTimebased(const edm::ParameterSet& iConfig);
+  void loadModuleLevel(const edm::ParameterSet& iConfig);
+  void loadFEDCabling(const SiPixelFedCablingMap*);
 
   const edm::ParameterSet iConfig;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
+  // When converting this module to use esConsumes I preserved the previous behavior.
+  // In one place a configurable label is allowed when getting SiPixelFedCablingMap
+  // and in another place it always assumes an empty label. I am not sure if this is
+  // actually correct (seems strange). Maybe it does not matter as in all the configurations
+  // I could find in the repository the parameter was an empty string... An expert who
+  // understands this might want to fix this or eliminate this comment if the behavior is
+  // correct.
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapToken_;
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> labeledSiPixelFedCablingMapToken_;
+  std::string cablingMapLabel_;
 
   bool is_loaded = false;
 

--- a/DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h
+++ b/DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h
@@ -19,17 +19,18 @@
 //
 // Original Author: Janos Karancsi
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
-
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
 
 class SiPixelCoordinates {
 public:
@@ -37,7 +38,7 @@ public:
   SiPixelCoordinates(int);
   virtual ~SiPixelCoordinates();
 
-  void init(edm::EventSetup const&);
+  void init(const TrackerTopology*, const TrackerGeometry*, const SiPixelFedCablingMap*);
 
   // Integers
   int quadrant(const DetId&);

--- a/DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h
+++ b/DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h
@@ -19,13 +19,14 @@
 
 #include "DQM/SiPixelPhase1Common/interface/HistogramManager.h"
 
+#include <utility>
 #include <vector>
 
 // used as a mixin for Analyzer and Harvester.
 class HistogramManagerHolder {
 public:
-  HistogramManagerHolder(const edm::ParameterSet& iConfig)
-      : geometryInterface(iConfig.getParameter<edm::ParameterSet>("geometry")) {
+  HistogramManagerHolder(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+      : geometryInterface(iConfig.getParameter<edm::ParameterSet>("geometry"), std::move(iC)) {
     auto histograms = iConfig.getParameter<edm::VParameterSet>("histograms");
     for (auto histoconf : histograms) {
       histo.emplace_back(HistogramManager(histoconf, geometryInterface));
@@ -44,17 +45,17 @@ public:
   SiPixelPhase1Base(const edm::ParameterSet& iConfig);
 
   // You should analyze something, and call histoman.fill(...). Setting to pure virtual function
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override = 0;
+  void analyze(edm::Event const& e, edm::EventSetup const&) override = 0;
 
   // This booking is usually fine.
   // Also used to store the required triggers
-  void bookHistograms(DQMStore::IBooker& iBooker, edm::Run const& run, edm::EventSetup const& iSetup) override;
+  void bookHistograms(DQMStore::IBooker& iBooker, edm::Run const& run, edm::EventSetup const&) override;
 
   ~SiPixelPhase1Base() override{};
 
 protected:
   // Returns a value of whether the trigger stored at position "trgidx" is properly fired.
-  bool checktrigger(const edm::Event& iEvent, const edm::EventSetup& iSetup, const unsigned trgidx) const;
+  bool checktrigger(const edm::Event& iEvent, const edm::EventSetup&, const unsigned trgidx) const;
 
   // must match order in TriggerEventFlag_cfi.py
   enum { DCS };
@@ -71,12 +72,13 @@ private:
 // For custom harvesting, you have to derive from this.
 class SiPixelPhase1Harvester : public DQMEDHarvester, public HistogramManagerHolder {
 public:
-  SiPixelPhase1Harvester(const edm::ParameterSet& iConfig) : DQMEDHarvester(), HistogramManagerHolder(iConfig){};
+  SiPixelPhase1Harvester(const edm::ParameterSet& iConfig)
+      : DQMEDHarvester(), HistogramManagerHolder(iConfig, consumesCollector()){};
 
   void dqmEndLuminosityBlock(DQMStore::IBooker& iBooker,
                              DQMStore::IGetter& iGetter,
                              edm::LuminosityBlock const& lumiBlock,
-                             edm::EventSetup const& eSetup) override;
+                             edm::EventSetup const&) override;
   void dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) override;
 };
 #endif

--- a/DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h
+++ b/DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h
@@ -15,6 +15,7 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
 #include "DQM/SiPixelPhase1Common/interface/HistogramManager.h"
@@ -25,8 +26,10 @@
 // used as a mixin for Analyzer and Harvester.
 class HistogramManagerHolder {
 public:
-  HistogramManagerHolder(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
-      : geometryInterface(iConfig.getParameter<edm::ParameterSet>("geometry"), std::move(iC)) {
+  HistogramManagerHolder(const edm::ParameterSet& iConfig,
+                         edm::ConsumesCollector&& iC,
+                         edm::Transition transition = edm::Transition::BeginRun)
+      : geometryInterface(iConfig.getParameter<edm::ParameterSet>("geometry"), std::move(iC), transition) {
     auto histograms = iConfig.getParameter<edm::VParameterSet>("histograms");
     for (auto histoconf : histograms) {
       histo.emplace_back(HistogramManager(histoconf, geometryInterface));
@@ -73,7 +76,7 @@ private:
 class SiPixelPhase1Harvester : public DQMEDHarvester, public HistogramManagerHolder {
 public:
   SiPixelPhase1Harvester(const edm::ParameterSet& iConfig)
-      : DQMEDHarvester(), HistogramManagerHolder(iConfig, consumesCollector()){};
+      : DQMEDHarvester(), HistogramManagerHolder(iConfig, consumesCollector(), edm::Transition::EndLuminosityBlock){};
 
   void dqmEndLuminosityBlock(DQMStore::IBooker& iBooker,
                              DQMStore::IGetter& iGetter,

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1Clusters.cc
@@ -10,8 +10,8 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
@@ -49,9 +49,11 @@ namespace {
   private:
     edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> pixelSrcToken_;
     edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> stripSrcToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
   };
 
-  SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig) : SiPixelPhase1Base(iConfig) {
+  SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig)
+      : SiPixelPhase1Base(iConfig), trackerGeometryToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()) {
     pixelSrcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("pixelSrc"));
 
     stripSrcToken_ = consumes<edmNew::DetSetVector<SiStripCluster>>(iConfig.getParameter<edm::InputTag>("stripSrc"));
@@ -79,15 +81,13 @@ namespace {
 
     bool hasClusters = false;
 
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
-    assert(tracker.isValid());
+    const TrackerGeometry& tracker = iSetup.getData(trackerGeometryToken_);
 
     edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
     for (it = inputPixel->begin(); it != inputPixel->end(); ++it) {
       auto id = DetId(it->detId());
 
-      const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*>(tracker->idToDet(id));
+      const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*>(tracker.idToDet(id));
       const PixelTopology& topol = theGeomDet->specificTopology();
 
       for (SiPixelCluster const& cluster : *it) {

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -15,17 +15,13 @@
 // edm stuff
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
 // Tracker Geometry/Topology  stuff
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
 
 // Pixel names
@@ -41,13 +37,36 @@
 
 const GeometryInterface::Value GeometryInterface::UNDEFINED = 999999999.9f;
 
+GeometryInterface::GeometryInterface(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC)
+    : iConfig(conf),
+      trackerGeometryToken_{iC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()},
+      trackerTopologyToken_{iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()},
+      siPixelFedCablingMapToken_{
+          iC.esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd, edm::Transition::BeginRun>()},
+      cablingMapLabel_{conf.getParameter<std::string>("CablingMapLabel")} {
+  if (!cablingMapLabel_.empty()) {
+    labeledSiPixelFedCablingMapToken_ =
+        iC.esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd, edm::Transition::BeginRun>(
+            edm::ESInputTag("", cablingMapLabel_));
+  }
+}
+
 void GeometryInterface::load(edm::EventSetup const& iSetup) {
+  const TrackerGeometry& trackerGeometry = iSetup.getData(trackerGeometryToken_);
+  const TrackerTopology& trackerTopology = iSetup.getData(trackerTopologyToken_);
+  const SiPixelFedCablingMap& siPixelFedCablingMap = iSetup.getData(siPixelFedCablingMapToken_);
+
+  const SiPixelFedCablingMap* labeledSiPixelFedCablingMap = &siPixelFedCablingMap;
+  if (!cablingMapLabel_.empty()) {
+    labeledSiPixelFedCablingMap = &iSetup.getData(labeledSiPixelFedCablingMapToken_);
+  }
+
   //loadFromAlignment(iSetup, iConfig);
-  loadFromTopology(iSetup, iConfig);
-  loadTimebased(iSetup, iConfig);
-  loadModuleLevel(iSetup, iConfig);
-  loadFEDCabling(iSetup, iConfig);
-  loadFromSiPixelCoordinates(iSetup, iConfig);
+  loadFromTopology(trackerGeometry, trackerTopology, iConfig);
+  loadTimebased(iConfig);
+  loadModuleLevel(iConfig);
+  loadFEDCabling(labeledSiPixelFedCablingMap);
+  loadFromSiPixelCoordinates(trackerGeometry, trackerTopology, siPixelFedCablingMap, iConfig);
   edm::LogInfo log("GeometryInterface");
   log << "Known colum names:\n";
   for (auto e : ids)
@@ -56,12 +75,9 @@ void GeometryInterface::load(edm::EventSetup const& iSetup) {
   is_loaded = true;
 }
 
-void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig) {
-  // Get a Topology
-  edm::ESHandle<TrackerTopology> trackerTopologyHandle;
-  iSetup.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
-  assert(trackerTopologyHandle.isValid());
-
+void GeometryInterface::loadFromTopology(const TrackerGeometry& trackerGeometry,
+                                         const TrackerTopology& trackerTopology,
+                                         const edm::ParameterSet& iConfig) {
   std::vector<ID> geomquantities;
 
   struct TTField {
@@ -75,7 +91,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
     };
   };
 
-  const TrackerTopology* tt = trackerTopologyHandle.operator->();
+  const TrackerTopology* tt = &trackerTopology;
 
   std::vector<std::pair<std::string, TTField>> namedPartitions{
       {"PXEndcap", {tt, TrackerTopology::PFSide}},
@@ -132,13 +148,8 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   int phase = iConfig.getParameter<int>("upgradePhase");
   bool isUpgrade = phase == 1;
 
-  // Get a Geometry
-  edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
-  assert(trackerGeometryHandle.isValid());
-
   // Now traverse the detector and collect whatever we need.
-  auto detids = trackerGeometryHandle->detIds();
+  auto detids = trackerGeometry.detIds();
   for (DetId id : detids) {
     if (id.subdetId() != PixelSubdetector::PixelBarrel && id.subdetId() != PixelSubdetector::PixelEndcap)
       continue;
@@ -157,7 +168,7 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
 
     // we record each module 4 times, one for each corner, so we also get ROCs
     // in booking (at least for the ranges)
-    const PixelGeomDetUnit* detUnit = dynamic_cast<const PixelGeomDetUnit*>(trackerGeometryHandle->idToDetUnit(id));
+    const PixelGeomDetUnit* detUnit = dynamic_cast<const PixelGeomDetUnit*>(trackerGeometry.idToDetUnit(id));
     assert(detUnit);
     const PixelTopology* topo = &detUnit->specificTopology();
     iq.row = 0;
@@ -175,7 +186,10 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
   }
 }
 
-void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig) {
+void GeometryInterface::loadFromSiPixelCoordinates(const TrackerGeometry& trackerGeometry,
+                                                   const TrackerTopology& trackerTopology,
+                                                   const SiPixelFedCablingMap& siPixelFedCablingMap,
+                                                   const edm::ParameterSet& iConfig) {
   // TODO: SiPixelCoordinates has a large overlap with theis GeometryInterface
   // in general.
   // Rough convention is to use own code for things that are easy and fast to
@@ -191,7 +205,7 @@ void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup
   // note that we should reeinit for each event. But this probably won't explode
   // thanks to the massive memoization in SiPixelCoordinates which is completely
   // initialized while booking.
-  coord->init(iSetup);
+  coord->init(&trackerTopology, &trackerGeometry, &siPixelFedCablingMap);
 
   // SiPixelCoordinates uses a different convention for UNDEFINED:
   auto from_coord = [](double in) { return (in == -9999.0) ? UNDEFINED : Value(in); };
@@ -363,7 +377,7 @@ void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup
   });
 }
 
-void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig) {
+void GeometryInterface::loadTimebased(const edm::ParameterSet& iConfig) {
   // extractors for quantities that are roughly time-based. We cannot book plots based on these; they have to
   // be grouped away in step1.
   addExtractor(
@@ -414,7 +428,7 @@ void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::
       iConfig.getParameter<int>("max_bunchcrossing"));
 }
 
-void GeometryInterface::loadModuleLevel(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig) {
+void GeometryInterface::loadModuleLevel(const edm::ParameterSet& iConfig) {
   // stuff that is within modules. Might require some phase0/phase1/strip switching later
   addExtractor(
       intern("row"),
@@ -428,14 +442,10 @@ void GeometryInterface::loadModuleLevel(edm::EventSetup const& iSetup, const edm
       iConfig.getParameter<int>("module_cols") - 1);
 }
 
-void GeometryInterface::loadFEDCabling(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig) {
-  auto cablingMapLabel = iConfig.getParameter<std::string>("CablingMapLabel");
-  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
-  iSetup.get<SiPixelFedCablingMapRcd>().get(cablingMapLabel, theCablingMap);
-
+void GeometryInterface::loadFEDCabling(const SiPixelFedCablingMap* labeledSiPixelFedCablingMap) {
   std::shared_ptr<SiPixelFrameReverter> siPixelFrameReverter =
       // I think passing the bare pointer here is safe, but who knows...
-      std::make_shared<SiPixelFrameReverter>(iSetup, theCablingMap.operator->());
+      std::make_shared<SiPixelFrameReverter>(labeledSiPixelFedCablingMap);
 
   addExtractor(intern("FED"), [siPixelFrameReverter](InterestingQuantities const& iq) {
     if (iq.sourceModule == 0xFFFFFFFF)

--- a/DQM/SiPixelPhase1Common/src/SiPixelCoordinates.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelCoordinates.cc
@@ -10,8 +10,6 @@
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
@@ -29,22 +27,14 @@ SiPixelCoordinates::~SiPixelCoordinates() {}
 
 // _________________________________________________________
 //       init, called in the beginning of each event
-void SiPixelCoordinates::init(edm::EventSetup const& iSetup) {
-  // Get CablingMap (used for ROC number)
-  edm::ESHandle<SiPixelFedCablingMap> cablingMapHandle;
-  iSetup.get<SiPixelFedCablingMapRcd>().get(cablingMapHandle);
-  cablingMap_ = cablingMapHandle.product();
+void SiPixelCoordinates::init(const TrackerTopology* trackerTopology,
+                              const TrackerGeometry* trackerGeometry,
+                              const SiPixelFedCablingMap* siPixelFedCablingMap) {
+  tTopo_ = trackerTopology;
+  tGeom_ = trackerGeometry;
+  cablingMap_ = siPixelFedCablingMap;
+
   fedid_ = cablingMap_->det2fedMap();
-
-  // Get TrackerTopology
-  edm::ESHandle<TrackerTopology> trackerTopologyHandle;
-  iSetup.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
-  tTopo_ = trackerTopologyHandle.product();
-
-  // Get TrackerGeometry
-  edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
-  tGeom_ = trackerGeometryHandle.product();
 
   // If not specified, determine from the geometry
   if (phase_ == -1) {

--- a/DQM/SiPixelPhase1Common/src/SiPixelPhase1Base.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelPhase1Base.cc
@@ -12,7 +12,7 @@
 // Since constructor of GenericTriggerEventFlag requires
 // EDConsumerBase class protected member calls
 SiPixelPhase1Base::SiPixelPhase1Base(const edm::ParameterSet& iConfig)
-    : DQMEDAnalyzer(), HistogramManagerHolder(iConfig) {
+    : DQMEDAnalyzer(), HistogramManagerHolder(iConfig, consumesCollector()) {
   // Flags will default to empty vector if not specified in configuration file
   auto flags = iConfig.getUntrackedParameter<edm::VParameterSet>("triggerflags", {});
 

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -15,15 +15,22 @@ track residuals on each detector module
 // Author:  Marcel Schneider
 //         Extended to Pixel Residuals.
 #include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
+#include "CalibTracker/SiStripCommon/interface/TkDetMap.h"
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
 #include <fstream>
 #include <memory>
 
@@ -70,6 +77,11 @@ private:
   edm::ParameterSet conf_;
   edm::ParameterSet Parameters;
   edm::EDGetTokenT<reco::VertexCollection> offlinePrimaryVerticesToken_;
+
+  edm::ESGetToken<TkDetMap, TrackerTopologyRcd> tkDetMapToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyRunToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyEventToken_;
 
   unsigned long long m_cacheID_;
   bool ModOn;

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiToRaw.cc
@@ -97,7 +97,7 @@ std::shared_ptr<pr::Cache> SiPixelDigiToRaw::globalBeginLuminosityBlock(edm::Lum
     es.get<SiPixelFedCablingMapRcd>().get(cablingMap);
     previousCache_ = std::make_shared<pr::Cache>();
     previousCache_->cablingTree_ = cablingMap->cablingTree();
-    previousCache_->frameReverter_ = std::make_unique<SiPixelFrameReverter>(es, cablingMap.product());
+    previousCache_->frameReverter_ = std::make_unique<SiPixelFrameReverter>(cablingMap.product());
   }
   return previousCache_;
 }


### PR DESCRIPTION
#### PR description:

Migrates MonitorTrackResiduals, SiPixelPhase1Clusters,
SiPixelStatusHarvestor, and SiPixelStatusProducer.

Deletes SiPixelQuality::IsAreaBad which was not used
anywhere in the repository and was causing problems with
the way it used the EventSetup. I could restore this function
if it is actually needed.

Note GeometryInterface gets SiPixelFedCablingMap in somewhat
inconsistent ways, one way allows a label but the other doesn't.
I preserved the current behavior (probably harmless), but
I could modify this if someone understands what it should be
doing here.

#### PR validation:

Relies on existing tests. Results should be unchanged. There is no new functionality.
