### PR TITLE
MTD geometry: add test workflows for scenario D53, update material budget validation

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -49,6 +49,8 @@ upgradeKeys[2026] = [
     '2026D51PU',
     '2026D52',
     '2026D52PU',
+    '2026D53',
+    '2026D53PU',
 ]
 
 # pre-generation of WF numbers
@@ -737,6 +739,13 @@ upgradeProperties[2026] = {
     },
     '2026D52' : {
         'Geom' : 'Extended2026D52',
+        'HLTmenu': '@fake2',
+        'GT' : 'auto:phase2_realistic_T15',
+        'Era' : 'Phase2C9',
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
+    },
+    '2026D53' : {
+        'Geom' : 'Extended2026D53',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T15',
         'Era' : 'Phase2C9',

--- a/Validation/Geometry/data/mtdMaterials.l0
+++ b/Validation/Geometry/data/mtdMaterials.l0
@@ -5,26 +5,48 @@
 #CommonMaterials 0 0 0 0 0
 
 tkLayout_SenLYSO                                         0.000 1.000 0.000 0.000 0.000
-                                                                                      
+
+mtdtkLayout_SenLYSO                                      0.000 1.000 0.000 0.000 0.000
+
 LYSO                                                     0.000 1.000 0.000 0.000 0.000
-                                                                                      
+
 tkLayout_SenSi                                           0.000 1.000 0.000 0.000 0.000
-                                                                                      
+
+mtdtkLayout_SenSi                                        0.000 1.000 0.000 0.000 0.000
+
 tkLayout_Al                                              0.000 0.000 0.000 1.000 0.000
+
+mtdtkLayout_Al                                           0.000 0.000 0.000 1.000 0.000
+
+Aluminium                                                0.000 0.000 0.000 1.000 0.000
 
 hybridcompositeBModule1Layer1PositiveZFSide              0.000 0.000 0.000 0.000 1.000
 
+mtdhybridcompositeBModule1Layer1PositiveZFSide           0.000 0.000 0.000 0.000 1.000
+
 hybridcompositeBModule1Layer1PositiveZSupportPlate       0.000 0.000 0.000 1.000 0.000
 
-hybridcompositeEModule1Disc1Between                      0.000 0.000 0.000 0.000 1.000    
+mtdhybridcompositeBModule1Layer1PositiveZSupportPlate    0.000 0.000 0.000 1.000 0.000
+
+hybridcompositeEModule1Disc1Between                      0.000 0.000 0.000 0.000 1.000
+
+mtdhybridcompositeEModule1Disc1Between                   0.000 0.000 0.000 0.000 1.000
 
 hybridcompositeEModule1Disc1BSide                        0.000 0.000 0.000 0.000 1.000
 
+mtdhybridcompositeEModule1Disc1BSide                     0.000 0.000 0.000 0.000 1.000
+
 hybridcompositeEModule1Disc1FSide                        0.000 0.000 0.000 0.000 1.000
+
+mtdhybridcompositeEModule1Disc1FSide                     0.000 0.000 0.000 0.000 1.000
 
 hybridcompositeEModule1Disc1LSide                        0.000 0.000 0.000 0.000 1.000
 
+mtdhybridcompositeEModule1Disc1LSide                     0.000 0.000 0.000 0.000 1.000
+
 hybridcompositeEModule1Disc1SupportPlate                 0.000 0.000 0.000 0.000 1.000
+
+mtdhybridcompositeEModule1Disc1SupportPlate              0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR1038Z2666                               0.000 0.000 0.000 0.000 1.000
 
@@ -41,25 +63,25 @@ servicecompositeR688Z2666                                0.000 0.000 0.000 0.000
 servicecompositeR772Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR864Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR946Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR1059Z2666                               0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR264Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR361Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR452Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR537Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR629Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR713Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR805Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR887Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR979Z2666                                0.000 0.000 0.000 0.000 1.000

--- a/Validation/Geometry/data/mtdMaterials.l0
+++ b/Validation/Geometry/data/mtdMaterials.l0
@@ -14,6 +14,8 @@ tkLayout_SenSi                                           0.000 1.000 0.000 0.000
 
 mtdtkLayout_SenSi                                        0.000 1.000 0.000 0.000 0.000
 
+Silicon                                                  0.000 1.000 0.000 0.000 0.000
+
 tkLayout_Al                                              0.000 0.000 0.000 1.000 0.000
 
 mtdtkLayout_Al                                           0.000 0.000 0.000 1.000 0.000
@@ -54,7 +56,7 @@ servicecompositeR323Z2666                                0.000 0.000 0.000 0.000
 
 servicecompositeR420Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR511Z2666                                0.000 0.000 0.000 0.000 1.000 
+servicecompositeR511Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR596Z2666                                0.000 0.000 0.000 0.000 1.000
 
@@ -85,3 +87,13 @@ servicecompositeR805Z2666                                0.000 0.000 0.000 0.000
 servicecompositeR887Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR979Z2666                                0.000 0.000 0.000 0.000 1.000
+
+Epoxy                                                    0.000 0.000 0.000 0.000 1.000
+
+Laird                                                    0.000 0.000 0.000 0.000 1.000
+
+ServiceHybrid_PCB                                        0.000 0.000 0.000 0.000 1.000
+
+Aluminium_Nitride                                        0.000 0.000 0.000 0.000 1.000
+
+ThermalScreenComposite                                   0.000 0.000 0.000 1.000 0.000

--- a/Validation/Geometry/data/mtdMaterials.x0
+++ b/Validation/Geometry/data/mtdMaterials.x0
@@ -5,26 +5,48 @@
 #CommonMaterials 0 0 0 0 0
 
 tkLayout_SenLYSO                                         0.000 1.000 0.000 0.000 0.000
-                                                                                      
+
+mtdtkLayout_SenLYSO                                      0.000 1.000 0.000 0.000 0.000
+
 LYSO                                                     0.000 1.000 0.000 0.000 0.000
-                                                                                      
+
 tkLayout_SenSi                                           0.000 1.000 0.000 0.000 0.000
-                                                                                      
+
+mtdtkLayout_SenSi                                        0.000 1.000 0.000 0.000 0.000
+
 tkLayout_Al                                              0.000 0.000 0.000 1.000 0.000
+
+mtdtkLayout_Al                                           0.000 0.000 0.000 1.000 0.000
+
+Aluminium                                                0.000 0.000 0.000 1.000 0.000
 
 hybridcompositeBModule1Layer1PositiveZFSide              0.000 0.000 0.000 0.000 1.000
 
+mtdhybridcompositeBModule1Layer1PositiveZFSide           0.000 0.000 0.000 0.000 1.000
+
 hybridcompositeBModule1Layer1PositiveZSupportPlate       0.000 0.000 0.000 1.000 0.000
 
-hybridcompositeEModule1Disc1Between                      0.000 0.000 0.000 0.000 1.000    
+mtdhybridcompositeBModule1Layer1PositiveZSupportPlate    0.000 0.000 0.000 1.000 0.000
+
+hybridcompositeEModule1Disc1Between                      0.000 0.000 0.000 0.000 1.000
+
+mtdhybridcompositeEModule1Disc1Between                   0.000 0.000 0.000 0.000 1.000
 
 hybridcompositeEModule1Disc1BSide                        0.000 0.000 0.000 0.000 1.000
 
+mtdhybridcompositeEModule1Disc1BSide                     0.000 0.000 0.000 0.000 1.000
+
 hybridcompositeEModule1Disc1FSide                        0.000 0.000 0.000 0.000 1.000
+
+mtdhybridcompositeEModule1Disc1FSide                     0.000 0.000 0.000 0.000 1.000
 
 hybridcompositeEModule1Disc1LSide                        0.000 0.000 0.000 0.000 1.000
 
+mtdhybridcompositeEModule1Disc1LSide                     0.000 0.000 0.000 0.000 1.000
+
 hybridcompositeEModule1Disc1SupportPlate                 0.000 0.000 0.000 0.000 1.000
+
+mtdhybridcompositeEModule1Disc1SupportPlate              0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR1038Z2666                               0.000 0.000 0.000 0.000 1.000
 
@@ -41,25 +63,25 @@ servicecompositeR688Z2666                                0.000 0.000 0.000 0.000
 servicecompositeR772Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR864Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR946Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR1059Z2666                               0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR264Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR361Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR452Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR537Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR629Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR713Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR805Z2666                                0.000 0.000 0.000 0.000 1.000
-                                                                                      
+
 servicecompositeR887Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR979Z2666                                0.000 0.000 0.000 0.000 1.000

--- a/Validation/Geometry/data/mtdMaterials.x0
+++ b/Validation/Geometry/data/mtdMaterials.x0
@@ -14,6 +14,8 @@ tkLayout_SenSi                                           0.000 1.000 0.000 0.000
 
 mtdtkLayout_SenSi                                        0.000 1.000 0.000 0.000 0.000
 
+Silicon                                                  0.000 1.000 0.000 0.000 0.000
+
 tkLayout_Al                                              0.000 0.000 0.000 1.000 0.000
 
 mtdtkLayout_Al                                           0.000 0.000 0.000 1.000 0.000
@@ -54,7 +56,7 @@ servicecompositeR323Z2666                                0.000 0.000 0.000 0.000
 
 servicecompositeR420Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR511Z2666                                0.000 0.000 0.000 0.000 1.000 
+servicecompositeR511Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR596Z2666                                0.000 0.000 0.000 0.000 1.000
 
@@ -85,3 +87,13 @@ servicecompositeR805Z2666                                0.000 0.000 0.000 0.000
 servicecompositeR887Z2666                                0.000 0.000 0.000 0.000 1.000
 
 servicecompositeR979Z2666                                0.000 0.000 0.000 0.000 1.000
+
+Epoxy                                                    0.000 0.000 0.000 0.000 1.000
+
+Laird                                                    0.000 0.000 0.000 0.000 1.000
+
+ServiceHybrid_PCB                                        0.000 0.000 0.000 0.000 1.000
+
+Aluminium_Nitride                                        0.000 0.000 0.000 0.000 1.000
+
+ThermalScreenComposite                                   0.000 0.000 0.000 1.000 0.000


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #28788 adding:

- definition of test workflows for scenario D53 in the upgrade section of PyReleaseValidation. No test is added to the standard matrix, as the workflows is fully functional up to GEN-SIM, the RECO geometry needs to be updated. Anyway the availability of the definition is useful to perform tests and debugging;

- update of Validation/Geometry adding the materials needed by the new ETL. This allows the user to produce material budget plots for the new scenario D53, showing the increase in the ETL region due to the double disk structure.

![image](https://user-images.githubusercontent.com/4058194/73515733-9f309b00-43f6-11ea-95d5-db0b0db4b9d5.png)


#### PR validation:

The produced material budget plot is linked above. Test workflows runs in step1, and fail as expected for the time being in step2.