### PR TITLE
Add Unit Test for Alignment PV Validation plotting

### DIFF
--- a/Alignment/OfflineValidation/macros/CMS_lumi.C
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.C
@@ -76,7 +76,7 @@ CMS_lumi( TPad* pad, int iPeriod, int iPosX )
       lumiText += lumi_sqrtS;
     }
    
-  std::cout << lumiText << endl;
+  std::cout << lumiText << std::endl;
 
   TLatex latex;
   latex.SetNDC();
@@ -124,11 +124,9 @@ CMS_lumi( TPad* pad, int iPeriod, int iPosX )
 	  float yl_0 = posY_ - 0.15;
 	  float xl_1 = posX_ + 0.15*H/W;
 	  float yl_1 = posY_;
-	  TASImage* CMS_logo = new TASImage("CMS-BW-label.png");
 	  TPad* pad_logo = new TPad("logo","logo", xl_0, yl_0, xl_1, yl_1 );
 	  pad_logo->Draw();
 	  pad_logo->cd();
-	  CMS_logo->Draw("X");
 	  pad_logo->Modified();
 	  pad->cd();
 	}

--- a/Alignment/OfflineValidation/macros/CMS_lumi.C
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.C
@@ -1,24 +1,27 @@
 #include "CMS_lumi.h"
 #include <iostream>
 
-void 
-CMS_lumi( TPad* pad, int iPeriod, int iPosX )
-{            
-  bool outOfFrame    = false;
-  if( iPosX/10==0 ) 
-    {
-      outOfFrame = true;
-    }
-  int alignY_=3;
-  int alignX_=2;
-  if( iPosX/10==0 ) alignX_=1;
-  if( iPosX==0    ) alignX_=1;
-  if( iPosX==0    ) alignY_=1;
-  if( iPosX/10==1 ) alignX_=1;
-  if( iPosX/10==2 ) alignX_=2;
-  if( iPosX/10==3 ) alignX_=3;
+void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
+  bool outOfFrame = false;
+  if (iPosX / 10 == 0) {
+    outOfFrame = true;
+  }
+  int alignY_ = 3;
+  int alignX_ = 2;
+  if (iPosX / 10 == 0)
+    alignX_ = 1;
+  if (iPosX == 0)
+    alignX_ = 1;
+  if (iPosX == 0)
+    alignY_ = 1;
+  if (iPosX / 10 == 1)
+    alignX_ = 1;
+  if (iPosX / 10 == 2)
+    alignX_ = 2;
+  if (iPosX / 10 == 3)
+    alignX_ = 3;
   //if( iPosX == 0  ) relPosX = 0.12;
-  int align_ = 10*alignX_ + alignY_;
+  int align_ = 10 * alignX_ + alignY_;
 
   float H = pad->GetWh();
   float W = pad->GetWw();
@@ -31,131 +34,106 @@ CMS_lumi( TPad* pad, int iPeriod, int iPosX )
   pad->cd();
 
   TString lumiText;
-  if( iPeriod==1 )
-    {
-      lumiText += lumi_7TeV;
-      lumiText += " (7 TeV)";
-    }
-  else if ( iPeriod==2 )
-    {
-      lumiText += lumi_8TeV;
-      lumiText += " (8 TeV)";
-    }
-  else if( iPeriod==3 ) 
-    {
-      lumiText = lumi_8TeV; 
-      lumiText += " (8 TeV)";
-      lumiText += " + ";
-      lumiText += lumi_7TeV;
-      lumiText += " (7 TeV)";
-    }
-  else if ( iPeriod==4 )
-    {
-      lumiText += lumi_13TeV;
-      lumiText += " (#sqrt{s} = 13 TeV)";
-    }
-  else if ( iPeriod==7 )
-    { 
-      if( outOfFrame ) lumiText += "#scale[0.85]{";
-      lumiText += lumi_13TeV; 
-      lumiText += " (13 TeV)";
-      lumiText += " + ";
-      lumiText += lumi_8TeV; 
-      lumiText += " (8 TeV)";
-      lumiText += " + ";
-      lumiText += lumi_7TeV;
-      lumiText += " (7 TeV)";
-      if( outOfFrame) lumiText += "}";
-    }
-  else if ( iPeriod==12 )
-    {
-      lumiText += "8 TeV";
-    }
-  else if ( iPeriod==0 )
-    {
-      lumiText += lumi_sqrtS;
-    }
-   
+  if (iPeriod == 1) {
+    lumiText += lumi_7TeV;
+    lumiText += " (7 TeV)";
+  } else if (iPeriod == 2) {
+    lumiText += lumi_8TeV;
+    lumiText += " (8 TeV)";
+  } else if (iPeriod == 3) {
+    lumiText = lumi_8TeV;
+    lumiText += " (8 TeV)";
+    lumiText += " + ";
+    lumiText += lumi_7TeV;
+    lumiText += " (7 TeV)";
+  } else if (iPeriod == 4) {
+    lumiText += lumi_13TeV;
+    lumiText += " (#sqrt{s} = 13 TeV)";
+  } else if (iPeriod == 7) {
+    if (outOfFrame)
+      lumiText += "#scale[0.85]{";
+    lumiText += lumi_13TeV;
+    lumiText += " (13 TeV)";
+    lumiText += " + ";
+    lumiText += lumi_8TeV;
+    lumiText += " (8 TeV)";
+    lumiText += " + ";
+    lumiText += lumi_7TeV;
+    lumiText += " (7 TeV)";
+    if (outOfFrame)
+      lumiText += "}";
+  } else if (iPeriod == 12) {
+    lumiText += "8 TeV";
+  } else if (iPeriod == 0) {
+    lumiText += lumi_sqrtS;
+  }
+
   std::cout << lumiText << std::endl;
 
   TLatex latex;
   latex.SetNDC();
   latex.SetTextAngle(0);
-  latex.SetTextColor(kBlack);    
+  latex.SetTextColor(kBlack);
 
-  float extraTextSize = extraOverCmsTextSize*cmsTextSize;
+  float extraTextSize = extraOverCmsTextSize * cmsTextSize;
 
   latex.SetTextFont(42);
-  latex.SetTextAlign(31); 
-  latex.SetTextSize(lumiTextSize*t);    
-  latex.DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex.SetTextAlign(31);
+  latex.SetTextSize(lumiTextSize * t);
+  latex.DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
-  if( outOfFrame )
-    {
-      latex.SetTextFont(cmsTextFont);
-      latex.SetTextAlign(11); 
-      latex.SetTextSize(cmsTextSize*t);    
-      latex.DrawLatex(l,1-t+lumiTextOffset*t,cmsText);
-    }
-  
+  if (outOfFrame) {
+    latex.SetTextFont(cmsTextFont);
+    latex.SetTextAlign(11);
+    latex.SetTextSize(cmsTextSize * t);
+    latex.DrawLatex(l, 1 - t + lumiTextOffset * t, cmsText);
+  }
+
   pad->cd();
 
-  float posX_=0;
-  if( iPosX%10<=1 )
-    {
-      posX_ =   l + relPosX*(1-l-r);
-    }
-  else if( iPosX%10==2 )
-    {
-      posX_ =  l + 0.5*(1-l-r);
-    }
-  else if( iPosX%10==3 )
-    {
-      posX_ =  1-r - relPosX*(1-l-r);
-    }
-  float posY_ = 1-t - relPosY*(1-t-b);
-  if( !outOfFrame )
-    {
-      if( drawLogo )
-	{
-	  posX_ =   l + 0.045*(1-l-r)*W/H;
-	  posY_ = 1-t - 0.045*(1-t-b);
-	  float xl_0 = posX_;
-	  float yl_0 = posY_ - 0.15;
-	  float xl_1 = posX_ + 0.15*H/W;
-	  float yl_1 = posY_;
-	  TPad* pad_logo = new TPad("logo","logo", xl_0, yl_0, xl_1, yl_1 );
-	  pad_logo->Draw();
-	  pad_logo->cd();
-	  pad_logo->Modified();
-	  pad->cd();
-	}
-      else
-	{
-	  latex.SetTextFont(cmsTextFont);
-	  latex.SetTextSize(cmsTextSize*t);
-	  latex.SetTextAlign(align_);
-	  latex.DrawLatex(posX_, posY_, cmsText);
-	  if( writeExtraText ) 
-	    {
-	      latex.SetTextFont(extraTextFont);
-	      latex.SetTextAlign(align_);
-	      latex.SetTextSize(extraTextSize*t);
-	      latex.DrawLatex(posX_, posY_- relExtraDY*cmsTextSize*t, extraText);
-	    }
-	}
-    }
-  else if( writeExtraText )
-    {
-      if( iPosX==0) 
-	{
-	  posX_ =   l +  relPosX*(1-l-r);
-	  posY_ =   1-t+lumiTextOffset*t;
-	}
-      latex.SetTextFont(extraTextFont);
-      latex.SetTextSize(extraTextSize*t);
+  float posX_ = 0;
+  if (iPosX % 10 <= 1) {
+    posX_ = l + relPosX * (1 - l - r);
+  } else if (iPosX % 10 == 2) {
+    posX_ = l + 0.5 * (1 - l - r);
+  } else if (iPosX % 10 == 3) {
+    posX_ = 1 - r - relPosX * (1 - l - r);
+  }
+  float posY_ = 1 - t - relPosY * (1 - t - b);
+  if (!outOfFrame) {
+    if (drawLogo) {
+      posX_ = l + 0.045 * (1 - l - r) * W / H;
+      posY_ = 1 - t - 0.045 * (1 - t - b);
+      float xl_0 = posX_;
+      float yl_0 = posY_ - 0.15;
+      float xl_1 = posX_ + 0.15 * H / W;
+      float yl_1 = posY_;
+      TPad* pad_logo = new TPad("logo", "logo", xl_0, yl_0, xl_1, yl_1);
+      pad_logo->Draw();
+      pad_logo->cd();
+      pad_logo->Modified();
+      pad->cd();
+    } else {
+      latex.SetTextFont(cmsTextFont);
+      latex.SetTextSize(cmsTextSize * t);
       latex.SetTextAlign(align_);
-      latex.DrawLatex(posX_, posY_, extraText);      
+      latex.DrawLatex(posX_, posY_, cmsText);
+      if (writeExtraText) {
+        latex.SetTextFont(extraTextFont);
+        latex.SetTextAlign(align_);
+        latex.SetTextSize(extraTextSize * t);
+        latex.DrawLatex(posX_, posY_ - relExtraDY * cmsTextSize * t, extraText);
+      }
     }
+  } else if (writeExtraText) {
+    if (iPosX == 0) {
+      posX_ = l + relPosX * (1 - l - r);
+      posY_ = 1 - t + lumiTextOffset * t;
+    }
+    latex.SetTextFont(extraTextFont);
+    latex.SetTextSize(extraTextSize * t);
+    latex.SetTextAlign(align_);
+    latex.DrawLatex(posX_, posY_, extraText);
+  }
   return;
 }

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <fstream>
 #include <cassert>
-#include <Riostream.h>
 #include "TFile.h"
 #include "TPaveStats.h"
 #include "TROOT.h"
@@ -343,7 +342,7 @@ void setStyle();
 
 // global variables
 
-ofstream outfile("FittedDeltaZ.txt");
+std::ofstream outfile("FittedDeltaZ.txt");
 
 Int_t nBins_ = 48;
 Int_t nLadders_ = 20;
@@ -466,6 +465,11 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     theFileCount = sourceList.size();
   }
 
+  if(theFileCount==0){
+    std::cout << "FitPVResiduals::FitPVResiduals(): empty input file list has been passed." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
   //  const Int_t nFiles_ = FileList->GetSize();
   const Int_t nFiles_ = theFileCount;
   TString LegLabels[10];
@@ -490,7 +494,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
       colors[j] = sourceList[j]->getLineColor();
     }
     LegLabels[j].ReplaceAll("_", " ");
-    cout << "FitPVResiduals::FitPVResiduals(): label[" << j << "] " << LegLabels[j] << endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): label[" << j << "] " << LegLabels[j] << std::endl;
   }
 
   //
@@ -779,7 +783,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     std::cout << "======================================================" << std::endl;
     std::cout << "FitPVResiduals::FitPVResiduals(): the eta range is different" << std::endl;
     std::cout << "exiting..." << std::endl;
-    return;
+    exit(EXIT_FAILURE);
   } else {
     etaRange = theEtaMax_[0];
     std::cout << "======================================================" << std::endl;
@@ -794,7 +798,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     std::cout << "======================================================" << std::endl;
     std::cout << "FitPVResiduals::FitPVResiduals(): the number of bins is different" << std::endl;
     std::cout << "exiting..." << std::endl;
-    return;
+    exit(EXIT_FAILURE);
   } else {
     nBins_ = theNBINS[0];
 
@@ -862,7 +866,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     std::cout << "======================================================" << std::endl;
     std::cout << "FitPVResiduals::FitPVResiduals(): not all the files have events" << std::endl;
     std::cout << "exiting (...to prevent a segmentation fault)" << std::endl;
-    return;
+    exit(EXIT_FAILURE);
   }
 
   Double_t highedge = nBins_ - 0.5;
@@ -2531,7 +2535,7 @@ void arrangeFitCanvas(TCanvas *canv, TH1F *meanplots[100], Int_t nFiles, TString
     lego->AddEntry(meanplots[j], LegLabels[j] + MYOUT);
 
     if (j == nFiles - 1) {
-      outfile << deltaZ << "|" << sigmadeltaZ << endl;
+      outfile << deltaZ << "|" << sigmadeltaZ << std::endl;
     }
 
     delete theNewCanvas2;
@@ -3278,7 +3282,7 @@ void FillMap(TH2F *trendMap, std::vector<std::vector<TH1F *> > residualsMapPlot,
     trendMap->GetYaxis()->SetBinLabel(i + 1, phipositionString);
 
     for (int j = 0; j < nBins_; ++j) {
-      //cout<<"(i,j)="<<i<<","<<j<<endl;
+      //std::cout<<"(i,j)="<<i<<","<<j<<std::endl;
 
       char etapositionString[129];
       float etaposition = (-etaRange + j * etaInterval) + (etaInterval / 2);
@@ -3463,10 +3467,10 @@ std::pair<TH2F *, TH2F *> trimTheMap(TH2 *hist) {
   params::measurement theMAD = getMAD(histContentByCell);
 
   if (isDebugMode) {
-    std::cout << std::setw(24) << left << hist->GetName() << "| mean: " << std::setw(10) << setprecision(4)
-              << theMeanOfCells << "| min: " << std::setw(10) << setprecision(4) << min << "| max: " << std::setw(10)
-              << setprecision(4) << max << "| rms: " << std::setw(10) << setprecision(4) << theRMSOfCells
-              << "| mad: " << std::setw(10) << setprecision(4) << theMAD.first << std::endl;
+    std::cout << std::setw(24) << std::left << hist->GetName() << "| mean: " << std::setw(10) << std::setprecision(4)
+              << theMeanOfCells << "| min: " << std::setw(10) << std::setprecision(4) << min << "| max: " << std::setw(10)
+              << std::setprecision(4) << max << "| rms: " << std::setw(10) << std::setprecision(4) << theRMSOfCells
+              << "| mad: " << std::setw(10) << std::setprecision(4) << theMAD.first << std::endl;
   }
 
   TCanvas *cCheck = new TCanvas(Form("cCheck_%s", hist->GetName()), Form("cCheck_%s", hist->GetName()), 1200, 1000);
@@ -3574,9 +3578,9 @@ std::pair<TH2F *, TH2F *> trimTheMap(TH2 *hist) {
     cCheck->SaveAs(Form("cCheck_%s.png", hist->GetName()));
     cCheck->SaveAs(Form("cCheck_%s.pdf", hist->GetName()));
 
-    std::cout << "histo:" << setw(25) << hist->GetName() << " old min: " << setw(10) << hist->GetMinimum()
-              << " old max: " << setw(10) << hist->GetMaximum();
-    std::cout << " | new min: " << setw(15) << hist->GetMinimum() << " new max: " << setw(10) << hist->GetMaximum()
+    std::cout << "histo:" << std::setw(25) << hist->GetName() << " old min: " << std::setw(10) << hist->GetMinimum()
+              << " old max: " << std::setw(10) << hist->GetMaximum();
+    std::cout << " | new min: " << std::setw(15) << hist->GetMinimum() << " new max: " << std::setw(10) << hist->GetMaximum()
               << std::endl;
   }
 
@@ -3867,7 +3871,7 @@ void FitULine(TH1 *hist)
     if (hist->GetFunction(func1.GetName())) {  // Take care that it is later on drawn:
       hist->GetFunction(func1.GetName())->ResetBit(TF1::kNotDraw);
     }
-    //cout<<"FitPVResiduals() fit Up done!"<<endl;
+    //std::cout<<"FitPVResiduals() fit Up done!"<<std::endl;
   }
 }
 
@@ -3885,7 +3889,7 @@ void FitDLine(TH1 *hist)
     if (hist->GetFunction(func2.GetName())) {  // Take care that it is later on drawn:
       hist->GetFunction(func2.GetName())->ResetBit(TF1::kNotDraw);
     }
-    // cout<<"FitPVResiduals() fit Down done!"<<endl;
+    // std::cout<<"FitPVResiduals() fit Down done!"<<std::endl;
   }
 }
 

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -465,7 +465,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     theFileCount = sourceList.size();
   }
 
-  if(theFileCount==0){
+  if (theFileCount == 0) {
     std::cout << "FitPVResiduals::FitPVResiduals(): empty input file list has been passed." << std::endl;
     exit(EXIT_FAILURE);
   }
@@ -3468,9 +3468,10 @@ std::pair<TH2F *, TH2F *> trimTheMap(TH2 *hist) {
 
   if (isDebugMode) {
     std::cout << std::setw(24) << std::left << hist->GetName() << "| mean: " << std::setw(10) << std::setprecision(4)
-              << theMeanOfCells << "| min: " << std::setw(10) << std::setprecision(4) << min << "| max: " << std::setw(10)
-              << std::setprecision(4) << max << "| rms: " << std::setw(10) << std::setprecision(4) << theRMSOfCells
-              << "| mad: " << std::setw(10) << std::setprecision(4) << theMAD.first << std::endl;
+              << theMeanOfCells << "| min: " << std::setw(10) << std::setprecision(4) << min
+              << "| max: " << std::setw(10) << std::setprecision(4) << max << "| rms: " << std::setw(10)
+              << std::setprecision(4) << theRMSOfCells << "| mad: " << std::setw(10) << std::setprecision(4)
+              << theMAD.first << std::endl;
   }
 
   TCanvas *cCheck = new TCanvas(Form("cCheck_%s", hist->GetName()), Form("cCheck_%s", hist->GetName()), 1200, 1000);
@@ -3580,8 +3581,8 @@ std::pair<TH2F *, TH2F *> trimTheMap(TH2 *hist) {
 
     std::cout << "histo:" << std::setw(25) << hist->GetName() << " old min: " << std::setw(10) << hist->GetMinimum()
               << " old max: " << std::setw(10) << hist->GetMaximum();
-    std::cout << " | new min: " << std::setw(15) << hist->GetMinimum() << " new max: " << std::setw(10) << hist->GetMaximum()
-              << std::endl;
+    std::cout << " | new min: " << std::setw(15) << hist->GetMinimum() << " new max: " << std::setw(10)
+              << hist->GetMaximum() << std::endl;
   }
 
   delete histContentByCell;

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -1,6 +1,12 @@
 <environment>
-  <bin   file="testAlignmentOfflineValidation.cpp">
+  <bin name="testAlignmentOfflineValidation" file="testAlignmentOfflineValidation.cpp">
     <flags   TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_all.sh"/>
-		<use   name="FWCore/Utilities"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
+  <bin file="testPVPlotting.cpp">
+    <flags PRE_TEST="testAlignmentOfflineValidation"/>
+    <use   name="rootmath"/>
+    <use   name="roothistmatrix"/>
+    <use   name="rootgraphics"/>
   </bin>
 </environment>

--- a/Alignment/OfflineValidation/test/testPVPlotting.cpp
+++ b/Alignment/OfflineValidation/test/testPVPlotting.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include <sstream>
+#include "Alignment/OfflineValidation/macros/FitPVResiduals.C"
+
+int main(int argc, char** argv) {
+  FitPVResiduals("PVValidation_test_0.root=testing",true,true,"",true);
+}

--- a/Alignment/OfflineValidation/test/testPVPlotting.cpp
+++ b/Alignment/OfflineValidation/test/testPVPlotting.cpp
@@ -2,6 +2,4 @@
 #include <sstream>
 #include "Alignment/OfflineValidation/macros/FitPVResiduals.C"
 
-int main(int argc, char** argv) {
-  FitPVResiduals("PVValidation_test_0.root=testing",true,true,"",true);
-}
+int main(int argc, char** argv) { FitPVResiduals("PVValidation_test_0.root=testing", true, true, "", true); }

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -6,10 +6,10 @@
 # general settings applying to all validations
 # - one can override `jobmode` in the individual validation's section
 [general]
-jobmode = lxBatch, -q cmscaf1nd
+jobmode = condor
 datadir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/PVValidationTest
 # if you want your root files stored in a subdirectory on eos, put it here:
-# eosdir = Test
+eosdir = Test
 # if you want your logs to be stored somewhere else, put it here:
 # logdir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/log
 
@@ -96,7 +96,8 @@ w_dzEtaNormMax = 1.8
 
 [primaryvertex:phase0MC]
 maxevents = 10000
-dataset = /RelValTTbar_13/CMSSW_8_1_0_pre16-TkAlMinBias-81X_mcRun2_asymptotic_v11-v1/ALCARECO 
+multiIOV = false
+dataset = /RelValTTbar_13/CMSSW_11_0_0_pre13-TkAlMinBias-110X_mcRun2_asymptotic_v5-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
 isda = True
@@ -110,6 +111,7 @@ runControl = False
 
 [primaryvertex:phaseIMC]
 maxevents = 10000
+multiIOV = false
 dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -133,6 +135,7 @@ runControl = False
 [primaryvertex:phaseIMC_BPixOnly]
 maxevents = 10000
 dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
+multiIOV = false
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
 isda = True
@@ -148,6 +151,7 @@ runControl = False
 
 [primaryvertex:run2016data]
 maxevents = 10000
+multiIOV = false
 dataset = /HLTPhysics/Run2016H-TkAlMinBias-PromptReco-v2/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -162,6 +166,7 @@ runControl = True
 
 [primaryvertex:run2018data]
 maxevents = 10000
+multiIOV = false
 dataset = /StreamExpressAlignment/Run2018B-TkAlMinBias-Express-v1/ALCARECO 
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -182,6 +187,7 @@ runControl = False
 
 [primaryvertex:run2018data_forcedBS]
 maxevents = 10000
+multiIOV = false
 dataset = /StreamExpressAlignment/Run2018B-TkAlMinBias-Express-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -204,5 +210,3 @@ primaryvertex phaseIMC    : mc_2017
 primaryvertex phaseIMC_BPixOnly : mc_2017_bpixonly
 primaryvertex run2018data : data_2018
 primaryvertex run2018data_forcedBS : data_2018
-
-


### PR DESCRIPTION
#### PR description:

This PR adds a unit test for the plotting macro used to produce the tracker alignment PrimaryVertex Validation results. 
   * the new test is run after the production of a suitable file from the existing unit test `testAlignmentOfflineValidation`.
   * few modifications are done to the source code of the plotting macro to be able to compile it with `scram`
   * I profit of this PR to modernize the example `ini` file for submitting the PV Validation to condor.

#### PR validation:

PR validation relies on the existing unit tests and in the one introduced in this PR.

#### if this PR is a backport please specify the original PR:

This PR is not a backport.
