### PR TITLE
PPS: DQM update

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -51,6 +51,8 @@ private:
   const edm::EDGetTokenT<std::vector<CTPPSLocalTrackLite>> tokenLocalTrackLite;
   const edm::EDGetTokenT<std::vector<reco::ForwardProton>> tokenRecoProtons;
 
+  bool makeProtonRecoPlots_;
+
   int currentLS;
   int endLS;
 
@@ -90,7 +92,7 @@ private:
 
     ArmPlots() {}
 
-    ArmPlots(DQMStore::IBooker &ibooker, int _id);
+    ArmPlots(DQMStore::IBooker &ibooker, int _id, bool makeProtonRecoPlots);
   };
 
   std::map<unsigned int, ArmPlots> armPlots;
@@ -195,7 +197,7 @@ void CTPPSCommonDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker) {
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id) : id(_id) {
+CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id, bool makeProtonRecoPlots) : id(_id) {
   string name;
   CTPPSDetId(CTPPSDetId::sdTrackingStrip, id, 0).armName(name, CTPPSDetId::nShort);
 
@@ -247,9 +249,11 @@ CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id) : 
   xa->SetBinLabel(7, "220, far, bot");
   ya->SetBinLabel(7, "220, far, bot");
 
-  h_proton_xi = ibooker.book1D("proton xi", title + ";xi", 100, 0., 0.3);
-  h_proton_t = ibooker.book1D("proton t", title + ";|t|   GeV^{2}", 100, 0., 5.);
-  h_proton_time = ibooker.book1D("proton time", title + ";time   (ns)", 100, -25., 50.);
+  if (makeProtonRecoPlots) {
+    h_proton_xi = ibooker.book1D("proton xi", title + ";xi", 100, 0., 0.3);
+    h_proton_t = ibooker.book1D("proton t", title + ";|t|   GeV^{2}", 100, 0., 5.);
+    h_proton_time = ibooker.book1D("proton time", title + ";time   (ns)", 100, -25., 50.);
+  }
 
   for (const unsigned int &rpDecId : {2, 3, 16, 23}) {
     unsigned int st = rpDecId / 10, rp = rpDecId % 10, rpFullDecId = id * 100 + rpDecId;
@@ -279,7 +283,8 @@ CTPPSCommonDQMSource::CTPPSCommonDQMSource(const edm::ParameterSet &ps)
     : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
       ctppsRecordToken(consumes<CTPPSRecord>(ps.getUntrackedParameter<edm::InputTag>("ctppsmetadata"))),
       tokenLocalTrackLite(consumes<vector<CTPPSLocalTrackLite>>(ps.getParameter<edm::InputTag>("tagLocalTrackLite"))),
-      tokenRecoProtons(consumes<std::vector<reco::ForwardProton>>(ps.getParameter<InputTag>("tagRecoProtons"))) {
+      tokenRecoProtons(consumes<std::vector<reco::ForwardProton>>(ps.getParameter<InputTag>("tagRecoProtons"))),
+      makeProtonRecoPlots_(ps.getParameter<bool>("makeProtonRecoPlots")) {
   currentLS = 0;
   endLS = 0;
   rpstate.clear();
@@ -297,7 +302,7 @@ void CTPPSCommonDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
 
   // loop over arms
   for (unsigned int arm = 0; arm < 2; arm++) {
-    armPlots[arm] = ArmPlots(ibooker, arm);
+    armPlots[arm] = ArmPlots(ibooker, arm, makeProtonRecoPlots_);
   }
 }
 
@@ -306,7 +311,9 @@ void CTPPSCommonDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
 void CTPPSCommonDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
   analyzeCTPPSRecord(event, eventSetup);
   analyzeTracks(event, eventSetup);
-  analyzeProtons(event, eventSetup);
+
+  if (makeProtonRecoPlots_)
+    analyzeProtons(event, eventSetup);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -252,7 +252,7 @@ CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id, bo
   if (makeProtonRecoPlots) {
     h_proton_xi = ibooker.book1D("proton xi", title + ";xi", 100, 0., 0.3);
     h_proton_t = ibooker.book1D("proton t", title + ";|t|   GeV^{2}", 100, 0., 5.);
-    h_proton_time = ibooker.book1D("proton time", title + ";time   (ns)", 100, -25., 50.);
+    h_proton_time = ibooker.book1D("proton time", title + ";time   (ns)", 100, -1., 1.);
   }
 
   for (const unsigned int &rpDecId : {2, 3, 16, 23}) {

--- a/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
@@ -6,5 +6,8 @@ ctppsCommonDQMSource = DQMEDAnalyzer('CTPPSCommonDQMSource',
     ctppsmetadata = cms.untracked.InputTag("onlineMetaDataDigis"),
     tagLocalTrackLite = cms.InputTag('ctppsLocalTrackLiteProducer'),
     tagRecoProtons = cms.InputTag("ctppsProtons", "multiRP"),
+
+    makeProtonRecoPlots = cms.bool(True),
+
     verbosity = cms.untracked.uint32(0),
 )

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -15,49 +15,64 @@ from DQM.CTPPS.elasticPlotDQMSource_cfi import *
 
 from DQM.CTPPS.ctppsCommonDQMSource_cfi import *
 
-ctppsDQM = cms.Sequence()
-ctppsDQMOffline = cms.Sequence()
-ctppsDQMElastic = cms.Sequence()
-ctppsDQMHarvest = cms.Sequence()
-
-_ctppsDQM = ctppsDQM.copy()
-_ctppsDQMOffline = ctppsDQMOffline.copy()
-_ctppsDQMElastic = ctppsDQMElastic.copy()
-_ctppsDQMHarvest = ctppsDQMHarvest.copy()
-
-_ctppsDQM = cms.Sequence(
-    totemDAQTriggerDQMSource
-    + totemRPDQMSource
-    + ctppsDiamondDQMSource
-    + totemTimingDQMSource
-    + ctppsPixelDQMSource
-    + ctppsCommonDQMSource
+# sequences used by the online DQM in normal running
+ctppsCommonDQMSourceOnline = ctppsCommonDQMSource.clone(
+  makeProtonRecoPlots = False
 )
 
-
-_ctppsDQMOffline = cms.Sequence(
-    totemDAQTriggerDQMSource
-    + totemRPDQMSource
-    + ctppsDiamondDQMSource
-    + totemTimingDQMSource
-    + ctppsPixelDQMOfflineSource
-    + ctppsCommonDQMSource
+_ctppsDQMOnlineSource = cms.Sequence(
+  ctppsPixelDQMSource
+  + ctppsDiamondDQMSource
+  + totemTimingDQMSource
+  + ctppsCommonDQMSourceOnline
 )
 
-_ctppsDQMElastic = cms.Sequence(
-    totemDAQTriggerDQMSource
-    + totemRPDQMSource
-    + ctppsDiamondDQMSource
-    + totemTimingDQMSource
-    + ctppsPixelDQMSource
-    + ctppsCommonDQMSource
-    + elasticPlotDQMSource
+_ctppsDQMOnlineHarvest = cms.Sequence(
 )
 
-_ctppsDQMHarvest = cms.Sequence(totemRPDQMHarvester)
+# sequences used by the online DQM in calibration mode
+_ctppsDQMCalibrationSource = cms.Sequence(
+  totemRPDQMSource
+  + ctppsPixelDQMSource
+  + ctppsDiamondDQMSource
+  + totemTimingDQMSource
+  + ctppsCommonDQMSourceOnline
+  + elasticPlotDQMSource
+)
 
+_ctppsDQMCalibrationHarvest = cms.Sequence(
+  totemRPDQMHarvester
+)
+
+# sequences used by the offline DQM
+ctppsCommonDQMSourceOffline = ctppsCommonDQMSource.clone(
+  makeProtonRecoPlots = True
+)
+
+_ctppsDQMOfflineSource = cms.Sequence(
+  ctppsPixelDQMOfflineSource
+  + ctppsDiamondDQMSource
+  + totemTimingDQMSource
+  + ctppsCommonDQMSourceOffline
+)
+
+_ctppsDQMOfflineHarvest = cms.Sequence(
+)
+
+# the actually used sequences must be empty for pre-PPS data
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-ctpps_2016.toReplaceWith(ctppsDQM, _ctppsDQM)
-ctpps_2016.toReplaceWith(ctppsDQMOffline, _ctppsDQMOffline)
-ctpps_2016.toReplaceWith(ctppsDQMElastic, _ctppsDQMElastic)
-ctpps_2016.toReplaceWith(ctppsDQMHarvest, _ctppsDQMHarvest)
+
+ctppsDQMOnlineSource = cms.Sequence()
+ctppsDQMOnlineHarvest = cms.Sequence()
+ctpps_2016.toReplaceWith(ctppsDQMOnlineSource, _ctppsDQMOnlineSource)
+ctpps_2016.toReplaceWith(ctppsDQMOnlineHarvest, _ctppsDQMOnlineHarvest)
+
+ctppsDQMCalibrationSource = cms.Sequence()
+ctppsDQMCalibrationHarvest = cms.Sequence()
+ctpps_2016.toReplaceWith(ctppsDQMCalibrationSource, _ctppsDQMCalibrationSource)
+ctpps_2016.toReplaceWith(ctppsDQMCalibrationHarvest, _ctppsDQMCalibrationHarvest)
+
+ctppsDQMOfflineSource = cms.Sequence()
+ctppsDQMOfflineHarvest = cms.Sequence()
+ctpps_2016.toReplaceWith(ctppsDQMOfflineSource, _ctppsDQMOfflineSource)
+ctpps_2016.toReplaceWith(ctppsDQMOfflineHarvest, _ctppsDQMOfflineHarvest)

--- a/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
@@ -13,8 +13,9 @@ else:
   # for testing in lxplus
   process.load("DQM.Integration.config.fileinputsource_cfi")
   process.source.fileNames = cms.untracked.vstring(
-    #'root://eostotem.cern.ch//eos/totem/user/j/jkaspar/04C8034A-9626-E611-9B6E-02163E011F93.root'
-    '/store/express/Run2016H/ExpressPhysics/FEVT/Express-v2/000/283/877/00000/4EE44B0E-2499-E611-A155-02163E011938.root'
+    #"root://eoscms.cern.ch//eos/cms/store/group/phys_pps/sw_test_input/001D08EE-C4B1-E711-B92D-02163E013864.root"
+    #"/store/express/Run2016H/ExpressPhysics/FEVT/Express-v2/000/283/877/00000/4EE44B0E-2499-E611-A155-02163E011938.root"
+    "/store/data/Run2017B/SingleMuon/RAW/v1/000/297/050/00000/30346DF0-0153-E711-BBC7-02163E01437C.root"
   )
   process.source.inputCommands = cms.untracked.vstring(
     'drop *',
@@ -62,15 +63,24 @@ process.recoStep = cms.Sequence(
 )
 
 process.dqmModules = cms.Sequence(
-  process.ctppsDQM +
-  process.ctppsDQMHarvest +
-  process.dqmEnv +
-  process.dqmSaver
+  process.ctppsDQMOnlineSource +
+  process.ctppsDQMOnlineHarvest
+)
+
+process.dqmModulesCalibration = cms.Sequence(
+  process.ctppsDQMCalibrationSource +
+  process.ctppsDQMCalibrationHarvest
 )
 
 process.path = cms.Path(
   process.recoStep *
-  process.dqmModules
+
+  # here: (un)comment to switch between normal and calibration mode
+  process.dqmModules *
+  #process.dqmModulesCalibration *
+
+  process.dqmEnv *
+  process.dqmSaver
 )
 
 process.schedule = cms.Schedule(process.path)

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -187,7 +187,7 @@ DQMHarvestOuterTracker = cms.Sequence(
 DQMHarvestTrackerPhase2 = cms.Sequence(trackerphase2DQMHarvesting)
 
 
-DQMHarvestCTPPS = cms.Sequence(ctppsDQMHarvest)
+DQMHarvestCTPPS = cms.Sequence( ctppsDQMOfflineHarvest )
 
 DQMHarvestMuon = cms.Sequence( dtClients *
                                rpcTier0Client *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -49,7 +49,7 @@ DQMOfflineMuonDPG = cms.Sequence( dtSources *
 
 DQMOfflineCASTOR = cms.Sequence( castorSources )
 
-DQMOfflineCTPPS = cms.Sequence( ctppsDQMOffline )
+DQMOfflineCTPPS = cms.Sequence( ctppsDQMOfflineSource )
 
 DQMOfflinePreDPG = cms.Sequence( DQMOfflineDCS *
 				 DQMOfflineL1T *


### PR DESCRIPTION
#### PR description:

  * better structure of PPS DQM sequences
  * introduced flag to enable/disable creation of proton-reconstruction plots
  * adjusted range of proton time histogram
  * strip-RP plots removed from the online and offline sequences since these RPs will not be used in Run 3 (the plots still remain in the "calibration" sequence for special runs)

#### PR validation:

Running
```
runTheMatrix.py --ibeos -l 136.731,136.7611,136.788,136.8311,136.85
```
gave
```
5 5 5 3 tests passed, 0 0 0 0 failed
```

This PR doesn't change the results of the reconstruction - see the plot below - blue = before the PR, red = with this PR.

![make_cmp](https://user-images.githubusercontent.com/17830858/72453387-4985ad00-37bf-11ea-8c0d-42cd0d6aa307.png)
