### PR TITLE
Migrate Alignment Validation all-in-one meta-tool to be Py3 compliant

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -8,7 +8,6 @@ import copy
 import collections
 from .TkAlExceptions import AllInOneError
 
-
 class AdaptedDict(collections.OrderedDict):
     """
     Dictionary which handles updates of values for already existing keys
@@ -35,7 +34,7 @@ class AdaptedDict(collections.OrderedDict):
         """
 
         if key != "__name__" and "__name__" in self and self["__name__"]=="validation":
-            if isinstance(value, (str, unicode)):
+            if isinstance(value, str):
                 for index, item in enumerate(self.validationslist[:]):
                     if item == (key, value.split("\n")):
                         self.validationslist[index] = (key, value)
@@ -160,10 +159,8 @@ class BetterConfigParser(ConfigParser.ConfigParser):
             "datadir":os.getcwd(),
             "logdir":os.getcwd(),
             }
-        mandatories = [
-            "eosdir",
-        ]
-        self.checkInput("general", knownSimpleOptions = defaults.keys() + mandatories)
+        mandatories = ["eosdir",]
+        self.checkInput("general", knownSimpleOptions = list(defaults.keys()) + mandatories )
         general = self.getResultingSection( "general", defaultDict = defaults, demandPars = mandatories )
         internal_section = "internals"
         if not self.has_section(internal_section):
@@ -231,7 +228,7 @@ class BetterConfigParser(ConfigParser.ConfigParser):
         for section in self._sections:
             fp.write("[%s]\n" % section)
             for (key, value) in self._sections[section].items():
-                if key == "__name__" or not isinstance(value, (str, unicode)):
+                if key == "__name__" or not isinstance(value, str):
                     continue
                 if value is not None:
                     key = " = ".join((key, str(value).replace('\n', '\n\t')))

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
-#import configparser as ConfigParser
+
 import ConfigParser
 import os
 import re

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+#import configparser as ConfigParser
 import ConfigParser
 import os
 import re

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import ConfigParser
+import configparser as ConfigParser
 import os
 import re
 import copy
@@ -171,7 +171,7 @@ class BetterConfigParser(ConfigParser.ConfigParser):
         if not self.has_option(internal_section, "workdir"):
             self.set(internal_section, "workdir", "/tmp/$USER")
         if not self.has_option(internal_section, "scriptsdir"):
-            self.set(internal_section, "scriptsdir", None)
+            self.set(internal_section, "scriptsdir", "")
             #replaceByMap will fail if this is not replaced (which it is in validateAlignments.py)
 
         general["workdir"] = self.get(internal_section, "workdir")

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -107,7 +107,7 @@ class Dataset(object):
                         "%(files)s\n"
                         "%(lumiSecExtend)s\n"
                         "%(process)smaxEvents = cms.untracked.PSet( "
-                        "input = cms.untracked.int32(%(nEvents)s) )\n"
+                        "input = cms.untracked.int32(int(%(nEvents)s)) )\n"
                         "%(skipEventsString)s\n")
 
     __dummy_source_template = ("readFiles = cms.untracked.vstring()\n"
@@ -119,7 +119,7 @@ class Dataset(object):
                                ")\n"
                                "readFiles.extend(['dummy_File.root'])\n"
                                "%(process)smaxEvents = cms.untracked.PSet( "
-                               "input = cms.untracked.int32(%(nEvents)s) )\n"
+                               "input = cms.untracked.int32(int(%(nEvents)s)) )\n"
                                "%(skipEventsString)s\n")
 
     def __lumiSelectionSnippet( self, jsonPath = None, firstRun = None, lastRun = None ):
@@ -755,7 +755,7 @@ class Dataset(object):
                        "process.maxEvents = cms.untracked.PSet(\n"
                        "    input = cms.untracked.int32(.oO[nEvents]Oo. / .oO[parallelJobs]Oo.)\n"
                        ")\n"
-                       "process.source.skipEvents=cms.untracked.uint32(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[parallelJobs]Oo.)"
+                       "process.source.skipEvents=cms.untracked.uint32(int(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[parallelJobs]Oo.))"
                        %(self.__name))
             if not parent:
                 with open(self.__filename) as f:
@@ -765,7 +765,7 @@ class Dataset(object):
         theMap = { "process": "process.",
                    "tab": " " * len( "process." ),
                    "nEvents": ".oO[nEvents]Oo. / .oO[parallelJobs]Oo.",
-                   "skipEventsString": "process.source.skipEvents=cms.untracked.uint32(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[parallelJobs]Oo.)\n",
+                   "skipEventsString": "process.source.skipEvents=cms.untracked.uint32(int(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[parallelJobs]Oo.))\n",
                    "importCms": "",
                    "header": ""
                    }

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -39,7 +39,6 @@ class ValidationMetaClass(ABCMeta):
 
         return super(ValidationMetaClass, cls).__new__(cls, clsname, bases, dct)
 
-#class GenericValidation(object,metaclass=ValidationMetaClass):
 class GenericValidation(with_metaclass(ValidationMetaClass,object)):
     defaultReferenceName = "DEFAULT"
     mandatories = set()

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -10,6 +10,7 @@ from . import configTemplates
 from .dataset import Dataset
 from .helperFunctions import replaceByMap, addIndex, getCommandOutput2, boolfromstring, pythonboolstring
 from .TkAlExceptions import AllInOneError
+from six import with_metaclass
 
 class ValidationMetaClass(ABCMeta):
     sets = ["mandatories", "optionals", "needpackages"]
@@ -38,8 +39,8 @@ class ValidationMetaClass(ABCMeta):
 
         return super(ValidationMetaClass, cls).__new__(cls, clsname, bases, dct)
 
-class GenericValidation(object):
-    __metaclass__ = ValidationMetaClass
+#class GenericValidation(object,metaclass=ValidationMetaClass):
+class GenericValidation(with_metaclass(ValidationMetaClass,object)):
     defaultReferenceName = "DEFAULT"
     mandatories = set()
     defaults = {

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
@@ -88,7 +88,7 @@ class GeometryComparison(GenericValidation):
             referenceTitle = self.referenceAlignment.title
 
         assert len(self.__compares) == 1 #? not sure how it can be anything else, but just in case
-        common = self.__compares.keys()[0]
+        common = list(self.__compares.keys())[0]
 
         repMap.update({
             "common": clean_name(common),
@@ -125,7 +125,7 @@ class GeometryComparison(GenericValidation):
             cfgs[cfgFileName] = configTemplates.intoNTuplesTemplate
             repMaps[cfgFileName] = referenceRepMap
 
-        cfgSchedule = cfgs.keys()
+        cfgSchedule = list(cfgs.keys())
         for common in self.__compares:
             repMap.update({
                            "levels": self.__compares[common][0],

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
@@ -14,9 +14,10 @@ from .TkAlExceptions import AllInOneError
 from .trackSplittingValidation import TrackSplittingValidation
 from .zMuMuValidation import ZMuMuValidation
 from .overlapValidation import OverlapValidation
+from six import with_metaclass
 
-class BasePlottingOptions(object):
-    __metaclass__ = ValidationMetaClass
+#class BasePlottingOptions(object,metaclass=ValidationMetaClass):
+class BasePlottingOptions(with_metaclass(ValidationMetaClass,object)):
     defaults = {
                 "cmssw" : os.environ["CMSSW_BASE"],
                 "publicationstatus" : "",

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/plottingOptions.py
@@ -16,7 +16,6 @@ from .zMuMuValidation import ZMuMuValidation
 from .overlapValidation import OverlapValidation
 from six import with_metaclass
 
-#class BasePlottingOptions(object,metaclass=ValidationMetaClass):
 class BasePlottingOptions(with_metaclass(ValidationMetaClass,object)):
     defaults = {
                 "cmssw" : os.environ["CMSSW_BASE"],

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -10,7 +10,7 @@ runboundary = .oO[runboundary]Oo.
 isMultipleRuns=False
 if(isinstance(runboundary, (list, tuple))):
      isMultipleRuns=True
-     print "Multiple Runs are selected"
+     print("Multiple Runs are selected")
        
 if(isMultipleRuns):
      process.source.firstRun = cms.untracked.uint32(int(runboundary[0]))
@@ -21,12 +21,12 @@ else:
 # JSON Filtering
 ###################################################################
 if isMC:
-     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is simulation!"
+     print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is simulation!")
      runboundary = 1
 else:
-     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is real DATA!"
+     print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: This is real DATA!")
      if ('.oO[lumilist]Oo.'):
-          print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: JSON filtering with: .oO[lumilist]Oo. "
+          print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: JSON filtering with: .oO[lumilist]Oo. ")
           import FWCore.PythonUtilities.LumiList as LumiList
           process.source.lumisToProcess = LumiList.LumiList(filename ='.oO[lumilist]Oo.').getVLuminosityBlockRange()
 
@@ -71,7 +71,7 @@ else:
 # Deterministic annealing clustering
 ####################################################################
 if isDA:
-     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running DA Algorithm!"
+     print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running DA Algorithm!")
      process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
                                            TrackCollectionTag = cms.InputTag("FinalTrackRefitter"),
                                            VertexCollectionTag = cms.InputTag(".oO[VertexCollection]Oo."),
@@ -118,7 +118,7 @@ if isDA:
 # GAP clustering
 ####################################################################
 else:
-     print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running GAP Algorithm!"
+     print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running GAP Algorithm!")
      process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
                                            TrackCollectionTag = cms.InputTag("FinalTrackRefitter"),
                                            VertexCollectionTag = cms.InputTag(".oO[VertexCollection]Oo."),

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -529,7 +529,7 @@ def createMergeScript( path, validations, options ):
     #pprint.pprint(comparisonLists)
     anythingToMerge = []
 
-    for (validationtype, validationName, referenceName), validations in comparisonLists.iteritems():
+    for (validationtype, validationName, referenceName), validations in six.iteritems(comparisonLists):
         #pprint.pprint("validations")
         #pprint.pprint(validations)
         globalDictionaries.plottingOptions = {}

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #test execute: export CMSSW_BASE=/tmp/CMSSW && ./validateAlignments.py -c defaultCRAFTValidation.ini,test.ini -n -N test
 from __future__ import print_function
+from future.utils import lmap
 import subprocess
 import os
 import sys
@@ -214,6 +215,7 @@ class ValidationJob(ValidationBase):
                           os.path.abspath( self.commandLineOptions.Name) )
 
     def runJob( self ):
+
         general = self.config.getGeneral()
         log = ""
 
@@ -405,7 +407,7 @@ class ValidationJobMultiIOV(ValidationBase):
         return validations
 
     def createJob( self ):
-        map( lambda validation: validation.createJob(), self.validations )
+        lmap( lambda validation: validation.createJob(), self.validations )
 
     def runJob( self ):
         return [validation.runJob() for validation in self.validations]
@@ -533,7 +535,7 @@ def createMergeScript( path, validations, options ):
         #pprint.pprint("validations")
         #pprint.pprint(validations)
         globalDictionaries.plottingOptions = {}
-        map( lambda validation: validation.getRepMap(), validations )
+        lmap( lambda validation: validation.getRepMap(), validations )
         #plotInfo = "plots:offline"
         #allPlotInfo = dict(validations[0].config.items(plotInfo))
         #repMap[(validationtype, validationName, referenceName)].update(allPlotInfo)
@@ -639,7 +641,6 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     (options, args) = optParser.parse_args(argv)
 
-
     if not options.restrictTo == None:
         options.restrictTo = options.restrictTo.split(",")
 
@@ -720,8 +721,8 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
                                 for alignment in alignmentList]
         validations.extend(validationsToAdd)
 
-
     for validation in validations:
+
         job = ValidationJobMultiIOV(validation, config, options, outPath, len(validations))
         if (job.optionMultiIOV == True):
             jobs.extend(job)
@@ -732,15 +733,14 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
         if job.needsproxy and not proxyexists:
             raise AllInOneError("At least one job needs a grid proxy, please init one.")
 
-    map( lambda job: job.createJob(), jobs )
+    lmap( lambda job: job.createJob(), jobs )
 
     validations = [ job.getValidation() for job in jobs ]
     validations = flatten(validations)
 
     createMergeScript(outPath, validations, options)
 
-
-    map( lambda job: job.runJob(), jobs )
+    lmap( lambda job: job.runJob(), jobs )
 
     if options.dryRun:
         pass

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -714,7 +714,7 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
     validations = []
     jobs = []
     for validation in config.items("validation"):
-	validation = validation[0].split("-")
+        validation = validation[0].split("-")
         alignmentList = [validation[1]]
         validationsToAdd = [(validation[0],alignment) \
                                 for alignment in alignmentList]

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -714,6 +714,7 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
     validations = []
     jobs = []
     for validation in config.items("validation"):
+	validation = validation[0].split("-")
         alignmentList = [validation[1]]
         validationsToAdd = [(validation[0],alignment) \
                                 for alignment in alignmentList]

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -205,8 +205,9 @@ runControl = False
 # configure which validation to run on which alignment
 
 [validation]
-primaryvertex phase0MC    : mc_2016 
-primaryvertex phaseIMC    : mc_2017
-primaryvertex phaseIMC_BPixOnly : mc_2017_bpixonly
-primaryvertex run2018data : data_2018
-primaryvertex run2018data_forcedBS : data_2018
+primaryvertex phase0MC - mc_2016 :
+primaryvertex phase0MC - mc_2017 : # this is broken on purpose to test two geometries on the same dataset
+primaryvertex phaseIMC - mc_2017 :
+primaryvertex phaseIMC_BPixOnly - mc_2017_bpixonly :
+primaryvertex run2018data - data_2018 :
+primaryvertex run2018data_forcedBS - data_2018 :

--- a/Alignment/OfflineValidation/test/testValidate.ini
+++ b/Alignment/OfflineValidation/test/testValidate.ini
@@ -116,15 +116,15 @@ customrighttitle = 2016G Z#rightarrow#mu#mu data, |#eta|<2.4
 # configure which validation to run on which alignment
 
 [validation]
-offline validation_MinBias : prompt
-offline validation_MinBias : express
-offline validation_cosmics : prompt
-offline validation_cosmics : express
+offline validation_MinBias - prompt :
+offline validation_MinBias - express : 
+offline validation_cosmics - prompt :
+offline validation_cosmics - express :
 #278819 is the run number.  Note that the plots will show (first geometry) - (second geometry), in this case prompt - express
-compare Tracker: prompt 278819, express 278819
-zmumu some_zmumu_validation : prompt
-zmumu some_zmumu_validation : express
-split some_split_validation : prompt
-split some_split_validation : express
+compare Tracker - prompt 278819, express 278819 :
+zmumu some_zmumu_validation - prompt :
+zmumu some_zmumu_validation - express :
+split some_split_validation - prompt :
+split some_split_validation - express :
 #mcValidate some_mc_validation : alignment_0
 

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -82,15 +82,15 @@ customrighttitle = 2016G Z#rightarrow#mu#mu data, |#eta|<2.4
 legendheader = header
 
 [validation]
-offline validation_MinBias : prompt
-offline validation_MinBias : express
-offline validation_cosmics : prompt
-offline validation_cosmics : express
-compare Tracker: prompt 278819, express 278819
-zmumu some_zmumu_validation : prompt
-zmumu some_zmumu_validation : express
-split some_split_validation : prompt
-split some_split_validation : express
+offline validation_MinBias - prompt :
+offline validation_MinBias - express :
+offline validation_cosmics - prompt :
+offline validation_cosmics - express :
+compare Tracker - prompt 278819, express 278819
+zmumu some_zmumu_validation - prompt :
+zmumu some_zmumu_validation - express :
+split some_split_validation - prompt :
+split some_split_validation - express :
 EOF
 
 validateAlignments.py -c validation_config.ini -N testingAllInOneTool --dryRun || die "Failure running all-in-one test" $?

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -86,7 +86,7 @@ offline validation_MinBias - prompt :
 offline validation_MinBias - express :
 offline validation_cosmics - prompt :
 offline validation_cosmics - express :
-compare Tracker - prompt 278819, express 278819
+compare Tracker - prompt 278819, express 278819 :
 zmumu some_zmumu_validation - prompt :
 zmumu some_zmumu_validation - express :
 split some_split_validation - prompt :


### PR DESCRIPTION
resolves #28830 

#### PR description:
Title says it all.

#### PR validation:

Relies on existing unit tests (introduced in https://github.com/cms-sw/cmssw/pull/28739).
Tested functional both in `CMSSW_11_1_X_2020-01-30-2300` *and* `CMSSW_11_1_PY3_X_2020-01-30-2300` (requires https://github.com/cms-sw/cmssw/pull/28822 to be merged first, though).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is not a backport and no backport is meant as the failing unit test exists only in this release cycle.
