### PR TITLE
TestProcessor supports Run and Lumi product testing

### DIFF
--- a/FWCore/TestProcessor/Readme.md
+++ b/FWCore/TestProcessor/Readme.md
@@ -111,6 +111,20 @@ The return value of `test()` is an `edm::test::Event`. The `Event` class gives a
   
 The `edm::test::Event` also has the method `modulePassed()` which is only useful when testing an `EDFilter`. In that case, the method returns `true` if the module passed the Event and `false` otherwise.
 
+### Run and LuminosityBlock product testing
+It is possible to also test Run and LuminosityBlock products created by the module. This can be accomplished by calling
+* `testBeginRun(edm::RunNumber_t)`
+* `testEndRun()`
+* `testBeginLuminosityBlock(edm::LuminosityBlockNumber_t)`
+* `testEndLuminosityBlock()`
+
+Like `test()` one can pass an unlimited number of arguments of type  `std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>` in order to control EventSetup data passed to the module (`EDPutToken` are not supported at this time). Each of the above `test` functions also return either `edm::test::Run` or `edm::test::LuminosityBlock` which has the same interface as `edm::test::Event` except they do not have the method `modulePassed()` because filtering does not occur on those transitions. 
+
+The `test` methods all make sure all the needed transitions occur in the necessary order. For example, calling `test()` and then `testEndRun()` will cause _streamEndLuminosityBlock_ and _globalEndLuminosityBlock_ to occur.
+
+When calling `testBeginRun(edm:RunNumber_t)` or `testBeginLuminosityBlock(edm::LuminosityBlockNumber_t)` one is required to pass in a Run or LuminosityBlock number which is different from the number previously used by any earlier calls to a `test` function. 
+
+
 ### Full Example 
 
 ```cpp

--- a/FWCore/TestProcessor/interface/LuminosityBlock.h
+++ b/FWCore/TestProcessor/interface/LuminosityBlock.h
@@ -1,0 +1,73 @@
+#ifndef FWCore_TestProcessor_LuminosityBlock_h
+#define FWCore_TestProcessor_LuminosityBlock_h
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     LuminosityBlock
+//
+/**\class LuminosityBlock LuminosityBlock.h "LuminosityBlock.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:27 GMT
+//
+
+// system include files
+#include <string>
+
+// user include files
+#include "FWCore/TestProcessor/interface/TestHandle.h"
+#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+// forward declarations
+
+namespace edm {
+
+  namespace test {
+
+    class LuminosityBlock {
+    public:
+      LuminosityBlock(std::shared_ptr<LuminosityBlockPrincipal const> iPrincipal,
+                      std::string iModuleLabel,
+                      std::string iProcessName);
+
+      // ---------- const member functions ---------------------
+      template <typename T>
+      TestHandle<T> get() const {
+        static const std::string s_null;
+        return get<T>(s_null);
+      }
+
+      template <typename T>
+      TestHandle<T> get(std::string const& iInstanceLabel) const {
+        auto h = principal_->getByLabel(
+            edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), label_, iInstanceLabel, processName_, nullptr, nullptr, nullptr);
+        if (h.failedToGet()) {
+          return TestHandle<T>(std::move(h.whyFailedFactory()));
+        }
+        void const* basicWrapper = h.wrapper();
+        assert(basicWrapper);
+        Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(basicWrapper);
+        return TestHandle<T>(wrapper->product());
+      }
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+    private:
+      // ---------- member data --------------------------------
+      std::shared_ptr<LuminosityBlockPrincipal const> principal_;
+      std::string label_;
+      std::string processName_;
+    };
+  }  // namespace test
+}  // namespace edm
+
+#endif

--- a/FWCore/TestProcessor/interface/Run.h
+++ b/FWCore/TestProcessor/interface/Run.h
@@ -1,0 +1,72 @@
+#ifndef FWCore_TestProcessor_Run_h
+#define FWCore_TestProcessor_Run_h
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     Run
+//
+/**\class Run Run.h "Run.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:27 GMT
+//
+
+// system include files
+#include <string>
+
+// user include files
+#include "FWCore/TestProcessor/interface/TestHandle.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+// forward declarations
+
+namespace edm {
+
+  namespace test {
+
+    class Run {
+    public:
+      Run(std::shared_ptr<RunPrincipal const> iPrincipal, std::string iModuleLabel, std::string iProcessName);
+
+      // ---------- const member functions ---------------------
+      template <typename T>
+      TestHandle<T> get() const {
+        static const std::string s_null;
+        return get<T>(s_null);
+      }
+
+      template <typename T>
+      TestHandle<T> get(std::string const& iInstanceLabel) const {
+        auto h = principal_->getByLabel(
+            edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), label_, iInstanceLabel, processName_, nullptr, nullptr, nullptr);
+        if (h.failedToGet()) {
+          return TestHandle<T>(std::move(h.whyFailedFactory()));
+        }
+        void const* basicWrapper = h.wrapper();
+        assert(basicWrapper);
+        Wrapper<T> const* wrapper = static_cast<Wrapper<T> const*>(basicWrapper);
+        return TestHandle<T>(wrapper->product());
+      }
+
+      // ---------- static member functions --------------------
+
+      // ---------- member functions ---------------------------
+
+    private:
+      // ---------- member data --------------------------------
+      std::shared_ptr<RunPrincipal const> principal_;
+      std::string label_;
+      std::string processName_;
+    };
+  }  // namespace test
+}  // namespace edm
+
+#endif

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -42,6 +42,8 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 
 #include "FWCore/TestProcessor/interface/Event.h"
+#include "FWCore/TestProcessor/interface/LuminosityBlock.h"
+#include "FWCore/TestProcessor/interface/Run.h"
 #include "FWCore/TestProcessor/interface/TestDataProxy.h"
 #include "FWCore/TestProcessor/interface/ESPutTokenT.h"
 #include "FWCore/TestProcessor/interface/ESProduceEntry.h"
@@ -164,6 +166,24 @@ namespace edm {
         return testImpl(std::forward<T>(iArgs)...);
       }
 
+      template <typename... T>
+      edm::test::LuminosityBlock testBeginLuminosityBlock(edm::LuminosityBlockNumber_t iNum, T&&... iArgs) {
+        return testBeginLuminosityBlockImpl(iNum, std::forward<T>(iArgs)...);
+      }
+      template <typename... T>
+      edm::test::LuminosityBlock testEndLuminosityBlock(T&&... iArgs) {
+        return testEndLuminosityBlockImpl(std::forward<T>(iArgs)...);
+      }
+
+      template <typename... T>
+      edm::test::Run testBeginRun(edm::RunNumber_t iNum, T&&... iArgs) {
+        return testBeginRunImpl(iNum, std::forward<T>(iArgs)...);
+      }
+      template <typename... T>
+      edm::test::Run testEndRun(T&&... iArgs) {
+        return testEndRunImpl(std::forward<T>(iArgs)...);
+      }
+
       /** Run only beginJob and endJob. Once this is used, you should not attempt to run any further tests.
 This simulates a problem happening early in the job which causes processing not to proceed.
    */
@@ -224,6 +244,40 @@ This simulates a problem happening early in the job which causes processing not 
 
       edm::test::Event testImpl();
 
+      template <typename T, typename... U>
+      edm::test::LuminosityBlock testBeginLuminosityBlockImpl(
+          edm::LuminosityBlockNumber_t iNum,
+          std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut,
+          U&&... iArgs) {
+        put(std::move(iPut));
+        return testBeginLuminosityBlockImpl(iNum, std::forward<U>(iArgs)...);
+      }
+      edm::test::LuminosityBlock testBeginLuminosityBlockImpl(edm::LuminosityBlockNumber_t);
+
+      template <typename T, typename... U>
+      edm::test::LuminosityBlock testEndLuminosityBlockImpl(
+          std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut, U&&... iArgs) {
+        put(std::move(iPut));
+        return testEndLuminosityBlockImpl(std::forward<U>(iArgs)...);
+      }
+      edm::test::LuminosityBlock testEndLuminosityBlockImpl();
+
+      template <typename T, typename... U>
+      edm::test::Run testBeginRunImpl(edm::RunNumber_t iNum,
+                                      std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut,
+                                      U&&... iArgs) {
+        put(std::move(iPut));
+        return testBeginRunImpl(iNum, std::forward<U>(iArgs)...);
+      }
+      edm::test::Run testBeginRunImpl(edm::RunNumber_t);
+      template <typename T, typename... U>
+      edm::test::LuminosityBlock testEndRunImpl(std::pair<edm::test::ESPutTokenT<T>, std::unique_ptr<T>>&& iPut,
+                                                U&&... iArgs) {
+        put(std::move(iPut));
+        return testEndRunImpl(std::forward<U>(iArgs)...);
+      }
+      edm::test::Run testEndRunImpl();
+
       void setupProcessing();
       void teardownProcessing();
 
@@ -231,8 +285,8 @@ This simulates a problem happening early in the job which causes processing not 
       void beginRun();
       void beginLuminosityBlock();
       void event();
-      void endLuminosityBlock();
-      void endRun();
+      std::shared_ptr<LuminosityBlockPrincipal> endLuminosityBlock();
+      std::shared_ptr<RunPrincipal> endRun();
       void endJob();
 
       // ---------- member data --------------------------------
@@ -268,8 +322,6 @@ This simulates a problem happening early in the job which causes processing not 
       bool beginJobCalled_ = false;
       bool beginRunCalled_ = false;
       bool beginLumiCalled_ = false;
-      bool newRun_ = true;
-      bool newLumi_ = true;
     };
   }  // namespace test
 }  // namespace edm

--- a/FWCore/TestProcessor/src/LuminosityBlock.cc
+++ b/FWCore/TestProcessor/src/LuminosityBlock.cc
@@ -1,0 +1,50 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     LuminosityBlock
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/TestProcessor/interface/LuminosityBlock.h"
+
+namespace edm {
+  namespace test {
+
+    //
+    // constants, enums and typedefs
+    //
+
+    //
+    // static data member definitions
+    //
+
+    //
+    // constructors and destructor
+    //
+    LuminosityBlock::LuminosityBlock(std::shared_ptr<LuminosityBlockPrincipal const> iPrincipal,
+                                     std::string iModuleLabel,
+                                     std::string iProcessName)
+        : principal_{std::move(iPrincipal)}, label_{std::move(iModuleLabel)}, processName_{std::move(iProcessName)} {}
+
+    //
+    // member functions
+    //
+
+    //
+    // const member functions
+    //
+
+    //
+    // static member functions
+    //
+
+  }  // namespace test
+}  // namespace edm

--- a/FWCore/TestProcessor/src/Run.cc
+++ b/FWCore/TestProcessor/src/Run.cc
@@ -1,0 +1,48 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/TestProcessor
+// Class  :     Run
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Mon, 30 Apr 2018 18:51:33 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/TestProcessor/interface/Run.h"
+
+namespace edm {
+  namespace test {
+
+    //
+    // constants, enums and typedefs
+    //
+
+    //
+    // static data member definitions
+    //
+
+    //
+    // constructors and destructor
+    //
+    Run::Run(std::shared_ptr<RunPrincipal const> iPrincipal, std::string iModuleLabel, std::string iProcessName)
+        : principal_{std::move(iPrincipal)}, label_{std::move(iModuleLabel)}, processName_{std::move(iProcessName)} {}
+
+    //
+    // member functions
+    //
+
+    //
+    // const member functions
+    //
+
+    //
+    // static member functions
+    //
+
+  }  // namespace test
+}  // namespace edm

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -222,6 +222,85 @@ namespace edm {
           principalCache_.eventPrincipal(0), labelOfTestModule_, processConfiguration_->processName(), result);
     }
 
+    edm::test::LuminosityBlock TestProcessor::testBeginLuminosityBlockImpl(edm::LuminosityBlockNumber_t iNum) {
+      if (not beginJobCalled_) {
+        beginJob();
+      }
+      if (not beginRunCalled_) {
+        beginRun();
+      }
+      if (beginLumiCalled_) {
+        endLuminosityBlock();
+        assert(lumiNumber_ != iNum);
+      }
+      lumiNumber_ = iNum;
+      beginLuminosityBlock();
+
+      if (esHelper_) {
+        //We want each test to have its own ES data products
+        esHelper_->resetAllProxies();
+      }
+
+      return edm::test::LuminosityBlock(lumiPrincipal_, labelOfTestModule_, processConfiguration_->processName());
+    }
+
+    edm::test::LuminosityBlock TestProcessor::testEndLuminosityBlockImpl() {
+      if (not beginJobCalled_) {
+        beginJob();
+      }
+      if (not beginRunCalled_) {
+        beginRun();
+      }
+      if (not beginLumiCalled_) {
+        beginLuminosityBlock();
+      }
+      auto lumi = endLuminosityBlock();
+
+      if (esHelper_) {
+        //We want each test to have its own ES data products
+        esHelper_->resetAllProxies();
+      }
+
+      return edm::test::LuminosityBlock(std::move(lumi), labelOfTestModule_, processConfiguration_->processName());
+    }
+
+    edm::test::Run TestProcessor::testBeginRunImpl(edm::RunNumber_t iNum) {
+      if (not beginJobCalled_) {
+        beginJob();
+      }
+
+      if (beginRunCalled_) {
+        assert(runNumber_ != iNum);
+        endRun();
+      }
+      runNumber_ = iNum;
+      beginRun();
+
+      if (esHelper_) {
+        //We want each test to have its own ES data products
+        esHelper_->resetAllProxies();
+      }
+
+      return edm::test::Run(
+          principalCache_.runPrincipalPtr(), labelOfTestModule_, processConfiguration_->processName());
+    }
+    edm::test::Run TestProcessor::testEndRunImpl() {
+      if (not beginJobCalled_) {
+        beginJob();
+      }
+      if (not beginRunCalled_) {
+        beginRun();
+      }
+      auto rp = endRun();
+
+      if (esHelper_) {
+        //We want each test to have its own ES data products
+        esHelper_->resetAllProxies();
+      }
+
+      return edm::test::Run(rp, labelOfTestModule_, processConfiguration_->processName());
+    }
+
     void TestProcessor::setupProcessing() {
       if (not beginJobCalled_) {
         beginJob();
@@ -337,6 +416,7 @@ namespace edm {
     void TestProcessor::beginLuminosityBlock() {
       LuminosityBlockAuxiliary aux(runNumber_, lumiNumber_, Timestamp(), Timestamp());
       lumiPrincipal_ = principalCache_.getAvailableLumiPrincipalPtr();
+      lumiPrincipal_->clearPrincipal();
       assert(lumiPrincipal_);
       lumiPrincipal_->setAux(aux);
 
@@ -428,10 +508,10 @@ namespace edm {
       ++eventNumber_;
     }
 
-    void TestProcessor::endLuminosityBlock() {
+    std::shared_ptr<LuminosityBlockPrincipal> TestProcessor::endLuminosityBlock() {
+      auto lumiPrincipal = lumiPrincipal_;
       if (beginLumiCalled_) {
         beginLumiCalled_ = false;
-        auto lumiPrincipal = lumiPrincipal_;
         lumiPrincipal_.reset();
 
         IOVSyncValue ts(EventID(runNumber_, lumiNumber_, eventNumber_), lumiPrincipal->endTime());
@@ -484,14 +564,16 @@ namespace edm {
           }
         }
       }
+      return lumiPrincipal;
     }
 
-    void TestProcessor::endRun() {
+    std::shared_ptr<edm::RunPrincipal> TestProcessor::endRun() {
+      std::shared_ptr<RunPrincipal> rp;
       if (beginRunCalled_) {
         beginRunCalled_ = false;
         ProcessHistoryID phid;
-
-        RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, runNumber_);
+        rp = principalCache_.runPrincipalPtr(phid, runNumber_);
+        RunPrincipal& runPrincipal = *rp;
 
         IOVSyncValue ts(
             EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
@@ -547,6 +629,7 @@ namespace edm {
 
         principalCache_.deleteRun(phid, runNumber_);
       }
+      return rp;
     }
 
     void TestProcessor::endJob() {


### PR DESCRIPTION
#### PR description:

Can now explicitly cause a begin/end/ LuminosityBlock/Run transition and then check any data products added by the module.

#### PR validation:

The updated unit test passes.