### PR TITLE
Utilities/StaticAnalysers: Unregister unused getParamDumper checker 

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
@@ -14,7 +14,7 @@ cd ${LOCALRT}/src/Utilities/StaticAnalyzers
 scram b -j $J
 cd ${LOCALRT}/
 export USER_CXXFLAGS="-DEDM_ML_DEBUG -w"
-export USER_LLVM_CHECKERS="-enable-checker cms.FunctionDumper -enable-checker optional.ClassDumper -enable-checker optional.ClassDumperCT -enable-checker optional.ClassDumperFT -enable-checker optional.EDMPluginDumper -enable-checker optional.getParamDumper"
+export USER_LLVM_CHECKERS="-enable-checker cms.FunctionDumper -enable-checker optional.ClassDumper -enable-checker optional.ClassDumperCT -enable-checker optional.ClassDumperFT -enable-checker optional.EDMPluginDumper"
 scram b -k -j $J checker SCRAM_IGNORE_PACKAGES=Fireworks/% SCRAM_IGNORE_SUBDIRS=test > $LOCALRT/tmp/class+function-dumper.log 2>&1
 find ${LOCALRT}/src/ -name classes\*.h.cc | xargs rm -fv
 cd ${LOCALRT}/tmp

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -22,7 +22,6 @@
 #include "FunctionDumper.h"
 #include "EDMPluginDumper.h"
 #include "ThrUnsafeFCallChecker.h"
-#include "getParamDumper.h"
 
 #include <clang/StaticAnalyzer/Frontend/CheckerRegistry.h>
 
@@ -86,10 +85,6 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "optional.EDMPluginDumper", "Dumps macro DEFINE_EDM_PLUGIN types", "no docs");
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
       "cms.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
-  registry.addChecker<clangcms::getParamDumper>(
-      "optional.getParamDumper",
-      "Dumps out calls to edm::ParamaterSet:: getParameter and getUntrackedParameter",
-      "no docs");
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;


### PR DESCRIPTION
Unused getParamDumper checker requires a change to evalCall parameters in llvm/clang 9 in order to be registered. The text file produced was never used for anything. Unregistering the checker rather than removing it because it still compiles. It can be fixed at a later time if there is interest.
