### PR TITLE
Fix gcc9 warnings in DQMRootSource

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -601,7 +601,7 @@ std::unique_ptr<edm::FileBlock> DQMRootSource::readFile_() {
   for (auto& metadata : m_fileMetadatas) {
     if (run < metadata.m_run && metadata.m_lumi != 0) {
       // run transition and lumi transition at the same time!
-      FileMetadata dummy{0};  // zero initialize
+      FileMetadata dummy{};  // zero initialize
       dummy.m_run = metadata.m_run;
       dummy.m_lumi = 0;
       dummy.m_type = kNoTypesStored;


### PR DESCRIPTION
#### PR description:

Gcc 9 builds complain
```
.../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_lumi' [-Wmissing-field-initializers]
   604 |       FileMetadata dummy{0};  // zero initialize
      |                           ^
  .../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_beginTime' [-Wmissing-field-initializers]
  .../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_endTime' [-Wmissing-field-initializers]
   .../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_firstIndex' [-Wmissing-field-initializers]
   .../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_lastIndex' [-Wmissing-field-initializers]
   .../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_type' [-Wmissing-field-initializers]
   .../CMSSW_11_1_X_2020-02-10-2300/src/DQMServices/FwkIO/plugins/DQMRootSource.cc:604:27: warning: missing initializer for member 'DQMTTreeIO::FileMetadata::m_file' [-Wmissing-field-initializers]

```

#### PR validation:

Code compiles, the warnings are removed.