### PR TITLE
backport of quark and gluons Py8EGun in CMSSW_10_2_X

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -7,17 +7,17 @@
 namespace gen {
 
 class Py8EGun : public Py8GunBase {
-   
+
    public:
-      
+
       Py8EGun( edm::ParameterSet const& );
       ~Py8EGun() override {}
-	 
+
       bool generatePartonsAndHadronize() override;
       const char* classname() const override;
-	 
+
    private:
-      
+
       // EGun particle(s) characteristics
       double  fMinEta;
       double  fMaxEta;
@@ -27,20 +27,20 @@ class Py8EGun : public Py8GunBase {
 
 };
 
-// implementation 
+// implementation
 //
 Py8EGun::Py8EGun( edm::ParameterSet const& ps )
-   : Py8GunBase(ps) 
+   : Py8GunBase(ps)
 {
 
    // ParameterSet defpset ;
-   edm::ParameterSet pgun_params = 
+   edm::ParameterSet pgun_params =
       ps.getParameter<edm::ParameterSet>("PGunParameters"); // , defpset ) ;
    fMinEta     = pgun_params.getParameter<double>("MinEta"); // ,-2.2);
    fMaxEta     = pgun_params.getParameter<double>("MaxEta"); // , 2.2);
    fMinE       = pgun_params.getParameter<double>("MinE"); // ,  0.);
    fMaxE       = pgun_params.getParameter<double>("MaxE"); // ,  0.);
-   fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle"); //, false) ;  
+   fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle"); //, false) ;
 
 }
 
@@ -48,7 +48,7 @@ bool Py8EGun::generatePartonsAndHadronize()
 {
 
    fMasterGen->event.reset();
-   
+
    for ( size_t i=0; i<fPartIDs.size(); i++ )
    {
 
@@ -70,46 +70,59 @@ bool Py8EGun::generatePartonsAndHadronize()
       {
          particleID = std::fabs(particleID) ;
       }
-      (fMasterGen->event).append( particleID, 1, 0, 0, px, py, pz, ee, mass ); 
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
+      (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
+      else if (std::abs(particleID) == 21)  // gluons
+      (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
+      // other
+      else {
+        (fMasterGen->event).append( particleID, 1, 0, 0, px, py, pz, ee, mass );
       int eventSize = (fMasterGen->event).size()-1;
 // -log(flat) = exponential distribution
       double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
       (fMasterGen->event)[eventSize].tau( tauTmp );
+      }
 
 
 // Here also need to add anti-particle (if any)
-// otherwise just add a 2nd particle of the same type 
+// otherwise just add a 2nd particle of the same type
 // (for example, gamma)
 //
       if ( fAddAntiParticle )
       {
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+          (fMasterGen->event).append(-particleID, 23, 0, 101, -px, -py, -pz, ee, mass);
+        } else if (std::abs(particleID) == 21) {  // gluons
+          (fMasterGen->event).append(21, 23, 102, 101, -px, -py, -pz, ee, mass);
+        } else {
          if ( (fMasterGen->particleData).isParticle( -particleID ) )
-	 {
-	    (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-	 }
-	 else
-	 {
-	    (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
-	 }
-         eventSize = (fMasterGen->event).size()-1;
-// -log(flat) = exponential distribution
-         tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
-         (fMasterGen->event)[eventSize].tau( tauTmp );
-      }
+	        {
+	           (fMasterGen->event).append( -particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
+	         }
+	        else
+	            {
+	               (fMasterGen->event).append( particleID, 1, 0, 0, -px, -py, -pz, ee, mass );
+	            }
+          int eventSize = (fMasterGen->event).size()-1;
+          // -log(flat) = exponential distribution
+          double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+          (fMasterGen->event)[eventSize].tau( tauTmp );
+          }
 
-   }
-   
+      }
+    }
+
    if ( !fMasterGen->next() ) return false;
    evtGenDecay();
 
    event().reset(new HepMC::GenEvent);
    return toHepMC.fill_next_event( fMasterGen->event, event().get() );
-  
+
 }
 
 const char* Py8EGun::classname() const
 {
-   return "Py8EGun"; 
+   return "Py8EGun";
 }
 
 typedef edm::GeneratorFilter<gen::Py8EGun, gen::ExternalDecayDriver> Pythia8EGun;


### PR DESCRIPTION
#### PR description:

Added a feature to the Py8EGun: now the gun can use also quark or gluons. This feature was already present in the Py8PtGun, but not in the EGun.
This feature is required for the MC production for the training of DeeoCore Algorithm in forward region. see this jira ticked for details: [(https://its.cern.ch/jira/browse/PDMVRELVALS-65#add-comment)].

#### if this PR is a backport please specify the original PR:
This is the original PR on master. Because the modification is a single file, I did it by hand reimplementing the features (copy-paste of the modified line instead using rebase/cherry pick of the commit).
https://github.com/cms-sw/cmssw/pull/28658
