### PR TITLE
New unit test to check if valgrind memory leaks functionality is working

### DIFF
--- a/Utilities/ReleaseScripts/test/BuildFile.xml
+++ b/Utilities/ReleaseScripts/test/BuildFile.xml
@@ -1,1 +1,6 @@
 <test name="TestSCRAM" command="run.sh"/>
+<test name="TestValgrind" command="test-valgrind.sh">
+  <flags PRE_TEST="test-valgrind-memleak"/>
+  <use name="valgrind"/>
+</test>
+<bin name="test-valgrind-memleak" file="test-valgrind-memleak.cpp"/>

--- a/Utilities/ReleaseScripts/test/test-valgrind-memleak.cpp
+++ b/Utilities/ReleaseScripts/test/test-valgrind-memleak.cpp
@@ -1,0 +1,4 @@
+int main() {
+   int* a = new int[10];
+   return a[0];
+}

--- a/Utilities/ReleaseScripts/test/test-valgrind-memleak.cpp
+++ b/Utilities/ReleaseScripts/test/test-valgrind-memleak.cpp
@@ -1,4 +1,4 @@
 int main() {
-   int* a = new int[10];
-   return a[0];
+  int* a = new int[10];
+  return a[0];
 }

--- a/Utilities/ReleaseScripts/test/test-valgrind.sh
+++ b/Utilities/ReleaseScripts/test/test-valgrind.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+SCRIPT_NAME=$(basename $0)
+TEST_NAME="test-valgrind-memleak"
+valgrind --leak-check=full --undef-value-errors=no --error-limit=no \
+  ${CMSSW_BASE}/test/${SCRAM_ARCH}/${TEST_NAME} > ${SCRIPT_NAME}.log 2>&1
+
+cat ${SCRIPT_NAME}.log
+echo ""
+COUNT=$(grep 'definitely lost: [1-9][0-9]*' ${SCRIPT_NAME}.log | wc -l)
+rm -f ${SCRIPT_NAME}.log
+
+if [ $COUNT -eq 0 ] ; then
+  echo "ERROR: Valgrind was suppose to find memory leaks"
+  exit 1
+else
+  echo "ALL OK"
+fi


### PR DESCRIPTION
#### PR description:

Valgrind in CMSSW is broken and does not report even simple memory leaks ( https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3546/2/1/1/2/1/1/1/1/2/1/1/1/1/1.html
 ) . This PR adds a unit tests to make sure that valgrind in CMSSW env actually works for memory leaks. More tests can be added later.

#### PR validation:

Build and run locally. This should be tests along with https://github.com/cms-sw/cmsdist/pull/5502