### PR TITLE
Running code-format for analysis-reconstruction

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -1079,7 +1079,8 @@ namespace pat {
                              "Trying to access covariance matrix for a "
                              "PackedCandidate for which it's not available. "
                              "Check hasTrackDetails() before!\n");
-      std::call_once(covariance_load_flag, [](int v) { covarianceParameterization_.load(v); }, covarianceVersion_);
+      std::call_once(
+          covariance_load_flag, [](int v) { covarianceParameterization_.load(v); }, covarianceVersion_);
       if (covarianceParameterization_.loadedVersion() != covarianceVersion_) {
         throw edm::Exception(edm::errors::UnimplementedFeature)
             << "Attempting to load multiple covariance version in same process. "


### PR DESCRIPTION

Applying code-format for CMSSW category analysis,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/474//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


