### PR TITLE
DQM: Switch to `edm::stream` for `DQMEDAnalyzer`

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
@@ -37,10 +37,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  void beginJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
 
   edm::EDGetTokenT<EBDigiCollection> digiTokenEB_;
   edm::EDGetTokenT<EEDigiCollection> digiTokenEE_;

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
@@ -96,10 +96,6 @@ void ECALpedestalPCLworker::analyze(const edm::Event& iEvent, const edm::EventSe
   }  // ee digis
 }
 
-void ECALpedestalPCLworker::beginJob() {}
-
-void ECALpedestalPCLworker::endJob() {}
-
 void ECALpedestalPCLworker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setUnknown();

--- a/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
+++ b/DQM/CSCMonitorModule/plugins/CSCMonitorModule.h
@@ -27,11 +27,9 @@
 #include <set>
 
 /// DQM Framework stuff
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 
-#include <DQMServices/Core/interface/DQMStore.h>
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
 #include <FWCore/ServiceRegistry/interface/Service.h>
 #include <FWCore/Framework/interface/ESHandle.h>
@@ -72,7 +70,7 @@ static const unsigned int MAX_DMB_SLOT = 10;
  * @class CSCMonitorModule
  * @brief Common CSC DQM Module that uses CSCDQM Framework  
  */
-class CSCMonitorModule : public DQMEDAnalyzer, public cscdqm::MonitorObjectProvider {
+class CSCMonitorModule : public DQMOneEDAnalyzer<>, public cscdqm::MonitorObjectProvider {
   /**
    * Global stuff
    */

--- a/DQM/EcalPreshowerMonitorModule/interface/ESFEDIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESFEDIntegrityTask.h
@@ -22,8 +22,6 @@ protected:
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  void endJob() override;
-
 private:
   int ievt_;
 

--- a/DQM/EcalPreshowerMonitorModule/interface/ESOccupancyTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESOccupancyTask.h
@@ -1,16 +1,13 @@
 #ifndef ESOccupancyTask_H
 #define ESOccupancyTask_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-
-class ESOccupancyTask : public DQMEDAnalyzer {
+class ESOccupancyTask : public DQMOneEDAnalyzer<> {
 public:
   ESOccupancyTask(const edm::ParameterSet& ps);
   ~ESOccupancyTask() override {}

--- a/DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h
@@ -18,7 +18,6 @@ public:
 private:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob(void) override;
 
   edm::EDGetTokenT<ESDigiCollection> digitoken_;
   edm::FileInPath lookup_;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
@@ -20,9 +20,6 @@ protected:
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  /// EndJob
-  void endJob(void) override;
-
   /// Setup
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 

--- a/DQM/EcalPreshowerMonitorModule/interface/ESTrendTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESTrendTask.h
@@ -27,9 +27,6 @@ protected:
   // Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
-  // EndJob
-  void endJob(void) override;
-
   // BeginRun
   void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) override;
 

--- a/DQM/EcalPreshowerMonitorModule/src/ESFEDIntegrityTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESFEDIntegrityTask.cc
@@ -52,8 +52,6 @@ void ESFEDIntegrityTask::bookHistograms(DQMStore::IBooker& iBooker, Run const&, 
   meESFedsNonFatal_ = iBooker.book1D(histo, histo, 56, 520, 576);
 }
 
-void ESFEDIntegrityTask::endJob(void) { LogInfo("ESFEDIntegrityTask") << "analyzed " << ievt_ << " events"; }
-
 void ESFEDIntegrityTask::analyze(const Event& e, const EventSetup& c) {
   ievt_++;
 

--- a/DQM/EcalPreshowerMonitorModule/src/ESPedestalTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESPedestalTask.cc
@@ -72,8 +72,6 @@ void ESPedestalTask::bookHistograms(DQMStore::IBooker& iBooker, Run const&, Even
   }
 }
 
-void ESPedestalTask::endJob(void) { LogInfo("ESPedestalTask") << "analyzed " << ievt_ << " events"; }
-
 void ESPedestalTask::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   ievt_++;
   runNum_ = e.id().run();

--- a/DQM/EcalPreshowerMonitorModule/src/ESRawDataTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESRawDataTask.cc
@@ -75,8 +75,6 @@ void ESRawDataTask::bookHistograms(DQMStore::IBooker& iBooker, Run const&, Event
   meOrbitNumberDiff_->setAxisTitle("Num of Events", 2);
 }
 
-void ESRawDataTask::endJob(void) { LogInfo("ESRawDataTask") << "analyzed " << ievt_ << " events"; }
-
 void ESRawDataTask::analyze(const Event& e, const EventSetup& c) {
   ievt_++;
   runNum_ = e.id().run();

--- a/DQM/EcalPreshowerMonitorModule/src/ESTrendTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESTrendTask.cc
@@ -88,8 +88,6 @@ void ESTrendTask::bookHistograms(DQMStore::IBooker& iBooker, Run const&, EventSe
   hESFiberErrTrendHr_->setAxisTitle("ES Fiber Err / hour", 2);
 }
 
-void ESTrendTask::endJob(void) { LogInfo("ESTrendTask") << "analyzed " << ievt_ << " events"; }
-
 void ESTrendTask::analyze(const Event& e, const EventSetup& c) {
   ievt_++;
 

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -4,8 +4,7 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/Framework/interface/Event.h"
-#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DQM/Physics/interface/TopDQMHelpers.h"
@@ -241,7 +240,6 @@ namespace SingleTopTChannelLepton {
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 /**
    \class   SingleTopTChannelLeptonDQM SingleTopTChannelLeptonDQM.h
@@ -277,7 +275,7 @@ namespace SingleTopTChannelLepton {
 /// define MonitorEnsembple to be used
 // using SingleTopTChannelLepton::MonitorEnsemble;
 
-class SingleTopTChannelLeptonDQM : public DQMEDAnalyzer {
+class SingleTopTChannelLeptonDQM : public DQMOneEDAnalyzer<> {
 public:
   /// default constructor
   SingleTopTChannelLeptonDQM(const edm::ParameterSet& cfg);

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
@@ -1,11 +1,10 @@
 #ifndef SINGLETOPTCHANNELLEPTONDQM_MINIAOD
 #define SINGLETOPTCHANNELLEPTONDQM_MINIAOD
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include <string>
 #include <vector>
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DQM/Physics/interface/TopDQMHelpers.h"
@@ -182,9 +181,8 @@ namespace SingleTopTChannelLepton_miniAOD {
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-class SingleTopTChannelLeptonDQM_miniAOD : public DQMEDAnalyzer {
+class SingleTopTChannelLeptonDQM_miniAOD : public DQMOneEDAnalyzer<> {
 public:
   /// default constructor
   SingleTopTChannelLeptonDQM_miniAOD(const edm::ParameterSet& cfg);

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.h
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.h
@@ -1,11 +1,10 @@
 #ifndef TOPDILEPTONOFFLINEDQM
 #define TOPDILEPTONOFFLINEDQM
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+
 #include <string>
 #include <vector>
-
-#include "FWCore/Framework/interface/Event.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -253,7 +252,6 @@ namespace TopDiLeptonOffline {
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 /**
    \class   TopDiLeptonOfflineDQM TopDiLeptonOfflineDQM.h
@@ -295,7 +293,7 @@ namespace TopDiLeptonOffline {
 /// define MonitorEnsembple to be used
 // using TopDiLeptonOffline::MonitorEnsemble;
 
-class TopDiLeptonOfflineDQM : public DQMEDAnalyzer {
+class TopDiLeptonOfflineDQM : public DQMOneEDAnalyzer<> {
 public:
   /// default constructor
   TopDiLeptonOfflineDQM(const edm::ParameterSet& cfg);

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -1,11 +1,9 @@
 #ifndef TOPSINGLELEPTONDQM
 #define TOPSINGLELEPTONDQM
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include <string>
 #include <vector>
-
-#include "FWCore/Framework/interface/Event.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DQM/Physics/interface/TopDQMHelpers.h"
@@ -223,7 +221,6 @@ namespace TopSingleLepton {
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 /**
    \class   TopSingleLeptonDQM TopSingleLeptonDQM.h
@@ -266,7 +263,7 @@ namespace TopSingleLepton {
 /// define MonitorEnsembple to be used
 // using TopSingleLepton::MonitorEnsemble;
 
-class TopSingleLeptonDQM : public DQMEDAnalyzer {
+class TopSingleLeptonDQM : public DQMOneEDAnalyzer<> {
 public:
   /// default constructor
   TopSingleLeptonDQM(const edm::ParameterSet& cfg);

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
@@ -1,11 +1,10 @@
 #ifndef TOPSINGLELEPTONDQM_MINIAOD
 #define TOPSINGLELEPTONDQM_MINIAOD
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include <string>
 #include <vector>
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DQM/Physics/interface/TopDQMHelpers.h"
@@ -182,9 +181,8 @@ namespace TopSingleLepton_miniAOD {
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-class TopSingleLeptonDQM_miniAOD : public DQMEDAnalyzer {
+class TopSingleLeptonDQM_miniAOD : public DQMOneEDAnalyzer<> {
 public:
   /// default constructor
   TopSingleLeptonDQM_miniAOD(const edm::ParameterSet& cfg);

--- a/DQM/SiStripCommon/test/plugins/testTkHistoMap.cc
+++ b/DQM/SiStripCommon/test/plugins/testTkHistoMap.cc
@@ -5,7 +5,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,7 +35,7 @@
 // class declaration
 //
 
-class testTkHistoMap : public DQMEDAnalyzer {
+class testTkHistoMap : public DQMOneEDAnalyzer<> {
 public:
   explicit testTkHistoMap(const edm::ParameterSet&);
   ~testTkHistoMap();

--- a/DQM/TrackingMonitor/interface/LogMessageMonitor.h
+++ b/DQM/TrackingMonitor/interface/LogMessageMonitor.h
@@ -20,10 +20,10 @@
 #include <memory>
 
 // user include files
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -32,10 +32,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
-
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
 #include <vector>
 #include <string>
@@ -49,7 +46,7 @@ class GetLumi;
 // class declaration
 //
 
-class LogMessageMonitor : public DQMEDAnalyzer {
+class LogMessageMonitor : public DQMOneEDAnalyzer<> {
 public:
   explicit LogMessageMonitor(const edm::ParameterSet&);
   ~LogMessageMonitor() override;

--- a/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackEfficiencyMonitor.h
@@ -43,8 +43,6 @@ public:
   typedef reco::TrackCollection TrackCollection;
   explicit TrackEfficiencyMonitor(const edm::ParameterSet&);
   ~TrackEfficiencyMonitor() override;
-  void beginJob(void) override;
-  void endJob(void) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;

--- a/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxAnalyzer.h
@@ -39,7 +39,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  void endJob() override;
   double mass(double P, double I);
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;

--- a/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackEfficiencyMonitor.cc
@@ -273,11 +273,6 @@ void TrackEfficiencyMonitor::bookHistograms(DQMStore::IBooker& ibooker,
 }
 
 //-----------------------------------------------------------------------------------
-void TrackEfficiencyMonitor::beginJob(void)
-//-----------------------------------------------------------------------------------
-{}
-
-//-----------------------------------------------------------------------------------
 void TrackEfficiencyMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 //-----------------------------------------------------------------------------------
 {
@@ -364,19 +359,6 @@ void TrackEfficiencyMonitor::analyze(const edm::Event& iEvent, const edm::EventS
   }
 
   delete theNavigation;
-}
-
-//-----------------------------------------------------------------------------------
-void TrackEfficiencyMonitor::endJob(void)
-//-----------------------------------------------------------------------------------
-{
-  bool outputMEsInRootFile = conf_.getParameter<bool>("OutputMEsInRootFile");
-  std::string outputFileName = conf_.getParameter<std::string>("OutputFileName");
-  if (outputMEsInRootFile) {
-    dqmStore_->save(outputFileName);
-  }
-
-  //if ( theNavigation ) delete theNavigation;
 }
 
 //-----------------------------------------------------------------------------------

--- a/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxAnalyzer.cc
@@ -41,15 +41,6 @@ dEdxAnalyzer::~dEdxAnalyzer() {
     delete genTriggerEventFlag_;
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void dEdxAnalyzer::endJob() {
-  bool outputMEsInRootFile = conf_.getParameter<bool>("OutputMEsInRootFile");
-  std::string outputFileName = conf_.getParameter<std::string>("OutputFileName");
-  if (outputMEsInRootFile) {
-    dqmStore_->save(outputFileName);
-  }
-}
-
 /*
 // -- BeginRun
 //---------------------------------------------------------------------------------//

--- a/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
+++ b/DQMOffline/Hcal/interface/CaloTowersAnalyzer.h
@@ -44,8 +44,6 @@ public:
   ~CaloTowersAnalyzer() override;
 
   void analyze(edm::Event const &, edm::EventSetup const &) override;
-  void beginJob() override;
-  void endJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
 

--- a/DQMOffline/Hcal/interface/HcalNoiseRates.h
+++ b/DQMOffline/Hcal/interface/HcalNoiseRates.h
@@ -45,9 +45,7 @@ public:
   ~HcalNoiseRates() override;
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
   std::string outputFile_;

--- a/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
+++ b/DQMOffline/Hcal/src/CaloTowersAnalyzer.cc
@@ -451,10 +451,6 @@ void CaloTowersAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
 
 CaloTowersAnalyzer::~CaloTowersAnalyzer() {}
 
-void CaloTowersAnalyzer::endJob() {}
-
-void CaloTowersAnalyzer::beginJob() { nevent = 0; }
-
 void CaloTowersAnalyzer::analyze(edm::Event const &event, edm::EventSetup const &) {
   nevent++;
 

--- a/DQMOffline/Hcal/src/HcalNoiseRates.cc
+++ b/DQMOffline/Hcal/src/HcalNoiseRates.cc
@@ -165,16 +165,5 @@ void HcalNoiseRates::analyze(const edm::Event &iEvent, const edm::EventSetup &ev
   }  // done looping over RBXs
 }
 
-// ------------ method called once each job just before starting event loop
-// ------------
-void HcalNoiseRates::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop
-// ------------
-void HcalNoiseRates::endJob() {
-  if (useAllHistos_)
-    hLumiBlockCount_->Fill(0.0, lumiCountMap_.size());
-}
-
 // define this as a plug-in
 DEFINE_FWK_MODULE(HcalNoiseRates);

--- a/DQMOffline/JetMET/interface/DQMPFCandidateAnalyzer.h
+++ b/DQMOffline/JetMET/interface/DQMPFCandidateAnalyzer.h
@@ -15,15 +15,14 @@
  *          V. Sordini
  */
 
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include <memory>
 #include <fstream>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
@@ -43,8 +42,6 @@
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
@@ -60,7 +57,7 @@
 //class StripSignalOverNoiseCalculator;
 //}
 
-class DQMPFCandidateAnalyzer : public DQMEDAnalyzer {
+class DQMPFCandidateAnalyzer : public DQMOneEDAnalyzer<> {
 public:
   /// Constructor
   DQMPFCandidateAnalyzer(const edm::ParameterSet&);

--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -86,7 +86,6 @@ protected:
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endJob() override;
 
 private:
   //histos booking function

--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -87,7 +87,6 @@ protected:
   void dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endJob() override;
 
   const reco::Vertex getPrimaryVertex(edm::Handle<reco::VertexCollection> const& vertex,
                                       edm::Handle<reco::BeamSpot> const& beamSpot);

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -988,11 +988,6 @@ bool L1TStage2CaloLayer2Offline::doesNotOverlapWithHLTObjects(const l1t::Jet& je
   return matchedObjects.empty();
 }
 
-void L1TStage2CaloLayer2Offline::endJob() {
-  // TODO: In offline, this runs after histograms are saved!
-  //normalise2DHistogramsToBinArea();
-}
-
 void L1TStage2CaloLayer2Offline::normalise2DHistogramsToBinArea() {
   std::vector<MonitorElement*> monElementstoNormalize = {
       h_L1METvsCaloMET_,         h_L1ETMHFvsCaloETMHF_,       h_L1METvsPFMetNoMu_,      h_L1MHTvsRecoMHT_,

--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -670,10 +670,6 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
     }
   }
 }
-void L1TTauOffline::endJob() {
-  // TODO: In offline, this runs after histograms are saved!
-  //normalise2DHistogramsToBinArea();
-}
 
 void L1TTauOffline::normalise2DHistogramsToBinArea() {
   std::vector<MonitorElement*> monElementstoNormalize = {h_L1TauETvsTauET_EB_,

--- a/DQMServices/Components/plugins/DQMEventInfo.cc
+++ b/DQMServices/Components/plugins/DQMEventInfo.cc
@@ -4,7 +4,7 @@
  * \author M. Zanetti - INFN Padova
  *
 */
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include <DQMServices/Core/interface/DQMOneEDAnalyzer.h>
 
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
@@ -32,7 +32,7 @@
 
 #include <boost/algorithm/string/join.hpp>
 
-class DQMEventInfo : public DQMEDAnalyzer {
+class DQMEventInfo : public DQMOneEDAnalyzer<> {
 public:
   /// Constructor
   DQMEventInfo(const edm::ParameterSet& ps);

--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -1,22 +1,45 @@
 #ifndef DQMServices_Core_DQMEDAnalyzer_h
 #define DQMServices_Core_DQMEDAnalyzer_h
 
+#include "FWCore/Framework/interface/stream/makeGlobal.h"
+
+struct DQMEDAnalyzerGlobalCache;
+
+// If we declare a global cache (which is not absolutely needed right now, but
+// might be in the future), the framework will try to pass it to the
+// constructor. But, we don't want to change all subsystem code whenever we
+// change that implementation detail, so instead we hack the framework to not
+// do that. See issue #27125.
+namespace edm::stream::impl {
+  template <typename T>
+  T* makeStreamModule(edm::ParameterSet const& iPSet, DQMEDAnalyzerGlobalCache const* global) {
+    return new T(iPSet);
+  }
+}  // namespace edm::stream::impl
+
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Histograms/interface/DQMToken.h"
+
+struct DQMEDAnalyzerGlobalCache {
+  // slightly overkill for now, but we might want to putt the full DQMStore
+  // here at some point.
+  mutable std::mutex master_;
+  mutable edm::EDPutTokenT<DQMToken> lumiToken_;
+  mutable edm::EDPutTokenT<DQMToken> runToken_;
+};
 
 /**
  * The standard DQM module base.
  */
-class DQMEDAnalyzer : public edm::one::EDProducer<edm::EndRunProducer,
-                                                  edm::one::WatchRuns,
-                                                  edm::EndLuminosityBlockProducer,
-                                                  edm::one::WatchLuminosityBlocks,
-                                                  edm::Accumulator> {
+class DQMEDAnalyzer : public edm::stream::EDProducer<edm::GlobalCache<DQMEDAnalyzerGlobalCache>,
+                                                     edm::EndRunProducer,
+                                                     edm::EndLuminosityBlockProducer,
+                                                     edm::Accumulator> {
 public:
   typedef dqm::reco::DQMStore DQMStore;
   typedef dqm::reco::MonitorElement MonitorElement;
@@ -24,10 +47,28 @@ public:
   virtual bool getCanSaveByLumi() { return true; }
 
   // framework calls in the order of invocation
+
+  static std::unique_ptr<DQMEDAnalyzerGlobalCache> initializeGlobalCache(edm::ParameterSet const&) {
+    return std::make_unique<DQMEDAnalyzerGlobalCache>();
+  }
+
   DQMEDAnalyzer() {
     // for whatever reason we need the explicit `template` keyword here.
     runToken_ = this->template produces<DQMToken, edm::Transition::EndRun>("DQMGenerationRecoRun");
     lumiToken_ = this->template produces<DQMToken, edm::Transition::EndLuminosityBlock>("DQMGenerationRecoLumi");
+  }
+
+  void beginStream(edm::StreamID id) final {
+    // now, since we can't access the global cache in the constructor (we
+    // blocked that above to not expose the cache to the subsystem code,
+    // we need to store the tokens here.
+    // This also requires locking, since the streams will run in parallel.
+    // See https://github.com/cms-sw/cmssw/issues/27291#issuecomment-505909101
+    auto lock = std::scoped_lock(globalCache()->master_);
+    if (globalCache()->runToken_.isUninitialized()) {
+      globalCache()->lumiToken_ = lumiToken_;
+      globalCache()->runToken_ = runToken_;
+    }
   }
 
   void beginRun(edm::Run const& run, edm::EventSetup const& setup) final {
@@ -48,23 +89,24 @@ public:
 
   void accumulate(edm::Event const& event, edm::EventSetup const& setup) final { analyze(event, setup); }
 
-  void endLuminosityBlockProduce(edm::LuminosityBlock& lumi, edm::EventSetup const& setup) final {
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) final {
     edm::Service<DQMStore>()->leaveLumi(lumi.run(), lumi.luminosityBlock(), this->moduleDescription().id());
-    lumi.emplace(lumiToken_);
   }
 
-  // Subsystems could safely override this, but any changes to MEs would not be
-  // noticeable since the product was made already.
-  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final{};
+  static void globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumi,
+                                              edm::EventSetup const& setup,
+                                              LuminosityBlockContext const* context) {
+    lumi.emplace(context->global()->lumiToken_);
+  }
 
-  void endRunProduce(edm::Run& run, edm::EventSetup const& setup) final {
+  void endRun(edm::Run const& run, edm::EventSetup const& setup) final {
     edm::Service<DQMStore>()->leaveLumi(run.run(), /* lumi */ 0, this->moduleDescription().id());
-    run.emplace<DQMToken>(runToken_);
+  }
+  static void globalEndRunProduce(edm::Run& run, edm::EventSetup const& setup, RunContext const* context) {
+    run.emplace<DQMToken>(context->global()->runToken_);
   }
 
-  // Subsystems could safely override this, but any changes to MEs would not be
-  // noticeable since the product was made already.
-  void endRun(edm::Run const&, edm::EventSetup const&) final{};
+  static void globalEndJob(DQMEDAnalyzerGlobalCache const*) {}
 
   // methods to be implemented by the user, in order of invocation
   virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) {}

--- a/FastSimulation/MaterialEffects/test/testMaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/test/testMaterialEffects.cc
@@ -1,5 +1,5 @@
 // user include files
-#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -13,8 +13,6 @@
 #include "FastSimulation/Event/interface/FSimTrack.h"
 #include "FastSimulation/Event/interface/FSimVertex.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include <vector>
 #include <string>

--- a/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
+++ b/FastSimulation/MaterialEffects/test/testNuclearInteractions.cc
@@ -1,5 +1,5 @@
 // user include files
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -16,9 +16,6 @@
 #include "FastSimulation/Event/interface/FSimVertex.h"
 #include "FastSimDataFormats/NuclearInteractions/interface/NUEvent.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include <vector>
 #include <string>
 #include "TFile.h"

--- a/Validation/HcalHits/interface/HcalSimHitsValidation.h
+++ b/Validation/HcalHits/interface/HcalSimHitsValidation.h
@@ -1,7 +1,7 @@
 #ifndef HcalSimHitsValidation_H
 #define HcalSimHitsValidation_H
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -38,7 +38,7 @@
 #include <utility>
 #include <vector>
 
-class HcalSimHitsValidation : public DQMEDAnalyzer {
+class HcalSimHitsValidation : public DQMOneEDAnalyzer<> {
 public:
   HcalSimHitsValidation(edm::ParameterSet const &conf);
   ~HcalSimHitsValidation() override;

--- a/Validation/RecoMuon/src/MuonTrackAnalyzer.cc
+++ b/Validation/RecoMuon/src/MuonTrackAnalyzer.cc
@@ -88,9 +88,6 @@ MuonTrackAnalyzer::~MuonTrackAnalyzer() {
     delete theService;
 }
 
-void MuonTrackAnalyzer::beginJob() {
-  //theFile->cd();
-}
 void MuonTrackAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
                                        edm::Run const &iRun,
                                        edm::EventSetup const & /* iSetup */) {

--- a/Validation/RecoMuon/src/MuonTrackAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackAnalyzer.h
@@ -61,7 +61,6 @@ public:
 
   // Operations
 
-  void beginJob() override;
   void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
   void tracksAnalysis(const edm::Event &event,
                       const edm::EventSetup &eventSetup,

--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -10,11 +10,8 @@
 #define Validation_RecoTrack_SiPixelTrackingRecHitsValid_h
 
 //DQM services for histogram
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -65,7 +62,7 @@
 class TTree;
 class TFile;
 
-class SiPixelTrackingRecHitsValid : public DQMEDAnalyzer {
+class SiPixelTrackingRecHitsValid : public DQMOneEDAnalyzer<> {
 public:
   explicit SiPixelTrackingRecHitsValid(const edm::ParameterSet& conf);
 

--- a/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
@@ -247,7 +247,6 @@ protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) override;
   const MagneticField* magfield2_;
-  void endJob() override;
 
 private:
   DQMStore* dbe_;

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -547,13 +547,6 @@ void SiStripTrackingRecHitsValid::bookHistograms(DQMStore::IBooker &ibooker,
   }
 }
 
-void SiStripTrackingRecHitsValid::endJob() {
-  //Only in standalone mode save local root file
-  if (runStandalone && outputMEsInRootFile) {
-    dbe_->save(outputFileName);
-  }
-}
-
 // Functions that gets called by framework every event
 void SiStripTrackingRecHitsValid::analyze(const edm::Event &e, const edm::EventSetup &es) {
   LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();

--- a/Validation/TrackerDigis/interface/SiPixelDigiValid.h
+++ b/Validation/TrackerDigis/interface/SiPixelDigiValid.h
@@ -25,7 +25,6 @@ public:
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
-  void endJob(void) override;
 
 private:
   std::string outputFile_;

--- a/Validation/TrackerDigis/interface/SiStripDigiValid.h
+++ b/Validation/TrackerDigis/interface/SiStripDigiValid.h
@@ -22,7 +22,6 @@ public:
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
-  void endJob(void) override;
 
 private:
   // TIB  ADC

--- a/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiPixelDigiValid.cc
@@ -272,13 +272,6 @@ void SiPixelDigiValid::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run
   }
 }
 
-void SiPixelDigiValid::endJob() {
-  // Save histos in a file only in standalone mode
-  if (runStandalone && !outputFile_.empty() && dbe_) {
-    dbe_->save(outputFile_);
-  }
-}
-
 void SiPixelDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
   // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;

--- a/Validation/TrackerDigis/plugins/SiStripDigiValid.cc
+++ b/Validation/TrackerDigis/plugins/SiStripDigiValid.cc
@@ -323,12 +323,6 @@ void SiStripDigiValid::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run
   }
 }
 
-void SiStripDigiValid::endJob() {
-  if (runStandalone && !outputFile_.empty() && dbe_) {
-    dbe_->save(outputFile_);
-  }
-}
-
 void SiStripDigiValid::analyze(const edm::Event &e, const edm::EventSetup &c) {
   // Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;

--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -33,9 +33,6 @@ protected:
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
 
-  // EndJob
-  void endJob() override;
-
   // void BookTestHistos(Char_t sname, int nbin, float *xmin, float *xmax);
 
 private:

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -332,19 +332,6 @@ TrackerHitAnalyzer::~TrackerHitAnalyzer() {
   // don't try to delete any pointers - they're handled by DQM machinery
 }
 
-void TrackerHitAnalyzer::endJob() {
-  // According to the previous code some profile plots were created here
-  // However, these profile plots are not in the final root file
-  // For now we comment out these plots (since they are not created in any case)
-  // Then, if needed we will consider moving the booking of the profileplots to
-  // the bookHistograms function and here we will do the profile
-
-  // Save root file only in standalone mode
-  if (runStandalone && !fOutputFile.empty() && fDBE) {
-    fDBE->save(fOutputFile);
-  }
-}
-
 void TrackerHitAnalyzer::analyze(const edm::Event &e, const edm::EventSetup &c) {
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
 

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -34,7 +34,6 @@ public:
 
 protected:
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void beginJob() override;
   void bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) override;
 
 private:

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -51,8 +51,6 @@ SiPixelRecHitsValid::SiPixelRecHitsValid(const edm::ParameterSet& ps)
 
 SiPixelRecHitsValid::~SiPixelRecHitsValid() {}
 
-void SiPixelRecHitsValid::beginJob() {}
-
 void SiPixelRecHitsValid::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, const edm::EventSetup& es) {
   ibooker.setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Pixel/clustBPIX");
 

--- a/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
+++ b/Validation/TrackingMCTruth/interface/TrackingTruthValid.h
@@ -22,7 +22,6 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
   void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &run, const edm::EventSetup &es) override;
-  void endJob() override;
 
 private:
   bool runStandalone;

--- a/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
+++ b/Validation/TrackingMCTruth/plugins/TrackingTruthValid.cc
@@ -185,10 +185,3 @@ void TrackingTruthValid::analyze(const edm::Event &event, const edm::EventSetup 
   }  // End loop over TrackingVertex
   */
 }
-
-void TrackingTruthValid::endJob() {
-  // Only in standalone mode save local root file
-  if (runStandalone && !outputFile.empty() && dbe_) {
-    dbe_->save(outputFile);
-  }
-}


### PR DESCRIPTION
#### PR description:
This PR cashes in on the work in #28622 and all the previous PRs, by changing the module type of `DQMEDAnalyzer` back to `edm::stream`. This should significantly reduce the number of modules blocking concurrent lumisections on production sequences.

This PR depends on #28622 *and includes it*, it should be merged once the other one is in. For now, this is to allow some validation of this change. [Edit: #28622 is in! Rebased on top of it. Validation will still take a while.] [Edit2: #28916 brought in some of the changes that used to be here/are required here, that makes this one a bit cleaner.]

`DQMEDAnalyzer` used to be `edm::stream` based from 2015 to 2018, so *basically* not much should break. However, over the last two years DQM has changed, and some modules grew dependencies on `edm::one` behaviour, while others where migrated from legacy `edm::EDAnalyzer` to `DQMEDAnalyzer` as this became possible. This PR includes a lot of changes to these modules to remove their usage of `beginJob`/`endJob` methods: While we could provide it (and call it e.g. from `beginStream`/`endStream`), it does not make much sense, and most of the modules don't do anything important there anyways. So, I rather banned and removed those methods.

In a few cases, there was non-trivial logic that I'd rather keep, those where migrated to `DQMOneEDAnalyzer` which still provides those methods. However, it still does not make much sense to do anything in `endJob` in a `DQMEDAnalyzer`, since by the time it is called, the DQM output is typically already written to file.

A large number of `DQMOneEDAnalyzer`s remain, so we won't get concurrent LS immediately. These modules need to be either reviewed and rewritten in a concurrent-lumi save way (e.g. by using `LuminosityBlockCache`s), or removed from the production sequences.

Back in 2018, we moved to `edm::one` to reduce memory usage. This change gets us the best of both worlds: concurrent processing while the memory usage stays within O(#concurrentLS), compared to the O(#streams) in 2015, thanks to the new `DQMStore` logic added in #28622.


#### PR validation:

Not much so far, and it is going to be hard. The PR/IB tests barely use multi-threaded execution, leave alone concurrent LS. The big risk are race conditions, which are notoriously hard to spot, even when the right code paths are executed. A clean, bit-by-bit comparison on a larger sample might be a good idea.
