### PR TITLE
Running code-format for fastsim

### DIFF
--- a/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
@@ -1364,7 +1364,8 @@ void EcalHitMaker::cracksPads(std::vector<neighbour>& cracks, unsigned iq) {
         mycorners[2] = (myPad.edge(SOUTHWEST));
         mycorners[3] = (padsatdepth_[cracks[ic].second].edge(SOUTHEAST));
       } break;
-      default: {}
+      default: {
+      }
     }
     CrystalPad crackpad(ic, mycorners);
     // to be tuned. A simpleconfigurable should be used


### PR DESCRIPTION

Applying code-format for CMSSW category fastsim.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/450//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


