### PR TITLE
Replace ConfigParser with configparser (Python3 compatibility)

### DIFF
--- a/Alignment/APEEstimation/test/autoSubmitter/autoSubmitter.py
+++ b/Alignment/APEEstimation/test/autoSubmitter/autoSubmitter.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import ConfigParser
+import configparser as ConfigParser
 import argparse
 import shelve
 import sys

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import os
-import ConfigParser # needed for exceptions in this module
+import configparser as ConfigParser # needed for exceptions in this module
 from . import configTemplates
 from .genericValidation import GenericValidation
 from .helperFunctions import replaceByMap, getCommandOutput2, cppboolstring, pythonboolstring, clean_name

--- a/Alignment/OfflineValidation/test/submitAllJobs.py
+++ b/Alignment/OfflineValidation/test/submitAllJobs.py
@@ -17,7 +17,7 @@ import datetime,time
 import os,sys
 import copy
 import string, re
-import ConfigParser, json
+import configparser as ConfigParser, json
 from optparse import OptionParser
 from subprocess import Popen, PIPE
 

--- a/CondCore/DBOutputService/scripts/cmscond_logdb_dump
+++ b/CondCore/DBOutputService/scripts/cmscond_logdb_dump
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from ConfigParser import ConfigParser
+from ConfigParser import configparser as ConfigParser
 from copy import copy
 from optparse import OptionParser, Option, OptionValueError
 import coral

--- a/DQM/Integration/python/config/environment_cfi.py
+++ b/DQM/Integration/python/config/environment_cfi.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os
 import FWCore.ParameterSet.Config as cms
-import ConfigParser
+import configparser as ConfigParser
 
 def loadDQMRunConfigFromFile():
     # try reading the config

--- a/DQMOffline/Alignment/test/alcarecoTester.py
+++ b/DQMOffline/Alignment/test/alcarecoTester.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 import os
 import sys
-import ConfigParser
+import configparser as ConfigParser
 import optparse
 import datetime
 

--- a/FastSimulation/Calorimetry/test/calculateECALresponceScales.py
+++ b/FastSimulation/Calorimetry/test/calculateECALresponceScales.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import ConfigParser
+import configparser as ConfigParser
 import argparse
 import numpy
 

--- a/Geometry/TrackerCommonData/test/twikiExport.py
+++ b/Geometry/TrackerCommonData/test/twikiExport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import optparse
-import ConfigParser
+import configparser as ConfigParser
 
 from os.path import expandvars
 

--- a/HLTriggerOffline/Btag/python/helper.py
+++ b/HLTriggerOffline/Btag/python/helper.py
@@ -5,7 +5,7 @@ http://stackoverflow.com/questions/3220670/read-all-the-contents-in-ini-file-int
 """
 from __future__ import print_function
 
-import ConfigParser as cp 
+import configparser as cp 
 
 Config=cp.ConfigParser()
 

--- a/RecoVertex/BeamSpotProducer/scripts/BeamSpotWorkflow.py
+++ b/RecoVertex/BeamSpotProducer/scripts/BeamSpotWorkflow.py
@@ -37,7 +37,7 @@ from builtins import range
 import sys,os
 import commands, re, time
 import datetime
-import ConfigParser
+import configparser as ConfigParser
 import xmlrpclib
 from BeamSpotObj import BeamSpot
 from IOVObj import IOV

--- a/RecoVertex/BeamSpotProducer/test/InspectFwBeamSpot.py
+++ b/RecoVertex/BeamSpotProducer/test/InspectFwBeamSpot.py
@@ -10,7 +10,7 @@
 
 
 from __future__ import print_function
-import ConfigParser
+import configparser as ConfigParser
 import ROOT
 import sys
 import math


### PR DESCRIPTION
#### PR description:

This PR replaces "import ConfigParser" (compatible only with Python2.X) with "import configparser as ConfigParser" (compatible with both Python 2 and Python 3).
See https://python-future.org/compatible_idioms.html#configparser.

This PR will fix the unit test error of Alignment/OfflineValidation in Python 3
https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_1_PY3_X_2020-01-28-2300/unitTestLogs/Alignment/OfflineValidation#/
The unit test was added with #28739.

#### PR validation:

Unit tests