### PR TITLE
PyReleaseValidation production-like workflow for Run3 (2021)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -60,10 +60,10 @@ for year in upgradeKeys:
                     elif (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step
-                        if specialType == 'Run3ProdLike' and 'RecoFull' in step:
-                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFull','MiniAODFullGlobal'),specialWF.suffix))
                         if specialType == 'ProdLike' and 'RecoFullGlobal' in step:
                             stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFullGlobal','MiniAODFullGlobal'),specialWF.suffix))
+                        elif specialType == 'ProdLike' and 'RecoFull' in step:
+                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFull','MiniAODFullGlobal'),specialWF.suffix))
                     else:
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,''))
 

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -60,6 +60,8 @@ for year in upgradeKeys:
                     elif (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step
+                        if specialType == 'Run3ProdLike' and 'RecoFull' in step:
+                            stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFull','MiniAODFullGlobal'),specialWF.suffix))
                         if specialType == 'ProdLike' and 'RecoFullGlobal' in step:
                             stepList[specialType].append(stepMaker(key,frag[:-4],step.replace('RecoFullGlobal','MiniAODFullGlobal'),specialWF.suffix))
                     else:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -351,9 +351,11 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         elif 'MiniAOD' in step:
             # the separate miniAOD step is used here
             stepDict[stepName][k] = deepcopy(stepDict[step][k])
-        if 'ALCAFull' in step or 'HARVEST' in step:
+        if 'ALCA' in step or 'HARVEST' in step:
             # remove step
             stepDict[stepName][k] = None
+	if 'Nano' in step:
+            stepDict[stepName][k] = merge([{'--filein':'file:step4.root'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key)
 upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
@@ -365,6 +367,7 @@ upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
         'HARVESTFullGlobal',
         'MiniAODFullGlobal',
         'ALCAFull',
+        'NanoFull',
     ],
     PU = [
         'DigiFull',
@@ -374,6 +377,7 @@ upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
         'HARVESTFullGlobal',
         'MiniAODFullGlobal',
         'ALCAFull',
+        'NanoFull',
     ],
     suffix = '_ProdLike',
     offset = 0.21,

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -342,6 +342,37 @@ upgradeWFs['PatatrackPixelOnlyGPU'].step3 = {
 }
 # end of Patatrack workflows
 
+class UpgradeWorkflow_Run3ProdLike(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Digi' in step:
+	    stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
+	elif 'Reco' in step:
+            stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
+        elif 'MiniAOD' in step:
+            # the separate miniAOD step is used here
+            stepDict[stepName][k] = deepcopy(stepDict[step][k])
+        if 'HARVEST' in step:
+            # remove step
+            stepDict[stepName][k] = None
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return '2021' in key
+upgradeWFs['Run3ProdLike'] = UpgradeWorkflow_Run3ProdLike(
+    steps = [
+	'DigiFull',
+        'RecoFull',
+        'HARVESTFull',
+        'MiniAODFullGlobal',
+    ],
+    PU = [
+	'DigiFull',
+        'RecoFull',
+        'HARVESTFull',
+	'MiniAODFullGlobal',
+    ],
+    suffix = '_Run3ProdLike',
+    offset = 0.22,
+)
+
 class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -354,7 +354,7 @@ class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
         if 'ALCA' in step or 'HARVEST' in step:
             # remove step
             stepDict[stepName][k] = None
-	if 'Nano' in step:
+        if 'Nano' in step:
             stepDict[stepName][k] = merge([{'--filein':'file:step4.root'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -351,7 +351,7 @@ class UpgradeWorkflow_Run3ProdLike(UpgradeWorkflow):
         elif 'MiniAOD' in step:
             # the separate miniAOD step is used here
             stepDict[stepName][k] = deepcopy(stepDict[step][k])
-        if 'HARVEST' in step:
+        if 'ALCAFull' in step or 'HARVEST' in step:
             # remove step
             stepDict[stepName][k] = None
     def condition(self, fragment, stepList, key, hasHarvest):
@@ -362,12 +362,14 @@ upgradeWFs['Run3ProdLike'] = UpgradeWorkflow_Run3ProdLike(
         'RecoFull',
         'HARVESTFull',
         'MiniAODFullGlobal',
+	'ALCAFull',
     ],
     PU = [
 	'DigiFull',
         'RecoFull',
         'HARVESTFull',
 	'MiniAODFullGlobal',
+	'ALCAFull',
     ],
     suffix = '_Run3ProdLike',
     offset = 0.22,

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -345,8 +345,8 @@ upgradeWFs['PatatrackPixelOnlyGPU'].step3 = {
 class UpgradeWorkflow_Run3ProdLike(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Digi' in step:
-	    stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
-	elif 'Reco' in step:
+            stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
+        elif 'Reco' in step:
             stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
         elif 'MiniAOD' in step:
             # the separate miniAOD step is used here
@@ -358,18 +358,18 @@ class UpgradeWorkflow_Run3ProdLike(UpgradeWorkflow):
         return '2021' in key
 upgradeWFs['Run3ProdLike'] = UpgradeWorkflow_Run3ProdLike(
     steps = [
-	'DigiFull',
+        'DigiFull',
         'RecoFull',
         'HARVESTFull',
         'MiniAODFullGlobal',
-	'ALCAFull',
+        'ALCAFull',
     ],
     PU = [
-	'DigiFull',
+        'DigiFull',
         'RecoFull',
         'HARVESTFull',
-	'MiniAODFullGlobal',
-	'ALCAFull',
+        'MiniAODFullGlobal',
+        'ALCAFull',
     ],
     suffix = '_Run3ProdLike',
     offset = 0.22,

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -342,9 +342,9 @@ upgradeWFs['PatatrackPixelOnlyGPU'].step3 = {
 }
 # end of Patatrack workflows
 
-class UpgradeWorkflow_Run3ProdLike(UpgradeWorkflow):
+class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Digi' in step:
+        if 'Digi' in step and 'Trigger' not in step:
             stepDict[stepName][k] = merge([{'-s': 'DIGI,L1,DIGI2RAW,HLT:@relval2021', '--datatier':'GEN-SIM-DIGI-RAW', '--eventcontent':'RAWSIM'}, stepDict[step][k]])
         elif 'Reco' in step:
             stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
@@ -355,48 +355,25 @@ class UpgradeWorkflow_Run3ProdLike(UpgradeWorkflow):
             # remove step
             stepDict[stepName][k] = None
     def condition(self, fragment, stepList, key, hasHarvest):
-        return '2021' in key
-upgradeWFs['Run3ProdLike'] = UpgradeWorkflow_Run3ProdLike(
-    steps = [
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
-        'MiniAODFullGlobal',
-        'ALCAFull',
-    ],
-    PU = [
-        'DigiFull',
-        'RecoFull',
-        'HARVESTFull',
-        'MiniAODFullGlobal',
-        'ALCAFull',
-    ],
-    suffix = '_Run3ProdLike',
-    offset = 0.22,
-)
-
-class UpgradeWorkflow_ProdLike(UpgradeWorkflow):
-    def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step:
-            stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,L1Reco,RECO,RECOSIM', '--datatier':'AODSIM', '--eventcontent':'AODSIM'}, stepDict[step][k]])
-        elif 'MiniAOD' in step:
-            # the separate miniAOD step is used here
-            stepDict[stepName][k] = deepcopy(stepDict[step][k])
-        if 'HARVEST' in step:
-            # remove step
-            stepDict[stepName][k] = None
-    def condition(self, fragment, stepList, key, hasHarvest):
-        return fragment=="TTbar_14TeV" and '2026' in key
+        return fragment=="TTbar_14TeV" and ('2026' in key or '2021' in key)
 upgradeWFs['ProdLike'] = UpgradeWorkflow_ProdLike(
     steps = [
+        'DigiFull',
+        'RecoFull',
         'RecoFullGlobal',
+        'HARVESTFull',
         'HARVESTFullGlobal',
         'MiniAODFullGlobal',
+        'ALCAFull',
     ],
     PU = [
+        'DigiFull',
+        'RecoFull',
         'RecoFullGlobal',
+        'HARVESTFull',
         'HARVESTFullGlobal',
         'MiniAODFullGlobal',
+        'ALCAFull',
     ],
     suffix = '_ProdLike',
     offset = 0.21,


### PR DESCRIPTION
#### PR description:

This PR proposes a special set of Run3 (2021) workflows in a "production-like" setup, mimicking what already available for Phase2 by @kpedro88 . The purpose is to provide a tool for performance evaluation ready out-of-the-box, and it is not added to the standard set of workflows to avoid inflating it further for such a specific use case (so ```--what upgrade``` option needs to be invoked).

#### PR validation:

The added configuration cannot be tested directly by the bot. Here is the output:

```
12:35 cmsdev25 653> runTheMatrix.py --what upgrade -l 11634.21 --dryRun
ignoring non-requested file relval_standard
ignoring non-requested file relval_highstats
ignoring non-requested file relval_pileup
ignoring non-requested file relval_generator
ignoring non-requested file relval_extendedgen
ignoring non-requested file relval_production
ignoring non-requested file relval_ged
processing relval_upgrade
ignoring non-requested file relval_2017
ignoring non-requested file relval_2026
ignoring non-requested file relval_identity
ignoring non-requested file relval_machine
ignoring non-requested file relval_unsch
ignoring non-requested file relval_premix
Running in 4 thread(s)

Preparing to run 11634.21 TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021

# in: /build/fabiocos/111X/prodlikeWF/CMSSW_11_1_X_2020-01-21-2300/work dryRun for 'cd 11634.21_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021
 cmsDriver.py TTbar_14TeV_TuneCUETP8M1_cfi  --conditions auto:phase1_2021_realistic -n 10 --era Run3 --eventcontent FEVTDEBUG --relval 9000,100 -s GEN,SIM --datatier GEN-SIM --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --geometry DB:Extended --fileout file:step1.root  > step1_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021.log  2>&1
 

# in: /build/fabiocos/111X/prodlikeWF/CMSSW_11_1_X_2020-01-21-2300/work dryRun for 'cd 11634.21_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021
 cmsDriver.py step2  --conditions auto:phase1_2021_realistic -s DIGI,L1,DIGI2RAW,HLT:@relval2021 --datatier GEN-SIM-DIGI-RAW -n 10 --geometry DB:Extended --era Run3 --eventcontent RAWSIM --filein  file:step1.root  --fileout file:step2.root  > step2_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021.log  2>&1
 

# in: /build/fabiocos/111X/prodlikeWF/CMSSW_11_1_X_2020-01-21-2300/work dryRun for 'cd 11634.21_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021
 cmsDriver.py step3  --conditions auto:phase1_2021_realistic -n 10 --era Run3 --eventcontent AODSIM --runUnscheduled  -s RAW2DIGI,L1Reco,RECO,RECOSIM --datatier AODSIM --geometry DB:Extended --filein  file:step2.root  --fileout file:step3.root  > step3_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021.log  2>&1
 

# in: /build/fabiocos/111X/prodlikeWF/CMSSW_11_1_X_2020-01-21-2300/work dryRun for 'cd 11634.21_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021
 cmsDriver.py step4  --conditions auto:phase1_2021_realistic -n 10 --era Run3 --eventcontent MINIAODSIM --runUnscheduled  -s PAT --datatier MINIAODSIM --geometry DB:Extended --filein  file:step3.root  --fileout file:step4.root  > step4_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021.log  2>&1
 
11634.21_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2021_GenSimFull+DigiFull_ProdLike_2021+RecoFull_ProdLike_2021+MiniAODFullGlobal_ProdLike_2021 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Sun Jan 26 12:35:14 2020-date Sun Jan 26 12:35:14 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed

```