### PR TITLE
Running code-format for alca-db-l1

### DIFF
--- a/CondFormats/L1TObjects/src/L1GtCondition.cc
+++ b/CondFormats/L1TObjects/src/L1GtCondition.cc
@@ -397,7 +397,9 @@ void L1GtCondition::print(std::ostream& myCout) const {
       }
 
       break;
-      default: { myCout << " Unknown type " << m_objectType[i]; } break;
+      default: {
+        myCout << " Unknown type " << m_objectType[i];
+      } break;
     }
   }
 


### PR DESCRIPTION

Applying code-format for CMSSW category alca,db,l1.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/445//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


