### PR TITLE
Adding parameters needed for PUjetID 94X and 102X

### DIFF
--- a/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
@@ -1,12 +1,62 @@
 import FWCore.ParameterSet.Config as cms
 
 ###########################################################
+## Working points for the 102X training
+###########################################################
+full_102x_chs_wp  = cms.PSet(
+    #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
+
+    #Tight Id
+    Pt010_Tight    = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
+    Pt1020_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
+    Pt2030_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
+    Pt3050_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
+
+    #Medium Id
+    Pt010_Medium   = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
+    Pt1020_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
+    Pt2030_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
+    Pt3050_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
+
+    #Loose Id
+    Pt010_Loose    = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
+    Pt1020_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
+    Pt2030_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
+    Pt3050_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30)
+)
+
+###########################################################
+## Working points for the 94X training
+###########################################################
+full_94x_chs_wp  = cms.PSet(
+    #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
+
+    #Tight Id
+    Pt010_Tight    = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
+    Pt1020_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
+    Pt2030_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
+    Pt3050_Tight   = cms.vdouble( 0.86, -0.10, -0.05, -0.01),
+
+    #Medium Id
+    Pt010_Medium   = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
+    Pt1020_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
+    Pt2030_Medium  = cms.vdouble( 0.18, -0.55, -0.42, -0.36),
+    Pt3050_Medium  = cms.vdouble( 0.61, -0.35, -0.23, -0.17),
+
+    #Loose Id
+    Pt010_Loose    = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
+    Pt1020_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
+    Pt2030_Loose   = cms.vdouble(-0.97, -0.68, -0.53, -0.47),
+    Pt3050_Loose   = cms.vdouble(-0.89, -0.52, -0.38, -0.30)
+)
+
+###########################################################
 ## Working points for the 81X training (completed in 80X with variable fixes)
 ###########################################################
 full_81x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
 
-    #Tight Id            
+    #Tight Id
     Pt010_Tight    = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt1020_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt2030_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
@@ -31,7 +81,7 @@ full_81x_chs_wp  = cms.PSet(
 full_80x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
 
-    #Tight Id            
+    #Tight Id
     Pt010_Tight    = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt1020_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt2030_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
@@ -55,8 +105,8 @@ full_80x_chs_wp  = cms.PSet(
 ###########################################################
 full_76x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
-    
-    #Tight Id            
+
+    #Tight Id
     Pt010_Tight    = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt1020_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt2030_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
@@ -72,7 +122,7 @@ full_76x_chs_wp  = cms.PSet(
     Pt010_Loose    = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt1020_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt2030_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
-    Pt3050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)   
+    Pt3050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)
 )
 
 ###########################################################
@@ -80,24 +130,24 @@ full_76x_chs_wp  = cms.PSet(
 ###########################################################
 full_74x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
-                
-    #Tight Id                                                                                                                                                                                 
+
+    #Tight Id
     Pt010_Tight    = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt1020_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt2030_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt3050_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
 
-    #Medium Id                                                                                                                                                                                  
+    #Medium Id
     Pt010_Medium   = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt1020_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt2030_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt3050_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
 
-    #Loose Id                                                                                                                                                                                   
+    #Loose Id
     Pt010_Loose    = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt1020_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt2030_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
-    Pt3050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)   
+    Pt3050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)
 )
 
 ###########################################################
@@ -111,19 +161,19 @@ full_53x_wp  = cms.PSet(
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
     Pt3050_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
-    
+
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
     Pt3050_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
-    
+
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt2030_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
     Pt3050_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
-    
+
     #MET
     Pt010_MET	   = cms.vdouble( 0.  ,-0.6,-0.4,-0.4),
     Pt1020_MET     = cms.vdouble( 0.3 ,-0.2,-0.4,-0.4),
@@ -139,13 +189,13 @@ full_53x_chs_wp  = cms.PSet(
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
     Pt3050_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
-    
+
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
     Pt3050_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
-    
+
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
@@ -154,7 +204,7 @@ full_53x_chs_wp  = cms.PSet(
     )
 
 met_53x_wp  = cms.PSet(
-    
+
     #Tight Id
     Pt010_Tight    = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
@@ -217,7 +267,7 @@ full_5x_wp = cms.PSet(
 
 simple_5x_wp = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
-    
+
     #Tight Id
     Pt010_Tight    = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
     Pt1020_Tight   = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
@@ -235,7 +285,7 @@ simple_5x_wp = cms.PSet(
     Pt1020_Loose   = cms.vdouble(-0.95,-0.97,-0.96,-0.97),
     Pt2030_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84),
     Pt3050_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84)
-    
+
 )
 
 ###########################################################
@@ -364,13 +414,13 @@ PuJetIdCutBased_wp = cms.PSet(
     Pt1020_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt2030_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt3050_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
-    
+
     #Medium Id => Daniele
     Pt010_BetaStarMedium   = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt2030_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt3050_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
-    
+
     #Loose Id
     Pt010_BetaStarLoose    = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
@@ -383,13 +433,13 @@ PuJetIdCutBased_wp = cms.PSet(
     Pt1020_RMSTight        = cms.vdouble( 0.06, 0.07, 0.04, 0.05),
     Pt2030_RMSTight        = cms.vdouble( 0.05, 0.07, 0.03, 0.045),
     Pt3050_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
-    
+
     #Medium Id => Daniele
     Pt010_RMSMedium        = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt1020_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt2030_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt3050_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
-    
+
     #Loose Id
     Pt010_RMSLoose         = cms.vdouble( 0.06, 0.05, 0.05, 0.07),
     Pt1020_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.07),

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -100,7 +100,7 @@ full_102x_chs = cms.PSet(
             "jetPt" ,
             "jetEta",
         ),
-        JetIdParams = full_81x_chs_wp,
+        JetIdParams = full_102x_chs_wp,
         label = cms.string("full")
 )
 
@@ -203,7 +203,7 @@ full_94x_chs = cms.PSet(
             "jetPt" ,
             "jetEta",
         ),
-        JetIdParams = full_81x_chs_wp,
+        JetIdParams = full_94x_chs_wp,
         label = cms.string("full")
 )
 

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -2,6 +2,212 @@ import FWCore.ParameterSet.Config as cms
 from RecoJets.JetProducers.PileupJetIDCutParams_cfi import *
 
 ####################################################################################################################
+full_102x_chs = cms.PSet(
+        impactParTkThreshold = cms.double(1.),
+        cutBased = cms.bool(False),
+        etaBinnedWeights = cms.bool(True),
+        tmvaMethod = cms.string("JetIDMVAHighPt"),
+        version = cms.int32(-1),
+        nEtaBins = cms.int32(4),
+        trainings = cms.VPSet(
+            cms.PSet(
+                jEtaMin = cms.double(0.0),
+                jEtaMax = cms.double(2.5),
+                tmvaWeights  = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "nCharged"  ,
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "beta"      ,
+                    "pull"      ,
+                    "jetR"      ,
+                    "jetRchg"   ,
+                )
+                ),
+            cms.PSet(
+                jEtaMin = cms.double(2.5),
+                jEtaMax = cms.double(2.75),
+                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "nCharged"  ,
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "beta"      ,
+                    "pull"      ,
+                    "jetR"      ,
+                    "jetRchg"   ,
+                )
+                ),
+            cms.PSet(
+                jEtaMin = cms.double(2.75),
+                jEtaMax = cms.double(3.0),
+                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "nCharged"  ,
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "beta"      ,
+                    "pull"      ,
+                    "jetR"      ,
+                    "jetRchg"   ,
+                )
+                ),
+            cms.PSet(
+                jEtaMin = cms.double(3.),
+                jEtaMax = cms.double(5.),
+                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "pull"      ,
+                    "jetR"      ,
+                )
+                ),
+        ),
+        tmvaSpectators = cms.vstring(
+            "jetPt" ,
+            "jetEta",
+        ),
+        JetIdParams = full_81x_chs_wp,
+        label = cms.string("full")
+)
+
+###################################################################################################################
+full_94x_chs = cms.PSet(
+        impactParTkThreshold = cms.double(1.),
+        cutBased = cms.bool(False),
+        etaBinnedWeights = cms.bool(True),
+        tmvaMethod = cms.string("JetIDMVAHighPt"),
+        version = cms.int32(-1),
+        nEtaBins = cms.int32(4),
+        trainings = cms.VPSet(
+            cms.PSet(
+                jEtaMin = cms.double(0.0),
+                jEtaMax = cms.double(2.5),
+                tmvaWeights  = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "nCharged"  ,
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "beta"      ,
+                    "pull"      ,
+                    "jetR"      ,
+                    "jetRchg"   ,
+                )
+                ),
+            cms.PSet(
+                jEtaMin = cms.double(2.5),
+                jEtaMax = cms.double(2.75),
+                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "nCharged"  ,
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "beta"      ,
+                    "pull"      ,
+                    "jetR"      ,
+                    "jetRchg"   ,
+                )
+                ),
+            cms.PSet(
+                jEtaMin = cms.double(2.75),
+                jEtaMax = cms.double(3.0),
+                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "nCharged"  ,
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "beta"      ,
+                    "pull"      ,
+                    "jetR"      ,
+                    "jetRchg"   ,
+                )
+                ),
+            cms.PSet(
+                jEtaMin = cms.double(3.),
+                jEtaMax = cms.double(5.),
+                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"),
+                tmvaVariables = cms.vstring(
+                    "nvtx"      ,
+                    "dR2Mean"   ,
+                    "nParticles",
+                    "majW"      ,
+                    "minW"      ,
+                    "frac01"    ,
+                    "frac02"    ,
+                    "frac03"    ,
+                    "frac04"    ,
+                    "ptD"       ,
+                    "pull"      ,
+                    "jetR"      ,
+                )
+                ),
+        ),
+        tmvaSpectators = cms.vstring(
+            "jetPt" ,
+            "jetEta",
+        ),
+        JetIdParams = full_81x_chs_wp,
+        label = cms.string("full")
+)
+
+####################################################################################################################
 full_81x_chs = cms.PSet(
         impactParTkThreshold = cms.double(1.),
         cutBased = cms.bool(False),
@@ -208,7 +414,7 @@ full_80x_chs = cms.PSet(
         label = cms.string("full")
 )
 
-####################################################################################################################                                                                                      
+####################################################################################################################
 full_76x_chs = cms.PSet(
     impactParTkThreshold = cms.double(1.) ,
     cutBased = cms.bool(False),
@@ -310,7 +516,7 @@ full_76x_chs = cms.PSet(
     JetIdParams = full_76x_chs_wp,
     label = cms.string("full")
  )
-####################################################################################################################                                                                                      
+####################################################################################################################
 full_74x_chs = cms.PSet(
     impactParTkThreshold = cms.double(1.) ,
     cutBased = cms.bool(False),
@@ -416,7 +622,7 @@ full_74x_chs = cms.PSet(
     JetIdParams = full_74x_chs_wp,
     label = cms.string("full")
  )
-####################################################################################################################  
+####################################################################################################################
 full_53x = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -426,18 +632,18 @@ full_53x = cms.PSet(
  version = cms.int32(-1),
  tmvaVariables = cms.vstring(
     "nvtx"     ,
-    "dZ"       , 
-    "beta"     , 
-    "betaStar" , 
-    "nCharged" , 
-    "nNeutrals", 
-    "dR2Mean"  , 
-    "ptD"      , 
-    "frac01"   , 
-    "frac02"   , 
-    "frac03"   , 
-    "frac04"   , 
-    "frac05"   , 
+    "dZ"       ,
+    "beta"     ,
+    "betaStar" ,
+    "nCharged" ,
+    "nNeutrals",
+    "dR2Mean"  ,
+    "ptD"      ,
+    "frac01"   ,
+    "frac02"   ,
+    "frac03"   ,
+    "frac04"   ,
+    "frac05"   ,
     ),
  tmvaSpectators = cms.vstring(
     "jetPt",
@@ -447,7 +653,7 @@ full_53x = cms.PSet(
  JetIdParams = full_53x_wp,
  label = cms.string("full53x")
  )
-####################################################################################################################  
+####################################################################################################################
 full_53x_chs = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -458,18 +664,18 @@ full_53x_chs = cms.PSet(
  version = cms.int32(-1),
  tmvaVariables = cms.vstring(
     "nvtx"     ,
-    "dZ"       , 
-    "beta"     , 
-    "betaStar" , 
-    "nCharged" , 
-    "nNeutrals", 
-    "dR2Mean"  , 
-    "ptD"      , 
-    "frac01"   , 
-    "frac02"   , 
-    "frac03"   , 
-    "frac04"   , 
-    "frac05"   , 
+    "dZ"       ,
+    "beta"     ,
+    "betaStar" ,
+    "nCharged" ,
+    "nNeutrals",
+    "dR2Mean"  ,
+    "ptD"      ,
+    "frac01"   ,
+    "frac02"   ,
+    "frac03"   ,
+    "frac04"   ,
+    "frac05"   ,
     ),
  tmvaSpectators = cms.vstring(
     "jetPt",
@@ -479,7 +685,7 @@ full_53x_chs = cms.PSet(
  JetIdParams = full_53x_chs_wp,
  label = cms.string("full")
  )
-####################################################################################################################  
+####################################################################################################################
 met_53x = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -492,24 +698,24 @@ met_53x = cms.PSet(
     "jetPt"    ,
     "jetEta"   ,
     "jetPhi"   ,
-    "dZ"       , 
-    "beta"     , 
-    "betaStar" , 
-    "nCharged" , 
-    "nNeutrals", 
-    "dR2Mean"  , 
-    "ptD"      , 
-    "frac01"   , 
-    "frac02"   , 
-    "frac03"   , 
-    "frac04"   , 
-    "frac05"   , 
+    "dZ"       ,
+    "beta"     ,
+    "betaStar" ,
+    "nCharged" ,
+    "nNeutrals",
+    "dR2Mean"  ,
+    "ptD"      ,
+    "frac01"   ,
+    "frac02"   ,
+    "frac03"   ,
+    "frac04"   ,
+    "frac05"   ,
     ),
  tmvaSpectators = cms.vstring(),
  JetIdParams = met_53x_wp,
  label = cms.string("met53x")
  )
-##################################################################################################################  
+##################################################################################################################
 full_5x = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -539,7 +745,7 @@ full_5x = cms.PSet(
  label = cms.string("full")
  )
 
-##################################################################################################################  
+##################################################################################################################
 full_5x_chs = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -569,15 +775,15 @@ full_5x_chs = cms.PSet(
  label = cms.string("full")
  )
 
-####################################################################################################################  
-cutbased = cms.PSet( 
+####################################################################################################################
+cutbased = cms.PSet(
  impactParTkThreshold = cms.double(1.),
  cutBased = cms.bool(True),
  JetIdParams = PuJetIdCutBased_wp,
  label = cms.string("cutbased")
  )
 
-####################################################################################################################  
+####################################################################################################################
 PhilV1 = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -13,7 +13,7 @@ full_102x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(0.0),
                 jEtaMax = cms.double(2.5),
-                tmvaWeights  = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz"),
+                tmvaWeights  = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -35,7 +35,7 @@ full_102x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(2.5),
                 jEtaMax = cms.double(2.75),
-                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz"),
+                tmvaWeights   = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -57,7 +57,7 @@ full_102x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(2.75),
                 jEtaMax = cms.double(3.0),
-                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz"),
+                tmvaWeights   = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -79,7 +79,7 @@ full_102x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(3.),
                 jEtaMax = cms.double(5.),
-                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz"),
+                tmvaWeights   = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -116,7 +116,7 @@ full_94x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(0.0),
                 jEtaMax = cms.double(2.5),
-                tmvaWeights  = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz"),
+                tmvaWeights  = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -138,7 +138,7 @@ full_94x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(2.5),
                 jEtaMax = cms.double(2.75),
-                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz"),
+                tmvaWeights   = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -160,7 +160,7 @@ full_94x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(2.75),
                 jEtaMax = cms.double(3.0),
-                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz"),
+                tmvaWeights   = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,
@@ -182,7 +182,7 @@ full_94x_chs = cms.PSet(
             cms.PSet(
                 jEtaMin = cms.double(3.),
                 jEtaMax = cms.double(5.),
-                tmvaWeights   = cms.string("RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"),
+                tmvaWeights   = cms.FileInPath("RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"),
                 tmvaVariables = cms.vstring(
                     "nvtx"      ,
                     "dR2Mean"   ,

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -14,7 +14,7 @@ _chsalgos_81x = cms.VPSet(full_81x_chs,cutbased)
 _chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
 _chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
 
-_stdalgos    = _chsalgos_81x
+_stdalgos    = _chsalgos_102x
 
 # Calculate+store variables and run MVAs
 pileupJetId = cms.EDProducer('PileupJetIdProducer',

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -1,16 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoJets.JetProducers.PileupJetIDParams_cfi import * 
+from RecoJets.JetProducers.PileupJetIDParams_cfi import *
 
 #_stdalgos_4x = cms.VPSet(full,   cutbased,PhilV1)
 _stdalgos_5x = cms.VPSet(full_5x,cutbased,PhilV1)
 
-#_chsalgos_4x = cms.VPSet(full,   cutbased) 
+#_chsalgos_4x = cms.VPSet(full,   cutbased)
 _chsalgos_5x = cms.VPSet(full_5x_chs,cutbased)
 _chsalgos_74x = cms.VPSet(full_74x_chs,cutbased)
 _chsalgos_76x = cms.VPSet(full_76x_chs,cutbased)
 _chsalgos_80x = cms.VPSet(full_80x_chs,cutbased)
 _chsalgos_81x = cms.VPSet(full_81x_chs,cutbased)
+_chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
+_chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
 
 _stdalgos    = _chsalgos_81x
 


### PR DESCRIPTION
#### PR description:

  - Including the files and parameters needed for the latest PUjetID training for 94X and 102X samples. 
  - Once merged, we need to backport this PR to the corresponding CMSSW release for the latest nanoAOD. 
  - There is also a PR for the new weights for PUJetID https://github.com/cms-data/RecoJets-JetProducers/pull/10#issuecomment-579821257

#### PR validation:

Successfully run the runTheMatrix tests and here is the output: https://cernbox.cern.ch/index.php/s/XNTEPDN5VU01O84

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
