### PR TITLE
Update TTTrack for chi2 split

### DIFF
--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -115,7 +115,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
     if (nStubs >= HQNStubs_ && trackChi2R <= HQChi2dof_) {
       numHQTracks++;
 
-      Track_HQ_Pt->Fill(tempTrackPtr->getMomentum(4).perp());  //4 for now for backwards compatibility
+      Track_HQ_Pt->Fill(tempTrackPtr->momentum().perp());  //4 for now for backwards compatibility
       Track_HQ_Eta->Fill(tempTrackPtr->eta());
       Track_HQ_Phi->Fill(tempTrackPtr->phi());
       Track_HQ_VtxZ->Fill(tempTrackPtr->z0());
@@ -132,7 +132,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
     // LQ: now defined as all tracks (including HQ tracks)
     numLQTracks++;
 
-    Track_LQ_Pt->Fill(tempTrackPtr->getMomentum(4).perp());
+    Track_LQ_Pt->Fill(tempTrackPtr->momentum().perp());
     Track_LQ_Eta->Fill(tempTrackPtr->eta());
     Track_LQ_Phi->Fill(tempTrackPtr->phi());
     Track_LQ_VtxZ->Fill(tempTrackPtr->z0());

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -167,6 +167,8 @@ TTTrack<T>::TTTrack() {
   theMomentum = GlobalVector(0.0, 0.0, 0.0);
   theRInv = 0.0;
   thePOCA = GlobalPoint(0.0, 0.0, 0.0);
+  theD0 = 0.;
+  theZ0 = 0.;
   theTanL = 0;
   thePhi = 0;
   theTrkMVA1 = 0;
@@ -187,6 +189,8 @@ TTTrack<T>::TTTrack(std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStu
   theMomentum = GlobalVector(0.0, 0.0, 0.0);
   theRInv = 0.0;
   thePOCA = GlobalPoint(0.0, 0.0, 0.0);
+  theD0 = 0.;
+  theZ0 = 0.;
   theTanL = 0;
   thePhi = 0;
   theTrkMVA1 = 0;
@@ -215,10 +219,12 @@ TTTrack<T>::TTTrack(double aRinv,
                     unsigned int nPar,
                     double aBfield) {
   theStubRefs.clear();
-  double thePT = MagConstant * 1.0 / aRinv * aBfield / 100.0;  // Rinv is in cm-1
+  double thePT = fabs(MagConstant * 1.0 / aRinv * aBfield / 100.0);  // Rinv is in cm-1
   theMomentum = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv = aRinv;
   thePOCA = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
+  theD0 = ad0;
+  theZ0 = az0;
   thePhi = aphi0;
   theTanL = aTanlambda;
   thePhiSector = 0;      // must be set externally
@@ -251,10 +257,12 @@ TTTrack<T>::TTTrack(double aRinv,
                     unsigned int nPar,
                     double aBfield) {
   theStubRefs.clear();
-  double thePT = MagConstant * 1.0 / aRinv * aBfield / 100.0;  // Rinv is in cm-1
+  double thePT = fabs(MagConstant * 1.0 / aRinv * aBfield / 100.0);  // Rinv is in cm-1
   theMomentum = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv = aRinv;
   thePOCA = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
+  theD0 = ad0;
+  theZ0 = az0;
   thePhi = aphi0;
   theTanL = aTanlambda;
   thePhiSector = 0;      // must be set externally

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -115,7 +115,6 @@ public:
 
   /// POCA
   GlobalPoint POCA() const;
-  GlobalPoint getPOCA(unsigned int npar = Npars4) const;
 
   /// MVA Track quality variables
   double trkMVA1() const;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -49,7 +49,7 @@ private:
   double theBField_;  // needed for unpacking
   static constexpr unsigned int Npars4 = 4;
   static constexpr unsigned int Npars5 = 5;
-  static constexpr float MagConstant = CLHEP::c_light / 1.0E9;  //0.299792458;
+  static constexpr float MagConstant = CLHEP::c_light / 1.0E3;  //constant is 0.299792458; who knew c_light was in mm/ns?
 
 public:
   /// Constructors

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -49,7 +49,8 @@ private:
   double theBField_;  // needed for unpacking
   static constexpr unsigned int Npars4 = 4;
   static constexpr unsigned int Npars5 = 5;
-  static constexpr float MagConstant = CLHEP::c_light / 1.0E3;  //constant is 0.299792458; who knew c_light was in mm/ns?
+  static constexpr float MagConstant =
+      CLHEP::c_light / 1.0E3;  //constant is 0.299792458; who knew c_light was in mm/ns?
 
 public:
   /// Constructors

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -63,7 +63,7 @@ public:
           double aChi2,
           double trkMVA1,
           double trkMVA2,
-          double trkMVA3_,
+          double trkMVA3,
           unsigned int aHitpattern,
           unsigned int nPar,
           double Bfield);
@@ -77,7 +77,7 @@ public:
           double aChi2zfit,
           double trkMVA1,
           double trkMVA2,
-          double trkMVA3_,
+          double trkMVA3,
           unsigned int aHitpattern,
           unsigned int nPar,
           double Bfield);
@@ -371,13 +371,13 @@ double TTTrack<T>::stubPtConsistency() const {
   return theStubPtConsistency_;
 }
 
-/// StubPtConsistency
+/// Hit Pattern
 template <typename T>
 unsigned int TTTrack<T>::hitPattern() const {
   return theHitPattern_;
 }
 
-/// StubPtConsistency
+/// set B field if need be
 template <typename T>
 void TTTrack<T>::setBField(double aBField) {
   // if, for some reason, we want to change the value of the B-Field, recompute pT and momentum:

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -344,7 +344,7 @@ double TTTrack<T>::chi2Red() const {
 /// Chi2XY reduced
 template <typename T>
 double TTTrack<T>::chi2XYRed() const {
-  return theChi2_XY_ / (theStubRefs.size() - theNumFitPars_ - 2);
+  return theChi2_XY_ / (theStubRefs.size() - (theNumFitPars_ - 2));
 }
 
 /// Chi2Z reduced

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -13,6 +13,7 @@
 #ifndef L1_TRACK_TRIGGER_TRACK_FORMAT_H
 #define L1_TRACK_TRIGGER_TRACK_FORMAT_H
 
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -26,34 +27,33 @@ class TTTrack : public TTTrack_TrackWord {
 private:
   /// Data members
   std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > theStubRefs;
-  GlobalVector theMomentum;
-  GlobalPoint thePOCA;
-  double theRInv;
-  double thePhi;
-  double theTanL;
-  double theD0;
-  double theZ0;
-  unsigned int thePhiSector;
-  unsigned int theEtaSector;
-  double theStubPtConsistency;
-  double theChi2;
-  double theChi2XY;
-  double theChi2Z;
-  unsigned int numFitPars;
-  unsigned int theHitPattern;
-  double theTrkMVA1;
-  double theTrkMVA2;
-  double theTrkMVA3;
-  int theTrackSeedType;
-  double theBField;  // needed for unpacking
+  GlobalVector theMomentum_;
+  GlobalPoint thePOCA_;
+  double theRInv_;
+  double thePhi_;
+  double theTanL_;
+  double theD0_;
+  double theZ0_;
+  unsigned int thePhiSector_;
+  unsigned int theEtaSector_;
+  double theStubPtConsistency_;
+  double theChi2_;
+  double theChi2_XY_;
+  double theChi2_Z_;
+  unsigned int theNumFitPars_;
+  unsigned int theHitPattern_;
+  double theTrkMVA1_;
+  double theTrkMVA2_;
+  double theTrkMVA3_;
+  int theTrackSeedType_;
+  double theBField_;  // needed for unpacking
   static constexpr unsigned int Npars4 = 4;
   static constexpr unsigned int Npars5 = 5;
-  static constexpr float MagConstant = 0.299792458;
+  static constexpr float MagConstant = CLHEP::c_light/1.0E9;  //0.299792458;
 
 public:
   /// Constructors
   TTTrack();
-  TTTrack(std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > aStubs);
 
   TTTrack(double aRinv,
           double aphi,
@@ -63,7 +63,7 @@ public:
           double aChi2,
           double trkMVA1,
           double trkMVA2,
-          double trkMVA3,
+          double trkMVA3_,
           unsigned int aHitpattern,
           unsigned int nPar,
           double Bfield);
@@ -77,7 +77,7 @@ public:
           double aChi2zfit,
           double trkMVA1,
           double trkMVA2,
-          double trkMVA3,
+          double trkMVA3_,
           unsigned int aHitpattern,
           unsigned int nPar,
           double Bfield);
@@ -122,28 +122,35 @@ public:
   double trkMVA3() const;
 
   /// Phi Sector
-  unsigned int phiSector() const { return thePhiSector; }
-  void setPhiSector(unsigned int aSector) { thePhiSector = aSector; }
+  unsigned int phiSector() const { return thePhiSector_; }
+  void setPhiSector(unsigned int aSector) { thePhiSector_ = aSector; }
 
   /// Eta Sector
-  unsigned int etaSector() const { return theEtaSector; }
-  void setEtaSector(unsigned int aSector) { theEtaSector = aSector; }
+  unsigned int etaSector() const { return theEtaSector_; }
+  void setEtaSector(unsigned int aSector) { theEtaSector_ = aSector; }
 
   /// Track seeding (for debugging)
-  unsigned int trackSeedType() const { return theTrackSeedType; }
-  void setTrackSeedType(int aSeed) { theTrackSeedType = aSeed; }
+  unsigned int trackSeedType() const { return theTrackSeedType_; }
+  void setTrackSeedType(int aSeed) { theTrackSeedType_ = aSeed; }
 
   /// Chi2
   double chi2() const;
   double chi2Red() const;
-  double chi2z() const;
+  double chi2Z() const;
+  double chi2XY() const;
 
   /// Stub Pt consistency
   double stubPtConsistency() const;
   void setStubPtConsistency(double aPtConsistency);
 
   void setFitParNo(unsigned int aFitParNo);
-  int nFitPars() const { return numFitPars; }
+  int nFitPars() const { return theNumFitPars_; }
+
+  /// Hit Pattern
+  unsigned int hitPattern() const;
+
+  /// set new Bfield
+  void setBField( double aBField );
 
   void setTrackWordBits();
   void testTrackWordBits();
@@ -164,45 +171,26 @@ public:
 template <typename T>
 TTTrack<T>::TTTrack() {
   theStubRefs.clear();
-  theMomentum = GlobalVector(0.0, 0.0, 0.0);
-  theRInv = 0.0;
-  thePOCA = GlobalPoint(0.0, 0.0, 0.0);
-  theD0 = 0.;
-  theZ0 = 0.;
-  theTanL = 0;
-  thePhi = 0;
-  theTrkMVA1 = 0;
-  theTrkMVA2 = 0;
-  theTrkMVA3 = 0;
-  thePhiSector = 0;
-  theEtaSector = 0;
-  theTrackSeedType = 0;
-  theChi2 = 0.0;
-  theStubPtConsistency = 0.0;
-  numFitPars = 0;
+  theMomentum_ = GlobalVector(0.0, 0.0, 0.0);
+  theRInv_ = 0.0;
+  thePOCA_ = GlobalPoint(0.0, 0.0, 0.0);
+  theD0_ = 0.;
+  theZ0_ = 0.;
+  theTanL_ = 0;
+  thePhi_ = 0;
+  theTrkMVA1_ = 0;
+  theTrkMVA2_ = 0;
+  theTrkMVA3_ = 0;
+  thePhiSector_ = 0;
+  theEtaSector_ = 0;
+  theTrackSeedType_ = 0;
+  theChi2_ = 0.0;
+  theChi2_XY_ = 0.0;
+  theChi2_Z_ = 0.0;
+  theStubPtConsistency_ = 0.0;
+  theNumFitPars_ = 0;
 }
 
-/// Another Constructor
-template <typename T>
-TTTrack<T>::TTTrack(std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > aStubs) {
-  theStubRefs = aStubs;
-  theMomentum = GlobalVector(0.0, 0.0, 0.0);
-  theRInv = 0.0;
-  thePOCA = GlobalPoint(0.0, 0.0, 0.0);
-  theD0 = 0.;
-  theZ0 = 0.;
-  theTanL = 0;
-  thePhi = 0;
-  theTrkMVA1 = 0;
-  theTrkMVA2 = 0;
-  theTrkMVA3 = 0;
-  thePhiSector = 0;
-  theEtaSector = 0;
-  theTrackSeedType = 0;
-  theChi2 = 0.0;
-  theStubPtConsistency = 0.0;
-  numFitPars = 0;
-}
 
 /// Meant to be default constructor
 template <typename T>
@@ -219,26 +207,28 @@ TTTrack<T>::TTTrack(double aRinv,
                     unsigned int nPar,
                     double aBfield) {
   theStubRefs.clear();
-  double thePT = fabs(MagConstant * 1.0 / aRinv * aBfield / 100.0);  // Rinv is in cm-1
-  theMomentum = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
-  theRInv = aRinv;
-  thePOCA = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
-  theD0 = ad0;
-  theZ0 = az0;
-  thePhi = aphi0;
-  theTanL = aTanlambda;
-  thePhiSector = 0;      // must be set externally
-  theEtaSector = 0;      // must be set externally
-  theTrackSeedType = 0;  // must be set externally
-  theChi2 = aChi2;
-  theTrkMVA1 = trkMVA1;
-  theTrkMVA2 = trkMVA2;
-  theTrkMVA3 = trkMVA3;
-  theStubPtConsistency = 0.0;  // must be set externally
-  numFitPars = nPar;
-  theHitPattern = aHitPattern;
-  theBField = aBfield;
-  // should probably fill the momentum vectur
+  double thePT = std::abs(MagConstant / aRinv * aBfield / 100.0);  // Rinv is in cm-1
+  theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
+  theRInv_ = aRinv;
+  thePOCA_ = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
+  theD0_ = ad0;
+  theZ0_ = az0;
+  thePhi_ = aphi0;
+  theTanL_ = aTanlambda;
+  thePhiSector_ = 0;      // must be set externally
+  theEtaSector_ = 0;      // must be set externally
+  theTrackSeedType_ = 0;  // must be set externally
+  theChi2_ = aChi2;
+  theTrkMVA1_ = trkMVA1;
+  theTrkMVA2_ = trkMVA2;
+  theTrkMVA3_ = trkMVA3;
+  theStubPtConsistency_ = 0.0;  // must be set externally
+  theNumFitPars_ = nPar;
+  theHitPattern_ = aHitPattern;
+  theBField_ = aBfield;
+  theChi2_XY_ = -999.;
+  theChi2_Z_ = -999.;
+
 }
 
 /// Second default constructor with split chi2
@@ -255,29 +245,23 @@ TTTrack<T>::TTTrack(double aRinv,
                     double trkMVA3,
                     unsigned int aHitPattern,
                     unsigned int nPar,
-                    double aBfield) {
-  theStubRefs.clear();
-  double thePT = fabs(MagConstant * 1.0 / aRinv * aBfield / 100.0);  // Rinv is in cm-1
-  theMomentum = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
-  theRInv = aRinv;
-  thePOCA = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
-  theD0 = ad0;
-  theZ0 = az0;
-  thePhi = aphi0;
-  theTanL = aTanlambda;
-  thePhiSector = 0;      // must be set externally
-  theEtaSector = 0;      // must be set externally
-  theTrackSeedType = 0;  // must be set externally
-  theChi2XY = aChi2XY;
-  theChi2Z = aChi2Z;
-  theTrkMVA1 = trkMVA1;
-  theTrkMVA2 = trkMVA2;
-  theTrkMVA3 = trkMVA3;
-  theStubPtConsistency = 0.0;  // must be set externally
-  numFitPars = nPar;
-  theHitPattern = aHitPattern;
-  theBField = aBfield;
-  // should probably fill the momentum vectur
+                    double aBfield):TTTrack( 
+		      aRinv,
+                      aphi0,
+		      aTanlambda,
+		      az0,
+		      ad0,
+		      aChi2XY+aChi2Z, // add chi2 values
+		      trkMVA1,
+		      trkMVA2,
+		      trkMVA3,
+		      aHitPattern,
+		      nPar,
+		      aBfield){  
+
+		      this->theChi2_XY_ = aChi2XY;
+		      this->theChi2_Z_ = aChi2Z;
+
 }
 
 /// Destructor
@@ -286,7 +270,7 @@ TTTrack<T>::~TTTrack() {}
 
 template <typename T>
 void TTTrack<T>::setFitParNo(unsigned int nPar) {
-  numFitPars = nPar;
+  theNumFitPars_ = nPar;
 
   return;
 }
@@ -296,96 +280,119 @@ void TTTrack<T>::setFitParNo(unsigned int nPar) {
 
 template <typename T>
 GlobalVector TTTrack<T>::momentum() const {
-  return theMomentum;
+  return theMomentum_;
 }
 
 template <typename T>
 double TTTrack<T>::rInv() const {
-  return theRInv;
+  return theRInv_;
 }
 
 template <typename T>
 double TTTrack<T>::tanL() const {
-  return theTanL;
+  return theTanL_;
 }
 
 template <typename T>
 double TTTrack<T>::eta() const {
-  return theMomentum.eta();
+  return theMomentum_.eta();
 }
 
 template <typename T>
 double TTTrack<T>::phi() const {
-  return thePhi;
+  return thePhi_;
 }
 
 template <typename T>
 double TTTrack<T>::d0() const {
-  return theD0;
+  return theD0_;
 }
 
 template <typename T>
 double TTTrack<T>::z0() const {
-  return theZ0;
+  return theZ0_;
 }
 
 template <typename T>
 GlobalPoint TTTrack<T>::POCA() const {
-  return thePOCA;
+  return thePOCA_;
 }
 
 /// Chi2
 template <typename T>
 double TTTrack<T>::chi2() const {
-  return theChi2;
+  return theChi2_;
 }
 
-/// Chi2z
+/// Chi2Z
 template <typename T>
-double TTTrack<T>::chi2z() const {
-  return theChi2Z;
+double TTTrack<T>::chi2Z() const {
+  return theChi2_Z_;
+}
+
+/// Chi2XY
+template <typename T>
+double TTTrack<T>::chi2XY() const {
+  return theChi2_XY_;
 }
 
 /// Chi2 reduced
 template <typename T>
 double TTTrack<T>::chi2Red() const {
-  return theChi2 / (2 * theStubRefs.size() - numFitPars);
+  return theChi2_ / (2 * theStubRefs.size() - theNumFitPars_);
 }
 
 /// MVA quality variables
 template <typename T>
 double TTTrack<T>::trkMVA1() const {
-  return theTrkMVA1;
+  return theTrkMVA1_;
 }
 
 template <typename T>
 double TTTrack<T>::trkMVA2() const {
-  return theTrkMVA2;
+  return theTrkMVA2_;
 }
 
 template <typename T>
 double TTTrack<T>::trkMVA3() const {
-  return theTrkMVA3;
+  return theTrkMVA3_;
 }
 
 /// StubPtConsistency
 template <typename T>
 void TTTrack<T>::setStubPtConsistency(double aStubPtConsistency) {
-  theStubPtConsistency = aStubPtConsistency;
+  theStubPtConsistency_ = aStubPtConsistency;
   return;
 }
 
 /// StubPtConsistency
 template <typename T>
 double TTTrack<T>::stubPtConsistency() const {
-  return theStubPtConsistency;
+  return theStubPtConsistency_;
 }
+
+/// StubPtConsistency
+template <typename T>
+unsigned int TTTrack<T>::hitPattern() const {
+  return theHitPattern_;
+}
+
+/// StubPtConsistency
+template <typename T>
+void TTTrack<T>::setBField(double aBField) {
+  // if, for some reason, we want to change the value of the B-Field, recompute pT and momentum:
+  double thePT = std::abs(MagConstant / theRInv_ * aBField / 100.0);  // Rinv is in cm-1
+  theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, thePhi_, thePT * theTanL_));
+
+  return;
+}
+
 
 /// Set bits in 96-bit Track word
 template <typename T>
 void TTTrack<T>::setTrackWordBits() {
-  if (!(numFitPars == Npars4 || numFitPars == Npars5)) {
-    edm::LogError("TTTrack") << " setTrackWordBits method is called with numFitPars=" << numFitPars
+  if (!(theNumFitPars_ == Npars4 || theNumFitPars_ == Npars5)) {
+    edm::LogError("TTTrack") << " setTrackWordBits method is called with theNumFitPars_=" << theNumFitPars_
                              << " only possible values are 4/5" << std::endl;
     return;
   }
@@ -394,11 +401,11 @@ void TTTrack<T>::setTrackWordBits() {
 
   // missing conversion of global phi to difference from sector center phi
 
-  if (theChi2Z == 0.) {
-    setTrackWord(theMomentum, thePOCA, theRInv, theChi2, theChi2Z, theStubPtConsistency, theHitPattern, sparebits);
+  if (theChi2_Z_ <0 ) {    
+    setTrackWord(theMomentum_, thePOCA_, theRInv_, theChi2_, 0, theStubPtConsistency_, theHitPattern_, sparebits);
 
   } else {
-    setTrackWord(theMomentum, thePOCA, theRInv, theChi2XY, theChi2Z, theStubPtConsistency, theHitPattern, sparebits);
+    setTrackWord(theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, sparebits);
   }
   return;
 }
@@ -406,10 +413,10 @@ void TTTrack<T>::setTrackWordBits() {
 /// Test bits in 96-bit Track word
 template <typename T>
 void TTTrack<T>::testTrackWordBits() {
-  //  float rPhi = theMomentum.phi();  // this needs to be phi relative to center of sector ****
-  //float rEta = theMomentum.eta();
-  //float rZ0 = thePOCA.z();
-  //float rD0 = thePOCA.perp();
+  //  float rPhi = theMomentum_.phi();  // this needs to be phi relative to center of sector ****
+  //float rEta = theMomentum_.eta();
+  //float rZ0 = thePOCA_.z();
+  //float rD0 = thePOCA_.perp();
 
   //this is meant for debugging only.
 
@@ -417,8 +424,8 @@ void TTTrack<T>::testTrackWordBits() {
   //std::cout << " eta " << rEta << " " << get_ieta() << std::endl;
   //std::cout << " Z0 " << rZ0 << " " << get_iz0() << std::endl;
   //std::cout << " D0 " << rD0 << " " << get_id0() << std::endl;
-  //std::cout << " Rinv " << theRInv << " " << get_iRinv() << std::endl;
-  //std::cout << " chi2 " << theChi2 << " " << get_ichi2() << std::endl;
+  //std::cout << " Rinv " << theRInv_ << " " << get_iRinv() << std::endl;
+  //std::cout << " chi2 " << theChi2_ << " " << get_ichi2() << std::endl;
 
   return;
 }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -137,7 +137,9 @@ public:
   double chi2() const;
   double chi2Red() const;
   double chi2Z() const;
+  double chi2ZRed() const;
   double chi2XY() const;
+  double chi2XYRed() const;
 
   /// Stub Pt consistency
   double stubPtConsistency() const;
@@ -336,6 +338,18 @@ double TTTrack<T>::chi2XY() const {
 template <typename T>
 double TTTrack<T>::chi2Red() const {
   return theChi2_ / (2 * theStubRefs.size() - theNumFitPars_);
+}
+
+/// Chi2XY reduced
+template <typename T>
+double TTTrack<T>::chi2XYRed() const {
+  return theChi2_XY_ / (theStubRefs.size() - theNumFitPars_ - 2);
+}
+
+/// Chi2Z reduced
+template <typename T>
+double TTTrack<T>::chi2ZRed() const {
+  return theChi2_Z_ / (theStubRefs.size() - 2.);
 }
 
 /// MVA quality variables

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -61,13 +61,12 @@ public:
           double az0,
           double ad0,
           double aChi2,
-	  double trkMVA1,
-	  double trkMVA2,
-	  double trkMVA3,
+          double trkMVA1,
+          double trkMVA2,
+          double trkMVA3,
           unsigned int aHitpattern,
           unsigned int nPar,
           double Bfield);
-
 
   TTTrack(double aRinv,
           double aphi,
@@ -76,9 +75,9 @@ public:
           double ad0,
           double aChi2xyfit,
           double aChi2zfit,
-	  double trkMVA1,
-	  double trkMVA2,
-	  double trkMVA3,
+          double trkMVA1,
+          double trkMVA2,
+          double trkMVA3,
           unsigned int aHitpattern,
           unsigned int nPar,
           double Bfield);
@@ -117,7 +116,6 @@ public:
   /// POCA
   GlobalPoint POCA() const;
   GlobalPoint getPOCA(unsigned int npar = Npars4) const;
-
 
   /// MVA Track quality variables
   double trkMVA1() const;
@@ -211,21 +209,21 @@ TTTrack<T>::TTTrack(double aRinv,
                     double az0,
                     double ad0,
                     double aChi2,
-		    double trkMVA1,
-		    double trkMVA2,
-		    double trkMVA3,
+                    double trkMVA1,
+                    double trkMVA2,
+                    double trkMVA3,
                     unsigned int aHitPattern,
                     unsigned int nPar,
                     double aBfield) {
   theStubRefs.clear();
-  double thePT = MagConstant * 1.0/aRinv * aBfield/100.0;  // Rinv is in cm-1
+  double thePT = MagConstant * 1.0 / aRinv * aBfield / 100.0;  // Rinv is in cm-1
   theMomentum = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv = aRinv;
   thePOCA = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
   thePhi = aphi0;
   theTanL = aTanlambda;
-  thePhiSector = 0;  // must be set externally
-  theEtaSector = 0;  // must be set externally
+  thePhiSector = 0;      // must be set externally
+  theEtaSector = 0;      // must be set externally
   theTrackSeedType = 0;  // must be set externally
   theChi2 = aChi2;
   theTrkMVA1 = trkMVA1;
@@ -247,21 +245,21 @@ TTTrack<T>::TTTrack(double aRinv,
                     double ad0,
                     double aChi2XY,
                     double aChi2Z,
-		    double trkMVA1,
-		    double trkMVA2,
-		    double trkMVA3,
+                    double trkMVA1,
+                    double trkMVA2,
+                    double trkMVA3,
                     unsigned int aHitPattern,
                     unsigned int nPar,
                     double aBfield) {
   theStubRefs.clear();
-  double thePT = MagConstant * 1.0/aRinv * aBfield/100.0;  // Rinv is in cm-1
+  double thePT = MagConstant * 1.0 / aRinv * aBfield / 100.0;  // Rinv is in cm-1
   theMomentum = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
   theRInv = aRinv;
   thePOCA = GlobalPoint(ad0 * cos(aphi0), ad0 * sin(aphi0), az0);
   thePhi = aphi0;
   theTanL = aTanlambda;
-  thePhiSector = 0;  // must be set externally
-  theEtaSector = 0;  // must be set externally
+  thePhiSector = 0;      // must be set externally
+  theEtaSector = 0;      // must be set externally
   theTrackSeedType = 0;  // must be set externally
   theChi2XY = aChi2XY;
   theChi2Z = aChi2Z;
@@ -294,12 +292,10 @@ GlobalVector TTTrack<T>::momentum() const {
   return theMomentum;
 }
 
-
 template <typename T>
 double TTTrack<T>::rInv() const {
   return theRInv;
 }
-
 
 template <typename T>
 double TTTrack<T>::tanL() const {
@@ -343,13 +339,11 @@ double TTTrack<T>::chi2z() const {
   return theChi2Z;
 }
 
-
 /// Chi2 reduced
 template <typename T>
 double TTTrack<T>::chi2Red() const {
   return theChi2 / (2 * theStubRefs.size() - numFitPars);
 }
-
 
 /// MVA quality variables
 template <typename T>
@@ -366,8 +360,6 @@ template <typename T>
 double TTTrack<T>::trkMVA3() const {
   return theTrkMVA3;
 }
-
-
 
 /// StubPtConsistency
 template <typename T>
@@ -395,15 +387,11 @@ void TTTrack<T>::setTrackWordBits() {
 
   // missing conversion of global phi to difference from sector center phi
 
-  if(theChi2Z == 0.) {
-
+  if (theChi2Z == 0.) {
     setTrackWord(theMomentum, thePOCA, theRInv, theChi2, theChi2Z, theStubPtConsistency, theHitPattern, sparebits);
 
-  }
-  else {
-
+  } else {
     setTrackWord(theMomentum, thePOCA, theRInv, theChi2XY, theChi2Z, theStubPtConsistency, theHitPattern, sparebits);
-
   }
   return;
 }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -49,7 +49,7 @@ private:
   double theBField_;  // needed for unpacking
   static constexpr unsigned int Npars4 = 4;
   static constexpr unsigned int Npars5 = 5;
-  static constexpr float MagConstant = CLHEP::c_light/1.0E9;  //0.299792458;
+  static constexpr float MagConstant = CLHEP::c_light / 1.0E9;  //0.299792458;
 
 public:
   /// Constructors
@@ -150,7 +150,7 @@ public:
   unsigned int hitPattern() const;
 
   /// set new Bfield
-  void setBField( double aBField );
+  void setBField(double aBField);
 
   void setTrackWordBits();
   void testTrackWordBits();
@@ -191,7 +191,6 @@ TTTrack<T>::TTTrack() {
   theNumFitPars_ = 0;
 }
 
-
 /// Meant to be default constructor
 template <typename T>
 TTTrack<T>::TTTrack(double aRinv,
@@ -228,7 +227,6 @@ TTTrack<T>::TTTrack(double aRinv,
   theBField_ = aBfield;
   theChi2_XY_ = -999.;
   theChi2_Z_ = -999.;
-
 }
 
 /// Second default constructor with split chi2
@@ -245,23 +243,21 @@ TTTrack<T>::TTTrack(double aRinv,
                     double trkMVA3,
                     unsigned int aHitPattern,
                     unsigned int nPar,
-                    double aBfield):TTTrack( 
-		      aRinv,
-                      aphi0,
-		      aTanlambda,
-		      az0,
-		      ad0,
-		      aChi2XY+aChi2Z, // add chi2 values
-		      trkMVA1,
-		      trkMVA2,
-		      trkMVA3,
-		      aHitPattern,
-		      nPar,
-		      aBfield){  
-
-		      this->theChi2_XY_ = aChi2XY;
-		      this->theChi2_Z_ = aChi2Z;
-
+                    double aBfield)
+    : TTTrack(aRinv,
+              aphi0,
+              aTanlambda,
+              az0,
+              ad0,
+              aChi2XY + aChi2Z,  // add chi2 values
+              trkMVA1,
+              trkMVA2,
+              trkMVA3,
+              aHitPattern,
+              nPar,
+              aBfield) {
+  this->theChi2_XY_ = aChi2XY;
+  this->theChi2_Z_ = aChi2Z;
 }
 
 /// Destructor
@@ -387,7 +383,6 @@ void TTTrack<T>::setBField(double aBField) {
   return;
 }
 
-
 /// Set bits in 96-bit Track word
 template <typename T>
 void TTTrack<T>::setTrackWordBits() {
@@ -401,11 +396,12 @@ void TTTrack<T>::setTrackWordBits() {
 
   // missing conversion of global phi to difference from sector center phi
 
-  if (theChi2_Z_ <0 ) {    
+  if (theChi2_Z_ < 0) {
     setTrackWord(theMomentum_, thePOCA_, theRInv_, theChi2_, 0, theStubPtConsistency_, theHitPattern_, sparebits);
 
   } else {
-    setTrackWord(theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, sparebits);
+    setTrackWord(
+        theMomentum_, thePOCA_, theRInv_, theChi2_XY_, theChi2_Z_, theStubPtConsistency_, theHitPattern_, sparebits);
   }
   return;
 }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -66,7 +66,7 @@ public:
 
   float get_iRinv();
   float get_iphi();
-  float get_ieta();
+  float get_itanl();
   float get_iz0();
   float get_id0();
   float get_ichi2XY();
@@ -77,7 +77,7 @@ public:
 
   float unpack_iRinv();
   float unpack_iphi();
-  float unpack_ieta();
+  float unpack_itanl();
   float unpack_iz0();
   float unpack_id0();
   float unpack_ichi2XY();
@@ -95,7 +95,7 @@ public:
 
   unsigned int get_RinvBits();
   unsigned int get_phiBits();
-  unsigned int get_etaBits();
+  unsigned int get_tanlBits();
   unsigned int get_z0Bits();
   unsigned int get_d0Bits();
   unsigned int get_chi2XYBits();
@@ -109,7 +109,7 @@ public:
 
     iRinv = word.iRinv;
     iphi = word.iphi;
-    ieta = word.ieta;
+    itanl = word.itanl;
     iz0 = word.iz0;
     id0 = word.id0;
     ichi2XY = word.ichi2XY;
@@ -128,7 +128,7 @@ public:
     initialize();
     iRinv = word.iRinv;
     iphi = word.iphi;
-    ieta = word.ieta;
+    itanl = word.itanl;
     iz0 = word.iz0;
     id0 = word.id0;
     ichi2XY = word.ichi2XY;
@@ -155,7 +155,7 @@ private:
   // individual data members (not packed into 96 bits)
   unsigned int iRinv;
   unsigned int iphi;
-  unsigned int ieta;
+  unsigned int itanl;
   unsigned int iz0;
   unsigned int id0;
   unsigned int ichi2XY;
@@ -174,7 +174,7 @@ private:
 
   float valLSBCurv;
   float valLSBPhi;
-  float valLSBEta;
+  float valLSBTanl;
   float valLSBZ0;
   float valLSBD0;
 
@@ -190,7 +190,7 @@ private:
 
   q/R = 14+1 
   phi = 11+1  (relative to sector center)
-  eta = 15+1
+  tanl = 15+1
   z0  = 11+1
   d0  = 12+1                                                                                                                                                      
 
@@ -206,7 +206,7 @@ private:
   // signed quantities: total bits are these values plus one
   const unsigned int NCurvBits = 14;
   const unsigned int NPhiBits = 11;
-  const unsigned int NEtaBits = 15;
+  const unsigned int NTanlBits = 15;
   const unsigned int NZ0Bits = 11;
   const unsigned int ND0Bits = 12;
 
@@ -218,8 +218,8 @@ private:
 
   // establish binning
   const float maxCurv = 0.00855;  // 2 GeV pT Rinv is in cm
-  const float maxPhi = 0.35;      // relative to the center of the sector
-  const float maxEta = 2.776;
+  const float maxPhi = 1.026;     // relative to the center of the sector
+  const float maxTanl = 8.0;
   const float maxZ0 = 30.;
   const float maxD0 = 15.4;
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -24,7 +24,8 @@ public:
   TTTrack_TrackWord(const GlobalVector& Momentum,
                     const GlobalPoint& POCA,
                     double theRinv,
-                    double theChi2,
+                    double theChi2,  // would be xy chisq if chi2Z is non-zero
+                    double theChi2Z,
                     double theBendChi2,
                     unsigned int theHitPattern,
                     unsigned int iSpare);
@@ -34,7 +35,8 @@ public:
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int theChi2,
+                    unsigned int theChi2, // would be xy chisq if chi2Z is non-zero 
+                    unsigned int theChi2Z,
                     unsigned int theBendChi2,
                     unsigned int theHitPattern,
                     unsigned int iSpare);
@@ -42,7 +44,8 @@ public:
   void setTrackWord(const GlobalVector& Momentum,
                     const GlobalPoint& POCA,
                     double theRinv,
-                    double theChi2,
+                    double theChi2,  // would be xy chisq if chi2Z is non-zero 
+		    double theChi2Z,
                     double theBendChi2,
                     unsigned int theHitPattern,
                     unsigned int iSpare);
@@ -52,7 +55,8 @@ public:
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int theChi2,
+                    unsigned int theChi2, // would be xy chisq if chi2Z is non-zero 
+                    unsigned int theChi2Z,
                     unsigned int theBendChi2,
                     unsigned int theHitPattern,
                     unsigned int iSpare);
@@ -66,6 +70,7 @@ public:
   float get_iz0();
   float get_id0();
   float get_ichi2();
+  float get_ichi2Z();
   float get_iBendChi2();
 
   // separate functions for unpacking 96-bit track word
@@ -76,6 +81,7 @@ public:
   float unpack_iz0();
   float unpack_id0();
   float unpack_ichi2();
+  float unpack_ichi2Z();
   float unpack_iBendChi2();
   unsigned int unpack_ispare();
   unsigned int unpack_hitPattern();
@@ -93,6 +99,7 @@ public:
   unsigned int get_z0Bits();
   unsigned int get_d0Bits();
   unsigned int get_chi2Bits();
+  unsigned int get_chi2ZBits();
   unsigned int get_BendChi2Bits();
 
   // copy constructor
@@ -106,6 +113,7 @@ public:
     iz0 = word.iz0;
     id0 = word.id0;
     ichi2 = word.ichi2;
+    ichi2Z = word.ichi2Z;
     iBendChi2 = word.iBendChi2;
     ispare = word.ispare;
     iHitPattern = word.iHitPattern;
@@ -124,6 +132,7 @@ public:
     iz0 = word.iz0;
     id0 = word.id0;
     ichi2 = word.ichi2;
+    ichi2Z = word.ichi2Z;
     iBendChi2 = word.iBendChi2;
     ispare = word.ispare;
     iHitPattern = word.iHitPattern;
@@ -150,6 +159,7 @@ private:
   unsigned int iz0;
   unsigned int id0;
   unsigned int ichi2;
+  unsigned int ichi2Z;
   unsigned int iBendChi2;
   unsigned int ispare;
   unsigned int iHitPattern;
@@ -169,9 +179,10 @@ private:
   float valLSBD0;
 
   float chi2Bins[16];
+  float chi2ZBins[16];
   float Bchi2Bins[8];
 
-  unsigned int Nchi2;
+  unsigned int Nchi2;  // both chi2 have same packing
   unsigned int NBchi2;
 
   /* bits for packing: 
@@ -184,10 +195,11 @@ private:
   d0  = 12+1                                                                                                                                                      
 
   unsigned:
-  chi2     = 4
+  chi2     = 4  (or chisqXY)
   BendChi2 = 3
   hitmask  = 7
-  Spare    = 14 
+  chi2Z    = 4
+  Spare    = 10 
 
   */
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -23,42 +23,42 @@ public:
   TTTrack_TrackWord() {}
   TTTrack_TrackWord(const GlobalVector& Momentum,
                     const GlobalPoint& POCA,
-                    double theRinv,
-                    double theChi2,  // would be xy chisq if chi2Z is non-zero
-                    double theChi2Z,
-                    double theBendChi2,
-                    unsigned int theHitPattern,
+                    double Rinv,
+                    double Chi2,  // would be xy chisq if chi2Z is non-zero
+                    double Chi2Z,
+                    double BendChi2,
+                    unsigned int HitPattern,
                     unsigned int iSpare);
 
-  TTTrack_TrackWord(unsigned int theRinv,
+  TTTrack_TrackWord(unsigned int Rinv,
                     unsigned int phi0,
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int theChi2,  // would be xy chisq if chi2Z is non-zero
-                    unsigned int theChi2Z,
-                    unsigned int theBendChi2,
-                    unsigned int theHitPattern,
+                    unsigned int Chi2XY,  // would be total chisq if chi2Z is zero
+                    unsigned int Chi2Z,
+                    unsigned int BendChi2,
+                    unsigned int HitPattern,
                     unsigned int iSpare);
 
   void setTrackWord(const GlobalVector& Momentum,
                     const GlobalPoint& POCA,
-                    double theRinv,
-                    double theChi2,  // would be xy chisq if chi2Z is non-zero
-                    double theChi2Z,
-                    double theBendChi2,
-                    unsigned int theHitPattern,
+                    double Rinv,
+                    double Chi2XY,  // would be total chisq if chi2Z is zero
+                    double Chi2Z,
+                    double BendChi2,
+                    unsigned int HitPattern,
                     unsigned int iSpare);
 
-  void setTrackWord(unsigned int theRinv,
+  void setTrackWord(unsigned int Rinv,
                     unsigned int phi0,
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int theChi2,  // would be xy chisq if chi2Z is non-zero
-                    unsigned int theChi2Z,
-                    unsigned int theBendChi2,
-                    unsigned int theHitPattern,
+                    unsigned int Chi2XY,  // would be total chisq if chi2Z is zero
+                    unsigned int Chi2Z,
+                    unsigned int BendChi2,
+                    unsigned int HitPattern,
                     unsigned int iSpare);
 
   // getters for unpacked and converted values.
@@ -69,7 +69,7 @@ public:
   float get_ieta();
   float get_iz0();
   float get_id0();
-  float get_ichi2();
+  float get_ichi2XY();
   float get_ichi2Z();
   float get_iBendChi2();
 
@@ -80,7 +80,7 @@ public:
   float unpack_ieta();
   float unpack_iz0();
   float unpack_id0();
-  float unpack_ichi2();
+  float unpack_ichi2XY();
   float unpack_ichi2Z();
   float unpack_iBendChi2();
   unsigned int unpack_ispare();
@@ -98,7 +98,7 @@ public:
   unsigned int get_etaBits();
   unsigned int get_z0Bits();
   unsigned int get_d0Bits();
-  unsigned int get_chi2Bits();
+  unsigned int get_chi2XYBits();
   unsigned int get_chi2ZBits();
   unsigned int get_BendChi2Bits();
 
@@ -112,7 +112,7 @@ public:
     ieta = word.ieta;
     iz0 = word.iz0;
     id0 = word.id0;
-    ichi2 = word.ichi2;
+    ichi2XY = word.ichi2XY;
     ichi2Z = word.ichi2Z;
     iBendChi2 = word.iBendChi2;
     ispare = word.ispare;
@@ -131,7 +131,7 @@ public:
     ieta = word.ieta;
     iz0 = word.iz0;
     id0 = word.id0;
-    ichi2 = word.ichi2;
+    ichi2XY = word.ichi2XY;
     ichi2Z = word.ichi2Z;
     iBendChi2 = word.iBendChi2;
     ispare = word.ispare;
@@ -158,7 +158,7 @@ private:
   unsigned int ieta;
   unsigned int iz0;
   unsigned int id0;
-  unsigned int ichi2;
+  unsigned int ichi2XY;
   unsigned int ichi2Z;
   unsigned int iBendChi2;
   unsigned int ispare;
@@ -217,11 +217,11 @@ private:
   const unsigned int NSpareBits = 14;
 
   // establish binning
-  const float maxCurv = 0.5;  // 2 GeV pT
-  const float maxPhi = 0.35;  // relative to the center of the sector
-  const float maxEta = 2.5;
-  const float maxZ0 = 20.;
-  const float maxD0 = 15.;
+  const float maxCurv = 0.00855;  // 2 GeV pT Rinv is in cm
+  const float maxPhi = 0.35;      // relative to the center of the sector
+  const float maxEta = 2.776;
+  const float maxZ0 = 30.;
+  const float maxD0 = 15.4;
 
 };  // end of class def
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -35,7 +35,7 @@ public:
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int theChi2, // would be xy chisq if chi2Z is non-zero 
+                    unsigned int theChi2,  // would be xy chisq if chi2Z is non-zero
                     unsigned int theChi2Z,
                     unsigned int theBendChi2,
                     unsigned int theHitPattern,
@@ -44,8 +44,8 @@ public:
   void setTrackWord(const GlobalVector& Momentum,
                     const GlobalPoint& POCA,
                     double theRinv,
-                    double theChi2,  // would be xy chisq if chi2Z is non-zero 
-		    double theChi2Z,
+                    double theChi2,  // would be xy chisq if chi2Z is non-zero
+                    double theChi2Z,
                     double theBendChi2,
                     unsigned int theHitPattern,
                     unsigned int iSpare);
@@ -55,7 +55,7 @@ public:
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int theChi2, // would be xy chisq if chi2Z is non-zero 
+                    unsigned int theChi2,  // would be xy chisq if chi2Z is non-zero
                     unsigned int theChi2Z,
                     unsigned int theBendChi2,
                     unsigned int theHitPattern,

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -223,6 +223,22 @@ private:
   const float maxZ0 = 30.;
   const float maxD0 = 15.4;
 
+  // List of offsets and masks.  In principle, all of these could be derived from first
+  // principles given the number of bits. At some future time, we'll do this.
+
+  const unsigned int maskRinv = 0xFFFE0000;
+  const unsigned int maskPhi = 0xFFF00000;
+  const unsigned int maskTanL = 0xFFFF0000;
+  const unsigned int maskD0 = 0x000FFF80;
+  const unsigned int maskZ0 = 0x0000FFF0;
+  const unsigned int maskChi2XY = 0x0000000F;
+  const unsigned int maskChi2Z = 0x00003C00;
+  const unsigned int maskBendChi2 = 0x0001C000;
+  const unsigned int maskHitPat = 0x0000007F;
+  const unsigned int maskSpare = 0x000003FF;
+
+  const unsigned int nWordBits = 32;
+
 };  // end of class def
 
 #endif

--- a/DataFormats/L1TrackTrigger/interface/TTTypes.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTypes.h
@@ -17,6 +17,7 @@
 #include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 
 /// The reference types
 typedef edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> Ref_Phase2TrackerDigi_;

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -164,8 +164,8 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 
   //now pack bits; leave hardcoded for now as am example of how this could work
 
-  seg1 = (itanl << 16);  //take care of word packing later...
-  seg2 = (iz0 << 4);
+  seg1 = (itanl << (nWordBits - (NTanlBits+1)));  // extra bit or bits is for sign //16
+  seg2 = (iz0 << (nWordBits - (NTanlBits + NZ0Bits +2))); //4
   seg3 = ichi2XY;
 
   //set bits
@@ -176,8 +176,8 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
   seg3 = 0;
 
   //second 32-bit word
-  seg1 = (iphi << 20);
-  seg2 = (id0 << 7);
+  seg1 = (iphi << (nWordBits - (NPhiBits+1)));  //20
+  seg2 = (id0 << (nWordBits - (NPhiBits+ND0Bits+2)));//7
 
   //HitMask
   seg3 = theHitPattern;
@@ -191,9 +191,9 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 
   //third 32-bit word
 
-  seg1 = (iRinv << 17);
-  seg2 = (iBendChi2 << 14);
-  seg3 = (ichi2Z << 10);
+  seg1 = (iRinv << (nWordBits - (NCurvBits+1)));  //17
+  seg2 = (iBendChi2 << (nWordBits - (NCurvBits+NBChi2Bits+1))); //14
+  seg3 = (ichi2Z << (nWordBits - (NCurvBits+NBChi2Bits+NChi2Bits+1))); //10
   unsigned int seg4 = ispare;
 
   TrackWord3 = seg1 + seg2 + seg3 + seg4;
@@ -201,7 +201,7 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 // unpack
 
 float TTTrack_TrackWord::unpack_itanl() {
-  unsigned int bits = (TrackWord1 & 0xFFFF0000) >> 16;
+  unsigned int bits = (TrackWord1 & maskTanL) >> (nWordBits - (NTanlBits+1)); //16
   float unpTanl = unpack_Signed(bits, NTanlBits, valLSBTanl);
   return unpTanl;
 }
@@ -217,7 +217,7 @@ unsigned int TTTrack_TrackWord::get_tanlBits() {
 }
 
 float TTTrack_TrackWord::unpack_iz0() {
-  unsigned int bits = (TrackWord1 & 0x0000FFF0) >> 4;
+  unsigned int bits = (TrackWord1 & maskZ0) >> (nWordBits - (NTanlBits + NZ0Bits +2)); //4
   float unpZ0 = unpack_Signed(bits, NZ0Bits, valLSBZ0);
   return unpZ0;
 }
@@ -233,7 +233,7 @@ unsigned int TTTrack_TrackWord::get_z0Bits() {
 }
 
 float TTTrack_TrackWord::unpack_ichi2XY() {
-  unsigned int bits = (TrackWord1 & 0x0000000F);
+  unsigned int bits = (TrackWord1 & maskChi2XY);
   float unpChi2 = chi2Bins[bits];
   return unpChi2;
 }
@@ -249,7 +249,7 @@ unsigned int TTTrack_TrackWord::get_chi2XYBits() {
 }
 
 float TTTrack_TrackWord::unpack_iphi() {
-  unsigned int bits = (TrackWord2 & 0xFFF00000) >> 20;
+  unsigned int bits = (TrackWord2 & maskPhi) >> (nWordBits - (NPhiBits+1)); //20
   float unpPhi = unpack_Signed(bits, NPhiBits, valLSBPhi);
   return unpPhi;
 }
@@ -265,7 +265,7 @@ unsigned int TTTrack_TrackWord::get_phiBits() {
 }
 
 float TTTrack_TrackWord::unpack_id0() {
-  unsigned int bits = (TrackWord2 & 0x000FFF80) >> 7;
+  unsigned int bits = (TrackWord2 & maskD0) >> (nWordBits - (NPhiBits+ND0Bits+2)); //7
   float unpD0 = unpack_Signed(bits, ND0Bits, valLSBD0);
   return unpD0;
 }
@@ -281,14 +281,14 @@ unsigned int TTTrack_TrackWord::get_d0Bits() {
 }
 
 unsigned int TTTrack_TrackWord::unpack_hitPattern() {
-  unsigned int bits = (TrackWord2 & 0x0000007F);
+  unsigned int bits = (TrackWord2 & maskHitPat);
   return bits;
 }
 
 unsigned int TTTrack_TrackWord::get_hitPattern() { return iHitPattern; }
 
 float TTTrack_TrackWord::unpack_iRinv() {
-  unsigned int bits = (TrackWord3 & 0xFFFE0000) >> 17;
+  unsigned int bits = (TrackWord3 & maskRinv) >> (nWordBits - (NCurvBits+1)); //17
   float unpCurv = unpack_Signed(bits, NCurvBits, valLSBCurv);
   return unpCurv;
 }
@@ -299,7 +299,7 @@ float TTTrack_TrackWord::get_iRinv() {
 }
 
 float TTTrack_TrackWord::unpack_iBendChi2() {
-  unsigned int bits = (TrackWord3 & 0x0001C000) >> 14;
+  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits+NBChi2Bits+1));//14
   float unpBChi2 = Bchi2Bins[bits];
   return unpBChi2;
 }
@@ -310,12 +310,12 @@ float TTTrack_TrackWord::get_iBendChi2() {
 }
 
 unsigned int TTTrack_TrackWord::get_BendChi2Bits() {
-  unsigned int bits = (TrackWord3 & 0x0001C000) >> 14;
+  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits+NBChi2Bits+1));//14
   return bits;
 }
 
 float TTTrack_TrackWord::unpack_ichi2Z() {
-  unsigned int bits = (TrackWord3 & 0x00003C00) >> 10;
+  unsigned int bits = (TrackWord3 & maskChi2Z) >> (nWordBits - (NCurvBits+NBChi2Bits+NChi2Bits+1));//10
   float unpChi2Z = chi2ZBins[bits];
   return unpChi2Z;
 }
@@ -326,7 +326,7 @@ float TTTrack_TrackWord::get_ichi2Z() {
 }
 
 unsigned int TTTrack_TrackWord::unpack_ispare() {
-  unsigned int bits = (TrackWord3 & 0x000003FF);
+  unsigned int bits = (TrackWord3 & maskSpare);
   return bits;
 }
 

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -164,8 +164,8 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 
   //now pack bits; leave hardcoded for now as am example of how this could work
 
-  seg1 = (itanl << (nWordBits - (NTanlBits+1)));  // extra bit or bits is for sign //16
-  seg2 = (iz0 << (nWordBits - (NTanlBits + NZ0Bits +2))); //4
+  seg1 = (itanl << (nWordBits - (NTanlBits + 1)));          // extra bit or bits is for sign //16
+  seg2 = (iz0 << (nWordBits - (NTanlBits + NZ0Bits + 2)));  //4
   seg3 = ichi2XY;
 
   //set bits
@@ -176,8 +176,8 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
   seg3 = 0;
 
   //second 32-bit word
-  seg1 = (iphi << (nWordBits - (NPhiBits+1)));  //20
-  seg2 = (id0 << (nWordBits - (NPhiBits+ND0Bits+2)));//7
+  seg1 = (iphi << (nWordBits - (NPhiBits + 1)));           //20
+  seg2 = (id0 << (nWordBits - (NPhiBits + ND0Bits + 2)));  //7
 
   //HitMask
   seg3 = theHitPattern;
@@ -191,9 +191,9 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 
   //third 32-bit word
 
-  seg1 = (iRinv << (nWordBits - (NCurvBits+1)));  //17
-  seg2 = (iBendChi2 << (nWordBits - (NCurvBits+NBChi2Bits+1))); //14
-  seg3 = (ichi2Z << (nWordBits - (NCurvBits+NBChi2Bits+NChi2Bits+1))); //10
+  seg1 = (iRinv << (nWordBits - (NCurvBits + 1)));                            //17
+  seg2 = (iBendChi2 << (nWordBits - (NCurvBits + NBChi2Bits + 1)));           //14
+  seg3 = (ichi2Z << (nWordBits - (NCurvBits + NBChi2Bits + NChi2Bits + 1)));  //10
   unsigned int seg4 = ispare;
 
   TrackWord3 = seg1 + seg2 + seg3 + seg4;
@@ -201,7 +201,7 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 // unpack
 
 float TTTrack_TrackWord::unpack_itanl() {
-  unsigned int bits = (TrackWord1 & maskTanL) >> (nWordBits - (NTanlBits+1)); //16
+  unsigned int bits = (TrackWord1 & maskTanL) >> (nWordBits - (NTanlBits + 1));  //16
   float unpTanl = unpack_Signed(bits, NTanlBits, valLSBTanl);
   return unpTanl;
 }
@@ -217,7 +217,7 @@ unsigned int TTTrack_TrackWord::get_tanlBits() {
 }
 
 float TTTrack_TrackWord::unpack_iz0() {
-  unsigned int bits = (TrackWord1 & maskZ0) >> (nWordBits - (NTanlBits + NZ0Bits +2)); //4
+  unsigned int bits = (TrackWord1 & maskZ0) >> (nWordBits - (NTanlBits + NZ0Bits + 2));  //4
   float unpZ0 = unpack_Signed(bits, NZ0Bits, valLSBZ0);
   return unpZ0;
 }
@@ -249,7 +249,7 @@ unsigned int TTTrack_TrackWord::get_chi2XYBits() {
 }
 
 float TTTrack_TrackWord::unpack_iphi() {
-  unsigned int bits = (TrackWord2 & maskPhi) >> (nWordBits - (NPhiBits+1)); //20
+  unsigned int bits = (TrackWord2 & maskPhi) >> (nWordBits - (NPhiBits + 1));  //20
   float unpPhi = unpack_Signed(bits, NPhiBits, valLSBPhi);
   return unpPhi;
 }
@@ -265,7 +265,7 @@ unsigned int TTTrack_TrackWord::get_phiBits() {
 }
 
 float TTTrack_TrackWord::unpack_id0() {
-  unsigned int bits = (TrackWord2 & maskD0) >> (nWordBits - (NPhiBits+ND0Bits+2)); //7
+  unsigned int bits = (TrackWord2 & maskD0) >> (nWordBits - (NPhiBits + ND0Bits + 2));  //7
   float unpD0 = unpack_Signed(bits, ND0Bits, valLSBD0);
   return unpD0;
 }
@@ -288,7 +288,7 @@ unsigned int TTTrack_TrackWord::unpack_hitPattern() {
 unsigned int TTTrack_TrackWord::get_hitPattern() { return iHitPattern; }
 
 float TTTrack_TrackWord::unpack_iRinv() {
-  unsigned int bits = (TrackWord3 & maskRinv) >> (nWordBits - (NCurvBits+1)); //17
+  unsigned int bits = (TrackWord3 & maskRinv) >> (nWordBits - (NCurvBits + 1));  //17
   float unpCurv = unpack_Signed(bits, NCurvBits, valLSBCurv);
   return unpCurv;
 }
@@ -299,7 +299,7 @@ float TTTrack_TrackWord::get_iRinv() {
 }
 
 float TTTrack_TrackWord::unpack_iBendChi2() {
-  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits+NBChi2Bits+1));//14
+  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits + NBChi2Bits + 1));  //14
   float unpBChi2 = Bchi2Bins[bits];
   return unpBChi2;
 }
@@ -310,12 +310,12 @@ float TTTrack_TrackWord::get_iBendChi2() {
 }
 
 unsigned int TTTrack_TrackWord::get_BendChi2Bits() {
-  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits+NBChi2Bits+1));//14
+  unsigned int bits = (TrackWord3 & maskBendChi2) >> (nWordBits - (NCurvBits + NBChi2Bits + 1));  //14
   return bits;
 }
 
 float TTTrack_TrackWord::unpack_ichi2Z() {
-  unsigned int bits = (TrackWord3 & maskChi2Z) >> (nWordBits - (NCurvBits+NBChi2Bits+NChi2Bits+1));//10
+  unsigned int bits = (TrackWord3 & maskChi2Z) >> (nWordBits - (NCurvBits + NBChi2Bits + NChi2Bits + 1));  //10
   float unpChi2Z = chi2ZBins[bits];
   return unpChi2Z;
 }

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -18,12 +18,12 @@
 TTTrack_TrackWord::TTTrack_TrackWord(const GlobalVector& Momentum,
                                      const GlobalPoint& POCA,
                                      double theRinv,
-                                     double theChi2,
+                                     double theChi2XY,
                                      double theChi2Z,
                                      double theBendChi2,
                                      unsigned int theHitPattern,
                                      unsigned int iSpare) {
-  setTrackWord(Momentum, POCA, theRinv, theChi2, theChi2Z, theBendChi2, theHitPattern, iSpare);
+  setTrackWord(Momentum, POCA, theRinv, theChi2XY, theChi2Z, theBendChi2, theHitPattern, iSpare);
 }
 
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int theRinv,
@@ -31,7 +31,7 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int theRinv,
                                      unsigned int eta,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int theChi2,
+                                     unsigned int theChi2XY,
                                      unsigned int theChi2Z,
                                      unsigned int theBendChi2,
                                      unsigned int theHitPattern,
@@ -41,7 +41,7 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int theRinv,
       ieta(eta),
       iz0(z0),
       id0(d0),
-      ichi2(theChi2),          //revert to other packing?  Or will be unpacked wrong
+      ichi2XY(theChi2XY),      //revert to other packing?  Or will be unpacked wrong
       ichi2Z(theChi2Z),        //revert to other packing?  Or will be unpacked wrong
       iBendChi2(theBendChi2),  // revert to ogher packing? Or will be unpacked wrong
       ispare(iSpare),
@@ -56,7 +56,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int theRinv,
                                      unsigned int eta,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int theChi2,
+                                     unsigned int theChi2XY,
                                      unsigned int theChi2Z,
                                      unsigned int theBendChi2,
                                      unsigned int theHitPattern,
@@ -66,7 +66,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int theRinv,
   ieta = eta;
   iz0 = z0;
   id0 = d0;
-  ichi2 = theChi2;          //revert to other packing?  Or will be unpacked wrong
+  ichi2XY = theChi2XY;      //revert to other packing?  Or will be unpacked wrong
   ichi2Z = theChi2Z;        //revert to other packing?  Or will be unpacked wrong
   iBendChi2 = theBendChi2;  // revert to ogher packing? Or will be unpacked wrong
   ispare = iSpare;
@@ -79,7 +79,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int theRinv,
 void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
                                      const GlobalPoint& POCA,
                                      double theRinv,
-                                     double theChi2,
+                                     double theChi2XY,
                                      double theChi2Z,
                                      double theBendChi2,
                                      unsigned int theHitPattern,
@@ -109,11 +109,11 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 
   //chi2 has non-linear bins
 
-  ichi2 = 0;
+  ichi2XY = 0;
 
   for (unsigned int ibin = 0; ibin < Nchi2; ++ibin) {
-    ichi2 = ibin;
-    if (theChi2 < chi2Bins[ibin])
+    ichi2XY = ibin;
+    if (theChi2XY < chi2Bins[ibin])
       break;
   }
 
@@ -166,7 +166,7 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
 
   seg1 = (ieta << 16);  //take care of word packing later...
   seg2 = (iz0 << 4);
-  seg3 = ichi2;
+  seg3 = ichi2XY;
 
   //set bits
 
@@ -232,20 +232,20 @@ unsigned int TTTrack_TrackWord::get_z0Bits() {
   return iz0;
 }
 
-float TTTrack_TrackWord::unpack_ichi2() {
+float TTTrack_TrackWord::unpack_ichi2XY() {
   unsigned int bits = (TrackWord1 & 0x0000000F);
   float unpChi2 = chi2Bins[bits];
   return unpChi2;
 }
 
-float TTTrack_TrackWord::get_ichi2() {
-  float unpChi2 = chi2Bins[ichi2];
+float TTTrack_TrackWord::get_ichi2XY() {
+  float unpChi2 = chi2Bins[ichi2XY];
   return unpChi2;
 }
 
-unsigned int TTTrack_TrackWord::get_chi2Bits() {
+unsigned int TTTrack_TrackWord::get_chi2XYBits() {
   //unsigned int bits = (TrackWord1 & 0x0000000F);
-  return ichi2;
+  return ichi2XY;
 }
 
 float TTTrack_TrackWord::unpack_iphi() {
@@ -321,7 +321,7 @@ float TTTrack_TrackWord::unpack_ichi2Z() {
 }
 
 float TTTrack_TrackWord::get_ichi2Z() {
-  float unpChi2Z = chi2ZBins[ichi2];
+  float unpChi2Z = chi2ZBins[ichi2Z];
   return unpChi2Z;
 }
 

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -194,7 +194,7 @@ void TTTrack_TrackWord::setTrackWord(const GlobalVector& Momentum,
   seg1 = (iRinv << 17);
   seg2 = (iBendChi2 << 14);
   seg3 = (ichi2Z << 10);
-  unsigned int seg4 = ispare; 
+  unsigned int seg4 = ispare;
 
   TrackWord3 = seg1 + seg2 + seg3 + seg4;
 }
@@ -315,7 +315,7 @@ unsigned int TTTrack_TrackWord::get_BendChi2Bits() {
 }
 
 float TTTrack_TrackWord::unpack_ichi2Z() {
-  unsigned int bits = (TrackWord3 & 0x00003C00) >> 10; 
+  unsigned int bits = (TrackWord3 & 0x00003C00) >> 10;
   float unpChi2Z = chi2ZBins[bits];
   return unpChi2Z;
 }
@@ -394,7 +394,6 @@ void TTTrack_TrackWord::initialize() {
   valLSBZ0 = maxZ0 / float(z0Bins);
   valLSBD0 = maxD0 / float(d0Bins);
 
-
   chi2Bins[0] = 0.25;
   chi2Bins[1] = 0.5;
   chi2Bins[2] = 1.0;
@@ -426,7 +425,6 @@ void TTTrack_TrackWord::initialize() {
   chi2ZBins[12] = 500.;
   chi2ZBins[13] = 1000.;
   chi2ZBins[14] = 3000.;
-
 
   Bchi2Bins[0] = 0.5;
   Bchi2Bins[1] = 1.25;

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -23,6 +23,6 @@
  <class name="TTTrack_TrackWord"/>
  <class name="std::vector<TTTrack_TrackWord>"/>
  <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>
-
+ <class name="edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
 </lcgdict>
 

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -20,6 +20,9 @@
   <class name="vector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
+ <class name="TTTrack_TrackWord"/>
+ <class name="std::vector<TTTrack_TrackWord>"/>
+ <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>
 
 </lcgdict>
 

--- a/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
+++ b/L1Trigger/TrackTrigger/src/StubPtConsistency.cc
@@ -21,7 +21,7 @@ namespace StubPtConsistency {
 
     // Need the pT signed in order to determine if bend is positive or negative
     // P(MeV/c) = (c/10^9)·Q·B(kG)·R(cm)
-    float trk_signedPt = speedOfLightConverted * mMagneticFieldStrength / aTrack.getRInv(nPar);
+    float trk_signedPt = speedOfLightConverted * mMagneticFieldStrength / aTrack.rInv();
 
     // loop over stubs
     const auto& stubRefs = aTrack.getStubRefs();

--- a/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
+++ b/Validation/SiOuterTrackerV/plugins/OuterTrackerMonitorTrackingParticles.cc
@@ -239,7 +239,7 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event &iEvent, con
         dmatch_eta = std::fabs(my_tp->p4().eta() - tmp_tp_eta);
         dmatch_phi = std::fabs(my_tp->p4().phi() - tmp_tp_phi);
         match_id = my_tp->pdgId();
-        float tmp_trk_chi2dof = (thisTrack->getChi2(L1Tk_nPar)) / (2 * tmp_trk_nstub - L1Tk_nPar);
+        float tmp_trk_chi2dof = (thisTrack->chi2()) / (2 * tmp_trk_nstub - L1Tk_nPar);
 
         // ensure that track is uniquely matched to the TP we are looking at!
         if (dmatch_pt < 0.1 && dmatch_eta < 0.1 && dmatch_phi < 0.1 && tmp_tp_pdgid == match_id) {
@@ -264,20 +264,20 @@ void OuterTrackerMonitorTrackingParticles::analyze(const edm::Event &iEvent, con
       int tmp_matchTrk_nStub = -999;
       float tmp_matchtrk_d0 = -999;
 
-      tmp_matchtrk_pt = matchedTracks[i_track]->getMomentum(L1Tk_nPar).perp();
-      tmp_matchtrk_eta = matchedTracks[i_track]->getMomentum(L1Tk_nPar).eta();
-      tmp_matchtrk_phi = matchedTracks[i_track]->getMomentum(L1Tk_nPar).phi();
-      tmp_matchtrk_VtxZ = matchedTracks[i_track]->getPOCA(L1Tk_nPar).z();
-      tmp_matchtrk_chi2 = matchedTracks[i_track]->getChi2(L1Tk_nPar);
-      tmp_matchtrk_chi2dof = matchedTracks[i_track]->getChi2Red(L1Tk_nPar);
+      tmp_matchtrk_pt = matchedTracks[i_track]->momentum().perp();
+      tmp_matchtrk_eta = matchedTracks[i_track]->eta();
+      tmp_matchtrk_phi = matchedTracks[i_track]->phi();
+      tmp_matchtrk_VtxZ = matchedTracks[i_track]->z0();
+      tmp_matchtrk_chi2 = matchedTracks[i_track]->chi2();
+      tmp_matchtrk_chi2dof = matchedTracks[i_track]->chi2Red();
       tmp_matchTrk_nStub = (int)matchedTracks[i_track]->getStubRefs().size();
 
       Track_MatchedChi2->Fill(tmp_matchtrk_chi2);
       Track_MatchedChi2Red->Fill(tmp_matchtrk_chi2dof);
 
       //for d0
-      float tmp_matchtrk_x0 = matchedTracks[i_track]->getPOCA(L1Tk_nPar).x();
-      float tmp_matchtrk_y0 = matchedTracks[i_track]->getPOCA(L1Tk_nPar).y();
+      float tmp_matchtrk_x0 = matchedTracks[i_track]->POCA().x();
+      float tmp_matchtrk_y0 = matchedTracks[i_track]->POCA().y();
       tmp_matchtrk_d0 = -tmp_matchtrk_x0 * sin(tmp_matchtrk_phi) + tmp_matchtrk_y0 * cos(tmp_matchtrk_phi);
 
       //Add cuts for the matched tracks, numerator


### PR DESCRIPTION
#### PR description:

Added capability of splitting chisq into separate xy and z calculations for different track fits. Added three new (as yet undefined) MVA-based track quality variables.  Cleaned up some of the code, including some variable assignments that were previously missing.

#### PR validation:

Track finding code runs with these new modifications.  TTTrack just stores information.

