### PR TITLE
DQM: Fix potential deadlock in setBinLabel.

### DIFF
--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -828,7 +828,9 @@ namespace dqm::impl {
   void MonitorElement::enableSumw2() {
     auto access = this->accessMut();
     update();
-    access.value.object_->Sumw2();
+    if (access.value.object_->GetSumw2() == nullptr) {
+      access.value.object_->Sumw2();
+    }
   }
 
   void MonitorElement::disableAlphanumeric() {

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -721,18 +721,24 @@ namespace dqm::impl {
 
   /// set bin label for x, y or z axis (axis=1, 2, 3 respectively)
   void MonitorElement::setBinLabel(int bin, const std::string &label, int axis /* = 1 */) {
-    auto access = this->accessMut();
-    update();
-    if (getAxis(access, __PRETTY_FUNCTION__, axis)->GetNbins() >= bin) {
-      getAxis(access, __PRETTY_FUNCTION__, axis)->SetBinLabel(bin, label.c_str());
-    } else {
-#if WITHOUT_CMS_FRAMEWORK
-      std::cout
-#else
-      edm::LogWarning("MonitorElement")
-#endif
-          << "*** MonitorElement: WARNING:"
-          << "setBinLabel: attempting to set label of non-existent bin number for ME: " << getFullname() << " \n";
+    bool fail = false;
+    {
+      auto access = this->accessMut();
+      update();
+      if (getAxis(access, __PRETTY_FUNCTION__, axis)->GetNbins() >= bin) {
+        getAxis(access, __PRETTY_FUNCTION__, axis)->SetBinLabel(bin, label.c_str());
+      } else {
+        fail = true;
+      }
+    }
+    // do this with the ME lock released to prevent a deadlock
+    if (fail) {
+      // this also takes the lock, make sure to release it before going to edm
+      // (which might take more locks)
+      auto name = getFullname();
+      edm::LogWarning("MonitorElement") << "*** MonitorElement: WARNING:"
+                                        << "setBinLabel: attempting to set label of non-existent bin number for ME: "
+                                        << name << " \n";
     }
   }
 

--- a/Validation/EventGenerator/src/DQMHelper.cc
+++ b/Validation/EventGenerator/src/DQMHelper.cc
@@ -6,8 +6,7 @@ DQMHelper::~DQMHelper() {}
 
 DQMHelper::MonitorElement* DQMHelper::book1dHisto(
     std::string name, std::string title, int n, double xmin, double xmax, std::string xaxis, std::string yaxis) {
-  MonitorElement* dqm = ibooker->book1D(name, title, n, xmin, xmax);
-  dqm->getTH1()->Sumw2();
+  MonitorElement* dqm = ibooker->book1D(name, title, n, xmin, xmax, [](TH1* th1) { th1->Sumw2(); });
   dqm->setAxisTitle(xaxis, 1);
   dqm->setAxisTitle(yaxis, 2);
   return dqm;
@@ -15,8 +14,7 @@ DQMHelper::MonitorElement* DQMHelper::book1dHisto(
 
 DQMHelper::MonitorElement* DQMHelper::book1dHisto(
     const std::string& name, const std::string& title, int n, double xmin, double xmax) {
-  MonitorElement* dqm = ibooker->book1D(name, title, n, xmin, xmax);
-  dqm->getTH1()->Sumw2();
+  MonitorElement* dqm = ibooker->book1D(name, title, n, xmin, xmax, [](TH1* th1) { th1->Sumw2(); });
   return dqm;
 }
 
@@ -30,8 +28,7 @@ DQMHelper::MonitorElement* DQMHelper::book2dHisto(std::string name,
                                                   double ymax,
                                                   std::string xaxis,
                                                   std::string yaxis) {
-  MonitorElement* dqm = ibooker->book2D(name, title, nx, xmin, xmax, ny, ymin, ymax);
-  dqm->getTH1()->Sumw2();
+  MonitorElement* dqm = ibooker->book2D(name, title, nx, xmin, xmax, ny, ymin, ymax, [](TH1* th1) { th1->Sumw2(); });
   dqm->setAxisTitle(xaxis, 1);
   dqm->setAxisTitle(yaxis, 2);
   return dqm;
@@ -45,7 +42,6 @@ DQMHelper::MonitorElement* DQMHelper::book2dHisto(const std::string& name,
                                                   int ny,
                                                   double ymin,
                                                   double ymax) {
-  MonitorElement* dqm = ibooker->book2D(name, title, nx, xmin, xmax, ny, ymin, ymax);
-  dqm->getTH1()->Sumw2();
+  MonitorElement* dqm = ibooker->book2D(name, title, nx, xmin, xmax, ny, ymin, ymax, [](TH1* th1) { th1->Sumw2(); });
   return dqm;
 }

--- a/Validation/MuonIsolation/interface/MuIsoValidation.h
+++ b/Validation/MuonIsolation/interface/MuIsoValidation.h
@@ -76,11 +76,7 @@ private:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
   void MakeLogBinsForProfile(Double_t* bin_edges, const double min, const double max);
-  void FillHistos();       //Fills histograms with data
-  void NormalizeHistos();  //Normalize to number of muons
-  TH1* GetTH1FromMonitorElement(MonitorElement* me);
-  TH2* GetTH2FromMonitorElement(MonitorElement* me);
-  TProfile* GetTProfileFromMonitorElement(MonitorElement* me);
+  void FillHistos();  //Fills histograms with data
 
   //----------Static Variables---------------
 


### PR DESCRIPTION
#### PR description:

Fixes the IB test failure in 136.8861 (and maybe others). The deadlock was triggered by `LogMessageMonitor:ClusterizerLogMessageMonCommon` in `bookHistograms`. Reported in #28622.

This one only triggers in the error path, because getFullname tries to
take a lock that we already hold.

However, there is another opportunity for a deadlock via edm::Log*
(which probably takes a lock), and the per ME-locks which could be taken
before or after edm::Log* is called. I reviewed all usages of edm::Log*
in DQMServices/Core and did not see anything problematic.

Note that this is the only usage of edm::Log* in MonitorElement, and it
now avoids taking multiple locks at the same time, so there should not
be any more problems of this type.

This PR now also includes some commits from #28813 related to `Sumw2`, to fix a completely unrelated problem with 250202.183 which happens after the previous deadlock.

#### PR validation:
 Runs 136.8861 without deadlock.