### PR TITLE
[CLANG] Fix compilation error with LLVM 9.0.1

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h
@@ -22,7 +22,7 @@ namespace fastTrackerRecHitType {
     siStripProjectedStereo2D = 5,
   };
   inline trackerHitRTTI::RTTI rtti(HitType hitType) {
-    if (hitType >= 0 && hitType <= 2)
+    if (hitType >= siPixel && hitType <= siStrip2D)
       return trackerHitRTTI::fastSingle;
     else if (hitType == siStripMatched2D)
       return trackerHitRTTI::fastMatch;


### PR DESCRIPTION
Fix compilation error [a] which we see while using LLVM 9.0.1

[a]
```
In file included from CMSSW_11_1_CLANG_X_2020-01-17-2300/src/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h:47:
  CMSSW_11_1_CLANG_X_2020-01-17-2300/src/DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h:25:17: error: result of comparison of unsigned enum expression >= 0 is always true [-Werror,-Wtautological-unsigned-enum-zero-compare]
     if (hitType >= 0 && hitType <= 2)
        ~~~~~~~ ^  ~
```