### PR TITLE
bug-fix for infinite loop in MuonSimClassifier.cc

### DIFF
--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -321,10 +321,12 @@ void MuonSimClassifier::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
               if (mMom->numberOfMothers() > 0) {
                 mMom = mMom->motherRef();
               } else {
-                LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
-                                              << ", status= " << mMom->status();
+                LogTrace("MuonSimClassifier") << "\t No Mother is found ";
                 break;
               }
+
+              LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
+                                            << ", status= " << mMom->status();
             }
             genMom = mMom;  // redefine genMom
             simInfo[i].motherPdgId = genMom->pdgId();

--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -321,8 +321,11 @@ void MuonSimClassifier::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
               if (mMom->numberOfMothers() > 0) {
                 mMom = mMom->motherRef();
               }
-              LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
-                                            << ", status= " << mMom->status();
+	      else{
+		LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
+					      << ", status= " << mMom->status();
+		break;
+	      }
             }
             genMom = mMom;  // redefine genMom
             simInfo[i].motherPdgId = genMom->pdgId();

--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -320,12 +320,11 @@ void MuonSimClassifier::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
               jm++;
               if (mMom->numberOfMothers() > 0) {
                 mMom = mMom->motherRef();
+              } else {
+                LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
+                                              << ", status= " << mMom->status();
+                break;
               }
-	      else{
-		LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
-					      << ", status= " << mMom->status();
-		break;
-	      }
             }
             genMom = mMom;  // redefine genMom
             simInfo[i].motherPdgId = genMom->pdgId();


### PR DESCRIPTION
#### PR description:

Infinite loop happens in the RECOSIM step, because Gen Muons appear as the first GenParticle in the tree: https://its.cern.ch/jira/browse/CMSMUONS-312
Added a break to end the loop (when it happens) still keeping the LogTrace.
This fix the issue.

#### PR validation:
Validation done using the configuration, LHE and few root files provided by pdmv (can be found in
/afs/cern.ch/user/s/srimanob/public/ForPdmV/McM/PPS-RunIIFall18GS-00004)

Running runTheMatrix.py -l limited -i all
6 5 4 3 2 0 0 0 0 tests passed, 28 0 0 0 0 0 0 0 0 failed 

Backporting is needed in 10_2_X  
