### PR TITLE
do not run test-valgrind-memleak with full path

### DIFF
--- a/Utilities/ReleaseScripts/test/test-valgrind.sh
+++ b/Utilities/ReleaseScripts/test/test-valgrind.sh
@@ -2,8 +2,9 @@
 
 SCRIPT_NAME=$(basename $0)
 TEST_NAME="test-valgrind-memleak"
+which ${TEST_NAME}
 valgrind --leak-check=full --undef-value-errors=no --error-limit=no \
-  ${CMSSW_BASE}/test/${SCRAM_ARCH}/${TEST_NAME} > ${SCRIPT_NAME}.log 2>&1
+         ${TEST_NAME} > ${SCRIPT_NAME}.log 2>&1
 
 cat ${SCRIPT_NAME}.log
 echo ""


### PR DESCRIPTION
#### PR description:

This should fix the `test-valgrind-memleak` unit test which fails when run for IBs. As for IBs, we use tests from release area instead of re-building them locally so that is why `$CMSSW_BASE/test/$SCRAM_ARCH/test-valgrind-memleak` is not available during IB tests. We need to run `test-valgrind-memleak` directly which will be in `PATH` 

#### PR validation:

Local test builds and runs