### PR TITLE
Remove exceptions from the strip unpacker

### DIFF
--- a/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
@@ -68,12 +68,12 @@ bool LaserAlignmentEventFilter::filter(edm::StreamID sid, edm::Event& iEvent, co
 
     // construct FEDBuffer
     const auto st_buffer = sistrip::preconstructCheckFEDBuffer(input.data(), input.size());
-    if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+    if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
       throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
     }
     sistrip::FEDBuffer buffer(input.data(), input.size());
     const auto st_chan = buffer.findChannels();
-    if ( sistrip::FEDBufferStatusCode::SUCCESS != st_chan ) {
+    if (sistrip::FEDBufferStatusCode::SUCCESS != st_chan) {
       throw cms::Exception("FEDBuffer") << st_chan << " (check debug output for more details)";
     }
     if (not buffer.doChecks(true)) {

--- a/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
@@ -67,11 +67,11 @@ bool LaserAlignmentEventFilter::filter(edm::StreamID sid, edm::Event& iEvent, co
       continue;
 
     // construct FEDBuffer
-    const auto st_buffer = sistrip::preconstructCheckFEDBuffer(input.data(), input.size());
+    const auto st_buffer = sistrip::preconstructCheckFEDBuffer(input);
     if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
       throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
     }
-    sistrip::FEDBuffer buffer(input.data(), input.size());
+    sistrip::FEDBuffer buffer{input};
     const auto st_chan = buffer.findChannels();
     if (sistrip::FEDBufferStatusCode::SUCCESS != st_chan) {
       throw cms::Exception("FEDBuffer") << st_chan << " (check debug output for more details)";

--- a/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
@@ -67,7 +67,15 @@ bool LaserAlignmentEventFilter::filter(edm::StreamID sid, edm::Event& iEvent, co
       continue;
 
     // construct FEDBuffer
+    const auto st_buffer = sistrip::preconstructCheckFEDBuffer(input.data(), input.size());
+    if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+      throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
+    }
     sistrip::FEDBuffer buffer(input.data(), input.size());
+    const auto st_chan = buffer.findChannels();
+    if ( sistrip::FEDBufferStatusCode::SUCCESS != st_chan ) {
+      throw cms::Exception("FEDBuffer") << st_chan << " (check debug output for more details)";
+    }
     if (not buffer.doChecks(true)) {
       edm::LogWarning("LaserAlignmentEventFilter") << "FED Buffer check fails for FED ID " << *ifed << ".";
       continue;

--- a/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
+++ b/CalibTracker/SiStripAPVAnalysis/src/ApvAnalysisFactory.cc
@@ -153,7 +153,7 @@ void ApvAnalysisFactory::updatePair(uint32_t detId, size_t pairNumber, const edm
 
         for (size_t istrip = startStrip; istrip < stopStrip; istrip++) {
           if (in.data.size() <= istrip)
-            tmpRawDigi.data.push_back(0);
+            tmpRawDigi.data.push_back(SiStripRawDigi(0));
           else
             tmpRawDigi.data.push_back(in.data[istrip]);  //maybe dangerous
         }
@@ -183,7 +183,7 @@ void ApvAnalysisFactory::update(uint32_t detId, const edm::DetSet<SiStripRawDigi
 
       for (size_t istrip = startStrip; istrip < stopStrip; istrip++) {
         if (in.data.size() <= istrip)
-          tmpRawDigi.data.push_back(0);
+          tmpRawDigi.data.push_back(SiStripRawDigi(0));
         else
           tmpRawDigi.data.push_back(in.data[istrip]);  //maybe dangerous
       }

--- a/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
+++ b/DQM/SiStripMonitorHardware/interface/FEDErrors.hh
@@ -148,7 +148,7 @@ public:
   bool fillFatalFEDErrors(const FEDRawData& aFedData, const unsigned int aPrintDebug);
 
   //expensive check: fatal but kept separate
-  bool fillCorruptBuffer(const sistrip::FEDBuffer* aBuffer);
+  bool fillCorruptBuffer(const sistrip::FEDBuffer& aBuffer);
 
   //FE/Channel check: rate of channels with error (only considering connected channels)
   float fillNonFatalFEDErrors(const sistrip::FEDBuffer* aBuffer, const SiStripFedCabling* aCabling = nullptr);
@@ -165,11 +165,11 @@ public:
                      const bool aDoFEMaj,
                      std::vector<std::vector<std::pair<unsigned int, unsigned int> > >& aFeMajFrac);
 
-  bool fillFEErrors(const sistrip::FEDBuffer* aBuffer,
+  bool fillFEErrors(const sistrip::FEDBuffer& aBuffer,
                     const bool aDoFEMaj,
                     std::vector<std::vector<std::pair<unsigned int, unsigned int> > >& aFeMajFrac);
 
-  bool fillChannelErrors(const sistrip::FEDBuffer* aBuffer,
+  bool fillChannelErrors(const sistrip::FEDBuffer& aBuffer,
                          bool& aFullDebug,
                          const unsigned int aPrintDebug,
                          unsigned int& aCounterMonitoring,

--- a/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
@@ -85,6 +85,16 @@ namespace sistrip {
   // Inline function definitions
   //
 
+  inline FEDBufferStatusCode preconstructCheckFEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize) {
+    const auto st_base = preconstructCheckFEDBufferBase(fedBuffer, fedBufferSize, true);
+    if (FEDBufferStatusCode::SUCCESS != st_base)
+      return st_base;
+    const TrackerSpecialHeader hdr{fedBuffer + 8};
+    if (READOUT_MODE_SPY != hdr.readoutMode())
+      return FEDBufferStatusCode::EXPECT_SPY;
+    return FEDBufferStatusCode::SUCCESS;
+  }
+
   //FEDSpyChannelUnpacker
 
   inline FEDSpyChannelUnpacker::FEDSpyChannelUnpacker(const FEDChannel& channel)

--- a/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripFEDSpyBuffer.h
@@ -32,8 +32,16 @@ namespace sistrip {
   //class representing spy channel buffers
   class FEDSpyBuffer : public FEDBufferBase {
   public:
+    /**
+     * constructor from a FEDRawData buffer
+     *
+     * The sistrip::preconstructCheckFEDSpyBuffer() method should be used
+     * to check the validity of fedBuffer before constructing a sistrip::FEDBuffer.
+     *
+     * @see sistrip::preconstructCheckFEDSpyBuffer()
+     */
     //construct from buffer
-    FEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize);
+    explicit FEDSpyBuffer(const FEDRawData& fedBuffer);
     ~FEDSpyBuffer() override;
     void print(std::ostream& os) const override;
 
@@ -85,11 +93,23 @@ namespace sistrip {
   // Inline function definitions
   //
 
-  inline FEDBufferStatusCode preconstructCheckFEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize) {
-    const auto st_base = preconstructCheckFEDBufferBase(fedBuffer, fedBufferSize, true);
+  /**
+   * Check if a FEDRawData object satisfies the requirements for constructing a sistrip::FEDSpyBuffer
+   *
+   * These are:
+   *   - those from sistrip::preconstructCheckFEDBufferBase() (with checkRecognizedFormat equal to true)
+   *   - the readout mode should be equal to sistrip::READOUT_MODE_SPY
+   *
+   * In case any check fails, a value different from sistrip::FEDBufferStatusCode::SUCCESS
+   * is returned, and detailed information printed to LogDebug("FEDBuffer"), if relevant.
+   *
+   * @see sistrip::preconstructCheckFEDBufferBase()
+   */
+  inline FEDBufferStatusCode preconstructCheckFEDSpyBuffer(const FEDRawData& fedBuffer) {
+    const auto st_base = preconstructCheckFEDBufferBase(fedBuffer, true);
     if (FEDBufferStatusCode::SUCCESS != st_base)
       return st_base;
-    const TrackerSpecialHeader hdr{fedBuffer + 8};
+    const TrackerSpecialHeader hdr{fedBuffer.data() + 8};
     if (READOUT_MODE_SPY != hdr.readoutMode())
       return FEDBufferStatusCode::EXPECT_SPY;
     return FEDBufferStatusCode::SUCCESS;

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -206,14 +206,14 @@ bool FEDErrors::checkDataPresent(const FEDRawData& aFedData) {
 bool FEDErrors::failUnpackerFEDCheck() { return failUnpackerFEDCheck_; }
 
 bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData, const unsigned int aPrintDebug) {
-  const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(aFedData.data(), aFedData.size());
+  const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(aFedData);
   if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
     fedErrors_.InvalidBuffers = true;
     failUnpackerFEDCheck_ = true;
     //don't check anything else if the buffer is invalid
     return false;
   }
-  const sistrip::FEDBufferBase buffer{aFedData.data(), aFedData.size()};
+  const sistrip::FEDBufferBase buffer{aFedData};
 
   //CRC checks
   //if CRC fails then don't continue as if the buffer has been corrupted in DAQ then anything else could be invalid
@@ -311,11 +311,11 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
     return false;
 
   //need to construct full object to go any further
-  const auto st_buffer = sistrip::preconstructCheckFEDBuffer(aFedData.data(), aFedData.size(), true);
+  const auto st_buffer = sistrip::preconstructCheckFEDBuffer(aFedData, true);
   if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
     throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
   }
-  sistrip::FEDBuffer buffer(aFedData.data(), aFedData.size(), true);
+  sistrip::FEDBuffer buffer{aFedData, true};
   buffer.findChannels();  // no need to check the status, also bad buffers are allowed
 
   //fill remaining unpackerFEDcheck

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -206,7 +206,7 @@ bool FEDErrors::checkDataPresent(const FEDRawData& aFedData) {
 bool FEDErrors::failUnpackerFEDCheck() { return failUnpackerFEDCheck_; }
 
 bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData, const unsigned int aPrintDebug) {
-  const auto st_buffer = preconstructCheckFEDBufferBase(aFedData.data(), aFedData.size());
+  const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(aFedData.data(), aFedData.size());
   if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
     fedErrors_.InvalidBuffers = true;
     failUnpackerFEDCheck_ = true;

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -206,20 +206,14 @@ bool FEDErrors::checkDataPresent(const FEDRawData& aFedData) {
 bool FEDErrors::failUnpackerFEDCheck() { return failUnpackerFEDCheck_; }
 
 bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData, const unsigned int aPrintDebug) {
-
-  if ( ! ( aFedData.data() && sistrip::FEDBufferBase::hasMinimumLength(aFedData.size()) ) ) {
+  const auto st_buffer = preconstructCheckFEDBufferBase(aFedData.data(), aFedData.size());
+  if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
     fedErrors_.InvalidBuffers = true;
     failUnpackerFEDCheck_ = true;
     //don't check anything else if the buffer is invalid
     return false;
   }
   const sistrip::FEDBufferBase buffer{aFedData.data(), aFedData.size()};
-  if ( buffer.hasUnrecognizedFormat() ) {
-    fedErrors_.InvalidBuffers = true;
-    failUnpackerFEDCheck_ = true;
-    //don't check anything else if the buffer is invalid
-    return false;
-  }
 
   //CRC checks
   //if CRC fails then don't continue as if the buffer has been corrupted in DAQ then anything else could be invalid

--- a/DQM/SiStripMonitorHardware/src/FEDErrors.cc
+++ b/DQM/SiStripMonitorHardware/src/FEDErrors.cc
@@ -207,7 +207,7 @@ bool FEDErrors::failUnpackerFEDCheck() { return failUnpackerFEDCheck_; }
 
 bool FEDErrors::fillFatalFEDErrors(const FEDRawData& aFedData, const unsigned int aPrintDebug) {
   const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(aFedData.data(), aFedData.size());
-  if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+  if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
     fedErrors_.InvalidBuffers = true;
     failUnpackerFEDCheck_ = true;
     //don't check anything else if the buffer is invalid
@@ -312,11 +312,11 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
 
   //need to construct full object to go any further
   const auto st_buffer = sistrip::preconstructCheckFEDBuffer(aFedData.data(), aFedData.size(), true);
-  if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+  if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
     throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
   }
   sistrip::FEDBuffer buffer(aFedData.data(), aFedData.size(), true);
-  buffer.findChannels(); // no need to check the status, also bad buffers are allowed
+  buffer.findChannels();  // no need to check the status, also bad buffers are allowed
 
   //fill remaining unpackerFEDcheck
   if (!buffer.checkChannelLengths())
@@ -341,14 +341,8 @@ bool FEDErrors::fillFEDErrors(const FEDRawData& aFedData,
     fillFEErrors(buffer, aDoFEMaj, aFeMajFrac);
 
     //channel checks
-    fillChannelErrors(buffer,
-                      aFullDebug,
-                      aPrintDebug,
-                      aCounterMonitoring,
-                      aCounterUnpacker,
-                      aDoMeds,
-                      aMedianHist0,
-                      aMedianHist1);
+    fillChannelErrors(
+        buffer, aFullDebug, aPrintDebug, aCounterMonitoring, aCounterUnpacker, aDoMeds, aMedianHist0, aMedianHist1);
   }
 
   if (printDebug() && aPrintDebug > 2) {

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -224,11 +224,11 @@ void SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent, const edm::EventS
       continue;
     } else {
       //need to construct full object to go any further
-      const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+      const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData, true);
       if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
         throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
       }
-      auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+      auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData, true);
       tmp_buffer->findChannels();
       buffer = std::move(tmp_buffer);  // const now
       bool channelLengthsOK = buffer->checkChannelLengthsMatchBufferLength();

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -225,12 +225,12 @@ void SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent, const edm::EventS
     } else {
       //need to construct full object to go any further
       const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
-      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+      if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
         throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
       }
       auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
       tmp_buffer->findChannels();
-      buffer = std::move(tmp_buffer); // const now
+      buffer = std::move(tmp_buffer);  // const now
       bool channelLengthsOK = buffer->checkChannelLengthsMatchBufferLength();
       bool channelPacketCodesOK = buffer->checkChannelPacketCodes();
       bool feLengthsOK = buffer->checkFEUnitLengths();

--- a/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripCMMonitor.cc
@@ -224,7 +224,13 @@ void SiStripCMMonitorPlugin::analyze(const edm::Event& iEvent, const edm::EventS
       continue;
     } else {
       //need to construct full object to go any further
-      buffer.reset(new sistrip::FEDBuffer(fedData.data(), fedData.size(), true));
+      const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+        throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
+      }
+      auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+      tmp_buffer->findChannels();
+      buffer = std::move(tmp_buffer); // const now
       bool channelLengthsOK = buffer->checkChannelLengthsMatchBufferLength();
       bool channelPacketCodesOK = buffer->checkChannelPacketCodes();
       bool feLengthsOK = buffer->checkFEUnitLengths();

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -234,12 +234,12 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
       //need to construct full object to go any further
       if (doPayloadChecks_ || checkChannelStatusBits_) {
         const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
-        if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+        if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
           throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
         }
         auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
         tmp_buffer->findChannels();
-        buffer = std::move(tmp_buffer); // const now
+        buffer = std::move(tmp_buffer);  // const now
         if (doPayloadChecks_) {
           bool channelLengthsOK = checkChannelLengths_ ? buffer->checkChannelLengthsMatchBufferLength() : true;
           bool channelPacketCodesOK = checkPacketCodes_ ? buffer->checkChannelPacketCodes() : true;
@@ -258,12 +258,12 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
       if (printDebug_) {
         if (!buffer.get()) {
           const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
-          if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+          if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
             throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
           }
           auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
           tmp_buffer->findChannels();
-          buffer = std::move(tmp_buffer); // const now
+          buffer = std::move(tmp_buffer);  // const now
         }
         edm::LogInfo("SiStripFEDCheck") << "Fatal error with FED ID " << fedId << ". Check summary: " << std::endl
                                         << buffer->checkSummary() << std::endl;
@@ -278,12 +278,12 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
       if (printDebug_ && rateNonFatal > 0) {
         if (!buffer.get()) {
           const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
-          if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+          if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
             throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
           }
           auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
           tmp_buffer->findChannels();
-          buffer = std::move(tmp_buffer); // const now
+          buffer = std::move(tmp_buffer);  // const now
         }
         edm::LogInfo("SiStripFEDCheck") << "Non-fatal error with FED ID " << fedId << " for " << rateNonFatal
                                         << " of the channels. Check summary: " << std::endl

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -233,7 +233,13 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
     } else {
       //need to construct full object to go any further
       if (doPayloadChecks_ || checkChannelStatusBits_) {
-        buffer.reset(new sistrip::FEDBuffer(fedData.data(), fedData.size(), true));
+        const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+        if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+          throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
+        }
+        auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+        tmp_buffer->findChannels();
+        buffer = std::move(tmp_buffer); // const now
         if (doPayloadChecks_) {
           bool channelLengthsOK = checkChannelLengths_ ? buffer->checkChannelLengthsMatchBufferLength() : true;
           bool channelPacketCodesOK = checkPacketCodes_ ? buffer->checkChannelPacketCodes() : true;
@@ -250,8 +256,15 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
     if (hasFatalErrors) {
       fillFatalError(fedId, true);
       if (printDebug_) {
-        if (!buffer.get())
-          buffer.reset(new sistrip::FEDBuffer(fedData.data(), fedData.size(), true));
+        if (!buffer.get()) {
+          const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+          if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+            throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
+          }
+          auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+          tmp_buffer->findChannels();
+          buffer = std::move(tmp_buffer); // const now
+        }
         edm::LogInfo("SiStripFEDCheck") << "Fatal error with FED ID " << fedId << ". Check summary: " << std::endl
                                         << buffer->checkSummary() << std::endl;
         std::stringstream ss;
@@ -263,8 +276,15 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
       //fill non-fatal errors histogram if there were no fatal errors
       fillNonFatalError(fedId, rateNonFatal);
       if (printDebug_ && rateNonFatal > 0) {
-        if (!buffer.get())
-          buffer.reset(new sistrip::FEDBuffer(fedData.data(), fedData.size(), true));
+        if (!buffer.get()) {
+          const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+          if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+            throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
+          }
+          auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+          tmp_buffer->findChannels();
+          buffer = std::move(tmp_buffer); // const now
+        }
         edm::LogInfo("SiStripFEDCheck") << "Non-fatal error with FED ID " << fedId << " for " << rateNonFatal
                                         << " of the channels. Check summary: " << std::endl
                                         << buffer->checkSummary() << std::endl;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -233,11 +233,11 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
     } else {
       //need to construct full object to go any further
       if (doPayloadChecks_ || checkChannelStatusBits_) {
-        const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+        const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData, true);
         if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
           throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
         }
-        auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+        auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData, true);
         tmp_buffer->findChannels();
         buffer = std::move(tmp_buffer);  // const now
         if (doPayloadChecks_) {
@@ -257,11 +257,11 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
       fillFatalError(fedId, true);
       if (printDebug_) {
         if (!buffer.get()) {
-          const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+          const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData, true);
           if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
             throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
           }
-          auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+          auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData, true);
           tmp_buffer->findChannels();
           buffer = std::move(tmp_buffer);  // const now
         }
@@ -277,11 +277,11 @@ void SiStripFEDCheckPlugin::analyze(const edm::Event& iEvent, const edm::EventSe
       fillNonFatalError(fedId, rateNonFatal);
       if (printDebug_ && rateNonFatal > 0) {
         if (!buffer.get()) {
-          const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData.data(), fedData.size(), true);
+          const auto st_buffer = sistrip::preconstructCheckFEDBuffer(fedData, true);
           if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
             throw cms::Exception("FEDBuffer") << st_buffer << " (check debug output for more details)";
           }
-          auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData.data(), fedData.size(), true);
+          auto tmp_buffer = std::make_unique<sistrip::FEDBuffer>(fedData, true);
           tmp_buffer->findChannels();
           buffer = std::move(tmp_buffer);  // const now
         }

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -64,7 +64,13 @@ void SiStripFEDDumpPlugin::analyze(const edm::Event& iEvent, const edm::EventSet
   const FEDRawDataCollection& rawDataCollection = *rawDataCollectionHandle;
 
   const FEDRawData& rawData = rawDataCollection.FEDData(fedIdToDump_);
-  const sistrip::FEDBufferBase buffer(rawData.data(), rawData.size(), true);
+  if ( ! rawData.data() )
+    throw cms::Exception("FEDBuffer") << "Buffer pointer is NULL.";
+  if ( ! sistrip::FEDBufferBase::hasMinimumLength(rawData.size()) )
+    throw cms::Exception("FEDBuffer")
+       << "Buffer is too small. Min size is 24. "
+       << "Buffer size is " << rawData.size() << ". ";
+  const sistrip::FEDBufferBase buffer(rawData.data(), rawData.size());
   std::ostringstream os;
   os << buffer << std::endl;
   buffer.dump(os);

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -64,12 +64,10 @@ void SiStripFEDDumpPlugin::analyze(const edm::Event& iEvent, const edm::EventSet
   const FEDRawDataCollection& rawDataCollection = *rawDataCollectionHandle;
 
   const FEDRawData& rawData = rawDataCollection.FEDData(fedIdToDump_);
-  if ( ! rawData.data() )
-    throw cms::Exception("FEDBuffer") << "Buffer pointer is NULL.";
-  if ( ! sistrip::FEDBufferBase::hasMinimumLength(rawData.size()) )
-    throw cms::Exception("FEDBuffer")
-       << "Buffer is too small. Min size is 24. "
-       << "Buffer size is " << rawData.size() << ". ";
+  const auto st_buffer = preconstructCheckFEDBufferBase(rawData.data(), rawData.size(), false);
+  if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+    throw cms::Exception("FEDBuffer") << st_buffer;
+  }
   const sistrip::FEDBufferBase buffer(rawData.data(), rawData.size());
   std::ostringstream os;
   os << buffer << std::endl;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -64,11 +64,11 @@ void SiStripFEDDumpPlugin::analyze(const edm::Event& iEvent, const edm::EventSet
   const FEDRawDataCollection& rawDataCollection = *rawDataCollectionHandle;
 
   const FEDRawData& rawData = rawDataCollection.FEDData(fedIdToDump_);
-  const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(rawData.data(), rawData.size(), false);
+  const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(rawData, false);
   if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
     throw cms::Exception("FEDBuffer") << st_buffer;
   }
-  const sistrip::FEDBufferBase buffer(rawData.data(), rawData.size());
+  const sistrip::FEDBufferBase buffer{rawData};
   std::ostringstream os;
   os << buffer << std::endl;
   buffer.dump(os);

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -64,7 +64,7 @@ void SiStripFEDDumpPlugin::analyze(const edm::Event& iEvent, const edm::EventSet
   const FEDRawDataCollection& rawDataCollection = *rawDataCollectionHandle;
 
   const FEDRawData& rawData = rawDataCollection.FEDData(fedIdToDump_);
-  const auto st_buffer = preconstructCheckFEDBufferBase(rawData.data(), rawData.size(), false);
+  const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(rawData.data(), rawData.size(), false);
   if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
     throw cms::Exception("FEDBuffer") << st_buffer;
   }

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -65,7 +65,7 @@ void SiStripFEDDumpPlugin::analyze(const edm::Event& iEvent, const edm::EventSet
 
   const FEDRawData& rawData = rawDataCollection.FEDData(fedIdToDump_);
   const auto st_buffer = sistrip::preconstructCheckFEDBufferBase(rawData.data(), rawData.size(), false);
-  if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+  if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
     throw cms::Exception("FEDBuffer") << st_buffer;
   }
   const sistrip::FEDBufferBase buffer(rawData.data(), rawData.size());

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDSpyBuffer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDSpyBuffer.cc
@@ -5,8 +5,8 @@ namespace sistrip {
 
   const uint8_t FEDSpyBuffer::channelPositionsInData_[FEDCH_PER_DELAY_CHIP] = {0, 3, 2, 1};
 
-  FEDSpyBuffer::FEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize)
-      : FEDBufferBase(fedBuffer, fedBufferSize),
+  FEDSpyBuffer::FEDSpyBuffer(const FEDRawData& fedBuffer)
+      : FEDBufferBase(fedBuffer),
         payloadPointer_(getPointerToDataAfterTrackerSpecialHeader() + 16),
         payloadLength_(getPointerToByteAfterEndOfPayload() - payloadPointer_),
         versionId_(*(getPointerToDataAfterTrackerSpecialHeader() + 3)) {

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDSpyBuffer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDSpyBuffer.cc
@@ -10,9 +10,6 @@ namespace sistrip {
         payloadPointer_(getPointerToDataAfterTrackerSpecialHeader() + 16),
         payloadLength_(getPointerToByteAfterEndOfPayload() - payloadPointer_),
         versionId_(*(getPointerToDataAfterTrackerSpecialHeader() + 3)) {
-    //Check it is spy data
-    if (!(readoutMode() == READOUT_MODE_SPY))
-      throw cms::Exception("FEDSpyBuffer") << "Buffer is not from spy channel";
     //Check the buffer format version ID and take action for any exceptions
     if (versionId_ == 0x00) {
       payloadPointer_ = payloadPointer_ - 8;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDSpyBuffer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDSpyBuffer.cc
@@ -6,7 +6,7 @@ namespace sistrip {
   const uint8_t FEDSpyBuffer::channelPositionsInData_[FEDCH_PER_DELAY_CHIP] = {0, 3, 2, 1};
 
   FEDSpyBuffer::FEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize)
-      : FEDBufferBase(fedBuffer, fedBufferSize, false),
+      : FEDBufferBase(fedBuffer, fedBufferSize),
         payloadPointer_(getPointerToDataAfterTrackerSpecialHeader() + 16),
         payloadLength_(getPointerToByteAfterEndOfPayload() - payloadPointer_),
         versionId_(*(getPointerToDataAfterTrackerSpecialHeader() + 3)) {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -112,8 +112,10 @@ namespace sistrip {
     const FEDRawDataCollection& fedRawData = *fedRawDataHandle;
     for (auto iFedId = cabling.fedIds().begin(); iFedId != cabling.fedIds().end(); ++iFedId) {
       const FEDRawData& data = fedRawData.FEDData(*iFedId);
-      if ((!data.data()) || (!data.size())) {
-        LogDebug(messageLabel_) << "Failed to get FED data for FED ID " << *iFedId;
+      const auto st_buffer = preconstructCheckFEDBuffer(data.data(), data.size());
+      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+        LogInfo(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId << ". Exception was "
+          << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
         continue;
       }
       std::unique_ptr<FEDBuffer> buffer;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -113,17 +113,17 @@ namespace sistrip {
     for (auto iFedId = cabling.fedIds().begin(); iFedId != cabling.fedIds().end(); ++iFedId) {
       const FEDRawData& data = fedRawData.FEDData(*iFedId);
       const auto st_buffer = preconstructCheckFEDBuffer(data.data(), data.size());
-      if ( FEDBufferStatusCode::SUCCESS != st_buffer ) {
+      if (FEDBufferStatusCode::SUCCESS != st_buffer) {
         LogInfo(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId
-          << ". Exception was: An exception of category 'FEDBuffer' occurred.\n"
-          << st_buffer << " (see debug output for details)";
+                               << ". Exception was: An exception of category 'FEDBuffer' occurred.\n"
+                               << st_buffer << " (see debug output for details)";
         continue;
       }
       FEDBuffer buffer(data.data(), data.size());
       const auto st_chan = buffer.findChannels();
-      if ( FEDBufferStatusCode::SUCCESS != st_chan ) {
-        LogDebug(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId
-          << ". Exception was " << st_chan << " (see above for more details)";
+      if (FEDBufferStatusCode::SUCCESS != st_chan) {
+        LogDebug(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId << ". Exception was " << st_chan
+                                << " (see above for more details)";
         continue;
       }
       if (!buffer.doChecks(true)) {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -112,14 +112,14 @@ namespace sistrip {
     const FEDRawDataCollection& fedRawData = *fedRawDataHandle;
     for (auto iFedId = cabling.fedIds().begin(); iFedId != cabling.fedIds().end(); ++iFedId) {
       const FEDRawData& data = fedRawData.FEDData(*iFedId);
-      const auto st_buffer = preconstructCheckFEDBuffer(data.data(), data.size());
+      const auto st_buffer = preconstructCheckFEDBuffer(data);
       if (FEDBufferStatusCode::SUCCESS != st_buffer) {
         LogInfo(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId
                                << ". Exception was: An exception of category 'FEDBuffer' occurred.\n"
                                << st_buffer << " (see debug output for details)";
         continue;
       }
-      FEDBuffer buffer(data.data(), data.size());
+      FEDBuffer buffer{data};
       const auto st_chan = buffer.findChannels();
       if (FEDBufferStatusCode::SUCCESS != st_chan) {
         LogDebug(messageLabel_) << "Failed to build FED buffer for FED ID " << *iFedId << ". Exception was " << st_chan

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -74,14 +74,14 @@ namespace sistrip {
     for (uint16_t fedId = sistrip::FED_ID_MIN; fedId <= sistrip::FED_ID_MAX; ++fedId) {
       const FEDRawData& fedData = rawData.FEDData(fedId);
       if (fedData.size() && fedData.data()) {
-        const auto st_buffer = preconstructCheckFEDBufferBase(fedData.data(), fedData.size());
+        const auto st_buffer = preconstructCheckFEDBufferBase(fedData);
         if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
           LogInfo(messageLabel_) << "Skipping FED " << fedId << " because of exception: "
                                  << "An exception of category 'FEDBuffer' occurred.\n"
                                  << st_buffer;
           continue;
         }
-        const sistrip::FEDBufferBase buffer{fedData.data(), fedData.size()};
+        const sistrip::FEDBufferBase buffer{fedData};
         fedEventNumber = buffer.daqLvl1ID();
         fedBxNumber = buffer.daqBXID();
         fedFound = true;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -74,20 +74,13 @@ namespace sistrip {
     for (uint16_t fedId = sistrip::FED_ID_MIN; fedId <= sistrip::FED_ID_MAX; ++fedId) {
       const FEDRawData& fedData = rawData.FEDData(fedId);
       if (fedData.size() && fedData.data()) {
-        if ( ! sistrip::FEDBufferBase::hasMinimumLength(fedData.size()) ) {
+        const auto st_buffer = preconstructCheckFEDBufferBase(fedData.data(), fedData.size());
+        if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
           LogInfo(messageLabel_) << "Skipping FED " << fedId << " because of exception: "
-            << "An exception of category 'FEDBuffer' occurred.\n"
-            << "Buffer is too small. Min size is 24. Buffer size is " << fedData.size() << ". ";
+            << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
           continue;
         }
         const sistrip::FEDBufferBase buffer{fedData.data(), fedData.size()};
-        if ( buffer.hasUnrecognizedFormat() ) {
-          LogInfo(messageLabel_) << "Skipping FED " << fedId << " because of exception: "
-            << "An exception of category 'FEDBuffer' occurred.\n"
-            << "Buffer format not recognized. "
-            << "Tracker special header: " << buffer.trackerSpecialHeader();
-          continue;
-        }
         fedEventNumber = buffer.daqLvl1ID();
         fedBxNumber = buffer.daqBXID();
         fedFound = true;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -75,9 +75,10 @@ namespace sistrip {
       const FEDRawData& fedData = rawData.FEDData(fedId);
       if (fedData.size() && fedData.data()) {
         const auto st_buffer = preconstructCheckFEDBufferBase(fedData.data(), fedData.size());
-        if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
+        if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
           LogInfo(messageLabel_) << "Skipping FED " << fedId << " because of exception: "
-            << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
+                                 << "An exception of category 'FEDBuffer' occurred.\n"
+                                 << st_buffer;
           continue;
         }
         const sistrip::FEDBufferBase buffer{fedData.data(), fedData.size()};

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -105,7 +105,7 @@ namespace sistrip {
       if (!input.data() || !input.size())
         continue;
       //construct FEDBuffer
-      const auto st_buffer = preconstructCheckFEDSpyBuffer(input.data(), input.size());
+      const auto st_buffer = preconstructCheckFEDSpyBuffer(input);
       if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
         edm::LogWarning("SiStripSpyIdentifyRuns")
             << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
@@ -114,7 +114,7 @@ namespace sistrip {
         if (sistrip::FEDBufferStatusCode::EXPECT_SPY == st_buffer)
           break;
       }
-      const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
+      const sistrip::FEDSpyBuffer buffer{input};
       edm::LogWarning("SiStripSpyIdentifyRuns") << " -- this is a spy file, run " << lRunNum << std::endl;
       writeRunInFile(lRunNum);
       break;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -105,23 +105,14 @@ namespace sistrip {
       if (!input.data() || !input.size())
         continue;
       //construct FEDBuffer
-      if ( ! sistrip::FEDBufferBase::hasMinimumLength(input.size()) ) {
+      const auto st_buffer = preconstructCheckFEDSpyBuffer(input.data(), input.size());
+      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
         edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
-          << "An exception of category 'FEDBuffer' occurred.\n"
-          << "Buffer is too small. Min size is 24. Buffer size is " << input.size() << ". ";
-      }
-      if ( READOUT_MODE_SPY != sistrip::FEDBufferBase::readoutMode(input.data()) ) {
-        edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
-          << "An exception of category 'FEDSpyBuffer' occurred.\n"
-          << "Buffer is not from spy channel";
-        break;
+          << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
+        if ( sistrip::FEDBufferStatusCode::EXPECT_SPY == st_buffer )
+          break;
       }
       const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
-      if ( buffer.hasUnrecognizedFormat() ) {
-        edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
-          << "An exception of category 'FEDBuffer' occurred.\n"
-          << "Buffer format not recognized. Tracker special header: " << buffer.trackerSpecialHeader();
-      }
       edm::LogWarning("SiStripSpyIdentifyRuns") << " -- this is a spy file, run " << lRunNum << std::endl;
       writeRunInFile(lRunNum);
       break;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -106,10 +106,12 @@ namespace sistrip {
         continue;
       //construct FEDBuffer
       const auto st_buffer = preconstructCheckFEDSpyBuffer(input.data(), input.size());
-      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
-        edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
-          << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
-        if ( sistrip::FEDBufferStatusCode::EXPECT_SPY == st_buffer )
+      if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
+        edm::LogWarning("SiStripSpyIdentifyRuns")
+            << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
+            << "An exception of category 'FEDBuffer' occurred.\n"
+            << st_buffer;
+        if (sistrip::FEDBufferStatusCode::EXPECT_SPY == st_buffer)
           break;
       }
       const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -105,20 +105,20 @@ namespace sistrip {
       if (!input.data() || !input.size())
         continue;
       //construct FEDBuffer
-      if ( ! sistrip::FEDBufferBase::hasMinimumLength(fedData.size()) ) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
+      if ( ! sistrip::FEDBufferBase::hasMinimumLength(input.size()) ) {
+        edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
           << "An exception of category 'FEDBuffer' occurred.\n"
-          << "Buffer is too small. Min size is 24. Buffer size is " << fedData.size() << ". ";
+          << "Buffer is too small. Min size is 24. Buffer size is " << input.size() << ". ";
       }
-      if ( READOUT_MODE_SPY != sistrip::FEDBufferBase::readoutMode(fedData.data()) ) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
+      if ( READOUT_MODE_SPY != sistrip::FEDBufferBase::readoutMode(input.data()) ) {
+        edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
           << "An exception of category 'FEDSpyBuffer' occurred.\n"
           << "Buffer is not from spy channel";
         break;
       }
       const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
       if ( buffer.hasUnrecognizedFormat() ) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
+        edm::LogWarning("SiStripSpyIdentifyRuns") << "Exception caught when creating FEDSpyBuffer object for FED " << iFed << ": "
           << "An exception of category 'FEDBuffer' occurred.\n"
           << "Buffer format not recognized. Tracker special header: " << buffer.trackerSpecialHeader();
       }

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -111,25 +111,13 @@ namespace sistrip {
       auto conns = cabling.fedConnections(lFedId);
 
       //construct FEDBuffer
-      if ( ! sistrip::FEDBufferBase::hasMinimumLength(input.size()) ) {
+      const auto st_buffer = preconstructCheckFEDSpyBuffer(input.data(), input.size());
+      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
         edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
-          << "An exception of category 'FEDBuffer' occurred.\n"
-          << "Buffer is too small. Min size is 24. Buffer size is " << input.size() << ". ";
-        continue;
-      }
-      if ( READOUT_MODE_SPY != sistrip::FEDBufferBase::readoutMode(input.data()) ) {
-        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
-          << "An exception of category 'FEDSpyBuffer' occurred.\n"
-          << "Buffer is not from spy channel";
+          << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
         continue;
       }
       const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
-      if ( buffer.hasUnrecognizedFormat() ) {
-        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
-          << "An exception of category 'FEDBuffer' occurred.\n"
-          << "Buffer format not recognized. Tracker special header: " << buffer.trackerSpecialHeader();
-        continue;
-      }
       if (!buffer.doChecks() && !allowIncompleteEvents_) {
         edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
           << "An exception of category 'FEDSpyBuffer' occurred.\n"

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -112,26 +112,26 @@ namespace sistrip {
 
       //construct FEDBuffer
       if ( ! sistrip::FEDBufferBase::hasMinimumLength(input.size()) ) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
+        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
           << "An exception of category 'FEDBuffer' occurred.\n"
           << "Buffer is too small. Min size is 24. Buffer size is " << input.size() << ". ";
         continue;
       }
-      if ( READOUT_MODE_SPY != sistrip::FEDBufferBase::readoutMode(fedData.data()) ) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
+      if ( READOUT_MODE_SPY != sistrip::FEDBufferBase::readoutMode(input.data()) ) {
+        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
           << "An exception of category 'FEDSpyBuffer' occurred.\n"
           << "Buffer is not from spy channel";
         continue;
       }
       const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
       if ( buffer.hasUnrecognizedFormat() ) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
+        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
           << "An exception of category 'FEDBuffer' occurred.\n"
           << "Buffer format not recognized. Tracker special header: " << buffer.trackerSpecialHeader();
         continue;
       }
       if (!buffer.doChecks() && !allowIncompleteEvents_) {
-        LogInfo(messageLabel_) << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
+        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
           << "An exception of category 'FEDSpyBuffer' occurred.\n"
           << "FED Buffer check fails for FED ID " << lFedId << ".";
         continue;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -112,16 +112,19 @@ namespace sistrip {
 
       //construct FEDBuffer
       const auto st_buffer = preconstructCheckFEDSpyBuffer(input.data(), input.size());
-      if ( sistrip::FEDBufferStatusCode::SUCCESS != st_buffer ) {
-        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
-          << "An exception of category 'FEDBuffer' occurred.\n" << st_buffer;
+      if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
+        edm::LogWarning("SiStripSpyUnpacker")
+            << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
+            << "An exception of category 'FEDBuffer' occurred.\n"
+            << st_buffer;
         continue;
       }
       const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
       if (!buffer.doChecks() && !allowIncompleteEvents_) {
-        edm::LogWarning("SiStripSpyUnpacker") << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
-          << "An exception of category 'FEDSpyBuffer' occurred.\n"
-          << "FED Buffer check fails for FED ID " << lFedId << ".";
+        edm::LogWarning("SiStripSpyUnpacker")
+            << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
+            << "An exception of category 'FEDSpyBuffer' occurred.\n"
+            << "FED Buffer check fails for FED ID " << lFedId << ".";
         continue;
       }
       // end of buffer reset try.

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -190,7 +190,7 @@ namespace sistrip {
 
         // Unpack the data into dsv filler
         while (unpacker.hasData()) {
-          dsvFiller.addItem(unpacker.adc());
+          dsvFiller.addItem(SiStripRawDigi{unpacker.adc()});
           unpacker++;
         }
       }  // end of channel loop

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -111,7 +111,7 @@ namespace sistrip {
       auto conns = cabling.fedConnections(lFedId);
 
       //construct FEDBuffer
-      const auto st_buffer = preconstructCheckFEDSpyBuffer(input.data(), input.size());
+      const auto st_buffer = preconstructCheckFEDSpyBuffer(input);
       if (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
         edm::LogWarning("SiStripSpyUnpacker")
             << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "
@@ -119,7 +119,7 @@ namespace sistrip {
             << st_buffer;
         continue;
       }
-      const sistrip::FEDSpyBuffer buffer{input.data(), input.size()};
+      const sistrip::FEDSpyBuffer buffer{input};
       if (!buffer.doChecks() && !allowIncompleteEvents_) {
         edm::LogWarning("SiStripSpyUnpacker")
             << "Exception caught when creating FEDSpyBuffer object for FED " << lFedId << ": "

--- a/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
@@ -14,10 +14,10 @@
 */
 class SiStripRawDigi : public edm::DoNotSortUponInsertion {
 public:
-  explicit SiStripRawDigi(uint16_t adc) : adc_(adc) { ; }
+  explicit SiStripRawDigi(uint16_t adc) : adc_(adc) {}
 
-  SiStripRawDigi() : adc_(0) { ; }
-  ~SiStripRawDigi() { ; }
+  SiStripRawDigi() : adc_(0) {}
+  ~SiStripRawDigi() {}
 
   inline uint16_t adc() const { return adc_; }
 

--- a/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
@@ -14,12 +14,14 @@
 */
 class SiStripRawDigi : public edm::DoNotSortUponInsertion {
 public:
-  SiStripRawDigi(const uint16_t& adc) : adc_(adc) { ; }
+  explicit SiStripRawDigi(uint16_t adc) : adc_(adc) { ; }
 
   SiStripRawDigi() : adc_(0) { ; }
   ~SiStripRawDigi() { ; }
 
-  inline const uint16_t& adc() const;
+  inline uint16_t adc() const { return adc_; }
+
+  inline operator uint16_t() const { return adc_; }
 
   /** Not used! (even if implementation is required). */
   inline bool operator<(const SiStripRawDigi& other) const;
@@ -32,7 +34,6 @@ private:
 inline std::ostream& operator<<(std::ostream& o, const SiStripRawDigi& digi) { return o << " " << digi.adc(); }
 
 // inline methods
-const uint16_t& SiStripRawDigi::adc() const { return adc_; }
-bool SiStripRawDigi::operator<(const SiStripRawDigi& other) const { return (this->adc() < other.adc()); }
+bool SiStripRawDigi::operator<(const SiStripRawDigi& other) const { return (adc() < other.adc()); }
 
 #endif  // DataFormats_SiStripDigi_SiStripRawDigi_H

--- a/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
@@ -21,8 +21,6 @@ public:
 
   inline uint16_t adc() const { return adc_; }
 
-  inline operator uint16_t() const { return adc_; }
-
   /** Not used! (even if implementation is required). */
   inline bool operator<(const SiStripRawDigi& other) const;
 

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -230,7 +230,7 @@ namespace sistrip {
 
       template <uint8_t num_bits, typename OUT>
       StatusCode unpackZSW(
-          const FEDChannel& channel, OUT& out, uint8_t headerLength, uint16_t stripStart, uint8_t bits_shift = 0) {
+          const FEDChannel& channel, OUT&& out, uint8_t headerLength, uint16_t stripStart, uint8_t bits_shift = 0) {
         constexpr auto num_words = num_bits / 8;
         static_assert(((num_bits % 8) == 0) && (num_words > 0) && (num_words < 3));
         const uint8_t* data = channel.data();
@@ -238,6 +238,9 @@ namespace sistrip {
         if (channel.length() & 0xF000) {
           LogDebug("FEDBuffer") << "Channel length is invalid. Channel length is " << uint16_t(channel.length()) << ".";
           return StatusCode::BAD_CHANNEL_LENGTH;
+        }
+        if ( channel.length() <= headerLength ) {
+          return StatusCode::SUCCESS;
         }
         uint_fast8_t firstStrip = data[(offset++) ^ 7];
         uint_fast8_t nInCluster = data[(offset++) ^ 7];
@@ -269,7 +272,7 @@ namespace sistrip {
 
       // Generic implementation (for 10bit, essentially)
       template <uint_fast8_t num_bits, typename OUT>
-      StatusCode unpackZSB(const FEDChannel& channel, OUT& out, uint8_t headerLength, uint16_t stripStart) {
+      StatusCode unpackZSB(const FEDChannel& channel, OUT&& out, uint8_t headerLength, uint16_t stripStart) {
         constexpr uint16_t mask = (1 << num_bits) - 1;
         const uint8_t* data = channel.data();
         uint_fast16_t wOffset = channel.offset() + headerLength;  // header is 2 (lite) or 7
@@ -277,6 +280,9 @@ namespace sistrip {
         if (channel.length() & 0xF000) {
           LogDebug("FEDBuffer") << "Channel length is invalid. Channel length is " << uint16_t(channel.length()) << ".";
           return StatusCode::BAD_CHANNEL_LENGTH;
+        }
+        if ( channel.length() <= headerLength ) {
+          return StatusCode::SUCCESS;
         }
         uint_fast8_t firstStrip = data[(wOffset++) ^ 7];
         uint_fast8_t nInCluster = data[(wOffset++) ^ 7];

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -8,6 +8,8 @@
 #include <cstring>
 #include <cmath>
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h"
+#include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
+#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <cstdint>
@@ -110,100 +112,6 @@ namespace sistrip {
     bool legacyUnpacker_ = false;
   };
 
-  //class for unpacking data from ZS FED channels
-  class FEDZSChannelUnpacker {
-  public:
-    static FEDZSChannelUnpacker zeroSuppressedModeUnpacker(const FEDChannel& channel);
-    static FEDZSChannelUnpacker zeroSuppressedLiteModeUnpacker(const FEDChannel& channel);
-    static FEDZSChannelUnpacker preMixRawModeUnpacker(const FEDChannel& channel);
-    FEDZSChannelUnpacker();
-    uint8_t sampleNumber() const;
-    uint8_t adc() const;
-    uint16_t adcPreMix() const;
-    bool hasData() const;
-    FEDZSChannelUnpacker& operator++();
-    FEDZSChannelUnpacker& operator++(int);
-
-  private:
-    //pointer to beginning of FED or FE data, offset of start of channel payload in data and length of channel payload
-    FEDZSChannelUnpacker(const uint8_t* payload,
-                         const uint16_t channelPayloadOffset,
-                         const int16_t channelPayloadLength,
-                         const uint16_t offsetIncrement = 1);
-    void readNewClusterInfo();
-    static void throwBadChannelLength(const uint16_t length);
-    void throwBadClusterLength();
-    static void throwUnorderedData(const uint8_t currentStrip, const uint8_t firstStripOfNewCluster);
-    const uint8_t* data_;
-    uint16_t currentOffset_;
-    uint16_t offsetIncrement_;
-    uint8_t currentStrip_;
-    uint8_t valuesLeftInCluster_;
-    uint16_t channelPayloadOffset_;
-    uint16_t channelPayloadLength_;
-  };
-
-  //class for unpacking data from raw FED channels
-  class FEDRawChannelUnpacker {
-  public:
-    static FEDRawChannelUnpacker scopeModeUnpacker(const FEDChannel& channel) { return FEDRawChannelUnpacker(channel); }
-    static FEDRawChannelUnpacker virginRawModeUnpacker(const FEDChannel& channel) {
-      return FEDRawChannelUnpacker(channel);
-    }
-    static FEDRawChannelUnpacker procRawModeUnpacker(const FEDChannel& channel) {
-      return FEDRawChannelUnpacker(channel);
-    }
-    explicit FEDRawChannelUnpacker(const FEDChannel& channel);
-    uint8_t sampleNumber() const;
-    uint16_t adc() const;
-    bool hasData() const;
-    FEDRawChannelUnpacker& operator++();
-    FEDRawChannelUnpacker& operator++(int);
-
-  private:
-    static void throwBadChannelLength(const uint16_t length);
-    const uint8_t* data_;
-    uint16_t currentOffset_;
-    uint8_t currentStrip_;
-    uint16_t valuesLeft_;
-  };
-
-  //class for unpacking data from any FED channels with a non-integer words bits stripping mode
-  class FEDBSChannelUnpacker {
-  public:
-    static FEDBSChannelUnpacker virginRawModeUnpacker(const FEDChannel& channel, uint16_t num_bits);
-    static FEDBSChannelUnpacker zeroSuppressedModeUnpacker(const FEDChannel& channel, uint16_t num_bits);
-    static FEDBSChannelUnpacker zeroSuppressedLiteModeUnpacker(const FEDChannel& channel, uint16_t num_bits);
-    FEDBSChannelUnpacker();
-    uint8_t sampleNumber() const;
-    uint16_t adc() const;
-    bool hasData() const;
-    FEDBSChannelUnpacker& operator++();
-    FEDBSChannelUnpacker& operator++(int);
-
-  private:
-    //pointer to beginning of FED or FE data, offset of start of channel payload in data and length of channel payload
-    FEDBSChannelUnpacker(const uint8_t* payload,
-                         const uint16_t channelPayloadOffset,
-                         const int16_t channelPayloadLength,
-                         const uint16_t offsetIncrement,
-                         bool useZS);
-    void readNewClusterInfo();
-    static void throwBadChannelLength(const uint16_t length);
-    static void throwBadWordLength(const uint16_t word_length);
-    static void throwUnorderedData(const uint8_t currentStrip, const uint8_t firstStripOfNewCluster);
-    const uint8_t* data_;
-    uint16_t oldWordOffset_;
-    uint16_t currentWordOffset_;
-    uint16_t currentLocalBitOffset_;
-    uint16_t bitOffsetIncrement_;
-    uint8_t currentStrip_;
-    uint16_t channelPayloadOffset_;
-    uint16_t channelPayloadLength_;
-    bool useZS_;
-    uint8_t valuesLeftInCluster_;
-  };
-
   //
   // Inline function definitions
   //
@@ -264,251 +172,289 @@ namespace sistrip {
     return checkStatusBits(internalFEDChannelNum(internalFEUnitNum, internalChannelNum));
   }
 
-  //FEDBSChannelUnpacker
+  namespace FEDChannelUnpacker {
+    enum class StatusCode { SUCCESS = 0, BAD_CHANNEL_LENGTH, UNORDERED_DATA, BAD_PACKET_CODE, ZERO_PACKET_CODE };
 
-  inline FEDBSChannelUnpacker::FEDBSChannelUnpacker()
-      : data_(nullptr),
-        oldWordOffset_(0),
-        currentWordOffset_(0),
-        currentLocalBitOffset_(0),
-        bitOffsetIncrement_(10),
-        currentStrip_(0),
-        channelPayloadOffset_(0),
-        channelPayloadLength_(0),
-        useZS_(false),
-        valuesLeftInCluster_(0) {}
+    namespace detail {
 
-  inline FEDBSChannelUnpacker::FEDBSChannelUnpacker(const uint8_t* payload,
-                                                    const uint16_t channelPayloadOffset,
-                                                    const int16_t channelPayloadLength,
-                                                    const uint16_t offsetIncrement,
-                                                    bool useZS)
-      : data_(payload),
-        oldWordOffset_(0),
-        currentWordOffset_(channelPayloadOffset),
-        currentLocalBitOffset_(0),
-        bitOffsetIncrement_(offsetIncrement),
-        currentStrip_(0),
-        channelPayloadOffset_(channelPayloadOffset),
-        channelPayloadLength_(channelPayloadLength),
-        useZS_(useZS),
-        valuesLeftInCluster_(0) {
-    if (bitOffsetIncrement_ > 16)
-      throwBadWordLength(bitOffsetIncrement_);  // more than 2 words... still to be implemented
-    if (useZS_ && channelPayloadLength_)
-      readNewClusterInfo();
-  }
+      // Unpack Raw with ADCs in whole 8-bit words (8bit and 10-in-16bit)
+      template <uint8_t num_bits, typename OUT>
+      StatusCode unpackRawW(const FEDChannel& channel, OUT&& out, uint8_t bits_shift = 0) {
+        constexpr auto num_words = num_bits / 8;
+        static_assert(((num_bits % 8) == 0) && (num_words > 0) && (num_words < 3));
+        const uint8_t* data = channel.data();
+        if ((num_words > 1) && ((channel.length() - 3) % num_words)) {
+          LogDebug("FEDBuffer") << "Channel length is invalid. Raw channels have 3 header bytes and " << num_words
+                                << " bytes per sample. "
+                                << "Channel length is " << uint16_t(channel.length()) << ".";
+          return StatusCode::BAD_CHANNEL_LENGTH;
+        }
+        const uint_fast16_t end = channel.offset() + channel.length();
+        for (uint_fast16_t offset = channel.offset() + 3; offset != end; offset += num_words) {
+          *out++ = SiStripRawDigi((data[offset ^ 7] + (num_words == 2 ? ((data[(offset + 1) ^ 7] & 0x03) << 8) : 0))
+                                  << bits_shift);
+        }
+        return StatusCode::SUCCESS;
+      }
 
-  inline FEDBSChannelUnpacker FEDBSChannelUnpacker::virginRawModeUnpacker(const FEDChannel& channel,
-                                                                          uint16_t num_bits) {
-    uint16_t length = channel.length();
-    if (length & 0xF000)
-      throwBadChannelLength(length);
-    if (num_bits <= 0 or num_bits > 16)
-      throwBadWordLength(num_bits);
-    FEDBSChannelUnpacker result(channel.data(), channel.offset() + 3, length - 3, num_bits, false);
-    return result;
-  }
+      // Generic implementation for non-whole words (10bit, essentially)
+      template <uint_fast8_t num_bits, typename OUT>
+      StatusCode unpackRawB(const FEDChannel& channel, OUT& out) {
+        if (channel.length() & 0xF000) {
+          LogDebug("FEDBuffer") << "Channel length is invalid. Channel length is " << uint16_t(channel.length()) << ".";
+          return StatusCode::BAD_CHANNEL_LENGTH;
+        }
+        static_assert(num_bits <= 16, "Word length must be between 0 and 16.");
+        constexpr uint16_t mask = (1 << num_bits) - 1;
+        const uint8_t* data = channel.data();
+        const uint_fast16_t chEnd = channel.offset() + channel.length();
+        uint_fast16_t wOffset = channel.offset() + 3;
+        uint_fast16_t bOffset = 0;
+        while (((wOffset + 1) < chEnd) || ((chEnd - wOffset) * BITS_PER_BYTE - bOffset >= num_bits)) {
+          bOffset += num_bits;
+          uint16_t adc;
+          if (bOffset > BITS_PER_BYTE) {
+            bOffset -= BITS_PER_BYTE;
+            adc = ((data[wOffset ^ 7]) << bOffset) + (data[(wOffset + 1) ^ 7] >> (BITS_PER_BYTE - bOffset));
+            ++wOffset;
+          } else {
+            adc = data[wOffset ^ 7] >> (BITS_PER_BYTE - bOffset);
+          }
+          **out++ = SiStripRawDigi((adc & mask));  // TODO move back up
+          if (bOffset == BITS_PER_BYTE) {
+            bOffset = 0;
+            ++wOffset;
+          }
+        }
+        return StatusCode::SUCCESS;
+      }
 
-  inline FEDBSChannelUnpacker FEDBSChannelUnpacker::zeroSuppressedModeUnpacker(const FEDChannel& channel,
-                                                                               uint16_t num_bits) {
-    uint16_t length = channel.length();
-    if (length & 0xF000)
-      throwBadChannelLength(length);
-    FEDBSChannelUnpacker result(channel.data(), channel.offset() + 7, length - 7, num_bits, true);
-    return result;
-  }
+      template <uint8_t num_bits, typename OUT>
+      StatusCode unpackZSW(
+          const FEDChannel& channel, OUT& out, uint8_t headerLength, uint16_t stripStart, uint8_t bits_shift = 0) {
+        constexpr auto num_words = num_bits / 8;
+        static_assert(((num_bits % 8) == 0) && (num_words > 0) && (num_words < 3));
+        const uint8_t* data = channel.data();
+        uint_fast16_t offset = channel.offset() + headerLength;  // header is 2 (lite) or 7
+        if (channel.length() & 0xF000) {
+          LogDebug("FEDBuffer") << "Channel length is invalid. Channel length is " << uint16_t(channel.length()) << ".";
+          return StatusCode::BAD_CHANNEL_LENGTH;
+        }
+        uint_fast8_t strip = data[(offset++) ^ 7];
+        uint_fast8_t endStrip = strip + data[(offset++) ^ 7];
+        const uint_fast16_t end = channel.offset() + channel.length();
+        while (offset != end) {
+          if (strip == endStrip) {
+            if (offset + 2 >= end) {
+              // offset should already be at end then (empty cluster)
+              break;
+            }
+            const uint_fast8_t newStrip = data[(offset++) ^ 7];
+            if (!(newStrip > strip)) {
+              LogDebug("FEDBuffer") << "First strip of new cluster is not greater than last strip of previous cluster. "
+                                    << "Last strip of previous cluster is " << uint16_t(strip) << ". "
+                                    << "First strip of new cluster is " << uint16_t(newStrip) << ".";
+              return StatusCode::UNORDERED_DATA;
+            }
+            strip = newStrip;
+            endStrip = strip + data[(offset++) ^ 7];
+          }
+          *out++ = SiStripDigi(stripStart + strip, (data[offset ^ 7] + (num_words == 2 ? ((data[(offset + 1) ^ 7] & 0x03) << 8) : 0)) << bits_shift);
+          offset += num_words;
+          ++strip;
+        }
+        return StatusCode::SUCCESS;
+      }
 
-  inline FEDBSChannelUnpacker FEDBSChannelUnpacker::zeroSuppressedLiteModeUnpacker(const FEDChannel& channel,
-                                                                                   uint16_t num_bits) {
-    uint16_t length = channel.length();
-    if (length & 0xF000)
-      throwBadChannelLength(length);
-    FEDBSChannelUnpacker result(channel.data(), channel.offset() + 2, length - 2, num_bits, true);
-    return result;
-  }
+      // Generic implementation (for 10bit, essentially)
+      template <uint_fast8_t num_bits, typename OUT>
+      StatusCode unpackZSB(const FEDChannel& channel, OUT& out, uint8_t headerLength, uint16_t stripStart) {
+        constexpr uint16_t mask = (1 << num_bits) - 1;
+        const uint8_t* data = channel.data();
+        uint_fast16_t wOffset = channel.offset() + headerLength;  // header is 2 (lite) or 7
+        uint_fast16_t bOffset = 0;
+        if (channel.length() & 0xF000) {
+          LogDebug("FEDBuffer") << "Channel length is invalid. Channel length is " << uint16_t(channel.length()) << ".";
+          return StatusCode::BAD_CHANNEL_LENGTH;
+        }
+        uint_fast8_t strip = data[(wOffset++) ^ 7];
+        uint_fast8_t endStrip = strip + data[(wOffset++) ^ 7];
+        const uint_fast16_t chEnd = channel.offset() + channel.length();
+        while (((wOffset + 1) < chEnd) || ((chEnd - wOffset) * BITS_PER_BYTE - bOffset >= num_bits)) {
+          if (strip == endStrip) {
+            if (wOffset + 2 >= chEnd) {
+              // offset should already be at end then (empty cluster)
+              break;
+            }
+            const uint_fast8_t newStrip = data[(wOffset++) ^ 7];
+            if (!(newStrip > strip)) {
+              LogDebug("FEDBuffer") << "First strip of new cluster is not greater than last strip of previous cluster. "
+                                    << "Last strip of previous cluster is " << uint16_t(strip) << ". "
+                                    << "First strip of new cluster is " << uint16_t(newStrip) << ".";
+              return StatusCode::UNORDERED_DATA;
+            }
+            strip = newStrip;
+            endStrip = strip + data[(wOffset++) ^ 7];
+            bOffset = 0;
+          }
+          bOffset += num_bits;
+          uint16_t adc;
+          if (bOffset > BITS_PER_BYTE) {
+            bOffset -= BITS_PER_BYTE;
+            adc = ((data[wOffset ^ 7]) << bOffset) + (data[(wOffset + 1) ^ 7] >> (BITS_PER_BYTE - bOffset));
+            ++wOffset;
+          } else {
+            adc = (data[wOffset ^ 7] >> (BITS_PER_BYTE - bOffset));
+          }
+          *out++ = SiStripDigi(stripStart + strip, adc & mask);  // TODO move back up
+          ++strip;
+          if (bOffset == BITS_PER_BYTE) {
+            bOffset = 0;
+            ++wOffset;
+          }
+        }
+        return StatusCode::SUCCESS;
+      }
 
-  inline uint8_t FEDBSChannelUnpacker::sampleNumber() const { return currentStrip_; }
+      inline uint16_t readoutOrder(uint16_t physical_order) {
+        return (4 * ((static_cast<uint16_t>((static_cast<float>(physical_order) / 8.0))) % 4) +
+                         static_cast<uint16_t>(static_cast<float>(physical_order) / 32.0) + 16 * (physical_order % 8));
+      }
+    };  // namespace detail
 
-  inline uint16_t FEDBSChannelUnpacker::adc() const {
-    uint16_t bits_missing = (bitOffsetIncrement_ - BITS_PER_BYTE) + currentLocalBitOffset_;
-    uint16_t adc = (data_[currentWordOffset_ ^ 7] << bits_missing);
-    if (currentWordOffset_ > oldWordOffset_) {
-      adc += ((data_[(currentWordOffset_ + 1) ^ 7] >> (BITS_PER_BYTE - bits_missing)));
-    }
-    return (adc & ((1 << bitOffsetIncrement_) - 1));
-  }
-
-  inline bool FEDBSChannelUnpacker::hasData() const {
-    const uint16_t nextChanWordOffset = channelPayloadOffset_ + channelPayloadLength_;
-    if (currentWordOffset_ + 1 < nextChanWordOffset) {
-      return true;  // fast case: 2 bytes always fit an ADC (even if offset)
-    } else {        // close to end
-      const uint16_t plusOneBitOffset = currentLocalBitOffset_ + bitOffsetIncrement_;
-      const uint16_t plusOneWordOffset = currentWordOffset_ + plusOneBitOffset / BITS_PER_BYTE;
-      return (plusOneBitOffset % BITS_PER_BYTE) ? (plusOneWordOffset < nextChanWordOffset)
-                                                : (plusOneWordOffset <= nextChanWordOffset);
-    }
-  }
-
-  inline FEDBSChannelUnpacker& FEDBSChannelUnpacker::operator++() {
-    oldWordOffset_ = currentWordOffset_;
-    currentLocalBitOffset_ += bitOffsetIncrement_;
-    while (currentLocalBitOffset_ >= BITS_PER_BYTE) {
-      currentWordOffset_++;
-      currentLocalBitOffset_ -= BITS_PER_BYTE;
-    }
-    if (useZS_) {
-      if (valuesLeftInCluster_) {
-        currentStrip_++;
-        valuesLeftInCluster_--;
+    inline bool isZeroSuppressed(FEDReadoutMode mode,
+                          bool legacy = false,
+                          FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+      if (!legacy) {
+        switch (mode) {
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
+          case READOUT_MODE_PREMIX_RAW:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
+          case READOUT_MODE_ZERO_SUPPRESSED:
+          case READOUT_MODE_ZERO_SUPPRESSED_FAKE:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
+          case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE:
+            return true;
+            break;
+          default:
+            return false;
+        }
       } else {
-        if (hasData()) {
-          const uint8_t oldStrip = currentStrip_;
-          readNewClusterInfo();
-          if (!(currentStrip_ > oldStrip))
-            throwUnorderedData(oldStrip, currentStrip_);
+        switch (lmode) {
+          case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL:
+          case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE:
+          case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL:
+          case READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE:
+          case READOUT_MODE_LEGACY_PREMIX_RAW:
+            return true;
+          default:
+            return false;
         }
       }
-    } else {
-      currentStrip_++;
     }
-    return (*this);
-  }
-
-  inline FEDBSChannelUnpacker& FEDBSChannelUnpacker::operator++(int) {
-    ++(*this);
-    return *this;
-  }
-
-  inline void FEDBSChannelUnpacker::readNewClusterInfo() {
-    if (currentLocalBitOffset_) {
-      ++currentWordOffset_;
-      currentLocalBitOffset_ = 0;
+    inline bool isNonLiteZS(FEDReadoutMode mode,
+                     bool legacy = false,
+                     FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+      return (!legacy) ? (mode == READOUT_MODE_ZERO_SUPPRESSED || mode == READOUT_MODE_ZERO_SUPPRESSED_FAKE)
+                       : (lmode == READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL ||
+                          lmode == READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE);
     }
-    currentStrip_ = data_[(currentWordOffset_++) ^ 7];
-    valuesLeftInCluster_ = data_[(currentWordOffset_++) ^ 7] - 1;
-  }
+    inline bool isVirginRaw(FEDReadoutMode mode,
+                     bool legacy = false,
+                     FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+      return (!legacy) ? mode == READOUT_MODE_VIRGIN_RAW
+                       : (lmode == READOUT_MODE_LEGACY_VIRGIN_RAW_REAL || lmode == READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE);
+    }
+    inline bool isProcessedRaw(FEDReadoutMode mode,
+                        bool legacy = false,
+                        FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+      return (!legacy) ? mode == READOUT_MODE_PROC_RAW
+                       : (lmode == READOUT_MODE_LEGACY_PROC_RAW_REAL || lmode == READOUT_MODE_LEGACY_PROC_RAW_FAKE);
+    }
+    inline bool isScopeMode(FEDReadoutMode mode,
+                     bool legacy = false,
+                     FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+      return (!legacy) ? mode == READOUT_MODE_SCOPE : lmode == READOUT_MODE_LEGACY_SCOPE;
+    }
 
-  //FEDRawChannelUnpacker
+    template <typename OUT>
+    StatusCode unpackScope(const FEDChannel& channel, OUT&& out) {
+      return detail::unpackRawW<16>(channel, out);
+    }
+    template <typename OUT>
+    StatusCode unpackProcessedRaw(const FEDChannel& channel, OUT&& out) {
+      return detail::unpackRawW<16>(channel, out);
+    }
 
-  inline FEDRawChannelUnpacker::FEDRawChannelUnpacker(const FEDChannel& channel)
-      : data_(channel.data()),
-        currentOffset_(channel.offset() + 3),
-        currentStrip_(0),
-        valuesLeft_((channel.length() - 3) / 2) {
-    if ((channel.length() - 3) % 2)
-      throwBadChannelLength(channel.length());
-  }
-
-  inline uint8_t FEDRawChannelUnpacker::sampleNumber() const { return currentStrip_; }
-
-  inline uint16_t FEDRawChannelUnpacker::adc() const {
-    return (data_[currentOffset_ ^ 7] + ((data_[(currentOffset_ + 1) ^ 7] & 0x03) << 8));
-  }
-
-  inline bool FEDRawChannelUnpacker::hasData() const { return valuesLeft_; }
-
-  inline FEDRawChannelUnpacker& FEDRawChannelUnpacker::operator++() {
-    currentOffset_ += 2;
-    currentStrip_++;
-    valuesLeft_--;
-    return (*this);
-  }
-
-  inline FEDRawChannelUnpacker& FEDRawChannelUnpacker::operator++(int) {
-    ++(*this);
-    return *this;
-  }
-
-  //FEDZSChannelUnpacker
-
-  inline FEDZSChannelUnpacker::FEDZSChannelUnpacker()
-      : data_(nullptr),
-        offsetIncrement_(1),
-        valuesLeftInCluster_(0),
-        channelPayloadOffset_(0),
-        channelPayloadLength_(0) {}
-
-  inline FEDZSChannelUnpacker::FEDZSChannelUnpacker(const uint8_t* payload,
-                                                    const uint16_t channelPayloadOffset,
-                                                    const int16_t channelPayloadLength,
-                                                    const uint16_t offsetIncrement)
-      : data_(payload),
-        currentOffset_(channelPayloadOffset),
-        offsetIncrement_(offsetIncrement),
-        currentStrip_(0),
-        valuesLeftInCluster_(0),
-        channelPayloadOffset_(channelPayloadOffset),
-        channelPayloadLength_(channelPayloadLength) {
-    if (channelPayloadLength_)
-      readNewClusterInfo();
-  }
-
-  inline FEDZSChannelUnpacker FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(const FEDChannel& channel) {
-    uint16_t length = channel.length();
-    if (length & 0xF000)
-      throwBadChannelLength(length);
-    FEDZSChannelUnpacker result(channel.data(), channel.offset() + 7, length - 7);
-    return result;
-  }
-
-  inline FEDZSChannelUnpacker FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(const FEDChannel& channel) {
-    uint16_t length = channel.length();
-    if (length & 0xF000)
-      throwBadChannelLength(length);
-    FEDZSChannelUnpacker result(channel.data(), channel.offset() + 2, length - 2);
-    return result;
-  }
-
-  inline FEDZSChannelUnpacker FEDZSChannelUnpacker::preMixRawModeUnpacker(const FEDChannel& channel) {
-    //CAMM - to modify more ?
-    uint16_t length = channel.length();
-    if (length & 0xF000)
-      throwBadChannelLength(length);
-    FEDZSChannelUnpacker result(channel.data(), channel.offset() + 7, length - 7, 2);
-    return result;
-  }
-
-  inline uint8_t FEDZSChannelUnpacker::sampleNumber() const { return currentStrip_; }
-
-  inline uint8_t FEDZSChannelUnpacker::adc() const { return data_[currentOffset_ ^ 7]; }
-
-  inline uint16_t FEDZSChannelUnpacker::adcPreMix() const {
-    return (data_[currentOffset_ ^ 7] + ((data_[(currentOffset_ + 1) ^ 7] & 0x03) << 8));
-  }
-
-  inline bool FEDZSChannelUnpacker::hasData() const {
-    return (currentOffset_ < channelPayloadOffset_ + channelPayloadLength_);
-  }
-
-  inline FEDZSChannelUnpacker& FEDZSChannelUnpacker::operator++() {
-    if (valuesLeftInCluster_) {
-      currentStrip_++;
-      currentOffset_ += offsetIncrement_;
-      valuesLeftInCluster_--;
-    } else {
-      currentOffset_ += offsetIncrement_;
-      if (hasData()) {
-        const uint8_t oldStrip = currentStrip_;
-        readNewClusterInfo();
-        if (!(currentStrip_ > oldStrip))
-          throwUnorderedData(oldStrip, currentStrip_);
+    template <typename OUT>
+    StatusCode unpackVirginRaw(const FEDChannel& channel, OUT&& out, uint8_t packetCode) {
+      std::vector<SiStripRawDigi> samples;
+      auto st = StatusCode::SUCCESS;
+      if (PACKET_CODE_VIRGIN_RAW == packetCode) {
+        samples.reserve((channel.length() - 3) / 2);
+        st = detail::unpackRawW<16>(channel, out);
+      } else if (PACKET_CODE_VIRGIN_RAW10 == packetCode) {
+        samples.reserve((channel.length() - 3) * 10 / 8);
+        st = detail::unpackRawB<10>(channel, out);
+      } else if (PACKET_CODE_VIRGIN_RAW8_BOTBOT == packetCode || PACKET_CODE_VIRGIN_RAW8_TOPBOT == packetCode) {
+        samples.reserve(channel.length() - 3);
+        st = detail::unpackRawW<8>(channel, out, (PACKET_CODE_VIRGIN_RAW8_BOTBOT == packetCode ? 2 : 1));
+      }
+      if (!samples.empty()) {
+        // reorder
+        for (uint_fast16_t i{0}; i != samples.size(); ++i) {
+          const auto physical = i % 128;
+          uint16_t readout = detail::readoutOrder(physical);             // convert index from physical to readout order
+          (i / 128) ? readout = readout* 2 + 1 : readout = readout * 2;  // un-multiplex data
+          *out++ = samples[readout];
+        }
+      }
+      return st;
+    }
+    template <typename OUT>
+    StatusCode unpackZeroSuppressed(const FEDChannel& channel,
+                                    OUT&& out,
+                                    uint16_t stripStart,
+                                    bool isNonLite,
+                                    FEDReadoutMode mode,
+                                    bool legacy = false,
+                                    FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID,
+                                    uint8_t packetCode = 0) {
+      if ((isNonLite && packetCode == PACKET_CODE_ZERO_SUPPRESSED10) ||
+          ((!legacy) &&
+           (mode == READOUT_MODE_ZERO_SUPPRESSED_LITE10 || mode == READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE))) {
+        return detail::unpackZSB<10>(channel, out, stripStart, (isNonLite ? 7 : 2));
+      } else if ((!legacy) ? mode == READOUT_MODE_PREMIX_RAW : lmode == READOUT_MODE_LEGACY_PREMIX_RAW) {
+        return detail::unpackZSW<16>(channel, out, stripStart, 7);
+      } else {  // 8bit
+        uint8_t bits_shift = 0;
+        if (isNonLite) {
+          if (packetCode == PACKET_CODE_ZERO_SUPPRESSED8_TOPBOT)
+            bits_shift = 1;
+          else if (packetCode == PACKET_CODE_ZERO_SUPPRESSED8_BOTBOT)
+            bits_shift = 2;
+        } else {  // lite
+          if (mode == READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT ||
+              mode == READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE)
+            bits_shift = 1;
+          else if (mode == READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT ||
+                   mode == READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE)
+            bits_shift = 2;
+        }
+        auto st = detail::unpackZSW<8>(channel, out, stripStart, (isNonLite ? 7 : 2), bits_shift);
+        if (isNonLite && packetCode == 0 && StatusCode::SUCCESS == st) {
+          // workaround for a pre-2015 bug in the packer: assume default ZS packing
+          return StatusCode::ZERO_PACKET_CODE;
+        }
+        return st;
       }
     }
-    return (*this);
-  }
-
-  inline FEDZSChannelUnpacker& FEDZSChannelUnpacker::operator++(int) {
-    ++(*this);
-    return *this;
-  }
-
-  inline void FEDZSChannelUnpacker::readNewClusterInfo() {
-    currentStrip_ = data_[(currentOffset_++) ^ 7];
-    valuesLeftInCluster_ = data_[(currentOffset_++) ^ 7] - 1;
-  }
-
+  };  // namespace FEDChannelUnpacker
+  std::string toString(FEDChannelUnpacker::StatusCode status);
 }  // namespace sistrip
 
 #endif  //ndef EventFilter_SiStripRawToDigi_SiStripFEDBuffer_H

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -26,6 +26,12 @@ namespace sistrip {
     //if allowBadBuffer is set to true then exceptions will not be thrown if the channel lengths do not make sense or the event format is not recognized
     FEDBuffer(const uint8_t* fedBuffer, const uint16_t fedBufferSize, const bool allowBadBuffer = false);
     ~FEDBuffer() override;
+
+    // retrieve the channel information (everything beyond the headers)
+    // must be called after the constructor before using any channel-level information
+    // and FEDBufferStatusCode compared with FEDBufferStatusCode::SUCCESS, unless bad buffers are allowed
+    FEDBufferStatusCode findChannels();
+
     void print(std::ostream& os) const override;
     const FEDFEHeader* feHeader() const;
     //check that a FE unit is enabled, has a good majority address and, if in full debug mode, that it is present
@@ -74,7 +80,6 @@ namespace sistrip {
 
   private:
     uint8_t nFEUnitsPresent() const;
-    void findChannels();
     inline uint8_t getCorrectPacketCode() const { return packetCode(legacyUnpacker_); }
     uint16_t calculateFEUnitLength(const uint8_t internalFEUnitNumber) const;
     std::unique_ptr<FEDFEHeader> feHeader_;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -415,8 +415,8 @@ namespace sistrip {
       if (!samples.empty()) {  // reorder
         for (uint_fast16_t i{0}; i != samples.size(); ++i) {
           const auto physical = i % 128;
-          uint16_t readout = detail::readoutOrder(physical);             // convert index from physical to readout order
-          (i / 128) ? readout = readout* 2 + 1 : readout = readout * 2;  // un-multiplex data
+          const auto readout = (detail::readoutOrder(physical) * 2  // convert index from physical to readout order
+                                + (i >= 128 ? 1 : 0));              // un-multiplex data
           *out++ = samples[readout];
         }
       }

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -173,7 +173,7 @@ namespace sistrip {
     return checkStatusBits(internalFEDChannelNum(internalFEUnitNum, internalChannelNum));
   }
 
-  namespace FEDChannelUnpacker {
+  namespace fedchannelunpacker {
     enum class StatusCode { SUCCESS = 0, BAD_CHANNEL_LENGTH, UNORDERED_DATA, BAD_PACKET_CODE, ZERO_PACKET_CODE };
 
     namespace detail {
@@ -460,8 +460,8 @@ namespace sistrip {
         return st;
       }
     }
-  };  // namespace FEDChannelUnpacker
-  std::string toString(FEDChannelUnpacker::StatusCode status);
+  };  // namespace fedchannelunpacker
+  std::string toString(fedchannelunpacker::StatusCode status);
 }  // namespace sistrip
 
 #endif  //ndef EventFilter_SiStripRawToDigi_SiStripFEDBuffer_H

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -215,7 +215,8 @@ namespace sistrip {
           bOffset += num_bits;
           if (bOffset > BITS_PER_BYTE) {
             bOffset -= BITS_PER_BYTE;
-            **out++ = SiStripRawDigi((((data[wOffset ^ 7]) << bOffset) + (data[(wOffset + 1) ^ 7] >> (BITS_PER_BYTE - bOffset))) & mask);
+            **out++ = SiStripRawDigi(
+                (((data[wOffset ^ 7]) << bOffset) + (data[(wOffset + 1) ^ 7] >> (BITS_PER_BYTE - bOffset))) & mask);
             ++wOffset;
           } else {
             **out++ = SiStripRawDigi((data[wOffset ^ 7] >> (BITS_PER_BYTE - bOffset)) & mask);
@@ -248,9 +249,9 @@ namespace sistrip {
               break;
             }
             const uint_fast8_t newFirstStrip = data[(offset++) ^ 7];
-            if (newFirstStrip < (firstStrip+inCluster)) {
+            if (newFirstStrip < (firstStrip + inCluster)) {
               LogDebug("FEDBuffer") << "First strip of new cluster is not greater than last strip of previous cluster. "
-                                    << "Last strip of previous cluster is " << uint16_t(firstStrip+inCluster) << ". "
+                                    << "Last strip of previous cluster is " << uint16_t(firstStrip + inCluster) << ". "
                                     << "First strip of new cluster is " << uint16_t(newFirstStrip) << ".";
               return StatusCode::UNORDERED_DATA;
             }
@@ -258,7 +259,9 @@ namespace sistrip {
             nInCluster = data[(offset++) ^ 7];
             inCluster = 0;
           }
-          *out++ = SiStripDigi(stripStart + firstStrip + inCluster, (data[offset ^ 7] + (num_words == 2 ? ((data[(offset + 1) ^ 7] & 0x03) << 8) : 0)) << bits_shift);
+          *out++ = SiStripDigi(stripStart + firstStrip + inCluster,
+                               (data[offset ^ 7] + (num_words == 2 ? ((data[(offset + 1) ^ 7] & 0x03) << 8) : 0))
+                                   << bits_shift);
           offset += num_words;
           ++inCluster;
         }
@@ -277,7 +280,8 @@ namespace sistrip {
         uint_fast16_t wOffset = channel.offset() + headerLength;  // header is 2 (lite) or 7
         uint_fast8_t bOffset{0}, firstStrip{0}, nInCluster{0}, inCluster{0};
         const uint_fast16_t chEnd = channel.offset() + channel.length();
-        while (((wOffset + 1) < chEnd) || ( (inCluster != nInCluster) && ((chEnd - wOffset) * BITS_PER_BYTE - bOffset >= num_bits) )) {
+        while (((wOffset + 1) < chEnd) ||
+               ((inCluster != nInCluster) && ((chEnd - wOffset) * BITS_PER_BYTE - bOffset >= num_bits))) {
           if (inCluster == nInCluster) {
             if (wOffset + 2 >= chEnd) {
               // offset should already be at end then (empty cluster)
@@ -288,9 +292,9 @@ namespace sistrip {
               bOffset = 0;
             }
             const uint_fast8_t newFirstStrip = data[(wOffset++) ^ 7];
-            if (newFirstStrip < (firstStrip+inCluster)) {
+            if (newFirstStrip < (firstStrip + inCluster)) {
               LogDebug("FEDBuffer") << "First strip of new cluster is not greater than last strip of previous cluster. "
-                                    << "Last strip of previous cluster is " << uint16_t(firstStrip+inCluster) << ". "
+                                    << "Last strip of previous cluster is " << uint16_t(firstStrip + inCluster) << ". "
                                     << "First strip of new cluster is " << uint16_t(newFirstStrip) << ".";
               return StatusCode::UNORDERED_DATA;
             }
@@ -302,10 +306,13 @@ namespace sistrip {
           bOffset += num_bits;
           if (bOffset > BITS_PER_BYTE) {
             bOffset -= BITS_PER_BYTE;
-            *out++ = SiStripDigi(stripStart + firstStrip + inCluster, (((data[wOffset ^ 7]) << bOffset) + (data[(wOffset + 1) ^ 7] >> (BITS_PER_BYTE - bOffset))) & mask);
+            *out++ = SiStripDigi(
+                stripStart + firstStrip + inCluster,
+                (((data[wOffset ^ 7]) << bOffset) + (data[(wOffset + 1) ^ 7] >> (BITS_PER_BYTE - bOffset))) & mask);
             ++wOffset;
           } else {
-            *out++ = SiStripDigi(stripStart + firstStrip + inCluster, (data[wOffset ^ 7] >> (BITS_PER_BYTE - bOffset)) & mask);
+            *out++ = SiStripDigi(stripStart + firstStrip + inCluster,
+                                 (data[wOffset ^ 7] >> (BITS_PER_BYTE - bOffset)) & mask);
           }
           ++inCluster;
           if (bOffset == BITS_PER_BYTE) {
@@ -318,13 +325,13 @@ namespace sistrip {
 
       inline uint16_t readoutOrder(uint16_t physical_order) {
         return (4 * ((static_cast<uint16_t>((static_cast<float>(physical_order) / 8.0))) % 4) +
-                         static_cast<uint16_t>(static_cast<float>(physical_order) / 32.0) + 16 * (physical_order % 8));
+                static_cast<uint16_t>(static_cast<float>(physical_order) / 32.0) + 16 * (physical_order % 8));
       }
     };  // namespace detail
 
     inline bool isZeroSuppressed(FEDReadoutMode mode,
-                          bool legacy = false,
-                          FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+                                 bool legacy = false,
+                                 FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
       if (!legacy) {
         switch (mode) {
           case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
@@ -357,27 +364,27 @@ namespace sistrip {
       }
     }
     inline bool isNonLiteZS(FEDReadoutMode mode,
-                     bool legacy = false,
-                     FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+                            bool legacy = false,
+                            FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
       return (!legacy) ? (mode == READOUT_MODE_ZERO_SUPPRESSED || mode == READOUT_MODE_ZERO_SUPPRESSED_FAKE)
                        : (lmode == READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL ||
                           lmode == READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE);
     }
     inline bool isVirginRaw(FEDReadoutMode mode,
-                     bool legacy = false,
-                     FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+                            bool legacy = false,
+                            FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
       return (!legacy) ? mode == READOUT_MODE_VIRGIN_RAW
                        : (lmode == READOUT_MODE_LEGACY_VIRGIN_RAW_REAL || lmode == READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE);
     }
     inline bool isProcessedRaw(FEDReadoutMode mode,
-                        bool legacy = false,
-                        FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+                               bool legacy = false,
+                               FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
       return (!legacy) ? mode == READOUT_MODE_PROC_RAW
                        : (lmode == READOUT_MODE_LEGACY_PROC_RAW_REAL || lmode == READOUT_MODE_LEGACY_PROC_RAW_FAKE);
     }
     inline bool isScopeMode(FEDReadoutMode mode,
-                     bool legacy = false,
-                     FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
+                            bool legacy = false,
+                            FEDLegacyReadoutMode lmode = READOUT_MODE_LEGACY_INVALID) {
       return (!legacy) ? mode == READOUT_MODE_SCOPE : lmode == READOUT_MODE_LEGACY_SCOPE;
     }
 
@@ -402,9 +409,10 @@ namespace sistrip {
         st = detail::unpackRawB<10>(channel, std::back_inserter(samples));
       } else if (PACKET_CODE_VIRGIN_RAW8_BOTBOT == packetCode || PACKET_CODE_VIRGIN_RAW8_TOPBOT == packetCode) {
         samples.reserve(channel.length() - 3);
-        st = detail::unpackRawW<8>(channel, std::back_inserter(samples), (PACKET_CODE_VIRGIN_RAW8_BOTBOT == packetCode ? 2 : 1));
+        st = detail::unpackRawW<8>(
+            channel, std::back_inserter(samples), (PACKET_CODE_VIRGIN_RAW8_BOTBOT == packetCode ? 2 : 1));
       }
-      if (!samples.empty()) { // reorder
+      if (!samples.empty()) {  // reorder
         for (uint_fast16_t i{0}; i != samples.size(); ++i) {
           const auto physical = i % 128;
           uint16_t readout = detail::readoutOrder(physical);             // convert index from physical to readout order

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -579,8 +579,8 @@ namespace sistrip {
     void set32BitReservedRegister(const uint8_t internalFEUnitNum, const uint32_t reservedRegister) override;
     void setFEUnitLength(const uint8_t internalFEUnitNum, const uint16_t length) override;
     static uint32_t get32BitWordFrom(const uint8_t* startOfWord);
-    const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
     uint8_t* feWord(const uint8_t internalFEUnitNum);
+    const uint8_t* feWord(const uint8_t internalFEUnitNum) const;
     FEDFullDebugHeader(const std::vector<uint16_t>& feUnitLengths = std::vector<uint16_t>(FEUNITS_PER_FED, 0),
                        const std::vector<uint8_t>& feMajorityAddresses = std::vector<uint8_t>(FEUNITS_PER_FED, 0),
                        const std::vector<FEDChannelStatus>& channelStatus =
@@ -1301,13 +1301,13 @@ namespace sistrip {
     memcpy(startOfWord, &value, 4);
   }
 
-  inline const uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) const {
+  inline uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) {
     return header_ + internalFEUnitNum * 2 * 8;
   }
 
-  //re-use const method
-  inline uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) {
-    return const_cast<uint8_t*>(static_cast<const FEDFullDebugHeader*>(this)->feWord(internalFEUnitNum));
+  //re-use non-const method
+  inline const uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) const {
+    return feWord(internalFEUnitNum);
   }
 
   inline void FEDFullDebugHeader::setUnlocked(const uint8_t internalFEDChannelNum, const bool value) {

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -1301,13 +1301,13 @@ namespace sistrip {
     memcpy(startOfWord, &value, 4);
   }
 
-  inline uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) {
+  inline const uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) const {
     return header_ + internalFEUnitNum * 2 * 8;
   }
 
-  //re-use non-const method
-  inline const uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) const {
-    return feWord(internalFEUnitNum);
+  //re-use const method
+  inline uint8_t* FEDFullDebugHeader::feWord(const uint8_t internalFEUnitNum) {
+    return const_cast<uint8_t*>(std::as_const(*this).feWord(internalFEUnitNum));
   }
 
   inline void FEDFullDebugHeader::setUnlocked(const uint8_t internalFEDChannelNum, const bool value) {

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -146,6 +146,9 @@ namespace sistrip {
     EXPECT_SPY,
     // for FEDBuffer
     WRONG_HEADERTYPE,
+    CHANNEL_BEGIN_BEYOND_PAYLOAD,
+    CHANNEL_TOO_SHORT,
+    CHANNEL_END_BEYOND_PAYLOAD,
   };
 
   //

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -357,13 +357,12 @@ namespace sistrip {
                          const FEDStatusRegister fedStatusRegister = FEDStatusRegister());
 
     // detect the buffer format without constructing the full header
-    static FEDBufferFormat bufferFormat(const uint8_t* headerPointer)
-    {
-      if ( headerPointer[BUFFERFORMAT] == BUFFER_FORMAT_CODE_NEW ) {
+    static FEDBufferFormat bufferFormat(const uint8_t* headerPointer) {
+      if (headerPointer[BUFFERFORMAT] == BUFFER_FORMAT_CODE_NEW) {
         return BUFFER_FORMAT_NEW;
-      } else if ( headerPointer[BUFFERFORMAT] == BUFFER_FORMAT_CODE_OLD ) {
+      } else if (headerPointer[BUFFERFORMAT] == BUFFER_FORMAT_CODE_OLD) {
         return BUFFER_FORMAT_OLD_SLINK;
-      } else if ( headerPointer[BUFFERFORMAT^4] == BUFFER_FORMAT_CODE_OLD ) {
+      } else if (headerPointer[BUFFERFORMAT ^ 4] == BUFFER_FORMAT_CODE_OLD) {
         // same case as used to detect "wordSwapped_" in the constructor
         return BUFFER_FORMAT_OLD_VME;
       } else {
@@ -710,9 +709,7 @@ namespace sistrip {
   protected:
     const uint8_t* getPointerToDataAfterTrackerSpecialHeader() const;
     const uint8_t* getPointerToByteAfterEndOfPayload() const;
-    FEDBufferBase(const uint8_t* fedBuffer,
-                  const size_t fedBufferSize,
-                  const bool fillChannelVector);
+    FEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool fillChannelVector);
     std::vector<FEDChannel> channels_;
 
   private:
@@ -808,7 +805,7 @@ namespace sistrip {
     const auto nibble = trackerEventTypeNibble();
     //if it is scope mode then return as is (it cannot be fake data)
     //if it is premix then return as is: stripping last bit would make it spy data !
-    if ( (nibble == READOUT_MODE_SCOPE) || (nibble == READOUT_MODE_PREMIX_RAW) )
+    if ((nibble == READOUT_MODE_SCOPE) || (nibble == READOUT_MODE_PREMIX_RAW))
       return FEDReadoutMode(nibble);
     //if not then ignore the last bit which indicates if it is real or fake
     else {
@@ -1523,45 +1520,46 @@ namespace sistrip {
 
   // new methods for checks, replacing exceptions
 
-  inline FEDBufferStatusCode preconstructCheckFEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize, bool checkRecognizedFormat=true)
-  {
-    if ( ! fedBuffer )
+  inline FEDBufferStatusCode preconstructCheckFEDBufferBase(const uint8_t* fedBuffer,
+                                                            const size_t fedBufferSize,
+                                                            bool checkRecognizedFormat = true) {
+    if (!fedBuffer)
       return FEDBufferStatusCode::BUFFER_NULL;
     //min buffer length. DAQ header, DAQ trailer, tracker special header.
     static const size_t MIN_BUFFER_SIZE = 8 + 8 + 8;
     //check size is non zero
-    if ( fedBufferSize < MIN_BUFFER_SIZE )
+    if (fedBufferSize < MIN_BUFFER_SIZE)
       return FEDBufferStatusCode::BUFFER_TOO_SHORT;
-    if ( checkRecognizedFormat ) {
-      if ( BUFFER_FORMAT_INVALID == TrackerSpecialHeader::bufferFormat(fedBuffer+8) ) {
+    if (checkRecognizedFormat) {
+      if (BUFFER_FORMAT_INVALID == TrackerSpecialHeader::bufferFormat(fedBuffer + 8)) {
         return FEDBufferStatusCode::UNRECOGNIZED_FORMAT;
       }
     }
     return FEDBufferStatusCode::SUCCESS;
   }
 
-  inline FEDBufferStatusCode preconstructCheckFEDBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize, bool allowBadBuffer=false)
-  {
-    const auto st_base = preconstructCheckFEDBufferBase(fedBuffer, fedBufferSize, ! allowBadBuffer);
-    if ( FEDBufferStatusCode::SUCCESS != st_base )
+  inline FEDBufferStatusCode preconstructCheckFEDBuffer(const uint8_t* fedBuffer,
+                                                        const size_t fedBufferSize,
+                                                        bool allowBadBuffer = false) {
+    const auto st_base = preconstructCheckFEDBufferBase(fedBuffer, fedBufferSize, !allowBadBuffer);
+    if (FEDBufferStatusCode::SUCCESS != st_base)
       return st_base;
-    const TrackerSpecialHeader hdr{fedBuffer+8};
+    const TrackerSpecialHeader hdr{fedBuffer + 8};
     const auto hdr_type = hdr.headerType();
-    if ( ( ! allowBadBuffer ) && ( ( hdr_type == sistrip::HEADER_TYPE_INVALID ) || ( hdr_type == sistrip::HEADER_TYPE_NONE ) ) )
+    if ((!allowBadBuffer) && ((hdr_type == sistrip::HEADER_TYPE_INVALID) || (hdr_type == sistrip::HEADER_TYPE_NONE)))
       return FEDBufferStatusCode::WRONG_HEADERTYPE;
-    if ( READOUT_MODE_SPY == hdr.readoutMode() )
+    if (READOUT_MODE_SPY == hdr.readoutMode())
       return FEDBufferStatusCode::EXPECT_NOT_SPY;
     // TODO add more (?)
     return FEDBufferStatusCode::SUCCESS;
   }
 
-  inline FEDBufferStatusCode preconstructCheckFEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize)
-  {
+  inline FEDBufferStatusCode preconstructCheckFEDSpyBuffer(const uint8_t* fedBuffer, const size_t fedBufferSize) {
     const auto st_base = preconstructCheckFEDBufferBase(fedBuffer, fedBufferSize, true);
-    if ( FEDBufferStatusCode::SUCCESS != st_base )
+    if (FEDBufferStatusCode::SUCCESS != st_base)
       return st_base;
-    const TrackerSpecialHeader hdr{fedBuffer+8};
-    if ( READOUT_MODE_SPY != hdr.readoutMode() )
+    const TrackerSpecialHeader hdr{fedBuffer + 8};
+    if (READOUT_MODE_SPY != hdr.readoutMode())
       return FEDBufferStatusCode::EXPECT_SPY;
     // TODO add more (?)
     return FEDBufferStatusCode::SUCCESS;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -621,6 +621,13 @@ namespace sistrip {
     uint16_t length() const;
     const uint8_t* data() const;
     size_t offset() const;
+    /**
+     * Retrieve the APV CM median for a non-lite zero-suppressed channel
+     *
+     * apvIndex should be either 0 or 1 (there are, by construction, two APVs on every channel)
+     * No additional checks are done here, so the caller should check
+     * the readout mode and/or packet code.
+     */
     uint16_t cmMedian(const uint8_t apvIndex) const;
     //third byte of channel data for normal FED channels
     uint8_t packetCode() const;
@@ -1556,6 +1563,14 @@ namespace sistrip {
   inline uint16_t FEDChannel::length() const { return length_; }
 
   inline uint8_t FEDChannel::packetCode() const { return data_[(offset_ + 2) ^ 7]; }
+
+  inline uint16_t FEDChannel::cmMedian(const uint8_t apvIndex) const {
+    uint16_t result = 0;
+    //CM median is 10 bits with lowest order byte first. First APV CM median starts in 4th byte of channel data
+    result |= data_[(offset_ + 3 + 2 * apvIndex) ^ 7];
+    result |= (((data_[(offset_ + 4 + 2 * apvIndex) ^ 7]) << 8) & 0x300);
+    return result;
+  }
 
   inline const uint8_t* FEDChannel::data() const { return data_; }
 

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -339,6 +339,21 @@ namespace sistrip {
                          const uint8_t feOverflowRegister = 0x00,
                          const FEDStatusRegister fedStatusRegister = FEDStatusRegister());
 
+    // helper method: detect the buffer format without constructing the full header
+    static FEDBufferFormat bufferFormat(const uint8_t* headerPointer)
+    {
+      if ( headerPointer[BUFFERFORMAT] == BUFFER_FORMAT_CODE_NEW ) {
+        return BUFFER_FORMAT_NEW;
+      } else if ( headerPointer[BUFFERFORMAT] == BUFFER_FORMAT_CODE_OLD ) {
+        return BUFFER_FORMAT_OLD_SLINK;
+      } else if ( headerPointer[BUFFERFORMAT^4] == BUFFER_FORMAT_CODE_OLD ) {
+        // same case as used to detect "wordSwapped_" in the constructor
+        return BUFFER_FORMAT_OLD_VME;
+      } else {
+        return BUFFER_FORMAT_INVALID;
+      }
+    }
+
   private:
     void setBufferFormatByte(const FEDBufferFormat newBufferFormat);
     void setHeaderTypeNibble(const uint8_t value);
@@ -685,7 +700,7 @@ namespace sistrip {
     std::vector<FEDChannel> channels_;
 
   private:
-    void init(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool allowUnrecognizedFormat);
+    void init(const bool allowUnrecognizedFormat);
     const uint8_t* originalBuffer_;
     const uint8_t* orderedBuffer_;
     const size_t bufferSize_;

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -198,8 +198,8 @@ namespace sistrip {
   inline FEDStripData::FEDStripData(const std::vector<ChannelData>& data) : data_(data) {}
 
   //re-use non-const method
-  inline FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) {
-    return const_cast<ChannelData&>(static_cast<const FEDStripData*>(this)->channel(internalFEDChannelNum));
+  inline const FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) const {
+    return channel(internalFEDChannelNum);
   }
 
   inline FEDStripData::ChannelData& FEDStripData::operator[](const uint8_t internalFEDChannelNum) {
@@ -217,13 +217,13 @@ namespace sistrip {
 
   inline size_t FEDStripData::ChannelData::size() const { return data_.size(); }
 
-  inline const uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) const {
+  inline uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) {
     return data_[sampleNumber];
   }
 
-  //re-use const method
-  inline uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) {
-    return const_cast<uint16_t&>(static_cast<const ChannelData&>(*this)[sampleNumber]);
+  //re-use non-const method
+  inline const uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) const {
+    return (*this)[sampleNumber];
   }
 
   inline uint16_t FEDStripData::ChannelData::getSample(const uint16_t sampleNumber) const {

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -217,9 +217,7 @@ namespace sistrip {
 
   inline size_t FEDStripData::ChannelData::size() const { return data_.size(); }
 
-  inline uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) {
-    return data_[sampleNumber];
-  }
+  inline uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) { return data_[sampleNumber]; }
 
   //re-use non-const method
   inline const uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) const {

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferGenerator.h
@@ -197,9 +197,9 @@ namespace sistrip {
 
   inline FEDStripData::FEDStripData(const std::vector<ChannelData>& data) : data_(data) {}
 
-  //re-use non-const method
-  inline const FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) const {
-    return channel(internalFEDChannelNum);
+  //re-use const method
+  inline FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) {
+    return const_cast<FEDStripData::ChannelData&>(std::as_const(*this).channel(internalFEDChannelNum));
   }
 
   inline FEDStripData::ChannelData& FEDStripData::operator[](const uint8_t internalFEDChannelNum) {
@@ -217,11 +217,13 @@ namespace sistrip {
 
   inline size_t FEDStripData::ChannelData::size() const { return data_.size(); }
 
-  inline uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) { return data_[sampleNumber]; }
-
-  //re-use non-const method
   inline const uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) const {
-    return (*this)[sampleNumber];
+    return data_[sampleNumber];
+  }
+
+  //re-use const method
+  inline uint16_t& FEDStripData::ChannelData::operator[](const size_t sampleNumber) {
+    return const_cast<uint16_t&>(std::as_const(*this)[sampleNumber]);
   }
 
   inline uint16_t FEDStripData::ChannelData::getSample(const uint16_t sampleNumber) const {

--- a/EventFilter/SiStripRawToDigi/interface/TFHeaderDescription.h
+++ b/EventFilter/SiStripRawToDigi/interface/TFHeaderDescription.h
@@ -23,13 +23,13 @@ public:
   void setFedType(unsigned long t) { fedType_ = t; }
   void setFedId(unsigned long t) { fedId_ = t; }
   void setFedEventNumber(unsigned long t) { fedEventNumber_ = t; }
-  unsigned long getBunchCrossing() { return bunchCrossing_; }
-  unsigned long getNumberOfChannels() { return numberOfChannels_; }
-  unsigned long getNumberOfSamples() { return numberOfSamples_; }
-  unsigned long getFedType() { return fedType_; }
-  unsigned long getFedId() { return fedId_; }
-  unsigned long getFedEventNumber() { return fedEventNumber_; }
-  void Print() {
+  unsigned long getBunchCrossing() const { return bunchCrossing_; }
+  unsigned long getNumberOfChannels() const { return numberOfChannels_; }
+  unsigned long getNumberOfSamples() const { return numberOfSamples_; }
+  unsigned long getFedType() const { return fedType_; }
+  unsigned long getFedId() const { return fedId_; }
+  unsigned long getFedEventNumber() const { return fedEventNumber_; }
+  void Print() const {
     printf(
         "Bunch crossing %lx \n Number Of Channels %ld \n Number of Samples %ld \n Fed Type %lx \n Fed Id %lx \n Fed "
         "Event Number %ld \n",

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -135,13 +135,13 @@ namespace sistrip {
           //need to construct full object to copy full header
           if (rawfedData.size() == 0)
             warnings_.add("Invalid raw data for FED, skipping", (boost::format("id %1%") % *ifed).str());
-          const auto st_buffer = preconstructCheckFEDBuffer(rawfedData.data(), rawfedData.size(), true);
+          const auto st_buffer = preconstructCheckFEDBuffer(rawfedData, true);
           if (FEDBufferStatusCode::SUCCESS != st_buffer) {
             edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
                                          << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
             continue;
           }
-          sistrip::FEDBuffer fedbuffer(rawfedData.data(), rawfedData.size(), true);
+          sistrip::FEDBuffer fedbuffer{rawfedData, true};
           const auto st_chan = fedbuffer.findChannels();
           if (FEDBufferStatusCode::SUCCESS != st_chan) {
             edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -136,14 +136,14 @@ namespace sistrip {
           if (rawfedData.size() == 0)
             warnings_.add("Invalid raw data for FED, skipping", (boost::format("id %1%") % *ifed).str());
           const auto st_buffer = preconstructCheckFEDBuffer(rawfedData.data(), rawfedData.size(), true);
-          if ( FEDBufferStatusCode::SUCCESS != st_buffer ) {
+          if (FEDBufferStatusCode::SUCCESS != st_buffer) {
             edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
                                          << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
             continue;
           }
           sistrip::FEDBuffer fedbuffer(rawfedData.data(), rawfedData.size(), true);
           const auto st_chan = fedbuffer.findChannels();
-          if ( FEDBufferStatusCode::SUCCESS != st_chan ) {
+          if (FEDBufferStatusCode::SUCCESS != st_chan) {
             edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
                                          << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
           }
@@ -233,10 +233,10 @@ namespace sistrip {
               std::cout << std::endl;
             }
             bufferGenerator_.feHeader().print(debugStream);
-            edm::LogWarning("DigiToRaw")
-                << "[sistrip::DigiToRaw::createFedBuffers_]"
-                << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
-                << debugStream.str();
+            edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                                         << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes()
+                                         << "\n"
+                                         << debugStream.str();
           }
           auto conns = cabling->fedConnections(*ifed);
 
@@ -320,10 +320,10 @@ namespace sistrip {
           if (edm::isDebugEnabled()) {
             std::ostringstream debugStream;
             bufferGenerator_.feHeader().print(debugStream);
-            edm::LogWarning("DigiToRaw")
-                << "[sistrip::DigiToRaw::createFedBuffers_]"
-                << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
-                << debugStream.str();
+            edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                                         << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes()
+                                         << "\n"
+                                         << debugStream.str();
           }
         }  //loop on fedids
         if (edm::isDebugEnabled()) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripDigiToRaw.cc
@@ -133,195 +133,197 @@ namespace sistrip {
           }
 
           //need to construct full object to copy full header
-          std::unique_ptr<const sistrip::FEDBuffer> fedbuffer;
-          if (rawfedData.size() == 0) {
+          if (rawfedData.size() == 0)
             warnings_.add("Invalid raw data for FED, skipping", (boost::format("id %1%") % *ifed).str());
-          } else {
-            try {
-              fedbuffer.reset(new sistrip::FEDBuffer(rawfedData.data(), rawfedData.size(), true));
-            } catch (const cms::Exception& e) {
-              edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
-                                           << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
-            }
+          const auto st_buffer = preconstructCheckFEDBuffer(rawfedData.data(), rawfedData.size(), true);
+          if ( FEDBufferStatusCode::SUCCESS != st_buffer ) {
+            edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                                         << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
+            continue;
+          }
+          sistrip::FEDBuffer fedbuffer(rawfedData.data(), rawfedData.size(), true);
+          const auto st_chan = fedbuffer.findChannels();
+          if ( FEDBufferStatusCode::SUCCESS != st_chan ) {
+            edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                                         << " Could not construct FEDBuffer for FED " << *ifed << std::endl;
+          }
+          if (fedbuffer.headerType() == sistrip::HEADER_TYPE_INVALID) {
+            warnings_.add("Invalid header type for FED, skipping", (boost::format("id %1%") % *ifed).str());
+            continue;
+          }
 
-            if (fedbuffer->headerType() == sistrip::HEADER_TYPE_INVALID) {
-              warnings_.add("Invalid header type for FED, skipping", (boost::format("id %1%") % *ifed).str());
+          if (edm::isDebugEnabled()) {
+            edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                                         << " Original header type: " << fedbuffer.headerType();
+          }
+
+          bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_FULL_DEBUG);
+          //fedbuffer.headerType());
+          bufferGenerator_.daqHeader() = fedbuffer.daqHeader();
+          bufferGenerator_.daqTrailer() = fedbuffer.daqTrailer();
+
+          bufferGenerator_.trackerSpecialHeader() = fedbuffer.trackerSpecialHeader();
+          bufferGenerator_.setReadoutMode(mode_);
+
+          if (edm::isDebugEnabled()) {
+            std::ostringstream debugStream;
+            if (ifed == fed_ids.begin()) {
+              bufferGenerator_.trackerSpecialHeader().print(std::cout);
+              std::cout << std::endl;
+            }
+            bufferGenerator_.trackerSpecialHeader().print(debugStream);
+            edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " Tracker special header apveAddress: "
+                << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apveAddress())
+                << " - event type = " << bufferGenerator_.getDAQEventType()
+                << " - buffer format = " << bufferGenerator_.getBufferFormat() << "\n"
+                << " - SpecialHeader bufferformat " << bufferGenerator_.trackerSpecialHeader().bufferFormat()
+                << " - headertype " << bufferGenerator_.trackerSpecialHeader().headerType() << " - readoutmode "
+                << bufferGenerator_.trackerSpecialHeader().readoutMode() << " - apvaddrregister " << std::hex
+                << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apvAddressErrorRegister())
+                << " - feenabledregister " << std::hex
+                << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feEnableRegister())
+                << " - feoverflowregister " << std::hex
+                << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feOverflowRegister())
+                << " - statusregister " << bufferGenerator_.trackerSpecialHeader().fedStatusRegister() << "\n"
+                << " SpecialHeader: " << debugStream.str();
+          }
+
+          std::unique_ptr<FEDFEHeader> tempFEHeader(fedbuffer.feHeader()->clone());
+          FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
+          if (edm::isDebugEnabled()) {
+            std::ostringstream debugStream;
+            if (ifed == fed_ids.begin()) {
+              std::cout << "FEHeader before transfer: " << std::endl;
+              fedFeHeader->print(std::cout);
+              std::cout << std::endl;
+            }
+            fedFeHeader->print(debugStream);
+            edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
+                                         << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
+                                         << debugStream.str();
+          }
+          //status registers
+          (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
+          (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
+          (bufferGenerator_.feHeader()).setDAQRegister(fedFeHeader->daqRegister());
+          for (uint8_t iFE = 1; iFE < 6; iFE++) {
+            (bufferGenerator_.feHeader())
+                .set32BitReservedRegister(iFE, fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE) + 10));
+          }
+
+          std::vector<bool> feEnabledVec;
+          feEnabledVec.resize(FEUNITS_PER_FED, true);
+          for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
+            feEnabledVec[iFE] = fedbuffer.trackerSpecialHeader().feEnabled(iFE);
+            (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE, fedFeHeader->feUnitMajorityAddress(iFE));
+            for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
+              (bufferGenerator_.feHeader())
+                  .setChannelStatus(iFE, iFEUnitChannel, fedFeHeader->getChannelStatus(iFE, iFEUnitChannel));
+            }  //loop on channels
+          }    //loop on fe units
+          bufferGenerator_.setFEUnitEnables(feEnabledVec);
+
+          if (edm::isDebugEnabled()) {
+            std::ostringstream debugStream;
+            if (ifed == fed_ids.begin()) {
+              std::cout << "\nFEHeader after transfer: " << std::endl;
+              bufferGenerator_.feHeader().print(std::cout);
+              std::cout << std::endl;
+            }
+            bufferGenerator_.feHeader().print(debugStream);
+            edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+                << debugStream.str();
+          }
+          auto conns = cabling->fedConnections(*ifed);
+
+          FEDStripData fedData(dataIsAlready8BitTruncated);
+
+          for (auto iconn = conns.begin(); iconn != conns.end(); iconn++) {
+            // Determine FED key from cabling
+            uint32_t fed_key = ((iconn->fedId() & sistrip::invalid_) << 16) | (iconn->fedCh() & sistrip::invalid_);
+
+            // Determine whether DetId or FED key should be used to index digi containers
+            uint32_t key = (useFedKey_ || mode_ == READOUT_MODE_SCOPE) ? fed_key : iconn->detId();
+
+            // Check key is non-zero and valid
+            if (!key || (key == sistrip::invalid32_)) {
               continue;
             }
 
-            if (edm::isDebugEnabled()) {
-              edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
-                                           << " Original header type: " << fedbuffer->headerType();
-            }
+            // Determine APV pair number (needed only when using DetId)
+            uint16_t ipair = (useFedKey_ || mode_ == READOUT_MODE_SCOPE) ? 0 : iconn->apvPairNumber();
 
-            bufferGenerator_.setHeaderType(FEDHeaderType::HEADER_TYPE_FULL_DEBUG);
-            //fedbuffer->headerType());
-            bufferGenerator_.daqHeader() = fedbuffer->daqHeader();
-            bufferGenerator_.daqTrailer() = fedbuffer->daqTrailer();
+            FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
 
-            bufferGenerator_.trackerSpecialHeader() = fedbuffer->trackerSpecialHeader();
-            bufferGenerator_.setReadoutMode(mode_);
-
-            if (edm::isDebugEnabled()) {
-              std::ostringstream debugStream;
-              if (ifed == fed_ids.begin()) {
-                bufferGenerator_.trackerSpecialHeader().print(std::cout);
-                std::cout << std::endl;
+            // Find digis for DetID in collection
+            if (!collection.isValid()) {
+              if (edm::isDebugEnabled()) {
+                edm::LogWarning("DigiToRaw") << "[DigiToRaw::createFedBuffers] "
+                                             << "digis collection is not valid...";
               }
-              bufferGenerator_.trackerSpecialHeader().print(debugStream);
-              edm::LogWarning("DigiToRaw")
-                  << "[sistrip::DigiToRaw::createFedBuffers_]"
-                  << " Tracker special header apveAddress: "
-                  << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apveAddress())
-                  << " - event type = " << bufferGenerator_.getDAQEventType()
-                  << " - buffer format = " << bufferGenerator_.getBufferFormat() << "\n"
-                  << " - SpecialHeader bufferformat " << bufferGenerator_.trackerSpecialHeader().bufferFormat()
-                  << " - headertype " << bufferGenerator_.trackerSpecialHeader().headerType() << " - readoutmode "
-                  << bufferGenerator_.trackerSpecialHeader().readoutMode() << " - apvaddrregister " << std::hex
-                  << static_cast<int>(bufferGenerator_.trackerSpecialHeader().apvAddressErrorRegister())
-                  << " - feenabledregister " << std::hex
-                  << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feEnableRegister())
-                  << " - feoverflowregister " << std::hex
-                  << static_cast<int>(bufferGenerator_.trackerSpecialHeader().feOverflowRegister())
-                  << " - statusregister " << bufferGenerator_.trackerSpecialHeader().fedStatusRegister() << "\n"
-                  << " SpecialHeader: " << debugStream.str();
+              break;
+            }
+            typename std::vector<edm::DetSet<Digi_t> >::const_iterator digis = collection->find(key);
+            if (digis == collection->end()) {
+              continue;
             }
 
-            std::unique_ptr<FEDFEHeader> tempFEHeader(fedbuffer->feHeader()->clone());
-            FEDFullDebugHeader* fedFeHeader = dynamic_cast<FEDFullDebugHeader*>(tempFEHeader.get());
-            if (edm::isDebugEnabled()) {
-              std::ostringstream debugStream;
-              if (ifed == fed_ids.begin()) {
-                std::cout << "FEHeader before transfer: " << std::endl;
-                fedFeHeader->print(std::cout);
-                std::cout << std::endl;
+            typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
+            for (idigi = digis_begin; idigi != digis->data.end(); idigi++) {
+              if (STRIP(idigi, digis_begin) < ipair * 256 || STRIP(idigi, digis_begin) > ipair * 256 + 255) {
+                continue;
               }
-              fedFeHeader->print(debugStream);
-              edm::LogWarning("DigiToRaw") << "[sistrip::DigiToRaw::createFedBuffers_]"
-                                           << " length of original feHeader: " << fedFeHeader->lengthInBytes() << "\n"
-                                           << debugStream.str();
-            }
-            //status registers
-            (bufferGenerator_.feHeader()).setBEStatusRegister(fedFeHeader->beStatusRegister());
-            (bufferGenerator_.feHeader()).setDAQRegister2(fedFeHeader->daqRegister2());
-            (bufferGenerator_.feHeader()).setDAQRegister(fedFeHeader->daqRegister());
-            for (uint8_t iFE = 1; iFE < 6; iFE++) {
-              (bufferGenerator_.feHeader())
-                  .set32BitReservedRegister(iFE, fedFeHeader->get32BitWordFrom(fedFeHeader->feWord(iFE) + 10));
-            }
+              const unsigned short strip = STRIP(idigi, digis_begin) % 256;
 
-            std::vector<bool> feEnabledVec;
-            feEnabledVec.resize(FEUNITS_PER_FED, true);
-            for (uint8_t iFE = 0; iFE < FEUNITS_PER_FED; iFE++) {
-              feEnabledVec[iFE] = fedbuffer->trackerSpecialHeader().feEnabled(iFE);
-              (bufferGenerator_.feHeader()).setFEUnitMajorityAddress(iFE, fedFeHeader->feUnitMajorityAddress(iFE));
-              for (uint8_t iFEUnitChannel = 0; iFEUnitChannel < FEDCH_PER_FEUNIT; iFEUnitChannel++) {
-                (bufferGenerator_.feHeader())
-                    .setChannelStatus(iFE, iFEUnitChannel, fedFeHeader->getChannelStatus(iFE, iFEUnitChannel));
-              }  //loop on channels
-            }    //loop on fe units
-            bufferGenerator_.setFEUnitEnables(feEnabledVec);
-
-            if (edm::isDebugEnabled()) {
-              std::ostringstream debugStream;
-              if (ifed == fed_ids.begin()) {
-                std::cout << "\nFEHeader after transfer: " << std::endl;
-                bufferGenerator_.feHeader().print(std::cout);
-                std::cout << std::endl;
-              }
-              bufferGenerator_.feHeader().print(debugStream);
-              edm::LogWarning("DigiToRaw")
-                  << "[sistrip::DigiToRaw::createFedBuffers_]"
-                  << " length of feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
-                  << debugStream.str();
-            }
-            auto conns = cabling->fedConnections(*ifed);
-
-            FEDStripData fedData(dataIsAlready8BitTruncated);
-
-            for (auto iconn = conns.begin(); iconn != conns.end(); iconn++) {
-              // Determine FED key from cabling
-              uint32_t fed_key = ((iconn->fedId() & sistrip::invalid_) << 16) | (iconn->fedCh() & sistrip::invalid_);
-
-              // Determine whether DetId or FED key should be used to index digi containers
-              uint32_t key = (useFedKey_ || mode_ == READOUT_MODE_SCOPE) ? fed_key : iconn->detId();
-
-              // Check key is non-zero and valid
-              if (!key || (key == sistrip::invalid32_)) {
+              if (strip >= STRIPS_PER_FEDCH) {
+                if (edm::isDebugEnabled()) {
+                  std::stringstream ss;
+                  ss << "[sistrip::DigiToRaw::createFedBuffers]"
+                     << " strip >= strips_per_fedCh";
+                  edm::LogWarning("DigiToRaw") << ss.str();
+                }
                 continue;
               }
 
-              // Determine APV pair number (needed only when using DetId)
-              uint16_t ipair = (useFedKey_ || mode_ == READOUT_MODE_SCOPE) ? 0 : iconn->apvPairNumber();
-
-              FEDStripData::ChannelData& chanData = fedData[iconn->fedCh()];
-
-              // Find digis for DetID in collection
-              if (!collection.isValid()) {
-                if (edm::isDebugEnabled()) {
-                  edm::LogWarning("DigiToRaw") << "[DigiToRaw::createFedBuffers] "
-                                               << "digis collection is not valid...";
+              // check if value already exists
+              if (edm::isDebugEnabled()) {
+                const uint16_t value = 0;  //chanData[strip];
+                if (value && value != (*idigi).adc()) {
+                  std::stringstream ss;
+                  ss << "[sistrip::DigiToRaw::createFedBuffers]"
+                     << " Incompatible ADC values in buffer!"
+                     << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
+                     << "  DetStrip: " << STRIP(idigi, digis_begin) << "  FedChStrip: " << strip
+                     << "  AdcValue: " << (*idigi).adc() << "  RawData[" << strip << "]: " << value;
+                  edm::LogWarning("DigiToRaw") << ss.str();
                 }
-                break;
-              }
-              typename std::vector<edm::DetSet<Digi_t> >::const_iterator digis = collection->find(key);
-              if (digis == collection->end()) {
-                continue;
               }
 
-              typename edm::DetSet<Digi_t>::const_iterator idigi, digis_begin(digis->data.begin());
-              for (idigi = digis_begin; idigi != digis->data.end(); idigi++) {
-                if (STRIP(idigi, digis_begin) < ipair * 256 || STRIP(idigi, digis_begin) > ipair * 256 + 255) {
-                  continue;
-                }
-                const unsigned short strip = STRIP(idigi, digis_begin) % 256;
-
-                if (strip >= STRIPS_PER_FEDCH) {
-                  if (edm::isDebugEnabled()) {
-                    std::stringstream ss;
-                    ss << "[sistrip::DigiToRaw::createFedBuffers]"
-                       << " strip >= strips_per_fedCh";
-                    edm::LogWarning("DigiToRaw") << ss.str();
-                  }
-                  continue;
-                }
-
-                // check if value already exists
-                if (edm::isDebugEnabled()) {
-                  const uint16_t value = 0;  //chanData[strip];
-                  if (value && value != (*idigi).adc()) {
-                    std::stringstream ss;
-                    ss << "[sistrip::DigiToRaw::createFedBuffers]"
-                       << " Incompatible ADC values in buffer!"
-                       << "  FedId/FedCh: " << *ifed << "/" << iconn->fedCh()
-                       << "  DetStrip: " << STRIP(idigi, digis_begin) << "  FedChStrip: " << strip
-                       << "  AdcValue: " << (*idigi).adc() << "  RawData[" << strip << "]: " << value;
-                    edm::LogWarning("DigiToRaw") << ss.str();
-                  }
-                }
-
-                // Add digi to buffer
-                chanData[strip] = (*idigi).adc();
-              }
+              // Add digi to buffer
+              chanData[strip] = (*idigi).adc();
             }
-            // if ((*idigi).strip() >= (ipair+1)*256) break;
+          }
+          // if ((*idigi).strip() >= (ipair+1)*256) break;
 
-            if (edm::isDebugEnabled()) {
-              edm::LogWarning("DigiToRaw") << "DigiToRaw::createFedBuffers] "
-                                           << "Almost at the end...";
-            }
-            //create the buffer
-            FEDRawData& fedrawdata = buffers->FEDData(*ifed);
-            bufferGenerator_.generateBuffer(&fedrawdata, fedData, *ifed, packetCode_);
+          if (edm::isDebugEnabled()) {
+            edm::LogWarning("DigiToRaw") << "DigiToRaw::createFedBuffers] "
+                                         << "Almost at the end...";
+          }
+          //create the buffer
+          FEDRawData& fedrawdata = buffers->FEDData(*ifed);
+          bufferGenerator_.generateBuffer(&fedrawdata, fedData, *ifed, packetCode_);
 
-            if (edm::isDebugEnabled()) {
-              std::ostringstream debugStream;
-              bufferGenerator_.feHeader().print(debugStream);
-              edm::LogWarning("DigiToRaw")
-                  << "[sistrip::DigiToRaw::createFedBuffers_]"
-                  << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
-                  << debugStream.str();
-            }
+          if (edm::isDebugEnabled()) {
+            std::ostringstream debugStream;
+            bufferGenerator_.feHeader().print(debugStream);
+            edm::LogWarning("DigiToRaw")
+                << "[sistrip::DigiToRaw::createFedBuffers_]"
+                << " length of final feHeader: " << bufferGenerator_.feHeader().lengthInBytes() << "\n"
+                << debugStream.str();
           }
         }  //loop on fedids
         if (edm::isDebugEnabled()) {

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -809,7 +809,7 @@ namespace sistrip {
       }
 
       // Write event-specific data to event
-      TFHeaderDescription* header = (TFHeaderDescription*)data_u32;
+      const TFHeaderDescription* header = (const TFHeaderDescription*)data_u32;
       summary.event(static_cast<uint32_t>(header->getFedEventNumber()));
       summary.bx(static_cast<uint32_t>(header->getBunchCrossing()));
 

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -286,7 +286,7 @@ namespace sistrip {
           const auto isNonLite = FEDChannelUnpacker::isNonLiteZS(mode, legacy_, lmode);
           const uint8_t pCode = (isNonLite ? buffer.packetCode(legacy_, iconn->fedCh()) : 0);
           if (isNonLite)
-            LogDebug("SiStripRawToDigi") << "Non-lite zero-suppressed mode. Packet code=" << std::hex << uint16_t(pCode) << std::dec;
+            LogDebug("SiStripRawToDigi") << "Non-lite zero-suppressed mode. Packet code=0x" << std::hex << uint16_t(pCode) << std::dec;
           const auto st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
               fedChannel, std::back_inserter(zs_work_digis_), ipair * 256,
               isNonLite, mode, legacy_, lmode, pCode);
@@ -299,7 +299,7 @@ namespace sistrip {
             detids.push_back(iconn->detId());  //@@ Possible multiple entries (ok for Giovanni)
             continue;
           }
-          if (regItem.index != scope_work_digis_.size()) {
+          if (regItem.index != zs_work_digis_.size()) {
             regItem.length = zs_work_digis_.size() - regItem.index;
             regItem.first = zs_work_digis_[regItem.index].strip();
             zs_work_registry_.push_back(regItem);

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -69,14 +69,14 @@ namespace sistrip {
     edm::RunningAverage localRA(10000);
 
     void maskFED(DetIdCollection& maskedModules, SiStripFedCabling::ConnsConstIterRange fedConnections) {
-      maskedModules.reserve(maskedModules.size()+fedConnections.size());
-      for ( const auto& conn : fedConnections ) {
-        if ( conn.detId() && ( conn.detId() != sistrip::invalid32_ ) ) {
+      maskedModules.reserve(maskedModules.size() + fedConnections.size());
+      for (const auto& conn : fedConnections) {
+        if (conn.detId() && (conn.detId() != sistrip::invalid32_)) {
           maskedModules.push_back(conn.detId());  //@@ Possible multiple entries (ok for Giovanni)
         }
       }
     }
-  }
+  }  // namespace
 
   void RawToDigiUnpacker::createDigis(const SiStripFedCabling& cabling,
                                       const FEDRawDataCollection& buffers,
@@ -150,8 +150,8 @@ namespace sistrip {
       // check FEDRawData pointer, size, and more
       const auto st_buffer = preconstructCheckFEDBuffer(input.data(), input.size());
       // construct FEDBuffer
-      if ( FEDBufferStatusCode::SUCCESS != st_buffer ) {
-        if ( FEDBufferStatusCode::BUFFER_NULL == st_buffer ) {
+      if (FEDBufferStatusCode::SUCCESS != st_buffer) {
+        if (FEDBufferStatusCode::BUFFER_NULL == st_buffer) {
           warnings_.add("NULL pointer to FEDRawData for FED", (boost::format("id %1%") % *ifed).str());
         } else if (!input.size()) {
           warnings_.add("FEDRawData has zero size for FED", (boost::format("id %1%") % *ifed).str());
@@ -165,14 +165,14 @@ namespace sistrip {
       }
       FEDBuffer buffer(input.data(), input.size());
       const auto st_chan = buffer.findChannels();
-      if ( FEDBufferStatusCode::SUCCESS != st_chan ) {
+      if (FEDBufferStatusCode::SUCCESS != st_chan) {
         warnings_.add("Exception caught when creating FEDBuffer object for FED",
                       (boost::format("id %1%: %2%") % *ifed % st_chan).str());
         maskFED(detids, conns);
         continue;
       }
       buffer.setLegacyMode(legacy_);
-      if ( ( ! buffer.doChecks(true) ) && (!unpackBadChannels_ || !buffer.checkNoFEOverflows()) ) {
+      if ((!buffer.doChecks(true)) && (!unpackBadChannels_ || !buffer.checkNoFEOverflows())) {
         warnings_.add("Exception caught when creating FEDBuffer object for FED",
                       (boost::format("id %1%: FED Buffer check fails for FED ID %1%.") % *ifed).str());
         maskFED(detids, conns);

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -130,7 +130,7 @@ namespace sistrip {
           ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
              << " Found FED id " << std::setw(4) << std::setfill(' ') << *ifed << " in FEDRawDataCollection"
              << " with non-zero pointer 0x" << std::hex << std::setw(8) << std::setfill('0')
-             << reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(input.data())) << std::dec << " and size "
+             << reinterpret_cast<const uint32_t*>(input.data()) << std::dec << " and size "
              << std::setw(5) << std::setfill(' ') << input.size() << " chars";
           LogTrace("SiStripRawToDigi") << ss.str();
         }
@@ -721,7 +721,7 @@ namespace sistrip {
                                      SiStripEventSummary& summary,
                                      const uint32_t& event) {
     // Pointer to data (recast as 32-bit words) and number of 32-bit words
-    uint32_t* data_u32 = nullptr;
+    const uint32_t* data_u32 = nullptr;
     uint32_t size_u32 = 0;
 
     // Search mode
@@ -730,8 +730,8 @@ namespace sistrip {
       while (triggerFedId_ < 0 && ifed < 1 + FEDNumbering::lastFEDId()) {
         const FEDRawData& trigger_fed = buffers.FEDData(ifed);
         if (trigger_fed.data() && trigger_fed.size()) {
-          uint8_t* temp = const_cast<uint8_t*>(trigger_fed.data());
-          data_u32 = reinterpret_cast<uint32_t*>(temp) + FEDHeader::length / sizeof(uint32_t) + 1;
+          const uint8_t* temp = trigger_fed.data();
+          data_u32 = reinterpret_cast<const uint32_t*>(temp) + FEDHeader::length / sizeof(uint32_t) + 1;
           size_u32 = trigger_fed.size() / sizeof(uint32_t) - FEDHeader::length / sizeof(uint32_t) - 1;
           const FEDTrailer fedTrailer(temp + trigger_fed.size() - FEDTrailer::length);
           if (fedTrailer.conscheck() == 0xDEADFACE) {
@@ -763,8 +763,8 @@ namespace sistrip {
     else if (triggerFedId_ > 0) {
       const FEDRawData& trigger_fed = buffers.FEDData(triggerFedId_);
       if (trigger_fed.data() && trigger_fed.size()) {
-        uint8_t* temp = const_cast<uint8_t*>(trigger_fed.data());
-        data_u32 = reinterpret_cast<uint32_t*>(temp) + FEDHeader::length / sizeof(uint32_t) + 1;
+        const uint8_t* temp = trigger_fed.data();
+        data_u32 = reinterpret_cast<const uint32_t*>(temp) + FEDHeader::length / sizeof(uint32_t) + 1;
         size_u32 = trigger_fed.size() / sizeof(uint32_t) - FEDHeader::length / sizeof(uint32_t) - 1;
         const FEDTrailer fedTrailer(temp + trigger_fed.size() - FEDTrailer::length);
         if (fedTrailer.conscheck() != 0xDEADFACE) {
@@ -812,7 +812,7 @@ namespace sistrip {
 
       // Write commissioning information to event
       uint32_t hsize = sizeof(TFHeaderDescription) / sizeof(uint32_t);
-      uint32_t* head = &data_u32[hsize];
+      const uint32_t* head = &data_u32[hsize];
       summary.commissioningInfo(head, event);
       summary.triggerFed(triggerFedId_);
     }
@@ -850,8 +850,8 @@ namespace sistrip {
     while (ichar < input.size() - 16 && !found) {
       uint16_t offset =
           headerBytes_ < 0 ? ichar : headerBytes_;  // Negative value means use "search mode" to find DAQ header
-      uint32_t* input_u32 = reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(input.data()) + offset);
-      uint32_t* fed_trailer = reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(input.data()) + input.size() - 8);
+      const uint32_t* input_u32 = reinterpret_cast<const uint32_t*>(input.data() + offset);
+      const uint32_t* fed_trailer = reinterpret_cast<const uint32_t*>(input.data() + input.size() - 8);
 
       // see info on FED 32-bit swapping at end-of-file
 
@@ -889,7 +889,7 @@ namespace sistrip {
           // Found DAQ header (with MSB and LSB 32-bit words swapped) at byte position 'offset'
           found = true;
           output.resize(input.size() - offset);
-          uint32_t* output_u32 = reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(output.data()));
+          uint32_t* output_u32 = reinterpret_cast<uint32_t*>(output.data());
           uint16_t iter = offset;
           while (iter < output.size() / sizeof(uint32_t)) {
             output_u32[iter] = input_u32[iter + 1];
@@ -945,7 +945,7 @@ namespace sistrip {
           ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
              << " DAQ header not found within buffer for FED id: " << fed_id;
         } else {
-          uint32_t* input_u32 = reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(input.data()));
+          const uint32_t* input_u32 = reinterpret_cast<const uint32_t*>(input.data());
           ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
              << " DAQ header not found at expected location for FED id: " << fed_id << std::endl
              << " First 64-bit word of buffer is 0x" << std::hex << std::setfill('0') << std::setw(8) << input_u32[0]
@@ -1008,7 +1008,7 @@ namespace sistrip {
        << " Buffer contains " << buffer.size() << " bytes (NB: payload is byte-swapped)" << std::endl;
 
     if (false) {
-      uint32_t* buffer_u32 = reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(buffer.data()));
+      const uint32_t* buffer_u32 = reinterpret_cast<const uint32_t*>(buffer.data());
       unsigned int empty = 0;
 
       ss << "Byte->   4 5 6 7 0 1 2 3\n";

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -346,17 +346,22 @@ namespace sistrip {
 
           // Common mode values
           if (extractCm_) {
-            try {
+            const auto& fedChannel = buffer.channel(iconn->fedCh());
+            const auto pCode = fedChannel.packetCode();
+            if ((pCode == PACKET_CODE_ZERO_SUPPRESSED) || (pCode == PACKET_CODE_ZERO_SUPPRESSED10) ||
+                (pCode == PACKET_CODE_ZERO_SUPPRESSED8_BOTBOT) || (pCode == PACKET_CODE_ZERO_SUPPRESSED8_TOPBOT)) {
               Registry regItem2(key, 2 * ipair, cm_work_digis_.size(), 2);
-              cm_work_digis_.push_back(SiStripRawDigi(buffer.channel(iconn->fedCh()).cmMedian(0)));
-              cm_work_digis_.push_back(SiStripRawDigi(buffer.channel(iconn->fedCh()).cmMedian(1)));
+              cm_work_digis_.push_back(SiStripRawDigi(fedChannel.cmMedian(0)));
+              cm_work_digis_.push_back(SiStripRawDigi(fedChannel.cmMedian(1)));
               cm_work_registry_.push_back(regItem2);
-            } catch (const cms::Exception& e) {
+            } else {
               warnings_.add("Problem extracting common modes",
-                            (boost::format("FED %1% channel %2%:\n %3%") % *ifed % iconn->fedCh() % e.what()).str());
+                            (boost::format("FED %1% channel %2%:\n Request for CM median from channel with non-ZS "
+                                           "packet code. Packet code is %3%.") %
+                             *ifed % iconn->fedCh() % pCode)
+                                .str());
             }
           }
-
         }
 
         else if (!legacy_ && (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 ||

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -1297,40 +1297,6 @@ namespace sistrip {
     ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
        << " End of FED buffer";
   }
-
-  void RawToDigiUnpacker::handleException(std::string method_name, std::string extra_info) {
-    method_name = "sistrip::RawToDigiUnpacker::" + method_name;
-    try {
-      throw;  // rethrow caught exception to be dealt with below
-    } catch (const cms::Exception& e) {
-      //throw e; // rethrow cms::Exception to be caught by framework
-    } catch (const std::exception& e) {
-      if (edm::isDebugEnabled()) {
-        std::stringstream ss;
-        ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
-           << " Caught std::exception!" << std::endl;
-        if (!extra_info.empty()) {
-          ss << " Information: " << extra_info << std::endl;
-        }
-        ss << " Caught std::exception in [" << method_name << "] with message:" << std::endl << e.what();
-        edm::LogWarning(sistrip::mlRawToDigi_) << ss.str();
-      }
-      //throw cms::Exception(sistrip::mlRawToDigi_) << ss.str();
-    } catch (...) {
-      if (edm::isDebugEnabled()) {
-        std::stringstream ss;
-        ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
-           << " Caught unknown exception!" << std::endl;
-        if (!extra_info.empty()) {
-          ss << " Information: " << extra_info << std::endl;
-        }
-        ss << "Caught unknown exception in [" << method_name << "]" << std::endl;
-        edm::LogWarning(sistrip::mlRawToDigi_) << ss.str();
-      }
-      //throw cms::Exception(sistrip::mlRawToDigi_) << ss.str();
-    }
-  }
-
 }  // namespace sistrip
 
 /*

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -130,8 +130,8 @@ namespace sistrip {
           ss << "[sistrip::RawToDigiUnpacker::" << __func__ << "]"
              << " Found FED id " << std::setw(4) << std::setfill(' ') << *ifed << " in FEDRawDataCollection"
              << " with non-zero pointer 0x" << std::hex << std::setw(8) << std::setfill('0')
-             << reinterpret_cast<const uint32_t*>(input.data()) << std::dec << " and size "
-             << std::setw(5) << std::setfill(' ') << input.size() << " chars";
+             << reinterpret_cast<const uint32_t*>(input.data()) << std::dec << " and size " << std::setw(5)
+             << std::setfill(' ') << input.size() << " chars";
           LogTrace("SiStripRawToDigi") << ss.str();
         }
       }
@@ -252,7 +252,8 @@ namespace sistrip {
         }
 
         // Determine whether FED key is inferred from cabling or channel loop
-        const uint32_t fed_key = (summary.runType() == sistrip::FED_CABLING)
+        const uint32_t fed_key =
+            (summary.runType() == sistrip::FED_CABLING)
                 ? ((*ifed & sistrip::invalid_) << 16) | (chan & sistrip::invalid_)
                 : ((iconn->fedId() & sistrip::invalid_) << 16) | (iconn->fedCh() & sistrip::invalid_);
 
@@ -276,21 +277,21 @@ namespace sistrip {
           smode << mode;
         else
           smode << lmode;
-        LogDebug("SiStripRawToDigi")
-          << "Unpacking FED " << *ifed << " channel " << iconn->fedCh()
-          << ( (!legacy_)? " " : " legacy ") << "data in mode " << smode.str()
-          << " for module " << iconn->detId() << " pair " << ipair;
+        LogDebug("SiStripRawToDigi") << "Unpacking FED " << *ifed << " channel " << iconn->fedCh()
+                                     << ((!legacy_) ? " " : " legacy ") << "data in mode " << smode.str()
+                                     << " for module " << iconn->detId() << " pair " << ipair;
 #endif
         if (FEDChannelUnpacker::isZeroSuppressed(mode, legacy_, lmode)) {
           Registry regItem(key, 0, zs_work_digis_.size(), 0);
           const auto isNonLite = FEDChannelUnpacker::isNonLiteZS(mode, legacy_, lmode);
           const uint8_t pCode = (isNonLite ? buffer.packetCode(legacy_, iconn->fedCh()) : 0);
           if (isNonLite)
-            LogDebug("SiStripRawToDigi") << "Non-lite zero-suppressed mode. Packet code=0x" << std::hex << uint16_t(pCode) << std::dec;
+            LogDebug("SiStripRawToDigi") << "Non-lite zero-suppressed mode. Packet code=0x" << std::hex
+                                         << uint16_t(pCode) << std::dec;
           const auto st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
-              fedChannel, std::back_inserter(zs_work_digis_), ipair * 256,
-              isNonLite, mode, legacy_, lmode, pCode);
-          if (FEDChannelUnpacker::StatusCode::ZERO_PACKET_CODE == st_ch || FEDChannelUnpacker::StatusCode::BAD_PACKET_CODE == st_ch) {
+              fedChannel, std::back_inserter(zs_work_digis_), ipair * 256, isNonLite, mode, legacy_, lmode, pCode);
+          if (FEDChannelUnpacker::StatusCode::ZERO_PACKET_CODE == st_ch ||
+              FEDChannelUnpacker::StatusCode::BAD_PACKET_CODE == st_ch) {
             warnings_.add((boost::format("Invalid packet code %1$#x for zero-suppressed data") % uint16_t(pCode)).str(),
                           (boost::format("FED %1% channel %2%") % *ifed % iconn->fedCh()).str());
           } else if (FEDChannelUnpacker::StatusCode::SUCCESS != st_ch) {
@@ -325,8 +326,9 @@ namespace sistrip {
           auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
           if (FEDChannelUnpacker::isVirginRaw(mode, legacy_, lmode)) {
             Registry regItem(key, 256 * ipair, virgin_work_digis_.size(), 0);
-            LogDebug("SiStripRawToDigi")
-              << "Virgin raw packet code: 0x" << std::hex << uint16_t(buffer.packetCode(legacy_)) << "  0x" << uint16_t(fedChannel.packetCode()) << std::dec;
+            LogDebug("SiStripRawToDigi") << "Virgin raw packet code: 0x" << std::hex
+                                         << uint16_t(buffer.packetCode(legacy_)) << "  0x"
+                                         << uint16_t(fedChannel.packetCode()) << std::dec;
             st_ch = FEDChannelUnpacker::unpackVirginRaw(
                 fedChannel, std::back_inserter(virgin_work_digis_), buffer.packetCode(legacy_));
             if (regItem.index != virgin_work_digis_.size()) {
@@ -356,15 +358,16 @@ namespace sistrip {
               scope_work_registry_.push_back(regItem);
               if (edm::isDebugEnabled()) {
                 std::stringstream ss;
-                ss << "Extracted " << regItem.length << " SCOPE MODE digis (samples[0] = " << scope_work_digis_[regItem.index]
-                   << ") from FED id/ch " << iconn->fedId() << "/" << iconn->fedCh();
+                ss << "Extracted " << regItem.length
+                   << " SCOPE MODE digis (samples[0] = " << scope_work_digis_[regItem.index] << ") from FED id/ch "
+                   << iconn->fedId() << "/" << iconn->fedCh();
                 LogTrace("SiStripRawToDigi") << ss.str();
               }
             } else {
               warnings_.add("No SM digis found!");
             }
           }
-          if ( FEDChannelUnpacker::StatusCode::SUCCESS != st_ch ) {
+          if (FEDChannelUnpacker::StatusCode::SUCCESS != st_ch) {
             warnings_.add(toString(st_ch), (boost::format("FED %1% channel %2%:") % *ifed % iconn->fedCh()).str());
           }
         }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -281,20 +281,20 @@ namespace sistrip {
                                      << ((!legacy_) ? " " : " legacy ") << "data in mode " << smode.str()
                                      << " for module " << iconn->detId() << " pair " << ipair;
 #endif
-        if (FEDChannelUnpacker::isZeroSuppressed(mode, legacy_, lmode)) {
+        if (fedchannelunpacker::isZeroSuppressed(mode, legacy_, lmode)) {
           Registry regItem(key, 0, zs_work_digis_.size(), 0);
-          const auto isNonLite = FEDChannelUnpacker::isNonLiteZS(mode, legacy_, lmode);
+          const auto isNonLite = fedchannelunpacker::isNonLiteZS(mode, legacy_, lmode);
           const uint8_t pCode = (isNonLite ? buffer.packetCode(legacy_, iconn->fedCh()) : 0);
           if (isNonLite)
             LogDebug("SiStripRawToDigi") << "Non-lite zero-suppressed mode. Packet code=0x" << std::hex
                                          << uint16_t(pCode) << std::dec;
-          const auto st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
+          const auto st_ch = fedchannelunpacker::unpackZeroSuppressed(
               fedChannel, std::back_inserter(zs_work_digis_), ipair * 256, isNonLite, mode, legacy_, lmode, pCode);
-          if (FEDChannelUnpacker::StatusCode::ZERO_PACKET_CODE == st_ch ||
-              FEDChannelUnpacker::StatusCode::BAD_PACKET_CODE == st_ch) {
+          if (fedchannelunpacker::StatusCode::ZERO_PACKET_CODE == st_ch ||
+              fedchannelunpacker::StatusCode::BAD_PACKET_CODE == st_ch) {
             warnings_.add((boost::format("Invalid packet code %1$#x for zero-suppressed data") % uint16_t(pCode)).str(),
                           (boost::format("FED %1% channel %2%") % *ifed % iconn->fedCh()).str());
-          } else if (FEDChannelUnpacker::StatusCode::SUCCESS != st_ch) {
+          } else if (fedchannelunpacker::StatusCode::SUCCESS != st_ch) {
             warnings_.add("Clusters are not ordered",
                           (boost::format("FED %1% channel %2%: %3%") % *ifed % iconn->fedCh() % toString(st_ch)).str());
             detids.push_back(iconn->detId());  //@@ Possible multiple entries (ok for Giovanni)
@@ -323,28 +323,28 @@ namespace sistrip {
             }
           }
         } else {
-          auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
-          if (FEDChannelUnpacker::isVirginRaw(mode, legacy_, lmode)) {
+          auto st_ch = fedchannelunpacker::StatusCode::SUCCESS;
+          if (fedchannelunpacker::isVirginRaw(mode, legacy_, lmode)) {
             Registry regItem(key, 256 * ipair, virgin_work_digis_.size(), 0);
             LogDebug("SiStripRawToDigi") << "Virgin raw packet code: 0x" << std::hex
                                          << uint16_t(buffer.packetCode(legacy_)) << "  0x"
                                          << uint16_t(fedChannel.packetCode()) << std::dec;
-            st_ch = FEDChannelUnpacker::unpackVirginRaw(
+            st_ch = fedchannelunpacker::unpackVirginRaw(
                 fedChannel, std::back_inserter(virgin_work_digis_), buffer.packetCode(legacy_));
             if (regItem.index != virgin_work_digis_.size()) {
               regItem.length = virgin_work_digis_.size() - regItem.index;
               virgin_work_registry_.push_back(regItem);
             }
-          } else if (FEDChannelUnpacker::isProcessedRaw(mode, legacy_, lmode)) {
+          } else if (fedchannelunpacker::isProcessedRaw(mode, legacy_, lmode)) {
             Registry regItem(key, 256 * ipair, proc_work_digis_.size(), 0);
-            st_ch = FEDChannelUnpacker::unpackProcessedRaw(fedChannel, std::back_inserter(proc_work_digis_));
+            st_ch = fedchannelunpacker::unpackProcessedRaw(fedChannel, std::back_inserter(proc_work_digis_));
             if (regItem.index != proc_work_digis_.size()) {
               regItem.length = proc_work_digis_.size() - regItem.index;
               proc_work_registry_.push_back(regItem);
             }
-          } else if (FEDChannelUnpacker::isScopeMode(mode, legacy_, lmode)) {
+          } else if (fedchannelunpacker::isScopeMode(mode, legacy_, lmode)) {
             Registry regItem(key, 0, scope_work_digis_.size(), 0);
-            st_ch = FEDChannelUnpacker::unpackScope(fedChannel, std::back_inserter(scope_work_digis_));
+            st_ch = fedchannelunpacker::unpackScope(fedChannel, std::back_inserter(scope_work_digis_));
             if (regItem.index != scope_work_digis_.size()) {
               regItem.length = scope_work_digis_.size() - regItem.index;
               scope_work_registry_.push_back(regItem);
@@ -352,7 +352,7 @@ namespace sistrip {
           } else {  // Unknown readout mode! => assume scope mode
             warnings_.add((boost::format("Unknown FED readout mode (%1%)! Assuming SCOPE MODE...") % mode).str());
             Registry regItem(key, 0, scope_work_digis_.size(), 0);
-            st_ch = FEDChannelUnpacker::unpackScope(fedChannel, std::back_inserter(scope_work_digis_));
+            st_ch = fedchannelunpacker::unpackScope(fedChannel, std::back_inserter(scope_work_digis_));
             if (regItem.index != scope_work_digis_.size()) {
               regItem.length = scope_work_digis_.size() - regItem.index;
               scope_work_registry_.push_back(regItem);
@@ -367,7 +367,7 @@ namespace sistrip {
               warnings_.add("No SM digis found!");
             }
           }
-          if (FEDChannelUnpacker::StatusCode::SUCCESS != st_ch) {
+          if (fedchannelunpacker::StatusCode::SUCCESS != st_ch) {
             warnings_.add(toString(st_ch), (boost::format("FED %1% channel %2%:") % *ifed % iconn->fedCh()).str());
           }
         }

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -148,7 +148,7 @@ namespace sistrip {
       // get the cabling connections for this FED
       auto conns = cabling.fedConnections(*ifed);
       // check FEDRawData pointer, size, and more
-      const auto st_buffer = preconstructCheckFEDBuffer(input.data(), input.size());
+      const auto st_buffer = preconstructCheckFEDBuffer(input);
       // construct FEDBuffer
       if (FEDBufferStatusCode::SUCCESS != st_buffer) {
         if (FEDBufferStatusCode::BUFFER_NULL == st_buffer) {
@@ -163,7 +163,7 @@ namespace sistrip {
         maskFED(detids, conns);
         continue;
       }
-      FEDBuffer buffer(input.data(), input.size());
+      FEDBuffer buffer{input};
       const auto st_chan = buffer.findChannels();
       if (FEDBufferStatusCode::SUCCESS != st_chan) {
         warnings_.add("Exception caught when creating FEDBuffer object for FED",

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -277,7 +277,9 @@ namespace sistrip {
         else
           smode << lmode;
         LogDebug("SiStripRawToDigi")
-          << "Unpacking " << ( (!legacy_)? "" : "legacy ") << "data in mode " << smode.str();
+          << "Unpacking FED " << *ifed << " channel " << iconn->fedCh()
+          << ( (!legacy_)? " " : " legacy ") << "data in mode " << smode.str()
+          << " for module " << iconn->detId() << " pair " << ipair;
 #endif
         if (FEDChannelUnpacker::isZeroSuppressed(mode, legacy_, lmode)) {
           Registry regItem(key, 0, zs_work_digis_.size(), 0);
@@ -323,9 +325,10 @@ namespace sistrip {
           auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
           if (FEDChannelUnpacker::isVirginRaw(mode, legacy_, lmode)) {
             Registry regItem(key, 256 * ipair, virgin_work_digis_.size(), 0);
+            LogDebug("SiStripRawToDigi")
+              << "Virgin raw packet code: 0x" << std::hex << uint16_t(buffer.packetCode(legacy_)) << "  0x" << uint16_t(fedChannel.packetCode()) << std::dec;
             st_ch = FEDChannelUnpacker::unpackVirginRaw(
                 fedChannel, std::back_inserter(virgin_work_digis_), buffer.packetCode(legacy_));
-            // TODO check if this is the channel's packet code
             if (regItem.index != virgin_work_digis_.size()) {
               regItem.length = virgin_work_digis_.size() - regItem.index;
               virgin_work_registry_.push_back(regItem);

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -270,10 +270,21 @@ namespace sistrip {
 
         const auto& fedChannel = buffer.channel(iconn->fedCh());
 
+#ifdef EDM_ML_DEBUG
+        std::stringstream smode;
+        if (!legacy_)
+          smode << mode;
+        else
+          smode << lmode;
+        LogDebug("SiStripRawToDigi")
+          << "Unpacking " << ( (!legacy_)? "" : "legacy ") << "data in mode " << smode.str();
+#endif
         if (FEDChannelUnpacker::isZeroSuppressed(mode, legacy_, lmode)) {
           Registry regItem(key, 0, zs_work_digis_.size(), 0);
           const auto isNonLite = FEDChannelUnpacker::isNonLiteZS(mode, legacy_, lmode);
           const uint8_t pCode = (isNonLite ? buffer.packetCode(legacy_, iconn->fedCh()) : 0);
+          if (isNonLite)
+            LogDebug("SiStripRawToDigi") << "Non-lite zero-suppressed mode. Packet code=" << std::hex << uint16_t(pCode) << std::dec;
           const auto st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
               fedChannel, std::back_inserter(zs_work_digis_), ipair * 256,
               isNonLite, mode, legacy_, lmode, pCode);

--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.h
@@ -106,9 +106,6 @@ namespace sistrip {
     /// dumps raw data to stdout (NB: payload is byte-swapped,headers/trailer are not).
     static void dumpRawData(uint16_t fed_id, const FEDRawData&, std::stringstream&);
 
-    /// catches all possible exceptions and rethrows them as cms::Exceptions
-    void handleException(std::string method_name, std::string extra_info = "");
-
     /// method to clear registries and digi collections
     void cleanupWorkVectors();
 

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -9,8 +9,7 @@
 
 namespace sistrip {
 
-  FEDBuffer::FEDBuffer(const uint8_t* fedBuffer, const uint16_t fedBufferSize, const bool allowBadBuffer)
-      : FEDBufferBase(fedBuffer, fedBufferSize, false) {
+  FEDBuffer::FEDBuffer(const FEDRawData& fedBuffer, const bool allowBadBuffer) : FEDBufferBase(fedBuffer, false) {
     validChannels_ = 0;
     channels_.reserve(FEDCH_PER_FED);
     //build the correct type of FE header object

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -408,8 +408,8 @@ namespace sistrip {
     }
   }
 
-  std::string toString(FEDChannelUnpacker::StatusCode status) {
-    using namespace sistrip::FEDChannelUnpacker;
+  std::string toString(fedchannelunpacker::StatusCode status) {
+    using namespace sistrip::fedchannelunpacker;
     switch (status) {
       case StatusCode::SUCCESS:
         return "SUCCESS";

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -85,47 +85,47 @@ namespace sistrip {
         }
       //if FE unit is enabled
       //check that channel length bytes fit into buffer
-      if UNLIKELY(offsetBeginningOfChannel + 1 >= payloadLength_) {
-        const SiStripFedKey key(0, i / FEDCH_PER_FEUNIT, i % FEDCH_PER_FEUNIT);
-        LogDebug("FEDBuffer") << "Channel " << uint16_t(i)
-           << " (FE unit " << key.feUnit() << " channel " << key.feChan()
-           << " according to external numbering scheme) "
-           << "does not fit into buffer. "
-           << "Channel starts at " << uint16_t(offsetBeginningOfChannel) << " in payload. "
-           << "Payload length is " << uint16_t(payloadLength_) << ". ";
-        st = FEDBufferStatusCode::CHANNEL_BEGIN_BEYOND_PAYLOAD;
-        break;
-      }
+      if
+        UNLIKELY(offsetBeginningOfChannel + 1 >= payloadLength_) {
+          const SiStripFedKey key(0, i / FEDCH_PER_FEUNIT, i % FEDCH_PER_FEUNIT);
+          LogDebug("FEDBuffer") << "Channel " << uint16_t(i) << " (FE unit " << key.feUnit() << " channel "
+                                << key.feChan() << " according to external numbering scheme) "
+                                << "does not fit into buffer. "
+                                << "Channel starts at " << uint16_t(offsetBeginningOfChannel) << " in payload. "
+                                << "Payload length is " << uint16_t(payloadLength_) << ". ";
+          st = FEDBufferStatusCode::CHANNEL_BEGIN_BEYOND_PAYLOAD;
+          break;
+        }
 
       channels_.push_back(FEDChannel(payloadPointer_, offsetBeginningOfChannel));
       //get length and check that whole channel fits into buffer
       uint16_t channelLength = channels_.back().length();
 
       //check that the channel length is long enough to contain the header
-      if UNLIKELY(channelLength < minLength) {
-        const SiStripFedKey key(0, i / FEDCH_PER_FEUNIT, i % FEDCH_PER_FEUNIT);
-        LogDebug("FEDBuffer") << "Channel " << uint16_t(i)
-           << " (FE unit " << key.feUnit() << " channel " << key.feChan()
-           << " according to external numbering scheme)"
-           << " is too short. "
-           << "Channel starts at " << uint16_t(offsetBeginningOfChannel) << " in payload. "
-           << "Channel length is " << uint16_t(channelLength) << ". "
-           << "Min length is " << uint16_t(minLength) << ". ";
-        st = FEDBufferStatusCode::CHANNEL_TOO_SHORT;
-        break;
-      }
-      if UNLIKELY(offsetBeginningOfChannel + channelLength > payloadLength_) {
-        const SiStripFedKey key(0, i / FEDCH_PER_FEUNIT, i % FEDCH_PER_FEUNIT);
-        LogDebug("FEDBuffer") << "Channel " << uint16_t(i)
-           << " (FE unit " << key.feUnit() << " channel " << key.feChan()
-           << " according to external numbering scheme)"
-           << "does not fit into buffer. "
-           << "Channel starts at " << uint16_t(offsetBeginningOfChannel) << " in payload. "
-           << "Channel length is " << uint16_t(channelLength) << ". "
-           << "Payload length is " << uint16_t(payloadLength_) << ". ";
-        st = FEDBufferStatusCode::CHANNEL_END_BEYOND_PAYLOAD;
-        break;
-      }
+      if
+        UNLIKELY(channelLength < minLength) {
+          const SiStripFedKey key(0, i / FEDCH_PER_FEUNIT, i % FEDCH_PER_FEUNIT);
+          LogDebug("FEDBuffer") << "Channel " << uint16_t(i) << " (FE unit " << key.feUnit() << " channel "
+                                << key.feChan() << " according to external numbering scheme)"
+                                << " is too short. "
+                                << "Channel starts at " << uint16_t(offsetBeginningOfChannel) << " in payload. "
+                                << "Channel length is " << uint16_t(channelLength) << ". "
+                                << "Min length is " << uint16_t(minLength) << ". ";
+          st = FEDBufferStatusCode::CHANNEL_TOO_SHORT;
+          break;
+        }
+      if
+        UNLIKELY(offsetBeginningOfChannel + channelLength > payloadLength_) {
+          const SiStripFedKey key(0, i / FEDCH_PER_FEUNIT, i % FEDCH_PER_FEUNIT);
+          LogDebug("FEDBuffer") << "Channel " << uint16_t(i) << " (FE unit " << key.feUnit() << " channel "
+                                << key.feChan() << " according to external numbering scheme)"
+                                << "does not fit into buffer. "
+                                << "Channel starts at " << uint16_t(offsetBeginningOfChannel) << " in payload. "
+                                << "Channel length is " << uint16_t(channelLength) << ". "
+                                << "Payload length is " << uint16_t(payloadLength_) << ". ";
+          st = FEDBufferStatusCode::CHANNEL_END_BEYOND_PAYLOAD;
+          break;
+        }
 
       validChannels_++;
       const uint16_t offsetEndOfChannel = offsetBeginningOfChannel + channelLength;
@@ -139,9 +139,10 @@ namespace sistrip {
         offsetBeginningOfChannel = offsetEndOfChannel;
       }
     }
-    if UNLIKELY( FEDBufferStatusCode::SUCCESS != st ) { // for the allowBadBuffer case
-      channels_.insert(channels_.end(), uint16_t(FEDCH_PER_FED - validChannels_), FEDChannel(payloadPointer_, 0, 0));
-    }
+    if
+      UNLIKELY(FEDBufferStatusCode::SUCCESS != st) {  // for the allowBadBuffer case
+        channels_.insert(channels_.end(), uint16_t(FEDCH_PER_FED - validChannels_), FEDChannel(payloadPointer_, 0, 0));
+      }
     return st;
   }
 

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -408,55 +408,20 @@ namespace sistrip {
     }
   }
 
-  void FEDRawChannelUnpacker::throwBadChannelLength(const uint16_t length) {
-    std::ostringstream ss;
-    ss << "Channel length is invalid. Raw channels have 3 header bytes and 2 bytes per sample. "
-       << "Channel length is " << uint16_t(length) << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
+  std::string toString(FEDChannelUnpacker::StatusCode status) {
+    using namespace sistrip::FEDChannelUnpacker;
+    switch (status) {
+      case StatusCode::SUCCESS:
+        return "SUCCESS";
+      case StatusCode::BAD_CHANNEL_LENGTH:
+        return "Channel length is invalid.";
+      case StatusCode::UNORDERED_DATA:
+        return "First strip of new cluster is not greater than last strip of previous cluster.";
+      case StatusCode::BAD_PACKET_CODE:
+        return "Invalid packet code.";
+      case StatusCode::ZERO_PACKET_CODE:
+        return "Invalid packet code 0 for zero-suppressed data.";
+    }
+    return "";
   }
-
-  void FEDBSChannelUnpacker::throwBadChannelLength(const uint16_t length) {
-    std::ostringstream ss;
-    ss << "Channel length is invalid. "
-       << "Channel length is " << uint16_t(length) << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
-  }
-
-  void FEDBSChannelUnpacker::throwBadWordLength(const uint16_t word_length) {
-    std::ostringstream ss;
-    ss << "Word length is invalid. "
-       << "Word length is " << word_length << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
-  }
-
-  void FEDBSChannelUnpacker::throwUnorderedData(const uint8_t currentStrip, const uint8_t firstStripOfNewCluster) {
-    std::ostringstream ss;
-    ss << "First strip of new cluster is not greater than last strip of previous cluster. "
-       << "Last strip of previous cluster is " << uint16_t(currentStrip) << ". "
-       << "First strip of new cluster is " << uint16_t(firstStripOfNewCluster) << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
-  }
-
-  void FEDZSChannelUnpacker::throwBadChannelLength(const uint16_t length) {
-    std::ostringstream ss;
-    ss << "Channel length is longer than max allowed value. "
-       << "Channel length is " << uint16_t(length) << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
-  }
-
-  void FEDZSChannelUnpacker::throwBadClusterLength() {
-    std::ostringstream ss;
-    ss << "Cluster does not fit into channel. "
-       << "Cluster length is " << uint16_t(valuesLeftInCluster_) << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
-  }
-
-  void FEDZSChannelUnpacker::throwUnorderedData(const uint8_t currentStrip, const uint8_t firstStripOfNewCluster) {
-    std::ostringstream ss;
-    ss << "First strip of new cluster is not greater than last strip of previous cluster. "
-       << "Last strip of previous cluster is " << uint16_t(currentStrip) << ". "
-       << "First strip of new cluster is " << uint16_t(firstStripOfNewCluster) << "." << std::endl;
-    throw cms::Exception("FEDBuffer") << ss.str();
-  }
-
 }  // namespace sistrip

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBuffer.cc
@@ -10,7 +10,7 @@
 namespace sistrip {
 
   FEDBuffer::FEDBuffer(const uint8_t* fedBuffer, const uint16_t fedBufferSize, const bool allowBadBuffer)
-      : FEDBufferBase(fedBuffer, fedBufferSize, allowBadBuffer, false) {
+      : FEDBufferBase(fedBuffer, fedBufferSize, false) {
     channels_.reserve(FEDCH_PER_FED);
     //build the correct type of FE header object
     if ((headerType() != HEADER_TYPE_INVALID) && (headerType() != HEADER_TYPE_NONE)) {
@@ -19,18 +19,6 @@ namespace sistrip {
     } else {
       feHeader_ = std::unique_ptr<FEDFEHeader>();
       payloadPointer_ = getPointerToDataAfterTrackerSpecialHeader();
-      if (!allowBadBuffer) {
-        std::ostringstream ss;
-        ss << "Header type is invalid. "
-           << "Header type nibble is ";
-        uint8_t headerNibble = trackerSpecialHeader().headerTypeNibble();
-        printHex(&headerNibble, 1, ss);
-        ss << ". ";
-        throw cms::Exception("FEDBuffer") << ss.str();
-      }
-    }
-    if (readoutMode() == READOUT_MODE_SPY) {
-      throw cms::Exception("FEDBuffer") << "Unpacking of spy channel data with FEDBuffer is not supported" << std::endl;
     }
     payloadLength_ = getPointerToByteAfterEndOfPayload() - payloadPointer_;
     //check if FE units are present in data

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1254,7 +1254,7 @@ namespace sistrip {
 
   FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool allowUnrecognizedFormat)
       : channels_(FEDCH_PER_FED, FEDChannel(nullptr, 0, 0)), originalBuffer_(fedBuffer), bufferSize_(fedBufferSize) {
-    init(fedBuffer, fedBufferSize, allowUnrecognizedFormat);
+    init(allowUnrecognizedFormat);
   }
 
   FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer,
@@ -1262,12 +1262,12 @@ namespace sistrip {
                                const bool allowUnrecognizedFormat,
                                const bool fillChannelVector)
       : originalBuffer_(fedBuffer), bufferSize_(fedBufferSize) {
-    init(fedBuffer, fedBufferSize, allowUnrecognizedFormat);
+    init(allowUnrecognizedFormat);
     if (fillChannelVector)
       channels_.assign(FEDCH_PER_FED, FEDChannel(nullptr, 0, 0));
   }
 
-  void FEDBufferBase::init(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool allowUnrecognizedFormat) {
+  void FEDBufferBase::init(const bool allowUnrecognizedFormat) {
     //min buffer length. DAQ header, DAQ trailer, tracker special header.
     static const size_t MIN_BUFFER_SIZE = 8 + 8 + 8;
     //check size is non zero and data pointer is not NULL

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1245,13 +1245,15 @@ namespace sistrip {
 
   FEDFEHeader::~FEDFEHeader() {}
 
-  FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize)
-      : channels_(FEDCH_PER_FED, FEDChannel(nullptr, 0, 0)), originalBuffer_(fedBuffer), bufferSize_(fedBufferSize) {
+  FEDBufferBase::FEDBufferBase(const FEDRawData& fedBuffer)
+      : channels_(FEDCH_PER_FED, FEDChannel(nullptr, 0, 0)),
+        originalBuffer_(fedBuffer.data()),
+        bufferSize_(fedBuffer.size()) {
     init();
   }
 
-  FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool fillChannelVector)
-      : originalBuffer_(fedBuffer), bufferSize_(fedBufferSize) {
+  FEDBufferBase::FEDBufferBase(const FEDRawData& fedBuffer, const bool fillChannelVector)
+      : originalBuffer_(fedBuffer.data()), bufferSize_(fedBuffer.size()) {
     init();
     if (fillChannelVector)
       channels_.assign(FEDCH_PER_FED, FEDChannel(nullptr, 0, 0));

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1250,9 +1250,7 @@ namespace sistrip {
     init();
   }
 
-  FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer,
-                               const size_t fedBufferSize,
-                               const bool fillChannelVector)
+  FEDBufferBase::FEDBufferBase(const uint8_t* fedBuffer, const size_t fedBufferSize, const bool fillChannelVector)
       : originalBuffer_(fedBuffer), bufferSize_(fedBufferSize) {
     init();
     if (fillChannelVector)

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -349,6 +349,33 @@ namespace sistrip {
     return os;
   }
 
+  std::ostream& operator<<(std::ostream& os, const FEDBufferStatusCode& value) {
+    switch (value) {
+      case FEDBufferStatusCode::SUCCESS:
+        os << "SUCCESS";
+        break;
+      case FEDBufferStatusCode::BUFFER_NULL:
+        os << "Buffer pointer is NULL.";
+        break;
+      case FEDBufferStatusCode::BUFFER_TOO_SHORT:
+        os << "Buffer is too small. Min size is 24.";
+        break;
+      case FEDBufferStatusCode::UNRECOGNIZED_FORMAT:
+        os << "Buffer format not recognized. ";
+        break;
+      case FEDBufferStatusCode::EXPECT_NOT_SPY:
+        os << "Unpacking of spy channel data with FEDBuffer is not supported";
+        break;
+      case FEDBufferStatusCode::EXPECT_SPY:
+        os << "Buffer is not from spy channel";
+        break;
+      case FEDBufferStatusCode::WRONG_HEADERTYPE:
+        os << "No or invalid header type";
+        break;
+    }
+    return os;
+  }
+
   FEDBufferFormat fedBufferFormatFromString(const std::string& bufferFormatString) {
     if ((bufferFormatString == "OLD_VME") || (bufferFormatString == "BUFFER_FORMAT_OLD_VME") ||
         (bufferFormatString == "Old VME")) {

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -372,6 +372,13 @@ namespace sistrip {
       case FEDBufferStatusCode::WRONG_HEADERTYPE:
         os << "No or invalid header type";
         break;
+      case FEDBufferStatusCode::CHANNEL_BEGIN_BEYOND_PAYLOAD:
+      case FEDBufferStatusCode::CHANNEL_END_BEYOND_PAYLOAD:
+        os << "Channel does not fit into buffer";
+        break;
+      case FEDBufferStatusCode::CHANNEL_TOO_SHORT:
+        os << "Channel is too short";
+        break;
     }
     return os;
   }

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferComponents.cc
@@ -1401,27 +1401,4 @@ namespace sistrip {
     summary << "Check length from trailer: " << (checkLengthFromTrailer() ? "passed" : "FAILED") << std::endl;
     return summary.str();
   }
-
-  uint16_t FEDChannel::cmMedian(const uint8_t apvIndex) const {
-    const auto pCode = packetCode();
-    if ((pCode != PACKET_CODE_ZERO_SUPPRESSED) && (pCode != PACKET_CODE_ZERO_SUPPRESSED10) &&
-        (pCode != PACKET_CODE_ZERO_SUPPRESSED8_BOTBOT) && (pCode != PACKET_CODE_ZERO_SUPPRESSED8_TOPBOT)) {
-      std::ostringstream ss;
-      ss << "Request for CM median from channel with non-ZS packet code. "
-         << "Packet code is " << uint16_t(packetCode()) << "." << std::endl;
-      throw cms::Exception("FEDBuffer") << ss.str();
-    }
-    if (apvIndex > 1) {
-      std::ostringstream ss;
-      ss << "Channel APV index out of range when requesting CM median for APV. "
-         << "Channel APV index is " << uint16_t(apvIndex) << "." << std::endl;
-      throw cms::Exception("FEDBuffer") << ss.str();
-    }
-    uint16_t result = 0;
-    //CM median is 10 bits with lowest order byte first. First APV CM median starts in 4th byte of channel data
-    result |= data_[(offset_ + 3 + 2 * apvIndex) ^ 7];
-    result |= (((data_[(offset_ + 4 + 2 * apvIndex) ^ 7]) << 8) & 0x300);
-    return result;
-  }
-
 }  // namespace sistrip

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
@@ -18,7 +18,7 @@ namespace sistrip {
     }
   }
 
-  const FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) const {
+  FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) {
     try {
       return data_.at(internalFEDChannelNum);
     } catch (const std::out_of_range&) {

--- a/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
+++ b/EventFilter/SiStripRawToDigi/src/SiStripFEDBufferGenerator.cc
@@ -18,7 +18,7 @@ namespace sistrip {
     }
   }
 
-  FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) {
+  const FEDStripData::ChannelData& FEDStripData::channel(const uint8_t internalFEDChannelNum) const {
     try {
       return data_.at(internalFEDChannelNum);
     } catch (const std::out_of_range&) {

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -67,8 +67,7 @@ void SiStripFEDRawDataAnalyzer::analyze(const edm::Event& event, const edm::Even
 
   for (uint16_t ifed = 0; ifed <= sistrip::CMS_FED_ID_MAX; ++ifed) {
     const FEDRawData& fed = buffers->FEDData(static_cast<int>(ifed));
-    uint8_t* data = const_cast<uint8_t*>(fed.data());  // look for trigger fed
-    FEDTrailer* fed_trailer = reinterpret_cast<FEDTrailer*>(data + fed.size() - sizeof(FEDTrailer));
+    const FEDTrailer* fed_trailer = reinterpret_cast<const FEDTrailer*>(fed.data() + fed.size() - sizeof(FEDTrailer));
     if (fed.size() && fed_trailer->check()) {
       trg_feds.push_back(Fed(ifed, fed.size()));
     } else {

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -217,24 +217,19 @@ void SiStripFEDRawDataAnalyzer::analyze(const edm::Event& event, const edm::Even
 
       // find channel data
 
-      if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED &&
-          sistrip::FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(buffer->channel(ichan)).hasData())
+      if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED && buffer->channel(ichan).length() > 7)
         channels_with_data[ifed].push_back(ichan);
 
-      else if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 &&
-               sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(ichan)).hasData())
+      else if (mode == sistrip::READOUT_MODE_ZERO_SUPPRESSED_LITE10 && buffer->channel(ichan).length() > 2)
         channels_with_data[ifed].push_back(ichan);
 
-      else if (mode == sistrip::READOUT_MODE_VIRGIN_RAW &&
-               sistrip::FEDRawChannelUnpacker::virginRawModeUnpacker(buffer->channel(ichan)).hasData())
+      else if (mode == sistrip::READOUT_MODE_VIRGIN_RAW && buffer->channel(ichan).length() > 3)
         channels_with_data[ifed].push_back(ichan);
 
-      else if (mode == sistrip::READOUT_MODE_PROC_RAW &&
-               sistrip::FEDRawChannelUnpacker::procRawModeUnpacker(buffer->channel(ichan)).hasData())
+      else if (mode == sistrip::READOUT_MODE_PROC_RAW && buffer->channel(ichan).length() > 3)
         channels_with_data[ifed].push_back(ichan);
 
-      else if (mode == sistrip::READOUT_MODE_SCOPE &&
-               sistrip::FEDRawChannelUnpacker::scopeModeUnpacker(buffer->channel(ichan)).hasData())
+      else if (mode == sistrip::READOUT_MODE_SCOPE && buffer->channel(ichan).length() > 3)
         channels_with_data[ifed].push_back(ichan);
 
       else

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -194,11 +194,11 @@ void SiStripFEDRawDataAnalyzer::analyze(const edm::Event& event, const edm::Even
 
     // construct buffer
     std::unique_ptr<FEDBuffer> buffer;
-    if ( FEDBufferStatusCode::SUCCESS != preconstructCheckFEDBuffer(fed.data(), fed.size()) ) {
+    if (FEDBufferStatusCode::SUCCESS != preconstructCheckFEDBuffer(fed.data(), fed.size())) {
       construct[ifed].push_back(0);
     } else {
       buffer = std::make_unique<FEDBuffer>(fed.data(), fed.size());
-      if ( FEDBufferStatusCode::SUCCESS != buffer->findChannels() ) {
+      if (FEDBufferStatusCode::SUCCESS != buffer->findChannels()) {
         construct[ifed].push_back(0);
       }
     }

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -194,10 +194,10 @@ void SiStripFEDRawDataAnalyzer::analyze(const edm::Event& event, const edm::Even
 
     // construct buffer
     std::unique_ptr<FEDBuffer> buffer;
-    if (FEDBufferStatusCode::SUCCESS != preconstructCheckFEDBuffer(fed.data(), fed.size())) {
+    if (FEDBufferStatusCode::SUCCESS != preconstructCheckFEDBuffer(fed)) {
       construct[ifed].push_back(0);
     } else {
-      buffer = std::make_unique<FEDBuffer>(fed.data(), fed.size());
+      buffer = std::make_unique<FEDBuffer>(fed);
       if (FEDBufferStatusCode::SUCCESS != buffer->findChannels()) {
         construct[ifed].push_back(0);
       }

--- a/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
@@ -66,17 +66,9 @@ public:
   //HLT stripByStrip interface
   virtual Det stripByStripBegin(uint32_t id) const = 0;
 
-  virtual void addFed(Det const& det,
-                      sistrip::FEDZSChannelUnpacker& unpacker,
-                      uint16_t ipair,
-                      std::vector<SiStripCluster>& out) const {}
   virtual void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, std::vector<SiStripCluster>& out) const {}
   virtual void stripByStripEnd(State& state, std::vector<SiStripCluster>& out) const {}
 
-  virtual void addFed(State& state,
-                      sistrip::FEDZSChannelUnpacker& unpacker,
-                      uint16_t ipair,
-                      output_t::TSFastFiller& out) const {}
   virtual void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, output_t::TSFastFiller& out) const {}
   virtual void stripByStripEnd(State& state, output_t::TSFastFiller& out) const {}
 

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -18,27 +18,6 @@ public:
   void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, std::vector<SiStripCluster>& out) const override;
   void stripByStripEnd(State& state, std::vector<SiStripCluster>& out) const override;
 
-  void addFed(State& state,
-              sistrip::FEDZSChannelUnpacker& unpacker,
-              uint16_t ipair,
-              std::vector<SiStripCluster>& out) const {
-    while (unpacker.hasData()) {
-      stripByStripAdd(state, unpacker.sampleNumber() + ipair * 256, unpacker.adc(), out);
-      unpacker++;
-    }
-  }
-  using StripClusterizerAlgorithm::addFed;
-  // detset interface
-  void addFed(State& state,
-              sistrip::FEDZSChannelUnpacker& unpacker,
-              uint16_t ipair,
-              output_t::TSFastFiller& out) const override {
-    while (unpacker.hasData()) {
-      stripByStripAdd(state, unpacker.sampleNumber() + ipair * 256, unpacker.adc(), out);
-      unpacker++;
-    }
-  }
-
   void stripByStripAdd(State& state, uint16_t strip, uint8_t adc, output_t::TSFastFiller& out) const override {
     if (candidateEnded(state, strip))
       endCandidate(state, out);

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -261,83 +261,6 @@ void SiStripClusterizerFromRaw::run(const FEDRawDataCollection& rawColl, edmNew:
 }
 
 namespace {
-  template <typename OUT>
-  OUT unpackZS(const sistrip::FEDChannel& chan, sistrip::FEDReadoutMode mode, uint16_t stripOffset, OUT out) {
-    using namespace sistrip;
-    switch (mode) {
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE8:
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_CMOVERRIDE: {
-        auto unpacker = FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(chan);
-        while (unpacker.hasData()) {
-          *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc());
-          unpacker++;
-        }
-      } break;
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE10:
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE10_CMOVERRIDE: {
-        auto unpacker = FEDBSChannelUnpacker::zeroSuppressedLiteModeUnpacker(chan, 10);
-        while (unpacker.hasData()) {
-          *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc());
-          unpacker++;
-        }
-      } break;
-      case READOUT_MODE_ZERO_SUPPRESSED:
-      case READOUT_MODE_ZERO_SUPPRESSED_FAKE: {
-        switch (chan.packetCode()) {
-          case PACKET_CODE_ZERO_SUPPRESSED: {
-            auto unpacker = FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(chan);
-            while (unpacker.hasData()) {
-              *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc());
-              unpacker++;
-            }
-          } break;
-          case PACKET_CODE_ZERO_SUPPRESSED10: {
-            auto unpacker = FEDBSChannelUnpacker::zeroSuppressedModeUnpacker(chan, 10);
-            while (unpacker.hasData()) {
-              *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc());
-              unpacker++;
-            }
-          } break;
-          case PACKET_CODE_ZERO_SUPPRESSED8_BOTBOT: {
-            auto unpacker = FEDBSChannelUnpacker::zeroSuppressedModeUnpacker(chan, 8);
-            while (unpacker.hasData()) {
-              *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc() << 2);
-              unpacker++;
-            }
-          } break;
-          case PACKET_CODE_ZERO_SUPPRESSED8_TOPBOT: {
-            auto unpacker = FEDBSChannelUnpacker::zeroSuppressedModeUnpacker(chan, 8);
-            while (unpacker.hasData()) {
-              *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc() << 1);
-              unpacker++;
-            }
-          } break;
-          default:
-            edm::LogWarning(mlRawToCluster_) << "[ClustersFromRawProducer::" << __func__ << "]"
-                                             << " invalid packet code " << chan.packetCode() << " for zero-suppressed.";
-        }
-      } break;
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT:
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_TOPBOT_CMOVERRIDE: {
-        auto unpacker = FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(chan);
-        while (unpacker.hasData()) {
-          *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc() << 1);
-          unpacker++;
-        }
-      } break;
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT:
-      case READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE: {
-        auto unpacker = FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(chan);
-        while (unpacker.hasData()) {
-          *out++ = SiStripDigi(stripOffset + unpacker.sampleNumber(), unpacker.adc() << 2);
-          unpacker++;
-        }
-      } break;
-      default:;
-    }
-    return out;
-  }
-
   class StripByStripAdder {
   public:
     typedef std::output_iterator_tag iterator_category;
@@ -432,132 +355,79 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
       const sistrip::FEDLegacyReadoutMode lmode =
           legacy_ ? buffer->legacyReadoutMode() : sistrip::READOUT_MODE_LEGACY_INVALID;
 
-      if
-        LIKELY((!legacy_) && (mode > sistrip::READOUT_MODE_VIRGIN_RAW) && (mode < sistrip::READOUT_MODE_SPY) &&
-               (mode != sistrip::READOUT_MODE_PROC_RAW)) {
-          // ZS modes
-          try {
-            auto perStripAdder = StripByStripAdder(clusterizer, state, record);
-            if
-              LIKELY(!hybridZeroSuppressed_) { unpackZS(buffer->channel(fedCh), mode, ipair * 256, perStripAdder); }
-            else {
-              const uint32_t id = conn->detId();
-              edm::DetSet<SiStripDigi> unpDigis{id};
-              unpDigis.reserve(256);
-              unpackZS(buffer->channel(fedCh), mode, ipair * 256, std::back_inserter(unpDigis));
-              SiStripRawProcessingAlgorithms::digivector_t workRawDigis;
-              rawAlgos.convertHybridDigiToRawDigiVector(unpDigis, workRawDigis);
-              edm::DetSet<SiStripDigi> suppDigis{id};
-              rawAlgos.suppressHybridData(id, ipair * 2, workRawDigis, suppDigis);
-              std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
-            }
-          } catch (edmNew::CapacityExaustedException const&) {
-            throw;
-          } catch (const cms::Exception& e) {
-            if (edm::isDebugEnabled()) {
-              edm::LogWarning(sistrip::mlRawToCluster_)
-                  << "Unordered clusters for channel " << fedCh << " on FED " << fedId << ": " << e.what();
-            }
-            continue;
+      using namespace sistrip;
+      if LIKELY(FEDChannelUnpacker::isZeroSuppressed(mode, legacy_, lmode)) {
+        auto perStripAdder = StripByStripAdder(clusterizer, state, record);
+        const auto isNonLite = FEDChannelUnpacker::isNonLiteZS(mode, legacy_, lmode);
+        const uint8_t pCode = (isNonLite ? buffer->packetCode(legacy_, fedCh) : 0);
+        auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
+        if LIKELY(!hybridZeroSuppressed_) {
+          st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
+              buffer->channel(fedCh), perStripAdder, ipair * 256,
+              isNonLite, mode, legacy_, lmode, pCode);
+        } else {
+          const uint32_t id = conn->detId();
+          edm::DetSet<SiStripDigi> unpDigis{id};
+          unpDigis.reserve(256);
+          st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
+              buffer->channel(fedCh), std::back_inserter(unpDigis), ipair * 256,
+              isNonLite, mode, legacy_, lmode, pCode);
+          if ( FEDChannelUnpacker::StatusCode::SUCCESS == st_ch ) {
+            SiStripRawProcessingAlgorithms::digivector_t workRawDigis;
+            rawAlgos.convertHybridDigiToRawDigiVector(unpDigis, workRawDigis);
+            edm::DetSet<SiStripDigi> suppDigis{id};
+            rawAlgos.suppressHybridData(id, ipair * 2, workRawDigis, suppDigis);
+            std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
           }
         }
-      else if (legacy_ && (lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_REAL ||
-                           lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_FAKE)) {
-        auto unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedModeUnpacker(buffer->channel(fedCh));
-        clusterizer.addFed(state, unpacker, ipair, record);
-      } else if (legacy_ && (lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_REAL ||
-                             lmode == sistrip::READOUT_MODE_LEGACY_ZERO_SUPPRESSED_LITE_FAKE)) {
-        auto unpacker = sistrip::FEDZSChannelUnpacker::zeroSuppressedLiteModeUnpacker(buffer->channel(fedCh));
-        while (unpacker.hasData()) {
-          clusterizer.stripByStripAdd(state, ipair * 256 + unpacker.sampleNumber(), unpacker.adc(), record);
-          unpacker++;
-        }
-      } else if (!legacy_ ? (mode == sistrip::READOUT_MODE_VIRGIN_RAW)
-                          : (lmode == sistrip::READOUT_MODE_LEGACY_VIRGIN_RAW_REAL ||
-                             lmode == sistrip::READOUT_MODE_LEGACY_VIRGIN_RAW_FAKE)) {
-        std::vector<int16_t> samples;
-        switch (buffer->channel(fedCh).packetCode()) {
-          case sistrip::PACKET_CODE_VIRGIN_RAW: {
-            auto unpacker = sistrip::FEDRawChannelUnpacker::virginRawModeUnpacker(buffer->channel(fedCh));
-            while (unpacker.hasData()) {
-              samples.push_back(unpacker.adc());
-              unpacker++;
-            }
-          } break;
-          case sistrip::PACKET_CODE_VIRGIN_RAW10: {
-            auto unpacker = sistrip::FEDBSChannelUnpacker::virginRawModeUnpacker(buffer->channel(fedCh), 10);
-            while (unpacker.hasData()) {
-              samples.push_back(unpacker.adc());
-              unpacker++;
-            }
-          } break;
-          case sistrip::PACKET_CODE_VIRGIN_RAW8_BOTBOT: {
-            auto unpacker = sistrip::FEDBSChannelUnpacker::virginRawModeUnpacker(buffer->channel(fedCh), 8);
-            while (unpacker.hasData()) {
-              samples.push_back(unpacker.adc() << 2);
-              unpacker++;
-            }
-          } break;
-          case sistrip::PACKET_CODE_VIRGIN_RAW8_TOPBOT: {
-            auto unpacker = sistrip::FEDBSChannelUnpacker::virginRawModeUnpacker(buffer->channel(fedCh), 8);
-            while (unpacker.hasData()) {
-              samples.push_back(unpacker.adc() << 1);
-              unpacker++;
-            }
-          } break;
-          default:
-            edm::LogWarning(sistrip::mlRawToCluster_)
-                << "[ClustersFromRawProducer::" << __func__ << "]"
-                << " invalid packet code " << buffer->channel(fedCh).packetCode() << " for virgin raw.";
-        }
-        // un-multiplex the digis (from readout to physical order)
-        std::vector<int16_t> digis;
-        for (uint16_t i = 0; i != samples.size(); ++i) {
-          // move bits around:   2-0->7-5   ,   4-3->4-3   ,      6-5->2-1     ,      7->0
-          const auto readout = ((i & 0x7) << 5) + (i & (0x3 << 3)) + ((i & (0x3 << 5)) >> 4) + ((i & (0x1 << 7)) >> 7);
-          digis.push_back(samples[readout]);
-        }
-        //process raw
-        uint32_t id = conn->detId();
-        edm::DetSet<SiStripDigi> zsdigis(id);
-        //rawAlgos_->subtractorPed->subtract( id, ipair*256, digis);
-        //rawAlgos_->subtractorCMN->subtract( id, digis);
-        //rawAlgos_->suppressor->suppress( digis, zsdigis);
-        uint16_t firstAPV = ipair * 2;
-        rawAlgos.suppressVirginRawData(id, firstAPV, digis, zsdigis);
-        for (const auto digi : zsdigis) {
-          clusterizer.stripByStripAdd(state, digi.strip(), digi.adc(), record);
-        }
-
-      } else if (!legacy_ ? (mode == sistrip::READOUT_MODE_PROC_RAW)
-                          : (lmode == sistrip::READOUT_MODE_LEGACY_PROC_RAW_REAL ||
-                             lmode == sistrip::READOUT_MODE_LEGACY_PROC_RAW_FAKE)) {
-        // create unpacker
-        sistrip::FEDRawChannelUnpacker unpacker =
-            sistrip::FEDRawChannelUnpacker::procRawModeUnpacker(buffer->channel(fedCh));
-
-        // unpack
-        std::vector<int16_t> digis;
-        while (unpacker.hasData()) {
-          digis.push_back(unpacker.adc());
-          unpacker++;
-        }
-
-        //process raw
-        uint32_t id = conn->detId();
-        edm::DetSet<SiStripDigi> zsdigis(id);
-        //rawAlgos_->subtractorCMN->subtract( id, digis);
-        //rawAlgos_->suppressor->suppress( digis, zsdigis);
-        uint16_t firstAPV = ipair * 2;
-        rawAlgos.suppressProcessedRawData(id, firstAPV, digis, zsdigis);
-        for (edm::DetSet<SiStripDigi>::const_iterator it = zsdigis.begin(); it != zsdigis.end(); it++) {
-          clusterizer.stripByStripAdd(state, it->strip(), it->adc(), record);
+        if ( FEDChannelUnpacker::StatusCode::SUCCESS != st_ch && edm::isDebugEnabled() ) {
+          edm::LogWarning(sistrip::mlRawToCluster_)
+              << "Unordered clusters for channel " << fedCh << " on FED " << fedId << ": " << toString(st_ch);
+          continue;
         }
       } else {
-        edm::LogWarning(sistrip::mlRawToCluster_)
-            << "[ClustersFromRawProducer::" << __func__ << "]"
-            << " FEDRawData readout mode " << mode << " from FED id " << fedId << " not supported.";
-        continue;
+        auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
+        if (FEDChannelUnpacker::isVirginRaw(mode, legacy_, lmode)) {
+          std::vector<int16_t> digis;
+          st_ch = FEDChannelUnpacker::unpackVirginRaw(buffer->channel(fedCh), std::back_inserter(digis), buffer->channel(fedCh).packetCode());
+          if ( FEDChannelUnpacker::StatusCode::SUCCESS == st_ch ) {
+            //process raw
+            uint32_t id = conn->detId();
+            edm::DetSet<SiStripDigi> zsdigis(id);
+            //rawAlgos_->subtractorPed->subtract( id, ipair*256, digis);
+            //rawAlgos_->subtractorCMN->subtract( id, digis);
+            //rawAlgos_->suppressor->suppress( digis, zsdigis);
+            uint16_t firstAPV = ipair * 2;
+            rawAlgos.suppressVirginRawData(id, firstAPV, digis, zsdigis);
+            for (const auto digi : zsdigis) {
+              clusterizer.stripByStripAdd(state, digi.strip(), digi.adc(), record);
+            }
+          }
+        } else if (FEDChannelUnpacker::isProcessedRaw(mode, legacy_, lmode)) {
+          std::vector<int16_t> digis;
+          st_ch = FEDChannelUnpacker::unpackProcessedRaw(buffer->channel(fedCh), std::back_inserter(digis));
+          if ( FEDChannelUnpacker::StatusCode::SUCCESS == st_ch ) {
+            //process raw
+            uint32_t id = conn->detId();
+            edm::DetSet<SiStripDigi> zsdigis(id);
+            //rawAlgos_->subtractorCMN->subtract( id, digis);
+            //rawAlgos_->suppressor->suppress( digis, zsdigis);
+            uint16_t firstAPV = ipair * 2;
+            rawAlgos.suppressProcessedRawData(id, firstAPV, digis, zsdigis);
+            for (edm::DetSet<SiStripDigi>::const_iterator it = zsdigis.begin(); it != zsdigis.end(); it++) {
+              clusterizer.stripByStripAdd(state, it->strip(), it->adc(), record);
+            }
+          }
+        } else {
+          edm::LogWarning(sistrip::mlRawToCluster_)
+              << "[ClustersFromRawProducer::" << __func__ << "]"
+              << " FEDRawData readout mode " << mode << " from FED id " << fedId << " not supported.";
+        }
+        if ( FEDChannelUnpacker::StatusCode::SUCCESS != st_ch && edm::isDebugEnabled() ) {
+          edm::LogWarning(sistrip::mlRawToCluster_)
+              << "[ClustersFromRawProducer::" << __func__ << "]"
+              << toString(st_ch) << " from FED id " << fedId << " channel " << fedCh;
+        }
       }
     }  // end loop over conn
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -288,6 +288,28 @@ namespace {
     StripClusterizerAlgorithm::State& state_;
     StripClusterizerAlgorithm::output_t::TSFastFiller& record_;
   };
+
+  template<typename Container>
+  class ADC_back_inserter {
+  public:
+    typedef std::output_iterator_tag iterator_category;
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
+
+    ADC_back_inserter(Container& c) : c_(c) {}
+
+    ADC_back_inserter& operator=(SiStripRawDigi digi) {
+      c_.push_back(digi.adc());
+      return *this;
+    }
+    ADC_back_inserter& operator*() { return *this; }
+    ADC_back_inserter& operator++() { return *this; }
+    ADC_back_inserter& operator++(int) { return *this; }
+  private:
+    Container& c_;
+  };
 }  // namespace
 
 void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) {
@@ -398,7 +420,7 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
         if (FEDChannelUnpacker::isVirginRaw(mode, legacy_, lmode)) {
           std::vector<int16_t> digis;
           st_ch = FEDChannelUnpacker::unpackVirginRaw(
-              buffer->channel(fedCh), std::back_inserter(digis), buffer->channel(fedCh).packetCode());
+              buffer->channel(fedCh), ADC_back_inserter(digis), buffer->channel(fedCh).packetCode());
           if (FEDChannelUnpacker::StatusCode::SUCCESS == st_ch) {
             //process raw
             uint32_t id = conn->detId();
@@ -414,7 +436,7 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
           }
         } else if (FEDChannelUnpacker::isProcessedRaw(mode, legacy_, lmode)) {
           std::vector<int16_t> digis;
-          st_ch = FEDChannelUnpacker::unpackProcessedRaw(buffer->channel(fedCh), std::back_inserter(digis));
+          st_ch = FEDChannelUnpacker::unpackProcessedRaw(buffer->channel(fedCh), ADC_back_inserter(digis));
           if (FEDChannelUnpacker::StatusCode::SUCCESS == st_ch) {
             //process raw
             uint32_t id = conn->detId();

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -46,7 +46,7 @@ namespace {
     const FEDRawData& rawData = rawColl.FEDData(fedId);
 
     // Check on FEDRawData pointer
-    const auto st_buffer = sistrip::preconstructCheckFEDBuffer(rawData.data(), rawData.size());
+    const auto st_buffer = sistrip::preconstructCheckFEDBuffer(rawData);
     if
       UNLIKELY(sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
         if (edm::isDebugEnabled()) {
@@ -55,7 +55,7 @@ namespace {
         }
         return buffer;
       }
-    buffer = std::make_unique<sistrip::FEDBuffer>(rawData.data(), rawData.size());
+    buffer = std::make_unique<sistrip::FEDBuffer>(rawData);
     const auto st_chan = buffer->findChannels();
     if
       UNLIKELY(sistrip::FEDBufferStatusCode::SUCCESS != st_chan) {

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -50,31 +50,31 @@ namespace {
     if
       UNLIKELY(sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
         if (edm::isDebugEnabled()) {
-          edm::LogWarning(sistrip::mlRawToCluster_) << "[ClustersFromRawProducer::" << __func__ << "]"
-                                                    << st_buffer << " for FED ID " << fedId;
+          edm::LogWarning(sistrip::mlRawToCluster_)
+              << "[ClustersFromRawProducer::" << __func__ << "]" << st_buffer << " for FED ID " << fedId;
         }
         return buffer;
       }
     buffer = std::make_unique<sistrip::FEDBuffer>(rawData.data(), rawData.size());
     const auto st_chan = buffer->findChannels();
     if
-      UNLIKELY( sistrip::FEDBufferStatusCode::SUCCESS != st_chan ) {
+      UNLIKELY(sistrip::FEDBufferStatusCode::SUCCESS != st_chan) {
         if (edm::isDebugEnabled()) {
           edm::LogWarning(sistrip::mlRawToCluster_)
               << "Exception caught when creating FEDBuffer object for FED " << fedId << ": " << st_chan;
         }
         buffer.reset();
         return buffer;
-    }
+      }
     if
-      UNLIKELY( !buffer->doChecks(false) ) {
+      UNLIKELY(!buffer->doChecks(false)) {
         if (edm::isDebugEnabled()) {
           edm::LogWarning(sistrip::mlRawToCluster_)
               << "Exception caught when creating FEDBuffer object for FED " << fedId << ": FED Buffer check fails";
         }
         buffer.reset();
         return buffer;
-    }
+      }
 
     /*
     // dump of FEDRawData to stdout

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -289,7 +289,7 @@ namespace {
     StripClusterizerAlgorithm::output_t::TSFastFiller& record_;
   };
 
-  template<typename Container>
+  template <typename Container>
   class ADC_back_inserter {
   public:
     typedef std::output_iterator_tag iterator_category;
@@ -307,6 +307,7 @@ namespace {
     ADC_back_inserter& operator*() { return *this; }
     ADC_back_inserter& operator++() { return *this; }
     ADC_back_inserter& operator++(int) { return *this; }
+
   private:
     Container& c_;
   };

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -292,12 +292,6 @@ namespace {
   template <typename Container>
   class ADC_back_inserter {
   public:
-    typedef std::output_iterator_tag iterator_category;
-    typedef void value_type;
-    typedef void difference_type;
-    typedef void pointer;
-    typedef void reference;
-
     ADC_back_inserter(Container& c) : c_(c) {}
 
     ADC_back_inserter& operator=(SiStripRawDigi digi) {
@@ -380,21 +374,21 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
 
       using namespace sistrip;
       if
-        LIKELY(FEDChannelUnpacker::isZeroSuppressed(mode, legacy_, lmode)) {
+        LIKELY(fedchannelunpacker::isZeroSuppressed(mode, legacy_, lmode)) {
           auto perStripAdder = StripByStripAdder(clusterizer, state, record);
-          const auto isNonLite = FEDChannelUnpacker::isNonLiteZS(mode, legacy_, lmode);
+          const auto isNonLite = fedchannelunpacker::isNonLiteZS(mode, legacy_, lmode);
           const uint8_t pCode = (isNonLite ? buffer->packetCode(legacy_, fedCh) : 0);
-          auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
+          auto st_ch = fedchannelunpacker::StatusCode::SUCCESS;
           if
             LIKELY(!hybridZeroSuppressed_) {
-              st_ch = FEDChannelUnpacker::unpackZeroSuppressed(
+              st_ch = fedchannelunpacker::unpackZeroSuppressed(
                   buffer->channel(fedCh), perStripAdder, ipair * 256, isNonLite, mode, legacy_, lmode, pCode);
             }
           else {
             const uint32_t id = conn->detId();
             edm::DetSet<SiStripDigi> unpDigis{id};
             unpDigis.reserve(256);
-            st_ch = FEDChannelUnpacker::unpackZeroSuppressed(buffer->channel(fedCh),
+            st_ch = fedchannelunpacker::unpackZeroSuppressed(buffer->channel(fedCh),
                                                              std::back_inserter(unpDigis),
                                                              ipair * 256,
                                                              isNonLite,
@@ -402,7 +396,7 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
                                                              legacy_,
                                                              lmode,
                                                              pCode);
-            if (FEDChannelUnpacker::StatusCode::SUCCESS == st_ch) {
+            if (fedchannelunpacker::StatusCode::SUCCESS == st_ch) {
               SiStripRawProcessingAlgorithms::digivector_t workRawDigis;
               rawAlgos.convertHybridDigiToRawDigiVector(unpDigis, workRawDigis);
               edm::DetSet<SiStripDigi> suppDigis{id};
@@ -410,19 +404,19 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
               std::copy(std::begin(suppDigis), std::end(suppDigis), perStripAdder);
             }
           }
-          if (FEDChannelUnpacker::StatusCode::SUCCESS != st_ch && edm::isDebugEnabled()) {
+          if (fedchannelunpacker::StatusCode::SUCCESS != st_ch && edm::isDebugEnabled()) {
             edm::LogWarning(sistrip::mlRawToCluster_)
                 << "Unordered clusters for channel " << fedCh << " on FED " << fedId << ": " << toString(st_ch);
             continue;
           }
         }
       else {
-        auto st_ch = FEDChannelUnpacker::StatusCode::SUCCESS;
-        if (FEDChannelUnpacker::isVirginRaw(mode, legacy_, lmode)) {
+        auto st_ch = fedchannelunpacker::StatusCode::SUCCESS;
+        if (fedchannelunpacker::isVirginRaw(mode, legacy_, lmode)) {
           std::vector<int16_t> digis;
-          st_ch = FEDChannelUnpacker::unpackVirginRaw(
+          st_ch = fedchannelunpacker::unpackVirginRaw(
               buffer->channel(fedCh), ADC_back_inserter(digis), buffer->channel(fedCh).packetCode());
-          if (FEDChannelUnpacker::StatusCode::SUCCESS == st_ch) {
+          if (fedchannelunpacker::StatusCode::SUCCESS == st_ch) {
             //process raw
             uint32_t id = conn->detId();
             edm::DetSet<SiStripDigi> zsdigis(id);
@@ -435,10 +429,10 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
               clusterizer.stripByStripAdd(state, digi.strip(), digi.adc(), record);
             }
           }
-        } else if (FEDChannelUnpacker::isProcessedRaw(mode, legacy_, lmode)) {
+        } else if (fedchannelunpacker::isProcessedRaw(mode, legacy_, lmode)) {
           std::vector<int16_t> digis;
-          st_ch = FEDChannelUnpacker::unpackProcessedRaw(buffer->channel(fedCh), ADC_back_inserter(digis));
-          if (FEDChannelUnpacker::StatusCode::SUCCESS == st_ch) {
+          st_ch = fedchannelunpacker::unpackProcessedRaw(buffer->channel(fedCh), ADC_back_inserter(digis));
+          if (fedchannelunpacker::StatusCode::SUCCESS == st_ch) {
             //process raw
             uint32_t id = conn->detId();
             edm::DetSet<SiStripDigi> zsdigis(id);
@@ -455,7 +449,7 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& reco
               << "[ClustersFromRawProducer::" << __func__ << "]"
               << " FEDRawData readout mode " << mode << " from FED id " << fedId << " not supported.";
         }
-        if (FEDChannelUnpacker::StatusCode::SUCCESS != st_ch && edm::isDebugEnabled()) {
+        if (fedchannelunpacker::StatusCode::SUCCESS != st_ch && edm::isDebugEnabled()) {
           edm::LogWarning(sistrip::mlRawToCluster_)
               << "[ClustersFromRawProducer::" << __func__ << "]" << toString(st_ch) << " from FED id " << fedId
               << " channel " << fedCh;


### PR DESCRIPTION
#### PR description:

These changes address https://github.com/cms-sw/cmssw/issues/24825 (also tracked in jira as [CMSTRACK-161](https://its.cern.ch/jira/browse/CMSTRACK-161)): the strip unpacker does not throw exceptions anymore (those left in EventFilter/SiStripRawToDigi are only used in the packer, and signal a bad input, so I think they are acceptable). Instead, status codes are returned.
The extra information that used to be in the exception message is printed through `LogDebug`, so it won't be there in release builds anymore, but the warnings (by default: maximally once per type, and then a count at the end of the job) that were printed are still there (minus the information that came from the exception message - FED and channel ID are still there, these are the most relevant anyway).

Most potential exceptions came from the `sistrip::FEDBuffer` (and `sistrip::FEDSpyBuffer`, together with their common base class `sistrip::FEDBufferBase`) constructor, so I moved the checks this does into a separate method that should be called before constructing a FED(Spy)Buffer, and returns a status code. For the FEDBuffer class there is also an initialisation step that could throw; I made it public and return a status code as well; a typical FEDBuffer construction then looks like this:
```C++
const auto st_buffer = sistrip::preconstructCheckFEDBuffer(input);
// check st_buffer
sistrip::FEDBuffer buffer{input};
const auto st_chan = buffer.findChannels();
// check st_chan
```
see [the AlignmentEventFilter diff](https://github.com/cms-sw/cmssw/compare/master...pieterdavid:stripunpacker_exceptions?expand=1#diff-65baa272872b1b76219e23f67163e9b5) for a full example (behaviour should be the same as before for this, except for the exception message) - this is also mentioned in the methods' documentation now.

Since I had to change the `operator++()` functions of the channel unpackers (from where some exceptions could be thrown), and these were all used from a loop like this:
```C++
while ( unpacker.hasData() ) {
  output.push_back(...); // (raw) digi with unpacker adc (and strip, for ZS)
  unpacker++;
}
```
I changed them into methods (see [here](https://github.com/pieterdavid/cmssw/blob/stripunpacker_exceptions/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h#L181-L324)) that take an output iterator instead, and unpack the whole channel (this allows for a bit of simplification, and makes the code more readable; this was already all inlined before, so I don't expect significant changes in CPU performance, but in principle a few more things could be optimised by the compiler now)<sup>1</sup>.
With this, I could also move the code that select the correct unpacking mode depending on the readout mode and packet code into a helper method (the earlier changes in https://github.com/cms-sw/cmssw/pull/24339 to the regional unpacker already went in this direction), that is shared between the "full" and "regional" unpacker (as a side-effect, the latter now supports all modes, except scope mode, which is only used for calibration, as far as I know), and quite a bit of code could be removed from these plugins.

These changes are purely technical, no changes are expected (also not on the computing performance; most of the unpacker time should be spent in allocating memory for all the digis, and the way that is done is not changed by this PR).

#### PR validation:

I took 100 events from a file taken in virgin raw mode (2015 HI, with 10bits packing), unpacked and saved all the raw digis, with the unmodified release. Then I ran, for all VR modes, a packer+unpacker combination on top of those and compared the raw digis before and after; likewise for the ZS modes, after running the zero-suppression - no unexpected differences ([config](https://github.com/pieterdavid/SiStripLocalRecoDebugging/blob/master/test/unpackVRAndCompare.py)).
`runTheMatrix.py -l 140.55` (2018 HI hybrid emulation + repacking + reco workflow, this is one of the more exotic unpacker use cases)
If anyone knows of data with problems that should trigger one of these exceptions-turned-warnings, that would be very useful to test as well.

CC: @robervalwalsh @mmusich @tsusa @alesaggio

<hr/> 

<sup>1</sup> in passing I made a few small changes to SiStripRawDigi (which is nothing more than a `uint16_t` that inherits from `edm::DoNotSortUponInsertion`) - the one that was convenient is conversion back to `uint16_t`, but I think the other ones are sensible and binary compatible (I don't know of anywhere these are persisted anyway).