### PR TITLE
Standardize include order in a few DataFormats packages

### DIFF
--- a/DataFormats/BTauReco/interface/DeepFlavourFeatures.h
+++ b/DataFormats/BTauReco/interface/DeepFlavourFeatures.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_BTauReco_DeepFlavourFeatures_h
 #define DataFormats_BTauReco_DeepFlavourFeatures_h
 
-#include <vector>
 
 #include "DataFormats/BTauReco/interface/JetFeatures.h"
 #include "DataFormats/BTauReco/interface/SecondaryVertexFeatures.h"
@@ -9,6 +8,8 @@
 #include "DataFormats/BTauReco/interface/NeutralCandidateFeatures.h"
 #include "DataFormats/BTauReco/interface/ChargedCandidateFeatures.h"
 #include "DataFormats/BTauReco/interface/SeedingTrackFeatures.h"
+
+#include <vector>
 
 namespace btagbtvdeep {
 

--- a/DataFormats/BTauReco/interface/DeepFlavourFeatures.h
+++ b/DataFormats/BTauReco/interface/DeepFlavourFeatures.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_BTauReco_DeepFlavourFeatures_h
 #define DataFormats_BTauReco_DeepFlavourFeatures_h
 
-
 #include "DataFormats/BTauReco/interface/JetFeatures.h"
 #include "DataFormats/BTauReco/interface/SecondaryVertexFeatures.h"
 #include "DataFormats/BTauReco/interface/ShallowTagInfoFeatures.h"

--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -1,12 +1,14 @@
 #ifndef DataFormats_NanoAOD_FlatTable_h
 #define DataFormats_NanoAOD_FlatTable_h
 
+#include "DataFormats/Math/interface/libminifloat.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <boost/range/sub_range.hpp>
+
 #include <cstdint>
 #include <vector>
 #include <string>
-#include <boost/range/sub_range.hpp>
-#include "FWCore/Utilities/interface/Exception.h"
-#include "DataFormats/Math/interface/libminifloat.h"
 
 namespace nanoaod {
 


### PR DESCRIPTION
Addresses IB compilation errors in cxxmodules build of 11_1_X. With modules enabled, compiler is more picky about ordering of includes and prefers std includes to be after the local cmssw ones (good practice anyway) @vgvassilev 