### PR TITLE
EventSetup consumes migration 1 GEM module and 1 L1T module

### DIFF
--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.h
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.h
@@ -6,10 +6,9 @@
  *  \author J. Lee - UoS
  */
 
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -26,10 +25,6 @@
 #include "EventFilter/GEMRawToDigi/interface/AMC13Event.h"
 #include "EventFilter/GEMRawToDigi/interface/VFATdata.h"
 
-namespace edm {
-  class ConfigurationDescriptions;
-}
-
 class GEMRawToDigiModule : public edm::global::EDProducer<edm::RunCache<GEMROMapping> > {
 public:
   /// Constructor
@@ -45,6 +40,7 @@ public:
 
 private:
   edm::EDGetTokenT<FEDRawDataCollection> fed_token;
+  edm::ESGetToken<GEMeMap, GEMeMapRcd> gemEMapToken_;
   bool useDBEMap_;
   bool unPackStatusDigis_;
 };

--- a/L1Trigger/L1TMuonOverlap/interface/AngleConverter.h
+++ b/L1Trigger/L1TMuonOverlap/interface/AngleConverter.h
@@ -1,21 +1,20 @@
 #ifndef ANGLECONVERTER_H
 #define ANGLECONVERTER_H
 
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
 #include <memory>
 
-namespace edm {
-  class EventSetup;
-}
-
-class RPCGeometry;
-class CSCGeometry;
 class CSCLayer;
-class DTGeometry;
 
 class L1MuDTChambPhDigi;
 class L1MuDTChambThContainer;
@@ -26,7 +25,7 @@ class RPCDetId;
 
 class AngleConverter {
 public:
-  AngleConverter();
+  AngleConverter(edm::ConsumesCollector &, bool getDuringEvent = true);
   ~AngleConverter();
 
   ///Update the Geometry with current Event Setup
@@ -62,11 +61,15 @@ private:
   ///Find BTI group
   const int findBTIgroup(const L1MuDTChambPhDigi &aDigi, const L1MuDTChambThContainer *dtThDigis);
 
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeometryToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeometryToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeometryToken_;
+
   // pointers to the current geometry records
   unsigned long long _geom_cache_id;
-  edm::ESHandle<RPCGeometry> _georpc;
-  edm::ESHandle<CSCGeometry> _geocsc;
-  edm::ESHandle<DTGeometry> _geodt;
+  RPCGeometry const *_georpc;
+  CSCGeometry const *_geocsc;
+  DTGeometry const *_geodt;
 
   ///Number of phi bins along 2Pi.
   unsigned int nPhiBins;

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFReconstruction.h
@@ -3,14 +3,16 @@
 
 #include "xercesc/util/XercesDefs.hpp"
 
+#include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
+
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "DataFormats/Common/interface/Handle.h"
 
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
@@ -21,7 +23,6 @@
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFSorter.h"
 #include "L1Trigger/L1TMuonOverlap/interface/GhostBuster.h"
 
-class L1TMuonOverlapParams;
 class OMTFProcessor;
 class OMTFConfiguration;
 class OMTFConfigMaker;
@@ -35,9 +36,7 @@ namespace XERCES_CPP_NAMESPACE {
 
 class OMTFReconstruction {
 public:
-  OMTFReconstruction();
-
-  OMTFReconstruction(const edm::ParameterSet &);
+  OMTFReconstruction(const edm::ParameterSet &, edm::ConsumesCollector &&);
 
   ~OMTFReconstruction();
 
@@ -45,7 +44,7 @@ public:
 
   void endJob();
 
-  void beginRun(edm::Run const &run, edm::EventSetup const &iSetup);
+  void beginRun(edm::Run const &, edm::EventSetup const &);
 
   std::unique_ptr<l1t::RegionalMuonCandBxCollection> reconstruct(const edm::Event &, const edm::EventSetup &);
 
@@ -56,6 +55,8 @@ private:
   edm::Handle<L1MuDTChambThContainer> dtThDigis;
   edm::Handle<CSCCorrelatedLCTDigiCollection> cscDigis;
   edm::Handle<RPCDigiCollection> rpcDigis;
+
+  edm::ESGetToken<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd> l1TMuonOverlapParamsToken_;
 
   void loadAndFilterDigis(const edm::Event &);
 

--- a/L1Trigger/L1TMuonOverlap/interface/OMTFinputMaker.h
+++ b/L1Trigger/L1TMuonOverlap/interface/OMTFinputMaker.h
@@ -7,24 +7,22 @@
 
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
-#include "L1Trigger/L1TMuonOverlap/interface/AngleConverter.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFinput.h"
 
+class AngleConverter;
 class OMTFConfiguration;
-
-namespace edm {
-  class EventSetup;
-}
 
 class OMTFinputMaker {
 public:
-  OMTFinputMaker();
+  OMTFinputMaker(edm::ConsumesCollector &, bool getDuringEvent = true);
 
   ~OMTFinputMaker();
 
-  void initialize(const edm::EventSetup &es, const OMTFConfiguration *);
+  void initialize(const edm::EventSetup &, const OMTFConfiguration *);
 
   ///Method translating trigger digis into input matrix with global phi coordinates
   OMTFinput buildInputForProcessor(const L1MuDTChambPhContainer *dtPhDigis,
@@ -70,7 +68,7 @@ private:
   ///Result is modulo allowed number of hits per chamber
   unsigned int getInputNumber(unsigned int rawId, unsigned int iProcessor, l1t::tftype type);
 
-  AngleConverter myAngleConverter;
+  std::unique_ptr<AngleConverter> myAngleConverter;
 
   const OMTFConfiguration *myOmtfConfig;
 

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
@@ -2,10 +2,8 @@
 #include <strstream>
 #include <vector>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
-#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
@@ -19,13 +17,13 @@
 #include "L1Trigger/RPCTrigger/interface/RPCConst.h"
 
 L1TMuonOverlapTrackProducer::L1TMuonOverlapTrackProducer(const edm::ParameterSet& cfg)
-    : theConfig(cfg), m_Reconstruction(cfg) {
+    : m_Reconstruction(cfg, consumesCollector()) {
   produces<l1t::RegionalMuonCandBxCollection>("OMTF");
 
-  inputTokenDTPh = consumes<L1MuDTChambPhContainer>(theConfig.getParameter<edm::InputTag>("srcDTPh"));
-  inputTokenDTTh = consumes<L1MuDTChambThContainer>(theConfig.getParameter<edm::InputTag>("srcDTTh"));
-  inputTokenCSC = consumes<CSCCorrelatedLCTDigiCollection>(theConfig.getParameter<edm::InputTag>("srcCSC"));
-  inputTokenRPC = consumes<RPCDigiCollection>(theConfig.getParameter<edm::InputTag>("srcRPC"));
+  inputTokenDTPh = consumes<L1MuDTChambPhContainer>(cfg.getParameter<edm::InputTag>("srcDTPh"));
+  inputTokenDTTh = consumes<L1MuDTChambThContainer>(cfg.getParameter<edm::InputTag>("srcDTTh"));
+  inputTokenCSC = consumes<CSCCorrelatedLCTDigiCollection>(cfg.getParameter<edm::InputTag>("srcCSC"));
+  inputTokenRPC = consumes<RPCDigiCollection>(cfg.getParameter<edm::InputTag>("srcRPC"));
 }
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.h
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.h
@@ -6,11 +6,10 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h"
@@ -43,14 +42,12 @@ public:
 
   void endJob() override;
 
-  void beginRun(edm::Run const& run, edm::EventSetup const& iSetup) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override {}
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
 private:
-  edm::ParameterSet theConfig;
-
   edm::EDGetTokenT<L1MuDTChambPhContainer> inputTokenDTPh;
   edm::EDGetTokenT<L1MuDTChambThContainer> inputTokenDTTh;
   edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> inputTokenCSC;

--- a/L1Trigger/L1TMuonOverlap/plugins/OMTFPatternMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/OMTFPatternMaker.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
@@ -27,7 +28,8 @@ OMTFPatternMaker::OMTFPatternMaker(const edm::ParameterSet& cfg)
   inputTokenRPC = consumes<RPCDigiCollection>(theConfig.getParameter<edm::InputTag>("srcRPC"));
   inputTokenSimHit = consumes<edm::SimTrackContainer>(theConfig.getParameter<edm::InputTag>("g4SimTrackSrc"));
 
-  myInputMaker = new OMTFinputMaker();
+  edm::ConsumesCollector consumesColl(consumesCollector());
+  myInputMaker = new OMTFinputMaker(consumesColl);
 
   makeGoldenPatterns = theConfig.getParameter<bool>("makeGoldenPatterns");
   makeConnectionsMaps = theConfig.getParameter<bool>("makeConnectionsMaps");

--- a/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
@@ -1,16 +1,14 @@
 #include "L1Trigger/L1TMuonOverlap/interface/AngleConverter.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "FWCore/Utilities/interface/Transition.h"
 
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
 #include "L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h"
 
-#include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "L1Trigger/DTUtilities/interface/DTTrigGeom.h"
-#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhDigi.h"
@@ -150,7 +148,17 @@ namespace {
 
 }  // namespace
 
-AngleConverter::AngleConverter() : _geom_cache_id(0ULL) {}
+AngleConverter::AngleConverter(edm::ConsumesCollector &iC, bool getDuringEvent) : _geom_cache_id(0ULL) {
+  if (getDuringEvent) {
+    rpcGeometryToken_ = iC.esConsumes<RPCGeometry, MuonGeometryRecord>();
+    cscGeometryToken_ = iC.esConsumes<CSCGeometry, MuonGeometryRecord>();
+    dtGeometryToken_ = iC.esConsumes<DTGeometry, MuonGeometryRecord>();
+  } else {
+    rpcGeometryToken_ = iC.esConsumes<RPCGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
+    cscGeometryToken_ = iC.esConsumes<CSCGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
+    dtGeometryToken_ = iC.esConsumes<DTGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
+  }
+}
 ///////////////////////////////////////
 ///////////////////////////////////////
 AngleConverter::~AngleConverter() {}
@@ -160,9 +168,9 @@ void AngleConverter::checkAndUpdateGeometry(const edm::EventSetup &es, unsigned 
   const MuonGeometryRecord &geom = es.get<MuonGeometryRecord>();
   unsigned long long geomid = geom.cacheIdentifier();
   if (_geom_cache_id != geomid) {
-    geom.get(_georpc);
-    geom.get(_geocsc);
-    geom.get(_geodt);
+    _georpc = &geom.get(rpcGeometryToken_);
+    _geocsc = &geom.get(cscGeometryToken_);
+    _geodt = &geom.get(dtGeometryToken_);
     _geom_cache_id = geomid;
   }
 

--- a/L1Trigger/L1TMuonOverlap/src/OMTFReconstruction.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFReconstruction.cc
@@ -1,10 +1,8 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
-#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
-
-#include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
-#include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFProcessor.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFinput.h"
@@ -16,13 +14,14 @@
 
 #include "L1Trigger/RPCTrigger/interface/RPCConst.h"
 
-OMTFReconstruction::OMTFReconstruction()
-    : m_OMTFConfig(nullptr), m_OMTF(nullptr), aTopElement(nullptr), m_OMTFConfigMaker(nullptr), m_Writer(nullptr) {}
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
-OMTFReconstruction::OMTFReconstruction(const edm::ParameterSet& theConfig)
+OMTFReconstruction::OMTFReconstruction(const edm::ParameterSet& theConfig, edm::ConsumesCollector&& iC)
     : m_Config(theConfig),
+      l1TMuonOverlapParamsToken_(
+          iC.esConsumes<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd, edm::Transition::BeginRun>()),
       m_OMTFConfig(nullptr),
+      m_InputMaker(iC, false),
       m_OMTF(nullptr),
       aTopElement(nullptr),
       m_OMTFConfigMaker(nullptr),
@@ -59,13 +58,8 @@ void OMTFReconstruction::endJob() {
 }
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
-void OMTFReconstruction::beginRun(edm::Run const& run, edm::EventSetup const& iSetup) {
-  const L1TMuonOverlapParamsRcd& omtfRcd = iSetup.get<L1TMuonOverlapParamsRcd>();
-
-  edm::ESHandle<L1TMuonOverlapParams> omtfParamsHandle;
-  omtfRcd.get(omtfParamsHandle);
-
-  const L1TMuonOverlapParams* omtfParams = omtfParamsHandle.product();
+void OMTFReconstruction::beginRun(edm::Run const&, edm::EventSetup const& iSetup) {
+  const L1TMuonOverlapParams* omtfParams = &iSetup.getData(l1TMuonOverlapParamsToken_);
 
   if (!omtfParams) {
     edm::LogError("L1TMuonOverlapTrackProducer") << "Could not retrieve parameters from Event Setup" << std::endl;
@@ -97,7 +91,7 @@ void OMTFReconstruction::beginRun(edm::Run const& run, edm::EventSetup const& iS
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 std::unique_ptr<l1t::RegionalMuonCandBxCollection> OMTFReconstruction::reconstruct(const edm::Event& iEvent,
-                                                                                   const edm::EventSetup& evSetup) {
+                                                                                   const edm::EventSetup&) {
   loadAndFilterDigis(iEvent);
 
   if (dumpResultToXML)

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -13,16 +13,16 @@
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
 #include "L1Trigger/L1TMuonOverlap/interface/AngleConverter.h"
 #include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ///////////////////////////////////////
 ///////////////////////////////////////
-OMTFinputMaker::OMTFinputMaker() {}
+OMTFinputMaker::OMTFinputMaker(edm::ConsumesCollector &iC, bool getDuringEvent)
+    : myAngleConverter(std::make_unique<AngleConverter>(iC, getDuringEvent)) {}
 ///////////////////////////////////////
 ///////////////////////////////////////
 void OMTFinputMaker::initialize(const edm::EventSetup &es, const OMTFConfiguration *omtfConfig) {
-  myAngleConverter.checkAndUpdateGeometry(es, omtfConfig->nPhiBins());
+  myAngleConverter->checkAndUpdateGeometry(es, omtfConfig->nPhiBins());
 
   myOmtfConfig = omtfConfig;
 }
@@ -248,8 +248,8 @@ OMTFinput OMTFinputMaker::processDT(const L1MuDTChambPhContainer *dtPhDigis,
 
     auto iter = myOmtfConfig->getHwToLogicLayer().find(hwNumber);
     unsigned int iLayer = iter->second;
-    int iPhi = myAngleConverter.getProcessorPhi(iProcessor, type, digiIt);
-    int iEta = myAngleConverter.getGlobalEta(detid.rawId(), digiIt, dtThDigis);
+    int iPhi = myAngleConverter->getProcessorPhi(iProcessor, type, digiIt);
+    int iEta = myAngleConverter->getGlobalEta(detid.rawId(), digiIt, dtThDigis);
     unsigned int iInput = getInputNumber(detid.rawId(), iProcessor, type);
     bool allowOverwrite = false;
     result.addLayerHit(iLayer, iInput, iPhi, iEta, allowOverwrite);
@@ -287,8 +287,8 @@ OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDi
         continue;
 
       unsigned int iLayer = myOmtfConfig->getHwToLogicLayer().at(hwNumber);
-      int iPhi = myAngleConverter.getProcessorPhi(iProcessor, type, CSCDetId(rawid), *digi);
-      int iEta = myAngleConverter.getGlobalEta(rawid, *digi);
+      int iPhi = myAngleConverter->getProcessorPhi(iProcessor, type, CSCDetId(rawid), *digi);
+      int iEta = myAngleConverter->getGlobalEta(rawid, *digi);
       ///Accept CSC digis only up to eta=1.26.
       ///The nominal OMTF range is up to 1.24, but cutting at 1.24
       ///kill efficnency at the edge. 1.26 is one eta bin above nominal.
@@ -348,14 +348,14 @@ OMTFinput OMTFinputMaker::processRPC(const RPCDigiCollection *rpcDigis,
     }
 
     for (auto &cluster : clusters) {
-      //      int iPhiHalfStrip1 = myAngleConverter.getProcessorPhi(iProcessor, type, roll, cluster.first);
-      //      int iPhiHalfStrip2 = myAngleConverter.getProcessorPhi(iProcessor, type, roll, cluster.second);
-      int iPhi = myAngleConverter.getProcessorPhi(iProcessor, type, roll, cluster.first, cluster.second);
+      //      int iPhiHalfStrip1 = myAngleConverter->getProcessorPhi(iProcessor, type, roll, cluster.first);
+      //      int iPhiHalfStrip2 = myAngleConverter->getProcessorPhi(iProcessor, type, roll, cluster.second);
+      int iPhi = myAngleConverter->getProcessorPhi(iProcessor, type, roll, cluster.first, cluster.second);
       int cSize = abs(int(cluster.first) - int(cluster.second)) + 1;
       //      std::cout << " HStrip_1: " << iPhiHalfStrip1 <<" HStrip_2: "<<iPhiHalfStrip2<<" iPhi: " << iPhi << " cluster: ["<< cluster.first << ", "<<  cluster.second <<"]"<< std::endl;
       if (cSize > 3)
         continue;
-      int iEta = myAngleConverter.getGlobalEta(rawid, cluster.first);
+      int iEta = myAngleConverter->getGlobalEta(rawid, cluster.first);
       unsigned int hwNumber = myOmtfConfig->getLayerNumber(rawid);
       unsigned int iLayer = myOmtfConfig->getHwToLogicLayer().at(hwNumber);
       unsigned int iInput = getInputNumber(rawid, iProcessor, type);


### PR DESCRIPTION
#### PR description:

EventSetup consumes migration for 2 modules,
GEMRawToDigiModule and
L1TMuonOverlapTrackProducer

Also migrated helper classes used by L1TMuonOverlapTrackProducer.

Also a little cleanup related to the includes and forward declarations.
Also cleanup, removed a data member containing an unnecessary
copy of the module's ParameterSet.

#### PR validation:

Should not change output. Relies on existing tests.
