### PR TITLE
Running code-format for visualization

### DIFF
--- a/Fireworks/Core/src/CmsAnnotation.cc
+++ b/Fireworks/Core/src/CmsAnnotation.cc
@@ -275,7 +275,9 @@ Bool_t CmsAnnotation::Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec, Even
       }
       return kTRUE;
     }
-    default: { return kFALSE; }
+    default: {
+      return kFALSE;
+    }
   }
 
   return false;

--- a/Fireworks/Core/src/CmsShowSearchFiles.cc
+++ b/Fireworks/Core/src/CmsShowSearchFiles.cc
@@ -192,7 +192,7 @@ void CmsShowSearchFiles::openClicked() {
 void CmsShowSearchFiles::showPrefixes() {
   if (nullptr == m_prefixMenu) {
     m_prefixMenu = new TGPopupMenu(this);
-    const char* const(*itEnd)[s_columns] = s_prefixes + sizeof(s_prefixes) / sizeof(const char * [3]);
+    const char* const(*itEnd)[s_columns] = s_prefixes + sizeof(s_prefixes) / sizeof(const char* [3]);
     int index = 0;
     for (const char* const(*it)[s_columns] = s_prefixes; it != itEnd; ++it, ++index) {
       //only add the protocols this version of the code actually can load

--- a/Fireworks/Core/src/FWPopupMenu.cc
+++ b/Fireworks/Core/src/FWPopupMenu.cc
@@ -72,7 +72,9 @@ public:
         void* dummy = nullptr;
         return EndMenu(dummy);
       }
-      default: { break; }
+      default: {
+        break;
+      }
     }
 
     return kTRUE;

--- a/Fireworks/FWInterface/src/FWPSetTableManager.cc
+++ b/Fireworks/FWInterface/src/FWPSetTableManager.cc
@@ -370,7 +370,9 @@ void FWPSetTableManager::handleEntry(const edm::Entry &entry, const std::string 
       createScalarString(data, entry.getEventRange());
       break;
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
 }
 


### PR DESCRIPTION

Applying code-format for CMSSW category visualization.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/458//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


