### PR TITLE
Fix valgrind unit test for clang

### DIFF
--- a/Utilities/ReleaseScripts/test/test-valgrind-memleak.cpp
+++ b/Utilities/ReleaseScripts/test/test-valgrind-memleak.cpp
@@ -1,4 +1,4 @@
 int main() {
-  int* a = new int[10];
+  volatile int* a = new int[10];
   return a[0];
 }


### PR DESCRIPTION
#### PR description:

The valgrind unit test is failing in CLANG IBs, presumably because clang appears to compile the test program to just `ret` (https://godbolt.org/z/nJY8Dg). Declaring the variable `volatile` seems to get clang to produce a non-trivial program.

#### PR validation:

Unit test runs on gcc build.