### PR TITLE
Be able to use external services with TestProcessor

### DIFF
--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -155,7 +155,7 @@ namespace edm {
     public:
       using Config = TestProcessorConfig;
 
-      TestProcessor(Config const& iConfig);
+      TestProcessor(Config const& iConfig, ServiceToken iToken = ServiceToken());
       ~TestProcessor() noexcept(false);
 
       /** Run the test. The function arguments are the data products to be added to the

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -81,7 +81,7 @@ namespace edm {
     //
     // constructors and destructor
     //
-    TestProcessor::TestProcessor(Config const& iConfig)
+    TestProcessor::TestProcessor(Config const& iConfig, ServiceToken iToken)
         : espController_(std::make_unique<eventsetup::EventSetupsController>()),
           historyAppender_(std::make_unique<HistoryAppender>()),
           moduleRegistry_(std::make_shared<ModuleRegistry>()) {
@@ -102,8 +102,7 @@ namespace edm {
 
       //initialize the services
       auto& serviceSets = procDesc->getServicesPSets();
-      ServiceToken token =
-          items.initServices(serviceSets, *psetPtr, ServiceToken(), serviceregistry::kOverlapIsError, true);
+      ServiceToken token = items.initServices(serviceSets, *psetPtr, iToken, serviceregistry::kOverlapIsError, true);
       serviceToken_ = items.addCPRandTNS(*psetPtr, token);
 
       //make the services available


### PR DESCRIPTION
#### PR description:

The TestProcessor now accepts a ServiceToken in the constructor. This will allow any Services created outside the TestProcessor to be used while the tests are executing.

#### PR validation:

The code compiles.