### PR TITLE
Fixing HB thresholds E/gamma saved rec-hits for run3 

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
@@ -148,3 +148,7 @@ egamma_lowPt_exclusive.toModify(interestingGedEgammaIsoHCALDetId,
 		           minEleEt= 1.0, #default 20
 			   minPhoEt= 1.0 #default 20
 ) 
+
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(interestingEgammaIsoHCALSel,
+                 minEnergyHB = 0.1)


### PR DESCRIPTION
#### PR description:

This bug fix for Run3 MC / data enables the proper saving of HCAL rec-hits for the barrel. The current threshold is 0.8 GeV which is not appropriate for the phaseI HB.   This adjusts the rec-hits e/gamma saves to have a minimum energy of 0.1 for phaseI HB workflows.  Thanks to @swagata87 for raising the issue!

This fix would be needed for the upcoming Run3 production, the samples will be sigificantly less useful for e/gamma without it as it wouldnt allow us to develop Hcal depth based variables in the barrel. 

#### PR validation:

This will increase the AOD and miniAOD sizes for workflows with the phaseI HB detector. 

This was done with 200 TTbar events with standard pileup. 

sample: /RelValTTbar_14TeV/CMSSW_11_0_0_pre13-PU_110X_mcRun3_2023_realistic_v6-v1/GEN-SIM-DIGI-RAW
reco config cmsDriver: 
```
cmsDriver.py step3 --conditions auto:phase1_2021_realistic -n 10 --era Run3 --eventcontent RECOSIM,AODSIM,MINIAODSIM --runUnscheduled -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT --datatier GEN-SIM-RECO,AODSIM,MINIAODSIM --geometry DB:Extended --io RecoFull_2021.io --python RecoFull_2021.py --conditions=110X_mcRun3_2023_realistic_v6 --no_exec --filein /store/relval/CMSSW_11_0_0_pre13/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_110X_mcRun3_2023_realistic_v6-v1/20000/C27EA1AE-ADDB-3149-9867-6ABE5F653A97.root --fileout file:ttbar.root --nThreads 8
```

size increases (via ls) for 200 events:
AOD: 138061572 -> 138231541 (0.1% increase)
MiniAOD: 20615277 -> 20496350. (0.6% increase)

In miniAOD:
HBHERecHitsSorted_reducedEgamma_reducedHBHEHits_RECO  compressed size 1236 -> 1830 (50% increase)

Some of this size increase could be reduced (probably by 1/3) by properly applying the depth specific thresholds of 0.1,0.2,0.3,0.3 but this needs c++ changes to do so. 

red is energy of rec-hits saved before fix, blue is after, behaves as expected.

![image](https://user-images.githubusercontent.com/5021403/72083147-9968fd80-3301-11ea-87f7-519948370a4e.png)
