### PR TITLE
EventSetup consumes migration for MuonServiceProxy

### DIFF
--- a/Alignment/OfflineValidation/plugins/ResidualRefitting.cc
+++ b/Alignment/OfflineValidation/plugins/ResidualRefitting.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -71,7 +72,7 @@ ResidualRefitting::ResidualRefitting(const edm::ParameterSet& cfg)
   edm::ParameterSet serviceParameters = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
 
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
 }  //The constructor
 

--- a/DQM/MuonMonitor/plugins/CosmicMuonRecoAnalyzer.cc
+++ b/DQM/MuonMonitor/plugins/CosmicMuonRecoAnalyzer.cc
@@ -15,7 +15,6 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
@@ -35,7 +34,6 @@ public:
 
 private:
   // ----------member data ---------------------------
-  MuonServiceProxy* theService;
   edm::ParameterSet parameters;
 
   edm::EDGetTokenT<edm::View<reco::Track> > theMuonCollectionLabel_;
@@ -104,7 +102,6 @@ CosmicMuonRecoAnalyzer::CosmicMuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   parameters = pSet;
 
   // the services:
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theMuonCollectionLabel_ = consumes<edm::View<reco::Track> >(parameters.getParameter<edm::InputTag>("MuonCollection"));
 
   nTrkBin = parameters.getParameter<int>("nTrkBin");
@@ -139,7 +136,7 @@ CosmicMuonRecoAnalyzer::CosmicMuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   theFolder = parameters.getParameter<string>("folder");
 }
 
-CosmicMuonRecoAnalyzer::~CosmicMuonRecoAnalyzer() { delete theService; }
+CosmicMuonRecoAnalyzer::~CosmicMuonRecoAnalyzer() {}
 
 void CosmicMuonRecoAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                             edm::Run const& /*iRun*/,
@@ -216,7 +213,6 @@ void CosmicMuonRecoAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 
 void CosmicMuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname) << "[MuonRecoAnalyzer] Analyze the mu";
-  theService->update(iSetup);
 
   // Take the muon container
   edm::Handle<edm::View<reco::Track> > muons;

--- a/DQMOffline/Muon/interface/EfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/EfficiencyAnalyzer.h
@@ -19,7 +19,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -43,7 +42,6 @@ public:
 
 private:
   edm::ParameterSet parameters;
-  MuonServiceProxy* theService;
 
   // Switch for verbosity
   std::string metname;

--- a/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonEnergyDepositAnalyzer.h
@@ -20,7 +20,6 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -41,7 +40,6 @@ public:
 private:
   // ----------member data ---------------------------
   edm::ParameterSet parameters;
-  MuonServiceProxy *theService;
   edm::EDGetTokenT<reco::MuonCollection> theMuonCollectionLabel_;
 
   // Switch for verbosity

--- a/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
@@ -28,7 +28,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 class MuonKinVsEtaAnalyzer : public DQMEDAnalyzer {
 public:
@@ -43,7 +42,6 @@ public:
 
 private:
   // ----------member data ---------------------------
-  MuonServiceProxy *theService;
   edm::ParameterSet parameters;
 
   // Switch for verbosity

--- a/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonRecoAnalyzer.h
@@ -20,8 +20,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -51,7 +49,6 @@ public:
 
 private:
   // ----------member data ---------------------------
-  MuonServiceProxy* theService;
   edm::ParameterSet parameters;
 
   edm::EDGetTokenT<edm::View<reco::Muon> > theMuonCollectionLabel_;

--- a/DQMOffline/Muon/interface/MuonRecoOneHLT.h
+++ b/DQMOffline/Muon/interface/MuonRecoOneHLT.h
@@ -10,7 +10,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
@@ -55,7 +54,6 @@ public:
 private:
   // ----------member data ---------------------------
   edm::ParameterSet parameters;
-  MuonServiceProxy* theService;
 
   // Switch for verbosity
   std::string metname;

--- a/DQMOffline/Muon/interface/MuonTiming.h
+++ b/DQMOffline/Muon/interface/MuonTiming.h
@@ -20,8 +20,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
@@ -39,7 +37,6 @@ public:
 
 private:
   // ----------member data ---------------------------
-  MuonServiceProxy *theService;
 
   edm::EDGetTokenT<edm::View<reco::Muon> > theMuonCollectionLabel_;
   // Switch for verbosity

--- a/DQMOffline/Muon/interface/SegmentTrackAnalyzer.h
+++ b/DQMOffline/Muon/interface/SegmentTrackAnalyzer.h
@@ -17,7 +17,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/TrackingTools/interface/SegmentsTrackAssociator.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -32,17 +31,13 @@ public:
   SegmentTrackAnalyzer(const edm::ParameterSet&);
 
   /// Destructor
-  ~SegmentTrackAnalyzer() override {
-    delete theService;
-    delete theSegmentsAssociator;
-  };
+  ~SegmentTrackAnalyzer() override { delete theSegmentsAssociator; };
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:
   // ----------member data ---------------------------
-  MuonServiceProxy* theService;
   edm::ParameterSet parameters;
   edm::EDGetTokenT<reco::TrackCollection> theMuTrackCollectionLabel_;
 

--- a/DQMOffline/Muon/interface/TriggerMatchMonitor.h
+++ b/DQMOffline/Muon/interface/TriggerMatchMonitor.h
@@ -27,7 +27,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
@@ -47,7 +46,6 @@ public:
 
 private:
   // ----------member data ---------------------------
-  MuonServiceProxy* theService;
   edm::ParameterSet parameters;
 
   // triggerNames to be passed from config

--- a/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
@@ -29,8 +29,6 @@ using namespace edm;
 EfficiencyAnalyzer::EfficiencyAnalyzer(const edm::ParameterSet& pSet) {
   parameters = pSet;
 
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-
   // DATA
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >(parameters.getParameter<edm::InputTag>("MuonCollection"));
   theTrackCollectionLabel_ = consumes<reco::TrackCollection>(parameters.getParameter<edm::InputTag>("TrackCollection"));
@@ -60,7 +58,7 @@ EfficiencyAnalyzer::EfficiencyAnalyzer(const edm::ParameterSet& pSet) {
   theFolder = parameters.getParameter<string>("folder");
 }
 
-EfficiencyAnalyzer::~EfficiencyAnalyzer() { delete theService; }
+EfficiencyAnalyzer::~EfficiencyAnalyzer() {}
 
 void EfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                         edm::Run const& /*iRun*/,
@@ -159,7 +157,6 @@ void EfficiencyAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 
 void EfficiencyAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname) << "[EfficiencyAnalyzer] Analyze the mu in different eta regions";
-  theService->update(iSetup);
   // ==========================================================
   // BEGIN READ DATA:
   // Muon information

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -24,9 +24,6 @@ using namespace edm;
 MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet) {
   parameters = pSet;
 
-  // the services
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));
 
   AlgoName = parameters.getParameter<std::string>("AlgoName");
@@ -54,7 +51,7 @@ MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pS
   hoS9NoMin = parameters.getParameter<double>("hoS9SizeMin");
   hoS9NoMax = parameters.getParameter<double>("hoS9SizeMax");
 }
-MuonEnergyDepositAnalyzer::~MuonEnergyDepositAnalyzer() { delete theService; }
+MuonEnergyDepositAnalyzer::~MuonEnergyDepositAnalyzer() {}
 void MuonEnergyDepositAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                                edm::Run const& /*iRun*/,
                                                edm::EventSetup const& /* iSetup */) {
@@ -160,7 +157,6 @@ void MuonEnergyDepositAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 }
 void MuonEnergyDepositAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname) << "[MuonEnergyDepositAnalyzer] Filling the histos";
-  theService->update(iSetup);
 
   // Take the muon container
   edm::Handle<reco::MuonCollection> muons;

--- a/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
@@ -21,9 +21,6 @@ MuonKinVsEtaAnalyzer::MuonKinVsEtaAnalyzer(const edm::ParameterSet& pSet) {
 
   parameters = pSet;
 
-  // the services
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >(parameters.getParameter<edm::InputTag>("MuonCollection"));
   theVertexLabel_ = consumes<reco::VertexCollection>(parameters.getParameter<edm::InputTag>("VertexLabel"));
 
@@ -61,7 +58,7 @@ MuonKinVsEtaAnalyzer::MuonKinVsEtaAnalyzer(const edm::ParameterSet& pSet) {
 
   theFolder = parameters.getParameter<string>("folder");
 }
-MuonKinVsEtaAnalyzer::~MuonKinVsEtaAnalyzer() { delete theService; }
+MuonKinVsEtaAnalyzer::~MuonKinVsEtaAnalyzer() {}
 
 void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                           edm::Run const& /*iRun*/,
@@ -167,7 +164,6 @@ void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 }
 void MuonKinVsEtaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname) << "[MuonKinVsEtaAnalyzer] Analyze the mu in different eta regions";
-  theService->update(iSetup);
 
   edm::Handle<edm::View<reco::Muon> > muons;
   iEvent.getByToken(theMuonCollectionLabel_, muons);

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -22,7 +22,6 @@ MuonRecoAnalyzer::MuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   IsminiAOD = parameters.getParameter<bool>("IsminiAOD");
   doMVA = parameters.getParameter<bool>("doMVA");
   // the services:
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >(parameters.getParameter<edm::InputTag>("MuonCollection"));
   theVertexLabel_ = consumes<reco::VertexCollection>(pSet.getParameter<InputTag>("inputTagVertex"));
   theBeamSpotLabel_ = consumes<reco::BeamSpot>(pSet.getParameter<InputTag>("inputTagBeamSpot"));
@@ -60,7 +59,7 @@ MuonRecoAnalyzer::MuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   theFolder = parameters.getParameter<string>("folder");
 }
 
-MuonRecoAnalyzer::~MuonRecoAnalyzer() { delete theService; }
+MuonRecoAnalyzer::~MuonRecoAnalyzer() {}
 void MuonRecoAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
                                       edm::Run const& /*iRun*/,
                                       edm::EventSetup const& /* iSetup */) {
@@ -575,7 +574,6 @@ void MuonRecoAnalyzer::GetRes(reco::TrackRef t1, reco::TrackRef t2, string par, 
 
 void MuonRecoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname) << "[MuonRecoAnalyzer] Analyze the mu";
-  theService->update(iSetup);
 
   // Take the muon container
   edm::Handle<edm::View<reco::Muon> > muons;

--- a/DQMOffline/Muon/src/MuonRecoOneHLT.cc
+++ b/DQMOffline/Muon/src/MuonRecoOneHLT.cc
@@ -10,12 +10,8 @@ using namespace edm;
 // Uncomment to DEBUG
 //#define DEBUG
 
-MuonRecoOneHLT::MuonRecoOneHLT(
-    const edm::ParameterSet& pSet) {  //, MuonServiceProxy *theService) :MuonAnalyzerBase(theService) {
+MuonRecoOneHLT::MuonRecoOneHLT(const edm::ParameterSet& pSet) {
   parameters = pSet;
-
-  // the services
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
 
   ParameterSet muonparms = parameters.getParameter<edm::ParameterSet>("SingleMuonTrigger");
   ParameterSet dimuonparms = parameters.getParameter<edm::ParameterSet>("DoubleMuonTrigger");
@@ -47,7 +43,6 @@ MuonRecoOneHLT::MuonRecoOneHLT(
   phiMax = parameters.getParameter<double>("phiMax");
 }
 MuonRecoOneHLT::~MuonRecoOneHLT() {
-  delete theService;
   delete _SingleMuonEventFlag;
   delete _DoubleMuonEventFlag;
 }
@@ -128,8 +123,6 @@ void MuonRecoOneHLT::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& 
     singlemuonExpr_ = _DoubleMuonEventFlag->expressionsFromDB(_DoubleMuonEventFlag->hltDBKey(), iSetup);
 }
 void MuonRecoOneHLT::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  theService->update(iSetup);
-
   // =================================================================================
   // Look for the Primary Vertex (and use the BeamSpot instead, if you can't find it):
   reco::Vertex::Point posVtx;

--- a/DQMOffline/Muon/src/MuonSeedsAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonSeedsAnalyzer.cc
@@ -25,6 +25,7 @@
 #include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <string>
@@ -35,7 +36,7 @@ using namespace edm;
 MuonSeedsAnalyzer::MuonSeedsAnalyzer(const edm::ParameterSet& pSet) {
   parameters = pSet;
 
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
+  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"), consumesCollector());
 
   theSeedsCollectionLabel_ = consumes<TrajectorySeedCollection>(parameters.getParameter<InputTag>("SeedCollection"));
 

--- a/DQMOffline/Muon/src/MuonTiming.cc
+++ b/DQMOffline/Muon/src/MuonTiming.cc
@@ -21,7 +21,6 @@ MuonTiming::MuonTiming(const edm::ParameterSet& pSet) {
   // Input booleans
 
   // the services:
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theMuonCollectionLabel_ = consumes<edm::View<reco::Muon> >(parameters.getParameter<edm::InputTag>("MuonCollection"));
 
   tnbins_ = parameters.getParameter<int>("tnbins");
@@ -56,7 +55,7 @@ MuonTiming::MuonTiming(const edm::ParameterSet& pSet) {
   theFolder_ = parameters.getParameter<string>("folder");
 }
 
-MuonTiming::~MuonTiming() { delete theService; }
+MuonTiming::~MuonTiming() {}
 
 void MuonTiming::bookHistograms(DQMStore::IBooker& ibooker,
                                 edm::Run const& /*iRun*/,
@@ -153,7 +152,6 @@ void MuonTiming::bookHistograms(DQMStore::IBooker& ibooker,
 
 void MuonTiming::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname_) << "[MuonTiming] Analyze the mu";
-  theService->update(iSetup);
 
   // Take the muon container
   edm::Handle<edm::View<reco::Muon> > muons;

--- a/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
+++ b/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
@@ -27,9 +27,6 @@ using namespace edm;
 SegmentTrackAnalyzer::SegmentTrackAnalyzer(const edm::ParameterSet& pSet) {
   parameters = pSet;
 
-  // MuonService
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-
   // Read Data:
   theMuTrackCollectionLabel_ =
       consumes<reco::TrackCollection>(parameters.getParameter<edm::InputTag>("MuTrackCollection"));
@@ -203,8 +200,6 @@ void SegmentTrackAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 }
 
 void SegmentTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  theService->update(iSetup);
-
   Handle<reco::TrackCollection> glbTracks;
   iEvent.getByToken(theMuTrackCollectionLabel_, glbTracks);
 

--- a/DQMOffline/Muon/src/TriggerMatchMonitor.cc
+++ b/DQMOffline/Muon/src/TriggerMatchMonitor.cc
@@ -22,9 +22,6 @@ TriggerMatchMonitor::TriggerMatchMonitor(const edm::ParameterSet& pSet) {
 
   parameters = pSet;
 
-  // the services
-  theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
-
   beamSpotToken_ = consumes<reco::BeamSpot>(parameters.getUntrackedParameter<edm::InputTag>("offlineBeamSpot")),
   primaryVerticesToken_ =
       consumes<std::vector<reco::Vertex>>(parameters.getUntrackedParameter<edm::InputTag>("offlinePrimaryVertices")),
@@ -46,7 +43,7 @@ TriggerMatchMonitor::TriggerMatchMonitor(const edm::ParameterSet& pSet) {
   triggerPtThresholdPath2_ = parameters.getParameter<double>("triggerPtThresholdPath2");
   theFolder = parameters.getParameter<string>("folder");
 }
-TriggerMatchMonitor::~TriggerMatchMonitor() { delete theService; }
+TriggerMatchMonitor::~TriggerMatchMonitor() {}
 
 void TriggerMatchMonitor::bookHistograms(DQMStore::IBooker& ibooker,
                                          edm::Run const& /*iRun*/,
@@ -139,7 +136,6 @@ void TriggerMatchMonitor::bookHistograms(DQMStore::IBooker& ibooker,
 }
 void TriggerMatchMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   LogTrace(metname) << "[TriggerMatchMonitor] Analyze the mu in different eta regions";
-  theService->update(iSetup);
 
   edm::Handle<edm::View<reco::Muon>> muons;
   iEvent.getByToken(theMuonCollectionLabel_, muons);

--- a/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
+++ b/FastSimulation/MuonSimHitProducer/src/MuonSimHitProducer.cc
@@ -21,6 +21,7 @@
 //
 
 // CMSSW headers
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 // Fast Simulation headers
@@ -89,7 +90,7 @@ MuonSimHitProducer::MuonSimHitProducer(const edm::ParameterSet& iConfig)
   produces<edm::PSimHitContainer>("MuonRPCHits");
 
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector(), MuonServiceProxy::UseEventSetupIn::Run);
 
   // consumes
   simMuonToken = consumes<std::vector<SimTrack> >(simMuonLabel);
@@ -115,7 +116,8 @@ void MuonSimHitProducer::beginRun(edm::Run const& run, const edm::EventSetup& es
   cscGeom = &(*cscGeometry);
   rpcGeom = &(*rpcGeometry);
 
-  theService->update(es);
+  bool duringEvent = false;
+  theService->update(es, duringEvent);
 
   // A few propagators
   propagatorWithMaterial = &(*(theService->propagator("SteppingHelixPropagatorAny")));

--- a/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
+++ b/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
@@ -7,7 +7,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -28,7 +27,6 @@ public:
 
     // initialize muon service proxy
     edm::ParameterSet servicePSet = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
-    theService = new MuonServiceProxy(servicePSet);
   }
 
   ~HIMuonTrackingRegionProducer() override {}
@@ -55,7 +53,6 @@ public:
     std::vector<std::unique_ptr<TrackingRegion> > result;
 
     // initialize the region builder
-    theService->update(es);
     theRegionBuilder->setEvent(ev);
 
     // get stand-alone muon collection
@@ -83,7 +80,6 @@ private:
   edm::InputTag theMuonSource;
   edm::EDGetTokenT<reco::TrackCollection> theMuonSourceToken;
   MuonTrackingRegionBuilder* theRegionBuilder;
-  MuonServiceProxy* theService;
 };
 
 #endif

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -1687,7 +1687,7 @@ CSCEfficiency::CSCEfficiency(const edm::ParameterSet &pset) {
 
   edm::ParameterSet serviceParameters = pset.getParameter<edm::ParameterSet>("ServiceParameters");
   // maybe use the service for getting magnetic field, propagators, etc. ...
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   // Trigger
   useTrigger = pset.getUntrackedParameter<bool>("useTrigger", false);

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonLinksProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonLinksProducer.cc
@@ -10,6 +10,7 @@
 #include <memory>
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -37,7 +38,7 @@ CosmicMuonLinksProducer::CosmicMuonLinksProducer(const ParameterSet& iConfig) {
 
   ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
 
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   std::vector<edm::ParameterSet> theMapPSets = iConfig.getParameter<std::vector<edm::ParameterSet> >("Maps");
   for (std::vector<edm::ParameterSet>::const_iterator iMPS = theMapPSets.begin(); iMPS != theMapPSets.end(); iMPS++) {

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
@@ -14,6 +14,7 @@
 #include <memory>
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -55,7 +56,7 @@ CosmicMuonProducer::CosmicMuonProducer(const ParameterSet& iConfig) {
 
   edm::ConsumesCollector iC = consumesCollector();
 
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
   theTrackFinder =
       std::make_unique<MuonTrackFinder>(std::make_unique<CosmicMuonTrajectoryBuilder>(tbpar, theService.get(), iC),
                                         std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get()));

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
@@ -47,7 +47,7 @@ GlobalCosmicMuonProducer::GlobalCosmicMuonProducer(const edm::ParameterSet& iCon
   edm::ParameterSet trackLoaderParameters = iConfig.getParameter<edm::ParameterSet>("TrackLoaderParameters");
 
   // the services
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
   edm::ConsumesCollector iC = consumesCollector();
   theTrackFinder = std::make_unique<MuonTrackFinder>(
       std::make_unique<GlobalCosmicMuonTrajectoryBuilder>(tbpar, theService.get(), iC),

--- a/RecoMuon/CosmicMuonProducer/test/CosmicMuonValidator.cc
+++ b/RecoMuon/CosmicMuonProducer/test/CosmicMuonValidator.cc
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
@@ -118,7 +119,7 @@ CosmicMuonValidator::CosmicMuonValidator(const edm::ParameterSet& iConfig) {
   // service parameters
   edm::ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   nEvent = 0;
   successR = 0;

--- a/RecoMuon/CosmicMuonProducer/test/RealCosmicDataAnalyzer.cc
+++ b/RecoMuon/CosmicMuonProducer/test/RealCosmicDataAnalyzer.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
@@ -101,7 +102,7 @@ RealCosmicDataAnalyzer::RealCosmicDataAnalyzer(const edm::ParameterSet& iConfig)
   // service parameters
   edm::ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   nEvent = 0;
   successR = 0;

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
@@ -10,6 +10,7 @@
  */
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -56,7 +57,7 @@ GlobalMuonProducer::GlobalMuonProducer(const ParameterSet& parameterSet) {
   ParameterSet trackLoaderParameters = parameterSet.getParameter<ParameterSet>("TrackLoaderParameters");
 
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   // instantiate the concrete trajectory builder in the Track Finder
   edm::ConsumesCollector iC = consumesCollector();

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
@@ -8,6 +8,7 @@
  */
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -44,7 +45,7 @@ TevMuonProducer::TevMuonProducer(const ParameterSet& parameterSet) {
   ParameterSet serviceParameters = parameterSet.getParameter<ParameterSet>("ServiceParameters");
 
   // the services
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
   edm::ConsumesCollector iC = consumesCollector();
 
   // TrackRefitter parameters

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -12,6 +12,7 @@
 #include <memory>
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/isFinite.h"
@@ -32,7 +33,7 @@ GlobalTrackQualityProducer::GlobalTrackQualityProducer(const edm::ParameterSet& 
       theGlbMatcher(nullptr) {
   // service parameters
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   // TrackRefitter parameters
   edm::ConsumesCollector iC = consumesCollector();

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
@@ -19,6 +19,7 @@
 #include "RecoMuon/L2MuonProducer/src/L2MuonProducer.h"
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -62,7 +63,7 @@ L2MuonProducer::L2MuonProducer(const ParameterSet& parameterSet) {
   ParameterSet trackLoaderParameters = parameterSet.getParameter<ParameterSet>("TrackLoaderParameters");
 
   // the services
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
 
   std::unique_ptr<MuonTrajectoryBuilder> trajectoryBuilder = nullptr;
   // instantiate the concrete trajectory builder in the Track Finder

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
@@ -19,6 +19,7 @@
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.h"
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -62,7 +63,7 @@ L2MuonSeedGenerator::L2MuonSeedGenerator(const edm::ParameterSet& iConfig)
   ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
 
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   // the estimator
   theEstimator = new Chi2MeasurementEstimator(10000.);

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -21,6 +21,7 @@
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h"
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -101,7 +102,7 @@ L2MuonSeedGeneratorFromL1T::L2MuonSeedGeneratorFromL1T(const edm::ParameterSet &
   ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
 
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   // the estimator
   theEstimator = new Chi2MeasurementEstimator(10000.);

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -9,6 +9,7 @@
  */
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -51,7 +52,7 @@ L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
   ParameterSet trackLoaderParameters = parameterSet.getParameter<ParameterSet>("TrackLoaderParameters");
 
   // the services
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
   ConsumesCollector iC = consumesCollector();
 
   // instantiate the concrete trajectory builder in the Track Finder

--- a/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
@@ -54,7 +54,7 @@ class MuonServiceProxy;
 class CSCTimingExtractor {
 public:
   /// Constructor
-  CSCTimingExtractor(const edm::ParameterSet &, MuonSegmentMatcher *segMatcher);
+  CSCTimingExtractor(const edm::ParameterSet &, MuonSegmentMatcher *segMatcher, edm::ConsumesCollector &);
 
   /// Destructor
   ~CSCTimingExtractor();

--- a/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
@@ -54,7 +54,7 @@ class MuonServiceProxy;
 class DTTimingExtractor {
 public:
   /// Constructor
-  DTTimingExtractor(const edm::ParameterSet&, MuonSegmentMatcher* segMatcher);
+  DTTimingExtractor(const edm::ParameterSet&, MuonSegmentMatcher* segMatcher, edm::ConsumesCollector&);
 
   /// Destructor
   ~DTTimingExtractor();

--- a/RecoMuon/MuonIdentification/interface/MuonCosmicCompatibilityFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCosmicCompatibilityFiller.h
@@ -36,7 +36,6 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 class GlobalMuonRefitter;
-class MuonServiceProxy;
 
 class MuonCosmicCompatibilityFiller {
 public:
@@ -85,8 +84,6 @@ private:
   std::vector<edm::EDGetTokenT<reco::TrackCollection> > trackTokens_;
   edm::EDGetTokenT<reco::MuonCollection> cosmicToken_;
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
-
-  MuonServiceProxy* service_;
 
   double maxdxyLoose_;
   double maxdzLoose_;

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -17,6 +17,7 @@
 #include "RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h"
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 
@@ -64,7 +65,9 @@ class MuonServiceProxy;
 //
 // constructors and destructor
 //
-CSCTimingExtractor::CSCTimingExtractor(const edm::ParameterSet& iConfig, MuonSegmentMatcher* segMatcher)
+CSCTimingExtractor::CSCTimingExtractor(const edm::ParameterSet& iConfig,
+                                       MuonSegmentMatcher* segMatcher,
+                                       edm::ConsumesCollector& iC)
     : thePruneCut_(iConfig.getParameter<double>("PruneCut")),
       theStripTimeOffset_(iConfig.getParameter<double>("CSCStripTimeOffset")),
       theWireTimeOffset_(iConfig.getParameter<double>("CSCWireTimeOffset")),
@@ -74,7 +77,7 @@ CSCTimingExtractor::CSCTimingExtractor(const edm::ParameterSet& iConfig, MuonSeg
       UseStripTime(iConfig.getParameter<bool>("UseStripTime")),
       debug(iConfig.getParameter<bool>("debug")) {
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, edm::ConsumesCollector(iC));
   theMatcher = segMatcher;
 }
 

--- a/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
@@ -17,6 +17,7 @@
 #include "RecoMuon/MuonIdentification/interface/DTTimingExtractor.h"
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 
@@ -70,7 +71,9 @@ class MuonServiceProxy;
 //
 // constructors and destructor
 //
-DTTimingExtractor::DTTimingExtractor(const edm::ParameterSet& iConfig, MuonSegmentMatcher* segMatcher)
+DTTimingExtractor::DTTimingExtractor(const edm::ParameterSet& iConfig,
+                                     MuonSegmentMatcher* segMatcher,
+                                     edm::ConsumesCollector& iC)
     : theHitsMin_(iConfig.getParameter<int>("HitsMin")),
       thePruneCut_(iConfig.getParameter<double>("PruneCut")),
       theTimeOffset_(iConfig.getParameter<double>("DTTimeOffset")),
@@ -81,7 +84,7 @@ DTTimingExtractor::DTTimingExtractor(const edm::ParameterSet& iConfig, MuonSegme
       requireBothProjections_(iConfig.getParameter<bool>("RequireBothProjections")),
       debug(iConfig.getParameter<bool>("debug")) {
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, edm::ConsumesCollector(iC));
   theMatcher = segMatcher;
 }
 

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -20,7 +20,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
@@ -48,12 +47,7 @@ MuonCosmicCompatibilityFiller::MuonCosmicCompatibilityFiller(const edm::Paramete
     : inputMuonCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("InputMuonCollections")),
       inputTrackCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("InputTrackCollections")),
       inputCosmicMuonCollection_(iConfig.getParameter<edm::InputTag>("InputCosmicMuonCollection")),
-      inputVertexCollection_(iConfig.getParameter<edm::InputTag>("InputVertexCollection")),
-      service_(nullptr) {
-  // service parameters
-  edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  service_ = new MuonServiceProxy(serviceParameters);
-
+      inputVertexCollection_(iConfig.getParameter<edm::InputTag>("InputVertexCollection")) {
   //kinematic vars
   angleThreshold_ = iConfig.getParameter<double>("angleCut");
   deltaPt_ = iConfig.getParameter<double>("deltaPt");
@@ -102,10 +96,7 @@ MuonCosmicCompatibilityFiller::MuonCosmicCompatibilityFiller(const edm::Paramete
   vertexToken_ = iC.consumes<reco::VertexCollection>(inputVertexCollection_);
 }
 
-MuonCosmicCompatibilityFiller::~MuonCosmicCompatibilityFiller() {
-  if (service_)
-    delete service_;
-}
+MuonCosmicCompatibilityFiller::~MuonCosmicCompatibilityFiller() {}
 
 reco::MuonCosmicCompatibility MuonCosmicCompatibilityFiller::fillCompatibility(const reco::Muon& muon,
                                                                                edm::Event& iEvent,
@@ -113,8 +104,6 @@ reco::MuonCosmicCompatibility MuonCosmicCompatibilityFiller::fillCompatibility(c
   const std::string theCategory = "MuonCosmicCompatibilityFiller";
 
   reco::MuonCosmicCompatibility returnComp;
-
-  service_->update(iSetup);
 
   float timeCompatibility = muonTiming(iEvent, muon, false);
   float backToBackCompatibility = backToBack2LegCosmic(iEvent, muon);

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -77,7 +77,7 @@ MuonShowerInformationFiller::MuonShowerInformationFiller(const edm::ParameterSet
   theDT4DRecSegmentToken = iC.consumes<DTRecSegment4DCollection>(theDT4DRecSegmentLabel);
 
   edm::ParameterSet serviceParameters = par.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, edm::ConsumesCollector(iC));
 
   theTrackerRecHitBuilderName = par.getParameter<string>("TrackerRecHitBuilder");
   theMuonRecHitBuilderName = par.getParameter<string>("MuonRecHitBuilder");

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -55,8 +55,8 @@ MuonTimingFiller::MuonTimingFiller(const edm::ParameterSet& iConfig, edm::Consum
     matchParameters = dtTimingParameters.getParameter<edm::ParameterSet>("MatchParameters");
 
   theMatcher_ = std::make_unique<MuonSegmentMatcher>(matchParameters, iC);
-  theDTTimingExtractor_ = std::make_unique<DTTimingExtractor>(dtTimingParameters, theMatcher_.get());
-  theCSCTimingExtractor_ = std::make_unique<CSCTimingExtractor>(cscTimingParameters, theMatcher_.get());
+  theDTTimingExtractor_ = std::make_unique<DTTimingExtractor>(dtTimingParameters, theMatcher_.get(), iC);
+  theCSCTimingExtractor_ = std::make_unique<CSCTimingExtractor>(cscTimingParameters, theMatcher_.get(), iC);
 
   errorEB_ = iConfig.getParameter<double>("ErrorEB");
   errorEE_ = iConfig.getParameter<double>("ErrorEE");

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc
@@ -57,7 +57,7 @@ CaloExtractorByAssociator::CaloExtractorByAssociator(const ParameterSet& par, ed
       theAssociator(nullptr),
       thePrintTimeReport(par.getUntrackedParameter<bool>("PrintTimeReport")) {
   ParameterSet serviceParameters = par.getParameter<ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, edm::ConsumesCollector(iC));
 
   //theAssociatorParameters = new TrackAssociatorParameters(par.getParameter<edm::ParameterSet>("TrackAssociatorParameters"), iC);
   theAssociatorParameters = new TrackAssociatorParameters();

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.cc
@@ -40,7 +40,7 @@ JetExtractor::JetExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
       theAssociator(nullptr),
       thePrintTimeReport(par.getUntrackedParameter<bool>("PrintTimeReport")) {
   ParameterSet serviceParameters = par.getParameter<ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, edm::ConsumesCollector(iC));
 
   //  theAssociatorParameters = new TrackAssociatorParameters(par.getParameter<edm::ParameterSet>("TrackAssociatorParameters"), iC_);
   theAssociatorParameters = new TrackAssociatorParameters();

--- a/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.cc
+++ b/RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.cc
@@ -5,6 +5,7 @@
 #include "RecoMuon/MuonSeedGenerator/plugins/SETMuonSeedProducer.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
@@ -36,7 +37,7 @@ SETMuonSeedProducer::SETMuonSeedProducer(const ParameterSet& parameterSet)
   //std::cout<<" The SET SEED producer started."<<std::endl;
 
   ParameterSet serviceParameters = parameterSet.getParameter<ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
   thePatternRecognition->setServiceProxy(theService);
   theSeedFinder.setServiceProxy(theService);
   // Parameter set for the Builder

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedBuilder.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedBuilder.cc
@@ -80,13 +80,9 @@ MuonSeedBuilder::MuonSeedBuilder(const edm::ParameterSet& pset, edm::ConsumesCol
   maxEtaResolutionCSC = pset.getParameter<double>("maxEtaResolutionCSC");
   maxPhiResolutionCSC = pset.getParameter<double>("maxPhiResolutionCSC");
 
-  // muon service
-  edm::ParameterSet serviceParameters = pset.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
-
   // Class for forming muon seeds
   muonSeedCreate_ = new MuonSeedCreator(pset);
-  muonSeedClean_ = new MuonSeedCleaner(pset);
+  muonSeedClean_ = new MuonSeedCleaner(pset, edm::ConsumesCollector(iC));
 
   // Instantiate the accessor (get the segments: DT + CSC but not RPC=false)
   muonMeasurements = new MuonDetLayerMeasurements(theDTSegmentLabel,
@@ -108,8 +104,6 @@ MuonSeedBuilder::MuonSeedBuilder(const edm::ParameterSet& pset, edm::ConsumesCol
 MuonSeedBuilder::~MuonSeedBuilder() {
   delete muonSeedCreate_;
   delete muonSeedClean_;
-  if (theService)
-    delete theService;
   if (muonMeasurements)
     delete muonMeasurements;
 }

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedBuilder.h
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedBuilder.h
@@ -17,9 +17,6 @@
 #include <DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h>
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-//muon service
-#include <RecoMuon/TrackingTools/interface/MuonServiceProxy.h>
-
 #include <vector>
 
 class DetLayer;
@@ -147,9 +144,6 @@ private:
 
   // Cache Magnetic Field for current event
   const MagneticField* BField;
-
-  // muon service
-  MuonServiceProxy* theService;
 
   // Minimum separation when we can distinguish between 2 muon seeds
   // (to suppress combinatorics)

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedCleaner.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedCleaner.cc
@@ -46,13 +46,13 @@ static bool lengthSorting(const TrajectorySeed& s1, const TrajectorySeed& s2) { 
 /*
  * Constructor
  */
-MuonSeedCleaner::MuonSeedCleaner(const edm::ParameterSet& pset) {
+MuonSeedCleaner::MuonSeedCleaner(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC) {
   // Local Debug flag
   debug = pset.getParameter<bool>("DebugMuonSeed");
 
   // muon service
   edm::ParameterSet serviceParameters = pset.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, std::move(iC));
 }
 
 /*

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedCleaner.h
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedCleaner.h
@@ -9,6 +9,7 @@
  *
  */
 
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h>
 #include <DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h>
@@ -30,7 +31,7 @@ public:
   typedef std::deque<bool> BoolContainer;
 
   /// Constructor
-  explicit MuonSeedCleaner(const edm::ParameterSet&);
+  explicit MuonSeedCleaner(const edm::ParameterSet&, edm::ConsumesCollector&&);
 
   /// Destructor
   ~MuonSeedCleaner();

--- a/RecoMuon/MuonSeedGenerator/test/MCSeedGenerator/MCMuonSeedGenerator.cc
+++ b/RecoMuon/MuonSeedGenerator/test/MCSeedGenerator/MCMuonSeedGenerator.cc
@@ -8,6 +8,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -44,7 +45,7 @@ MCMuonSeedGenerator2::MCMuonSeedGenerator2(const edm::ParameterSet& parameterSet
   ParameterSet serviceParameters = parameterSet.getParameter<ParameterSet>("ServiceParameters");
 
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   // Error Scale
   theErrorScale = parameterSet.getParameter<double>("ErrorScale");

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.cc
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -60,7 +61,7 @@ MuonSeedValidator::MuonSeedValidator(const ParameterSet& pset) {
   eta_High = pset.getUntrackedParameter<double>("eta_High");
 
   ParameterSet serviceParameters = pset.getParameter<ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   recsegSelector = new SegSelector(pset);
 

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
@@ -11,6 +11,7 @@
  */
 
 // Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -58,7 +59,7 @@ StandAloneMuonProducer::StandAloneMuonProducer(const ParameterSet& parameterSet)
   edm::ConsumesCollector iC = consumesCollector();
 
   // the services
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
 
   auto trackLoader = std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get());
   std::unique_ptr<MuonTrajectoryBuilder> trajectoryBuilder;

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -1,4 +1,5 @@
 #include "TSGFromL2Muon.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
@@ -12,7 +13,8 @@ TSGFromL2Muon::TSGFromL2Muon(const edm::ParameterSet& cfg) {
   edm::ConsumesCollector iC = consumesCollector();
 
   edm::ParameterSet serviceParameters = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = std::make_unique<MuonServiceProxy>(serviceParameters);
+  theService = std::make_unique<MuonServiceProxy>(
+      serviceParameters, consumesCollector(), MuonServiceProxy::UseEventSetupIn::RunAndEvent);
 
   //Pt and P cuts
   thePtCut = cfg.getParameter<double>("PtCut");
@@ -46,7 +48,8 @@ TSGFromL2Muon::~TSGFromL2Muon() = default;
 
 void TSGFromL2Muon::beginRun(const edm::Run& run, const edm::EventSetup& es) {
   //update muon proxy service
-  theService->update(es);
+  bool duringEvent = false;
+  theService->update(es, duringEvent);
   theTkSeedGenerator->init(theService.get());
   if (theSeedCleaner)
     theSeedCleaner->init(theService.get());

--- a/Validation/RecoMuon/src/MuonSeedTrack.cc
+++ b/Validation/RecoMuon/src/MuonSeedTrack.cc
@@ -10,6 +10,7 @@
 
 #include "Validation/RecoMuon/src/MuonSeedTrack.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -38,7 +39,7 @@ typedef TrajectoryStateOnSurface TSOS;
 MuonSeedTrack::MuonSeedTrack(const edm::ParameterSet& pset) {
   // service parameters
   ParameterSet serviceParameters = pset.getParameter<ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   ParameterSet updatorPar = pset.getParameter<ParameterSet>("MuonUpdatorAtVertexParameters");
   //theSeedPropagatorName = updatorPar.getParameter<string>("Propagator");

--- a/Validation/RecoMuon/src/MuonTrackAnalyzer.cc
+++ b/Validation/RecoMuon/src/MuonTrackAnalyzer.cc
@@ -7,6 +7,7 @@
 #include "Validation/RecoMuon/src/MuonTrackAnalyzer.h"
 
 // Collaborating Class Header
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,7 +43,7 @@ MuonTrackAnalyzer::MuonTrackAnalyzer(const ParameterSet &ps) {
   pset = ps;
   ParameterSet serviceParameters = pset.getParameter<ParameterSet>("ServiceParameters");
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   theSimTracksLabel = edm::InputTag("g4SimHits");
   theSimTracksToken = consumes<edm::SimTrackContainer>(theSimTracksLabel);

--- a/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.cc
+++ b/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.cc
@@ -1,6 +1,7 @@
 #include "Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h"
 
 // Collaborating Class Header
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -39,7 +40,7 @@ MuonTrackResidualAnalyzer::MuonTrackResidualAnalyzer(const edm::ParameterSet &ps
   // service parameters
   ParameterSet serviceParameters = pset.getParameter<ParameterSet>("ServiceParameters");
   // the services
-  theService = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
   theMuonTrackLabel = pset.getParameter<InputTag>("MuonTrack");
   theMuonTrackToken = consumes<reco::TrackCollection>(theMuonTrackLabel);

--- a/Validation/RecoMuon/src/RecoMuonValidator.cc
+++ b/Validation/RecoMuon/src/RecoMuonValidator.cc
@@ -671,7 +671,6 @@ RecoMuonValidator::RecoMuonValidator(const edm::ParameterSet& pset)
 
   // the service parameters
   ParameterSet serviceParameters = pset.getParameter<ParameterSet>("ServiceParameters");
-  theMuonService = new MuonServiceProxy(serviceParameters);
 
   // retrieve the instance of DQMService
   dbe_ = Service<DQMStore>().operator->();
@@ -792,19 +791,13 @@ void RecoMuonValidator::bookHistograms(DQMStore::IBooker& ibooker,
 //
 //Destructor
 //
-RecoMuonValidator::~RecoMuonValidator() {
-  if (theMuonService)
-    delete theMuonService;
-}
+RecoMuonValidator::~RecoMuonValidator() {}
 
 //
 //Begin run
 //
 
-void RecoMuonValidator::dqmBeginRun(const edm::Run&, const EventSetup& eventSetup) {
-  if (theMuonService)
-    theMuonService->update(eventSetup);
-}
+void RecoMuonValidator::dqmBeginRun(const edm::Run&, const EventSetup& eventSetup) {}
 
 //
 //End run

--- a/Validation/RecoMuon/src/RecoMuonValidator.h
+++ b/Validation/RecoMuon/src/RecoMuonValidator.h
@@ -24,7 +24,6 @@
 // for selection cut
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-class MuonServiceProxy;
 class TrackAssociatorBase;
 
 class RecoMuonValidator : public DQMOneEDAnalyzer<> {
@@ -61,7 +60,6 @@ protected:
   std::string subsystemname_;
   edm::ParameterSet pset;
 
-  MuonServiceProxy* theMuonService;
   DQMStore* dbe_;
 
   bool doAbsEta_;


### PR DESCRIPTION
#### PR description:

This completes the migration of MuonServiceProxy to call
consumes for the EventSetup products it gets. An earlier
commit added support for this if a new constructor was
called, but the old constructor still existed and most clients
were still using the old constructor. This commit migrates all
clients to use the new constructor and deletes the old one.

The main change is that a ConsumesCollector needs to
be passed to the MuonServiceProxy constructor as an argument.
Another change is that MuonServiceProxy now allows calling
update at beginRun because a few modules were doing that
instead of calling update during the event.

Note some modules were constructing and updating a MuonServiceProxy
object, but then never using it. Instead of migrating those, I deleted
MuonServiceProxy from those modules.

Note that this deletes the old constructor. This will break code
outside the repository that uses MuonServiceProxy, but eventually
support for that mode will be dropped by the Framework anyway.

#### PR validation:

Relies on existing tests. Nothing should change in the output.
