### PR TITLE
PPS: faster proton reconstruction

### DIFF
--- a/RecoCTPPS/ProtonReconstruction/interface/ProtonReconstructionAlgorithm.h
+++ b/RecoCTPPS/ProtonReconstruction/interface/ProtonReconstructionAlgorithm.h
@@ -25,7 +25,10 @@
 
 class ProtonReconstructionAlgorithm {
 public:
-  ProtonReconstructionAlgorithm(bool fit_vtx_y, bool improved_estimate, unsigned int verbosity);
+  ProtonReconstructionAlgorithm(bool fit_vtx_y,
+                                bool improved_estimate,
+                                const std::string &multiRPAlgorithm,
+                                unsigned int verbosity);
   ~ProtonReconstructionAlgorithm() = default;
 
   void init(const LHCInterpolatedOpticalFunctionsSetCollection &opticalFunctions);
@@ -45,12 +48,13 @@ private:
   unsigned int verbosity_;
   bool fitVtxY_;
   bool useImprovedInitialEstimate_;
+  enum { mrpaUndefined, mrpaChi2, mrpaNewton, mrpaAnalIter } multi_rp_algorithm_;
   bool initialized_;
 
   /// optics data associated with 1 RP
   struct RPOpticsData {
     const LHCInterpolatedOpticalFunctionsSet *optics;
-    std::shared_ptr<const TSpline3> s_xi_vs_x_d, s_y_d_vs_xi, s_v_y_vs_xi, s_L_y_vs_xi;
+    std::shared_ptr<const TSpline3> s_x_d_vs_xi, s_L_x_vs_xi, s_xi_vs_x_d, s_y_d_vs_xi, s_v_y_vs_xi, s_L_y_vs_xi;
     double x0;   ///< beam horizontal position, cm
     double y0;   ///< beam vertical position, cm
     double ch0;  ///< intercept for linear approximation of \f$x(\xi)\f$
@@ -80,6 +84,8 @@ private:
   std::unique_ptr<ChiSquareCalculator> chiSquareCalculator_;
 
   static void doLinearFit(const std::vector<double> &vx, const std::vector<double> &vy, double &b, double &a);
+
+  static double newtonGoalFcn(double xi, double x_N, double x_F, const RPOpticsData &i_N, const RPOpticsData &i_F);
 };
 
 #endif

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -132,8 +132,10 @@ CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet &iConfig)
 
       max_n_timing_tracks_(iConfig.getParameter<unsigned int>("max_n_timing_tracks")),
 
-      algorithm_(
-          iConfig.getParameter<bool>("fitVtxY"), iConfig.getParameter<bool>("useImprovedInitialEstimate"), verbosity_),
+      algorithm_(iConfig.getParameter<bool>("fitVtxY"),
+                 iConfig.getParameter<bool>("useImprovedInitialEstimate"),
+                 iConfig.getParameter<std::string>("multiRPAlgorithm"),
+                 verbosity_),
       opticsValid_(false) {
   for (const std::string &sector : {"45", "56"}) {
     const unsigned int arm = (sector == "45") ? 0 : 1;
@@ -191,6 +193,9 @@ void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions &descr
   desc.add<bool>("useImprovedInitialEstimate", true)
       ->setComment(
           "for multi-RP reconstruction, flag whether a quadratic estimate of the initial point should be used");
+
+  desc.add<std::string>("multiRPAlgorithm", "chi2")
+      ->setComment("algorithm for multi-RP reco, options include chi2, newton, anal-iter");
 
   descriptions.add("ctppsProtons", desc);
 }

--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -21,15 +21,28 @@ using namespace edm;
 
 ProtonReconstructionAlgorithm::ProtonReconstructionAlgorithm(bool fit_vtx_y,
                                                              bool improved_estimate,
+                                                             const std::string &multiRPAlgorithm,
                                                              unsigned int verbosity)
     : verbosity_(verbosity),
       fitVtxY_(fit_vtx_y),
       useImprovedInitialEstimate_(improved_estimate),
+      multi_rp_algorithm_(mrpaUndefined),
       initialized_(false),
       fitter_(new ROOT::Fit::Fitter),
       chiSquareCalculator_(new ChiSquareCalculator) {
   // needed for thread safety
   TMinuitMinimizer::UseStaticMinuit(false);
+
+  // check and set multi-RP algorithm
+  if (multiRPAlgorithm == "chi2")
+    multi_rp_algorithm_ = mrpaChi2;
+  if (multiRPAlgorithm == "newton")
+    multi_rp_algorithm_ = mrpaNewton;
+  if (multiRPAlgorithm == "anal-iter")
+    multi_rp_algorithm_ = mrpaAnalIter;
+
+  if (multi_rp_algorithm_ == mrpaUndefined)
+    throw cms::Exception("ProtonReconstructionAlgorithm") << "Algorithm '" << multiRPAlgorithm << "' not understood.";
 
   // initialise fitter
   double pStart[] = {0, 0, 0, 0};
@@ -49,6 +62,8 @@ void ProtonReconstructionAlgorithm::init(const LHCInterpolatedOpticalFunctionsSe
     // make record
     RPOpticsData rpod;
     rpod.optics = &p.second;
+    rpod.s_x_d_vs_xi = ofs.splines()[LHCOpticalFunctionsSet::exd];
+    rpod.s_L_x_vs_xi = ofs.splines()[LHCOpticalFunctionsSet::eLx];
     rpod.s_y_d_vs_xi = ofs.splines()[LHCOpticalFunctionsSet::eyd];
     rpod.s_v_y_vs_xi = ofs.splines()[LHCOpticalFunctionsSet::evy];
     rpod.s_L_y_vs_xi = ofs.splines()[LHCOpticalFunctionsSet::eLy];
@@ -142,6 +157,17 @@ double ProtonReconstructionAlgorithm::ChiSquareCalculator::operator()(const doub
 
 //----------------------------------------------------------------------------------------------------
 
+double ProtonReconstructionAlgorithm::newtonGoalFcn(double xi,
+                                                    double x_N,
+                                                    double x_F,
+                                                    const ProtonReconstructionAlgorithm::RPOpticsData &i_N,
+                                                    const ProtonReconstructionAlgorithm::RPOpticsData &i_F) {
+  return (x_N - i_N.s_x_d_vs_xi->Eval(xi)) * i_F.s_L_x_vs_xi->Eval(xi) -
+         (x_F - i_F.s_x_d_vs_xi->Eval(xi)) * i_N.s_L_x_vs_xi->Eval(xi);
+}
+
+//----------------------------------------------------------------------------------------------------
+
 reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector &tracks,
                                                                           const LHCInfo &lhcInfo,
                                                                           std::ostream &os) const {
@@ -230,38 +256,140 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
        << "    initial estimate: xi_init = " << xi_init << ", th_x_init = " << th_x_init
        << ", th_y_init = " << th_y_init << ", vtx_y_init = " << vtx_y_init << "." << std::endl;
 
-  // minimisation
-  fitter_->Config().ParSettings(0).Set("xi", xi_init, 0.005);
-  fitter_->Config().ParSettings(1).Set("th_x", th_x_init, 2E-6);
-  fitter_->Config().ParSettings(2).Set("th_y", th_y_init, 2E-6);
-  fitter_->Config().ParSettings(3).Set("vtx_y", vtx_y_init, 10E-6);
+  // prepare result containers
+  bool valid = false;
+  double chi2 = 0.;
+  double xi = 0., th_x = 0., th_y = 0., vtx_y = 0.;
 
-  if (!fitVtxY_)
-    fitter_->Config().ParSettings(3).Fix();
+  using FP = reco::ForwardProton;
+  FP::CovarianceMatrix cm;
 
-  chiSquareCalculator_->tracks = &tracks;
-  chiSquareCalculator_->m_rp_optics = &m_rp_optics_;
+  if (multi_rp_algorithm_ == mrpaChi2) {
+    // minimisation
+    fitter_->Config().ParSettings(0).Set("xi", xi_init, 0.005);
+    fitter_->Config().ParSettings(1).Set("th_x", th_x_init, 2E-6);
+    fitter_->Config().ParSettings(2).Set("th_y", th_y_init, 2E-6);
+    fitter_->Config().ParSettings(3).Set("vtx_y", vtx_y_init, 10E-6);
 
-  fitter_->FitFCN();
-  fitter_->FitFCN();  // second minimisation in case the first one had troubles
+    if (!fitVtxY_)
+      fitter_->Config().ParSettings(3).Fix();
 
-  // extract proton parameters
-  const ROOT::Fit::FitResult &result = fitter_->Result();
-  const double *params = result.GetParams();
+    chiSquareCalculator_->tracks = &tracks;
+    chiSquareCalculator_->m_rp_optics = &m_rp_optics_;
 
+    fitter_->FitFCN();
+    fitter_->FitFCN();  // second minimisation in case the first one had troubles
+
+    // extract proton parameters
+    const ROOT::Fit::FitResult &result = fitter_->Result();
+    const double *params = result.GetParams();
+
+    valid = result.IsValid();
+    chi2 = result.Chi2();
+    xi = params[0];
+    th_x = params[1];
+    th_y = params[2];
+    vtx_y = params[3];
+
+    map<unsigned int, signed int> index_map = {
+        {(unsigned int)FP::Index::xi, 0},
+        {(unsigned int)FP::Index::th_x, 1},
+        {(unsigned int)FP::Index::th_y, 2},
+        {(unsigned int)FP::Index::vtx_y, ((fitVtxY_) ? 3 : -1)},
+        {(unsigned int)FP::Index::vtx_x, -1},
+    };
+
+    for (unsigned int i = 0; i < (unsigned int)FP::Index::num_indices; ++i) {
+      signed int fit_i = index_map[i];
+
+      for (unsigned int j = 0; j < (unsigned int)FP::Index::num_indices; ++j) {
+        signed int fit_j = index_map[j];
+
+        cm(i, j) = (fit_i >= 0 && fit_j >= 0) ? result.CovMatrix(fit_i, fit_j) : 0.;
+      }
+    }
+  }
+
+  if (multi_rp_algorithm_ == mrpaNewton || multi_rp_algorithm_ == mrpaAnalIter) {
+    // settings
+    const unsigned int maxIterations = 100;
+    const double maxXiDiff = 1E-6;
+    const double xi_ep = 1E-5;
+
+    // collect input
+    double x_N = tracks[0]->x() * 1E-1,  // conversion: mm --> cm
+        x_F = tracks[1]->x() * 1E-1;
+
+    double y_N = tracks[0]->y() * 1E-1,  // conversion: mm --> cm
+        y_F = tracks[1]->y() * 1E-1;
+
+    const RPOpticsData &i_N = m_rp_optics_.find(tracks[0]->rpId())->second,
+                       &i_F = m_rp_optics_.find(tracks[1]->rpId())->second;
+
+    // horizontal reconstruction - run iterations
+    valid = false;
+    double xi_prev = xi_init;
+    for (unsigned int it = 0; it < maxIterations; ++it) {
+      if (multi_rp_algorithm_ == mrpaNewton) {
+        const double g = newtonGoalFcn(xi_prev, x_N, x_F, i_N, i_F);
+        const double gp = (newtonGoalFcn(xi_prev + xi_ep, x_N, x_F, i_N, i_F) - g) / xi_ep;
+
+        xi = xi_prev - g / gp;
+      }
+
+      if (multi_rp_algorithm_ == mrpaAnalIter) {
+        const double D_x_eff_N = i_N.s_x_d_vs_xi->Eval(xi_prev) / xi_prev;
+        const double D_x_eff_F = i_F.s_x_d_vs_xi->Eval(xi_prev) / xi_prev;
+
+        const double L_x_N = i_N.s_L_x_vs_xi->Eval(xi_prev);
+        const double L_x_F = i_F.s_L_x_vs_xi->Eval(xi_prev);
+
+        xi = (L_x_N * x_F - L_x_F * x_N) / (L_x_N * D_x_eff_F - L_x_F * D_x_eff_N);
+      }
+
+      os << "    it = " << it << ": xi_prev = " << xi_prev << ", xi = " << xi << std::endl;
+
+      if (abs(xi - xi_prev) < maxXiDiff) {
+        valid = true;
+        break;
+      }
+
+      xi_prev = xi;
+    }
+
+    th_x = (x_F - i_F.s_x_d_vs_xi->Eval(xi)) / i_F.s_L_x_vs_xi->Eval(xi);
+
+    // vertical reconstruction
+    const double y_eff_N = y_N - i_N.s_y_d_vs_xi->Eval(xi);
+    const double y_eff_F = y_F - i_F.s_y_d_vs_xi->Eval(xi);
+
+    const double L_y_N = i_N.s_L_y_vs_xi->Eval(xi);
+    const double L_y_F = i_F.s_L_y_vs_xi->Eval(xi);
+
+    const double v_y_N = i_N.s_v_y_vs_xi->Eval(xi);
+    const double v_y_F = i_F.s_v_y_vs_xi->Eval(xi);
+
+    const double D = L_y_N * v_y_F - L_y_F * v_y_N;
+
+    if (fitVtxY_) {
+      th_y = (y_eff_N * v_y_F - y_eff_F * v_y_N) / D;
+      vtx_y = (L_y_N * y_eff_F - L_y_F * y_eff_N) / D;
+    } else {
+      th_y = (y_eff_N / L_y_N + y_eff_F / L_y_F) / 2.;
+      vtx_y = 0.;
+    }
+
+    // covariance matrix kept empty - not to compromise the speed of these special algorithms
+  }
+
+  // print results
   if (verbosity_)
-    os << "    xi=" << params[0] << " +- " << result.Error(0) << ", th_x=" << params[1] << " +-" << result.Error(1)
-       << ", th_y=" << params[2] << " +-" << result.Error(2) << ", vtx_y=" << params[3] << " +-" << result.Error(3)
-       << ", chiSq = " << result.Chi2() << std::endl;
+    os << "    xi=" << xi << ", th_x=" << th_x << ", th_y=" << th_y << ", vtx_y=" << vtx_y << ", chiSq = " << chi2
+       << std::endl;
 
   // save reco candidate
-  using FP = reco::ForwardProton;
-
   const double sign_z = (armId == 0) ? +1. : -1.;  // CMS convention
-  const FP::Point vertex(0., params[3], 0.);
-  const double xi = params[0];
-  const double th_x = params[1];
-  const double th_y = params[2];
+  const FP::Point vertex(0., vtx_y, 0.);
   const double cos_th = sqrt(1. - th_x * th_x - th_y * th_y);
   const double p = lhcInfo.energy() * (1. - xi);
   const FP::Vector momentum(-p * th_x,  // the signs reflect change LHC --> CMS convention
@@ -269,27 +397,7 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
                             sign_z * p * cos_th);
   signed int ndf = 2. * tracks.size() - ((fitVtxY_) ? 4. : 3.);
 
-  map<unsigned int, signed int> index_map = {
-      {(unsigned int)FP::Index::xi, 0},
-      {(unsigned int)FP::Index::th_x, 1},
-      {(unsigned int)FP::Index::th_y, 2},
-      {(unsigned int)FP::Index::vtx_y, ((fitVtxY_) ? 3 : -1)},
-      {(unsigned int)FP::Index::vtx_x, -1},
-  };
-
-  FP::CovarianceMatrix cm;
-  for (unsigned int i = 0; i < (unsigned int)FP::Index::num_indices; ++i) {
-    signed int fit_i = index_map[i];
-
-    for (unsigned int j = 0; j < (unsigned int)FP::Index::num_indices; ++j) {
-      signed int fit_j = index_map[j];
-
-      cm(i, j) = (fit_i >= 0 && fit_j >= 0) ? result.CovMatrix(fit_i, fit_j) : 0.;
-    }
-  }
-
-  return reco::ForwardProton(
-      result.Chi2(), ndf, vertex, momentum, xi, cm, FP::ReconstructionMethod::multiRP, tracks, result.IsValid());
+  return reco::ForwardProton(chi2, ndf, vertex, momentum, xi, cm, FP::ReconstructionMethod::multiRP, tracks, valid);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -36,9 +36,9 @@ ProtonReconstructionAlgorithm::ProtonReconstructionAlgorithm(bool fit_vtx_y,
   // check and set multi-RP algorithm
   if (multiRPAlgorithm == "chi2")
     multi_rp_algorithm_ = mrpaChi2;
-  if (multiRPAlgorithm == "newton")
+  else if (multiRPAlgorithm == "newton")
     multi_rp_algorithm_ = mrpaNewton;
-  if (multiRPAlgorithm == "anal-iter")
+  else if (multiRPAlgorithm == "anal-iter")
     multi_rp_algorithm_ = mrpaAnalIter;
 
   if (multi_rp_algorithm_ == mrpaUndefined)
@@ -310,7 +310,7 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
     }
   }
 
-  if (multi_rp_algorithm_ == mrpaNewton || multi_rp_algorithm_ == mrpaAnalIter) {
+  else if (multi_rp_algorithm_ == mrpaNewton || multi_rp_algorithm_ == mrpaAnalIter) {
     // settings
     const unsigned int maxIterations = 100;
     const double maxXiDiff = 1E-6;
@@ -338,13 +338,13 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
       }
 
       if (multi_rp_algorithm_ == mrpaAnalIter) {
-        const double D_x_eff_N = i_N.s_x_d_vs_xi->Eval(xi_prev) / xi_prev;
-        const double D_x_eff_F = i_F.s_x_d_vs_xi->Eval(xi_prev) / xi_prev;
+        const double d_x_eff_N = i_N.s_x_d_vs_xi->Eval(xi_prev) / xi_prev;
+        const double d_x_eff_F = i_F.s_x_d_vs_xi->Eval(xi_prev) / xi_prev;
 
-        const double L_x_N = i_N.s_L_x_vs_xi->Eval(xi_prev);
-        const double L_x_F = i_F.s_L_x_vs_xi->Eval(xi_prev);
+        const double l_x_N = i_N.s_L_x_vs_xi->Eval(xi_prev);
+        const double l_x_F = i_F.s_L_x_vs_xi->Eval(xi_prev);
 
-        xi = (L_x_N * x_F - L_x_F * x_N) / (L_x_N * D_x_eff_F - L_x_F * D_x_eff_N);
+        xi = (l_x_N * x_F - l_x_F * x_N) / (l_x_N * d_x_eff_F - l_x_F * d_x_eff_N);
       }
 
       if (abs(xi - xi_prev) < maxXiDiff) {
@@ -361,19 +361,19 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
     const double y_eff_N = y_N - i_N.s_y_d_vs_xi->Eval(xi);
     const double y_eff_F = y_F - i_F.s_y_d_vs_xi->Eval(xi);
 
-    const double L_y_N = i_N.s_L_y_vs_xi->Eval(xi);
-    const double L_y_F = i_F.s_L_y_vs_xi->Eval(xi);
+    const double l_y_N = i_N.s_L_y_vs_xi->Eval(xi);
+    const double l_y_F = i_F.s_L_y_vs_xi->Eval(xi);
 
     const double v_y_N = i_N.s_v_y_vs_xi->Eval(xi);
     const double v_y_F = i_F.s_v_y_vs_xi->Eval(xi);
 
-    const double D = L_y_N * v_y_F - L_y_F * v_y_N;
+    const double det = l_y_N * v_y_F - l_y_F * v_y_N;
 
     if (fitVtxY_) {
-      th_y = (y_eff_N * v_y_F - y_eff_F * v_y_N) / D;
-      vtx_y = (L_y_N * y_eff_F - L_y_F * y_eff_N) / D;
+      th_y = (y_eff_N * v_y_F - y_eff_F * v_y_N) / det;
+      vtx_y = (l_y_N * y_eff_F - l_y_F * y_eff_N) / det;
     } else {
-      th_y = (y_eff_N / L_y_N + y_eff_F / L_y_F) / 2.;
+      th_y = (y_eff_N / l_y_N + y_eff_F / l_y_F) / 2.;
       vtx_y = 0.;
     }
 

--- a/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoCTPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -347,8 +347,6 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
         xi = (L_x_N * x_F - L_x_F * x_N) / (L_x_N * D_x_eff_F - L_x_F * D_x_eff_N);
       }
 
-      os << "    it = " << it << ": xi_prev = " << xi_prev << ", xi = " << xi << std::endl;
-
       if (abs(xi - xi_prev) < maxXiDiff) {
         valid = true;
         break;

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionDiffPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionDiffPlotter.cc
@@ -1,0 +1,112 @@
+/****************************************************************************
+* Authors:
+*  Jan Kašpar (jan.kaspar@gmail.com)
+****************************************************************************/
+
+// TODO: clean
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+#include "DataFormats/ProtonReco/interface/ForwardProton.h"
+#include "DataFormats/ProtonReco/interface/ForwardProtonFwd.h"
+
+#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+
+#include "TFile.h"
+#include "TGraphErrors.h"
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TProfile.h"
+
+//----------------------------------------------------------------------------------------------------
+
+class CTPPSProtonReconstructionDiffPlotter : public edm::one::EDAnalyzer<> {
+public:
+  explicit CTPPSProtonReconstructionDiffPlotter(const edm::ParameterSet &);
+  ~CTPPSProtonReconstructionDiffPlotter() override {}
+
+private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+  void endJob() override;
+
+  edm::EDGetTokenT<reco::ForwardProtonCollection> tokenRecoProtonsRef_;
+  edm::EDGetTokenT<reco::ForwardProtonCollection> tokenRecoProtonsTest_;
+
+  std::string outputFile_;
+
+  std::unique_ptr<TH1D> h_de_xi, h_de_th_x, h_de_th_y, h_de_vtx_y;
+};
+
+//----------------------------------------------------------------------------------------------------
+
+using namespace std;
+using namespace edm;
+
+//----------------------------------------------------------------------------------------------------
+
+CTPPSProtonReconstructionDiffPlotter::CTPPSProtonReconstructionDiffPlotter(const edm::ParameterSet &ps)
+    : tokenRecoProtonsRef_(consumes<reco::ForwardProtonCollection>(ps.getParameter<InputTag>("tagRecoProtonsRef"))),
+      tokenRecoProtonsTest_(consumes<reco::ForwardProtonCollection>(ps.getParameter<InputTag>("tagRecoProtonsTest"))),
+
+      outputFile_(ps.getParameter<string>("outputFile")),
+
+      h_de_xi(new TH1D("", ";#Delta#xi", 200, -0.01, +0.01)),
+      h_de_th_x(new TH1D("", ";#Delta#theta_{x}", 200, -100E-6, +100E-6)),
+      h_de_th_y(new TH1D("", ";#Delta#theta_{y}", 200, -100E-6, +100E-6)),
+      h_de_vtx_y(new TH1D("", ";#Deltay^{*}   (cm)", 200, -0.01, +0.01)) {}
+
+//----------------------------------------------------------------------------------------------------
+
+void CTPPSProtonReconstructionDiffPlotter::analyze(const edm::Event &event, const edm::EventSetup &iSetup) {
+  // get input
+  Handle<reco::ForwardProtonCollection> hRecoProtonsRef;
+  event.getByToken(tokenRecoProtonsRef_, hRecoProtonsRef);
+
+  Handle<reco::ForwardProtonCollection> hRecoProtonsTest;
+  event.getByToken(tokenRecoProtonsTest_, hRecoProtonsTest);
+
+  if (hRecoProtonsRef->size() != hRecoProtonsTest->size()) {
+    edm::LogWarning("CTPPSProtonReconstructionDiffPlotter::analyze")
+        << "Different number of Ref and Test protons. Skipping event.";
+    return;
+  }
+
+  for (unsigned int i = 0; i < hRecoProtonsRef->size(); ++i) {
+    const auto &pr_ref = hRecoProtonsRef->at(i);
+    const auto &pr_test = hRecoProtonsTest->at(i);
+
+    if (!pr_ref.validFit() || !pr_test.validFit())
+      continue;
+
+    h_de_xi->Fill(pr_test.xi() - pr_ref.xi());
+    h_de_th_x->Fill(pr_test.thetaX() - pr_ref.thetaX());
+    h_de_th_y->Fill(pr_test.thetaY() - pr_ref.thetaY());
+    h_de_vtx_y->Fill(pr_test.vy() - pr_ref.vy());
+  }
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void CTPPSProtonReconstructionDiffPlotter::endJob() {
+  auto f_out = std::make_unique<TFile>(outputFile_.c_str(), "recreate");
+
+  h_de_xi->Write("h_de_xi");
+  h_de_th_x->Write("h_de_th_x");
+  h_de_th_y->Write("h_de_th_y");
+  h_de_vtx_y->Write("h_de_vtx_y");
+}
+
+//----------------------------------------------------------------------------------------------------
+
+DEFINE_FWK_MODULE(CTPPSProtonReconstructionDiffPlotter);


### PR DESCRIPTION
#### PR description:

This PR adds two faster proton reconstruction algorithms for PPS. Details and performance tests are available in this [PPS POG presentation](https://indico.cern.ch/event/878643/contributions/3701646/attachments/1968874/3274622/kaspar_pps_pog_faster_pr_reco.pdf). By default the original `chi2` algorithm remains used:
  * not to change the default results for Run 2 data
  * in view of Run 3, the `chi2` can work with any optics.

#### PR validation:

Running
```
runTheMatrix.py -l limited --ibeos
```
yielded
```
34 33 32 26 16 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed
```

The plot below demonstrates that the default-reconstruction results are not changed: blue = before this PR, red dashed = with this PR.
![make_cmp](https://user-images.githubusercontent.com/17830858/72365114-e9780380-36f7-11ea-8e2a-25189cdd5d41.png)
