### PR TITLE
Add 2 workflows for default PR test, target for PPS plots

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -62,7 +62,9 @@ if __name__ == '__main__':
                      136.7611, #2016E JetHT reMINIAOD from 80X legacy
                      136.8311, #2017F JetHT reMINIAOD from 94X reprocessing
                      136.788, #2017B Photon data
+                     136.801, #2017C ZeroBias
                      136.85, #2018A Egamma data
+                     136.880, #2018C ZeroBias
                      140.53, #2011 HI data
                      140.56, #2018 HI data
                      158.0, #2018 HI MC with pp-like reco

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -61,10 +61,8 @@ if __name__ == '__main__':
                      136.731, #2016B Photon data
                      136.7611, #2016E JetHT reMINIAOD from 80X legacy
                      136.8311, #2017F JetHT reMINIAOD from 94X reprocessing
-                     136.788, #2017B Photon data
-                     136.801, #2017C ZeroBias
-                     136.85, #2018A Egamma data
-                     136.880, #2018C ZeroBias
+                     136.793, #2017C DoubleEG
+                     136.874, #2018C EGamma
                      140.53, #2011 HI data
                      140.56, #2018 HI data
                      158.0, #2018 HI MC with pp-like reco


### PR DESCRIPTION
#### PR description:
PPS would like to request to add 2 workflows for PR test by default as the workflows used by default in CMSSW PR tests do not cover well the needs of PPS. Workflows include 2017C, 2018C Egamma (was ZeroBias but change after discussed with RECO conveners)

FYI
@jan-kaspar 

#### PR validation:
These workflows are part of relval_standard.py, and run regularly in relvals submitted by PdmV.

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
