### PR TITLE
Photos createHistoryEntries

### DIFF
--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -49,7 +49,7 @@ void PhotosppInterface::init() {
   if (fIsInitialized)
     return;  // do init only once
   Photospp::Photos::initialize();
-  Photospp::Photos::createHistoryEntries(true, 746); // P-H-O
+  Photospp::Photos::createHistoryEntries(true, 746);  // P-H-O
   std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
   for (unsigned int ip = 0; ip < par.size(); ++ip) {
     std::string curSet = par[ip];

--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -49,6 +49,7 @@ void PhotosppInterface::init() {
   if (fIsInitialized)
     return;  // do init only once
   Photospp::Photos::initialize();
+  Photospp::Photos::createHistoryEntries(true, 746); // P-H-O
   std::vector<std::string> par = fPSet->getParameter<std::vector<std::string> >("parameterSets");
   for (unsigned int ip = 0; ip < par.size(); ++ip) {
     std::string curSet = par[ip];
@@ -97,6 +98,8 @@ void PhotosppInterface::init() {
       Photospp::Photos::setPhotonEmission(fPSet->getParameter<bool>(curSet));
     if (curSet == "setStopAtCriticalError")
       Photospp::Photos::setStopAtCriticalError(fPSet->getParameter<bool>(curSet));
+    if (curSet == "createHistoryEntries")
+      Photospp::Photos::createHistoryEntries(fPSet->getParameter<bool>(curSet), 746);
 
     // Now setup more complicated radiation/mass supression and forcing.
     if (curSet == "suppressBremForBranch") {

--- a/GeneratorInterface/PhotosInterface/test/DYphotospp_Tune4C_13TeV_pythia8.py
+++ b/GeneratorInterface/PhotosInterface/test/DYphotospp_Tune4C_13TeV_pythia8.py
@@ -100,7 +100,17 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     )
 )
 
-process.ProductionFilterSequence = cms.Sequence(process.generator)
+process.genParticles = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator:unsmeared"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+process.printTree1 = cms.EDAnalyzer("ParticleListDrawer",
+    src = cms.InputTag("genParticles"),
+    maxEventsToPrint  = cms.untracked.int32(10)
+)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator*process.genParticles*process.printTree1)
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)


### PR DESCRIPTION
#### PR description:

Photos adjusts the momenta of resonance decay products to compensate for the photon emission. With the `createHistoryEntries` option also it stores copies of the original decay products, needed for Born-level studies. The status code is set to `746` (P-H-O) which does not interfere with Pythia status codes.


#### PR validation:

Z boson and its decay products:
```
 idx  |    ID -       Name |Stat|  Mo1  Mo2  Da1  Da2 |nMo nDa|    pt       eta     phi   |     px         py         pz        m     |
   46 |    23 -         Z0 | 62 |   15   15   59  220 |  1  5 |   6.117      6.611  2.654 |     -5.405      2.863   2273.266   91.033 |
altered by Photos:
   59 |    13 -        mu- |  1 |   46   46   -1   -1 |  1  0 |  45.616      3.950  1.162 |     18.124     41.861   1183.619    0.106 |
   60 |   -13 -        mu+ |  1 |   46   46   -1   -1 |  1  0 |  44.536      3.869 -2.114 |    -23.002    -38.136   1066.140    0.106 |
added by Photos:
  218 |    22 -      gamma |  1 |   46   46   -1   -1 |  1  0 |   1.011      3.840 -2.120 |     -0.527     -0.862     23.506   -0.000 |
  219 |    13 -        mu- | 746 |   46   46   -1   -1 |  1  0 |  45.617      3.950  1.162 |     18.124     41.862   1183.625    0.106 |
  220 |   -13 -        mu+ | 746 |   46   46   -1   -1 |  1  0 |  45.547      3.868 -2.114 |    -23.529    -38.998   1089.641    0.106 |
```
Note that the additional muon copies do not have `status=1`, so they will not be reconstructed.

@bendavid 
