### PR TITLE
Bugfix: Crash in DaqTestHistograms (11_0_X)

### DIFF
--- a/DQM/HLTEvF/plugins/DaqTestHistograms.cc
+++ b/DQM/HLTEvF/plugins/DaqTestHistograms.cc
@@ -20,7 +20,7 @@ namespace {
 
     RunBasedHistograms()
         :  // overall event count and event types
-          events_processed(),
+          events_processed(nullptr),
           element_array() {}
   };
 }  // namespace
@@ -63,7 +63,6 @@ DaqTestHistograms::DaqTestHistograms(edm::ParameterSet const &config)
 void DaqTestHistograms::dqmBeginRun(edm::Run const &run,
                                     edm::EventSetup const &setup,
                                     RunBasedHistograms &histograms) const {
-  histograms.events_processed->Reset();
   histograms.element_array.resize(m_num_histograms);
 }
 


### PR DESCRIPTION
#### PR description:
Problem was introduced in #28092 commit:
bb6f53f
Fixes (removes) a call into uninitialized pointer.

#### PR validation:

Verified to work in DAQ (HLT) test environment.

#### if this PR is a backport please specify the original PR:
Backport of #28751