### PR TITLE
Rename candidate GTs to use official names and update alcareco trigger bits

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,10 +32,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '110X_dataRun2_relval_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v9',
+    'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v10',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v9',
-    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v9',
+    'run2_data_promptlike'    : '110X_dataRun2_PromptLike_v10',
+    'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,21 +16,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '110X_mcRun2_design_v5',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_Candidate_2020_01_21_10_53_15',
+    'run2_mc_pre_vfp'   :   '110X_mcRun2_asymptotic_preVFP_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '110X_mcRun2_asymptotic_Candidate_2020_01_21_10_51_32',
+    'run2_mc'           :   '110X_mcRun2_asymptotic_v7',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_Candidate_2020_01_21_10_58_30',
+    'run2_mc_cosmics'   :   '110X_mcRun2cosmics_startup_deco_v6',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_2017_2018_Candidate_2020_01_17_14_50_24',
+    'run1_data'         :   '110X_dataRun2_v10',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_2017_2018_Candidate_2020_01_17_14_50_24',
+    'run2_data'         :   '110X_dataRun2_v10',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_Candidate_2020_01_17_14_52_17',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -46,37 +46,37 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_Candidate_2020_01_19_15_27_07',
+    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '110X_mc2017_design_Candidate_2020_01_17_14_56_45',
+    'phase1_2017_design'       :  '110X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '110X_mc2017_realistic_Candidate_2020_01_17_14_54_08',
+    'phase1_2017_realistic'    :  '110X_mc2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_Candidate_2020_01_17_14_54_57',
+    'phase1_2017_cosmics'      :  '110X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_Candidate_2020_01_17_14_55_41',
+    'phase1_2017_cosmics_peak' :  '110X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '110X_upgrade2018_design_Candidate_2020_01_17_14_58_40',
+    'phase1_2018_design'       :  '110X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_Candidate_2020_01_17_14_59_48',
+    'phase1_2018_realistic'    :  '110X_upgrade2018_realistic_v9',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '110X_upgrade2018_realistic_HEfail_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_Candidate_2020_01_17_15_00_52',
+    'phase1_2018_cosmics'      :   '110X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_Candidate_2020_01_17_15_01_24',
+    'phase1_2018_cosmics_peak' :   '110X_upgrade2018cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '110X_mcRun3_2021_design_Candidate_2020_01_17_15_02_07', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '110X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_Candidate_2020_01_17_15_02_54', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '110X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_Candidate_2020_01_17_15_04_04',
+    'phase1_2021_cosmics'      : '110X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_Candidate_2020_01_17_15_05_07', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '110X_mcRun3_2023_realistic_v8', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_Candidate_2020_01_17_15_06_09', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '110X_mcRun3_2024_realistic_v8', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v2'
 }


### PR DESCRIPTION
#### PR description:

PR #28762 was accidentally approved and merged prior to renaming the GTs to follow the usual convention for official GTs. The string "Candidate" indicates a test GT, which could cause confusion, so this PR simply renames the global tags. The GT diffs below demonstrate that there is no change to the tag content to any of the GTs.

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_preVFP_Candidate_2020_01_21_10_53_15/110X_mcRun2_asymptotic_preVFP_v4 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_Candidate_2020_01_21_10_51_32/110X_mcRun2_asymptotic_v7 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2cosmics_startup_deco_Candidate_2020_01_21_10_58_30/110X_mcRun2cosmics_startup_deco_v6 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_2017_2018_Candidate_2020_01_17_14_50_24/110X_dataRun2_v10 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_Candidate_2020_01_17_14_52_17/110X_dataRun2_relval_v10 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun3_Prompt_Candidate_2020_01_19_15_27_07/106X_dataRun3_Prompt_v5 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mc2017_design_Candidate_2020_01_17_14_56_45/110X_mc2017_design_v3 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mc2017_realistic_Candidate_2020_01_17_14_54_08/110X_mc2017_realistic_v4 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mc2017cosmics_realistic_deco_Candidate_2020_01_17_14_54_57/110X_mc2017cosmics_realistic_deco_v3 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mc2017cosmics_realistic_peak_Candidate_2020_01_17_14_55_41/110X_mc2017cosmics_realistic_peak_v3 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_design_Candidate_2020_01_17_14_58_40/110X_upgrade2018_design_v4 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_Candidate_2020_01_17_14_59_48/110X_upgrade2018_realistic_v9 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_deco_Candidate_2020_01_17_15_00_52/110X_upgrade2018cosmics_realistic_deco_v6 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018cosmics_realistic_peak_Candidate_2020_01_17_15_01_24/110X_upgrade2018cosmics_realistic_peak_v7 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_design_Candidate_2020_01_17_15_02_07/110X_mcRun3_2021_design_v6 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021_realistic_Candidate_2020_01_17_15_02_54/110X_mcRun3_2021_realistic_v8 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2021cosmics_realistic_deco_Candidate_2020_01_17_15_04_04/110X_mcRun3_2021cosmics_realistic_deco_v5  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2023_realistic_Candidate_2020_01_17_15_05_07/110X_mcRun3_2023_realistic_v8  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun3_2024_realistic_Candidate_2020_01_17_15_06_09/110X_mcRun3_2024_realistic_v8  

#### PR validation:

A technical test was performed: `runTheMatrix.py -l limited,7.2,7.22 --ibeos`

#### if this PR is a backport please specify the original PR:

This PR is not a backport and should not be backported.
