### PR TITLE
BTL simulation: OOT effects + premix fix

### DIFF
--- a/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
+++ b/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
@@ -29,12 +29,12 @@ public:
   };
   class Data {
   public:
-    constexpr static unsigned energyOffset = 15;
-    constexpr static unsigned energyMask = 0x1;
-    constexpr static unsigned sampleOffset = 11;
+    constexpr static unsigned energyOffset = 14;
+    constexpr static unsigned energyMask = 0x3;
+    constexpr static unsigned sampleOffset = 10;
     constexpr static unsigned sampleMask = 0xf;
     constexpr static unsigned dataOffset = 0;
-    constexpr static unsigned dataMask = 0x7ff;
+    constexpr static unsigned dataMask = 0x3ff;
 
     Data() : data_(0) {}
     Data(unsigned short ei, unsigned short si, unsigned short d)

--- a/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/BTLElectronicsSim.h
@@ -60,7 +60,7 @@ private:
   const float DarkCountRate_;
   const float SigmaElectronicNoise_;
   const float SigmaClock_;
-
+  const bool smearTimeForOOTtails_;
   const float Npe_to_pC_;
   const float Npe_to_V_;
 
@@ -80,6 +80,7 @@ private:
   const float sinPhi_;
 
   const float ScintillatorDecayTime2_;
+  const float ScintillatorDecayTimeInv_;
   const float SPTR2_;
   const float DCRxRiseTime_;
   const float SigmaElectronicNoise2_;

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -59,10 +59,10 @@ namespace mtd_digitizer {
                                     const float minCharge,
                                     const float maxCharge) {
     constexpr auto nEnergies = std::tuple_size<decltype(MTDCellInfo().hit_info)>::value;
-    static_assert(nEnergies <= PMTDSimAccumulator::Data::energyMask + 1,
-                  "PMTDSimAccumulator bit pattern needs to updated");
-    static_assert(nSamples <= PMTDSimAccumulator::Data::sampleMask + 1,
-                  "PMTDSimAccumulator bit pattern needs to updated");
+    static_assert(nEnergies == PMTDSimAccumulator::Data::energyMask + 1,
+                  "PMTDSimAccumulator bit pattern needs to be updated");
+    static_assert(nSamples == PMTDSimAccumulator::Data::sampleMask,
+                  "PMTDSimAccumulator bit pattern needs to be updated");
 
     const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
     const float maxPackChargeLog = std::log(maxCharge);
@@ -78,7 +78,7 @@ namespace mtd_digitizer {
           if (samples[iSample] > minCharge) {
             unsigned short packed;
             if (iEn == 1 || iEn == 3) {
-              // assuming linear range for tof of 0..26
+              // assuming linear range for tof of 0..25
               packed = samples[iSample] / PREMIX_MAX_TOF * base;
             } else {
               packed = logintpack::pack16log(samples[iSample], minPackChargeLog, maxPackChargeLog, base);
@@ -106,6 +106,10 @@ namespace mtd_digitizer {
 
       size_t iEn = detIdIndexHitInfo.energyIndex();
       size_t iSample = detIdIndexHitInfo.sampleIndex();
+
+      if ( iEn > PMTDSimAccumulator::Data::energyMask + 1 || iSample > PMTDSimAccumulator::Data::sampleMask )
+	throw cms::Exception("MTDDigitixer::loadSimHitAccumulator") << "Index out of range: iEn = " << iEn
+	  << " iSample = " << iSample << std::endl;
 
       float value;
       if (iEn == 1 || iEn == 3) {

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -107,9 +107,9 @@ namespace mtd_digitizer {
       size_t iEn = detIdIndexHitInfo.energyIndex();
       size_t iSample = detIdIndexHitInfo.sampleIndex();
 
-      if ( iEn > PMTDSimAccumulator::Data::energyMask + 1 || iSample > PMTDSimAccumulator::Data::sampleMask )
-	throw cms::Exception("MTDDigitixer::loadSimHitAccumulator") << "Index out of range: iEn = " << iEn
-	  << " iSample = " << iSample << std::endl;
+      if (iEn > PMTDSimAccumulator::Data::energyMask + 1 || iSample > PMTDSimAccumulator::Data::sampleMask)
+        throw cms::Exception("MTDDigitixer::loadSimHitAccumulator")
+            << "Index out of range: iEn = " << iEn << " iSample = " << iSample << std::endl;
 
       float value;
       if (iEn == 1 || iEn == 3) {

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -69,7 +69,7 @@ namespace mtd_digitizer {
     constexpr uint16_t base = 1 << PMTDSimAccumulator::Data::sampleOffset;
 
     simResult.reserve(simData.size());
-    // mimicing the digitization
+    // mimicking the digitization
     for (const auto& elem : simData) {
       // store only non-zero
       for (size_t iEn = 0; iEn < nEnergies; ++iEn) {
@@ -77,7 +77,7 @@ namespace mtd_digitizer {
         for (size_t iSample = 0; iSample < nSamples; ++iSample) {
           if (samples[iSample] > minCharge) {
             unsigned short packed;
-            if (iEn == 1) {
+            if (iEn == 1 || iEn == 3) {
               // assuming linear range for tof of 0..26
               packed = samples[iSample] / PREMIX_MAX_TOF * base;
             } else {
@@ -108,13 +108,13 @@ namespace mtd_digitizer {
       size_t iSample = detIdIndexHitInfo.sampleIndex();
 
       float value;
-      if (iEn == 1) {
+      if (iEn == 1 || iEn == 3) {
         value = static_cast<float>(detIdIndexHitInfo.data()) / base * PREMIX_MAX_TOF;
       } else {
         value = logintpack::unpack16log(detIdIndexHitInfo.data(), minPackChargeLog, maxPackChargeLog, base);
       }
 
-      if (iEn == 0) {
+      if (iEn == 0 || iEn == 2) {
         hit_info[iEn][iSample] += value;
       } else if (hit_info[iEn][iSample] == 0) {
         // For iEn==1 the digitizers just set the TOF of the first SimHit

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -15,8 +15,11 @@ namespace mtd_digitizer {
   typedef std::array<MTDSimData_t, nSamples> MTDSimHitData;
 
   struct MTDCellInfo {
-    //1st array=energy, 2nd array=time-of-flight
-    std::array<MTDSimHitData, 2> hit_info;
+    // for the BTL tile geometry and ETL:
+    //     1st array=energy, 2nd array=time-of-flight
+    // for the BTL bar geometry:
+    //     3rd array=energy (right side), 4th array=time-of-flight (right side)
+    std::array<MTDSimHitData, 4> hit_info;
   };
 
   // Maximum value of time-of-flight for premixing packing
@@ -36,6 +39,9 @@ namespace mtd_digitizer {
   // use a wider integer now since we have to add row and column in an
   // intermediate det id for ETL
   typedef std::unordered_map<MTDCellId, MTDCellInfo> MTDSimHitDataAccumulator;
+
+  constexpr int kNumberOfBX = 15;
+  constexpr int kInTimeBX = 9;
 
 }  // namespace mtd_digitizer
 

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h
@@ -23,7 +23,7 @@ namespace mtd_digitizer {
   };
 
   // Maximum value of time-of-flight for premixing packing
-  constexpr float PREMIX_MAX_TOF = 26.0f;
+  constexpr float PREMIX_MAX_TOF = 25.0f;
 
   struct MTDCellId {
     MTDCellId() : detid_(0), row_(0), column_(0) {}

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -33,6 +33,7 @@ _barrel_tile_MTDDigitizer = cms.PSet(
         SigmaElectronicNoise       = cms.double(1.),    # [p.e.]
         SigmaClock                 = cms.double(0.015), # [ns]
         CorrelationCoefficient     = cms.double(1.),
+        SmearTimeForOOTtails       = cms.bool(True),
         Npe_to_pC                  = cms.double(0.016), # [pC] 
         Npe_to_V                   = cms.double(0.0064),# [V] 
 

--- a/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
@@ -109,7 +109,7 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
 
       // Store the time of the first SimHit in the i-th BX
       if ((simHitIt->second).hit_info[1][iBXR] == 0 || tR < (simHitIt->second).hit_info[1][iBXR])
-        (simHitIt->second).hit_info[1][iBXR] = tR;
+        (simHitIt->second).hit_info[1][iBXR] = tR - (iBXR - mtd_digitizer::kInTimeBX) * bxTime_;
     }
 
     // --- Left side
@@ -119,7 +119,7 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
 
       // Store the time of the first SimHit in the i-th BX
       if ((simHitIt->second).hit_info[3][iBXL] == 0 || tL < (simHitIt->second).hit_info[3][iBXL])
-        (simHitIt->second).hit_info[3][iBXL] = tL;
+        (simHitIt->second).hit_info[3][iBXL] = tL - (iBXL - mtd_digitizer::kInTimeBX) * bxTime_;
     }
 
   }  // hitRef loop

--- a/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLBarDeviceSim.cc
@@ -84,36 +84,43 @@ void BTLBarDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t
     // --- Get the simHit energy and convert it from MeV to photo-electrons
     float Npe = 1000. * hit.energyLoss() * LightYield_ * LightCollEff_ * PDE_;
 
-    // --- Get the simHit time of arrival
-    float toa = std::get<2>(hitRef);
-
-    if (toa > bxTime_ || toa < 0)  //just consider BX==0
-      continue;
-
-    // --- Accumulate the energy of simHits in the same crystal for the BX==0
-    // this is to simulate the charge integration in a 25 ns window
-    (simHitIt->second).hit_info[0][0] += Npe;
-    (simHitIt->second).hit_info[0][1] += Npe;
-
+    // --- Calculate the light propagation time to the crystal bases (labeled L and R)
     double distR = 0.5 * topo.pitch().second - 0.1 * hit.localPosition().y();
     double distL = 0.5 * topo.pitch().second + 0.1 * hit.localPosition().y();
 
-    // This is for the layout with bars along phi
+    // This is for the layouts with bars along phi
     if (topo_->getMTDTopologyMode() == (int)BTLDetId::CrysLayout::bar ||
         topo_->getMTDTopologyMode() == (int)BTLDetId::CrysLayout::barphiflat) {
       distR = 0.5 * topo.pitch().first - 0.1 * hit.localPosition().x();
       distL = 0.5 * topo.pitch().first + 0.1 * hit.localPosition().x();
     }
 
-    double tR = toa + LightCollSlopeR_ * distR;
-    double tL = toa + LightCollSlopeL_ * distL;
+    double tR = std::get<2>(hitRef) + LightCollSlopeR_ * distR;
+    double tL = std::get<2>(hitRef) + LightCollSlopeL_ * distL;
 
-    // --- Store the time of the first SimHit
-    if ((simHitIt->second).hit_info[1][0] == 0 || tR < (simHitIt->second).hit_info[1][0])
-      (simHitIt->second).hit_info[1][0] = tR;
+    // --- Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
+    const int iBXR = std::floor(tR / bxTime_) + mtd_digitizer::kInTimeBX;
+    const int iBXL = std::floor(tL / bxTime_) + mtd_digitizer::kInTimeBX;
 
-    if ((simHitIt->second).hit_info[1][1] == 0 || tL < (simHitIt->second).hit_info[1][1])
-      (simHitIt->second).hit_info[1][1] = tL;
+    // --- Right side
+    if (iBXR > 0 && iBXR < mtd_digitizer::kNumberOfBX) {
+      // Accumulate the energy of simHits in the same crystal
+      (simHitIt->second).hit_info[0][iBXR] += Npe;
+
+      // Store the time of the first SimHit in the i-th BX
+      if ((simHitIt->second).hit_info[1][iBXR] == 0 || tR < (simHitIt->second).hit_info[1][iBXR])
+        (simHitIt->second).hit_info[1][iBXR] = tR;
+    }
+
+    // --- Left side
+    if (iBXL > 0 && iBXL < mtd_digitizer::kNumberOfBX) {
+      // Accumulate the energy of simHits in the same crystal
+      (simHitIt->second).hit_info[2][iBXL] += Npe;
+
+      // Store the time of the first SimHit in the i-th BX
+      if ((simHitIt->second).hit_info[3][iBXL] == 0 || tL < (simHitIt->second).hit_info[3][iBXL])
+        (simHitIt->second).hit_info[3][iBXL] = tL;
+    }
 
   }  // hitRef loop
 }

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -23,6 +23,7 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset)
       DarkCountRate_(pset.getParameter<double>("DarkCountRate")),
       SigmaElectronicNoise_(pset.getParameter<double>("SigmaElectronicNoise")),
       SigmaClock_(pset.getParameter<double>("SigmaClock")),
+      smearTimeForOOTtails_(pset.getParameter<bool>("SmearTimeForOOTtails")),
       Npe_to_pC_(pset.getParameter<double>("Npe_to_pC")),
       Npe_to_V_(pset.getParameter<double>("Npe_to_V")),
       adcNbits_(pset.getParameter<uint32_t>("adcNbits")),
@@ -37,6 +38,7 @@ BTLElectronicsSim::BTLElectronicsSim(const edm::ParameterSet& pset)
       cosPhi_(0.5 * (sqrt(1. + CorrCoeff_) + sqrt(1. - CorrCoeff_))),
       sinPhi_(0.5 * CorrCoeff_ / cosPhi_),
       ScintillatorDecayTime2_(ScintillatorDecayTime_ * ScintillatorDecayTime_),
+      ScintillatorDecayTimeInv_(1. / ScintillatorDecayTime_),
       SPTR2_(SinglePhotonTimeResolution_ * SinglePhotonTimeResolution_),
       DCRxRiseTime_(DarkCountRate_ * ScintillatorRiseTime_),
       SigmaElectronicNoise2_(SigmaElectronicNoise_ * SigmaElectronicNoise_),
@@ -48,17 +50,20 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
   MTDSimHitData chargeColl, toa1, toa2;
 
   for (MTDSimHitDataAccumulator::const_iterator it = input.begin(); it != input.end(); it++) {
+    // --- Digitize only the in-time bucket:
+    const unsigned int iBX = mtd_digitizer::kInTimeBX;
+
     chargeColl.fill(0.f);
     toa1.fill(0.f);
     toa2.fill(0.f);
-    for (size_t i = 0; i < it->second.hit_info[0].size(); i++) {
+    for (size_t iside = 0; iside < 2; iside++) {
       // --- Fluctuate the total number of photo-electrons
-      float Npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[0][i]);
+      float Npe = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][iBX]);
       if (Npe < EnergyThreshold_)
         continue;
 
       // --- Get the time of arrival and add a channel time offset
-      float finalToA1 = (it->second).hit_info[1][i] + ChannelTimeOffset_;
+      float finalToA1 = (it->second).hit_info[1 + 2 * iside][iBX] + ChannelTimeOffset_;
 
       if (smearChannelTimeOffset_ > 0.) {
         float timeSmearing = CLHEP::RandGaussQ::shoot(hre, 0., smearChannelTimeOffset_);
@@ -76,6 +81,26 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
 
       float finalToA2 = finalToA1 + times[1];
       finalToA1 += times[0];
+
+      // --- Estimate the time uncertainty due to photons from earlier OOT hits in the current BTL cell
+      if (smearTimeForOOTtails_) {
+        float rate_oot = 0.;
+        // Loop on earlier OOT hits
+        for (unsigned int ibx = 0; ibx < mtd_digitizer::kInTimeBX; ++ibx) {
+          if ((it->second).hit_info[2 * iside][ibx] > 0.) {
+            float npe_oot = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][ibx]);
+            rate_oot += npe_oot * exp((it->second).hit_info[1 + 2 * iside][ibx] * ScintillatorDecayTimeInv_) *
+                        ScintillatorDecayTimeInv_;
+          }
+        }  // ibx loop
+
+        if (rate_oot > 0.) {
+          float sigma_oot = sqrt(rate_oot * ScintillatorRiseTime_) * ScintillatorDecayTime_ / Npe;
+          float smearing_oot = CLHEP::RandGaussQ::shoot(hre, 0., sigma_oot);
+          finalToA1 += smearing_oot;
+          finalToA2 += smearing_oot;
+        }
+      }  // if smearTimeForOOTtails_
 
       // --- Uncertainty due to the fluctuations of the n-th photon arrival time:
       if (testBeamMIPTimeRes_ > 0.) {
@@ -115,17 +140,19 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       finalToA1 += cosPhi_ * smearing_thr1_uncorr + sinPhi_ * smearing_thr2_uncorr;
       finalToA2 += sinPhi_ * smearing_thr1_uncorr + cosPhi_ * smearing_thr2_uncorr;
 
-      chargeColl[i] = Npe * Npe_to_pC_;  // the p.e. number is here converted to pC
+      chargeColl[iside] = Npe * Npe_to_pC_;  // the p.e. number is here converted to pC
 
-      toa1[i] = finalToA1;
-      toa2[i] = finalToA2;
-    }
+      toa1[iside] = finalToA1;
+      toa2[iside] = finalToA2;
+
+    }  // iside loop
 
     //run the shaper to create a new data frame
     BTLDataFrame rawDataFrame(it->first.detid_);
     runTrivialShaper(rawDataFrame, chargeColl, toa1, toa2, it->first.row_, it->first.column_);
     updateOutput(output, rawDataFrame);
-  }
+
+  }  // MTDSimHitDataAccumulator loop
 }
 
 void BTLElectronicsSim::runTrivialShaper(BTLDataFrame& dataFrame,

--- a/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLElectronicsSim.cc
@@ -86,11 +86,11 @@ void BTLElectronicsSim::run(const mtd::MTDSimHitDataAccumulator& input,
       if (smearTimeForOOTtails_) {
         float rate_oot = 0.;
         // Loop on earlier OOT hits
-        for (unsigned int ibx = 0; ibx < mtd_digitizer::kInTimeBX; ++ibx) {
+        for (int ibx = 0; ibx < mtd_digitizer::kInTimeBX; ++ibx) {
           if ((it->second).hit_info[2 * iside][ibx] > 0.) {
+            float hit_time = (it->second).hit_info[1 + 2 * iside][ibx] + bxTime_ * (ibx - mtd_digitizer::kInTimeBX);
             float npe_oot = CLHEP::RandPoissonQ::shoot(hre, (it->second).hit_info[2 * iside][ibx]);
-            rate_oot += npe_oot * exp((it->second).hit_info[1 + 2 * iside][ibx] * ScintillatorDecayTimeInv_) *
-                        ScintillatorDecayTimeInv_;
+            rate_oot += npe_oot * exp(hit_time * ScintillatorDecayTimeInv_) * ScintillatorDecayTimeInv_;
           }
         }  // ibx loop
 

--- a/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
@@ -93,7 +93,7 @@ void BTLTileDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_
 
     // --- Store the time of the first SimHit in the i-th BX
     if ((simHitIt->second).hit_info[1][iBX] == 0 || toa < (simHitIt->second).hit_info[1][iBX])
-      (simHitIt->second).hit_info[1][iBX] = toa;
+      (simHitIt->second).hit_info[1][iBX] = toa - (iBX - mtd_digitizer::kInTimeBX) * bxTime_;
 
   }  // hitRef loop
 }

--- a/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLTileDeviceSim.cc
@@ -84,14 +84,16 @@ void BTLTileDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_
     if (smearLightCollTime_ > 0.)
       toa += CLHEP::RandGaussQ::shoot(hre, 0., smearLightCollTime_);
 
-    if (toa > bxTime_ || toa < 0)  //just consider BX==0
+    // Accumulate in 15 buckets of 25ns (9 pre-samples, 1 in-time, 5 post-samples)
+    const int iBX = std::floor(toa / bxTime_) + mtd_digitizer::kInTimeBX;
+    if (iBX < 0 || iBX >= mtd_digitizer::kNumberOfBX)
       continue;
 
-    (simHitIt->second).hit_info[0][0] += Npe;
+    (simHitIt->second).hit_info[0][iBX] += Npe;
 
-    // --- Store the time of the first SimHit
-    if ((simHitIt->second).hit_info[1][0] == 0 || toa < (simHitIt->second).hit_info[1][0])
-      (simHitIt->second).hit_info[1][0] = toa;
+    // --- Store the time of the first SimHit in the i-th BX
+    if ((simHitIt->second).hit_info[1][iBX] == 0 || toa < (simHitIt->second).hit_info[1][iBX])
+      (simHitIt->second).hit_info[1][iBX] = toa;
 
   }  // hitRef loop
 }


### PR DESCRIPTION
#### PR description:

This PR improves the BTL digitization including the effects on time resolution due to the photon tails of earlier OOT hits in the same crystal, like in PR #28433, and fixes the memory issue that had emerged when testing the premixing for that PR.

The cause of the problem was that the method that packs the SIM hits info into the premix bank expects times expressed modulo 25n, but that was not my case. As a consequence, the bit word with the SIM info was corrupted and the unpacking resulted into an overflowing index.


#### PR validation:

This branch has been tested in CMSSW_11_0_0_pre13 with the TTbar WFs 22234.0 and 22234.99.

--------------------------------------
**WF 22234.0**

**step 2:**

MemoryReport> Peak virtual size 7964.15 Mbytes
 Key events increasing vsize: 
[60] run: 1 lumi: 1 event: 60  vsize = 6286.11 deltaVsize = 640 rss = 3096.59 delta = 206.461
[249] run: 1 lumi: 1 event: 249  vsize = 7068.14 deltaVsize = 782 rss = 2927.33 delta = -169.258
[485] run: 1 lumi: 1 event: 485  vsize = 7964.15 deltaVsize = 896 rss = 3123.05 delta = 195.715
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[487] run: 1 lumi: 1 event: 487  vsize = 7964.15 deltaVsize = 0 rss = 3021.71 delta = -101.34
[486] run: 1 lumi: 1 event: 486  vsize = 7964.15 deltaVsize = 0 rss = 3107.3 delta = -15.75
[485] run: 1 lumi: 1 event: 485  vsize = 7964.15 deltaVsize = 896 rss = 3123.05 delta = 124.598
TimeReport> Time report complete in 44014 seconds
 Time Summary: 
 - Min event:   65.8531
 - Max event:   110.886
 - Avg event:   87.1839
 - Total loop:  43980.1
 - Total init:  33.3893
 - Total job:   44014
 - EventSetup Lock:   8.51154e-05
 - EventSetup Get:   76.1835
 Event Throughput: 0.0113688 ev/s
 CPU Summary: 
 - Total loop:  41805.5
 - Total init:  11.4153
 - Total extra: 0
 - Total job:   41817.4

**step 3**

MemoryReport> Peak virtual size 12965.9 Mbytes
 Key events increasing vsize: 
[32] run: 1 lumi: 1 event: 32  vsize = 10146.7 deltaVsize = 1024 rss = 6783.16 delta = 280.848
[143] run: 1 lumi: 1 event: 143  vsize = 11426.8 deltaVsize = 1280 rss = 6918.56 delta = 135.406
[408] run: 1 lumi: 1 event: 408  vsize = 12962.9 deltaVsize = 1535 rss = 7269.84 delta = 351.277
[492] run: 1 lumi: 1 event: 492  vsize = 12965.9 deltaVsize = 3 rss = 7312.45 delta = 42.6055
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[494] run: 1 lumi: 1 event: 494  vsize = 12963.9 deltaVsize = -2 rss = 6955.95 delta = -356.496
[493] run: 1 lumi: 1 event: 493  vsize = 12963.9 deltaVsize = -2 rss = 7115.16 delta = -197.281
[492] run: 1 lumi: 1 event: 492  vsize = 12965.9 deltaVsize = 3 rss = 7312.45 delta = 42.6055
TimeReport> Time report complete in 89719 seconds
 Time Summary: 
 - Min event:   104.361
 - Max event:   346.13
 - Avg event:   175.392
 - Total loop:  89587.9
 - Total init:  121.492
 - Total job:   89719
 - EventSetup Lock:   0.000196457
 - EventSetup Get:   83.9121
 Event Throughput: 0.00558111 ev/s
 CPU Summary: 
 - Total loop:  82191.3
 - Total init:  96.2134
 - Total extra: 0
 - Total job:   82296.5

--------------------------------------
**WF 22234.99**

premix bank size:

> MTDSimAccumulator_mix_FTLBarrel_DIGI. 2.97066e+06 2.39297e+06
> PMTDSimAccumulator_mix_FTLEndcap_DIGI. 1.33694e+06 779230


**step 3**

MemoryReport> Peak virtual size 5278.37 Mbytes
 Key events increasing vsize: 
[2] run: 1 lumi: 1 event: 2  vsize = 4446.24 deltaVsize = 12 rss = 2998.72 delta = -134.793
[16] run: 1 lumi: 1 event: 16  vsize = 4830.32 deltaVsize = 384 rss = 2981.2 delta = -17.5234
[458] run: 1 lumi: 1 event: 458  vsize = 5278.37 deltaVsize = 448 rss = 3136.12 delta = 154.93
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[460] run: 1 lumi: 1 event: 460  vsize = 5278.37 deltaVsize = 0 rss = 3103.74 delta = -32.3867
[459] run: 1 lumi: 1 event: 459  vsize = 5278.37 deltaVsize = 0 rss = 3062.41 delta = -73.7148
[458] run: 1 lumi: 1 event: 458  vsize = 5278.37 deltaVsize = 448 rss = 3136.12 delta = 3.17578
TimeReport> Time report complete in 24610.4 seconds
 Time Summary: 
 - Min event:   39.9079
 - Max event:   104.543
 - Avg event:   48.7014
 - Total loop:  24556
 - Total init:  53.7632
 - Total job:   24610.4
 - EventSetup Lock:   7.58171e-05
 - EventSetup Get:   67.2327
 Event Throughput: 0.0203616 ev/s
 CPU Summary: 
 - Total loop:  22172.9
 - Total init:  12.3361
 - Total extra: 0
 - Total job:   22185.7


**step 4**

MemoryReport> Peak virtual size 9123.34 Mbytes
 Key events increasing vsize: 
[2] run: 1 lumi: 1 event: 2  vsize = 7422.96 deltaVsize = 660.016 rss = 5336.09 delta = -65.8555
[15] run: 1 lumi: 1 event: 15  vsize = 8227.02 deltaVsize = 768 rss = 5545.06 delta = 208.977
[154] run: 1 lumi: 1 event: 154  vsize = 9123.32 deltaVsize = 896 rss = 5983.21 delta = 438.148
[458] run: 1 lumi: 1 event: 458  vsize = 9123.34 deltaVsize = 0.0195312 rss = 6423.86 delta = 440.652
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[460] run: 1 lumi: 1 event: 460  vsize = 9123.34 deltaVsize = 0 rss = 6370.79 delta = -53.0742
[459] run: 1 lumi: 1 event: 459  vsize = 9123.34 deltaVsize = 0 rss = 6262.03 delta = -161.836
[458] run: 1 lumi: 1 event: 458  vsize = 9123.34 deltaVsize = 0.0195312 rss = 6423.86 delta = 440.652
TimeReport> Time report complete in 81246.8 seconds
 Time Summary: 
 - Min event:   89.7388
 - Max event:   467.405
 - Avg event:   158.661
 - Total loop:  81027.2
 - Total init:  166.451
 - Total job:   81246.8
 - EventSetup Lock:   0.000249386
 - EventSetup Get:   101.051
 Event Throughput: 0.00617077 ev/s
 CPU Summary: 
 - Total loop:  75961.9
 - Total init:  120.744
 - Total extra: 0
 - Total job:   76134.6
 

=============================================

In the case of current code, as a reference:

**WF 22234.0**

**step 2**

MemoryReport> Peak virtual size 6286.12 Mbytes
 Key events increasing vsize: 
[4] run: 1 lumi: 1 event: 4  vsize = 5134.07 deltaVsize = 448 rss = 3084.34 delta = -16
[15] run: 1 lumi: 1 event: 15  vsize = 5646.11 deltaVsize = 512 rss = 3022.9 delta = -61.4336
[61] run: 1 lumi: 1 event: 61  vsize = 6286.12 deltaVsize = 640 rss = 3414.31 delta = 391.41
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[63] run: 1 lumi: 1 event: 63  vsize = 6286.12 deltaVsize = 0 rss = 3323.92 delta = -90.3945
[62] run: 1 lumi: 1 event: 62  vsize = 6286.12 deltaVsize = 0 rss = 3402.76 delta = -11.5547
[61] run: 1 lumi: 1 event: 61  vsize = 6286.12 deltaVsize = 640 rss = 3414.31 delta = -82.2305
TimeReport> Time report complete in 9059.45 seconds
 Time Summary: 
 - Min event:   73.8451
 - Max event:   114.501
 - Avg event:   89.0312
 - Total loop:  9016.34
 - Total init:  42.7557
 - Total job:   9059.45
 - EventSetup Lock:   9.46522e-05
 - EventSetup Get:   73.5861
 Event Throughput: 0.011091 ev/s
 CPU Summary: 
 - Total loop:  8343.95
 - Total init:  21.0478
 - Total extra: 0
 - Total job:   8365.25


**step 3**

MemoryReport> Peak virtual size 10145.7 Mbytes
 Key events increasing vsize: 
[3] run: 1 lumi: 1 event: 3  vsize = 9089.55 deltaVsize = 4 rss = 6709.96 delta = 18.8125
[6] run: 1 lumi: 1 event: 6  vsize = 9121.55 deltaVsize = 32 rss = 6750.29 delta = 40.3281
[29] run: 1 lumi: 1 event: 29  vsize = 10145.7 deltaVsize = 1024 rss = 7010.46 delta = 260.172
[83] run: 1 lumi: 1 event: 83  vsize = 10145.7 deltaVsize = 0.0273438 rss = 7426.93 delta = 416.469
[46] run: 1 lumi: 1 event: 46  vsize = 10145.7 deltaVsize = 0.0078125 rss = 7203.63 delta = 193.168
[85] run: 1 lumi: 1 event: 85  vsize = 10145.7 deltaVsize = 0 rss = 7077.25 delta = -349.68
[84] run: 1 lumi: 1 event: 84  vsize = 10145.7 deltaVsize = 0 rss = 7218.67 delta = -208.262
[83] run: 1 lumi: 1 event: 83  vsize = 10145.7 deltaVsize = 0.0273438 rss = 7426.93 delta = 223.301
TimeReport> Time report complete in 19135.3 seconds
 Time Summary: 
 - Min event:   129.462
 - Max event:   314.8
 - Avg event:   185.461
 - Total loop:  18963.7
 - Total init:  162.735
 - Total job:   19135.3
 - EventSetup Lock:   0.000247478
 - EventSetup Get:   92.7902
 Event Throughput: 0.00527324 ev/s
 CPU Summary: 
 - Total loop:  17414.4
 - Total init:  117.035
 - Total extra: 0
 - Total job:   17539.8