### PR TITLE
Fix for clang LLVM 9.0.1 warning

### DIFF
--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -171,7 +171,7 @@ void TIDLayer::groupedCompatibleDetsV(const TrajectoryStateOnSurface& startingSt
 #else
   constexpr int ringOrder[3]{1, 2, 0};
 #endif
-  auto index = [&ringIndices, &ringOrder](int i) { return ringOrder[ringIndices[i]]; };
+  auto index = [&ringIndices](int i) { return ringOrder[ringIndices[i]]; };
 
   auto& closestResult = groupsAtRingLevel[index(0)];
   theComps[ringIndices[0]]->groupedCompatibleDetsV(startingState, prop, est, closestResult);

--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -166,16 +166,8 @@ void TIDLayer::groupedCompatibleDetsV(const TrajectoryStateOnSurface& startingSt
   std::array<vector<DetGroup>, 3> groupsAtRingLevel;
   //order is ring3,ring1,ring2 i.e. 2 0 1
   //                                0 1 2
-#ifdef __INTEL_COMPILER
-  const int ringOrder[3]{1, 2, 0};
-#else
-  constexpr int ringOrder[3]{1, 2, 0};
-#endif
-#if defined __clang_major__ && __clang_major__ >= 9
+  static constexpr int ringOrder[3]{1, 2, 0};
   auto index = [&ringIndices](int i) { return ringOrder[ringIndices[i]]; };
-#else
-  auto index = [&ringIndices, &ringOrder](int i) { return ringOrder[ringIndices[i]]; };
-#endif
 
   auto& closestResult = groupsAtRingLevel[index(0)];
   theComps[ringIndices[0]]->groupedCompatibleDetsV(startingState, prop, est, closestResult);

--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -171,7 +171,11 @@ void TIDLayer::groupedCompatibleDetsV(const TrajectoryStateOnSurface& startingSt
 #else
   constexpr int ringOrder[3]{1, 2, 0};
 #endif
+#if defined __clang_major__ && __clang_major__ >= 9
   auto index = [&ringIndices](int i) { return ringOrder[ringIndices[i]]; };
+#else
+  auto index = [&ringIndices, &ringOrder](int i) { return ringOrder[ringIndices[i]]; };
+#endif
 
   auto& closestResult = groupsAtRingLevel[index(0)];
   theComps[ringIndices[0]]->groupedCompatibleDetsV(startingState, prop, est, closestResult);


### PR DESCRIPTION
#### PR description:

Trivial fix for the new CLANG warning noticed in CMSSW_11_1_CLANG_X_2020-01-31-2300 
```
>> Compiling  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/7ccc5691cf34b615ad2cf3aa3101fa13/opt/cmssw/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_1_CLANG_X_2020-01-31-2300/src/RecoTracker/TkDetLayers/src/CompatibleDetToGroupAdder.cc 
/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/llvm/9.0.1/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=80301 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DCMSSW_GIT_HASH='CMSSW_11_1_CLANG_X_2020-01-31-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_11_1_CLANG_X_2020-01-31-2300' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/7ccc5691cf34b615ad2cf3aa3101fa13/opt/cmssw/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_1_CLANG_X_2020-01-31-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/dd4hep/v01-10x-chofgf/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/lcg/root/6.18.04-chofgf/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/pcre/8.37-pafccj/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/boost/1.67.0-pafccj/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/bz2lib/1.0.6-pafccj/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/clhep/2.4.0.0-nmpfii/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/gsl/2.2.1-bcolbf/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/libuuid/2.34/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/tbb/2019_U9/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/cms/vdt/0.4.0-nmpfii/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/xerces-c/3.1.3-pafccj/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/xz/5.2.4/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/zlib-x86_64/1.2.11-pafccj/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/md5/1.0.0-pafccj/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/OpenBLAS/0.3.7/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc820/external/tinyxml2/6.2.0-nmpfii/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-tautological-type-limit-compare -fsized-deallocation -Ofast -Wno-error=unused-variable -Wno-error=unused-variable -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS   -fPIC      -MMD -MF tmp/slc7_amd64_gcc820/src/RecoTracker/TkDetLayers/src/RecoTrackerTkDetLayers/CompatibleDetToGroupAdder.cc.d /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/7ccc5691cf34b615ad2cf3aa3101fa13/opt/cmssw/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_1_CLANG_X_2020-01-31-2300/src/RecoTracker/TkDetLayers/src/CompatibleDetToGroupAdder.cc -o tmp/slc7_amd64_gcc820/src/RecoTracker/TkDetLayers/src/RecoTrackerTkDetLayers/CompatibleDetToGroupAdder.cc.o
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/7ccc5691cf34b615ad2cf3aa3101fa13/opt/cmssw/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_1_CLANG_X_2020-01-31-2300/src/RecoTracker/TkDetLayers/src/TIDLayer.cc:174:32: warning: lambda capture 'ringOrder' is not required to be captured for this use [-Wunused-lambda-capture]
   auto index = [&ringIndices, &ringOrder](int i) { return ringOrder[ringIndices[i]]; };
                            ~~~^~~~~~~~~
1 warning generated.
```

#### PR validation:

The short matrix runs smoothly in the CLANG build, the clang warning is no more present.