### PR TITLE
Running code-format for generators

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h
@@ -6,101 +6,98 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/PdfInfo.h"
 
-namespace HepMC { class GenEvent; } // forward declaration
+namespace HepMC {
+  class GenEvent;
+}  // namespace HepMC
 
 /** \class GenEventInfoProduct
  *
  */
 
 class GenEventInfoProduct {
-    public:
-	GenEventInfoProduct();
-	GenEventInfoProduct(const HepMC::GenEvent *evt);
-	GenEventInfoProduct(const GenEventInfoProduct &other);
-	GenEventInfoProduct(GenEventInfoProduct&& other);
-	virtual ~GenEventInfoProduct();
+public:
+  GenEventInfoProduct();
+  GenEventInfoProduct(const HepMC::GenEvent *evt);
+  GenEventInfoProduct(const GenEventInfoProduct &other);
+  GenEventInfoProduct(GenEventInfoProduct &&other);
+  virtual ~GenEventInfoProduct();
 
-	GenEventInfoProduct &operator = (const GenEventInfoProduct &other);
-	GenEventInfoProduct &operator = (GenEventInfoProduct &&other);
+  GenEventInfoProduct &operator=(const GenEventInfoProduct &other);
+  GenEventInfoProduct &operator=(GenEventInfoProduct &&other);
 
-	typedef gen::PdfInfo PDF;
+  typedef gen::PdfInfo PDF;
 
-	// getters
+  // getters
 
-	std::vector<double> &weights() { return weights_; }
-	const std::vector<double> &weights() const { return weights_; }
-	
-	double weight() const { return weights_.empty() ? 1.0 : weights_[0]; }
-	
-	double weightProduct() const;
+  std::vector<double> &weights() { return weights_; }
+  const std::vector<double> &weights() const { return weights_; }
 
-	unsigned int signalProcessID() const { return signalProcessID_; }
+  double weight() const { return weights_.empty() ? 1.0 : weights_[0]; }
 
-	double qScale() const { return qScale_; }
-	double alphaQCD() const { return alphaQCD_; }
-	double alphaQED() const { return alphaQED_; }
+  double weightProduct() const;
 
-	const PDF *pdf() const { return pdf_.get(); }
-	bool hasPDF() const { return pdf() != nullptr; }
+  unsigned int signalProcessID() const { return signalProcessID_; }
 
-	const std::vector<double> &binningValues() const { return binningValues_; }
-	bool hasBinningValues() const { return !binningValues_.empty(); }
+  double qScale() const { return qScale_; }
+  double alphaQCD() const { return alphaQCD_; }
+  double alphaQED() const { return alphaQED_; }
 
-        const std::vector<float> &DJRValues() const { return DJRValues_; }
-        bool hasDJRValues() const { return !DJRValues_.empty(); }
+  const PDF *pdf() const { return pdf_.get(); }
+  bool hasPDF() const { return pdf() != nullptr; }
 
-        int nMEPartons() const { return nMEPartons_; }
-        
-        int nMEPartonsFiltered() const { return nMEPartonsFiltered_; }
+  const std::vector<double> &binningValues() const { return binningValues_; }
+  bool hasBinningValues() const { return !binningValues_.empty(); }
 
-	// setters
+  const std::vector<float> &DJRValues() const { return DJRValues_; }
+  bool hasDJRValues() const { return !DJRValues_.empty(); }
 
-	void setWeights(const std::vector<double> &weights)
-	{ weights_ = weights; }
+  int nMEPartons() const { return nMEPartons_; }
 
-	void setSignalProcessID(unsigned int procID)
-	{ signalProcessID_  = procID; }
+  int nMEPartonsFiltered() const { return nMEPartonsFiltered_; }
 
-	void setScales(double q = -1., double qcd = -1., double qed = -1.)
-	{ qScale_ = q, alphaQCD_ = qcd, alphaQED_ = qed; }
+  // setters
 
-	void setPDF(const PDF *pdf) { pdf_.reset(pdf ? new PDF(*pdf) : nullptr); }
+  void setWeights(const std::vector<double> &weights) { weights_ = weights; }
 
-	void setBinningValues(const std::vector<double> &values)
-	{ binningValues_ = values; }
- 
-	void setDJR(const std::vector<float> &values)
-	{DJRValues_ = values;}
+  void setSignalProcessID(unsigned int procID) { signalProcessID_ = procID; }
 
-	void setNMEPartons(int n) {nMEPartons_ = n;}
-	
-	void setNMEPartonsFiltered(int n) {nMEPartonsFiltered_ = n;}
+  void setScales(double q = -1., double qcd = -1., double qed = -1.) { qScale_ = q, alphaQCD_ = qcd, alphaQED_ = qed; }
 
-    private:
-	// HepMC::GenEvent provides a list of weights
-	std::vector<double>	weights_;
+  void setPDF(const PDF *pdf) { pdf_.reset(pdf ? new PDF(*pdf) : nullptr); }
 
-	// generator-dependent process ID
-	unsigned int		signalProcessID_;
+  void setBinningValues(const std::vector<double> &values) { binningValues_ = values; }
 
-	// information about scales
-	double			qScale_;
-	double			alphaQCD_, alphaQED_;
+  void setDJR(const std::vector<float> &values) { DJRValues_ = values; }
 
-	// optional PDF info
-	std::unique_ptr<PDF>	pdf_;
+  void setNMEPartons(int n) { nMEPartons_ = n; }
 
-	// If event was produced in bis, this contains
-	// the values that were used to define which
-	// bin the event belongs in
-	// This replaces the genEventScale, which only
-	// corresponds to Pythia pthat.  The RunInfo
-	// will contain the information what physical
-	// quantity these values actually belong to
-	std::vector<double>	binningValues_;
-        std::vector<float>      DJRValues_;
-        int                     nMEPartons_;
-        int                     nMEPartonsFiltered_;
+  void setNMEPartonsFiltered(int n) { nMEPartonsFiltered_ = n; }
+
+private:
+  // HepMC::GenEvent provides a list of weights
+  std::vector<double> weights_;
+
+  // generator-dependent process ID
+  unsigned int signalProcessID_;
+
+  // information about scales
+  double qScale_;
+  double alphaQCD_, alphaQED_;
+
+  // optional PDF info
+  std::unique_ptr<PDF> pdf_;
+
+  // If event was produced in bis, this contains
+  // the values that were used to define which
+  // bin the event belongs in
+  // This replaces the genEventScale, which only
+  // corresponds to Pythia pthat.  The RunInfo
+  // will contain the information what physical
+  // quantity these values actually belong to
+  std::vector<double> binningValues_;
+  std::vector<float> DJRValues_;
+  int nMEPartons_;
+  int nMEPartonsFiltered_;
 };
 
-#endif // SimDataFormats_GeneratorProducts_GenEventInfoProduct_h
+#endif  // SimDataFormats_GeneratorProducts_GenEventInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -10,104 +10,104 @@
 #include "SimDataFormats/GeneratorProducts/interface/WeightsInfo.h"
 
 class LHEEventProduct {
-    public:
-	typedef gen::PdfInfo PDF;
-	typedef gen::WeightsInfo WGT;
+public:
+  typedef gen::PdfInfo PDF;
+  typedef gen::WeightsInfo WGT;
 
-	typedef std::vector<std::string>::const_iterator
-						comments_const_iterator;
-	typedef std::vector<std::string>::size_type size_type;
+  typedef std::vector<std::string>::const_iterator comments_const_iterator;
+  typedef std::vector<std::string>::size_type size_type;
 
-	LHEEventProduct() {}
-        LHEEventProduct(const lhef::HEPEUP &hepeup) : 
-	  hepeup_(hepeup), originalXWGTUP_(0) {}
-	LHEEventProduct(const lhef::HEPEUP &hepeup,
-			const double originalXWGTUP) : 
-	  hepeup_(hepeup), originalXWGTUP_(originalXWGTUP) {}
-	LHEEventProduct(LHEEventProduct&& other) = default;
+  LHEEventProduct() {}
+  LHEEventProduct(const lhef::HEPEUP &hepeup) : hepeup_(hepeup), originalXWGTUP_(0) {}
+  LHEEventProduct(const lhef::HEPEUP &hepeup, const double originalXWGTUP)
+      : hepeup_(hepeup), originalXWGTUP_(originalXWGTUP) {}
+  LHEEventProduct(LHEEventProduct &&other) = default;
 
-	LHEEventProduct& operator=(LHEEventProduct&& other) =default;
+  LHEEventProduct &operator=(LHEEventProduct &&other) = default;
 
-	~LHEEventProduct() =default;
+  ~LHEEventProduct() = default;
 
-	void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }
-	void addWeight(const WGT& wgt) { 	  
-	  weights_.push_back(wgt);
-	}
-	void addComment(const std::string &line) { comments_.push_back(line); }
+  void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }
+  void addWeight(const WGT &wgt) { weights_.push_back(wgt); }
+  void addComment(const std::string &line) { comments_.push_back(line); }
 
-	double originalXWGTUP() const { return originalXWGTUP_; }
-	const std::vector<WGT>& weights() const { return weights_; }
+  double originalXWGTUP() const { return originalXWGTUP_; }
+  const std::vector<WGT> &weights() const { return weights_; }
 
-	const std::vector<float> &scales() const { return scales_; }
-	void setScales(const std::vector<float> &scales) { scales_ = scales; }
-	
-        int npLO() const { return npLO_; }
-        int npNLO() const { return npNLO_; }
-        
-        void setNpLO(int n) { npLO_ = n; }
-        void setNpNLO(int n) { npNLO_ = n; }	
-	
-	const lhef::HEPEUP &hepeup() const { return hepeup_; }
-	const PDF *pdf() const { return pdf_.get(); }
+  const std::vector<float> &scales() const { return scales_; }
+  void setScales(const std::vector<float> &scales) { scales_ = scales; }
 
-	size_type comments_size() const { return comments_.size(); }
-	comments_const_iterator comments_begin() const { return comments_.begin(); }
-	comments_const_iterator comments_end() const { return comments_.end(); }
-  
-  const char* getComment(unsigned i) const {
-    if(comments_.empty() || i>=comments_.size()) return "";
-    else return (const char*) comments_[i].c_str();
+  int npLO() const { return npLO_; }
+  int npNLO() const { return npNLO_; }
+
+  void setNpLO(int n) { npLO_ = n; }
+  void setNpNLO(int n) { npNLO_ = n; }
+
+  const lhef::HEPEUP &hepeup() const { return hepeup_; }
+  const PDF *pdf() const { return pdf_.get(); }
+
+  size_type comments_size() const { return comments_.size(); }
+  comments_const_iterator comments_begin() const { return comments_.begin(); }
+  comments_const_iterator comments_end() const { return comments_.end(); }
+
+  const char *getComment(unsigned i) const {
+    if (comments_.empty() || i >= comments_.size())
+      return "";
+    else
+      return (const char *)comments_[i].c_str();
   }
 
-	class const_iterator {
-	    public:
-		typedef std::forward_iterator_tag	iterator_category;
-		typedef std::string			value_type;
-		typedef std::ptrdiff_t			difference_type;
-		typedef std::string			*pointer;
-		typedef std::string			&reference;
+  class const_iterator {
+  public:
+    typedef std::forward_iterator_tag iterator_category;
+    typedef std::string value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef std::string *pointer;
+    typedef std::string &reference;
 
-		const_iterator() : line(npos) {}
-		~const_iterator() {}
+    const_iterator() : line(npos) {}
+    ~const_iterator() {}
 
-		inline bool operator == (const const_iterator &other) const
-		{ return line == other.line; }
-		inline bool operator != (const const_iterator &other) const
-		{ return !operator == (other); }
+    inline bool operator==(const const_iterator &other) const { return line == other.line; }
+    inline bool operator!=(const const_iterator &other) const { return !operator==(other); }
 
-		inline const_iterator &operator ++ ()
-		{ next(); return *this; }
-		inline const_iterator operator ++ (int dummy)
-		{ const_iterator orig = *this; next(); return orig; }
+    inline const_iterator &operator++() {
+      next();
+      return *this;
+    }
+    inline const_iterator operator++(int dummy) {
+      const_iterator orig = *this;
+      next();
+      return orig;
+    }
 
-		const std::string &operator * () const { return tmp; }
-		const std::string *operator -> () const { return &tmp; }
+    const std::string &operator*() const { return tmp; }
+    const std::string *operator->() const { return &tmp; }
 
-	    private:
-		friend class LHEEventProduct;
+  private:
+    friend class LHEEventProduct;
 
-		void next();
+    void next();
 
-		const LHEEventProduct	*event;
-		unsigned int		line;
-		std::string		tmp;
+    const LHEEventProduct *event;
+    unsigned int line;
+    std::string tmp;
 
-		static const unsigned int npos = 99999;
-	};
+    static const unsigned int npos = 99999;
+  };
 
-	const_iterator begin() const;
-	inline const_iterator end() const { return const_iterator(); }
+  const_iterator begin() const;
+  inline const_iterator end() const { return const_iterator(); }
 
-    private:
-	lhef::HEPEUP			hepeup_;
-	std::vector<std::string>	comments_;
-	std::unique_ptr<PDF>		pdf_;
-	std::vector<WGT>                weights_;
-	double                          originalXWGTUP_;
-        std::vector<float>              scales_; //scale value used to exclude EWK-produced partons from matching
-        int                             npLO_; //number of partons for LO process (used to steer matching/merging)
-        int                             npNLO_; //number of partons for NLO process (used to steer matching/merging)
+private:
+  lhef::HEPEUP hepeup_;
+  std::vector<std::string> comments_;
+  std::unique_ptr<PDF> pdf_;
+  std::vector<WGT> weights_;
+  double originalXWGTUP_;
+  std::vector<float> scales_;  //scale value used to exclude EWK-produced partons from matching
+  int npLO_;                   //number of partons for LO process (used to steer matching/merging)
+  int npNLO_;                  //number of partons for NLO process (used to steer matching/merging)
 };
 
-#endif // GeneratorEvent_LHEInterface_LHEEventProduct_h
+#endif  // GeneratorEvent_LHEInterface_LHEEventProduct_h


### PR DESCRIPTION

Applying code-format for CMSSW category generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/451//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


