### PR TITLE
[DD4hep] DDShape access to a composite shape's right solid

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -32,6 +32,7 @@ namespace cms {
     explicit DDSolid(dd4hep::Solid s) : solid_(s) {}
     dd4hep::Solid solid() const { return solid_; }
     dd4hep::Solid solidA() const;
+    dd4hep::Solid solidB() const;
     const std::vector<double> parameters() const;
 
   private:

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -24,6 +24,17 @@ dd4hep::Solid DDSolid::solidA() const {
   return solid_;
 }
 
+dd4hep::Solid DDSolid::solidB() const {
+  if (dd4hep::isA<dd4hep::SubtractionSolid>(solid_) || dd4hep::isA<dd4hep::UnionSolid>(solid_) ||
+      dd4hep::isA<dd4hep::IntersectionSolid>(solid_)) {
+    const TGeoCompositeShape* sh = (const TGeoCompositeShape*)solid_.ptr();
+    const TGeoBoolNode* boolean = sh->GetBoolNode();
+    TGeoShape* solidB = boolean->GetRightShape();
+    return dd4hep::Solid(solidB);
+  }
+  return solid_;
+}
+
 const std::vector<double> DDSolid::parameters() const { return solid().dimensions(); }
 
 DDFilteredView::DDFilteredView(const DDDetector* det, const Volume volume) : registry_(&det->specpars()) {

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -27,7 +27,7 @@ dd4hep::Solid DDSolid::solidA() const {
 dd4hep::Solid DDSolid::solidB() const {
   if (dd4hep::isA<dd4hep::SubtractionSolid>(solid_) || dd4hep::isA<dd4hep::UnionSolid>(solid_) ||
       dd4hep::isA<dd4hep::IntersectionSolid>(solid_)) {
-    const TGeoCompositeShape* sh = (const TGeoCompositeShape*)solid_.ptr();
+    const TGeoCompositeShape* sh = static_cast<const TGeoCompositeShape*>(solid_.ptr());
     const TGeoBoolNode* boolean = sh->GetBoolNode();
     TGeoShape* solidB = boolean->GetRightShape();
     return dd4hep::Solid(solidB);

--- a/DetectorDescription/DDCMS/test/DDSolid.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolid.cppunit.cc
@@ -56,7 +56,7 @@ void testDDSolid::checkDDSolid() {
       for (auto const& i : a.parameters())
         cout << i << ", ";
       cout << "\n";
-      
+
       auto solidB = solid.solidB();
       std::cout << "Solid B is a " << solidB->GetTitle() << "\n";
       if (dd4hep::isA<dd4hep::ConeSegment>(dd4hep::Solid(solidB))) {

--- a/DetectorDescription/DDCMS/test/DDSolid.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolid.cppunit.cc
@@ -56,6 +56,19 @@ void testDDSolid::checkDDSolid() {
       for (auto const& i : a.parameters())
         cout << i << ", ";
       cout << "\n";
+      
+      auto solidB = solid.solidB();
+      std::cout << "Solid B is a " << solidB->GetTitle() << "\n";
+      if (dd4hep::isA<dd4hep::ConeSegment>(dd4hep::Solid(solidB))) {
+        cout << " is a ConeSegment:\n";
+        for (auto const& i : solidB.dimensions())
+          cout << i << ", ";
+      }
+      cout << "\n";
+      DDSolid b(solidB);
+      for (auto const& i : b.parameters())
+        cout << i << ", ";
+      cout << "\n";
     }
   }
 }


### PR DESCRIPTION
#### PR description:

* GEM geometry builder requires access to both left and right solid of a composite shape

#### PR validation:

```DetectorDescription/DDCMS/test/DDSolid.cppunit.cc``` unit test 

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
