### PR TITLE
GEM DQM updates - full GE1/1, backport to 11_0_X

### DIFF
--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -19,165 +19,164 @@
 #include <TDirectoryFile.h>
 #include <TKey.h>
 
-
 using namespace edm;
 
-
-class GEMDQMHarvester: public DQMEDHarvester
-{  
+class GEMDQMHarvester : public DQMEDHarvester {
 public:
-  GEMDQMHarvester(const edm::ParameterSet&);
-  ~GEMDQMHarvester() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  GEMDQMHarvester(const edm::ParameterSet &);
+  ~GEMDQMHarvester() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
 protected:
-  void endRun(edm::Run const&, edm::EventSetup const&) override;
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; // Cannot use; it is called after dqmSaver
-  
+  void endRun(edm::Run const &, edm::EventSetup const &) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  // Cannot use; it is called after dqmSaver
+
   void refineTimeHistograms(edm::Service<DQMStore> &);
   void refineTimeHistograms(DQMStore::IBooker &, DQMStore::IGetter &);
   void refineTimeHistograms(TFile *);
   void refineTimeHistogramsCore(TH2F *, std::string &, TH2F *&, std::string strTmpPrefix = "tmp_");
-  
+
   void createSummaryPlots(edm::Service<DQMStore> &);
-  
+
   std::string strOutFile_;
 };
-
 
 GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
   strOutFile_ = cfg.getParameter<std::string>("fromFile");
 }
 
-
-void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("fromFile", "");
-  descriptions.add("GEMDQMHarvester", desc);  
+  descriptions.add("GEMDQMHarvester", desc);
 }
-
 
 void GEMDQMHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   return;
-  if ( strOutFile_.empty() ) {
+  if (strOutFile_.empty()) {
     refineTimeHistograms(ibooker, igetter);
   } else {
     TFile *fDQM = TFile::Open(strOutFile_.c_str(), "UPDATE");
-    
+
     refineTimeHistograms(fDQM);
-    
+
     fDQM->Close();
   }
 }
 
-
-void GEMDQMHarvester::endRun(edm::Run const&, edm::EventSetup const&) {
+void GEMDQMHarvester::endRun(edm::Run const &, edm::EventSetup const &) {
   /*edm::Service<DQMStore> store;
   
   refineTimeHistograms(store);
   createSummaryPlots(store);*/
 }
 
-
 void GEMDQMHarvester::refineTimeHistograms(edm::Service<DQMStore> &store) {
   store->setCurrentFolder("GEM/StatusDigi");
   auto listME = store->getMEs();
-  
-  for ( auto strName : listME ) {
-    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
-    
+
+  for (auto strName : listME) {
+    if (strName.find("primitive_per_time_") == std::string::npos)
+      continue;
+
     MonitorElement *h2Curr = store->get("GEM/StatusDigi/" + strName);
     std::string strNewName;
     TH2F *h2New;
-    
+
     refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
-    
+
     store->book2D(strNewName, h2New);
     store->removeElement(strName);
   }
 }
 
-
 void GEMDQMHarvester::refineTimeHistograms(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   igetter.cd("GEM/StatusDigi");
   ibooker.setCurrentFolder("GEM/StatusDigi");
   auto listME = igetter.getMEs();
-  
-  for ( auto strName : listME ) {
-    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
-    
+
+  for (auto strName : listME) {
+    if (strName.find("primitive_per_time_") == std::string::npos)
+      continue;
+
     MonitorElement *h2Curr = igetter.get("GEM/StatusDigi/" + strName);
     std::string strNewName;
     TH2F *h2New;
-    
+
     refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
-    
+
     ibooker.book2D(strNewName, h2New);
     igetter.removeElement(strName);
   }
 }
 
-
 void GEMDQMHarvester::refineTimeHistograms(TFile *fDQM) {
-  std::string strRunnum = ( (TDirectoryFile *)fDQM->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
+  std::string strRunnum = ((TDirectoryFile *)fDQM->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
   std::string strPathMain = "DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi";
-  
+
   fDQM->cd(strPathMain.c_str());
-  auto dirMain = ( (TDirectoryFile *)fDQM->Get(strPathMain.c_str()) );
-  
-  for ( auto k : *dirMain->GetListOfKeys() ) {
+  auto dirMain = ((TDirectoryFile *)fDQM->Get(strPathMain.c_str()));
+
+  for (auto k : *dirMain->GetListOfKeys()) {
     TKey *key = (TKey *)k;
     std::string strName = key->ReadObj()->GetName();
     std::string strNewName;
-    
-    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
-    
-    TH2F *h2Curr = (TH2F *)fDQM->Get(( strPathMain + "/" + strName ).c_str());
+
+    if (strName.find("primitive_per_time_") == std::string::npos)
+      continue;
+
+    TH2F *h2Curr = (TH2F *)fDQM->Get((strPathMain + "/" + strName).c_str());
     TH2F *h2New;
     refineTimeHistogramsCore(h2Curr, strNewName, h2New, "");
-    
+
     fDQM->Write();
   }
-  
-  for ( auto k : *dirMain->GetListOfKeys() ) std::cout << ( (TKey *)k )->ReadObj()->GetName() << std::endl;
+
+  for (auto k : *dirMain->GetListOfKeys())
+    std::cout << ((TKey *)k)->ReadObj()->GetName() << std::endl;
 }
 
-
-void GEMDQMHarvester::refineTimeHistogramsCore(TH2F *h2Curr, std::string &strNewName, 
-                                               TH2F *&h2New, std::string strTmpPrefix)
-{
+void GEMDQMHarvester::refineTimeHistogramsCore(TH2F *h2Curr,
+                                               std::string &strNewName,
+                                               TH2F *&h2New,
+                                               std::string strTmpPrefix) {
   strNewName = std::string(h2Curr->GetName()).substr(std::string("primitive_").size());
-  
+
   Int_t nNbinsX = h2Curr->GetNbinsX();
   Int_t nNbinsY = h2Curr->GetNbinsY();
   Int_t nNbinsXActual = 0;
-  
-  for ( nNbinsXActual = 0 ; nNbinsXActual < nNbinsX ; nNbinsXActual++ ) {
-    if ( h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0 ) break;
+
+  for (nNbinsXActual = 0; nNbinsXActual < nNbinsX; nNbinsXActual++) {
+    if (h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0)
+      break;
   }
-  
-  std::string strTitle = std::string(h2Curr->GetTitle()) + ";" + 
-    std::string(h2Curr->GetXaxis()->GetTitle()) + ";" + std::string(h2Curr->GetYaxis()->GetTitle());
+
+  std::string strTitle = std::string(h2Curr->GetTitle()) + ";" + std::string(h2Curr->GetXaxis()->GetTitle()) + ";" +
+                         std::string(h2Curr->GetYaxis()->GetTitle());
   std::cout << strTitle << "(" << nNbinsXActual << ", " << nNbinsY << ")" << std::endl;
-  
+
   strTitle = "";
-  h2New = new TH2F(( strTmpPrefix + strNewName ).c_str(), strTitle.c_str(), 
-      nNbinsXActual, 0.0, (Double_t)nNbinsXActual, nNbinsY, 0.0, (Double_t)nNbinsY);
-  
-  for ( Int_t i = 1 ; false && i <= nNbinsY ; i++ ) {
+  h2New = new TH2F((strTmpPrefix + strNewName).c_str(),
+                   strTitle.c_str(),
+                   nNbinsXActual,
+                   0.0,
+                   (Double_t)nNbinsXActual,
+                   nNbinsY,
+                   0.0,
+                   (Double_t)nNbinsY);
+
+  for (Int_t i = 1; false && i <= nNbinsY; i++) {
     std::string strLabel = h2Curr->GetYaxis()->GetBinLabel(i);
-    if ( !strLabel.empty() ) h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
+    if (!strLabel.empty())
+      h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
   }
-  
-  for ( Int_t j = 0 ; false && j <= nNbinsY ; j++ ) 
-  for ( Int_t i = 1 ; i <= nNbinsXActual ; i++ ) {
-    h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
-  }
+
+  for (Int_t j = 0; false && j <= nNbinsY; j++)
+    for (Int_t i = 1; i <= nNbinsXActual; i++) {
+      h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
+    }
 }
 
-
-void GEMDQMHarvester::createSummaryPlots(edm::Service<DQMStore> &store) {
-}
-
+void GEMDQMHarvester::createSummaryPlots(edm::Service<DQMStore> &store) {}
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -19,164 +19,165 @@
 #include <TDirectoryFile.h>
 #include <TKey.h>
 
+
 using namespace edm;
 
-class GEMDQMHarvester : public DQMEDHarvester {
+
+class GEMDQMHarvester: public DQMEDHarvester
+{  
 public:
-  GEMDQMHarvester(const edm::ParameterSet &);
-  ~GEMDQMHarvester() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
-
+  GEMDQMHarvester(const edm::ParameterSet&);
+  ~GEMDQMHarvester() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 protected:
-  void endRun(edm::Run const &, edm::EventSetup const &) override;
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  // Cannot use; it is called after dqmSaver
-
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; // Cannot use; it is called after dqmSaver
+  
   void refineTimeHistograms(edm::Service<DQMStore> &);
   void refineTimeHistograms(DQMStore::IBooker &, DQMStore::IGetter &);
   void refineTimeHistograms(TFile *);
   void refineTimeHistogramsCore(TH2F *, std::string &, TH2F *&, std::string strTmpPrefix = "tmp_");
-
+  
   void createSummaryPlots(edm::Service<DQMStore> &);
-
+  
   std::string strOutFile_;
 };
+
 
 GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
   strOutFile_ = cfg.getParameter<std::string>("fromFile");
 }
 
-void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+
+void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
   desc.add<std::string>("fromFile", "");
-  descriptions.add("GEMDQMHarvester", desc);
+  descriptions.add("GEMDQMHarvester", desc);  
 }
+
 
 void GEMDQMHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   return;
-  if (strOutFile_.empty()) {
+  if ( strOutFile_.empty() ) {
     refineTimeHistograms(ibooker, igetter);
   } else {
     TFile *fDQM = TFile::Open(strOutFile_.c_str(), "UPDATE");
-
+    
     refineTimeHistograms(fDQM);
-
+    
     fDQM->Close();
   }
 }
 
-void GEMDQMHarvester::endRun(edm::Run const &, edm::EventSetup const &) {
+
+void GEMDQMHarvester::endRun(edm::Run const&, edm::EventSetup const&) {
   /*edm::Service<DQMStore> store;
   
   refineTimeHistograms(store);
   createSummaryPlots(store);*/
 }
 
+
 void GEMDQMHarvester::refineTimeHistograms(edm::Service<DQMStore> &store) {
   store->setCurrentFolder("GEM/StatusDigi");
   auto listME = store->getMEs();
-
-  for (auto strName : listME) {
-    if (strName.find("primitive_per_time_") == std::string::npos)
-      continue;
-
+  
+  for ( auto strName : listME ) {
+    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
+    
     MonitorElement *h2Curr = store->get("GEM/StatusDigi/" + strName);
     std::string strNewName;
     TH2F *h2New;
-
+    
     refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
-
+    
     store->book2D(strNewName, h2New);
     store->removeElement(strName);
   }
 }
 
+
 void GEMDQMHarvester::refineTimeHistograms(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
   igetter.cd("GEM/StatusDigi");
   ibooker.setCurrentFolder("GEM/StatusDigi");
   auto listME = igetter.getMEs();
-
-  for (auto strName : listME) {
-    if (strName.find("primitive_per_time_") == std::string::npos)
-      continue;
-
+  
+  for ( auto strName : listME ) {
+    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
+    
     MonitorElement *h2Curr = igetter.get("GEM/StatusDigi/" + strName);
     std::string strNewName;
     TH2F *h2New;
-
+    
     refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
-
+    
     ibooker.book2D(strNewName, h2New);
     igetter.removeElement(strName);
   }
 }
 
+
 void GEMDQMHarvester::refineTimeHistograms(TFile *fDQM) {
-  std::string strRunnum = ((TDirectoryFile *)fDQM->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
+  std::string strRunnum = ( (TDirectoryFile *)fDQM->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
   std::string strPathMain = "DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi";
-
+  
   fDQM->cd(strPathMain.c_str());
-  auto dirMain = ((TDirectoryFile *)fDQM->Get(strPathMain.c_str()));
-
-  for (auto k : *dirMain->GetListOfKeys()) {
+  auto dirMain = ( (TDirectoryFile *)fDQM->Get(strPathMain.c_str()) );
+  
+  for ( auto k : *dirMain->GetListOfKeys() ) {
     TKey *key = (TKey *)k;
     std::string strName = key->ReadObj()->GetName();
     std::string strNewName;
-
-    if (strName.find("primitive_per_time_") == std::string::npos)
-      continue;
-
-    TH2F *h2Curr = (TH2F *)fDQM->Get((strPathMain + "/" + strName).c_str());
+    
+    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
+    
+    TH2F *h2Curr = (TH2F *)fDQM->Get(( strPathMain + "/" + strName ).c_str());
     TH2F *h2New;
     refineTimeHistogramsCore(h2Curr, strNewName, h2New, "");
-
+    
     fDQM->Write();
   }
-
-  for (auto k : *dirMain->GetListOfKeys())
-    std::cout << ((TKey *)k)->ReadObj()->GetName() << std::endl;
+  
+  for ( auto k : *dirMain->GetListOfKeys() ) std::cout << ( (TKey *)k )->ReadObj()->GetName() << std::endl;
 }
 
-void GEMDQMHarvester::refineTimeHistogramsCore(TH2F *h2Curr,
-                                               std::string &strNewName,
-                                               TH2F *&h2New,
-                                               std::string strTmpPrefix) {
-  strNewName = std::string(h2Curr->GetName()).substr(std::string("primitive_").size());
 
+void GEMDQMHarvester::refineTimeHistogramsCore(TH2F *h2Curr, std::string &strNewName, 
+                                               TH2F *&h2New, std::string strTmpPrefix)
+{
+  strNewName = std::string(h2Curr->GetName()).substr(std::string("primitive_").size());
+  
   Int_t nNbinsX = h2Curr->GetNbinsX();
   Int_t nNbinsY = h2Curr->GetNbinsY();
   Int_t nNbinsXActual = 0;
-
-  for (nNbinsXActual = 0; nNbinsXActual < nNbinsX; nNbinsXActual++) {
-    if (h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0)
-      break;
+  
+  for ( nNbinsXActual = 0 ; nNbinsXActual < nNbinsX ; nNbinsXActual++ ) {
+    if ( h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0 ) break;
   }
-
-  std::string strTitle = std::string(h2Curr->GetTitle()) + ";" + std::string(h2Curr->GetXaxis()->GetTitle()) + ";" +
-                         std::string(h2Curr->GetYaxis()->GetTitle());
+  
+  std::string strTitle = std::string(h2Curr->GetTitle()) + ";" + 
+    std::string(h2Curr->GetXaxis()->GetTitle()) + ";" + std::string(h2Curr->GetYaxis()->GetTitle());
   std::cout << strTitle << "(" << nNbinsXActual << ", " << nNbinsY << ")" << std::endl;
-
+  
   strTitle = "";
-  h2New = new TH2F((strTmpPrefix + strNewName).c_str(),
-                   strTitle.c_str(),
-                   nNbinsXActual,
-                   0.0,
-                   (Double_t)nNbinsXActual,
-                   nNbinsY,
-                   0.0,
-                   (Double_t)nNbinsY);
-
-  for (Int_t i = 1; false && i <= nNbinsY; i++) {
+  h2New = new TH2F(( strTmpPrefix + strNewName ).c_str(), strTitle.c_str(), 
+      nNbinsXActual, 0.0, (Double_t)nNbinsXActual, nNbinsY, 0.0, (Double_t)nNbinsY);
+  
+  for ( Int_t i = 1 ; false && i <= nNbinsY ; i++ ) {
     std::string strLabel = h2Curr->GetYaxis()->GetBinLabel(i);
-    if (!strLabel.empty())
-      h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
+    if ( !strLabel.empty() ) h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
   }
-
-  for (Int_t j = 0; false && j <= nNbinsY; j++)
-    for (Int_t i = 1; i <= nNbinsXActual; i++) {
-      h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
-    }
+  
+  for ( Int_t j = 0 ; false && j <= nNbinsY ; j++ ) 
+  for ( Int_t i = 1 ; i <= nNbinsXActual ; i++ ) {
+    h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
+  }
 }
 
-void GEMDQMHarvester::createSummaryPlots(edm::Service<DQMStore> &store) {}
+
+void GEMDQMHarvester::createSummaryPlots(edm::Service<DQMStore> &store) {
+}
+
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -86,7 +86,7 @@ void GEMDQMHarvester::refineTimeHistograms(edm::Service<DQMStore> &store) {
     refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
 
     store->book2D(strNewName, h2New);
-    store->removeElement(strName);
+    //store->removeElement(strName);
   }
 }
 
@@ -106,7 +106,7 @@ void GEMDQMHarvester::refineTimeHistograms(DQMStore::IBooker &ibooker, DQMStore:
     refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
 
     ibooker.book2D(strNewName, h2New);
-    igetter.removeElement(strName);
+    //igetter.removeElement(strName);
   }
 }
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -29,11 +29,11 @@ public:
 
 protected:
   void endRun(edm::Run const &, edm::EventSetup const &) override;
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override {};  // Cannot use; it is called after dqmSaver
-  
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
+
   void refineSummaryHistogram(edm::Service<DQMStore> &);
   void refineSummaryHistogramCore(TH3F *, std::string &, TH2F *&, std::string strTmpPrefix = "tmp_");
-  
+
   void fillUnderOverflowBunchCrossing(edm::Service<DQMStore> &, std::string);
 
   std::string strOutFile_;
@@ -52,10 +52,10 @@ void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descripti
 void GEMDQMHarvester::endRun(edm::Run const &, edm::EventSetup const &) {
   edm::Service<DQMStore> store;
   refineSummaryHistogram(store);
-  
+
   store->setCurrentFolder("GEM/StatusDigi");
   auto listME = store->getMEs();
-  
+
   for (auto strName : listME) {
     if (strName.find("vfatStatus_BC_") != std::string::npos) {
       fillUnderOverflowBunchCrossing(store, strName);
@@ -67,41 +67,42 @@ void GEMDQMHarvester::refineSummaryHistogram(edm::Service<DQMStore> &store) {
   std::string strDirCurr = "GEM/EventInfo";
   std::string strNameSrc = "reportSummaryMapPreliminary";
   std::string strNewName = "reportSummaryMap";
-  
+
   store->setCurrentFolder(strDirCurr.c_str());
-  
-  MonitorElement *h3Curr = store->get(( strDirCurr + "/" + strNameSrc ).c_str());
+
+  MonitorElement *h3Curr = store->get((strDirCurr + "/" + strNameSrc).c_str());
   TH2F *h2New = NULL;
-  
+
   refineSummaryHistogramCore(h3Curr->getTH3F(), strNewName, h2New);
   store->book2D(strNewName, h2New);
 }
 
-void GEMDQMHarvester::refineSummaryHistogramCore(TH3F *h3Src, 
-                                                 std::string &strNewName, 
-                                                 TH2F *&h2New, 
-                                                 std::string strTmpPrefix) 
-{
+void GEMDQMHarvester::refineSummaryHistogramCore(TH3F *h3Src,
+                                                 std::string &strNewName,
+                                                 TH2F *&h2New,
+                                                 std::string strTmpPrefix) {
   Int_t i, j;
-  
+
   Int_t nNBinX = h3Src->GetNbinsX();
   Int_t nNBinY = h3Src->GetNbinsY();
-  
-  Float_t arrfBinX[ 128 ], arrfBinY[ 32 ];
-  
-  for ( i = 0 ; i <= nNBinX ; i++ ) arrfBinX[ i ] = h3Src->GetXaxis()->GetBinLowEdge(i + 1);
-  for ( i = 0 ; i <= nNBinY ; i++ ) arrfBinY[ i ] = h3Src->GetYaxis()->GetBinLowEdge(i + 1);
-  
+
+  Float_t arrfBinX[128], arrfBinY[32];
+
+  for (i = 0; i <= nNBinX; i++)
+    arrfBinX[i] = h3Src->GetXaxis()->GetBinLowEdge(i + 1);
+  for (i = 0; i <= nNBinY; i++)
+    arrfBinY[i] = h3Src->GetYaxis()->GetBinLowEdge(i + 1);
+
   h2New = new TH2F(strNewName.c_str(), h3Src->GetTitle(), nNBinX, arrfBinX, nNBinY, arrfBinY);
-  
-  for ( i = 0 ; i < nNBinX ; i++ ) {
+
+  for (i = 0; i < nNBinX; i++) {
     h2New->GetXaxis()->SetBinLabel(i + 1, h3Src->GetXaxis()->GetBinLabel(i + 1));
-    for ( j = 0 ; j < nNBinY ; j++ ) {
+    for (j = 0; j < nNBinY; j++) {
       h2New->GetYaxis()->SetBinLabel(j + 1, h3Src->GetYaxis()->GetBinLabel(j + 1));
-      
-      if ( h3Src->GetBinContent(i + 1, j + 1, 2) != 0 ) {
+
+      if (h3Src->GetBinContent(i + 1, j + 1, 2) != 0) {
         h2New->SetBinContent(i + 1, j + 1, 2);
-      } else if ( h3Src->GetBinContent(i + 1, j + 1, 1) != 0 ) {
+      } else if (h3Src->GetBinContent(i + 1, j + 1, 1) != 0) {
         h2New->SetBinContent(i + 1, j + 1, 1);
       }
     }
@@ -110,15 +111,15 @@ void GEMDQMHarvester::refineSummaryHistogramCore(TH3F *h3Src,
 
 void GEMDQMHarvester::fillUnderOverflowBunchCrossing(edm::Service<DQMStore> &store, std::string strNameSrc) {
   std::string strDirCurr = "GEM/StatusDigi";
-  
+
   store->setCurrentFolder(strDirCurr.c_str());
-  MonitorElement *h2Curr = store->get(( strDirCurr + "/" + strNameSrc ).c_str());
-  
+  MonitorElement *h2Curr = store->get((strDirCurr + "/" + strNameSrc).c_str());
+
   Int_t nNBinX = h2Curr->getNbinsX();
   Int_t nNBinY = h2Curr->getNbinsY();
-  
+
   for (Int_t i = 0; i < nNBinY; i++) {
-    h2Curr->setBinContent(1,      i, h2Curr->getBinContent(0, i)      + h2Curr->getBinContent(1, i));
+    h2Curr->setBinContent(1, i, h2Curr->getBinContent(0, i) + h2Curr->getBinContent(1, i));
     h2Curr->setBinContent(nNBinX, i, h2Curr->getBinContent(nNBinX, i) + h2Curr->getBinContent(nNBinX + 1, i));
   }
 }

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -29,14 +29,12 @@ public:
 
 protected:
   void endRun(edm::Run const &, edm::EventSetup const &) override;
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  // Cannot use; it is called after dqmSaver
-
-  void refineTimeHistograms(edm::Service<DQMStore> &);
-  void refineTimeHistograms(DQMStore::IBooker &, DQMStore::IGetter &);
-  void refineTimeHistograms(TFile *);
-  void refineTimeHistogramsCore(TH2F *, std::string &, TH2F *&, std::string strTmpPrefix = "tmp_");
-
-  void createSummaryPlots(edm::Service<DQMStore> &);
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override {};  // Cannot use; it is called after dqmSaver
+  
+  void refineSummaryHistogram(edm::Service<DQMStore> &);
+  void refineSummaryHistogramCore(TH3F *, std::string &, TH2F *&, std::string strTmpPrefix = "tmp_");
+  
+  void fillUnderOverflowBunchCrossing(edm::Service<DQMStore> &, std::string);
 
   std::string strOutFile_;
 };
@@ -51,132 +49,78 @@ void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descripti
   descriptions.add("GEMDQMHarvester", desc);
 }
 
-void GEMDQMHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
-  return;
-  if (strOutFile_.empty()) {
-    refineTimeHistograms(ibooker, igetter);
-  } else {
-    TFile *fDQM = TFile::Open(strOutFile_.c_str(), "UPDATE");
-
-    refineTimeHistograms(fDQM);
-
-    fDQM->Close();
-  }
-}
-
 void GEMDQMHarvester::endRun(edm::Run const &, edm::EventSetup const &) {
-  /*edm::Service<DQMStore> store;
+  edm::Service<DQMStore> store;
+  refineSummaryHistogram(store);
   
-  refineTimeHistograms(store);
-  createSummaryPlots(store);*/
-}
-
-void GEMDQMHarvester::refineTimeHistograms(edm::Service<DQMStore> &store) {
   store->setCurrentFolder("GEM/StatusDigi");
   auto listME = store->getMEs();
-
+  
   for (auto strName : listME) {
-    if (strName.find("primitive_per_time_") == std::string::npos)
-      continue;
-
-    MonitorElement *h2Curr = store->get("GEM/StatusDigi/" + strName);
-    std::string strNewName;
-    TH2F *h2New;
-
-    refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
-
-    store->book2D(strNewName, h2New);
-    //store->removeElement(strName);
-  }
-}
-
-void GEMDQMHarvester::refineTimeHistograms(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
-  igetter.cd("GEM/StatusDigi");
-  ibooker.setCurrentFolder("GEM/StatusDigi");
-  auto listME = igetter.getMEs();
-
-  for (auto strName : listME) {
-    if (strName.find("primitive_per_time_") == std::string::npos)
-      continue;
-
-    MonitorElement *h2Curr = igetter.get("GEM/StatusDigi/" + strName);
-    std::string strNewName;
-    TH2F *h2New;
-
-    refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
-
-    ibooker.book2D(strNewName, h2New);
-    //igetter.removeElement(strName);
-  }
-}
-
-void GEMDQMHarvester::refineTimeHistograms(TFile *fDQM) {
-  std::string strRunnum = ((TDirectoryFile *)fDQM->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
-  std::string strPathMain = "DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi";
-
-  fDQM->cd(strPathMain.c_str());
-  auto dirMain = ((TDirectoryFile *)fDQM->Get(strPathMain.c_str()));
-
-  for (auto k : *dirMain->GetListOfKeys()) {
-    TKey *key = (TKey *)k;
-    std::string strName = key->ReadObj()->GetName();
-    std::string strNewName;
-
-    if (strName.find("primitive_per_time_") == std::string::npos)
-      continue;
-
-    TH2F *h2Curr = (TH2F *)fDQM->Get((strPathMain + "/" + strName).c_str());
-    TH2F *h2New;
-    refineTimeHistogramsCore(h2Curr, strNewName, h2New, "");
-
-    fDQM->Write();
-  }
-
-  for (auto k : *dirMain->GetListOfKeys())
-    std::cout << ((TKey *)k)->ReadObj()->GetName() << std::endl;
-}
-
-void GEMDQMHarvester::refineTimeHistogramsCore(TH2F *h2Curr,
-                                               std::string &strNewName,
-                                               TH2F *&h2New,
-                                               std::string strTmpPrefix) {
-  strNewName = std::string(h2Curr->GetName()).substr(std::string("primitive_").size());
-
-  Int_t nNbinsX = h2Curr->GetNbinsX();
-  Int_t nNbinsY = h2Curr->GetNbinsY();
-  Int_t nNbinsXActual = 0;
-
-  for (nNbinsXActual = 0; nNbinsXActual < nNbinsX; nNbinsXActual++) {
-    if (h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0)
-      break;
-  }
-
-  std::string strTitle = std::string(h2Curr->GetTitle()) + ";" + std::string(h2Curr->GetXaxis()->GetTitle()) + ";" +
-                         std::string(h2Curr->GetYaxis()->GetTitle());
-  std::cout << strTitle << "(" << nNbinsXActual << ", " << nNbinsY << ")" << std::endl;
-
-  strTitle = "";
-  h2New = new TH2F((strTmpPrefix + strNewName).c_str(),
-                   strTitle.c_str(),
-                   nNbinsXActual,
-                   0.0,
-                   (Double_t)nNbinsXActual,
-                   nNbinsY,
-                   0.0,
-                   (Double_t)nNbinsY);
-
-  for (Int_t i = 1; false && i <= nNbinsY; i++) {
-    std::string strLabel = h2Curr->GetYaxis()->GetBinLabel(i);
-    if (!strLabel.empty())
-      h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
-  }
-
-  for (Int_t j = 0; false && j <= nNbinsY; j++)
-    for (Int_t i = 1; i <= nNbinsXActual; i++) {
-      h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
+    if (strName.find("vfatStatus_BC_") != std::string::npos) {
+      fillUnderOverflowBunchCrossing(store, strName);
     }
+  }
 }
 
-void GEMDQMHarvester::createSummaryPlots(edm::Service<DQMStore> &store) {}
+void GEMDQMHarvester::refineSummaryHistogram(edm::Service<DQMStore> &store) {
+  std::string strDirCurr = "GEM/EventInfo";
+  std::string strNameSrc = "reportSummaryMapPreliminary";
+  std::string strNewName = "reportSummaryMap";
+  
+  store->setCurrentFolder(strDirCurr.c_str());
+  
+  MonitorElement *h3Curr = store->get(( strDirCurr + "/" + strNameSrc ).c_str());
+  TH2F *h2New = NULL;
+  
+  refineSummaryHistogramCore(h3Curr->getTH3F(), strNewName, h2New);
+  store->book2D(strNewName, h2New);
+}
+
+void GEMDQMHarvester::refineSummaryHistogramCore(TH3F *h3Src, 
+                                                 std::string &strNewName, 
+                                                 TH2F *&h2New, 
+                                                 std::string strTmpPrefix) 
+{
+  Int_t i, j;
+  
+  Int_t nNBinX = h3Src->GetNbinsX();
+  Int_t nNBinY = h3Src->GetNbinsY();
+  
+  Float_t arrfBinX[ 128 ], arrfBinY[ 32 ];
+  
+  for ( i = 0 ; i <= nNBinX ; i++ ) arrfBinX[ i ] = h3Src->GetXaxis()->GetBinLowEdge(i + 1);
+  for ( i = 0 ; i <= nNBinY ; i++ ) arrfBinY[ i ] = h3Src->GetYaxis()->GetBinLowEdge(i + 1);
+  
+  h2New = new TH2F(strNewName.c_str(), h3Src->GetTitle(), nNBinX, arrfBinX, nNBinY, arrfBinY);
+  
+  for ( i = 0 ; i < nNBinX ; i++ ) {
+    h2New->GetXaxis()->SetBinLabel(i + 1, h3Src->GetXaxis()->GetBinLabel(i + 1));
+    for ( j = 0 ; j < nNBinY ; j++ ) {
+      h2New->GetYaxis()->SetBinLabel(j + 1, h3Src->GetYaxis()->GetBinLabel(j + 1));
+      
+      if ( h3Src->GetBinContent(i + 1, j + 1, 2) != 0 ) {
+        h2New->SetBinContent(i + 1, j + 1, 2);
+      } else if ( h3Src->GetBinContent(i + 1, j + 1, 1) != 0 ) {
+        h2New->SetBinContent(i + 1, j + 1, 1);
+      }
+    }
+  }
+}
+
+void GEMDQMHarvester::fillUnderOverflowBunchCrossing(edm::Service<DQMStore> &store, std::string strNameSrc) {
+  std::string strDirCurr = "GEM/StatusDigi";
+  
+  store->setCurrentFolder(strDirCurr.c_str());
+  MonitorElement *h2Curr = store->get(( strDirCurr + "/" + strNameSrc ).c_str());
+  
+  Int_t nNBinX = h2Curr->getNbinsX();
+  Int_t nNBinY = h2Curr->getNbinsY();
+  
+  for (Int_t i = 0; i < nNBinY; i++) {
+    h2Curr->setBinContent(1,      i, h2Curr->getBinContent(0, i)      + h2Curr->getBinContent(1, i));
+    h2Curr->setBinContent(nNBinX, i, h2Curr->getBinContent(nNBinX, i) + h2Curr->getBinContent(nNBinX + 1, i));
+  }
+}
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -68,10 +68,10 @@ void GEMDQMHarvester::refineSummaryHistogram(edm::Service<DQMStore> &store) {
   std::string strNameSrc = "reportSummaryMapPreliminary";
   std::string strNewName = "reportSummaryMap";
 
-  store->setCurrentFolder(strDirCurr.c_str());
+  store->setCurrentFolder(strDirCurr);
 
-  MonitorElement *h3Curr = store->get((strDirCurr + "/" + strNameSrc).c_str());
-  TH2F *h2New = NULL;
+  MonitorElement *h3Curr = store->get(strDirCurr + "/" + strNameSrc);
+  TH2F *h2New = nullptr;
 
   refineSummaryHistogramCore(h3Curr->getTH3F(), strNewName, h2New);
   store->book2D(strNewName, h2New);
@@ -112,8 +112,8 @@ void GEMDQMHarvester::refineSummaryHistogramCore(TH3F *h3Src,
 void GEMDQMHarvester::fillUnderOverflowBunchCrossing(edm::Service<DQMStore> &store, std::string strNameSrc) {
   std::string strDirCurr = "GEM/StatusDigi";
 
-  store->setCurrentFolder(strDirCurr.c_str());
-  MonitorElement *h2Curr = store->get((strDirCurr + "/" + strNameSrc).c_str());
+  store->setCurrentFolder(strDirCurr);
+  MonitorElement *h2Curr = store->get(strDirCurr + "/" + strNameSrc);
 
   Int_t nNBinX = h2Curr->getNbinsX();
   Int_t nNBinY = h2Curr->getNbinsY();

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -11,23 +11,173 @@
 //DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <TH2F.h>
+#include <TFile.h>
+#include <TDirectoryFile.h>
+#include <TKey.h>
+
 
 using namespace edm;
 
-class GEMDQMHarvester : public DQMEDHarvester {
-public:
-  GEMDQMHarvester(const edm::ParameterSet &){};
-  ~GEMDQMHarvester() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
+class GEMDQMHarvester: public DQMEDHarvester
+{  
+public:
+  GEMDQMHarvester(const edm::ParameterSet&);
+  ~GEMDQMHarvester() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 protected:
-  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override; // Cannot use; it is called after dqmSaver
+  
+  void refineTimeHistograms(edm::Service<DQMStore> &);
+  void refineTimeHistograms(DQMStore::IBooker &, DQMStore::IGetter &);
+  void refineTimeHistograms(TFile *);
+  void refineTimeHistogramsCore(TH2F *, std::string &, TH2F *&, std::string strTmpPrefix = "tmp_");
+  
+  void createSummaryPlots(edm::Service<DQMStore> &);
+  
+  std::string strOutFile_;
 };
 
-void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-  edm::ParameterSetDescription desc;
-  descriptions.add("GEMDQMHarvester", desc);
+
+GEMDQMHarvester::GEMDQMHarvester(const edm::ParameterSet &cfg) {
+  strOutFile_ = cfg.getParameter<std::string>("fromFile");
 }
+
+
+void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("fromFile", "");
+  descriptions.add("GEMDQMHarvester", desc);  
+}
+
+
+void GEMDQMHarvester::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  return;
+  if ( strOutFile_.empty() ) {
+    refineTimeHistograms(ibooker, igetter);
+  } else {
+    TFile *fDQM = TFile::Open(strOutFile_.c_str(), "UPDATE");
+    
+    refineTimeHistograms(fDQM);
+    
+    fDQM->Close();
+  }
+}
+
+
+void GEMDQMHarvester::endRun(edm::Run const&, edm::EventSetup const&) {
+  /*edm::Service<DQMStore> store;
+  
+  refineTimeHistograms(store);
+  createSummaryPlots(store);*/
+}
+
+
+void GEMDQMHarvester::refineTimeHistograms(edm::Service<DQMStore> &store) {
+  store->setCurrentFolder("GEM/StatusDigi");
+  auto listME = store->getMEs();
+  
+  for ( auto strName : listME ) {
+    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
+    
+    MonitorElement *h2Curr = store->get("GEM/StatusDigi/" + strName);
+    std::string strNewName;
+    TH2F *h2New;
+    
+    refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
+    
+    store->book2D(strNewName, h2New);
+    store->removeElement(strName);
+  }
+}
+
+
+void GEMDQMHarvester::refineTimeHistograms(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  igetter.cd("GEM/StatusDigi");
+  ibooker.setCurrentFolder("GEM/StatusDigi");
+  auto listME = igetter.getMEs();
+  
+  for ( auto strName : listME ) {
+    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
+    
+    MonitorElement *h2Curr = igetter.get("GEM/StatusDigi/" + strName);
+    std::string strNewName;
+    TH2F *h2New;
+    
+    refineTimeHistogramsCore(h2Curr->getTH2F(), strNewName, h2New);
+    
+    ibooker.book2D(strNewName, h2New);
+    igetter.removeElement(strName);
+  }
+}
+
+
+void GEMDQMHarvester::refineTimeHistograms(TFile *fDQM) {
+  std::string strRunnum = ( (TDirectoryFile *)fDQM->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
+  std::string strPathMain = "DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi";
+  
+  fDQM->cd(strPathMain.c_str());
+  auto dirMain = ( (TDirectoryFile *)fDQM->Get(strPathMain.c_str()) );
+  
+  for ( auto k : *dirMain->GetListOfKeys() ) {
+    TKey *key = (TKey *)k;
+    std::string strName = key->ReadObj()->GetName();
+    std::string strNewName;
+    
+    if ( strName.find("primitive_per_time_") == std::string::npos ) continue;
+    
+    TH2F *h2Curr = (TH2F *)fDQM->Get(( strPathMain + "/" + strName ).c_str());
+    TH2F *h2New;
+    refineTimeHistogramsCore(h2Curr, strNewName, h2New, "");
+    
+    fDQM->Write();
+  }
+  
+  for ( auto k : *dirMain->GetListOfKeys() ) std::cout << ( (TKey *)k )->ReadObj()->GetName() << std::endl;
+}
+
+
+void GEMDQMHarvester::refineTimeHistogramsCore(TH2F *h2Curr, std::string &strNewName, 
+                                               TH2F *&h2New, std::string strTmpPrefix)
+{
+  strNewName = std::string(h2Curr->GetName()).substr(std::string("primitive_").size());
+  
+  Int_t nNbinsX = h2Curr->GetNbinsX();
+  Int_t nNbinsY = h2Curr->GetNbinsY();
+  Int_t nNbinsXActual = 0;
+  
+  for ( nNbinsXActual = 0 ; nNbinsXActual < nNbinsX ; nNbinsXActual++ ) {
+    if ( h2Curr->GetBinContent(nNbinsXActual + 1, 0) <= 0 ) break;
+  }
+  
+  std::string strTitle = std::string(h2Curr->GetTitle()) + ";" + 
+    std::string(h2Curr->GetXaxis()->GetTitle()) + ";" + std::string(h2Curr->GetYaxis()->GetTitle());
+  std::cout << strTitle << "(" << nNbinsXActual << ", " << nNbinsY << ")" << std::endl;
+  
+  strTitle = "";
+  h2New = new TH2F(( strTmpPrefix + strNewName ).c_str(), strTitle.c_str(), 
+      nNbinsXActual, 0.0, (Double_t)nNbinsXActual, nNbinsY, 0.0, (Double_t)nNbinsY);
+  
+  for ( Int_t i = 1 ; false && i <= nNbinsY ; i++ ) {
+    std::string strLabel = h2Curr->GetYaxis()->GetBinLabel(i);
+    if ( !strLabel.empty() ) h2New->GetYaxis()->SetBinLabel(i, strLabel.c_str());
+  }
+  
+  for ( Int_t j = 0 ; false && j <= nNbinsY ; j++ ) 
+  for ( Int_t i = 1 ; i <= nNbinsXActual ; i++ ) {
+    h2New->SetBinContent(i, j, h2Curr->GetBinContent(i, j));
+  }
+}
+
+
+void GEMDQMHarvester::createSummaryPlots(edm::Service<DQMStore> &store) {
+}
+
 
 DEFINE_FWK_MODULE(GEMDQMHarvester);

--- a/DQM/GEM/plugins/GEMDQMSource.cc
+++ b/DQM/GEM/plugins/GEMDQMSource.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -21,206 +22,200 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
-
-class GEMDQMSource : public DQMEDAnalyzer {
+ 
+class GEMDQMSource: public DQMEDAnalyzer
+{
 public:
   GEMDQMSource(const edm::ParameterSet& cfg);
-  ~GEMDQMSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  ~GEMDQMSource() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
 protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override{};
 
 private:
   edm::EDGetToken tagRecHit_;
-
+  
   float fGlobXMin_, fGlobXMax_;
   float fGlobYMin_, fGlobYMax_;
-
+  
   int nIdxFirstStrip_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-
-  const GEMGeometry* GEMGeometry_;
+     
+  const GEMGeometry* GEMGeometry_; 
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
-  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
-  std::unordered_map<UInt_t, MonitorElement*> StripsFired_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
+  std::unordered_map<UInt_t,  MonitorElement*> recHitME_;
+  std::unordered_map<UInt_t,  MonitorElement*> VFAT_vs_ClusterSize_;
+  std::unordered_map<UInt_t,  MonitorElement*> StripsFired_vs_eta_;
+  std::unordered_map<UInt_t,  MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t,  MonitorElement*> recGlobalPos;
+
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSource::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = abs(max_ - min_) / 3.0;
-  if (x_ < (min(min_, max_) + step)) {
-    return 8 - roll_;
-  } else if (x_ < (min(min_, max_) + 2.0 * step)) {
-    return 16 - roll_;
-  } else {
-    return 24 - roll_;
-  }
+  float step = abs(max_-min_)/3.0;
+  if ( x_ < (min(min_,max_)+step) ) { return 8 - roll_;}
+  else if ( x_ < (min(min_,max_)+2.0*step) ) { return 16 - roll_;}
+  else { return 24 - roll_;}
 }
 
-const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const& iSetup) {
+const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const & iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  }
+  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
   return GEMGeometry_;
 }
 
-GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg) {
-  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
-
+GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg)
+{
+  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel")); 
+  
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
-
+  
   fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
   fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
   fGlobYMin_ = cfg.getParameter<double>("global_y_bound_min");
   fGlobYMax_ = cfg.getParameter<double>("global_y_bound_max");
 }
 
-void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
-
+  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", "")); 
+  
   desc.add<int>("idxFirstStrip", 0);
-
+  
   desc.add<double>("global_x_bound_min", -350);
-  desc.add<double>("global_x_bound_max", 350);
+  desc.add<double>("global_x_bound_max",  350);
   desc.add<double>("global_y_bound_min", -260);
-  desc.add<double>("global_y_bound_max", 260);
-
-  descriptions.add("GEMDQMSource", desc);
+  desc.add<double>("global_y_bound_max",  260);
+  
+  descriptions.add("GEMDQMSource", desc);  
 }
 
-void GEMDQMSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
+void GEMDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
+{
   std::vector<GEMDetId> listLayerOcc;
-
+  
   GEMGeometry_ = initGeometry(iSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
+  if ( GEMGeometry_ == nullptr) return ;  
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
+  for (auto sch : superChambers_){
     int n_lay = sch->nChambers();
-    for (int l = 0; l < n_lay; l++) {
+    for (int l=0;l<n_lay;l++){
       Bool_t bExist = false;
-      for (auto ch : gemChambers_)
-        if (ch.id() == sch->chamber(l + 1)->id())
-          bExist = true;
-      if (bExist)
-        continue;
-
-      gemChambers_.push_back(*sch->chamber(l + 1));
+      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
+      if ( bExist ) continue;
+      
+      gemChambers_.push_back(*sch->chamber(l+1));
     }
   }
-
+  
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/recHit");
-
-  for (auto ch : gemChambers_) {
+  
+  for (auto ch : gemChambers_){
     GEMDetId gid = ch.id();
-
-    std::string strIdxName = "Gemini_" + to_string(gid.chamber()) + "_GE" + (gid.region() > 0 ? "p" : "m") +
-                             to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
-                              to_string(gid.station()) + "/" + to_string(gid.layer());
-
-    std::string strStId = (gid.region() > 0 ? "p" : "m") + std::to_string(gid.station());
-    std::string strStT = (gid.region() > 0 ? "+" : "-") + std::to_string(gid.station());
-
+    
+    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
+      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
+      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
+    
+    std::string strStId = ( gid.region() > 0 ? "p" : "m" ) + std::to_string(gid.station());
+    std::string strStT  = ( gid.region() > 0 ? "+" : "-" ) + std::to_string(gid.station());
+    
     std::string strLa = std::to_string(gid.layer());
     std::string strCh = std::to_string(gid.chamber());
-
+    
     string hName = "recHit_" + strIdxName;
     string hTitle = "recHit " + strIdxTitle;
     hTitle += ";VFAT;";
-    recHitME_[gid] = ibooker.book1D(hName, hTitle, 24, 0, 24);
+    recHitME_[ gid ] = ibooker.book1D(hName, hTitle, 24,0,24);
 
     string hName_2 = "VFAT_vs_ClusterSize_" + strIdxName;
     string hTitle_2 = "VFAT vs ClusterSize " + strIdxTitle;
     hTitle_2 += ";Cluster size;VFAT";
-    VFAT_vs_ClusterSize_[gid] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
-
+    VFAT_vs_ClusterSize_[ gid ] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
+    
     string hName_fired = "StripFired_" + strIdxName;
     string hTitle_fired = "StripsFired " + strIdxTitle;
     hTitle_fired += ";Strip;iEta";
-    StripsFired_vs_eta_[gid] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1, 9);
+    StripsFired_vs_eta_[ gid ] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1,9);
 
     string hName_rh = "recHit_x_" + strIdxName;
     string hTitle_rh = "recHit local x " + strIdxTitle;
     hTitle_rh += ";Local x (cm);iEta";
-    rh_vs_eta_[gid] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1, 9);
-
+    rh_vs_eta_[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1,9);
+    
     GEMDetId lid(gid.region(), gid.ring(), gid.station(), gid.layer(), 0, 0);
     Int_t nIdxOcc = 0;
-
-    for (; nIdxOcc < (Int_t)listLayerOcc.size(); nIdxOcc++)
-      if (listLayerOcc[nIdxOcc] == lid)
-        break;
-    if (nIdxOcc >= (Int_t)listLayerOcc.size())
-      listLayerOcc.push_back(lid);
+    
+    for ( ; nIdxOcc < (Int_t)listLayerOcc.size() ; nIdxOcc++ ) if ( listLayerOcc[ nIdxOcc ] == lid ) break;
+    if ( nIdxOcc >= (Int_t)listLayerOcc.size() ) listLayerOcc.push_back(lid);
   }
-
-  for (auto gid : listLayerOcc) {
-    std::string strIdxName =
-        std::string("GE") + (gid.region() > 0 ? "p" : "m") + to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle =
-        std::string("GE") + (gid.region() > 0 ? "+" : "-") + to_string(gid.station()) + "/" + to_string(gid.layer());
-
+  
+  for ( auto gid : listLayerOcc ) {
+    std::string strIdxName  = std::string("GE") + ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + 
+      "_" + to_string(gid.layer());
+    std::string strIdxTitle = std::string("GE") + ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + 
+      "/" + to_string(gid.layer());
+    
     string hName_rh = "recHit_globalPos_Gemini_" + strIdxName;
     string hTitle_rh = "recHit global position Gemini chamber : " + strIdxTitle;
     hTitle_rh += ";Global X (cm);Global Y (cm)";
-    recGlobalPos[gid] = ibooker.book2D(hName_rh, hTitle_rh, 100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
+    recGlobalPos[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 
+        100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
   }
 }
 
-void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
-  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
+void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
+{
+  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
+  if ( GEMGeometry_ == nullptr) return; 
 
   edm::Handle<GEMRecHitCollection> gemRecHits;
-  event.getByToken(this->tagRecHit_, gemRecHits);
+  event.getByToken( this->tagRecHit_, gemRecHits);
   if (!gemRecHits.isValid()) {
     edm::LogError("GEMDQMSource") << "GEM recHit is not valid.\n";
-    return;
-  }
-  for (auto ch : gemChambers_) {
+    return ;
+  }  
+  for (auto ch : gemChambers_){
     GEMDetId cId = ch.id();
-    for (auto roll : ch.etaPartitions()) {
+    for(auto roll : ch.etaPartitions()){
       GEMDetId rId = roll->id();
-      const auto& recHitsRange = gemRecHits->get(rId);
+      const auto& recHitsRange = gemRecHits->get(rId); 
       auto gemRecHit = recHitsRange.first;
-      for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
+      for ( auto hit = gemRecHit; hit != recHitsRange.second; ++hit ) {
         //int nVfat = findVFAT(0.0, 384.0, hit->firstClusterStrip()+0.5*hit->clusterSize(), rId.roll());
-        Int_t nIdxStrip = hit->firstClusterStrip() + 0.5 * hit->clusterSize() - nIdxFirstStrip_;
-        Int_t nVfat = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
-        recHitME_[cId]->Fill(nVfat);
-        rh_vs_eta_[cId]->Fill(hit->localPosition().x(), rId.roll());
-        VFAT_vs_ClusterSize_[cId]->Fill(hit->clusterSize(), nVfat);
-        for (int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++) {
-          StripsFired_vs_eta_[cId]->Fill(i, rId.roll());
+        Int_t nIdxStrip = hit->firstClusterStrip()+0.5*hit->clusterSize() - nIdxFirstStrip_;
+        Int_t nVfat = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
+        recHitME_[ cId ]->Fill(nVfat);
+        rh_vs_eta_[ cId ]->Fill(hit->localPosition().x(), rId.roll());
+        VFAT_vs_ClusterSize_[ cId ]->Fill(hit->clusterSize(), nVfat);
+        for(int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++){
+          StripsFired_vs_eta_[ cId ]->Fill(i, rId.roll());
         }
-
+        
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
         GEMDetId idLayer(rId.region(), rId.ring(), rId.station(), rId.layer(), 0, 0);
-        recGlobalPos[idLayer]->Fill(recHitGP.x(), recHitGP.y());
+        recGlobalPos[ idLayer ]->Fill(recHitGP.x(), recHitGP.y());
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSource.cc
+++ b/DQM/GEM/plugins/GEMDQMSource.cc
@@ -7,8 +7,10 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
@@ -20,133 +22,201 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
-
-class GEMDQMSource : public DQMEDAnalyzer {
+ 
+class GEMDQMSource: public DQMEDAnalyzer
+{
 public:
   GEMDQMSource(const edm::ParameterSet& cfg);
-  ~GEMDQMSource() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  ~GEMDQMSource() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
 protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
 
 private:
   edm::EDGetToken tagRecHit_;
+  
+  float fGlobXMin_, fGlobXMax_;
+  float fGlobYMin_, fGlobYMax_;
+  
+  int nIdxFirstStrip_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-
-  const GEMGeometry* GEMGeometry_;
+     
+  const GEMGeometry* GEMGeometry_; 
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
-  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
-  std::unordered_map<UInt_t, MonitorElement*> StripsFired_vs_eta_;
-  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t,  MonitorElement*> recHitME_;
+  std::unordered_map<UInt_t,  MonitorElement*> VFAT_vs_ClusterSize_;
+  std::unordered_map<UInt_t,  MonitorElement*> StripsFired_vs_eta_;
+  std::unordered_map<UInt_t,  MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t,  MonitorElement*> recGlobalPos;
+
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSource::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = abs(max_ - min_) / 3.0;
-  if (x_ < (min(min_, max_) + step)) {
-    return 8 - roll_;
-  } else if (x_ < (min(min_, max_) + 2.0 * step)) {
-    return 16 - roll_;
-  } else {
-    return 24 - roll_;
-  }
+  float step = abs(max_-min_)/3.0;
+  if ( x_ < (min(min_,max_)+step) ) { return 8 - roll_;}
+  else if ( x_ < (min(min_,max_)+2.0*step) ) { return 16 - roll_;}
+  else { return 24 - roll_;}
 }
 
-const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const& iSetup) {
+const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const & iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  }
+  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
   return GEMGeometry_;
 }
 
-GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg) {
-  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
+GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg)
+{
+  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel")); 
+  
+  nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
+  
+  fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
+  fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
+  fGlobYMin_ = cfg.getParameter<double>("global_y_bound_min");
+  fGlobYMax_ = cfg.getParameter<double>("global_y_bound_max");
 }
 
-void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
-  descriptions.add("GEMDQMSource", desc);
+  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", "")); 
+  
+  desc.add<int>("idxFirstStrip", 0);
+  
+  desc.add<double>("global_x_bound_min", -350);
+  desc.add<double>("global_x_bound_max",  350);
+  desc.add<double>("global_y_bound_min", -260);
+  desc.add<double>("global_y_bound_max",  260);
+  
+  descriptions.add("GEMDQMSource", desc);  
 }
 
-void GEMDQMSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
+void GEMDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
+{
+  std::vector<GEMDetId> listLayerOcc;
+  
   GEMGeometry_ = initGeometry(iSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
+  if ( GEMGeometry_ == nullptr) return ;  
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
+  for (auto sch : superChambers_){
     int n_lay = sch->nChambers();
-    for (int l = 0; l < n_lay; l++) {
-      gemChambers_.push_back(*sch->chamber(l + 1));
+    for (int l=0;l<n_lay;l++){
+      Bool_t bExist = false;
+      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
+      if ( bExist ) continue;
+      
+      gemChambers_.push_back(*sch->chamber(l+1));
     }
   }
+  
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/recHit");
-  for (auto ch : gemChambers_) {
+  
+  for (auto ch : gemChambers_){
     GEMDetId gid = ch.id();
-    string hName = "recHit_Gemini_" + to_string(gid.chamber()) + "_la_" + to_string(gid.layer());
-    string hTitle = "recHit Gemini chamber : " + to_string(gid.chamber()) + ", layer : " + to_string(gid.layer());
-    recHitME_[ch.id()] = ibooker.book1D(hName, hTitle, 24, 0, 24);
+    
+    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
+      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
+      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
+    
+    std::string strStId = ( gid.region() > 0 ? "p" : "m" ) + std::to_string(gid.station());
+    std::string strStT  = ( gid.region() > 0 ? "+" : "-" ) + std::to_string(gid.station());
+    
+    std::string strLa = std::to_string(gid.layer());
+    std::string strCh = std::to_string(gid.chamber());
+    
+    string hName = "recHit_" + strIdxName;
+    string hTitle = "recHit " + strIdxTitle;
+    hTitle += ";VFAT;";
+    recHitME_[ gid ] = ibooker.book1D(hName, hTitle, 24,0,24);
 
-    string hName_2 = "VFAT_vs_ClusterSize_Gemini_" + to_string(gid.chamber()) + "_la_" + to_string(gid.layer());
-    string hTitle_2 =
-        "VFAT vs ClusterSize Gemini chamber : " + to_string(gid.chamber()) + ", layer : " + to_string(gid.layer());
-    VFAT_vs_ClusterSize_[ch.id()] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
+    string hName_2 = "VFAT_vs_ClusterSize_" + strIdxName;
+    string hTitle_2 = "VFAT vs ClusterSize " + strIdxTitle;
+    hTitle_2 += ";Cluster size;VFAT";
+    VFAT_vs_ClusterSize_[ gid ] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
+    
+    string hName_fired = "StripFired_" + strIdxName;
+    string hTitle_fired = "StripsFired " + strIdxTitle;
+    hTitle_fired += ";Strip;iEta";
+    StripsFired_vs_eta_[ gid ] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1,9);
 
-    string hName_fired = "StripFired_Gemini_" + to_string(gid.chamber()) + "_la_" + to_string(gid.layer());
-    string hTitle_fired =
-        "StripsFired Gemini chamber : " + to_string(gid.chamber()) + ", layer : " + to_string(gid.layer());
-    StripsFired_vs_eta_[ch.id()] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1, 9);
-
-    string hName_rh = "recHit_x_Gemini_" + to_string(gid.chamber()) + "_la_" + to_string(gid.layer());
-    string hTitle_rh =
-        "recHit local x Gemini chamber : " + to_string(gid.chamber()) + ", layer : " + to_string(gid.layer());
-    rh_vs_eta_[ch.id()] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1, 9);
+    string hName_rh = "recHit_x_" + strIdxName;
+    string hTitle_rh = "recHit local x " + strIdxTitle;
+    hTitle_rh += ";Local x (cm);iEta";
+    rh_vs_eta_[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1,9);
+    
+    GEMDetId lid(gid.region(), gid.ring(), gid.station(), gid.layer(), 0, 0);
+    Int_t nIdxOcc = 0;
+    
+    for ( ; nIdxOcc < (Int_t)listLayerOcc.size() ; nIdxOcc++ ) if ( listLayerOcc[ nIdxOcc ] == lid ) break;
+    if ( nIdxOcc >= (Int_t)listLayerOcc.size() ) listLayerOcc.push_back(lid);
+  }
+  
+  for ( auto gid : listLayerOcc ) {
+    std::string strIdxName  = std::string("GE") + ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + 
+      "_" + to_string(gid.layer());
+    std::string strIdxTitle = std::string("GE") + ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + 
+      "/" + to_string(gid.layer());
+    
+    string hName_rh = "recHit_globalPos_Gemini_" + strIdxName;
+    string hTitle_rh = "recHit global position Gemini chamber : " + strIdxTitle;
+    hTitle_rh += ";Global X (cm);Global Y (cm)";
+    recGlobalPos[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 
+        100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
   }
 }
 
-void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
-  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
+void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
+{
+  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
+  if ( GEMGeometry_ == nullptr) return; 
 
   edm::Handle<GEMRecHitCollection> gemRecHits;
-  event.getByToken(this->tagRecHit_, gemRecHits);
+  event.getByToken( this->tagRecHit_, gemRecHits);
   if (!gemRecHits.isValid()) {
     edm::LogError("GEMDQMSource") << "GEM recHit is not valid.\n";
-    return;
-  }
-  for (auto ch : gemChambers_) {
+    return ;
+  }  
+  for (auto ch : gemChambers_){
     GEMDetId cId = ch.id();
-    for (auto roll : ch.etaPartitions()) {
+    for(auto roll : ch.etaPartitions()){
       GEMDetId rId = roll->id();
-      const auto& recHitsRange = gemRecHits->get(rId);
+      const auto& recHitsRange = gemRecHits->get(rId); 
       auto gemRecHit = recHitsRange.first;
-      for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
-        int nVfat = findVFAT(1.0, 385.0, hit->firstClusterStrip() + 0.5 * hit->clusterSize(), rId.roll());
-        recHitME_[cId]->Fill(nVfat);
-        rh_vs_eta_[cId]->Fill(hit->localPosition().x(), rId.roll());
-        VFAT_vs_ClusterSize_[cId]->Fill(hit->clusterSize(), nVfat);
-        for (int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++) {
-          StripsFired_vs_eta_[cId]->Fill(i, rId.roll());
+      for ( auto hit = gemRecHit; hit != recHitsRange.second; ++hit ) {
+        //int nVfat = findVFAT(0.0, 384.0, hit->firstClusterStrip()+0.5*hit->clusterSize(), rId.roll());
+        Int_t nIdxStrip = hit->firstClusterStrip()+0.5*hit->clusterSize() - nIdxFirstStrip_;
+        Int_t nVfat = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
+        recHitME_[ cId ]->Fill(nVfat);
+        rh_vs_eta_[ cId ]->Fill(hit->localPosition().x(), rId.roll());
+        VFAT_vs_ClusterSize_[ cId ]->Fill(hit->clusterSize(), nVfat);
+        for(int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++){
+          StripsFired_vs_eta_[ cId ]->Fill(i, rId.roll());
         }
+        
+        GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
+        GEMDetId idLayer(rId.region(), rId.ring(), rId.station(), rId.layer(), 0, 0);
+        recGlobalPos[ idLayer ]->Fill(recHitGP.x(), recHitGP.y());
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSource.cc
+++ b/DQM/GEM/plugins/GEMDQMSource.cc
@@ -7,7 +7,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -22,201 +21,206 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
- 
-class GEMDQMSource: public DQMEDAnalyzer
-{
+
+class GEMDQMSource : public DQMEDAnalyzer {
 public:
   GEMDQMSource(const edm::ParameterSet& cfg);
-  ~GEMDQMSource() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
+  ~GEMDQMSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override{};
 
 private:
   edm::EDGetToken tagRecHit_;
-  
+
   float fGlobXMin_, fGlobXMax_;
   float fGlobYMin_, fGlobYMax_;
-  
+
   int nIdxFirstStrip_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-     
-  const GEMGeometry* GEMGeometry_; 
+
+  const GEMGeometry* GEMGeometry_;
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t,  MonitorElement*> recHitME_;
-  std::unordered_map<UInt_t,  MonitorElement*> VFAT_vs_ClusterSize_;
-  std::unordered_map<UInt_t,  MonitorElement*> StripsFired_vs_eta_;
-  std::unordered_map<UInt_t,  MonitorElement*> rh_vs_eta_;
-  std::unordered_map<UInt_t,  MonitorElement*> recGlobalPos;
-
+  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
+  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
+  std::unordered_map<UInt_t, MonitorElement*> StripsFired_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSource::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = abs(max_-min_)/3.0;
-  if ( x_ < (min(min_,max_)+step) ) { return 8 - roll_;}
-  else if ( x_ < (min(min_,max_)+2.0*step) ) { return 16 - roll_;}
-  else { return 24 - roll_;}
+  float step = abs(max_ - min_) / 3.0;
+  if (x_ < (min(min_, max_) + step)) {
+    return 8 - roll_;
+  } else if (x_ < (min(min_, max_) + 2.0 * step)) {
+    return 16 - roll_;
+  } else {
+    return 24 - roll_;
+  }
 }
 
-const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const & iSetup) {
+const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const& iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  }
-  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
   return GEMGeometry_;
 }
 
-GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg)
-{
-  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel")); 
-  
+GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg) {
+  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
+
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
-  
+
   fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
   fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
   fGlobYMin_ = cfg.getParameter<double>("global_y_bound_min");
   fGlobYMax_ = cfg.getParameter<double>("global_y_bound_max");
 }
 
-void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", "")); 
-  
+  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
+
   desc.add<int>("idxFirstStrip", 0);
-  
+
   desc.add<double>("global_x_bound_min", -350);
-  desc.add<double>("global_x_bound_max",  350);
+  desc.add<double>("global_x_bound_max", 350);
   desc.add<double>("global_y_bound_min", -260);
-  desc.add<double>("global_y_bound_max",  260);
-  
-  descriptions.add("GEMDQMSource", desc);  
+  desc.add<double>("global_y_bound_max", 260);
+
+  descriptions.add("GEMDQMSource", desc);
 }
 
-void GEMDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
-{
+void GEMDQMSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
   std::vector<GEMDetId> listLayerOcc;
-  
-  GEMGeometry_ = initGeometry(iSetup);
-  if ( GEMGeometry_ == nullptr) return ;  
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
-  for (auto sch : superChambers_){
+  GEMGeometry_ = initGeometry(iSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
+
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
+  for (auto sch : superChambers_) {
     int n_lay = sch->nChambers();
-    for (int l=0;l<n_lay;l++){
+    for (int l = 0; l < n_lay; l++) {
       Bool_t bExist = false;
-      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
-      if ( bExist ) continue;
-      
-      gemChambers_.push_back(*sch->chamber(l+1));
+      for (auto ch : gemChambers_)
+        if (ch.id() == sch->chamber(l + 1)->id())
+          bExist = true;
+      if (bExist)
+        continue;
+
+      gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
-  
+
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/recHit");
-  
-  for (auto ch : gemChambers_){
+
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
-    
-    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
-      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
-      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
-    
-    std::string strStId = ( gid.region() > 0 ? "p" : "m" ) + std::to_string(gid.station());
-    std::string strStT  = ( gid.region() > 0 ? "+" : "-" ) + std::to_string(gid.station());
-    
+
+    std::string strIdxName = "Gemini_" + to_string(gid.chamber()) + "_GE" + (gid.region() > 0 ? "p" : "m") +
+                             to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
+                              to_string(gid.station()) + "/" + to_string(gid.layer());
+
+    std::string strStId = (gid.region() > 0 ? "p" : "m") + std::to_string(gid.station());
+    std::string strStT = (gid.region() > 0 ? "+" : "-") + std::to_string(gid.station());
+
     std::string strLa = std::to_string(gid.layer());
     std::string strCh = std::to_string(gid.chamber());
-    
+
     string hName = "recHit_" + strIdxName;
     string hTitle = "recHit " + strIdxTitle;
     hTitle += ";VFAT;";
-    recHitME_[ gid ] = ibooker.book1D(hName, hTitle, 24,0,24);
+    recHitME_[gid] = ibooker.book1D(hName, hTitle, 24, 0, 24);
 
     string hName_2 = "VFAT_vs_ClusterSize_" + strIdxName;
     string hTitle_2 = "VFAT vs ClusterSize " + strIdxTitle;
     hTitle_2 += ";Cluster size;VFAT";
-    VFAT_vs_ClusterSize_[ gid ] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
-    
+    VFAT_vs_ClusterSize_[gid] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
+
     string hName_fired = "StripFired_" + strIdxName;
     string hTitle_fired = "StripsFired " + strIdxTitle;
     hTitle_fired += ";Strip;iEta";
-    StripsFired_vs_eta_[ gid ] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1,9);
+    StripsFired_vs_eta_[gid] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1, 9);
 
     string hName_rh = "recHit_x_" + strIdxName;
     string hTitle_rh = "recHit local x " + strIdxTitle;
     hTitle_rh += ";Local x (cm);iEta";
-    rh_vs_eta_[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1,9);
-    
+    rh_vs_eta_[gid] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1, 9);
+
     GEMDetId lid(gid.region(), gid.ring(), gid.station(), gid.layer(), 0, 0);
     Int_t nIdxOcc = 0;
-    
-    for ( ; nIdxOcc < (Int_t)listLayerOcc.size() ; nIdxOcc++ ) if ( listLayerOcc[ nIdxOcc ] == lid ) break;
-    if ( nIdxOcc >= (Int_t)listLayerOcc.size() ) listLayerOcc.push_back(lid);
+
+    for (; nIdxOcc < (Int_t)listLayerOcc.size(); nIdxOcc++)
+      if (listLayerOcc[nIdxOcc] == lid)
+        break;
+    if (nIdxOcc >= (Int_t)listLayerOcc.size())
+      listLayerOcc.push_back(lid);
   }
-  
-  for ( auto gid : listLayerOcc ) {
-    std::string strIdxName  = std::string("GE") + ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + 
-      "_" + to_string(gid.layer());
-    std::string strIdxTitle = std::string("GE") + ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + 
-      "/" + to_string(gid.layer());
-    
+
+  for (auto gid : listLayerOcc) {
+    std::string strIdxName =
+        std::string("GE") + (gid.region() > 0 ? "p" : "m") + to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle =
+        std::string("GE") + (gid.region() > 0 ? "+" : "-") + to_string(gid.station()) + "/" + to_string(gid.layer());
+
     string hName_rh = "recHit_globalPos_Gemini_" + strIdxName;
     string hTitle_rh = "recHit global position Gemini chamber : " + strIdxTitle;
     hTitle_rh += ";Global X (cm);Global Y (cm)";
-    recGlobalPos[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 
-        100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
+    recGlobalPos[gid] = ibooker.book2D(hName_rh, hTitle_rh, 100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
   }
 }
 
-void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
-  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
-  if ( GEMGeometry_ == nullptr) return; 
+void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
+  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
 
   edm::Handle<GEMRecHitCollection> gemRecHits;
-  event.getByToken( this->tagRecHit_, gemRecHits);
+  event.getByToken(this->tagRecHit_, gemRecHits);
   if (!gemRecHits.isValid()) {
     edm::LogError("GEMDQMSource") << "GEM recHit is not valid.\n";
-    return ;
-  }  
-  for (auto ch : gemChambers_){
+    return;
+  }
+  for (auto ch : gemChambers_) {
     GEMDetId cId = ch.id();
-    for(auto roll : ch.etaPartitions()){
+    for (auto roll : ch.etaPartitions()) {
       GEMDetId rId = roll->id();
-      const auto& recHitsRange = gemRecHits->get(rId); 
+      const auto& recHitsRange = gemRecHits->get(rId);
       auto gemRecHit = recHitsRange.first;
-      for ( auto hit = gemRecHit; hit != recHitsRange.second; ++hit ) {
+      for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
         //int nVfat = findVFAT(0.0, 384.0, hit->firstClusterStrip()+0.5*hit->clusterSize(), rId.roll());
-        Int_t nIdxStrip = hit->firstClusterStrip()+0.5*hit->clusterSize() - nIdxFirstStrip_;
-        Int_t nVfat = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
-        recHitME_[ cId ]->Fill(nVfat);
-        rh_vs_eta_[ cId ]->Fill(hit->localPosition().x(), rId.roll());
-        VFAT_vs_ClusterSize_[ cId ]->Fill(hit->clusterSize(), nVfat);
-        for(int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++){
-          StripsFired_vs_eta_[ cId ]->Fill(i, rId.roll());
+        Int_t nIdxStrip = hit->firstClusterStrip() + 0.5 * hit->clusterSize() - nIdxFirstStrip_;
+        Int_t nVfat = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
+        recHitME_[cId]->Fill(nVfat);
+        rh_vs_eta_[cId]->Fill(hit->localPosition().x(), rId.roll());
+        VFAT_vs_ClusterSize_[cId]->Fill(hit->clusterSize(), nVfat);
+        for (int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++) {
+          StripsFired_vs_eta_[cId]->Fill(i, rId.roll());
         }
-        
+
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
         GEMDetId idLayer(rId.region(), rId.ring(), rId.station(), rId.layer(), 0, 0);
-        recGlobalPos[ idLayer ]->Fill(recHitGP.x(), recHitGP.y());
+        recGlobalPos[idLayer]->Fill(recHitGP.x(), recHitGP.y());
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSource.cc
+++ b/DQM/GEM/plugins/GEMDQMSource.cc
@@ -7,7 +7,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -22,200 +21,205 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
- 
-class GEMDQMSource: public DQMEDAnalyzer
-{
+
+class GEMDQMSource : public DQMEDAnalyzer {
 public:
   GEMDQMSource(const edm::ParameterSet& cfg);
-  ~GEMDQMSource() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
+  ~GEMDQMSource() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
 private:
   edm::EDGetToken tagRecHit_;
-  
+
   float fGlobXMin_, fGlobXMax_;
   float fGlobYMin_, fGlobYMax_;
-  
+
   int nIdxFirstStrip_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-     
-  const GEMGeometry* GEMGeometry_; 
+
+  const GEMGeometry* GEMGeometry_;
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t,  MonitorElement*> recHitME_;
-  std::unordered_map<UInt_t,  MonitorElement*> VFAT_vs_ClusterSize_;
-  std::unordered_map<UInt_t,  MonitorElement*> StripsFired_vs_eta_;
-  std::unordered_map<UInt_t,  MonitorElement*> rh_vs_eta_;
-  std::unordered_map<UInt_t,  MonitorElement*> recGlobalPos;
-
+  std::unordered_map<UInt_t, MonitorElement*> recHitME_;
+  std::unordered_map<UInt_t, MonitorElement*> VFAT_vs_ClusterSize_;
+  std::unordered_map<UInt_t, MonitorElement*> StripsFired_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
+  std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSource::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = abs(max_-min_)/3.0;
-  if ( x_ < (min(min_,max_)+step) ) { return 8 - roll_;}
-  else if ( x_ < (min(min_,max_)+2.0*step) ) { return 16 - roll_;}
-  else { return 24 - roll_;}
+  float step = abs(max_ - min_) / 3.0;
+  if (x_ < (min(min_, max_) + step)) {
+    return 8 - roll_;
+  } else if (x_ < (min(min_, max_) + 2.0 * step)) {
+    return 16 - roll_;
+  } else {
+    return 24 - roll_;
+  }
 }
 
-const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const & iSetup) {
+const GEMGeometry* GEMDQMSource::initGeometry(edm::EventSetup const& iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  }
-  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
   return GEMGeometry_;
 }
 
-GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg)
-{
-  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel")); 
-  
+GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg) {
+  tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
+
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
-  
+
   fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
   fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
   fGlobYMin_ = cfg.getParameter<double>("global_y_bound_min");
   fGlobYMax_ = cfg.getParameter<double>("global_y_bound_max");
 }
 
-void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", "")); 
-  
+  desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
+
   desc.add<int>("idxFirstStrip", 0);
-  
+
   desc.add<double>("global_x_bound_min", -350);
-  desc.add<double>("global_x_bound_max",  350);
+  desc.add<double>("global_x_bound_max", 350);
   desc.add<double>("global_y_bound_min", -260);
-  desc.add<double>("global_y_bound_max",  260);
-  
-  descriptions.add("GEMDQMSource", desc);  
+  desc.add<double>("global_y_bound_max", 260);
+
+  descriptions.add("GEMDQMSource", desc);
 }
 
-void GEMDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
-{
+void GEMDQMSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
   std::vector<GEMDetId> listLayerOcc;
-  
-  GEMGeometry_ = initGeometry(iSetup);
-  if ( GEMGeometry_ == nullptr) return ;  
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
-  for (auto sch : superChambers_){
+  GEMGeometry_ = initGeometry(iSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
+
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
+  for (auto sch : superChambers_) {
     int n_lay = sch->nChambers();
-    for (int l=0;l<n_lay;l++){
+    for (int l = 0; l < n_lay; l++) {
       Bool_t bExist = false;
-      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
-      if ( bExist ) continue;
-      
-      gemChambers_.push_back(*sch->chamber(l+1));
+      for (auto ch : gemChambers_)
+        if (ch.id() == sch->chamber(l + 1)->id())
+          bExist = true;
+      if (bExist)
+        continue;
+
+      gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
-  
+
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/recHit");
-  
-  for (auto ch : gemChambers_){
+
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
-    
-    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
-      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
-      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
-    
-    std::string strStId = ( gid.region() > 0 ? "p" : "m" ) + std::to_string(gid.station());
-    std::string strStT  = ( gid.region() > 0 ? "+" : "-" ) + std::to_string(gid.station());
-    
+
+    std::string strIdxName = "Gemini_" + to_string(gid.chamber()) + "_GE" + (gid.region() > 0 ? "p" : "m") +
+                             to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
+                              to_string(gid.station()) + "/" + to_string(gid.layer());
+
+    std::string strStId = (gid.region() > 0 ? "p" : "m") + std::to_string(gid.station());
+    std::string strStT = (gid.region() > 0 ? "+" : "-") + std::to_string(gid.station());
+
     std::string strLa = std::to_string(gid.layer());
     std::string strCh = std::to_string(gid.chamber());
-    
+
     string hName = "recHit_" + strIdxName;
     string hTitle = "recHit " + strIdxTitle;
     hTitle += ";VFAT;";
-    recHitME_[ gid ] = ibooker.book1D(hName, hTitle, 24,0,24);
+    recHitME_[gid] = ibooker.book1D(hName, hTitle, 24, 0, 24);
 
     string hName_2 = "VFAT_vs_ClusterSize_" + strIdxName;
     string hTitle_2 = "VFAT vs ClusterSize " + strIdxTitle;
     hTitle_2 += ";Cluster size;VFAT";
-    VFAT_vs_ClusterSize_[ gid ] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
-    
+    VFAT_vs_ClusterSize_[gid] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
+
     string hName_fired = "StripFired_" + strIdxName;
     string hTitle_fired = "StripsFired " + strIdxTitle;
     hTitle_fired += ";Strip;iEta";
-    StripsFired_vs_eta_[ gid ] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1,9);
+    StripsFired_vs_eta_[gid] = ibooker.book2D(hName_fired, hTitle_fired, 384, 1, 385, 8, 1, 9);
 
     string hName_rh = "recHit_x_" + strIdxName;
     string hTitle_rh = "recHit local x " + strIdxTitle;
     hTitle_rh += ";Local x (cm);iEta";
-    rh_vs_eta_[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1,9);
-    
+    rh_vs_eta_[gid] = ibooker.book2D(hName_rh, hTitle_rh, 50, -25, 25, 8, 1, 9);
+
     GEMDetId lid(gid.region(), gid.ring(), gid.station(), gid.layer(), 0, 0);
     Int_t nIdxOcc = 0;
-    
-    for ( ; nIdxOcc < (Int_t)listLayerOcc.size() ; nIdxOcc++ ) if ( listLayerOcc[ nIdxOcc ] == lid ) break;
-    if ( nIdxOcc >= (Int_t)listLayerOcc.size() ) listLayerOcc.push_back(lid);
+
+    for (; nIdxOcc < (Int_t)listLayerOcc.size(); nIdxOcc++)
+      if (listLayerOcc[nIdxOcc] == lid)
+        break;
+    if (nIdxOcc >= (Int_t)listLayerOcc.size())
+      listLayerOcc.push_back(lid);
   }
-  
-  for ( auto gid : listLayerOcc ) {
-    std::string strIdxName  = std::string("GE") + ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + 
-      "_" + to_string(gid.layer());
-    std::string strIdxTitle = std::string("GE") + ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + 
-      "/" + to_string(gid.layer());
-    
+
+  for (auto gid : listLayerOcc) {
+    std::string strIdxName =
+        std::string("GE") + (gid.region() > 0 ? "p" : "m") + to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle =
+        std::string("GE") + (gid.region() > 0 ? "+" : "-") + to_string(gid.station()) + "/" + to_string(gid.layer());
+
     string hName_rh = "recHit_globalPos_Gemini_" + strIdxName;
     string hTitle_rh = "recHit global position Gemini chamber : " + strIdxTitle;
     hTitle_rh += ";Global X (cm);Global Y (cm)";
-    recGlobalPos[ gid ] = ibooker.book2D(hName_rh, hTitle_rh, 
-        100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
+    recGlobalPos[gid] = ibooker.book2D(hName_rh, hTitle_rh, 100, fGlobXMin_, fGlobXMax_, 100, fGlobYMin_, fGlobYMax_);
   }
 }
 
-void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
-  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
-  if ( GEMGeometry_ == nullptr) return; 
+void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
+  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
 
   edm::Handle<GEMRecHitCollection> gemRecHits;
-  event.getByToken( this->tagRecHit_, gemRecHits);
+  event.getByToken(this->tagRecHit_, gemRecHits);
   if (!gemRecHits.isValid()) {
     edm::LogError("GEMDQMSource") << "GEM recHit is not valid.\n";
-    return ;
-  }  
-  for (auto ch : gemChambers_){
+    return;
+  }
+  for (auto ch : gemChambers_) {
     GEMDetId cId = ch.id();
-    for(auto roll : ch.etaPartitions()){
+    for (auto roll : ch.etaPartitions()) {
       GEMDetId rId = roll->id();
-      const auto& recHitsRange = gemRecHits->get(rId); 
+      const auto& recHitsRange = gemRecHits->get(rId);
       auto gemRecHit = recHitsRange.first;
-      for ( auto hit = gemRecHit; hit != recHitsRange.second; ++hit ) {
+      for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
         //int nVfat = findVFAT(0.0, 384.0, hit->firstClusterStrip()+0.5*hit->clusterSize(), rId.roll());
-        Int_t nIdxStrip = hit->firstClusterStrip()+0.5*hit->clusterSize() - nIdxFirstStrip_;
-        Int_t nVfat = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
-        recHitME_[ cId ]->Fill(nVfat);
-        rh_vs_eta_[ cId ]->Fill(hit->localPosition().x(), rId.roll());
-        VFAT_vs_ClusterSize_[ cId ]->Fill(hit->clusterSize(), nVfat);
-        for(int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++){
-          StripsFired_vs_eta_[ cId ]->Fill(i, rId.roll());
+        Int_t nIdxStrip = hit->firstClusterStrip() + 0.5 * hit->clusterSize() - nIdxFirstStrip_;
+        Int_t nVfat = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
+        recHitME_[cId]->Fill(nVfat);
+        rh_vs_eta_[cId]->Fill(hit->localPosition().x(), rId.roll());
+        VFAT_vs_ClusterSize_[cId]->Fill(hit->clusterSize(), nVfat);
+        for (int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++) {
+          StripsFired_vs_eta_[cId]->Fill(i, rId.roll());
         }
-        
+
         GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
         GEMDetId idLayer(rId.region(), rId.ring(), rId.station(), rId.layer(), 0, 0);
-        recGlobalPos[ idLayer ]->Fill(recHitGP.x(), recHitGP.y());
+        recGlobalPos[idLayer]->Fill(recHitGP.x(), recHitGP.y());
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSourceDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMSourceDigi.cc
@@ -20,55 +20,52 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
-
-class GEMDQMSourceDigi : public DQMEDAnalyzer {
+ 
+class GEMDQMSourceDigi: public DQMEDAnalyzer
+{
 public:
   GEMDQMSourceDigi(const edm::ParameterSet& cfg);
-  ~GEMDQMSourceDigi() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  ~GEMDQMSourceDigi() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
 protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override{};
 
 private:
   edm::EDGetToken tagDigi_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-
-  const GEMGeometry* GEMGeometry_;
+     
+  const GEMGeometry* GEMGeometry_; 
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t, MonitorElement*> Digi_2D_;
-  std::unordered_map<UInt_t, MonitorElement*> Digi_1D_;
-  std::unordered_map<UInt_t, MonitorElement*> BxVsVFAT;
+  std::unordered_map<UInt_t,  MonitorElement*> Digi_2D_;
+  std::unordered_map<UInt_t,  MonitorElement*> Digi_1D_;
+  std::unordered_map<UInt_t,  MonitorElement*> BxVsVFAT;
+
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSourceDigi::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = max_ / 3;
-  if (x_ < (min_ + step)) {
-    return 8 - roll_;
-  } else if (x_ < (min_ + 2 * step)) {
-    return 16 - roll_;
-  } else {
-    return 24 - roll_;
-  }
+  float step = max_/3;
+  if ( x_ < (min_+step) ) { return 8 - roll_;}
+  else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
+  else { return 24 - roll_;}
 }
 
-const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const& iSetup) {
+const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const & iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  }
+  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -76,75 +73,74 @@ const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const& iSetup)
   return GEMGeometry_;
 }
 
-GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg) {
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
+GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg)
+{
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
 }
 
-void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
-  descriptions.add("GEMDQMSourceDigi", desc);
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
+  descriptions.add("GEMDQMSourceDigi", desc);  
 }
 
-void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
+void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
+{
   GEMGeometry_ = initGeometry(iSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
+  if ( GEMGeometry_ == nullptr) return ;  
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
+  for (auto sch : superChambers_){
     int n_lay = sch->nChambers();
-    for (int l = 0; l < n_lay; l++) {
+    for (int l=0;l<n_lay;l++){
       Bool_t bExist = false;
-      for (auto ch : gemChambers_)
-        if (ch.id() == sch->chamber(l + 1)->id())
-          bExist = true;
-      if (bExist)
-        continue;
-
-      gemChambers_.push_back(*sch->chamber(l + 1));
+      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
+      if ( bExist ) continue;
+      
+      gemChambers_.push_back(*sch->chamber(l+1));
     }
   }
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/digi");
-  for (auto ch : gemChambers_) {
+  for (auto ch : gemChambers_){
     GEMDetId gid = ch.id();
-
-    std::string strIdxName = "Gemini_" + to_string(gid.chamber()) + "_GE" + (gid.region() > 0 ? "p" : "m") +
-                             to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
-                              to_string(gid.station()) + "/" + to_string(gid.layer());
-
+    
+    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
+      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
+      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
+    
     string hName_digi = "Digi_Strips_" + strIdxName;
     string hTitle_digi = "Digi Strip " + strIdxTitle;
     string hAxis_digi = ";Strip;iEta";
-    Digi_2D_[ch.id()] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5, 8.5);
-    Digi_1D_[ch.id()] = ibooker.book1D(hName_digi + "_VFAT", hTitle_digi + " VFAT" + hAxis_digi, 24, 0, 24);
-
+    Digi_2D_[ ch.id() ] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5,8.5);
+    Digi_1D_[ ch.id() ] = ibooker.book1D(hName_digi+"_VFAT", hTitle_digi+" VFAT"+hAxis_digi, 24, 0, 24);
+    
     string hNameBx = "bx_vs_VFAT_" + strIdxName;
     string hTitleBx = "bx vs VFAT " + strIdxTitle;
     hTitleBx += ";Bunch crossing;VFAT";
-    BxVsVFAT[ch.id()] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0, 24);
+    BxVsVFAT[ ch.id() ] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0,24);
   }
 }
 
-void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
-  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
-
+void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
+{
+  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
+  if ( GEMGeometry_ == nullptr) return; 
+  
   edm::Handle<GEMDigiCollection> gemDigis;
-  event.getByToken(this->tagDigi_, gemDigis);
-  for (auto ch : gemChambers_) {
+  event.getByToken( this->tagDigi_, gemDigis);
+  for (auto ch : gemChambers_){
     GEMDetId cId = ch.id();
-    for (auto roll : ch.etaPartitions()) {
-      GEMDetId rId = roll->id();
+    for(auto roll : ch.etaPartitions()){
+      GEMDetId rId = roll->id();      
       const auto& digis_in_det = gemDigis->get(rId);
-      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
+      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d){
         auto nVFAT = findVFAT(1, roll->nstrips(), d->strip(), rId.roll());
-        Digi_2D_[cId]->Fill(d->strip(), rId.roll());
-        Digi_1D_[cId]->Fill(nVFAT);
-        BxVsVFAT[cId]->Fill(d->bx(), nVFAT);
+        Digi_2D_[ cId ]->Fill(d->strip(), rId.roll());
+        Digi_1D_[ cId ]->Fill(nVFAT);
+        BxVsVFAT[ cId ]->Fill(d->bx(), nVFAT);
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSourceDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMSourceDigi.cc
@@ -20,52 +20,54 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
- 
-class GEMDQMSourceDigi: public DQMEDAnalyzer
-{
+
+class GEMDQMSourceDigi : public DQMEDAnalyzer {
 public:
   GEMDQMSourceDigi(const edm::ParameterSet& cfg);
-  ~GEMDQMSourceDigi() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
+  ~GEMDQMSourceDigi() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
 
 private:
   edm::EDGetToken tagDigi_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-     
-  const GEMGeometry* GEMGeometry_; 
+
+  const GEMGeometry* GEMGeometry_;
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t,  MonitorElement*> Digi_2D_;
-  std::unordered_map<UInt_t,  MonitorElement*> Digi_1D_;
-  std::unordered_map<UInt_t,  MonitorElement*> BxVsVFAT;
-
+  std::unordered_map<UInt_t, MonitorElement*> Digi_2D_;
+  std::unordered_map<UInt_t, MonitorElement*> Digi_1D_;
+  std::unordered_map<UInt_t, MonitorElement*> BxVsVFAT;
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSourceDigi::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = max_/3;
-  if ( x_ < (min_+step) ) { return 8 - roll_;}
-  else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
-  else { return 24 - roll_;}
+  float step = max_ / 3;
+  if (x_ < (min_ + step)) {
+    return 8 - roll_;
+  } else if (x_ < (min_ + 2 * step)) {
+    return 16 - roll_;
+  } else {
+    return 24 - roll_;
+  }
 }
 
-const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const & iSetup) {
+const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const& iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  }
-  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -73,74 +75,75 @@ const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const & iSetup
   return GEMGeometry_;
 }
 
-GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg)
-{
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
+GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg) {
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
 }
 
-void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
-  descriptions.add("GEMDQMSourceDigi", desc);  
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
+  descriptions.add("GEMDQMSourceDigi", desc);
 }
 
-void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
-{
+void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
   GEMGeometry_ = initGeometry(iSetup);
-  if ( GEMGeometry_ == nullptr) return ;  
+  if (GEMGeometry_ == nullptr)
+    return;
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
-  for (auto sch : superChambers_){
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
+  for (auto sch : superChambers_) {
     int n_lay = sch->nChambers();
-    for (int l=0;l<n_lay;l++){
+    for (int l = 0; l < n_lay; l++) {
       Bool_t bExist = false;
-      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
-      if ( bExist ) continue;
-      
-      gemChambers_.push_back(*sch->chamber(l+1));
+      for (auto ch : gemChambers_)
+        if (ch.id() == sch->chamber(l + 1)->id())
+          bExist = true;
+      if (bExist)
+        continue;
+
+      gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/digi");
-  for (auto ch : gemChambers_){
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
-    
-    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
-      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
-      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
-    
+
+    std::string strIdxName = "Gemini_" + to_string(gid.chamber()) + "_GE" + (gid.region() > 0 ? "p" : "m") +
+                             to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
+                              to_string(gid.station()) + "/" + to_string(gid.layer());
+
     string hName_digi = "Digi_Strips_" + strIdxName;
     string hTitle_digi = "Digi Strip " + strIdxTitle;
     string hAxis_digi = ";Strip;iEta";
-    Digi_2D_[ ch.id() ] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5,8.5);
-    Digi_1D_[ ch.id() ] = ibooker.book1D(hName_digi+"_VFAT", hTitle_digi+" VFAT"+hAxis_digi, 24, 0, 24);
-    
+    Digi_2D_[ch.id()] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5, 8.5);
+    Digi_1D_[ch.id()] = ibooker.book1D(hName_digi + "_VFAT", hTitle_digi + " VFAT" + hAxis_digi, 24, 0, 24);
+
     string hNameBx = "bx_vs_VFAT_" + strIdxName;
     string hTitleBx = "bx vs VFAT " + strIdxTitle;
     hTitleBx += ";Bunch crossing;VFAT";
-    BxVsVFAT[ ch.id() ] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0,24);
+    BxVsVFAT[ch.id()] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0, 24);
   }
 }
 
-void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
-  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
-  if ( GEMGeometry_ == nullptr) return; 
-  
+void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
+  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
+
   edm::Handle<GEMDigiCollection> gemDigis;
-  event.getByToken( this->tagDigi_, gemDigis);
-  for (auto ch : gemChambers_){
+  event.getByToken(this->tagDigi_, gemDigis);
+  for (auto ch : gemChambers_) {
     GEMDetId cId = ch.id();
-    for(auto roll : ch.etaPartitions()){
-      GEMDetId rId = roll->id();      
+    for (auto roll : ch.etaPartitions()) {
+      GEMDetId rId = roll->id();
       const auto& digis_in_det = gemDigis->get(rId);
-      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d){
+      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         auto nVFAT = findVFAT(1, roll->nstrips(), d->strip(), rId.roll());
-        Digi_2D_[ cId ]->Fill(d->strip(), rId.roll());
-        Digi_1D_[ cId ]->Fill(nVFAT);
-        BxVsVFAT[ cId ]->Fill(d->bx(), nVFAT);
+        Digi_2D_[cId]->Fill(d->strip(), rId.roll());
+        Digi_1D_[cId]->Fill(nVFAT);
+        BxVsVFAT[cId]->Fill(d->bx(), nVFAT);
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSourceDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMSourceDigi.cc
@@ -10,6 +10,7 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 
@@ -19,53 +20,53 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
-
-class GEMDQMSourceDigi : public DQMEDAnalyzer {
+ 
+class GEMDQMSourceDigi: public DQMEDAnalyzer
+{
 public:
   GEMDQMSourceDigi(const edm::ParameterSet& cfg);
-  ~GEMDQMSourceDigi() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
+  ~GEMDQMSourceDigi() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
 protected:
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
 
 private:
   edm::EDGetToken tagDigi_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-
-  const GEMGeometry* GEMGeometry_;
+     
+  const GEMGeometry* GEMGeometry_; 
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t, MonitorElement*> Digi_2D_;
-  std::unordered_map<UInt_t, MonitorElement*> Digi_1D_;
+  std::unordered_map<UInt_t,  MonitorElement*> Digi_2D_;
+  std::unordered_map<UInt_t,  MonitorElement*> Digi_1D_;
+  std::unordered_map<UInt_t,  MonitorElement*> BxVsVFAT;
+
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSourceDigi::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = max_ / 3;
-  if (x_ < (min_ + step)) {
-    return 8 - roll_;
-  } else if (x_ < (min_ + 2 * step)) {
-    return 16 - roll_;
-  } else {
-    return 24 - roll_;
-  }
+  float step = max_/3;
+  if ( x_ < (min_+step) ) { return 8 - roll_;}
+  else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
+  else { return 24 - roll_;}
 }
 
-const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const& iSetup) {
+const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const & iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  }
+  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -73,54 +74,74 @@ const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const& iSetup)
   return GEMGeometry_;
 }
 
-GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg) {
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
+GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg)
+{
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
 }
 
-void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
-  descriptions.add("GEMDQMSourceDigi", desc);
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
+  descriptions.add("GEMDQMSourceDigi", desc);  
 }
 
-void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
+void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
+{
   GEMGeometry_ = initGeometry(iSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
+  if ( GEMGeometry_ == nullptr) return ;  
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
+  for (auto sch : superChambers_){
     int n_lay = sch->nChambers();
-    for (int l = 0; l < n_lay; l++) {
-      gemChambers_.push_back(*sch->chamber(l + 1));
+    for (int l=0;l<n_lay;l++){
+      Bool_t bExist = false;
+      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
+      if ( bExist ) continue;
+      
+      gemChambers_.push_back(*sch->chamber(l+1));
     }
   }
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/digi");
-  for (auto ch : gemChambers_) {
+  for (auto ch : gemChambers_){
     GEMDetId gid = ch.id();
-    string hName_digi = "Digi_Strips_Gemini_" + to_string(gid.chamber()) + "_l_" + to_string(gid.layer());
-    string hTitle_digi = "Digi Strip GEMINIm" + to_string(gid.chamber()) + "l" + to_string(gid.layer());
-    Digi_2D_[ch.id()] = ibooker.book2D(hName_digi, hTitle_digi, 384, 1, 385, 8, 0.5, 8.5);
-    Digi_1D_[ch.id()] = ibooker.book1D(hName_digi + "_VFAT", hTitle_digi + " VFAT", 24, 0, 24);
+    
+    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
+      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
+      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
+    
+    string hName_digi = "Digi_Strips_" + strIdxName;
+    string hTitle_digi = "Digi Strip " + strIdxTitle;
+    string hAxis_digi = ";Strip;iEta";
+    Digi_2D_[ ch.id() ] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5,8.5);
+    Digi_1D_[ ch.id() ] = ibooker.book1D(hName_digi+"_VFAT", hTitle_digi+" VFAT"+hAxis_digi, 24, 0, 24);
+    
+    string hNameBx = "bx_vs_VFAT_" + strIdxName;
+    string hTitleBx = "bx vs VFAT " + strIdxTitle;
+    hTitleBx += ";Bunch crossing;VFAT";
+    BxVsVFAT[ ch.id() ] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0,24);
   }
 }
 
-void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
-  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
-
+void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
+{
+  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
+  if ( GEMGeometry_ == nullptr) return; 
+  
   edm::Handle<GEMDigiCollection> gemDigis;
-  event.getByToken(this->tagDigi_, gemDigis);
-  for (auto ch : gemChambers_) {
+  event.getByToken( this->tagDigi_, gemDigis);
+  for (auto ch : gemChambers_){
     GEMDetId cId = ch.id();
-    for (auto roll : ch.etaPartitions()) {
-      GEMDetId rId = roll->id();
+    for(auto roll : ch.etaPartitions()){
+      GEMDetId rId = roll->id();      
       const auto& digis_in_det = gemDigis->get(rId);
-      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
-        Digi_2D_[cId]->Fill(d->strip(), rId.roll());
-        Digi_1D_[cId]->Fill(findVFAT(1, roll->nstrips(), d->strip(), rId.roll()));
+      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d){
+        auto nVFAT = findVFAT(1, roll->nstrips(), d->strip(), rId.roll());
+        Digi_2D_[ cId ]->Fill(d->strip(), rId.roll());
+        Digi_1D_[ cId ]->Fill(nVFAT);
+        BxVsVFAT[ cId ]->Fill(d->bx(), nVFAT);
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMSourceDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMSourceDigi.cc
@@ -20,53 +20,55 @@
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
- 
-class GEMDQMSourceDigi: public DQMEDAnalyzer
-{
+
+class GEMDQMSourceDigi : public DQMEDAnalyzer {
 public:
   GEMDQMSourceDigi(const edm::ParameterSet& cfg);
-  ~GEMDQMSourceDigi() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
+  ~GEMDQMSourceDigi() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override {};
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override {};
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override{};
 
 private:
   edm::EDGetToken tagDigi_;
 
-  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
+  const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
-     
-  const GEMGeometry* GEMGeometry_; 
+
+  const GEMGeometry* GEMGeometry_;
 
   std::vector<GEMChamber> gemChambers_;
 
-  std::unordered_map<UInt_t,  MonitorElement*> Digi_2D_;
-  std::unordered_map<UInt_t,  MonitorElement*> Digi_1D_;
-  std::unordered_map<UInt_t,  MonitorElement*> BxVsVFAT;
-
+  std::unordered_map<UInt_t, MonitorElement*> Digi_2D_;
+  std::unordered_map<UInt_t, MonitorElement*> Digi_1D_;
+  std::unordered_map<UInt_t, MonitorElement*> BxVsVFAT;
 };
 
 using namespace std;
 using namespace edm;
 
 int GEMDQMSourceDigi::findVFAT(float min_, float max_, float x_, int roll_) {
-  float step = max_/3;
-  if ( x_ < (min_+step) ) { return 8 - roll_;}
-  else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
-  else { return 24 - roll_;}
+  float step = max_ / 3;
+  if (x_ < (min_ + step)) {
+    return 8 - roll_;
+  } else if (x_ < (min_ + 2 * step)) {
+    return 16 - roll_;
+  } else {
+    return 24 - roll_;
+  }
 }
 
-const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const & iSetup) {
+const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const& iSetup) {
   const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  }
-  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -74,74 +76,75 @@ const GEMGeometry* GEMDQMSourceDigi::initGeometry(edm::EventSetup const & iSetup
   return GEMGeometry_;
 }
 
-GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg)
-{
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
+GEMDQMSourceDigi::GEMDQMSourceDigi(const edm::ParameterSet& cfg) {
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
 }
 
-void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMSourceDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
-  descriptions.add("GEMDQMSourceDigi", desc);  
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
+  descriptions.add("GEMDQMSourceDigi", desc);
 }
 
-void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
-{
+void GEMDQMSourceDigi::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
   GEMGeometry_ = initGeometry(iSetup);
-  if ( GEMGeometry_ == nullptr) return ;  
+  if (GEMGeometry_ == nullptr)
+    return;
 
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
-  for (auto sch : superChambers_){
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
+  for (auto sch : superChambers_) {
     int n_lay = sch->nChambers();
-    for (int l=0;l<n_lay;l++){
+    for (int l = 0; l < n_lay; l++) {
       Bool_t bExist = false;
-      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
-      if ( bExist ) continue;
-      
-      gemChambers_.push_back(*sch->chamber(l+1));
+      for (auto ch : gemChambers_)
+        if (ch.id() == sch->chamber(l + 1)->id())
+          bExist = true;
+      if (bExist)
+        continue;
+
+      gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/digi");
-  for (auto ch : gemChambers_){
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
-    
-    std::string strIdxName  = "Gemini_" + to_string(gid.chamber()) + "_GE" + 
-      ( gid.region() > 0 ? "p" : "m" ) + to_string(gid.station()) + "_" + to_string(gid.layer());
-    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
-      ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
-    
+
+    std::string strIdxName = "Gemini_" + to_string(gid.chamber()) + "_GE" + (gid.region() > 0 ? "p" : "m") +
+                             to_string(gid.station()) + "_" + to_string(gid.layer());
+    std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
+                              to_string(gid.station()) + "/" + to_string(gid.layer());
+
     string hName_digi = "Digi_Strips_" + strIdxName;
     string hTitle_digi = "Digi Strip " + strIdxTitle;
     string hAxis_digi = ";Strip;iEta";
-    Digi_2D_[ ch.id() ] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5,8.5);
-    Digi_1D_[ ch.id() ] = ibooker.book1D(hName_digi+"_VFAT", hTitle_digi+" VFAT"+hAxis_digi, 24, 0, 24);
-    
+    Digi_2D_[ch.id()] = ibooker.book2D(hName_digi, hTitle_digi + hAxis_digi, 384, 1, 385, 8, 0.5, 8.5);
+    Digi_1D_[ch.id()] = ibooker.book1D(hName_digi + "_VFAT", hTitle_digi + " VFAT" + hAxis_digi, 24, 0, 24);
+
     string hNameBx = "bx_vs_VFAT_" + strIdxName;
     string hTitleBx = "bx vs VFAT " + strIdxTitle;
     hTitleBx += ";Bunch crossing;VFAT";
-    BxVsVFAT[ ch.id() ] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0,24);
+    BxVsVFAT[ch.id()] = ibooker.book2D(hNameBx, hTitleBx, 10, -5, 5, 24, 0, 24);
   }
 }
 
-void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
-  const GEMGeometry* GEMGeometry_  = initGeometry(eventSetup);
-  if ( GEMGeometry_ == nullptr) return; 
-  
+void GEMDQMSourceDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup) {
+  const GEMGeometry* GEMGeometry_ = initGeometry(eventSetup);
+  if (GEMGeometry_ == nullptr)
+    return;
+
   edm::Handle<GEMDigiCollection> gemDigis;
-  event.getByToken( this->tagDigi_, gemDigis);
-  for (auto ch : gemChambers_){
+  event.getByToken(this->tagDigi_, gemDigis);
+  for (auto ch : gemChambers_) {
     GEMDetId cId = ch.id();
-    for(auto roll : ch.etaPartitions()){
-      GEMDetId rId = roll->id();      
+    for (auto roll : ch.etaPartitions()) {
+      GEMDetId rId = roll->id();
       const auto& digis_in_det = gemDigis->get(rId);
-      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d){
+      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         auto nVFAT = findVFAT(1, roll->nstrips(), d->strip(), rId.roll());
-        Digi_2D_[ cId ]->Fill(d->strip(), rId.roll());
-        Digi_1D_[ cId ]->Fill(nVFAT);
-        BxVsVFAT[ cId ]->Fill(d->bx(), nVFAT);
+        Digi_2D_[cId]->Fill(d->strip(), rId.roll());
+        Digi_1D_[cId]->Fill(nVFAT);
+        BxVsVFAT[cId]->Fill(d->bx(), nVFAT);
       }
     }
   }

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -131,7 +131,7 @@ private:
 
   std::unordered_map<UInt_t, Bool_t> m_mapStatusFill;
   std::unordered_map<UInt_t, Bool_t> m_mapStatusErr;
-  
+
   MonitorElement *h3SummaryStatusPre_;
   const Int_t m_nIdxSummaryFill = 1, m_nIdxSummaryErr = 2;
 
@@ -319,8 +319,8 @@ int GEMDQMStatusDigi::SetConfigTimeRecord() {
   listTimeStore_[0] = newTimeStore;
 
   for (auto layerId : m_listLayers) {
-    std::string strSuffix = (layerId.region() > 0 ? "p" : "m") + 
-      std::to_string(layerId.station()) + "_" + std::to_string(layerId.layer());
+    std::string strSuffix =
+        (layerId.region() > 0 ? "p" : "m") + std::to_string(layerId.station()) + "_" + std::to_string(layerId.layer());
 
     newTimeStore.strName = strCommonName + "status_GEB_" + suffixLayer(layerId);
     newTimeStore.strTitle = "";
@@ -389,7 +389,7 @@ int GEMDQMStatusDigi::LoadPrevData() {
 
   std::cout << strPathPrevDQMRoot_ << " is being loaded" << std::endl;
   std::string strRunnum = ((TDirectoryFile *)fPrev->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
-  
+
   // In this stage, we need to use them to check the consistence of time-histograms
   nStackedBin_ = -1;
   nStackedEvt_ = -1;
@@ -397,27 +397,28 @@ int GEMDQMStatusDigi::LoadPrevData() {
   for (auto &itStore : listTimeStore_) {
     std::string strNameStore = "DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi/" + itStore.second.strName;
     TH2F *h2Prev = (TH2F *)fPrev->Get(strNameStore.c_str());
-    
+
     Int_t nNBinX = h2Prev->GetNbinsX();
     Int_t nNBinY = h2Prev->GetNbinsY();
-    
+
     // Including all under/overflow bins (they contain important infos)
     nStackedEvt_ = 0;
-    for ( Int_t i = 0 ; i <= nNBinX + 1 ; i++ ) {
-      if ( i > 0 ) nStackedEvt_ += h2Prev->GetBinContent(i, 0);
-      for ( Int_t j = 0 ; j <= nNBinY + 1 ; j++ ) {
+    for (Int_t i = 0; i <= nNBinX + 1; i++) {
+      if (i > 0)
+        nStackedEvt_ += h2Prev->GetBinContent(i, 0);
+      for (Int_t j = 0; j <= nNBinY + 1; j++) {
         itStore.second.h2Histo->setBinContent(i, j, h2Prev->GetBinContent(i, j));
       }
     }
-    
-    Int_t nStackedBinCurr = nStackedEvt_ / ( nNSecPerBin_ * nNEvtPerSec_ );
-    Int_t nStackedEvtCurr = nStackedEvt_ % ( nNSecPerBin_ * nNEvtPerSec_ );
-    
-    if ( nStackedBin_ < 0 ) {
+
+    Int_t nStackedBinCurr = nStackedEvt_ / (nNSecPerBin_ * nNEvtPerSec_);
+    Int_t nStackedEvtCurr = nStackedEvt_ % (nNSecPerBin_ * nNEvtPerSec_);
+
+    if (nStackedBin_ < 0) {
       nStackedBin_ = nStackedBinCurr;
       nStackedEvt_ = nStackedEvtCurr;
     } else {
-      bSync = ( nStackedBin_ == nStackedBinCurr && nStackedEvt_ == nStackedEvtCurr );
+      bSync = (nStackedBin_ == nStackedBinCurr && nStackedEvt_ == nStackedEvtCurr);
     }
   }
 
@@ -576,7 +577,7 @@ void GEMDQMStatusDigi::bookHistogramsTimeRecordPart(DQMStore::IBooker &ibooker) 
     infoCurr.h2Histo = ibooker.book2D(
         infoCurr.strName,
         //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX,
-        infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_*nNEvtPerSec_) + " events;" + infoCurr.strAxisX,
+        infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX,
         nNTimeBinPrimitive_,
         0,
         nNTimeBinPrimitive_,
@@ -684,8 +685,8 @@ void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
   m_summaryReport_ = ibooker.bookFloat("reportSummary");
   m_summaryReport_->Fill(1.0);
 
-  h3SummaryStatusPre_ = ibooker.book3D("reportSummaryMapPreliminary", ";Chamber;", 
-      nNCh_, 0, nNCh_, m_listLayers.size(), 0, m_listLayers.size(), 2, 0, 1);
+  h3SummaryStatusPre_ = ibooker.book3D(
+      "reportSummaryMapPreliminary", ";Chamber;", nNCh_, 0, nNCh_, m_listLayers.size(), 0, m_listLayers.size(), 2, 0, 1);
 
   for (Int_t i = 0; i < nNCh_; i++) {
     auto &gid = this->m_listChambers[i];
@@ -747,7 +748,7 @@ void GEMDQMStatusDigi::seekIdxSummary(GEMDetId gid, Int_t &nIdxLayer, Int_t &nId
   Int_t nLayer = (bPerSuperchamber_ ? gid.layer() : 0);
   GEMDetId layerId(gid.region(), gid.ring(), gid.station(), nLayer, 0, 0);
   GEMDetId chamberId(0, 1, 1, gid.layer() - nLayer, gid.chamber(), 0);
-  
+
   nIdxLayer = seekIdx(m_listLayers, layerId);
   nIdxChamber = seekIdx(m_listChambers, chamberId) + 1;
 }
@@ -766,7 +767,7 @@ void GEMDQMStatusDigi::analyze(edm::Event const &event, edm::EventSetup const &e
   auto fillTimeHisto = [](TimeStoreItem &listCurr, int nStackedBin, int nIdx, bool bFill) -> void {
     Int_t nX = nStackedBin + 1;
     Int_t nY = nIdx + 1;
-    
+
     listCurr.h2Histo->setBinContent(nX, 0, listCurr.h2Histo->getBinContent(nX, 0) + 1);
     if (bFill)
       listCurr.h2Histo->setBinContent(nX, nY, listCurr.h2Histo->getBinContent(nX, nY) + 1);

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -9,7 +9,6 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -27,29 +26,26 @@
 
 //----------------------------------------------------------------------------------------------------
 
-
 typedef struct tagTimeStoreItem {
   std::string strName;
   std::string strTitle;
   std::string strAxisX;
-  
+
   MonitorElement *h2Histo;
-  
+
   Int_t nNbinY;
   Int_t nNbinMin;
   Int_t nNbinMax;
-  
+
   std::vector<std::vector<Double_t>> listOccupy;
   std::vector<std::vector<Double_t>> listRecord;
 } TimeStoreItem;
 
- 
-class GEMDQMStatusDigi: public DQMEDAnalyzer
-{
+class GEMDQMStatusDigi : public DQMEDAnalyzer {
 public:
-  GEMDQMStatusDigi(const edm::ParameterSet& cfg);
-  ~GEMDQMStatusDigi() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
+  GEMDQMStatusDigi(const edm::ParameterSet &cfg);
+  ~GEMDQMStatusDigi() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
@@ -57,109 +53,107 @@ protected:
   void bookHistogramsStationPart(DQMStore::IBooker &, GEMDetId &);
   void bookHistogramsAMCPart(DQMStore::IBooker &);
   void bookHistogramsTimeRecordPart(DQMStore::IBooker &);
-  
+
   int SetInfoChambers();
   int SetConfigTimeRecord();
   int LoadPrevData();
-  
+
   Int_t seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId);
-  
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
+
+  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+  void endRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
-  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
-  
+  const GEMGeometry *initGeometry(edm::EventSetup const &iSetup);
+
   void AddLabel();
-  
+
   std::string suffixChamber(GEMDetId &id);
   std::string suffixLayer(GEMDetId &id);
-  
+
   void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits);
   void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nY);
-  
-  const GEMGeometry* GEMGeometry_; 
+
+  const GEMGeometry *GEMGeometry_;
   std::vector<GEMChamber> gemChambers_;
-  
+
   int nVfat_ = 24;
-  
+
   int nNCh_;
-  
+
   int cBit_ = 9;
   int qVFATBit_ = 5;
   int fVFATBit_ = 4;
   int eBit_ = 16;
   int amcStatusBit_ = 6;
-  
+
   int nNEvtPerSec_;
   int nNSecPerBin_;
   int nNTimeBinTotal_;
   int nNTimeBinPrimitive_;
-  
+
   int nIdxFirstStrip_;
-  
+
   int nNBxBin_;
   int nNBxRange_;
-  
+
   std::string strFmtSummaryLabel_;
   bool bFlipSummary_;
   bool bPerSuperchamber_;
-  
+
   std::string strPathPrevDQMRoot_;
-  
+
   edm::EDGetToken tagVFAT_;
   edm::EDGetToken tagGEB_;
   edm::EDGetToken tagAMC_;
   edm::EDGetToken tagDigi_;
-  
+
   std::vector<Int_t> listAMCSlots_;
-  
+
   std::vector<GEMDetId> m_listLayers;
   std::vector<GEMDetId> m_listChambers;
 
   MonitorElement *h1_vfat_qualityflag_;
   MonitorElement *h2_vfat_qualityflag_;
-  
-  std::unordered_map<UInt_t, MonitorElement*> listVFATQualityFlag_;
-  std::unordered_map<UInt_t, MonitorElement*> listVFATBC_;
-  std::unordered_map<UInt_t, MonitorElement*> listVFATEC_;
 
-  std::unordered_map<UInt_t, MonitorElement*> listGEBInputStatus_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBInputID_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCnt_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCntT_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBZeroSupWordsCnt_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBbcOH_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBecOH_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBOHCRC_;
-  
+  std::unordered_map<UInt_t, MonitorElement *> listVFATQualityFlag_;
+  std::unordered_map<UInt_t, MonitorElement *> listVFATBC_;
+  std::unordered_map<UInt_t, MonitorElement *> listVFATEC_;
+
+  std::unordered_map<UInt_t, MonitorElement *> listGEBInputStatus_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBInputID_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBVFATWordCnt_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBVFATWordCntT_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBZeroSupWordsCnt_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBbcOH_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBecOH_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBOHCRC_;
+
   std::unordered_map<UInt_t, Bool_t> m_mapStatusFill;
   std::unordered_map<UInt_t, Bool_t> m_mapStatusErr;
-  
+
   MonitorElement *h1_amc_ttsState_;
   MonitorElement *h1_amc_davCnt_;
   MonitorElement *h1_amc_buffState_;
   MonitorElement *h1_amc_oosGlib_;
   MonitorElement *h1_amc_chTimeOut_;
   MonitorElement *h2AMCStatus_;
-  
+
   MonitorElement *m_summaryReport_;
   MonitorElement *h2SummaryStatus_;
-  
+
   // For more information, see SetConfigTimeRecord()
   std::unordered_map<UInt_t, TimeStoreItem> listTimeStore_;
   Int_t nStackedEvt_;
-
 };
 
-const GEMGeometry* GEMDQMStatusDigi::initGeometry(edm::EventSetup const & iSetup) {
-  const GEMGeometry* GEMGeometry_ = nullptr;
+const GEMGeometry *GEMDQMStatusDigi::initGeometry(edm::EventSetup const &iSetup) {
+  const GEMGeometry *GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  }
-  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  } catch (edm::eventsetup::NoProxyException<GEMGeometry> &e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -169,423 +163,438 @@ const GEMGeometry* GEMDQMStatusDigi::initGeometry(edm::EventSetup const & iSetup
 using namespace std;
 using namespace edm;
 
-GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet& cfg)
-{
+GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet &cfg) {
+  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
+  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel"));
+  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
 
-  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel")); 
-  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel")); 
-  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel")); 
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
-  
   listAMCSlots_ = cfg.getParameter<std::vector<int>>("AMCSlots");
-  
+
   strFmtSummaryLabel_ = cfg.getParameter<std::string>("summaryLabelFmt");
   bFlipSummary_ = cfg.getParameter<bool>("flipSummary");
   bPerSuperchamber_ = cfg.getParameter<bool>("perSuperchamber");
-  
+
   strPathPrevDQMRoot_ = cfg.getParameter<std::string>("pathOfPrevDQMRoot");
   nNEvtPerSec_ = cfg.getParameter<int>("numOfEvtPerSec");
   nNSecPerBin_ = cfg.getParameter<int>("secOfEvtPerBin");
   nNTimeBinPrimitive_ = cfg.getParameter<int>("totalTimeInterval");
-  
+
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
-  
+
   nNBxRange_ = cfg.getParameter<int>("bxRange");
   nNBxBin_ = cfg.getParameter<int>("bxBin");
-  
 }
 
-void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus")); 
-  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus")); 
-  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata")); 
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
-  
+  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus"));
+  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus"));
+  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata"));
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
+
   std::vector<int> listAMCSlotsDef = {0, 1, 2, 3, 4, 5, 6, 7};
-  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef); // TODO: Find how to get this from the geometry
-  
+  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef);  // TODO: Find how to get this from the geometry
+
   desc.add<std::string>("summaryLabelFmt", "GE%(station_signed)+i/%(layer)i");
   desc.add<bool>("flipSummary", false);
   desc.add<bool>("perSuperchamber", true);
-  
+
   desc.add<std::string>("pathOfPrevDQMRoot", "");
   desc.add<int>("numOfEvtPerSec", 100);
   desc.add<int>("secOfEvtPerBin", 10);
   desc.add<int>("totalTimeInterval", 50000);
-  
+
   desc.add<int>("idxFirstStrip", 0);
-  
+
   desc.add<int>("bxRange", 10);
   desc.add<int>("bxBin", 20);
-  
-  descriptions.add("GEMDQMStatusDigi", desc);  
-}
 
+  descriptions.add("GEMDQMStatusDigi", desc);
+}
 
 std::string GEMDQMStatusDigi::suffixChamber(GEMDetId &id) {
-  return "Gemini_" + to_string(id.chamber()) + "_GE" + ( id.region() > 0 ? "p" : "m" ) + 
-    to_string(id.station()) + "_" + to_string(id.layer());
+  return "Gemini_" + to_string(id.chamber()) + "_GE" + (id.region() > 0 ? "p" : "m") + to_string(id.station()) + "_" +
+         to_string(id.layer());
 }
-
 
 std::string GEMDQMStatusDigi::suffixLayer(GEMDetId &id) {
-  return std::string("st_") + ( id.region() >= 0 ? "p" : "m" ) + std::to_string(id.station()) +
-    ( bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "" );
+  return std::string("st_") + (id.region() >= 0 ? "p" : "m") + std::to_string(id.station()) +
+         (bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "");
 }
 
-
 int GEMDQMStatusDigi::SetInfoChambers() {
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
-  for ( auto sch : superChambers_ ) {
+  const std::vector<const GEMSuperChamber *> &superChambers_ = GEMGeometry_->superChambers();
+  for (auto sch : superChambers_) {
     int nLayer = sch->nChambers();
-    for ( int l = 0 ; l < nLayer ; l++ ) {
+    for (int l = 0; l < nLayer; l++) {
       Bool_t bExist = false;
-      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
-      if ( bExist ) continue;
-      
+      for (auto ch : gemChambers_)
+        if (ch.id() == sch->chamber(l + 1)->id())
+          bExist = true;
+      if (bExist)
+        continue;
+
       gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
-  
+
   // End: Loading the GEM geometry
-  
+
   // Start: Set the configurations
-  
+
   m_listLayers.clear();
-  
+
   // Summarizing geometry configurations
-  for ( auto ch : gemChambers_ ) {
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
-    
-    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), ( bPerSuperchamber_ ? gid.layer() : 0 ), 0, 0);
+
+    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), (bPerSuperchamber_ ? gid.layer() : 0), 0, 0);
     Bool_t bOcc = false;
-    
-    for ( auto lid : m_listLayers ) {
-      if ( lid == layerID ) {
+
+    for (auto lid : m_listLayers) {
+      if (lid == layerID) {
         bOcc = true;
         break;
       }
     }
-    
-    if ( !bOcc ) m_listLayers.push_back(layerID);
-    
-    GEMDetId chamberID(0, 1, 1, ( bPerSuperchamber_ ? 0 : gid.layer() ), gid.chamber(), 0);
+
+    if (!bOcc)
+      m_listLayers.push_back(layerID);
+
+    GEMDetId chamberID(0, 1, 1, (bPerSuperchamber_ ? 0 : gid.layer()), gid.chamber(), 0);
     bOcc = false;
-    
-    for ( auto cid : m_listChambers ) {
-      if ( cid == chamberID ) {
+
+    for (auto cid : m_listChambers) {
+      if (cid == chamberID) {
         bOcc = true;
         break;
       }
     }
-    
-    if ( !bOcc ) m_listChambers.push_back(chamberID);
+
+    if (!bOcc)
+      m_listChambers.push_back(chamberID);
   }
-  
+
   // Preliminary for sorting the summaries
-  auto lambdaLayer = [this](GEMDetId a, GEMDetId b)->Bool_t {
-    Int_t nFlipSign = ( this->bFlipSummary_ ? -1 : 1 );
-    Int_t nA = nFlipSign * a.region() * ( 20 * a.station() + a.layer() );
-    Int_t nB = nFlipSign * b.region() * ( 20 * b.station() + b.layer() );
+  auto lambdaLayer = [this](GEMDetId a, GEMDetId b) -> Bool_t {
+    Int_t nFlipSign = (this->bFlipSummary_ ? -1 : 1);
+    Int_t nA = nFlipSign * a.region() * (20 * a.station() + a.layer());
+    Int_t nB = nFlipSign * b.region() * (20 * b.station() + b.layer());
     return nA > nB;
   };
-  
-  auto lambdaChamber = [this](GEMDetId a, GEMDetId b)->Bool_t {
+
+  auto lambdaChamber = [this](GEMDetId a, GEMDetId b) -> Bool_t {
     Int_t nA = 20 * a.chamber() + a.layer();
     Int_t nB = 20 * b.chamber() + b.layer();
     return nA < nB;
   };
-  
+
   // Sorting the summaries
   std::sort(m_listLayers.begin(), m_listLayers.end(), lambdaLayer);
   std::sort(m_listChambers.begin(), m_listChambers.end(), lambdaChamber);
-  
+
   nNCh_ = (int)m_listChambers.size();
-  
+
   return 0;
 }
-
 
 // 0: General; for whole AMC slots
 int GEMDQMStatusDigi::SetConfigTimeRecord() {
   TimeStoreItem newTimeStore;
-  
+
   newTimeStore.nNbinMin = 0;
   newTimeStore.nNbinMax = 0;
-  
+
   std::string strCommonName = "per_time_";
-  
+
   // Very general GEMDetId
-  newTimeStore.strName  = strCommonName + "status_AMCslots";
+  newTimeStore.strName = strCommonName + "status_AMCslots";
   newTimeStore.strTitle = "Status of AMC slots per time";
   newTimeStore.strAxisX = "AMC slot";
-  newTimeStore.nNbinY   = listAMCSlots_.size();
-  listTimeStore_[ 0 ] = newTimeStore;
-  
-  for ( auto layerId : m_listLayers ) {
-    std::string strSuffix = ( layerId.region() > 0 ? "p" : "m" ) + std::to_string(layerId.station()) 
-        + "_" + std::to_string(layerId.layer());
-    
-    newTimeStore.strName  = strCommonName + "status_GEB_" + suffixLayer(layerId);
+  newTimeStore.nNbinY = listAMCSlots_.size();
+  listTimeStore_[0] = newTimeStore;
+
+  for (auto layerId : m_listLayers) {
+    std::string strSuffix =
+        (layerId.region() > 0 ? "p" : "m") + std::to_string(layerId.station()) + "_" + std::to_string(layerId.layer());
+
+    newTimeStore.strName = strCommonName + "status_GEB_" + suffixLayer(layerId);
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "Chamber";
-    
-    newTimeStore.nNbinY   = nNCh_;
-    listTimeStore_[ layerId ] = newTimeStore;
+
+    newTimeStore.nNbinY = nNCh_;
+    listTimeStore_[layerId] = newTimeStore;
   }
-  
-  for ( auto ch : gemChambers_ ) {
+
+  for (auto ch : gemChambers_) {
     auto chId = ch.id();
     GEMDetId chIdStatus(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 1);
     GEMDetId chIdDigi(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 2);
     GEMDetId chIdBx(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 3);
-    
+
     std::string strSuffix = suffixChamber(chId);
-    
-    newTimeStore.strName  = strCommonName + "status_chamber_" + strSuffix;
+
+    newTimeStore.strName = strCommonName + "status_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "VFAT";
-    
-    newTimeStore.nNbinY   = nVfat_;
-    listTimeStore_[ chIdStatus ] = newTimeStore;
-    
-    newTimeStore.strName  = strCommonName + "digi_chamber_" + strSuffix;
+
+    newTimeStore.nNbinY = nVfat_;
+    listTimeStore_[chIdStatus] = newTimeStore;
+
+    newTimeStore.strName = strCommonName + "digi_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "VFAT";
-    
-    newTimeStore.nNbinY   = nVfat_;
-    listTimeStore_[ chIdDigi ] = newTimeStore;
-    
-    newTimeStore.strName  = strCommonName + "bx_chamber_" + strSuffix;
+
+    newTimeStore.nNbinY = nVfat_;
+    listTimeStore_[chIdDigi] = newTimeStore;
+
+    newTimeStore.strName = strCommonName + "bx_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "Bunch crossing";
-    
-    newTimeStore.nNbinY   =  nNBxBin_;
+
+    newTimeStore.nNbinY = nNBxBin_;
     newTimeStore.nNbinMin = -nNBxRange_;
-    newTimeStore.nNbinMax =  nNBxRange_;
-    
-    listTimeStore_[ chIdBx ] = newTimeStore;
-    
+    newTimeStore.nNbinMax = nNBxRange_;
+
+    listTimeStore_[chIdBx] = newTimeStore;
+
     newTimeStore.nNbinMin = newTimeStore.nNbinMax = 0;
   }
-  
+
   return 0;
 }
-
 
 int GEMDQMStatusDigi::LoadPrevData() {
   TFile *fPrev;
   Bool_t bSync = true;
-  
+
   nStackedEvt_ = 0;
-  
-  for ( auto &itStore : listTimeStore_ ) {
+
+  for (auto &itStore : listTimeStore_) {
     itStore.second.listOccupy.clear();
     itStore.second.listRecord.clear();
   }
-  
-  if ( strPathPrevDQMRoot_ == "" ) return 0;
-  
+
+  if (strPathPrevDQMRoot_ == "")
+    return 0;
+
   std::ifstream fExist(strPathPrevDQMRoot_.c_str());
-  if ( !fExist.good() ) return 0;
+  if (!fExist.good())
+    return 0;
   fExist.close();
-  
+
   fPrev = new TFile(strPathPrevDQMRoot_.c_str());
-  if ( fPrev == NULL ) return 1;
-  
+  if (fPrev == NULL)
+    return 1;
+
   std::cout << strPathPrevDQMRoot_ << " is being loaded" << std::endl;
-  std::string strRunnum = ( (TDirectoryFile *)fPrev->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
-  
-  for ( auto &itStore : listTimeStore_ ) {
-    TH2F *h2Prev = (TH2F *)fPrev->Get(( "DQMData/" + strRunnum 
-      + "/GEM/Run summary/StatusDigi/" + itStore.second.strName ).c_str());
+  std::string strRunnum = ((TDirectoryFile *)fPrev->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
+
+  for (auto &itStore : listTimeStore_) {
+    TH2F *h2Prev =
+        (TH2F *)fPrev->Get(("DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi/" + itStore.second.strName).c_str());
     auto &listCurrRec = itStore.second.listRecord;
     auto &listCurrOcc = itStore.second.listOccupy;
-    
+
     listCurrRec.clear();
     listCurrOcc.clear();
-    
-    if ( h2Prev == NULL ) continue; // Hmmm, is it an error...?
-    
+
+    if (h2Prev == NULL)
+      continue;  // Hmmm, is it an error...?
+
     Int_t nNbinX = h2Prev->GetNbinsX();
     Int_t nNbinY = h2Prev->GetNbinsY();
-    
+
     Int_t nX, nY;
     Int_t nXMaxOcc = 0;
     Int_t nNNonFullFill = 0;
-    
-    for ( nX = 1 ; nX <= nNbinX ; nX++ ) {
-      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0); // The (nX, 0)-bin keeps the number of filled events
-      if ( 0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_ ) nNNonFullFill++;
-      if ( nNEvtCurrTime > 0 ) nXMaxOcc = nX;
+
+    for (nX = 1; nX <= nNbinX; nX++) {
+      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0);  // The (nX, 0)-bin keeps the number of filled events
+      if (0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_)
+        nNNonFullFill++;
+      if (nNEvtCurrTime > 0)
+        nXMaxOcc = nX;
     }
-    
-    if ( nNNonFullFill > 1 ) { // The last bin may not full
+
+    if (nNNonFullFill > 1) {  // The last bin may not full
       std::cerr << "WARNING: There is a bin of the previous histograms which is not fully filled" << std::endl;
     }
-    
-    for ( nY = 1 ; nY <= nNbinY ; nY++ ) {
+
+    for (nY = 1; nY <= nNbinY; nY++) {
       listCurrRec.emplace_back();
       listCurrOcc.emplace_back();
-      
-      if ( nXMaxOcc > 0 ) {
-        for ( nX = 1 ; nX <= nXMaxOcc ; nX++ ) {
+
+      if (nXMaxOcc > 0) {
+        for (nX = 1; nX <= nXMaxOcc; nX++) {
           //listCurr[ nY - 1 ].push_back(h2Prev->GetBinContent(nX, nY));
-          listCurrRec[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
-          listCurrOcc[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
+          listCurrRec[nY - 1].push_back(0);  // If hadd is used, then it must be blanked
+          listCurrOcc[nY - 1].push_back(0);  // If hadd is used, then it must be blanked
         }
-        
-        if ( nNNonFullFill <= 0 ) {
-          listCurrRec[ nY - 1 ].push_back(0);
-          listCurrOcc[ nY - 1 ].push_back(0);
+
+        if (nNNonFullFill <= 0) {
+          listCurrRec[nY - 1].push_back(0);
+          listCurrOcc[nY - 1].push_back(0);
         }
-      } else { // Empty...?
-        listCurrRec[ nY - 1 ].push_back(0);
-        listCurrOcc[ nY - 1 ].push_back(0);
+      } else {  // Empty...?
+        listCurrRec[nY - 1].push_back(0);
+        listCurrOcc[nY - 1].push_back(0);
       }
     }
-    
-    if ( nXMaxOcc <= 0 ) std::cout << "nXMacOcc has a problem" << std::endl;
-    if ( nXMaxOcc <= 0 ) continue; // Empty...?
-    
+
+    if (nXMaxOcc <= 0)
+      std::cout << "nXMacOcc has a problem" << std::endl;
+    if (nXMaxOcc <= 0)
+      continue;  // Empty...?
+
     // Keeping the number of lastly stacked events
     // And also checking if the sync is okay
-    if ( nStackedEvt_ == 0 ) nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
+    if (nStackedEvt_ == 0)
+      nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
     else {
-      if ( nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0) ) bSync = false;
+      if (nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0))
+        bSync = false;
     }
   }
-  
-  if ( nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_ ) nStackedEvt_ = 0;
-  
-  if ( !bSync ) { // No sync...!
+
+  if (nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_)
+    nStackedEvt_ = 0;
+
+  if (!bSync) {  // No sync...!
     std::cerr << "WARNING: No sync on time histograms" << std::endl;
   }
-  
+
   fPrev->Close();
-  
+
   return 0;
 }
 
-
 void GEMDQMStatusDigi::bookHistogramsChamberPart(DQMStore::IBooker &ibooker, GEMDetId &gid) {
   std::string hName, hTitle;
-  
+
   UInt_t unBinPos;
   //std::cout << "B: " << gid << std::endl;
-  
-  std::string strIdxName  = suffixChamber(gid);
-  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
-    ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
-  
+
+  std::string strIdxName = suffixChamber(gid);
+  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
+                            to_string(gid.station()) + "/" + to_string(gid.layer());
+
   hName = "vfatStatus_QualityFlag_" + strIdxName;
   hTitle = "VFAT quality " + strIdxTitle;
   hTitle += ";VFAT;";
   std::cout << "booking: " << gid << std::endl;
-  listVFATQualityFlag_[ gid ] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
-  
+  listVFATQualityFlag_[gid] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
+
   hName = "vfatStatus_BC_" + strIdxName;
   hTitle = "VFAT bunch crossing " + strIdxTitle;
   hTitle += ";Bunch crossing;VFAT";
-  listVFATBC_[ gid ] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
-  
+  listVFATBC_[gid] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
+
   hName = "vfatStatus_EC_" + strIdxName;
   hTitle = "VFAT event counter " + strIdxTitle;
   hTitle += ";Event counter;VFAT";
-  listVFATEC_[ gid ] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
-  
-  unBinPos = 1;
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Good", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "CRC fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1010 fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1100 fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1110 fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Hamming error", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "AFULL", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SEUlogic", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SUEI2C", 2);
-  
-  m_mapStatusFill[ gid ] = false;
-  m_mapStatusErr[ gid ] = false;
-}
+  listVFATEC_[gid] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
 
+  unBinPos = 1;
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "Good", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "CRC fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1010 fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1100 fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1110 fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "Hamming error", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "AFULL", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "SEUlogic", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "SUEI2C", 2);
+
+  m_mapStatusFill[gid] = false;
+  m_mapStatusErr[gid] = false;
+}
 
 void GEMDQMStatusDigi::bookHistogramsStationPart(DQMStore::IBooker &ibooker, GEMDetId &lid) {
   UInt_t unBinPos;
-  
-  Int_t  re = lid.region();
+
+  Int_t re = lid.region();
   UInt_t st = lid.station();
   UInt_t la = lid.layer();
-  
-  auto newbookGEB = [this](DQMStore::IBooker &ibooker, 
-                           std::string strName, std::string strTitle, std::string strAxis, 
-                           GEMDetId &lid, int nLayer, int nStation, int re, 
-                           int nBin, float fMin, float fMax)->MonitorElement *
-  {
-    strName  = strName  + "_" + suffixLayer(lid);
-    strTitle = strTitle + ", station: " + (re>=0 ? "+" : "-") + std::to_string(nStation);
-    
-    if ( bPerSuperchamber_ ) {
+
+  auto newbookGEB = [this](DQMStore::IBooker &ibooker,
+                           std::string strName,
+                           std::string strTitle,
+                           std::string strAxis,
+                           GEMDetId &lid,
+                           int nLayer,
+                           int nStation,
+                           int re,
+                           int nBin,
+                           float fMin,
+                           float fMax) -> MonitorElement * {
+    strName = strName + "_" + suffixLayer(lid);
+    strTitle = strTitle + ", station: " + (re >= 0 ? "+" : "-") + std::to_string(nStation);
+
+    if (bPerSuperchamber_) {
       strTitle += ", layer: " + std::to_string(nLayer);
     }
-    
+
     strTitle += ";Chamber;" + strAxis;
-    
+
     auto hNew = ibooker.book2D(strName, strTitle, this->nNCh_, 0, this->nNCh_, nBin, fMin, fMax);
-    
-    for ( Int_t i = 0 ; i < this->nNCh_ ; i++ ) {
-      auto &gid = this->m_listChambers[ i ];
-      Int_t nCh = gid.chamber() + ( this->bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+
+    for (Int_t i = 0; i < this->nNCh_; i++) {
+      auto &gid = this->m_listChambers[i];
+      Int_t nCh = gid.chamber() + (this->bPerSuperchamber_ ? 0 : gid.layer() - 1);
       hNew->setBinLabel(i + 1, std::to_string(nCh), 1);
     }
-    
+
     return hNew;
   };
-  
-  listGEBInputStatus_[ lid ]  = newbookGEB(ibooker, "geb_input_status", 
-      "inputStatus",       "",                           lid, la, st, re, eBit_, 0, eBit_);
-  listGEBInputID_[ lid ]      = newbookGEB(ibooker, "geb_input_ID", 
-      "inputID",           "Input ID",                   lid, la, st, re, 32, 0, 32);
-  listGEBVFATWordCnt_[ lid ]  = newbookGEB(ibooker, "geb_no_vfats", 
-      "nvfats in header",  "Number of VFATs in header",  lid, la, st, re, 25, 0, 25);
-  listGEBVFATWordCntT_[ lid ] = newbookGEB(ibooker, "geb_no_vfatsT", 
-      "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
-  listGEBZeroSupWordsCnt_[ lid ] = newbookGEB(ibooker, "geb_zeroSupWordsCnt", 
-      "zeroSupWordsCnt",   "Zero sup. words count",      lid, la, st, re, 10, 0, 10);
-  
-  listGEBbcOH_[ lid ]  = newbookGEB(ibooker, "geb_bcOH",  "OH bunch crossing", 
-      "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
-  listGEBecOH_[ lid ]  = newbookGEB(ibooker, "geb_ecOH",  "OH event coounter", 
-      "OH event counter", lid, la, st, re, 256, 0, 256);
-  listGEBOHCRC_[ lid ] = newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", 
-      "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
-  
+
+  listGEBInputStatus_[lid] =
+      newbookGEB(ibooker, "geb_input_status", "inputStatus", "", lid, la, st, re, eBit_, 0, eBit_);
+  listGEBInputID_[lid] = newbookGEB(ibooker, "geb_input_ID", "inputID", "Input ID", lid, la, st, re, 32, 0, 32);
+  listGEBVFATWordCnt_[lid] =
+      newbookGEB(ibooker, "geb_no_vfats", "nvfats in header", "Number of VFATs in header", lid, la, st, re, 25, 0, 25);
+  listGEBVFATWordCntT_[lid] = newbookGEB(
+      ibooker, "geb_no_vfatsT", "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
+  listGEBZeroSupWordsCnt_[lid] = newbookGEB(
+      ibooker, "geb_zeroSupWordsCnt", "zeroSupWordsCnt", "Zero sup. words count", lid, la, st, re, 10, 0, 10);
+
+  listGEBbcOH_[lid] =
+      newbookGEB(ibooker, "geb_bcOH", "OH bunch crossing", "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
+  listGEBecOH_[lid] =
+      newbookGEB(ibooker, "geb_ecOH", "OH event coounter", "OH event counter", lid, la, st, re, 256, 0, 256);
+  listGEBOHCRC_[lid] =
+      newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
+
   unBinPos = 1;
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "No VFAT marker", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size warn", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO near full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size overflow", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Stuck data", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "No VFAT marker", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event size warn", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "InFIFO near full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event size overflow", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "InFIFO full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Stuck data", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
 }
 
-
 void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
-  h2AMCStatus_ = ibooker.book2D("amc_statusflag", "Status of AMC slots;AMC slot;", 
-      listAMCSlots_.size(), 0, listAMCSlots_.size(), amcStatusBit_, 0, amcStatusBit_);
-  
+  h2AMCStatus_ = ibooker.book2D("amc_statusflag",
+                                "Status of AMC slots;AMC slot;",
+                                listAMCSlots_.size(),
+                                0,
+                                listAMCSlots_.size(),
+                                amcStatusBit_,
+                                0,
+                                amcStatusBit_);
+
   uint32_t unBinPos = 1;
   h2AMCStatus_->setBinLabel(unBinPos++, "BC0 not locked", 2);
   h2AMCStatus_->setBinLabel(unBinPos++, "DAQ not ready", 2);
@@ -595,110 +604,115 @@ void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
   h2AMCStatus_->setBinLabel(unBinPos++, "GLIB out-of-sync", 2);
 }
 
-
 void GEMDQMStatusDigi::bookHistogramsTimeRecordPart(DQMStore::IBooker &ibooker) {
   //Int_t nNBinX = ( listTimeStore_[ 0 ].listRecord.size() / nNTimeBinTotal_ + 1 ) * nNTimeBinTotal_;
-  
-  for ( auto &itStore : listTimeStore_ ) {
+
+  for (auto &itStore : listTimeStore_) {
     auto &infoCurr = itStore.second;
-    
+
     Float_t fMin = -0.5, fMax = infoCurr.nNbinY - 0.5;
-    
-    if ( infoCurr.nNbinMin < infoCurr.nNbinMax ) {
+
+    if (infoCurr.nNbinMin < infoCurr.nNbinMax) {
       fMin = infoCurr.nNbinMin;
       fMax = infoCurr.nNbinMax;
     }
-    
-    infoCurr.h2Histo = ibooker.book2D(infoCurr.strName, 
-      //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX, 
-      infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX, 
-      nNTimeBinPrimitive_, 0, nNTimeBinPrimitive_, infoCurr.nNbinY, fMin, fMax);
-    
-    if ( seekIdx(m_listLayers, itStore.first) >= 0 ) {
-      for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
-        auto &gid = m_listChambers[ i ];
-        Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+
+    infoCurr.h2Histo = ibooker.book2D(
+        infoCurr.strName,
+        //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX,
+        infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX,
+        nNTimeBinPrimitive_,
+        0,
+        nNTimeBinPrimitive_,
+        infoCurr.nNbinY,
+        fMin,
+        fMax);
+
+    if (seekIdx(m_listLayers, itStore.first) >= 0) {
+      for (Int_t i = 0; i < nNCh_; i++) {
+        auto &gid = m_listChambers[i];
+        Int_t nCh = gid.chamber() + (bPerSuperchamber_ ? 0 : gid.layer() - 1);
         infoCurr.h2Histo->setBinLabel(i + 1, std::to_string(nCh), 2);
       }
     }
   }
 }
 
-
 // To make labels like python, with std::(unordered_)map
 std::string printfWithMap(std::string strFmt, std::unordered_map<std::string, Int_t> mapArg) {
   std::string strRes = strFmt;
-  char szOutFmt[ 64 ];
+  char szOutFmt[64];
   size_t unPos, unPosEnd;
-  
-  for ( unPos = strRes.find('%') ; unPos != std::string::npos ; unPos = strRes.find('%', unPos + 1) ) {
+
+  for (unPos = strRes.find('%'); unPos != std::string::npos; unPos = strRes.find('%', unPos + 1)) {
     unPosEnd = strRes.find(')', unPos);
-    if ( strRes[ unPos + 1 ] != '(' || unPosEnd == std::string::npos ) break; // Syntax error
-    
+    if (strRes[unPos + 1] != '(' || unPosEnd == std::string::npos)
+      break;  // Syntax error
+
     // Extracting the key
-    std::string strKey = strRes.substr(unPos + 2, unPosEnd - ( unPos + 2 ));
-    
+    std::string strKey = strRes.substr(unPos + 2, unPosEnd - (unPos + 2));
+
     // To treat formats like '%5i' or '%02i', extracting '5' or '02'
-    // After do this, 
+    // After do this,
     std::string strOptNum = "%";
     unPosEnd++;
-    
-    for ( ;; unPosEnd++ ) {
-      if ( !( '0' <= strRes[ unPosEnd ] && strRes[ unPosEnd ] <= '9' ) && 
-           strRes[ unPosEnd ] != '+' ) break;
-      strOptNum += strRes[ unPosEnd ];
+
+    for (;; unPosEnd++) {
+      if (!('0' <= strRes[unPosEnd] && strRes[unPosEnd] <= '9') && strRes[unPosEnd] != '+')
+        break;
+      strOptNum += strRes[unPosEnd];
     }
-    
-    if ( strRes[ unPosEnd ] != 'i' && strRes[ unPosEnd ] != 'd' ) break; // Syntax error
-    strOptNum += strRes[ unPosEnd ];
+
+    if (strRes[unPosEnd] != 'i' && strRes[unPosEnd] != 'd')
+      break;  // Syntax error
+    strOptNum += strRes[unPosEnd];
     unPosEnd++;
-    
-    sprintf(szOutFmt, strOptNum.c_str(), mapArg[ strKey ]);
+
+    sprintf(szOutFmt, strOptNum.c_str(), mapArg[strKey]);
     strRes = strRes.substr(0, unPos) + szOutFmt + strRes.substr(unPosEnd);
   }
-  
-  if ( unPos != std::string::npos ) { // It means... an syntax error occurs!
+
+  if (unPos != std::string::npos) {  // It means... an syntax error occurs!
     std::cerr << "ERROR: Syntax error on printfWithMap(); " << std::endl;
     return "";
   }
-  
+
   return strRes;
 }
 
-
-void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
-{
+void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &iSetup) {
   // Start: Loading the GEM geometry
-  
+
   GEMGeometry_ = initGeometry(iSetup);
-  if ( GEMGeometry_ == nullptr) return;
-  
+  if (GEMGeometry_ == nullptr)
+    return;
+
   SetInfoChambers();
-  
+
   // Setting the informations for time histograms
   SetConfigTimeRecord();
   LoadPrevData();
-  
+
   // The loading does not work well or something goes wrong...
   // In this case, we need to make a new start of recording.
-  for ( auto &itStore : listTimeStore_ ) {
+  for (auto &itStore : listTimeStore_) {
     auto &infoCurr = itStore.second;
-    
-    if ( infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size() ) { 
-      if ( infoCurr.listRecord.size() > 0 ) {
+
+    if (infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size()) {
+      if (infoCurr.listRecord.size() > 0) {
         std::cerr << "WARNING: The previous result is not compatible to the current geometry. "
-          << "We will discard the previous data." << std::endl;
-        
+                  << "We will discard the previous data." << std::endl;
+
         infoCurr.listRecord.clear();
         infoCurr.listOccupy.clear();
       }
-      
-      for ( Int_t i = 0 ; i < infoCurr.nNbinY ; i++ ) {
+
+      for (Int_t i = 0; i < infoCurr.nNbinY; i++) {
         infoCurr.listRecord.emplace_back();
-        infoCurr.listRecord[ i ].push_back(0);
-        
+        infoCurr.listRecord[i].push_back(0);
+
         infoCurr.listOccupy.emplace_back();
-        infoCurr.listOccupy[ i ].push_back(0);
+        infoCurr.listOccupy[i].push_back(0);
       }
     }
     /*for ( Int_t i = 0 ; i < (Int_t)infoCurr.listRecord[ 0 ].size() ; i++ ) 
@@ -707,365 +721,375 @@ void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
     
     std::cout << "Init time: " << itStore.first << ", " << infoCurr.strName << ", " << infoCurr.nNbinY << ", " << infoCurr.listRecord.size() << "; " << listTimeStore_[ itStore.first ].listRecord.size() << std::endl;*/
   }
-  
+
   // End: Set the configurations
-  
+
   // Start: Setting books
-  
+
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/StatusDigi");
-  
-  for ( auto ch : gemChambers_ ) {
+
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
     bookHistogramsChamberPart(ibooker, gid);
   }
-  
-  for ( auto lid : m_listLayers ) {
+
+  for (auto lid : m_listLayers) {
     bookHistogramsStationPart(ibooker, lid);
   }
-  
+
   bookHistogramsAMCPart(ibooker);
   bookHistogramsTimeRecordPart(ibooker);
-  
+
   h1_vfat_qualityflag_ = ibooker.book1D("vfat_quality_flag", "quality and flag", 9, 0, 9);
   h2_vfat_qualityflag_ = ibooker.book2D("vfat_quality_flag_per_geb", "quality and flag", nNCh_, 0, nNCh_, 9, 0, 9);
-  
-  h1_amc_ttsState_  = ibooker.book1D("amc_ttsState",  "ttsState",  10, 0, 10);
-  h1_amc_davCnt_    = ibooker.book1D("amc_davCnt",    "davCnt",    10, 0, 10);
+
+  h1_amc_ttsState_ = ibooker.book1D("amc_ttsState", "ttsState", 10, 0, 10);
+  h1_amc_davCnt_ = ibooker.book1D("amc_davCnt", "davCnt", 10, 0, 10);
   h1_amc_buffState_ = ibooker.book1D("amc_buffState", "buffState", 10, 0, 10);
-  h1_amc_oosGlib_   = ibooker.book1D("amc_oosGlib",   "oosGlib",   10, 0, 10);
+  h1_amc_oosGlib_ = ibooker.book1D("amc_oosGlib", "oosGlib", 10, 0, 10);
   h1_amc_chTimeOut_ = ibooker.book1D("amc_chTimeOut", "chTimeOut", 10, 0, 10);
-  
+
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/EventInfo");
-  
+
   // TODO: We need a study for setting the rule for this
   m_summaryReport_ = ibooker.bookFloat("reportSummary");
   m_summaryReport_->Fill(1.0);
-  
-  h2SummaryStatus_ = ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, 
-      m_listLayers.size(), 0, m_listLayers.size());
-  
-  for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
-    auto &gid = this->m_listChambers[ i ];
-    Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+
+  h2SummaryStatus_ =
+      ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, m_listLayers.size(), 0, m_listLayers.size());
+
+  for (Int_t i = 0; i < nNCh_; i++) {
+    auto &gid = this->m_listChambers[i];
+    Int_t nCh = gid.chamber() + (bPerSuperchamber_ ? 0 : gid.layer() - 1);
     h2SummaryStatus_->setBinLabel(i + 1, std::to_string(nCh), 1);
   }
-  
+
   Int_t nIdxLayer = 0;
   std::unordered_map<std::string, Int_t> mapArg;
-  
+
   // Start: Labeling section
-    
-  for ( auto lid : m_listLayers ) {
-    mapArg[ "station_signed" ] = lid.region() * lid.station();
-    mapArg[ "region"  ] = lid.region();
-    mapArg[ "station" ] = lid.station();
-    mapArg[ "layer"   ] = lid.layer();
-    mapArg[ "chamber" ] = lid.chamber();
-    
+
+  for (auto lid : m_listLayers) {
+    mapArg["station_signed"] = lid.region() * lid.station();
+    mapArg["region"] = lid.region();
+    mapArg["station"] = lid.station();
+    mapArg["layer"] = lid.layer();
+    mapArg["chamber"] = lid.chamber();
+
     h2SummaryStatus_->setBinLabel(nIdxLayer + 1, printfWithMap(strFmtSummaryLabel_, mapArg), 2);
     nIdxLayer++;
   }
 }
 
-
 void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits) {
   int i = 0;
   uint64_t unFlag = 1;
-  
-  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
-    if ( ( unVal & unFlag ) != 0 ) {
+
+  for (; i < nNumBits; i++, unFlag <<= 1) {
+    if ((unVal & unFlag) != 0) {
       monitor->Fill(i);
     }
   }
 }
 
-
 void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nX) {
   int i = 0;
   uint64_t unFlag = 1;
-  
-  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
-    if ( ( unVal & unFlag ) != 0 ) {
+
+  for (; i < nNumBits; i++, unFlag <<= 1) {
+    if ((unVal & unFlag) != 0) {
       monitor->Fill(nX, i);
     }
   }
 }
 
-
 Int_t GEMDQMStatusDigi::seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId) {
-  if ( unId < 256 ) return -1;
-  
+  if (unId < 256)
+    return -1;
+
   GEMDetId id(unId);
-  for ( Int_t nIdx = 0 ; nIdx < (Int_t)listLayers.size() ; nIdx++ ) if ( id == listLayers[ nIdx ] ) return nIdx;
+  for (Int_t nIdx = 0; nIdx < (Int_t)listLayers.size(); nIdx++)
+    if (id == listLayers[nIdx])
+      return nIdx;
   return -1;
 }
-  
 
-void GEMDQMStatusDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
+void GEMDQMStatusDigi::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
   edm::Handle<GEMVfatStatusDigiCollection> gemVFAT;
   edm::Handle<GEMGEBdataCollection> gemGEB;
   edm::Handle<GEMAMCdataCollection> gemAMC;
   edm::Handle<GEMDigiCollection> gemDigis;
-  
-  event.getByToken( tagVFAT_, gemVFAT);
-  event.getByToken( tagGEB_, gemGEB);
-  event.getByToken( tagAMC_, gemAMC);
-  event.getByToken( tagDigi_, gemDigis);
-  
-  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill)->void {
+
+  event.getByToken(tagVFAT_, gemVFAT);
+  event.getByToken(tagGEB_, gemGEB);
+  event.getByToken(tagAMC_, gemAMC);
+  event.getByToken(tagDigi_, gemDigis);
+
+  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill) -> void {
     return;
-    auto &listRecord = listCurr.listRecord[ nIdx ];
-    auto &listOccupy = listCurr.listOccupy[ nIdx ];
+    auto &listRecord = listCurr.listRecord[nIdx];
+    auto &listOccupy = listCurr.listOccupy[nIdx];
     int nIdxTime = listRecord.size() - 1;
-    
-    listOccupy[ nIdxTime ] = 1;
-    if ( bFill ) listRecord[ nIdxTime ]++;
+
+    listOccupy[nIdxTime] = 1;
+    if (bFill)
+      listRecord[nIdxTime]++;
   };
 
-  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt){
+  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt) {
     GEMDetId gemid = (*vfatIt).first;
     GEMDetId gemchId = gemid.chamberId();
     //std::cout << "A: " << gemchId << std::endl;
-    GEMDetId gemOnlychId(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
-    
+    GEMDetId gemOnlychId(0, 1, 1, (bPerSuperchamber_ ? 0 : gemid.layer()), gemid.chamber(), 0);
+
     int nIdx = seekIdx(m_listChambers, gemOnlychId);
     int nRoll = gemid.roll();
-    const GEMVfatStatusDigiCollection::Range& range = (*vfatIt).second;
-    
+    const GEMVfatStatusDigiCollection::Range &range = (*vfatIt).second;
+
     GEMDetId chIdStatus(gemid.region(), gemid.ring(), gemid.station(), gemid.layer(), gemid.chamber(), 1);
-    auto &listCurr = listTimeStore_[ chIdStatus ];
-    
-    for ( auto vfatStat = range.first; vfatStat != range.second; ++vfatStat ) {
-      uint64_t unQFVFAT = vfatStat->quality() | ( vfatStat->flag() << qVFATBit_ );
-      if ( ( unQFVFAT & ~0x1 ) == 0 )  {
-        unQFVFAT |= 0x1; // If no error, then it should be 'Good'
-      } else { // Error!!
-        m_mapStatusErr[ gemchId ] = true;
+    auto &listCurr = listTimeStore_[chIdStatus];
+
+    for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
+      uint64_t unQFVFAT = vfatStat->quality() | (vfatStat->flag() << qVFATBit_);
+      if ((unQFVFAT & ~0x1) == 0) {
+        unQFVFAT |= 0x1;  // If no error, then it should be 'Good'
+      } else {            // Error!!
+        m_mapStatusErr[gemchId] = true;
       }
-      
+
       FillBits(h1_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_);
       FillBits(h2_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_, nIdx);
-      
-      int nVFAT = ( 8 - nRoll ) + 8 * vfatStat->phi(); // vfatStat.phi()? or 2 - vfatStat.phi()?
-      
-      FillBits(listVFATQualityFlag_[ gemchId ], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
+
+      int nVFAT = (8 - nRoll) + 8 * vfatStat->phi();  // vfatStat.phi()? or 2 - vfatStat.phi()?
+
+      FillBits(listVFATQualityFlag_[gemchId], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
       //listVFATBC_[ gemchId ]->Fill(vfatStat->bc(), nVFAT);
-      listVFATEC_[ gemchId ]->Fill(vfatStat->ec(), nVFAT);
-      
-      fillTimeHisto(listCurr, nVFAT, ( unQFVFAT & ~0x1 ) != 0);
+      listVFATEC_[gemchId]->Fill(vfatStat->ec(), nVFAT);
+
+      fillTimeHisto(listCurr, nVFAT, (unQFVFAT & ~0x1) != 0);
     }
   }
-  
-  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt){
+
+  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt) {
     GEMDetId gemid = (*gebIt).first;
-    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), ( bPerSuperchamber_ ? gemid.layer() : 0 ), 0, 0);
-    GEMDetId chid(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
-    
+    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), (bPerSuperchamber_ ? gemid.layer() : 0), 0, 0);
+    GEMDetId chid(0, 1, 1, (bPerSuperchamber_ ? 0 : gemid.layer()), gemid.chamber(), 0);
+
     Int_t nCh = seekIdx(m_listChambers, chid);
-    auto &listCurr = listTimeStore_[ lid ];
-    
-    const GEMGEBdataCollection::Range& range = (*gebIt).second;    
-    for ( auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus ) {
+    auto &listCurr = listTimeStore_[lid];
+
+    const GEMGEBdataCollection::Range &range = (*gebIt).second;
+    for (auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus) {
       uint64_t unBit = 0;
       uint64_t unStatus = 0;
-      
-      unStatus |= ( GEBStatus->bxmVvV()    << unBit++ ); 
-      unStatus |= ( GEBStatus->bxmAvV()    << unBit++ ); 
-      unStatus |= ( GEBStatus->oOScVvV()   << unBit++ ); 
-      unStatus |= ( GEBStatus->oOScAvV()   << unBit++ ); 
-      unStatus |= ( GEBStatus->noVFAT()    << unBit++ ); 
-      unStatus |= ( GEBStatus->evtSzW()    << unBit++ ); 
-      unStatus |= ( GEBStatus->l1aNF()     << unBit++ ); 
-      unStatus |= ( GEBStatus->inNF()      << unBit++ ); 
-      unStatus |= ( GEBStatus->evtNF()     << unBit++ ); 
-      unStatus |= ( GEBStatus->evtSzOFW()  << unBit++ ); 
-      unStatus |= ( GEBStatus->l1aF()      << unBit++ ); 
-      unStatus |= ( GEBStatus->inF()       << unBit++ ); 
-      unStatus |= ( GEBStatus->evtF()      << unBit++ ); 
-      unStatus |= ( GEBStatus->inUfw()     << unBit++ ); 
-      unStatus |= ( GEBStatus->stuckData() << unBit++ ); 
-      unStatus |= ( GEBStatus->evUfw()     << unBit++ );
-      
+
+      unStatus |= (GEBStatus->bxmVvV() << unBit++);
+      unStatus |= (GEBStatus->bxmAvV() << unBit++);
+      unStatus |= (GEBStatus->oOScVvV() << unBit++);
+      unStatus |= (GEBStatus->oOScAvV() << unBit++);
+      unStatus |= (GEBStatus->noVFAT() << unBit++);
+      unStatus |= (GEBStatus->evtSzW() << unBit++);
+      unStatus |= (GEBStatus->l1aNF() << unBit++);
+      unStatus |= (GEBStatus->inNF() << unBit++);
+      unStatus |= (GEBStatus->evtNF() << unBit++);
+      unStatus |= (GEBStatus->evtSzOFW() << unBit++);
+      unStatus |= (GEBStatus->l1aF() << unBit++);
+      unStatus |= (GEBStatus->inF() << unBit++);
+      unStatus |= (GEBStatus->evtF() << unBit++);
+      unStatus |= (GEBStatus->inUfw() << unBit++);
+      unStatus |= (GEBStatus->stuckData() << unBit++);
+      unStatus |= (GEBStatus->evUfw() << unBit++);
+
       //std::cout << gemid;
       //printf("%06X\n", (unsigned int)unStatus);
-      if ( unStatus != 0 ) { // Error!
-        m_mapStatusErr[ gemid ] = true;
+      if (unStatus != 0) {  // Error!
+        m_mapStatusErr[gemid] = true;
       }
-      
-      FillBits(listGEBInputStatus_[ lid ], unStatus, eBit_, nCh);
-      
-      listGEBInputID_[ lid ]->Fill(nCh, GEBStatus->inputID());
-      listGEBVFATWordCnt_[ lid ]->Fill(nCh, GEBStatus->vfatWordCnt()/3);
-      listGEBVFATWordCntT_[ lid ]->Fill(nCh, GEBStatus->vfatWordCntT()/3);
-      listGEBZeroSupWordsCnt_[ lid ]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
-      
-      listGEBbcOH_[ lid ]->Fill(nCh, GEBStatus->bcOH());
-      listGEBecOH_[ lid ]->Fill(nCh, GEBStatus->ecOH());
-      listGEBOHCRC_[ lid ]->Fill(nCh, GEBStatus->crc());
-      
+
+      FillBits(listGEBInputStatus_[lid], unStatus, eBit_, nCh);
+
+      listGEBInputID_[lid]->Fill(nCh, GEBStatus->inputID());
+      listGEBVFATWordCnt_[lid]->Fill(nCh, GEBStatus->vfatWordCnt() / 3);
+      listGEBVFATWordCntT_[lid]->Fill(nCh, GEBStatus->vfatWordCntT() / 3);
+      listGEBZeroSupWordsCnt_[lid]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
+
+      listGEBbcOH_[lid]->Fill(nCh, GEBStatus->bcOH());
+      listGEBecOH_[lid]->Fill(nCh, GEBStatus->ecOH());
+      listGEBOHCRC_[lid]->Fill(nCh, GEBStatus->crc());
+
       fillTimeHisto(listCurr, nCh, unStatus != 0);
     }
   }
-  
-  auto findAMCIdx = [this](Int_t nAMCnum)->Int_t {
-    for ( Int_t i = 0 ; i < (Int_t)listAMCSlots_.size() ; i++ ) if ( listAMCSlots_[ i ] == nAMCnum ) return i;
+
+  auto findAMCIdx = [this](Int_t nAMCnum) -> Int_t {
+    for (Int_t i = 0; i < (Int_t)listAMCSlots_.size(); i++)
+      if (listAMCSlots_[i] == nAMCnum)
+        return i;
     return -1;
   };
-  
-  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt){
-    const GEMAMCdataCollection::Range& range = (*amcIt).second;
-    auto &listCurr = listTimeStore_[ 0 ];
-    for ( auto amc = range.first; amc != range.second; ++amc ) {
+
+  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
+    const GEMAMCdataCollection::Range &range = (*amcIt).second;
+    auto &listCurr = listTimeStore_[0];
+    for (auto amc = range.first; amc != range.second; ++amc) {
       Int_t nIdAMC = findAMCIdx(amc->amcNum());
       uint64_t unBit = 0;
       uint64_t unStatus = 0;
-      
-      unStatus |= ( ( amc->bc0locked()      == 0 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->daqReady()       != 1 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->daqClockLocked() == 0 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->mmcmLocked()     != 1 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->backPressure()   == 1 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->oosGlib()        != 0 ? 1 : 0 ) << unBit++ );
-      
+
+      unStatus |= ((amc->bc0locked() == 0 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->daqReady() != 1 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->daqClockLocked() == 0 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->mmcmLocked() != 1 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->backPressure() == 1 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->oosGlib() != 0 ? 1 : 0) << unBit++);
+
       FillBits(h2AMCStatus_, unStatus, amcStatusBit_, nIdAMC);
-      
+
       h1_amc_ttsState_->Fill(amc->ttsState());
       h1_amc_davCnt_->Fill(amc->davCnt());
       h1_amc_buffState_->Fill(amc->buffState());
       h1_amc_oosGlib_->Fill(amc->oosGlib());
       h1_amc_chTimeOut_->Fill(amc->linkTo());
-      
+
       fillTimeHisto(listCurr, nIdAMC, unStatus != 0);
     }
   }
-  
+
   /*auto findVFAT = [this](float min_, int nNumStripPerVFAT, float x_, int roll_)->int {
     float step = max_/3;
     if ( x_ < (min_+step) ) { return 8 - roll_;}
     else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
     else { return this->nVfat_ - roll_;}
   };*/
-  
+
   // Checking if there is a fire (data)
-  for ( auto ch : gemChambers_ ) {
+  for (auto ch : gemChambers_) {
     GEMDetId cId = ch.id();
     Bool_t bIsHit = false;
-    
+
     // Because every fired strip in a same VFAT shares a same bx, we keep bx from only one strip
     std::unordered_map<Int_t, Int_t> mapBXVFAT;
-    
+
     GEMDetId chIdDigi(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 2);
     GEMDetId chIdBx(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 3);
-    
-    auto &listCurrDigi = listTimeStore_[ chIdDigi ];
-    auto &listCurrBx   = listTimeStore_[ chIdBx ];
-    
-    for ( auto roll : ch.etaPartitions() ) {
-      GEMDetId rId = roll->id();      
+
+    auto &listCurrDigi = listTimeStore_[chIdDigi];
+    auto &listCurrBx = listTimeStore_[chIdBx];
+
+    for (auto roll : ch.etaPartitions()) {
+      GEMDetId rId = roll->id();
       const auto &digis_in_det = gemDigis->get(rId);
-      
-      for ( auto d = digis_in_det.first ; d != digis_in_det.second ; ++d ){
+
+      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         //Int_t nVFAT = findVFAT(0, roll->nstrips(), d->strip(), rId.roll()); // Starts at 0
         Int_t nIdxStrip = d->strip() - nIdxFirstStrip_;
-        Int_t nVFAT = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
-        
+        Int_t nVFAT = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
+
         bIsHit = true;
-        mapBXVFAT[ nVFAT ] = d->bx();
+        mapBXVFAT[nVFAT] = d->bx();
         fillTimeHisto(listCurrDigi, nVFAT, true);
-        
+
         Int_t nIdxBx;
-        
-        if      ( d->bx() <  listCurrBx.nNbinMin ) nIdxBx = 0;
-        else if ( d->bx() >= listCurrBx.nNbinMax ) nIdxBx = listCurrBx.nNbinY - 1;
-        else nIdxBx = (Int_t)( listCurrBx.nNbinY * 1.0 * 
-            ( d->bx() - listCurrBx.nNbinMin ) / ( listCurrBx.nNbinMax - listCurrBx.nNbinMin ) );
-        
+
+        if (d->bx() < listCurrBx.nNbinMin)
+          nIdxBx = 0;
+        else if (d->bx() >= listCurrBx.nNbinMax)
+          nIdxBx = listCurrBx.nNbinY - 1;
+        else
+          nIdxBx = (Int_t)(listCurrBx.nNbinY * 1.0 * (d->bx() - listCurrBx.nNbinMin) /
+                           (listCurrBx.nNbinMax - listCurrBx.nNbinMin));
+
         fillTimeHisto(listCurrBx, nIdxBx, true);
       }
-      
-      if ( bIsHit ) break;
+
+      if (bIsHit)
+        break;
     }
-    
-    for ( auto bx : mapBXVFAT ) listVFATBC_[ cId ]->Fill(bx.second, bx.first);
-    
-    if ( bIsHit ) { // Data occur!
-      m_mapStatusFill[ cId ] = true;
+
+    for (auto bx : mapBXVFAT)
+      listVFATBC_[cId]->Fill(bx.second, bx.first);
+
+    if (bIsHit) {  // Data occur!
+      m_mapStatusFill[cId] = true;
     }
   }
-  
+
   // Counting the time tables
   nStackedEvt_++;
-  if ( nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_ ) { // Time to jump!
-    for ( auto &itStore : listTimeStore_ ) 
-    for ( Int_t i = 0 ; i < itStore.second.nNbinY ; i++ ) {
-      itStore.second.listOccupy[ i ].push_back(0);
-      itStore.second.listRecord[ i ].push_back(0);
-    }
-    
+  if (nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_) {  // Time to jump!
+    for (auto &itStore : listTimeStore_)
+      for (Int_t i = 0; i < itStore.second.nNbinY; i++) {
+        itStore.second.listOccupy[i].push_back(0);
+        itStore.second.listRecord[i].push_back(0);
+      }
+
     nStackedEvt_ = 0;
   }
 }
 
-
-void GEMDQMStatusDigi::endRun(edm::Run const& run, edm::EventSetup const& eSetup) {
+void GEMDQMStatusDigi::endRun(edm::Run const &run, edm::EventSetup const &eSetup) {
   //std::cout << "End run" << std::endl;
-  
-  for ( auto chamber : gemChambers_ ) {
+
+  for (auto chamber : gemChambers_) {
     auto gid = chamber.id();
-    
-    UInt_t unVal = 0; // No data, no error
-    if      ( m_mapStatusErr[ gid ]  ) unVal = 2; // Error! (no matter there are data or not)
-    else if ( m_mapStatusFill[ gid ] ) unVal = 1; // Data occur, with no error
+
+    UInt_t unVal = 0;  // No data, no error
+    if (m_mapStatusErr[gid])
+      unVal = 2;  // Error! (no matter there are data or not)
+    else if (m_mapStatusFill[gid])
+      unVal = 1;  // Data occur, with no error
     //std::cout << gid << ": " << unVal << std::endl;
-    
-    Int_t nLayer = ( bPerSuperchamber_ ? gid.layer() : 0 );
+
+    Int_t nLayer = (bPerSuperchamber_ ? gid.layer() : 0);
     GEMDetId layerId(gid.region(), gid.ring(), gid.station(), nLayer, 0, 0);
     GEMDetId chamberId(0, 1, 1, gid.layer() - nLayer, gid.chamber(), 0);
-    
-    Int_t nIdxLayer   = seekIdx(m_listLayers,   layerId);
+
+    Int_t nIdxLayer = seekIdx(m_listLayers, layerId);
     Int_t nIdxChamber = seekIdx(m_listChambers, chamberId);
-    
-    if ( h2SummaryStatus_ ) h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
-    
+
+    if (h2SummaryStatus_)
+      h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
+
     // The below is for under/overflow of BX histograms
-    Int_t nNbinX = listVFATBC_[ gid ]->getNbinsX();
-    Int_t nNbinY = listVFATBC_[ gid ]->getNbinsY();
-    
-    for ( Int_t i = 0 ; i < nNbinY ; i++ ) {
-      listVFATBC_[ gid ]->setBinContent(1, i, 
-          listVFATBC_[ gid ]->getBinContent(0, i) + listVFATBC_[ gid ]->getBinContent(1, i));
-      listVFATBC_[ gid ]->setBinContent(nNbinX, i, 
-          listVFATBC_[ gid ]->getBinContent(nNbinX, i) + listVFATBC_[ gid ]->getBinContent(nNbinX + 1 , i));
+    Int_t nNbinX = listVFATBC_[gid]->getNbinsX();
+    Int_t nNbinY = listVFATBC_[gid]->getNbinsY();
+
+    for (Int_t i = 0; i < nNbinY; i++) {
+      listVFATBC_[gid]->setBinContent(
+          1, i, listVFATBC_[gid]->getBinContent(0, i) + listVFATBC_[gid]->getBinContent(1, i));
+      listVFATBC_[gid]->setBinContent(
+          nNbinX, i, listVFATBC_[gid]->getBinContent(nNbinX, i) + listVFATBC_[gid]->getBinContent(nNbinX + 1, i));
     }
   }
-   
-  for ( auto &itStore : listTimeStore_ ) {
+
+  for (auto &itStore : listTimeStore_) {
     auto &listCurrOcc = itStore.second.listOccupy;
     auto &listCurrRec = itStore.second.listRecord;
     MonitorElement *h2Curr = itStore.second.h2Histo;
-    
+
     h2Curr->setBinContent(0, 0, nNSecPerBin_ * nNEvtPerSec_);
     h2Curr->setBinContent(0, 1, 1);
-    
-    Int_t nSize = listCurrRec[ 0 ].size();
+
+    Int_t nSize = listCurrRec[0].size();
     //Int_t nXOffset = std::max(nSize - nNTimeBinTotal_, 0);
     Int_t nXOffset = 0;
     Int_t nNbinY = listCurrRec.size();
-    
-    for ( Int_t nX = nXOffset ; nX < nSize ; nX++ ) {
-      Int_t nNEvt = ( nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_ );
+
+    for (Int_t nX = nXOffset; nX < nSize; nX++) {
+      Int_t nNEvt = (nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_);
       h2Curr->setBinContent(nX - nXOffset + 1, 0, nNEvt);
-      
-      for ( Int_t nY = 1 ; nY <= nNbinY ; nY++ ) {
-        Double_t dVal = listCurrRec[ nY - 1 ][ nX ];
-        Double_t dErr = listCurrOcc[ nY - 1 ][ nX ];
-        
-        if ( dErr > 0 && dVal <= 0 ) dVal = -1;
-        
-        if ( dVal != 0 ) h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
+
+      for (Int_t nY = 1; nY <= nNbinY; nY++) {
+        Double_t dVal = listCurrRec[nY - 1][nX];
+        Double_t dErr = listCurrOcc[nY - 1][nX];
+
+        if (dErr > 0 && dVal <= 0)
+          dVal = -1;
+
+        if (dVal != 0)
+          h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
         //if ( dErr > 0 ) h2Curr->setBinError(nX - nXOffset + 1, nY, 1);
       }
     }

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -9,9 +9,10 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
+
+#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "EventFilter/GEMRawToDigi/interface/GEMVfatStatusDigiCollection.h"
 #include "EventFilter/GEMRawToDigi/interface/GEMGEBdataCollection.h"
@@ -26,26 +27,32 @@
 
 //----------------------------------------------------------------------------------------------------
 
+
+using namespace dqm::impl;
+
+
 typedef struct tagTimeStoreItem {
   std::string strName;
   std::string strTitle;
   std::string strAxisX;
-
+  
   MonitorElement *h2Histo;
-
+  
   Int_t nNbinY;
   Int_t nNbinMin;
   Int_t nNbinMax;
-
+  
   std::vector<std::vector<Double_t>> listOccupy;
   std::vector<std::vector<Double_t>> listRecord;
 } TimeStoreItem;
 
-class GEMDQMStatusDigi : public DQMEDAnalyzer {
+ 
+class GEMDQMStatusDigi: public DQMEDAnalyzer
+{
 public:
-  GEMDQMStatusDigi(const edm::ParameterSet &cfg);
-  ~GEMDQMStatusDigi() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  GEMDQMStatusDigi(const edm::ParameterSet& cfg);
+  ~GEMDQMStatusDigi() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
 
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
@@ -53,107 +60,109 @@ protected:
   void bookHistogramsStationPart(DQMStore::IBooker &, GEMDetId &);
   void bookHistogramsAMCPart(DQMStore::IBooker &);
   void bookHistogramsTimeRecordPart(DQMStore::IBooker &);
-
+  
   int SetInfoChambers();
   int SetConfigTimeRecord();
   int LoadPrevData();
-
+  
   Int_t seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId);
-
-  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void endRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
+  
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
 private:
-  const GEMGeometry *initGeometry(edm::EventSetup const &iSetup);
-
+  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
+  
   void AddLabel();
-
+  
   std::string suffixChamber(GEMDetId &id);
   std::string suffixLayer(GEMDetId &id);
-
+  
   void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits);
   void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nY);
-
-  const GEMGeometry *GEMGeometry_;
+  
+  const GEMGeometry* GEMGeometry_; 
   std::vector<GEMChamber> gemChambers_;
-
+  
   int nVfat_ = 24;
-
+  
   int nNCh_;
-
+  
   int cBit_ = 9;
   int qVFATBit_ = 5;
   int fVFATBit_ = 4;
   int eBit_ = 16;
   int amcStatusBit_ = 6;
-
+  
   int nNEvtPerSec_;
   int nNSecPerBin_;
   int nNTimeBinTotal_;
   int nNTimeBinPrimitive_;
-
+  
   int nIdxFirstStrip_;
-
+  
   int nNBxBin_;
   int nNBxRange_;
-
+  
   std::string strFmtSummaryLabel_;
   bool bFlipSummary_;
   bool bPerSuperchamber_;
-
+  
   std::string strPathPrevDQMRoot_;
-
+  
   edm::EDGetToken tagVFAT_;
   edm::EDGetToken tagGEB_;
   edm::EDGetToken tagAMC_;
   edm::EDGetToken tagDigi_;
-
+  
   std::vector<Int_t> listAMCSlots_;
-
+  
   std::vector<GEMDetId> m_listLayers;
   std::vector<GEMDetId> m_listChambers;
 
   MonitorElement *h1_vfat_qualityflag_;
   MonitorElement *h2_vfat_qualityflag_;
+  
+  std::unordered_map<UInt_t, MonitorElement*> listVFATQualityFlag_;
+  std::unordered_map<UInt_t, MonitorElement*> listVFATBC_;
+  std::unordered_map<UInt_t, MonitorElement*> listVFATEC_;
 
-  std::unordered_map<UInt_t, MonitorElement *> listVFATQualityFlag_;
-  std::unordered_map<UInt_t, MonitorElement *> listVFATBC_;
-  std::unordered_map<UInt_t, MonitorElement *> listVFATEC_;
-
-  std::unordered_map<UInt_t, MonitorElement *> listGEBInputStatus_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBInputID_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBVFATWordCnt_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBVFATWordCntT_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBZeroSupWordsCnt_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBbcOH_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBecOH_;
-  std::unordered_map<UInt_t, MonitorElement *> listGEBOHCRC_;
-
+  std::unordered_map<UInt_t, MonitorElement*> listGEBInputStatus_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBInputID_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCnt_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCntT_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBZeroSupWordsCnt_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBbcOH_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBecOH_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBOHCRC_;
+  
   std::unordered_map<UInt_t, Bool_t> m_mapStatusFill;
   std::unordered_map<UInt_t, Bool_t> m_mapStatusErr;
-
+  
   MonitorElement *h1_amc_ttsState_;
   MonitorElement *h1_amc_davCnt_;
   MonitorElement *h1_amc_buffState_;
   MonitorElement *h1_amc_oosGlib_;
   MonitorElement *h1_amc_chTimeOut_;
   MonitorElement *h2AMCStatus_;
-
+  
   MonitorElement *m_summaryReport_;
   MonitorElement *h2SummaryStatus_;
-
+  
   // For more information, see SetConfigTimeRecord()
   std::unordered_map<UInt_t, TimeStoreItem> listTimeStore_;
   Int_t nStackedEvt_;
+
 };
 
-const GEMGeometry *GEMDQMStatusDigi::initGeometry(edm::EventSetup const &iSetup) {
-  const GEMGeometry *GEMGeometry_ = nullptr;
+const GEMGeometry* GEMDQMStatusDigi::initGeometry(edm::EventSetup const & iSetup) {
+  const GEMGeometry* GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry> &e) {
+  }
+  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -163,438 +172,423 @@ const GEMGeometry *GEMDQMStatusDigi::initGeometry(edm::EventSetup const &iSetup)
 using namespace std;
 using namespace edm;
 
-GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet &cfg) {
-  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
-  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel"));
-  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
+GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet& cfg)
+{
 
+  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel")); 
+  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel")); 
+  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel")); 
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
+  
   listAMCSlots_ = cfg.getParameter<std::vector<int>>("AMCSlots");
-
+  
   strFmtSummaryLabel_ = cfg.getParameter<std::string>("summaryLabelFmt");
   bFlipSummary_ = cfg.getParameter<bool>("flipSummary");
   bPerSuperchamber_ = cfg.getParameter<bool>("perSuperchamber");
-
+  
   strPathPrevDQMRoot_ = cfg.getParameter<std::string>("pathOfPrevDQMRoot");
   nNEvtPerSec_ = cfg.getParameter<int>("numOfEvtPerSec");
   nNSecPerBin_ = cfg.getParameter<int>("secOfEvtPerBin");
   nNTimeBinPrimitive_ = cfg.getParameter<int>("totalTimeInterval");
-
+  
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
-
+  
   nNBxRange_ = cfg.getParameter<int>("bxRange");
   nNBxBin_ = cfg.getParameter<int>("bxBin");
+  
 }
 
-void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus"));
-  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus"));
-  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata"));
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
-
+  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus")); 
+  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus")); 
+  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata")); 
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
+  
   std::vector<int> listAMCSlotsDef = {0, 1, 2, 3, 4, 5, 6, 7};
-  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef);  // TODO: Find how to get this from the geometry
-
+  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef); // TODO: Find how to get this from the geometry
+  
   desc.add<std::string>("summaryLabelFmt", "GE%(station_signed)+i/%(layer)i");
   desc.add<bool>("flipSummary", false);
   desc.add<bool>("perSuperchamber", true);
-
+  
   desc.add<std::string>("pathOfPrevDQMRoot", "");
   desc.add<int>("numOfEvtPerSec", 100);
   desc.add<int>("secOfEvtPerBin", 10);
   desc.add<int>("totalTimeInterval", 50000);
-
+  
   desc.add<int>("idxFirstStrip", 0);
-
+  
   desc.add<int>("bxRange", 10);
   desc.add<int>("bxBin", 20);
-
-  descriptions.add("GEMDQMStatusDigi", desc);
+  
+  descriptions.add("GEMDQMStatusDigi", desc);  
 }
+
 
 std::string GEMDQMStatusDigi::suffixChamber(GEMDetId &id) {
-  return "Gemini_" + to_string(id.chamber()) + "_GE" + (id.region() > 0 ? "p" : "m") + to_string(id.station()) + "_" +
-         to_string(id.layer());
+  return "Gemini_" + to_string(id.chamber()) + "_GE" + ( id.region() > 0 ? "p" : "m" ) + 
+    to_string(id.station()) + "_" + to_string(id.layer());
 }
+
 
 std::string GEMDQMStatusDigi::suffixLayer(GEMDetId &id) {
-  return std::string("st_") + (id.region() >= 0 ? "p" : "m") + std::to_string(id.station()) +
-         (bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "");
+  return std::string("st_") + ( id.region() >= 0 ? "p" : "m" ) + std::to_string(id.station()) +
+    ( bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "" );
 }
 
-int GEMDQMStatusDigi::SetInfoChambers() {
-  const std::vector<const GEMSuperChamber *> &superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {
-    int nLayer = sch->nChambers();
-    for (int l = 0; l < nLayer; l++) {
-      Bool_t bExist = false;
-      for (auto ch : gemChambers_)
-        if (ch.id() == sch->chamber(l + 1)->id())
-          bExist = true;
-      if (bExist)
-        continue;
 
+int GEMDQMStatusDigi::SetInfoChambers() {
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
+  for ( auto sch : superChambers_ ) {
+    int nLayer = sch->nChambers();
+    for ( int l = 0 ; l < nLayer ; l++ ) {
+      Bool_t bExist = false;
+      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
+      if ( bExist ) continue;
+      
       gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
-
+  
   // End: Loading the GEM geometry
-
+  
   // Start: Set the configurations
-
+  
   m_listLayers.clear();
-
+  
   // Summarizing geometry configurations
-  for (auto ch : gemChambers_) {
+  for ( auto ch : gemChambers_ ) {
     GEMDetId gid = ch.id();
-
-    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), (bPerSuperchamber_ ? gid.layer() : 0), 0, 0);
+    
+    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), ( bPerSuperchamber_ ? gid.layer() : 0 ), 0, 0);
     Bool_t bOcc = false;
-
-    for (auto lid : m_listLayers) {
-      if (lid == layerID) {
+    
+    for ( auto lid : m_listLayers ) {
+      if ( lid == layerID ) {
         bOcc = true;
         break;
       }
     }
-
-    if (!bOcc)
-      m_listLayers.push_back(layerID);
-
-    GEMDetId chamberID(0, 1, 1, (bPerSuperchamber_ ? 0 : gid.layer()), gid.chamber(), 0);
+    
+    if ( !bOcc ) m_listLayers.push_back(layerID);
+    
+    GEMDetId chamberID(0, 1, 1, ( bPerSuperchamber_ ? 0 : gid.layer() ), gid.chamber(), 0);
     bOcc = false;
-
-    for (auto cid : m_listChambers) {
-      if (cid == chamberID) {
+    
+    for ( auto cid : m_listChambers ) {
+      if ( cid == chamberID ) {
         bOcc = true;
         break;
       }
     }
-
-    if (!bOcc)
-      m_listChambers.push_back(chamberID);
+    
+    if ( !bOcc ) m_listChambers.push_back(chamberID);
   }
-
+  
   // Preliminary for sorting the summaries
-  auto lambdaLayer = [this](GEMDetId a, GEMDetId b) -> Bool_t {
-    Int_t nFlipSign = (this->bFlipSummary_ ? -1 : 1);
-    Int_t nA = nFlipSign * a.region() * (20 * a.station() + a.layer());
-    Int_t nB = nFlipSign * b.region() * (20 * b.station() + b.layer());
+  auto lambdaLayer = [this](GEMDetId a, GEMDetId b)->Bool_t {
+    Int_t nFlipSign = ( this->bFlipSummary_ ? -1 : 1 );
+    Int_t nA = nFlipSign * a.region() * ( 20 * a.station() + a.layer() );
+    Int_t nB = nFlipSign * b.region() * ( 20 * b.station() + b.layer() );
     return nA > nB;
   };
-
-  auto lambdaChamber = [this](GEMDetId a, GEMDetId b) -> Bool_t {
+  
+  auto lambdaChamber = [this](GEMDetId a, GEMDetId b)->Bool_t {
     Int_t nA = 20 * a.chamber() + a.layer();
     Int_t nB = 20 * b.chamber() + b.layer();
     return nA < nB;
   };
-
+  
   // Sorting the summaries
   std::sort(m_listLayers.begin(), m_listLayers.end(), lambdaLayer);
   std::sort(m_listChambers.begin(), m_listChambers.end(), lambdaChamber);
-
+  
   nNCh_ = (int)m_listChambers.size();
-
+  
   return 0;
 }
+
 
 // 0: General; for whole AMC slots
 int GEMDQMStatusDigi::SetConfigTimeRecord() {
   TimeStoreItem newTimeStore;
-
+  
   newTimeStore.nNbinMin = 0;
   newTimeStore.nNbinMax = 0;
-
+  
   std::string strCommonName = "per_time_";
-
+  
   // Very general GEMDetId
-  newTimeStore.strName = strCommonName + "status_AMCslots";
+  newTimeStore.strName  = strCommonName + "status_AMCslots";
   newTimeStore.strTitle = "Status of AMC slots per time";
   newTimeStore.strAxisX = "AMC slot";
-  newTimeStore.nNbinY = listAMCSlots_.size();
-  listTimeStore_[0] = newTimeStore;
-
-  for (auto layerId : m_listLayers) {
-    std::string strSuffix =
-        (layerId.region() > 0 ? "p" : "m") + std::to_string(layerId.station()) + "_" + std::to_string(layerId.layer());
-
-    newTimeStore.strName = strCommonName + "status_GEB_" + suffixLayer(layerId);
+  newTimeStore.nNbinY   = listAMCSlots_.size();
+  listTimeStore_[ 0 ] = newTimeStore;
+  
+  for ( auto layerId : m_listLayers ) {
+    std::string strSuffix = ( layerId.region() > 0 ? "p" : "m" ) + std::to_string(layerId.station()) 
+        + "_" + std::to_string(layerId.layer());
+    
+    newTimeStore.strName  = strCommonName + "status_GEB_" + suffixLayer(layerId);
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "Chamber";
-
-    newTimeStore.nNbinY = nNCh_;
-    listTimeStore_[layerId] = newTimeStore;
+    
+    newTimeStore.nNbinY   = nNCh_;
+    listTimeStore_[ layerId ] = newTimeStore;
   }
-
-  for (auto ch : gemChambers_) {
+  
+  for ( auto ch : gemChambers_ ) {
     auto chId = ch.id();
     GEMDetId chIdStatus(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 1);
     GEMDetId chIdDigi(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 2);
     GEMDetId chIdBx(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 3);
-
+    
     std::string strSuffix = suffixChamber(chId);
-
-    newTimeStore.strName = strCommonName + "status_chamber_" + strSuffix;
+    
+    newTimeStore.strName  = strCommonName + "status_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "VFAT";
-
-    newTimeStore.nNbinY = nVfat_;
-    listTimeStore_[chIdStatus] = newTimeStore;
-
-    newTimeStore.strName = strCommonName + "digi_chamber_" + strSuffix;
+    
+    newTimeStore.nNbinY   = nVfat_;
+    listTimeStore_[ chIdStatus ] = newTimeStore;
+    
+    newTimeStore.strName  = strCommonName + "digi_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "VFAT";
-
-    newTimeStore.nNbinY = nVfat_;
-    listTimeStore_[chIdDigi] = newTimeStore;
-
-    newTimeStore.strName = strCommonName + "bx_chamber_" + strSuffix;
+    
+    newTimeStore.nNbinY   = nVfat_;
+    listTimeStore_[ chIdDigi ] = newTimeStore;
+    
+    newTimeStore.strName  = strCommonName + "bx_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "Bunch crossing";
-
-    newTimeStore.nNbinY = nNBxBin_;
+    
+    newTimeStore.nNbinY   =  nNBxBin_;
     newTimeStore.nNbinMin = -nNBxRange_;
-    newTimeStore.nNbinMax = nNBxRange_;
-
-    listTimeStore_[chIdBx] = newTimeStore;
-
+    newTimeStore.nNbinMax =  nNBxRange_;
+    
+    listTimeStore_[ chIdBx ] = newTimeStore;
+    
     newTimeStore.nNbinMin = newTimeStore.nNbinMax = 0;
   }
-
+  
   return 0;
 }
+
 
 int GEMDQMStatusDigi::LoadPrevData() {
   TFile *fPrev;
   Bool_t bSync = true;
-
+  
   nStackedEvt_ = 0;
-
-  for (auto &itStore : listTimeStore_) {
+  
+  for ( auto &itStore : listTimeStore_ ) {
     itStore.second.listOccupy.clear();
     itStore.second.listRecord.clear();
   }
-
-  if (strPathPrevDQMRoot_ == "")
-    return 0;
-
+  
+  if ( strPathPrevDQMRoot_ == "" ) return 0;
+  
   std::ifstream fExist(strPathPrevDQMRoot_.c_str());
-  if (!fExist.good())
-    return 0;
+  if ( !fExist.good() ) return 0;
   fExist.close();
-
+  
   fPrev = new TFile(strPathPrevDQMRoot_.c_str());
-  if (fPrev == NULL)
-    return 1;
-
+  if ( fPrev == NULL ) return 1;
+  
   std::cout << strPathPrevDQMRoot_ << " is being loaded" << std::endl;
-  std::string strRunnum = ((TDirectoryFile *)fPrev->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
-
-  for (auto &itStore : listTimeStore_) {
-    TH2F *h2Prev =
-        (TH2F *)fPrev->Get(("DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi/" + itStore.second.strName).c_str());
+  std::string strRunnum = ( (TDirectoryFile *)fPrev->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
+  
+  for ( auto &itStore : listTimeStore_ ) {
+    TH2F *h2Prev = (TH2F *)fPrev->Get(( "DQMData/" + strRunnum 
+      + "/GEM/Run summary/StatusDigi/" + itStore.second.strName ).c_str());
     auto &listCurrRec = itStore.second.listRecord;
     auto &listCurrOcc = itStore.second.listOccupy;
-
+    
     listCurrRec.clear();
     listCurrOcc.clear();
-
-    if (h2Prev == NULL)
-      continue;  // Hmmm, is it an error...?
-
+    
+    if ( h2Prev == NULL ) continue; // Hmmm, is it an error...?
+    
     Int_t nNbinX = h2Prev->GetNbinsX();
     Int_t nNbinY = h2Prev->GetNbinsY();
-
+    
     Int_t nX, nY;
     Int_t nXMaxOcc = 0;
     Int_t nNNonFullFill = 0;
-
-    for (nX = 1; nX <= nNbinX; nX++) {
-      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0);  // The (nX, 0)-bin keeps the number of filled events
-      if (0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_)
-        nNNonFullFill++;
-      if (nNEvtCurrTime > 0)
-        nXMaxOcc = nX;
+    
+    for ( nX = 1 ; nX <= nNbinX ; nX++ ) {
+      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0); // The (nX, 0)-bin keeps the number of filled events
+      if ( 0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_ ) nNNonFullFill++;
+      if ( nNEvtCurrTime > 0 ) nXMaxOcc = nX;
     }
-
-    if (nNNonFullFill > 1) {  // The last bin may not full
+    
+    if ( nNNonFullFill > 1 ) { // The last bin may not full
       std::cerr << "WARNING: There is a bin of the previous histograms which is not fully filled" << std::endl;
     }
-
-    for (nY = 1; nY <= nNbinY; nY++) {
+    
+    for ( nY = 1 ; nY <= nNbinY ; nY++ ) {
       listCurrRec.emplace_back();
       listCurrOcc.emplace_back();
-
-      if (nXMaxOcc > 0) {
-        for (nX = 1; nX <= nXMaxOcc; nX++) {
+      
+      if ( nXMaxOcc > 0 ) {
+        for ( nX = 1 ; nX <= nXMaxOcc ; nX++ ) {
           //listCurr[ nY - 1 ].push_back(h2Prev->GetBinContent(nX, nY));
-          listCurrRec[nY - 1].push_back(0);  // If hadd is used, then it must be blanked
-          listCurrOcc[nY - 1].push_back(0);  // If hadd is used, then it must be blanked
+          listCurrRec[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
+          listCurrOcc[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
         }
-
-        if (nNNonFullFill <= 0) {
-          listCurrRec[nY - 1].push_back(0);
-          listCurrOcc[nY - 1].push_back(0);
+        
+        if ( nNNonFullFill <= 0 ) {
+          listCurrRec[ nY - 1 ].push_back(0);
+          listCurrOcc[ nY - 1 ].push_back(0);
         }
-      } else {  // Empty...?
-        listCurrRec[nY - 1].push_back(0);
-        listCurrOcc[nY - 1].push_back(0);
+      } else { // Empty...?
+        listCurrRec[ nY - 1 ].push_back(0);
+        listCurrOcc[ nY - 1 ].push_back(0);
       }
     }
-
-    if (nXMaxOcc <= 0)
-      std::cout << "nXMacOcc has a problem" << std::endl;
-    if (nXMaxOcc <= 0)
-      continue;  // Empty...?
-
+    
+    if ( nXMaxOcc <= 0 ) std::cout << "nXMacOcc has a problem" << std::endl;
+    if ( nXMaxOcc <= 0 ) continue; // Empty...?
+    
     // Keeping the number of lastly stacked events
     // And also checking if the sync is okay
-    if (nStackedEvt_ == 0)
-      nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
+    if ( nStackedEvt_ == 0 ) nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
     else {
-      if (nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0))
-        bSync = false;
+      if ( nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0) ) bSync = false;
     }
   }
-
-  if (nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_)
-    nStackedEvt_ = 0;
-
-  if (!bSync) {  // No sync...!
+  
+  if ( nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_ ) nStackedEvt_ = 0;
+  
+  if ( !bSync ) { // No sync...!
     std::cerr << "WARNING: No sync on time histograms" << std::endl;
   }
-
+  
   fPrev->Close();
-
+  
   return 0;
 }
 
+
 void GEMDQMStatusDigi::bookHistogramsChamberPart(DQMStore::IBooker &ibooker, GEMDetId &gid) {
   std::string hName, hTitle;
-
+  
   UInt_t unBinPos;
   //std::cout << "B: " << gid << std::endl;
-
-  std::string strIdxName = suffixChamber(gid);
-  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
-                            to_string(gid.station()) + "/" + to_string(gid.layer());
-
+  
+  std::string strIdxName  = suffixChamber(gid);
+  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
+    ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
+  
   hName = "vfatStatus_QualityFlag_" + strIdxName;
   hTitle = "VFAT quality " + strIdxTitle;
   hTitle += ";VFAT;";
   std::cout << "booking: " << gid << std::endl;
-  listVFATQualityFlag_[gid] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
-
+  listVFATQualityFlag_[ gid ] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
+  
   hName = "vfatStatus_BC_" + strIdxName;
   hTitle = "VFAT bunch crossing " + strIdxTitle;
   hTitle += ";Bunch crossing;VFAT";
-  listVFATBC_[gid] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
-
+  listVFATBC_[ gid ] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
+  
   hName = "vfatStatus_EC_" + strIdxName;
   hTitle = "VFAT event counter " + strIdxTitle;
   hTitle += ";Event counter;VFAT";
-  listVFATEC_[gid] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
-
+  listVFATEC_[ gid ] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
+  
   unBinPos = 1;
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "Good", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "CRC fail", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1010 fail", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1100 fail", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1110 fail", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "Hamming error", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "AFULL", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "SEUlogic", 2);
-  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "SUEI2C", 2);
-
-  m_mapStatusFill[gid] = false;
-  m_mapStatusErr[gid] = false;
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Good", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "CRC fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1010 fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1100 fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1110 fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Hamming error", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "AFULL", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SEUlogic", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SUEI2C", 2);
+  
+  m_mapStatusFill[ gid ] = false;
+  m_mapStatusErr[ gid ] = false;
 }
+
 
 void GEMDQMStatusDigi::bookHistogramsStationPart(DQMStore::IBooker &ibooker, GEMDetId &lid) {
   UInt_t unBinPos;
-
-  Int_t re = lid.region();
+  
+  Int_t  re = lid.region();
   UInt_t st = lid.station();
   UInt_t la = lid.layer();
-
-  auto newbookGEB = [this](DQMStore::IBooker &ibooker,
-                           std::string strName,
-                           std::string strTitle,
-                           std::string strAxis,
-                           GEMDetId &lid,
-                           int nLayer,
-                           int nStation,
-                           int re,
-                           int nBin,
-                           float fMin,
-                           float fMax) -> MonitorElement * {
-    strName = strName + "_" + suffixLayer(lid);
-    strTitle = strTitle + ", station: " + (re >= 0 ? "+" : "-") + std::to_string(nStation);
-
-    if (bPerSuperchamber_) {
+  
+  auto newbookGEB = [this](DQMStore::IBooker &ibooker, 
+                           std::string strName, std::string strTitle, std::string strAxis, 
+                           GEMDetId &lid, int nLayer, int nStation, int re, 
+                           int nBin, float fMin, float fMax)->MonitorElement *
+  {
+    strName  = strName  + "_" + suffixLayer(lid);
+    strTitle = strTitle + ", station: " + (re>=0 ? "+" : "-") + std::to_string(nStation);
+    
+    if ( bPerSuperchamber_ ) {
       strTitle += ", layer: " + std::to_string(nLayer);
     }
-
+    
     strTitle += ";Chamber;" + strAxis;
-
+    
     auto hNew = ibooker.book2D(strName, strTitle, this->nNCh_, 0, this->nNCh_, nBin, fMin, fMax);
-
-    for (Int_t i = 0; i < this->nNCh_; i++) {
-      auto &gid = this->m_listChambers[i];
-      Int_t nCh = gid.chamber() + (this->bPerSuperchamber_ ? 0 : gid.layer() - 1);
+    
+    for ( Int_t i = 0 ; i < this->nNCh_ ; i++ ) {
+      auto &gid = this->m_listChambers[ i ];
+      Int_t nCh = gid.chamber() + ( this->bPerSuperchamber_ ? 0 : gid.layer() - 1 );
       hNew->setBinLabel(i + 1, std::to_string(nCh), 1);
     }
-
+    
     return hNew;
   };
-
-  listGEBInputStatus_[lid] =
-      newbookGEB(ibooker, "geb_input_status", "inputStatus", "", lid, la, st, re, eBit_, 0, eBit_);
-  listGEBInputID_[lid] = newbookGEB(ibooker, "geb_input_ID", "inputID", "Input ID", lid, la, st, re, 32, 0, 32);
-  listGEBVFATWordCnt_[lid] =
-      newbookGEB(ibooker, "geb_no_vfats", "nvfats in header", "Number of VFATs in header", lid, la, st, re, 25, 0, 25);
-  listGEBVFATWordCntT_[lid] = newbookGEB(
-      ibooker, "geb_no_vfatsT", "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
-  listGEBZeroSupWordsCnt_[lid] = newbookGEB(
-      ibooker, "geb_zeroSupWordsCnt", "zeroSupWordsCnt", "Zero sup. words count", lid, la, st, re, 10, 0, 10);
-
-  listGEBbcOH_[lid] =
-      newbookGEB(ibooker, "geb_bcOH", "OH bunch crossing", "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
-  listGEBecOH_[lid] =
-      newbookGEB(ibooker, "geb_ecOH", "OH event coounter", "OH event counter", lid, la, st, re, 256, 0, 256);
-  listGEBOHCRC_[lid] =
-      newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
-
+  
+  listGEBInputStatus_[ lid ]  = newbookGEB(ibooker, "geb_input_status", 
+      "inputStatus",       "",                           lid, la, st, re, eBit_, 0, eBit_);
+  listGEBInputID_[ lid ]      = newbookGEB(ibooker, "geb_input_ID", 
+      "inputID",           "Input ID",                   lid, la, st, re, 32, 0, 32);
+  listGEBVFATWordCnt_[ lid ]  = newbookGEB(ibooker, "geb_no_vfats", 
+      "nvfats in header",  "Number of VFATs in header",  lid, la, st, re, 25, 0, 25);
+  listGEBVFATWordCntT_[ lid ] = newbookGEB(ibooker, "geb_no_vfatsT", 
+      "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
+  listGEBZeroSupWordsCnt_[ lid ] = newbookGEB(ibooker, "geb_zeroSupWordsCnt", 
+      "zeroSupWordsCnt",   "Zero sup. words count",      lid, la, st, re, 10, 0, 10);
+  
+  listGEBbcOH_[ lid ]  = newbookGEB(ibooker, "geb_bcOH",  "OH bunch crossing", 
+      "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
+  listGEBecOH_[ lid ]  = newbookGEB(ibooker, "geb_ecOH",  "OH event coounter", 
+      "OH event counter", lid, la, st, re, 256, 0, 256);
+  listGEBOHCRC_[ lid ] = newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", 
+      "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
+  
   unBinPos = 1;
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "No VFAT marker", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event size warn", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "InFIFO near full", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event size overflow", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "InFIFO full", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Stuck data", 2);
-  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "No VFAT marker", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size warn", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO near full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size overflow", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Stuck data", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
 }
 
-void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
-  h2AMCStatus_ = ibooker.book2D("amc_statusflag",
-                                "Status of AMC slots;AMC slot;",
-                                listAMCSlots_.size(),
-                                0,
-                                listAMCSlots_.size(),
-                                amcStatusBit_,
-                                0,
-                                amcStatusBit_);
 
+void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
+  h2AMCStatus_ = ibooker.book2D("amc_statusflag", "Status of AMC slots;AMC slot;", 
+      listAMCSlots_.size(), 0, listAMCSlots_.size(), amcStatusBit_, 0, amcStatusBit_);
+  
   uint32_t unBinPos = 1;
   h2AMCStatus_->setBinLabel(unBinPos++, "BC0 not locked", 2);
   h2AMCStatus_->setBinLabel(unBinPos++, "DAQ not ready", 2);
@@ -604,115 +598,110 @@ void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
   h2AMCStatus_->setBinLabel(unBinPos++, "GLIB out-of-sync", 2);
 }
 
+
 void GEMDQMStatusDigi::bookHistogramsTimeRecordPart(DQMStore::IBooker &ibooker) {
   //Int_t nNBinX = ( listTimeStore_[ 0 ].listRecord.size() / nNTimeBinTotal_ + 1 ) * nNTimeBinTotal_;
-
-  for (auto &itStore : listTimeStore_) {
+  
+  for ( auto &itStore : listTimeStore_ ) {
     auto &infoCurr = itStore.second;
-
+    
     Float_t fMin = -0.5, fMax = infoCurr.nNbinY - 0.5;
-
-    if (infoCurr.nNbinMin < infoCurr.nNbinMax) {
+    
+    if ( infoCurr.nNbinMin < infoCurr.nNbinMax ) {
       fMin = infoCurr.nNbinMin;
       fMax = infoCurr.nNbinMax;
     }
-
-    infoCurr.h2Histo = ibooker.book2D(
-        infoCurr.strName,
-        //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX,
-        infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX,
-        nNTimeBinPrimitive_,
-        0,
-        nNTimeBinPrimitive_,
-        infoCurr.nNbinY,
-        fMin,
-        fMax);
-
-    if (seekIdx(m_listLayers, itStore.first) >= 0) {
-      for (Int_t i = 0; i < nNCh_; i++) {
-        auto &gid = m_listChambers[i];
-        Int_t nCh = gid.chamber() + (bPerSuperchamber_ ? 0 : gid.layer() - 1);
+    
+    infoCurr.h2Histo = ibooker.book2D(infoCurr.strName, 
+      //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX, 
+      infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX, 
+      nNTimeBinPrimitive_, 0, nNTimeBinPrimitive_, infoCurr.nNbinY, fMin, fMax);
+    
+    if ( seekIdx(m_listLayers, itStore.first) >= 0 ) {
+      for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
+        auto &gid = m_listChambers[ i ];
+        Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
         infoCurr.h2Histo->setBinLabel(i + 1, std::to_string(nCh), 2);
       }
     }
   }
 }
 
+
 // To make labels like python, with std::(unordered_)map
 std::string printfWithMap(std::string strFmt, std::unordered_map<std::string, Int_t> mapArg) {
   std::string strRes = strFmt;
-  char szOutFmt[64];
+  char szOutFmt[ 64 ];
   size_t unPos, unPosEnd;
-
-  for (unPos = strRes.find('%'); unPos != std::string::npos; unPos = strRes.find('%', unPos + 1)) {
+  
+  for ( unPos = strRes.find('%') ; unPos != std::string::npos ; unPos = strRes.find('%', unPos + 1) ) {
     unPosEnd = strRes.find(')', unPos);
-    if (strRes[unPos + 1] != '(' || unPosEnd == std::string::npos)
-      break;  // Syntax error
-
+    if ( strRes[ unPos + 1 ] != '(' || unPosEnd == std::string::npos ) break; // Syntax error
+    
     // Extracting the key
-    std::string strKey = strRes.substr(unPos + 2, unPosEnd - (unPos + 2));
-
+    std::string strKey = strRes.substr(unPos + 2, unPosEnd - ( unPos + 2 ));
+    
     // To treat formats like '%5i' or '%02i', extracting '5' or '02'
-    // After do this,
+    // After do this, 
     std::string strOptNum = "%";
     unPosEnd++;
-
-    for (;; unPosEnd++) {
-      if (!('0' <= strRes[unPosEnd] && strRes[unPosEnd] <= '9') && strRes[unPosEnd] != '+')
-        break;
-      strOptNum += strRes[unPosEnd];
+    
+    for ( ;; unPosEnd++ ) {
+      if ( !( '0' <= strRes[ unPosEnd ] && strRes[ unPosEnd ] <= '9' ) && 
+           strRes[ unPosEnd ] != '+' ) break;
+      strOptNum += strRes[ unPosEnd ];
     }
-
-    if (strRes[unPosEnd] != 'i' && strRes[unPosEnd] != 'd')
-      break;  // Syntax error
-    strOptNum += strRes[unPosEnd];
+    
+    if ( strRes[ unPosEnd ] != 'i' && strRes[ unPosEnd ] != 'd' ) break; // Syntax error
+    strOptNum += strRes[ unPosEnd ];
     unPosEnd++;
-
-    sprintf(szOutFmt, strOptNum.c_str(), mapArg[strKey]);
+    
+    sprintf(szOutFmt, strOptNum.c_str(), mapArg[ strKey ]);
     strRes = strRes.substr(0, unPos) + szOutFmt + strRes.substr(unPosEnd);
   }
-
-  if (unPos != std::string::npos) {  // It means... an syntax error occurs!
+  
+  if ( unPos != std::string::npos ) { // It means... an syntax error occurs!
     std::cerr << "ERROR: Syntax error on printfWithMap(); " << std::endl;
     return "";
   }
-
+  
   return strRes;
 }
 
-void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &iSetup) {
+
+void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
+{
   // Start: Loading the GEM geometry
-
+  
   GEMGeometry_ = initGeometry(iSetup);
-  if (GEMGeometry_ == nullptr)
-    return;
-
+  if ( GEMGeometry_ == nullptr) return;
+  
   SetInfoChambers();
-
+  
   // Setting the informations for time histograms
   SetConfigTimeRecord();
   LoadPrevData();
-
+  
   // The loading does not work well or something goes wrong...
   // In this case, we need to make a new start of recording.
-  for (auto &itStore : listTimeStore_) {
+  for ( auto &itStore : listTimeStore_ ) {
     auto &infoCurr = itStore.second;
-
-    if (infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size()) {
-      if (infoCurr.listRecord.size() > 0) {
+    
+    if ( infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size() ) { 
+      if ( infoCurr.listRecord.size() > 0 ) {
         std::cerr << "WARNING: The previous result is not compatible to the current geometry. "
-                  << "We will discard the previous data." << std::endl;
-
+          << "We will discard the previous data." << std::endl;
+        
         infoCurr.listRecord.clear();
         infoCurr.listOccupy.clear();
       }
-
-      for (Int_t i = 0; i < infoCurr.nNbinY; i++) {
+      
+      for ( Int_t i = 0 ; i < infoCurr.nNbinY ; i++ ) {
         infoCurr.listRecord.emplace_back();
-        infoCurr.listRecord[i].push_back(0);
-
+        infoCurr.listRecord[ i ].push_back(0);
+        
         infoCurr.listOccupy.emplace_back();
-        infoCurr.listOccupy[i].push_back(0);
+        infoCurr.listOccupy[ i ].push_back(0);
       }
     }
     /*for ( Int_t i = 0 ; i < (Int_t)infoCurr.listRecord[ 0 ].size() ; i++ ) 
@@ -721,375 +710,365 @@ void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
     
     std::cout << "Init time: " << itStore.first << ", " << infoCurr.strName << ", " << infoCurr.nNbinY << ", " << infoCurr.listRecord.size() << "; " << listTimeStore_[ itStore.first ].listRecord.size() << std::endl;*/
   }
-
+  
   // End: Set the configurations
-
+  
   // Start: Setting books
-
+  
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/StatusDigi");
-
-  for (auto ch : gemChambers_) {
+  
+  for ( auto ch : gemChambers_ ) {
     GEMDetId gid = ch.id();
     bookHistogramsChamberPart(ibooker, gid);
   }
-
-  for (auto lid : m_listLayers) {
+  
+  for ( auto lid : m_listLayers ) {
     bookHistogramsStationPart(ibooker, lid);
   }
-
+  
   bookHistogramsAMCPart(ibooker);
   bookHistogramsTimeRecordPart(ibooker);
-
+  
   h1_vfat_qualityflag_ = ibooker.book1D("vfat_quality_flag", "quality and flag", 9, 0, 9);
   h2_vfat_qualityflag_ = ibooker.book2D("vfat_quality_flag_per_geb", "quality and flag", nNCh_, 0, nNCh_, 9, 0, 9);
-
-  h1_amc_ttsState_ = ibooker.book1D("amc_ttsState", "ttsState", 10, 0, 10);
-  h1_amc_davCnt_ = ibooker.book1D("amc_davCnt", "davCnt", 10, 0, 10);
+  
+  h1_amc_ttsState_  = ibooker.book1D("amc_ttsState",  "ttsState",  10, 0, 10);
+  h1_amc_davCnt_    = ibooker.book1D("amc_davCnt",    "davCnt",    10, 0, 10);
   h1_amc_buffState_ = ibooker.book1D("amc_buffState", "buffState", 10, 0, 10);
-  h1_amc_oosGlib_ = ibooker.book1D("amc_oosGlib", "oosGlib", 10, 0, 10);
+  h1_amc_oosGlib_   = ibooker.book1D("amc_oosGlib",   "oosGlib",   10, 0, 10);
   h1_amc_chTimeOut_ = ibooker.book1D("amc_chTimeOut", "chTimeOut", 10, 0, 10);
-
+  
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/EventInfo");
-
+  
   // TODO: We need a study for setting the rule for this
   m_summaryReport_ = ibooker.bookFloat("reportSummary");
   m_summaryReport_->Fill(1.0);
-
-  h2SummaryStatus_ =
-      ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, m_listLayers.size(), 0, m_listLayers.size());
-
-  for (Int_t i = 0; i < nNCh_; i++) {
-    auto &gid = this->m_listChambers[i];
-    Int_t nCh = gid.chamber() + (bPerSuperchamber_ ? 0 : gid.layer() - 1);
+  
+  h2SummaryStatus_ = ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, 
+      m_listLayers.size(), 0, m_listLayers.size());
+  
+  for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
+    auto &gid = this->m_listChambers[ i ];
+    Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
     h2SummaryStatus_->setBinLabel(i + 1, std::to_string(nCh), 1);
   }
-
+  
   Int_t nIdxLayer = 0;
   std::unordered_map<std::string, Int_t> mapArg;
-
+  
   // Start: Labeling section
-
-  for (auto lid : m_listLayers) {
-    mapArg["station_signed"] = lid.region() * lid.station();
-    mapArg["region"] = lid.region();
-    mapArg["station"] = lid.station();
-    mapArg["layer"] = lid.layer();
-    mapArg["chamber"] = lid.chamber();
-
+    
+  for ( auto lid : m_listLayers ) {
+    mapArg[ "station_signed" ] = lid.region() * lid.station();
+    mapArg[ "region"  ] = lid.region();
+    mapArg[ "station" ] = lid.station();
+    mapArg[ "layer"   ] = lid.layer();
+    mapArg[ "chamber" ] = lid.chamber();
+    
     h2SummaryStatus_->setBinLabel(nIdxLayer + 1, printfWithMap(strFmtSummaryLabel_, mapArg), 2);
     nIdxLayer++;
   }
 }
 
+
 void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits) {
   int i = 0;
   uint64_t unFlag = 1;
-
-  for (; i < nNumBits; i++, unFlag <<= 1) {
-    if ((unVal & unFlag) != 0) {
+  
+  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
+    if ( ( unVal & unFlag ) != 0 ) {
       monitor->Fill(i);
     }
   }
 }
 
+
 void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nX) {
   int i = 0;
   uint64_t unFlag = 1;
-
-  for (; i < nNumBits; i++, unFlag <<= 1) {
-    if ((unVal & unFlag) != 0) {
+  
+  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
+    if ( ( unVal & unFlag ) != 0 ) {
       monitor->Fill(nX, i);
     }
   }
 }
 
-Int_t GEMDQMStatusDigi::seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId) {
-  if (unId < 256)
-    return -1;
 
+Int_t GEMDQMStatusDigi::seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId) {
+  if ( unId < 256 ) return -1;
+  
   GEMDetId id(unId);
-  for (Int_t nIdx = 0; nIdx < (Int_t)listLayers.size(); nIdx++)
-    if (id == listLayers[nIdx])
-      return nIdx;
+  for ( Int_t nIdx = 0 ; nIdx < (Int_t)listLayers.size() ; nIdx++ ) if ( id == listLayers[ nIdx ] ) return nIdx;
   return -1;
 }
+  
 
-void GEMDQMStatusDigi::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
+void GEMDQMStatusDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
+{
   edm::Handle<GEMVfatStatusDigiCollection> gemVFAT;
   edm::Handle<GEMGEBdataCollection> gemGEB;
   edm::Handle<GEMAMCdataCollection> gemAMC;
   edm::Handle<GEMDigiCollection> gemDigis;
-
-  event.getByToken(tagVFAT_, gemVFAT);
-  event.getByToken(tagGEB_, gemGEB);
-  event.getByToken(tagAMC_, gemAMC);
-  event.getByToken(tagDigi_, gemDigis);
-
-  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill) -> void {
+  
+  event.getByToken( tagVFAT_, gemVFAT);
+  event.getByToken( tagGEB_, gemGEB);
+  event.getByToken( tagAMC_, gemAMC);
+  event.getByToken( tagDigi_, gemDigis);
+  
+  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill)->void {
     return;
-    auto &listRecord = listCurr.listRecord[nIdx];
-    auto &listOccupy = listCurr.listOccupy[nIdx];
+    auto &listRecord = listCurr.listRecord[ nIdx ];
+    auto &listOccupy = listCurr.listOccupy[ nIdx ];
     int nIdxTime = listRecord.size() - 1;
-
-    listOccupy[nIdxTime] = 1;
-    if (bFill)
-      listRecord[nIdxTime]++;
+    
+    listOccupy[ nIdxTime ] = 1;
+    if ( bFill ) listRecord[ nIdxTime ]++;
   };
 
-  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt) {
+  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt){
     GEMDetId gemid = (*vfatIt).first;
     GEMDetId gemchId = gemid.chamberId();
     //std::cout << "A: " << gemchId << std::endl;
-    GEMDetId gemOnlychId(0, 1, 1, (bPerSuperchamber_ ? 0 : gemid.layer()), gemid.chamber(), 0);
-
+    GEMDetId gemOnlychId(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
+    
     int nIdx = seekIdx(m_listChambers, gemOnlychId);
     int nRoll = gemid.roll();
-    const GEMVfatStatusDigiCollection::Range &range = (*vfatIt).second;
-
+    const GEMVfatStatusDigiCollection::Range& range = (*vfatIt).second;
+    
     GEMDetId chIdStatus(gemid.region(), gemid.ring(), gemid.station(), gemid.layer(), gemid.chamber(), 1);
-    auto &listCurr = listTimeStore_[chIdStatus];
-
-    for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
-      uint64_t unQFVFAT = vfatStat->quality() | (vfatStat->flag() << qVFATBit_);
-      if ((unQFVFAT & ~0x1) == 0) {
-        unQFVFAT |= 0x1;  // If no error, then it should be 'Good'
-      } else {            // Error!!
-        m_mapStatusErr[gemchId] = true;
+    auto &listCurr = listTimeStore_[ chIdStatus ];
+    
+    for ( auto vfatStat = range.first; vfatStat != range.second; ++vfatStat ) {
+      uint64_t unQFVFAT = vfatStat->quality() | ( vfatStat->flag() << qVFATBit_ );
+      if ( ( unQFVFAT & ~0x1 ) == 0 )  {
+        unQFVFAT |= 0x1; // If no error, then it should be 'Good'
+      } else { // Error!!
+        m_mapStatusErr[ gemchId ] = true;
       }
-
+      
       FillBits(h1_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_);
       FillBits(h2_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_, nIdx);
-
-      int nVFAT = (8 - nRoll) + 8 * vfatStat->phi();  // vfatStat.phi()? or 2 - vfatStat.phi()?
-
-      FillBits(listVFATQualityFlag_[gemchId], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
+      
+      int nVFAT = ( 8 - nRoll ) + 8 * vfatStat->phi(); // vfatStat.phi()? or 2 - vfatStat.phi()?
+      
+      FillBits(listVFATQualityFlag_[ gemchId ], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
       //listVFATBC_[ gemchId ]->Fill(vfatStat->bc(), nVFAT);
-      listVFATEC_[gemchId]->Fill(vfatStat->ec(), nVFAT);
-
-      fillTimeHisto(listCurr, nVFAT, (unQFVFAT & ~0x1) != 0);
+      listVFATEC_[ gemchId ]->Fill(vfatStat->ec(), nVFAT);
+      
+      fillTimeHisto(listCurr, nVFAT, ( unQFVFAT & ~0x1 ) != 0);
     }
   }
-
-  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt) {
+  
+  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt){
     GEMDetId gemid = (*gebIt).first;
-    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), (bPerSuperchamber_ ? gemid.layer() : 0), 0, 0);
-    GEMDetId chid(0, 1, 1, (bPerSuperchamber_ ? 0 : gemid.layer()), gemid.chamber(), 0);
-
+    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), ( bPerSuperchamber_ ? gemid.layer() : 0 ), 0, 0);
+    GEMDetId chid(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
+    
     Int_t nCh = seekIdx(m_listChambers, chid);
-    auto &listCurr = listTimeStore_[lid];
-
-    const GEMGEBdataCollection::Range &range = (*gebIt).second;
-    for (auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus) {
+    auto &listCurr = listTimeStore_[ lid ];
+    
+    const GEMGEBdataCollection::Range& range = (*gebIt).second;    
+    for ( auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus ) {
       uint64_t unBit = 0;
       uint64_t unStatus = 0;
-
-      unStatus |= (GEBStatus->bxmVvV() << unBit++);
-      unStatus |= (GEBStatus->bxmAvV() << unBit++);
-      unStatus |= (GEBStatus->oOScVvV() << unBit++);
-      unStatus |= (GEBStatus->oOScAvV() << unBit++);
-      unStatus |= (GEBStatus->noVFAT() << unBit++);
-      unStatus |= (GEBStatus->evtSzW() << unBit++);
-      unStatus |= (GEBStatus->l1aNF() << unBit++);
-      unStatus |= (GEBStatus->inNF() << unBit++);
-      unStatus |= (GEBStatus->evtNF() << unBit++);
-      unStatus |= (GEBStatus->evtSzOFW() << unBit++);
-      unStatus |= (GEBStatus->l1aF() << unBit++);
-      unStatus |= (GEBStatus->inF() << unBit++);
-      unStatus |= (GEBStatus->evtF() << unBit++);
-      unStatus |= (GEBStatus->inUfw() << unBit++);
-      unStatus |= (GEBStatus->stuckData() << unBit++);
-      unStatus |= (GEBStatus->evUfw() << unBit++);
-
+      
+      unStatus |= ( GEBStatus->bxmVvV()    << unBit++ ); 
+      unStatus |= ( GEBStatus->bxmAvV()    << unBit++ ); 
+      unStatus |= ( GEBStatus->oOScVvV()   << unBit++ ); 
+      unStatus |= ( GEBStatus->oOScAvV()   << unBit++ ); 
+      unStatus |= ( GEBStatus->noVFAT()    << unBit++ ); 
+      unStatus |= ( GEBStatus->evtSzW()    << unBit++ ); 
+      unStatus |= ( GEBStatus->l1aNF()     << unBit++ ); 
+      unStatus |= ( GEBStatus->inNF()      << unBit++ ); 
+      unStatus |= ( GEBStatus->evtNF()     << unBit++ ); 
+      unStatus |= ( GEBStatus->evtSzOFW()  << unBit++ ); 
+      unStatus |= ( GEBStatus->l1aF()      << unBit++ ); 
+      unStatus |= ( GEBStatus->inF()       << unBit++ ); 
+      unStatus |= ( GEBStatus->evtF()      << unBit++ ); 
+      unStatus |= ( GEBStatus->inUfw()     << unBit++ ); 
+      unStatus |= ( GEBStatus->stuckData() << unBit++ ); 
+      unStatus |= ( GEBStatus->evUfw()     << unBit++ );
+      
       //std::cout << gemid;
       //printf("%06X\n", (unsigned int)unStatus);
-      if (unStatus != 0) {  // Error!
-        m_mapStatusErr[gemid] = true;
+      if ( unStatus != 0 ) { // Error!
+        m_mapStatusErr[ gemid ] = true;
       }
-
-      FillBits(listGEBInputStatus_[lid], unStatus, eBit_, nCh);
-
-      listGEBInputID_[lid]->Fill(nCh, GEBStatus->inputID());
-      listGEBVFATWordCnt_[lid]->Fill(nCh, GEBStatus->vfatWordCnt() / 3);
-      listGEBVFATWordCntT_[lid]->Fill(nCh, GEBStatus->vfatWordCntT() / 3);
-      listGEBZeroSupWordsCnt_[lid]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
-
-      listGEBbcOH_[lid]->Fill(nCh, GEBStatus->bcOH());
-      listGEBecOH_[lid]->Fill(nCh, GEBStatus->ecOH());
-      listGEBOHCRC_[lid]->Fill(nCh, GEBStatus->crc());
-
+      
+      FillBits(listGEBInputStatus_[ lid ], unStatus, eBit_, nCh);
+      
+      listGEBInputID_[ lid ]->Fill(nCh, GEBStatus->inputID());
+      listGEBVFATWordCnt_[ lid ]->Fill(nCh, GEBStatus->vfatWordCnt()/3);
+      listGEBVFATWordCntT_[ lid ]->Fill(nCh, GEBStatus->vfatWordCntT()/3);
+      listGEBZeroSupWordsCnt_[ lid ]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
+      
+      listGEBbcOH_[ lid ]->Fill(nCh, GEBStatus->bcOH());
+      listGEBecOH_[ lid ]->Fill(nCh, GEBStatus->ecOH());
+      listGEBOHCRC_[ lid ]->Fill(nCh, GEBStatus->crc());
+      
       fillTimeHisto(listCurr, nCh, unStatus != 0);
     }
   }
-
-  auto findAMCIdx = [this](Int_t nAMCnum) -> Int_t {
-    for (Int_t i = 0; i < (Int_t)listAMCSlots_.size(); i++)
-      if (listAMCSlots_[i] == nAMCnum)
-        return i;
+  
+  auto findAMCIdx = [this](Int_t nAMCnum)->Int_t {
+    for ( Int_t i = 0 ; i < (Int_t)listAMCSlots_.size() ; i++ ) if ( listAMCSlots_[ i ] == nAMCnum ) return i;
     return -1;
   };
-
-  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
-    const GEMAMCdataCollection::Range &range = (*amcIt).second;
-    auto &listCurr = listTimeStore_[0];
-    for (auto amc = range.first; amc != range.second; ++amc) {
+  
+  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt){
+    const GEMAMCdataCollection::Range& range = (*amcIt).second;
+    auto &listCurr = listTimeStore_[ 0 ];
+    for ( auto amc = range.first; amc != range.second; ++amc ) {
       Int_t nIdAMC = findAMCIdx(amc->amcNum());
       uint64_t unBit = 0;
       uint64_t unStatus = 0;
-
-      unStatus |= ((amc->bc0locked() == 0 ? 1 : 0) << unBit++);
-      unStatus |= ((amc->daqReady() != 1 ? 1 : 0) << unBit++);
-      unStatus |= ((amc->daqClockLocked() == 0 ? 1 : 0) << unBit++);
-      unStatus |= ((amc->mmcmLocked() != 1 ? 1 : 0) << unBit++);
-      unStatus |= ((amc->backPressure() == 1 ? 1 : 0) << unBit++);
-      unStatus |= ((amc->oosGlib() != 0 ? 1 : 0) << unBit++);
-
+      
+      unStatus |= ( ( amc->bc0locked()      == 0 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->daqReady()       != 1 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->daqClockLocked() == 0 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->mmcmLocked()     != 1 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->backPressure()   == 1 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->oosGlib()        != 0 ? 1 : 0 ) << unBit++ );
+      
       FillBits(h2AMCStatus_, unStatus, amcStatusBit_, nIdAMC);
-
+      
       h1_amc_ttsState_->Fill(amc->ttsState());
       h1_amc_davCnt_->Fill(amc->davCnt());
       h1_amc_buffState_->Fill(amc->buffState());
       h1_amc_oosGlib_->Fill(amc->oosGlib());
       h1_amc_chTimeOut_->Fill(amc->linkTo());
-
+      
       fillTimeHisto(listCurr, nIdAMC, unStatus != 0);
     }
   }
-
+  
   /*auto findVFAT = [this](float min_, int nNumStripPerVFAT, float x_, int roll_)->int {
     float step = max_/3;
     if ( x_ < (min_+step) ) { return 8 - roll_;}
     else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
     else { return this->nVfat_ - roll_;}
   };*/
-
+  
   // Checking if there is a fire (data)
-  for (auto ch : gemChambers_) {
+  for ( auto ch : gemChambers_ ) {
     GEMDetId cId = ch.id();
     Bool_t bIsHit = false;
-
+    
     // Because every fired strip in a same VFAT shares a same bx, we keep bx from only one strip
     std::unordered_map<Int_t, Int_t> mapBXVFAT;
-
+    
     GEMDetId chIdDigi(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 2);
     GEMDetId chIdBx(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 3);
-
-    auto &listCurrDigi = listTimeStore_[chIdDigi];
-    auto &listCurrBx = listTimeStore_[chIdBx];
-
-    for (auto roll : ch.etaPartitions()) {
-      GEMDetId rId = roll->id();
+    
+    auto &listCurrDigi = listTimeStore_[ chIdDigi ];
+    auto &listCurrBx   = listTimeStore_[ chIdBx ];
+    
+    for ( auto roll : ch.etaPartitions() ) {
+      GEMDetId rId = roll->id();      
       const auto &digis_in_det = gemDigis->get(rId);
-
-      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
+      
+      for ( auto d = digis_in_det.first ; d != digis_in_det.second ; ++d ){
         //Int_t nVFAT = findVFAT(0, roll->nstrips(), d->strip(), rId.roll()); // Starts at 0
         Int_t nIdxStrip = d->strip() - nIdxFirstStrip_;
-        Int_t nVFAT = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
-
+        Int_t nVFAT = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
+        
         bIsHit = true;
-        mapBXVFAT[nVFAT] = d->bx();
+        mapBXVFAT[ nVFAT ] = d->bx();
         fillTimeHisto(listCurrDigi, nVFAT, true);
-
+        
         Int_t nIdxBx;
-
-        if (d->bx() < listCurrBx.nNbinMin)
-          nIdxBx = 0;
-        else if (d->bx() >= listCurrBx.nNbinMax)
-          nIdxBx = listCurrBx.nNbinY - 1;
-        else
-          nIdxBx = (Int_t)(listCurrBx.nNbinY * 1.0 * (d->bx() - listCurrBx.nNbinMin) /
-                           (listCurrBx.nNbinMax - listCurrBx.nNbinMin));
-
+        
+        if      ( d->bx() <  listCurrBx.nNbinMin ) nIdxBx = 0;
+        else if ( d->bx() >= listCurrBx.nNbinMax ) nIdxBx = listCurrBx.nNbinY - 1;
+        else nIdxBx = (Int_t)( listCurrBx.nNbinY * 1.0 * 
+            ( d->bx() - listCurrBx.nNbinMin ) / ( listCurrBx.nNbinMax - listCurrBx.nNbinMin ) );
+        
         fillTimeHisto(listCurrBx, nIdxBx, true);
       }
-
-      if (bIsHit)
-        break;
+      
+      if ( bIsHit ) break;
     }
-
-    for (auto bx : mapBXVFAT)
-      listVFATBC_[cId]->Fill(bx.second, bx.first);
-
-    if (bIsHit) {  // Data occur!
-      m_mapStatusFill[cId] = true;
+    
+    for ( auto bx : mapBXVFAT ) listVFATBC_[ cId ]->Fill(bx.second, bx.first);
+    
+    if ( bIsHit ) { // Data occur!
+      m_mapStatusFill[ cId ] = true;
     }
   }
-
+  
   // Counting the time tables
   nStackedEvt_++;
-  if (nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_) {  // Time to jump!
-    for (auto &itStore : listTimeStore_)
-      for (Int_t i = 0; i < itStore.second.nNbinY; i++) {
-        itStore.second.listOccupy[i].push_back(0);
-        itStore.second.listRecord[i].push_back(0);
-      }
-
+  if ( nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_ ) { // Time to jump!
+    for ( auto &itStore : listTimeStore_ ) 
+    for ( Int_t i = 0 ; i < itStore.second.nNbinY ; i++ ) {
+      itStore.second.listOccupy[ i ].push_back(0);
+      itStore.second.listRecord[ i ].push_back(0);
+    }
+    
     nStackedEvt_ = 0;
   }
 }
 
-void GEMDQMStatusDigi::endRun(edm::Run const &run, edm::EventSetup const &eSetup) {
+
+void GEMDQMStatusDigi::dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) {
   //std::cout << "End run" << std::endl;
-
-  for (auto chamber : gemChambers_) {
+  
+  for ( auto chamber : gemChambers_ ) {
     auto gid = chamber.id();
-
-    UInt_t unVal = 0;  // No data, no error
-    if (m_mapStatusErr[gid])
-      unVal = 2;  // Error! (no matter there are data or not)
-    else if (m_mapStatusFill[gid])
-      unVal = 1;  // Data occur, with no error
+    
+    UInt_t unVal = 0; // No data, no error
+    if      ( m_mapStatusErr[ gid ]  ) unVal = 2; // Error! (no matter there are data or not)
+    else if ( m_mapStatusFill[ gid ] ) unVal = 1; // Data occur, with no error
     //std::cout << gid << ": " << unVal << std::endl;
-
-    Int_t nLayer = (bPerSuperchamber_ ? gid.layer() : 0);
+    
+    Int_t nLayer = ( bPerSuperchamber_ ? gid.layer() : 0 );
     GEMDetId layerId(gid.region(), gid.ring(), gid.station(), nLayer, 0, 0);
     GEMDetId chamberId(0, 1, 1, gid.layer() - nLayer, gid.chamber(), 0);
-
-    Int_t nIdxLayer = seekIdx(m_listLayers, layerId);
+    
+    Int_t nIdxLayer   = seekIdx(m_listLayers,   layerId);
     Int_t nIdxChamber = seekIdx(m_listChambers, chamberId);
-
-    if (h2SummaryStatus_)
-      h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
-
+    
+    if ( h2SummaryStatus_ ) h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
+    
     // The below is for under/overflow of BX histograms
-    Int_t nNbinX = listVFATBC_[gid]->getNbinsX();
-    Int_t nNbinY = listVFATBC_[gid]->getNbinsY();
-
-    for (Int_t i = 0; i < nNbinY; i++) {
-      listVFATBC_[gid]->setBinContent(
-          1, i, listVFATBC_[gid]->getBinContent(0, i) + listVFATBC_[gid]->getBinContent(1, i));
-      listVFATBC_[gid]->setBinContent(
-          nNbinX, i, listVFATBC_[gid]->getBinContent(nNbinX, i) + listVFATBC_[gid]->getBinContent(nNbinX + 1, i));
+    Int_t nNbinX = listVFATBC_[ gid ]->getNbinsX();
+    Int_t nNbinY = listVFATBC_[ gid ]->getNbinsY();
+    
+    for ( Int_t i = 0 ; i < nNbinY ; i++ ) {
+      listVFATBC_[ gid ]->setBinContent(1, i, 
+          listVFATBC_[ gid ]->getBinContent(0, i) + listVFATBC_[ gid ]->getBinContent(1, i));
+      listVFATBC_[ gid ]->setBinContent(nNbinX, i, 
+          listVFATBC_[ gid ]->getBinContent(nNbinX, i) + listVFATBC_[ gid ]->getBinContent(nNbinX + 1 , i));
     }
   }
-
-  for (auto &itStore : listTimeStore_) {
+   
+  for ( auto &itStore : listTimeStore_ ) {
     auto &listCurrOcc = itStore.second.listOccupy;
     auto &listCurrRec = itStore.second.listRecord;
     MonitorElement *h2Curr = itStore.second.h2Histo;
-
+    
     h2Curr->setBinContent(0, 0, nNSecPerBin_ * nNEvtPerSec_);
     h2Curr->setBinContent(0, 1, 1);
-
-    Int_t nSize = listCurrRec[0].size();
+    
+    Int_t nSize = listCurrRec[ 0 ].size();
     //Int_t nXOffset = std::max(nSize - nNTimeBinTotal_, 0);
     Int_t nXOffset = 0;
     Int_t nNbinY = listCurrRec.size();
-
-    for (Int_t nX = nXOffset; nX < nSize; nX++) {
-      Int_t nNEvt = (nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_);
+    
+    for ( Int_t nX = nXOffset ; nX < nSize ; nX++ ) {
+      Int_t nNEvt = ( nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_ );
       h2Curr->setBinContent(nX - nXOffset + 1, 0, nNEvt);
-
-      for (Int_t nY = 1; nY <= nNbinY; nY++) {
-        Double_t dVal = listCurrRec[nY - 1][nX];
-        Double_t dErr = listCurrOcc[nY - 1][nX];
-
-        if (dErr > 0 && dVal <= 0)
-          dVal = -1;
-
-        if (dVal != 0)
-          h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
+      
+      for ( Int_t nY = 1 ; nY <= nNbinY ; nY++ ) {
+        Double_t dVal = listCurrRec[ nY - 1 ][ nX ];
+        Double_t dErr = listCurrOcc[ nY - 1 ][ nX ];
+        
+        if ( dErr > 0 && dVal <= 0 ) dVal = -1;
+        
+        if ( dVal != 0 ) h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
         //if ( dErr > 0 ) h2Curr->setBinError(nX - nXOffset + 1, nY, 1);
       }
     }

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -759,7 +759,7 @@ void GEMDQMStatusDigi::seekIdxSummary(GEMDetId gid, Int_t &nIdxLayer, Int_t &nId
   GEMDetId layerId(gid.region(), gid.ring(), gid.station(), nLayer, 0, 0);
   GEMDetId chamberId(0, 1, 1, gid.layer() - nLayer, gid.chamber(), 0);
 
-  nIdxLayer = seekIdx(m_listLayers, layerId);
+  nIdxLayer = seekIdx(m_listLayers, layerId) + 1;
   nIdxChamber = seekIdx(m_listChambers, chamberId) + 1;
 }
 
@@ -887,7 +887,7 @@ void GEMDQMStatusDigi::analyze(edm::Event const &event, edm::EventSetup const &e
       unStatus |= (!amc->daqReady() << unBit++);
       unStatus |= (!amc->daqClockLocked() << unBit++);
       unStatus |= (!amc->mmcmLocked() << unBit++);
-      unStatus |= (!amc->backPressure() << unBit++);
+      unStatus |= (amc->backPressure() << unBit++);
       unStatus |= (amc->oosGlib() << unBit++);
 
       FillBits(h2AMCStatus_, unStatus, amcStatusBit_, nIdAMC);

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -9,7 +9,6 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -27,32 +26,28 @@
 
 //----------------------------------------------------------------------------------------------------
 
-
 using namespace dqm::impl;
-
 
 typedef struct tagTimeStoreItem {
   std::string strName;
   std::string strTitle;
   std::string strAxisX;
-  
+
   MonitorElement *h2Histo;
-  
+
   Int_t nNbinY;
   Int_t nNbinMin;
   Int_t nNbinMax;
-  
+
   std::vector<std::vector<Double_t>> listOccupy;
   std::vector<std::vector<Double_t>> listRecord;
 } TimeStoreItem;
 
- 
-class GEMDQMStatusDigi: public DQMEDAnalyzer
-{
+class GEMDQMStatusDigi : public DQMEDAnalyzer {
 public:
-  GEMDQMStatusDigi(const edm::ParameterSet& cfg);
-  ~GEMDQMStatusDigi() override {};
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
+  GEMDQMStatusDigi(const edm::ParameterSet &cfg);
+  ~GEMDQMStatusDigi() override{};
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
@@ -60,109 +55,107 @@ protected:
   void bookHistogramsStationPart(DQMStore::IBooker &, GEMDetId &);
   void bookHistogramsAMCPart(DQMStore::IBooker &);
   void bookHistogramsTimeRecordPart(DQMStore::IBooker &);
-  
+
   int SetInfoChambers();
   int SetConfigTimeRecord();
   int LoadPrevData();
-  
+
   Int_t seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId);
-  
-  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
-  void dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
+
+  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) override;
 
 private:
-  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
-  
+  const GEMGeometry *initGeometry(edm::EventSetup const &iSetup);
+
   void AddLabel();
-  
+
   std::string suffixChamber(GEMDetId &id);
   std::string suffixLayer(GEMDetId &id);
-  
+
   void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits);
   void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nY);
-  
-  const GEMGeometry* GEMGeometry_; 
+
+  const GEMGeometry *GEMGeometry_;
   std::vector<GEMChamber> gemChambers_;
-  
+
   int nVfat_ = 24;
-  
+
   int nNCh_;
-  
+
   int cBit_ = 9;
   int qVFATBit_ = 5;
   int fVFATBit_ = 4;
   int eBit_ = 16;
   int amcStatusBit_ = 6;
-  
+
   int nNEvtPerSec_;
   int nNSecPerBin_;
   int nNTimeBinTotal_;
   int nNTimeBinPrimitive_;
-  
+
   int nIdxFirstStrip_;
-  
+
   int nNBxBin_;
   int nNBxRange_;
-  
+
   std::string strFmtSummaryLabel_;
   bool bFlipSummary_;
   bool bPerSuperchamber_;
-  
+
   std::string strPathPrevDQMRoot_;
-  
+
   edm::EDGetToken tagVFAT_;
   edm::EDGetToken tagGEB_;
   edm::EDGetToken tagAMC_;
   edm::EDGetToken tagDigi_;
-  
+
   std::vector<Int_t> listAMCSlots_;
-  
+
   std::vector<GEMDetId> m_listLayers;
   std::vector<GEMDetId> m_listChambers;
 
   MonitorElement *h1_vfat_qualityflag_;
   MonitorElement *h2_vfat_qualityflag_;
-  
-  std::unordered_map<UInt_t, MonitorElement*> listVFATQualityFlag_;
-  std::unordered_map<UInt_t, MonitorElement*> listVFATBC_;
-  std::unordered_map<UInt_t, MonitorElement*> listVFATEC_;
 
-  std::unordered_map<UInt_t, MonitorElement*> listGEBInputStatus_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBInputID_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCnt_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCntT_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBZeroSupWordsCnt_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBbcOH_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBecOH_;
-  std::unordered_map<UInt_t, MonitorElement*> listGEBOHCRC_;
-  
+  std::unordered_map<UInt_t, MonitorElement *> listVFATQualityFlag_;
+  std::unordered_map<UInt_t, MonitorElement *> listVFATBC_;
+  std::unordered_map<UInt_t, MonitorElement *> listVFATEC_;
+
+  std::unordered_map<UInt_t, MonitorElement *> listGEBInputStatus_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBInputID_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBVFATWordCnt_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBVFATWordCntT_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBZeroSupWordsCnt_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBbcOH_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBecOH_;
+  std::unordered_map<UInt_t, MonitorElement *> listGEBOHCRC_;
+
   std::unordered_map<UInt_t, Bool_t> m_mapStatusFill;
   std::unordered_map<UInt_t, Bool_t> m_mapStatusErr;
-  
+
   MonitorElement *h1_amc_ttsState_;
   MonitorElement *h1_amc_davCnt_;
   MonitorElement *h1_amc_buffState_;
   MonitorElement *h1_amc_oosGlib_;
   MonitorElement *h1_amc_chTimeOut_;
   MonitorElement *h2AMCStatus_;
-  
+
   MonitorElement *m_summaryReport_;
   MonitorElement *h2SummaryStatus_;
-  
+
   // For more information, see SetConfigTimeRecord()
   std::unordered_map<UInt_t, TimeStoreItem> listTimeStore_;
   Int_t nStackedEvt_;
-
 };
 
-const GEMGeometry* GEMDQMStatusDigi::initGeometry(edm::EventSetup const & iSetup) {
-  const GEMGeometry* GEMGeometry_ = nullptr;
+const GEMGeometry *GEMDQMStatusDigi::initGeometry(edm::EventSetup const &iSetup) {
+  const GEMGeometry *GEMGeometry_ = nullptr;
   try {
     edm::ESHandle<GEMGeometry> hGeom;
     iSetup.get<MuonGeometryRecord>().get(hGeom);
     GEMGeometry_ = &*hGeom;
-  }
-  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  } catch (edm::eventsetup::NoProxyException<GEMGeometry> &e) {
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
@@ -172,423 +165,438 @@ const GEMGeometry* GEMDQMStatusDigi::initGeometry(edm::EventSetup const & iSetup
 using namespace std;
 using namespace edm;
 
-GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet& cfg)
-{
+GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet &cfg) {
+  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
+  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel"));
+  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
 
-  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel")); 
-  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel")); 
-  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel")); 
-  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
-  
   listAMCSlots_ = cfg.getParameter<std::vector<int>>("AMCSlots");
-  
+
   strFmtSummaryLabel_ = cfg.getParameter<std::string>("summaryLabelFmt");
   bFlipSummary_ = cfg.getParameter<bool>("flipSummary");
   bPerSuperchamber_ = cfg.getParameter<bool>("perSuperchamber");
-  
+
   strPathPrevDQMRoot_ = cfg.getParameter<std::string>("pathOfPrevDQMRoot");
   nNEvtPerSec_ = cfg.getParameter<int>("numOfEvtPerSec");
   nNSecPerBin_ = cfg.getParameter<int>("secOfEvtPerBin");
   nNTimeBinPrimitive_ = cfg.getParameter<int>("totalTimeInterval");
-  
+
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
-  
+
   nNBxRange_ = cfg.getParameter<int>("bxRange");
   nNBxBin_ = cfg.getParameter<int>("bxBin");
-  
 }
 
-void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus")); 
-  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus")); 
-  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata")); 
-  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
-  
+  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus"));
+  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus"));
+  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata"));
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", ""));
+
   std::vector<int> listAMCSlotsDef = {0, 1, 2, 3, 4, 5, 6, 7};
-  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef); // TODO: Find how to get this from the geometry
-  
+  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef);  // TODO: Find how to get this from the geometry
+
   desc.add<std::string>("summaryLabelFmt", "GE%(station_signed)+i/%(layer)i");
   desc.add<bool>("flipSummary", false);
   desc.add<bool>("perSuperchamber", true);
-  
+
   desc.add<std::string>("pathOfPrevDQMRoot", "");
   desc.add<int>("numOfEvtPerSec", 100);
   desc.add<int>("secOfEvtPerBin", 10);
   desc.add<int>("totalTimeInterval", 50000);
-  
+
   desc.add<int>("idxFirstStrip", 0);
-  
+
   desc.add<int>("bxRange", 10);
   desc.add<int>("bxBin", 20);
-  
-  descriptions.add("GEMDQMStatusDigi", desc);  
-}
 
+  descriptions.add("GEMDQMStatusDigi", desc);
+}
 
 std::string GEMDQMStatusDigi::suffixChamber(GEMDetId &id) {
-  return "Gemini_" + to_string(id.chamber()) + "_GE" + ( id.region() > 0 ? "p" : "m" ) + 
-    to_string(id.station()) + "_" + to_string(id.layer());
+  return "Gemini_" + to_string(id.chamber()) + "_GE" + (id.region() > 0 ? "p" : "m") + to_string(id.station()) + "_" +
+         to_string(id.layer());
 }
-
 
 std::string GEMDQMStatusDigi::suffixLayer(GEMDetId &id) {
-  return std::string("st_") + ( id.region() >= 0 ? "p" : "m" ) + std::to_string(id.station()) +
-    ( bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "" );
+  return std::string("st_") + (id.region() >= 0 ? "p" : "m") + std::to_string(id.station()) +
+         (bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "");
 }
 
-
 int GEMDQMStatusDigi::SetInfoChambers() {
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
-  for ( auto sch : superChambers_ ) {
+  const std::vector<const GEMSuperChamber *> &superChambers_ = GEMGeometry_->superChambers();
+  for (auto sch : superChambers_) {
     int nLayer = sch->nChambers();
-    for ( int l = 0 ; l < nLayer ; l++ ) {
+    for (int l = 0; l < nLayer; l++) {
       Bool_t bExist = false;
-      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
-      if ( bExist ) continue;
-      
+      for (auto ch : gemChambers_)
+        if (ch.id() == sch->chamber(l + 1)->id())
+          bExist = true;
+      if (bExist)
+        continue;
+
       gemChambers_.push_back(*sch->chamber(l + 1));
     }
   }
-  
+
   // End: Loading the GEM geometry
-  
+
   // Start: Set the configurations
-  
+
   m_listLayers.clear();
-  
+
   // Summarizing geometry configurations
-  for ( auto ch : gemChambers_ ) {
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
-    
-    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), ( bPerSuperchamber_ ? gid.layer() : 0 ), 0, 0);
+
+    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), (bPerSuperchamber_ ? gid.layer() : 0), 0, 0);
     Bool_t bOcc = false;
-    
-    for ( auto lid : m_listLayers ) {
-      if ( lid == layerID ) {
+
+    for (auto lid : m_listLayers) {
+      if (lid == layerID) {
         bOcc = true;
         break;
       }
     }
-    
-    if ( !bOcc ) m_listLayers.push_back(layerID);
-    
-    GEMDetId chamberID(0, 1, 1, ( bPerSuperchamber_ ? 0 : gid.layer() ), gid.chamber(), 0);
+
+    if (!bOcc)
+      m_listLayers.push_back(layerID);
+
+    GEMDetId chamberID(0, 1, 1, (bPerSuperchamber_ ? 0 : gid.layer()), gid.chamber(), 0);
     bOcc = false;
-    
-    for ( auto cid : m_listChambers ) {
-      if ( cid == chamberID ) {
+
+    for (auto cid : m_listChambers) {
+      if (cid == chamberID) {
         bOcc = true;
         break;
       }
     }
-    
-    if ( !bOcc ) m_listChambers.push_back(chamberID);
+
+    if (!bOcc)
+      m_listChambers.push_back(chamberID);
   }
-  
+
   // Preliminary for sorting the summaries
-  auto lambdaLayer = [this](GEMDetId a, GEMDetId b)->Bool_t {
-    Int_t nFlipSign = ( this->bFlipSummary_ ? -1 : 1 );
-    Int_t nA = nFlipSign * a.region() * ( 20 * a.station() + a.layer() );
-    Int_t nB = nFlipSign * b.region() * ( 20 * b.station() + b.layer() );
+  auto lambdaLayer = [this](GEMDetId a, GEMDetId b) -> Bool_t {
+    Int_t nFlipSign = (this->bFlipSummary_ ? -1 : 1);
+    Int_t nA = nFlipSign * a.region() * (20 * a.station() + a.layer());
+    Int_t nB = nFlipSign * b.region() * (20 * b.station() + b.layer());
     return nA > nB;
   };
-  
-  auto lambdaChamber = [this](GEMDetId a, GEMDetId b)->Bool_t {
+
+  auto lambdaChamber = [this](GEMDetId a, GEMDetId b) -> Bool_t {
     Int_t nA = 20 * a.chamber() + a.layer();
     Int_t nB = 20 * b.chamber() + b.layer();
     return nA < nB;
   };
-  
+
   // Sorting the summaries
   std::sort(m_listLayers.begin(), m_listLayers.end(), lambdaLayer);
   std::sort(m_listChambers.begin(), m_listChambers.end(), lambdaChamber);
-  
+
   nNCh_ = (int)m_listChambers.size();
-  
+
   return 0;
 }
-
 
 // 0: General; for whole AMC slots
 int GEMDQMStatusDigi::SetConfigTimeRecord() {
   TimeStoreItem newTimeStore;
-  
+
   newTimeStore.nNbinMin = 0;
   newTimeStore.nNbinMax = 0;
-  
+
   std::string strCommonName = "per_time_";
-  
+
   // Very general GEMDetId
-  newTimeStore.strName  = strCommonName + "status_AMCslots";
+  newTimeStore.strName = strCommonName + "status_AMCslots";
   newTimeStore.strTitle = "Status of AMC slots per time";
   newTimeStore.strAxisX = "AMC slot";
-  newTimeStore.nNbinY   = listAMCSlots_.size();
-  listTimeStore_[ 0 ] = newTimeStore;
-  
-  for ( auto layerId : m_listLayers ) {
-    std::string strSuffix = ( layerId.region() > 0 ? "p" : "m" ) + std::to_string(layerId.station()) 
-        + "_" + std::to_string(layerId.layer());
-    
-    newTimeStore.strName  = strCommonName + "status_GEB_" + suffixLayer(layerId);
+  newTimeStore.nNbinY = listAMCSlots_.size();
+  listTimeStore_[0] = newTimeStore;
+
+  for (auto layerId : m_listLayers) {
+    std::string strSuffix =
+        (layerId.region() > 0 ? "p" : "m") + std::to_string(layerId.station()) + "_" + std::to_string(layerId.layer());
+
+    newTimeStore.strName = strCommonName + "status_GEB_" + suffixLayer(layerId);
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "Chamber";
-    
-    newTimeStore.nNbinY   = nNCh_;
-    listTimeStore_[ layerId ] = newTimeStore;
+
+    newTimeStore.nNbinY = nNCh_;
+    listTimeStore_[layerId] = newTimeStore;
   }
-  
-  for ( auto ch : gemChambers_ ) {
+
+  for (auto ch : gemChambers_) {
     auto chId = ch.id();
     GEMDetId chIdStatus(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 1);
     GEMDetId chIdDigi(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 2);
     GEMDetId chIdBx(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 3);
-    
+
     std::string strSuffix = suffixChamber(chId);
-    
-    newTimeStore.strName  = strCommonName + "status_chamber_" + strSuffix;
+
+    newTimeStore.strName = strCommonName + "status_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "VFAT";
-    
-    newTimeStore.nNbinY   = nVfat_;
-    listTimeStore_[ chIdStatus ] = newTimeStore;
-    
-    newTimeStore.strName  = strCommonName + "digi_chamber_" + strSuffix;
+
+    newTimeStore.nNbinY = nVfat_;
+    listTimeStore_[chIdStatus] = newTimeStore;
+
+    newTimeStore.strName = strCommonName + "digi_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "VFAT";
-    
-    newTimeStore.nNbinY   = nVfat_;
-    listTimeStore_[ chIdDigi ] = newTimeStore;
-    
-    newTimeStore.strName  = strCommonName + "bx_chamber_" + strSuffix;
+
+    newTimeStore.nNbinY = nVfat_;
+    listTimeStore_[chIdDigi] = newTimeStore;
+
+    newTimeStore.strName = strCommonName + "bx_chamber_" + strSuffix;
     newTimeStore.strTitle = "";
     newTimeStore.strAxisX = "Bunch crossing";
-    
-    newTimeStore.nNbinY   =  nNBxBin_;
+
+    newTimeStore.nNbinY = nNBxBin_;
     newTimeStore.nNbinMin = -nNBxRange_;
-    newTimeStore.nNbinMax =  nNBxRange_;
-    
-    listTimeStore_[ chIdBx ] = newTimeStore;
-    
+    newTimeStore.nNbinMax = nNBxRange_;
+
+    listTimeStore_[chIdBx] = newTimeStore;
+
     newTimeStore.nNbinMin = newTimeStore.nNbinMax = 0;
   }
-  
+
   return 0;
 }
-
 
 int GEMDQMStatusDigi::LoadPrevData() {
   TFile *fPrev;
   Bool_t bSync = true;
-  
+
   nStackedEvt_ = 0;
-  
-  for ( auto &itStore : listTimeStore_ ) {
+
+  for (auto &itStore : listTimeStore_) {
     itStore.second.listOccupy.clear();
     itStore.second.listRecord.clear();
   }
-  
-  if ( strPathPrevDQMRoot_ == "" ) return 0;
-  
+
+  if (strPathPrevDQMRoot_ == "")
+    return 0;
+
   std::ifstream fExist(strPathPrevDQMRoot_.c_str());
-  if ( !fExist.good() ) return 0;
+  if (!fExist.good())
+    return 0;
   fExist.close();
-  
+
   fPrev = new TFile(strPathPrevDQMRoot_.c_str());
-  if ( fPrev == NULL ) return 1;
-  
+  if (fPrev == NULL)
+    return 1;
+
   std::cout << strPathPrevDQMRoot_ << " is being loaded" << std::endl;
-  std::string strRunnum = ( (TDirectoryFile *)fPrev->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
-  
-  for ( auto &itStore : listTimeStore_ ) {
-    TH2F *h2Prev = (TH2F *)fPrev->Get(( "DQMData/" + strRunnum 
-      + "/GEM/Run summary/StatusDigi/" + itStore.second.strName ).c_str());
+  std::string strRunnum = ((TDirectoryFile *)fPrev->Get("DQMData"))->GetListOfKeys()->At(0)->GetName();
+
+  for (auto &itStore : listTimeStore_) {
+    TH2F *h2Prev =
+        (TH2F *)fPrev->Get(("DQMData/" + strRunnum + "/GEM/Run summary/StatusDigi/" + itStore.second.strName).c_str());
     auto &listCurrRec = itStore.second.listRecord;
     auto &listCurrOcc = itStore.second.listOccupy;
-    
+
     listCurrRec.clear();
     listCurrOcc.clear();
-    
-    if ( h2Prev == NULL ) continue; // Hmmm, is it an error...?
-    
+
+    if (h2Prev == NULL)
+      continue;  // Hmmm, is it an error...?
+
     Int_t nNbinX = h2Prev->GetNbinsX();
     Int_t nNbinY = h2Prev->GetNbinsY();
-    
+
     Int_t nX, nY;
     Int_t nXMaxOcc = 0;
     Int_t nNNonFullFill = 0;
-    
-    for ( nX = 1 ; nX <= nNbinX ; nX++ ) {
-      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0); // The (nX, 0)-bin keeps the number of filled events
-      if ( 0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_ ) nNNonFullFill++;
-      if ( nNEvtCurrTime > 0 ) nXMaxOcc = nX;
+
+    for (nX = 1; nX <= nNbinX; nX++) {
+      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0);  // The (nX, 0)-bin keeps the number of filled events
+      if (0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_)
+        nNNonFullFill++;
+      if (nNEvtCurrTime > 0)
+        nXMaxOcc = nX;
     }
-    
-    if ( nNNonFullFill > 1 ) { // The last bin may not full
+
+    if (nNNonFullFill > 1) {  // The last bin may not full
       std::cerr << "WARNING: There is a bin of the previous histograms which is not fully filled" << std::endl;
     }
-    
-    for ( nY = 1 ; nY <= nNbinY ; nY++ ) {
+
+    for (nY = 1; nY <= nNbinY; nY++) {
       listCurrRec.emplace_back();
       listCurrOcc.emplace_back();
-      
-      if ( nXMaxOcc > 0 ) {
-        for ( nX = 1 ; nX <= nXMaxOcc ; nX++ ) {
+
+      if (nXMaxOcc > 0) {
+        for (nX = 1; nX <= nXMaxOcc; nX++) {
           //listCurr[ nY - 1 ].push_back(h2Prev->GetBinContent(nX, nY));
-          listCurrRec[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
-          listCurrOcc[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
+          listCurrRec[nY - 1].push_back(0);  // If hadd is used, then it must be blanked
+          listCurrOcc[nY - 1].push_back(0);  // If hadd is used, then it must be blanked
         }
-        
-        if ( nNNonFullFill <= 0 ) {
-          listCurrRec[ nY - 1 ].push_back(0);
-          listCurrOcc[ nY - 1 ].push_back(0);
+
+        if (nNNonFullFill <= 0) {
+          listCurrRec[nY - 1].push_back(0);
+          listCurrOcc[nY - 1].push_back(0);
         }
-      } else { // Empty...?
-        listCurrRec[ nY - 1 ].push_back(0);
-        listCurrOcc[ nY - 1 ].push_back(0);
+      } else {  // Empty...?
+        listCurrRec[nY - 1].push_back(0);
+        listCurrOcc[nY - 1].push_back(0);
       }
     }
-    
-    if ( nXMaxOcc <= 0 ) std::cout << "nXMacOcc has a problem" << std::endl;
-    if ( nXMaxOcc <= 0 ) continue; // Empty...?
-    
+
+    if (nXMaxOcc <= 0)
+      std::cout << "nXMacOcc has a problem" << std::endl;
+    if (nXMaxOcc <= 0)
+      continue;  // Empty...?
+
     // Keeping the number of lastly stacked events
     // And also checking if the sync is okay
-    if ( nStackedEvt_ == 0 ) nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
+    if (nStackedEvt_ == 0)
+      nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
     else {
-      if ( nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0) ) bSync = false;
+      if (nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0))
+        bSync = false;
     }
   }
-  
-  if ( nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_ ) nStackedEvt_ = 0;
-  
-  if ( !bSync ) { // No sync...!
+
+  if (nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_)
+    nStackedEvt_ = 0;
+
+  if (!bSync) {  // No sync...!
     std::cerr << "WARNING: No sync on time histograms" << std::endl;
   }
-  
+
   fPrev->Close();
-  
+
   return 0;
 }
 
-
 void GEMDQMStatusDigi::bookHistogramsChamberPart(DQMStore::IBooker &ibooker, GEMDetId &gid) {
   std::string hName, hTitle;
-  
+
   UInt_t unBinPos;
   //std::cout << "B: " << gid << std::endl;
-  
-  std::string strIdxName  = suffixChamber(gid);
-  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
-    ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
-  
+
+  std::string strIdxName = suffixChamber(gid);
+  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + (gid.region() > 0 ? "+" : "-") +
+                            to_string(gid.station()) + "/" + to_string(gid.layer());
+
   hName = "vfatStatus_QualityFlag_" + strIdxName;
   hTitle = "VFAT quality " + strIdxTitle;
   hTitle += ";VFAT;";
   std::cout << "booking: " << gid << std::endl;
-  listVFATQualityFlag_[ gid ] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
-  
+  listVFATQualityFlag_[gid] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
+
   hName = "vfatStatus_BC_" + strIdxName;
   hTitle = "VFAT bunch crossing " + strIdxTitle;
   hTitle += ";Bunch crossing;VFAT";
-  listVFATBC_[ gid ] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
-  
+  listVFATBC_[gid] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
+
   hName = "vfatStatus_EC_" + strIdxName;
   hTitle = "VFAT event counter " + strIdxTitle;
   hTitle += ";Event counter;VFAT";
-  listVFATEC_[ gid ] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
-  
-  unBinPos = 1;
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Good", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "CRC fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1010 fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1100 fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1110 fail", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Hamming error", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "AFULL", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SEUlogic", 2);
-  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SUEI2C", 2);
-  
-  m_mapStatusFill[ gid ] = false;
-  m_mapStatusErr[ gid ] = false;
-}
+  listVFATEC_[gid] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
 
+  unBinPos = 1;
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "Good", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "CRC fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1010 fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1100 fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "b1110 fail", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "Hamming error", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "AFULL", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "SEUlogic", 2);
+  listVFATQualityFlag_[gid]->setBinLabel(unBinPos++, "SUEI2C", 2);
+
+  m_mapStatusFill[gid] = false;
+  m_mapStatusErr[gid] = false;
+}
 
 void GEMDQMStatusDigi::bookHistogramsStationPart(DQMStore::IBooker &ibooker, GEMDetId &lid) {
   UInt_t unBinPos;
-  
-  Int_t  re = lid.region();
+
+  Int_t re = lid.region();
   UInt_t st = lid.station();
   UInt_t la = lid.layer();
-  
-  auto newbookGEB = [this](DQMStore::IBooker &ibooker, 
-                           std::string strName, std::string strTitle, std::string strAxis, 
-                           GEMDetId &lid, int nLayer, int nStation, int re, 
-                           int nBin, float fMin, float fMax)->MonitorElement *
-  {
-    strName  = strName  + "_" + suffixLayer(lid);
-    strTitle = strTitle + ", station: " + (re>=0 ? "+" : "-") + std::to_string(nStation);
-    
-    if ( bPerSuperchamber_ ) {
+
+  auto newbookGEB = [this](DQMStore::IBooker &ibooker,
+                           std::string strName,
+                           std::string strTitle,
+                           std::string strAxis,
+                           GEMDetId &lid,
+                           int nLayer,
+                           int nStation,
+                           int re,
+                           int nBin,
+                           float fMin,
+                           float fMax) -> MonitorElement * {
+    strName = strName + "_" + suffixLayer(lid);
+    strTitle = strTitle + ", station: " + (re >= 0 ? "+" : "-") + std::to_string(nStation);
+
+    if (bPerSuperchamber_) {
       strTitle += ", layer: " + std::to_string(nLayer);
     }
-    
+
     strTitle += ";Chamber;" + strAxis;
-    
+
     auto hNew = ibooker.book2D(strName, strTitle, this->nNCh_, 0, this->nNCh_, nBin, fMin, fMax);
-    
-    for ( Int_t i = 0 ; i < this->nNCh_ ; i++ ) {
-      auto &gid = this->m_listChambers[ i ];
-      Int_t nCh = gid.chamber() + ( this->bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+
+    for (Int_t i = 0; i < this->nNCh_; i++) {
+      auto &gid = this->m_listChambers[i];
+      Int_t nCh = gid.chamber() + (this->bPerSuperchamber_ ? 0 : gid.layer() - 1);
       hNew->setBinLabel(i + 1, std::to_string(nCh), 1);
     }
-    
+
     return hNew;
   };
-  
-  listGEBInputStatus_[ lid ]  = newbookGEB(ibooker, "geb_input_status", 
-      "inputStatus",       "",                           lid, la, st, re, eBit_, 0, eBit_);
-  listGEBInputID_[ lid ]      = newbookGEB(ibooker, "geb_input_ID", 
-      "inputID",           "Input ID",                   lid, la, st, re, 32, 0, 32);
-  listGEBVFATWordCnt_[ lid ]  = newbookGEB(ibooker, "geb_no_vfats", 
-      "nvfats in header",  "Number of VFATs in header",  lid, la, st, re, 25, 0, 25);
-  listGEBVFATWordCntT_[ lid ] = newbookGEB(ibooker, "geb_no_vfatsT", 
-      "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
-  listGEBZeroSupWordsCnt_[ lid ] = newbookGEB(ibooker, "geb_zeroSupWordsCnt", 
-      "zeroSupWordsCnt",   "Zero sup. words count",      lid, la, st, re, 10, 0, 10);
-  
-  listGEBbcOH_[ lid ]  = newbookGEB(ibooker, "geb_bcOH",  "OH bunch crossing", 
-      "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
-  listGEBecOH_[ lid ]  = newbookGEB(ibooker, "geb_ecOH",  "OH event coounter", 
-      "OH event counter", lid, la, st, re, 256, 0, 256);
-  listGEBOHCRC_[ lid ] = newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", 
-      "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
-  
+
+  listGEBInputStatus_[lid] =
+      newbookGEB(ibooker, "geb_input_status", "inputStatus", "", lid, la, st, re, eBit_, 0, eBit_);
+  listGEBInputID_[lid] = newbookGEB(ibooker, "geb_input_ID", "inputID", "Input ID", lid, la, st, re, 32, 0, 32);
+  listGEBVFATWordCnt_[lid] =
+      newbookGEB(ibooker, "geb_no_vfats", "nvfats in header", "Number of VFATs in header", lid, la, st, re, 25, 0, 25);
+  listGEBVFATWordCntT_[lid] = newbookGEB(
+      ibooker, "geb_no_vfatsT", "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
+  listGEBZeroSupWordsCnt_[lid] = newbookGEB(
+      ibooker, "geb_zeroSupWordsCnt", "zeroSupWordsCnt", "Zero sup. words count", lid, la, st, re, 10, 0, 10);
+
+  listGEBbcOH_[lid] =
+      newbookGEB(ibooker, "geb_bcOH", "OH bunch crossing", "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
+  listGEBecOH_[lid] =
+      newbookGEB(ibooker, "geb_ecOH", "OH event coounter", "OH event counter", lid, la, st, re, 256, 0, 256);
+  listGEBOHCRC_[lid] =
+      newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
+
   unBinPos = 1;
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "No VFAT marker", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size warn", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO near full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size overflow", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Stuck data", 2);
-  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "No VFAT marker", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event size warn", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "InFIFO near full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event size overflow", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "InFIFO full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Stuck data", 2);
+  listGEBInputStatus_[lid]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
 }
 
-
 void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
-  h2AMCStatus_ = ibooker.book2D("amc_statusflag", "Status of AMC slots;AMC slot;", 
-      listAMCSlots_.size(), 0, listAMCSlots_.size(), amcStatusBit_, 0, amcStatusBit_);
-  
+  h2AMCStatus_ = ibooker.book2D("amc_statusflag",
+                                "Status of AMC slots;AMC slot;",
+                                listAMCSlots_.size(),
+                                0,
+                                listAMCSlots_.size(),
+                                amcStatusBit_,
+                                0,
+                                amcStatusBit_);
+
   uint32_t unBinPos = 1;
   h2AMCStatus_->setBinLabel(unBinPos++, "BC0 not locked", 2);
   h2AMCStatus_->setBinLabel(unBinPos++, "DAQ not ready", 2);
@@ -598,110 +606,115 @@ void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
   h2AMCStatus_->setBinLabel(unBinPos++, "GLIB out-of-sync", 2);
 }
 
-
 void GEMDQMStatusDigi::bookHistogramsTimeRecordPart(DQMStore::IBooker &ibooker) {
   //Int_t nNBinX = ( listTimeStore_[ 0 ].listRecord.size() / nNTimeBinTotal_ + 1 ) * nNTimeBinTotal_;
-  
-  for ( auto &itStore : listTimeStore_ ) {
+
+  for (auto &itStore : listTimeStore_) {
     auto &infoCurr = itStore.second;
-    
+
     Float_t fMin = -0.5, fMax = infoCurr.nNbinY - 0.5;
-    
-    if ( infoCurr.nNbinMin < infoCurr.nNbinMax ) {
+
+    if (infoCurr.nNbinMin < infoCurr.nNbinMax) {
       fMin = infoCurr.nNbinMin;
       fMax = infoCurr.nNbinMax;
     }
-    
-    infoCurr.h2Histo = ibooker.book2D(infoCurr.strName, 
-      //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX, 
-      infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX, 
-      nNTimeBinPrimitive_, 0, nNTimeBinPrimitive_, infoCurr.nNbinY, fMin, fMax);
-    
-    if ( seekIdx(m_listLayers, itStore.first) >= 0 ) {
-      for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
-        auto &gid = m_listChambers[ i ];
-        Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+
+    infoCurr.h2Histo = ibooker.book2D(
+        infoCurr.strName,
+        //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX,
+        infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX,
+        nNTimeBinPrimitive_,
+        0,
+        nNTimeBinPrimitive_,
+        infoCurr.nNbinY,
+        fMin,
+        fMax);
+
+    if (seekIdx(m_listLayers, itStore.first) >= 0) {
+      for (Int_t i = 0; i < nNCh_; i++) {
+        auto &gid = m_listChambers[i];
+        Int_t nCh = gid.chamber() + (bPerSuperchamber_ ? 0 : gid.layer() - 1);
         infoCurr.h2Histo->setBinLabel(i + 1, std::to_string(nCh), 2);
       }
     }
   }
 }
 
-
 // To make labels like python, with std::(unordered_)map
 std::string printfWithMap(std::string strFmt, std::unordered_map<std::string, Int_t> mapArg) {
   std::string strRes = strFmt;
-  char szOutFmt[ 64 ];
+  char szOutFmt[64];
   size_t unPos, unPosEnd;
-  
-  for ( unPos = strRes.find('%') ; unPos != std::string::npos ; unPos = strRes.find('%', unPos + 1) ) {
+
+  for (unPos = strRes.find('%'); unPos != std::string::npos; unPos = strRes.find('%', unPos + 1)) {
     unPosEnd = strRes.find(')', unPos);
-    if ( strRes[ unPos + 1 ] != '(' || unPosEnd == std::string::npos ) break; // Syntax error
-    
+    if (strRes[unPos + 1] != '(' || unPosEnd == std::string::npos)
+      break;  // Syntax error
+
     // Extracting the key
-    std::string strKey = strRes.substr(unPos + 2, unPosEnd - ( unPos + 2 ));
-    
+    std::string strKey = strRes.substr(unPos + 2, unPosEnd - (unPos + 2));
+
     // To treat formats like '%5i' or '%02i', extracting '5' or '02'
-    // After do this, 
+    // After do this,
     std::string strOptNum = "%";
     unPosEnd++;
-    
-    for ( ;; unPosEnd++ ) {
-      if ( !( '0' <= strRes[ unPosEnd ] && strRes[ unPosEnd ] <= '9' ) && 
-           strRes[ unPosEnd ] != '+' ) break;
-      strOptNum += strRes[ unPosEnd ];
+
+    for (;; unPosEnd++) {
+      if (!('0' <= strRes[unPosEnd] && strRes[unPosEnd] <= '9') && strRes[unPosEnd] != '+')
+        break;
+      strOptNum += strRes[unPosEnd];
     }
-    
-    if ( strRes[ unPosEnd ] != 'i' && strRes[ unPosEnd ] != 'd' ) break; // Syntax error
-    strOptNum += strRes[ unPosEnd ];
+
+    if (strRes[unPosEnd] != 'i' && strRes[unPosEnd] != 'd')
+      break;  // Syntax error
+    strOptNum += strRes[unPosEnd];
     unPosEnd++;
-    
-    sprintf(szOutFmt, strOptNum.c_str(), mapArg[ strKey ]);
+
+    sprintf(szOutFmt, strOptNum.c_str(), mapArg[strKey]);
     strRes = strRes.substr(0, unPos) + szOutFmt + strRes.substr(unPosEnd);
   }
-  
-  if ( unPos != std::string::npos ) { // It means... an syntax error occurs!
+
+  if (unPos != std::string::npos) {  // It means... an syntax error occurs!
     std::cerr << "ERROR: Syntax error on printfWithMap(); " << std::endl;
     return "";
   }
-  
+
   return strRes;
 }
 
-
-void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
-{
+void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &iSetup) {
   // Start: Loading the GEM geometry
-  
+
   GEMGeometry_ = initGeometry(iSetup);
-  if ( GEMGeometry_ == nullptr) return;
-  
+  if (GEMGeometry_ == nullptr)
+    return;
+
   SetInfoChambers();
-  
+
   // Setting the informations for time histograms
   SetConfigTimeRecord();
   LoadPrevData();
-  
+
   // The loading does not work well or something goes wrong...
   // In this case, we need to make a new start of recording.
-  for ( auto &itStore : listTimeStore_ ) {
+  for (auto &itStore : listTimeStore_) {
     auto &infoCurr = itStore.second;
-    
-    if ( infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size() ) { 
-      if ( infoCurr.listRecord.size() > 0 ) {
+
+    if (infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size()) {
+      if (infoCurr.listRecord.size() > 0) {
         std::cerr << "WARNING: The previous result is not compatible to the current geometry. "
-          << "We will discard the previous data." << std::endl;
-        
+                  << "We will discard the previous data." << std::endl;
+
         infoCurr.listRecord.clear();
         infoCurr.listOccupy.clear();
       }
-      
-      for ( Int_t i = 0 ; i < infoCurr.nNbinY ; i++ ) {
+
+      for (Int_t i = 0; i < infoCurr.nNbinY; i++) {
         infoCurr.listRecord.emplace_back();
-        infoCurr.listRecord[ i ].push_back(0);
-        
+        infoCurr.listRecord[i].push_back(0);
+
         infoCurr.listOccupy.emplace_back();
-        infoCurr.listOccupy[ i ].push_back(0);
+        infoCurr.listOccupy[i].push_back(0);
       }
     }
     /*for ( Int_t i = 0 ; i < (Int_t)infoCurr.listRecord[ 0 ].size() ; i++ ) 
@@ -710,365 +723,375 @@ void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const
     
     std::cout << "Init time: " << itStore.first << ", " << infoCurr.strName << ", " << infoCurr.nNbinY << ", " << infoCurr.listRecord.size() << "; " << listTimeStore_[ itStore.first ].listRecord.size() << std::endl;*/
   }
-  
+
   // End: Set the configurations
-  
+
   // Start: Setting books
-  
+
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/StatusDigi");
-  
-  for ( auto ch : gemChambers_ ) {
+
+  for (auto ch : gemChambers_) {
     GEMDetId gid = ch.id();
     bookHistogramsChamberPart(ibooker, gid);
   }
-  
-  for ( auto lid : m_listLayers ) {
+
+  for (auto lid : m_listLayers) {
     bookHistogramsStationPart(ibooker, lid);
   }
-  
+
   bookHistogramsAMCPart(ibooker);
   bookHistogramsTimeRecordPart(ibooker);
-  
+
   h1_vfat_qualityflag_ = ibooker.book1D("vfat_quality_flag", "quality and flag", 9, 0, 9);
   h2_vfat_qualityflag_ = ibooker.book2D("vfat_quality_flag_per_geb", "quality and flag", nNCh_, 0, nNCh_, 9, 0, 9);
-  
-  h1_amc_ttsState_  = ibooker.book1D("amc_ttsState",  "ttsState",  10, 0, 10);
-  h1_amc_davCnt_    = ibooker.book1D("amc_davCnt",    "davCnt",    10, 0, 10);
+
+  h1_amc_ttsState_ = ibooker.book1D("amc_ttsState", "ttsState", 10, 0, 10);
+  h1_amc_davCnt_ = ibooker.book1D("amc_davCnt", "davCnt", 10, 0, 10);
   h1_amc_buffState_ = ibooker.book1D("amc_buffState", "buffState", 10, 0, 10);
-  h1_amc_oosGlib_   = ibooker.book1D("amc_oosGlib",   "oosGlib",   10, 0, 10);
+  h1_amc_oosGlib_ = ibooker.book1D("amc_oosGlib", "oosGlib", 10, 0, 10);
   h1_amc_chTimeOut_ = ibooker.book1D("amc_chTimeOut", "chTimeOut", 10, 0, 10);
-  
+
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/EventInfo");
-  
+
   // TODO: We need a study for setting the rule for this
   m_summaryReport_ = ibooker.bookFloat("reportSummary");
   m_summaryReport_->Fill(1.0);
-  
-  h2SummaryStatus_ = ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, 
-      m_listLayers.size(), 0, m_listLayers.size());
-  
-  for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
-    auto &gid = this->m_listChambers[ i ];
-    Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+
+  h2SummaryStatus_ =
+      ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, m_listLayers.size(), 0, m_listLayers.size());
+
+  for (Int_t i = 0; i < nNCh_; i++) {
+    auto &gid = this->m_listChambers[i];
+    Int_t nCh = gid.chamber() + (bPerSuperchamber_ ? 0 : gid.layer() - 1);
     h2SummaryStatus_->setBinLabel(i + 1, std::to_string(nCh), 1);
   }
-  
+
   Int_t nIdxLayer = 0;
   std::unordered_map<std::string, Int_t> mapArg;
-  
+
   // Start: Labeling section
-    
-  for ( auto lid : m_listLayers ) {
-    mapArg[ "station_signed" ] = lid.region() * lid.station();
-    mapArg[ "region"  ] = lid.region();
-    mapArg[ "station" ] = lid.station();
-    mapArg[ "layer"   ] = lid.layer();
-    mapArg[ "chamber" ] = lid.chamber();
-    
+
+  for (auto lid : m_listLayers) {
+    mapArg["station_signed"] = lid.region() * lid.station();
+    mapArg["region"] = lid.region();
+    mapArg["station"] = lid.station();
+    mapArg["layer"] = lid.layer();
+    mapArg["chamber"] = lid.chamber();
+
     h2SummaryStatus_->setBinLabel(nIdxLayer + 1, printfWithMap(strFmtSummaryLabel_, mapArg), 2);
     nIdxLayer++;
   }
 }
 
-
 void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits) {
   int i = 0;
   uint64_t unFlag = 1;
-  
-  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
-    if ( ( unVal & unFlag ) != 0 ) {
+
+  for (; i < nNumBits; i++, unFlag <<= 1) {
+    if ((unVal & unFlag) != 0) {
       monitor->Fill(i);
     }
   }
 }
 
-
 void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nX) {
   int i = 0;
   uint64_t unFlag = 1;
-  
-  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
-    if ( ( unVal & unFlag ) != 0 ) {
+
+  for (; i < nNumBits; i++, unFlag <<= 1) {
+    if ((unVal & unFlag) != 0) {
       monitor->Fill(nX, i);
     }
   }
 }
 
-
 Int_t GEMDQMStatusDigi::seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId) {
-  if ( unId < 256 ) return -1;
-  
+  if (unId < 256)
+    return -1;
+
   GEMDetId id(unId);
-  for ( Int_t nIdx = 0 ; nIdx < (Int_t)listLayers.size() ; nIdx++ ) if ( id == listLayers[ nIdx ] ) return nIdx;
+  for (Int_t nIdx = 0; nIdx < (Int_t)listLayers.size(); nIdx++)
+    if (id == listLayers[nIdx])
+      return nIdx;
   return -1;
 }
-  
 
-void GEMDQMStatusDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
-{
+void GEMDQMStatusDigi::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
   edm::Handle<GEMVfatStatusDigiCollection> gemVFAT;
   edm::Handle<GEMGEBdataCollection> gemGEB;
   edm::Handle<GEMAMCdataCollection> gemAMC;
   edm::Handle<GEMDigiCollection> gemDigis;
-  
-  event.getByToken( tagVFAT_, gemVFAT);
-  event.getByToken( tagGEB_, gemGEB);
-  event.getByToken( tagAMC_, gemAMC);
-  event.getByToken( tagDigi_, gemDigis);
-  
-  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill)->void {
+
+  event.getByToken(tagVFAT_, gemVFAT);
+  event.getByToken(tagGEB_, gemGEB);
+  event.getByToken(tagAMC_, gemAMC);
+  event.getByToken(tagDigi_, gemDigis);
+
+  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill) -> void {
     return;
-    auto &listRecord = listCurr.listRecord[ nIdx ];
-    auto &listOccupy = listCurr.listOccupy[ nIdx ];
+    auto &listRecord = listCurr.listRecord[nIdx];
+    auto &listOccupy = listCurr.listOccupy[nIdx];
     int nIdxTime = listRecord.size() - 1;
-    
-    listOccupy[ nIdxTime ] = 1;
-    if ( bFill ) listRecord[ nIdxTime ]++;
+
+    listOccupy[nIdxTime] = 1;
+    if (bFill)
+      listRecord[nIdxTime]++;
   };
 
-  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt){
+  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt) {
     GEMDetId gemid = (*vfatIt).first;
     GEMDetId gemchId = gemid.chamberId();
     //std::cout << "A: " << gemchId << std::endl;
-    GEMDetId gemOnlychId(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
-    
+    GEMDetId gemOnlychId(0, 1, 1, (bPerSuperchamber_ ? 0 : gemid.layer()), gemid.chamber(), 0);
+
     int nIdx = seekIdx(m_listChambers, gemOnlychId);
     int nRoll = gemid.roll();
-    const GEMVfatStatusDigiCollection::Range& range = (*vfatIt).second;
-    
+    const GEMVfatStatusDigiCollection::Range &range = (*vfatIt).second;
+
     GEMDetId chIdStatus(gemid.region(), gemid.ring(), gemid.station(), gemid.layer(), gemid.chamber(), 1);
-    auto &listCurr = listTimeStore_[ chIdStatus ];
-    
-    for ( auto vfatStat = range.first; vfatStat != range.second; ++vfatStat ) {
-      uint64_t unQFVFAT = vfatStat->quality() | ( vfatStat->flag() << qVFATBit_ );
-      if ( ( unQFVFAT & ~0x1 ) == 0 )  {
-        unQFVFAT |= 0x1; // If no error, then it should be 'Good'
-      } else { // Error!!
-        m_mapStatusErr[ gemchId ] = true;
+    auto &listCurr = listTimeStore_[chIdStatus];
+
+    for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
+      uint64_t unQFVFAT = vfatStat->quality() | (vfatStat->flag() << qVFATBit_);
+      if ((unQFVFAT & ~0x1) == 0) {
+        unQFVFAT |= 0x1;  // If no error, then it should be 'Good'
+      } else {            // Error!!
+        m_mapStatusErr[gemchId] = true;
       }
-      
+
       FillBits(h1_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_);
       FillBits(h2_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_, nIdx);
-      
-      int nVFAT = ( 8 - nRoll ) + 8 * vfatStat->phi(); // vfatStat.phi()? or 2 - vfatStat.phi()?
-      
-      FillBits(listVFATQualityFlag_[ gemchId ], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
+
+      int nVFAT = (8 - nRoll) + 8 * vfatStat->phi();  // vfatStat.phi()? or 2 - vfatStat.phi()?
+
+      FillBits(listVFATQualityFlag_[gemchId], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
       //listVFATBC_[ gemchId ]->Fill(vfatStat->bc(), nVFAT);
-      listVFATEC_[ gemchId ]->Fill(vfatStat->ec(), nVFAT);
-      
-      fillTimeHisto(listCurr, nVFAT, ( unQFVFAT & ~0x1 ) != 0);
+      listVFATEC_[gemchId]->Fill(vfatStat->ec(), nVFAT);
+
+      fillTimeHisto(listCurr, nVFAT, (unQFVFAT & ~0x1) != 0);
     }
   }
-  
-  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt){
+
+  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt) {
     GEMDetId gemid = (*gebIt).first;
-    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), ( bPerSuperchamber_ ? gemid.layer() : 0 ), 0, 0);
-    GEMDetId chid(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
-    
+    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), (bPerSuperchamber_ ? gemid.layer() : 0), 0, 0);
+    GEMDetId chid(0, 1, 1, (bPerSuperchamber_ ? 0 : gemid.layer()), gemid.chamber(), 0);
+
     Int_t nCh = seekIdx(m_listChambers, chid);
-    auto &listCurr = listTimeStore_[ lid ];
-    
-    const GEMGEBdataCollection::Range& range = (*gebIt).second;    
-    for ( auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus ) {
+    auto &listCurr = listTimeStore_[lid];
+
+    const GEMGEBdataCollection::Range &range = (*gebIt).second;
+    for (auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus) {
       uint64_t unBit = 0;
       uint64_t unStatus = 0;
-      
-      unStatus |= ( GEBStatus->bxmVvV()    << unBit++ ); 
-      unStatus |= ( GEBStatus->bxmAvV()    << unBit++ ); 
-      unStatus |= ( GEBStatus->oOScVvV()   << unBit++ ); 
-      unStatus |= ( GEBStatus->oOScAvV()   << unBit++ ); 
-      unStatus |= ( GEBStatus->noVFAT()    << unBit++ ); 
-      unStatus |= ( GEBStatus->evtSzW()    << unBit++ ); 
-      unStatus |= ( GEBStatus->l1aNF()     << unBit++ ); 
-      unStatus |= ( GEBStatus->inNF()      << unBit++ ); 
-      unStatus |= ( GEBStatus->evtNF()     << unBit++ ); 
-      unStatus |= ( GEBStatus->evtSzOFW()  << unBit++ ); 
-      unStatus |= ( GEBStatus->l1aF()      << unBit++ ); 
-      unStatus |= ( GEBStatus->inF()       << unBit++ ); 
-      unStatus |= ( GEBStatus->evtF()      << unBit++ ); 
-      unStatus |= ( GEBStatus->inUfw()     << unBit++ ); 
-      unStatus |= ( GEBStatus->stuckData() << unBit++ ); 
-      unStatus |= ( GEBStatus->evUfw()     << unBit++ );
-      
+
+      unStatus |= (GEBStatus->bxmVvV() << unBit++);
+      unStatus |= (GEBStatus->bxmAvV() << unBit++);
+      unStatus |= (GEBStatus->oOScVvV() << unBit++);
+      unStatus |= (GEBStatus->oOScAvV() << unBit++);
+      unStatus |= (GEBStatus->noVFAT() << unBit++);
+      unStatus |= (GEBStatus->evtSzW() << unBit++);
+      unStatus |= (GEBStatus->l1aNF() << unBit++);
+      unStatus |= (GEBStatus->inNF() << unBit++);
+      unStatus |= (GEBStatus->evtNF() << unBit++);
+      unStatus |= (GEBStatus->evtSzOFW() << unBit++);
+      unStatus |= (GEBStatus->l1aF() << unBit++);
+      unStatus |= (GEBStatus->inF() << unBit++);
+      unStatus |= (GEBStatus->evtF() << unBit++);
+      unStatus |= (GEBStatus->inUfw() << unBit++);
+      unStatus |= (GEBStatus->stuckData() << unBit++);
+      unStatus |= (GEBStatus->evUfw() << unBit++);
+
       //std::cout << gemid;
       //printf("%06X\n", (unsigned int)unStatus);
-      if ( unStatus != 0 ) { // Error!
-        m_mapStatusErr[ gemid ] = true;
+      if (unStatus != 0) {  // Error!
+        m_mapStatusErr[gemid] = true;
       }
-      
-      FillBits(listGEBInputStatus_[ lid ], unStatus, eBit_, nCh);
-      
-      listGEBInputID_[ lid ]->Fill(nCh, GEBStatus->inputID());
-      listGEBVFATWordCnt_[ lid ]->Fill(nCh, GEBStatus->vfatWordCnt()/3);
-      listGEBVFATWordCntT_[ lid ]->Fill(nCh, GEBStatus->vfatWordCntT()/3);
-      listGEBZeroSupWordsCnt_[ lid ]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
-      
-      listGEBbcOH_[ lid ]->Fill(nCh, GEBStatus->bcOH());
-      listGEBecOH_[ lid ]->Fill(nCh, GEBStatus->ecOH());
-      listGEBOHCRC_[ lid ]->Fill(nCh, GEBStatus->crc());
-      
+
+      FillBits(listGEBInputStatus_[lid], unStatus, eBit_, nCh);
+
+      listGEBInputID_[lid]->Fill(nCh, GEBStatus->inputID());
+      listGEBVFATWordCnt_[lid]->Fill(nCh, GEBStatus->vfatWordCnt() / 3);
+      listGEBVFATWordCntT_[lid]->Fill(nCh, GEBStatus->vfatWordCntT() / 3);
+      listGEBZeroSupWordsCnt_[lid]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
+
+      listGEBbcOH_[lid]->Fill(nCh, GEBStatus->bcOH());
+      listGEBecOH_[lid]->Fill(nCh, GEBStatus->ecOH());
+      listGEBOHCRC_[lid]->Fill(nCh, GEBStatus->crc());
+
       fillTimeHisto(listCurr, nCh, unStatus != 0);
     }
   }
-  
-  auto findAMCIdx = [this](Int_t nAMCnum)->Int_t {
-    for ( Int_t i = 0 ; i < (Int_t)listAMCSlots_.size() ; i++ ) if ( listAMCSlots_[ i ] == nAMCnum ) return i;
+
+  auto findAMCIdx = [this](Int_t nAMCnum) -> Int_t {
+    for (Int_t i = 0; i < (Int_t)listAMCSlots_.size(); i++)
+      if (listAMCSlots_[i] == nAMCnum)
+        return i;
     return -1;
   };
-  
-  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt){
-    const GEMAMCdataCollection::Range& range = (*amcIt).second;
-    auto &listCurr = listTimeStore_[ 0 ];
-    for ( auto amc = range.first; amc != range.second; ++amc ) {
+
+  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
+    const GEMAMCdataCollection::Range &range = (*amcIt).second;
+    auto &listCurr = listTimeStore_[0];
+    for (auto amc = range.first; amc != range.second; ++amc) {
       Int_t nIdAMC = findAMCIdx(amc->amcNum());
       uint64_t unBit = 0;
       uint64_t unStatus = 0;
-      
-      unStatus |= ( ( amc->bc0locked()      == 0 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->daqReady()       != 1 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->daqClockLocked() == 0 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->mmcmLocked()     != 1 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->backPressure()   == 1 ? 1 : 0 ) << unBit++ ); 
-      unStatus |= ( ( amc->oosGlib()        != 0 ? 1 : 0 ) << unBit++ );
-      
+
+      unStatus |= ((amc->bc0locked() == 0 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->daqReady() != 1 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->daqClockLocked() == 0 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->mmcmLocked() != 1 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->backPressure() == 1 ? 1 : 0) << unBit++);
+      unStatus |= ((amc->oosGlib() != 0 ? 1 : 0) << unBit++);
+
       FillBits(h2AMCStatus_, unStatus, amcStatusBit_, nIdAMC);
-      
+
       h1_amc_ttsState_->Fill(amc->ttsState());
       h1_amc_davCnt_->Fill(amc->davCnt());
       h1_amc_buffState_->Fill(amc->buffState());
       h1_amc_oosGlib_->Fill(amc->oosGlib());
       h1_amc_chTimeOut_->Fill(amc->linkTo());
-      
+
       fillTimeHisto(listCurr, nIdAMC, unStatus != 0);
     }
   }
-  
+
   /*auto findVFAT = [this](float min_, int nNumStripPerVFAT, float x_, int roll_)->int {
     float step = max_/3;
     if ( x_ < (min_+step) ) { return 8 - roll_;}
     else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
     else { return this->nVfat_ - roll_;}
   };*/
-  
+
   // Checking if there is a fire (data)
-  for ( auto ch : gemChambers_ ) {
+  for (auto ch : gemChambers_) {
     GEMDetId cId = ch.id();
     Bool_t bIsHit = false;
-    
+
     // Because every fired strip in a same VFAT shares a same bx, we keep bx from only one strip
     std::unordered_map<Int_t, Int_t> mapBXVFAT;
-    
+
     GEMDetId chIdDigi(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 2);
     GEMDetId chIdBx(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 3);
-    
-    auto &listCurrDigi = listTimeStore_[ chIdDigi ];
-    auto &listCurrBx   = listTimeStore_[ chIdBx ];
-    
-    for ( auto roll : ch.etaPartitions() ) {
-      GEMDetId rId = roll->id();      
+
+    auto &listCurrDigi = listTimeStore_[chIdDigi];
+    auto &listCurrBx = listTimeStore_[chIdBx];
+
+    for (auto roll : ch.etaPartitions()) {
+      GEMDetId rId = roll->id();
       const auto &digis_in_det = gemDigis->get(rId);
-      
-      for ( auto d = digis_in_det.first ; d != digis_in_det.second ; ++d ){
+
+      for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         //Int_t nVFAT = findVFAT(0, roll->nstrips(), d->strip(), rId.roll()); // Starts at 0
         Int_t nIdxStrip = d->strip() - nIdxFirstStrip_;
-        Int_t nVFAT = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
-        
+        Int_t nVFAT = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
+
         bIsHit = true;
-        mapBXVFAT[ nVFAT ] = d->bx();
+        mapBXVFAT[nVFAT] = d->bx();
         fillTimeHisto(listCurrDigi, nVFAT, true);
-        
+
         Int_t nIdxBx;
-        
-        if      ( d->bx() <  listCurrBx.nNbinMin ) nIdxBx = 0;
-        else if ( d->bx() >= listCurrBx.nNbinMax ) nIdxBx = listCurrBx.nNbinY - 1;
-        else nIdxBx = (Int_t)( listCurrBx.nNbinY * 1.0 * 
-            ( d->bx() - listCurrBx.nNbinMin ) / ( listCurrBx.nNbinMax - listCurrBx.nNbinMin ) );
-        
+
+        if (d->bx() < listCurrBx.nNbinMin)
+          nIdxBx = 0;
+        else if (d->bx() >= listCurrBx.nNbinMax)
+          nIdxBx = listCurrBx.nNbinY - 1;
+        else
+          nIdxBx = (Int_t)(listCurrBx.nNbinY * 1.0 * (d->bx() - listCurrBx.nNbinMin) /
+                           (listCurrBx.nNbinMax - listCurrBx.nNbinMin));
+
         fillTimeHisto(listCurrBx, nIdxBx, true);
       }
-      
-      if ( bIsHit ) break;
+
+      if (bIsHit)
+        break;
     }
-    
-    for ( auto bx : mapBXVFAT ) listVFATBC_[ cId ]->Fill(bx.second, bx.first);
-    
-    if ( bIsHit ) { // Data occur!
-      m_mapStatusFill[ cId ] = true;
+
+    for (auto bx : mapBXVFAT)
+      listVFATBC_[cId]->Fill(bx.second, bx.first);
+
+    if (bIsHit) {  // Data occur!
+      m_mapStatusFill[cId] = true;
     }
   }
-  
+
   // Counting the time tables
   nStackedEvt_++;
-  if ( nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_ ) { // Time to jump!
-    for ( auto &itStore : listTimeStore_ ) 
-    for ( Int_t i = 0 ; i < itStore.second.nNbinY ; i++ ) {
-      itStore.second.listOccupy[ i ].push_back(0);
-      itStore.second.listRecord[ i ].push_back(0);
-    }
-    
+  if (nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_) {  // Time to jump!
+    for (auto &itStore : listTimeStore_)
+      for (Int_t i = 0; i < itStore.second.nNbinY; i++) {
+        itStore.second.listOccupy[i].push_back(0);
+        itStore.second.listRecord[i].push_back(0);
+      }
+
     nStackedEvt_ = 0;
   }
 }
 
-
-void GEMDQMStatusDigi::dqmEndRun(edm::Run const& run, edm::EventSetup const& eSetup) {
+void GEMDQMStatusDigi::dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup) {
   //std::cout << "End run" << std::endl;
-  
-  for ( auto chamber : gemChambers_ ) {
+
+  for (auto chamber : gemChambers_) {
     auto gid = chamber.id();
-    
-    UInt_t unVal = 0; // No data, no error
-    if      ( m_mapStatusErr[ gid ]  ) unVal = 2; // Error! (no matter there are data or not)
-    else if ( m_mapStatusFill[ gid ] ) unVal = 1; // Data occur, with no error
+
+    UInt_t unVal = 0;  // No data, no error
+    if (m_mapStatusErr[gid])
+      unVal = 2;  // Error! (no matter there are data or not)
+    else if (m_mapStatusFill[gid])
+      unVal = 1;  // Data occur, with no error
     //std::cout << gid << ": " << unVal << std::endl;
-    
-    Int_t nLayer = ( bPerSuperchamber_ ? gid.layer() : 0 );
+
+    Int_t nLayer = (bPerSuperchamber_ ? gid.layer() : 0);
     GEMDetId layerId(gid.region(), gid.ring(), gid.station(), nLayer, 0, 0);
     GEMDetId chamberId(0, 1, 1, gid.layer() - nLayer, gid.chamber(), 0);
-    
-    Int_t nIdxLayer   = seekIdx(m_listLayers,   layerId);
+
+    Int_t nIdxLayer = seekIdx(m_listLayers, layerId);
     Int_t nIdxChamber = seekIdx(m_listChambers, chamberId);
-    
-    if ( h2SummaryStatus_ ) h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
-    
+
+    if (h2SummaryStatus_)
+      h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
+
     // The below is for under/overflow of BX histograms
-    Int_t nNbinX = listVFATBC_[ gid ]->getNbinsX();
-    Int_t nNbinY = listVFATBC_[ gid ]->getNbinsY();
-    
-    for ( Int_t i = 0 ; i < nNbinY ; i++ ) {
-      listVFATBC_[ gid ]->setBinContent(1, i, 
-          listVFATBC_[ gid ]->getBinContent(0, i) + listVFATBC_[ gid ]->getBinContent(1, i));
-      listVFATBC_[ gid ]->setBinContent(nNbinX, i, 
-          listVFATBC_[ gid ]->getBinContent(nNbinX, i) + listVFATBC_[ gid ]->getBinContent(nNbinX + 1 , i));
+    Int_t nNbinX = listVFATBC_[gid]->getNbinsX();
+    Int_t nNbinY = listVFATBC_[gid]->getNbinsY();
+
+    for (Int_t i = 0; i < nNbinY; i++) {
+      listVFATBC_[gid]->setBinContent(
+          1, i, listVFATBC_[gid]->getBinContent(0, i) + listVFATBC_[gid]->getBinContent(1, i));
+      listVFATBC_[gid]->setBinContent(
+          nNbinX, i, listVFATBC_[gid]->getBinContent(nNbinX, i) + listVFATBC_[gid]->getBinContent(nNbinX + 1, i));
     }
   }
-   
-  for ( auto &itStore : listTimeStore_ ) {
+
+  for (auto &itStore : listTimeStore_) {
     auto &listCurrOcc = itStore.second.listOccupy;
     auto &listCurrRec = itStore.second.listRecord;
     MonitorElement *h2Curr = itStore.second.h2Histo;
-    
+
     h2Curr->setBinContent(0, 0, nNSecPerBin_ * nNEvtPerSec_);
     h2Curr->setBinContent(0, 1, 1);
-    
-    Int_t nSize = listCurrRec[ 0 ].size();
+
+    Int_t nSize = listCurrRec[0].size();
     //Int_t nXOffset = std::max(nSize - nNTimeBinTotal_, 0);
     Int_t nXOffset = 0;
     Int_t nNbinY = listCurrRec.size();
-    
-    for ( Int_t nX = nXOffset ; nX < nSize ; nX++ ) {
-      Int_t nNEvt = ( nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_ );
+
+    for (Int_t nX = nXOffset; nX < nSize; nX++) {
+      Int_t nNEvt = (nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_);
       h2Curr->setBinContent(nX - nXOffset + 1, 0, nNEvt);
-      
-      for ( Int_t nY = 1 ; nY <= nNbinY ; nY++ ) {
-        Double_t dVal = listCurrRec[ nY - 1 ][ nX ];
-        Double_t dErr = listCurrOcc[ nY - 1 ][ nX ];
-        
-        if ( dErr > 0 && dVal <= 0 ) dVal = -1;
-        
-        if ( dVal != 0 ) h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
+
+      for (Int_t nY = 1; nY <= nNbinY; nY++) {
+        Double_t dVal = listCurrRec[nY - 1][nX];
+        Double_t dErr = listCurrOcc[nY - 1][nX];
+
+        if (dErr > 0 && dVal <= 0)
+          dVal = -1;
+
+        if (dVal != 0)
+          h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
         //if ( dErr > 0 ) h2Curr->setBinError(nX - nXOffset + 1, nY, 1);
       }
     }

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -6,133 +6,1068 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "EventFilter/GEMRawToDigi/interface/GEMVfatStatusDigiCollection.h"
 #include "EventFilter/GEMRawToDigi/interface/GEMGEBdataCollection.h"
 #include "EventFilter/GEMRawToDigi/interface/GEMAMCdataCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 
 #include <string>
+#include <fstream>
+
+#include <TFile.h>
+#include <TDirectoryFile.h>
 
 //----------------------------------------------------------------------------------------------------
 
-class GEMDQMStatusDigi : public DQMEDAnalyzer {
+
+typedef struct tagTimeStoreItem {
+  std::string strName;
+  std::string strTitle;
+  std::string strAxisX;
+  
+  MonitorElement *h2Histo;
+  
+  Int_t nNbinY;
+  Int_t nNbinMin;
+  Int_t nNbinMax;
+  
+  std::vector<std::vector<Double_t>> listOccupy;
+  std::vector<std::vector<Double_t>> listRecord;
+} TimeStoreItem;
+
+ 
+class GEMDQMStatusDigi: public DQMEDAnalyzer
+{
 public:
-  GEMDQMStatusDigi(const edm::ParameterSet &cfg);
-  ~GEMDQMStatusDigi() override{};
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  GEMDQMStatusDigi(const edm::ParameterSet& cfg);
+  ~GEMDQMStatusDigi() override {};
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
 
 protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+  void bookHistogramsChamberPart(DQMStore::IBooker &, GEMDetId &);
+  void bookHistogramsStationPart(DQMStore::IBooker &, GEMDetId &);
+  void bookHistogramsAMCPart(DQMStore::IBooker &);
+  void bookHistogramsTimeRecordPart(DQMStore::IBooker &);
+  
+  int SetInfoChambers();
+  int SetConfigTimeRecord();
+  int LoadPrevData();
+  
+  Int_t seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId);
+  
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
 
 private:
+  const GEMGeometry* initGeometry(edm::EventSetup const & iSetup);
+  
+  void AddLabel();
+  
+  std::string suffixChamber(GEMDetId &id);
+  std::string suffixLayer(GEMDetId &id);
+  
+  void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits);
+  void FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nY);
+  
+  const GEMGeometry* GEMGeometry_; 
+  std::vector<GEMChamber> gemChambers_;
+  
   int nVfat_ = 24;
+  
+  int nNCh_;
+  
   int cBit_ = 9;
-  int eBit_ = 13;
+  int qVFATBit_ = 5;
+  int fVFATBit_ = 4;
+  int eBit_ = 16;
+  int amcStatusBit_ = 6;
+  
+  int nNEvtPerSec_;
+  int nNSecPerBin_;
+  int nNTimeBinTotal_;
+  int nNTimeBinPrimitive_;
+  
+  int nIdxFirstStrip_;
+  
+  int nNBxBin_;
+  int nNBxRange_;
+  
+  std::string strFmtSummaryLabel_;
+  bool bFlipSummary_;
+  bool bPerSuperchamber_;
+  
+  std::string strPathPrevDQMRoot_;
+  
   edm::EDGetToken tagVFAT_;
   edm::EDGetToken tagGEB_;
   edm::EDGetToken tagAMC_;
+  edm::EDGetToken tagDigi_;
+  
+  std::vector<Int_t> listAMCSlots_;
+  
+  std::vector<GEMDetId> m_listLayers;
+  std::vector<GEMDetId> m_listChambers;
 
-  MonitorElement *h1_vfat_quality_;
-  MonitorElement *h1_vfat_flag_;
-  MonitorElement *h2_vfat_quality_;
-  MonitorElement *h2_vfat_flag_;
+  MonitorElement *h1_vfat_qualityflag_;
+  MonitorElement *h2_vfat_qualityflag_;
+  
+  std::unordered_map<UInt_t, MonitorElement*> listVFATQualityFlag_;
+  std::unordered_map<UInt_t, MonitorElement*> listVFATBC_;
+  std::unordered_map<UInt_t, MonitorElement*> listVFATEC_;
 
-  MonitorElement *h1_geb_inputStatus_;
-  MonitorElement *h1_geb_vfatWordCnt_;
-  MonitorElement *h1_geb_zeroSupWordsCnt_;
-  MonitorElement *h1_geb_stuckData_;
-  MonitorElement *h1_geb_inFIFOund_;
-
+  std::unordered_map<UInt_t, MonitorElement*> listGEBInputStatus_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBInputID_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCnt_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBVFATWordCntT_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBZeroSupWordsCnt_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBbcOH_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBecOH_;
+  std::unordered_map<UInt_t, MonitorElement*> listGEBOHCRC_;
+  
+  std::unordered_map<UInt_t, Bool_t> m_mapStatusFill;
+  std::unordered_map<UInt_t, Bool_t> m_mapStatusErr;
+  
   MonitorElement *h1_amc_ttsState_;
   MonitorElement *h1_amc_davCnt_;
   MonitorElement *h1_amc_buffState_;
   MonitorElement *h1_amc_oosGlib_;
   MonitorElement *h1_amc_chTimeOut_;
+  MonitorElement *h2AMCStatus_;
+  
+  MonitorElement *m_summaryReport_;
+  MonitorElement *h2SummaryStatus_;
+  
+  // For more information, see SetConfigTimeRecord()
+  std::unordered_map<UInt_t, TimeStoreItem> listTimeStore_;
+  Int_t nStackedEvt_;
+
 };
+
+const GEMGeometry* GEMDQMStatusDigi::initGeometry(edm::EventSetup const & iSetup) {
+  const GEMGeometry* GEMGeometry_ = nullptr;
+  try {
+    edm::ESHandle<GEMGeometry> hGeom;
+    iSetup.get<MuonGeometryRecord>().get(hGeom);
+    GEMGeometry_ = &*hGeom;
+  }
+  catch( edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+    edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
+    return nullptr;
+  }
+  return GEMGeometry_;
+}
 
 using namespace std;
 using namespace edm;
 
-GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet &cfg) {
-  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
-  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel"));
-  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
+GEMDQMStatusDigi::GEMDQMStatusDigi(const edm::ParameterSet& cfg)
+{
+
+  tagVFAT_ = consumes<GEMVfatStatusDigiCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel")); 
+  tagGEB_ = consumes<GEMGEBdataCollection>(cfg.getParameter<edm::InputTag>("GEBInputLabel")); 
+  tagAMC_ = consumes<GEMAMCdataCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel")); 
+  tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel")); 
+  
+  listAMCSlots_ = cfg.getParameter<std::vector<int>>("AMCSlots");
+  
+  strFmtSummaryLabel_ = cfg.getParameter<std::string>("summaryLabelFmt");
+  bFlipSummary_ = cfg.getParameter<bool>("flipSummary");
+  bPerSuperchamber_ = cfg.getParameter<bool>("perSuperchamber");
+  
+  strPathPrevDQMRoot_ = cfg.getParameter<std::string>("pathOfPrevDQMRoot");
+  nNEvtPerSec_ = cfg.getParameter<int>("numOfEvtPerSec");
+  nNSecPerBin_ = cfg.getParameter<int>("secOfEvtPerBin");
+  nNTimeBinPrimitive_ = cfg.getParameter<int>("totalTimeInterval");
+  
+  nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
+  
+  nNBxRange_ = cfg.getParameter<int>("bxRange");
+  nNBxBin_ = cfg.getParameter<int>("bxBin");
+  
 }
 
-void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+void GEMDQMStatusDigi::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus"));
-  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus"));
-  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCStatus"));
-  descriptions.add("GEMDQMStatusDigi", desc);
+  desc.add<edm::InputTag>("VFATInputLabel", edm::InputTag("muonGEMDigis", "vfatStatus")); 
+  desc.add<edm::InputTag>("GEBInputLabel", edm::InputTag("muonGEMDigis", "gebStatus")); 
+  desc.add<edm::InputTag>("AMCInputLabel", edm::InputTag("muonGEMDigis", "AMCdata")); 
+  desc.add<edm::InputTag>("digisInputLabel", edm::InputTag("muonGEMDigis", "")); 
+  
+  std::vector<int> listAMCSlotsDef = {0, 1, 2, 3, 4, 5, 6, 7};
+  desc.add<std::vector<int>>("AMCSlots", listAMCSlotsDef); // TODO: Find how to get this from the geometry
+  
+  desc.add<std::string>("summaryLabelFmt", "GE%(station_signed)+i/%(layer)i");
+  desc.add<bool>("flipSummary", false);
+  desc.add<bool>("perSuperchamber", true);
+  
+  desc.add<std::string>("pathOfPrevDQMRoot", "");
+  desc.add<int>("numOfEvtPerSec", 100);
+  desc.add<int>("secOfEvtPerBin", 10);
+  desc.add<int>("totalTimeInterval", 50000);
+  
+  desc.add<int>("idxFirstStrip", 0);
+  
+  desc.add<int>("bxRange", 10);
+  desc.add<int>("bxBin", 20);
+  
+  descriptions.add("GEMDQMStatusDigi", desc);  
 }
 
-void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &iSetup) {
+
+std::string GEMDQMStatusDigi::suffixChamber(GEMDetId &id) {
+  return "Gemini_" + to_string(id.chamber()) + "_GE" + ( id.region() > 0 ? "p" : "m" ) + 
+    to_string(id.station()) + "_" + to_string(id.layer());
+}
+
+
+std::string GEMDQMStatusDigi::suffixLayer(GEMDetId &id) {
+  return std::string("st_") + ( id.region() >= 0 ? "p" : "m" ) + std::to_string(id.station()) +
+    ( bPerSuperchamber_ ? "_la_" + std::to_string(id.layer()) : "" );
+}
+
+
+int GEMDQMStatusDigi::SetInfoChambers() {
+  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();   
+  for ( auto sch : superChambers_ ) {
+    int nLayer = sch->nChambers();
+    for ( int l = 0 ; l < nLayer ; l++ ) {
+      Bool_t bExist = false;
+      for ( auto ch : gemChambers_ ) if ( ch.id() == sch->chamber(l+1)->id() ) bExist = true;
+      if ( bExist ) continue;
+      
+      gemChambers_.push_back(*sch->chamber(l + 1));
+    }
+  }
+  
+  // End: Loading the GEM geometry
+  
+  // Start: Set the configurations
+  
+  m_listLayers.clear();
+  
+  // Summarizing geometry configurations
+  for ( auto ch : gemChambers_ ) {
+    GEMDetId gid = ch.id();
+    
+    GEMDetId layerID(gid.region(), gid.ring(), gid.station(), ( bPerSuperchamber_ ? gid.layer() : 0 ), 0, 0);
+    Bool_t bOcc = false;
+    
+    for ( auto lid : m_listLayers ) {
+      if ( lid == layerID ) {
+        bOcc = true;
+        break;
+      }
+    }
+    
+    if ( !bOcc ) m_listLayers.push_back(layerID);
+    
+    GEMDetId chamberID(0, 1, 1, ( bPerSuperchamber_ ? 0 : gid.layer() ), gid.chamber(), 0);
+    bOcc = false;
+    
+    for ( auto cid : m_listChambers ) {
+      if ( cid == chamberID ) {
+        bOcc = true;
+        break;
+      }
+    }
+    
+    if ( !bOcc ) m_listChambers.push_back(chamberID);
+  }
+  
+  // Preliminary for sorting the summaries
+  auto lambdaLayer = [this](GEMDetId a, GEMDetId b)->Bool_t {
+    Int_t nFlipSign = ( this->bFlipSummary_ ? -1 : 1 );
+    Int_t nA = nFlipSign * a.region() * ( 20 * a.station() + a.layer() );
+    Int_t nB = nFlipSign * b.region() * ( 20 * b.station() + b.layer() );
+    return nA > nB;
+  };
+  
+  auto lambdaChamber = [this](GEMDetId a, GEMDetId b)->Bool_t {
+    Int_t nA = 20 * a.chamber() + a.layer();
+    Int_t nB = 20 * b.chamber() + b.layer();
+    return nA < nB;
+  };
+  
+  // Sorting the summaries
+  std::sort(m_listLayers.begin(), m_listLayers.end(), lambdaLayer);
+  std::sort(m_listChambers.begin(), m_listChambers.end(), lambdaChamber);
+  
+  nNCh_ = (int)m_listChambers.size();
+  
+  return 0;
+}
+
+
+// 0: General; for whole AMC slots
+int GEMDQMStatusDigi::SetConfigTimeRecord() {
+  TimeStoreItem newTimeStore;
+  
+  newTimeStore.nNbinMin = 0;
+  newTimeStore.nNbinMax = 0;
+  
+  std::string strCommonName = "per_time_";
+  
+  // Very general GEMDetId
+  newTimeStore.strName  = strCommonName + "status_AMCslots";
+  newTimeStore.strTitle = "Status of AMC slots per time";
+  newTimeStore.strAxisX = "AMC slot";
+  newTimeStore.nNbinY   = listAMCSlots_.size();
+  listTimeStore_[ 0 ] = newTimeStore;
+  
+  for ( auto layerId : m_listLayers ) {
+    std::string strSuffix = ( layerId.region() > 0 ? "p" : "m" ) + std::to_string(layerId.station()) 
+        + "_" + std::to_string(layerId.layer());
+    
+    newTimeStore.strName  = strCommonName + "status_GEB_" + suffixLayer(layerId);
+    newTimeStore.strTitle = "";
+    newTimeStore.strAxisX = "Chamber";
+    
+    newTimeStore.nNbinY   = nNCh_;
+    listTimeStore_[ layerId ] = newTimeStore;
+  }
+  
+  for ( auto ch : gemChambers_ ) {
+    auto chId = ch.id();
+    GEMDetId chIdStatus(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 1);
+    GEMDetId chIdDigi(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 2);
+    GEMDetId chIdBx(chId.region(), chId.ring(), chId.station(), chId.layer(), chId.chamber(), 3);
+    
+    std::string strSuffix = suffixChamber(chId);
+    
+    newTimeStore.strName  = strCommonName + "status_chamber_" + strSuffix;
+    newTimeStore.strTitle = "";
+    newTimeStore.strAxisX = "VFAT";
+    
+    newTimeStore.nNbinY   = nVfat_;
+    listTimeStore_[ chIdStatus ] = newTimeStore;
+    
+    newTimeStore.strName  = strCommonName + "digi_chamber_" + strSuffix;
+    newTimeStore.strTitle = "";
+    newTimeStore.strAxisX = "VFAT";
+    
+    newTimeStore.nNbinY   = nVfat_;
+    listTimeStore_[ chIdDigi ] = newTimeStore;
+    
+    newTimeStore.strName  = strCommonName + "bx_chamber_" + strSuffix;
+    newTimeStore.strTitle = "";
+    newTimeStore.strAxisX = "Bunch crossing";
+    
+    newTimeStore.nNbinY   =  nNBxBin_;
+    newTimeStore.nNbinMin = -nNBxRange_;
+    newTimeStore.nNbinMax =  nNBxRange_;
+    
+    listTimeStore_[ chIdBx ] = newTimeStore;
+    
+    newTimeStore.nNbinMin = newTimeStore.nNbinMax = 0;
+  }
+  
+  return 0;
+}
+
+
+int GEMDQMStatusDigi::LoadPrevData() {
+  TFile *fPrev;
+  Bool_t bSync = true;
+  
+  nStackedEvt_ = 0;
+  
+  for ( auto &itStore : listTimeStore_ ) {
+    itStore.second.listOccupy.clear();
+    itStore.second.listRecord.clear();
+  }
+  
+  if ( strPathPrevDQMRoot_ == "" ) return 0;
+  
+  std::ifstream fExist(strPathPrevDQMRoot_.c_str());
+  if ( !fExist.good() ) return 0;
+  fExist.close();
+  
+  fPrev = new TFile(strPathPrevDQMRoot_.c_str());
+  if ( fPrev == NULL ) return 1;
+  
+  std::cout << strPathPrevDQMRoot_ << " is being loaded" << std::endl;
+  std::string strRunnum = ( (TDirectoryFile *)fPrev->Get("DQMData") )->GetListOfKeys()->At(0)->GetName();
+  
+  for ( auto &itStore : listTimeStore_ ) {
+    TH2F *h2Prev = (TH2F *)fPrev->Get(( "DQMData/" + strRunnum 
+      + "/GEM/Run summary/StatusDigi/" + itStore.second.strName ).c_str());
+    auto &listCurrRec = itStore.second.listRecord;
+    auto &listCurrOcc = itStore.second.listOccupy;
+    
+    listCurrRec.clear();
+    listCurrOcc.clear();
+    
+    if ( h2Prev == NULL ) continue; // Hmmm, is it an error...?
+    
+    Int_t nNbinX = h2Prev->GetNbinsX();
+    Int_t nNbinY = h2Prev->GetNbinsY();
+    
+    Int_t nX, nY;
+    Int_t nXMaxOcc = 0;
+    Int_t nNNonFullFill = 0;
+    
+    for ( nX = 1 ; nX <= nNbinX ; nX++ ) {
+      Int_t nNEvtCurrTime = h2Prev->GetBinContent(nX, 0); // The (nX, 0)-bin keeps the number of filled events
+      if ( 0 < nNEvtCurrTime && nNEvtCurrTime < nNSecPerBin_ * nNEvtPerSec_ ) nNNonFullFill++;
+      if ( nNEvtCurrTime > 0 ) nXMaxOcc = nX;
+    }
+    
+    if ( nNNonFullFill > 1 ) { // The last bin may not full
+      std::cerr << "WARNING: There is a bin of the previous histograms which is not fully filled" << std::endl;
+    }
+    
+    for ( nY = 1 ; nY <= nNbinY ; nY++ ) {
+      listCurrRec.emplace_back();
+      listCurrOcc.emplace_back();
+      
+      if ( nXMaxOcc > 0 ) {
+        for ( nX = 1 ; nX <= nXMaxOcc ; nX++ ) {
+          //listCurr[ nY - 1 ].push_back(h2Prev->GetBinContent(nX, nY));
+          listCurrRec[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
+          listCurrOcc[ nY - 1 ].push_back(0); // If hadd is used, then it must be blanked
+        }
+        
+        if ( nNNonFullFill <= 0 ) {
+          listCurrRec[ nY - 1 ].push_back(0);
+          listCurrOcc[ nY - 1 ].push_back(0);
+        }
+      } else { // Empty...?
+        listCurrRec[ nY - 1 ].push_back(0);
+        listCurrOcc[ nY - 1 ].push_back(0);
+      }
+    }
+    
+    if ( nXMaxOcc <= 0 ) std::cout << "nXMacOcc has a problem" << std::endl;
+    if ( nXMaxOcc <= 0 ) continue; // Empty...?
+    
+    // Keeping the number of lastly stacked events
+    // And also checking if the sync is okay
+    if ( nStackedEvt_ == 0 ) nStackedEvt_ = h2Prev->GetBinContent(nXMaxOcc, 0);
+    else {
+      if ( nStackedEvt_ != h2Prev->GetBinContent(nXMaxOcc, 0) ) bSync = false;
+    }
+  }
+  
+  if ( nStackedEvt_ == nNSecPerBin_ * nNEvtPerSec_ ) nStackedEvt_ = 0;
+  
+  if ( !bSync ) { // No sync...!
+    std::cerr << "WARNING: No sync on time histograms" << std::endl;
+  }
+  
+  fPrev->Close();
+  
+  return 0;
+}
+
+
+void GEMDQMStatusDigi::bookHistogramsChamberPart(DQMStore::IBooker &ibooker, GEMDetId &gid) {
+  std::string hName, hTitle;
+  
+  UInt_t unBinPos;
+  //std::cout << "B: " << gid << std::endl;
+  
+  std::string strIdxName  = suffixChamber(gid);
+  std::string strIdxTitle = "GEMINIm" + to_string(gid.chamber()) + " in GE" + 
+    ( gid.region() > 0 ? "+" : "-" ) + to_string(gid.station()) + "/" + to_string(gid.layer());
+  
+  hName = "vfatStatus_QualityFlag_" + strIdxName;
+  hTitle = "VFAT quality " + strIdxTitle;
+  hTitle += ";VFAT;";
+  std::cout << "booking: " << gid << std::endl;
+  listVFATQualityFlag_[ gid ] = ibooker.book2D(hName, hTitle, nVfat_, 0, nVfat_, 9, 0, 9);
+  
+  hName = "vfatStatus_BC_" + strIdxName;
+  hTitle = "VFAT bunch crossing " + strIdxTitle;
+  hTitle += ";Bunch crossing;VFAT";
+  listVFATBC_[ gid ] = ibooker.book2D(hName, hTitle, nNBxBin_, -nNBxRange_, nNBxRange_, nVfat_, 0, nVfat_);
+  
+  hName = "vfatStatus_EC_" + strIdxName;
+  hTitle = "VFAT event counter " + strIdxTitle;
+  hTitle += ";Event counter;VFAT";
+  listVFATEC_[ gid ] = ibooker.book2D(hName, hTitle, 256, 0, 256, nVfat_, 0, nVfat_);
+  
+  unBinPos = 1;
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Good", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "CRC fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1010 fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1100 fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "b1110 fail", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "Hamming error", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "AFULL", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SEUlogic", 2);
+  listVFATQualityFlag_[ gid ]->setBinLabel(unBinPos++, "SUEI2C", 2);
+  
+  m_mapStatusFill[ gid ] = false;
+  m_mapStatusErr[ gid ] = false;
+}
+
+
+void GEMDQMStatusDigi::bookHistogramsStationPart(DQMStore::IBooker &ibooker, GEMDetId &lid) {
+  UInt_t unBinPos;
+  
+  Int_t  re = lid.region();
+  UInt_t st = lid.station();
+  UInt_t la = lid.layer();
+  
+  auto newbookGEB = [this](DQMStore::IBooker &ibooker, 
+                           std::string strName, std::string strTitle, std::string strAxis, 
+                           GEMDetId &lid, int nLayer, int nStation, int re, 
+                           int nBin, float fMin, float fMax)->MonitorElement *
+  {
+    strName  = strName  + "_" + suffixLayer(lid);
+    strTitle = strTitle + ", station: " + (re>=0 ? "+" : "-") + std::to_string(nStation);
+    
+    if ( bPerSuperchamber_ ) {
+      strTitle += ", layer: " + std::to_string(nLayer);
+    }
+    
+    strTitle += ";Chamber;" + strAxis;
+    
+    auto hNew = ibooker.book2D(strName, strTitle, this->nNCh_, 0, this->nNCh_, nBin, fMin, fMax);
+    
+    for ( Int_t i = 0 ; i < this->nNCh_ ; i++ ) {
+      auto &gid = this->m_listChambers[ i ];
+      Int_t nCh = gid.chamber() + ( this->bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+      hNew->setBinLabel(i + 1, std::to_string(nCh), 1);
+    }
+    
+    return hNew;
+  };
+  
+  listGEBInputStatus_[ lid ]  = newbookGEB(ibooker, "geb_input_status", 
+      "inputStatus",       "",                           lid, la, st, re, eBit_, 0, eBit_);
+  listGEBInputID_[ lid ]      = newbookGEB(ibooker, "geb_input_ID", 
+      "inputID",           "Input ID",                   lid, la, st, re, 32, 0, 32);
+  listGEBVFATWordCnt_[ lid ]  = newbookGEB(ibooker, "geb_no_vfats", 
+      "nvfats in header",  "Number of VFATs in header",  lid, la, st, re, 25, 0, 25);
+  listGEBVFATWordCntT_[ lid ] = newbookGEB(ibooker, "geb_no_vfatsT", 
+      "nvfats in trailer", "Number of VFATs in trailer", lid, la, st, re, 25, 0, 25);
+  listGEBZeroSupWordsCnt_[ lid ] = newbookGEB(ibooker, "geb_zeroSupWordsCnt", 
+      "zeroSupWordsCnt",   "Zero sup. words count",      lid, la, st, re, 10, 0, 10);
+  
+  listGEBbcOH_[ lid ]  = newbookGEB(ibooker, "geb_bcOH",  "OH bunch crossing", 
+      "OH bunch crossing", lid, la, st, re, 3600, 0, 3600);
+  listGEBecOH_[ lid ]  = newbookGEB(ibooker, "geb_ecOH",  "OH event coounter", 
+      "OH event counter", lid, la, st, re, 256, 0, 256);
+  listGEBOHCRC_[ lid ] = newbookGEB(ibooker, "geb_OHCRC", "CRC of OH data", 
+      "CRC of OH data", lid, la, st, re, 65536, 0, 65536);
+  
+  unBinPos = 1;
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB OH", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "BX mismatch GLIB VFAT", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB OH", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "OOS GLIB VFAT", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "No VFAT marker", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size warn", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO near full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO near full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO near full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event size overflow", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "L1AFIFO full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "InFIFO full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "EvtFIFO full", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Input FIFO underflow", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Stuck data", 2);
+  listGEBInputStatus_[ lid ]->setBinLabel(unBinPos++, "Event FIFO underflow", 2);
+}
+
+
+void GEMDQMStatusDigi::bookHistogramsAMCPart(DQMStore::IBooker &ibooker) {
+  h2AMCStatus_ = ibooker.book2D("amc_statusflag", "Status of AMC slots;AMC slot;", 
+      listAMCSlots_.size(), 0, listAMCSlots_.size(), amcStatusBit_, 0, amcStatusBit_);
+  
+  uint32_t unBinPos = 1;
+  h2AMCStatus_->setBinLabel(unBinPos++, "BC0 not locked", 2);
+  h2AMCStatus_->setBinLabel(unBinPos++, "DAQ not ready", 2);
+  h2AMCStatus_->setBinLabel(unBinPos++, "DAQ clock not locked", 2);
+  h2AMCStatus_->setBinLabel(unBinPos++, "MMCM not locked", 2);
+  h2AMCStatus_->setBinLabel(unBinPos++, "Back pressure", 2);
+  h2AMCStatus_->setBinLabel(unBinPos++, "GLIB out-of-sync", 2);
+}
+
+
+void GEMDQMStatusDigi::bookHistogramsTimeRecordPart(DQMStore::IBooker &ibooker) {
+  //Int_t nNBinX = ( listTimeStore_[ 0 ].listRecord.size() / nNTimeBinTotal_ + 1 ) * nNTimeBinTotal_;
+  
+  for ( auto &itStore : listTimeStore_ ) {
+    auto &infoCurr = itStore.second;
+    
+    Float_t fMin = -0.5, fMax = infoCurr.nNbinY - 0.5;
+    
+    if ( infoCurr.nNbinMin < infoCurr.nNbinMax ) {
+      fMin = infoCurr.nNbinMin;
+      fMax = infoCurr.nNbinMax;
+    }
+    
+    infoCurr.h2Histo = ibooker.book2D(infoCurr.strName, 
+      //infoCurr.strTitle + ";Time (per " + std::to_string(nNSecPerBin_) + " sec);" + infoCurr.strAxisX, 
+      infoCurr.strTitle + ";Per " + std::to_string(nNSecPerBin_ * nNEvtPerSec_) + " events;" + infoCurr.strAxisX, 
+      nNTimeBinPrimitive_, 0, nNTimeBinPrimitive_, infoCurr.nNbinY, fMin, fMax);
+    
+    if ( seekIdx(m_listLayers, itStore.first) >= 0 ) {
+      for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
+        auto &gid = m_listChambers[ i ];
+        Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+        infoCurr.h2Histo->setBinLabel(i + 1, std::to_string(nCh), 2);
+      }
+    }
+  }
+}
+
+
+// To make labels like python, with std::(unordered_)map
+std::string printfWithMap(std::string strFmt, std::unordered_map<std::string, Int_t> mapArg) {
+  std::string strRes = strFmt;
+  char szOutFmt[ 64 ];
+  size_t unPos, unPosEnd;
+  
+  for ( unPos = strRes.find('%') ; unPos != std::string::npos ; unPos = strRes.find('%', unPos + 1) ) {
+    unPosEnd = strRes.find(')', unPos);
+    if ( strRes[ unPos + 1 ] != '(' || unPosEnd == std::string::npos ) break; // Syntax error
+    
+    // Extracting the key
+    std::string strKey = strRes.substr(unPos + 2, unPosEnd - ( unPos + 2 ));
+    
+    // To treat formats like '%5i' or '%02i', extracting '5' or '02'
+    // After do this, 
+    std::string strOptNum = "%";
+    unPosEnd++;
+    
+    for ( ;; unPosEnd++ ) {
+      if ( !( '0' <= strRes[ unPosEnd ] && strRes[ unPosEnd ] <= '9' ) && 
+           strRes[ unPosEnd ] != '+' ) break;
+      strOptNum += strRes[ unPosEnd ];
+    }
+    
+    if ( strRes[ unPosEnd ] != 'i' && strRes[ unPosEnd ] != 'd' ) break; // Syntax error
+    strOptNum += strRes[ unPosEnd ];
+    unPosEnd++;
+    
+    sprintf(szOutFmt, strOptNum.c_str(), mapArg[ strKey ]);
+    strRes = strRes.substr(0, unPos) + szOutFmt + strRes.substr(unPosEnd);
+  }
+  
+  if ( unPos != std::string::npos ) { // It means... an syntax error occurs!
+    std::cerr << "ERROR: Syntax error on printfWithMap(); " << std::endl;
+    return "";
+  }
+  
+  return strRes;
+}
+
+
+void GEMDQMStatusDigi::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const & iSetup)
+{
+  // Start: Loading the GEM geometry
+  
+  GEMGeometry_ = initGeometry(iSetup);
+  if ( GEMGeometry_ == nullptr) return;
+  
+  SetInfoChambers();
+  
+  // Setting the informations for time histograms
+  SetConfigTimeRecord();
+  LoadPrevData();
+  
+  // The loading does not work well or something goes wrong...
+  // In this case, we need to make a new start of recording.
+  for ( auto &itStore : listTimeStore_ ) {
+    auto &infoCurr = itStore.second;
+    
+    if ( infoCurr.nNbinY != (Int_t)infoCurr.listRecord.size() ) { 
+      if ( infoCurr.listRecord.size() > 0 ) {
+        std::cerr << "WARNING: The previous result is not compatible to the current geometry. "
+          << "We will discard the previous data." << std::endl;
+        
+        infoCurr.listRecord.clear();
+        infoCurr.listOccupy.clear();
+      }
+      
+      for ( Int_t i = 0 ; i < infoCurr.nNbinY ; i++ ) {
+        infoCurr.listRecord.emplace_back();
+        infoCurr.listRecord[ i ].push_back(0);
+        
+        infoCurr.listOccupy.emplace_back();
+        infoCurr.listOccupy[ i ].push_back(0);
+      }
+    }
+    /*for ( Int_t i = 0 ; i < (Int_t)infoCurr.listRecord[ 0 ].size() ; i++ ) 
+    for ( Int_t j = 0 ; j < infoCurr.nNbinY ; j++ ) 
+      std::cout << "Init time: " << infoCurr.strName << ", " << j << ", " << i << ", " << infoCurr.listRecord[ j ][ i ] << std::endl;
+    
+    std::cout << "Init time: " << itStore.first << ", " << infoCurr.strName << ", " << infoCurr.nNbinY << ", " << infoCurr.listRecord.size() << "; " << listTimeStore_[ itStore.first ].listRecord.size() << std::endl;*/
+  }
+  
+  // End: Set the configurations
+  
+  // Start: Setting books
+  
   ibooker.cd();
   ibooker.setCurrentFolder("GEM/StatusDigi");
-
-  h1_vfat_quality_ = ibooker.book1D("vfat quality", "quality", 6, 0, 6);
-  h1_vfat_flag_ = ibooker.book1D("vfat flag", "flag", 5, 0, 5);
-
-  h2_vfat_quality_ = ibooker.book2D("vfat quality per geb", "quality", 6, 0, 6, 36, 0, 36);
-  h2_vfat_flag_ = ibooker.book2D("vfat flag per geb", "flag", 5, 0, 5, 36, 0, 36);
-
-  h1_geb_inputStatus_ = ibooker.book1D("geb input status", "inputStatus", 10, 0, 10);
-  h1_geb_vfatWordCnt_ = ibooker.book1D("geb no vfats", "nvfats", 25, 0, 25);
-  h1_geb_zeroSupWordsCnt_ = ibooker.book1D("geb zeroSupWordsCnt", "zeroSupWordsCnt", 10, 0, 10);
-  h1_geb_stuckData_ = ibooker.book1D("geb stuckData", "stuckData", 10, 0, 10);
-  h1_geb_inFIFOund_ = ibooker.book1D("geb inFIFOund", "inFIFOund", 10, 0, 10);
-
-  h1_amc_ttsState_ = ibooker.book1D("amc ttsState", "ttsState", 10, 0, 10);
-  h1_amc_davCnt_ = ibooker.book1D("amc davCnt", "davCnt", 10, 0, 10);
-  h1_amc_buffState_ = ibooker.book1D("amc buffState", "buffState", 10, 0, 10);
-  h1_amc_oosGlib_ = ibooker.book1D("amc oosGlib", "oosGlib", 10, 0, 10);
-  h1_amc_chTimeOut_ = ibooker.book1D("amc chTimeOut", "chTimeOut", 10, 0, 10);
+  
+  for ( auto ch : gemChambers_ ) {
+    GEMDetId gid = ch.id();
+    bookHistogramsChamberPart(ibooker, gid);
+  }
+  
+  for ( auto lid : m_listLayers ) {
+    bookHistogramsStationPart(ibooker, lid);
+  }
+  
+  bookHistogramsAMCPart(ibooker);
+  bookHistogramsTimeRecordPart(ibooker);
+  
+  h1_vfat_qualityflag_ = ibooker.book1D("vfat_quality_flag", "quality and flag", 9, 0, 9);
+  h2_vfat_qualityflag_ = ibooker.book2D("vfat_quality_flag_per_geb", "quality and flag", nNCh_, 0, nNCh_, 9, 0, 9);
+  
+  h1_amc_ttsState_  = ibooker.book1D("amc_ttsState",  "ttsState",  10, 0, 10);
+  h1_amc_davCnt_    = ibooker.book1D("amc_davCnt",    "davCnt",    10, 0, 10);
+  h1_amc_buffState_ = ibooker.book1D("amc_buffState", "buffState", 10, 0, 10);
+  h1_amc_oosGlib_   = ibooker.book1D("amc_oosGlib",   "oosGlib",   10, 0, 10);
+  h1_amc_chTimeOut_ = ibooker.book1D("amc_chTimeOut", "chTimeOut", 10, 0, 10);
+  
+  ibooker.cd();
+  ibooker.setCurrentFolder("GEM/EventInfo");
+  
+  // TODO: We need a study for setting the rule for this
+  m_summaryReport_ = ibooker.bookFloat("reportSummary");
+  m_summaryReport_->Fill(1.0);
+  
+  h2SummaryStatus_ = ibooker.book2D("reportSummaryMap", ";Chamber;", nNCh_, 0, nNCh_, 
+      m_listLayers.size(), 0, m_listLayers.size());
+  
+  for ( Int_t i = 0 ; i < nNCh_ ; i++ ) {
+    auto &gid = this->m_listChambers[ i ];
+    Int_t nCh = gid.chamber() + ( bPerSuperchamber_ ? 0 : gid.layer() - 1 );
+    h2SummaryStatus_->setBinLabel(i + 1, std::to_string(nCh), 1);
+  }
+  
+  Int_t nIdxLayer = 0;
+  std::unordered_map<std::string, Int_t> mapArg;
+  
+  // Start: Labeling section
+    
+  for ( auto lid : m_listLayers ) {
+    mapArg[ "station_signed" ] = lid.region() * lid.station();
+    mapArg[ "region"  ] = lid.region();
+    mapArg[ "station" ] = lid.station();
+    mapArg[ "layer"   ] = lid.layer();
+    mapArg[ "chamber" ] = lid.chamber();
+    
+    h2SummaryStatus_->setBinLabel(nIdxLayer + 1, printfWithMap(strFmtSummaryLabel_, mapArg), 2);
+    nIdxLayer++;
+  }
 }
 
-void GEMDQMStatusDigi::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
+
+void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits) {
+  int i = 0;
+  uint64_t unFlag = 1;
+  
+  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
+    if ( ( unVal & unFlag ) != 0 ) {
+      monitor->Fill(i);
+    }
+  }
+}
+
+
+void GEMDQMStatusDigi::FillBits(MonitorElement *monitor, uint64_t unVal, int nNumBits, int nX) {
+  int i = 0;
+  uint64_t unFlag = 1;
+  
+  for ( ; i < nNumBits ; i++, unFlag <<= 1 ) {
+    if ( ( unVal & unFlag ) != 0 ) {
+      monitor->Fill(nX, i);
+    }
+  }
+}
+
+
+Int_t GEMDQMStatusDigi::seekIdx(std::vector<GEMDetId> &listLayers, UInt_t unId) {
+  if ( unId < 256 ) return -1;
+  
+  GEMDetId id(unId);
+  for ( Int_t nIdx = 0 ; nIdx < (Int_t)listLayers.size() ; nIdx++ ) if ( id == listLayers[ nIdx ] ) return nIdx;
+  return -1;
+}
+  
+
+void GEMDQMStatusDigi::analyze(edm::Event const& event, edm::EventSetup const& eventSetup)
+{
   edm::Handle<GEMVfatStatusDigiCollection> gemVFAT;
   edm::Handle<GEMGEBdataCollection> gemGEB;
   edm::Handle<GEMAMCdataCollection> gemAMC;
-  event.getByToken(tagVFAT_, gemVFAT);
-  event.getByToken(tagGEB_, gemGEB);
-  event.getByToken(tagAMC_, gemAMC);
+  edm::Handle<GEMDigiCollection> gemDigis;
+  
+  event.getByToken( tagVFAT_, gemVFAT);
+  event.getByToken( tagGEB_, gemGEB);
+  event.getByToken( tagAMC_, gemAMC);
+  event.getByToken( tagDigi_, gemDigis);
+  
+  auto fillTimeHisto = [](TimeStoreItem &listCurr, int nIdx, bool bFill)->void {
+    return;
+    auto &listRecord = listCurr.listRecord[ nIdx ];
+    auto &listOccupy = listCurr.listOccupy[ nIdx ];
+    int nIdxTime = listRecord.size() - 1;
+    
+    listOccupy[ nIdxTime ] = 1;
+    if ( bFill ) listRecord[ nIdxTime ]++;
+  };
 
-  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt) {
+  for (GEMVfatStatusDigiCollection::DigiRangeIterator vfatIt = gemVFAT->begin(); vfatIt != gemVFAT->end(); ++vfatIt){
     GEMDetId gemid = (*vfatIt).first;
-    float nIdx = gemid.chamber() + (gemid.layer() - 1) / 2.0;
-    const GEMVfatStatusDigiCollection::Range &range = (*vfatIt).second;
-    for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
-      h1_vfat_quality_->Fill(vfatStat->quality());
-      h1_vfat_flag_->Fill(vfatStat->flag());
-      h2_vfat_quality_->Fill(vfatStat->quality(), nIdx);
-      h2_vfat_flag_->Fill(vfatStat->flag(), nIdx);
+    GEMDetId gemchId = gemid.chamberId();
+    //std::cout << "A: " << gemchId << std::endl;
+    GEMDetId gemOnlychId(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
+    
+    int nIdx = seekIdx(m_listChambers, gemOnlychId);
+    int nRoll = gemid.roll();
+    const GEMVfatStatusDigiCollection::Range& range = (*vfatIt).second;
+    
+    GEMDetId chIdStatus(gemid.region(), gemid.ring(), gemid.station(), gemid.layer(), gemid.chamber(), 1);
+    auto &listCurr = listTimeStore_[ chIdStatus ];
+    
+    for ( auto vfatStat = range.first; vfatStat != range.second; ++vfatStat ) {
+      uint64_t unQFVFAT = vfatStat->quality() | ( vfatStat->flag() << qVFATBit_ );
+      if ( ( unQFVFAT & ~0x1 ) == 0 )  {
+        unQFVFAT |= 0x1; // If no error, then it should be 'Good'
+      } else { // Error!!
+        m_mapStatusErr[ gemchId ] = true;
+      }
+      
+      FillBits(h1_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_);
+      FillBits(h2_vfat_qualityflag_, unQFVFAT, qVFATBit_ + fVFATBit_, nIdx);
+      
+      int nVFAT = ( 8 - nRoll ) + 8 * vfatStat->phi(); // vfatStat.phi()? or 2 - vfatStat.phi()?
+      
+      FillBits(listVFATQualityFlag_[ gemchId ], unQFVFAT, qVFATBit_ + fVFATBit_, nVFAT);
+      //listVFATBC_[ gemchId ]->Fill(vfatStat->bc(), nVFAT);
+      listVFATEC_[ gemchId ]->Fill(vfatStat->ec(), nVFAT);
+      
+      fillTimeHisto(listCurr, nVFAT, ( unQFVFAT & ~0x1 ) != 0);
     }
   }
-
-  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt) {
-    const GEMGEBdataCollection::Range &range = (*gebIt).second;
-    for (auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus) {
-      //h1_geb_inputStatus_->Fill(GEBStatus->inputStatus());
-      h1_geb_vfatWordCnt_->Fill(GEBStatus->vfatWordCnt() / 3);
-      h1_geb_zeroSupWordsCnt_->Fill(GEBStatus->zeroSupWordsCnt());
-      h1_geb_stuckData_->Fill(GEBStatus->stuckData());
-      h1_geb_inFIFOund_->Fill(GEBStatus->evUfw());
+  
+  for (GEMGEBdataCollection::DigiRangeIterator gebIt = gemGEB->begin(); gebIt != gemGEB->end(); ++gebIt){
+    GEMDetId gemid = (*gebIt).first;
+    GEMDetId lid(gemid.region(), gemid.ring(), gemid.station(), ( bPerSuperchamber_ ? gemid.layer() : 0 ), 0, 0);
+    GEMDetId chid(0, 1, 1, ( bPerSuperchamber_ ? 0 : gemid.layer() ), gemid.chamber(), 0);
+    
+    Int_t nCh = seekIdx(m_listChambers, chid);
+    auto &listCurr = listTimeStore_[ lid ];
+    
+    const GEMGEBdataCollection::Range& range = (*gebIt).second;    
+    for ( auto GEBStatus = range.first; GEBStatus != range.second; ++GEBStatus ) {
+      uint64_t unBit = 0;
+      uint64_t unStatus = 0;
+      
+      unStatus |= ( GEBStatus->bxmVvV()    << unBit++ ); 
+      unStatus |= ( GEBStatus->bxmAvV()    << unBit++ ); 
+      unStatus |= ( GEBStatus->oOScVvV()   << unBit++ ); 
+      unStatus |= ( GEBStatus->oOScAvV()   << unBit++ ); 
+      unStatus |= ( GEBStatus->noVFAT()    << unBit++ ); 
+      unStatus |= ( GEBStatus->evtSzW()    << unBit++ ); 
+      unStatus |= ( GEBStatus->l1aNF()     << unBit++ ); 
+      unStatus |= ( GEBStatus->inNF()      << unBit++ ); 
+      unStatus |= ( GEBStatus->evtNF()     << unBit++ ); 
+      unStatus |= ( GEBStatus->evtSzOFW()  << unBit++ ); 
+      unStatus |= ( GEBStatus->l1aF()      << unBit++ ); 
+      unStatus |= ( GEBStatus->inF()       << unBit++ ); 
+      unStatus |= ( GEBStatus->evtF()      << unBit++ ); 
+      unStatus |= ( GEBStatus->inUfw()     << unBit++ ); 
+      unStatus |= ( GEBStatus->stuckData() << unBit++ ); 
+      unStatus |= ( GEBStatus->evUfw()     << unBit++ );
+      
+      //std::cout << gemid;
+      //printf("%06X\n", (unsigned int)unStatus);
+      if ( unStatus != 0 ) { // Error!
+        m_mapStatusErr[ gemid ] = true;
+      }
+      
+      FillBits(listGEBInputStatus_[ lid ], unStatus, eBit_, nCh);
+      
+      listGEBInputID_[ lid ]->Fill(nCh, GEBStatus->inputID());
+      listGEBVFATWordCnt_[ lid ]->Fill(nCh, GEBStatus->vfatWordCnt()/3);
+      listGEBVFATWordCntT_[ lid ]->Fill(nCh, GEBStatus->vfatWordCntT()/3);
+      listGEBZeroSupWordsCnt_[ lid ]->Fill(nCh, GEBStatus->zeroSupWordsCnt());
+      
+      listGEBbcOH_[ lid ]->Fill(nCh, GEBStatus->bcOH());
+      listGEBecOH_[ lid ]->Fill(nCh, GEBStatus->ecOH());
+      listGEBOHCRC_[ lid ]->Fill(nCh, GEBStatus->crc());
+      
+      fillTimeHisto(listCurr, nCh, unStatus != 0);
     }
   }
-
-  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt) {
-    const GEMAMCdataCollection::Range &range = (*amcIt).second;
-    for (auto amc = range.first; amc != range.second; ++amc) {
+  
+  auto findAMCIdx = [this](Int_t nAMCnum)->Int_t {
+    for ( Int_t i = 0 ; i < (Int_t)listAMCSlots_.size() ; i++ ) if ( listAMCSlots_[ i ] == nAMCnum ) return i;
+    return -1;
+  };
+  
+  for (GEMAMCdataCollection::DigiRangeIterator amcIt = gemAMC->begin(); amcIt != gemAMC->end(); ++amcIt){
+    const GEMAMCdataCollection::Range& range = (*amcIt).second;
+    auto &listCurr = listTimeStore_[ 0 ];
+    for ( auto amc = range.first; amc != range.second; ++amc ) {
+      Int_t nIdAMC = findAMCIdx(amc->amcNum());
+      uint64_t unBit = 0;
+      uint64_t unStatus = 0;
+      
+      unStatus |= ( ( amc->bc0locked()      == 0 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->daqReady()       != 1 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->daqClockLocked() == 0 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->mmcmLocked()     != 1 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->backPressure()   == 1 ? 1 : 0 ) << unBit++ ); 
+      unStatus |= ( ( amc->oosGlib()        != 0 ? 1 : 0 ) << unBit++ );
+      
+      FillBits(h2AMCStatus_, unStatus, amcStatusBit_, nIdAMC);
+      
       h1_amc_ttsState_->Fill(amc->ttsState());
       h1_amc_davCnt_->Fill(amc->davCnt());
       h1_amc_buffState_->Fill(amc->buffState());
       h1_amc_oosGlib_->Fill(amc->oosGlib());
       h1_amc_chTimeOut_->Fill(amc->linkTo());
+      
+      fillTimeHisto(listCurr, nIdAMC, unStatus != 0);
+    }
+  }
+  
+  /*auto findVFAT = [this](float min_, int nNumStripPerVFAT, float x_, int roll_)->int {
+    float step = max_/3;
+    if ( x_ < (min_+step) ) { return 8 - roll_;}
+    else if ( x_ < (min_+2*step) )  { return 16 - roll_;}
+    else { return this->nVfat_ - roll_;}
+  };*/
+  
+  // Checking if there is a fire (data)
+  for ( auto ch : gemChambers_ ) {
+    GEMDetId cId = ch.id();
+    Bool_t bIsHit = false;
+    
+    // Because every fired strip in a same VFAT shares a same bx, we keep bx from only one strip
+    std::unordered_map<Int_t, Int_t> mapBXVFAT;
+    
+    GEMDetId chIdDigi(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 2);
+    GEMDetId chIdBx(cId.region(), cId.ring(), cId.station(), cId.layer(), cId.chamber(), 3);
+    
+    auto &listCurrDigi = listTimeStore_[ chIdDigi ];
+    auto &listCurrBx   = listTimeStore_[ chIdBx ];
+    
+    for ( auto roll : ch.etaPartitions() ) {
+      GEMDetId rId = roll->id();      
+      const auto &digis_in_det = gemDigis->get(rId);
+      
+      for ( auto d = digis_in_det.first ; d != digis_in_det.second ; ++d ){
+        //Int_t nVFAT = findVFAT(0, roll->nstrips(), d->strip(), rId.roll()); // Starts at 0
+        Int_t nIdxStrip = d->strip() - nIdxFirstStrip_;
+        Int_t nVFAT = 8 * ( (Int_t)( nIdxStrip / ( roll->nstrips() / 3 ) ) + 1 ) - rId.roll(); // Strip:Start at 0
+        
+        bIsHit = true;
+        mapBXVFAT[ nVFAT ] = d->bx();
+        fillTimeHisto(listCurrDigi, nVFAT, true);
+        
+        Int_t nIdxBx;
+        
+        if      ( d->bx() <  listCurrBx.nNbinMin ) nIdxBx = 0;
+        else if ( d->bx() >= listCurrBx.nNbinMax ) nIdxBx = listCurrBx.nNbinY - 1;
+        else nIdxBx = (Int_t)( listCurrBx.nNbinY * 1.0 * 
+            ( d->bx() - listCurrBx.nNbinMin ) / ( listCurrBx.nNbinMax - listCurrBx.nNbinMin ) );
+        
+        fillTimeHisto(listCurrBx, nIdxBx, true);
+      }
+      
+      if ( bIsHit ) break;
+    }
+    
+    for ( auto bx : mapBXVFAT ) listVFATBC_[ cId ]->Fill(bx.second, bx.first);
+    
+    if ( bIsHit ) { // Data occur!
+      m_mapStatusFill[ cId ] = true;
+    }
+  }
+  
+  // Counting the time tables
+  nStackedEvt_++;
+  if ( nStackedEvt_ >= nNSecPerBin_ * nNEvtPerSec_ ) { // Time to jump!
+    for ( auto &itStore : listTimeStore_ ) 
+    for ( Int_t i = 0 ; i < itStore.second.nNbinY ; i++ ) {
+      itStore.second.listOccupy[ i ].push_back(0);
+      itStore.second.listRecord[ i ].push_back(0);
+    }
+    
+    nStackedEvt_ = 0;
+  }
+}
+
+
+void GEMDQMStatusDigi::endRun(edm::Run const& run, edm::EventSetup const& eSetup) {
+  //std::cout << "End run" << std::endl;
+  
+  for ( auto chamber : gemChambers_ ) {
+    auto gid = chamber.id();
+    
+    UInt_t unVal = 0; // No data, no error
+    if      ( m_mapStatusErr[ gid ]  ) unVal = 2; // Error! (no matter there are data or not)
+    else if ( m_mapStatusFill[ gid ] ) unVal = 1; // Data occur, with no error
+    //std::cout << gid << ": " << unVal << std::endl;
+    
+    Int_t nLayer = ( bPerSuperchamber_ ? gid.layer() : 0 );
+    GEMDetId layerId(gid.region(), gid.ring(), gid.station(), nLayer, 0, 0);
+    GEMDetId chamberId(0, 1, 1, gid.layer() - nLayer, gid.chamber(), 0);
+    
+    Int_t nIdxLayer   = seekIdx(m_listLayers,   layerId);
+    Int_t nIdxChamber = seekIdx(m_listChambers, chamberId);
+    
+    if ( h2SummaryStatus_ ) h2SummaryStatus_->setBinContent(nIdxChamber, nIdxLayer + 1, unVal);
+    
+    // The below is for under/overflow of BX histograms
+    Int_t nNbinX = listVFATBC_[ gid ]->getNbinsX();
+    Int_t nNbinY = listVFATBC_[ gid ]->getNbinsY();
+    
+    for ( Int_t i = 0 ; i < nNbinY ; i++ ) {
+      listVFATBC_[ gid ]->setBinContent(1, i, 
+          listVFATBC_[ gid ]->getBinContent(0, i) + listVFATBC_[ gid ]->getBinContent(1, i));
+      listVFATBC_[ gid ]->setBinContent(nNbinX, i, 
+          listVFATBC_[ gid ]->getBinContent(nNbinX, i) + listVFATBC_[ gid ]->getBinContent(nNbinX + 1 , i));
+    }
+  }
+   
+  for ( auto &itStore : listTimeStore_ ) {
+    auto &listCurrOcc = itStore.second.listOccupy;
+    auto &listCurrRec = itStore.second.listRecord;
+    MonitorElement *h2Curr = itStore.second.h2Histo;
+    
+    h2Curr->setBinContent(0, 0, nNSecPerBin_ * nNEvtPerSec_);
+    h2Curr->setBinContent(0, 1, 1);
+    
+    Int_t nSize = listCurrRec[ 0 ].size();
+    //Int_t nXOffset = std::max(nSize - nNTimeBinTotal_, 0);
+    Int_t nXOffset = 0;
+    Int_t nNbinY = listCurrRec.size();
+    
+    for ( Int_t nX = nXOffset ; nX < nSize ; nX++ ) {
+      Int_t nNEvt = ( nX < nSize - 1 ? nNEvtPerSec_ * nNSecPerBin_ : nStackedEvt_ );
+      h2Curr->setBinContent(nX - nXOffset + 1, 0, nNEvt);
+      
+      for ( Int_t nY = 1 ; nY <= nNbinY ; nY++ ) {
+        Double_t dVal = listCurrRec[ nY - 1 ][ nX ];
+        Double_t dErr = listCurrOcc[ nY - 1 ][ nX ];
+        
+        if ( dErr > 0 && dVal <= 0 ) dVal = -1;
+        
+        if ( dVal != 0 ) h2Curr->setBinContent(nX - nXOffset + 1, nY, dVal);
+        //if ( dErr > 0 ) h2Curr->setBinError(nX - nXOffset + 1, nY, 1);
+      }
     }
   }
 }

--- a/DQM/GEM/plugins/GEMDQMStatusDigi.cc
+++ b/DQM/GEM/plugins/GEMDQMStatusDigi.cc
@@ -61,7 +61,6 @@ protected:
   void seekIdxSummary(GEMDetId gid, Int_t &nIdxLayer, Int_t &nIdxChamber);
 
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
-  void dqmEndRun(edm::Run const &run, edm::EventSetup const &eSetup);
 
 private:
   const GEMGeometry *initGeometry(edm::EventSetup const &iSetup);
@@ -375,7 +374,7 @@ int GEMDQMStatusDigi::LoadPrevData() {
   nStackedBin_ = 0;
   nStackedEvt_ = 0;
 
-  if (strPathPrevDQMRoot_ == "")
+  if (strPathPrevDQMRoot_.empty())
     return 0;
 
   std::ifstream fExist(strPathPrevDQMRoot_.c_str());
@@ -384,7 +383,7 @@ int GEMDQMStatusDigi::LoadPrevData() {
   fExist.close();
 
   fPrev = new TFile(strPathPrevDQMRoot_.c_str());
-  if (fPrev == NULL)
+  if (fPrev == nullptr)
     return 1;
 
   std::cout << strPathPrevDQMRoot_ << " is being loaded" << std::endl;

--- a/DQM/GEM/test/test.py
+++ b/DQM/GEM/test/test.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+import os
+
+from Configuration.Eras.Era_Phase2_cff import Phase2
+
 process = cms.Process('DQMTEST')
 
 
@@ -11,7 +15,8 @@ process.MessageLogger = cms.Service("MessageLogger",
   )
 )
 
-process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 
@@ -24,11 +29,11 @@ process.dqmSaver.tag = "GEM"
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    'file:/eos/cms/store/express/Commissioning2018/ExpressCosmics/FEVT/Express-v1/000/310/292/00000/6C23251D-4F18-E811-AEC5-02163E01A41D.root'    
+    'file:/eos/cms/store/express/Commissioning2018/ExpressCosmics/FEVT/Express-v1/000/310/292/00000/6C23251D-4F18-E811-AEC5-02163E01A41D.root'
   ),
   inputCommands = cms.untracked.vstring(
-    'drop *',
-    'keep FEDRawDataCollection_*_*_*'
+    'keep *',
+    #'keep FEDRawDataCollection_*_*_*'
   )
 )
 
@@ -43,22 +48,25 @@ process.load("DQM.GEM.GEMDQM_cff")
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.unPackStatusDigis = True
 
-############## DB file ################# 
-from CondCore.CondDB.CondDB_cfi import *
-CondDB.DBParameters.authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-CondDB.connect = cms.string('sqlite_fip:DQM/GEM/data/GEMeMap.db')
+process.GEMDQMStatusDigi.pathOfPrevDQMRoot = "DQM_V0001_GEM_R000030000.root"
+process.GEMDQMHarvester.fromFile = "DQM_V0001_GEM_R000020150.root"
 
-process.GEMCabling = cms.ESSource("PoolDBESSource",
-    CondDB,
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('GEMeMapRcd'),
-        tag = cms.string('GEMeMap_v2')
-    )),
-)
+############## DB file ################# 
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDB.DBParameters.authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+#CondDB.connect = cms.string('sqlite_fip:DQM/GEM/data/GEMeMap.db')
+#
+#process.GEMCabling = cms.ESSource("PoolDBESSource",
+#    CondDB,
+#    toGet = cms.VPSet(cms.PSet(
+#        record = cms.string('GEMeMapRcd'),
+#        tag = cms.string('GEMeMap_v2')
+#    )),
+#)
 ####################################
 process.path = cms.Path(
-  process.muonGEMDigis *
-  process.gemRecHits *
+  #process.muonGEMDigis *
+  #process.gemRecHits *
   process.GEMDQM
 )
 

--- a/DQM/GEM/test/test.py
+++ b/DQM/GEM/test/test.py
@@ -16,7 +16,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 )
 
 #process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D35Reco_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 


### PR DESCRIPTION
#### PR description:
This backport PR to 11_0_X (from #28769) updates and extends the part of onlineDQM for GEM. The details are following: 

 - The existing parts are fixed to match the VFAT version which is used in CMSSW currently
 - Summary plot is added
 - Histograms which displays the status of devices (AMCs, GEBs, VFATs) by time are added

Please see [this](https://indico.cern.ch/event/881121/contributions/3712072/attachments/1972921/3282493/20200120_DQM_Online_PR.pdf) to check more details, especially the visualization with [DQM GUI](https://github.com/dmwm/deployment) (there is also an update for GEM part for onlineDQM GUI, which will be PRed soon)

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij