### PR TITLE
Tracking DQM: fix multiple ME bookings for Track Seed Monitoring

### DIFF
--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -266,7 +266,10 @@ for _step, _pset in six.iteritems(seedMonitoring):
     )
     locals()['TrackSeedMon'+str(_step)] = _mod
     _mod.TrackProducer = cms.InputTag("generalTracks")
-    _mod.FolderName    = cms.string("Tracking/TrackParameters/generalTracks")
+    _mod.FolderName = cms.string("Tracking/TrackParameters/generalTracks/SeedMon/"+str(_step))
+    _mod.doPUmonitoring = cms.bool(False)
+    _mod.doLumiAnalysis = cms.bool(False)
+    _mod.doPlotsVsGoodPVtx = cms.bool(False)
     _mod.SeedProducer  = _pset.seedInputTag
     _mod.TCProducer    = _pset.trackCandInputTag
     _mod.AlgoName      = cms.string( str(_step) )


### PR DESCRIPTION
#### PR description:

This PR attempts to fix the issue reported at https://github.com/cms-sw/cmssw/pull/28823#issuecomment-580657869.
The multiple booking of plots in the same folder done by several instances of `TrackingMonitor`:
```
TrackSeedMondetachedQuadStep
TrackSeedMondetachedTripletStep
TrackSeedMonhighPtTripletStep
TrackSeedMoninitialStep
TrackSeedMonjetCoreRegionalStep
TrackSeedMonlowPtQuadStep
TrackSeedMonlowPtTripletStep
TrackSeedMonmixedTripletStep
TrackSeedMonmuonSeededStepInOut
TrackSeedMonmuonSeededStepOutIn
TrackSeedMonpixelLessStep
TrackSeedMonpixelPairStep
TrackSeedMontobTecStep
TrackerCollisionSelected
TrackMonCommongeneralTracks
```
are now dispatched to several subfolders.
The redundant plots vs PU or vs GoodVtx that do not make sense per seeding type are switched off.

#### PR validation:

Basic integration tests have been run. Visual inspection of the output file looks compatible with expectations.
I also run the DQM bin-by-bin comparison tool on local files produced with wf 25202, but at the moment it does not make sense to me, so I am waiting for experts to debug it.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is intended.
cc:

@mtosi @sroychow @arossi83

