### PR TITLE
Running code-format for l1

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysCandUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/PhysCandUnpacker.cc
@@ -73,94 +73,106 @@ namespace l1t {
   namespace stage1 {
     bool IsoEGammaUnpackerLeft::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getEGammas();
-      return process(block,
-                     res,
-                     [](l1t::EGamma eg) {
-                       eg.setHwIso(1);
-                       return eg;
-                     },
-                     true,
-                     true,
-                     false);
+      return process(
+          block,
+          res,
+          [](l1t::EGamma eg) {
+            eg.setHwIso(1);
+            return eg;
+          },
+          true,
+          true,
+          false);
     }
 
     bool NonIsoEGammaUnpackerLeft::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getEGammas();
-      return process(block, res, [](const l1t::EGamma& eg) { return eg; }, true, false, false);
+      return process(
+          block, res, [](const l1t::EGamma& eg) { return eg; }, true, false, false);
     }
 
     bool CentralJetUnpackerLeft::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getJets();
-      return process(block, res, [](const l1t::Jet& j) { return j; }, true, true, false);
+      return process(
+          block, res, [](const l1t::Jet& j) { return j; }, true, true, false);
     }
 
     bool ForwardJetUnpackerLeft::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getJets();
-      return process(block,
-                     res,
-                     [](l1t::Jet j) {
-                       j.setHwQual(j.hwQual() | 2);
-                       return j;
-                     },
-                     true,
-                     false,
-                     false);
+      return process(
+          block,
+          res,
+          [](l1t::Jet j) {
+            j.setHwQual(j.hwQual() | 2);
+            return j;
+          },
+          true,
+          false,
+          false);
     }
 
     bool TauUnpackerLeft::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getTaus();
-      return process(block, res, [](const l1t::Tau& t) { return t; }, true, true, true);
+      return process(
+          block, res, [](const l1t::Tau& t) { return t; }, true, true, true);
     }
 
     bool IsoTauUnpackerLeft::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getIsoTaus();
-      return process(block, res, [](const l1t::Tau& t) { return t; }, true, true, true);
+      return process(
+          block, res, [](const l1t::Tau& t) { return t; }, true, true, true);
     }
 
     bool IsoEGammaUnpackerRight::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getEGammas();
-      return process(block,
-                     res,
-                     [](l1t::EGamma eg) {
-                       eg.setHwIso(1);
-                       return eg;
-                     },
-                     false,
-                     true,
-                     false);
+      return process(
+          block,
+          res,
+          [](l1t::EGamma eg) {
+            eg.setHwIso(1);
+            return eg;
+          },
+          false,
+          true,
+          false);
     }
 
     bool NonIsoEGammaUnpackerRight::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getEGammas();
-      return process(block, res, [](const l1t::EGamma& eg) { return eg; }, false, false, false);
+      return process(
+          block, res, [](const l1t::EGamma& eg) { return eg; }, false, false, false);
     }
 
     bool CentralJetUnpackerRight::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getJets();
-      return process(block, res, [](const l1t::Jet& j) { return j; }, false, true, false);
+      return process(
+          block, res, [](const l1t::Jet& j) { return j; }, false, true, false);
     }
 
     bool ForwardJetUnpackerRight::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getJets();
-      return process(block,
-                     res,
-                     [](l1t::Jet j) {
-                       j.setHwQual(j.hwQual() | 2);
-                       return j;
-                     },
-                     false,
-                     false,
-                     false);
+      return process(
+          block,
+          res,
+          [](l1t::Jet j) {
+            j.setHwQual(j.hwQual() | 2);
+            return j;
+          },
+          false,
+          false,
+          false);
     }
 
     bool TauUnpackerRight::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getTaus();
-      return process(block, res, [](const l1t::Tau& t) { return t; }, false, true, true);
+      return process(
+          block, res, [](const l1t::Tau& t) { return t; }, false, true, true);
     }
 
     bool IsoTauUnpackerRight::unpack(const Block& block, UnpackerCollections* coll) {
       auto res = static_cast<CaloCollections*>(coll)->getIsoTaus();
-      return process(block, res, [](const l1t::Tau& t) { return t; }, false, true, true);
+      return process(
+          block, res, [](const l1t::Tau& t) { return t; }, false, true, true);
     }
   }  // namespace stage1
 }  // namespace l1t

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMAssignmentUnit.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMAssignmentUnit.cc
@@ -369,7 +369,9 @@ unsigned int L1MuBMAssignmentUnit::Quality() {
       quality = 1;
       break;
     }
-    default: { quality = 0; }
+    default: {
+      quality = 0;
+    }
   }
 
   return quality;
@@ -478,7 +480,9 @@ int L1MuBMAssignmentUnit::getCharge(L1MuBMLUTHandler::PtAssMethod method) {
       //                         << endl;
       break;
     }
-    default: { chargesign = 0; }
+    default: {
+      chargesign = 0;
+    }
   }
 
   return chargesign;
@@ -612,7 +616,9 @@ int L1MuBMAssignmentUnit::getPtAddress(L1MuBMLUTHandler::PtAssMethod method, int
       //                    cerr << "AssignmentUnit::getPtAddress : undefined PtAssMethod" << endl;
       break;
     }
-    default: { bendangle = 0; }
+    default: {
+      bendangle = 0;
+    }
   }
 
   int signo = 1;
@@ -708,7 +714,9 @@ L1MuBMLUTHandler::PtAssMethod L1MuBMAssignmentUnit::getPt1Method(L1MuBMLUTHandle
       pam = L1MuBMLUTHandler::NODEF;
       break;
     }
-    default: { pam = L1MuBMLUTHandler::NODEF; }
+    default: {
+      pam = L1MuBMLUTHandler::NODEF;
+    }
   }
 
   return pam;
@@ -739,7 +747,9 @@ L1MuBMLUTHandler::PtAssMethod L1MuBMAssignmentUnit::getPt2Method(L1MuBMLUTHandle
       pam = L1MuBMLUTHandler::NODEF;
       break;
     }
-    default: { pam = L1MuBMLUTHandler::NODEF; }
+    default: {
+      pam = L1MuBMLUTHandler::NODEF;
+    }
   }
 
   return pam;
@@ -784,7 +794,9 @@ int L1MuBMAssignmentUnit::getPt1Address(L1MuBMLUTHandler::PtAssMethod method) co
       bendangle = -999;
       break;
     }
-    default: { bendangle = -999; }
+    default: {
+      bendangle = -999;
+    }
   }
 
   return bendangle;
@@ -819,7 +831,9 @@ int L1MuBMAssignmentUnit::getPt2Address(L1MuBMLUTHandler::PtAssMethod method) co
       bendangle = -999;
       break;
     }
-    default: { bendangle = -999; }
+    default: {
+      bendangle = -999;
+    }
   }
 
   return bendangle;


### PR DESCRIPTION

Applying code-format for CMSSW category l1.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/453//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


