### PR TITLE
Fixing HB thresholds E/gamma saved rec-hits for run3 : 11_0_0

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
@@ -148,3 +148,7 @@ egamma_lowPt_exclusive.toModify(interestingGedEgammaIsoHCALDetId,
 		           minEleEt= 1.0, #default 20
 			   minPhoEt= 1.0 #default 20
 ) 
+
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(interestingEgammaIsoHCALSel,
+                 minEnergyHB = 0.1)


### PR DESCRIPTION
#### PR description:

Bug fixes to the HB threshold to be correct for Run3 for the hits e/gmama saves for Hcal studies

backport of https://github.com/cms-sw/cmssw/pull/28723

