### PR TITLE
Bug fix in DaqProvenanceHelper

### DIFF
--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -14,22 +14,28 @@
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
+namespace {
+  edm::BranchDescription makeDescriptionForDaqProvHelper(edm::TypeID const& rawDataType) {
+    edm::BranchDescription desc(edm::InEvent,
+                                "rawDataCollector",
+                                // "source",
+                                "LHC",
+                                // "HLT",
+                                "FEDRawDataCollection",
+                                "FEDRawDataCollection",
+                                "",
+                                "FedRawDataInputSource",
+                                edm::ParameterSetID(),
+                                edm::TypeWithDict(rawDataType.typeInfo()),
+                                false);
+    desc.setIsProvenanceSetOnRead();
+    return desc;
+  }
+}  // namespace
+
 namespace edm {
   DaqProvenanceHelper::DaqProvenanceHelper(TypeID const& rawDataType)
-      : constBranchDescription_(BranchDescription(InEvent,
-                                                  "rawDataCollector"
-                                                  //, "source"
-                                                  ,
-                                                  "LHC"
-                                                  // , "HLT"
-                                                  ,
-                                                  "FEDRawDataCollection",
-                                                  "FEDRawDataCollection",
-                                                  "",
-                                                  "FedRawDataInputSource",
-                                                  ParameterSetID(),
-                                                  TypeWithDict(rawDataType.typeInfo()),
-                                                  false)),
+      : constBranchDescription_(makeDescriptionForDaqProvHelper(rawDataType)),
         dummyProvenance_(constBranchDescription_.branchID()),
         processParameterSet_(),
         oldProcessName_(),


### PR DESCRIPTION
#### PR description:

This fixes the bug reported in issue #28786. I understand
the problem causing the exception and fixed it.

I added a call to setIsProvenanceSetOnRead on the
BranchDescription. This has been needed since
PR #28536 for FedRawDataInputSource to work
properly.

#### PR validation:

Using the test provided in the issue with the problem
report, I reproduced the exception and verified the
exception does not occur with the fix in place.

I somewhat narrowly focused on the reported exception.
It might be worth it for an expert responsible for
FedRawDataInputSource to verify it is really working.
Maybe the test in the bug report is sufficient, it runs
successfully to completion with the fix.
