### PR TITLE
Fix reading memory after freed in HLTPerformanceInfo

### DIFF
--- a/DataFormats/HLTReco/interface/HLTPerformanceInfo.h
+++ b/DataFormats/HLTReco/interface/HLTPerformanceInfo.h
@@ -153,8 +153,8 @@ public:
   double totalCPUTime() const;
   double longestModuleTime() const;
   double longestModuleCPUTime() const;
-  const char *longestModuleTimeName() const;
-  const char *longestModuleCPUTimeName() const;
+  std::string longestModuleTimeName() const;
+  std::string longestModuleCPUTimeName() const;
 
   double totalPathTime(const size_t path);
   double totalPathCPUTime(const size_t path);

--- a/DataFormats/HLTReco/src/HLTPerformanceInfo.cc
+++ b/DataFormats/HLTReco/src/HLTPerformanceInfo.cc
@@ -75,7 +75,7 @@ double HLTPerformanceInfo::longestModuleCPUTime() const {
   return t;
 }
 
-const char* HLTPerformanceInfo::longestModuleTimeName() const {
+std::string HLTPerformanceInfo::longestModuleTimeName() const {
   double t = -1;
   std::string slowpoke("unknown");
   for (Modules::const_iterator i = modules_.begin(); i != modules_.end(); ++i) {
@@ -84,10 +84,10 @@ const char* HLTPerformanceInfo::longestModuleTimeName() const {
       t = i->time();
     }
   }
-  return slowpoke.c_str();
+  return slowpoke;
 }
 
-const char* HLTPerformanceInfo::longestModuleCPUTimeName() const {
+std::string HLTPerformanceInfo::longestModuleCPUTimeName() const {
   double t = -1;
   std::string slowpoke("unknown");
   for (Modules::const_iterator i = modules_.begin(); i != modules_.end(); ++i) {
@@ -96,7 +96,7 @@ const char* HLTPerformanceInfo::longestModuleCPUTimeName() const {
       t = i->cputime();
     }
   }
-  return slowpoke.c_str();
+  return slowpoke;
 }
 
 // I think we can no longer do this as it requires going from path -> modules


### PR DESCRIPTION
#### PR description:

The memory in the string was deleted at the end of the function so it is not safe to return as a const char*.

The problem was found by the clang static analyzer.

#### PR validation:

The code compiles.