### PR TITLE
Changes to the PPS pixels Online/Offline DQM

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -69,8 +69,8 @@ private:
   const float mapXmax = 30. * TMath::Cos(18.4 / 180. * TMath::Pi());
 
   CTPPSPixelIndices thePixIndices;
-  int pixRowMAX = 160;            // defaultDetSizeInX, CMS Y-axis
-  int pixColMAX = 156;            // defaultDetSizeInY, CMS X-axis
+  int pixRowMAX = thePixIndices.getDefaultRowDetSize(); // defaultDetSizeInX, CMS Y-axis
+  int pixColMAX = thePixIndices.getDefaultColDetSize(); // defaultDetSizeInY, CMS X-axis
   int ROCSizeInX = pixRowMAX / 2; // ROC row size in pixels = 80
   int ROCSizeInY = pixColMAX / 3; // ROC col size in pixels = 52
 
@@ -204,8 +204,7 @@ CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet &ps)
       int rp = stoi(armStationRpPlane.at(2));
       int plane = stoi(armStationRpPlane.at(3));
 
-      if (arm < NArms && station < NStationMAX && rp < NRPotsMAX &&
-          plane < NplaneMAX) {
+      if (arm < NArms && station < NStationMAX && rp < NRPotsMAX && plane < NplaneMAX) {
         if (verbosity)
           LogPrint("CTPPSPixelDQMSource")
               << "Shutting off plots for: Arm " << arm << " Station " << station
@@ -330,14 +329,12 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
 
       CTPPSDetId(ID.stationId()).stationName(stnd, CTPPSDetId::nPath);
       CTPPSDetId(ID.stationId()).stationName(stnTitle, CTPPSDetId::nFull);
-      CTPPSDetId(ID.stationId())
-          .stationName(stnTitleShort, CTPPSDetId::nShort);
+      CTPPSDetId(ID.stationId()).stationName(stnTitleShort, CTPPSDetId::nShort);
 
       ibooker.setCurrentFolder(stnd);
       //--------- RPots ---
       int pixBinW = 4;
-      for (int rp = RPn_first; rp < RPn_last;
-           rp++) { // only installed pixel pots
+      for (int rp = RPn_first; rp < RPn_last;rp++) { // only installed pixel pots
         ID.setRP(rp);
         string rpd, rpTitle;
         CTPPSDetId(ID.rpId()).rpName(rpTitle, CTPPSDetId::nShort);
@@ -385,8 +382,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
             ROCSizeInX *ROCSizeInY, "");
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetOption("colz");
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetMinimum(1.0e-10);
-        hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetCanExtend(
-            TProfile2D::kXaxis);
+        hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetCanExtend(TProfile2D::kXaxis);
         TAxis *yahp2 = hp2HitsMultROC_LS[indexP]->getTProfile2D()->GetYaxis();
         for (int p = 0; p < NplaneMAX; p++) {
           sprintf(s, "plane%d_0", p);
@@ -454,8 +450,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
 
           if (onlinePlots) {
             st = "hits position";
-            h2xyHits[indexP][p] =
-                ibooker.book2DD(st, st1 + ";pix col;pix row", pixRowMAX, 0,
+            h2xyHits[indexP][p] = ibooker.book2DD(st, st1 + ";pix col;pix row", pixRowMAX, 0,
                                 pixRowMAX, pixRowMAX, 0, pixRowMAX);
             h2xyHits[indexP][p]->getTH2D()->SetOption("colz");
 
@@ -574,9 +569,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
                  ++frh_it) { // there should always be only one hit in each
                              // vector
               if (frh_it != ds_frh.begin())
-                if (verbosity > 1)
-                  LogPrint("CTPPSPixelDQMSource")
-                      << "More than one FittedRecHit found in plane " << plane;
+                if (verbosity > 1) LogPrint("CTPPSPixelDQMSource") << "More than one FittedRecHit found in plane " << plane;
               if (frh_it->isRealHit())
                 for (int p = 0; p < NplaneMAX; p++) {
                   if (p != plane)
@@ -597,18 +590,12 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
             int plane = getPixPlane(ds_frh.id);
             if (isPlanePlotsTurnedOff[arm][station][rpot][plane])
               continue;
-            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it =
-                     ds_frh.begin();
-                 frh_it != ds_frh.end(); ++frh_it) {
-              float frhX0 =
-                  frh_it->globalCoordinates().x() + frh_it->xResidual();
-              float frhY0 =
-                  frh_it->globalCoordinates().y() + frh_it->yResidual();
+            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it = ds_frh.begin(); frh_it != ds_frh.end(); ++frh_it) {
+              float frhX0 = frh_it->globalCoordinates().x() + frh_it->xResidual();
+              float frhY0 = frh_it->globalCoordinates().y() + frh_it->yResidual();
               if (numberOfPointPerPlaneEff[plane] >= 3) {
-                if (frh_it->isRealHit())
-                  h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 1);
-                else
-                  h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 0);
+                if (frh_it->isRealHit()) h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 1);
+                else h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 0);
               }
             }
           }
@@ -646,54 +633,42 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
       ++RPdigiSize[rpInd];
 
       if (StationStatus[station] && RPstatus[station][rpot]) {
-
-        if (onlinePlots)
-          h2HitsMultipl[arm][station]->Fill(prIndex(rpot, plane),
-                                            ds_digi.data.size());
-
-        if (onlinePlots)
+        if (onlinePlots) {
+          h2HitsMultipl[arm][station]->Fill(prIndex(rpot, plane), ds_digi.data.size());
           h2AllPlanesActive->Fill(plane, getRPglobalBin(arm, station));
-
+        }
         int index = getRPindex(arm, station, rpot);
         HitsMultPlane[index][plane] += ds_digi.data.size();
         if (RPindexValid[index]) {
           int nh = ds_digi.data.size();
           if (nh > hitMultMAX)
             nh = hitMultMAX;
-          if (isPlanePlotsTurnedOff[arm][station][rpot][plane])
+          if (!isPlanePlotsTurnedOff[arm][station][rpot][plane])
             if (onlinePlots)
               hHitsMult[index][plane]->Fill(nh);
         }
         int rocHistIndex = getPlaneIndex(arm, station, rpot, plane);
 
-        for (DetSet<CTPPSPixelDigi>::const_iterator dit = ds_digi.begin();
-             dit != ds_digi.end(); ++dit) {
+        for (DetSet<CTPPSPixelDigi>::const_iterator dit = ds_digi.begin(); dit != ds_digi.end(); ++dit) {
           int row = dit->row();
           int col = dit->column();
           int adc = dit->adc();
 
           if (RPindexValid[index]) {
-            if (isPlanePlotsTurnedOff[arm][station][rpot][plane]) {
-              if (onlinePlots)
-                h2xyHits[index][plane]->Fill(col, row);
-
+            if (!isPlanePlotsTurnedOff[arm][station][rpot][plane]) {
+              if (onlinePlots) h2xyHits[index][plane]->Fill(col, row);
               hp2xyADC[index][plane]->Fill(col, row, adc);
             }
             int colROC, rowROC;
             int trocId;
-            if (!thePixIndices.transformToROC(col, row, trocId, colROC,
-                                              rowROC)) {
+            if (!thePixIndices.transformToROC(col, row, trocId, colROC, rowROC)) {
               if (trocId >= 0 && trocId < NROCsMAX) {
                 ++HitsMultROC[rocHistIndex][trocId];
               }
             }
-
           } // end if(RPindexValid[index]) {
         }
-        if (int(ds_digi.data.size()) > multHitsMax)
-          multHitsMax = ds_digi.data.size();
-
-
+        if (int(ds_digi.data.size()) > multHitsMax) multHitsMax = ds_digi.data.size();
       } // end  if(StationStatus[station]) {
     }   // end for(const auto &ds_digi : *pixDigi)
   }     // if(pixDigi.isValid()) {
@@ -702,8 +677,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
     for (const auto &ds : *pixClus) {
       int idet = getDet(ds.id);
       if (idet != DetId::VeryForward) {
-        if (verbosity > 1)
-          LogPrint("CTPPSPixelDQMSource") << "not CTPPS: cluster.id" << ds.id;
+        if (verbosity > 1) LogPrint("CTPPSPixelDQMSource") << "not CTPPS: cluster.id" << ds.id;
         continue;
       }
       //   int subdet = getSubdet(ds.id);
@@ -795,11 +769,8 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
         }
         int max = 0;
         for (int r = 0; r < NROCsMAX; r++)
-          if (max < rocf[r]) {
-            max = rocf[r];
-          }
-        if (max >= 4 && onlinePlots)
-          hRPotActivBXroc[index]->Fill(event.bunchCrossing());
+          if (max < rocf[r]) max = rocf[r];
+        if (max >= 4 && onlinePlots) hRPotActivBXroc[index]->Fill(event.bunchCrossing());
       } // end for(int rp=0; rp<NRPotsMAX; rp++) {
     }
   } // end for(int arm=0; arm<2; arm++) {
@@ -812,8 +783,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
 
 //-----------------------------------------------------------------------------
 void CTPPSPixelDQMSource::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  if (!verbosity)
-    return;
+  if (!verbosity) return;
   LogPrint("CTPPSPixelDQMSource") << "end of Run " << run.run() << ": " << nEvents << " events\n"
                                   << "multHitsMax= " << multHitsMax << "   cluSizeMax= " << cluSizeMax
                                   << "\nx0: " << x0_MIN << "/" << x0_MAX << "y0: " << y0_MIN << "/" << y0_MAX << "\n";

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -69,10 +69,6 @@ private:
   const float mapXmax = 30. * TMath::Cos(18.4 / 180. * TMath::Pi());
 
   CTPPSPixelIndices thePixIndices;
-  int pixRowMAX = thePixIndices.getDefaultRowDetSize(); // defaultDetSizeInX, CMS Y-axis
-  int pixColMAX = thePixIndices.getDefaultColDetSize(); // defaultDetSizeInY, CMS X-axis
-  int ROCSizeInX = pixRowMAX / 2; // ROC row size in pixels = 80
-  int ROCSizeInY = pixColMAX / 3; // ROC col size in pixels = 52
 
   int TrackFitDimension = 4;
 
@@ -234,11 +230,6 @@ void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run,
   CTPPSPixelLocalTrack thePixelLocalTrack;
   TrackFitDimension = thePixelLocalTrack.dimension;
 
-  pixRowMAX = thePixIndices.getDefaultRowDetSize();
-  pixColMAX = thePixIndices.getDefaultColDetSize();
-  ROCSizeInX = pixRowMAX / 2; // ROC row size in pixels = 80
-  ROCSizeInY = pixColMAX / 3;
-
   for (int stn = 0; stn < StationIDMAX; stn++) {
     StationStatus[stn] = 0;
     for (int rp = 0; rp < RPotsIDMAX; rp++)
@@ -275,9 +266,9 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
   char s[50];
   string armTitleShort, stnTitleShort;
 
-  TAxis *yah1st = NULL;
-  TAxis *xaRPact = NULL;
-  TAxis *xah1trk = NULL;
+  TAxis *yah1st = nullptr;
+  TAxis *xaRPact = nullptr;
+  TAxis *xah1trk = nullptr;
   if (onlinePlots) {
     hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5,
                          4000. + 0.5);
@@ -432,7 +423,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
           hRPotActivBXall[indexP] = ibooker.book1D(
               "hits per BX", rpTitle + ";Event.BX", 4002, -1.5, 4000. + 0.5);
         }
-        int nbins = pixRowMAX / pixBinW;
+        int nbins = defaultDetSizeInX / pixBinW;
 
         for (int p = 0; p < NplaneMAX; p++) {
           if (isPlanePlotsTurnedOff[arm][stn][rp][p])
@@ -444,14 +435,14 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
 
           st = "adc average value";
           hp2xyADC[indexP][p] = ibooker.bookProfile2D(
-              st, st1 + ";pix col;pix row", nbins, 0, pixRowMAX, nbins, 0,
-              pixRowMAX, 0., 512., "");
+              st, st1 + ";pix col;pix row", nbins, 0, defaultDetSizeInX, nbins, 0,
+              defaultDetSizeInX, 0., 512., "");
           hp2xyADC[indexP][p]->getTProfile2D()->SetOption("colz");
 
           if (onlinePlots) {
             st = "hits position";
-            h2xyHits[indexP][p] = ibooker.book2DD(st, st1 + ";pix col;pix row", pixRowMAX, 0,
-                                pixRowMAX, pixRowMAX, 0, pixRowMAX);
+            h2xyHits[indexP][p] = ibooker.book2DD(st, st1 + ";pix col;pix row", defaultDetSizeInX, 0,
+                                defaultDetSizeInX, defaultDetSizeInX, 0, defaultDetSizeInX);
             h2xyHits[indexP][p]->getTH2D()->SetOption("colz");
 
             st = "hits multiplicity";

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -1,16 +1,16 @@
 /******************************************
-*
-* This is a part of CTPPSDQM software.
-* Authors:
-*   F.Ferro INFN Genova
-*   Vladimir Popov (vladimir.popov@cern.ch)
-*
-*******************************************/
+ *
+ * This is a part of CTPPSDQM software.
+ * Authors:
+ *   F.Ferro INFN Genova
+ *   Vladimir Popov (vladimir.popov@cern.ch)
+ *
+ *******************************************/
 
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -20,59 +20,70 @@
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelIndices.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelCluster.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
-#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelIndices.h"
 
 #include <string>
 
 //-----------------------------------------------------------------------------
- 
-class CTPPSPixelDQMSource: public DQMEDAnalyzer
-{
- public:
-   CTPPSPixelDQMSource(const edm::ParameterSet& ps);
-   ~CTPPSPixelDQMSource() override;
-  
- protected:
-   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
-   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-   void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
- private:
-   unsigned int verbosity;
-   long int nEvents = 0;
+class CTPPSPixelDQMSource : public DQMEDAnalyzer {
+public:
+  CTPPSPixelDQMSource(const edm::ParameterSet &ps);
+  ~CTPPSPixelDQMSource() override;
+
+protected:
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
+                      edm::EventSetup const &) override;
+  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+  void endRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
+
+private:
+  unsigned int verbosity;
+  long int nEvents = 0;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelDigi>> tokenDigi;
-  edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelCluster> > tokenCluster;
-  edm::EDGetTokenT< edm::DetSetVector<CTPPSPixelLocalTrack> > tokenTrack;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelCluster>> tokenCluster;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack>> tokenTrack;
 
- static constexpr int NArms=2;
- static constexpr int NStationMAX=3;  // in an arm
- static constexpr int NRPotsMAX=6;	// per station
- static constexpr int NplaneMAX=6;	// per RPot
- static constexpr int NROCsMAX = 6;	// per plane
- static constexpr int RPn_first = 3, RPn_last = 4;
- static constexpr int ADCMax = 256;
- static constexpr int StationIDMAX=4;  // possible range of ID
- static constexpr int RPotsIDMAX=8;    // possible range of ID
- static constexpr int NLocalTracksMAX=20;
- static constexpr int hitMultMAX = 50; // tuned
- static constexpr int ClusMultMAX = 10; // tuned
- static constexpr int ClusterSizeMax = 9;
+  // Flags for disabling set of plots
+  bool offlinePlots = true;
+  bool onlinePlots = true;
 
- CTPPSPixelIndices thePixIndices;
- int pixRowMAX = 160;  // defaultDetSizeInX, CMS Y-axis
- int pixColMAX = 156;  // defaultDetSizeInY, CMS X-axis
- int ROCSizeInX = pixRowMAX/2;  // ROC row size in pixels = 80
- int ROCSizeInY = pixColMAX/3;  // ROC col size in pixels = 52
+  static constexpr int NArms = 2;
+  static constexpr int NStationMAX = 3; // in an arm
+  static constexpr int NRPotsMAX = 6;   // per station
+  static constexpr int NplaneMAX = 6;   // per RPot
+  static constexpr int NROCsMAX = 6;    // per plane
+  static constexpr int RPn_first = 3, RPn_last = 4;
+  static constexpr int ADCMax = 256;
+  static constexpr int StationIDMAX = 4; // possible range of ID
+  static constexpr int RPotsIDMAX = 8;   // possible range of ID
+  static constexpr int NLocalTracksMAX = 20;
+  static constexpr int hitMultMAX = 50;  // tuned
+  static constexpr int ClusMultMAX = 10; // tuned
+  static constexpr int ClusterSizeMax = 9;
 
- int TrackFitDimension = 4;
+  static constexpr int mapXbins = 200;
+  static constexpr int mapYbins = 240;
+  static constexpr float mapYmin = -16.;
+  static constexpr float mapYmax = 8.;
+  const float mapXmin = 0. * TMath::Cos(18.4 / 180. * TMath::Pi());
+  const float mapXmax = 30. * TMath::Cos(18.4 / 180. * TMath::Pi());
 
- static constexpr int NRPotBinsInStation = RPn_last-RPn_first;
- static constexpr int NPlaneBins = NplaneMAX*NRPotBinsInStation;
+  CTPPSPixelIndices thePixIndices;
+  int pixRowMAX = 160;            // defaultDetSizeInX, CMS Y-axis
+  int pixColMAX = 156;            // defaultDetSizeInY, CMS X-axis
+  int ROCSizeInX = pixRowMAX / 2; // ROC row size in pixels = 80
+  int ROCSizeInY = pixColMAX / 3; // ROC col size in pixels = 52
+
+  int TrackFitDimension = 4;
+
+  static constexpr int NRPotBinsInStation = RPn_last - RPn_first;
+  static constexpr int NPlaneBins = NplaneMAX * NRPotBinsInStation;
 
   MonitorElement *hBX, *hBXshort, *h2AllPlanesActive, *hpixLTrack;
   MonitorElement *hpRPactive;
@@ -80,9 +91,9 @@ class CTPPSPixelDQMSource: public DQMEDAnalyzer
   MonitorElement *h2HitsMultipl[NArms][NStationMAX];
   MonitorElement *h2CluSize[NArms][NStationMAX];
 
-  static constexpr int RPotsTotalNumber=NArms*NStationMAX*NRPotsMAX;
+  static constexpr int RPotsTotalNumber = NArms * NStationMAX * NRPotsMAX;
 
-  int	          RPindexValid[RPotsTotalNumber];
+  int RPindexValid[RPotsTotalNumber];
   MonitorElement *h2trackXY0[RPotsTotalNumber];
   MonitorElement *htrackMult[RPotsTotalNumber];
   MonitorElement *htrackHits[RPotsTotalNumber];
@@ -91,55 +102,58 @@ class CTPPSPixelDQMSource: public DQMEDAnalyzer
   MonitorElement *hRPotActivBXroc[RPotsTotalNumber];
   MonitorElement *h2HitsMultROC[RPotsTotalNumber];
   MonitorElement *hp2HitsMultROC_LS[RPotsTotalNumber];
-  MonitorElement   *hHitsMult[RPotsTotalNumber][NplaneMAX];
-  MonitorElement    *h2xyHits[RPotsTotalNumber][NplaneMAX];
-  MonitorElement    *hp2xyADC[RPotsTotalNumber][NplaneMAX];
-  MonitorElement *h2xyROCHits[RPotsTotalNumber*NplaneMAX][NROCsMAX];
-  MonitorElement  *hROCadc[RPotsTotalNumber*NplaneMAX][NROCsMAX];
+  MonitorElement *hHitsMult[RPotsTotalNumber][NplaneMAX];
+  MonitorElement *h2xyHits[RPotsTotalNumber][NplaneMAX];
+  MonitorElement *hp2xyADC[RPotsTotalNumber][NplaneMAX];
+  MonitorElement *h2Efficiency[RPotsTotalNumber][NplaneMAX];
+  MonitorElement *h2xyROCHits[RPotsTotalNumber * NplaneMAX][NROCsMAX];
+  MonitorElement *hROCadc[RPotsTotalNumber * NplaneMAX][NROCsMAX];
   MonitorElement *hRPotActivBXall[RPotsTotalNumber];
-  int		  HitsMultROC[RPotsTotalNumber*NplaneMAX][NROCsMAX];
-  int           HitsMultPlane[RPotsTotalNumber][NplaneMAX];
-  int           ClusMultPlane[RPotsTotalNumber][NplaneMAX];
+  int HitsMultROC[RPotsTotalNumber * NplaneMAX][NROCsMAX];
+  int HitsMultPlane[RPotsTotalNumber][NplaneMAX];
+  int ClusMultPlane[RPotsTotalNumber][NplaneMAX];
 
-
-  unsigned int rpStatusWord = 0x8008; //220_fr_hr(stn2rp3)+ 210_fr_hr
+  unsigned int rpStatusWord = 0x8008;     // 220_fr_hr(stn2rp3)+ 210_fr_hr
   int RPstatus[StationIDMAX][RPotsIDMAX]; // symmetric in both arms
-  int StationStatus[StationIDMAX]; // symmetric in both arms
+  int StationStatus[StationIDMAX];        // symmetric in both arms
   const int IndexNotValid = 0;
 
   int getRPindex(int arm, int station, int rp) {
-	if(arm<0 || station<0 || rp<0) return(IndexNotValid);
-	if(arm>1 || station>=NStationMAX || rp>=NRPotsMAX) return(IndexNotValid);
-	int rc = (arm*NStationMAX+station)*NRPotsMAX + rp;
-	return(rc);
+    if (arm < 0 || station < 0 || rp < 0)
+      return (IndexNotValid);
+    if (arm > 1 || station >= NStationMAX || rp >= NRPotsMAX)
+      return (IndexNotValid);
+    int rc = (arm * NStationMAX + station) * NRPotsMAX + rp;
+    return (rc);
   }
 
   int getPlaneIndex(int arm, int station, int rp, int plane) {
-    if(plane<0 || plane>=NplaneMAX) return(IndexNotValid);
+    if (plane < 0 || plane >= NplaneMAX)
+      return (IndexNotValid);
     int rc = getRPindex(arm, station, rp);
-    if(rc == IndexNotValid) return(IndexNotValid);
-    return(rc*NplaneMAX + plane);
+    if (rc == IndexNotValid)
+      return (IndexNotValid);
+    return (rc * NplaneMAX + plane);
   }
 
-  int getRPInStationBin(int rp) { return(rp - RPn_first +1); }
+  int getRPInStationBin(int rp) { return (rp - RPn_first + 1); }
 
-  
-  static constexpr int NRPglobalBins = 4; //2 arms w. 2 stations w. 1 RP
-  int getRPglobalBin(int arm, int stn) { 
-   static constexpr int stationBinOrder[NStationMAX] = {0, 4, 1};
-   return( arm*2 + stationBinOrder[stn] +1 );
+  static constexpr int NRPglobalBins = 4; // 2 arms w. 2 stations w. 1 RP
+  int getRPglobalBin(int arm, int stn) {
+    static constexpr int stationBinOrder[NStationMAX] = {0, 4, 1};
+    return (arm * 2 + stationBinOrder[stn] + 1);
   }
 
   int prIndex(int rp, int plane) // plane index in station
-	{return((rp - RPn_first)*NplaneMAX + plane);}
-  int getDet(int id) 
-	{ return (id>>DetId::kDetOffset)&0xF; }
-  int getPixPlane(int id)
-	{ return ((id>>16)&0x7); }
-//  int getSubdet(int id) { return ((id>>kSubdetOffset)&0x7); }
+  {
+    return ((rp - RPn_first) * NplaneMAX + plane);
+  }
+  int getDet(int id) { return (id >> DetId::kDetOffset) & 0xF; }
+  int getPixPlane(int id) { return ((id >> 16) & 0x7); }
+  //  int getSubdet(int id) { return ((id>>kSubdetOffset)&0x7); }
 
- int multHitsMax, cluSizeMax; // for tuning
- float x0_MIN, x0_MAX, y0_MIN, y0_MAX;
+  int multHitsMax, cluSizeMax; // for tuning
+  float x0_MIN, x0_MAX, y0_MIN, y0_MAX;
 };
 
 //----------------------------------------------------------------------------------
@@ -149,26 +163,30 @@ using namespace edm;
 
 //-------------------------------------------------------------------------------
 
-CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet& ps) :
-  verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
-  rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord",0x8008))
-{
- tokenDigi = consumes<DetSetVector<CTPPSPixelDigi> >(ps.getParameter<edm::InputTag>("tagRPixDigi"));
- tokenCluster=consumes<DetSetVector<CTPPSPixelCluster>>(ps.getParameter<edm::InputTag>("tagRPixCluster"));
-tokenTrack=consumes<DetSetVector<CTPPSPixelLocalTrack>>(ps.getParameter<edm::InputTag>("tagRPixLTrack"));
+CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet &ps)
+    : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      rpStatusWord(
+          ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
+  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(
+      ps.getParameter<edm::InputTag>("tagRPixDigi"));
+  tokenCluster = consumes<DetSetVector<CTPPSPixelCluster>>(
+      ps.getParameter<edm::InputTag>("tagRPixCluster"));
+  tokenTrack = consumes<DetSetVector<CTPPSPixelLocalTrack>>(
+      ps.getParameter<edm::InputTag>("tagRPixLTrack"));
+  offlinePlots = ps.getUntrackedParameter<bool>("offlinePlots", true);
+  onlinePlots = ps.getUntrackedParameter<bool>("onlinePlots", true);
 }
 
 //----------------------------------------------------------------------------------
 
-CTPPSPixelDQMSource::~CTPPSPixelDQMSource()
-{
-}
+CTPPSPixelDQMSource::~CTPPSPixelDQMSource() {}
 
 //--------------------------------------------------------------------------
 
-void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup const &)
-{
-  if(verbosity) LogPrint("CTPPSPixelDQMSource") <<"RPstatusWord= "<<rpStatusWord;
+void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run,
+                                      edm::EventSetup const &) {
+  if (verbosity)
+    LogPrint("CTPPSPixelDQMSource") << "RPstatusWord= " << rpStatusWord;
   nEvents = 0;
 
   CTPPSPixelLocalTrack thePixelLocalTrack;
@@ -176,427 +194,567 @@ void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup const
 
   pixRowMAX = thePixIndices.getDefaultRowDetSize();
   pixColMAX = thePixIndices.getDefaultColDetSize();
-  ROCSizeInX = pixRowMAX/2;  // ROC row size in pixels = 80
-  ROCSizeInY = pixColMAX/3;
+  ROCSizeInX = pixRowMAX / 2; // ROC row size in pixels = 80
+  ROCSizeInY = pixColMAX / 3;
 
- for(int stn=0; stn<StationIDMAX; stn++) {
-  StationStatus[stn]=0;
-  for(int rp=0; rp<RPotsIDMAX; rp++) RPstatus[stn][rp]=0;
- } 
+  for (int stn = 0; stn < StationIDMAX; stn++) {
+    StationStatus[stn] = 0;
+    for (int rp = 0; rp < RPotsIDMAX; rp++)
+      RPstatus[stn][rp] = 0;
+  }
 
- unsigned int rpSts = rpStatusWord<<1;
- for(int stn=0; stn<NStationMAX; stn++) {
-   int stns = 0;
-   for(int rp=0; rp<NRPotsMAX; rp++) {
-     rpSts = (rpSts >> 1); RPstatus[stn][rp] = rpSts&1;
-     if(RPstatus[stn][rp] > 0) stns = 1;
-   }
-   StationStatus[stn]=stns;
- }
- 
- for(int ind=0; ind<2*3*NRPotsMAX; ind++) RPindexValid[ind] = 0;
+  unsigned int rpSts = rpStatusWord << 1;
+  for (int stn = 0; stn < NStationMAX; stn++) {
+    int stns = 0;
+    for (int rp = 0; rp < NRPotsMAX; rp++) {
+      rpSts = (rpSts >> 1);
+      RPstatus[stn][rp] = rpSts & 1;
+      if (RPstatus[stn][rp] > 0)
+        stns = 1;
+    }
+    StationStatus[stn] = stns;
+  }
 
- multHitsMax = cluSizeMax = -1;
- x0_MIN = y0_MIN =  1.0e06;
- x0_MAX = y0_MAX = -1.0e06;
+  for (int ind = 0; ind < 2 * 3 * NRPotsMAX; ind++)
+    RPindexValid[ind] = 0;
+
+  multHitsMax = cluSizeMax = -1;
+  x0_MIN = y0_MIN = 1.0e06;
+  x0_MAX = y0_MAX = -1.0e06;
 }
 
 //-------------------------------------------------------------------------------------
 
-void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, 
-edm::EventSetup const &)
-{
+void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
+                                         edm::Run const &,
+                                         edm::EventSetup const &) {
   ibooker.cd();
   ibooker.setCurrentFolder("CTPPS/TrackingPixel");
   char s[50];
   string armTitleShort, stnTitleShort;
-  hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5, 4000. +0.5);
-  hBXshort = ibooker.book1D("events per BX(short)", "ctpps_pixel;Event.BX", 102, -1.5, 100. + 0.5);
 
-  string str1st = "Pixel planes activity";
-  h2AllPlanesActive = ibooker.book2DD(str1st,str1st+"(digi task);Plane #",
-                NplaneMAX,0,NplaneMAX, NRPglobalBins, 0.5, NRPglobalBins+0.5);
-  TH2D *h1st = h2AllPlanesActive->getTH2D();
-  h1st->SetOption("colz");
-  TAxis *yah1st = h1st->GetYaxis();
+  TAxis *yah1st = NULL;
+  TAxis *xaRPact = NULL;
+  TAxis *xah1trk = NULL;
+  if (onlinePlots) {
+    hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5,
+                         4000. + 0.5);
+    hBXshort = ibooker.book1D("events per BX(short)", "ctpps_pixel;Event.BX",
+                              102, -1.5, 100. + 0.5);
 
-  string str2 = "Pixel RP active";
-  hpRPactive = ibooker.bookProfile(str2,str2+" per event(digi task)",
-        NRPglobalBins, 0.5,NRPglobalBins+0.5, -0.1, 1.1,"" );
-  TAxis *xaRPact = hpRPactive->getTProfile()->GetXaxis();
-  hpRPactive->getTProfile()->SetOption("hist");
-  hpRPactive->getTProfile()->SetMinimum(0.);
-  hpRPactive->getTProfile()->SetMaximum(1.1);
+    string str1st = "Pixel planes activity";
+    h2AllPlanesActive =
+        ibooker.book2DD(str1st, str1st + "(digi task);Plane #", NplaneMAX, 0,
+                        NplaneMAX, NRPglobalBins, 0.5, NRPglobalBins + 0.5);
+    TH2D *h1st = h2AllPlanesActive->getTH2D();
+    h1st->SetOption("colz");
+    yah1st = h1st->GetYaxis();
 
-  str2 = "Pixel Local Tracks";
-  hpixLTrack = ibooker.bookProfile(str2,str2+" per event",
-        NRPglobalBins, 0.5, NRPglobalBins+0.5,-0.1,NLocalTracksMAX,"");
+    string str2 = "Pixel RP active";
+    hpRPactive =
+        ibooker.bookProfile(str2, str2 + " per event(digi task)", NRPglobalBins,
+                            0.5, NRPglobalBins + 0.5, -0.1, 1.1, "");
+    xaRPact = hpRPactive->getTProfile()->GetXaxis();
+    hpRPactive->getTProfile()->SetOption("hist");
+    hpRPactive->getTProfile()->SetMinimum(0.);
+    hpRPactive->getTProfile()->SetMaximum(1.1);
 
-  TAxis *xah1trk = hpixLTrack->getTProfile()->GetXaxis();
-  hpixLTrack->getTProfile()->GetYaxis()->SetTitle("average number of tracks per event");
-  hpixLTrack->getTProfile()->SetOption("hist");
+    str2 = "Pixel Local Tracks";
+    hpixLTrack =
+        ibooker.bookProfile(str2, str2 + " per event", NRPglobalBins, 0.5,
+                            NRPglobalBins + 0.5, -0.1, NLocalTracksMAX, "");
 
- for(int arm=0; arm<2; arm++) {
-   CTPPSDetId ID(CTPPSDetId::sdTrackingPixel,arm,0);
-   string sd, armTitle;
-   ID.armName(sd, CTPPSDetId::nPath);
-   ID.armName(armTitle, CTPPSDetId::nFull);
-   ID.armName(armTitleShort, CTPPSDetId::nShort);
+    xah1trk = hpixLTrack->getTProfile()->GetXaxis();
+    hpixLTrack->getTProfile()->GetYaxis()->SetTitle(
+        "average number of tracks per event");
+    hpixLTrack->getTProfile()->SetOption("hist");
+  }
 
-   ibooker.setCurrentFolder(sd);
+  for (int arm = 0; arm < 2; arm++) {
+    CTPPSDetId ID(CTPPSDetId::sdTrackingPixel, arm, 0);
+    string sd, armTitle;
+    ID.armName(sd, CTPPSDetId::nPath);
+    ID.armName(armTitle, CTPPSDetId::nFull);
+    ID.armName(armTitleShort, CTPPSDetId::nShort);
 
- for(int stn=0; stn<NStationMAX; stn++) {
-   if(StationStatus[stn]==0) continue;
-   ID.setStation(stn);
-   string stnd, stnTitle;
+    ibooker.setCurrentFolder(sd);
 
-   CTPPSDetId(ID.getStationId()).stationName(stnd, CTPPSDetId::nPath);
-   CTPPSDetId(ID.getStationId()).stationName(stnTitle, CTPPSDetId::nFull);
-   CTPPSDetId(ID.getStationId()).stationName(stnTitleShort, CTPPSDetId::nShort);
+    for (int stn = 0; stn < NStationMAX; stn++) {
+      if (StationStatus[stn] == 0)
+        continue;
+      ID.setStation(stn);
+      string stnd, stnTitle;
 
-   ibooker.setCurrentFolder(stnd);
-//--------- RPots ---
-   int pixBinW = 4;
-     for(int rp=RPn_first; rp<RPn_last; rp++) { // only installed pixel pots
-       ID.setRP(rp);
-       string rpd, rpTitle;
-       CTPPSDetId(ID.getRPId()).rpName(rpTitle, CTPPSDetId::nShort);
-       string rpBinName = armTitleShort + "_" + stnTitleShort+"_"+rpTitle;
-       yah1st->SetBinLabel(getRPglobalBin(arm,stn), rpBinName.c_str());
-       xah1trk->SetBinLabel(getRPglobalBin(arm,stn), rpBinName.c_str());
-       xaRPact->SetBinLabel(getRPglobalBin(arm,stn), rpBinName.c_str());
+      CTPPSDetId(ID.getStationId()).stationName(stnd, CTPPSDetId::nPath);
+      CTPPSDetId(ID.getStationId()).stationName(stnTitle, CTPPSDetId::nFull);
+      CTPPSDetId(ID.getStationId())
+          .stationName(stnTitleShort, CTPPSDetId::nShort);
 
-       if(RPstatus[stn][rp]==0) continue;
-       int indexP = getRPindex(arm,stn,rp);
-       RPindexValid[indexP] = 1;
+      ibooker.setCurrentFolder(stnd);
+      //--------- RPots ---
+      int pixBinW = 4;
+      for (int rp = RPn_first; rp < RPn_last;
+           rp++) { // only installed pixel pots
+        ID.setRP(rp);
+        string rpd, rpTitle;
+        CTPPSDetId(ID.getRPId()).rpName(rpTitle, CTPPSDetId::nShort);
+        string rpBinName = armTitleShort + "_" + stnTitleShort + "_" + rpTitle;
+        if (onlinePlots) {
+          yah1st->SetBinLabel(getRPglobalBin(arm, stn), rpBinName.c_str());
+          xah1trk->SetBinLabel(getRPglobalBin(arm, stn), rpBinName.c_str());
+          xaRPact->SetBinLabel(getRPglobalBin(arm, stn), rpBinName.c_str());
+        }
+        if (RPstatus[stn][rp] == 0)
+          continue;
+        int indexP = getRPindex(arm, stn, rp);
+        RPindexValid[indexP] = 1;
 
-       CTPPSDetId(ID.getRPId()).rpName(rpTitle, CTPPSDetId::nFull);
-       CTPPSDetId(ID.getRPId()).rpName(rpd, CTPPSDetId::nPath);
+        CTPPSDetId(ID.getRPId()).rpName(rpTitle, CTPPSDetId::nFull);
+        CTPPSDetId(ID.getRPId()).rpName(rpd, CTPPSDetId::nPath);
 
-       ibooker.setCurrentFolder(rpd);
+        ibooker.setCurrentFolder(rpd);
 
-   string st2 = ": " + stnTitle;
+        string st2 = ": " + stnTitle;
 
-   string st = "hit multiplicity in planes";
-   string st3 = ";PlaneIndex(=pixelPot*PlaneMAX + plane)";
-   h2HitsMultipl[arm][stn]= ibooker.book2DD(st,st+st2+st3+";multiplicity",
-	NPlaneBins,0,NPlaneBins,hitMultMAX,0,hitMultMAX);
-   h2HitsMultipl[arm][stn]->getTH2D()->SetOption("colz");
+        string st = "hit multiplicity in planes";
+        string st3 = ";PlaneIndex(=pixelPot*PlaneMAX + plane)";
+        if (onlinePlots) {
+          h2HitsMultipl[arm][stn] =
+              ibooker.book2DD(st, st + st2 + st3 + ";multiplicity", NPlaneBins,
+                              0, NPlaneBins, hitMultMAX, 0, hitMultMAX);
+          h2HitsMultipl[arm][stn]->getTH2D()->SetOption("colz");
 
-   st = "cluster size in planes";
-  h2CluSize[arm][stn] = ibooker.book2D(st,st+st2+st3+";Cluster size",
-	NPlaneBins,0,NPlaneBins, ClusterSizeMax+1,0,ClusterSizeMax+1);  
-   h2CluSize[arm][stn]->getTH2F()->SetOption("colz");
+          st = "cluster size in planes";
+          h2CluSize[arm][stn] = ibooker.book2D(
+              st, st + st2 + st3 + ";Cluster size", NPlaneBins, 0, NPlaneBins,
+              ClusterSizeMax + 1, 0, ClusterSizeMax + 1);
+          h2CluSize[arm][stn]->getTH2F()->SetOption("colz");
 
-   const float x0Maximum = 70.;
-   const float y0Maximum =  15.;
-   st = "track intercept point";
-   h2trackXY0[indexP] = ibooker.book2D(st,st+st2+";x0;y0",
-    int(x0Maximum)*2, 0.,x0Maximum,int(y0Maximum)*4,-y0Maximum,y0Maximum);
-   h2trackXY0[indexP]->getTH2F()->SetOption("colz");
+          const float x0Maximum = 70.;
+          const float y0Maximum = 15.;
+          st = "track intercept point";
+          h2trackXY0[indexP] = ibooker.book2D(
+              st, st + st2 + ";x0;y0", int(x0Maximum) * 2, 0., x0Maximum,
+              int(y0Maximum) * 4, -y0Maximum, y0Maximum);
+          h2trackXY0[indexP]->getTH2F()->SetOption("colz");
 
-       st = "number of tracks per event";
-       htrackMult[indexP] = ibooker.bookProfile(st,rpTitle+";number of tracks",
-	 NLocalTracksMAX+1, -0.5,NLocalTracksMAX+0.5, -0.5,NLocalTracksMAX+0.5,"");
-       htrackMult[indexP]->getTProfile()->SetOption("hist");
+          st = "number of tracks per event";
+          htrackMult[indexP] = ibooker.bookProfile(
+              st, rpTitle + ";number of tracks", NLocalTracksMAX + 1, -0.5,
+              NLocalTracksMAX + 0.5, -0.5, NLocalTracksMAX + 0.5, "");
+          htrackMult[indexP]->getTProfile()->SetOption("hist");
 
-       st = "number of hits per track";
-       htrackHits[indexP] = ibooker.bookProfile(st,rpTitle+";number of hits",
-	 5,1.5,6.5, -0.1,1.1, "");
-       htrackHits[indexP]->getTProfile()->SetOption("hist");
+          st = "number of hits per track";
+          htrackHits[indexP] = ibooker.bookProfile(
+              st, rpTitle + ";number of hits", 5, 1.5, 6.5, -0.1, 1.1, "");
+          htrackHits[indexP]->getTProfile()->SetOption("hist");
 
-       hRPotActivPlanes[indexP] = 
-        ibooker.bookProfile("number of fired planes per event", rpTitle+";nPlanes;Probability",
-	 NplaneMAX+1, -0.5, NplaneMAX+0.5, -0.5,NplaneMAX+0.5,"");
-       hRPotActivPlanes[indexP]->getTProfile()->SetOption("hist");
+          hRPotActivPlanes[indexP] = ibooker.bookProfile(
+              "number of fired planes per event",
+              rpTitle + ";nPlanes;Probability", NplaneMAX + 1, -0.5,
+              NplaneMAX + 0.5, -0.5, NplaneMAX + 0.5, "");
+          hRPotActivPlanes[indexP]->getTProfile()->SetOption("hist");
 
-       h2HitsMultROC[indexP] = ibooker.bookProfile2D("ROCs hits multiplicity per event",
-       rpTitle+";plane # ;ROC #", NplaneMAX,-0.5,NplaneMAX-0.5, NROCsMAX,-0.5,NROCsMAX-0.5,
-	0.,ROCSizeInX*ROCSizeInY,"");
-       h2HitsMultROC[indexP]->getTProfile2D()->SetOption("colztext");
-       h2HitsMultROC[indexP]->getTProfile2D()->SetMinimum(1.e-10);
+          h2HitsMultROC[indexP] = ibooker.bookProfile2D(
+              "ROCs hits multiplicity per event", rpTitle + ";plane # ;ROC #",
+              NplaneMAX, -0.5, NplaneMAX - 0.5, NROCsMAX, -0.5, NROCsMAX - 0.5,
+              0., ROCSizeInX * ROCSizeInY, "");
+          h2HitsMultROC[indexP]->getTProfile2D()->SetOption("colztext");
+          h2HitsMultROC[indexP]->getTProfile2D()->SetMinimum(1.e-10);
 
-	
-       hp2HitsMultROC_LS[indexP]=ibooker.bookProfile2D("ROCs_hits_multiplicity_per_event vs LS",
-	 rpTitle+";LumiSection;Plane#___ROC#", 1000,0.,1000.,
-	 NplaneMAX*NROCsMAX,0.,double(NplaneMAX*NROCsMAX),0.,ROCSizeInX*ROCSizeInY,"");
-       hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetOption("colz");
-       hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetMinimum(1.0e-10);
-       hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetCanExtend(TProfile2D::kXaxis);
-       TAxis *yahp2 = hp2HitsMultROC_LS[indexP]->getTProfile2D()->GetYaxis();
-       for(int p=0; p<NplaneMAX; p++) {
-	 sprintf(s,"plane%d_0",p);
-	 yahp2->SetBinLabel(p*NplaneMAX+1,s); 
-	 for(int r=1; r<NROCsMAX; r++) {
-	   sprintf(s,"   %d_%d",p,r);
-	   yahp2->SetBinLabel(p*NplaneMAX+r+1,s);
-	 }
-       }
+          hp2HitsMultROC_LS[indexP] = ibooker.bookProfile2D(
+              "ROCs_hits_multiplicity_per_event vs LS",
+              rpTitle + ";LumiSection;Plane#___ROC#", 1000, 0., 1000.,
+              NplaneMAX * NROCsMAX, 0., double(NplaneMAX * NROCsMAX), 0.,
+              ROCSizeInX *ROCSizeInY, "");
+          hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetOption("colz");
+          hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetMinimum(1.0e-10);
+          hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetCanExtend(
+              TProfile2D::kXaxis);
+          TAxis *yahp2 = hp2HitsMultROC_LS[indexP]->getTProfile2D()->GetYaxis();
+          for (int p = 0; p < NplaneMAX; p++) {
+            sprintf(s, "plane%d_0", p);
+            yahp2->SetBinLabel(p * NplaneMAX + 1, s);
+            for (int r = 1; r < NROCsMAX; r++) {
+              sprintf(s, "   %d_%d", p, r);
+              yahp2->SetBinLabel(p * NplaneMAX + r + 1, s);
+            }
+          }
 
-       ibooker.setCurrentFolder(rpd+"/latency");
-       hRPotActivBX[indexP] = 
-       ibooker.book1D("5 fired planes per BX", rpTitle+";Event.BX",4002,-1.5, 4000.+0.5);
+          ibooker.setCurrentFolder(rpd + "/latency");
+          hRPotActivBX[indexP] =
+              ibooker.book1D("5 fired planes per BX", rpTitle + ";Event.BX",
+                             4002, -1.5, 4000. + 0.5);
 
-       hRPotActivBXroc[indexP] = 
-        ibooker.book1D("4 fired ROCs per BX", rpTitle+";Event.BX", 4002, -1.5, 4000.+0.5);
+          hRPotActivBXroc[indexP] =
+              ibooker.book1D("4 fired ROCs per BX", rpTitle + ";Event.BX", 4002,
+                             -1.5, 4000. + 0.5);
 
-       hRPotActivBXall[indexP] =
-        ibooker.book1D("hits per BX", rpTitle+";Event.BX", 4002, -1.5, 4000.+0.5);
+          hRPotActivBXall[indexP] = ibooker.book1D(
+              "hits per BX", rpTitle + ";Event.BX", 4002, -1.5, 4000. + 0.5);
+        }
+        int nbins = pixRowMAX / pixBinW;
 
-       int nbins = pixRowMAX/pixBinW;
+        for (int p = 0; p < NplaneMAX; p++) {
+          sprintf(s, "plane_%d", p);
+          string pd = rpd + "/" + string(s);
+          ibooker.setCurrentFolder(pd);
+          string st1 = ": " + rpTitle + "_" + string(s);
 
-       for(int p=0; p<NplaneMAX; p++) {
-         sprintf(s,"plane_%d",p);
-         string pd = rpd+"/"+string(s);
-         ibooker.setCurrentFolder(pd);
-         string st1 = ": "+rpTitle+"_"+string(s);
+          if (onlinePlots) {
+            st = "hits position";
+            h2xyHits[indexP][p] =
+                ibooker.book2DD(st, st1 + ";pix col;pix row", pixRowMAX, 0,
+                                pixRowMAX, pixRowMAX, 0, pixRowMAX);
+            h2xyHits[indexP][p]->getTH2D()->SetOption("colz");
 
-         st = "hits position";
-         h2xyHits[indexP][p]=ibooker.book2DD(st,st1+";pix col;pix row",
-           pixRowMAX,0,pixRowMAX, pixRowMAX,0,pixRowMAX);
-         h2xyHits[indexP][p]->getTH2D()->SetOption("colz");
+            st = "adc average value";
+            hp2xyADC[indexP][p] = ibooker.bookProfile2D(
+                st, st1 + ";pix col;pix row", nbins, 0, pixRowMAX, nbins, 0,
+                pixRowMAX, 0., 512., "");
+            hp2xyADC[indexP][p]->getTProfile2D()->SetOption("colz");
 
- 	 st = "adc average value";
-	 hp2xyADC[indexP][p]=ibooker.bookProfile2D(st,st1+";pix col;pix row",
-	   nbins,0,pixRowMAX,nbins,0,pixRowMAX, 0.,512.,"");
-	 hp2xyADC[indexP][p]->getTProfile2D()->SetOption("colz");
+            st = "hits multiplicity";
+            hHitsMult[indexP][p] =
+                ibooker.book1DD(st, st1 + ";number of hits;N / 1 hit",
+                                hitMultMAX + 1, -0.5, hitMultMAX + 0.5);
+          }
 
-         st = "hits multiplicity";
-         hHitsMult[indexP][p]=ibooker.book1DD(st,st1+";number of hits;N / 1 hit",
-	   hitMultMAX+1,-0.5,hitMultMAX+0.5);
-       } // end of for(int p=0; p<NplaneMAX;..
+          if (offlinePlots) {
+            st = "plane efficiency";
+            h2Efficiency[indexP][p] = ibooker.bookProfile2D(
+                st, st1 + ";x0;y0", mapXbins, mapXmin, mapXmax, mapYbins,
+                mapYmin, mapYmax, 0, 1, "");
+            h2Efficiency[indexP][p]->getTProfile2D()->SetOption("colz");
+          }
+        } // end of for(int p=0; p<NplaneMAX;..
 
-     } // end for(int rp=0; rp<NRPotsMAX;...
-   } // end of for(int stn=0; stn<
-  } //end of for(int arm=0; arm<2;...
+      } // end for(int rp=0; rp<NRPotsMAX;...
+    }   // end of for(int stn=0; stn<
+  }     // end of for(int arm=0; arm<2;...
 
- return;
+  return;
 }
 
 //-------------------------------------------------------------------------------
 
-void CTPPSPixelDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
+void CTPPSPixelDQMSource::analyze(edm::Event const &event,
+                                  edm::EventSetup const &eventSetup) {
   ++nEvents;
   int lumiId = event.getLuminosityBlock().id().luminosityBlock();
-  if(lumiId<0) lumiId=0;
+  if (lumiId < 0)
+    lumiId = 0;
 
   int RPactivity[RPotsTotalNumber], RPdigiSize[RPotsTotalNumber];
   int pixRPTracks[RPotsTotalNumber];
 
-  for(int rp=0; rp<RPotsTotalNumber; rp++)
-    { RPactivity[rp] = RPdigiSize[rp] = pixRPTracks[rp] = 0;}
+  for (int rp = 0; rp < RPotsTotalNumber; rp++) {
+    RPactivity[rp] = RPdigiSize[rp] = pixRPTracks[rp] = 0;
+  }
 
-  for(int ind=0; ind<RPotsTotalNumber; ind++) { 
-    for(int p=0; p<NplaneMAX; p++) {
+  for (int ind = 0; ind < RPotsTotalNumber; ind++) {
+    for (int p = 0; p < NplaneMAX; p++) {
       HitsMultPlane[ind][p] = 0;
       ClusMultPlane[ind][p] = 0;
     }
   }
-  for(int ind=0; ind<RPotsTotalNumber*NplaneMAX; ind++)  {
-    for(int roc=0; roc<NROCsMAX; roc++) {
+  for (int ind = 0; ind < RPotsTotalNumber * NplaneMAX; ind++) {
+    for (int roc = 0; roc < NROCsMAX; roc++) {
       HitsMultROC[ind][roc] = 0;
     }
   }
-  Handle< DetSetVector<CTPPSPixelDigi> > pixDigi;
+  Handle<DetSetVector<CTPPSPixelDigi>> pixDigi;
   event.getByToken(tokenDigi, pixDigi);
 
-  Handle< DetSetVector<CTPPSPixelCluster> > pixClus;
+  Handle<DetSetVector<CTPPSPixelCluster>> pixClus;
   event.getByToken(tokenCluster, pixClus);
 
-  Handle< DetSetVector<CTPPSPixelLocalTrack> > pixTrack;
+  Handle<DetSetVector<CTPPSPixelLocalTrack>> pixTrack;
   event.getByToken(tokenTrack, pixTrack);
 
-  hBX->Fill(event.bunchCrossing());
-  hBXshort->Fill(event.bunchCrossing());
+  if (onlinePlots) {
+    hBX->Fill(event.bunchCrossing());
+    hBXshort->Fill(event.bunchCrossing());
+  }
 
-  if(pixTrack.isValid()) {
-   for(const auto &ds_tr : *pixTrack)
-   {
-     int idet = getDet(ds_tr.id);
-     if(idet != DetId::VeryForward) {
-      if(verbosity>1) LogPrint("CTPPSPixelDQMSource") <<"not CTPPS: ds_tr.id"<<ds_tr.id;
-      continue;
-     }
-     CTPPSDetId theId(ds_tr.id);
-     int arm = theId.arm()&0x1;
-     int station = theId.station()&0x3;
-     int rpot = theId.rp()&0x7;  
-     int rpInd = getRPindex(arm,station,rpot);
+  if (pixTrack.isValid()) {
+    for (const auto &ds_tr : *pixTrack) {
+      int idet = getDet(ds_tr.id);
+      if (idet != DetId::VeryForward) {
+        if (verbosity > 1)
+          LogPrint("CTPPSPixelDQMSource") << "not CTPPS: ds_tr.id" << ds_tr.id;
+        continue;
+      }
+      CTPPSDetId theId(ds_tr.id);
+      int arm = theId.arm() & 0x1;
+      int station = theId.station() & 0x3;
+      int rpot = theId.rp() & 0x7;
+      int rpInd = getRPindex(arm, station, rpot);
 
-     for(DetSet<CTPPSPixelLocalTrack>::const_iterator dit = ds_tr.begin();
-            dit != ds_tr.end(); ++dit) {
-       ++pixRPTracks[rpInd];
-       int nh_tr = (dit->getNDF() + TrackFitDimension)/2;
-       for(int i=0; i<=NplaneMAX; i++) {
-         if(i==nh_tr) htrackHits[rpInd]->Fill(nh_tr,1.);
-         else htrackHits[rpInd]->Fill(i,0.);
-       }
-       float x0 = dit->getX0();
-       float y0 = dit->getY0();
-       h2trackXY0[rpInd]->Fill(x0,y0);
-       if(x0_MAX < x0) x0_MAX = x0;
-       if(y0_MAX < y0) y0_MAX = y0;
-       if(x0_MIN > x0) x0_MIN = x0;
-       if(y0_MIN > y0) y0_MIN = y0;
-     }
-   }
+      for (DetSet<CTPPSPixelLocalTrack>::const_iterator dit = ds_tr.begin();
+           dit != ds_tr.end(); ++dit) {
+        ++pixRPTracks[rpInd];
+        int nh_tr = (dit->getNDF() + TrackFitDimension) / 2;
+        if (onlinePlots) {
+          for (int i = 0; i <= NplaneMAX; i++) {
+            if (i == nh_tr)
+              htrackHits[rpInd]->Fill(nh_tr, 1.);
+            else
+              htrackHits[rpInd]->Fill(i, 0.);
+          }
+        }
+        float x0 = dit->getX0();
+        float y0 = dit->getY0();
+        if (onlinePlots)
+          h2trackXY0[rpInd]->Fill(x0, y0);
+
+        if (x0_MAX < x0)
+          x0_MAX = x0;
+        if (y0_MAX < y0)
+          y0_MAX = y0;
+        if (x0_MIN > x0)
+          x0_MIN = x0;
+        if (y0_MIN > y0)
+          y0_MIN = y0;
+
+        if (offlinePlots) {
+          edm::DetSetVector<CTPPSPixelFittedRecHit> fittedHits = dit->getHits();
+
+          std::map<int, int> numberOfPointPerPlaneEff;
+          for (const auto &ds_frh : fittedHits) {
+            int plane = getPixPlane(ds_frh.id);
+            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it =
+                     ds_frh.begin();
+                 frh_it != ds_frh.end();
+                 ++frh_it) { // there should always be only one hit in each
+                             // vector
+              if (frh_it != ds_frh.begin())
+                if (verbosity > 1)
+                  LogPrint("CTPPSPixelDQMSource")
+                      << "More than one FittedRecHit found in plane " << plane;
+              if (frh_it->getIsRealHit())
+                for (int p = 0; p < NplaneMAX; p++) {
+                  if (p != plane)
+                    numberOfPointPerPlaneEff[p]++;
+                }
+            }
+          }
+
+          if (verbosity > 1)
+            for (auto planeAndHitsOnOthers : numberOfPointPerPlaneEff) {
+              LogPrint("CTPPSPixelDQMSource")
+                  << "For plane " << planeAndHitsOnOthers.first << ", "
+                  << planeAndHitsOnOthers.second
+                  << " hits on other planes were found" << endl;
+            }
+
+          for (const auto &ds_frh : fittedHits) {
+            int plane = getPixPlane(ds_frh.id);
+            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it =
+                     ds_frh.begin();
+                 frh_it != ds_frh.end(); ++frh_it) {
+              float frhX0 =
+                  frh_it->getGlobalCoordinates().x() + frh_it->getXResidual();
+              float frhY0 =
+                  frh_it->getGlobalCoordinates().y() + frh_it->getYResidual();
+              if (numberOfPointPerPlaneEff[plane] >= 3) {
+                if (frh_it->getIsRealHit())
+                  h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 1);
+                else
+                  h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 0);
+              }
+            }
+          }
+        }
+      }
+    }
   } // end  if(pixTrack.isValid())
-
 
   bool valid = false;
   valid |= pixDigi.isValid();
-//  valid |= Clus.isValid();
+  //  valid |= Clus.isValid();
 
-  if(!valid && verbosity) LogPrint("CTPPSPixelDQMSource") <<"No valid data in Event "<<nEvents;
-
-  if(pixDigi.isValid()) {
-    for(const auto &ds_digi : *pixDigi)
-    {
-      int idet = getDet(ds_digi.id);
-      if(idet != DetId::VeryForward) {
-        if(verbosity>1) LogPrint("CTPPSPixelDQMSource") <<"not CTPPS: ds_digi.id"<<ds_digi.id;
-        continue;
-      }
-      //   int subdet = getSubdet(ds_digi.id);
-
-      int plane = getPixPlane(ds_digi.id);
-   
-      CTPPSDetId theId(ds_digi.id);
-      int arm = theId.arm()&0x1;
-      int station = theId.station()&0x3;
-      int rpot = theId.rp()&0x7;
-      int rpInd = getRPindex(arm,station,rpot);
-      RPactivity[rpInd] = 1;
-      ++RPdigiSize[rpInd];
-
-      if(StationStatus[station] && RPstatus[station][rpot]) {
-
-        h2HitsMultipl[arm][station]->Fill(prIndex(rpot,plane),ds_digi.data.size());
-        h2AllPlanesActive->Fill(plane,getRPglobalBin(arm,station));
-
-        int index = getRPindex(arm,station,rpot);
-        HitsMultPlane[index][plane] += ds_digi.data.size();
-        if(RPindexValid[index]) {
-	  int nh = ds_digi.data.size();
-          if(nh > hitMultMAX) nh = hitMultMAX;
-          hHitsMult[index][plane]->Fill(nh);
+  if (!valid && verbosity)
+    LogPrint("CTPPSPixelDQMSource") << "No valid data in Event " << nEvents;
+  if (onlinePlots) {
+    if (pixDigi.isValid()) {
+      for (const auto &ds_digi : *pixDigi) {
+        int idet = getDet(ds_digi.id);
+        if (idet != DetId::VeryForward) {
+          if (verbosity > 1)
+            LogPrint("CTPPSPixelDQMSource")
+                << "not CTPPS: ds_digi.id" << ds_digi.id;
+          continue;
         }
-        int rocHistIndex = getPlaneIndex(arm,station,rpot,plane);
+        //   int subdet = getSubdet(ds_digi.id);
 
-        for(DetSet<CTPPSPixelDigi>::const_iterator dit = ds_digi.begin();
-            dit != ds_digi.end(); ++dit) {
-          int row = dit->row();
-          int col = dit->column();
-          int adc = dit->adc();
+        int plane = getPixPlane(ds_digi.id);
 
-          if(RPindexValid[index]) {
-            h2xyHits[index][plane]->Fill(col,row);
-            hp2xyADC[index][plane]->Fill(col,row,adc);
-            int colROC, rowROC;
-            int trocId;
-            if(!thePixIndices.transformToROC(col,row, trocId, colROC, rowROC)) {
-              if(trocId>=0 && trocId<NROCsMAX) {
-                ++HitsMultROC[rocHistIndex][trocId];
-              }
-            }
-          } //end if(RPindexValid[index]) {
-        }
-        if(int(ds_digi.data.size()) > multHitsMax) multHitsMax = ds_digi.data.size();
+        CTPPSDetId theId(ds_digi.id);
+        int arm = theId.arm() & 0x1;
+        int station = theId.station() & 0x3;
+        int rpot = theId.rp() & 0x7;
+        int rpInd = getRPindex(arm, station, rpot);
+        RPactivity[rpInd] = 1;
+        ++RPdigiSize[rpInd];
 
-      } // end  if(StationStatus[station]) {
-    } // end for(const auto &ds_digi : *pixDigi)
-  } //if(pixDigi.isValid()) {
+        if (StationStatus[station] && RPstatus[station][rpot]) {
 
-  if(pixClus.isValid()) 
-    for(const auto &ds : *pixClus)
-    {
-      int idet = getDet(ds.id);
-      if(idet != DetId::VeryForward) {
-        if(verbosity>1) LogPrint("CTPPSPixelDQMSource") <<"not CTPPS: cluster.id"<<ds.id;
-        continue;
-      }
-      //   int subdet = getSubdet(ds.id);
+          h2HitsMultipl[arm][station]->Fill(prIndex(rpot, plane),
+                                            ds_digi.data.size());
+          h2AllPlanesActive->Fill(plane, getRPglobalBin(arm, station));
 
-      int plane = getPixPlane(ds.id);
-
-      CTPPSDetId theId(ds.id);
-      int arm = theId.arm()&0x1;
-      int station = theId.station()&0x3;
-      int rpot = theId.rp()&0x7;
-
-      if((StationStatus[station]==0) || (RPstatus[station][rpot]==0)) continue;
-
-      int index = getRPindex(arm,station,rpot);
-      ++ClusMultPlane[index][plane];
-
-      for (const auto &p : ds) {
-	int clusize = p.size(); 
-	h2CluSize[arm][station]->Fill(prIndex(rpot,plane),clusize);
-        if(cluSizeMax < clusize) cluSizeMax = clusize;
-        if(clusize > ClusterSizeMax) clusize = ClusterSizeMax;
-      }
-   } // end if(pixClus.isValid()) for(const auto &ds : *pixClus)
-
-  bool allRPactivity = false;
-  for(int rp=0; rp<RPotsTotalNumber; rp++) if(RPactivity[rp]>0) allRPactivity=true; 
-  for(int arm=0; arm<2; arm++) {
-    for(int stn=0; stn<NStationMAX; stn++) {
-      for(int rp=0; rp<NRPotsMAX; rp++) {
-        int index = getRPindex(arm,stn,rp);
-        if(RPindexValid[index]==0) continue;
-        hpRPactive->Fill(getRPglobalBin(arm,stn),RPactivity[index]);
-//        if(RPactivity[index]==0) continue;
-          if(!allRPactivity) continue;
-        hpixLTrack->Fill(getRPglobalBin(arm,stn),pixRPTracks[index]);
-        int ntr = pixRPTracks[index];
-        if(ntr > NLocalTracksMAX) ntr = NLocalTracksMAX;
-	for(int i=0; i<=NLocalTracksMAX; i++) {
-	 if(i==ntr) htrackMult[index]->Fill(ntr,1.);
-	 else htrackMult[index]->Fill(i,0.);
-	}
-
-        int np = 0; 
-        for(int p=0; p<NplaneMAX; p++) if(HitsMultPlane[index][p]>0) np++;
-	for(int p=0; p<=NplaneMAX; p++) {
-	  if(p == np) hRPotActivPlanes[index]->Fill(p,1.);
-	  else hRPotActivPlanes[index]->Fill(p,0.);
-	}
-        if(np>=5) hRPotActivBX[index]->Fill(event.bunchCrossing());
-        hRPotActivBXall[index]->Fill(event.bunchCrossing(),float(RPdigiSize[index]));
-
-        int rocf[NplaneMAX];
-        for(int r=0; r<NROCsMAX; r++) rocf[r]=0;
-        for(int p=0; p<NplaneMAX; p++) {
-          int indp = getPlaneIndex(arm,stn,rp,p);
-          for(int r=0; r<NROCsMAX; r++) if(HitsMultROC[indp][r] > 0) ++rocf[r];
-          for(int r=0; r<NROCsMAX; r++) { 
-            h2HitsMultROC[index]->Fill(p,r,HitsMultROC[indp][r]);
-            hp2HitsMultROC_LS[index]->Fill(lumiId,p*NROCsMAX+r,HitsMultROC[indp][r]);
+          int index = getRPindex(arm, station, rpot);
+          HitsMultPlane[index][plane] += ds_digi.data.size();
+          if (RPindexValid[index]) {
+            int nh = ds_digi.data.size();
+            if (nh > hitMultMAX)
+              nh = hitMultMAX;
+            hHitsMult[index][plane]->Fill(nh);
           }
-        }
-        int max = 0;
-        for(int r=0; r<NROCsMAX; r++) 
-          if(max < rocf[r]) { max = rocf[r]; }
-        if(max >= 4) hRPotActivBXroc[index]->Fill(event.bunchCrossing());
-      } //end for(int rp=0; rp<NRPotsMAX; rp++) {
-    }
-  } //end for(int arm=0; arm<2; arm++) {
+          int rocHistIndex = getPlaneIndex(arm, station, rpot, plane);
 
-  if((nEvents % 100)) return;
-  if(verbosity) LogPrint("CTPPSPixelDQMSource")<<"analyze event "<<nEvents;
+          for (DetSet<CTPPSPixelDigi>::const_iterator dit = ds_digi.begin();
+               dit != ds_digi.end(); ++dit) {
+            int row = dit->row();
+            int col = dit->column();
+            int adc = dit->adc();
+
+            if (RPindexValid[index]) {
+              h2xyHits[index][plane]->Fill(col, row);
+              hp2xyADC[index][plane]->Fill(col, row, adc);
+              int colROC, rowROC;
+              int trocId;
+              if (!thePixIndices.transformToROC(col, row, trocId, colROC,
+                                                rowROC)) {
+                if (trocId >= 0 && trocId < NROCsMAX) {
+                  ++HitsMultROC[rocHistIndex][trocId];
+                }
+              }
+            } // end if(RPindexValid[index]) {
+          }
+          if (int(ds_digi.data.size()) > multHitsMax)
+            multHitsMax = ds_digi.data.size();
+
+        } // end  if(StationStatus[station]) {
+      }   // end for(const auto &ds_digi : *pixDigi)
+    }     // if(pixDigi.isValid()) {
+
+    if (pixClus.isValid())
+      for (const auto &ds : *pixClus) {
+        int idet = getDet(ds.id);
+        if (idet != DetId::VeryForward) {
+          if (verbosity > 1)
+            LogPrint("CTPPSPixelDQMSource") << "not CTPPS: cluster.id" << ds.id;
+          continue;
+        }
+        //   int subdet = getSubdet(ds.id);
+
+        int plane = getPixPlane(ds.id);
+
+        CTPPSDetId theId(ds.id);
+        int arm = theId.arm() & 0x1;
+        int station = theId.station() & 0x3;
+        int rpot = theId.rp() & 0x7;
+
+        if ((StationStatus[station] == 0) || (RPstatus[station][rpot] == 0))
+          continue;
+
+        int index = getRPindex(arm, station, rpot);
+        ++ClusMultPlane[index][plane];
+
+        for (const auto &p : ds) {
+          int clusize = p.size();
+          h2CluSize[arm][station]->Fill(prIndex(rpot, plane), clusize);
+          if (cluSizeMax < clusize)
+            cluSizeMax = clusize;
+          if (clusize > ClusterSizeMax)
+            clusize = ClusterSizeMax;
+        }
+      } // end if(pixClus.isValid()) for(const auto &ds : *pixClus)
+
+    bool allRPactivity = false;
+    for (int rp = 0; rp < RPotsTotalNumber; rp++)
+      if (RPactivity[rp] > 0)
+        allRPactivity = true;
+    for (int arm = 0; arm < 2; arm++) {
+      for (int stn = 0; stn < NStationMAX; stn++) {
+        for (int rp = 0; rp < NRPotsMAX; rp++) {
+          int index = getRPindex(arm, stn, rp);
+          if (RPindexValid[index] == 0)
+            continue;
+          hpRPactive->Fill(getRPglobalBin(arm, stn), RPactivity[index]);
+          //        if(RPactivity[index]==0) continue;
+          if (!allRPactivity)
+            continue;
+          hpixLTrack->Fill(getRPglobalBin(arm, stn), pixRPTracks[index]);
+          int ntr = pixRPTracks[index];
+          if (ntr > NLocalTracksMAX)
+            ntr = NLocalTracksMAX;
+          for (int i = 0; i <= NLocalTracksMAX; i++) {
+            if (i == ntr)
+              htrackMult[index]->Fill(ntr, 1.);
+            else
+              htrackMult[index]->Fill(i, 0.);
+          }
+
+          int np = 0;
+          for (int p = 0; p < NplaneMAX; p++)
+            if (HitsMultPlane[index][p] > 0)
+              np++;
+          for (int p = 0; p <= NplaneMAX; p++) {
+            if (p == np)
+              hRPotActivPlanes[index]->Fill(p, 1.);
+            else
+              hRPotActivPlanes[index]->Fill(p, 0.);
+          }
+          if (np >= 5)
+            hRPotActivBX[index]->Fill(event.bunchCrossing());
+          hRPotActivBXall[index]->Fill(event.bunchCrossing(),
+                                       float(RPdigiSize[index]));
+
+          int rocf[NplaneMAX];
+          for (int r = 0; r < NROCsMAX; r++)
+            rocf[r] = 0;
+          for (int p = 0; p < NplaneMAX; p++) {
+            int indp = getPlaneIndex(arm, stn, rp, p);
+            for (int r = 0; r < NROCsMAX; r++)
+              if (HitsMultROC[indp][r] > 0)
+                ++rocf[r];
+            for (int r = 0; r < NROCsMAX; r++) {
+              h2HitsMultROC[index]->Fill(p, r, HitsMultROC[indp][r]);
+              hp2HitsMultROC_LS[index]->Fill(lumiId, p * NROCsMAX + r,
+                                             HitsMultROC[indp][r]);
+            }
+          }
+          int max = 0;
+          for (int r = 0; r < NROCsMAX; r++)
+            if (max < rocf[r]) {
+              max = rocf[r];
+            }
+          if (max >= 4)
+            hRPotActivBXroc[index]->Fill(event.bunchCrossing());
+        } // end for(int rp=0; rp<NRPotsMAX; rp++) {
+      }
+    } // end for(int arm=0; arm<2; arm++) {
+  }
+  if ((nEvents % 100))
+    return;
+  if (verbosity)
+    LogPrint("CTPPSPixelDQMSource") << "analyze event " << nEvents;
 }
 
 //-----------------------------------------------------------------------------
-void CTPPSPixelDQMSource::endRun(edm::Run const& run, edm::EventSetup const& eSetup)
-{
- if(!verbosity) return; 
- LogPrint("CTPPSPixelDQMSource") 
-  <<"end of Run "<<run.run()<<": "<<nEvents<<" events\n"
-  <<"multHitsMax= "<<multHitsMax <<"   cluSizeMax= "<<cluSizeMax
-  <<"\nx0: "<< x0_MIN<<"/" << x0_MAX<<"y0: "<<y0_MIN<<"/"<<y0_MAX<<"\n";
+void CTPPSPixelDQMSource::endRun(edm::Run const &run,
+                                 edm::EventSetup const &eSetup) {
+  if (!verbosity)
+    return;
+  LogPrint("CTPPSPixelDQMSource")
+      << "end of Run " << run.run() << ": " << nEvents << " events\n"
+      << "multHitsMax= " << multHitsMax << "   cluSizeMax= " << cluSizeMax
+      << "\nx0: " << x0_MIN << "/" << x0_MAX << "y0: " << y0_MIN << "/"
+      << y0_MAX << "\n";
 }
 
 //---------------------------------------------------------------------------
 DEFINE_FWK_MODULE(CTPPSPixelDQMSource);
-

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -48,17 +48,17 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack>> tokenTrack;
 
   static constexpr int NArms = 2;
-  static constexpr int NStationMAX = 3; // in an arm
-  static constexpr int NRPotsMAX = 6;   // per station
-  static constexpr int NplaneMAX = 6;   // per RPot
-  static constexpr int NROCsMAX = 6;    // per plane
+  static constexpr int NStationMAX = 3;  // in an arm
+  static constexpr int NRPotsMAX = 6;    // per station
+  static constexpr int NplaneMAX = 6;    // per RPot
+  static constexpr int NROCsMAX = 6;     // per plane
   static constexpr int RPn_first = 3, RPn_last = 4;
   static constexpr int ADCMax = 256;
-  static constexpr int StationIDMAX = 4; // possible range of ID
-  static constexpr int RPotsIDMAX = 8;   // possible range of ID
+  static constexpr int StationIDMAX = 4;  // possible range of ID
+  static constexpr int RPotsIDMAX = 8;    // possible range of ID
   static constexpr int NLocalTracksMAX = 20;
-  static constexpr int hitMultMAX = 50;  // tuned
-  static constexpr int ClusMultMAX = 10; // tuned
+  static constexpr int hitMultMAX = 50;   // tuned
+  static constexpr int ClusMultMAX = 10;  // tuned
   static constexpr int ClusterSizeMax = 9;
 
   static constexpr int mapXbins = 200;
@@ -110,9 +110,9 @@ private:
   // Flags for disabling plots of a plane
   bool isPlanePlotsTurnedOff[NArms][NStationMAX][NRPotsMAX][NplaneMAX] = {};
 
-  unsigned int rpStatusWord = 0x8008;     // 220_fr_hr(stn2rp3)+ 210_fr_hr
-  int RPstatus[StationIDMAX][RPotsIDMAX]; // symmetric in both arms
-  int StationStatus[StationIDMAX];        // symmetric in both arms
+  unsigned int rpStatusWord = 0x8008;      // 220_fr_hr(stn2rp3)+ 210_fr_hr
+  int RPstatus[StationIDMAX][RPotsIDMAX];  // symmetric in both arms
+  int StationStatus[StationIDMAX];         // symmetric in both arms
   const int IndexNotValid = 0;
 
   int getRPindex(int arm, int station, int rp) {
@@ -151,7 +151,7 @@ private:
   int getPixPlane(int id) { return ((id >> 16) & 0x7); }
   //  int getSubdet(int id) { return ((id>>kSubdetOffset)&0x7); }
 
-  int multHitsMax, cluSizeMax; // for tuning
+  int multHitsMax, cluSizeMax;  // for tuning
   float x0_MIN, x0_MAX, y0_MIN, y0_MAX;
 };
 
@@ -164,28 +164,22 @@ using namespace edm;
 
 CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet &ps)
     : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
-      rpStatusWord(
-          ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
-  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(
-      ps.getParameter<edm::InputTag>("tagRPixDigi"));
-  tokenCluster = consumes<DetSetVector<CTPPSPixelCluster>>(
-      ps.getParameter<edm::InputTag>("tagRPixCluster"));
-  tokenTrack = consumes<DetSetVector<CTPPSPixelLocalTrack>>(
-      ps.getParameter<edm::InputTag>("tagRPixLTrack"));
+      rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
+  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(ps.getParameter<edm::InputTag>("tagRPixDigi"));
+  tokenCluster = consumes<DetSetVector<CTPPSPixelCluster>>(ps.getParameter<edm::InputTag>("tagRPixCluster"));
+  tokenTrack = consumes<DetSetVector<CTPPSPixelLocalTrack>>(ps.getParameter<edm::InputTag>("tagRPixLTrack"));
   offlinePlots = ps.getUntrackedParameter<bool>("offlinePlots", true);
   onlinePlots = ps.getUntrackedParameter<bool>("onlinePlots", true);
 
   vector<string> disabledPlanePlotsVec =
-      ps.getUntrackedParameter<vector<string>>("turnOffPlanePlots",
-                                               vector<string>());
+      ps.getUntrackedParameter<vector<string>>("turnOffPlanePlots", vector<string>());
 
   // Parse the strings in disabledPlanePlotsVec and set the flags in
   // isPlanePlotsTurnedOff
   for (auto s : disabledPlanePlotsVec) {
     // Check that the format is <arm>_<station>_<RP>_<Plane>
     if (count(s.begin(), s.end(), '_') != 3)
-      throw cms::Exception("RPixPlaneCombinatoryTracking")
-          << "Invalid string in turnOffPlanePlots: " << s;
+      throw cms::Exception("RPixPlaneCombinatoryTracking") << "Invalid string in turnOffPlanePlots: " << s;
     else {
       vector<string> armStationRpPlane;
       size_t pos = 0;
@@ -203,12 +197,10 @@ CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet &ps)
       if (arm < NArms && station < NStationMAX && rp < NRPotsMAX && plane < NplaneMAX) {
         if (verbosity)
           LogPrint("CTPPSPixelDQMSource")
-              << "Shutting off plots for: Arm " << arm << " Station " << station
-              << " Rp " << rp << " Plane " << plane;
+              << "Shutting off plots for: Arm " << arm << " Station " << station << " Rp " << rp << " Plane " << plane;
         isPlanePlotsTurnedOff[arm][station][rp][plane] = true;
       } else {
-        throw cms::Exception("RPixPlaneCombinatoryTracking")
-            << "Invalid string in turnOffPlanePlots: " << s;
+        throw cms::Exception("RPixPlaneCombinatoryTracking") << "Invalid string in turnOffPlanePlots: " << s;
       }
     }
   }
@@ -220,9 +212,7 @@ CTPPSPixelDQMSource::~CTPPSPixelDQMSource() {}
 
 //--------------------------------------------------------------------------
 
-
-void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run,
-                                      edm::EventSetup const &) {
+void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup const &) {
   if (verbosity)
     LogPrint("CTPPSPixelDQMSource") << "RPstatusWord= " << rpStatusWord;
   nEvents = 0;
@@ -258,9 +248,7 @@ void CTPPSPixelDQMSource::dqmBeginRun(edm::Run const &run,
 
 //-------------------------------------------------------------------------------------
 
-void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
-                                         edm::Run const &,
-                                         edm::EventSetup const &) {
+void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   ibooker.cd();
   ibooker.setCurrentFolder("CTPPS/TrackingPixel");
   char s[50];
@@ -270,36 +258,30 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
   TAxis *xaRPact = nullptr;
   TAxis *xah1trk = nullptr;
   if (onlinePlots) {
-    hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5,
-                         4000. + 0.5);
-    hBXshort = ibooker.book1D("events per BX(short)", "ctpps_pixel;Event.BX",
-                              102, -1.5, 100. + 0.5);
+    hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5, 4000. + 0.5);
+    hBXshort = ibooker.book1D("events per BX(short)", "ctpps_pixel;Event.BX", 102, -1.5, 100. + 0.5);
 
     string str1st = "Pixel planes activity";
-    h2AllPlanesActive =
-        ibooker.book2DD(str1st, str1st + "(digi task);Plane #", NplaneMAX, 0,
-                        NplaneMAX, NRPglobalBins, 0.5, NRPglobalBins + 0.5);
+    h2AllPlanesActive = ibooker.book2DD(
+        str1st, str1st + "(digi task);Plane #", NplaneMAX, 0, NplaneMAX, NRPglobalBins, 0.5, NRPglobalBins + 0.5);
     TH2D *h1st = h2AllPlanesActive->getTH2D();
     h1st->SetOption("colz");
     yah1st = h1st->GetYaxis();
 
     string str2 = "Pixel RP active";
-    hpRPactive =
-        ibooker.bookProfile(str2, str2 + " per event(digi task)", NRPglobalBins,
-                            0.5, NRPglobalBins + 0.5, -0.1, 1.1, "");
+    hpRPactive = ibooker.bookProfile(
+        str2, str2 + " per event(digi task)", NRPglobalBins, 0.5, NRPglobalBins + 0.5, -0.1, 1.1, "");
     xaRPact = hpRPactive->getTProfile()->GetXaxis();
     hpRPactive->getTProfile()->SetOption("hist");
     hpRPactive->getTProfile()->SetMinimum(0.);
     hpRPactive->getTProfile()->SetMaximum(1.1);
 
     str2 = "Pixel Local Tracks";
-    hpixLTrack =
-        ibooker.bookProfile(str2, str2 + " per event", NRPglobalBins, 0.5,
-                            NRPglobalBins + 0.5, -0.1, NLocalTracksMAX, "");
+    hpixLTrack = ibooker.bookProfile(
+        str2, str2 + " per event", NRPglobalBins, 0.5, NRPglobalBins + 0.5, -0.1, NLocalTracksMAX, "");
 
     xah1trk = hpixLTrack->getTProfile()->GetXaxis();
-    hpixLTrack->getTProfile()->GetYaxis()->SetTitle(
-        "average number of tracks per event");
+    hpixLTrack->getTProfile()->GetYaxis()->SetTitle("average number of tracks per event");
     hpixLTrack->getTProfile()->SetOption("hist");
   }
 
@@ -325,7 +307,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
       ibooker.setCurrentFolder(stnd);
       //--------- RPots ---
       int pixBinW = 4;
-      for (int rp = RPn_first; rp < RPn_last;rp++) { // only installed pixel pots
+      for (int rp = RPn_first; rp < RPn_last; rp++) {  // only installed pixel pots
         ID.setRP(rp);
         string rpd, rpTitle;
         CTPPSDetId(ID.rpId()).rpName(rpTitle, CTPPSDetId::nShort);
@@ -350,27 +332,41 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
         string st = "track intercept point";
         string st2 = ": " + stnTitle;
         h2trackXY0[indexP] = ibooker.book2D(
-            st, st + st2 + ";x0;y0", int(x0Maximum) * 2, 0., x0Maximum,
-            int(y0Maximum) * 4, -y0Maximum, y0Maximum);
+            st, st + st2 + ";x0;y0", int(x0Maximum) * 2, 0., x0Maximum, int(y0Maximum) * 4, -y0Maximum, y0Maximum);
         h2trackXY0[indexP]->getTH2F()->SetOption("colz");
 
         st = "number of tracks per event";
-        htrackMult[indexP] = ibooker.bookProfile(
-            st, rpTitle + ";number of tracks", NLocalTracksMAX + 1, -0.5,
-            NLocalTracksMAX + 0.5, -0.5, NLocalTracksMAX + 0.5, "");
+        htrackMult[indexP] = ibooker.bookProfile(st,
+                                                 rpTitle + ";number of tracks",
+                                                 NLocalTracksMAX + 1,
+                                                 -0.5,
+                                                 NLocalTracksMAX + 0.5,
+                                                 -0.5,
+                                                 NLocalTracksMAX + 0.5,
+                                                 "");
         htrackMult[indexP]->getTProfile()->SetOption("hist");
 
-        hRPotActivPlanes[indexP] = ibooker.bookProfile(
-            "number of fired planes per event",
-            rpTitle + ";nPlanes;Probability", NplaneMAX + 1, -0.5,
-            NplaneMAX + 0.5, -0.5, NplaneMAX + 0.5, "");
+        hRPotActivPlanes[indexP] = ibooker.bookProfile("number of fired planes per event",
+                                                       rpTitle + ";nPlanes;Probability",
+                                                       NplaneMAX + 1,
+                                                       -0.5,
+                                                       NplaneMAX + 0.5,
+                                                       -0.5,
+                                                       NplaneMAX + 0.5,
+                                                       "");
         hRPotActivPlanes[indexP]->getTProfile()->SetOption("hist");
 
-        hp2HitsMultROC_LS[indexP] = ibooker.bookProfile2D(
-            "ROCs hits multiplicity per event vs LS",
-            rpTitle + ";LumiSection;Plane#___ROC#", 1000, 0., 1000.,
-            NplaneMAX * NROCsMAX, 0., double(NplaneMAX * NROCsMAX), 0.,
-            ROCSizeInX *ROCSizeInY, "");
+        hp2HitsMultROC_LS[indexP] = ibooker.bookProfile2D("ROCs hits multiplicity per event vs LS",
+                                                          rpTitle + ";LumiSection;Plane#___ROC#",
+                                                          1000,
+                                                          0.,
+                                                          1000.,
+                                                          NplaneMAX * NROCsMAX,
+                                                          0.,
+                                                          double(NplaneMAX * NROCsMAX),
+                                                          0.,
+                                                          ROCSizeInX *ROCSizeInY,
+                                                          "");
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetOption("colz");
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetMinimum(1.0e-10);
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetCanExtend(TProfile2D::kXaxis);
@@ -388,40 +384,47 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
           string st3 = ";PlaneIndex(=pixelPot*PlaneMAX + plane)";
 
           st = "hit multiplicity in planes";
-          h2HitsMultipl[arm][stn] =
-              ibooker.book2DD(st, st + st2 + st3 + ";multiplicity", NPlaneBins,
-                              0, NPlaneBins, hitMultMAX, 0, hitMultMAX);
+          h2HitsMultipl[arm][stn] = ibooker.book2DD(
+              st, st + st2 + st3 + ";multiplicity", NPlaneBins, 0, NPlaneBins, hitMultMAX, 0, hitMultMAX);
           h2HitsMultipl[arm][stn]->getTH2D()->SetOption("colz");
 
           st = "cluster size in planes";
-          h2CluSize[arm][stn] = ibooker.book2D(
-              st, st + st2 + st3 + ";Cluster size", NPlaneBins, 0, NPlaneBins,
-              ClusterSizeMax + 1, 0, ClusterSizeMax + 1);
+          h2CluSize[arm][stn] = ibooker.book2D(st,
+                                               st + st2 + st3 + ";Cluster size",
+                                               NPlaneBins,
+                                               0,
+                                               NPlaneBins,
+                                               ClusterSizeMax + 1,
+                                               0,
+                                               ClusterSizeMax + 1);
           h2CluSize[arm][stn]->getTH2F()->SetOption("colz");
 
           st = "number of hits per track";
-          htrackHits[indexP] = ibooker.bookProfile(
-              st, rpTitle + ";number of hits", 5, 1.5, 6.5, -0.1, 1.1, "");
+          htrackHits[indexP] = ibooker.bookProfile(st, rpTitle + ";number of hits", 5, 1.5, 6.5, -0.1, 1.1, "");
           htrackHits[indexP]->getTProfile()->SetOption("hist");
 
-          h2HitsMultROC[indexP] = ibooker.bookProfile2D(
-              "ROCs hits multiplicity per event", rpTitle + ";plane # ;ROC #",
-              NplaneMAX, -0.5, NplaneMAX - 0.5, NROCsMAX, -0.5, NROCsMAX - 0.5,
-              0., ROCSizeInX * ROCSizeInY, "");
+          h2HitsMultROC[indexP] = ibooker.bookProfile2D("ROCs hits multiplicity per event",
+                                                        rpTitle + ";plane # ;ROC #",
+                                                        NplaneMAX,
+                                                        -0.5,
+                                                        NplaneMAX - 0.5,
+                                                        NROCsMAX,
+                                                        -0.5,
+                                                        NROCsMAX - 0.5,
+                                                        0.,
+                                                        ROCSizeInX * ROCSizeInY,
+                                                        "");
           h2HitsMultROC[indexP]->getTProfile2D()->SetOption("colztext");
           h2HitsMultROC[indexP]->getTProfile2D()->SetMinimum(1.e-10);
 
           ibooker.setCurrentFolder(rpd + "/latency");
           hRPotActivBX[indexP] =
-              ibooker.book1D("5 fired planes per BX", rpTitle + ";Event.BX",
-                             4002, -1.5, 4000. + 0.5);
+              ibooker.book1D("5 fired planes per BX", rpTitle + ";Event.BX", 4002, -1.5, 4000. + 0.5);
 
           hRPotActivBXroc[indexP] =
-              ibooker.book1D("4 fired ROCs per BX", rpTitle + ";Event.BX", 4002,
-                             -1.5, 4000. + 0.5);
+              ibooker.book1D("4 fired ROCs per BX", rpTitle + ";Event.BX", 4002, -1.5, 4000. + 0.5);
 
-          hRPotActivBXall[indexP] = ibooker.book1D(
-              "hits per BX", rpTitle + ";Event.BX", 4002, -1.5, 4000. + 0.5);
+          hRPotActivBXall[indexP] = ibooker.book1D("hits per BX", rpTitle + ";Event.BX", 4002, -1.5, 4000. + 0.5);
         }
         int nbins = defaultDetSizeInX / pixBinW;
 
@@ -435,43 +438,44 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker,
 
           st = "adc average value";
           hp2xyADC[indexP][p] = ibooker.bookProfile2D(
-              st, st1 + ";pix col;pix row", nbins, 0, defaultDetSizeInX, nbins, 0,
-              defaultDetSizeInX, 0., 512., "");
+              st, st1 + ";pix col;pix row", nbins, 0, defaultDetSizeInX, nbins, 0, defaultDetSizeInX, 0., 512., "");
           hp2xyADC[indexP][p]->getTProfile2D()->SetOption("colz");
 
           if (onlinePlots) {
             st = "hits position";
-            h2xyHits[indexP][p] = ibooker.book2DD(st, st1 + ";pix col;pix row", defaultDetSizeInX, 0,
-                                defaultDetSizeInX, defaultDetSizeInX, 0, defaultDetSizeInX);
+            h2xyHits[indexP][p] = ibooker.book2DD(st,
+                                                  st1 + ";pix col;pix row",
+                                                  defaultDetSizeInX,
+                                                  0,
+                                                  defaultDetSizeInX,
+                                                  defaultDetSizeInX,
+                                                  0,
+                                                  defaultDetSizeInX);
             h2xyHits[indexP][p]->getTH2D()->SetOption("colz");
 
             st = "hits multiplicity";
             hHitsMult[indexP][p] =
-                ibooker.book1DD(st, st1 + ";number of hits;N / 1 hit",
-                                hitMultMAX + 1, -0.5, hitMultMAX + 0.5);
+                ibooker.book1DD(st, st1 + ";number of hits;N / 1 hit", hitMultMAX + 1, -0.5, hitMultMAX + 0.5);
           }
 
           if (offlinePlots) {
             st = "plane efficiency";
             h2Efficiency[indexP][p] = ibooker.bookProfile2D(
-                st, st1 + ";x0;y0", mapXbins, mapXmin, mapXmax, mapYbins,
-                mapYmin, mapYmax, 0, 1, "");
+                st, st1 + ";x0;y0", mapXbins, mapXmin, mapXmax, mapYbins, mapYmin, mapYmax, 0, 1, "");
             h2Efficiency[indexP][p]->getTProfile2D()->SetOption("colz");
           }
-        } // end of for(int p=0; p<NplaneMAX;..
+        }  // end of for(int p=0; p<NplaneMAX;..
 
-      } // end for(int rp=0; rp<NRPotsMAX;...
-    }   // end of for(int stn=0; stn<
-  }     // end of for(int arm=0; arm<2;...
+      }  // end for(int rp=0; rp<NRPotsMAX;...
+    }    // end of for(int stn=0; stn<
+  }      // end of for(int arm=0; arm<2;...
 
   return;
 }
 
 //-------------------------------------------------------------------------------
 
-
-void CTPPSPixelDQMSource::analyze(edm::Event const &event,
-                                  edm::EventSetup const &eventSetup) {
+void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
   ++nEvents;
   int lumiId = event.getLuminosityBlock().id().luminosityBlock();
   if (lumiId < 0)
@@ -523,8 +527,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
       int rpot = theId.rp() & 0x7;
       int rpInd = getRPindex(arm, station, rpot);
 
-      for (DetSet<CTPPSPixelLocalTrack>::const_iterator dit = ds_tr.begin();
-           dit != ds_tr.end(); ++dit) {
+      for (DetSet<CTPPSPixelLocalTrack>::const_iterator dit = ds_tr.begin(); dit != ds_tr.end(); ++dit) {
         ++pixRPTracks[rpInd];
         int nh_tr = (dit->ndf() + TrackFitDimension) / 2;
         if (onlinePlots) {
@@ -554,13 +557,12 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
           std::map<int, int> numberOfPointPerPlaneEff;
           for (const auto &ds_frh : fittedHits) {
             int plane = getPixPlane(ds_frh.id);
-            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it =
-                     ds_frh.begin();
-                 frh_it != ds_frh.end();
-                 ++frh_it) { // there should always be only one hit in each
-                             // vector
+            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it = ds_frh.begin(); frh_it != ds_frh.end();
+                 ++frh_it) {  // there should always be only one hit in each
+                              // vector
               if (frh_it != ds_frh.begin())
-                if (verbosity > 1) LogPrint("CTPPSPixelDQMSource") << "More than one FittedRecHit found in plane " << plane;
+                if (verbosity > 1)
+                  LogPrint("CTPPSPixelDQMSource") << "More than one FittedRecHit found in plane " << plane;
               if (frh_it->isRealHit())
                 for (int p = 0; p < NplaneMAX; p++) {
                   if (p != plane)
@@ -572,8 +574,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
           if (verbosity > 1)
             for (auto planeAndHitsOnOthers : numberOfPointPerPlaneEff) {
               LogPrint("CTPPSPixelDQMSource")
-                  << "For plane " << planeAndHitsOnOthers.first << ", "
-                  << planeAndHitsOnOthers.second
+                  << "For plane " << planeAndHitsOnOthers.first << ", " << planeAndHitsOnOthers.second
                   << " hits on other planes were found" << endl;
             }
 
@@ -581,19 +582,22 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
             int plane = getPixPlane(ds_frh.id);
             if (isPlanePlotsTurnedOff[arm][station][rpot][plane])
               continue;
-            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it = ds_frh.begin(); frh_it != ds_frh.end(); ++frh_it) {
+            for (DetSet<CTPPSPixelFittedRecHit>::const_iterator frh_it = ds_frh.begin(); frh_it != ds_frh.end();
+                 ++frh_it) {
               float frhX0 = frh_it->globalCoordinates().x() + frh_it->xResidual();
               float frhY0 = frh_it->globalCoordinates().y() + frh_it->yResidual();
               if (numberOfPointPerPlaneEff[plane] >= 3) {
-                if (frh_it->isRealHit()) h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 1);
-                else h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 0);
+                if (frh_it->isRealHit())
+                  h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 1);
+                else
+                  h2Efficiency[rpInd][plane]->Fill(frhX0, frhY0, 0);
               }
             }
           }
         }
       }
     }
-  } // end  if(pixTrack.isValid())
+  }  // end  if(pixTrack.isValid())
 
   bool valid = false;
   valid |= pixDigi.isValid();
@@ -607,8 +611,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
       int idet = getDet(ds_digi.id);
       if (idet != DetId::VeryForward) {
         if (verbosity > 1)
-          LogPrint("CTPPSPixelDQMSource")
-              << "not CTPPS: ds_digi.id" << ds_digi.id;
+          LogPrint("CTPPSPixelDQMSource") << "not CTPPS: ds_digi.id" << ds_digi.id;
         continue;
       }
       //   int subdet = getSubdet(ds_digi.id);
@@ -647,7 +650,8 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
 
           if (RPindexValid[index]) {
             if (!isPlanePlotsTurnedOff[arm][station][rpot][plane]) {
-              if (onlinePlots) h2xyHits[index][plane]->Fill(col, row);
+              if (onlinePlots)
+                h2xyHits[index][plane]->Fill(col, row);
               hp2xyADC[index][plane]->Fill(col, row, adc);
             }
             int colROC, rowROC;
@@ -657,18 +661,20 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
                 ++HitsMultROC[rocHistIndex][trocId];
               }
             }
-          } // end if(RPindexValid[index]) {
+          }  // end if(RPindexValid[index]) {
         }
-        if (int(ds_digi.data.size()) > multHitsMax) multHitsMax = ds_digi.data.size();
-      } // end  if(StationStatus[station]) {
-    }   // end for(const auto &ds_digi : *pixDigi)
-  }     // if(pixDigi.isValid()) {
+        if (int(ds_digi.data.size()) > multHitsMax)
+          multHitsMax = ds_digi.data.size();
+      }  // end  if(StationStatus[station]) {
+    }    // end for(const auto &ds_digi : *pixDigi)
+  }      // if(pixDigi.isValid()) {
 
   if (pixClus.isValid())
     for (const auto &ds : *pixClus) {
       int idet = getDet(ds.id);
       if (idet != DetId::VeryForward) {
-        if (verbosity > 1) LogPrint("CTPPSPixelDQMSource") << "not CTPPS: cluster.id" << ds.id;
+        if (verbosity > 1)
+          LogPrint("CTPPSPixelDQMSource") << "not CTPPS: cluster.id" << ds.id;
         continue;
       }
       //   int subdet = getSubdet(ds.id);
@@ -697,7 +703,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
           clusize = ClusterSizeMax;
       }
 
-    } // end if(pixClus.isValid()) for(const auto &ds : *pixClus)
+    }  // end if(pixClus.isValid()) for(const auto &ds : *pixClus)
 
   bool allRPactivity = false;
   for (int rp = 0; rp < RPotsTotalNumber; rp++)
@@ -740,8 +746,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
         if (onlinePlots) {
           if (np >= 5)
             hRPotActivBX[index]->Fill(event.bunchCrossing());
-          hRPotActivBXall[index]->Fill(event.bunchCrossing(),
-                                       float(RPdigiSize[index]));
+          hRPotActivBXall[index]->Fill(event.bunchCrossing(), float(RPdigiSize[index]));
         }
         int rocf[NplaneMAX];
         for (int r = 0; r < NROCsMAX; r++)
@@ -754,17 +759,18 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
           for (int r = 0; r < NROCsMAX; r++) {
             if (onlinePlots)
               h2HitsMultROC[index]->Fill(p, r, HitsMultROC[indp][r]);
-            hp2HitsMultROC_LS[index]->Fill(lumiId, p * NROCsMAX + r,
-                                           HitsMultROC[indp][r]);
+            hp2HitsMultROC_LS[index]->Fill(lumiId, p * NROCsMAX + r, HitsMultROC[indp][r]);
           }
         }
         int max = 0;
         for (int r = 0; r < NROCsMAX; r++)
-          if (max < rocf[r]) max = rocf[r];
-        if (max >= 4 && onlinePlots) hRPotActivBXroc[index]->Fill(event.bunchCrossing());
-      } // end for(int rp=0; rp<NRPotsMAX; rp++) {
+          if (max < rocf[r])
+            max = rocf[r];
+        if (max >= 4 && onlinePlots)
+          hRPotActivBXroc[index]->Fill(event.bunchCrossing());
+      }  // end for(int rp=0; rp<NRPotsMAX; rp++) {
     }
-  } // end for(int arm=0; arm<2; arm++) {
+  }  // end for(int arm=0; arm<2; arm++) {
 
   if ((nEvents % 100))
     return;
@@ -774,7 +780,8 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event,
 
 //-----------------------------------------------------------------------------
 void CTPPSPixelDQMSource::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
-  if (!verbosity) return;
+  if (!verbosity)
+    return;
   LogPrint("CTPPSPixelDQMSource") << "end of Run " << run.run() << ": " << nEvents << " events\n"
                                   << "multHitsMax= " << multHitsMax << "   cluSizeMax= " << cluSizeMax
                                   << "\nx0: " << x0_MIN << "/" << x0_MAX << "y0: " << y0_MIN << "/" << y0_MAX << "\n";

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -24,6 +24,15 @@ ctppsDQM = cms.Sequence(
     + ctppsCommonDQMSource
 )
 
+ctppsDQMOffline = cms.Sequence(
+    totemDAQTriggerDQMSource
+    + (totemRPDQMSource * totemRPDQMHarvester)
+    + ctppsDiamondDQMSource
+    + totemTimingDQMSource
+    + ctppsPixelDQMOfflineSource
+    + ctppsCommonDQMSource
+)
+
 ctppsDQMElastic = cms.Sequence(
     totemDAQTriggerDQMSource
     + (totemRPDQMSource * totemRPDQMHarvester)

--- a/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
@@ -7,7 +7,9 @@ ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixCluster = cms.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
-    verbosity = cms.untracked.uint32(0),
+    verbosity = cms.untracked.uint32(2),
     offlinePlots = cms.untracked.bool(True),
-    onlinePlots = cms.untracked.bool(False)
+    onlinePlots = cms.untracked.bool(False),
+    turnOffPlanePlots = cms.untracked.vstring(), 	# add tags for planes to be shut off, 
+    												# e.g. "0_2_3_4" for arm 0 station 2 rp 3 plane 4
 )

--- a/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
@@ -7,5 +7,7 @@ ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixCluster = cms.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
-    verbosity = cms.untracked.uint32(0)
+    verbosity = cms.untracked.uint32(0),
+    offlinePlots = cms.untracked.bool(True),
+    onlinePlots = cms.untracked.bool(False)
 )

--- a/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
@@ -7,7 +7,19 @@ ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixCluster = cms.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
-    verbosity = cms.untracked.uint32(2),
+    verbosity = cms.untracked.uint32(0),
+    offlinePlots = cms.untracked.bool(False),
+    onlinePlots = cms.untracked.bool(True),
+    turnOffPlanePlots = cms.untracked.vstring(), 	# add tags for planes to be shut off, 
+    												# e.g. "0_2_3_4" for arm 0 station 2 rp 3 plane 4
+)
+
+ctppsPixelDQMOfflineSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
+    tagRPixDigi = cms.InputTag("ctppsPixelDigis", ""),
+    tagRPixCluster = cms.InputTag("ctppsPixelClusters", ""),  
+    tagRPixLTrack = cms.InputTag("ctppsPixelLocalTracks", ""),  
+    RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout: 220_fr_hr; 210_fr_hr
+    verbosity = cms.untracked.uint32(0),
     offlinePlots = cms.untracked.bool(True),
     onlinePlots = cms.untracked.bool(False),
     turnOffPlanePlots = cms.untracked.vstring(), 	# add tags for planes to be shut off, 

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
@@ -26,17 +26,14 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-# process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, '106X_dataRun2_v21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
 # raw data source
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
     # run 314255, alignment run April 2018
     '/store/data/Commissioning2018/ZeroBias1/AOD/PromptReco-v1/000/314/255/00000/0098845D-D642-E811-8E30-FA163EE31D2A.root'
-  ),
-  skipBadFiles = cms.untracked.bool(True),
-
+  )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
@@ -8,8 +8,7 @@ process.MessageLogger = cms.Service("MessageLogger",
   statistics = cms.untracked.vstring(),
   destinations = cms.untracked.vstring('cout'),
   cout = cms.untracked.PSet(
-      # threshold = cms.untracked.string('WARNING')
-      # threshold = cms.untracked.string('INFO')
+      threshold = cms.untracked.string('WARNING')
   )
 )
 
@@ -34,48 +33,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, '106X_dataRun2_v21', '')
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
     # run 314255, alignment run April 2018
-    # '/store/data/Commissioning2018/ZeroBias1/AOD/PromptReco-v1/000/314/255/00000/0098845D-D642-E811-8E30-FA163EE31D2A.root'
-    # '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/34E72BFF-B64F-E811-A60F-FA163E9C8F11.root'
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/40896981-AD4F-E811-BA55-FA163E2E52D5.root'
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/2C32C288-AE4F-E811-A240-FA163E96604B.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/580FDF29-B04F-E811-9D2C-FA163E8B221F.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/1A8EE801-B14F-E811-886F-FA163E4830E6.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/DEF10CD7-B24F-E811-BB39-FA163E5BE9EA.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/9C00F693-B34F-E811-8FC8-FA163E1B57DB.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/C6A0D209-B54F-E811-A8CB-FA163EE24CAD.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F8938BB9-B34F-E811-81E8-02163E015DCD.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/B8EE7FDD-B24F-E811-9C1A-FA163E0C3CBE.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F4B0E008-B54F-E811-A760-FA163E77762A.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/9AD3D368-B74F-E811-9042-FA163E4F8E43.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/74FE2295-B44F-E811-876D-FA163E95BBB1.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/3E7FD4A5-B64F-E811-8749-FA163EF5A563.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/88D57301-B74F-E811-9E19-02163E01A01B.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/1665E551-B94F-E811-9C27-FA163E7BA99F.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/92209A92-B94F-E811-9DA7-FA163E0581F0.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/14CD2CA9-B94F-E811-872F-FA163E9F4289.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/46770D65-BE4F-E811-86AE-FA163E63F443.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F0E546D6-B44F-E811-88DE-02163E019F01.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/9268D151-AD4F-E811-A688-02163E01A0E8.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/52F6C528-AD4F-E811-B566-FA163EFCCBD6.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/CEAE7DA1-B14F-E811-B365-FA163E7A4C8B.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/52E511EF-B04F-E811-B837-FA163E5FB578.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/A6524DF0-B24F-E811-8920-FA163E29F581.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F6668B61-B34F-E811-B4F4-FA163EEB4E2F.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/36DF6B4A-B44F-E811-B8E2-FA163E8F6459.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/C2DE5458-B44F-E811-BD63-FA163EC08F3E.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/36EF9753-B54F-E811-AE31-FA163E2B3387.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/2E065EEA-B74F-E811-BFF5-FA163E8A11D8.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/0CBFA0C6-B64F-E811-8C50-FA163E455B73.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/DE35E366-B84F-E811-B161-FA163E97727D.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/326BF670-B74F-E811-B303-FA163E5FB578.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/800D9E0F-C24F-E811-A9F4-FA163ED1B1DF.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/8E6113D5-CF4F-E811-8F63-FA163E54FDC7.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/909F10AB-B24F-E811-8002-FA163E756B33.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/BC73304D-B44F-E811-9929-FA163EBBA909.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/48A17F20-B54F-E811-96C0-FA163E9F4289.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/34E72BFF-B64F-E811-A60F-FA163E9C8F11.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/88B4804C-B74F-E811-AFFE-FA163EEA7BBD.root',
-    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/A69B5881-B94F-E811-85B9-FA163E6314D2.root'
+    '/store/data/Commissioning2018/ZeroBias1/AOD/PromptReco-v1/000/314/255/00000/0098845D-D642-E811-8E30-FA163EE31D2A.root'
   ),
   skipBadFiles = cms.untracked.bool(True),
 

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
@@ -8,7 +8,8 @@ process.MessageLogger = cms.Service("MessageLogger",
   statistics = cms.untracked.vstring(),
   destinations = cms.untracked.vstring('cout'),
   cout = cms.untracked.PSet(
-      threshold = cms.untracked.string('WARNING')
+      # threshold = cms.untracked.string('WARNING')
+      # threshold = cms.untracked.string('INFO')
   )
 )
 
@@ -26,14 +27,58 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+# process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_dataRun2_v21', '')
 
 # raw data source
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
     # run 314255, alignment run April 2018
-    '/store/data/Commissioning2018/ZeroBias1/AOD/PromptReco-v1/000/314/255/00000/0098845D-D642-E811-8E30-FA163EE31D2A.root'
-  )
+    # '/store/data/Commissioning2018/ZeroBias1/AOD/PromptReco-v1/000/314/255/00000/0098845D-D642-E811-8E30-FA163EE31D2A.root'
+    # '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/34E72BFF-B64F-E811-A60F-FA163E9C8F11.root'
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/40896981-AD4F-E811-BA55-FA163E2E52D5.root'
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/2C32C288-AE4F-E811-A240-FA163E96604B.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/580FDF29-B04F-E811-9D2C-FA163E8B221F.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/1A8EE801-B14F-E811-886F-FA163E4830E6.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/DEF10CD7-B24F-E811-BB39-FA163E5BE9EA.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/9C00F693-B34F-E811-8FC8-FA163E1B57DB.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/C6A0D209-B54F-E811-A8CB-FA163EE24CAD.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F8938BB9-B34F-E811-81E8-02163E015DCD.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/B8EE7FDD-B24F-E811-9C1A-FA163E0C3CBE.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F4B0E008-B54F-E811-A760-FA163E77762A.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/9AD3D368-B74F-E811-9042-FA163E4F8E43.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/74FE2295-B44F-E811-876D-FA163E95BBB1.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/3E7FD4A5-B64F-E811-8749-FA163EF5A563.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/88D57301-B74F-E811-9E19-02163E01A01B.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/1665E551-B94F-E811-9C27-FA163E7BA99F.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/92209A92-B94F-E811-9DA7-FA163E0581F0.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/14CD2CA9-B94F-E811-872F-FA163E9F4289.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/46770D65-BE4F-E811-86AE-FA163E63F443.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F0E546D6-B44F-E811-88DE-02163E019F01.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/9268D151-AD4F-E811-A688-02163E01A0E8.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/52F6C528-AD4F-E811-B566-FA163EFCCBD6.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/CEAE7DA1-B14F-E811-B365-FA163E7A4C8B.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/52E511EF-B04F-E811-B837-FA163E5FB578.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/A6524DF0-B24F-E811-8920-FA163E29F581.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/F6668B61-B34F-E811-B4F4-FA163EEB4E2F.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/36DF6B4A-B44F-E811-B8E2-FA163E8F6459.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/C2DE5458-B44F-E811-BD63-FA163EC08F3E.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/36EF9753-B54F-E811-AE31-FA163E2B3387.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/2E065EEA-B74F-E811-BFF5-FA163E8A11D8.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/0CBFA0C6-B64F-E811-8C50-FA163E455B73.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/DE35E366-B84F-E811-B161-FA163E97727D.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/326BF670-B74F-E811-B303-FA163E5FB578.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/800D9E0F-C24F-E811-A9F4-FA163ED1B1DF.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/8E6113D5-CF4F-E811-8F63-FA163E54FDC7.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/909F10AB-B24F-E811-8002-FA163E756B33.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/BC73304D-B44F-E811-9929-FA163EBBA909.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/48A17F20-B54F-E811-96C0-FA163E9F4289.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/34E72BFF-B64F-E811-A60F-FA163E9C8F11.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/88B4804C-B74F-E811-AFFE-FA163EEA7BBD.root',
+    '/store/data/Run2018A/ZeroBias/AOD/PromptReco-v1/000/315/512/00000/A69B5881-B94F-E811-85B9-FA163E6314D2.root'
+  ),
+  skipBadFiles = cms.untracked.bool(True),
+
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
+++ b/DQM/CTPPS/test/all_ctpps_dqm_test_from_aod_cfg.py
@@ -26,16 +26,14 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-# process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, '106X_dataRun2_v21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
 # raw data source
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
     # run 314255, alignment run April 2018
     '/store/data/Commissioning2018/ZeroBias1/AOD/PromptReco-v1/000/314/255/00000/0098845D-D642-E811-8E30-FA163EE31D2A.root'
-  ),
-  skipBadFiles = cms.untracked.bool(True),
+  )
 
 )
 


### PR DESCRIPTION
Changed PPS Offline DQM plots for the pixel tracker to include efficiency plots and exclude some unnecessary ones. Added flags to remove the plots of specific detector planes when needed.