### PR TITLE
Fixed sign in pat::Muon::dB() to match one obtained from the best track definition 

### DIFF
--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -335,6 +335,12 @@ namespace reco {
     /// error on beta
     double betaError() const;
 
+    /// error on dxy with respect to a user-given reference point + uncertainty (i.e. reco::Vertex position)
+    double dxyError(Point const &vtx, math::Error<3>::type const &vertexCov) const;
+
+    /// error on dxy with respect to a user-given beamspot
+    double dxyError(const BeamSpot &theBeamSpot) const;
+
     /// fill SMatrix
     CovarianceMatrix &fill(CovarianceMatrix &v) const;
 
@@ -735,6 +741,11 @@ namespace reco {
 
   // error on beta
   inline double TrackBase::betaError() const { return std::sqrt(covbetabeta_); }
+
+  // error on dxy with respect to a given beamspot
+  inline double TrackBase::dxyError(const BeamSpot &theBeamSpot) const {
+    return dxyError(theBeamSpot.position(vz()), theBeamSpot.rotatedCovariance3D());
+  }
 
   // number of valid hits found
   inline unsigned short TrackBase::numberOfValidHits() const { return hitPattern_.numberOfValidHits(); }

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -144,3 +144,20 @@ TrackBase::TrackAlgorithm TrackBase::algoByName(const std::string &name) {
   // cast
   return TrackAlgorithm(index);
 }
+
+double TrackBase::dxyError(Point const &vtx, math::Error<3>::type const &vertexCov) const {
+  // Gradient of TrackBase::dxy(const Point &myBeamSpot) with respect to track parameters
+  TrackBase::ParameterVector trackGrad =
+      TrackBase::ParameterVector(0,
+                                 0,
+                                 (vtx.x() * px() + vtx.y() * py()) / pt(),  // x_vert * cos(phi) + y_vert * sin(phi)
+                                 1,
+                                 0);
+  // Gradient with respect to point parameters
+  math::Vector<3>::type pointGrad = math::Vector<3>::type(py() / pt(),   // sin(phi)
+                                                          -px() / pt(),  // -cos(phi)
+                                                          0);
+  // Propagate covariance assuming cross-terms of the covariance between track and vertex parameters are 0
+  return std::sqrt(ROOT::Math::Dot(trackGrad, covariance() * trackGrad) +
+                   ROOT::Math::Dot(pointGrad, vertexCov * pointGrad));
+}

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -146,18 +146,14 @@ TrackBase::TrackAlgorithm TrackBase::algoByName(const std::string &name) {
 }
 
 double TrackBase::dxyError(Point const &vtx, math::Error<3>::type const &vertexCov) const {
-  // Gradient of TrackBase::dxy(const Point &myBeamSpot) with respect to track parameters
-  TrackBase::ParameterVector trackGrad =
-      TrackBase::ParameterVector(0,
-                                 0,
-                                 (vtx.x() * px() + vtx.y() * py()) / pt(),  // x_vert * cos(phi) + y_vert * sin(phi)
-                                 1,
-                                 0);
+  // Gradient of TrackBase::dxy(const Point &myBeamSpot) with respect to track parameters. Using unrolled expressions to avoid calling for higher dimension matrices
+  // ( 0, 0, x_vert * cos(phi) + y_vert * sin(phi), 1, 0 )
   // Gradient with respect to point parameters
-  math::Vector<3>::type pointGrad = math::Vector<3>::type(py() / pt(),   // sin(phi)
-                                                          -px() / pt(),  // -cos(phi)
-                                                          0);
+  // ( sin(phi), -cos(phi))
   // Propagate covariance assuming cross-terms of the covariance between track and vertex parameters are 0
-  return std::sqrt(ROOT::Math::Dot(trackGrad, covariance() * trackGrad) +
-                   ROOT::Math::Dot(pointGrad, vertexCov * pointGrad));
+  return std::sqrt((vtx.x() * px() + vtx.y() * py()) * (vtx.x() * px() + vtx.y() * py()) / (pt() * pt()) *
+                       covariance(i_phi, i_phi) +
+                   2 * (vtx.x() * px() + vtx.y() * py()) / pt() * covariance(i_phi, i_dxy) + covariance(i_dxy, i_dxy) +
+                   py() * py() / (pt() * pt()) * vertexCov(0, 0) - 2 * py() * px() / (pt() * pt()) * vertexCov(0, 1) +
+                   px() * px() / (pt() * pt()) * vertexCov(1, 1));
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1102,7 +1102,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy() > 0 ? 1 : -1)*fabs(d0_corr);
+  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1)*fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1102,7 +1102,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1)*fabs(d0_corr);
+  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1) * fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
@@ -1120,7 +1120,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1)*fabs(d0_corr);
+  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1) * fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
   // BS3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1102,7 +1102,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(primaryVertex.position()) > 0 ? 1 : -1) * fabs(d0_corr);
+  d0_corr = std::copysign(d0_corr, track->dxy(primaryVertex.position()));
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
@@ -1120,7 +1120,7 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   // Now correct the sign using information from the track
-  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1) * fabs(d0_corr);
+  d0_corr = std::copysign(d0_corr, track->dxy(beamspot)); 
   aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
   // BS3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1101,6 +1101,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
       IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+  // Now correct the sign using information from the track
+  d0_corr = (track->dxy() > 0 ? 1 : -1)*fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
 
   // PV3D
@@ -1117,6 +1119,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
+  // Now correct the sign using information from the track
+  d0_corr = (track->dxy(beamspot) > 0 ? 1 : -1)*fabs(d0_corr);
   aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
 
   // BS3D

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1125,8 +1125,6 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // PVDZ
   aMuon.setDB(
       track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
-
-              pat::Muon::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1097,31 +1097,24 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // Correct to PV
 
   // PV2D
-  std::pair<bool, Measurement1D> result =
-      IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  double d0_corr = result.second.value();
-  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
-  // Now correct the sign using information from the track
-  d0_corr = std::copysign(d0_corr, track->dxy(primaryVertex.position()));
-  aMuon.setDB(d0_corr, d0_err, pat::Muon::PV2D);
+  aMuon.setDB(track->dxy(primaryVertex.position()),
+              track->dxyError(primaryVertex.position(), primaryVertex.covariance()),
+              pat::Muon::PV2D);
 
   // PV3D
-  result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
-  d0_corr = result.second.value();
-  d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
+  std::pair<bool, Measurement1D> result =
+      IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+  double d0_corr = result.second.value();
+  double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   aMuon.setDB(d0_corr, d0_err, pat::Muon::PV3D);
 
   // Correct to beam spot
-  // make a fake vertex out of beam spot
-  reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
 
   // BS2D
-  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
-  d0_corr = result.second.value();
-  d0_err = beamspotIsValid ? result.second.error() : -1.0;
-  // Now correct the sign using information from the track
-  d0_corr = std::copysign(d0_corr, track->dxy(beamspot)); 
-  aMuon.setDB(d0_corr, d0_err, pat::Muon::BS2D);
+  aMuon.setDB(track->dxy(beamspot), track->dxyError(beamspot), pat::Muon::BS2D);
+
+  // make a fake vertex out of beam spot
+  reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
 
   // BS3D
   result = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
@@ -1132,6 +1125,8 @@ void PATMuonProducer::embedHighLevel(pat::Muon& aMuon,
   // PVDZ
   aMuon.setDB(
       track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
+
+              pat::Muon::PVDZ);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
**PR description:**

The the transverse impact parameter for pat::Muon was being computed using the IPTools package. It takes the sign from the scalar product of the tangent vector to the best track at the point of closest approach to the PCA to PV vector. While this makes sense for complex objects like jets, for muon tracks it should be ~0 by definition.  Thus, while the absolute dxy value makes sense the sign did not. This fixes it by switching to use the same IP sign as the dxy obtained from the best track.

This has been noted and later corrected from the nanoAOD side in
[https://github.com/cms-nanoAOD/cmssw/pull/475](https://github.com/cms-nanoAOD/cmssw/pull/475)

An open JIRA ticket was opened discussing the problem in the muon group
[https://its.cern.ch/jira/browse/CMSMUONS-311](https://its.cern.ch/jira/browse/CMSMUONS-311)

**Expected changes**

The sign obtained from pat::Muon.dB(pat::Muon::PV2D) and pat::Muon.dB(pat::Muon::BS2D) should now match what could be obtained from the track collection as pat::Muon.bestTrack()->dxy(PV _or_ BS). Expect no changes in the absolute value itself.

**PR validation**

Tested locally in a couple of Z->mumu RelVal AOD samples obtaining the desired results.
No additional changes from code checks.
Minimal integration checks from runTheMatrix.py -l limited -i all  passed.
