### PR TITLE
Replace tbb::tbb_hash and tbb::tbb_hasher with std::hash

### DIFF
--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -17,10 +17,7 @@
 
 namespace edm {
   struct TypeIDHasher {
-    size_t operator()(TypeID const& tid) const {
-      tbb::tbb_hash<std::string> hasher;
-      return hasher(std::string(tid.name()));
-    }
+    size_t operator()(TypeID const& tid) const { return std::hash<std::string>{}(std::string(tid.name())); }
   };
 }  // namespace edm
 

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -39,10 +39,7 @@ namespace edmplugin {
   class PluginFactoryBase;
 
   struct PluginManagerPathHasher {
-    size_t operator()(boost::filesystem::path const& iPath) const {
-      tbb::tbb_hash<std::string> hasher;
-      return hasher(iPath.native());
-    }
+    size_t operator()(boost::filesystem::path const& iPath) const { return std::hash<std::string>{}(iPath.native()); }
   };
 
   class PluginManager {

--- a/FWCore/Utilities/src/TypeID.cc
+++ b/FWCore/Utilities/src/TypeID.cc
@@ -34,10 +34,7 @@ namespace edm {
     }
   }  // namespace
   struct TypeIDHasher {
-    size_t operator()(TypeID const& tid) const {
-      tbb::tbb_hash<std::string> hasher;
-      return hasher(std::string(tid.name()));
-    }
+    size_t operator()(TypeID const& tid) const { return std::hash<std::string>{}(std::string(tid.name())); }
   };
 
   std::string const& TypeID::className() const {

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -26,7 +26,7 @@ namespace XrdAdaptor {
 
   struct SourceHash {
     using Key = std::shared_ptr<Source>;
-    size_t operator()(const Key &iKey) const { return tbb::tbb_hasher(iKey.get()); }
+    size_t operator()(const Key &iKey) const { return std::hash<Key::element_type *>{}(iKey.get()); }
   };
 
   class XrootdException : public edm::Exception {


### PR DESCRIPTION
#### PR description:

Lately I get these deprecation warnings from tbb [1] when compiling cmssw:
```
tbb::tbb_hash is deprecated, use std::hash
```

Is it maybe possible to do just what tbb suggests to silence these warnings? Thanks for considering this!

[1] https://github.com/intel/tbb/blob/tbb_2020/include/tbb/internal/_tbb_hash_compare_impl.h#L86

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR:

No backport intended.