### PR TITLE
[DD4hep] DDFilteredView current volume path and its copy numbers

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -66,6 +66,13 @@ namespace cms {
     //! The physical volume of the current node
     const PlacedVolume volume() const;
 
+    //! The full path to the current node
+    const std::string path() const;
+
+    //! The list of the volume copy numbers
+    //  along the full path to the current node
+    const std::vector<int> copyNos() const;
+
     //! The absolute translation of the current node
     // Return value is Double_t translation[3] with x, y, z elements.
     const Double_t* trans() const;

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -68,11 +68,10 @@ const PlacedVolume DDFilteredView::volume() const {
   return PlacedVolume(node_);
 }
 
-// 
+//
 // This should be used for debug purpose only
 //
-const std::string
-DDFilteredView::path() const {
+const std::string DDFilteredView::path() const {
   TString fullPath;
   it_.back().GetPath(fullPath);
   return std::string(fullPath.Data());
@@ -82,14 +81,13 @@ DDFilteredView::path() const {
 // The vector is filled from bottom up:
 // result[0] contains the current node copy number
 //
-const std::vector<int>
-DDFilteredView::copyNos() const {
+const std::vector<int> DDFilteredView::copyNos() const {
   std::vector<int> result;
 
-  for( int i = it_.back().GetLevel(); i > 0; --i ) {
+  for (int i = it_.back().GetLevel(); i > 0; --i) {
     result.emplace_back(it_.back().GetNode(i)->GetNumber());
   }
-    
+
   return result;
 }
 

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -68,6 +68,31 @@ const PlacedVolume DDFilteredView::volume() const {
   return PlacedVolume(node_);
 }
 
+// 
+// This should be used for debug purpose only
+//
+const std::string
+DDFilteredView::path() const {
+  TString fullPath;
+  it_.back().GetPath(fullPath);
+  return std::string(fullPath.Data());
+}
+
+//
+// The vector is filled from bottom up:
+// result[0] contains the current node copy number
+//
+const std::vector<int>
+DDFilteredView::copyNos() const {
+  std::vector<int> result;
+
+  for( int i = it_.back().GetLevel(); i > 0; --i ) {
+    result.emplace_back(it_.back().GetNode(i)->GetNumber());
+  }
+    
+  return result;
+}
+
 const Double_t* DDFilteredView::trans() const { return it_.back().GetCurrentMatrix()->GetTranslation(); }
 
 const Translation DDFilteredView::translation() const {

--- a/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
@@ -68,6 +68,8 @@ void testDDFilteredView::checkFilteredView() {
   DDFilteredView fview(det.get(), det->description()->worldVolume());
   fview.next(0);
   std::cout << fview.name() << " is a " << cms::dd::name(cms::DDSolidShapeMap, fview.shape()) << "\n";
+  std::cout << "Full path to it is " << fview.path() << "\n";
+  auto copyNos = fview.copyNos();
   if (fview.isA<dd4hep::Box>())
     cout << "It's a Box\n";
   fview.parent();


### PR DESCRIPTION
#### PR description:

* Add an iterator accessor ```path``` that returns a path to a current node. Please, use it sparingly.
*  Add an iterator accessor ```copyNos``` that returns a vector of the volumes copy numbers along the path. The vector index indicates the volume level, e.g. an index 0 refers to the current volume copy number, an index 1 refers to the current volume's parent copy number and so on.

as requested by @bsunanda 

Note: none of the above is needed if the xml selection parts specified in more details.

#### PR validation:

See  ```DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
