### PR TITLE
Running code-format for l1

### DIFF
--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -476,7 +476,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             et0Phy = 0.5 * (binEdges.second + binEdges.first);
             lutObj0 = "TAU";
           } break;
-          default: { } break; }  //end switch on calo type.
+          default: {
+          } break;
+        }  //end switch on calo type.
 
         //If needed convert calo scales to muon scales for comparison
         if (convertCaloScales) {
@@ -746,7 +748,9 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
               et1Phy = 0.5 * (binEdges.second + binEdges.first);
               lutObj1 = "TAU";
             } break;
-            default: { } break; }  //end switch on calo type.
+            default: {
+            } break;
+          }  //end switch on calo type.
 
           //If needed convert calo scales to muon scales for comparison
           if (convertCaloScales) {

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -632,7 +632,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
             et0Phy = 0.5 * (binEdges.second + binEdges.first);
             lutObj0 = "TAU";
           } break;
-          default: { } break; }  //end switch on calo type.
+          default: {
+          } break;
+        }  //end switch on calo type.
 
         phiORIndex0 = phiIndex0;
         etaORIndex0 = etaIndex0;
@@ -880,7 +882,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
               eta2Phy = 0.5 * (binEdges.second + binEdges.first);
               lutObj2 = "TAU";
             } break;
-            default: { } break; }  //end switch on calo type.
+            default: {
+            } break;
+          }  //end switch on calo type.
 
           //If needed convert calo scales to muon scales for comparison
           if (convertCaloScales) {
@@ -1279,7 +1283,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
               et1Phy = 0.5 * (binEdges.second + binEdges.first);
               lutObj1 = "TAU";
             } break;
-            default: { } break; }  //end switch on calo type.
+            default: {
+            } break;
+          }  //end switch on calo type.
 
           phiORIndex1 = phiIndex1;
           etaORIndex1 = etaIndex1;
@@ -1520,7 +1526,9 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
                 eta2Phy = 0.5 * (binEdges.second + binEdges.first);
                 lutObj2 = "TAU";
               } break;
-              default: { } break; }  //end switch on calo type.
+              default: {
+              } break;
+            }  //end switch on calo type.
 
             //If needed convert calo scales to muon scales for comparison
             if (convertCaloScales) {

--- a/L1Trigger/L1TGlobal/src/GlobalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalCondition.cc
@@ -555,7 +555,9 @@ void GlobalCondition::print(std::ostream& myCout) const {
       }
 
       break;
-      default: { myCout << " Unknown type " << m_objectType[i]; } break;
+      default: {
+        myCout << " Unknown type " << m_objectType[i];
+      } break;
     }
   }
 


### PR DESCRIPTION

Applying code-format for CMSSW category l1.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/478//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


