### PR TITLE
Fix use of replaced Configuration/Geometry/DD4hep_GeometrySim_cff fragment

### DIFF
--- a/Configuration/StandardSequences/python/DD4hep_GeometrySim_cff.py
+++ b/Configuration/StandardSequences/python/DD4hep_GeometrySim_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Geometry.DD4hep_GeometrySim_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2021_cff import *

--- a/Geometry/TrackerNumberingBuilder/test/trackerModuleNumberingDD4hep_cfg.py
+++ b/Geometry/TrackerNumberingBuilder/test/trackerModuleNumberingDD4hep_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("NumberingTest")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-process.load("Configuration.Geometry.DD4hep_GeometrySim_cff")
+process.load("Configuration.StandardSequences.DD4hep_GeometrySim_cff")
 process.load("Geometry.TrackerNumberingBuilder.DD4hep_trackerNumberingGeometry_cfi")
 
 #this is always needed if users want access to the vector<GeometricDetExtra>


### PR DESCRIPTION
#### PR description:

In #28847 ```Configuration.Geometry.DD4hep_GeometrySim_cff``` has been renamed to a more standard ```GeometryDD4hepExtended2021_cff``` to allow developers to use it with ```cmsDriver.py```. This PR fixes the two residual places where this update has not been propagated.

#### PR validation:

Code compiles, ```validateGEMGeometry_cfg.py``` does not complain any more because of the missing fragment (but it fails for apparently unrelated issues, @slomeo FYI).