### PR TITLE
Declare SiTrackerMultiRecHit::cloneSH() to override

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h
@@ -24,7 +24,7 @@ public:
 
   SiTrackerMultiRecHit* clone() const override { return new SiTrackerMultiRecHit(*this); }
 #ifdef NO_DICT
-  virtual RecHitPointer cloneSH() const { return std::make_shared<SiTrackerMultiRecHit>(*this); }
+  RecHitPointer cloneSH() const override { return std::make_shared<SiTrackerMultiRecHit>(*this); }
 #endif
 
   //  virtual int dimension() const {return 2;}


### PR DESCRIPTION
#### PR description:

Fixes clang warnings in `Validation/SiPixelPhase1HitsV`, `Validation/SiPixelPhase1RecHitsV`, and `Validation/SiPixelPhase1TrackingParticleV`.

#### PR validation:

Code compiles.