### PR TITLE
[HGCAL] TICL technical changes

### DIFF
--- a/DataFormats/HGCalReco/interface/Common.h
+++ b/DataFormats/HGCalReco/interface/Common.h
@@ -11,6 +11,7 @@ namespace ticl::constants {
   constexpr int nEtaBins = 34;
   constexpr int nPhiBins = 126;
   constexpr int nLayers = 104;
+  constexpr int iterations = 4;
 }  // namespace ticl::constants
 
 class TICLLayerTile;
@@ -18,6 +19,7 @@ namespace ticl {
   typedef std::vector<std::pair<unsigned int, float> > HgcalClusterFilterMask;
   typedef std::array<std::vector<unsigned int>, constants::nEtaBins * constants::nPhiBins> Tile;
   typedef std::array<TICLLayerTile, ticl::constants::nLayers> Tiles;
+  typedef std::array<TICLLayerTile, ticl::constants::iterations> TracksterTiles;
 }  // namespace ticl
 
 #endif  // DataFormats_HGCalReco_Common_h

--- a/DataFormats/HGCalReco/interface/Common.h
+++ b/DataFormats/HGCalReco/interface/Common.h
@@ -14,12 +14,9 @@ namespace ticl::constants {
   constexpr int iterations = 4;
 }  // namespace ticl::constants
 
-class TICLLayerTile;
 namespace ticl {
   typedef std::vector<std::pair<unsigned int, float> > HgcalClusterFilterMask;
   typedef std::array<std::vector<unsigned int>, constants::nEtaBins * constants::nPhiBins> Tile;
-  typedef std::array<TICLLayerTile, ticl::constants::nLayers> Tiles;
-  typedef std::array<TICLLayerTile, ticl::constants::iterations> TracksterTiles;
 }  // namespace ticl
 
 #endif  // DataFormats_HGCalReco_Common_h

--- a/DataFormats/HGCalReco/interface/Common.h
+++ b/DataFormats/HGCalReco/interface/Common.h
@@ -5,18 +5,20 @@
 #include <array>
 #include <cstdint>
 
-namespace ticl::constants {
-  constexpr float minEta = 1.5f;
-  constexpr float maxEta = 3.2f;
-  constexpr int nEtaBins = 34;
-  constexpr int nPhiBins = 126;
-  constexpr int nLayers = 104;
-  constexpr int iterations = 4;
-}  // namespace ticl::constants
+namespace ticl {
+  struct TileConstants {
+    static constexpr float minEta = 1.5f;
+    static constexpr float maxEta = 3.2f;
+    static constexpr int nEtaBins = 34;
+    static constexpr int nPhiBins = 126;
+    static constexpr int nLayers = 104;
+    static constexpr int iterations = 4;
+    static constexpr int nBins = nEtaBins * nPhiBins;
+  };
+}  // namespace ticl
 
 namespace ticl {
   typedef std::vector<std::pair<unsigned int, float> > HgcalClusterFilterMask;
-  typedef std::array<std::vector<unsigned int>, constants::nEtaBins * constants::nPhiBins> Tile;
 }  // namespace ticl
 
 #endif  // DataFormats_HGCalReco_Common_h

--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -53,9 +53,7 @@ public:
   // numbering is not handled internally. It is the user's responsibility to
   // properly use and consistently access it here.
   const TICLLayerTile& operator[](int index) const { return tiles_[index]; }
-  void fill(int index, double eta, double phi, unsigned int objectId) {
-    tiles_[index].fill(eta, phi, objectId);
-  }
+  void fill(int index, double eta, double phi, unsigned int objectId) { tiles_[index].fill(eta, phi, objectId); }
 
 private:
   T tiles_;
@@ -64,7 +62,7 @@ private:
 namespace ticl {
   using Tiles = std::array<TICLLayerTile, constants::nLayers>;
   using TracksterTiles = std::array<TICLLayerTile, constants::iterations>;
-} // namespace ticl
+}  // namespace ticl
 
 using TICLLayerTiles = TICLGenericTile<ticl::Tiles>;
 using TICLTracksterTiles = TICLGenericTile<ticl::TracksterTiles>;

--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -61,4 +61,18 @@ private:
   ticl::Tiles tiles_;
 };
 
+class TICLTracksterTiles {
+public:
+  // This class represents a collection of Tiles, one for each layer in
+  // HGCAL. The layer numbering should account for both sides of HGCAL and is
+  // not handled internally. It is the user's responsibility to properly
+  // number the layers and consistently access them here.
+  const TICLLayerTile& operator[](int iteration) const { return tiles_[iteration]; }
+  void fill(int iteration, double eta, double phi, unsigned int tracksterId) {
+    tiles_[iteration].fill(eta, phi, tracksterId);
+  }
+
+private:
+  ticl::TracksterTiles tiles_;
+};
 #endif

--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -46,33 +46,27 @@ private:
   ticl::Tile tile_;
 };
 
-class TICLLayerTiles {
+template <typename T>
+class TICLGenericTile {
 public:
-  // This class represents a collection of Tiles, one for each layer in
-  // HGCAL. The layer numbering should account for both sides of HGCAL and is
-  // not handled internally. It is the user's responsibility to properly
-  // number the layers and consistently access them here.
-  const TICLLayerTile& operator[](int layer) const { return tiles_[layer]; }
-  void fill(int layer, double eta, double phi, unsigned int layerClusterId) {
-    tiles_[layer].fill(eta, phi, layerClusterId);
+  // This class represents a generic collection of Tiles. The additional index
+  // numbering is not handled internally. It is the user's responsibility to
+  // properly use and consistently access it here.
+  const TICLLayerTile& operator[](int index) const { return tiles_[index]; }
+  void fill(int index, double eta, double phi, unsigned int objectId) {
+    tiles_[index].fill(eta, phi, objectId);
   }
 
 private:
-  ticl::Tiles tiles_;
+  T tiles_;
 };
 
-class TICLTracksterTiles {
-public:
-  // This class represents a collection of Tiles, one for each layer in
-  // HGCAL. The layer numbering should account for both sides of HGCAL and is
-  // not handled internally. It is the user's responsibility to properly
-  // number the layers and consistently access them here.
-  const TICLLayerTile& operator[](int iteration) const { return tiles_[iteration]; }
-  void fill(int iteration, double eta, double phi, unsigned int tracksterId) {
-    tiles_[iteration].fill(eta, phi, tracksterId);
-  }
+namespace ticl {
+  using Tiles = std::array<TICLLayerTile, constants::nLayers>;
+  using TracksterTiles = std::array<TICLLayerTile, constants::iterations>;
+} // namespace ticl
 
-private:
-  ticl::TracksterTiles tiles_;
-};
+using TICLLayerTiles = TICLGenericTile<ticl::Tiles>;
+using TICLTracksterTiles = TICLGenericTile<ticl::TracksterTiles>;
+
 #endif

--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -7,35 +7,36 @@
 #include "DataFormats/HGCalReco/interface/Common.h"
 #include "DataFormats/Math/interface/normalizedPhi.h"
 
-class TICLLayerTile {
+template <typename T>
+class TICLLayerTileT {
 public:
   void fill(double eta, double phi, unsigned int layerClusterId) {
     tile_[globalBin(eta, phi)].push_back(layerClusterId);
   }
 
   int etaBin(float eta) const {
-    constexpr float etaRange = ticl::constants::maxEta - ticl::constants::minEta;
+    constexpr float etaRange = T::maxEta - T::minEta;
     static_assert(etaRange >= 0.f);
-    float r = ticl::constants::nEtaBins / etaRange;
-    int etaBin = (std::abs(eta) - ticl::constants::minEta) * r;
-    etaBin = std::clamp(etaBin, 0, ticl::constants::nEtaBins - 1);
+    float r = T::nEtaBins / etaRange;
+    int etaBin = (std::abs(eta) - T::minEta) * r;
+    etaBin = std::clamp(etaBin, 0, T::nEtaBins - 1);
     return etaBin;
   }
 
   int phiBin(float phi) const {
     auto normPhi = normalizedPhi(phi);
-    float r = ticl::constants::nPhiBins * M_1_PI * 0.5f;
+    float r = T::nPhiBins * M_1_PI * 0.5f;
     int phiBin = (normPhi + M_PI) * r;
 
     return phiBin;
   }
 
-  int globalBin(int etaBin, int phiBin) const { return phiBin + etaBin * ticl::constants::nPhiBins; }
+  int globalBin(int etaBin, int phiBin) const { return phiBin + etaBin * T::nPhiBins; }
 
-  int globalBin(double eta, double phi) const { return phiBin(phi) + etaBin(eta) * ticl::constants::nPhiBins; }
+  int globalBin(double eta, double phi) const { return phiBin(phi) + etaBin(eta) * T::nPhiBins; }
 
   void clear() {
-    auto nBins = ticl::constants::nEtaBins * ticl::constants::nPhiBins;
+    auto nBins = T::nEtaBins * T::nPhiBins;
     for (int j = 0; j < nBins; ++j)
       tile_[j].clear();
   }
@@ -43,8 +44,14 @@ public:
   const std::vector<unsigned int>& operator[](int globalBinId) const { return tile_[globalBinId]; }
 
 private:
-  ticl::Tile tile_;
+  std::array<std::vector<unsigned int>, T::nBins> tile_;
 };
+
+namespace ticl {
+  using TICLLayerTile = TICLLayerTileT<TileConstants>;
+  using Tiles = std::array<TICLLayerTile, TileConstants::nLayers>;
+  using TracksterTiles = std::array<TICLLayerTile, TileConstants::iterations>;
+}
 
 template <typename T>
 class TICLGenericTile {
@@ -52,17 +59,12 @@ public:
   // This class represents a generic collection of Tiles. The additional index
   // numbering is not handled internally. It is the user's responsibility to
   // properly use and consistently access it here.
-  const TICLLayerTile& operator[](int index) const { return tiles_[index]; }
+  const auto & operator[](int index) const { return tiles_[index]; }
   void fill(int index, double eta, double phi, unsigned int objectId) { tiles_[index].fill(eta, phi, objectId); }
 
 private:
   T tiles_;
 };
-
-namespace ticl {
-  using Tiles = std::array<TICLLayerTile, constants::nLayers>;
-  using TracksterTiles = std::array<TICLLayerTile, constants::iterations>;
-}  // namespace ticl
 
 using TICLLayerTiles = TICLGenericTile<ticl::Tiles>;
 using TICLTracksterTiles = TICLGenericTile<ticl::TracksterTiles>;

--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -51,7 +51,7 @@ namespace ticl {
   using TICLLayerTile = TICLLayerTileT<TileConstants>;
   using Tiles = std::array<TICLLayerTile, TileConstants::nLayers>;
   using TracksterTiles = std::array<TICLLayerTile, TileConstants::iterations>;
-}
+}  // namespace ticl
 
 template <typename T>
 class TICLGenericTile {
@@ -59,7 +59,7 @@ public:
   // This class represents a generic collection of Tiles. The additional index
   // numbering is not handled internally. It is the user's responsibility to
   // properly use and consistently access it here.
-  const auto & operator[](int index) const { return tiles_[index]; }
+  const auto& operator[](int index) const { return tiles_[index]; }
   void fill(int index, double eta, double phi, unsigned int objectId) { tiles_[index].fill(eta, phi, objectId); }
 
 private:

--- a/DataFormats/HGCalReco/interface/TICLSeedingRegion.h
+++ b/DataFormats/HGCalReco/interface/TICLSeedingRegion.h
@@ -18,9 +18,13 @@ struct TICLSeedingRegion {
   // zSide can be either 0(neg) or 1(pos)
   int zSide;
   // the index in the seeding collection
-  // with index = -1 indicating a global seeding region
+  // with index = -1 indicating a global seeding region.
+  // For track-based seeding, the index of the track inside the track
+  // collection identified by the next ProductID.
   int index;
   // collectionID = 0 used for global seeding collection
+  // For track-based seeding, the ProductID of the track-collection used to
+  // create the seeding region.
   edm::ProductID collectionID;
 
   TICLSeedingRegion() {}

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -26,7 +26,15 @@ namespace ticl {
     // the outer element is on the outer layer.
     std::vector<std::array<unsigned int, 2> > edges;
 
+    // Product ID of the seeding collection used to create the Trackster.
+    // For GlobalSeeding the ProductID is set to 0. For track-based seeding
+    // this is the ProductID of the track-collection used to create the
+    // seeding-regions.
     edm::ProductID seedID;
+    // For Global Seeding the index is fixed to one. For track-based seeding,
+    // the index is the index of the track originating the seeding region that
+    // created the trackster. For track-based seeding the pointer to the track
+    // can be cooked using the previous ProductID and this index.
     int seedIndex;
 
     // -99, -1 if not available. ns units otherwise

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -13,10 +13,16 @@
   <class name="TICLLayerTile" persistent="false">
     <field name="tile_" transient="true"/>
   </class>
-  <class name="TICLLayerTiles" persistent="false">
+
+  <class name="TICLGenericTile<ticl::Tiles>" persistent="false">
     <field name="tiles_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<TICLLayerTiles> " />
+  <class name="edm::Wrapper<TICLGenericTile<ticl::Tiles>>" persistent="false"/>
+
+  <class name="TICLGenericTile<ticl::TracksterTiles>" persistent="false">
+    <field name="tiles_" transient="true"/>
+  </class>
+  <class name="edm::Wrapper<TICLGenericTile<ticl::TracksterTiles>>" persistent="false"/>
 
   <class name="TICLSeedingRegion" ClassVersion="3">
     <version ClassVersion="3" checksum="2409655320"/>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -10,7 +10,7 @@
   <class name="edm::Wrapper<ticl::Trackster>" />
   <class name="edm::Wrapper<std::vector<ticl::Trackster> >" />
 
-  <class name="TICLLayerTile" persistent="false">
+  <class name="ticl::TICLLayerTile" persistent="false">
     <field name="tile_" transient="true"/>
   </class>
 

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -54,18 +54,18 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
         auto const &outerLayerHisto = histo[currentOuterLayerId];
         auto const &innerLayerHisto = histo[currentInnerLayerId];
 
-        for (int oeta = startEtaBin; oeta < endEtaBin; ++oeta) {
-          auto offset = oeta * nPhiBins;
-          for (int ophi_it = startPhiBin; ophi_it < endPhiBin; ++ophi_it) {
-            int ophi = ((ophi_it % nPhiBins + nPhiBins) % nPhiBins);
-            for (auto outerClusterId : outerLayerHisto[offset + ophi]) {
+        for (int ieta = startEtaBin; ieta < endEtaBin; ++ieta) {
+          auto offset = ieta * nPhiBins;
+          for (int iphi_it = startPhiBin; iphi_it < endPhiBin; ++iphi_it) {
+            int iphi = ((iphi_it % nPhiBins + nPhiBins) % nPhiBins);
+            for (auto innerClusterId : innerLayerHisto[offset + iphi]) {
               // Skip masked clusters
-              if (mask[outerClusterId] == 0.)
+              if (mask[innerClusterId] == 0.)
                 continue;
-              const auto etaRangeMin = std::max(0, oeta - deltaIEta);
-              const auto etaRangeMax = std::min(oeta + deltaIEta + 1, nEtaBins);
+              const auto etaRangeMin = std::max(0, ieta - deltaIEta);
+              const auto etaRangeMax = std::min(ieta + deltaIEta + 1, nEtaBins);
 
-              for (int ieta = etaRangeMin; ieta < etaRangeMax; ++ieta) {
+              for (int oeta = etaRangeMin; oeta < etaRangeMax; ++oeta) {
                 // wrap phi bin
                 for (int phiRange = 0; phiRange < 2 * deltaIPhi + 1; ++phiRange) {
                   // The first wrapping is to take into account the
@@ -73,10 +73,10 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                   // negative bins. The second wrap is mandatory to
                   // account for all other cases, since we add in
                   // between a full nPhiBins slot.
-                  auto iphi = ((ophi + phiRange - deltaIPhi) % nPhiBins + nPhiBins) % nPhiBins;
-                  for (auto innerClusterId : innerLayerHisto[ieta * nPhiBins + iphi]) {
+                  auto ophi = ((iphi + phiRange - deltaIPhi) % nPhiBins + nPhiBins) % nPhiBins;
+                  for (auto outerClusterId : outerLayerHisto[oeta * nPhiBins + ophi]) {
                     // Skip masked clusters
-                    if (mask[innerClusterId] == 0.)
+                    if (mask[outerClusterId] == 0.)
                       continue;
                     auto doubletId = allDoublets_.size();
                     if (maxDeltaTime != -1 &&

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -47,7 +47,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
       startEtaBin = std::max(entryEtaBin - deltaIEta, 0);
       endEtaBin = std::min(entryEtaBin + deltaIEta + 1, nEtaBins);
       startPhiBin = entryPhiBin - deltaIPhi;
-      endPhiBin = entryPhiBin + deltaIPhi;
+      endPhiBin = entryPhiBin + deltaIPhi + 1;
     }
 
     for (int il = 0; il < maxNumberOfLayers - 1; ++il) {

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -25,11 +25,8 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
   isOuterClusterOfDoublets_.resize(layerClusters.size());
   allDoublets_.clear();
   theRootDoublets_.clear();
-  auto rindex = -1;
   for (const auto &r : regions) {
     bool isGlobal = (r.index == -1);
-    if (!isGlobal)
-      rindex++;
     auto zSide = r.zSide;
     int startEtaBin, endEtaBin, startPhiBin, endPhiBin;
 
@@ -85,7 +82,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                     if (maxDeltaTime != -1 &&
                         !areTimeCompatible(innerClusterId, outerClusterId, layerClustersTime, maxDeltaTime))
                       continue;
-                    allDoublets_.emplace_back(innerClusterId, outerClusterId, doubletId, &layerClusters, rindex);
+                    allDoublets_.emplace_back(innerClusterId, outerClusterId, doubletId, &layerClusters, r.index);
                     if (verbosity_ > Advanced) {
                       LogDebug("HGCGraph")
                           << "Creating doubletsId: " << doubletId << " layerLink in-out: [" << currentInnerLayerId

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -25,8 +25,11 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
   isOuterClusterOfDoublets_.resize(layerClusters.size());
   allDoublets_.clear();
   theRootDoublets_.clear();
+  auto rindex = -1;
   for (const auto &r : regions) {
     bool isGlobal = (r.index == -1);
+    if (!isGlobal)
+      rindex++;
     auto zSide = r.zSide;
     int startEtaBin, endEtaBin, startPhiBin, endPhiBin;
 
@@ -82,7 +85,7 @@ void HGCGraph::makeAndConnectDoublets(const TICLLayerTiles &histo,
                     if (maxDeltaTime != -1 &&
                         !areTimeCompatible(innerClusterId, outerClusterId, layerClustersTime, maxDeltaTime))
                       continue;
-                    allDoublets_.emplace_back(innerClusterId, outerClusterId, doubletId, &layerClusters, r.index);
+                    allDoublets_.emplace_back(innerClusterId, outerClusterId, doubletId, &layerClusters, rindex);
                     if (verbosity_ > Advanced) {
                       LogDebug("HGCGraph")
                           << "Creating doubletsId: " << doubletId << " layerLink in-out: [" << currentInnerLayerId

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -132,7 +132,7 @@ bool HGCGraph::areTimeCompatible(int innerIdx,
   float timeOut = layerClustersTime.get(outerIdx).first;
   float timeOutE = layerClustersTime.get(outerIdx).second;
 
-  return (timeIn == -99 || timeOut == -99 ||
+  return (timeIn == -99. || timeOut == -99. ||
           std::abs(timeIn - timeOut) < maxDeltaTime * sqrt(timeInE * timeInE + timeOutE * timeOutE));
 }
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -242,7 +242,7 @@ void PatternRecognitionbyCA::energyRegressionAndID(const std::vector<reco::CaloC
         float *features = &input.tensor<float, 4>()(i, j, seenClusters[j], 0);
 
         // fill features
-        *(features++) = float(cluster.eta());
+        *(features++) = float(std::abs(cluster.eta()));
         *(features++) = float(cluster.phi());
         *features = float(cluster.energy());
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -54,8 +54,8 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
   std::vector<uint8_t> layer_cluster_usage(input.layerClusters.size(), 0);
   theGraph_->makeAndConnectDoublets(input.tiles,
                                     input.regions,
-                                    ticl::constants::nEtaBins,
-                                    ticl::constants::nPhiBins,
+                                    ticl::TileConstants::nEtaBins,
+                                    ticl::TileConstants::nPhiBins,
                                     input.layerClusters,
                                     input.mask,
                                     input.layerClustersTime,

--- a/RecoHGCal/TICL/plugins/TICLCandidateFromTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateFromTrackstersProducer.cc
@@ -137,8 +137,13 @@ void TICLCandidateFromTrackstersProducer::produce(edm::Event& evt, const edm::Ev
         ticl_cand.setCharge(charge);
         ticl_cand.setPdgId(pdg_id * charge);
       } else {
-        // FIXME - placeholder for downstream PF code to work, but proper symmetric charge assignment needed
-        ticl_cand.setCharge(1);
+        // Demote them to be neutral, since there's not track associated.
+        ticl_cand.setCharge(0);
+        if (pdg_id == -11) {
+          ticl_cand.setPdgId(22);
+        } else {
+          ticl_cand.setPdgId(130);
+        }
       }
     }
   }

--- a/RecoHGCal/TICL/plugins/TracksterGeneralTrackPlugin.cc
+++ b/RecoHGCal/TICL/plugins/TracksterGeneralTrackPlugin.cc
@@ -26,7 +26,7 @@ namespace ticl {
     for (size_t i = 0; i < size; ++i) {
       const auto& trackster = *tracksters[i];
 
-      if (trackster.seedIndex == 0 || !trackster.seedID.isValid()) {
+      if (trackster.seedIndex == -1 || !trackster.seedID.isValid()) {
         return;  // leave default empty track ref
       }
 

--- a/RecoHGCal/TICL/plugins/TracksterP4FromEnergySumPlugin.cc
+++ b/RecoHGCal/TICL/plugins/TracksterP4FromEnergySumPlugin.cc
@@ -85,12 +85,14 @@ namespace ticl {
 
     math::XYZVector direction(barycentre[0] - vertex.x(), barycentre[1] - vertex.y(), barycentre[2] - vertex.z());
     direction = direction.Unit();
-    direction *= energy_from_regression_ ? trackster.regressed_energy : energy;
+    auto raw_energy = energy;
+    energy = energy_from_regression_ ? trackster.regressed_energy : raw_energy;
+    direction *= energy;
 
     math::XYZTLorentzVector cartesian(direction.X(), direction.Y(), direction.Z(), energy);
     // Convert px, py, pz, E vector to CMS standard pt/eta/phi/m vector
     TracksterP4FromEnergySum::LorentzVector p4(cartesian);
-    return std::tuple(p4, energy);
+    return std::tuple(p4, raw_energy);
   }
 }  // namespace ticl
 


### PR DESCRIPTION
#### PR description:

This PR is another step toward the inclusion of `TICL` into the `Phase2` reconstruction sequence. This PR, in particular, fixes a few bugs and add templated data structures that will be used in future internally by `TICL` and, possibly, other detectors (`HFNose`, in particular). In more details:

- Correct the cone direction while running the `Pattern Recognition`
- Fix the `phi` search window
- Fix the charge assignment to `TICL Candidates`
- Fix energy regression input variables
- Template `TICL Tile` data structures. 

#### PR validation:

The usual limited Matrix.

