### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/RecoCandidate/interface/IsoDeposit.h
+++ b/DataFormats/RecoCandidate/interface/IsoDeposit.h
@@ -89,21 +89,21 @@ namespace reco {
     double depositWithin(double coneSize,               //dR in which deposit is computed
                          const Vetos& vetos = Vetos(),  //additional vetos
                          bool skipDepositVeto = false   //skip exclusion of veto
-                         ) const;
+    ) const;
 
     //! Get deposit wrt other direction
     double depositWithin(Direction dir,
                          double coneSize,               //dR in which deposit is computed
                          const Vetos& vetos = Vetos(),  //additional vetos
                          bool skipDepositVeto = false   //skip exclusion of veto
-                         ) const;
+    ) const;
 
     //! Get deposit
     std::pair<double, int> depositAndCountWithin(double coneSize,               //dR in which deposit is computed
                                                  const Vetos& vetos = Vetos(),  //additional vetos
                                                  double threshold = -1e+36,     //threshold on counted deposits
                                                  bool skipDepositVeto = false   //skip exclusion of veto
-                                                 ) const;
+    ) const;
 
     //! Get deposit wrt other direction
     std::pair<double, int> depositAndCountWithin(Direction dir,                 //wrt another direction
@@ -111,19 +111,19 @@ namespace reco {
                                                  const Vetos& vetos = Vetos(),  //additional vetos
                                                  double threshold = -1e+36,     //threshold on deposits
                                                  bool skipDepositVeto = false   //skip exclusion of veto
-                                                 ) const;
+    ) const;
 
     //! Get deposit with new style vetos
     double depositWithin(double coneSize,              //dR in which deposit is computed
                          const AbsVetos& vetos,        //additional vetos
                          bool skipDepositVeto = false  //skip exclusion of veto
-                         ) const;
+    ) const;
 
     //! Get deposit
     std::pair<double, int> depositAndCountWithin(double coneSize,              //dR in which deposit is computed
                                                  const AbsVetos& vetos,        //additional vetos
                                                  bool skipDepositVeto = false  //skip exclusion of veto
-                                                 ) const;
+    ) const;
 
     //! Get energy or pT attached to cand trajectory
     double candEnergy() const { return theCandTag; }
@@ -249,44 +249,44 @@ namespace reco {
     double algoWithin(double coneSize,                     //dR in which deposit is computed
                       const AbsVetos& vetos = AbsVetos(),  //additional vetos
                       bool skipDepositVeto = false         //skip exclusion of veto
-                      ) const;
+    ) const;
     //! Get some info about the deposit (e.g. sum, max, sum2, count) w.r.t. other direction
     template <typename Algo>
     double algoWithin(const Direction&,
                       double coneSize,                     //dR in which deposit is computed
                       const AbsVetos& vetos = AbsVetos(),  //additional vetos
                       bool skipDepositVeto = false         //skip exclusion of veto
-                      ) const;
+    ) const;
     // count of the non-vetoed deposits in the cone
     double countWithin(double coneSize,                     //dR in which deposit is computed
                        const AbsVetos& vetos = AbsVetos(),  //additional vetos
                        bool skipDepositVeto = false         //skip exclusion of veto
-                       ) const;
+    ) const;
     // sum of the non-vetoed deposits in the cone
     double sumWithin(double coneSize,                     //dR in which deposit is computed
                      const AbsVetos& vetos = AbsVetos(),  //additional vetos
                      bool skipDepositVeto = false         //skip exclusion of veto
-                     ) const;
+    ) const;
     // sum of the non-vetoed deposits in the cone w.r.t. other direction
     double sumWithin(const Direction& dir,
                      double coneSize,                      //dR in which deposit is computed
                      const AbsVetos& vetos = AbsVetos(),   //additional vetos
                      bool skipDepositVeto = false          //skip exclusion of veto
-                     ) const;                              // sum of the squares of the non-vetoed deposits in the cone
+    ) const;                                               // sum of the squares of the non-vetoed deposits in the cone
     double sum2Within(double coneSize,                     //dR in which deposit is computed
                       const AbsVetos& vetos = AbsVetos(),  //additional vetos
                       bool skipDepositVeto = false         //skip exclusion of veto
-                      ) const;
+    ) const;
     // maximum value among the non-vetoed deposits in the cone
     double maxWithin(double coneSize,                     //dR in which deposit is computed
                      const AbsVetos& vetos = AbsVetos(),  //additional vetos
                      bool skipDepositVeto = false         //skip exclusion of veto
-                     ) const;
+    ) const;
     // maximum value among the non-vetoed deposits in the cone
     double nearestDR(double coneSize,                     //dR in which deposit is computed
                      const AbsVetos& vetos = AbsVetos(),  //additional vetos
                      bool skipDepositVeto = false         //skip exclusion of veto
-                     ) const;
+    ) const;
 
   private:
     //! direcion of deposit (center of isolation cone)

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -337,7 +337,7 @@ reco::SoftLeptonTagInfo SoftLepton::tag(const edm::RefToBase<reco::Jet> &jet,
 GlobalVector SoftLepton::refineJetAxis(const edm::RefToBase<reco::Jet> &jet,
                                        const reco::TrackRefVector &tracks,
                                        const reco::TrackBaseRef &exclude /* = reco::TrackBaseRef() */
-                                       ) const {
+) const {
   math::XYZVector axis = jet->momentum();
 
   if (m_refineJetAxis == AXIS_CHARGED_AVERAGE or m_refineJetAxis == AXIS_CHARGED_AVERAGE_NOLEPTON) {

--- a/RecoJets/JetProducers/plugins/BetaStarVarProducer.cc
+++ b/RecoJets/JetProducers/plugins/BetaStarVarProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    PhysicsTools/NanoAOD
 // Class:      BetaStarVarProducer
-// 
+//
 /**\class BetaStarVarProducer BetaStarVarProducer.cc PhysicsTools/NanoAOD/plugins/BetaStarVarProducer.cc
 
  Description: This produces value maps to store CHS-related variables for JERC. 
@@ -19,7 +19,6 @@
 // Original Author:  Sal Rappoccio
 //
 //
-
 
 #include <memory>
 
@@ -42,34 +41,30 @@
 
 template <typename T>
 class BetaStarVarProducer : public edm::global::EDProducer<> {
-   public:
-  explicit BetaStarVarProducer(const edm::ParameterSet &iConfig):
-    srcJet_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("srcJet"))),
-    srcPF_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("srcPF"))),
-    maxDR_( iConfig.getParameter<double>("maxDR") )
-  {
+public:
+  explicit BetaStarVarProducer(const edm::ParameterSet& iConfig)
+      : srcJet_(consumes<edm::View<pat::Jet>>(iConfig.getParameter<edm::InputTag>("srcJet"))),
+        srcPF_(consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("srcPF"))),
+        maxDR_(iConfig.getParameter<double>("maxDR")) {
     produces<edm::ValueMap<float>>("chargedHadronPUEnergyFraction");
     produces<edm::ValueMap<float>>("chargedHadronCHSEnergyFraction");
   }
-  ~BetaStarVarProducer() override {};
+  ~BetaStarVarProducer() override{};
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
+private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  std::tuple<float,float> calculateCHSEnergies( edm::Ptr<pat::Jet> const & jet, edm::View<T> const & cands) const;
+  std::tuple<float, float> calculateCHSEnergies(edm::Ptr<pat::Jet> const& jet, edm::View<T> const& cands) const;
 
   edm::EDGetTokenT<edm::View<pat::Jet>> srcJet_;
   edm::EDGetTokenT<edm::View<T>> srcPF_;
-  double maxDR_; 
+  double maxDR_;
 };
 
 template <typename T>
-void
-BetaStarVarProducer<T>::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-
+void BetaStarVarProducer<T>::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<edm::View<pat::Jet>> srcJet;
   iEvent.getByToken(srcJet_, srcJet);
   edm::Handle<edm::View<T>> srcPF;
@@ -77,95 +72,92 @@ BetaStarVarProducer<T>::produce(edm::StreamID streamID, edm::Event& iEvent, cons
 
   unsigned int nJet = srcJet->size();
 
-  std::vector<float> chargedHadronPUEnergyFraction(nJet,-1);
-  std::vector<float> chargedHadronCHSEnergyFraction(nJet,-1);
+  std::vector<float> chargedHadronPUEnergyFraction(nJet, -1);
+  std::vector<float> chargedHadronCHSEnergyFraction(nJet, -1);
 
-  for ( unsigned int ij = 0; ij < nJet; ++ij ) {
+  for (unsigned int ij = 0; ij < nJet; ++ij) {
     auto jet = srcJet->ptrAt(ij);
-    std::tuple<float,float> vals = calculateCHSEnergies( jet, *srcPF );
+    std::tuple<float, float> vals = calculateCHSEnergies(jet, *srcPF);
     auto chpuf = std::get<0>(vals);
-    auto chef  = std::get<1>(vals);
+    auto chef = std::get<1>(vals);
     chargedHadronPUEnergyFraction[ij] = chpuf;
     chargedHadronCHSEnergyFraction[ij] = chef;
   }
 
   std::unique_ptr<edm::ValueMap<float>> chargedHadronPUEnergyFractionV(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler fillerPU(*chargedHadronPUEnergyFractionV);
-  fillerPU.insert(srcJet,chargedHadronPUEnergyFraction.begin(),chargedHadronPUEnergyFraction.end());
+  fillerPU.insert(srcJet, chargedHadronPUEnergyFraction.begin(), chargedHadronPUEnergyFraction.end());
   fillerPU.fill();
-  iEvent.put(std::move(chargedHadronPUEnergyFractionV),"chargedHadronPUEnergyFraction");
-  
+  iEvent.put(std::move(chargedHadronPUEnergyFractionV), "chargedHadronPUEnergyFraction");
+
   std::unique_ptr<edm::ValueMap<float>> chargedHadronCHSEnergyFractionV(new edm::ValueMap<float>());
   edm::ValueMap<float>::Filler fillerCHE(*chargedHadronCHSEnergyFractionV);
-  fillerCHE.insert(srcJet,chargedHadronCHSEnergyFraction.begin(),chargedHadronCHSEnergyFraction.end());
+  fillerCHE.insert(srcJet, chargedHadronCHSEnergyFraction.begin(), chargedHadronCHSEnergyFraction.end());
   fillerCHE.fill();
-  iEvent.put(std::move(chargedHadronCHSEnergyFractionV),"chargedHadronCHSEnergyFraction");
-
+  iEvent.put(std::move(chargedHadronCHSEnergyFractionV), "chargedHadronCHSEnergyFraction");
 }
 
 template <typename T>
-std::tuple<float,float>
-BetaStarVarProducer<T>::calculateCHSEnergies( edm::Ptr<pat::Jet> const & ijet, edm::View<T> const & cands ) const {
-
+std::tuple<float, float> BetaStarVarProducer<T>::calculateCHSEnergies(edm::Ptr<pat::Jet> const& ijet,
+                                                                      edm::View<T> const& cands) const {
   auto rawP4 = ijet->correctedP4(0);
   std::vector<unsigned int> jet2pu;
 
   // Get all of the PF candidates within a cone of dR to the jet that
   // do NOT belong to the primary vertex.
-  // Store their indices. 
-  for ( unsigned int icand = 0; icand < cands.size(); ++icand ) {
+  // Store their indices.
+  for (unsigned int icand = 0; icand < cands.size(); ++icand) {
     auto cand = cands.ptrAt(icand);
-    if (cand->fromPV()!=0) continue;
-    float dR = reco::deltaR(*ijet,*cand);
-    if (dR<maxDR_) {
-      jet2pu.emplace_back( cand.key() );
+    if (cand->fromPV() != 0)
+      continue;
+    float dR = reco::deltaR(*ijet, *cand);
+    if (dR < maxDR_) {
+      jet2pu.emplace_back(cand.key());
     }
   }
-  
+
   // Keep track of energy for PU stuff
   double che = 0.0;
-  double pue = 0.0; 
+  double pue = 0.0;
 
   // Loop through the PF candidates within the jet.
-  // Store the sum of their energy, and their indices. 
+  // Store the sum of their energy, and their indices.
   std::vector<unsigned int> used;
   auto jetConstituents = ijet->daughterPtrVector();
-  for (auto const & ic : jetConstituents ) {
-    auto icpc = dynamic_cast<pat::PackedCandidate const *>(ic.get());
-    if ( icpc->charge()!=0) {
+  for (auto const& ic : jetConstituents) {
+    auto icpc = dynamic_cast<pat::PackedCandidate const*>(ic.get());
+    if (icpc->charge() != 0) {
       che += icpc->energy();
-      if (icpc->fromPV()==0) {
-	used.push_back( ic.key() );
+      if (icpc->fromPV() == 0) {
+        used.push_back(ic.key());
       }
     }
   }
   // Loop through the pileup PF candidates within the jet.
   for (auto pidx : jet2pu) {
-    auto const & dtr = cands.ptrAt(pidx);
+    auto const& dtr = cands.ptrAt(pidx);
     // We take the candidates that have not appeared before: these were removed by CHS
-    if (dtr->charge()!=0 and std::find(used.begin(),used.end(),dtr.key() )==used.end())
+    if (dtr->charge() != 0 and std::find(used.begin(), used.end(), dtr.key()) == used.end())
       pue += dtr->energy();
   }
-  
-  // Now get the fractions relative to the raw jet. 
+
+  // Now get the fractions relative to the raw jet.
   auto puf = pue / rawP4.energy();
   auto chf = che / rawP4.energy();
-  
-  return std::tuple<float,float>(puf,chf);
+
+  return std::tuple<float, float>(puf, chf);
 }
 
 template <typename T>
-void
-BetaStarVarProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BetaStarVarProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("srcJet")->setComment("jet input collection");
   desc.add<edm::InputTag>("srcPF")->setComment("PF candidate input collection");
   desc.add<double>("maxDR")->setComment("Maximum DR to consider for jet-->pf cand association");
-  std::string modname ("BetaStarVarProducer");
-  descriptions.add(modname,desc);
+  std::string modname("BetaStarVarProducer");
+  descriptions.add(modname, desc);
 }
 
 typedef BetaStarVarProducer<pat::PackedCandidate> BetaStarPackedCandidateVarProducer;
 
 DEFINE_FWK_MODULE(BetaStarPackedCandidateVarProducer);
-

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h
@@ -11,7 +11,8 @@ template <class O>
 class ConfFitterBuilder {
 public:
   ConfFitterBuilder<O>(const std::string& name, const std::string& description) {
-    VertexFitterManager::Instance().registerFitter(name, []() -> AbstractConfFitter* { return new O(); }, description);
+    VertexFitterManager::Instance().registerFitter(
+        name, []() -> AbstractConfFitter* { return new O(); }, description);
   }
 };
 

--- a/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
@@ -10,13 +10,14 @@ void VertexFitterManager::registerFitter(const string& name, std::function<Abstr
   theDescription[name] = d;
 
   // every fitter registers as a reconstructor, also
-  VertexRecoManager::Instance().registerReconstructor(name,
-                                                      [o]() -> AbstractConfReconstructor* {
-                                                        //ReconstructorFromFitter clones the object passed
-                                                        std::unique_ptr<AbstractConfFitter> t{o()};
-                                                        return new ReconstructorFromFitter(std::move(t));
-                                                      },
-                                                      d);
+  VertexRecoManager::Instance().registerReconstructor(
+      name,
+      [o]() -> AbstractConfReconstructor* {
+        //ReconstructorFromFitter clones the object passed
+        std::unique_ptr<AbstractConfFitter> t{o()};
+        return new ReconstructorFromFitter(std::move(t));
+      },
+      d);
 }
 
 VertexFitterManager::~VertexFitterManager() {}


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/479//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


