### PR TITLE
PPS: vector classes used in reco, geometry etc.

### DIFF
--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -356,7 +356,7 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
         double ft_x = ft.x0() + ft.tx() * (ft_z - rp_z);
         double ft_y = ft.y0() + ft.ty() * (ft_z - rp_z);
 
-        double ft_v = geometry->globalToLocal(plId, CLHEP::Hep3Vector(ft_x, ft_y, ft_z)).y();
+        double ft_v = geometry->globalToLocal(plId, CTPPSGeometry::Vector(ft_x, ft_y, ft_z)).y();
 
         bool hasMatchingHit = false;
         const auto &hit_ds_it = hits->find(plId);
@@ -567,8 +567,8 @@ void TotemRPDQMSource::analyze(edm::Event const &event, edm::EventSetup const &e
       double rp_y = (geometry->sensor(plId_V)->translation().y() + geometry->sensor(plId_U)->translation().y()) / 2.;
 
       // mean read-out direction of U and V planes
-      CLHEP::Hep3Vector rod_U = geometry->localToGlobalDirection(plId_U, CLHEP::Hep3Vector(0., 1., 0.));
-      CLHEP::Hep3Vector rod_V = geometry->localToGlobalDirection(plId_V, CLHEP::Hep3Vector(0., 1., 0.));
+      const auto &rod_U = geometry->localToGlobalDirection(plId_U, CTPPSGeometry::Vector(0., 1., 0.));
+      const auto &rod_V = geometry->localToGlobalDirection(plId_V, CTPPSGeometry::Vector(0., 1., 0.));
 
       double x = ft.x0() - rp_x;
       double y = ft.y0() - rp_y;

--- a/Geometry/VeryForwardGeometryBuilder/BuildFile.xml
+++ b/Geometry/VeryForwardGeometryBuilder/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="Geometry/TrackerNumberingBuilder"/>
 <use name="CondFormats/CTPPSReadoutObjects"/>
 
-<use name="clhep"/>
 <use name="hepmc"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>

--- a/Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h
@@ -13,9 +13,6 @@
 #include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSDDDNames.h"
 
-#include "CLHEP/Vector/ThreeVector.h"
-#include "CLHEP/Vector/Rotation.h"
-
 #include <map>
 #include <set>
 
@@ -35,6 +32,8 @@ public:
   typedef std::map<unsigned int, const DetGeomDesc*> mapType;
   typedef std::map<int, const DetGeomDesc*> RPDeviceMapType;
   typedef std::map<unsigned int, std::set<unsigned int> > mapSetType;
+
+  using Vector = DetGeomDesc::Translation;
 
   CTPPSGeometry() {}
   ~CTPPSGeometry() {}
@@ -82,25 +81,25 @@ public:
   /// coordinate transformations between local<-->global reference frames
   /// dimensions in mm
   /// sensor id expected
-  CLHEP::Hep3Vector localToGlobal(const DetGeomDesc*, const CLHEP::Hep3Vector&) const;
-  CLHEP::Hep3Vector globalToLocal(const DetGeomDesc*, const CLHEP::Hep3Vector&) const;
-  CLHEP::Hep3Vector localToGlobal(unsigned int, const CLHEP::Hep3Vector&) const;
-  CLHEP::Hep3Vector globalToLocal(unsigned int, const CLHEP::Hep3Vector&) const;
+  Vector localToGlobal(const DetGeomDesc*, const Vector&) const;
+  Vector globalToLocal(const DetGeomDesc*, const Vector&) const;
+  Vector localToGlobal(unsigned int, const Vector&) const;
+  Vector globalToLocal(unsigned int, const Vector&) const;
 
   /// direction transformations between local and global reference frames
   /// \param id sensor id
-  CLHEP::Hep3Vector localToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector&) const;
+  Vector localToGlobalDirection(unsigned int id, const Vector&) const;
   /// direction transformations between global and local reference frames
   /// \param id sensor id
-  CLHEP::Hep3Vector globalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector&) const;
+  Vector globalToLocalDirection(unsigned int id, const Vector&) const;
 
   /// returns translation (position) of a detector
   /// \param id sensor id
-  CLHEP::Hep3Vector sensorTranslation(unsigned int id) const;
+  Vector sensorTranslation(unsigned int id) const;
 
   /// returns position of a RP box
   /// \param id RP id
-  CLHEP::Hep3Vector rpTranslation(unsigned int id) const;
+  Vector rpTranslation(unsigned int id) const;
 
   /// after checks returns set of station ids corresponding to the given arm id
   const std::set<unsigned int>& stationsInArm(unsigned int) const;

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryInfo.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryInfo.cc
@@ -170,10 +170,10 @@ void CTPPSGeometryInfo::printGeometry(const CTPPSGeometry& geometry, const edm::
     for (auto it = geometry.beginSensor(); it != geometry.endSensor(); ++it) {
       CTPPSDetId detId(it->first);
 
-      const CLHEP::Hep3Vector gl_o = geometry.localToGlobal(detId, CLHEP::Hep3Vector(0, 0, 0));
-      const CLHEP::Hep3Vector gl_a1 = geometry.localToGlobal(detId, CLHEP::Hep3Vector(1, 0, 0)) - gl_o;
-      const CLHEP::Hep3Vector gl_a2 = geometry.localToGlobal(detId, CLHEP::Hep3Vector(0, 1, 0)) - gl_o;
-      const CLHEP::Hep3Vector gl_a3 = geometry.localToGlobal(detId, CLHEP::Hep3Vector(0, 0, 1)) - gl_o;
+      const auto gl_o = geometry.localToGlobal(detId, CTPPSGeometry::Vector(0, 0, 0));
+      const auto gl_a1 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(1, 0, 0)) - gl_o;
+      const auto gl_a2 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(0, 1, 0)) - gl_o;
+      const auto gl_a3 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(0, 0, 1)) - gl_o;
 
       oss << formatDetId(detId) << std::fixed << std::setprecision(3) << std::showpos << " | ce=(" << gl_o.x() << ", "
           << gl_o.y() << ", " << gl_o.z() << ")"

--- a/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/CTPPSGeometry.cc
@@ -144,51 +144,50 @@ const std::set<unsigned int>& CTPPSGeometry::sensorsInRP(unsigned int id) const 
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::localToGlobal(const DetGeomDesc* gd, const CLHEP::Hep3Vector& r) const {
-  return gd->rotation() * r + CLHEP::Hep3Vector(gd->translation().x(), gd->translation().y(), gd->translation().z());
+CTPPSGeometry::Vector CTPPSGeometry::localToGlobal(const DetGeomDesc* gd, const CTPPSGeometry::Vector& r) const {
+  return gd->rotation() * r + gd->translation();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::localToGlobal(unsigned int id, const CLHEP::Hep3Vector& r) const {
+CTPPSGeometry::Vector CTPPSGeometry::localToGlobal(unsigned int id, const CTPPSGeometry::Vector& r) const {
   return localToGlobal(sensor(id), r);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::globalToLocal(const DetGeomDesc* gd, const CLHEP::Hep3Vector& r) const {
-  return gd->rotation().Inverse() *
-         (r - CLHEP::Hep3Vector(gd->translation().x(), gd->translation().y(), gd->translation().z()));
+CTPPSGeometry::Vector CTPPSGeometry::globalToLocal(const DetGeomDesc* gd, const CTPPSGeometry::Vector& r) const {
+  return gd->rotation().Inverse() * (r - gd->translation());
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::globalToLocal(unsigned int id, const CLHEP::Hep3Vector& r) const {
+CTPPSGeometry::Vector CTPPSGeometry::globalToLocal(unsigned int id, const CTPPSGeometry::Vector& r) const {
   return globalToLocal(sensor(id), r);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::localToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const {
+CTPPSGeometry::Vector CTPPSGeometry::localToGlobalDirection(unsigned int id, const CTPPSGeometry::Vector& dir) const {
   return sensor(id)->rotation() * dir;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::globalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const {
+CTPPSGeometry::Vector CTPPSGeometry::globalToLocalDirection(unsigned int id, const CTPPSGeometry::Vector& dir) const {
   return sensor(id)->rotation().Inverse() * dir;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::sensorTranslation(unsigned int id) const {
+CTPPSGeometry::Vector CTPPSGeometry::sensorTranslation(unsigned int id) const {
   auto gd = sensor(id);
-  return CLHEP::Hep3Vector(gd->translation().x(), gd->translation().y(), gd->translation().z());
+  return gd->translation();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector CTPPSGeometry::rpTranslation(unsigned int id) const {
+CTPPSGeometry::Vector CTPPSGeometry::rpTranslation(unsigned int id) const {
   auto gd = rp(id);
-  return CLHEP::Hep3Vector(gd->translation().x(), gd->translation().y(), gd->translation().z());
+  return gd->translation();
 }

--- a/Geometry/VeryForwardRPTopology/BuildFile.xml
+++ b/Geometry/VeryForwardRPTopology/BuildFile.xml
@@ -1,11 +1,8 @@
-<use   name="clhep"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="DataFormats/Common"/>
-<use   name="DataFormats/GeometryVector"/>
-<use   name="boost"/>
-<use   name="hepmc"/>
+
+<use   name="root"/>
 
 <export>
   <lib   name="1"/>

--- a/Geometry/VeryForwardRPTopology/interface/RPSimTopology.h
+++ b/Geometry/VeryForwardRPTopology/interface/RPSimTopology.h
@@ -3,7 +3,7 @@
 
 #include "TMath.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/GeometryVector/interface/LocalVector.h"
+
 #include "Geometry/VeryForwardRPTopology/interface/RPTopology.h"
 
 class strip_info {
@@ -46,9 +46,9 @@ private:
 
   int verbosity_;
 
-  const LocalVector strip_readout_direction_;
-  const LocalVector strip_direction_;
-  const LocalVector normal_direction_;
+  const Vector strip_readout_direction_;
+  const Vector strip_direction_;
+  const Vector normal_direction_;
 
   inline double ActiveEdgeFactor(double x, double y) {
     return TMath::Erf(DistanceFromActiveEdge(x, y) / sqrt_2 / active_edge_sigma_) / 2 + 0.5;

--- a/Geometry/VeryForwardRPTopology/interface/RPTopology.h
+++ b/Geometry/VeryForwardRPTopology/interface/RPTopology.h
@@ -10,17 +10,7 @@
 #ifndef Geometry_VeryForwardRPTopology_RPTopology
 #define Geometry_VeryForwardRPTopology_RPTopology
 
-#include <HepMC/SimpleVector.h>
-
-#include "TMath.h"
-#include "DataFormats/GeometryVector/interface/LocalVector.h"
-#include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
-#include "DataFormats/Math/interface/Point3D.h"
-
-namespace HepMC {
-  class ThreeVector;
-}
+#include "Math/Vector3D.h"
 
 /**
  *\brief Geometrical and topological information on RP silicon detector.
@@ -28,10 +18,13 @@ namespace HepMC {
  **/
 class RPTopology {
 public:
+  using Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
+  ;
+
   RPTopology();
-  inline const HepMC::ThreeVector& GetStripReadoutAxisDir() const { return strip_readout_direction_; }
-  inline const HepMC::ThreeVector& GetStripDirection() const { return strip_direction_; }
-  inline const HepMC::ThreeVector& GetNormalDirection() const { return normal_direction_; }
+  inline const Vector& GetStripReadoutAxisDir() const { return strip_readout_direction_; }
+  inline const Vector& GetStripDirection() const { return strip_direction_; }
+  inline const Vector& GetNormalDirection() const { return normal_direction_; }
 
   /// method converts strip number to a hit position [mm] in det readout coordinate
   /// in the origin in the middle of the si detector
@@ -65,9 +58,9 @@ public:
   static const double last_strip_to_border_dist_;
   static const double last_strip_to_center_dist_;
 
-  HepMC::ThreeVector strip_readout_direction_;
-  HepMC::ThreeVector strip_direction_;
-  HepMC::ThreeVector normal_direction_;
+  Vector strip_readout_direction_;
+  Vector strip_direction_;
+  Vector normal_direction_;
 };
 
 #endif  //Geometry_VeryForwardRPTopology_RPTopology

--- a/Geometry/VeryForwardRPTopology/interface/RPTopology.h
+++ b/Geometry/VeryForwardRPTopology/interface/RPTopology.h
@@ -19,7 +19,6 @@
 class RPTopology {
 public:
   using Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
-  ;
 
   RPTopology();
   inline const Vector& GetStripReadoutAxisDir() const { return strip_readout_direction_; }

--- a/RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h
@@ -19,8 +19,6 @@
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
-#include "CLHEP/Vector/ThreeVector.h"
-#include "CLHEP/Vector/RotationInterfaces.h"
 #include "DataFormats/Math/interface/Error.h"
 
 #include <vector>
@@ -32,7 +30,7 @@ public:
   virtual ~RPixDetPatternFinder(){};
 
   typedef struct {
-    CLHEP::Hep3Vector globalPoint;
+    CTPPSGeometry::Vector globalPoint;
     math::Error<3>::type globalError;
     CTPPSPixelRecHit recHit;
     CTPPSPixelDetId detId;

--- a/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
+++ b/RecoCTPPS/PixelLocal/interface/RPixDetTrackFinder.h
@@ -16,7 +16,6 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
 #include "RecoCTPPS/PixelLocal/interface/RPixDetPatternFinder.h"
 
-#include "CLHEP/Vector/ThreeVector.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 
 #include <vector>

--- a/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixPlaneCombinatoryTracking.cc
@@ -512,7 +512,7 @@ CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList poi
   //The matrices and vector xyCoordinates, varianceMatrix and varianceMatrix are built from the points
   for (uint32_t iHit = 0; iHit < numberOfPlanes; iHit++) {
     if (iHit < pointList.size()) {
-      CLHEP::Hep3Vector globalPoint = pointList[iHit].globalPoint;
+      const auto &globalPoint = pointList[iHit].globalPoint;
       xyCoordinates[2 * iHit] = globalPoint.x();
       xyCoordinates[2 * iHit + 1] = globalPoint.y();
       zMatrix(2 * iHit, 0) = 1.;
@@ -565,7 +565,7 @@ CTPPSPixelLocalTrack RPixPlaneCombinatoryTracking::fitTrack(PointInPlaneList poi
   goodTrack.setValid(true);
 
   for (const auto &hit : pointList) {
-    CLHEP::Hep3Vector globalPoint = hit.globalPoint;
+    const auto &globalPoint = hit.globalPoint;
     GlobalPoint pointOnDet;
     bool foundPoint = calculatePointOnDetector(&goodTrack, hit.detId, pointOnDet);
     if (!foundPoint) {
@@ -601,8 +601,8 @@ bool RPixPlaneCombinatoryTracking::calculatePointOnDetector(CTPPSPixelLocalTrack
   GlobalVector tmpLineUnitVector = track->directionVector();
   math::Vector<3>::type lineUnitVector(tmpLineUnitVector.x(), tmpLineUnitVector.y(), tmpLineUnitVector.z());
 
-  CLHEP::Hep3Vector tmpPointLocal(0., 0., 0.);
-  CLHEP::Hep3Vector tmpPointOnPlane = geometry_->localToGlobal(planeId, tmpPointLocal);
+  const CTPPSGeometry::Vector tmpPointLocal(0., 0., 0.);
+  const auto &tmpPointOnPlane = geometry_->localToGlobal(planeId, tmpPointLocal);
 
   math::Vector<3>::type pointOnPlane(tmpPointOnPlane.x(), tmpPointOnPlane.y(), tmpPointOnPlane.z());
   math::Vector<3>::type planeUnitVector(0., 0., 1.);

--- a/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
+++ b/RecoCTPPS/PixelLocal/src/RPixRoadFinder.cc
@@ -47,8 +47,8 @@ void RPixRoadFinder::findPattern() {
   for (const auto& ds_rh2 : *hitVector_) {
     const auto myid = CTPPSPixelDetId(ds_rh2.id);
     for (const auto& it_rh : ds_rh2.data) {
-      CLHEP::Hep3Vector localV(it_rh.point().x(), it_rh.point().y(), it_rh.point().z());
-      CLHEP::Hep3Vector globalV = geometry_->localToGlobal(ds_rh2.id, localV);
+      CTPPSGeometry::Vector localV(it_rh.point().x(), it_rh.point().y(), it_rh.point().z());
+      const auto& globalV = geometry_->localToGlobal(ds_rh2.id, localV);
       math::Error<3>::type localError;
       localError[0][0] = it_rh.error().xx();
       localError[0][1] = it_rh.error().xy();
@@ -92,7 +92,7 @@ void RPixRoadFinder::findPattern() {
 
     it_gh2 = it_gh1;
 
-    CLHEP::Hep3Vector currPoint = it_gh1->globalPoint;
+    const auto currPoint = it_gh1->globalPoint;
     CTPPSPixelDetId currDet = CTPPSPixelDetId(it_gh1->detId);
 
     while (it_gh2 != temp_all_hits.end()) {
@@ -100,9 +100,9 @@ void RPixRoadFinder::findPattern() {
       CTPPSPixelDetId tmpGh2Id = CTPPSPixelDetId(it_gh2->detId);
       if (currDet.rpId() == tmpGh2Id.rpId())
         same_pot = true;
-      CLHEP::Hep3Vector subtraction = currPoint - it_gh2->globalPoint;
+      const auto subtraction = currPoint - it_gh2->globalPoint;
 
-      if (subtraction.perp() < roadRadius_ && same_pot) {  /// 1mm
+      if (subtraction.Rho() < roadRadius_ && same_pot) {  /// 1mm
         temp_road.push_back(*it_gh2);
         temp_all_hits.erase(it_gh2);
       } else {

--- a/RecoCTPPS/TotemRPLocal/interface/TotemRPLocalTrackFitterAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemRPLocalTrackFitterAlgorithm.h
@@ -65,7 +65,7 @@ private:
   /// A matrix multiplication shorthand.
   void multiplyByDiagonalInPlace(TMatrixD &mt, const TVectorD &diag);
 
-  static TVector3 convert3vector(const CLHEP::Hep3Vector &v) { return TVector3(v.x(), v.y(), v.z()); }
+  static TVector3 convert3vector(const CTPPSGeometry::Vector &v) { return TVector3(v.x(), v.y(), v.z()); }
 };
 
 #endif

--- a/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
@@ -71,7 +71,7 @@ FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id) 
     return it->second;
 
   // calculate it
-  CLHEP::Hep3Vector d = geometry->localToGlobalDirection(id, CLHEP::Hep3Vector(0., 1., 0.));
+  const auto &d = geometry->localToGlobalDirection(id, CTPPSGeometry::Vector(0., 1., 0.));
   DetGeomDesc::Translation c = geometry->sensor(TotemRPDetId(id))->translation();
   GeomData gd;
   gd.z = c.z();

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
@@ -34,14 +34,7 @@ TotemRPLocalTrackFitterAlgorithm::prepareReconstAlgebraData(unsigned int det_id,
 
   det_algebra_obj.centre_of_det_global_position_ = convert3vector(tot_rp_geom.sensorTranslation(det_id));
 
-  HepMC::ThreeVector rp_topology_stripaxis = rp_topology_.GetStripReadoutAxisDir();
-  CLHEP::Hep3Vector rp_topology_stripaxis_clhep;
-
-  rp_topology_stripaxis_clhep.setX(rp_topology_stripaxis.x());
-  rp_topology_stripaxis_clhep.setY(rp_topology_stripaxis.y());
-  rp_topology_stripaxis_clhep.setZ(rp_topology_stripaxis.z());
-
-  TVector3 rd_dir = convert3vector(tot_rp_geom.localToGlobalDirection(det_id, rp_topology_stripaxis_clhep));
+  TVector3 rd_dir = convert3vector(tot_rp_geom.localToGlobalDirection(det_id, rp_topology_.GetStripReadoutAxisDir()));
 
   TVector2 v(rd_dir.X(), rd_dir.Y());
   det_algebra_obj.readout_direction_ = v.Unit();

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -380,9 +380,9 @@ void CTPPSDirectProtonSimulation::processProton(
 
       // determine the track impact point (in global coordinates)
       // !! this assumes that local axes (1, 0, 0) and (0, 1, 0) describe the sensor surface
-      CLHEP::Hep3Vector gl_o = geometry.localToGlobal(detId, CLHEP::Hep3Vector(0, 0, 0));
-      CLHEP::Hep3Vector gl_a1 = geometry.localToGlobal(detId, CLHEP::Hep3Vector(1, 0, 0)) - gl_o;
-      CLHEP::Hep3Vector gl_a2 = geometry.localToGlobal(detId, CLHEP::Hep3Vector(0, 1, 0)) - gl_o;
+      const auto &gl_o = geometry.localToGlobal(detId, CTPPSGeometry::Vector(0, 0, 0));
+      const auto &gl_a1 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(1, 0, 0)) - gl_o;
+      const auto &gl_a2 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(0, 1, 0)) - gl_o;
 
       TMatrixD A(3, 3);
       TVectorD B(3);
@@ -404,10 +404,10 @@ void CTPPSDirectProtonSimulation::processProton(
       P = Ai * B;
 
       double ze = P(0);
-      CLHEP::Hep3Vector h_glo(a_x * ze + b_x, a_y * ze + b_y, z_sign * ze + z_scoringPlane);
+      const CTPPSGeometry::Vector h_glo(a_x * ze + b_x, a_y * ze + b_y, z_sign * ze + z_scoringPlane);
 
       // hit in local coordinates
-      CLHEP::Hep3Vector h_loc = geometry.globalToLocal(detId, h_glo);
+      auto h_loc = geometry.globalToLocal(detId, h_glo);
 
       if (verbosity_) {
         ssLog << std::endl
@@ -475,8 +475,8 @@ void CTPPSDirectProtonSimulation::processProton(
           continue;
 
         if (roundToPitch_) {
-          h_loc.setX(pitchPixelsHor_ * floor(h_loc.x() / pitchPixelsHor_ + 0.5));
-          h_loc.setY(pitchPixelsVer_ * floor(h_loc.y() / pitchPixelsVer_ + 0.5));
+          h_loc.SetX(pitchPixelsHor_ * floor(h_loc.x() / pitchPixelsHor_ + 0.5));
+          h_loc.SetY(pitchPixelsVer_ * floor(h_loc.y() / pitchPixelsVer_ + 0.5));
         }
 
         if (verbosity_ > 5)


### PR DESCRIPTION
#### PR description:

This is a technical PR to reduce the number of different vector classes used in PPS reconstruction, geometry, etc. In particular, the dependence on CLHEP is dropped in favour of ROOT. Several unnecessary vector-format conversion are avoided. In the geometry-consumer code, whenever possible, the auto statement or CTPPSGeometry::Vector typedef is used in order simplify possible future type transitions.

#### PR validation:

Running
```
runTheMatrix.py -l limited --ibeos
```
gave
```
34 33 32 26 16 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed
```

This PR does not change the proton reconstruction results - see the comparison below. Blue = before this PR, red dashed = with this PR.
![make_cmp](https://user-images.githubusercontent.com/17830858/72153894-71d06e80-33af-11ea-8328-9c3ebf31fd43.png)


