### PR TITLE
Update phase-2 GT to D49 geometry

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -78,7 +78,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '110X_mcRun4_realistic_v2'
+    'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

The PR is to update phase-2 GT in autoCond which contains D49 (T15 in autoCondPhase2 ) geometry as in PR #27517

#### PR validation:

A technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR:

Not a backport

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
