### PR TITLE
[HLTrigger/JSONMonitoring] updated sanity check in L1TriggerJSONMonitoring

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -230,7 +230,7 @@ void L1TriggerJSONMonitoring::analyze(edm::StreamID sid, edm::Event const& event
 
   // get hold of TriggerResults
   edm::Handle<GlobalAlgBlkBxCollection> handle;
-  if (not event.getByToken(level1ResultsToken_, handle) or not handle.isValid()) {
+  if (not event.getByToken(level1ResultsToken_, handle) or not handle.isValid() or handle->isEmpty(0)){
     edm::LogError("L1TriggerJSONMonitoring")
         << "L1 trigger results with label [" + level1Results_.encode() + "] not present or invalid";
     return;

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -230,7 +230,7 @@ void L1TriggerJSONMonitoring::analyze(edm::StreamID sid, edm::Event const& event
 
   // get hold of TriggerResults
   edm::Handle<GlobalAlgBlkBxCollection> handle;
-  if (not event.getByToken(level1ResultsToken_, handle) or not handle.isValid() or handle->isEmpty(0)){
+  if (not event.getByToken(level1ResultsToken_, handle) or not handle.isValid() or handle->isEmpty(0)) {
     edm::LogError("L1TriggerJSONMonitoring")
         << "L1 trigger results with label [" + level1Results_.encode() + "] not present or invalid";
     return;


### PR DESCRIPTION
#### PR description:

This PR improves one sanity check done in the plugin `L1TriggerJSONMonitoring`, requiring that the `GlobalAlgBlk` object associated to BX=0 be not empty, in order to avoid a crash [here](https://github.com/cms-sw/cmssw/blob/36043c964252b5f2d3d993a7edc281776606932e/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc#L242).

This kind of crash occurred a few times during the last MWGR (see for example this [elog](http://cmsonline.cern.ch/cms-elog/1099177)); it was caused by the fact that the L1 uGT FED had not been included in the run.

If accepted, this should probably be backported to earlier releases that might be used in future global-runs.

Thanks to @fwyzard for suggesting the fix.

#### PR validation:

Validated with internal HLT tests (rerunning the HLT menu on the relevant error streams).