### PR TITLE
Removing An additional Accumulation of Charge in HGCDigitizer Standard Mixing

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -477,15 +477,9 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
              ((simHitIt->second).hit_info[1][itime] == 0 || orderChanged == true)) {
       float fireTDC = hitRefs_bx0[id].back().second;
       if (hitRefs_bx0[id].size() > 1) {
-        float chargeBeforeThr = 0.f;
-        float tofchargeBeforeThr = 0.f;
-        for (const auto& step : hitRefs_bx0[id]) {
-          if (step.first + chargeBeforeThr <= tdcForToAOnset[waferThickness - 1]) {
-            chargeBeforeThr += step.first;
-            tofchargeBeforeThr = step.second;
-          } else
-            break;
-        }
+        std::vector<std::pair<float, float>>::const_iterator charge_timeBeforeThr = (hitRefs_bx0[id].end() - 1);
+        float chargeBeforeThr = charge_timeBeforeThr->first;
+        float tofchargeBeforeThr = charge_timeBeforeThr->second;
         float deltaQ = accChargeForToA - chargeBeforeThr;
         float deltaTOF = fireTDC - tofchargeBeforeThr;
         fireTDC = (tdcForToAOnset[waferThickness - 1] - chargeBeforeThr) * deltaTOF / deltaQ + tofchargeBeforeThr;


### PR DESCRIPTION
#### PR description:

<Removing An additional Accumulation of Charge in HGCDigitizer Standard Mixing>

#### PR validation:

<In the standard Mixing of deposited charge, the accumulate function of HGCDigitizer saves cumulative sum of time-sorted charge in HitRefsbx0 container. When calculating timing of firing of the channel, it redoes the cumulative sum over the saved charges. This PR seeks to remove the second cumsum.>

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
