### PR TITLE
EventSetup consumes migration, 4 DQM modules

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -13,7 +13,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Framework/interface/Run.h"
 
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
@@ -101,6 +103,9 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit>> tokenDiamondHit_;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack>> tokenDiamondTrack_;
   edm::EDGetTokenT<std::vector<TotemFEDInfo>> tokenFEDInfo_;
+
+  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> ctppsGeometryRunToken_;
+  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> ctppsGeometryEventToken_;
 
   bool excludeMultipleHits_;
   double horizontalShiftBwDiamondPixels_;
@@ -479,6 +484,8 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource(const edm::ParameterSet& ps)
       tokenDiamondTrack_(
           consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(ps.getParameter<edm::InputTag>("tagDiamondLocalTracks"))),
       tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"))),
+      ctppsGeometryRunToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord, edm::Transition::BeginRun>()),
+      ctppsGeometryEventToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>()),
       excludeMultipleHits_(ps.getParameter<bool>("excludeMultipleHits")),
       centralOOT_(-999),
       verbosity_(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
@@ -506,17 +513,15 @@ void CTPPSDiamondDQMSource::dqmBeginRun(const edm::Run& iRun, const edm::EventSe
   }
 
   // Get detector shifts from the geometry
-  edm::ESHandle<CTPPSGeometry> geometry_;
-  iSetup.get<VeryForwardRealGeometryRecord>().get(geometry_);
-  const CTPPSGeometry* geom = geometry_.product();
+  const CTPPSGeometry& geom = iSetup.getData(ctppsGeometryRunToken_);
   const CTPPSDiamondDetId detid(0, CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID, 0, 0);
-  const DetGeomDesc* det = geom->sensor(detid);
+  const DetGeomDesc* det = geom.sensor(detid);
   horizontalShiftOfDiamond_ = det->translation().x() - det->params().at(0);
 
   // Rough alignement of pixel detector for diamond thomography
   const CTPPSPixelDetId pixid(0, CTPPS_PIXEL_STATION_ID, CTPPS_FAR_RP_ID, 0);
   if (iRun.run() > 300000) {  //Pixel installed
-    det = geom->sensor(pixid);
+    det = geom.sensor(pixid);
     horizontalShiftBwDiamondPixels_ = det->translation().x() - det->params().at(0) - horizontalShiftOfDiamond_ - 1;
   }
 }
@@ -577,8 +582,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
   edm::Handle<edm::DetSetVector<CTPPSDiamondLocalTrack>> diamondLocalTracks;
   event.getByToken(tokenDiamondTrack_, diamondLocalTracks);
 
-  edm::ESHandle<CTPPSGeometry> geometry_;
-  iSetup.get<VeryForwardRealGeometryRecord>().get(geometry_);
+  const CTPPSGeometry* ctppsGeometry = &iSetup.getData(ctppsGeometryEventToken_);
 
   // check validity
   bool valid = true;
@@ -858,7 +862,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
               potPlots_[detId_pot].effDoublecountingChMap[map_index] = 0;
             }
             CTPPSDiamondDetId detId(detId_pot.arm(), CTPPS_DIAMOND_STATION_ID, CTPPS_DIAMOND_RP_ID, plane, channel);
-            if (channelAlignedWithTrack(geometry_.product(), detId, track, 0.2)) {
+            if (channelAlignedWithTrack(ctppsGeometry, detId, track, 0.2)) {
               // Channel should fire
               ++(potPlots_[detId_pot].effDoublecountingChMap[map_index]);
               for (const auto& rechits : *diamondRecHits) {

--- a/DQM/CastorMonitor/interface/CastorDigiMonitor.h
+++ b/DQM/CastorMonitor/interface/CastorDigiMonitor.h
@@ -13,6 +13,10 @@
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/CastorObjects/interface/CastorChannelQuality.h"
+#include "CondFormats/DataRecord/interface/CastorChannelQualityRcd.h"
 
 //#include "FWCore/Framework/interface/Run.h"
 
@@ -20,20 +24,21 @@ class CastorDigiMonitor {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
-  CastorDigiMonitor(const edm::ParameterSet &ps);
+  CastorDigiMonitor(const edm::ParameterSet &ps, edm::ConsumesCollector &&);
   ~CastorDigiMonitor();
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, const edm::EventSetup &);
   void processEvent(edm::Event const &event,
                     const CastorDigiCollection &cast,
                     const edm::TriggerResults &trig,
                     const CastorDbService &cond);
   void endRun();
-  void getDbData(const edm::EventSetup &iSetup);
+  void getDbData(const edm::EventSetup &);
   int ModSecToIndex(int module, int sector);
   void fillTrigRes(edm::Event const &event, const edm::TriggerResults &TrigResults, double Etot);
 
 private:
+  edm::ESGetToken<CastorChannelQuality, CastorChannelQualityRcd> castorChannelQualityToken_;
   std::string subsystemname_;
   int fVerbosity;
   int ievt_;

--- a/DQM/CastorMonitor/interface/CastorLEDMonitor.h
+++ b/DQM/CastorMonitor/interface/CastorLEDMonitor.h
@@ -31,7 +31,7 @@ public:
   CastorLEDMonitor(const edm::ParameterSet &ps);
   ~CastorLEDMonitor();
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &);
   void processEvent(const CastorDigiCollection &cast, const CastorDbService &cond);
 
 private:

--- a/DQM/CastorMonitor/interface/CastorMonitorModule.h
+++ b/DQM/CastorMonitor/interface/CastorMonitorModule.h
@@ -1,8 +1,10 @@
 #ifndef CastorMonitorModule_H
 #define CastorMonitorModule_H
 
+#include "CalibFormats/CastorObjects/interface/CastorDbService.h"
+#include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
+
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,6 +34,7 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Utilities/interface/CPUTimer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Common/interface/TriggerNames.h"
@@ -75,12 +78,12 @@ public:
   ~CastorMonitorModule() override;
 
 protected:
-  void analyze(const edm::Event &iEvent, const edm::EventSetup &eventSetup) override;
+  void analyze(const edm::Event &iEvent, const edm::EventSetup &) override;
 
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, const edm::EventSetup &) override;
 
-  void dqmEndRun(const edm::Run &run, const edm::EventSetup &eventSetup) override;
+  void dqmEndRun(const edm::Run &run, const edm::EventSetup &) override;
 
 private:
   int fVerbosity;
@@ -100,6 +103,8 @@ private:
   edm::EDGetTokenT<CastorTowerCollection> inputTokenCastorTowers_;
   typedef std::vector<reco::BasicJet> BasicJetCollection;
   edm::EDGetTokenT<BasicJetCollection> JetAlgorithm;
+
+  edm::ESGetToken<CastorDbService, CastorDbRecord> castorDbServiceToken_;
 
   //  std::shared_ptr<l1t::L1TGlobalUtil> gtUtil_;
 

--- a/DQM/CastorMonitor/interface/CastorRecHitMonitor.h
+++ b/DQM/CastorMonitor/interface/CastorRecHitMonitor.h
@@ -24,7 +24,7 @@ public:
   CastorRecHitMonitor(const edm::ParameterSet &ps);
   ~CastorRecHitMonitor();
 
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &);
   void processEvent(const CastorRecHitCollection &castorHits);
   void processEventTowers(const reco::CastorTowerCollection &castorTowers);
   void processEventJets(const reco::BasicJetCollection &Jets);

--- a/DQM/CastorMonitor/src/CastorDigiMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorDigiMonitor.cc
@@ -10,7 +10,6 @@
 //     add rms check, DB   15.04.2015 (Vladimir Popov)
 //==================================================================//
 
-#include "CondFormats/CastorObjects/interface/CastorChannelQuality.h"
 #include "DQM/CastorMonitor/interface/CastorDigiMonitor.h"
 #include "DQM/CastorMonitor/interface/CastorLEDMonitor.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -18,6 +17,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
 #include <string>
 
 using namespace std;
@@ -32,7 +33,9 @@ namespace {
   int TrigIndexMax = 0;
 }  // namespace
 
-CastorDigiMonitor::CastorDigiMonitor(const edm::ParameterSet &ps) {
+CastorDigiMonitor::CastorDigiMonitor(const edm::ParameterSet &ps, edm::ConsumesCollector &&iC)
+    : castorChannelQualityToken_{
+          iC.esConsumes<CastorChannelQuality, CastorChannelQualityRcd, edm::Transition::BeginRun>()} {
   fVerbosity = ps.getUntrackedParameter<int>("debug", 0);
   subsystemname_ = ps.getUntrackedParameter<std::string>("subSystemFolder", "Castor");
   EtowerLastModule = ps.getUntrackedParameter<int>("towerLastModule", 6);
@@ -396,8 +399,7 @@ void CastorDigiMonitor::fillTrigRes(edm::Event const &event, const edm::TriggerR
 }
 
 void CastorDigiMonitor::getDbData(const edm::EventSetup &iSetup) {
-  edm::ESHandle<CastorChannelQuality> dbChQuality;
-  iSetup.get<CastorChannelQualityRcd>().get(dbChQuality);
+  edm::ESHandle<CastorChannelQuality> dbChQuality = iSetup.getHandle(castorChannelQualityToken_);
   if (fVerbosity > 0) {
     LogPrint("CastorDigiMonitor") << " CastorChQuality in CondDB=" << dbChQuality.isValid() << endl;
   }

--- a/DQM/CastorMonitor/src/CastorLEDMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorLEDMonitor.cc
@@ -20,7 +20,7 @@ CastorLEDMonitor::CastorLEDMonitor(const edm::ParameterSet &ps) {
 
 CastorLEDMonitor::~CastorLEDMonitor() {}
 
-void CastorLEDMonitor::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &iRun, const edm::EventSetup &iSetup) {
+void CastorLEDMonitor::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &iRun) {
   char s[60];
 
   ibooker.setCurrentFolder(subsystemname + "/CastorLEDMonitor");

--- a/DQM/CastorMonitor/src/CastorMonitorModule.cc
+++ b/DQM/CastorMonitor/src/CastorMonitorModule.cc
@@ -1,6 +1,5 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -26,7 +25,8 @@
 using namespace std;
 using namespace edm;
 
-CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet &ps) {
+CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet &ps)
+    : castorDbServiceToken_{esConsumes<CastorDbService, CastorDbRecord>()} {
   fVerbosity = ps.getUntrackedParameter<int>("debug", 0);
   subsystemname_ = ps.getUntrackedParameter<std::string>("subSystemFolder", "Castor");
   inputTokenRaw_ = consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("rawLabel"));
@@ -40,7 +40,7 @@ CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet &ps) {
   showTiming_ = ps.getUntrackedParameter<bool>("showTiming", false);
 
   if (ps.getUntrackedParameter<bool>("DigiMonitor", false))
-    DigiMon_ = std::make_unique<CastorDigiMonitor>(ps);
+    DigiMon_ = std::make_unique<CastorDigiMonitor>(ps, consumesCollector());
 
   if (ps.getUntrackedParameter<bool>("RecHitMonitor", false))
     RecHitMon_ = std::make_unique<CastorRecHitMonitor>(ps);
@@ -53,7 +53,7 @@ CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet &ps) {
 
 CastorMonitorModule::~CastorMonitorModule() {}
 
-void CastorMonitorModule::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
+void CastorMonitorModule::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &) {
   if (fVerbosity > 0)
     LogPrint("CastorMonitorModule") << "dqmBeginRun(start)";
 }
@@ -65,10 +65,10 @@ void CastorMonitorModule::bookHistograms(DQMStore::IBooker &ibooker,
     DigiMon_->bookHistograms(ibooker, iRun, iSetup);
   }
   if (RecHitMon_) {
-    RecHitMon_->bookHistograms(ibooker, iRun, iSetup);
+    RecHitMon_->bookHistograms(ibooker, iRun);
   }
   if (LedMon_) {
-    LedMon_->bookHistograms(ibooker, iRun, iSetup);
+    LedMon_->bookHistograms(ibooker, iRun);
   }
 
   ibooker.setCurrentFolder(subsystemname_);
@@ -94,7 +94,7 @@ void CastorMonitorModule::bookHistograms(DQMStore::IBooker &ibooker,
   return;
 }
 
-void CastorMonitorModule::dqmEndRun(const edm::Run &r, const edm::EventSetup &context) {
+void CastorMonitorModule::dqmEndRun(const edm::Run &r, const edm::EventSetup &) {
   if (DigiMon_) {
     DigiMon_->endRun();
   }
@@ -178,10 +178,8 @@ void CastorMonitorModule::analyze(const edm::Event &iEvent, const edm::EventSetu
   CastorEventProduct->Fill(5, jetsOK_);
 
   if (digiOK_) {
-    edm::ESHandle<CastorDbService> conditions;
-    iSetup.get<CastorDbRecord>().get(conditions);
-
-    DigiMon_->processEvent(iEvent, *CastorDigi, *TrigResults, *conditions);
+    const CastorDbService &conditions = iSetup.getData(castorDbServiceToken_);
+    DigiMon_->processEvent(iEvent, *CastorDigi, *TrigResults, conditions);
   }
   if (showTiming_) {
     cpu_timer.stop();

--- a/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorRecHitMonitor.cc
@@ -23,9 +23,7 @@ CastorRecHitMonitor::CastorRecHitMonitor(const edm::ParameterSet &ps) {
 
 CastorRecHitMonitor::~CastorRecHitMonitor() {}
 
-void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker,
-                                         const edm::Run &iRun,
-                                         const edm::EventSetup &iSetup) {
+void CastorRecHitMonitor::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &iRun) {
   char s[60];
   if (fVerbosity > 0)
     std::cout << "CastorRecHitMonitor::bookHistograms" << std::endl;

--- a/DQM/DTMonitorModule/src/DTDCSByLumiTask.cc
+++ b/DQM/DTMonitorModule/src/DTDCSByLumiTask.cc
@@ -14,24 +14,25 @@
 #include <FWCore/Framework/interface/EventSetup.h>
 
 // Geometry
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/DTGeometry/interface/DTLayer.h"
 #include "Geometry/DTGeometry/interface/DTTopology.h"
-
-#include "CondFormats/DataRecord/interface/DTHVStatusRcd.h"
-#include "CondFormats/DTObjects/interface/DTHVStatus.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include <FWCore/Framework/interface/EventSetupRecord.h>
 #include <FWCore/Framework/interface/EventSetupRecordKey.h>
+#include "FWCore/Utilities/interface/Transition.h"
+
 #include <iostream>
 
 using namespace edm;
 using namespace std;
 
-DTDCSByLumiTask::DTDCSByLumiTask(const edm::ParameterSet& ps) : theEvents(0), theLumis(0) {
+DTDCSByLumiTask::DTDCSByLumiTask(const edm::ParameterSet& ps)
+    : theEvents(0),
+      theLumis(0),
+      dtGeometryToken_(esConsumes<DTGeometry, MuonGeometryRecord, edm::Transition::BeginRun>()),
+      dtHVStatusToken_(esConsumes<DTHVStatus, DTHVStatusRcd, edm::Transition::EndLuminosityBlock>()) {
   LogTrace("DTDQM|DTMonitorModule|DTDCSByLumiTask") << "[DTDCSByLumiTask]: Constructor" << endl;
 
   // If needed put getParameter here
@@ -46,7 +47,7 @@ DTDCSByLumiTask::~DTDCSByLumiTask() {
 void DTDCSByLumiTask::dqmBeginRun(const edm::Run& run, const edm::EventSetup& context) {
   LogTrace("DTDQM|DTMonitorModule|DTDCSByLumiTask") << "[DTDCSByLumiTask]: begin run" << endl;
 
-  context.get<MuonGeometryRecord>().get(theDTGeom);
+  theDTGeom = context.getHandle(dtGeometryToken_);
 
   DTHVRecordFound = true;
 
@@ -64,7 +65,7 @@ void DTDCSByLumiTask::dqmBeginRun(const edm::Run& run, const edm::EventSetup& co
   }
 }
 
-void DTDCSByLumiTask::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& context) {
+void DTDCSByLumiTask::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const&) {
   // Book bylumi histo (# of bins as reduced as possible)
   ibooker.setCurrentFolder(topFolder());
 
@@ -80,7 +81,7 @@ void DTDCSByLumiTask::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   }
 }
 
-void DTDCSByLumiTask::dqmBeginLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const& context) {
+void DTDCSByLumiTask::dqmBeginLuminosityBlock(LuminosityBlock const& lumiSeg, EventSetup const&) {
   theLumis++;
 
   LogTrace("DTDQM|DTMonitorModule|DTDCSByLumiTask")
@@ -93,8 +94,9 @@ void DTDCSByLumiTask::dqmBeginLuminosityBlock(LuminosityBlock const& lumiSeg, Ev
 }
 
 void DTDCSByLumiTask::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& context) {
+  const DTHVStatus* dtHVStatus = nullptr;
   if (DTHVRecordFound) {
-    context.get<DTHVStatusRcd>().get(hvStatus);
+    dtHVStatus = &context.getData(dtHVStatusToken_);
   }
 
   vector<const DTLayer*>::const_iterator layersIt = theDTGeom->layers().begin();
@@ -118,11 +120,11 @@ void DTDCSByLumiTask::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
     // wires list
 
     if (DTHVRecordFound) {
-      if (!hvStatus->get((*layersIt)->id(), 0, first, last, flagA, flagC, flagS) && (flagA || flagC || flagS)) {
+      if (!dtHVStatus->get((*layersIt)->id(), 0, first, last, flagA, flagC, flagS) && (flagA || flagC || flagS)) {
         nActiveWires -= (last - first + 1);
       }
 
-      if (!hvStatus->get((*layersIt)->id(), 1, first, last, flagA, flagC, flagS) && (flagA || flagC || flagS)) {
+      if (!dtHVStatus->get((*layersIt)->id(), 1, first, last, flagA, flagC, flagS) && (flagA || flagC || flagS)) {
         nActiveWires -= (last - first + 1);
       }
     } else {
@@ -133,7 +135,7 @@ void DTDCSByLumiTask::dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
   }
 }
 
-void DTDCSByLumiTask::analyze(const edm::Event& event, const edm::EventSetup& c) { theEvents++; }
+void DTDCSByLumiTask::analyze(const edm::Event&, const edm::EventSetup&) { theEvents++; }
 
 string DTDCSByLumiTask::topFolder() const { return string("DT/EventInfo/DCSContents"); }
 

--- a/DQM/DTMonitorModule/src/DTDCSByLumiTask.h
+++ b/DQM/DTMonitorModule/src/DTDCSByLumiTask.h
@@ -25,10 +25,13 @@
 
 #include <FWCore/Framework/interface/LuminosityBlock.h>
 
-#include <vector>
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/DTHVStatusRcd.h"
+#include "CondFormats/DTObjects/interface/DTHVStatus.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-class DTGeometry;
-class DTHVStatus;
+#include <vector>
 
 class DTDCSByLumiTask : public DQMOneLumiEDAnalyzer<> {
 public:
@@ -46,13 +49,13 @@ protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   /// By Lumi DCS DB Operation
-  void dqmBeginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context) override;
+  void dqmBeginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const&) override;
 
   /// By Lumi DCS DB Operation
-  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& setup) override;
+  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) override;
 
   /// Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+  void analyze(const edm::Event& e, const edm::EventSetup&) override;
 
 private:
   std::string topFolder() const;
@@ -63,8 +66,9 @@ private:
   bool DTHVRecordFound;
 
   edm::ESHandle<DTGeometry> theDTGeom;
-  // CB Get HV DB and loop on half layers
-  edm::ESHandle<DTHVStatus> hvStatus;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeometryToken_;
+  edm::ESGetToken<DTHVStatus, DTHVStatusRcd> dtHVStatusToken_;
 
   std::vector<MonitorElement*> hActiveUnits;
 };

--- a/DQM/HcalCommon/interface/DQTask.h
+++ b/DQM/HcalCommon/interface/DQTask.h
@@ -7,10 +7,19 @@
  *	Date:		13.10.2015
  */
 
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "CondFormats/DataRecord/interface/HcalChannelQualityRcd.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
+
 #include "DQM/HcalCommon/interface/ContainerI.h"
 #include "DQM/HcalCommon/interface/ContainerS.h"
 #include "DQM/HcalCommon/interface/ContainerXXX.h"
 #include "DQM/HcalCommon/interface/DQModule.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 namespace hcaldqm {
   enum UpdateFreq { fEvent = 0, f1LS = 1, f10LS = 2, f50LS = 3, f100LS = 4, nUpdateFreq = 5 };
@@ -55,8 +64,12 @@ namespace hcaldqm {
     edm::EDGetTokenT<FEDRawDataCollection> _tokRaw;
 
     // Conditions and emap
+    edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDbServiceToken_;
+    edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
+    edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> hcalChannelQualityToken_;
+
     edm::ESHandle<HcalDbService> _dbService;
-    HcalElectronicsMap const *_emap;
+    HcalElectronicsMap const *_emap = nullptr;
   };
 }  // namespace hcaldqm
 

--- a/DQM/HcalTasks/plugins/DigiPhase1Task.cc
+++ b/DQM/HcalTasks/plugins/DigiPhase1Task.cc
@@ -29,9 +29,6 @@ DigiPhase1Task::DigiPhase1Task(edm::ParameterSet const& ps) : DQTask(ps) {
   DQTask::bookHistograms(ib, r, es);
 
   //  GET WHAT YOU NEED
-  edm::ESHandle<HcalDbService> dbs;
-  es.get<HcalDbRecord>().get(dbs);
-  _emap = dbs->getHcalMapping();
   std::vector<uint32_t> vVME;
   std::vector<uint32_t> vuTCA;
   vVME.push_back(


### PR DESCRIPTION
#### PR description:

Migrates CastorMonitorModule, CTPPSDiamondDQMSource, DTDCSByLumiTask, and DigiPhase1Task to call the esConsumes function for the EventSetup data they get.

#### PR validation:

Relies on existing tests. Output should not change.
