### PR TITLE
Running code-format for core

### DIFF
--- a/DataFormats/Common/interface/AssociationVector.h
+++ b/DataFormats/Common/interface/AssociationVector.h
@@ -162,8 +162,8 @@ namespace edm {
   }
 
   template <typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
-  inline typename CVal::const_reference AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::
-  operator[](KeyRef const& k) const {
+  inline typename CVal::const_reference
+      AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::operator[](KeyRef const& k) const {
     KeyRef keyRef = KeyReferenceHelper::get(k, ref_.id());
     checkForWrongProduct(keyRef.id(), ref_.id());
     return data_[keyRef.key()];
@@ -171,8 +171,8 @@ namespace edm {
 
   template <typename KeyRefProd, typename CVal, typename KeyRef, typename SizeType, typename KeyReferenceHelper>
   template <typename K>
-  inline typename CVal::const_reference AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::
-  operator[](edm::Ptr<K> const& k) const {
+  inline typename CVal::const_reference
+      AssociationVector<KeyRefProd, CVal, KeyRef, SizeType, KeyReferenceHelper>::operator[](edm::Ptr<K> const& k) const {
     static_assert(std::is_base_of<K, key_type>::value,
                   "edm::Ptr's key type is not a base class of AssociationVector's item type");
     checkForWrongProduct(k.id(), ref_.id());

--- a/DataFormats/Common/test/testMultiAssociation.cc
+++ b/DataFormats/Common/test/testMultiAssociation.cc
@@ -592,19 +592,27 @@ bool testMultiAssociation::tryBadFill(int i) {
       filler.setValues(Ref<CKey2>(handleK2, 0), coll1);
     }; break;
     case 2: {  // fill again with different id
-      { MultiRef::FastFiller filler = m.fastFiller(handleK1); }
+      {
+        MultiRef::FastFiller filler = m.fastFiller(handleK1);
+      }
       { MultiRef::FastFiller filler = m.fastFiller(handleK2); }
     }; break;
     case 3: {  // fill again with the same id
-      { MultiRef::FastFiller filler = m.fastFiller(handleK1); }
+      {
+        MultiRef::FastFiller filler = m.fastFiller(handleK1);
+      }
       { MultiRef::FastFiller filler = m.fastFiller(handleK1); }
     }; break;
     case 4: {  // Check lazyFiller doesn't fill if not requested
-      { MultiRef::LazyFiller filler = m.lazyFiller(handleK1); }
+      {
+        MultiRef::LazyFiller filler = m.lazyFiller(handleK1);
+      }
       { MultiRef::LazyFiller filler = m.lazyFiller(handleK1); }
     }; break;
     case 5: {  // Check lazyFiller can't fill twice the same key if requested
-      { MultiRef::LazyFiller filler = m.lazyFiller(handleK1, true); }
+      {
+        MultiRef::LazyFiller filler = m.lazyFiller(handleK1, true);
+      }
       { MultiRef::LazyFiller filler = m.lazyFiller(handleK1, true); }
     }; break;
     case 6: {  // Check lazyFiller doesn't fill twice by mistake
@@ -615,7 +623,9 @@ bool testMultiAssociation::tryBadFill(int i) {
       filler.fill();
     }; break;
     case 8: {  // Check lazyFiller doesn't fill if not requested
-      { MultiRef::LazyFiller filler = m.lazyFiller(handleK1, false); }
+      {
+        MultiRef::LazyFiller filler = m.lazyFiller(handleK1, false);
+      }
       CPPUNIT_ASSERT(m.empty());
     } break;
     case 9: {  // Check index out of bounds


### PR DESCRIPTION

Applying code-format for CMSSW category core.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/448//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


