### PR TITLE
update eventSetupPathsKey for Strip/Pixel AlCas

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -16,9 +16,7 @@ ALCARECOSiPixelCalCosmicsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcssta
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOSiPixelCalCosmicsHLTFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     andOr = True, ## choose logical OR between Triggerbits
-    HLTPaths = ["HLT_*"],
-    # eventually this needs to sterred via Global Tag in AlCaRecoTriggerBits
-    eventSetupPathsKey = '',
+    eventSetupPathsKey = 'SiPixelCalCosmics',
     throw = False # tolerate triggers stated above, but not available
 )
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuon_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuon_cff.py
@@ -7,8 +7,7 @@ ALCARECOSiPixelCalSingleMuonHLTFilter = copy.deepcopy(hltHighLevel)
 #seqALCARECOSiPixelCalSingleMuon = cms.Sequence(ALCARECOSiPixelCalSingleMuonHLTFilter)
 ALCARECOSiPixelCalSingleMuonHLTFilter.andOr = True ## choose logical OR between Triggerbits
 ALCARECOSiPixelCalSingleMuonHLTFilter.throw = False ## dont throw on unknown path names
-#ALCARECOSiPixelCalSingleMuonHLTFilter.eventSetupPathsKey = 'SiPixelCalSingleMuon'
-ALCARECOSiPixelCalSingleMuonHLTFilter.HLTPaths = ['HLT_*']
+ALCARECOSiPixelCalSingleMuonHLTFilter.eventSetupPathsKey = 'SiPixelCalSingleMuon'
 
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 ALCARECOSiPixelCalSingleMuon = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone()

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_cff.py
@@ -4,9 +4,7 @@ import FWCore.ParameterSet.Config as cms
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOSiStripCalCosmicsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     andOr = True, ## choose logical OR between Triggerbits
-    HLTPaths = ["HLT_*"],
-    # eventually this needs to sterred via Global Tag in AlCaRecoTriggerBits
-    #eventSetupPathsKey = 'SiStripCalCosmics',
+    eventSetupPathsKey = 'SiStripCalCosmics',
     throw = False # tolerate triggers stated above, but not available
     )
 

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -46,7 +46,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_v3',
+    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_Candidate_2020_01_19_15_27_07',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '110X_mc2017_design_Candidate_2020_01_17_14_56_45',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,11 +16,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_Candidate_2020_01_17_17_54_31',
+    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_Candidate_2020_01_21_10_53_15',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2020_01_17_17_53_08',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2020_01_21_10_51_32',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_Candidate_2020_01_17_17_53_50',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_Candidate_2020_01_21_10_58_30',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,21 +16,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v3',
+    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_Candidate_2020_01_17_17_54_31',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '110X_mcRun2_asymptotic_v6',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2020_01_17_17_53_08',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v5',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_Candidate_2020_01_17_17_53_50',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v9',
+    'run1_data'         :   '110X_dataRun2_2017_2018_Candidate_2020_01_17_14_50_24',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v9',
+    'run2_data'         :   '110X_dataRun2_2017_2018_Candidate_2020_01_17_14_50_24',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2020_01_17_14_52_17',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -48,35 +48,35 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_promptlike'         :   '106X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '110X_mc2017_design_v2',
+    'phase1_2017_design'       :  '110X_mc2017_design_Candidate_2020_01_17_14_56_45',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '110X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '110X_mc2017_realistic_Candidate_2020_01_17_14_54_08',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_Candidate_2020_01_17_14_54_57',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_Candidate_2020_01_17_14_55_41',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '110X_upgrade2018_design_v3',
+    'phase1_2018_design'       :  '110X_upgrade2018_design_Candidate_2020_01_17_14_58_40',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v7',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2020_01_17_14_59_48',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_Candidate_2020_01_17_15_00_52',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v6',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_Candidate_2020_01_17_15_01_24',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_v5', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_Candidate_2020_01_17_15_02_07', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2020_01_17_15_02_54', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2020_01_17_15_04_04',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2020_01_17_15_05_07', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2020_01_17_15_06_09', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v2'
 }


### PR DESCRIPTION
#### PR description:

This is a follow-up to PRs https://github.com/cms-sw/cmssw/pull/28535 and https://github.com/cms-sw/cmssw/pull/26032. 
The trigger bit selection for the three AlCaRecos `SiPixelCalSingleMuon`,`SiPixelCalCosmics` and `SiStripCalCosmics` is taken from DB tag instead of being hard-coded into the configuration file.
Three new tags are introduced:
   * MC workflows: `AlCaRecoHLTpaths_2017_MC_v4`, [diff w.r.t previous tag](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/AlCaRecoHLTpaths_2017_MC_v2/AlCaRecoHLTpaths_2017_MC_v4)

![image](https://user-images.githubusercontent.com/5082376/72683380-1b61df00-3ad7-11ea-819f-09d963a6baab.png)

   * Data offline workflows: `AlCaRecoHLTpaths_2017_offline_v4`, [diff w.r.t. previous tag](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/AlCaRecoHLTpaths_2017_offline_v2/AlCaRecoHLTpaths_2017_offline_v4)

![image](https://user-images.githubusercontent.com/5082376/72683394-42b8ac00-3ad7-11ea-9ffc-8fce7f32b230.png)

   * Prompt-reco workflow: `AlCaRecoHLTpaths8e29_5e33_v7_prompt`, [diff w.r.t. previous tag](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/tags/AlCaRecoHLTpaths8e29_5e33_v6_prompt/AlCaRecoHLTpaths8e29_5e33_v7_prompt)

![image](https://user-images.githubusercontent.com/5082376/72683449-c5416b80-3ad7-11ea-8c25-2e7df12f8202.png)

#### PR validation: 

PR validation relies on the limited matrix integration tests. Worklfows which have been run:
   * `runTheMatrix.py -l limited -t 4 -j 8 --ibeos`
   * `runTheMatrix.py -l 7.22,7.21,7.4,7.3 -t 4 -j 8`
   * `runTheMatrix.py -l 138.1 -t 4 -j 8 --ibeos`

**N.B.: no difference to any workflow is expected  from this PR**

#### if this PR is a backport please specify the original PR:

This PR is not a backport, and no backport is meant.
cc: @tvami 