### PR TITLE
DQM: Disable assertLegacySafe when concurrent lumis are enabled.

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2232,6 +2232,8 @@ class ConfigBuilder(object):
             self.pythonCfgCode +="process.options.numberOfThreads=cms.untracked.uint32("+self._options.nThreads+")\n"
             self.pythonCfgCode +="process.options.numberOfStreams=cms.untracked.uint32("+self._options.nStreams+")\n"
             self.pythonCfgCode +="process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32("+self._options.nConcurrentLumis+")\n"
+            if self._options.nConcurrentLumis > 1:
+              self.pythonCfgCode +="if process.DQMStore: process.DQMStore.assertLegacySafe=cms.untracked.bool(False)\n"
             self.process.options.numberOfThreads=cms.untracked.uint32(int(self._options.nThreads))
             self.process.options.numberOfStreams=cms.untracked.uint32(int(self._options.nStreams))
             self.process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(int(self._options.nConcurrentLumis))


### PR DESCRIPTION
#### PR description:

This prevents the crashes in 1361.181 reported in #28622. Prevents, not fixes.

I'd like to summon @Dr15Jones and @makortel to this discussion: What happens here is that a job with VALIDATION enabled (which I am pretty sure does contain some `edm::EDAnalyzer`s -- I have not checked it though) is requested to run with concurrent lumisections. EDM should prevent this, since it is not safe to have concurrent lumisections with legacy modules [1]. However, the new `DQMStore` still detects that a new lumisection starts before the previous one is saved, and that consequently it needs to copy MEs (this triggers the `assertLegacySafe` assertion by default, unless it is explicitly turned off). The problem with that is now that `edm::EDAnalyzer` based DQM code could hold pointers that get `free`'d by the `DQMStore` later (as the first lumisection ends). For this reason, it is only safe to disable `assertLegacySafe` when there are no `edm::EDAnalyzer` based `DQMStore` users in the process.

So, with this PR, 1361.181 runs but is unsafe. What we should do instead is either make sure that EDM actually does not use concurrent lumisections at all [2] when there are legacy modules (then we can keep the assertion enabled and it will not fire), or remove all legacy modules from the jobs using concurrent lumis (that is really what we need to do, but much harder than it sounds).

We can of course also just keep the unsafe behaviour. It seems to work for now (maybe because the legacy modules involved don't do anything dangerous [3]), but I can't make any guarantees about that.

[1] actually, the majority of DQM currently runs in `edm::one::EDProducer`s watching lumis which should cause the same effect.
[2] I *think* EDM might overlap writing the current lumi and processing the next even when there are modules blocking concurrent lumis -- that would explain the behaviour.
[3] (Edit:) Since this entire story is about lumis, but legacy modules by default deal with per-job MEs, we should actually be safe as long as the legacy modules don't explicitly use `Scope::LUMI`. But then the (meaningful) legacy plugins *do* actually set a scope different from `JOB` manually (else they would not produce any output in the reco step), and *technically* the same problem exists with `RUN` MEs. Except, we don't do anything close to concurrent runs currently. But, we have reasons to believe that there is no risk of use-after-free in this workflow today.

#### PR validation:
```
runTheMatrix.py  -l 1361.181  -i all --job-reports -t 4
```
passes. Note the `-t 4`, bare `1361.181` did not trigger the problem.

See concerns above.

