### PR TITLE
Fix testSiStripPayloadInspector for Py3

### DIFF
--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -6,4 +6,7 @@
 <use   name="CommonTools/TrackerMap"/>
 <use   name="CalibTracker/StandaloneTrackerTopology"/>
 <bin   file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
+  <ifrelease name="_PY3_">
+    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
+  </ifrelease>
 </bin>

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -142,4 +142,6 @@ int main(int argc, char** argv) {
   SiStripThresholdValueHigh histo14;
   histo14.process(connectionString, tag, runTimeType, start, start);
   std::cout << histo14.data() << std::endl;
+
+  Py_Finalize();
 }


### PR DESCRIPTION
resolves #28837

#### PR description:

Title says it all. Changes made in order to make `testSiStripPayloadInspector` work in python3.
 
#### PR validation:

PR has been tested in Py3 environment in `CMSSW_11_1_PY3_X_2020-01-30-2300`
Validation relies on existing unit tests, which now run successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is meant.