### PR TITLE
Payload Inspector: SiStrip Noise/Pedestals profile per module

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -561,15 +561,23 @@ namespace {
     TrackerMap of SiStripApvGains (ratio with previous gain per detid)
   *************************************************/
 
-  template <int nsigma>
   class SiStripApvGainsRatioWithPreviousIOVTrackerMapBase : public cond::payloadInspector::PlotImage<SiStripApvGain> {
   public:
     SiStripApvGainsRatioWithPreviousIOVTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of ratio of SiStripGains with previous IOV") {}
+        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of ratio of SiStripGains with previous IOV") {
+      cond::payloadInspector::PlotBase::addInputParam("nsigma");
+    }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+      unsigned int nsigma(1);
 
+      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto ip = paramValues.find("nsigma");
+      if (ip != paramValues.end()) {
+        nsigma = boost::lexical_cast<unsigned int>(ip->second);
+      }
+
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
       // make absolute sure the IOVs are sortd by since
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
         return std::get<0>(t1) < std::get<0>(t2);
@@ -644,53 +652,46 @@ namespace {
     }
   };
 
-  template <int nsigma>
-  class SiStripApvGainsRatioWithPreviousIOVTrackerMapSingleTag
-      : public SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<nsigma> {
+  class SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap
+      : public SiStripApvGainsRatioWithPreviousIOVTrackerMapBase {
   public:
-    SiStripApvGainsRatioWithPreviousIOVTrackerMapSingleTag()
-        : SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<nsigma>() {
+    SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap() : SiStripApvGainsRatioWithPreviousIOVTrackerMapBase() {
       this->setSingleIov(false);
     }
   };
 
-  template <int nsigma>
-  class SiStripApvGainsRatioWithPreviousIOVTrackerMapTwoTags
-      : public SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<nsigma> {
+  class SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags : public SiStripApvGainsRatioWithPreviousIOVTrackerMapBase {
   public:
-    SiStripApvGainsRatioWithPreviousIOVTrackerMapTwoTags()
-        : SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<nsigma>() {
+    SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags() : SiStripApvGainsRatioWithPreviousIOVTrackerMapBase() {
       this->setTwoTags(true);
     }
   };
-
-  typedef SiStripApvGainsRatioWithPreviousIOVTrackerMapSingleTag<1>
-      SiStripApvGainsAvgDeviationRatio1sigmaTrackerMapSingleTag;
-  typedef SiStripApvGainsRatioWithPreviousIOVTrackerMapSingleTag<2>
-      SiStripApvGainsAvgDeviationRatio2sigmaTrackerMapSingleTag;
-  typedef SiStripApvGainsRatioWithPreviousIOVTrackerMapSingleTag<3>
-      SiStripApvGainsAvgDeviationRatio3sigmaTrackerMapSingleTag;
-
-  typedef SiStripApvGainsRatioWithPreviousIOVTrackerMapTwoTags<1>
-      SiStripApvGainsAvgDeviationRatio1sigmaTrackerMapTwoTags;
-  typedef SiStripApvGainsRatioWithPreviousIOVTrackerMapTwoTags<2>
-      SiStripApvGainsAvgDeviationRatio2sigmaTrackerMapTwoTags;
-  typedef SiStripApvGainsRatioWithPreviousIOVTrackerMapTwoTags<3>
-      SiStripApvGainsAvgDeviationRatio3sigmaTrackerMapTwoTags;
 
   /************************************************
    TrackerMap of SiStripApvGains (ratio for largest deviation with previous gain per detid)
   *************************************************/
 
-  template <int nsigma>
   class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase
       : public cond::payloadInspector::PlotImage<SiStripApvGain> {
   public:
     SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase()
         : cond::payloadInspector::PlotImage<SiStripApvGain>(
-              "Tracker Map of ratio (for largest deviation) of SiStripGains with previous IOV") {}
+              "Tracker Map of ratio (for largest deviation) of SiStripGains with previous IOV") {
+      cond::payloadInspector::PlotBase::addInputParam("nsigma");
+    }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      unsigned int nsigma(1);
+
+      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto ip = paramValues.find("nsigma");
+      if (ip != paramValues.end()) {
+        nsigma = boost::lexical_cast<unsigned int>(ip->second);
+        std::cout << "using custom z-axis saturation: " << nsigma << " sigmas" << std::endl;
+      } else {
+        std::cout << "using default saturation: " << nsigma << " sigmas" << std::endl;
+      }
+
       std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
 
       // make absolute sure the IOVs are sortd by since
@@ -786,39 +787,23 @@ namespace {
     }
   };
 
-  template <int nsigma>
-  class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapSingleTag
-      : public SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<nsigma> {
+  class SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap
+      : public SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase {
   public:
-    SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapSingleTag()
-        : SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<nsigma>() {
+    SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap()
+        : SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase() {
       this->setSingleIov(false);
     }
   };
 
-  template <int nsigma>
-  class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapTwoTags
-      : public SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<nsigma> {
+  class SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags
+      : public SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase {
   public:
-    SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapTwoTags()
-        : SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<nsigma>() {
+    SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags()
+        : SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase() {
       this->setTwoTags(true);
     }
   };
-
-  typedef SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapSingleTag<1>
-      SiStripApvGainsMaxDeviationRatio1sigmaTrackerMapSingleTag;
-  typedef SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapSingleTag<2>
-      SiStripApvGainsMaxDeviationRatio2sigmaTrackerMapSingleTag;
-  typedef SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapSingleTag<3>
-      SiStripApvGainsMaxDeviationRatio3sigmaTrackerMapSingleTag;
-
-  typedef SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapTwoTags<1>
-      SiStripApvGainsMaxDeviationRatio1sigmaTrackerMapTwoTags;
-  typedef SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapTwoTags<2>
-      SiStripApvGainsMaxDeviationRatio2sigmaTrackerMapTwoTags;
-  typedef SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapTwoTags<3>
-      SiStripApvGainsMaxDeviationRatio3sigmaTrackerMapTwoTags;
 
   /************************************************
     TrackerMap of SiStripApvGains (maximum gain per detid)
@@ -2123,18 +2108,10 @@ PAYLOAD_INSPECTOR_MODULE(SiStripApvGain) {
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsDefaultTrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaximumTrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMinimumTrackerMap);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatio1sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatio1sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatio2sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatio2sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatio3sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatio3sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatio1sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatio1sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatio2sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatio2sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatio3sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatio3sigmaTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainByRunMeans);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainMin_History);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainMax_History);

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -817,12 +817,14 @@ namespace {
     SiStrip Noise Tracker Map  (ratio with previous gain per detid)
   *************************************************/
 
-  template <SiStripPI::estimator est, int nsigma>
+  template <SiStripPI::estimator est>
   class SiStripNoiseRatioWithPreviousIOVTrackerMapBase : public cond::payloadInspector::PlotImage<SiStripNoises> {
   public:
     SiStripNoiseRatioWithPreviousIOVTrackerMapBase()
         : cond::payloadInspector::PlotImage<SiStripNoises>("Tracker Map of ratio of SiStripNoises " +
-                                                           estimatorType(est) + "with previous IOV") {}
+                                                           estimatorType(est) + "with previous IOV") {
+      cond::payloadInspector::PlotBase::addInputParam("nsigma");
+    }
 
     std::map<unsigned int, float> computeEstimator(std::shared_ptr<SiStripNoises> payload) {
       std::map<unsigned int, float> info_per_detid;
@@ -881,8 +883,15 @@ namespace {
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
+      unsigned int nsigma(1);
 
+      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto ip = paramValues.find("nsigma");
+      if (ip != paramValues.end()) {
+        nsigma = boost::lexical_cast<unsigned int>(ip->second);
+      }
+
+      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
         return std::get<0>(t1) < std::get<0>(t2);
       });
@@ -931,75 +940,40 @@ namespace {
     }
   };
 
-  template <SiStripPI::estimator est, int nsigma>
+  template <SiStripPI::estimator est>
   class SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag
-      : public SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, nsigma> {
+      : public SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est> {
   public:
-    SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag()
-        : SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, nsigma>() {
+    SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag() : SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est>() {
       this->setSingleIov(false);
     }
   };
 
-  template <SiStripPI::estimator est, int nsigma>
-  class SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags
-      : public SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, nsigma> {
+  template <SiStripPI::estimator est>
+  class SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags : public SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est> {
   public:
-    SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags()
-        : SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, nsigma>() {
+    SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags() : SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est>() {
       this->setTwoTags(true);
     }
   };
 
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::min, 1>
-      SiStripNoiseMin_RatioWithPreviousIOV1sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::max, 1>
-      SiStripNoiseMax_RatioWithPreviousIOV1sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::mean, 1>
-      SiStripNoiseMean_RatioWithPreviousIOV1sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::rms, 1>
-      SiStripNoiseRms_RatioWithPreviousIOV1sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::min, 2>
-      SiStripNoiseMin_RatioWithPreviousIOV2sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::max, 2>
-      SiStripNoiseMax_RatioWithPreviousIOV2sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::mean, 2>
-      SiStripNoiseMean_RatioWithPreviousIOV2sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::rms, 2>
-      SiStripNoiseRms_RatioWithPreviousIOV2sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::min, 3>
-      SiStripNoiseMin_RatioWithPreviousIOV3sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::max, 3>
-      SiStripNoiseMax_RatioWithPreviousIOV3sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::mean, 3>
-      SiStripNoiseMean_RatioWithPreviousIOV3sigmaTrackerMapSingleTag;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::rms, 3>
-      SiStripNoiseRms_RatioWithPreviousIOV3sigmaTrackerMapSingleTag;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::min>
+      SiStripNoiseMin_RatioWithPreviousIOVTrackerMapSingleTag;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::max>
+      SiStripNoiseMax_RatioWithPreviousIOVTrackerMapSingleTag;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::mean>
+      SiStripNoiseMean_RatioWithPreviousIOVTrackerMapSingleTag;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::rms>
+      SiStripNoiseRms_RatioWithPreviousIOVTrackerMapSingleTag;
 
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::min, 1>
-      SiStripNoiseMin_RatioWithPreviousIOV1sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::max, 1>
-      SiStripNoiseMax_RatioWithPreviousIOV1sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::mean, 1>
-      SiStripNoiseMean_RatioWithPreviousIOV1sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::rms, 1>
-      SiStripNoiseRms_RatioWithPreviousIOV1sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::min, 2>
-      SiStripNoiseMin_RatioWithPreviousIOV2sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::max, 2>
-      SiStripNoiseMax_RatioWithPreviousIOV2sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::mean, 2>
-      SiStripNoiseMean_RatioWithPreviousIOV2sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::rms, 2>
-      SiStripNoiseRms_RatioWithPreviousIOV2sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::min, 3>
-      SiStripNoiseMin_RatioWithPreviousIOV3sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::max, 3>
-      SiStripNoiseMax_RatioWithPreviousIOV3sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::mean, 3>
-      SiStripNoiseMean_RatioWithPreviousIOV3sigmaTrackerMapTwoTags;
-  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::rms, 3>
-      SiStripNoiseRms_RatioWithPreviousIOV3sigmaTrackerMapTwoTags;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::min>
+      SiStripNoiseMin_RatioWithPreviousIOVTrackerMapTwoTags;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::max>
+      SiStripNoiseMax_RatioWithPreviousIOVTrackerMapTwoTags;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::mean>
+      SiStripNoiseMean_RatioWithPreviousIOVTrackerMapTwoTags;
+  typedef SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags<SiStripPI::rms>
+      SiStripNoiseRms_RatioWithPreviousIOVTrackerMapTwoTags;
 
   /************************************************
   SiStrip Noise Tracker Summaries 
@@ -1800,30 +1774,14 @@ PAYLOAD_INSPECTOR_MODULE(SiStripNoises) {
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorMinByRegionTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorMaxByRegionTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseComparatorRMSByRegionTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOV1sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV1sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV1sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV1sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOV2sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV2sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV2sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV2sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOV3sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV3sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV3sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV3sigmaTrackerMapSingleTag);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOV1sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV1sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV1sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV1sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOV2sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV2sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV2sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV2sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOV3sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOV3sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOV3sigmaTrackerMapTwoTags);
-  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOV3sigmaTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOVTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOVTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOVTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOVTrackerMapSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMin_RatioWithPreviousIOVTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMax_RatioWithPreviousIOVTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseMean_RatioWithPreviousIOVTrackerMapTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiStripNoiseRms_RatioWithPreviousIOVTrackerMapTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiStripNoiseLinearity);
   PAYLOAD_INSPECTOR_CLASS(TIBNoiseHistory);
   PAYLOAD_INSPECTOR_CLASS(TOBNoiseHistory);

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -10,6 +10,12 @@ eval `scram run -sh`;
 cd $W_DIR;
 # Run get payload data script
 
+mkdir -p $W_DIR/results
+
+if [ -f *.png ]; then
+    rm *.png
+fi
+
 ####################
 # Test Gains
 ####################
@@ -21,6 +27,8 @@ getPayloadData.py \
     --iovs '{"start_iov": "286042", "end_iov": "286042"}' \
     --db Prod \
     --test;
+
+mv *.png $W_DIR/results/SiStripApvGainsByRegion.png
 
 ######################
 # Test Lorentz Angle
@@ -34,6 +42,8 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+mv *.png $W_DIR/results/SiStripLorentzAngleByRegion.png
+
 ######################
 # Test Backplane correction
 ######################
@@ -45,6 +55,8 @@ getPayloadData.py \
     --iovs '{"start_iov": "153690", "end_iov": "153690"}' \
     --db Prod \
     --test;
+
+mv *.png $W_DIR/results/SiStripBackPlaneCorrectionByRegion.png
 
 ######################
 # Test Bad components
@@ -58,6 +70,8 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+mv *.png $W_DIR/results/SiStripBadStripQualityAnalysis.png
+
 ######################
 # Test Conf Object
 ######################
@@ -68,3 +82,5 @@ getPayloadData.py \
     --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test;
+
+mv *.png $W_DIR/results/SiStripConfObjectDisplay.png

--- a/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testGainsPayloadInspector.sh
@@ -41,31 +41,31 @@ getPayloadData.py \
     --db Prod \
     --test;
 
-
 mv *.png $W_DIR/plots/G2_Value_update_TT.png
 
 getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
-    --plot plot_SiStripApvGainsMaxDeviationRatio2sigmaTrackerMapSingleTag \
+    --plot plot_SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap \
     --tag SiStripApvGainAfterAbortGap_PCL_v0_prompt \
     --time_type Run \
     --iovs '{"start_iov": "302393", "end_iov": "305114"}' \
     --db Prep \
+    --input_params '{"nsigma":"3"}' \
     --test;
 
 mv *.png $W_DIR/plots/G2_MaxDeviatonRatio_update_ST.png
 
 getPayloadData.py \
     --plugin pluginSiStripApvGain_PayloadInspector \
-    --plot plot_SiStripApvGainsMaxDeviationRatio2sigmaTrackerMapTwoTags \
+    --plot plot_SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags \
     --tag SiStripApvGain_FromParticles_GR10_v1_express \
     --tagtwo SiStripApvGain_FromParticles_GR10_v1_hlt \
     --time_type Run \
     --iovs '{"start_iov": "286042", "end_iov": "286042"}' \
     --iovstwo '{"start_iov": "206037", "end_iov": "206037"}' \
     --db Prod \
+    --input_params '{"nsigma":"3"}' \
     --test;
-
 
 mv *.png $W_DIR/plots/G2_MaxDeviatonRatio_update_TT.png
 

--- a/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
@@ -22,6 +22,19 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+####################
+# Single DetId
+####################
+getPayloadData.py \
+    --plugin pluginSiStripNoises_PayloadInspector \
+    --plot plot_SiStripNoiseValuePerDetId \
+    --tag SiStripNoise_v2_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "303420", "end_iov": "303420"}' \
+    --db Prod \
+    --input_params '{"DetId":"470065830"}' \
+    --test ;
+
 estimators=(Mean Min Max RMS)
 plotTypes=(Strip APV Module)
 partition=(TIB TOB TEC TID)

--- a/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
@@ -22,6 +22,19 @@ getPayloadData.py \
     --db Prod \
     --test;
 
+####################
+# Single DetId
+####################
+getPayloadData.py \
+    --plugin pluginSiStripPedestals_PayloadInspector \
+    --plot plot_SiStripPedestalsValuePerDetId \
+    --tag SiStripPedestals_v2_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "303420", "end_iov": "303420"}' \
+    --db Prod \
+    --input_params '{"DetId":"470065830"}' \
+    --test ;
+
 estimators=(Mean Min Max RMS)
 plotTypes=(Strip APV Module)
 

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -13,6 +13,8 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 
 int main(int argc, char** argv) {
+  Py_Initialize();
+
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
 
@@ -82,6 +84,13 @@ int main(int argc, char** argv) {
   histoCompareMeanByRegion.process(connectionString, tag, runTimeType, start, start);
   std::cout << histoCompareMeanByRegion.data() << std::endl;
 
+  SiStripNoisePerDetId histoNoiseForDetId;
+  boost::python::dict inputs;
+  inputs["DetId"] = "470148232";
+  histoNoiseForDetId.setInputParamValues(inputs);
+  histoNoiseForDetId.process(connectionString, tag, runTimeType, start, start);
+  std::cout << histoNoiseForDetId.data() << std::endl;
+
   // Pedestals
 
   tag = "SiStripPedestals_v2_prompt";
@@ -97,6 +106,11 @@ int main(int argc, char** argv) {
   SiStripPedestalValueComparisonPerModuleSingleTag histo11;
   histo11.process(connectionString, tag, runTimeType, start, end);
   std::cout << histo11.data() << std::endl;
+
+  SiStripPedestalPerDetId histoPedestalForDetId;
+  histoPedestalForDetId.setInputParamValues(inputs);
+  histoPedestalForDetId.process(connectionString, tag, runTimeType, start, start);
+  std::cout << histoPedestalForDetId.data() << std::endl;
 
   //Latency
 

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -33,6 +33,7 @@ int main(int argc, char** argv) {
   std::string runTimeType = cond::time::timeTypeName(cond::runnumber);
   cond::Time_t start = boost::lexical_cast<unsigned long long>(132440);
   cond::Time_t end = boost::lexical_cast<unsigned long long>(285368);
+  boost::python::dict inputs;
 
   std::cout << "## Exercising Gains plots " << std::endl;
 
@@ -40,11 +41,15 @@ int main(int argc, char** argv) {
   histo1.process(connectionString, tag, runTimeType, start, start);
   std::cout << histo1.data() << std::endl;
 
-  SiStripApvGainsAvgDeviationRatio1sigmaTrackerMapSingleTag histo2;
+  SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap histo2;
+  inputs["nsigma"] = "1";
+  histo2.setInputParamValues(inputs);
   histo2.process(connectionString, tag, runTimeType, start, end);
   std::cout << histo2.data() << std::endl;
 
-  SiStripApvGainsMaxDeviationRatio1sigmaTrackerMapSingleTag histo3;
+  SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap histo3;
+  inputs["nsigma"] = "1";
+  histo3.setInputParamValues(inputs);
   histo3.process(connectionString, tag, runTimeType, start, end);
   std::cout << histo3.data() << std::endl;
 
@@ -85,7 +90,6 @@ int main(int argc, char** argv) {
   std::cout << histoCompareMeanByRegion.data() << std::endl;
 
   SiStripNoisePerDetId histoNoiseForDetId;
-  boost::python::dict inputs;
   inputs["DetId"] = "470148232";
   histoNoiseForDetId.setInputParamValues(inputs);
   histoNoiseForDetId.process(connectionString, tag, runTimeType, start, start);

--- a/CondCore/Utilities/scripts/getPayloadData.py
+++ b/CondCore/Utilities/scripts/getPayloadData.py
@@ -104,7 +104,7 @@ def deserialize_iovs(db, plugin_name, plot_name, tag, time_type, iovs, input_par
     output('deserialized data: ', result)
     return result
 @supress_output
-def deserialize_twoiovs(db, plugin_name, plot_name, tag,tagtwo,iovs,iovstwo):
+def deserialize_twoiovs(db, plugin_name, plot_name, tag,tagtwo,iovs,iovstwo, input_params):
     ''' Deserializes given iovs data and returns plot coordinates '''
     #print "Starting to deserialize iovs:"
     #print 'First Iovs',iovs
@@ -132,7 +132,8 @@ def deserialize_twoiovs(db, plugin_name, plot_name, tag,tagtwo,iovs,iovstwo):
     db_name = 'oracle://cms_orcon_adg/CMS_CONDITIONS' if db == 'Prod' else 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
     output('full DB name: ', db_name)
 
-
+    if input_params is not None:
+        plot.setInputParamValues( input_params )
     success = plot.processTwoTags(db_name, tag,tagtwo,int(iovs['start_iov']), int(iovstwo['end_iov']))
     #print "All good",success
     output('plot processed data successfully: ', success)
@@ -299,7 +300,7 @@ if __name__ == '__main__':
         #print 'A',a
         b=json.loads(args.iovstwo)
         #print 'B',b
-        result = deserialize_twoiovs(args.db, args.plugin, args.plot, args.tag,args.tagtwo,a,b)
+        result = deserialize_twoiovs(args.db, args.plugin, args.plot, args.tag,args.tagtwo,a,b, input_params)
         # If test -> output the result as formatted json
         if args.test:
             os.write( 1, json.dumps( json.loads( result ), indent=4 ))


### PR DESCRIPTION
#### PR description:

This is a follow-up on PR https://github.com/cms-sw/cmssw/pull/28648.
Profiting of the extension of the developer level interface of the Payload Inspector meant to support plot-specific input parameters developed in that PR, new classes are added to the SiStrip Payload Inspector to display single `DetId` frames of Noise and Pedestals values.
In addition, the `TrackerMap` image classes templated against the saturation level of the z-axis are removed in favour of a unique instance in which such parameter is prompted by the user.  The new plots are tested via addition to existing unit tests. 

#### PR validation:

The PR validation relies on the existing and new unit tests added to this PR.

#### if this PR is a backport please specify the original PR:

This PR is not a backport.

**N.B.: this PR shall be put on hold until it is validated  in the development service environment.**