### PR TITLE
Fix dd4hep modifier import

### DIFF
--- a/Geometry/HGCalCommonData/python/hgcalParametersInitialization_cfi.py
+++ b/Geometry/HGCalCommonData/python/hgcalParametersInitialization_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.HGCalCommonData.hgcalEEParametersInitialize_cfi import *
 
-from Configuration.Eras.Modifier_dd4hep_cff import dd4hep
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
 dd4hep.toModify(hgcalEEParametersInitialize,
                 fromDD4Hep = cms.bool(True)

--- a/Geometry/HGCalCommonData/python/hgcalV6ParametersInitialization_cfi.py
+++ b/Geometry/HGCalCommonData/python/hgcalV6ParametersInitialization_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.HGCalCommonData.hgcalEEParametersInitialize_cfi import *
 
-from Configuration.Eras.Modifier_dd4hep_cff import dd4hep
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
 dd4hep.toModify(hgcalEEParametersInitialize,
                 fromDD4Hep = cms.bool(True)


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/28847 missed to migrate two cfi configuration files for the new location of `dd4hep` Modifier. This PR fixes the those two files.

#### PR validation:

Evaluating the two cfi files through python succeeds.