### PR TITLE
Updates for Custom JME NanoAODs: Fix JetID, update modifiers and able to run on data

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
 
 from PhysicsTools.NanoAOD.common_cff import Var, P4Vars
 from PhysicsTools.NanoAOD.jets_cff import jetTable
@@ -178,11 +179,6 @@ JETVARS = cms.PSet(P4Vars,
   jercCHF   = jetTable.variables.jercCHF,
 )
 
-for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-  modifier.toModify(JETVARS,
-    jetId = Var("userInt('tightId')*2+userInt('looseId')", int, doc = "Jet ID flags bit1 is loose, bit2 is tight")
-  )
-
 #============================================
 #
 # TableGenJetAdder
@@ -330,14 +326,6 @@ class TableRecoJetAdder(object):
     )
     currentTasks.append(table)
 
-    tightJetIdLepVeto = "tightJetIdLepVeto{}".format(recoJetInfo.jetTagName)
-    if not recoJetInfo.skipUserData:
-      altTasks = copy.deepcopy(currentTasks)
-      for idx, task in enumerate(altTasks):
-        if task == tightJetIdLepVeto:
-          altTasks[idx] = looseJetId
-      for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-        modifier.toReplaceWith(currentTasks, altTasks)
     self.main.extend(currentTasks)
 
 def AddPileUpJetIDVars(proc):
@@ -399,7 +387,7 @@ def AddPileUpJetIDVars(proc):
   proc.jetTable.variables.jetRchg  = Var("userFloat('jetRchg')", float, doc="fraction of jet pT carried by the leading charged constituent", precision= 6) 
   proc.jetTable.variables.nCharged = Var("userInt('nCharged')",  int, doc="number of charged constituents")
 
-def PrepJMECustomNanoAOD(process):
+def PrepJMECustomNanoAOD(process,runOnMC):
   #
   # Additional variables to AK4GenJets 
   #
@@ -444,8 +432,8 @@ def PrepJMECustomNanoAOD(process):
   process.fatJetTable.variables.jercCHPUF = JETVARS.jercCHPUF
   process.fatJetTable.variables.jercCHF   = JETVARS.jercCHF
   #
-  # Remove any pT cuts.
-  #
+  # 
+  # 
   process.finalJets.cut             = "" # 15 -> 10
   process.finalJetsAK8.cut          = "" # 170 -> 170
   process.genJetTable.cut           = "" # 10 -> 8
@@ -470,13 +458,10 @@ def PrepJMECustomNanoAOD(process):
     genJetInfo = genJA.addGenJetCollection(process, **cfg)
     tableGenJA.addTable(process, genJetInfo)
 
-  process.nanoSequenceMC += genJA.getSequence(process)
-  process.nanoSequenceMC += tableGenJA.getSequence(process)
-
   #
   # Add RecoJets to NanoAOD
   #
-  recoJA = RecoJetAdder()
+  recoJA = RecoJetAdder(runOnMC=runOnMC)
   tableRecoJA = TableRecoJetAdder()
 
   for jetConfig in config_recojets:
@@ -484,5 +469,17 @@ def PrepJMECustomNanoAOD(process):
     recoJetInfo = recoJA.addRecoJetCollection(process, **cfg)
     tableRecoJA.addTable(process, recoJetInfo)
 
-  process.nanoSequenceMC += recoJA.getSequence(process)
-  process.nanoSequenceMC += tableRecoJA.getSequence(process)
+  if runOnMC:
+    process.nanoSequenceMC += genJA.getSequence(process)
+    process.nanoSequenceMC += recoJA.getSequence(process)
+    process.nanoSequenceMC += tableGenJA.getSequence(process)
+    process.nanoSequenceMC += tableRecoJA.getSequence(process)
+  else:
+    process.nanoSequence  += recoJA.getSequence(process)
+    process.nanoSequence  += tableRecoJA.getSequence(process)
+
+def PrepJMECustomNanoAOD_MC(process):
+  PrepJMECustomNanoAOD(process,runOnMC=True)
+
+def PrepJMECustomNanoAOD_Data(process):
+  PrepJMECustomNanoAOD(process,runOnMC=False)

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 
 from PhysicsTools.NanoAOD.common_cff import Var, P4Vars
 from PhysicsTools.NanoAOD.jets_cff import jetTable

--- a/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.PatAlgos.tools.ConfigToolBase import *
 
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 

--- a/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.ConfigToolBase import *
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
+from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 
 from RecoJets.JetProducers.PFJetParameters_cfi import PFJetParameters
 from RecoJets.JetProducers.GenJetParameters_cfi import GenJetParameters
@@ -205,7 +206,7 @@ class RecoJetAdder(object):
   """
   Tool to schedule modules for building a recojet collection with input MiniAODs
   """
-  def __init__(self):    
+  def __init__(self,runOnMC=True):    
     self.prerequisites = []
     self.main = []
     self.bTagDiscriminators = ["None"] # No b-tagging by default
@@ -216,6 +217,7 @@ class RecoJetAdder(object):
     self.muLabel = "slimmedMuons"
     self.elLabel = "slimmedElectrons"
     self.gpLabel = "prunedGenParticles"
+    self.runOnMC = runOnMC
 
   def getSequence(self, proc):
     tasks = self.prerequisites + self.main
@@ -407,6 +409,11 @@ class RecoJetAdder(object):
 
       getJetMCFlavour = not recoJetInfo.doCalo and recoJetInfo.jetPUMethod != "cs"
 
+      if not self.runOnMC: #Remove modules for Gen-level object matching
+        delattr(proc, 'patJetGenJetMatch{}'.format(tagName))
+        delattr(proc, 'patJetPartonMatch{}'.format(tagName))
+        getJetMCFlavour = False 
+
       setattr(getattr(proc, "patJets{}".format(tagName)),           "getJetMCFlavour", cms.bool(getJetMCFlavour))
       setattr(getattr(proc, "patJetCorrFactors{}".format(tagName)), "payload",         cms.string(recoJetInfo.jetCorrPayload))
       selJet = "selectedPatJets{}".format(tagName)
@@ -423,27 +430,64 @@ class RecoJetAdder(object):
       setattr(proc, jercVar, proc.jercVars.clone(srcJet = selJet))
       currentTasks.append(jercVar)
       #
-      # 
+      # JetID Loose
       #
       looseJetId = "looseJetId{}".format(tagName)
       if looseJetId in self.main:
         raise ValueError("Step '%s' already implemented" % looseJetId)
-      setattr(proc, looseJetId, proc.looseJetId.clone(src = selJet))
+      setattr(proc, looseJetId, proc.looseJetId.clone(
+          src = selJet,
+          filterParams=proc.looseJetId.filterParams.clone(
+            version ="WINTER16"
+          ),
+        )
+      )
+      currentTasks.append(looseJetId)
       #
-      # 
-      #
+      # JetID Tight
+      #      
       tightJetId = "tightJetId{}".format(tagName)
       if tightJetId in self.main:
         raise ValueError("Step '%s' already implemented" % tightJetId)
-      setattr(proc, tightJetId, proc.tightJetId.clone(src = selJet))
+      setattr(proc, tightJetId, proc.tightJetId.clone(
+          src = selJet,
+          filterParams=proc.tightJetId.filterParams.clone(
+            version = "SUMMER18{}".format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else "")
+          ),
+        )
+      )
+      tightJetIdObj = getattr(proc, tightJetId)
+      run2_jme_2016.toModify(
+        tightJetIdObj.filterParams, 
+          version = "WINTER16"
+      )
+      run2_jme_2017.toModify(
+        tightJetIdObj.filterParams, 
+          version = 'WINTER17{}'.format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else "")
+      )
       currentTasks.append(tightJetId)
       #
-      # 
+      # JetID TightLepVeto 
       #
       tightJetIdLepVeto = "tightJetIdLepVeto{}".format(tagName)
       if tightJetIdLepVeto in self.main:
         raise ValueError("Step '%s' already implemented" % tightJetIdLepVeto)
-      setattr(proc, tightJetIdLepVeto, proc.tightJetIdLepVeto.clone(src = selJet))
+      setattr(proc, tightJetIdLepVeto, proc.tightJetIdLepVeto.clone(
+          src = selJet,
+          filterParams=proc.tightJetIdLepVeto.filterParams.clone(
+            version = "SUMMER18{}".format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else "")
+          ),
+        )
+      )
+      tightJetIdLepVetoObj = getattr(proc, tightJetIdLepVeto)
+      run2_jme_2016.toModify(
+        tightJetIdLepVetoObj.filterParams, 
+        version = "WINTER16"
+      )
+      run2_jme_2017.toModify(
+        tightJetIdLepVetoObj.filterParams, 
+          version = 'WINTER17{}'.format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else ""),
+      )
       currentTasks.append(tightJetIdLepVeto)
       #
       # 
@@ -464,16 +508,14 @@ class RecoJetAdder(object):
           ),
         )
       )
-      for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-        selectedPatJetsWithUserDataObj = getattr(proc, selectedPatJetsWithUserData)
-        modifier.toModify(selectedPatJetsWithUserDataObj.userInts,
-          looseId        = looseJetId,
-          tightIdLepVeto = None,
-        )
+      selectedPatJetsWithUserDataObj = getattr(proc, selectedPatJetsWithUserData)
+      run2_jme_2016.toModify(selectedPatJetsWithUserDataObj.userInts,
+        looseId  = cms.InputTag(looseJetId),
+      )
       currentTasks.append(selectedPatJetsWithUserData)
     else:
       selectedPatJetsWithUserData = "selectedPatJets{}".format(tagName)
-    
+  
     #
     # Not sure why we can't re-use patJetCorrFactors* created by addJetCollection() 
     # (even cloning doesn't work) Let's just create our own
@@ -502,8 +544,8 @@ class RecoJetAdder(object):
         jetCorrFactorsSource = [jetCorrFactors],
       )
     )
-
     currentTasks.append(updatedJets)
+
     self.main.extend(currentTasks)
 
     return recoJetInfo


### PR DESCRIPTION
PR description:

This PR updates the Custom JME NanoAOD with the following items:

1. Update era modifiers with `run2_jme_2016 `and `run2_jme_2017`.
2. Setup the proper JetID versions according to PUPPI vs CHS for each year. 
3. Made necessary changes such that it can now run on data. Added wrapper functions 
to be used when specifying customise_commands when running on MC or data.

This PR needs to be backported to 10_6_X, once merged, for the ultra legacy campaigns.