### PR TITLE
MTD geometry: validation updates to support DD4hep migration

### DIFF
--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDPosition.cc
@@ -215,14 +215,13 @@ void DD4hep_TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventS
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
         dump << "Translation vector components: " << std::setw(14) << std::fixed << convertCmToMm(fv.translation().x())
-             << " " << std::setw(14) << std::fixed << convertCmToMm(fv.translation().y()) << " " << std::setw(14)
-             << std::fixed << convertCmToMm(fv.translation().z()) << " "
+             << " " << std::setw(14) << convertCmToMm(fv.translation().y()) << " " << std::setw(14)
+             << convertCmToMm(fv.translation().z()) << " "
              << "\n";
-        dump << "Rotation matrix components: " << std::setw(14) << std::fixed << x.X() << " " << std::setw(14)
-             << std::fixed << y.X() << " " << std::setw(14) << std::fixed << z.X() << " " << std::setw(14) << std::fixed
-             << x.Y() << " " << std::setw(14) << std::fixed << y.Y() << " " << std::setw(14) << std::fixed << z.Y()
-             << " " << std::setw(14) << std::fixed << x.Z() << " " << std::setw(14) << std::fixed << y.Z() << " "
-             << std::setw(14) << std::fixed << z.Z() << " "
+        dump << "Rotation matrix components: " << std::setw(14) << x.X() << " " << std::setw(14) << y.X() << " "
+             << std::setw(14) << z.X() << " " << std::setw(14) << x.Y() << " " << std::setw(14) << y.Y() << " "
+             << std::setw(14) << z.Y() << " " << std::setw(14) << x.Z() << " " << std::setw(14) << y.Z() << " "
+             << std::setw(14) << z.Z() << " "
              << "\n";
 
         DD3Vector zeroLocal(0., 0., 0.);
@@ -234,20 +233,18 @@ void DD4hep_TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventS
             std::sqrt(std::pow(zeroGlobal.X() - cn1Global.X(), 2) + std::pow(zeroGlobal.Y() - cn1Global.Y(), 2) +
                       std::pow(zeroGlobal.Z() - cn1Global.Z(), 2));
 
-        dump << "Center global   = " << std::setw(14) << std::fixed << convertCmToMm(zeroGlobal.X()) << std::setw(14)
-             << std::fixed << convertCmToMm(zeroGlobal.Y()) << std::setw(14) << std::fixed
-             << convertCmToMm(zeroGlobal.Z()) << " r = " << std::setw(14) << std::fixed
-             << convertCmToMm(zeroGlobal.Rho()) << " phi = " << std::setw(14) << std::fixed
+        dump << "Center global   = " << std::setw(14) << convertCmToMm(zeroGlobal.X()) << std::setw(14)
+             << convertCmToMm(zeroGlobal.Y()) << std::setw(14) << convertCmToMm(zeroGlobal.Z())
+             << " r = " << std::setw(14) << convertCmToMm(zeroGlobal.Rho()) << " phi = " << std::setw(14)
              << convertRadToDeg(zeroGlobal.Phi()) << "\n";
 
-        dump << "Corner 1 local  = " << std::setw(14) << std::fixed << convertCmToMm(cn1Local.X()) << std::setw(14)
-             << std::fixed << convertCmToMm(cn1Local.Y()) << std::setw(14) << std::fixed << convertCmToMm(cn1Local.Z())
-             << " DeltaR = " << std::setw(14) << std::fixed << convertCmToMm(distLocal) << "\n";
+        dump << "Corner 1 local  = " << std::setw(14) << convertCmToMm(cn1Local.X()) << std::setw(14)
+             << convertCmToMm(cn1Local.Y()) << std::setw(14) << convertCmToMm(cn1Local.Z())
+             << " DeltaR = " << std::setw(14) << convertCmToMm(distLocal) << "\n";
 
-        dump << "Corner 1 global = " << std::setw(14) << std::fixed << convertCmToMm(cn1Global.X()) << std::setw(14)
-             << std::fixed << convertCmToMm(cn1Global.Y()) << std::setw(14) << std::fixed
-             << convertCmToMm(cn1Global.Z()) << " DeltaR = " << std::setw(14) << std::fixed << convertCmToMm(distGlobal)
-             << "\n";
+        dump << "Corner 1 global = " << std::setw(14) << convertCmToMm(cn1Global.X()) << std::setw(14)
+             << convertCmToMm(cn1Global.Y()) << std::setw(14) << convertCmToMm(cn1Global.Z())
+             << " DeltaR = " << std::setw(14) << convertCmToMm(distGlobal) << "\n";
 
         dump << "\n";
         if (std::fabs(convertCmToMm(distGlobal - distLocal)) > 1.e-6) {

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDPosition.cc
@@ -212,27 +212,18 @@ void DD4hep_TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventS
         dump << "Box dimensions: " << convertCmToMm(mySens.halfX()) << " " << convertCmToMm(mySens.halfY()) << " "
              << convertCmToMm(mySens.halfZ()) << "\n";
 
-        char buf[256];
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
-        size_t s = snprintf(buf,
-                            256,
-                            ",%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f",
-                            convertCmToMm(fv.translation().x()),
-                            convertCmToMm(fv.translation().y()),
-                            convertCmToMm(fv.translation().z()),
-                            x.X(),
-                            y.X(),
-                            z.X(),
-                            x.Y(),
-                            y.Y(),
-                            z.Y(),
-                            x.Z(),
-                            y.Z(),
-                            z.Z());
-        assert(s < 256);
-        dump << "Translation vector and Rotation components: " << buf;
-        dump << "\n";
+        dump << "Translation vector components: " << std::setw(14) << std::fixed << convertCmToMm(fv.translation().x())
+             << " " << std::setw(14) << std::fixed << convertCmToMm(fv.translation().y()) << " " << std::setw(14)
+             << std::fixed << convertCmToMm(fv.translation().z()) << " "
+             << "\n";
+        dump << "Rotation matrix components: " << std::setw(14) << std::fixed << x.X() << " " << std::setw(14)
+             << std::fixed << y.X() << " " << std::setw(14) << std::fixed << z.X() << " " << std::setw(14) << std::fixed
+             << x.Y() << " " << std::setw(14) << std::fixed << y.Y() << " " << std::setw(14) << std::fixed << z.Y()
+             << " " << std::setw(14) << std::fixed << x.Z() << " " << std::setw(14) << std::fixed << y.Z() << " "
+             << std::setw(14) << std::fixed << z.Z() << " "
+             << "\n";
 
         DD3Vector zeroLocal(0., 0., 0.);
         DD3Vector cn1Local(mySens.halfX(), mySens.halfY(), mySens.halfZ());

--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -58,8 +58,7 @@ TestMTDNumbering::TestMTDNumbering(const edm::ParameterSet& iConfig)
       theLayout_(iConfig.getUntrackedParameter<uint32_t>("theLayout", 1)),
       thisN_(),
       btlNS_(),
-      etlNS_() {
-}
+      etlNS_() {}
 
 TestMTDNumbering::~TestMTDNumbering() {}
 
@@ -203,9 +202,8 @@ void TestMTDNumbering::theBaseNumber(const DDGeoHistory& gh) {
 }
 
 std::string TestMTDNumbering::noNSgeoHistory(const DDGeoHistory& gh) {
-
   std::string output;
-  for (uint i = 0; i < gh.size(); i++ ) {
+  for (uint i = 0; i < gh.size(); i++) {
     output += gh[i].logicalPart().name().name();
     output += "[";
     output += std::to_string(gh[i].copyno());
@@ -213,11 +211,10 @@ std::string TestMTDNumbering::noNSgeoHistory(const DDGeoHistory& gh) {
   }
 
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("TestMTDNumbering") << output;
+  edm::LogInfo("TestMTDNumbering") << output;
 #endif
 
   return output;
-
 }
 
 DEFINE_FWK_MODULE(TestMTDNumbering);

--- a/Geometry/MTDCommonData/test/TestMTDNumbering.cc
+++ b/Geometry/MTDCommonData/test/TestMTDNumbering.cc
@@ -13,7 +13,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
@@ -38,14 +37,10 @@ public:
 
   void theBaseNumber(const DDGeoHistory& gh);
 
-  void checkMTD(const DDCompactView& cpv,
-                std::string fname = "GeoHistory",
-                int nVols = 0,
-                std::string ddtop_ = "mtd:BarrelTimingLayer");
+  std::string noNSgeoHistory(const DDGeoHistory& gh);
 
 private:
   std::string label_;
-  bool isMagField_;
   std::string fname_;
   int nNodes_;
   std::string ddTopNodeName_;
@@ -58,17 +53,12 @@ private:
 
 TestMTDNumbering::TestMTDNumbering(const edm::ParameterSet& iConfig)
     : label_(iConfig.getUntrackedParameter<std::string>("label", "")),
-      isMagField_(iConfig.getUntrackedParameter<bool>("isMagField", false)),
       fname_(iConfig.getUntrackedParameter<std::string>("outFileName", "GeoHistory")),
-      nNodes_(iConfig.getUntrackedParameter<uint32_t>("numNodesToDump", 0)),
-      ddTopNodeName_(iConfig.getUntrackedParameter<std::string>("ddTopNodeName", "btl:BarrelTimingLayer")),
+      ddTopNodeName_(iConfig.getUntrackedParameter<std::string>("ddTopNodeName", "BarrelTimingLayer")),
       theLayout_(iConfig.getUntrackedParameter<uint32_t>("theLayout", 1)),
       thisN_(),
       btlNS_(),
       etlNS_() {
-  if (isMagField_) {
-    label_ = "magfield";
-  }
 }
 
 TestMTDNumbering::~TestMTDNumbering() {}
@@ -76,34 +66,28 @@ TestMTDNumbering::~TestMTDNumbering() {}
 void TestMTDNumbering::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
+  if (ddTopNodeName_ != "BarrelTimingLayer" && ddTopNodeName_ != "EndcapTimingLayer") {
+    edm::LogWarning("TestMTDNumbering") << ddTopNodeName_ << "Not valid top MTD volume";
+    return;
+  }
+
   edm::ESTransientHandle<DDCompactView> pDD;
-  if (!isMagField_) {
-    iSetup.get<IdealGeometryRecord>().get(label_, pDD);
-  } else {
-    iSetup.get<IdealMagneticFieldRecord>().get(label_, pDD);
+  iSetup.get<IdealGeometryRecord>().get(label_, pDD);
+
+  if (!pDD.isValid()) {
+    edm::LogError("TestMTDNumbering") << "ESTransientHandle<DDCompactView> pDD is not valid!";
+    return;
   }
   if (pDD.description()) {
     edm::LogInfo("TestMTDNumbering") << pDD.description()->type_ << " label: " << pDD.description()->label_;
   } else {
     edm::LogWarning("TestMTDNumbering") << "NO label found pDD.description() returned false.";
   }
-  if (!pDD.isValid()) {
-    edm::LogError("TestMTDNumbering") << "ESTransientHandle<DDCompactView> pDD is not valid!";
-  }
 
-  if (ddTopNodeName_ != "btl:BarrelTimingLayer" && ddTopNodeName_ != "etl:EndcapTimingLayer") {
-    edm::LogWarning("TestMTDNumbering") << ddTopNodeName_ << "Not valid top MTD volume";
-    return;
-  }
-
-  checkMTD(*pDD, fname_, nNodes_, ddTopNodeName_);
-}
-
-void TestMTDNumbering::checkMTD(const DDCompactView& cpv, std::string fname, int nVols, std::string ddtop_) {
-  fname = "dump" + fname;
+  std::string fname = "dump" + fname_;
 
   DDPassAllFilter filter;
-  DDFilteredView fv(cpv, filter);
+  DDFilteredView fv(*pDD, filter);
 
   edm::LogInfo("TestMTDNumbering") << "Top Most LogicalPart = " << fv.logicalPart();
 
@@ -112,7 +96,6 @@ void TestMTDNumbering::checkMTD(const DDCompactView& cpv, std::string fname, int
   id_type idMap;
   int id = 0;
   std::ofstream dump(fname.c_str());
-  bool notReachedDepth(true);
 
   bool write = false;
   bool isBarrel = true;
@@ -145,8 +128,8 @@ void TestMTDNumbering::checkMTD(const DDCompactView& cpv, std::string fname, int
 
     // Actions for MTD volumes: searchg for sensitive detectors
 
-    if (write && fv.geoHistory()[limit - 1].logicalPart().name() == ddtop_) {
-      dump << " - " << fv.geoHistory();
+    if (write && fv.geoHistory()[limit - 1].logicalPart().name().name() == ddTopNodeName_) {
+      dump << " - " << noNSgeoHistory(fv.geoHistory());
       dump << "\n";
 
       bool isSens = false;
@@ -200,9 +183,7 @@ void TestMTDNumbering::checkMTD(const DDCompactView& cpv, std::string fname, int
       }
     }
     ++id;
-    if (nVols != 0 && id > nVols)
-      notReachedDepth = false;
-  } while (fv.next() && notReachedDepth);
+  } while (fv.next());
   dump << std::flush;
   dump.close();
 }
@@ -219,6 +200,24 @@ void TestMTDNumbering::theBaseNumber(const DDGeoHistory& gh) {
     edm::LogInfo("TestMTDNumbering") << name << " " << copyN;
 #endif
   }
+}
+
+std::string TestMTDNumbering::noNSgeoHistory(const DDGeoHistory& gh) {
+
+  std::string output;
+  for (uint i = 0; i < gh.size(); i++ ) {
+    output += gh[i].logicalPart().name().name();
+    output += "[";
+    output += std::to_string(gh[i].copyno());
+    output += "]/";
+  }
+
+#ifdef EDM_ML_DEBUG
+    edm::LogInfo("TestMTDNumbering") << output;
+#endif
+
+  return output;
+
 }
 
 DEFINE_FWK_MODULE(TestMTDNumbering);

--- a/Geometry/MTDCommonData/test/TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/TestMTDPosition.cc
@@ -145,27 +145,18 @@ void TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         }
         dump << "Box dimensions: " << mySens.halfX() << " " << mySens.halfY() << " " << mySens.halfZ() << "\n";
 
-        char buf[256];
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
-        size_t s = snprintf(buf,
-                            256,
-                            ",%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f",
-                            fv.translation().x(),
-                            fv.translation().y(),
-                            fv.translation().z(),
-                            x.X(),
-                            y.X(),
-                            z.X(),
-                            x.Y(),
-                            y.Y(),
-                            z.Y(),
-                            x.Z(),
-                            y.Z(),
-                            z.Z());
-        assert(s < 256);
-        dump << "Translation vector and Rotation components: " << buf;
-        dump << "\n";
+        dump << "Translation vector components: " << std::setw(14) << std::fixed << fv.translation().x() << " "
+             << std::setw(14) << std::fixed << fv.translation().y() << " " << std::setw(14) << std::fixed
+             << fv.translation().z() << " "
+             << "\n";
+        dump << "Rotation matrix components: " << std::setw(14) << std::fixed << x.X() << " " << std::setw(14)
+             << std::fixed << y.X() << " " << std::setw(14) << std::fixed << z.X() << " " << std::setw(14) << std::fixed
+             << x.Y() << " " << std::setw(14) << std::fixed << y.Y() << " " << std::setw(14) << std::fixed << z.Y()
+             << " " << std::setw(14) << std::fixed << x.Z() << " " << std::setw(14) << std::fixed << y.Z() << " "
+             << std::setw(14) << std::fixed << z.Z() << " "
+             << "\n";
 
         DD3Vector zeroLocal(0., 0., 0.);
         DD3Vector cn1Local(mySens.halfX(), mySens.halfY(), mySens.halfZ());
@@ -203,9 +194,8 @@ void TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 }
 
 std::string TestMTDPosition::noNSgeoHistory(const DDGeoHistory& gh) {
-
   std::string output;
-  for (uint i = 0; i < gh.size(); i++ ) {
+  for (uint i = 0; i < gh.size(); i++) {
     output += gh[i].logicalPart().name().name();
     output += "[";
     output += std::to_string(gh[i].copyno());
@@ -213,11 +203,10 @@ std::string TestMTDPosition::noNSgeoHistory(const DDGeoHistory& gh) {
   }
 
 #ifdef EDM_ML_DEBUG
-    edm::LogInfo("TestMTDNumbering") << output;
+  edm::LogInfo("TestMTDNumbering") << output;
 #endif
 
   return output;
-
 }
 
 DEFINE_FWK_MODULE(TestMTDPosition);

--- a/Geometry/MTDCommonData/test/TestMTDPosition.cc
+++ b/Geometry/MTDCommonData/test/TestMTDPosition.cc
@@ -148,14 +148,12 @@ void TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
         dump << "Translation vector components: " << std::setw(14) << std::fixed << fv.translation().x() << " "
-             << std::setw(14) << std::fixed << fv.translation().y() << " " << std::setw(14) << std::fixed
-             << fv.translation().z() << " "
+             << std::setw(14) << fv.translation().y() << " " << std::setw(14) << fv.translation().z() << " "
              << "\n";
-        dump << "Rotation matrix components: " << std::setw(14) << std::fixed << x.X() << " " << std::setw(14)
-             << std::fixed << y.X() << " " << std::setw(14) << std::fixed << z.X() << " " << std::setw(14) << std::fixed
-             << x.Y() << " " << std::setw(14) << std::fixed << y.Y() << " " << std::setw(14) << std::fixed << z.Y()
-             << " " << std::setw(14) << std::fixed << x.Z() << " " << std::setw(14) << std::fixed << y.Z() << " "
-             << std::setw(14) << std::fixed << z.Z() << " "
+        dump << "Rotation matrix components: " << std::setw(14) << x.X() << " " << std::setw(14) << y.X() << " "
+             << std::setw(14) << z.X() << " " << std::setw(14) << x.Y() << " " << std::setw(14) << y.Y() << " "
+             << std::setw(14) << z.Y() << " " << std::setw(14) << x.Z() << " " << std::setw(14) << y.Z() << " "
+             << std::setw(14) << z.Z() << " "
              << "\n";
 
         DD3Vector zeroLocal(0., 0., 0.);
@@ -168,18 +166,15 @@ void TestMTDPosition::analyze(const edm::Event& iEvent, const edm::EventSetup& i
             std::sqrt(std::pow(zeroGlobal.X() - cn1Global.X(), 2) + std::pow(zeroGlobal.Y() - cn1Global.Y(), 2) +
                       std::pow(zeroGlobal.Z() - cn1Global.Z(), 2));
 
-        dump << "Center global   = " << std::setw(14) << std::fixed << zeroGlobal.X() << std::setw(14) << std::fixed
-             << zeroGlobal.Y() << std::setw(14) << std::fixed << zeroGlobal.Z() << " r = " << std::setw(14)
-             << std::fixed << zeroGlobal.Rho() << " phi = " << std::setw(14) << std::fixed << zeroGlobal.Phi() * rad2deg
-             << "\n";
+        dump << "Center global   = " << std::setw(14) << zeroGlobal.X() << std::setw(14) << zeroGlobal.Y()
+             << std::setw(14) << zeroGlobal.Z() << " r = " << std::setw(14) << zeroGlobal.Rho()
+             << " phi = " << std::setw(14) << zeroGlobal.Phi() * rad2deg << "\n";
 
-        dump << "Corner 1 local  = " << std::setw(14) << std::fixed << cn1Local.X() << std::setw(14) << std::fixed
-             << cn1Local.Y() << std::setw(14) << std::fixed << cn1Local.Z() << " DeltaR = " << std::setw(14)
-             << std::fixed << distLocal << "\n";
+        dump << "Corner 1 local  = " << std::setw(14) << cn1Local.X() << std::setw(14) << cn1Local.Y() << std::setw(14)
+             << cn1Local.Z() << " DeltaR = " << std::setw(14) << distLocal << "\n";
 
-        dump << "Corner 1 global = " << std::setw(14) << std::fixed << cn1Global.X() << std::setw(14) << std::fixed
-             << cn1Global.Y() << std::setw(14) << std::fixed << cn1Global.Z() << " DeltaR = " << std::setw(14)
-             << std::fixed << distGlobal << "\n";
+        dump << "Corner 1 global = " << std::setw(14) << cn1Global.X() << std::setw(14) << cn1Global.Y()
+             << std::setw(14) << cn1Global.Z() << " DeltaR = " << std::setw(14) << distGlobal << "\n";
 
         dump << "\n";
         if (std::fabs(distGlobal - distLocal) > 1.e-6) {

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CompareGeometryTest")
-process.load('Configuration.Geometry.GeometryExtended2026D41_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D50_cff')
 
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(1)
@@ -18,36 +18,28 @@ process.myprint = cms.OutputModule("AsciiOutputModule")
 
 process.testBTL = cms.EDAnalyzer("TestMTDNumbering",
                                label = cms.untracked.string(''),
-                               isMagField = cms.untracked.bool(False),
                                outFileName = cms.untracked.string('BTL'),
-                               numNodesToDump = cms.untracked.uint32(0),
-                               ddTopNodeName = cms.untracked.string('btl:BarrelTimingLayer'),
+                               ddTopNodeName = cms.untracked.string('BarrelTimingLayer'),
                                theLayout = cms.untracked.uint32(4)
                                )
 
 process.testETL = cms.EDAnalyzer("TestMTDNumbering",
                                label = cms.untracked.string(''),
-                               isMagField = cms.untracked.bool(False),
                                outFileName = cms.untracked.string('ETL'),
-                               numNodesToDump = cms.untracked.uint32(0),
-                               ddTopNodeName = cms.untracked.string('etl:EndcapTimingLayer')
+                               ddTopNodeName = cms.untracked.string('EndcapTimingLayer')
                                )
 
 
 process.testBTLpos = cms.EDAnalyzer("TestMTDPosition",
                                label = cms.untracked.string(''),
-                               isMagField = cms.untracked.bool(False),
                                outFileName = cms.untracked.string('BTLpos'),
-                               numNodesToDump = cms.untracked.uint32(0),
-                               ddTopNodeName = cms.untracked.string('btl:BarrelTimingLayer')
+                               ddTopNodeName = cms.untracked.string('BarrelTimingLayer')
                                )
 
 process.testETLpos = cms.EDAnalyzer("TestMTDPosition",
                                label = cms.untracked.string(''),
-                               isMagField = cms.untracked.bool(False),
                                outFileName = cms.untracked.string('ETLpos'),
-                               numNodesToDump = cms.untracked.uint32(0),
-                               ddTopNodeName = cms.untracked.string('etl:EndcapTimingLayer')
+                               ddTopNodeName = cms.untracked.string('EndcapTimingLayer')
                                )
 
 process.MessageLogger = cms.Service("MessageLogger",


### PR DESCRIPTION
#### PR description:

Technical updates of the ```Geometry/MTDCommonData``` validation analyzers: cleaning of the DDD-based classes, improved printout to make easier comparisons of log files, especially to compare the output of DDD and DD4hep on scenario D50.

#### PR validation:

The comparison of numbering dump shows no difference at all.
The comparison of reference positions (printed down to nanometer precision) shows no difference but for sign attributed to 0:

```
< Translation vector components:     313.500000      -0.000000    3017.850000 
< Center global   =     313.500000     -0.000000   3017.850000 r =     313.500000 phi =      -0.000000
---
> Translation vector components:     313.500000       0.000000    3017.850000 
> Center global   =     313.500000      0.000000   3017.850000 r =     313.500000 phi =       0.000000
```

```
< Rotation matrix components:      -0.448799      -0.893633      -0.000000       0.893633      -0.448799      -0.000000      -0.000000       0.000000       1.000000 
---
> Rotation matrix components:      -0.448799      -0.893633       0.000000       0.893633      -0.448799      -0.000000      -0.000000       0.000000       1.000000 
```

The validation of numbering and position can be considered as passed. Material budget comparison is not included in this check.
