### PR TITLE
esConsumes migration DTChamberEfficiency

### DIFF
--- a/DQM/DTMonitorModule/src/DTChamberEfficiency.h
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiency.h
@@ -17,27 +17,21 @@
  *
  */
 
-#include "DataFormats/Common/interface/Handle.h"
-
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-
 #include "RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h"
+
+#include <string>
 #include <vector>
 
 namespace reco {
@@ -95,18 +89,11 @@ private:
 
   std::string theNavigationType;
 
-  edm::ESHandle<DTGeometry> dtGeom;
-
   MuonServiceProxy* theService;
   MuonDetLayerMeasurements* theMeasurementExtractor;
   Chi2MeasurementEstimator* theEstimator;
 
-  edm::ESHandle<MagneticField> magfield;
-  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-
   std::vector<std::vector<MonitorElement*> > histosPerW;
-
-protected:
 };
 
 #endif  // DTANALYZER_H

--- a/FWCore/Framework/interface/FrameworkfwdMostUsed.h
+++ b/FWCore/Framework/interface/FrameworkfwdMostUsed.h
@@ -1,0 +1,18 @@
+#ifndef FWCore_Framework_FrameworkfwdMostUsed_h
+#define FWCore_Framework_FrameworkfwdMostUsed_h
+
+/*----------------------------------------------------------------------
+
+Forward declarations of types in the EDM that are most frequently used.
+
+----------------------------------------------------------------------*/
+namespace edm {
+  class ConsumesCollector;
+  class Event;
+  class EventSetup;
+  class LuminosityBlock;
+  class ParameterSet;
+  class Run;
+  class StreamID;
+}  // namespace edm
+#endif

--- a/RecoMuon/TrackingTools/src/MuonServiceProxy.cc
+++ b/RecoMuon/TrackingTools/src/MuonServiceProxy.cc
@@ -14,23 +14,14 @@
 // Class Header
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
-// Service Records
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "RecoMuon/Records/interface/MuonRecoGeometryRecord.h"
-#include "RecoMuon/Navigation/interface/MuonNavigationSchool.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-
 // Framework Headers
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 
-// C++ Headers
-#include <map>
-
-using namespace std;
-using namespace edm;
+#include <vector>
 
 // Constructor
 MuonServiceProxy::MuonServiceProxy(const edm::ParameterSet& par)
@@ -39,10 +30,6 @@ MuonServiceProxy::MuonServiceProxy(const edm::ParameterSet& par)
       theDetLayerGeometry(nullptr),
       theEventSetup(nullptr),
       theSchool(nullptr) {
-  // load the propagators map
-  vector<string> noPropagators;
-  vector<string> propagatorNames;
-
   theMuonNavigationFlag = par.getUntrackedParameter<bool>("UseMuonNavigation", true);
 
   if (theMuonNavigationFlag) {
@@ -70,15 +57,18 @@ MuonServiceProxy::MuonServiceProxy(const edm::ParameterSet& par)
     theME0Layer = true;
   }
 
-  propagatorNames = par.getUntrackedParameter<vector<string> >("Propagators", noPropagators);
+  // load the propagators map
+  std::vector<std::string> noPropagators;
+  std::vector<std::string> propagatorNames =
+      par.getUntrackedParameter<std::vector<std::string>>("Propagators", noPropagators);
 
   if (propagatorNames.empty())
     LogDebug("Muon|RecoMuon|MuonServiceProxy") << "NO propagator(s) selected!";
 
-  for (vector<string>::iterator propagatorName = propagatorNames.begin(); propagatorName != propagatorNames.end();
-       ++propagatorName)
-    thePropagators[*propagatorName] = ESHandle<Propagator>(nullptr);
-
+  for (auto const& propagatorName : propagatorNames) {
+    thePropagators[propagatorName] =
+        std::make_pair(edm::ESHandle<Propagator>(), edm::ESGetToken<Propagator, TrackingComponentsRecord>());
+  }
   theCacheId_GTG = 0;
   theCacheId_MG = 0;
   theCacheId_DG = 0;
@@ -86,15 +76,17 @@ MuonServiceProxy::MuonServiceProxy(const edm::ParameterSet& par)
   theChangeInTrackingComponentsRecord = false;
 }
 
+MuonServiceProxy::MuonServiceProxy(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) : MuonServiceProxy(par) {
+  globalTrackingGeometryToken_ = iC.esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>();
+  magneticFieldToken_ = iC.esConsumes<MagneticField, IdealMagneticFieldRecord>();
+  muonDetLayerGeometryToken_ = iC.esConsumes<MuonDetLayerGeometry, MuonRecoGeometryRecord>();
+  for (auto& element : thePropagators) {
+    element.second.second = iC.esConsumes<Propagator, TrackingComponentsRecord>(edm::ESInputTag("", element.first));
+  }
+}
+
 // Destructor
 MuonServiceProxy::~MuonServiceProxy() {
-  // FIXME: how do that?
-  // delete theTrackingGeometry;
-  // delete theMGField;
-  // delete theDetLayerGeometry;
-
-  // FIXME: is it enough?
-  thePropagators.clear();
   if (theSchool)
     delete theSchool;
 }
@@ -112,7 +104,11 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
   if (newCacheId_GTG != theCacheId_GTG) {
     LogTrace(metname) << "GlobalTrackingGeometry changed!";
     theCacheId_GTG = newCacheId_GTG;
-    setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+    if (globalTrackingGeometryToken_.isInitialized()) {
+      theTrackingGeometry = setup.getHandle(globalTrackingGeometryToken_);
+    } else {
+      setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+    }
   }
 
   // Magfield Field
@@ -120,7 +116,11 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
   if (newCacheId_MG != theCacheId_MG) {
     LogTrace(metname) << "Magnetic Field changed!";
     theCacheId_MG = newCacheId_MG;
-    setup.get<IdealMagneticFieldRecord>().get(theMGField);
+    if (magneticFieldToken_.isInitialized()) {
+      theMGField = setup.getHandle(magneticFieldToken_);
+    } else {
+      setup.get<IdealMagneticFieldRecord>().get(theMGField);
+    }
   }
 
   // DetLayer Geometry
@@ -128,7 +128,11 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
   if (newCacheId_DG != theCacheId_DG) {
     LogTrace(metname) << "Muon Reco Geometry changed!";
     theCacheId_DG = newCacheId_DG;
-    setup.get<MuonRecoGeometryRecord>().get(theDetLayerGeometry);
+    if (muonDetLayerGeometryToken_.isInitialized()) {
+      theDetLayerGeometry = setup.getHandle(muonDetLayerGeometryToken_);
+    } else {
+      setup.get<MuonRecoGeometryRecord>().get(theDetLayerGeometry);
+    }
     // MuonNavigationSchool should live until its validity expires, and then DELETE
     // the NavigableLayers (this is implemented in MuonNavigationSchool's dtor)
     if (theMuonNavigationFlag) {
@@ -144,21 +148,26 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
     LogTrace(metname) << "Tracking Component changed!";
     theChangeInTrackingComponentsRecord = true;
     theCacheId_P = newCacheId_P;
-    for (propagators::iterator prop = thePropagators.begin(); prop != thePropagators.end(); ++prop)
-      setup.get<TrackingComponentsRecord>().get(prop->first, prop->second);
+    for (auto& element : thePropagators) {
+      if (element.second.second.isInitialized()) {
+        // element.second.first is the ESHandle, element.second.second is the ESGetToken
+        element.second.first = setup.getHandle(element.second.second);
+      } else {
+        setup.get<TrackingComponentsRecord>().get(element.first, element.second.first);
+      }
+    }
   } else
     theChangeInTrackingComponentsRecord = false;
 }
 
 // get the propagator
-ESHandle<Propagator> MuonServiceProxy::propagator(std::string propagatorName) const {
-  propagators::const_iterator prop = thePropagators.find(propagatorName);
+edm::ESHandle<Propagator> MuonServiceProxy::propagator(std::string propagatorName) const {
+  PropagatorMap::const_iterator prop = thePropagators.find(propagatorName);
 
   if (prop == thePropagators.end()) {
-    LogError("Muon|RecoMuon|MuonServiceProxy") << "MuonServiceProxy: propagator with name: " << propagatorName
-                                               << " not found! Please load it in the MuonServiceProxy.cff";
-    return ESHandle<Propagator>(nullptr);
+    edm::LogError("Muon|RecoMuon|MuonServiceProxy") << "MuonServiceProxy: propagator with name: " << propagatorName
+                                                    << " not found! Please load it in the MuonServiceProxy.cff";
+    return edm::ESHandle<Propagator>(nullptr);
   }
-
-  return prop->second;
+  return prop->second.first;
 }

--- a/RecoMuon/TrackingTools/src/MuonServiceProxy.cc
+++ b/RecoMuon/TrackingTools/src/MuonServiceProxy.cc
@@ -107,6 +107,8 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
     if (globalTrackingGeometryToken_.isInitialized()) {
       theTrackingGeometry = setup.getHandle(globalTrackingGeometryToken_);
     } else {
+      // FIXME, when the deprecated constructor is deleted, then the following
+      // line can be deleted. Also the if-else conditional can be deleted.
       setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
     }
   }
@@ -119,6 +121,8 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
     if (magneticFieldToken_.isInitialized()) {
       theMGField = setup.getHandle(magneticFieldToken_);
     } else {
+      // FIXME, when the deprecated constructor is deleted, then the following
+      // line can be deleted. Also the if-else conditional can be deleted.
       setup.get<IdealMagneticFieldRecord>().get(theMGField);
     }
   }
@@ -131,6 +135,8 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
     if (muonDetLayerGeometryToken_.isInitialized()) {
       theDetLayerGeometry = setup.getHandle(muonDetLayerGeometryToken_);
     } else {
+      // FIXME, when the deprecated constructor is deleted, then the following
+      // line can be deleted. Also the if-else conditional can be deleted.
       setup.get<MuonRecoGeometryRecord>().get(theDetLayerGeometry);
     }
     // MuonNavigationSchool should live until its validity expires, and then DELETE
@@ -153,6 +159,8 @@ void MuonServiceProxy::update(const edm::EventSetup& setup) {
         // element.second.first is the ESHandle, element.second.second is the ESGetToken
         element.second.first = setup.getHandle(element.second.second);
       } else {
+        // FIXME, when the deprecated constructor is deleted, then the following
+        // line can be deleted. Also the if-else conditional can be deleted.
         setup.get<TrackingComponentsRecord>().get(element.first, element.second.first);
       }
     }


### PR DESCRIPTION
#### PR description:

Migrate DTChamberEfficiency to call esConsumes for EventSetup data that it gets. Actually I just removed the direct EventSetup calls in DTChamberEfficiency. It didn't use DTGeometry data it was getting and the other two types are obtainable from the MuonProxyService which it was already using. The only difference being that MuonProxyService gets the data each event instead of each run. (Before DTChamberEfficiency was getting them each run AND each event, but only using them in the event).

Upgraded the MuonServiceProxy helper class so that it supports both modes (with calls to esConsumes and without). More than 100 other modules seem to use MuonServiceProxy so this dual support is needed during the transition. To migrate to esConsumes support, the other modules only need to add the ConsumesCollector argument when constructing MuonServiceProxy. Eventually when all those modules are migrated, the old MuonProxyService constructor should be deleted.

Also added a new Framework header for Framework forward declarations that is less heavy than Frameworkfwd.h.

#### PR validation:

Relies on existing tests. No new functionality and existing results should not change.
