### PR TITLE
HGCAL: fix interpolation boundaries for ToA

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -456,7 +456,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
                                                  : std::pair<float, float>((findPos - 1)->first + charge, tof));
 	}
 
-	//cumulate the charge of new entry for all elements that follows in the sorted list
+	//cumulate the charge of new entry for all elements that follow in the sorted list
 	//and resize list accounting for cases when the inserted element itself crosses the threshold
         for (std::vector<std::pair<float, float>>::iterator step = insertedPos; step != hitRefs_bx0[id].end();
              ++step) {

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -437,31 +437,31 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
       if (hitRefs_bx0[id].empty()) {
         hitRefs_bx0[id].emplace_back(charge, tof);
       } else if (tof <= hitRefs_bx0[id].back().second) {
-	//find position to insert new entry preserving time sorting
+        //find position to insert new entry preserving time sorting
         std::vector<std::pair<float, float>>::iterator findPos =
             std::upper_bound(hitRefs_bx0[id].begin(),
                              hitRefs_bx0[id].end(),
                              std::pair<float, float>(0.f, tof),
                              [](const auto& i, const auto& j) { return i.second <= j.second; });
 
-	std::vector<std::pair<float, float>>::iterator insertedPos = findPos;
-	if(findPos->second == tof){
-	  //just merge timestamps with exact timing
-	  findPos->first += charge;
-	} else{
-	  //insert new element cumulating the charge
-	  insertedPos = hitRefs_bx0[id].insert(
-            findPos,
-            (findPos == hitRefs_bx0[id].begin()) ? std::pair<float, float>(charge, tof)
-                                                 : std::pair<float, float>((findPos - 1)->first + charge, tof));
-	}
+        std::vector<std::pair<float, float>>::iterator insertedPos = findPos;
+        if (findPos->second == tof) {
+          //just merge timestamps with exact timing
+          findPos->first += charge;
+        } else {
+          //insert new element cumulating the charge
+          insertedPos = hitRefs_bx0[id].insert(findPos,
+                                               (findPos == hitRefs_bx0[id].begin())
+                                                   ? std::pair<float, float>(charge, tof)
+                                                   : std::pair<float, float>((findPos - 1)->first + charge, tof));
+        }
 
-	//cumulate the charge of new entry for all elements that follow in the sorted list
-	//and resize list accounting for cases when the inserted element itself crosses the threshold
-        for (std::vector<std::pair<float, float>>::iterator step = insertedPos; step != hitRefs_bx0[id].end();
-             ++step) {
-          if(step != insertedPos) step->first += charge;
-	  // resize the list stopping with the first timeStamp with cumulative charge above threshold
+        //cumulate the charge of new entry for all elements that follow in the sorted list
+        //and resize list accounting for cases when the inserted element itself crosses the threshold
+        for (std::vector<std::pair<float, float>>::iterator step = insertedPos; step != hitRefs_bx0[id].end(); ++step) {
+          if (step != insertedPos)
+            step->first += charge;
+          // resize the list stopping with the first timeStamp with cumulative charge above threshold
           if (step->first > tdcForToAOnset[waferThickness - 1] && step->second != hitRefs_bx0[id].back().second) {
             hitRefs_bx0[id].resize(std::upper_bound(hitRefs_bx0[id].begin(),
                                                     hitRefs_bx0[id].end(),
@@ -475,7 +475,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
         }
         orderChanged = true;
       } else {
-	//add new entry at the end of the list
+        //add new entry at the end of the list
         if (hitRefs_bx0[id].back().first <= tdcForToAOnset[waferThickness - 1]) {
           hitRefs_bx0[id].emplace_back(hitRefs_bx0[id].back().first + charge, tof);
         }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizer.cc
@@ -428,27 +428,40 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
 
     (simHitIt->second).hit_info[0][itime] += charge;
 
+    //for time-of-arrival: save the time-sorted list of timestamps with cumulative charge just above threshold
     //working version with pileup only for in-time hits
     int waferThickness = getCellThickness(geom, id);
     bool orderChanged = false;
     if (itime == 9) {
+      //if start empty => just add charge and time
       if (hitRefs_bx0[id].empty()) {
         hitRefs_bx0[id].emplace_back(charge, tof);
       } else if (tof <= hitRefs_bx0[id].back().second) {
+	//find position to insert new entry preserving time sorting
         std::vector<std::pair<float, float>>::iterator findPos =
             std::upper_bound(hitRefs_bx0[id].begin(),
                              hitRefs_bx0[id].end(),
                              std::pair<float, float>(0.f, tof),
-                             [](const auto& i, const auto& j) { return i.second < j.second; });
+                             [](const auto& i, const auto& j) { return i.second <= j.second; });
 
-        std::vector<std::pair<float, float>>::iterator insertedPos = hitRefs_bx0[id].insert(
+	std::vector<std::pair<float, float>>::iterator insertedPos = findPos;
+	if(findPos->second == tof){
+	  //just merge timestamps with exact timing
+	  findPos->first += charge;
+	} else{
+	  //insert new element cumulating the charge
+	  insertedPos = hitRefs_bx0[id].insert(
             findPos,
             (findPos == hitRefs_bx0[id].begin()) ? std::pair<float, float>(charge, tof)
                                                  : std::pair<float, float>((findPos - 1)->first + charge, tof));
+	}
 
-        for (std::vector<std::pair<float, float>>::iterator step = insertedPos + 1; step != hitRefs_bx0[id].end();
+	//cumulate the charge of new entry for all elements that follows in the sorted list
+	//and resize list accounting for cases when the inserted element itself crosses the threshold
+        for (std::vector<std::pair<float, float>>::iterator step = insertedPos; step != hitRefs_bx0[id].end();
              ++step) {
-          step->first += charge;
+          if(step != insertedPos) step->first += charge;
+	  // resize the list stopping with the first timeStamp with cumulative charge above threshold
           if (step->first > tdcForToAOnset[waferThickness - 1] && step->second != hitRefs_bx0[id].back().second) {
             hitRefs_bx0[id].resize(std::upper_bound(hitRefs_bx0[id].begin(),
                                                     hitRefs_bx0[id].end(),
@@ -462,6 +475,7 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
         }
         orderChanged = true;
       } else {
+	//add new entry at the end of the list
         if (hitRefs_bx0[id].back().first <= tdcForToAOnset[waferThickness - 1]) {
           hitRefs_bx0[id].emplace_back(hitRefs_bx0[id].back().first + charge, tof);
         }
@@ -470,22 +484,16 @@ void HGCDigitizer::accumulate(edm::Handle<edm::PCaloHitContainer> const& hits,
 
     float accChargeForToA = hitRefs_bx0[id].empty() ? 0.f : hitRefs_bx0[id].back().first;
 
-    //time-of-arrival (check how to be used)
+    //now compute the firing ToA through the interpolation of the consecutive time-stamps at threshold
     if (weightToAbyEnergy)
       (simHitIt->second).hit_info[1][itime] += charge * tof;
     else if (accChargeForToA > tdcForToAOnset[waferThickness - 1] &&
              ((simHitIt->second).hit_info[1][itime] == 0 || orderChanged == true)) {
       float fireTDC = hitRefs_bx0[id].back().second;
       if (hitRefs_bx0[id].size() > 1) {
-        float chargeBeforeThr = 0.f;
-        float tofchargeBeforeThr = 0.f;
-        for (const auto& step : hitRefs_bx0[id]) {
-          if (step.first + chargeBeforeThr <= tdcForToAOnset[waferThickness - 1]) {
-            chargeBeforeThr += step.first;
-            tofchargeBeforeThr = step.second;
-          } else
-            break;
-        }
+        float chargeBeforeThr = (hitRefs_bx0[id].end() - 2)->first;
+        float tofchargeBeforeThr = (hitRefs_bx0[id].end() - 2)->second;
+
         float deltaQ = accChargeForToA - chargeBeforeThr;
         float deltaTOF = fireTDC - tofchargeBeforeThr;
         fireTDC = (tdcForToAOnset[waferThickness - 1] - chargeBeforeThr) * deltaTOF / deltaQ + tofchargeBeforeThr;


### PR DESCRIPTION
This PR 
- fixes a bug spotted by @adas1994 in the computation of the time-of-arrival in the HGCAL digi
- adds some comments to help the understanding of the code
- fixes in the way in which the PCaloHits are cumulated, to deal with PCaloHIts having exactly the same time stamps (very few cases only observed in high PU)

Quick reminder (how ToA firing works):
- In each Silicon cell, the ToA is fired when the cumulative charge is at threshold (12fC).
- Since a full pulse shape is not available, the single time stamps deposited by G4 in each cell (each with a time and a charge) are used:
      - the time-sorted list of time stamps is considered, and their cumulative charge computed.
      - the 2 time stamps with cumulative charge around the threshold (the one before, and the one after) are picked as reference
       - the ToA is extracted with the linear interpolation between the 2 chosen time-stamps, taking the value at which the interpolation crosses the 12fC threshold.

Explanation of  the bug fix:
- The bug is in the interpolation of the cumulated charge vs time, to compute the ToA at threshold, 
and consists in the further cumulation of the already cumulated charges.
- The first cumulation of time-stamps is correct
- The identification of the cells with ToA available is correct
- The bug only involves the identification of the time stamps used to interpolate and extract the ToA

We expect an impact if the delay among time stamps is "big", and this is what happens with PU.
The validation run, comparing the performance between the TDR version (with bug) and this PR version show a negligible impact also at 200PU.

Bug, fix and validation documented in the slides:
https://cernbox.cern.ch/index.php/s/gMcLoFLjHXBpNdi


For reference @rovere