### PR TITLE
fix python includes for ALCARECOSiPixelCalCosmics to comply with Py3

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -13,14 +13,17 @@ ALCARECOSiPixelCalCosmicsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcssta
     DebugOn      = cms.untracked.bool(False)
 )
 
-from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuonHLTFilter 
-ALCARECOSiPixelCalCosmicsHLTFilter = ALCARECOSiPixelCalSingleMuonHLTFilter.clone(
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOSiPixelCalCosmicsHLTFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, ## choose logical OR between Triggerbits
     HLTPaths = ["HLT_*"],
-    eventSetupPathsKey = ''
+    # eventually this needs to sterred via Global Tag in AlCaRecoTriggerBits
+    eventSetupPathsKey = '',
+    throw = False # tolerate triggers stated above, but not available
 )
 
-from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuon
-ALCARECOSiPixelCalCosmics = ALCARECOSiPixelCalSingleMuon.clone(
+import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
+ALCARECOSiPixelCalCosmics =  Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
     filter = True,
     applyBasicCuts = True,
     ptMin = 3.,


### PR DESCRIPTION
#### PR description:

Fixes issue reported at https://github.com/cms-sw/cmssw/pull/28535#issuecomment-572478430

#### PR validation:

This was tested successfully in `CMSSW_11_1_PY3_X_2020-01-08-2300` with:  `runTheMatrix.py -l 7.22,7.21,7.4,7.3 -t 4 -j 8`
and also with:
```
cmsDriver.py -s RAW2DIGI,RECO,ALCA:SiPixelCalCosmics --data --scenario cosmics --conditions 110X_dataRun2_2017_2018_Candidate_2019_11_21_04_11_05 --eventcontent=ALCARECO --datatier ALCARECO -n -1 --no_exec --era Run2_2018 --python_filename=SiPixelCalCosmics_2018_v1.py --nThreads=8 --dasquery='file dataset=/Cosmics/Commissioning2018-v1/RAW run=313084'
```

#### if this PR is a backport please specify the original PR:

This PR is not a backport, but this commit shall be taken as well in the 10.6.X backport of #28535  (i.e. https://github.com/cms-sw/cmssw/pull/28574)

cc:
@tvami 
