### PR TITLE
Clean dependencies for DataFormats/L1TMuon

### DIFF
--- a/DataFormats/L1TMuon/BuildFile.xml
+++ b/DataFormats/L1TMuon/BuildFile.xml
@@ -9,8 +9,6 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/L1CSCTrackFinder"/>
 <use name="DataFormats/Common"/>
-<use name="L1Trigger/CSCCommonTrigger"/>
 <use name="DataFormats/Candidate"/>
-<use name="L1Trigger/DTTrackFinder"/>
 <use name="rootrflx"/>
 <flags ADD_SUBDIR="1"/>


### PR DESCRIPTION
#### PR description:

Just a little change such that DataFormats/L1TMuon does not depend on anything else than other DataFormats packages. It's convenient if you want to build the data formats without the rest of CMSSW. Basically all other DataFormats packages don't have this problem, so this is a singular PR.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR:

No backport intended.
