### PR TITLE
Add ability to set RandomEngineStates in Service

### DIFF
--- a/FWCore/Utilities/interface/RandomNumberGenerator.h
+++ b/FWCore/Utilities/interface/RandomNumberGenerator.h
@@ -179,6 +179,9 @@ namespace edm {
     virtual void preBeginLumi(LuminosityBlock const& lumi) = 0;
     virtual void postEventRead(Event const& event) = 0;
 
+    virtual void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) = 0;
+    virtual void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) = 0;
+
     virtual std::vector<RandomEngineState> const& getEventCache(StreamID const&) const = 0;
     virtual std::vector<RandomEngineState> const& getLumiCache(LuminosityBlockIndex const&) const = 0;
 

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -446,6 +446,18 @@ namespace edm {
       }
     }
 
+    void RandomNumberGeneratorService::setLumiCache(LuminosityBlockIndex iLumi,
+                                                    std::vector<RandomEngineState> const& iStates) {
+      lumiCache_[iLumi] = iStates;
+      // Copy from cache to engine the state for a particular luminosityBlockIndex
+      restoreFromCache(lumiCache_[iLumi], lumiEngines_[iLumi]);
+    }
+    void RandomNumberGeneratorService::setEventCache(StreamID iStream, std::vector<RandomEngineState> const& iStates) {
+      eventCache_[iStream] = iStates;
+      // copy from event cache to engines
+      restoreFromCache(eventCache_[iStream], streamEngines_[iStream]);
+    }
+
     void RandomNumberGeneratorService::preModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
       preModuleStreamCheck(sc, mcc);
     }

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -83,6 +83,8 @@ namespace edm {
 
       void preBeginLumi(LuminosityBlock const& lumi) override;
       void postEventRead(Event const& event) override;
+      void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) override;
+      void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) override;
 
       /// These next 12 functions are only used to check that random numbers are not
       /// being generated in these methods when enable checking is configured on.


### PR DESCRIPTION
#### PR description:

This new API is intended to be used in conjunction with the TestProcessor and an external process controlling a generator module.

#### PR validation:

Code compiles.