### PR TITLE
Running code-format for simulation

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalDigiCollections.h
+++ b/DataFormats/EcalDigi/interface/EcalDigiCollections.h
@@ -23,97 +23,71 @@ class EcalDigiCollection : public edm::DataFrameContainer {
 public:
   typedef edm::DataFrameContainer::size_type size_type;
   static const size_type MAXSAMPLES = 10;
-  explicit EcalDigiCollection(size_type istride=MAXSAMPLES, int isubdet=0)  : 
-    edm::DataFrameContainer(istride, isubdet){}
-  void swap(DataFrameContainer& other) {this->DataFrameContainer::swap(other);}
-  
+  explicit EcalDigiCollection(size_type istride = MAXSAMPLES, int isubdet = 0)
+      : edm::DataFrameContainer(istride, isubdet) {}
+  void swap(DataFrameContainer& other) { this->DataFrameContainer::swap(other); }
 };
 
 // make edm (and ecal client) happy
-class EBDigiCollection : public  EcalDigiCollection {
+class EBDigiCollection : public EcalDigiCollection {
 public:
   typedef edm::DataFrameContainer::size_type size_type;
   typedef EBDataFrame Digi;
   typedef Digi::key_type DetId;
 
-  EBDigiCollection(size_type istride=MAXSAMPLES) : 
-    EcalDigiCollection(istride, EcalBarrel){}
-  void swap(EBDigiCollection& other) {this->EcalDigiCollection::swap(other);}
-  void push_back(const Digi& digi){ DataFrameContainer::push_back(digi.id(), digi.frame().begin()); }
-  void push_back(id_type iid){DataFrameContainer::push_back(iid);}
-  void push_back(id_type iid,data_type const* idata){DataFrameContainer::push_back(iid,idata);}
-  
+  EBDigiCollection(size_type istride = MAXSAMPLES) : EcalDigiCollection(istride, EcalBarrel) {}
+  void swap(EBDigiCollection& other) { this->EcalDigiCollection::swap(other); }
+  void push_back(const Digi& digi) { DataFrameContainer::push_back(digi.id(), digi.frame().begin()); }
+  void push_back(id_type iid) { DataFrameContainer::push_back(iid); }
+  void push_back(id_type iid, data_type const* idata) { DataFrameContainer::push_back(iid, idata); }
 };
 
-class EEDigiCollection : public  EcalDigiCollection {
-public:  
+class EEDigiCollection : public EcalDigiCollection {
+public:
   typedef edm::DataFrameContainer::size_type size_type;
   typedef EEDataFrame Digi;
   typedef Digi::key_type DetId;
 
-  EEDigiCollection(size_type istride=MAXSAMPLES) : 
-    EcalDigiCollection(istride, EcalEndcap){}
-  void swap(EEDigiCollection& other) {this->EcalDigiCollection::swap(other);}
-  void push_back(const Digi& digi){ edm::DataFrameContainer::push_back(digi.id(), digi.frame().begin()); }
-  void push_back(id_type iid){DataFrameContainer::push_back(iid);}
-  void push_back(id_type iid,data_type const* idata){DataFrameContainer::push_back(iid,idata);}
-  
+  EEDigiCollection(size_type istride = MAXSAMPLES) : EcalDigiCollection(istride, EcalEndcap) {}
+  void swap(EEDigiCollection& other) { this->EcalDigiCollection::swap(other); }
+  void push_back(const Digi& digi) { edm::DataFrameContainer::push_back(digi.id(), digi.frame().begin()); }
+  void push_back(id_type iid) { DataFrameContainer::push_back(iid); }
+  void push_back(id_type iid, data_type const* idata) { DataFrameContainer::push_back(iid, idata); }
 };
 
-class ESDigiCollection : public EcalDigiCollection 
-{
-   public:  
-      typedef edm::DataFrameContainer::size_type size_type;
-      typedef ESDataFrame Digi;
-      typedef Digi::key_type DetId;
+class ESDigiCollection : public EcalDigiCollection {
+public:
+  typedef edm::DataFrameContainer::size_type size_type;
+  typedef ESDataFrame Digi;
+  typedef Digi::key_type DetId;
 
-      static const size_type NSAMPLE = ESDataFrame::MAXSAMPLES ;
-      ESDigiCollection(size_type istride=NSAMPLE) : 
-	 EcalDigiCollection(istride, EcalPreshower){}
-      void swap(ESDigiCollection& other) {this->EcalDigiCollection::swap(other);}
+  static const size_type NSAMPLE = ESDataFrame::MAXSAMPLES;
+  ESDigiCollection(size_type istride = NSAMPLE) : EcalDigiCollection(istride, EcalPreshower) {}
+  void swap(ESDigiCollection& other) { this->EcalDigiCollection::swap(other); }
 
-      void push_back( unsigned int i ) 
-      {
-	 DataFrameContainer::push_back( i ) ;
-      }
+  void push_back(unsigned int i) { DataFrameContainer::push_back(i); }
 
-      void push_back( const Digi& digi ) 
-      {
-	 uint16_t esdata[NSAMPLE] ;
-	 for( unsigned int i ( 0 ) ; i != NSAMPLE; ++i )
-	 {
-	    static const int offset ( 65536 ) ; // for int16 to uint16
-	    const int16_t dshort ( digi[i].raw() ) ;
-	    const int     dint   ( (int) dshort + // add offset for uint16 conversion
-				   ( (int16_t) 0 > dshort ? 
-				     offset : (int) 0 ) ) ;
-	    esdata[i] = dint ;
-	 }
-	 EcalDigiCollection::push_back( digi.id()(), esdata ) ;
-      }
+  void push_back(const Digi& digi) {
+    uint16_t esdata[NSAMPLE];
+    for (unsigned int i(0); i != NSAMPLE; ++i) {
+      static const int offset(65536);  // for int16 to uint16
+      const int16_t dshort(digi[i].raw());
+      const int dint((int)dshort +  // add offset for uint16 conversion
+                     ((int16_t)0 > dshort ? offset : (int)0));
+      esdata[i] = dint;
+    }
+    EcalDigiCollection::push_back(digi.id()(), esdata);
+  }
 };
-
 
 // Free swap functions
-inline
-void swap(EcalDigiCollection& lhs, EcalDigiCollection& rhs) {
-  lhs.swap(rhs);
-}
+inline void swap(EcalDigiCollection& lhs, EcalDigiCollection& rhs) { lhs.swap(rhs); }
 
-inline
-void swap(EBDigiCollection& lhs, EBDigiCollection& rhs) {
-  lhs.swap(rhs);
-}
+inline void swap(EBDigiCollection& lhs, EBDigiCollection& rhs) { lhs.swap(rhs); }
 
-inline
-void swap(EEDigiCollection& lhs, EEDigiCollection& rhs) {
-  lhs.swap(rhs);
-}
+inline void swap(EEDigiCollection& lhs, EEDigiCollection& rhs) { lhs.swap(rhs); }
 
-inline
-void swap(ESDigiCollection& lhs, ESDigiCollection& rhs) {
-  lhs.swap(rhs);
-}
+inline void swap(ESDigiCollection& lhs, ESDigiCollection& rhs) { lhs.swap(rhs); }
 
 typedef edm::SortedCollection<EcalTimeDigi> EcalTimeDigiCollection;
 typedef edm::SortedCollection<EcalTriggerPrimitiveDigi> EcalTrigPrimDigiCollection;

--- a/DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveDigi.h
@@ -6,8 +6,6 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveSample.h"
 
-
-
 /** \class EcalEBTriggerPrimitiveDigi
 \author N. Marinelli - Univ. of Notre Dame
 
@@ -15,34 +13,33 @@
 */
 
 class EcalEBTriggerPrimitiveDigi {
- public:
-  typedef EBDetId key_type; ///< For the sorted collection
+public:
+  typedef EBDetId key_type;  ///< For the sorted collection
 
-  EcalEBTriggerPrimitiveDigi(); // for persistence
+  EcalEBTriggerPrimitiveDigi();  // for persistence
   EcalEBTriggerPrimitiveDigi(const EBDetId& id);
-  
 
   void swap(EcalEBTriggerPrimitiveDigi& rh) {
-    std::swap(id_,rh.id_);
-    std::swap(size_,rh.size_);
-    std::swap(data_,rh.data_);
+    std::swap(id_, rh.id_);
+    std::swap(size_, rh.size_);
+    std::swap(data_, rh.data_);
   }
-  
+
   const EBDetId& id() const { return id_; }
   int size() const { return size_; }
-    
+
   const EcalEBTriggerPrimitiveSample& operator[](int i) const { return data_[i]; }
   const EcalEBTriggerPrimitiveSample& sample(int i) const { return data_[i]; }
-    
+
   void setSize(int size);
   void setSample(int i, const EcalEBTriggerPrimitiveSample& sam);
   void setSampleValue(int i, uint16_t value) { data_[i].setValue(value); }
-    
+
   static const int MAXSAMPLES = 20;
 
   /// get the 10 bits Et of interesting sample
-  int encodedEt() const; 
-  
+  int encodedEt() const;
+
   /// Spike flag
   bool l1aSpike() const;
 
@@ -59,16 +56,10 @@ private:
   EBDetId id_;
   int size_;
   std::vector<EcalEBTriggerPrimitiveSample> data_;
-
 };
 
-
-inline void swap(EcalEBTriggerPrimitiveDigi& lh, EcalEBTriggerPrimitiveDigi& rh) {
-  lh.swap(rh);
-}
+inline void swap(EcalEBTriggerPrimitiveDigi& lh, EcalEBTriggerPrimitiveDigi& rh) { lh.swap(rh); }
 
 std::ostream& operator<<(std::ostream& s, const EcalEBTriggerPrimitiveDigi& digi);
-
-
 
 #endif

--- a/DataFormats/EcalDigi/src/EcalEBTriggerPrimitiveDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalEBTriggerPrimitiveDigi.cc
@@ -1,48 +1,38 @@
 #include "DataFormats/EcalDigi/interface/EcalEBTriggerPrimitiveDigi.h"
 #include <iostream>
 
-
-EcalEBTriggerPrimitiveDigi::EcalEBTriggerPrimitiveDigi() : size_(0), data_(MAXSAMPLES) {
-}
+EcalEBTriggerPrimitiveDigi::EcalEBTriggerPrimitiveDigi() : size_(0), data_(MAXSAMPLES) {}
 //EcalTriggerPrimitiveDigi::EcalTriggerPrimitiveDigi(const EcalTrigTowerDetId& id) : id_(id),
 //size_(0), data_(MAXSAMPLES) {
 //}
 
-EcalEBTriggerPrimitiveDigi::EcalEBTriggerPrimitiveDigi(const EBDetId& id) : id_(id),
-										   size_(0), data_(MAXSAMPLES) {
+EcalEBTriggerPrimitiveDigi::EcalEBTriggerPrimitiveDigi(const EBDetId& id) : id_(id), size_(0), data_(MAXSAMPLES) {}
+
+void EcalEBTriggerPrimitiveDigi::setSample(int i, const EcalEBTriggerPrimitiveSample& sam) {
+  //  std::cout << " In setSample  i " << i << "  sam " << sam << std::endl;
+  data_[i] = sam;
+  //  std::cout << " In setSample data_[i] " << data_[i] << std::endl;
 }
 
-void EcalEBTriggerPrimitiveDigi::setSample(int i, const EcalEBTriggerPrimitiveSample& sam) 
-{
-//  std::cout << " In setSample  i " << i << "  sam " << sam << std::endl;  
-  data_[i]=sam;
-//  std::cout << " In setSample data_[i] " << data_[i] << std::endl;  
-  
-}
-
-int EcalEBTriggerPrimitiveDigi::sampleOfInterest() const
-{
+int EcalEBTriggerPrimitiveDigi::sampleOfInterest() const {
   if (size_ == 1)
     return 0;
   else if (size_ == 5)
     return 2;
   else
     return -1;
-} 
+}
 
 /// get the encoded/compressed Et of interesting sample
-int EcalEBTriggerPrimitiveDigi::encodedEt() const 
-{
+int EcalEBTriggerPrimitiveDigi::encodedEt() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].encodedEt();
   else
     return -1;
 }
- 
 
-bool EcalEBTriggerPrimitiveDigi::l1aSpike() const
-{
+bool EcalEBTriggerPrimitiveDigi::l1aSpike() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].l1aSpike();
@@ -50,8 +40,7 @@ bool EcalEBTriggerPrimitiveDigi::l1aSpike() const
     return -1;
 }
 
-int EcalEBTriggerPrimitiveDigi::time() const
-{
+int EcalEBTriggerPrimitiveDigi::time() const {
   int sample = sampleOfInterest();
   if (sample != -1)
     return data_[sample].time();
@@ -59,8 +48,7 @@ int EcalEBTriggerPrimitiveDigi::time() const
     return -1;
 }
 
-bool EcalEBTriggerPrimitiveDigi::isDebug() const
-{
+bool EcalEBTriggerPrimitiveDigi::isDebug() const {
   if (size_ == 1)
     return false;
   else if (size_ > 1)
@@ -69,16 +57,17 @@ bool EcalEBTriggerPrimitiveDigi::isDebug() const
 }
 
 void EcalEBTriggerPrimitiveDigi::setSize(int size) {
-  if (size<0) size_=0;
-  else if (size>MAXSAMPLES) size_=MAXSAMPLES;
-  else size_=size;
+  if (size < 0)
+    size_ = 0;
+  else if (size > MAXSAMPLES)
+    size_ = MAXSAMPLES;
+  else
+    size_ = size;
 }
 
-  
 std::ostream& operator<<(std::ostream& s, const EcalEBTriggerPrimitiveDigi& digi) {
   s << digi.id() << " " << digi.size() << " samples " << std::endl;
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     s << "  " << digi.sample(i) << std::endl;
   return s;
 }
-

--- a/DataFormats/EcalDigi/src/classes.h
+++ b/DataFormats/EcalDigi/src/classes.h
@@ -1,4 +1,2 @@
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-
-

--- a/DataFormats/RPCDigi/src/DataRecord.cc
+++ b/DataFormats/RPCDigi/src/DataRecord.cc
@@ -94,7 +94,9 @@ std::string rpcrawtodigi::DataRecord::name(const rpcrawtodigi::DataRecord::DataR
       result = "RDM";
       break;
     }
-    default: { result = "UndefinedType"; }
+    default: {
+      result = "UndefinedType";
+    }
   }
   return result;
 }

--- a/DataFormats/RPCDigi/src/RPCRawDataCounts.cc
+++ b/DataFormats/RPCDigi/src/RPCRawDataCounts.cc
@@ -61,7 +61,8 @@ void RPCRawDataCounts::addDccRecord(int fed, const rpcrawtodigi::DataRecord& rec
       theBadEvents[make_pair(fed, ErrorRCDM(record).rmb())] += weight;
       break;
     }
-    default: {}
+    default: {
+    }
   }
 
   theRecordTypes[make_pair(fed, type)] += weight;

--- a/DataFormats/RPCDigi/src/ReadoutError.cc
+++ b/DataFormats/RPCDigi/src/ReadoutError.cc
@@ -65,7 +65,9 @@ std::string ReadoutError::name(const ReadoutErrorType &code) {
       result = "EOD";
       break;
     }
-    default: { result = "NoProblem"; }
+    default: {
+      result = "NoProblem";
+    }
   }
   return result;
 }

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02HcalNumberingScheme.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02HcalNumberingScheme.cc
@@ -64,8 +64,9 @@ int HcalTB02HcalNumberingScheme::getUnitID(const G4Step* aStep) const {
 
   G4VPhysicalVolume* thePV = preStepPoint->GetPhysicalVolume();
   int ilayer = ((thePV->GetCopyNo()) / 10) % 100;
-  edm::LogVerbatim("HcalTBSim") << "HcalTB02HcalNumberingScheme:: Layer " << thePV->GetName() << " found at phi = " 
-				<< phi << " eta = " << eta << " lay = " << thePV->GetCopyNo() << " " << ilayer;
+  edm::LogVerbatim("HcalTBSim") << "HcalTB02HcalNumberingScheme:: Layer " << thePV->GetName()
+                                << " found at phi = " << phi << " eta = " << eta << " lay = " << thePV->GetCopyNo()
+                                << " " << ilayer;
 
   scintID = phiScale * phi + etaScale * eta + ilayer;
   if (hy < 0.)

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02XtalNumberingScheme.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02XtalNumberingScheme.cc
@@ -39,6 +39,7 @@ int HcalTB02XtalNumberingScheme::getUnitID(const G4Step* aStep) const {
   if (touch->GetHistoryDepth() > 0)
     idl = touch->GetReplicaNumber(1);
   int idunit = idl * 100 + idx;
-  edm::LogVerbatim("HcalTBSim") << "HcalTB02XtalNumberingScheme:: Row " << idl << " Column " << idl << " idunit = " << idunit;
+  edm::LogVerbatim("HcalTBSim") << "HcalTB02XtalNumberingScheme:: Row " << idl << " Column " << idl
+                                << " idunit = " << idunit;
   return idunit;
 }

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB04XtalNumberingScheme.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB04XtalNumberingScheme.cc
@@ -47,8 +47,8 @@ uint32_t HcalTB04XtalNumberingScheme::getUnitID(const EcalBaseNumber& baseNumber
   int det = 10;
   uint32_t idunit = HcalTestNumbering::packHcalIndex(det, 0, 1, idl, idx, 1);
 
-  edm::LogVerbatim("HcalTBSim") << "HcalTB04XtalNumberingScheme : Crystal " << idx << " Layer " << idl 
-				<< " UnitID = 0x" << std::hex << idunit << std::dec;
+  edm::LogVerbatim("HcalTBSim") << "HcalTB04XtalNumberingScheme : Crystal " << idx << " Layer " << idl << " UnitID = 0x"
+                                << std::hex << idunit << std::dec;
 
   return idunit;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/456//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


