### PR TITLE
Payload Inspector: add more two-tags comparisons

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -799,35 +799,60 @@ namespace AlignmentPI {
     std::map<AlignmentPI::PARTITION, double> Zbarycenters;
     std::map<AlignmentPI::PARTITION, double> nmodules;
 
-    std::array<double, 6> m_Xbarycenters;
-    std::array<double, 6> m_Ybarycenters;
-    std::array<double, 6> m_Zbarycenters;
-    std::array<double, 6> m_nmodules;
-
   public:
     void init();
     GlobalPoint getPartitionAvg(AlignmentPI::PARTITION p);
     void computeBarycenters(const std::vector<AlignTransform>& input,
                             const TrackerTopology& tTopo,
                             const std::map<AlignmentPI::coordinate, float>& GPR);
-    const std::array<double, 6> getX() { return m_Xbarycenters; };
-    const std::array<double, 6> getY() { return m_Ybarycenters; };
-    const std::array<double, 6> getZ() { return m_Zbarycenters; };
-    const std::array<double, 6> getNModules() { return m_nmodules; };
+    const double getNModules(AlignmentPI::PARTITION p) { return nmodules[p]; };
+
+    // M.M. 2020/01/09
+    // introduce methods for entire partitions, summing up the two sides of the
+    // endcap detectors
+
+    /*--------------------------------------------------------------------*/
+    const std::array<double, 6> getX()
+    /*--------------------------------------------------------------------*/
+    {
+      return {{Xbarycenters[PARTITION::BPIX],
+               (Xbarycenters[PARTITION::FPIXm] + Xbarycenters[PARTITION::FPIXp]) / 2.,
+               Xbarycenters[PARTITION::TIB],
+               (Xbarycenters[PARTITION::TIDm] + Xbarycenters[PARTITION::TIDp]) / 2,
+               Xbarycenters[PARTITION::TOB],
+               (Xbarycenters[PARTITION::TECm] + Xbarycenters[PARTITION::TECp]) / 2}};
+    };
+
+    /*--------------------------------------------------------------------*/
+    const std::array<double, 6> getY()
+    /*--------------------------------------------------------------------*/
+    {
+      return {{Ybarycenters[PARTITION::BPIX],
+               (Ybarycenters[PARTITION::FPIXm] + Ybarycenters[PARTITION::FPIXp]) / 2.,
+               Ybarycenters[PARTITION::TIB],
+               (Ybarycenters[PARTITION::TIDm] + Ybarycenters[PARTITION::TIDp]) / 2,
+               Ybarycenters[PARTITION::TOB],
+               (Ybarycenters[PARTITION::TECm] + Ybarycenters[PARTITION::TECp]) / 2}};
+    };
+
+    /*--------------------------------------------------------------------*/
+    const std::array<double, 6> getZ()
+    /*--------------------------------------------------------------------*/
+    {
+      return {{Zbarycenters[PARTITION::BPIX],
+               (Zbarycenters[PARTITION::FPIXm] + Zbarycenters[PARTITION::FPIXp]) / 2.,
+               Zbarycenters[PARTITION::TIB],
+               (Zbarycenters[PARTITION::TIDm] + Zbarycenters[PARTITION::TIDp]) / 2,
+               Zbarycenters[PARTITION::TOB],
+               (Zbarycenters[PARTITION::TECm] + Zbarycenters[PARTITION::TECp]) / 2}};
+    };
     virtual ~TkAlBarycenters() {}
   };
 
   /*--------------------------------------------------------------------*/
-  void TkAlBarycenters::init()
+  GlobalPoint TkAlBarycenters::getPartitionAvg(AlignmentPI::PARTITION p)
   /*--------------------------------------------------------------------*/
   {
-    m_Xbarycenters = {{0., 0., 0., 0., 0., 0.}};
-    m_Ybarycenters = {{0., 0., 0., 0., 0., 0.}};
-    m_Zbarycenters = {{0., 0., 0., 0., 0., 0.}};
-    m_nmodules = {{0., 0., 0., 0., 0., 0.}};
-  }
-
-  GlobalPoint TkAlBarycenters::getPartitionAvg(AlignmentPI::PARTITION p) {
     return GlobalPoint(Xbarycenters[p], Ybarycenters[p], Zbarycenters[p]);
   }
 
@@ -852,10 +877,6 @@ namespace AlignmentPI {
           Ybarycenters[PARTITION::BPIX] += (ali.translation().y());
           Zbarycenters[PARTITION::BPIX] += (ali.translation().z());
           nmodules[PARTITION::BPIX]++;
-          m_Xbarycenters[0] += (ali.translation().x());
-          m_Ybarycenters[0] += (ali.translation().y());
-          m_Zbarycenters[0] += (ali.translation().z());
-          m_nmodules[0]++;
           break;
         case PixelSubdetector::PixelEndcap:
 
@@ -872,20 +893,12 @@ namespace AlignmentPI {
             Zbarycenters[PARTITION::FPIXp] += (ali.translation().z());
             nmodules[PARTITION::FPIXp]++;
           }
-          m_Xbarycenters[1] += (ali.translation().x());
-          m_Ybarycenters[1] += (ali.translation().y());
-          m_Zbarycenters[1] += (ali.translation().z());
-          m_nmodules[1]++;
           break;
         case StripSubdetector::TIB:
           Xbarycenters[PARTITION::TIB] += (ali.translation().x());
           Ybarycenters[PARTITION::TIB] += (ali.translation().y());
           Zbarycenters[PARTITION::TIB] += (ali.translation().z());
           nmodules[PARTITION::TIB]++;
-          m_Xbarycenters[2] += (ali.translation().x());
-          m_Ybarycenters[2] += (ali.translation().y());
-          m_Zbarycenters[2] += (ali.translation().z());
-          m_nmodules[2]++;
           break;
         case StripSubdetector::TID:
           // minus side
@@ -901,20 +914,12 @@ namespace AlignmentPI {
             Zbarycenters[PARTITION::TIDp] += (ali.translation().z());
             nmodules[PARTITION::TIDp]++;
           }
-          m_Xbarycenters[3] += (ali.translation().x());
-          m_Ybarycenters[3] += (ali.translation().y());
-          m_Zbarycenters[3] += (ali.translation().z());
-          m_nmodules[3]++;
           break;
         case StripSubdetector::TOB:
           Xbarycenters[PARTITION::TOB] += (ali.translation().x());
           Ybarycenters[PARTITION::TOB] += (ali.translation().y());
           Zbarycenters[PARTITION::TOB] += (ali.translation().z());
           nmodules[PARTITION::TOB]++;
-          m_Xbarycenters[4] += (ali.translation().x());
-          m_Ybarycenters[4] += (ali.translation().y());
-          m_Zbarycenters[4] += (ali.translation().z());
-          m_nmodules[4]++;
           break;
         case StripSubdetector::TEC:
           // minus side
@@ -930,27 +935,11 @@ namespace AlignmentPI {
             Zbarycenters[PARTITION::TECp] += (ali.translation().z());
             nmodules[PARTITION::TECp]++;
           }
-          m_Xbarycenters[5] += (ali.translation().x());
-          m_Ybarycenters[5] += (ali.translation().y());
-          m_Zbarycenters[5] += (ali.translation().z());
-          m_nmodules[5]++;
           break;
         default:
           edm::LogError("TrackerAlignment_PayloadInspector") << "Unrecognized partition " << subid << std::endl;
           break;
       }
-    }
-
-    for (unsigned int i = 0; i < 6; i++) {
-      m_Xbarycenters[i] /= m_nmodules[i];
-      m_Ybarycenters[i] /= m_nmodules[i];
-      m_Zbarycenters[i] /= m_nmodules[i];
-
-      // correct for GPR
-
-      m_Xbarycenters[i] += GPR.at(AlignmentPI::t_x);
-      m_Ybarycenters[i] += GPR.at(AlignmentPI::t_y);
-      m_Zbarycenters[i] += GPR.at(AlignmentPI::t_z);
     }
 
     for (const auto& p : PARTITIONS) {

--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -15,6 +15,14 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 
+//#define MMDEBUG
+#ifdef MMDEBUG
+#include <iostream>
+#define COUT std::cout << "MM "
+#else
+#define COUT edm::LogVerbatim("")
+#endif
+
 namespace AlignmentPI {
 
   // size of the phase-I Tracker APE payload (including both SS + DS modules)

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
@@ -506,13 +506,12 @@ namespace {
   // *************************************************/
 
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedComparator : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended> {
+  class TrackerAlignmentErrorExtendedComparatorBase
+      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended> {
   public:
-    TrackerAlignmentErrorExtendedComparator()
+    TrackerAlignmentErrorExtendedComparatorBase()
         : cond::payloadInspector::PlotImage<AlignmentErrorsExtended>("Summary per Tracker region of sqrt(d_{" +
-                                                                     getStringFromIndex(i) + "}) of APE matrix") {
-      setSingleIov(false);
-    }
+                                                                     getStringFromIndex(i) + "}) of APE matrix") {}
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
       gStyle->SetPaintTextFormat(".1f");
@@ -738,6 +737,22 @@ namespace {
     }  // ends fill method
   };
 
+  template <AlignmentPI::index i>
+  class TrackerAlignmentErrorExtendedComparator : public TrackerAlignmentErrorExtendedComparatorBase<i> {
+  public:
+    TrackerAlignmentErrorExtendedComparator() : TrackerAlignmentErrorExtendedComparatorBase<i>() {
+      this->setSingleIov(false);
+    }
+  };
+
+  template <AlignmentPI::index i>
+  class TrackerAlignmentErrorExtendedComparatorTwoTags : public TrackerAlignmentErrorExtendedComparatorBase<i> {
+  public:
+    TrackerAlignmentErrorExtendedComparatorTwoTags() : TrackerAlignmentErrorExtendedComparatorBase<i>() {
+      this->setTwoTags(true);
+    }
+  };
+
   // diagonal elements
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::XX> TrackerAlignmentErrorExtendedXXComparator;
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::YY> TrackerAlignmentErrorExtendedYYComparator;
@@ -747,6 +762,22 @@ namespace {
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::XY> TrackerAlignmentErrorExtendedXYComparator;
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::XZ> TrackerAlignmentErrorExtendedXZComparator;
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::YZ> TrackerAlignmentErrorExtendedYZComparator;
+
+  // diagonal elements
+  typedef TrackerAlignmentErrorExtendedComparatorTwoTags<AlignmentPI::XX>
+      TrackerAlignmentErrorExtendedXXComparatorTwoTags;
+  typedef TrackerAlignmentErrorExtendedComparatorTwoTags<AlignmentPI::YY>
+      TrackerAlignmentErrorExtendedYYComparatorTwoTags;
+  typedef TrackerAlignmentErrorExtendedComparatorTwoTags<AlignmentPI::ZZ>
+      TrackerAlignmentErrorExtendedZZComparatorTwoTags;
+
+  // off-diagonal elements
+  typedef TrackerAlignmentErrorExtendedComparatorTwoTags<AlignmentPI::XY>
+      TrackerAlignmentErrorExtendedXYComparatorTwoTags;
+  typedef TrackerAlignmentErrorExtendedComparatorTwoTags<AlignmentPI::XZ>
+      TrackerAlignmentErrorExtendedXZComparatorTwoTags;
+  typedef TrackerAlignmentErrorExtendedComparatorTwoTags<AlignmentPI::YZ>
+      TrackerAlignmentErrorExtendedYZComparatorTwoTags;
 
 }  // namespace
 
@@ -782,4 +813,10 @@ PAYLOAD_INSPECTOR_MODULE(TrackerAlignmentErrorExtended) {
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedXYComparator);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedXZComparator);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedYZComparator);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedXXComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedYYComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedZZComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedXYComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedXZComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentErrorExtendedYZComparatorTwoTags);
 }

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
@@ -194,7 +194,7 @@ namespace {
             }
             break;
           default:
-            std::cout << "will do nothing" << std::endl;
+            COUT << "will do nothing" << std::endl;
             break;
         }
       }
@@ -375,7 +375,7 @@ namespace {
             0,
             range);
 
-        //std::cout<<"begin ( "<< begin << "): " << AlignmentPI::getStringFromRegionEnum(begin) << " end ( " << end << "): " <<  AlignmentPI::getStringFromRegionEnum(end) <<" | range = "<< range << std::endl;
+        //COUT<<"begin ( "<< begin << "): " << AlignmentPI::getStringFromRegionEnum(begin) << " end ( " << end << "): " <<  AlignmentPI::getStringFromRegionEnum(end) <<" | range = "<< range << std::endl;
 
         for (int j = begin; j <= end; j++) {
           AlignmentPI::regions part = (AlignmentPI::regions)j;

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -813,7 +813,11 @@ namespace {
       t1.SetNDC();
       t1.SetTextAlign(26);
       t1.SetTextSize(0.03);
-      t1.DrawLatex(0.5, 0.97, Form("Pixel Barycenters comparison, IOV: %i / IOV: %i", last_run, first_run));
+      t1.DrawLatex(0.5,
+                   0.97,
+                   ("Pixel Barycenters comparison, IOV: #color[2]{" + std::to_string(first_run) +
+                    "} vs IOV: #color[4]{" + std::to_string(last_run) + "}")
+                       .c_str());
       t1.SetTextSize(0.025);
 
       for (unsigned int c = 1; c <= 4; c++) {
@@ -947,18 +951,18 @@ namespace {
         COUT << "final   x,y " << std::left << std::setw(7) << structures[c - 1] << " (" << x0f << "," << y0f << ") mm"
              << std::endl;
 
-        TMarker *initial = new TMarker(x0i, y0i, 20);
-        TMarker *final = new TMarker(x0f, y0f, 21);
+        TMarker *initial = new TMarker(x0i, y0i, 21);
+        TMarker *final = new TMarker(x0f, y0f, 20);
 
-        initial->SetMarkerColor(kBlue);
-        final->SetMarkerColor(kRed);
+        initial->SetMarkerColor(kRed);
+        final->SetMarkerColor(kBlue);
         initial->SetMarkerSize(2.5);
         final->SetMarkerSize(2.5);
-        initial->Draw();
-        t1.SetTextColor(kBlue);
-        t1.DrawLatex(x0i, y0i + 0.3, Form("(%.2f,%.2f)", x0i, y0i));
-        final->Draw("same");
         t1.SetTextColor(kRed);
+        initial->Draw();
+        t1.DrawLatex(x0i, y0i - 0.5, Form("(%.2f,%.2f)", x0i, y0i));
+        final->Draw("same");
+        t1.SetTextColor(kBlue);
         t1.DrawLatex(x0f, y0f + 0.3, Form("(%.2f,%.2f)", x0f, y0f));
       }
 
@@ -981,21 +985,21 @@ namespace {
         z0f =
             (cutFunctorFinal(c).z() - (isFinalPhase0 ? hardcodeIdealZPhase0[c - 1] : hardcodeIdealZPhase1[c - 1])) * 10;
 
-        TMarker *initial = new TMarker(c - 1, z0i, 20);
-        TMarker *final = new TMarker(c - 1, z0f, 21);
+        TMarker *initial = new TMarker(c - 1, z0i, 21);
+        TMarker *final = new TMarker(c - 1, z0f, 20);
 
         COUT << "initial   z " << std::left << std::setw(7) << structures[c - 1] << " " << z0i << " mm" << std::endl;
         COUT << "final     z " << std::left << std::setw(7) << structures[c - 1] << " " << z0f << " mm" << std::endl;
 
-        initial->SetMarkerColor(kBlue);
-        final->SetMarkerColor(kRed);
+        initial->SetMarkerColor(kRed);
+        final->SetMarkerColor(kBlue);
         initial->SetMarkerSize(2.5);
         final->SetMarkerSize(2.5);
         initial->Draw();
-        t1.SetTextColor(kBlue);
-        t1.DrawLatex(c - 1, z0i - 1.1, Form("(%.2f)", z0i));
-        final->Draw("same");
         t1.SetTextColor(kRed);
+        t1.DrawLatex(c - 1, z0i - 1.5, Form("(%.2f)", z0i));
+        final->Draw("same");
+        t1.SetTextColor(kBlue);
         t1.DrawLatex(c - 1, z0f + 1., Form("(%.2f)", z0f));
       }
 

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -606,7 +606,6 @@ namespace {
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
       AlignmentPI::TkAlBarycenters barycenters;
-      barycenters.init();
       // compute uncorrected barycenter
       barycenters.computeBarycenters(
           alignments, tTopo, {{AlignmentPI::t_x, 0.0}, {AlignmentPI::t_y, 0.0}, {AlignmentPI::t_z, 0.0}});
@@ -615,7 +614,6 @@ namespace {
       auto Ybarycenters = barycenters.getY();
       auto Zbarycenters = barycenters.getZ();
 
-      barycenters.init();
       // compute barycenter corrected for the GPR
       barycenters.computeBarycenters(alignments, tTopo, hardcodeGPR);
 
@@ -751,11 +749,9 @@ namespace {
       h2_BarycenterDiff->GetXaxis()->SetBinLabel(3, "Z [#mum]");
 
       AlignmentPI::TkAlBarycenters l_barycenters;
-      l_barycenters.init();
       l_barycenters.computeBarycenters(last_alignments, tTopo_l, hardcodeGPR);
 
       AlignmentPI::TkAlBarycenters f_barycenters;
-      f_barycenters.init();
       f_barycenters.computeBarycenters(first_alignments, tTopo_f, hardcodeGPR);
 
       unsigned int yBin = 6;
@@ -875,7 +871,6 @@ namespace {
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
       AlignmentPI::TkAlBarycenters myInitialBarycenters;
-      myInitialBarycenters.init();
       //myInitialBarycenters.computeBarycenters(first_alignments,tTopo_f,hardcodeGPR);
       myInitialBarycenters.computeBarycenters(
           first_alignments, tTopo_f, {{AlignmentPI::t_x, 0.0}, {AlignmentPI::t_y, 0.0}, {AlignmentPI::t_z, 0.0}});
@@ -887,7 +882,6 @@ namespace {
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
       AlignmentPI::TkAlBarycenters myFinalBarycenters;
-      myFinalBarycenters.init();
       //myFinalBarycenters.computeBarycenters(last_alignments,tTopo_l,hardcodeGPR);
       myFinalBarycenters.computeBarycenters(
           last_alignments, tTopo_l, {{AlignmentPI::t_x, 0.0}, {AlignmentPI::t_y, 0.0}, {AlignmentPI::t_z, 0.0}});

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -27,6 +27,7 @@
 // needed for mapping
 #include "CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include <memory>
 #include <sstream>
@@ -40,6 +41,7 @@
 #include "TStyle.h"
 #include "TLatex.h"
 #include "TPave.h"
+#include "TMarker.h"
 #include "TPaveStats.h"
 
 namespace {
@@ -64,8 +66,8 @@ namespace {
   class TrackerAlignmentComparatorBase : public cond::payloadInspector::PlotImage<Alignments> {
   public:
     TrackerAlignmentComparatorBase()
-      : cond::payloadInspector::PlotImage<Alignments>("comparison of " + AlignmentPI::getStringFromCoordinate(coord) +
-						      " coordinate between two geometries") {}
+        : cond::payloadInspector::PlotImage<Alignments>("comparison of " + AlignmentPI::getStringFromCoordinate(coord) +
+                                                        " coordinate between two geometries") {}
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
@@ -275,9 +277,7 @@ namespace {
   template <AlignmentPI::coordinate coord>
   class TrackerAlignmentCompareTwoTags : public TrackerAlignmentComparatorBase<coord> {
   public:
-    TrackerAlignmentCompareTwoTags() : TrackerAlignmentComparatorBase<coord>() {
-      this->setTwoTags(true);
-    }
+    TrackerAlignmentCompareTwoTags() : TrackerAlignmentComparatorBase<coord>() { this->setTwoTags(true); }
   };
 
   typedef TrackerAlignmentCompare<AlignmentPI::t_x> TrackerAlignmentCompareX;
@@ -288,13 +288,13 @@ namespace {
   typedef TrackerAlignmentCompare<AlignmentPI::rot_beta> TrackerAlignmentCompareBeta;
   typedef TrackerAlignmentCompare<AlignmentPI::rot_gamma> TrackerAlignmentCompareGamma;
 
-  typedef TrackerAlignmentCompare<AlignmentPI::t_x> TrackerAlignmentCompareXTwoTags;
-  typedef TrackerAlignmentCompare<AlignmentPI::t_y> TrackerAlignmentCompareYTwoTags;
-  typedef TrackerAlignmentCompare<AlignmentPI::t_z> TrackerAlignmentCompareZTwoTags;
+  typedef TrackerAlignmentCompareTwoTags<AlignmentPI::t_x> TrackerAlignmentCompareXTwoTags;
+  typedef TrackerAlignmentCompareTwoTags<AlignmentPI::t_y> TrackerAlignmentCompareYTwoTags;
+  typedef TrackerAlignmentCompareTwoTags<AlignmentPI::t_z> TrackerAlignmentCompareZTwoTags;
 
-  typedef TrackerAlignmentCompare<AlignmentPI::rot_alpha> TrackerAlignmentCompareAlphaTwoTags;
-  typedef TrackerAlignmentCompare<AlignmentPI::rot_beta> TrackerAlignmentCompareBetaTwoTags;
-  typedef TrackerAlignmentCompare<AlignmentPI::rot_gamma> TrackerAlignmentCompareGammaTwoTags;
+  typedef TrackerAlignmentCompareTwoTags<AlignmentPI::rot_alpha> TrackerAlignmentCompareAlphaTwoTags;
+  typedef TrackerAlignmentCompareTwoTags<AlignmentPI::rot_beta> TrackerAlignmentCompareBetaTwoTags;
+  typedef TrackerAlignmentCompareTwoTags<AlignmentPI::rot_gamma> TrackerAlignmentCompareGammaTwoTags;
 
   //*******************************************//
   // Summary canvas per subdetector
@@ -599,17 +599,15 @@ namespace {
       barycenters.init();
       // compute uncorrected barycenter
       barycenters.computeBarycenters(alignments,
-				     {{AlignmentPI::t_x,0.0},
-				      {AlignmentPI::t_y,0.0},
-				      {AlignmentPI::t_z,0.0}});
+                                     {{AlignmentPI::t_x, 0.0}, {AlignmentPI::t_y, 0.0}, {AlignmentPI::t_z, 0.0}});
 
-      auto Xbarycenters   = barycenters.getX();
-      auto Ybarycenters   = barycenters.getY();
-      auto Zbarycenters   = barycenters.getZ();
+      auto Xbarycenters = barycenters.getX();
+      auto Ybarycenters = barycenters.getY();
+      auto Zbarycenters = barycenters.getZ();
 
       barycenters.init();
       // compute barycenter corrected for the GPR
-      barycenters.computeBarycenters(alignments,hardcodeGPR);
+      barycenters.computeBarycenters(alignments, hardcodeGPR);
 
       auto c_Xbarycenters = barycenters.getX();
       auto c_Ybarycenters = barycenters.getY();
@@ -736,9 +734,12 @@ namespace {
         auto thePart = static_cast<AlignmentPI::partitions>(i + 1);
         std::string theLabel = getStringFromPart(thePart);
         h2_BarycenterDiff->GetYaxis()->SetBinLabel(yBin, theLabel.c_str());
-        h2_BarycenterDiff->SetBinContent(1, yBin, (l_barycenters.getX()[i] - f_barycenters.getX()[i])*AlignmentPI::cmToUm );
-	h2_BarycenterDiff->SetBinContent(2, yBin, (l_barycenters.getY()[i] - f_barycenters.getY()[i])*AlignmentPI::cmToUm );
-        h2_BarycenterDiff->SetBinContent(3, yBin, (l_barycenters.getZ()[i] - f_barycenters.getZ()[i])*AlignmentPI::cmToUm );
+        h2_BarycenterDiff->SetBinContent(
+            1, yBin, (l_barycenters.getX()[i] - f_barycenters.getX()[i]) * AlignmentPI::cmToUm);
+        h2_BarycenterDiff->SetBinContent(
+            2, yBin, (l_barycenters.getY()[i] - f_barycenters.getY()[i]) * AlignmentPI::cmToUm);
+        h2_BarycenterDiff->SetBinContent(
+            3, yBin, (l_barycenters.getZ()[i] - f_barycenters.getZ()[i]) * AlignmentPI::cmToUm);
         yBin--;
       }
 
@@ -774,6 +775,266 @@ namespace {
       this->setTwoTags(true);
     }
   };
+
+  /************************************************
+    Comparator of Pixel Tracker Detector barycenters
+  *************************************************/
+  class PixelBarycentersComparatorBase : public cond::payloadInspector::PlotImage<Alignments> {
+  public:
+    PixelBarycentersComparatorBase()
+        : cond::payloadInspector::PlotImage<Alignments>("Comparison of Pixel Barycenters") {}
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
+      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
+
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+
+      auto firstiov = sorted_iovs.front();
+      unsigned int first_run = std::get<0>(firstiov);
+
+      auto lastiov = sorted_iovs.back();
+      unsigned int last_run = std::get<0>(lastiov);
+
+      std::shared_ptr<Alignments> last_payload = fetchPayload(std::get<1>(lastiov));
+      std::vector<AlignTransform> last_alignments = last_payload->m_align;
+
+      std::shared_ptr<Alignments> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::vector<AlignTransform> first_alignments = first_payload->m_align;
+
+      TCanvas canvas("Pixel Barycenter Summary", "Pixel Barycenter summary", 1200, 1200);
+      canvas.Divide(2, 2);
+      canvas.cd();
+
+      TLatex t1;
+      t1.SetNDC();
+      t1.SetTextAlign(26);
+      t1.SetTextSize(0.03);
+      t1.DrawLatex(0.5, 0.97, Form("Pixel Barycenters comparison, IOV %i - IOV %i", last_run, first_run));
+      t1.SetTextSize(0.025);
+
+      for (unsigned int c = 1; c <= 4; c++) {
+        canvas.cd(c)->SetTopMargin(0.07);
+        canvas.cd(c)->SetBottomMargin(0.12);
+        canvas.cd(c)->SetLeftMargin(0.15);
+        canvas.cd(c)->SetRightMargin(0.03);
+        canvas.cd(c)->Modified();
+        canvas.cd(c)->SetGrid();
+      }
+
+      std::array<std::string, 3> structures = {{"FPix-", "BPix", "FPIx+"}};
+      std::array<std::unique_ptr<TH2F>, 3> histos;
+
+      // check that the geomtery is a tracker one
+      const char *path_toTopologyXML = (first_alignments.size() == AlignmentPI::phase0size)
+                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
+                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      TrackerTopology tTopo =
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+
+      PixBarycenters myInitialBarycenters;
+      myInitialBarycenters.init();
+      //myInitialBarycenters.computeBarycenters(first_alignments,tTopo,hardcodeGPR);
+      myInitialBarycenters.computeBarycenters(
+          first_alignments, tTopo, {{AlignmentPI::t_x, 0.0}, {AlignmentPI::t_y, 0.0}, {AlignmentPI::t_z, 0.0}});
+
+      PixBarycenters myFinalBarycenters;
+      myFinalBarycenters.init();
+      //myFinalBarycenters.computeBarycenters(last_alignments,tTopo,hardcodeGPR);
+      myFinalBarycenters.computeBarycenters(
+          last_alignments, tTopo, {{AlignmentPI::t_x, 0.0}, {AlignmentPI::t_y, 0.0}, {AlignmentPI::t_z, 0.0}});
+
+      unsigned int index(0);
+      for (const auto &piece : structures) {
+        const char *name = piece.c_str();
+        histos[index] = std::unique_ptr<TH2F>(
+            new TH2F(name,
+                     Form("%s x-y Barycenter Difference;x_{%s} [mm];y_{%s} [mm]", name, name, name),
+                     100,
+                     -2,
+                     2,
+                     100,
+                     -2,
+                     2));
+        histos[index]->SetStats(false);
+        histos[index]->SetTitle(nullptr);
+        //histos[index]->GetXaxis()->LabelsOption("h");
+        histos[index]->GetYaxis()->SetLabelSize(0.04);
+        histos[index]->GetXaxis()->SetLabelSize(0.04);
+        histos[index]->GetYaxis()->SetTitleSize(0.05);
+        histos[index]->GetXaxis()->SetTitleSize(0.05);
+        histos[index]->GetYaxis()->CenterTitle();
+        histos[index]->GetXaxis()->CenterTitle();
+        histos[index]->GetXaxis()->SetTitleOffset(1.2);
+        index++;
+      }
+
+      auto h2_ZBarycenterDiff = std::unique_ptr<TH2F>(
+          new TH2F("Pixel_z_diff", "Pixel z-Barycenter Difference;; z_{Pixel} [mm]", 3, 0, 3., 100, -10., 10.));
+      h2_ZBarycenterDiff->SetStats(false);
+      h2_ZBarycenterDiff->SetTitle(nullptr);
+      h2_ZBarycenterDiff->GetXaxis()->SetBinLabel(1, "FPIX -");
+      h2_ZBarycenterDiff->GetXaxis()->SetBinLabel(2, "BPIX");
+      h2_ZBarycenterDiff->GetXaxis()->SetBinLabel(3, "FPIX +");
+      //h2_ZBarycenterDiff->GetXaxis()->LabelsOption("h");
+      h2_ZBarycenterDiff->GetYaxis()->SetLabelSize(0.04);
+      h2_ZBarycenterDiff->GetXaxis()->SetLabelSize(0.04);
+      h2_ZBarycenterDiff->GetYaxis()->SetTitleSize(0.05);
+      h2_ZBarycenterDiff->GetXaxis()->SetTitleSize(0.05);
+      h2_ZBarycenterDiff->GetYaxis()->CenterTitle();
+      h2_ZBarycenterDiff->GetXaxis()->CenterTitle();
+      h2_ZBarycenterDiff->GetXaxis()->SetTitleOffset(1.2);
+
+      std::function<GlobalPoint(int)> cutFunctorInitial = [&myInitialBarycenters](int index) {
+        switch (index) {
+          case 1:
+            return myInitialBarycenters.getFPixMinusAvg();
+          case 2:
+            return myInitialBarycenters.getBPixAvg();
+          case 3:
+            return myInitialBarycenters.getFPixPlusAvg();
+          default:
+            return GlobalPoint(0, 0, 0);
+        }
+      };
+
+      std::function<GlobalPoint(int)> cutFunctorFinal = [&myFinalBarycenters](int index) {
+        switch (index) {
+          case 1:
+            return myFinalBarycenters.getFPixMinusAvg();
+          case 2:
+            return myFinalBarycenters.getBPixAvg();
+          case 3:
+            return myFinalBarycenters.getFPixPlusAvg();
+          default:
+            return GlobalPoint(0, 0, 0);
+        }
+      };
+
+      for (unsigned int c = 1; c <= 3; c++) {
+        canvas.cd(c);
+        histos[c - 1]->Draw();
+
+        std::cout << "initial :" << c << " " << cutFunctorInitial(c).x() * 10 << "," << cutFunctorInitial(c).y() * 10
+                  << std::endl;
+        std::cout << "final   :" << c << " " << cutFunctorFinal(c).x() * 10 << "," << cutFunctorFinal(c).y() * 10
+                  << std::endl;
+
+        TMarker *initial = new TMarker(cutFunctorInitial(c).x() * 10, cutFunctorInitial(c).y() * 10, 20);
+        TMarker *final = new TMarker(cutFunctorFinal(c).x() * 10, cutFunctorFinal(c).y() * 10, 22);
+
+        initial->SetMarkerColor(kBlue);
+        final->SetMarkerColor(kRed);
+        initial->SetMarkerSize(2);
+        final->SetMarkerSize(2);
+        initial->Draw();
+        final->Draw("same");
+      }
+
+      // fourth pad is a special case
+      canvas.cd(4);
+      h2_ZBarycenterDiff->Draw();
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  private:
+    struct PixBarycenters {
+      std::array<double, 3> m_Xbarycenters;
+      std::array<double, 3> m_Ybarycenters;
+      std::array<double, 3> m_Zbarycenters;
+      std::array<double, 3> m_nmodules;
+
+      /*--------------------------------------------------------------------*/
+      void init()
+      /*--------------------------------------------------------------------*/
+      {
+        // partitions      Fpix-  BPix  FPix+
+        m_Xbarycenters = {{0., 0., 0.}};
+        m_Ybarycenters = {{0., 0., 0.}};
+        m_Zbarycenters = {{0., 0., 0.}};
+        m_nmodules = {{0., 0., 0.}};
+      }
+
+      GlobalPoint getFPixMinusAvg() { return GlobalPoint(m_Xbarycenters[0], m_Ybarycenters[0], m_Zbarycenters[0]); }
+      GlobalPoint getBPixAvg() { return GlobalPoint(m_Xbarycenters[1], m_Ybarycenters[1], m_Zbarycenters[1]); }
+      GlobalPoint getFPixPlusAvg() { return GlobalPoint(m_Xbarycenters[2], m_Ybarycenters[2], m_Zbarycenters[2]); }
+
+      /*--------------------------------------------------------------------*/
+      void computeBarycenters(const std::vector<AlignTransform> &input,
+                              const TrackerTopology &tTopo,
+                              const std::map<AlignmentPI::coordinate, float> &GPR)
+      /*--------------------------------------------------------------------*/
+      {
+        for (const auto &ali : input) {
+          if (DetId(ali.rawId()).det() != DetId::Tracker) {
+            edm::LogWarning("PixBarycenters::computeBarycenters")
+                << "Encountered invalid Tracker DetId:" << ali.rawId() << " " << DetId(ali.rawId()).det()
+                << " is different from " << DetId::Tracker << "  - terminating ";
+            assert(DetId(ali.rawId()).det() != DetId::Tracker);
+          }
+
+          int subid = DetId(ali.rawId()).subdetId();
+
+          switch (subid) {
+            case 1:
+              m_Xbarycenters[1] += (ali.translation().x());
+              m_Ybarycenters[1] += (ali.translation().y());
+              m_Zbarycenters[1] += (ali.translation().z());
+              m_nmodules[1]++;
+              break;
+            case 2:
+
+              // minus side (details on topology https://github.com/cms-sw/cmssw/blob/master/Geometry/TrackerNumberingBuilder/README.md)
+              if (tTopo.pxfSide(DetId(ali.rawId())) == 1) {
+                m_Xbarycenters[0] += (ali.translation().x());
+                m_Ybarycenters[0] += (ali.translation().y());
+                m_Zbarycenters[0] += (ali.translation().z());
+                m_nmodules[0]++;
+              }
+              // plus side (details on topology https://github.com/cms-sw/cmssw/blob/master/Geometry/TrackerNumberingBuilder/README.md)
+              else {
+                m_Xbarycenters[2] += (ali.translation().x());
+                m_Ybarycenters[2] += (ali.translation().y());
+                m_Zbarycenters[2] += (ali.translation().z());
+                m_nmodules[2]++;
+              }
+              break;
+            default:
+              break;
+          }
+        }
+
+        for (unsigned int i = 0; i < m_nmodules.size(); i++) {
+          m_Xbarycenters[i] /= m_nmodules[i];
+          m_Ybarycenters[i] /= m_nmodules[i];
+          m_Zbarycenters[i] /= m_nmodules[i];
+
+          // correct for GPR
+
+          m_Xbarycenters[i] += GPR.at(AlignmentPI::t_x);
+          m_Ybarycenters[i] += GPR.at(AlignmentPI::t_y);
+          m_Zbarycenters[i] += GPR.at(AlignmentPI::t_z);
+        }
+      }
+    };  // end of the struct
+  };
+
+  class PixelBarycentersCompare : public PixelBarycentersComparatorBase {
+  public:
+    PixelBarycentersCompare() : PixelBarycentersComparatorBase() { this->setSingleIov(false); }
+  };
+
+  class PixelBarycentersCompareTwoTags : public PixelBarycentersComparatorBase {
+  public:
+    PixelBarycentersCompareTwoTags() : PixelBarycentersComparatorBase() { this->setTwoTags(true); }
+  };
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(TrackerAlignment) {
@@ -801,4 +1062,6 @@ PAYLOAD_INSPECTOR_MODULE(TrackerAlignment) {
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentBarycenters);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentBarycentersCompare);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentBarycentersCompareTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(PixelBarycentersCompare);
+  PAYLOAD_INSPECTOR_CLASS(PixelBarycentersCompareTwoTags);
 }

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -61,13 +61,11 @@ namespace {
   //******************************************//
 
   template <AlignmentPI::coordinate coord>
-  class TrackerAlignmentCompare : public cond::payloadInspector::PlotImage<Alignments> {
+  class TrackerAlignmentComparatorBase : public cond::payloadInspector::PlotImage<Alignments> {
   public:
-    TrackerAlignmentCompare()
-        : cond::payloadInspector::PlotImage<Alignments>("comparison of " + AlignmentPI::getStringFromCoordinate(coord) +
-                                                        " coordinate between two geometries") {
-      setSingleIov(false);
-    }
+    TrackerAlignmentComparatorBase()
+      : cond::payloadInspector::PlotImage<Alignments>("comparison of " + AlignmentPI::getStringFromCoordinate(coord) +
+						      " coordinate between two geometries") {}
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
@@ -268,6 +266,20 @@ namespace {
     }
   };
 
+  template <AlignmentPI::coordinate coord>
+  class TrackerAlignmentCompare : public TrackerAlignmentComparatorBase<coord> {
+  public:
+    TrackerAlignmentCompare() : TrackerAlignmentComparatorBase<coord>() { this->setSingleIov(false); }
+  };
+
+  template <AlignmentPI::coordinate coord>
+  class TrackerAlignmentCompareTwoTags : public TrackerAlignmentComparatorBase<coord> {
+  public:
+    TrackerAlignmentCompareTwoTags() : TrackerAlignmentComparatorBase<coord>() {
+      this->setTwoTags(true);
+    }
+  };
+
   typedef TrackerAlignmentCompare<AlignmentPI::t_x> TrackerAlignmentCompareX;
   typedef TrackerAlignmentCompare<AlignmentPI::t_y> TrackerAlignmentCompareY;
   typedef TrackerAlignmentCompare<AlignmentPI::t_z> TrackerAlignmentCompareZ;
@@ -275,6 +287,14 @@ namespace {
   typedef TrackerAlignmentCompare<AlignmentPI::rot_alpha> TrackerAlignmentCompareAlpha;
   typedef TrackerAlignmentCompare<AlignmentPI::rot_beta> TrackerAlignmentCompareBeta;
   typedef TrackerAlignmentCompare<AlignmentPI::rot_gamma> TrackerAlignmentCompareGamma;
+
+  typedef TrackerAlignmentCompare<AlignmentPI::t_x> TrackerAlignmentCompareXTwoTags;
+  typedef TrackerAlignmentCompare<AlignmentPI::t_y> TrackerAlignmentCompareYTwoTags;
+  typedef TrackerAlignmentCompare<AlignmentPI::t_z> TrackerAlignmentCompareZTwoTags;
+
+  typedef TrackerAlignmentCompare<AlignmentPI::rot_alpha> TrackerAlignmentCompareAlphaTwoTags;
+  typedef TrackerAlignmentCompare<AlignmentPI::rot_beta> TrackerAlignmentCompareBetaTwoTags;
+  typedef TrackerAlignmentCompare<AlignmentPI::rot_gamma> TrackerAlignmentCompareGammaTwoTags;
 
   //*******************************************//
   // Summary canvas per subdetector
@@ -763,6 +783,12 @@ PAYLOAD_INSPECTOR_MODULE(TrackerAlignment) {
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareAlpha);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareBeta);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareGamma);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareXTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareYTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareZTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareAlphaTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareBetaTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareGammaTwoTags);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentSummaryBPix);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentSummaryFPix);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentSummaryTIB);

--- a/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
@@ -58,16 +58,16 @@ namespace {
         if (payload.get()) {
           int i = 0;
           auto listOfItems = payload->items();
-          std::cout << "items size:" << listOfItems.size() << std::endl;
+          COUT << "items size:" << listOfItems.size() << std::endl;
 
           for (const auto &item : listOfItems) {
-            std::cout << i << " " << item.m_rawId << " Det: " << DetId(item.m_rawId).subdetId() << " " << item.m_index
-                      << std::endl;
+            COUT << i << " " << item.m_rawId << " Det: " << DetId(item.m_rawId).subdetId() << " " << item.m_index
+                 << std::endl;
             const auto beginEndPair = payload->parameters(i);
             std::vector<align::Scalar> params(beginEndPair.first, beginEndPair.second);
-            std::cout << "params.size()" << params.size() << std::endl;
+            COUT << "params.size()" << params.size() << std::endl;
             for (const auto &par : params) {
-              std::cout << par << std::endl;
+              COUT << par << std::endl;
             }
             i++;
           }
@@ -506,7 +506,7 @@ namespace {
 
           float delta = (l_entry.second - f_entry.second);
 
-          //std::cout<<" match! subid:" << subid << " rawId:" << f_entry.first << " delta:"<< delta << std::endl;
+          //COUT<<" match! subid:" << subid << " rawId:" << f_entry.first << " delta:"<< delta << std::endl;
 
           if (isPhase0) {
             tmap->addPixel(true);
@@ -671,7 +671,7 @@ namespace {
         DetId detid(it.m_rawId);
         t_info_fromXML.fillGeometryInfo(detid, f_tTopo, isPhase0);
 
-        //std::cout<<"sanityCheck: "<< t_info_fromXML.sanityCheck() << std::endl;
+        //COUT<<"sanityCheck: "<< t_info_fromXML.sanityCheck() << std::endl;
 
         if (!t_info_fromXML.sanityCheck()) {
           edm::LogWarning("TrackerSurfaceDeformations_PayloadInspector")
@@ -697,7 +697,7 @@ namespace {
           continue;
 
         FirstSurfDef_spectraByRegion[thePart]->Fill(first_params.at(m_par));
-        //std::cout<<  getStringFromRegionEnum(thePart) << " first payload: "<< first_params.at(m_par) << std::endl;
+        //COUT<<  getStringFromRegionEnum(thePart) << " first payload: "<< first_params.at(m_par) << std::endl;
 
       }  // ends loop on the vector of error transforms
 
@@ -732,7 +732,7 @@ namespace {
         DetId detid(it.m_rawId);
         t_info_fromXML.fillGeometryInfo(detid, l_tTopo, isPhase0);
 
-        //std::cout<<"sanityCheck: "<< t_info_fromXML.sanityCheck() << std::endl;
+        //COUT<<"sanityCheck: "<< t_info_fromXML.sanityCheck() << std::endl;
 
         if (!t_info_fromXML.sanityCheck()) {
           edm::LogWarning("TrackerSurfaceDeformations_PayloadInspector")
@@ -759,7 +759,7 @@ namespace {
           continue;
 
         LastSurfDef_spectraByRegion[thePart]->Fill(last_params.at(m_par));
-        //std::cout<< getStringFromRegionEnum(thePart) <<  " last payload: "<< last_params.at(m_par) << std::endl;
+        //COUT<< getStringFromRegionEnum(thePart) <<  " last payload: "<< last_params.at(m_par) << std::endl;
 
       }  // ends loop on the vector of error transforms
 

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignment.sh
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignment.sh
@@ -80,3 +80,26 @@ getPayloadData.py \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test ;
+
+
+# add examples of Pixel barycenter comparison
+#*************************************************************************#
+getPayloadData.py \
+    --plugin pluginTrackerAlignment_PayloadInspector \
+    --plot plot_PixelBarycentersCompare \
+    --tag TrackerAlignment_v28_offline \
+    --time_type Run \
+    --iovs '{"start_iov": "250000", "end_iov": "300000"}' \
+    --db Prod \
+    --test ;
+
+getPayloadData.py \
+    --plugin pluginTrackerAlignment_PayloadInspector \
+    --plot plot_PixelBarycentersCompareTwoTags \
+    --tag TrackerAlignment_Ideal62X_mc \
+    --tagtwo TrackerAlignment_Upgrade2017_design_v4 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentErrosExtended.sh
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentErrosExtended.sh
@@ -91,3 +91,18 @@ do
     mv *.png $W_DIR/results_APE/TrackerAlignmentErrorExtended${i}Detail.png
 
 done
+
+#*************************************************************************#
+# test two tags comparison
+#*************************************************************************#
+
+getPayloadData.py \
+    --plugin pluginTrackerAlignmentErrorExtended_PayloadInspector \
+    --plot plot_TrackerAlignmentErrorExtendedXXComparatorTwoTags \
+    --tag TrackerAlignmentExtendedErrors_2016_ultralegacymc_v1 \
+    --tagtwo TrackerAlignmentExtendedErrors_2016_ultralegacymc_preVFP_v1 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -50,4 +50,14 @@ int main(int argc, char** argv) {
   histo5.processTwoTags(
       connectionString, "TrackerAlignment_2017_ultralegacymc_v2", "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1);
   std::cout << histo5.data() << std::endl;
+
+  std::cout << "## Testing Barycenter Histos" << std::endl;
+
+  TrackerAlignmentBarycentersCompare histo6;
+  histo6.process(connectionString, tag, runTimeType, start, end);
+  std::cout << histo6.data() << std::endl;
+
+  PixelBarycentersCompare histo7;
+  histo7.process(connectionString, tag, runTimeType, start, end);
+  std::cout << histo7.data() << std::endl;
 }

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   cond::Time_t start = boost::lexical_cast<unsigned long long>(294034);
   cond::Time_t end = boost::lexical_cast<unsigned long long>(305898);
 
-  std::cout << "## TrackerMap Histo" << std::endl;
+  std::cout << "## Alignment Histos" << std::endl;
 
   TrackerAlignmentCompareX histo1;
   histo1.process(connectionString, tag, runTimeType, start, end);
@@ -38,4 +38,8 @@ int main(int argc, char** argv) {
   X_BPixBarycenterHistory histo3;
   histo3.process(connectionString, tag, runTimeType, start, end);
   std::cout << histo3.data() << std::endl;
+
+  TrackerAlignmentBarycentersCompareTwoTags histo4;
+  histo4.processTwoTags(connectionString,"TrackerAlignment_2017_ultralegacymc_v2","TrackerAlignment_Upgrade2017_realistic_v2",1,1);
+  std::cout << histo4.data() << std::endl;
 }

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -42,10 +42,12 @@ int main(int argc, char** argv) {
   std::cout << "## Testing Two Tag Histos" << std::endl;
 
   TrackerAlignmentBarycentersCompareTwoTags histo4;
-  histo4.processTwoTags(connectionString,"TrackerAlignment_2017_ultralegacymc_v2","TrackerAlignment_Upgrade2017_realistic_v2",1,1);
+  histo4.processTwoTags(
+      connectionString, "TrackerAlignment_2017_ultralegacymc_v2", "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1);
   std::cout << histo4.data() << std::endl;
 
   TrackerAlignmentCompareXTwoTags histo5;
-  histo5.processTwoTags(connectionString,"TrackerAlignment_2017_ultralegacymc_v2","TrackerAlignment_Upgrade2017_realistic_v2",1,1);
+  histo5.processTwoTags(
+      connectionString, "TrackerAlignment_2017_ultralegacymc_v2", "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1);
   std::cout << histo5.data() << std::endl;
 }

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -39,7 +39,13 @@ int main(int argc, char** argv) {
   histo3.process(connectionString, tag, runTimeType, start, end);
   std::cout << histo3.data() << std::endl;
 
+  std::cout << "## Testing Two Tag Histos" << std::endl;
+
   TrackerAlignmentBarycentersCompareTwoTags histo4;
   histo4.processTwoTags(connectionString,"TrackerAlignment_2017_ultralegacymc_v2","TrackerAlignment_Upgrade2017_realistic_v2",1,1);
   std::cout << histo4.data() << std::endl;
+
+  TrackerAlignmentCompareXTwoTags histo5;
+  histo5.processTwoTags(connectionString,"TrackerAlignment_2017_ultralegacymc_v2","TrackerAlignment_Upgrade2017_realistic_v2",1,1);
+  std::cout << histo5.data() << std::endl;
 }

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -127,12 +127,10 @@ namespace {
   /************************************************
     Compare AlCaRecoTriggerBits mapping
   *************************************************/
-  class AlCaRecoTriggerBits_Compare : public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
+  class AlCaRecoTriggerBits_CompareBase : public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
   public:
-    AlCaRecoTriggerBits_Compare()
-        : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>("Table of AlCaRecoTriggerBits comparison") {
-      setSingleIov(false);
-    }
+    AlCaRecoTriggerBits_CompareBase()
+        : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>("Table of AlCaRecoTriggerBits comparison") {}
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
@@ -399,9 +397,26 @@ namespace {
     }
   };
 
+  class AlCaRecoTriggerBits_Compare : public AlCaRecoTriggerBits_CompareBase {
+  public:
+    AlCaRecoTriggerBits_Compare() : AlCaRecoTriggerBits_CompareBase() {
+      this->setSingleIov(false);
+    }
+  };
+
+  class AlCaRecoTriggerBits_CompareTwoTags : public AlCaRecoTriggerBits_CompareBase {
+  public:
+    AlCaRecoTriggerBits_CompareTwoTags() : AlCaRecoTriggerBits_CompareBase() {
+      this->setTwoTags(true);
+    }
+  };
+
+
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(AlCaRecoTriggerBits) {
   PAYLOAD_INSPECTOR_CLASS(AlCaRecoTriggerBits_Display);
   PAYLOAD_INSPECTOR_CLASS(AlCaRecoTriggerBits_Compare);
+  PAYLOAD_INSPECTOR_CLASS(AlCaRecoTriggerBits_CompareTwoTags);
 }

--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -399,19 +399,13 @@ namespace {
 
   class AlCaRecoTriggerBits_Compare : public AlCaRecoTriggerBits_CompareBase {
   public:
-    AlCaRecoTriggerBits_Compare() : AlCaRecoTriggerBits_CompareBase() {
-      this->setSingleIov(false);
-    }
+    AlCaRecoTriggerBits_Compare() : AlCaRecoTriggerBits_CompareBase() { this->setSingleIov(false); }
   };
 
   class AlCaRecoTriggerBits_CompareTwoTags : public AlCaRecoTriggerBits_CompareBase {
   public:
-    AlCaRecoTriggerBits_CompareTwoTags() : AlCaRecoTriggerBits_CompareBase() {
-      this->setTwoTags(true);
-    }
+    AlCaRecoTriggerBits_CompareTwoTags() : AlCaRecoTriggerBits_CompareBase() { this->setTwoTags(true); }
   };
-
-
 
 }  // namespace
 

--- a/CondCore/HLTPlugins/test/BuildFile.xml
+++ b/CondCore/HLTPlugins/test/BuildFile.xml
@@ -1,0 +1,7 @@
+<use   name="CondCore/CondDB"/>
+<use   name="CondCore/Utilities"/>
+<use   name="CondFormats/Common"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/Utilities"/>
+<bin   file="testAlCaRecoTriggerBitsPayloadInspector.cpp" name="testAlCaRecoTriggerBitsPayloadInspector">
+</bin>

--- a/CondCore/HLTPlugins/test/testAlCaRecoTriggerBitsPayloadInspector.cpp
+++ b/CondCore/HLTPlugins/test/testAlCaRecoTriggerBitsPayloadInspector.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  std::string tag = "AlCaRecoHLTpaths8e29_1e31_v7_hlt";
+  std::string runTimeType = cond::time::timeTypeName(cond::runnumber);
+  cond::Time_t start = boost::lexical_cast<unsigned long long>(270000);
+  cond::Time_t end = boost::lexical_cast<unsigned long long>(304820);
+
+  std::cout << "## AlCaRecoTriggerBit Histos" << std::endl;
+
+  AlCaRecoTriggerBits_Display histo1;
+  histo1.process(connectionString, tag, runTimeType, 1, 1);
+  std::cout << histo1.data() << std::endl;
+
+  AlCaRecoTriggerBits_Compare histo2;
+  histo2.process(connectionString, tag, runTimeType, start, end);
+  std::cout << histo2.data() << std::endl;
+}


### PR DESCRIPTION
#### PR description:

This PR adds few more comparison plots for the`Alignment` and `AlCaRecoTriggerBits` `CondFormats` to be able to compare conditions across tags. In particular few new plots for checking the Tracker and Pixel center of gravity positions are added.

#### PR validation:

Relies on the unit tests implemented in this PR.

#### if this PR is a backport please specify the original PR:

This PR is not a backport, and a backport is not needed.
