### PR TITLE
add TestOldDigi workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -26,7 +26,7 @@ numWFIB.extend([21634.0]) #2026D45
 numWFIB.extend([22034.0]) #2026D46
 numWFIB.extend([22434.0]) #2026D47
 numWFIB.extend([22834.0]) #2026D48
-numWFIB.extend([23234.0]) #2026D49
+numWFIB.extend([23234.0,23234.1001,23434.1001]) #2026D49, TestOldDigi, TestOldDigi w/ PU
 numWFIB.extend([23634.0]) #2026D51
 numWFIB.extend([24034.0]) #2026D52
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3284,14 +3284,18 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                 stepName = step + specialWF.suffix
                 stepNamePU = step + 'PU' + specialWF.suffix
                 stepNamePUpmx = step + 'PUPRMX' + specialWF.suffix
-                if upgradeStepDict[stepName][k] is None:
+                if k not in upgradeStepDict[stepName] or upgradeStepDict[stepName][k] is None:
                     upgradeStepDict[stepNamePU][k] = None
+                elif stepNamePU in upgradeStepDict and k in upgradeStepDict[stepNamePU]:
+                    # in case special WF had PU-specific changes
+                    upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepNamePU][k]])
                 else:
                     upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepName][k]])
 
                 # Setup premixing stage2
                 if "Digi" in step or "Reco" in step:
                     d = merge([upgradeStepDict[stepName][k]])
+                    if d is None: continue
                     if "Digi" in step:
                         tmpsteps = []
                         for s in d["-s"].split(","):
@@ -3329,7 +3333,9 @@ for step in upgradeStepDict.keys():
             for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:
                 k=frag[:-4]+'_'+key+'_'+step
                 if (step in upgradeStepDict or step.replace("PUPRMX", "PU")) and key in upgradeStepDict[step]:
-                    if 'Premix' in step:
+                    if upgradeStepDict[step][key] is None:
+                        steps[k]=None
+                    elif 'Premix' in step:
                         # Include premixing stage1 only for SingleNu, use special step name
                         if not 'SingleNu' in frag:
                             continue

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -538,6 +538,37 @@ upgradeWFs['premixS1S2'] = UpgradeWorkflow(
     offset = 0.99,
 )
 
+class UpgradeWorkflow_TestOldDigi(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Reco' in step:
+            # use existing DIGI-RAW file from old release
+            stepDict[stepName][k] = merge([{'--filein': 'das:/RelValTTbar_14TeV/CMSSW_11_0_0_pre13-110X_mcRun4_realistic_v2_2026D49noPU-v1/GEN-SIM-DIGI-RAW'}, stepDict[step][k]])
+            # handle separate PU input
+            stepNamePU = step + 'PU' + self.suffix
+            stepDict[stepNamePU][k] = merge([{'--filein': 'das:/RelValTTbar_14TeV/CMSSW_11_0_0_pre13-PU25ns_110X_mcRun4_realistic_v2_2026D49PU200-v2/GEN-SIM-DIGI-RAW'},stepDict[stepName][k]])
+        elif 'GenSim' in step or 'Digi' in step:
+            # remove step
+            stepDict[stepName][k] = None
+    def condition(self, fragment, stepList, key, hasHarvest):
+        # limited to HLT TDR production geometry
+        return fragment=="TTbar_14TeV" and '2026D49' in key
+    def workflow_(self, workflows, num, fragment, stepList):
+        UpgradeWorkflow.workflow_(self, workflows, num, fragment, stepList)
+upgradeWFs['TestOldDigi'] = UpgradeWorkflow_TestOldDigi(
+    steps = [
+        'GenSimHLBeamSpotFull',
+        'GenSimHLBeamSpotFull14',
+        'DigiFullTrigger',
+        'RecoFullGlobal',
+    ],
+    PU = [
+        'DigiFullTrigger',
+        'RecoFullGlobal',
+    ],
+    suffix = '_TestOldDigi',
+    offset = 0.1001,
+)
+
 # check for duplicate offsets
 offsets = [specialWF.offset for specialType,specialWF in six.iteritems(upgradeWFs)]
 seen = set()


### PR DESCRIPTION
#### PR description:

A new special upgrade workflow is created to allow testing of 11_0_X GEN-SIM-DIGI-RAW files in 11_1_X. This supports the compatibility needed for the planned HLT TDR re-reco campaign.

The new workflows 23234.1001, 23434.1001 (without and with PU) are forwarded to the regular matrix so they can be called on demand in PR tests.

Technically, this PR required a few additional modifications in `relval_steps.py` to allow PU-specific changes by special workflows, as well as improved handling of steps that are None (and therefore should be removed by the matrix read).

#### PR validation:

Ran workflow 23234.1001 locally and it succeeded.

attn: @fwyzard @trtomei 