### PR TITLE
Create infrastructure to allow cmsRun to control an external process

### DIFF
--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin   name="cmsInterProcess" file="interprocess.cc">
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+</bin>

--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -1,5 +1,6 @@
-<bin   name="cmsInterProcess" file="interprocess.cc">
+<bin   name="cmsTestInterProcess" file="interprocess.cc">
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="FWCore/TestProcessor"/>
+  <use   name="FWCore/SharedMemory"/>
 </bin>

--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -1,4 +1,5 @@
 <bin   name="cmsInterProcess" file="interprocess.cc">
   <use   name="boost"/>
   <use   name="boost_program_options"/>
+  <use   name="FWCore/TestProcessor"/>
 </bin>

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -1,10 +1,10 @@
 #include "boost/program_options.hpp"
 
-#include <string>
-#include <iostream>
 #include <atomic>
+#include <csignal>
+#include <iostream>
+#include <string>
 #include <thread>
-#include <signal.h>
 
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
 
   monitorThread.startThread();
 
-  try {
+  CMS_SA_ALLOW try {
     std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
     std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
     {

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -6,9 +6,14 @@
 #include <boost/interprocess/sync/named_condition.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 
+#include "TClass.h"
+#include "TBufferFile.h"
 
 #include <string>
 #include <iostream>
+
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
 
 static char const* const kMemoryNameOpt = "memory-name";
 static char const* const kMemoryNameCommandOpt = "memory-name,m";
@@ -17,102 +22,175 @@ static char const* const kUniqueIDCommandOpt = "unique-id,i";
 static char const* const kHelpOpt = "help";
 static char const* const kHelpCommandOpt = "help,h";
 
+//NOTE: Can use TestProcessor as the harness for the worker
+
 namespace {
   std::string unique_name(std::string iBase, std::string_view ID) {
     iBase.append(ID);
     return iBase;
   }
-}
+
+  template <typename T>
+  class Serializer {
+  public:
+    Serializer(boost::interprocess::managed_shared_memory& iSM,
+               std::string iSMName,
+               std::string const& iBase,
+               std::string_view ID)
+        : managed_shm_(&iSM),
+          smName_{std::move(iSMName)},
+          name_{unique_name(iBase, ID)},
+          class_{TClass::GetClass(typeid(T))},
+          bufferFile_{TBuffer::kWrite} {
+      buffer_ = managed_shm_->find<char>(name_.c_str());
+      assert(buffer_.first);
+      std::pair<bool*, std::size_t> sm_buffer_resized =
+          managed_shm_->find<bool>(unique_name(iBase + "_resize", ID).c_str());
+      buffer_resized_ = sm_buffer_resized.first;
+      assert(buffer_resized_);
+    }
+
+    void serialize(T& iValue) {
+      bufferFile_.Reset();
+      class_->WriteBuffer(bufferFile_, &iValue);
+
+      if (static_cast<unsigned long>(bufferFile_.Length()) > buffer_.second) {
+        managed_shm_->destroy<char>(name_.c_str());
+        auto diff = bufferFile_.Length() - buffer_.second;
+        auto success = managed_shm_->grow(smName_.c_str(), diff);
+        assert(success);
+
+        buffer_.first = managed_shm_->construct<char>(name_.c_str())[bufferFile_.Length()](0);
+        buffer_.second = bufferFile_.Length();
+        *buffer_resized_ = true;
+      }
+      std::copy(bufferFile_.Buffer(), bufferFile_.Buffer() + bufferFile_.Length(), buffer_.first);
+    }
+
+  private:
+    boost::interprocess::managed_shared_memory* const managed_shm_;
+    std::string smName_;
+    std::string name_;
+    std::pair<char*, std::size_t> buffer_;
+    bool* buffer_resized_;
+    TClass* const class_;
+    TBufferFile bufferFile_;
+  };
+}  // namespace
+
+class Harness {
+public:
+  Harness(std::string const& iConfig) : tester_(edm::test::TestProcessor::Config{iConfig}) {}
+
+  edmtest::IntProduct getNextValue() {
+    auto event = tester_.test();
+    return *event.get<edmtest::IntProduct>();
+  }
+
+private:
+  edm::test::TestProcessor tester_;
+};
 
 int main(int argc, char* argv[]) {
-  
   std::string descString(argv[0]);
-  descString += " [--" ;
-  descString += kMemoryNameOpt ;
+  descString += " [--";
+  descString += kMemoryNameOpt;
   descString += "] memory_name";
   boost::program_options::options_description desc(descString);
-  
+
   desc.add_options()(kHelpCommandOpt, "produce help message")(
-    kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
-   kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
-  
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+
   boost::program_options::positional_options_description p;
   p.add(kMemoryNameOpt, 1);
   p.add(kUniqueIDOpt, 2);
-  
+
   boost::program_options::options_description all_options("All Options");
   all_options.add(desc);
-  
+
   boost::program_options::variables_map vm;
   try {
     store(boost::program_options::command_line_parser(argc, argv).options(all_options).positional(p).run(), vm);
     notify(vm);
   } catch (boost::program_options::error const& iException) {
-    std::cout
-        << argv[0] <<": Error while trying to process command line arguments:\n"
-        << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
+    std::cout << argv[0] << ": Error while trying to process command line arguments:\n"
+              << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
     return 1;
   }
-  
+
   if (vm.count(kHelpOpt)) {
     std::cout << desc << std::endl;
     return 0;
   }
-  
+
   if (!vm.count(kMemoryNameOpt)) {
-    std::cout <<" no argument given"<<std::endl;
+    std::cout << " no argument given" << std::endl;
     return 1;
   }
 
   if (!vm.count(kUniqueIDOpt)) {
-    std::cout <<" no second argument given"<<std::endl;
+    std::cout << " no second argument given" << std::endl;
     return 1;
   }
-  
+
   std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
   std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
   {
     using namespace boost::interprocess;
-    managed_shared_memory managed_shm{open_only, unique_name(memoryName, uniqueID).c_str()};
-    std::pair<long double *, std::size_t> sm_sum = managed_shm.find<long double>(unique_name("sum", uniqueID).c_str());
-    
-    const auto s_pi{std::acos(-1)};
-  
-    constexpr unsigned int iterations = 100000000;
-    
+    auto memoryNameUnique = unique_name(memoryName, uniqueID);
+    managed_shared_memory managed_shm{open_only, memoryNameUnique.c_str()};
+
     named_mutex named_mtx{open_or_create, unique_name("mtx", uniqueID).c_str()};
     named_condition named_cndFromMain{open_or_create, unique_name("cndFromMain", uniqueID).c_str()};
-    std::pair<bool *, std::size_t> sm_stop = managed_shm.find<bool>(unique_name("stop", uniqueID).c_str());
-    
-    //named_mutex named_mtxToMain{open_or_create, "mtxToMain"};
+    std::pair<bool*, std::size_t> sm_stop = managed_shm.find<bool>(unique_name("stop", uniqueID).c_str());
+
     named_condition named_cndToMain{open_or_create, unique_name("cndToMain", uniqueID).c_str()};
-  
+
     int counter = 0;
+
     scoped_lock<named_mutex> lock(named_mtx);
-    while(true) {
+    std::cerr << uniqueID << " process: initializing " << std::endl;
+    int nlines;
+    std::cin >> nlines;
+
+    std::string configuration;
+    for (int i = 0; i < nlines; ++i) {
+      std::string c;
+      std::getline(std::cin, c);
+      std::cerr << c << "\n";
+      configuration += c + "\n";
+    }
+
+    Harness harness(configuration);
+
+    Serializer<edmtest::IntProduct> serializer(managed_shm, memoryNameUnique, "buffer", uniqueID);
+
+    std::cerr << uniqueID << " process: done initializing" << std::endl;
+    named_cndToMain.notify_all();
+    while (true) {
       {
         ++counter;
-        std::cerr <<uniqueID<<" process: waiting "<<counter<<std::endl;
+        std::cerr << uniqueID << " process: waiting " << counter << std::endl;
         named_cndFromMain.wait(lock);
-        if(*sm_stop.first) { break;}
+        if (*sm_stop.first) {
+          break;
+        }
       }
-  
-      std::cerr <<uniqueID <<" process: integrating "<<counter<<std::endl;
-      long double sum = 0.;
-      const long double stepSize = s_pi / iterations;
-      for (unsigned int i = 0; i < iterations; ++i) {
-        sum += stepSize * cos(i * stepSize);
-      }
-      std::cerr <<uniqueID<<" process: integrated "<<counter<<std::endl;
+
+      std::cerr << uniqueID << " process: integrating " << counter << std::endl;
+      auto value = harness.getNextValue();
+
+      std::cerr << uniqueID << " process: integrated " << counter << std::endl;
 
       {
-        *sm_sum.first = sum;
-        std::cerr <<uniqueID<<" process: notifying "<<counter<<std::endl;
+        serializer.serialize(value);
+        std::cerr << uniqueID << " process: notifying " << counter << std::endl;
         named_cndToMain.notify_all();
       }
-      std::cerr <<uniqueID<<" process: "<<sum<<" "<<counter<<std::endl;
+      std::cerr << uniqueID << " process: " << value.value << " "
+                << " " << counter << std::endl;
     }
-  }  
+  }
   return 0;
-  
 }

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -195,17 +195,20 @@ namespace {
           stop_{managed_shm_.find<bool>("stop").first},
           transitionType_{managed_shm_.find<edm::Transition>("transitionType").first},
           transitionID_{managed_shm_.find<unsigned long long>("transitionID").first},
-          bufferIndex_{managed_shm_.find<char>("bufferIndex").first},
+          toWorkerBufferIndex_{managed_shm_.find<char>("bufferIndexToWorker").first},
+          fromWorkerBufferIndex_{managed_shm_.find<char>("bufferIndexFromWorker").first},
           cndToController_{open_or_create, unique_name("cndToMain", iUniqueID).c_str()},
           lock_{mutex_} {
       assert(stop_);
       assert(transitionType_);
       assert(transitionID_);
-      assert(bufferIndex_);
+      assert(toWorkerBufferIndex_);
+      assert(fromWorkerBufferIndex_);
     }
 
     scoped_lock<named_mutex>* accessLock() { return &lock_; }
-    char* bufferIndex() { return bufferIndex_; }
+    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
 
     edm::Transition transition() const noexcept { return *transitionType_; }
     unsigned long long transitionID() const noexcept { return *transitionID_; }
@@ -224,7 +227,8 @@ namespace {
     bool* stop_;
     edm::Transition* transitionType_;
     unsigned long long* transitionID_;
-    char* bufferIndex_;
+    char* toWorkerBufferIndex_;
+    char* fromWorkerBufferIndex_;
     named_condition cndToController_;
     scoped_lock<named_mutex> lock_;
   };
@@ -307,7 +311,7 @@ int main(int argc, char* argv[]) {
       //This class is holding the lock
       WorkerChannel communicationChannel(controlNameUnique, uniqueID);
 
-      SMWriteBuffer sm_buffer{controlNameUnique, communicationChannel.bufferIndex()};
+      SMWriteBuffer sm_buffer{controlNameUnique, communicationChannel.fromWorkerBufferIndex()};
       int counter = 0;
 
       s_lock.store(communicationChannel.accessLock());

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -198,6 +198,7 @@ namespace {
           toWorkerBufferIndex_{managed_shm_.find<char>("bufferIndexToWorker").first},
           fromWorkerBufferIndex_{managed_shm_.find<char>("bufferIndexFromWorker").first},
           cndToController_{open_or_create, unique_name("cndToMain", iUniqueID).c_str()},
+          keepEvent_{managed_shm_.find<bool>("keepEvent").first},
           lock_{mutex_} {
       assert(stop_);
       assert(transitionType_);
@@ -219,6 +220,8 @@ namespace {
 
     bool stopRequested() const noexcept { return *stop_; }
 
+    void shouldKeepEvent(bool iChoice) { *keepEvent_ = iChoice; }
+
   private:
     managed_shared_memory managed_shm_;
 
@@ -230,6 +233,7 @@ namespace {
     char* toWorkerBufferIndex_;
     char* fromWorkerBufferIndex_;
     named_condition cndToController_;
+    bool* keepEvent_;
     scoped_lock<named_mutex> lock_;
   };
 

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -1,13 +1,4 @@
 #include "boost/program_options.hpp"
-#include "boost/interprocess/shared_memory_object.hpp"
-
-#include "boost/interprocess/managed_shared_memory.hpp"
-#include <boost/interprocess/sync/named_mutex.hpp>
-#include <boost/interprocess/sync/named_condition.hpp>
-#include <boost/interprocess/sync/scoped_lock.hpp>
-
-#include "TClass.h"
-#include "TBufferFile.h"
 
 #include <string>
 #include <iostream>
@@ -19,6 +10,11 @@
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "DataFormats/TestObjects/interface/ThingCollection.h"
 
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
 static char const* const kMemoryNameOpt = "memory-name";
 static char const* const kMemoryNameCommandOpt = "memory-name,m";
 static char const* const kUniqueIDOpt = "unique-id";
@@ -28,82 +24,7 @@ static char const* const kHelpCommandOpt = "help,h";
 
 //NOTE: Can use TestProcessor as the harness for the worker
 
-namespace {
-  std::string unique_name(std::string iBase, std::string_view ID) {
-    iBase.append(ID);
-    return iBase;
-  }
-
-  using namespace boost::interprocess;
-
-  class SMWriteBuffer {
-    std::size_t bufferSize_;
-    char* buffer_;
-    char* bufferIndex_;
-    std::array<std::string, 2> bufferNames_;
-    std::unique_ptr<managed_shared_memory> sm_;
-
-  public:
-    SMWriteBuffer(std::string const& iUniqueName, char* iBufferIndex)
-        : bufferSize_{0}, buffer_{nullptr}, bufferIndex_{iBufferIndex} {
-      bufferNames_[0] = iUniqueName + "buffer0";
-      bufferNames_[1] = iUniqueName + "buffer1";
-      assert(bufferIndex_);
-    }
-
-    ~SMWriteBuffer() {
-      if (sm_) {
-        sm_->destroy<char>("buffer");
-        sm_.reset();
-        shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
-      }
-    }
-
-    void copyToBuffer(const char* iStart, std::size_t iLength) {
-      if (iLength > bufferSize_) {
-        growBuffer(iLength);
-      }
-      std::copy(iStart, iStart + iLength, buffer_);
-    }
-
-  private:
-    void growBuffer(std::size_t iLength) {
-      int newBuffer = (*bufferIndex_ + 1) % 2;
-      std::cerr << "growing buffer " << iLength << " new index " << newBuffer << "\n";
-      if (sm_) {
-        sm_->destroy<char>("buffer");
-        sm_.reset();
-        shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
-      }
-      sm_ = std::make_unique<managed_shared_memory>(open_or_create, bufferNames_[newBuffer].c_str(), iLength + 1024);
-      assert(sm_.get());
-      bufferSize_ = iLength;
-      *bufferIndex_ = newBuffer;
-      buffer_ = sm_->construct<char>("buffer")[iLength](0);
-      assert(buffer_);
-    }
-  };
-
-  template <typename T>
-  class Serializer {
-  public:
-    Serializer(SMWriteBuffer& iBuffer)
-        : buffer_(iBuffer), class_{TClass::GetClass(typeid(T))}, bufferFile_{TBuffer::kWrite} {}
-
-    void serialize(T& iValue) {
-      bufferFile_.Reset();
-      class_->WriteBuffer(bufferFile_, &iValue);
-
-      buffer_.copyToBuffer(bufferFile_.Buffer(), bufferFile_.Length());
-    }
-
-  private:
-    SMWriteBuffer& buffer_;
-    TClass* const class_;
-    TBufferFile bufferFile_;
-  };
-}  // namespace
-
+using namespace edm::shared_memory;
 class Harness {
 public:
   Harness(std::string const& iConfig) : tester_(edm::test::TestProcessor::Config{iConfig}) {}
@@ -136,108 +57,6 @@ public:
 private:
   edm::test::TestProcessor tester_;
 };
-
-namespace {
-  std::atomic<bool> s_stopRequested = false;
-  std::atomic<bool> s_signal_happened = false;
-  std::atomic<bool> s_helperReady = false;
-  std::atomic<boost::interprocess::scoped_lock<boost::interprocess::named_mutex>*> s_lock = nullptr;
-  std::atomic<bool> s_helperThreadDone = false;
-  int s_sig = 0;
-
-  void sig_handler(int sig, siginfo_t*, void*) {
-    s_sig = sig;
-    s_signal_happened = true;
-    while (not s_helperThreadDone) {
-    };
-    signal(sig, SIG_DFL);
-    raise(sig);
-  }
-
-  void cleanupThread() {
-    std::cerr << "Started cleanup thread\n";
-    sigset_t ensemble;
-
-    sigemptyset(&ensemble);
-    sigaddset(&ensemble, SIGABRT);
-    sigaddset(&ensemble, SIGILL);
-    sigaddset(&ensemble, SIGBUS);
-    sigaddset(&ensemble, SIGSEGV);
-    sigaddset(&ensemble, SIGTERM);
-    pthread_sigmask(SIG_BLOCK, &ensemble, NULL);
-
-    std::cerr << "Start loop\n";
-    s_helperReady = true;
-    while (not s_stopRequested.load()) {
-      sleep(60);
-      if (s_signal_happened) {
-        auto v = s_lock.load();
-        if (v) {
-          std::cerr << "SIGNAL CAUGHT: unlock\n";
-          v->unlock();
-        }
-        s_helperThreadDone = true;
-        std::cerr << "SIGNAL CAUGHT " << s_sig << "\n";
-        break;
-      } else {
-        std::cerr << "SIGNAL woke\n";
-      }
-    }
-    std::cerr << "Ending cleanup thread\n";
-  }
-
-  class WorkerChannel {
-  public:
-    WorkerChannel(std::string const& iName, const std::string& iUniqueID)
-        : managed_shm_{open_only, iName.c_str()},
-          mutex_{open_or_create, unique_name("mtx", iUniqueID).c_str()},
-          cndFromController_{open_or_create, unique_name("cndFromMain", iUniqueID).c_str()},
-          stop_{managed_shm_.find<bool>("stop").first},
-          transitionType_{managed_shm_.find<edm::Transition>("transitionType").first},
-          transitionID_{managed_shm_.find<unsigned long long>("transitionID").first},
-          toWorkerBufferIndex_{managed_shm_.find<char>("bufferIndexToWorker").first},
-          fromWorkerBufferIndex_{managed_shm_.find<char>("bufferIndexFromWorker").first},
-          cndToController_{open_or_create, unique_name("cndToMain", iUniqueID).c_str()},
-          keepEvent_{managed_shm_.find<bool>("keepEvent").first},
-          lock_{mutex_} {
-      assert(stop_);
-      assert(transitionType_);
-      assert(transitionID_);
-      assert(toWorkerBufferIndex_);
-      assert(fromWorkerBufferIndex_);
-    }
-
-    scoped_lock<named_mutex>* accessLock() { return &lock_; }
-    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
-    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
-
-    edm::Transition transition() const noexcept { return *transitionType_; }
-    unsigned long long transitionID() const noexcept { return *transitionID_; }
-
-    void notifyController() { cndToController_.notify_all(); }
-
-    void waitForController() { cndFromController_.wait(lock_); }
-
-    bool stopRequested() const noexcept { return *stop_; }
-
-    void shouldKeepEvent(bool iChoice) { *keepEvent_ = iChoice; }
-
-  private:
-    managed_shared_memory managed_shm_;
-
-    named_mutex mutex_;
-    named_condition cndFromController_;
-    bool* stop_;
-    edm::Transition* transitionType_;
-    unsigned long long* transitionID_;
-    char* toWorkerBufferIndex_;
-    char* fromWorkerBufferIndex_;
-    named_condition cndToController_;
-    bool* keepEvent_;
-    scoped_lock<named_mutex> lock_;
-  };
-
-}  // namespace
 
 int main(int argc, char* argv[]) {
   std::string descString(argv[0]);
@@ -282,43 +101,39 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  std::thread helperThread;
-  {
-    //Setup watchdog thread for crashing signals
+  WorkerMonitorThread monitorThread;
 
-    //Need to use signal handler since signals generated
-    // from within a program are thread specific which can
-    // only be handed by a signal handler
-    struct sigaction act;
-    act.sa_sigaction = sig_handler;
-    act.sa_flags = 0;
-    sigemptyset(&act.sa_mask);
-    sigaction(SIGABRT, &act, nullptr);
-    sigaction(SIGILL, &act, nullptr);
-    sigaction(SIGBUS, &act, nullptr);
-    sigaction(SIGSEGV, &act, nullptr);
-    sigaction(SIGTERM, &act, nullptr);
+  monitorThread.startThread();
 
-    std::thread t(cleanupThread);
-    t.detach();
-    helperThread = std::move(t);
-  }
-  while (s_helperReady.load() == false) {
-  }
   try {
     std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
     std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
     {
-      using namespace boost::interprocess;
-      auto controlNameUnique = unique_name(memoryName, uniqueID);
+      //using namespace boost::interprocess;
+      //auto controlNameUnique = unique_name(memoryName, uniqueID);
 
       //This class is holding the lock
-      WorkerChannel communicationChannel(controlNameUnique, uniqueID);
+      WorkerChannel communicationChannel(memoryName, uniqueID);
 
-      SMWriteBuffer sm_buffer{controlNameUnique, communicationChannel.fromWorkerBufferIndex()};
+      WriteBuffer sm_buffer{memoryName, communicationChannel.fromWorkerBufferIndex()};
       int counter = 0;
 
-      s_lock.store(communicationChannel.accessLock());
+      //The lock must be released if there is a catastrophic signal
+      auto lockPtr = communicationChannel.accessLock();
+      monitorThread.setAction([lockPtr]() {
+        if (lockPtr) {
+          std::cerr << "SIGNAL CAUGHT: unlock\n";
+          lockPtr->unlock();
+        }
+      });
+
+      using TCSerializer = ROOTSerializer<edmtest::ThingCollection, WriteBuffer>;
+      TCSerializer serializer(sm_buffer);
+      TCSerializer br_serializer(sm_buffer);
+      TCSerializer bl_serializer(sm_buffer);
+      TCSerializer el_serializer(sm_buffer);
+      TCSerializer er_serializer(sm_buffer);
+
       std::cerr << uniqueID << " process: initializing " << std::endl;
       int nlines;
       std::cin >> nlines;
@@ -333,40 +148,19 @@ int main(int argc, char* argv[]) {
 
       Harness harness(configuration);
 
-      {
-        struct sigaction act;
-        act.sa_sigaction = sig_handler;
-        act.sa_flags = 0;
-        sigemptyset(&act.sa_mask);
-        sigaction(SIGABRT, &act, nullptr);
-        sigaction(SIGILL, &act, nullptr);
-        sigaction(SIGBUS, &act, nullptr);
-        sigaction(SIGSEGV, &act, nullptr);
-        sigaction(SIGTERM, &act, nullptr);
-      }
-
-      Serializer<edmtest::ThingCollection> serializer(sm_buffer);
-      Serializer<edmtest::ThingCollection> br_serializer(sm_buffer);
-      Serializer<edmtest::ThingCollection> bl_serializer(sm_buffer);
-      Serializer<edmtest::ThingCollection> el_serializer(sm_buffer);
-      Serializer<edmtest::ThingCollection> er_serializer(sm_buffer);
+      //Either ROOT or the Framework are overriding the signal handlers
+      monitorThread.setupSignalHandling();
 
       std::cerr << uniqueID << " process: done initializing" << std::endl;
-      communicationChannel.notifyController();
-      while (true) {
-        {
-          ++counter;
-          std::cerr << uniqueID << " process: waiting " << counter << std::endl;
-          communicationChannel.waitForController();
-          if (communicationChannel.stopRequested()) {
-            break;
-          }
-        }
+      communicationChannel.workerSetupDone();
 
-        switch (communicationChannel.transition()) {
+      std::cerr << uniqueID << " process: waiting " << counter << std::endl;
+      communicationChannel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+        ++counter;
+        switch (iTransition) {
           case edm::Transition::BeginRun: {
             std::cerr << uniqueID << " process: start beginRun " << std::endl;
-            auto value = harness.getBeginRunValue(communicationChannel.transitionID());
+            auto value = harness.getBeginRunValue(iTransitionID);
 
             br_serializer.serialize(value);
             std::cerr << uniqueID << " process: end beginRun " << value.size() << std::endl;
@@ -375,7 +169,7 @@ int main(int argc, char* argv[]) {
           }
           case edm::Transition::BeginLuminosityBlock: {
             std::cerr << uniqueID << " process: start beginLumi " << std::endl;
-            auto value = harness.getBeginLumiValue(communicationChannel.transitionID());
+            auto value = harness.getBeginLumiValue(iTransitionID);
 
             bl_serializer.serialize(value);
             std::cerr << uniqueID << " process: end beginLumi " << value.size() << std::endl;
@@ -415,19 +209,15 @@ int main(int argc, char* argv[]) {
             assert(false);
           }
         }
-        std::cerr << uniqueID << " process: notifying " << counter << std::endl;
-        communicationChannel.notifyController();
-      }
+        std::cerr << uniqueID << " process: notifying and waiting" << counter << std::endl;
+      });
     }
   } catch (std::exception const& iExcept) {
     std::cerr << "caught exception \n" << iExcept.what() << "\n";
-    s_stopRequested = true;
     return 1;
   } catch (...) {
     std::cerr << "caught unknown exception";
-    s_stopRequested = true;
     return 1;
   }
-  s_stopRequested = true;
   return 0;
 }

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -1,0 +1,118 @@
+#include "boost/program_options.hpp"
+#include "boost/interprocess/shared_memory_object.hpp"
+
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/named_condition.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+
+#include <string>
+#include <iostream>
+
+static char const* const kMemoryNameOpt = "memory-name";
+static char const* const kMemoryNameCommandOpt = "memory-name,m";
+static char const* const kUniqueIDOpt = "unique-id";
+static char const* const kUniqueIDCommandOpt = "unique-id,i";
+static char const* const kHelpOpt = "help";
+static char const* const kHelpCommandOpt = "help,h";
+
+namespace {
+  std::string unique_name(std::string iBase, std::string_view ID) {
+    iBase.append(ID);
+    return iBase;
+  }
+}
+
+int main(int argc, char* argv[]) {
+  
+  std::string descString(argv[0]);
+  descString += " [--" ;
+  descString += kMemoryNameOpt ;
+  descString += "] memory_name";
+  boost::program_options::options_description desc(descString);
+  
+  desc.add_options()(kHelpCommandOpt, "produce help message")(
+    kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+   kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+  
+  boost::program_options::positional_options_description p;
+  p.add(kMemoryNameOpt, 1);
+  p.add(kUniqueIDOpt, 2);
+  
+  boost::program_options::options_description all_options("All Options");
+  all_options.add(desc);
+  
+  boost::program_options::variables_map vm;
+  try {
+    store(boost::program_options::command_line_parser(argc, argv).options(all_options).positional(p).run(), vm);
+    notify(vm);
+  } catch (boost::program_options::error const& iException) {
+    std::cout
+        << argv[0] <<": Error while trying to process command line arguments:\n"
+        << iException.what() << "\nFor usage and an options list, please do 'cmsRun --help'.";
+    return 1;
+  }
+  
+  if (vm.count(kHelpOpt)) {
+    std::cout << desc << std::endl;
+    return 0;
+  }
+  
+  if (!vm.count(kMemoryNameOpt)) {
+    std::cout <<" no argument given"<<std::endl;
+    return 1;
+  }
+
+  if (!vm.count(kUniqueIDOpt)) {
+    std::cout <<" no second argument given"<<std::endl;
+    return 1;
+  }
+  
+  std::string const memoryName(vm[kMemoryNameOpt].as<std::string>());
+  std::string const uniqueID(vm[kUniqueIDOpt].as<std::string>());
+  {
+    using namespace boost::interprocess;
+    managed_shared_memory managed_shm{open_only, unique_name(memoryName, uniqueID).c_str()};
+    std::pair<long double *, std::size_t> sm_sum = managed_shm.find<long double>(unique_name("sum", uniqueID).c_str());
+    
+    const auto s_pi{std::acos(-1)};
+  
+    constexpr unsigned int iterations = 100000000;
+    
+    named_mutex named_mtx{open_or_create, unique_name("mtx", uniqueID).c_str()};
+    named_condition named_cndFromMain{open_or_create, unique_name("cndFromMain", uniqueID).c_str()};
+    std::pair<bool *, std::size_t> sm_stop = managed_shm.find<bool>(unique_name("stop", uniqueID).c_str());
+    
+    //named_mutex named_mtxToMain{open_or_create, "mtxToMain"};
+    named_condition named_cndToMain{open_or_create, unique_name("cndToMain", uniqueID).c_str()};
+  
+    int counter = 0;
+    scoped_lock<named_mutex> lock(named_mtx);
+    while(true) {
+      {
+        ++counter;
+        std::cerr <<uniqueID<<" process: waiting "<<counter<<std::endl;
+        named_cndFromMain.wait(lock);
+        if(*sm_stop.first) { break;}
+      }
+  
+      std::cerr <<uniqueID <<" process: integrating "<<counter<<std::endl;
+      long double sum = 0.;
+      const long double stepSize = s_pi / iterations;
+      for (unsigned int i = 0; i < iterations; ++i) {
+        sum += stepSize * cos(i * stepSize);
+      }
+      std::cerr <<uniqueID<<" process: integrated "<<counter<<std::endl;
+
+      {
+        *sm_sum.first = sum;
+        std::cerr <<uniqueID<<" process: notifying "<<counter<<std::endl;
+        named_cndToMain.notify_all();
+      }
+      std::cerr <<uniqueID<<" process: "<<sum<<" "<<counter<<std::endl;
+    }
+  }  
+  return 0;
+  
+}

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -331,4 +331,5 @@
     <use   name="FWCore/SharedMemory"/>
     <use   name="boost"/>
   </library>
+  <test name="TestFWCoreIntegrationInterProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TestInterProcessProd_cfg.py"/>
 </environment>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -323,4 +323,11 @@
     <use   name="FWCore/Sources"/>
     <use   name="DataFormats/TestObjects"/>
   </library>
+  <library   file="TestInterProcessProd.cc" name="TestInterProcessProd">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="FWCore/Sources"/>
+    <use   name="boost"/>
+  </library>
 </environment>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -328,6 +328,7 @@
     <use   name="FWCore/Framework"/>
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Sources"/>
+    <use   name="FWCore/SharedMemory"/>
     <use   name="boost"/>
   </library>
 </environment>

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -1,8 +1,10 @@
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
 
 #include <stdio.h>
 #include <iostream>
@@ -18,9 +20,6 @@
 using namespace boost::interprocess;
 
 namespace testinter {
-  struct Cache {
-    mutable int id = 0;
-  };
 
   template <typename T>
   class Deserializer {
@@ -76,124 +75,320 @@ namespace testinter {
     TClass* const class_;
     TBufferFile bufferFile_;
   };
+
+  struct StreamCache {
+    StreamCache(const char* iConfig, int id)
+        : id_{id},
+          managed_sm_{open_or_create, unique_name("testProd").c_str(), 4048},
+          named_mtx_{open_or_create, unique_name("mtx").c_str()},
+          named_cndFromMain_{open_or_create, unique_name("cndFromMain").c_str()},
+          named_cndToMain_{open_or_create, unique_name("cndToMain").c_str()},
+          deserializer_{managed_sm_, "buffer", id_},
+          br_deserializer_{managed_sm_, "brbuffer", id_},
+          er_deserializer_{managed_sm_, "erbuffer", id_},
+          bl_deserializer_{managed_sm_, "blbuffer", id_},
+          el_deserializer_{managed_sm_, "elbuffer", id_} {
+      managed_sm_.destroy<bool>(unique_name("stop").c_str());
+      stop_ = managed_sm_.construct<bool>(unique_name("stop").c_str())(false);
+      assert(stop_);
+
+      managed_sm_.destroy<edm::Transition>(unique_name("transitionType").c_str());
+      transitionType_ = managed_sm_.construct<edm::Transition>(unique_name("transitionType").c_str())(
+          edm::Transition::NumberOfTransitions);
+      assert(transitionType_);
+
+      managed_sm_.destroy<unsigned long long>(unique_name("transitionID").c_str());
+      transitionID_ = managed_sm_.construct<unsigned long long>(unique_name("transitionID").c_str())(0);
+      assert(transitionID_);
+
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      scoped_lock<named_mutex> lock(named_mtx_);
+      std::cout << id_ << " starting external process" << std::endl;
+      pipe_ = popen(unique_name("cmsInterProcess testProd ").c_str(), "w");
+
+      if (NULL == pipe_) {
+        abort();
+      }
+
+      {
+        auto length = strlen(iConfig);
+        auto nlines = std::to_string(std::count(iConfig, iConfig + length, '\n'));
+        auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+        assert(result = nlines.size());
+        result = fwrite(iConfig, sizeof(char), strlen(iConfig), pipe_);
+        assert(result == strlen(iConfig));
+        fflush(pipe_);
+      }
+      std::cout << id_ << " waiting for external process" << std::endl;
+      named_cndToMain_.wait(lock);
+      std::cout << id_ << " done waiting for external process" << std::endl;
+    }
+
+    edmtest::ThingCollection produce(unsigned long long iTransitionID) {
+      std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(named_mtx_);
+
+      wait(lock, edm::Transition::Event, iTransitionID);
+
+      auto value = deserializer_.deserialize();
+      std::cout << id_ << " from shared memory " << value.size() << std::endl;
+      return value;
+    }
+
+    edmtest::ThingCollection beginRunProduce(unsigned long long iTransitionID) {
+      std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(named_mtx_);
+
+      wait(lock, edm::Transition::BeginRun, iTransitionID);
+
+      auto value = br_deserializer_.deserialize();
+      std::cout << id_ << " from shared memory " << value.size() << std::endl;
+      return value;
+    }
+
+    edmtest::ThingCollection endRunProduce(unsigned long long iTransitionID) {
+      std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(named_mtx_);
+
+      wait(lock, edm::Transition::EndRun, iTransitionID);
+
+      auto value = er_deserializer_.deserialize();
+      std::cout << id_ << " from shared memory " << value.size() << std::endl;
+      return value;
+    }
+
+    edmtest::ThingCollection beginLumiProduce(unsigned long long iTransitionID) {
+      std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(named_mtx_);
+
+      wait(lock, edm::Transition::BeginLuminosityBlock, iTransitionID);
+
+      auto value = bl_deserializer_.deserialize();
+      std::cout << id_ << " from shared memory " << value.size() << std::endl;
+      return value;
+    }
+
+    edmtest::ThingCollection endLumiProduce(unsigned long long iTransitionID) {
+      std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(named_mtx_);
+
+      wait(lock, edm::Transition::EndLuminosityBlock, iTransitionID);
+
+      auto value = el_deserializer_.deserialize();
+      std::cout << id_ << " from shared memory " << value.size() << std::endl;
+      return value;
+    }
+
+    ~StreamCache() {
+      {
+        scoped_lock<named_mutex> lock(named_mtx_);
+        *stop_ = true;
+        named_cndFromMain_.notify_all();
+      }
+      pclose(pipe_);
+      managed_sm_.destroy<bool>(unique_name("stop").c_str());
+      managed_sm_.destroy<unsigned int>(unique_name("transitionType").c_str());
+      managed_sm_.destroy<unsigned long long>(unique_name("transitionID").c_str());
+
+      named_mutex::remove(unique_name("mtx").c_str());
+      named_condition::remove(unique_name("cndFromMain").c_str());
+      named_condition::remove(unique_name("cndToMain").c_str());
+    }
+
+  private:
+    std::string unique_name(std::string iBase) {
+      auto pid = getpid();
+      iBase += std::to_string(pid);
+      iBase += "_";
+      iBase += std::to_string(id_);
+
+      return iBase;
+    }
+
+    void wait(scoped_lock<named_mutex>& lock, edm::Transition iTrans, unsigned long long iTransID) {
+      *transitionType_ = iTrans;
+      *transitionID_ = iTransID;
+      {
+        std::cout << id_ << " notifying" << std::endl;
+        named_cndFromMain_.notify_all();
+      }
+
+      std::cout << id_ << " waiting" << std::endl;
+      named_cndToMain_.wait(lock);
+    }
+
+    int id_;
+    FILE* pipe_;
+
+    managed_shared_memory managed_sm_;
+
+    named_mutex named_mtx_;
+    named_condition named_cndFromMain_;
+
+    named_condition named_cndToMain_;
+
+    testinter::Deserializer<edmtest::ThingCollection> deserializer_;
+    testinter::Deserializer<edmtest::ThingCollection> br_deserializer_;
+    testinter::Deserializer<edmtest::ThingCollection> er_deserializer_;
+    testinter::Deserializer<edmtest::ThingCollection> bl_deserializer_;
+    testinter::Deserializer<edmtest::ThingCollection> el_deserializer_;
+    edm::Transition* transitionType_;
+    unsigned long long* transitionID_;
+    bool* stop_;
+  };
+
+  struct RunCache {
+    mutable edmtest::ThingCollection thingCollection_;
+  };
+  struct LumiCache {
+    mutable edmtest::ThingCollection thingCollection_;
+  };
 }  // namespace testinter
 
-class TestInterProcessProd : public edm::stream::EDProducer<edm::GlobalCache<testinter::Cache>> {
+class TestInterProcessProd : public edm::global::EDProducer<edm::StreamCache<testinter::StreamCache>,
+                                                            edm::RunCache<testinter::RunCache>,
+                                                            edm::BeginRunProducer,
+                                                            edm::EndRunProducer,
+                                                            edm::LuminosityBlockCache<testinter::LumiCache>,
+                                                            edm::BeginLuminosityBlockProducer,
+                                                            edm::EndLuminosityBlockProducer> {
 public:
-  TestInterProcessProd(edm::ParameterSet const&, testinter::Cache const*);
-  ~TestInterProcessProd();
+  TestInterProcessProd(edm::ParameterSet const&);
 
-  void produce(edm::Event&, edm::EventSetup const&);
+  std::unique_ptr<testinter::StreamCache> beginStream(edm::StreamID) const final;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
 
-  static std::unique_ptr<testinter::Cache> initializeGlobalCache(edm::ParameterSet const&);
+  void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const final;
+  std::shared_ptr<testinter::RunCache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const final;
+  void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const final;
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) const final {}
+  void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const final;
 
-  static void globalEndJob(testinter::Cache*);
+  void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
+  std::shared_ptr<testinter::LumiCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                   edm::EventSetup const&) const final;
+  void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
+  void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const final;
 
 private:
-  int id_;
-  edm::EDPutTokenT<edmtest::IntProduct> token_;
-  FILE* pipe_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const token_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const brToken_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const erToken_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const blToken_;
+  edm::EDPutTokenT<edmtest::ThingCollection> const elToken_;
 
-  managed_shared_memory managed_sm_;
-
-  named_mutex named_mtx_;
-  named_condition named_cndFromMain_;
-
-  named_condition named_cndToMain_;
-
-  testinter::Deserializer<edmtest::IntProduct> deserializer_;
-  bool* stop_;
-
-  std::string unique_name(std::string iBase) {
-    auto pid = getpid();
-    iBase += std::to_string(pid);
-    iBase += "_";
-    iBase += std::to_string(id_);
-
-    return iBase;
-  }
+  mutable testinter::StreamCache* stream0Cache_ = nullptr;
+  mutable std::atomic<testinter::StreamCache*> availableForBeginLumi_;
+  mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
 };
 
-TestInterProcessProd::TestInterProcessProd(edm::ParameterSet const&, testinter::Cache const* cache)
-    : id_{++cache->id},
-      managed_sm_{open_or_create, unique_name("testProd").c_str(), 1024},
-      named_mtx_{open_or_create, unique_name("mtx").c_str()},
-      named_cndFromMain_{open_or_create, unique_name("cndFromMain").c_str()},
-      named_cndToMain_{open_or_create, unique_name("cndToMain").c_str()},
-      deserializer_{managed_sm_, "buffer", id_} {
-  token_ = produces<edmtest::IntProduct>();
+TestInterProcessProd::TestInterProcessProd(edm::ParameterSet const&)
+    : token_{produces<edmtest::ThingCollection>()},
+      brToken_{produces<edmtest::ThingCollection, edm::Transition::BeginRun>("beginRun")},
+      erToken_{produces<edmtest::ThingCollection, edm::Transition::EndRun>("endRun")},
+      blToken_{produces<edmtest::ThingCollection, edm::Transition::BeginLuminosityBlock>("beginLumi")},
+      elToken_{produces<edmtest::ThingCollection, edm::Transition::EndLuminosityBlock>("endLumi")} {}
 
-  managed_sm_.destroy<bool>(unique_name("stop").c_str());
-  stop_ = managed_sm_.construct<bool>(unique_name("stop").c_str())(false);
-  assert(stop_);
-
-  //make sure output is flushed before popen does any writing
-  fflush(stdout);
-  fflush(stderr);
-
-  scoped_lock<named_mutex> lock(named_mtx_);
-  std::cout << id_ << " starting external process" << std::endl;
-  pipe_ = popen(unique_name("cmsInterProcess testProd ").c_str(), "w");
-
-  if (NULL == pipe_) {
-    abort();
-  }
-
-  {
-    auto v = R"_(from FWCore.TestProcessor.TestProcess import *
+std::unique_ptr<testinter::StreamCache> TestInterProcessProd::beginStream(edm::StreamID iID) const {
+  constexpr auto v = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
-process.gen = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(6), iterations=cms.uint32(10000000))
+process.gen = cms.EDProducer("ThingProducer", nThings = cms.int32(100))
 process.moduleToTest(process.gen)
 )_";
-    auto length = strlen(v);
-    auto nlines = std::to_string(std::count(v, v + length, '\n'));
-    auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
-    assert(result = nlines.size());
-    result = fwrite(v, sizeof(char), strlen(v), pipe_);
-    assert(result == strlen(v));
-    fflush(pipe_);
-  }
-  std::cout << id_ << " waiting for external process" << std::endl;
-  named_cndToMain_.wait(lock);
-  std::cout << id_ << " done waiting for external process" << std::endl;
-}
 
-std::unique_ptr<testinter::Cache> TestInterProcessProd::initializeGlobalCache(edm::ParameterSet const&) {
-  return std::make_unique<testinter::Cache>();
-}
+  auto cache = std::make_unique<testinter::StreamCache>(v, iID.value());
+  if (iID.value() == 0) {
+    stream0Cache_ = cache.get();
 
-void TestInterProcessProd::globalEndJob(testinter::Cache*) {}
-
-TestInterProcessProd::~TestInterProcessProd() {
-  {
-    scoped_lock<named_mutex> lock(named_mtx_);
-    *stop_ = true;
-    named_cndFromMain_.notify_all();
+    availableForBeginLumi_ = stream0Cache_;
   }
 
-  pclose(pipe_);
-  managed_sm_.destroy<bool>(unique_name("stop").c_str());
-
-  named_mutex::remove(unique_name("mtx").c_str());
-  named_condition::remove(unique_name("cndFromMain").c_str());
-  named_condition::remove(unique_name("cndToMain").c_str());
+  return cache;
 }
 
-void TestInterProcessProd::produce(edm::Event& iEvent, edm::EventSetup const&) {
-  std::cout << id_ << " taking from lock" << std::endl;
-  scoped_lock<named_mutex> lock(named_mtx_);
-  {
-    std::cout << id_ << " notifying" << std::endl;
-    named_cndFromMain_.notify_all();
-  }
-
-  std::cout << id_ << " waiting" << std::endl;
-  named_cndToMain_.wait(lock);
-
-  auto value = deserializer_.deserialize();
-  std::cout << id_ << " from shared memory " << value.value << std::endl;
-
+void TestInterProcessProd::produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const {
+  auto value = streamCache(iID)->produce(iEvent.id().event());
   iEvent.emplace(token_, value);
+}
+
+void TestInterProcessProd::globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  auto v = stream0Cache_->beginRunProduce(iRun.run());
+  iRun.emplace(brToken_, v);
+}
+std::shared_ptr<testinter::RunCache> TestInterProcessProd::globalBeginRun(edm::Run const&,
+                                                                          edm::EventSetup const&) const {
+  return std::make_shared<testinter::RunCache>();
+}
+
+void TestInterProcessProd::streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+  if (iID.value() != 0) {
+    (void)streamCache(iID)->beginRunProduce(iRun.run());
+  }
+}
+void TestInterProcessProd::streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    runCache(iRun.index())->thingCollection_ = streamCache(iID)->endRunProduce(iRun.run());
+  } else {
+    (void)streamCache(iID)->endRunProduce(iRun.run());
+  }
+}
+void TestInterProcessProd::globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&) const {
+  iRun.emplace(erToken_, std::move(runCache(iRun.index())->thingCollection_));
+}
+
+void TestInterProcessProd::globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                             edm::EventSetup const&) const {
+  while (not availableForBeginLumi_.load()) {
+  }
+
+  auto v = availableForBeginLumi_.load()->beginLumiProduce(iLuminosityBlock.run());
+  iLuminosityBlock.emplace(blToken_, v);
+
+  lastLumiIndex_.store(iLuminosityBlock.index());
+}
+
+std::shared_ptr<testinter::LumiCache> TestInterProcessProd::globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                                       edm::EventSetup const&) const {
+  return std::make_shared<testinter::LumiCache>();
+}
+
+void TestInterProcessProd::streamBeginLuminosityBlock(edm::StreamID iID,
+                                                      edm::LuminosityBlock const& iLuminosityBlock,
+                                                      edm::EventSetup const&) const {
+  auto cache = streamCache(iID);
+  if (cache != availableForBeginLumi_.load()) {
+    (void)cache->beginLumiProduce(iLuminosityBlock.run());
+  } else {
+    availableForBeginLumi_ = nullptr;
+  }
+}
+
+void TestInterProcessProd::streamEndLuminosityBlock(edm::StreamID iID,
+                                                    edm::LuminosityBlock const& iLuminosityBlock,
+                                                    edm::EventSetup const&) const {
+  if (iID.value() == 0) {
+    luminosityBlockCache(iLuminosityBlock.index())->thingCollection_ =
+        streamCache(iID)->endLumiProduce(iLuminosityBlock.run());
+  } else {
+    (void)streamCache(iID)->endLumiProduce(iLuminosityBlock.run());
+  }
+
+  if (lastLumiIndex_ == iLuminosityBlock.index()) {
+    testinter::StreamCache* expected = nullptr;
+
+    availableForBeginLumi_.compare_exchange_strong(expected, streamCache(iID));
+  }
+}
+
+void TestInterProcessProd::globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLuminosityBlock,
+                                                           edm::EventSetup const&) const {
+  iLuminosityBlock.emplace(elToken_, std::move(luminosityBlockCache(iLuminosityBlock.index())->thingCollection_));
 }
 
 DEFINE_FWK_MODULE(TestInterProcessProd);

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -2,8 +2,12 @@
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+
 #include <stdio.h>
 #include <iostream>
+
+#include "TBufferFile.h"
 
 #include "boost/interprocess/shared_memory_object.hpp"
 #include "boost/interprocess/managed_shared_memory.hpp"
@@ -11,80 +15,147 @@
 #include <boost/interprocess/sync/named_condition.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 
-
 using namespace boost::interprocess;
 
 namespace testinter {
   struct Cache {
     mutable int id = 0;
   };
-}
+
+  template <typename T>
+  class Deserializer {
+  public:
+    Deserializer(boost::interprocess::managed_shared_memory& iSM, std::string iBase, int ID)
+        : managed_shm_(&iSM),
+          name_{unique_name(iBase, ID)},
+          resizeName_{unique_name(iBase + "_resize", ID)},
+          class_{TClass::GetClass(typeid(T))},
+          bufferFile_(TBuffer::kRead) {
+      managed_shm_->destroy<char>(name_.c_str());
+      managed_shm_->destroy<char>(resizeName_.c_str());
+
+      constexpr unsigned int bufferInitialSize = 5;
+      buffer_.first = managed_shm_->construct<char>(name_.c_str())[bufferInitialSize](0);
+      buffer_.second = bufferInitialSize;
+      assert(buffer_.first);
+      buffer_resized_ = managed_shm_->construct<bool>(resizeName_.c_str())(false);
+      assert(buffer_resized_);
+
+      bufferFile_.SetBuffer(buffer_.first, buffer_.second, kFALSE);
+    }
+
+    ~Deserializer() {
+      managed_shm_->destroy<char>(name_.c_str());
+      managed_shm_->destroy<bool>(resizeName_.c_str());
+    }
+
+    T deserialize() {
+      T value;
+      if (*buffer_resized_) {
+        buffer_ = managed_shm_->find<char>(name_.c_str());
+        bufferFile_.SetBuffer(buffer_.first, buffer_.second, kFALSE);
+        *buffer_resized_ = false;
+      }
+
+      class_->ReadBuffer(bufferFile_, &value);
+      bufferFile_.Reset();
+      return value;
+    }
+
+  private:
+    std::string unique_name(std::string const& iBase, int ID) {
+      auto pid = getpid();
+      return iBase + std::to_string(pid) + "_" + std::to_string(ID);
+    }
+
+    boost::interprocess::managed_shared_memory* const managed_shm_;
+    const std::string name_;
+    const std::string resizeName_;
+    std::pair<char*, std::size_t> buffer_;
+    bool* buffer_resized_;
+    TClass* const class_;
+    TBufferFile bufferFile_;
+  };
+}  // namespace testinter
 
 class TestInterProcessProd : public edm::stream::EDProducer<edm::GlobalCache<testinter::Cache>> {
-
 public:
-  TestInterProcessProd( edm::ParameterSet const&, testinter::Cache const* );
+  TestInterProcessProd(edm::ParameterSet const&, testinter::Cache const*);
   ~TestInterProcessProd();
-  
-  void produce(edm::Event& , edm::EventSetup const&);
+
+  void produce(edm::Event&, edm::EventSetup const&);
 
   static std::unique_ptr<testinter::Cache> initializeGlobalCache(edm::ParameterSet const&);
 
   static void globalEndJob(testinter::Cache*);
 
 private:
-
   int id_;
-  edm::EDPutTokenT<double> token_;
+  edm::EDPutTokenT<edmtest::IntProduct> token_;
   FILE* pipe_;
 
   managed_shared_memory managed_sm_;
-  
+
   named_mutex named_mtx_;
   named_condition named_cndFromMain_;
 
-  //named_mutex named_mtxToMain_;
   named_condition named_cndToMain_;
-  
-  long double* sm_sum_;
+
+  testinter::Deserializer<edmtest::IntProduct> deserializer_;
   bool* stop_;
 
   std::string unique_name(std::string iBase) {
     auto pid = getpid();
     iBase += std::to_string(pid);
-    iBase +="_";
-    iBase +=std::to_string(id_);
-    
+    iBase += "_";
+    iBase += std::to_string(id_);
+
     return iBase;
   }
-
 };
 
-TestInterProcessProd::TestInterProcessProd( edm::ParameterSet const&, testinter::Cache const* cache ):
-id_{ ++cache->id},
-managed_sm_{ open_or_create, unique_name("testProd").c_str(), 1024},
-named_mtx_{open_or_create, unique_name("mtx").c_str()},
-named_cndFromMain_{open_or_create, unique_name("cndFromMain").c_str()},
-//named_mtxToMain_{open_or_create, "mtxToMain"},
-named_cndToMain_{open_or_create, unique_name("cndToMain").c_str()}
+TestInterProcessProd::TestInterProcessProd(edm::ParameterSet const&, testinter::Cache const* cache)
+    : id_{++cache->id},
+      managed_sm_{open_or_create, unique_name("testProd").c_str(), 1024},
+      named_mtx_{open_or_create, unique_name("mtx").c_str()},
+      named_cndFromMain_{open_or_create, unique_name("cndFromMain").c_str()},
+      named_cndToMain_{open_or_create, unique_name("cndToMain").c_str()},
+      deserializer_{managed_sm_, "buffer", id_} {
+  token_ = produces<edmtest::IntProduct>();
 
- {
-  token_ = produces<double>();
-
-  managed_sm_.destroy<long double>(unique_name("sum").c_str());
   managed_sm_.destroy<bool>(unique_name("stop").c_str());
-
-  sm_sum_ = managed_sm_.construct<long double>(unique_name("sum").c_str())(0);
   stop_ = managed_sm_.construct<bool>(unique_name("stop").c_str())(false);
+  assert(stop_);
 
   //make sure output is flushed before popen does any writing
   fflush(stdout);
   fflush(stderr);
+
+  scoped_lock<named_mutex> lock(named_mtx_);
+  std::cout << id_ << " starting external process" << std::endl;
   pipe_ = popen(unique_name("cmsInterProcess testProd ").c_str(), "w");
-  
-  if(NULL == pipe_) {
+
+  if (NULL == pipe_) {
     abort();
   }
+
+  {
+    auto v = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.gen = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(6), iterations=cms.uint32(10000000))
+process.moduleToTest(process.gen)
+)_";
+    auto length = strlen(v);
+    auto nlines = std::to_string(std::count(v, v + length, '\n'));
+    auto result = fwrite(nlines.data(), sizeof(char), nlines.size(), pipe_);
+    assert(result = nlines.size());
+    result = fwrite(v, sizeof(char), strlen(v), pipe_);
+    assert(result == strlen(v));
+    fflush(pipe_);
+  }
+  std::cout << id_ << " waiting for external process" << std::endl;
+  named_cndToMain_.wait(lock);
+  std::cout << id_ << " done waiting for external process" << std::endl;
 }
 
 std::unique_ptr<testinter::Cache> TestInterProcessProd::initializeGlobalCache(edm::ParameterSet const&) {
@@ -93,37 +164,35 @@ std::unique_ptr<testinter::Cache> TestInterProcessProd::initializeGlobalCache(ed
 
 void TestInterProcessProd::globalEndJob(testinter::Cache*) {}
 
-
-
 TestInterProcessProd::~TestInterProcessProd() {
   {
     scoped_lock<named_mutex> lock(named_mtx_);
     *stop_ = true;
     named_cndFromMain_.notify_all();
   }
-  
+
   pclose(pipe_);
-  managed_sm_.destroy<long double>(unique_name("sum").c_str());
   managed_sm_.destroy<bool>(unique_name("stop").c_str());
+
+  named_mutex::remove(unique_name("mtx").c_str());
+  named_condition::remove(unique_name("cndFromMain").c_str());
+  named_condition::remove(unique_name("cndToMain").c_str());
 }
 
-
 void TestInterProcessProd::produce(edm::Event& iEvent, edm::EventSetup const&) {
-  std::cout <<id_<<" taking from lock"<<std::endl;
+  std::cout << id_ << " taking from lock" << std::endl;
   scoped_lock<named_mutex> lock(named_mtx_);
   {
-    std::cout <<id_ <<" notifying"<<std::endl;
-    named_cndFromMain_.notify_all();    
+    std::cout << id_ << " notifying" << std::endl;
+    named_cndFromMain_.notify_all();
   }
-  
-  long double value;
-  {
-    std::cout <<id_<< " waiting"<<std::endl;
-    named_cndToMain_.wait(lock);
-    value = *sm_sum_;
-  }
-  std::cout <<id_ << " from shared memory "<<value<<std::endl;
-  
+
+  std::cout << id_ << " waiting" << std::endl;
+  named_cndToMain_.wait(lock);
+
+  auto value = deserializer_.deserialize();
+  std::cout << id_ << " from shared memory " << value.value << std::endl;
+
   iEvent.emplace(token_, value);
 }
 

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -188,7 +188,7 @@ TestInterProcessProd::TestInterProcessProd(edm::ParameterSet const& iPSet)
       erToken_{produces<edmtest::ThingCollection, edm::Transition::EndRun>("endRun")},
       blToken_{produces<edmtest::ThingCollection, edm::Transition::BeginLuminosityBlock>("beginLumi")},
       elToken_{produces<edmtest::ThingCollection, edm::Transition::EndLuminosityBlock>("endLumi")},
-      config_{iPSet.getUntrackedParameter<std::string>("python_config")} {}
+      config_{iPSet.getUntrackedParameter<std::string>("@python_config")} {}
 
 std::unique_ptr<testinter::StreamCache> TestInterProcessProd::beginStream(edm::StreamID iID) const {
   auto const label = moduleDescription().moduleLabel();

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -123,10 +123,14 @@ namespace testinter {
   };
 
   struct RunCache {
-    mutable edmtest::ThingCollection thingCollection_;
+    //Only stream 0 sets this at stream end Run and it is read at global end run
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable edmtest::ThingCollection thingCollection_;
   };
   struct LumiCache {
-    mutable edmtest::ThingCollection thingCollection_;
+    //Only stream 0 sets this at stream end Lumi and it is read at global end Lumi
+    // the framework guarantees those calls can not happen simultaneously
+    CMS_THREAD_SAFE mutable edmtest::ThingCollection thingCollection_;
   };
 }  // namespace testinter
 
@@ -167,8 +171,14 @@ private:
 
   std::string config_;
 
-  mutable testinter::StreamCache* stream0Cache_ = nullptr;
+  //This is set at beginStream and used for globalBeginRun
+  //The framework guarantees that non of those can happen concurrently
+  CMS_THREAD_SAFE mutable testinter::StreamCache* stream0Cache_ = nullptr;
+  //A stream which has finished processing the last lumi is used for the
+  // call to globalBeginLuminosityBlockProduce
   mutable std::atomic<testinter::StreamCache*> availableForBeginLumi_;
+  //Streams all see the lumis in the same order, we want to be sure to pick a stream cache
+  // to use at globalBeginLumi which just finished the most recent lumi and not a previous one
   mutable std::atomic<unsigned int> lastLumiIndex_ = 0;
 };
 

--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -1,0 +1,130 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <stdio.h>
+#include <iostream>
+
+#include "boost/interprocess/shared_memory_object.hpp"
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include <boost/interprocess/sync/named_mutex.hpp>
+#include <boost/interprocess/sync/named_condition.hpp>
+#include <boost/interprocess/sync/scoped_lock.hpp>
+
+
+using namespace boost::interprocess;
+
+namespace testinter {
+  struct Cache {
+    mutable int id = 0;
+  };
+}
+
+class TestInterProcessProd : public edm::stream::EDProducer<edm::GlobalCache<testinter::Cache>> {
+
+public:
+  TestInterProcessProd( edm::ParameterSet const&, testinter::Cache const* );
+  ~TestInterProcessProd();
+  
+  void produce(edm::Event& , edm::EventSetup const&);
+
+  static std::unique_ptr<testinter::Cache> initializeGlobalCache(edm::ParameterSet const&);
+
+  static void globalEndJob(testinter::Cache*);
+
+private:
+
+  int id_;
+  edm::EDPutTokenT<double> token_;
+  FILE* pipe_;
+
+  managed_shared_memory managed_sm_;
+  
+  named_mutex named_mtx_;
+  named_condition named_cndFromMain_;
+
+  //named_mutex named_mtxToMain_;
+  named_condition named_cndToMain_;
+  
+  long double* sm_sum_;
+  bool* stop_;
+
+  std::string unique_name(std::string iBase) {
+    auto pid = getpid();
+    iBase += std::to_string(pid);
+    iBase +="_";
+    iBase +=std::to_string(id_);
+    
+    return iBase;
+  }
+
+};
+
+TestInterProcessProd::TestInterProcessProd( edm::ParameterSet const&, testinter::Cache const* cache ):
+id_{ ++cache->id},
+managed_sm_{ open_or_create, unique_name("testProd").c_str(), 1024},
+named_mtx_{open_or_create, unique_name("mtx").c_str()},
+named_cndFromMain_{open_or_create, unique_name("cndFromMain").c_str()},
+//named_mtxToMain_{open_or_create, "mtxToMain"},
+named_cndToMain_{open_or_create, unique_name("cndToMain").c_str()}
+
+ {
+  token_ = produces<double>();
+
+  managed_sm_.destroy<long double>(unique_name("sum").c_str());
+  managed_sm_.destroy<bool>(unique_name("stop").c_str());
+
+  sm_sum_ = managed_sm_.construct<long double>(unique_name("sum").c_str())(0);
+  stop_ = managed_sm_.construct<bool>(unique_name("stop").c_str())(false);
+
+  //make sure output is flushed before popen does any writing
+  fflush(stdout);
+  fflush(stderr);
+  pipe_ = popen(unique_name("cmsInterProcess testProd ").c_str(), "w");
+  
+  if(NULL == pipe_) {
+    abort();
+  }
+}
+
+std::unique_ptr<testinter::Cache> TestInterProcessProd::initializeGlobalCache(edm::ParameterSet const&) {
+  return std::make_unique<testinter::Cache>();
+}
+
+void TestInterProcessProd::globalEndJob(testinter::Cache*) {}
+
+
+
+TestInterProcessProd::~TestInterProcessProd() {
+  {
+    scoped_lock<named_mutex> lock(named_mtx_);
+    *stop_ = true;
+    named_cndFromMain_.notify_all();
+  }
+  
+  pclose(pipe_);
+  managed_sm_.destroy<long double>(unique_name("sum").c_str());
+  managed_sm_.destroy<bool>(unique_name("stop").c_str());
+}
+
+
+void TestInterProcessProd::produce(edm::Event& iEvent, edm::EventSetup const&) {
+  std::cout <<id_<<" taking from lock"<<std::endl;
+  scoped_lock<named_mutex> lock(named_mtx_);
+  {
+    std::cout <<id_ <<" notifying"<<std::endl;
+    named_cndFromMain_.notify_all();    
+  }
+  
+  long double value;
+  {
+    std::cout <<id_<< " waiting"<<std::endl;
+    named_cndToMain_.wait(lock);
+    value = *sm_sum_;
+  }
+  std::cout <<id_ << " from shared memory "<<value<<std::endl;
+  
+  iEvent.emplace(token_, value);
+}
+
+DEFINE_FWK_MODULE(TestInterProcessProd);

--- a/FWCore/Integration/test/ThingAlgorithm.cc
+++ b/FWCore/Integration/test/ThingAlgorithm.cc
@@ -5,7 +5,11 @@ namespace edmtest {
   void ThingAlgorithm::run(ThingCollection& thingCollection) const {
     thingCollection.reserve(nThings_);
     auto offset = offset_.fetch_add(offsetDelta_);
-    for (int i = 0; i < nThings_; ++i) {
+    int nItems = nThings_;
+    if (grow_) {
+      nItems *= offset;
+    }
+    for (int i = 0; i < nItems; ++i) {
       Thing tc;
       tc.a = i + offset;
       thingCollection.push_back(tc);

--- a/FWCore/Integration/test/ThingAlgorithm.h
+++ b/FWCore/Integration/test/ThingAlgorithm.h
@@ -10,8 +10,8 @@
 namespace edmtest {
   class ThingAlgorithm {
   public:
-    ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20)
-        : offset_(0), offsetDelta_(iOffsetDelta), nThings_(nThings) {}
+    ThingAlgorithm(long iOffsetDelta = 0, int nThings = 20, bool grow = false)
+        : offset_(0), offsetDelta_(iOffsetDelta), nThings_(nThings), grow_(grow) {}
 
     /// Runs the algorithm and returns a list of Things
     /// The user declares the vector and calls this method.
@@ -21,6 +21,7 @@ namespace edmtest {
     mutable std::atomic<long> offset_;
     const long offsetDelta_;
     const int nThings_;
+    const bool grow_;
   };
 
 }  // namespace edmtest

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -6,9 +6,9 @@
 
 namespace edmtest {
   ThingProducer::ThingProducer(edm::ParameterSet const& iConfig)
-      : alg_(iConfig.getParameter<int>(
-                 "offsetDelta"),  //this really should be tracked, but I want backwards compatibility
-             iConfig.getParameter<int>("nThings")),
+      : alg_(iConfig.getParameter<int>("offsetDelta"),
+             iConfig.getParameter<int>("nThings"),
+             iConfig.getParameter<bool>("grow")),
         noPut_(iConfig.getUntrackedParameter<bool>("noPut"))  // used for testing with missing products
   {
     evToken_ = produces<ThingCollection>();
@@ -101,7 +101,9 @@ namespace edmtest {
             "How much extra to increment the value used when creating Things for a new container. E.g. the last value "
             "used to create Thing from the previous event is incremented by 'offsetDelta' to compute the value to use "
             "of the first Thing created in the next Event.");
-    desc.add<int>("nThings", 20)->setComment("How many Things to put in each collection");
+    desc.add<int>("nThings", 20)->setComment("How many Things to put in each collection.");
+    desc.add<bool>("grow", false)
+        ->setComment("If true, multiply 'nThings' by the value of offset for each run of the algorithm.");
     desc.addUntracked<bool>("noPut", false)
         ->setComment("If true, data is not put into the Principal. This is used to test missing products.");
     descriptions.add("thingProd", desc);

--- a/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
+++ b/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
@@ -21,7 +21,7 @@ class ThingExternalProcessProducer(cms.EDProducer):
         newpset.addString(True, "@module_type", self.type_())
         newpset.addString(True, "@module_edm_type", cms.EDProducer.__name__)
         newpset.addString(True, "@external_type", self._prod.type_())
-        newpset.addString(False,"python_config", self._prod.dumpPython())
+        newpset.addString(False,"@python_config", self._prod.dumpPython())
         self._prod.insertContentsInto(newpset)
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 

--- a/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
+++ b/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+
+class ThingExternalProcessProducer(cms.EDProducer):
+    def __init__(self, prod):
+        self.__dict__['_prod'] = prod
+        super(cms.EDProducer,self).__init__('TestInterProcessProd')
+    def __setattr__(self, name, value):
+        setattr(self._prod, name, value)
+    def __getattr__(self, name):
+        if name =='_prod':
+            return self.__dict__['_prod']
+        return getattr(self._prod, name)
+    def clone(self, **params):
+        returnValue = ThingExternalProcessProducerProducer.__new__(type(self))
+        returnValue.__init__(self._prod)
+        return returnValue
+    def insertInto(self, parameterSet, myname):
+        newpset = parameterSet.newPSet()
+        newpset.addString(True, "@module_label", self.moduleLabel_(myname))
+        newpset.addString(True, "@module_type", self.type_())
+        newpset.addString(True, "@module_edm_type", cms.EDProducer.__name__)
+        newpset.addString(True, "@external_type", self._prod.type_())
+        newpset.addString(False,"python_config", self._prod.dumpPython())
+        self._prod.insertContentsInto(newpset)
+        parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
+
+
+_generator = cms.EDProducer("ThingProducer", nThings = cms.int32(100), grow=cms.bool(True), offsetDelta = cms.int32(1))
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 10;
+
+process.thing = ThingExternalProcessProducer(_generator)
+
+process.p = cms.Path(process.thing)
+
+process.getter = cms.EDAnalyzer("edmtest::ThingAnalyzer")
+
+process.o = cms.EndPath(process.getter)
+process.options.numberOfThreads = 4

--- a/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
+++ b/FWCore/Integration/test/test_TestInterProcessProd_cfg.py
@@ -13,7 +13,7 @@ class ThingExternalProcessProducer(cms.EDProducer):
         return getattr(self._prod, name)
     def clone(self, **params):
         returnValue = ThingExternalProcessProducerProducer.__new__(type(self))
-        returnValue.__init__(self._prod)
+        returnValue.__init__(self._prod.clone())
         return returnValue
     def insertInto(self, parameterSet, myname):
         newpset = parameterSet.newPSet()

--- a/FWCore/SharedMemory/BuildFile.xml
+++ b/FWCore/SharedMemory/BuildFile.xml
@@ -1,0 +1,5 @@
+<use   name="boost"/>
+<use   name="rootcore"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/FWCore/SharedMemory/Readme.md
+++ b/FWCore/SharedMemory/Readme.md
@@ -1,0 +1,21 @@
+# FWCore/SharedMemory Documentation
+
+## Introduction
+This package contains code to assist in having two processes communicate via shared memory. The primary idea is to have one of the processes be cmsRun (with a module working as the Controller) and then having the other process do work on behalf of the module as its Worker. One module can have several Workers, for example one Worker per Stream. Although the various classes in the package are capable of working independently, when used together they handle most of the needs for interprocess communication.
+
+The shared memory control is being handled by boost's interprocess package.
+
+## Classes
+The following are short descriptions for each class available in the package. All classes are in the edm::shared_memory namespace.
+
+### ROOTSerializer and ROOTDeserializer
+These classes do not directly use shared memory. They are wrappers around ROOT's mechanism for using dictionaries to serialize and deserialize C++ objects. These classes are used in conjunction with other classes which control the memory buffer into which the object is serialized and from which it is deserialized.
+
+### ReadBuffer and WriteBuffer
+A pair of ReadBuffer and WriteBuffer use the same shared memory area to communicate. They are capable of dynamically creating new buffers internally if there is a need to grow the buffer.
+
+### ControllerChannel and WorkerChannel
+These classes handle synchonizing communication between the Controller and Worker processes. They handle initialization of the Worker and then processing of the various framework transitions. These classes also work with the ReadBuffer and WriteBuffer objects to synchronize communication and handling the index used when the buffers change.
+
+### WorkerMonitorThread
+This class does not directly use shared memory. It is designed to use a helper thread and a signal handler to monitor the Worker process for a unix signal that will terminate the process. In the advent of such a signal, a user callable routine will be called. This is used to unlock the scoped lock being held by the WorkerChannel which will allow the Controller process to time out on its wait using that lock.

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -1,0 +1,132 @@
+#ifndef FWCore_SharedMemory_ControllerChannel_h
+#define FWCore_SharedMemory_ControllerChannel_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ControllerChannel
+//
+/**\class ControllerChannel ControllerChannel.h " FWCore/SharedMemory/interface/ControllerChannel.h"
+
+ Description: Primary communication channel for the Controller process
+
+ Usage:
+    Works in conjunction with the WorkerChannel
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <string>
+#include <iostream>
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include "boost/interprocess/sync/named_mutex.hpp"
+#include "boost/interprocess/sync/named_condition.hpp"
+#include "boost/interprocess/sync/scoped_lock.hpp"
+
+// user include files
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class ControllerChannel {
+  public:
+    /** iName is used as the base for the shared memory name. The full name uses iID as well as getpid() to create the value sharedMemoryName().
+     iID allows multiple ControllChannels to use the same base name iName.
+     */
+    ControllerChannel(std::string const& iName, int iID);
+    ~ControllerChannel();
+    ControllerChannel(const ControllerChannel&) = delete;
+    const ControllerChannel& operator=(const ControllerChannel&) = delete;
+
+    // ---------- member functions ---------------------------
+
+    /** setupWorker must be called only once and done before any calls to doTransition. The functor iF should setup values associated
+     with shared memory use, such as manipulating the value from toWorkerBufferIndex(). The call to setupWorker proper synchronizes
+     the Controller and Worker processes.
+     */
+    template <typename F>
+    void setupWorker(F&& iF) {
+      using namespace boost::interprocess;
+      scoped_lock<named_mutex> lock(mutex_);
+      iF();
+      using namespace boost::posix_time;
+      //std::cout << id_ << " waiting for external process" << std::endl;
+
+      if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(60))) {
+        //std::cout << id_ << " FAILED waiting for external process" << std::endl;
+        throw cms::Exception("ExternalFailed");
+      } else {
+        //std::cout << id_ << " done waiting for external process" << std::endl;
+      }
+    }
+
+    template <typename F>
+    bool doTransition(F&& iF, edm::Transition iTrans, unsigned long long iTransitionID) {
+      using namespace boost::interprocess;
+
+      //std::cout << id_ << " taking from lock" << std::endl;
+      scoped_lock<named_mutex> lock(mutex_);
+
+      if (not wait(lock, iTrans, iTransitionID)) {
+        return false;
+      }
+      //std::cout <<id_<<"running doTranstion command"<<std::endl;
+      iF();
+      return true;
+    }
+
+    ///This can be used with WriteBuffer to keep Controller and Worker in sync
+    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    ///This can be used with ReadBuffer to keep Controller and Worker in sync
+    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+
+    void stopWorker() {
+      //std::cout <<"stopWorker"<<std::endl;
+      using namespace boost::interprocess;
+      scoped_lock<named_mutex> lock(mutex_);
+      *stop_ = true;
+      //std::cout <<"stopWorker sending notification"<<std::endl;
+      cndFromMain_.notify_all();
+    }
+
+    // ---------- const member functions ---------------------------
+    std::string const& sharedMemoryName() const { return smName_; }
+    std::string uniqueID() const { return uniqueName(""); }
+
+    //should only be called after calling `doTransition`
+    bool shouldKeepEvent() const { return *keepEvent_; }
+
+  private:
+    static char* bufferIndex(const char* iWhich, boost::interprocess::managed_shared_memory& mem);
+
+    std::string uniqueName(std::string iBase) const;
+
+    bool wait(boost::interprocess::scoped_lock<boost::interprocess::named_mutex>& lock,
+              edm::Transition iTrans,
+              unsigned long long iTransID);
+
+    // ---------- member data --------------------------------
+    int id_;
+    std::string smName_;
+    boost::interprocess::managed_shared_memory managed_sm_;
+    char* toWorkerBufferIndex_;
+    char* fromWorkerBufferIndex_;
+
+    boost::interprocess::named_mutex mutex_;
+    boost::interprocess::named_condition cndFromMain_;
+
+    boost::interprocess::named_condition cndToMain_;
+
+    edm::Transition* transitionType_;
+    unsigned long long* transitionID_;
+    bool* stop_;
+    bool* keepEvent_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -42,6 +42,8 @@ namespace edm::shared_memory {
     ~ControllerChannel();
     ControllerChannel(const ControllerChannel&) = delete;
     const ControllerChannel& operator=(const ControllerChannel&) = delete;
+    ControllerChannel(ControllerChannel&&) = delete;
+    const ControllerChannel& operator=(ControllerChannel&&) = delete;
 
     // ---------- member functions ---------------------------
 

--- a/FWCore/SharedMemory/interface/ROOTDeserializer.h
+++ b/FWCore/SharedMemory/interface/ROOTDeserializer.h
@@ -35,6 +35,8 @@ namespace edm::shared_memory {
 
     ROOTDeserializer(const ROOTDeserializer&) = delete;
     const ROOTDeserializer& operator=(const ROOTDeserializer&) = delete;
+    ROOTDeserializer(ROOTDeserializer&&) = delete;
+    const ROOTDeserializer& operator=(ROOTDeserializer&&) = delete;
 
     // ---------- const member functions ---------------------
 

--- a/FWCore/SharedMemory/interface/ROOTDeserializer.h
+++ b/FWCore/SharedMemory/interface/ROOTDeserializer.h
@@ -1,0 +1,62 @@
+#ifndef FWCore_SharedMemory_ROOTDeserializer_h
+#define FWCore_SharedMemory_ROOTDeserializer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ROOTDeserializer
+//
+/**\class ROOTDeserializer ROOTDeserializer.h " FWCore/SharedMemory/interface/ROOTDeserializer.h"
+
+ Description: Use ROOT dictionaries to deserialize object from a buffer
+
+ Usage:
+    Used in conjunction with ROOTSerializer.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  22/01/2020
+//
+
+// system include files
+#include "TClass.h"
+#include "TBufferFile.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  template <typename T, typename READBUFFER>
+  class ROOTDeserializer {
+  public:
+    ROOTDeserializer(READBUFFER& iBuffer)
+        : buffer_{iBuffer}, class_{TClass::GetClass(typeid(T))}, bufferFile_(TBuffer::kRead) {}
+
+    ROOTDeserializer(const ROOTDeserializer&) = delete;
+    const ROOTDeserializer& operator=(const ROOTDeserializer&) = delete;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- member functions ---------------------------
+    T deserialize() {
+      T value;
+      if (buffer_.mustGetBufferAgain()) {
+        auto buff = buffer_.buffer();
+        bufferFile_.SetBuffer(buff.first, buff.second, kFALSE);
+      }
+
+      class_->ReadBuffer(bufferFile_, &value);
+      bufferFile_.Reset();
+      return value;
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    READBUFFER& buffer_;
+    TClass* const class_;
+    TBufferFile bufferFile_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ROOTSerializer.h
+++ b/FWCore/SharedMemory/interface/ROOTSerializer.h
@@ -1,0 +1,57 @@
+#ifndef FWCore_SharedMemory_ROOTSerializer_h
+#define FWCore_SharedMemory_ROOTSerializer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ROOTSerializer
+//
+/**\class ROOTSerializer ROOTSerializer.h " FWCore/SharedMemory/interface/ROOTSerializer.h"
+
+ Description: Use ROOT dictionaries to serialize object to a buffer
+
+ Usage:
+    This is used in conjuction with ROOTDeserializer.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  22/01/2020
+//
+
+// system include files
+#include "TClass.h"
+#include "TBufferFile.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  template <typename T, typename WRITEBUFFER>
+  class ROOTSerializer {
+  public:
+    ROOTSerializer(WRITEBUFFER& iBuffer)
+        : buffer_(iBuffer), class_{TClass::GetClass(typeid(T))}, bufferFile_{TBuffer::kWrite} {}
+
+    ROOTSerializer(const ROOTSerializer&) = delete;
+    const ROOTSerializer& operator=(const ROOTSerializer&) = delete;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- member functions ---------------------------
+    void serialize(T& iValue) {
+      bufferFile_.Reset();
+      class_->WriteBuffer(bufferFile_, &iValue);
+
+      buffer_.copyToBuffer(bufferFile_.Buffer(), bufferFile_.Length());
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    WRITEBUFFER& buffer_;
+    TClass* const class_;
+    TBufferFile bufferFile_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ROOTSerializer.h
+++ b/FWCore/SharedMemory/interface/ROOTSerializer.h
@@ -35,6 +35,8 @@ namespace edm::shared_memory {
 
     ROOTSerializer(const ROOTSerializer&) = delete;
     const ROOTSerializer& operator=(const ROOTSerializer&) = delete;
+    ROOTSerializer(ROOTSerializer&&) = delete;
+    const ROOTSerializer& operator=(ROOTSerializer&&) = delete;
 
     // ---------- const member functions ---------------------
 

--- a/FWCore/SharedMemory/interface/ReadBuffer.h
+++ b/FWCore/SharedMemory/interface/ReadBuffer.h
@@ -1,0 +1,71 @@
+#ifndef FWCore_SharedMemory_ReadBuffer_h
+#define FWCore_SharedMemory_ReadBuffer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ReadBuffer
+//
+/**\class ReadBuffer ReadBuffer.h " FWCore/SharedMemory/interface/ReadBuffer.h"
+
+ Description: Manages a shared memory buffer used for reading
+
+ Usage:
+      Handles reading from a dynamically allocatable shared memory buffer.
+This works in conjunction with WriteBuffer.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <array>
+#include <memory>
+#include <string>
+#include "boost/interprocess/managed_shared_memory.hpp"
+
+// user include files
+#include "FWCore/SharedMemory/interface/buffer_names.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class ReadBuffer {
+  public:
+    /** iUniqueName : must be unique for all processes running on a system.
+        iBufferIndex : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
+    */
+    ReadBuffer(std::string const& iUniqueName, char* iBufferIndex)
+        : buffer_{nullptr, 0}, bufferIndex_{iBufferIndex}, bufferOldIndex_{3} {
+      *bufferIndex_ = 0;
+      bufferNames_[0] = iUniqueName + buffer_names::kBuffer0;
+      bufferNames_[1] = iUniqueName + buffer_names::kBuffer1;
+    }
+    ReadBuffer(const ReadBuffer&) = delete;
+    const ReadBuffer& operator=(const ReadBuffer&) = delete;
+
+    // ---------- const member functions ---------------------
+    bool mustGetBufferAgain() const { return *bufferIndex_ != bufferOldIndex_; }
+
+    // ---------- member functions ---------------------------
+    std::pair<char*, std::size_t> buffer() {
+      if (mustGetBufferAgain()) {
+        using namespace boost::interprocess;
+        sm_ = std::make_unique<managed_shared_memory>(open_only, bufferNames_[*bufferIndex_].c_str());
+        buffer_ = sm_->find<char>(buffer_names::kBuffer);
+        bufferOldIndex_ = *bufferIndex_;
+      }
+      return buffer_;
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    std::pair<char*, std::size_t> buffer_;
+    char* bufferIndex_;
+    char bufferOldIndex_;
+    std::array<std::string, 2> bufferNames_;
+    std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/ReadBuffer.h
+++ b/FWCore/SharedMemory/interface/ReadBuffer.h
@@ -43,6 +43,8 @@ namespace edm::shared_memory {
     }
     ReadBuffer(const ReadBuffer&) = delete;
     const ReadBuffer& operator=(const ReadBuffer&) = delete;
+    ReadBuffer(ReadBuffer&&) = delete;
+    const ReadBuffer& operator=(ReadBuffer&&) = delete;
 
     // ---------- const member functions ---------------------
     bool mustGetBufferAgain() const { return *bufferIndex_ != bufferOldIndex_; }

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -1,0 +1,103 @@
+#ifndef FWCore_SharedMemory_WorkerChannel_h
+#define FWCore_SharedMemory_WorkerChannel_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerChannel
+//
+/**\class WorkerChannel WorkerChannel.h " FWCore/SharedMemory/interface/WorkerChannel.h"
+
+ Description:  Primary communication channel for the Worker process
+
+ Usage:
+    Used in conjunction with the ControllerChannel
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <string>
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include "boost/interprocess/sync/named_mutex.hpp"
+#include "boost/interprocess/sync/named_condition.hpp"
+#include "boost/interprocess/sync/scoped_lock.hpp"
+
+// user include files
+#include "FWCore/Utilities/interface/Transition.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class WorkerChannel {
+  public:
+    /** iName must match the value from ControllerChannel::sharedMemoryName()
+     iUniqueName must match the value from ControllerChannel::uniqueID()     
+     */
+    WorkerChannel(std::string const& iName, const std::string& iUniqueID);
+    WorkerChannel(const WorkerChannel&) = delete;
+    const WorkerChannel& operator=(const WorkerChannel&) = delete;
+
+    // ---------- member functions ---------------------------
+    /// the lock is made accessible so that the WorkerMonitorThread can be used to unlock it in the event of a unix signal
+    boost::interprocess::scoped_lock<boost::interprocess::named_mutex>* accessLock() { return &lock_; }
+
+    ///This can be used with ReadBuffer to keep Controller and Worker in sync
+    char* toWorkerBufferIndex() { return toWorkerBufferIndex_; }
+    ///This can be used with WriteBuffer to keep Controller and Worker in sync
+    char* fromWorkerBufferIndex() { return fromWorkerBufferIndex_; }
+
+    ///Matches the ControllerChannel::setupWorker call
+    void workerSetupDone() {
+      //The controller is waiting for the worker to be setup
+      notifyController();
+    }
+
+    /**Matches the ControllerChannel::doTransition calls.
+     iF is a function that takes as arguments a edm::Transition and unsigned long long
+     */
+    template <typename F>
+    void handleTransitions(F&& iF) {
+      while (true) {
+        waitForController();
+        if (stopRequested()) {
+          break;
+        }
+
+        iF(transition(), transitionID());
+        notifyController();
+      }
+    }
+
+    ///call this from the `handleTransitions` functor
+    void shouldKeepEvent(bool iChoice) { *keepEvent_ = iChoice; }
+
+    ///These are here for expert use
+    void notifyController() { cndToController_.notify_all(); }
+    void waitForController() { cndFromController_.wait(lock_); }
+
+    // ---------- const member functions ---------------------------
+    edm::Transition transition() const noexcept { return *transitionType_; }
+    unsigned long long transitionID() const noexcept { return *transitionID_; }
+    bool stopRequested() const noexcept { return *stop_; }
+
+  private:
+    // ---------- member data --------------------------------
+    boost::interprocess::managed_shared_memory managed_shm_;
+
+    boost::interprocess::named_mutex mutex_;
+    boost::interprocess::named_condition cndFromController_;
+    bool* stop_;
+    edm::Transition* transitionType_;
+    unsigned long long* transitionID_;
+    char* toWorkerBufferIndex_;
+    char* fromWorkerBufferIndex_;
+    boost::interprocess::named_condition cndToController_;
+    bool* keepEvent_;
+    boost::interprocess::scoped_lock<boost::interprocess::named_mutex> lock_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/WorkerChannel.h
+++ b/FWCore/SharedMemory/interface/WorkerChannel.h
@@ -39,6 +39,8 @@ namespace edm::shared_memory {
     WorkerChannel(std::string const& iName, const std::string& iUniqueID);
     WorkerChannel(const WorkerChannel&) = delete;
     const WorkerChannel& operator=(const WorkerChannel&) = delete;
+    WorkerChannel(WorkerChannel&&) = delete;
+    const WorkerChannel& operator=(WorkerChannel&&) = delete;
 
     // ---------- member functions ---------------------------
     /// the lock is made accessible so that the WorkerMonitorThread can be used to unlock it in the event of a unix signal

--- a/FWCore/SharedMemory/interface/WorkerMonitorThread.h
+++ b/FWCore/SharedMemory/interface/WorkerMonitorThread.h
@@ -1,0 +1,71 @@
+#ifndef FWCore_SharedMemory_WorkerMonitorThread_h
+#define FWCore_SharedMemory_WorkerMonitorThread_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerMonitorThread
+//
+/**\class WorkerMonitorThread WorkerMonitorThread.h " FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+ Description: Manages a thread that monitors the worker process for unix signals
+
+ Usage:
+      Allows a user settable action to happen in the case of a unix signal occuring.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <atomic>
+#include <functional>
+#include <thread>
+#include <signal.h>
+
+// user include files
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class WorkerMonitorThread {
+  public:
+    WorkerMonitorThread() {}
+    ~WorkerMonitorThread() { stopRequested_.store(true); }
+    WorkerMonitorThread(const WorkerMonitorThread&) = delete;
+    const WorkerMonitorThread& operator=(const WorkerMonitorThread&) = delete;
+
+    // ---------- const member functions ---------------------
+
+    // ---------- member functions ---------------------------
+    void setAction(std::function<void()> iFunc) {
+      action_ = std::move(iFunc);
+      actionSet_.store(true);
+    }
+
+    void startThread();
+
+    ///Sets the unix signal handler which communicates with the thread.
+    void setupSignalHandling();
+
+    void stop() { stopRequested_ = true; }
+
+  private:
+    static void sig_handler(int sig, siginfo_t*, void*);
+    void run();
+    // ---------- member data --------------------------------
+    std::atomic<bool> stopRequested_ = false;
+    std::atomic<bool> helperReady_ = false;
+    std::atomic<bool> actionSet_ = false;
+    CMS_THREAD_GUARD(actionSet_) std::function<void()> action_;
+
+    static std::atomic<bool> s_signal_happened;
+    static std::atomic<bool> s_helperThreadDone;
+    CMS_THREAD_GUARD(s_signal_happened) static int s_sig;
+
+    std::thread helperThread_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/WorkerMonitorThread.h
+++ b/FWCore/SharedMemory/interface/WorkerMonitorThread.h
@@ -66,7 +66,8 @@ namespace edm::shared_memory {
     std::atomic<bool> actionSet_ = false;
     CMS_THREAD_GUARD(actionSet_) std::function<void()> action_;
 
-    static int s_pipeEnds[2];
+    static std::atomic<int> s_pipeReadEnd;
+    static std::atomic<int> s_pipeWriteEnd;
     static std::atomic<bool> s_helperThreadDone;
 
     std::thread helperThread_;

--- a/FWCore/SharedMemory/interface/WorkerMonitorThread.h
+++ b/FWCore/SharedMemory/interface/WorkerMonitorThread.h
@@ -39,6 +39,8 @@ namespace edm::shared_memory {
     }
     WorkerMonitorThread(const WorkerMonitorThread&) = delete;
     const WorkerMonitorThread& operator=(const WorkerMonitorThread&) = delete;
+    WorkerMonitorThread(WorkerMonitorThread&&) = delete;
+    const WorkerMonitorThread& operator=(WorkerMonitorThread&&) = delete;
 
     // ---------- const member functions ---------------------
 

--- a/FWCore/SharedMemory/interface/WorkerMonitorThread.h
+++ b/FWCore/SharedMemory/interface/WorkerMonitorThread.h
@@ -19,9 +19,9 @@
 
 // system include files
 #include <atomic>
+#include <csignal>
 #include <functional>
 #include <thread>
-#include <signal.h>
 
 // user include files
 #include "FWCore/Utilities/interface/thread_safety_macros.h"

--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -47,6 +47,8 @@ namespace edm::shared_memory {
     }
     WriteBuffer(const WriteBuffer&) = delete;
     const WriteBuffer& operator=(const WriteBuffer&) = delete;
+    WriteBuffer(WriteBuffer&&) = delete;
+    const WriteBuffer& operator=(WriteBuffer&&) = delete;
 
     ~WriteBuffer();
 

--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -1,0 +1,73 @@
+#ifndef FWCore_SharedMemory_WriteBuffer_h
+#define FWCore_SharedMemory_WriteBuffer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WriteBuffer
+//
+/**\class WriteBuffer WriteBuffer.h " FWCore/SharedMemory/interface/WriteBuffer.h"
+
+ Description: Manages a shared memory buffer used for writing
+
+ Usage:
+    Handles writing to a shared memory buffer. The buffer size grows automatically when necessary.
+ This works in conjunction with ReadBuffer.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <array>
+#include <memory>
+#include <string>
+#include <cassert>
+#include <algorithm>
+#include "boost/interprocess/managed_shared_memory.hpp"
+
+// user include files
+#include "FWCore/SharedMemory/interface/buffer_names.h"
+
+// forward declarations
+
+namespace edm::shared_memory {
+  class WriteBuffer {
+  public:
+    /** iUniqueName : must be unique for all processes running on a system.
+        iBufferIndex : is a pointer to a shared_memory address where the same address needs to be shared by ReadBuffer and WriteBuffer.
+    */
+
+    WriteBuffer(std::string const& iUniqueName, char* iBufferIndex)
+        : bufferSize_{0}, buffer_{nullptr}, bufferIndex_{iBufferIndex} {
+      bufferNames_[0] = iUniqueName + buffer_names::kBuffer0;
+      bufferNames_[1] = iUniqueName + buffer_names::kBuffer1;
+      assert(bufferIndex_);
+    }
+    WriteBuffer(const WriteBuffer&) = delete;
+    const WriteBuffer& operator=(const WriteBuffer&) = delete;
+
+    ~WriteBuffer();
+
+    // ---------- member functions ---------------------------
+    void copyToBuffer(const char* iStart, std::size_t iLength) {
+      if (iLength > bufferSize_) {
+        growBuffer(iLength);
+      }
+      std::copy(iStart, iStart + iLength, buffer_);
+    }
+
+  private:
+    void growBuffer(std::size_t iLength);
+
+    // ---------- member data --------------------------------
+    std::size_t bufferSize_;
+    char* buffer_;
+    char* bufferIndex_;
+    std::array<std::string, 2> bufferNames_;
+    std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
+  };
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/buffer_names.h
+++ b/FWCore/SharedMemory/interface/buffer_names.h
@@ -1,0 +1,35 @@
+#ifndef FWCore_SharedMemory_buffer_names_h
+#define FWCore_SharedMemory_buffer_names_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     buffer_names
+//
+/**
+
+ Description: Shared memory names used for the ReadBuffer and WriteBuffer
+
+ Usage:
+      Internal details of ReadBuffer and WriteBuffer
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  namespace buffer_names {
+    constexpr char const* const kBuffer = "buffer";
+    constexpr char const* const kBuffer0 = "buffer0";
+    constexpr char const* const kBuffer1 = "buffer1";
+  }  // namespace buffer_names
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/interface/channel_names.h
+++ b/FWCore/SharedMemory/interface/channel_names.h
@@ -1,0 +1,41 @@
+#ifndef FWCore_SharedMemory_channel_names_h
+#define FWCore_SharedMemory_channel_names_h
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     channel_names
+//
+/**
+
+ Description: Shared memory names used for the ControllerChannel and WorkerChannel
+
+ Usage:
+      Internal details of ControllerChannel and WorkerChannel
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm::shared_memory {
+  namespace channel_names {
+    constexpr char const* const kToWorkerBufferIndex = "bufferIndexToWorker";
+    constexpr char const* const kFromWorkerBufferIndex = "bufferIndexFromWorker";
+    constexpr char const* const kMutex = "mtx";
+    constexpr char const* const kConditionFromMain = "cndFromMain";
+    constexpr char const* const kConditionToMain = "cndToMain";
+    constexpr char const* const kStop = "stop";
+    constexpr char const* const kKeepEvent = "keepEvent";
+    constexpr char const* const kTransitionType = "transitionType";
+    constexpr char const* const kTransitionID = "transitionID";
+  };  // namespace channel_names
+}  // namespace edm::shared_memory
+
+#endif

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -84,10 +84,8 @@ std::string ControllerChannel::uniqueName(std::string iBase) const {
 bool ControllerChannel::wait(scoped_lock<named_mutex>& lock, edm::Transition iTrans, unsigned long long iTransID) {
   *transitionType_ = iTrans;
   *transitionID_ = iTransID;
-  {
-    //std::cout << id_ << " notifying" << std::endl;
-    cndFromMain_.notify_all();
-  }
+  //std::cout << id_ << " notifying" << std::endl;
+  cndFromMain_.notify_all();
 
   //std::cout << id_ << " waiting" << std::endl;
   using namespace boost::posix_time;

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -1,0 +1,112 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     ControllerChannel
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <cassert>
+
+// user include files
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/channel_names.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+using namespace boost::interprocess;
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+ControllerChannel::ControllerChannel(std::string const& iName, int id)
+    : id_{id},
+      smName_{uniqueName(iName)},
+      managed_sm_{open_or_create, smName_.c_str(), 1024},
+      toWorkerBufferIndex_{bufferIndex(channel_names::kToWorkerBufferIndex, managed_sm_)},
+      fromWorkerBufferIndex_{bufferIndex(channel_names::kFromWorkerBufferIndex, managed_sm_)},
+      mutex_{open_or_create, uniqueName(channel_names::kMutex).c_str()},
+      cndFromMain_{open_or_create, uniqueName(channel_names::kConditionFromMain).c_str()},
+      cndToMain_{open_or_create, uniqueName(channel_names::kConditionToMain).c_str()} {
+  managed_sm_.destroy<bool>(channel_names::kStop);
+  stop_ = managed_sm_.construct<bool>(channel_names::kStop)(false);
+  assert(stop_);
+  keepEvent_ = managed_sm_.construct<bool>(channel_names::kKeepEvent)(true);
+  assert(keepEvent_);
+
+  managed_sm_.destroy<edm::Transition>(channel_names::kTransitionType);
+  transitionType_ =
+      managed_sm_.construct<edm::Transition>(channel_names::kTransitionType)(edm::Transition::NumberOfTransitions);
+  assert(transitionType_);
+
+  managed_sm_.destroy<unsigned long long>(channel_names::kTransitionID);
+  transitionID_ = managed_sm_.construct<unsigned long long>(channel_names::kTransitionID)(0);
+  assert(transitionID_);
+}
+
+ControllerChannel::~ControllerChannel() {
+  managed_sm_.destroy<bool>(channel_names::kKeepEvent);
+  managed_sm_.destroy<bool>(channel_names::kStop);
+  managed_sm_.destroy<unsigned int>(channel_names::kTransitionType);
+  managed_sm_.destroy<unsigned long long>(channel_names::kTransitionID);
+  managed_sm_.destroy<char>(channel_names::kToWorkerBufferIndex);
+  managed_sm_.destroy<char>(channel_names::kFromWorkerBufferIndex);
+
+  named_mutex::remove(uniqueName(channel_names::kMutex).c_str());
+  named_condition::remove(uniqueName(channel_names::kConditionFromMain).c_str());
+  named_condition::remove(uniqueName(channel_names::kConditionToMain).c_str());
+}
+
+//
+// member functions
+//
+std::string ControllerChannel::uniqueName(std::string iBase) const {
+  auto pid = getpid();
+  iBase += std::to_string(pid);
+  iBase += "_";
+  iBase += std::to_string(id_);
+
+  return iBase;
+}
+
+bool ControllerChannel::wait(scoped_lock<named_mutex>& lock, edm::Transition iTrans, unsigned long long iTransID) {
+  *transitionType_ = iTrans;
+  *transitionID_ = iTransID;
+  {
+    //std::cout << id_ << " notifying" << std::endl;
+    cndFromMain_.notify_all();
+  }
+
+  //std::cout << id_ << " waiting" << std::endl;
+  using namespace boost::posix_time;
+  if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(60))) {
+    //std::cout << id_ << " waiting FAILED" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//
+char* ControllerChannel::bufferIndex(const char* iWhich, managed_shared_memory& mem) {
+  mem.destroy<char>(iWhich);
+  char* v = mem.construct<char>(iWhich)();
+  return v;
+}

--- a/FWCore/SharedMemory/src/WorkerChannel.cc
+++ b/FWCore/SharedMemory/src/WorkerChannel.cc
@@ -1,0 +1,69 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerChannel
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <cassert>
+
+// user include files
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/SharedMemory/interface/channel_names.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+using namespace boost::interprocess;
+
+namespace {
+  std::string unique_name(std::string iBase, std::string_view ID) {
+    iBase.append(ID);
+    return iBase;
+  }
+}  // namespace
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+WorkerChannel::WorkerChannel(std::string const& iName, const std::string& iUniqueID)
+    : managed_shm_{open_only, iName.c_str()},
+      mutex_{open_or_create, unique_name(channel_names::kMutex, iUniqueID).c_str()},
+      cndFromController_{open_or_create, unique_name(channel_names::kConditionFromMain, iUniqueID).c_str()},
+      stop_{managed_shm_.find<bool>(channel_names::kStop).first},
+      transitionType_{managed_shm_.find<edm::Transition>(channel_names::kTransitionType).first},
+      transitionID_{managed_shm_.find<unsigned long long>(channel_names::kTransitionID).first},
+      toWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kToWorkerBufferIndex).first},
+      fromWorkerBufferIndex_{managed_shm_.find<char>(channel_names::kFromWorkerBufferIndex).first},
+      cndToController_{open_or_create, unique_name(channel_names::kConditionToMain, iUniqueID).c_str()},
+      keepEvent_{managed_shm_.find<bool>(channel_names::kKeepEvent).first},
+      lock_{mutex_} {
+  assert(stop_);
+  assert(transitionType_);
+  assert(transitionID_);
+  assert(toWorkerBufferIndex_);
+  assert(fromWorkerBufferIndex_);
+}
+
+//
+// member functions
+//
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//

--- a/FWCore/SharedMemory/src/WorkerMonitorThread.cc
+++ b/FWCore/SharedMemory/src/WorkerMonitorThread.cc
@@ -1,0 +1,113 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WorkerMonitorThread
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+#include <signal.h>
+#include <iostream>
+#include <unistd.h>
+
+// user include files
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+
+//
+// static data member definitions
+//
+std::atomic<bool> WorkerMonitorThread::s_signal_happened = false;
+std::atomic<bool> WorkerMonitorThread::s_helperThreadDone = false;
+int WorkerMonitorThread::s_sig = 0;
+
+//
+// constructors and destructor
+//
+
+//
+// member functions
+//
+void WorkerMonitorThread::run() {
+  //std::cerr << "Started cleanup thread\n";
+  sigset_t ensemble;
+
+  sigemptyset(&ensemble);
+  sigaddset(&ensemble, SIGABRT);
+  sigaddset(&ensemble, SIGILL);
+  sigaddset(&ensemble, SIGBUS);
+  sigaddset(&ensemble, SIGSEGV);
+  sigaddset(&ensemble, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &ensemble, NULL);
+
+  //std::cerr << "Start loop\n";
+  helperReady_ = true;
+  while (not stopRequested_.load()) {
+    sleep(60);
+    if (s_signal_happened) {
+      if (actionSet_) {
+        action_();
+      }
+      std::cerr << "Worker: SIGNAL CAUGHT " << s_sig << "\n";
+      s_helperThreadDone = true;
+      break;
+    } else {
+      //std::cerr << "SIGNAL woke\n";
+    }
+  }
+  //std::cerr << "Ending cleanup thread\n";
+}
+
+void WorkerMonitorThread::startThread() {
+  {
+    //Setup watchdog thread for crashing signals
+
+    //Need to use signal handler since signals generated
+    // from within a program are thread specific which can
+    // only be handed by a signal handler
+    setupSignalHandling();
+
+    std::thread t(&WorkerMonitorThread::run, this);
+    t.detach();
+    helperThread_ = std::move(t);
+  }
+  while (helperReady_.load() == false) {
+  }
+}
+
+void WorkerMonitorThread::setupSignalHandling() {
+  struct sigaction act;
+  act.sa_sigaction = sig_handler;
+  act.sa_flags = SA_SIGINFO;
+  sigemptyset(&act.sa_mask);
+  sigaction(SIGABRT, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+  sigaction(SIGBUS, &act, nullptr);
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTERM, &act, nullptr);
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//
+void WorkerMonitorThread::sig_handler(int sig, siginfo_t*, void*) {
+  s_sig = sig;
+  s_signal_happened = true;
+  while (not s_helperThreadDone) {
+  };
+  signal(sig, SIG_DFL);
+  raise(sig);
+}

--- a/FWCore/SharedMemory/src/WorkerMonitorThread.cc
+++ b/FWCore/SharedMemory/src/WorkerMonitorThread.cc
@@ -11,10 +11,10 @@
 //
 
 // system include files
-#include <signal.h>
+#include <cerrno>
+#include <csignal>
 #include <iostream>
 #include <unistd.h>
-#include <errno.h>
 
 // user include files
 #include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
@@ -47,7 +47,7 @@ void WorkerMonitorThread::run() {
   sigaddset(&ensemble, SIGBUS);
   sigaddset(&ensemble, SIGSEGV);
   sigaddset(&ensemble, SIGTERM);
-  pthread_sigmask(SIG_BLOCK, &ensemble, NULL);
+  pthread_sigmask(SIG_BLOCK, &ensemble, nullptr);
 
   //std::cerr << "Start loop\n";
   helperReady_ = true;

--- a/FWCore/SharedMemory/src/WriteBuffer.cc
+++ b/FWCore/SharedMemory/src/WriteBuffer.cc
@@ -1,0 +1,63 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/SharedMemory
+// Class  :     WriteBuffer
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  21/01/2020
+//
+
+// system include files
+
+// user include files
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm::shared_memory;
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+WriteBuffer::~WriteBuffer() {
+  if (sm_) {
+    sm_->destroy<char>(buffer_names::kBuffer);
+    sm_.reset();
+    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+  }
+}
+//
+// member functions
+//
+void WriteBuffer::growBuffer(std::size_t iLength) {
+  int newBuffer = (*bufferIndex_ + 1) % 2;
+  if (sm_) {
+    sm_->destroy<char>(buffer_names::kBuffer);
+    sm_.reset();
+    boost::interprocess::shared_memory_object::remove(bufferNames_[*bufferIndex_].c_str());
+  }
+  sm_ = std::make_unique<boost::interprocess::managed_shared_memory>(
+      boost::interprocess::open_or_create, bufferNames_[newBuffer].c_str(), iLength + 1024);
+  assert(sm_.get());
+  bufferSize_ = iLength;
+  *bufferIndex_ = newBuffer;
+  buffer_ = sm_->construct<char>(buffer_names::kBuffer)[iLength](0);
+  assert(buffer_);
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//

--- a/FWCore/SharedMemory/test/BuildFile.xml
+++ b/FWCore/SharedMemory/test/BuildFile.xml
@@ -1,0 +1,15 @@
+<bin file="test_catch2_*.cc" name="testFWCoreSharedMemoryCatch2">
+  <use name="catch2"/>
+  <use   name="FWCore/SharedMemory"/>
+<use   name="DataFormats/TestObjects"/>
+</bin>
+<bin file="test_channels.cc" name="testFWCoreSharedMemoryChannels">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
+<bin file="test_monitorthread.cc" name="testFWCoreSharedMemoryMonitorThread">
+  <use name="FWCore/SharedMemory"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+<test name="testFWCoreSharedMemoryMonitorThreadSignals" command="test_monitor_thread_signals.sh"/>

--- a/FWCore/SharedMemory/test/BuildFile.xml
+++ b/FWCore/SharedMemory/test/BuildFile.xml
@@ -12,4 +12,6 @@
   <use name="FWCore/SharedMemory"/>
   <use name="FWCore/Utilities"/>
 </bin>
-<test name="testFWCoreSharedMemoryMonitorThreadSignals" command="test_monitor_thread_signals.sh"/>
+<test name="testFWCoreSharedMemoryMonitorThreadSignals" command="test_monitor_thread_signals.sh">
+  <flags   PRE_TEST="testFWCoreSharedMemoryMonitorThread"/>
+</test>

--- a/FWCore/SharedMemory/test/test_catch2_buffer.cc
+++ b/FWCore/SharedMemory/test/test_catch2_buffer.cc
@@ -1,0 +1,71 @@
+#include "catch.hpp"
+#include <stdio.h>
+#include <string>
+#include <algorithm>
+
+#include "FWCore/SharedMemory/interface/WriteBuffer.h"
+#include "FWCore/SharedMemory/interface/ReadBuffer.h"
+
+using namespace edm::shared_memory;
+
+TEST_CASE("test Read/WriteBuffers", "[Buffers]") {
+  char bufferIndex = 0;
+
+  std::string const uniqueName = "BufferTest" + std::to_string(getpid());
+
+  WriteBuffer writeBuffer(uniqueName, &bufferIndex);
+
+  ReadBuffer readBuffer(uniqueName, &bufferIndex);
+
+  SECTION("First") {
+    std::array<char, 4> dummy = {{'t', 'e', 's', 't'}};
+
+    writeBuffer.copyToBuffer(dummy.data(), dummy.size());
+
+    REQUIRE(readBuffer.mustGetBufferAgain());
+    {
+      auto b = readBuffer.buffer();
+      REQUIRE(b.second == dummy.size());
+      REQUIRE(std::equal(b.first, b.first + b.second, dummy.cbegin(), dummy.cend()));
+    }
+
+    SECTION("Smaller") {
+      dummy[0] = 'm';
+
+      writeBuffer.copyToBuffer(dummy.data(), dummy.size() - 1);
+
+      REQUIRE(not readBuffer.mustGetBufferAgain());
+      {
+        auto b = readBuffer.buffer();
+        //the second argument is the buffer capacity, not the last length sent
+        REQUIRE(b.second == dummy.size());
+        REQUIRE(std::equal(b.first, b.first + b.second - 1, dummy.cbegin(), dummy.cbegin() + dummy.size() - 1));
+      }
+
+      SECTION("Larger") {
+        std::array<char, 6> dummy = {{'l', 'a', 'r', 'g', 'e', 'r'}};
+        writeBuffer.copyToBuffer(dummy.data(), dummy.size());
+
+        REQUIRE(readBuffer.mustGetBufferAgain());
+        {
+          auto b = readBuffer.buffer();
+          REQUIRE(b.second == dummy.size());
+          REQUIRE(std::equal(b.first, b.first + b.second, dummy.cbegin(), dummy.cend()));
+        }
+
+        SECTION("Largest") {
+          //this should go back to buffer0
+          std::array<char, 7> dummy = {{'l', 'a', 'r', 'g', 'e', 's', 't'}};
+          writeBuffer.copyToBuffer(dummy.data(), dummy.size());
+
+          REQUIRE(readBuffer.mustGetBufferAgain());
+          {
+            auto b = readBuffer.buffer();
+            REQUIRE(b.second == dummy.size());
+            REQUIRE(std::equal(b.first, b.first + b.second, dummy.cbegin(), dummy.cend()));
+          }
+        }
+      }
+    }
+  }
+}

--- a/FWCore/SharedMemory/test/test_catch2_main.cc
+++ b/FWCore/SharedMemory/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/FWCore/SharedMemory/test/test_catch2_serialize.cc
+++ b/FWCore/SharedMemory/test/test_catch2_serialize.cc
@@ -1,0 +1,129 @@
+#include "catch.hpp"
+#include <utility>
+#include <algorithm>
+#include <iterator>
+
+#include "FWCore/SharedMemory/interface/ROOTSerializer.h"
+#include "FWCore/SharedMemory/interface/ROOTDeserializer.h"
+
+#include "DataFormats/TestObjects/interface/Thing.h"
+
+namespace {
+  struct ReadWriteTestBuffer {
+    std::pair<char*, std::size_t> buffer() { return std::pair(&buffer_.front(), size()); }
+
+    bool mustGetBufferAgain() { return resized_; }
+
+    void copyToBuffer(char* iStart, std::size_t iLength) {
+      buffer_.clear();
+      if (iLength > buffer_.capacity()) {
+        buffer_.reserve(iLength);
+        resized_ = true;
+      } else {
+        resized_ = false;
+      }
+      std::copy(iStart, iStart + iLength, std::back_insert_iterator(buffer_));
+    }
+
+    std::size_t size() const { return buffer_.size(); }
+
+    std::vector<char> buffer_;
+    bool resized_ = true;
+  };
+
+  bool compare(std::vector<edmtest::Thing> const& iLHS, std::vector<edmtest::Thing> const& iRHS) {
+    if (iLHS.size() != iRHS.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < iLHS.size(); ++i) {
+      if (iLHS[i].a != iRHS[i].a) {
+        return false;
+      }
+    }
+    return true;
+  }
+}  // namespace
+using namespace edm::shared_memory;
+TEST_CASE("test De/ROOTSerializer", "[ROOTSerializer]") {
+  SECTION("Process edmtest::Thing") {
+    ReadWriteTestBuffer buffer;
+
+    ROOTSerializer<edmtest::Thing, ReadWriteTestBuffer> serializer(buffer);
+    ROOTDeserializer<edmtest::Thing, ReadWriteTestBuffer> deserializer(buffer);
+
+    edmtest::Thing t;
+    t.a = 42;
+
+    serializer.serialize(t);
+    REQUIRE(buffer.mustGetBufferAgain() == true);
+
+    auto newT = deserializer.deserialize();
+
+    REQUIRE(t.a == newT.a);
+    SECTION("Reuse buffer") {
+      t.a = 12;
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == false);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(t.a == newT.a);
+    }
+  }
+
+  SECTION("Process std::vector<edmtest::Thing>") {
+    ReadWriteTestBuffer buffer;
+
+    ROOTSerializer<std::vector<edmtest::Thing>, ReadWriteTestBuffer> serializer(buffer);
+    ROOTDeserializer<std::vector<edmtest::Thing>, ReadWriteTestBuffer> deserializer(buffer);
+
+    std::vector<edmtest::Thing> t;
+    t.reserve(4);
+    for (int i = 0; i < 4; ++i) {
+      edmtest::Thing temp;
+      temp.a = i;
+      t.push_back(temp);
+    }
+
+    serializer.serialize(t);
+    REQUIRE(buffer.mustGetBufferAgain() == true);
+
+    auto newT = deserializer.deserialize();
+
+    REQUIRE(compare(t, newT));
+    SECTION("Reuse edtest::Thing buffer") {
+      for (auto& v : t) {
+        v.a += 1;
+      }
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == false);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(compare(t, newT));
+    }
+
+    SECTION("Grow") {
+      t.emplace_back();
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == true);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(compare(t, newT));
+    }
+
+    SECTION("Shrink") {
+      t.pop_back();
+      t.pop_back();
+
+      serializer.serialize(t);
+      REQUIRE(buffer.mustGetBufferAgain() == false);
+
+      auto newT = deserializer.deserialize();
+
+      REQUIRE(compare(t, newT));
+    }
+  }
+}

--- a/FWCore/SharedMemory/test/test_channels.cc
+++ b/FWCore/SharedMemory/test/test_channels.cc
@@ -1,0 +1,186 @@
+#include "FWCore/SharedMemory/interface/ControllerChannel.h"
+#include "FWCore/SharedMemory/interface/WorkerChannel.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+#include <stdio.h>
+#include <cassert>
+namespace {
+  int controller(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    ControllerChannel channel("TestChannel", 0);
+
+    //Pipe has to close AFTER we tell the worker to stop
+    auto closePipe = [](FILE* iFile) { pclose(iFile); };
+    std::unique_ptr<FILE, decltype(closePipe)> pipe(nullptr, closePipe);
+
+    auto stopWorkerCmd = [](ControllerChannel* iChannel) { iChannel->stopWorker(); };
+    std::unique_ptr<ControllerChannel, decltype(stopWorkerCmd)> stopWorkerGuard(&channel, stopWorkerCmd);
+
+    {
+      std::string command(argv[0]);
+      command += " ";
+      command += channel.sharedMemoryName();
+      command += " ";
+      command += channel.uniqueID();
+      //make sure output is flushed before popen does any writing
+      fflush(stdout);
+      fflush(stderr);
+
+      channel.setupWorker([&]() {
+        pipe.reset(popen(command.c_str(), "w"));
+
+        if (not pipe) {
+          throw cms::Exception("PipeFailed") << "pipe failed to open " << command;
+        }
+      });
+    }
+    {
+      *channel.toWorkerBufferIndex() = 0;
+      auto result = channel.doTransition(
+          [&]() {
+            if (*channel.fromWorkerBufferIndex() != 1) {
+              throw cms::Exception("BadValue")
+                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+            }
+            if (not channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told not to keep event";
+            }
+          },
+          edm::Transition::Event,
+          2);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+    {
+      *channel.toWorkerBufferIndex() = 1;
+      auto result = channel.doTransition(
+          [&]() {
+            if (*channel.fromWorkerBufferIndex() != 0) {
+              throw cms::Exception("BadValue")
+                  << "wrong value of fromWorkerBufferIndex " << *channel.fromWorkerBufferIndex();
+            }
+            if (channel.shouldKeepEvent()) {
+              throw cms::Exception("BadValue") << "told to keep event";
+            }
+          },
+          edm::Transition::Event,
+          3);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    {
+      auto result = channel.doTransition([&]() {}, edm::Transition::EndLuminosityBlock, 1);
+      if (not result) {
+        throw cms::Exception("TimeOut") << "doTransition timed out";
+      }
+    }
+
+    //std::cout <<"controller going to stop"<<std::endl;
+    return 0;
+  }
+
+  int worker(int argc, char** argv) {
+    using namespace edm::shared_memory;
+
+    assert(argc == 3);
+    WorkerChannel channel(argv[1], argv[2]);
+
+    //std::cerr<<"worker setup\n";
+    channel.workerSetupDone();
+
+    int transitionCount = 0;
+    channel.handleTransitions([&](edm::Transition iTransition, unsigned long long iTransitionID) {
+      switch (transitionCount) {
+        case 0: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 2ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (*channel.toWorkerBufferIndex() != 0) {
+            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          }
+          *channel.fromWorkerBufferIndex() = 1;
+          channel.shouldKeepEvent(true);
+          break;
+        }
+
+        case 1: {
+          if (iTransition != edm::Transition::Event) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 3ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+
+          if (*channel.toWorkerBufferIndex() != 1) {
+            throw cms::Exception("BadValue") << "wrong toWorkerBufferIndex received " << *channel.toWorkerBufferIndex();
+          }
+          *channel.fromWorkerBufferIndex() = 0;
+          channel.shouldKeepEvent(false);
+          break;
+        }
+
+        case 2: {
+          if (iTransition != edm::Transition::EndLuminosityBlock) {
+            throw cms::Exception("BadValue") << "wrong transition received " << static_cast<int>(iTransition);
+          }
+          if (iTransitionID != 1ULL) {
+            throw cms::Exception("BadValue") << "wrong transitionID received " << static_cast<int>(iTransitionID);
+          }
+          break;
+        }
+        default: {
+          throw cms::Exception("MissingStop") << "stopRequested not set";
+        }
+      }
+      ++transitionCount;
+    });
+    if (transitionCount != 3) {
+      throw cms::Exception("MissingStop") << "stop requested too soon " << transitionCount;
+    }
+    return 0;
+  }
+  const char* jobType(bool isWorker) {
+    if (isWorker) {
+      return "Worker";
+    }
+    return "Controller";
+  }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool isWorker = true;
+  int retValue = 0;
+  try {
+    if (argc > 1) {
+      retValue = worker(argc, argv);
+    } else {
+      isWorker = false;
+      retValue = controller(argc, argv);
+    }
+  } catch (std::exception const& iException) {
+    std::cerr << "Caught exception\n" << iException.what() << "\n";
+    if (isWorker) {
+      std::cerr << "in worker\n";
+    } else {
+      std::cerr << "in controller\n";
+    }
+    return 1;
+  }
+  if (0 == retValue) {
+    std::cout << jobType(isWorker) << " success" << std::endl;
+  } else {
+    std::cout << jobType(isWorker) << " failed" << std::endl;
+  }
+  return 0;
+}

--- a/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
+++ b/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
@@ -7,7 +7,7 @@ dir=${PWD}
 cd ${LOCALTOP}
 
 #need to find a test program which we do not put on the PATH
-`find . -name "testFWCoreSharedMemoryMonitorThread" | grep -v '/tmp/'` 6 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread 6 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
 
 retValue=$?
 if [ "$retValue" != "134" ]; then
@@ -19,7 +19,7 @@ else
 fi
 
 
-`find . -name "testFWCoreSharedMemoryMonitorThread" | grep -v '/tmp/'` 11 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread 11 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
 
 retValue=$?
 if [ "$retValue" != "139" ]; then

--- a/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
+++ b/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+dir=${PWD}
+cd ${LOCALTOP}
+
+#need to find a test program which we do not put on the PATH
+`find . -name "testFWCoreSharedMemoryMonitorThread" | grep -v '/tmp/'` 6 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+
+retValue=$?
+if [ "$retValue" != "134" ]; then
+  echo "Wrong return value " $retValue
+  exit $retValue
+else
+  grep -q 'Action run' testFWCoreSharedMemoryMonitorThread.log || die 'Action not run' $?
+  grep -q 'Worker: SIGNAL CAUGHT 6' testFWCoreSharedMemoryMonitorThread.log || die 'Signal not reported' $?
+fi
+
+
+`find . -name "testFWCoreSharedMemoryMonitorThread" | grep -v '/tmp/'` 11 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+
+retValue=$?
+if [ "$retValue" != "139" ]; then
+  echo "Wrong return value " $retValue
+  exit $retValue
+else
+  grep -q 'Action run' testFWCoreSharedMemoryMonitorThread.log || die 'Action not run' $?
+  grep -q 'Worker: SIGNAL CAUGHT 11' testFWCoreSharedMemoryMonitorThread.log || die 'Signal not reported' $?
+fi
+

--- a/FWCore/SharedMemory/test/test_monitorthread.cc
+++ b/FWCore/SharedMemory/test/test_monitorthread.cc
@@ -1,0 +1,19 @@
+#include "FWCore/SharedMemory/interface/WorkerMonitorThread.h"
+#include <iostream>
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
+
+int main(int argc, char** argv) {
+  edm::shared_memory::WorkerMonitorThread monitor;
+
+  monitor.startThread();
+
+  monitor.setAction([&]() { std::cerr << "Action run\n"; });
+  if (argc > 1) {
+    char* end;
+    int sig = std::strtol(argv[1], &end, 10);
+    raise(sig);
+  }
+  return 0;
+}


### PR DESCRIPTION
#### PR description:

This adds the FWCore/SharedMemory package which can be used to allow bi-directional communication between a cmsRun module and an external process running on the same node. This includes an example implementation in FWCore/Integration.

#### PR validation:

The code compiles and all new and existing framework unit tests pass.