### PR TITLE
[cxxmodules] Workaround missing CLHEP modulemap.

### DIFF
--- a/DataFormats/BTauReco/src/classes.h
+++ b/DataFormats/BTauReco/src/classes.h
@@ -16,7 +16,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #if defined __has_feature
-#  if __has_feature(modules)
+#if __has_feature(modules)
 // Workaround the missing CLHEP.modulemap
 #include "CLHEP/Vector/LorentzVector.h"
 #include "DataFormats/BTauReco/interface/CombinedTauTagInfo.h"

--- a/DataFormats/BTauReco/src/classes.h
+++ b/DataFormats/BTauReco/src/classes.h
@@ -15,6 +15,13 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#if defined __has_feature
+#  if __has_feature(modules)
+// Workaround the missing CLHEP.modulemap
+#include "CLHEP/Vector/LorentzVector.h"
+#include "DataFormats/BTauReco/interface/CombinedTauTagInfo.h"
+#endif
+#endif
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"


### PR DESCRIPTION
Currently all contents are pasted N times in the including modules due to the lack of a CLHEP module for the external to cmssw package.

This walks on a very fragile path in the compiler (and roocling) as it needs to figure out while parsing the header content that a module already contained the definitions being parsed.

This patch avoids an issue where rootcling thinks that CLHEP/.../ThreeVector.h is included multiple times. We essentially tell the compiler to open the definition from a module rather than parsing.

Part of #15248

cc: @davidlange6, @smuzaffar, @oshadura