### PR TITLE
add mising resets for a couple of vectors in TrackingNtuple

### DIFF
--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1942,6 +1942,7 @@ void TrackingNtuple::clearVariables() {
   see_stopReason.clear();
   see_nCands.clear();
   see_trkIdx.clear();
+  see_isTrue.clear();
   see_bestSimTrkIdx.clear();
   see_bestSimTrkShareFrac.clear();
   see_bestFromFirstHitSimTrkIdx.clear();
@@ -1969,6 +1970,7 @@ void TrackingNtuple::clearVariables() {
   // Tracking vertices
   simvtx_event.clear();
   simvtx_bunchCrossing.clear();
+  simvtx_processType.clear();
   simvtx_x.clear();
   simvtx_y.clear();
   simvtx_z.clear();


### PR DESCRIPTION
I found a problem originally with ```simvtx_processType``` when ntuplizing 100K muon gun events. This branch in the end was 90% of the output file size.

No changes are expected in the production workflows