### PR TITLE
Running code-format for alca

### DIFF
--- a/Alignment/CommonAlignment/interface/SurveyDet.h
+++ b/Alignment/CommonAlignment/interface/SurveyDet.h
@@ -45,7 +45,7 @@ public:
   /// Find the Jacobian for a local point to be used in HIP algo.
   /// Does not check the range of index of local point.
   AlgebraicMatrix derivatives(unsigned int index  // index of point
-                              ) const;
+  ) const;
 
 private:
   AlignableSurface theSurface;  // surface of det from survey info

--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -8,33 +8,32 @@
 // Global variables
 //
 
-TString cmsText     = "CMS";
-float cmsTextFont   = 61;  // default is helvetic-bold
+TString cmsText = "CMS";
+float cmsTextFont = 61;  // default is helvetic-bold
 
 bool writeExtraText = false;
-TString extraText   = "Preliminary";
+TString extraText = "Preliminary";
 float extraTextFont = 52;  // default is helvetica-italics
 
 // text sizes and text offsets with respect to the top frame
 // in unit of the top margin size
-float lumiTextSize     = 0.6;
-float lumiTextOffset   = 0.2;
-float cmsTextSize      = 0.75;
-float cmsTextOffset    = 0.1;  // only used in outOfFrame version
+float lumiTextSize = 0.6;
+float lumiTextOffset = 0.2;
+float cmsTextSize = 0.75;
+float cmsTextOffset = 0.1;  // only used in outOfFrame version
 
-float relPosX    = 0.045;
-float relPosY    = 0.035;
+float relPosX = 0.045;
+float relPosY = 0.035;
 float relExtraDY = 1.2;
 
 // ratio of "CMS" and extra text size
-float extraOverCmsTextSize  = 0.76;
+float extraOverCmsTextSize = 0.76;
 
 TString lumi_13TeV = "20.1 fb^{-1}";
-TString lumi_8TeV  = "19.7 fb^{-1}";
-TString lumi_7TeV  = "5.1 fb^{-1}";
+TString lumi_8TeV = "19.7 fb^{-1}";
+TString lumi_7TeV = "5.1 fb^{-1}";
 TString lumi_sqrtS = "";
 
-bool drawLogo      = false;
+bool drawLogo = false;
 
-void CMS_lumi( TPad* pad, int iPeriod=3, int iPosX=10 );
-
+void CMS_lumi(TPad* pad, int iPeriod = 3, int iPosX = 10);

--- a/Alignment/OfflineValidation/plugins/ColorParser.C
+++ b/Alignment/OfflineValidation/plugins/ColorParser.C
@@ -5,65 +5,52 @@
 
 using namespace std;
 
+static const map<TString, Color_t> colormap{{"kWhite", kWhite},
+                                            {"kBlack", kBlack},
+                                            {"kGray", kGray},
+                                            {"kRed", kRed},
+                                            {"kGreen", kGreen},
+                                            {"kBlue", kBlue},
+                                            {"kYellow", kYellow},
+                                            {"kMagenta", kMagenta},
+                                            {"kCyan", kCyan},
+                                            {"kOrange", kOrange},
+                                            {"kSpring", kSpring},
+                                            {"kTeal", kTeal},
+                                            {"kAzure", kAzure},
+                                            {"kViolet", kViolet},
+                                            {"kPink", kPink}};
 
-static const map<TString, Color_t> colormap
-{
-       {"kWhite"   ,  kWhite  },
-       {"kBlack"   ,  kBlack  },
-       {"kGray"    ,  kGray   },
-       {"kRed"     ,  kRed    },
-       {"kGreen"   ,  kGreen  },
-       {"kBlue"    ,  kBlue   },
-       {"kYellow"  ,  kYellow },
-       {"kMagenta" ,  kMagenta},
-       {"kCyan"    ,  kCyan   },
-       {"kOrange"  ,  kOrange },
-       {"kSpring"  ,  kSpring },
-       {"kTeal"    ,  kTeal   },
-       {"kAzure"   ,  kAzure  },
-       {"kViolet"  ,  kViolet },
-       {"kPink"    ,  kPink   }
-};
+Color_t parser(TString input) {
+  // 1) remove all space
+  input.ReplaceAll(" ", "");
 
-Color_t parser (TString input)
-{
-    // 1) remove all space
-    input.ReplaceAll(" ", "");
+  // 2) if number, then just return it
+  if (input.IsDec())
+    return input.Atoi();
 
-    // 2) if number, then just return it
-    if (input.IsDec()) 
-        return input.Atoi();
+  // 3) if the first char is not a k, then crash
+  if (input(0) != 'k')
+    exit(EXIT_FAILURE);
 
-    // 3) if the first char is not a k, then crash
-    if (input(0) != 'k')
-        exit(EXIT_FAILURE);
-   
-    // 4) in case of + or -, needs to split the string
-    Ssiz_t Plus  = input.First('+'),
-           Minus = input.First('-');
+  // 4) in case of + or -, needs to split the string
+  Ssiz_t Plus = input.First('+'), Minus = input.First('-');
 
-    // 5) only one symbol is allowed
-    if (Plus != TString::kNPOS && Minus != TString::kNPOS)
-        exit(EXIT_FAILURE);
+  // 5) only one symbol is allowed
+  if (Plus != TString::kNPOS && Minus != TString::kNPOS)
+    exit(EXIT_FAILURE);
 
-    // 6) treat the three cases: +, - or nothing
-    if (Plus != TString::kNPOS) {
-        TString Left = input(0, Plus),
-                Right = input(Plus+1);
-        cout << Left << ' ' << Right << endl;
-        return colormap.at(Left) + Right.Atoi();
-    }
-    else if (Minus != TString::kNPOS) {
-        TString Left = input(0, Minus),
-                Right = input(Minus+1);
-        return colormap.at(Left) - Right.Atoi();
-    }
-    else {
-        return colormap.at(input);
-    }
+  // 6) treat the three cases: +, - or nothing
+  if (Plus != TString::kNPOS) {
+    TString Left = input(0, Plus), Right = input(Plus + 1);
+    cout << Left << ' ' << Right << endl;
+    return colormap.at(Left) + Right.Atoi();
+  } else if (Minus != TString::kNPOS) {
+    TString Left = input(0, Minus), Right = input(Minus + 1);
+    return colormap.at(Left) - Right.Atoi();
+  } else {
+    return colormap.at(input);
+  }
 }
 
-Color_t ColorParser (TString input)
-{
-    return parser(input);
-}
+Color_t ColorParser(TString input) { return parser(input); }


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/473//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


