### PR TITLE
Run3-hcx247 Try to make Hcal reco geometry to be derived from dd4hep

### DIFF
--- a/Geometry/HcalAlgo/data/cms-test-Phase2GeometryFine-algorithm.xml
+++ b/Geometry/HcalAlgo/data/cms-test-Phase2GeometryFine-algorithm.xml
@@ -20,7 +20,8 @@
   <close_geometry/>
 
   <IncludeSection>
-    <Include ref="Geometry/CMSCommonData/data/materials/2021/v1/materials.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/materials.xml"/>
+    <Include ref="Geometry/TrackerCommonData/data/trackermaterial.xml"/>
     <Include ref="Geometry/CMSCommonData/data/rotations.xml"/>
     <Include ref="Geometry/CMSCommonData/data/extend/v2/cmsextent.xml"/>
     <Include ref="Geometry/CMSCommonData/data/cavernData/2017/v1/cavernData.xml"/>
@@ -32,24 +33,42 @@
     <Include ref="Geometry/CMSCommonData/data/muonBase/2026/v2/muonBase.xml"/>
     <Include ref="Geometry/CMSCommonData/data/cmsMuon.xml"/>
     <Include ref="Geometry/CMSCommonData/data/muonMB.xml"/>
-    <Include ref="Geometry/HGCalCommonData/data/hgcal/v8/hgcal.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/ectkcable.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/eregalgo/2026/v1/eregalgo.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/ebalgo.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/ebcon.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/ebrot.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/eecon.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/escon/2026/v1/escon.xml"/>
+    <Include ref="Geometry/EcalCommonData/data/esalgo/2026/v1/esalgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcal/HGCal/hcalalgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalbarrelalgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalendcap/SSAbsorber/hcalendcapalgo.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalouteralgo.xml"/>
-    <Include ref="Geometry/HcalCommonData/data/hcalforwardmaterial.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalforwardalgo.xml"/>
-    <Include ref="Geometry/HcalCommonData/data/hcalforwardfibre.xml"/>
+    <Include ref="Geometry/HcalCommonData/data/hcalSimNumbering/2026/hcalSimNumbering.xml"/>
+    <Include ref="Geometry/HcalCommonData/data/hcalRecNumbering/2026/hcalRecNumbering.xml"/>
+    <Include ref="Geometry/HcalCommonData/data/average/hcalforwardmaterial.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcal/v8/hgcal.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalEE/v8/hgcalEE.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalHEsil/v8/hgcalHEsil.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalwafer/v7/hgcalwafer.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalCons/v8/hgcalCons.xml"/>
     <Include ref="Geometry/ForwardCommonData/data/forwardshield/2017/v1/forwardshield.xml"/>
+    <Include ref="Geometry/EcalSimData/data/PhaseII/ecalsens.xml"/>
     <Include ref="Geometry/HcalCommonData/data/hcalsens/HGCal/hcalsenspmf.xml"/>
-    <Include ref="Geometry/HcalCommonData/data/hcalSimNumbering.xml"/>
-    <Include ref="Geometry/HcalCommonData/data/hcalRecNumbering.xml"/>
     <Include ref="Geometry/HcalSimData/data/hf.xml"/>
     <Include ref="Geometry/HcalSimData/data/hfpmt.xml"/>
-    <Include ref="Geometry/HcalSimData/data/hffibre.xml"/>
     <Include ref="Geometry/HcalSimData/data/hffibrebundle.xml"/>
     <Include ref="Geometry/HcalSimData/data/CaloUtil.xml"/>
+    <Include ref="Geometry/HGCalSimData/data/hgcsensv8.xml"/>
+    <Include ref="Geometry/HGCalSimData/data/hgccons.xml"/>
+    <Include ref="Geometry/HGCalSimData/data/hgcProdCuts.xml"/>
+    <Include ref="Geometry/HcalSimData/data/HcalProdCuts.xml"/>
+    <Include ref="Geometry/EcalSimData/data/EcalProdCuts.xml"/>
+    <Include ref="Geometry/ForwardSimData/data/ForwardShieldProdCuts.xml"/>
+    <Include ref="Geometry/CMSCommonData/data/FieldParameters.xml"/>
   </IncludeSection>
   
 </DDDefinition>

--- a/Geometry/HcalCommonData/interface/HcalGeomParameters.h
+++ b/Geometry/HcalCommonData/interface/HcalGeomParameters.h
@@ -25,8 +25,16 @@ class HcalParameters;
 
 class HcalGeomParameters {
 public:
-  HcalGeomParameters();
-  ~HcalGeomParameters();
+  static constexpr double k_ScaleFromDDD = 0.1;
+  static constexpr double k_ScaleToDDD = 10.0;
+  static constexpr double k_ScaleFromDDDToG4 = 1.0;
+  static constexpr double k_ScaleToDDDFromG4 = 1.0;
+  static constexpr double k_ScaleFromDD4Hep = 1.0;
+  static constexpr double k_ScaleToDD4Hep = 1.0;
+  static constexpr double k_ScaleFromDD4HepToG4 = 10.0;
+  static constexpr double k_ScaleToDD4HepFromG4 = 0.1;
+
+  HcalGeomParameters() = default;
 
   double getConstDzHF() const { return dzVcal_; }
   void getConstRHO(std::vector<double>&) const;

--- a/Geometry/HcalCommonData/interface/HcalParametersFromDD.h
+++ b/Geometry/HcalCommonData/interface/HcalParametersFromDD.h
@@ -14,7 +14,8 @@ public:
   bool build(const cms::DDCompactView*, HcalParameters&);
 
 private:
-  bool build(const HcalParameters&);
+  bool build(HcalParameters&);
+  void rescale(std::vector<double>&, const double s);
 };
 
 #endif

--- a/Geometry/HcalCommonData/src/HcalGeomParameters.cc
+++ b/Geometry/HcalCommonData/src/HcalGeomParameters.cc
@@ -18,18 +18,6 @@ using namespace geant_units::operators;
 
 static const double tan10deg = std::tan(10._deg);
 
-HcalGeomParameters::HcalGeomParameters() {
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::HcalGeomParameters (void) constructor";
-#endif
-}
-
-HcalGeomParameters::~HcalGeomParameters() {
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::destructed!!!";
-#endif
-}
-
 void HcalGeomParameters::getConstRHO(std::vector<double>& rHO) const {
   rHO.emplace_back(rminHO_);
   for (double i : etaHO_)
@@ -67,23 +55,23 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters&
     double dx = 0, dy = 0, dz = 0, dx1 = 0, dx2 = 0;
     double alp(0);
     if (sol.shape() == DDSolidShape::ddbox) {
-      const DDBox& box = static_cast<DDBox>(fv.logicalPart().solid());
-      dx = box.halfX();
-      dy = box.halfY();
-      dz = box.halfZ();
+      const DDBox& box = static_cast<DDBox>(sol);
+      dx = HcalGeomParameters::k_ScaleFromDDDToG4 * box.halfX();
+      dy = HcalGeomParameters::k_ScaleFromDDDToG4 * box.halfY();
+      dz = HcalGeomParameters::k_ScaleFromDDDToG4 * box.halfZ();
     } else if (sol.shape() == DDSolidShape::ddtrap) {
-      const DDTrap& trp = static_cast<DDTrap>(fv.logicalPart().solid());
-      dx1 = trp.x1();
-      dx2 = trp.x2();
-      dx = 0.25 * (trp.x1() + trp.x2() + trp.x3() + trp.x4());
-      dy = 0.5 * (trp.y1() + trp.y2());
-      dz = trp.halfZ();
+      const DDTrap& trp = static_cast<DDTrap>(sol);
+      dx1 = HcalGeomParameters::k_ScaleFromDDDToG4 * trp.x1();
+      dx2 = HcalGeomParameters::k_ScaleFromDDDToG4 * trp.x2();
+      dx = 0.25 * HcalGeomParameters::k_ScaleFromDDDToG4 * (trp.x1() + trp.x2() + trp.x3() + trp.x4());
+      dy = 0.5 * HcalGeomParameters::k_ScaleFromDDDToG4 * (trp.y1() + trp.y2());
+      dz = HcalGeomParameters::k_ScaleFromDDDToG4 * trp.halfZ();
       alp = 0.5 * (trp.alpha1() + trp.alpha2());
     } else if (sol.shape() == DDSolidShape::ddtubs) {
-      const DDTubs& tub = static_cast<DDTubs>(fv.logicalPart().solid());
-      dx = tub.rIn();
-      dy = tub.rOut();
-      dz = tub.zhalf();
+      const DDTubs& tub = static_cast<DDTubs>(sol);
+      dx = HcalGeomParameters::k_ScaleFromDDDToG4 * tub.rIn();
+      dy = HcalGeomParameters::k_ScaleFromDDDToG4 * tub.rOut();
+      dz = HcalGeomParameters::k_ScaleFromDDDToG4 * tub.zhalf();
     }
     if (idet == 3) {
       // HB
@@ -93,7 +81,7 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters&
 #endif
       if (lay >= 0 && lay < maxLayer_) {
         ib_[lay]++;
-        rb_[lay] += t.Rho();
+        rb_[lay] += (HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho());
         if (thkb_[lay] <= 0) {
           if (lay < 17)
             thkb_[lay] = dx;
@@ -103,15 +91,15 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters&
         if (lay < 17) {
           bool found = false;
           for (double k : rxb_) {
-            if (std::abs(k - t.Rho()) < 0.01) {
+            if (std::abs(k - (HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho())) < 0.01) {
               found = true;
               break;
             }
           }
           if (!found) {
-            rxb_.emplace_back(t.Rho());
-            php.rhoxHB.emplace_back(t.Rho() * std::cos(t.phi()));
-            php.zxHB.emplace_back(std::abs(t.z()));
+            rxb_.emplace_back(HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho());
+            php.rhoxHB.emplace_back(HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho() * std::cos(t.phi()));
+            php.zxHB.emplace_back(HcalGeomParameters::k_ScaleFromDDDToG4 * std::abs(t.z()));
             php.dyHB.emplace_back(2. * dy);
             php.dxHB.emplace_back(2. * dz);
             php.layHB.emplace_back(lay);
@@ -134,8 +122,8 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters&
           ifi = copy[nsiz - 3];
         if (nsiz > 3)
           ich = copy[nsiz - 4];
-        double z1 = std::abs((t.z()) + dz);
-        double z2 = std::abs((t.z()) - dz);
+        double z1 = std::abs((HcalGeomParameters::k_ScaleFromDDDToG4 * t.z()) + dz);
+        double z2 = std::abs((HcalGeomParameters::k_ScaleFromDDDToG4 * t.z()) - dz);
         if (std::abs(z1 - z2) < 0.01)
           z1 = 0;
         if (ifi == 1 && ich == 4) {
@@ -179,26 +167,26 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters&
 #endif
       if (lay >= 0 && lay < maxLayer_) {
         ie_[lay]++;
-        ze_[lay] += std::abs(t.z());
+        ze_[lay] += std::abs(HcalGeomParameters::k_ScaleFromDDDToG4 * t.z());
         if (thke_[lay] <= 0)
           thke_[lay] = dz;
-        double rinHE = t.Rho() * cos(alp) - dy;
-        double routHE = t.Rho() * cos(alp) + dy;
+        double rinHE = HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho() * cos(alp) - dy;
+        double routHE = HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho() * cos(alp) + dy;
         rminHE_[lay] += rinHE;
         rmaxHE_[lay] += routHE;
         bool found = false;
         for (double k : php.zxHE) {
-          if (std::abs(k - std::abs(t.z())) < 0.01) {
+          if (std::abs(k - std::abs(HcalGeomParameters::k_ScaleFromDDDToG4 * t.z())) < 0.01) {
             found = true;
             break;
           }
         }
         if (!found) {
-          php.zxHE.emplace_back(std::abs(t.z()));
-          php.rhoxHE.emplace_back(t.Rho() * std::cos(t.phi()));
+          php.zxHE.emplace_back(HcalGeomParameters::k_ScaleFromDDDToG4 * std::abs(t.z()));
+          php.rhoxHE.emplace_back(HcalGeomParameters::k_ScaleFromDDDToG4 * t.Rho() * std::cos(t.phi()));
           php.dyHE.emplace_back(dy * std::cos(t.phi()));
-          dx1 -= 0.5 * (t.rho() - dy) * std::cos(t.phi()) * tan10deg;
-          dx2 -= 0.5 * (t.rho() + dy) * std::cos(t.phi()) * tan10deg;
+          dx1 -= 0.5 * (HcalGeomParameters::k_ScaleFromDDDToG4 * t.rho() - dy) * std::cos(t.phi()) * tan10deg;
+          dx2 -= 0.5 * (HcalGeomParameters::k_ScaleFromDDDToG4 * t.rho() + dy) * std::cos(t.phi()) * tan10deg;
           php.dx1HE.emplace_back(-dx1);
           php.dx2HE.emplace_back(-dx2);
           php.layHE.emplace_back(lay);
@@ -226,10 +214,10 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters&
 #endif
         if (sol.shape() == DDSolidShape::ddpolycone_rrz) {
           int nz = (int)(paras.size()) - 3;
-          dzVcal_ = 0.5 * (paras[nz] - paras[3]);
+          dzVcal_ = 0.5 * HcalGeomParameters::k_ScaleFromDDDToG4 * (paras[nz] - paras[3]);
           hf = true;
         } else if (sol.shape() == DDSolidShape::ddtubs || sol.shape() == DDSolidShape::ddcons) {
-          dzVcal_ = paras[0];
+          dzVcal_ = HcalGeomParameters::k_ScaleFromDDDToG4 * paras[0];
           hf = true;
         }
       }
@@ -258,37 +246,38 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
   while (dodet) {
     auto t = fv.translation();
     std::vector<double> paras = fv.parameters();
-    std::vector<int> copy = fv.history().copyNos;
+    std::vector<int> copy = fv.copyNos();
     int idet = 0, lay = -1;
     int nsiz = static_cast<int>(copy.size());
+    if (nsiz > 0)
+      lay = copy[0] / 10;
+    if (nsiz > 1)
+      idet = copy[1] / 1000;
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "Parameters: " << paras.size() << " Copy " << copy.size();
+    edm::LogVerbatim("HCalGeom") << "Name " << fv.name() << " Copy " << copy.size();
     for (unsigned int n = 0; n < copy.size(); ++n)
       edm::LogVerbatim("HCalGeom") << "[" << n << "] " << copy[n];
+    edm::LogVerbatim("HCalGeom") << "Detector " << idet << " Layer " << lay << " parameters: " << paras.size();
     for (unsigned int n = 0; n < paras.size(); ++n)
       edm::LogVerbatim("HCalGeom") << "[" << n << "] " << paras[n];
 #endif
-    if (nsiz > 0)
-      lay = copy[nsiz - 1] / 10;
-    if (nsiz > 1)
-      idet = copy[nsiz - 2] / 1000;
     double dx = 0, dy = 0, dz = 0, dx1 = 0, dx2 = 0;
     double alp(0);
-    if (fv.isA<dd4hep::Box>()) {
-      dx = paras[0];
-      dy = paras[1];
-      dz = paras[2];
-    } else if (fv.isA<dd4hep::Trap>()) {
-      dx1 = paras[4];
-      dx2 = paras[5];
-      dx = 0.25 * (paras[4] + paras[5] + paras[8] + paras[9]);
-      dy = 0.5 * (paras[3] + paras[7]);
-      dz = paras[0];
+    if (fv.isABox()) {
+      dx = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[0];
+      dy = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[1];
+      dz = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[2];
+    } else if (fv.isATrapezoid()) {
+      dx1 = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[4];
+      dx2 = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[5];
+      dx = 0.25 * HcalGeomParameters::k_ScaleFromDD4HepToG4 * (paras[4] + paras[5] + paras[8] + paras[9]);
+      dy = 0.5 * HcalGeomParameters::k_ScaleFromDD4HepToG4 * (paras[3] + paras[7]);
+      dz = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[0];
       alp = 0.5 * (paras[6] + paras[10]);
-    } else if (fv.isA<dd4hep::Tube>()) {
-      dx = paras[0];
-      dy = paras[1];
-      dz = paras[2];
+    } else if (fv.isATubeSeg()) {
+      dx = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[0];
+      dy = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[1];
+      dz = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[2];
     }
     if (idet == 3) {
       // HB
@@ -298,7 +287,7 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
 #endif
       if (lay >= 0 && lay < maxLayer_) {
         ib_[lay]++;
-        rb_[lay] += t.Rho();
+        rb_[lay] += (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho());
         if (thkb_[lay] <= 0) {
           if (lay < 17)
             thkb_[lay] = dx;
@@ -308,15 +297,15 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
         if (lay < 17) {
           bool found = false;
           for (double k : rxb_) {
-            if (std::abs(k - t.Rho()) < 0.01) {
+            if (std::abs(k - (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho())) < 0.01) {
               found = true;
               break;
             }
           }
           if (!found) {
-            rxb_.emplace_back(t.Rho());
-            php.rhoxHB.emplace_back(t.Rho() * std::cos(t.phi()));
-            php.zxHB.emplace_back(std::abs(t.z()));
+            rxb_.emplace_back(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho());
+            php.rhoxHB.emplace_back(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho() * std::cos(t.phi()));
+            php.zxHB.emplace_back(std::abs(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z()));
             php.dyHB.emplace_back(2. * dy);
             php.dxHB.emplace_back(2. * dz);
             php.layHB.emplace_back(lay);
@@ -324,8 +313,8 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
         }
       }
       if (lay == 2) {
-        int iz = copy[nsiz - 5];
-        int fi = copy[nsiz - 4];
+        int iz = copy[4];
+        int fi = copy[3];
         unsigned int it1 = find(iz, izb_);
         if (it1 == izb_.size())
           izb_.emplace_back(iz);
@@ -336,11 +325,11 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
       if (lay == 18) {
         int ifi = -1, ich = -1;
         if (nsiz > 2)
-          ifi = copy[nsiz - 3];
+          ifi = copy[2];
         if (nsiz > 3)
-          ich = copy[nsiz - 4];
-        double z1 = std::abs((t.z()) + dz);
-        double z2 = std::abs((t.z()) - dz);
+          ich = copy[3];
+        double z1 = std::abs((HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z()) + dz);
+        double z2 = std::abs((HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z()) - dz);
         if (std::abs(z1 - z2) < 0.01)
           z1 = 0;
         if (ifi == 1 && ich == 4) {
@@ -384,34 +373,34 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
 #endif
       if (lay >= 0 && lay < maxLayer_) {
         ie_[lay]++;
-        ze_[lay] += std::abs(t.z());
+        ze_[lay] += std::abs(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z());
         if (thke_[lay] <= 0)
           thke_[lay] = dz;
-        double rinHE = t.Rho() * cos(alp) - dy;
-        double routHE = t.Rho() * cos(alp) + dy;
+        double rinHE = HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho() * cos(alp) - dy;
+        double routHE = HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho() * cos(alp) + dy;
         rminHE_[lay] += rinHE;
         rmaxHE_[lay] += routHE;
         bool found = false;
         for (double k : php.zxHE) {
-          if (std::abs(k - std::abs(t.z())) < 0.01) {
+          if (std::abs(k - std::abs(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z())) < 0.01) {
             found = true;
             break;
           }
         }
         if (!found) {
-          php.zxHE.emplace_back(std::abs(t.z()));
-          php.rhoxHE.emplace_back(t.Rho() * std::cos(t.phi()));
+          php.zxHE.emplace_back(std::abs(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z()));
+          php.rhoxHE.emplace_back(HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho() * std::cos(t.phi()));
           php.dyHE.emplace_back(dy * std::cos(t.phi()));
-          dx1 -= 0.5 * (t.Rho() - dy) * std::cos(t.phi()) * tan10deg;
-          dx2 -= 0.5 * (t.Rho() + dy) * std::cos(t.phi()) * tan10deg;
+          dx1 -= 0.5 * (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho() - dy) * std::cos(t.phi()) * tan10deg;
+          dx2 -= 0.5 * (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho() + dy) * std::cos(t.phi()) * tan10deg;
           php.dx1HE.emplace_back(-dx1);
           php.dx2HE.emplace_back(-dx2);
           php.layHE.emplace_back(lay);
         }
       }
-      if (copy[nsiz - 1] == kHELayer1_ || copy[nsiz - 1] == kHELayer2_) {
-        int iz = copy[nsiz - 7];
-        int fi = copy[nsiz - 5];
+      if (copy[0] == kHELayer1_ || copy[0] == kHELayer2_) {
+        int iz = copy[6];
+        int fi = copy[4];
         unsigned int it1 = find(iz, ize_);
         if (it1 == ize_.size())
           ize_.emplace_back(iz);
@@ -424,28 +413,28 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
       if (!hf) {
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HCalGeom") << "HF " << fv.name() << " Shape "
-                                     << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " Z " << t.z() << " with "
+                                     << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " Z " << HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z() << " with "
                                      << paras.size() << " Parameters";
         for (unsigned j = 0; j < paras.size(); j++)
           edm::LogVerbatim("HCalGeom") << "HF Parameter[" << j << "] = " << paras[j];
 #endif
         if (fv.isA<dd4hep::Polycone>()) {
           int nz = (int)(paras.size()) - 3;
-          dzVcal_ = 0.5 * (paras[nz] - paras[3]);
+          dzVcal_ = 0.5 * HcalGeomParameters::k_ScaleFromDD4HepToG4 * (paras[nz] - paras[3]);
           hf = true;
         } else if (fv.isATubeSeg() || fv.isAConeSeg()) {
-          dzVcal_ = paras[0];
+          dzVcal_ = HcalGeomParameters::k_ScaleFromDD4HepToG4 * paras[2];
           hf = true;
         }
       }
 #ifdef EDM_ML_DEBUG
     } else {
       edm::LogVerbatim("HCalGeom") << "Unknown Detector " << idet << " for " << fv.name() << " Shape "
-                                   << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " R " << t.Rho() << " Z "
-                                   << t.z();
+                                   << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " R " << (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho()) << " Z "
+                                   << (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z());
 #endif
     }
-    dodet = fv.nextSibling();
+    dodet = fv.firstChild();
   }
   loadfinal(php);
 }

--- a/Geometry/HcalCommonData/src/HcalGeomParameters.cc
+++ b/Geometry/HcalCommonData/src/HcalGeomParameters.cc
@@ -413,8 +413,9 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
       if (!hf) {
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HCalGeom") << "HF " << fv.name() << " Shape "
-                                     << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " Z " << HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z() << " with "
-                                     << paras.size() << " Parameters";
+                                     << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " Z "
+                                     << HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z() << " with " << paras.size()
+                                     << " Parameters";
         for (unsigned j = 0; j < paras.size(); j++)
           edm::LogVerbatim("HCalGeom") << "HF Parameter[" << j << "] = " << paras[j];
 #endif
@@ -430,7 +431,8 @@ void HcalGeomParameters::loadGeometry(const cms::DDCompactView* cpv, HcalParamet
 #ifdef EDM_ML_DEBUG
     } else {
       edm::LogVerbatim("HCalGeom") << "Unknown Detector " << idet << " for " << fv.name() << " Shape "
-                                   << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " R " << (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho()) << " Z "
+                                   << cms::dd::name(cms::DDSolidShapeMap, fv.shape()) << " R "
+                                   << (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.Rho()) << " Z "
                                    << (HcalGeomParameters::k_ScaleFromDD4HepToG4 * t.z());
 #endif
     }

--- a/Geometry/HcalCommonData/test/python/runHcalParametersFromDD4HepAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalParametersFromDD4HepAnalyzer_cfg.py
@@ -14,7 +14,7 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/HcalAlgo/data/cms-test-ddhcalPhase2-algorithm.xml'),
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/HcalAlgo/data/cms-test-Phase2GeometryFine-algorithm.xml'),
                                             appendToDataLabel = cms.string('')
                                             )
 
@@ -24,6 +24,7 @@ process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
 
 process.hpa = cms.EDAnalyzer("HcalParametersAnalyzer")
 process.hcalParameters.fromDD4Hep = cms.bool(True)
+process.hcalSimulationParameters.fromDD4Hep = cms.bool(True)
 
 process.Timing = cms.Service("Timing")
 process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")


### PR DESCRIPTION
#### PR description:

Try to complete the geometry access from dd4hep for the hadron calorimeter

#### PR validation:

It is tested with 2 cfg files in Geometry/HcalCommonData/test/python and also used the standard runTheMatrix.py

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Normal