### PR TITLE
Fix #28803 (GenParticles2HepMC with exotic LHE)

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -138,7 +138,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   HepMC::GenVertex* vertex1 = nullptr;
   HepMC::GenVertex* vertex2 = nullptr;
-  if (parton1 == nullptr and parton2 == nullptr) {
+  if (parton1 == nullptr || parton2 == nullptr) {
     // Particle gun samples do not have incident partons. Put dummy incident particle and prod vertex
     // Note: leave parton1 and parton2 as nullptr since it is not used anymore after creating hepmc_parton1 and 2
     const reco::Candidate::LorentzVector nullP4(0, 0, 0, 0);


### PR DESCRIPTION
#### PR description:

Fixes crash in GenParticles2HepMCConverter (#28803) by adding fake beam particles for exotic LHE files with only one beam-particle candidate. This was used for NeutrinoGun samples (no beam particles) before.

#### PR validation:

* Problematic LHE expected to work now (tested in 102X: https://github.com/cms-sw/cmssw/pull/28856)
* Existing MiniAod test on standard sample successful