### PR TITLE
Fix phi-dependent JEC uncertainties [10_6_X backport] 

### DIFF
--- a/CondFormats/JetMETObjects/src/JetCorrectionUncertainty.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectionUncertainty.cc
@@ -136,7 +136,7 @@ std::vector<float> JetCorrectionUncertainty::fillVector(const std::vector<std::s
 	    edm::LogError("JetCorrectionUncertainty::")<<" jet phi is not set";  
 	    result.push_back(-999.0);
 	  } else {
-	    result.push_back(mJetPt);
+	    result.push_back(mJetPhi);
 	  }
         }
       else if (fNames[i] == "JetE")


### PR DESCRIPTION
Backport  of #28864

#### PR description:
Fix issue #28860.
This has no impact on any CMS workflow, since JEC uncertainty have never had phi-dependence. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This may have an impact once we introduce corrections for 2018-HEM issue, thus backport down to 10_2 releases.
