### PR TITLE
Running code-format for reco

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -111,14 +111,14 @@ private:
                                  float eff_charge_cut_low,    //!< Use edge if > W_eff (in pix) &&&
                                  float eff_charge_cut_high,   //!< Use edge if < W_eff (in pix) &&&
                                  float size_cut               //!< Use edge when size == cuts
-                                 ) const;
+  ) const;
 
   void collect_edge_charges(ClusterParam &theClusterParam,  //!< input, the cluster
                             int &Q_f_X,                     //!< output, Q first  in X
                             int &Q_l_X,                     //!< output, Q last   in X
                             int &Q_f_Y,                     //!< output, Q first  in Y
                             int &Q_l_Y                      //!< output, Q last   in Y
-                            ) const;
+  ) const;
 
   //--- Errors squared in x and y.  &&& Need to be revisited.
   float err2X(bool &, int &) const;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -412,7 +412,7 @@ float PixelCPEGeneric::generic_position_formula(int size,                    //!
                                                 float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
                                                 float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
                                                 float size_cut               //!< Use edge when size == cuts
-                                                ) const {
+) const {
   //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
 
   float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
@@ -522,7 +522,7 @@ void PixelCPEGeneric::collect_edge_charges(ClusterParam& theClusterParamBase,  /
                                            int& Q_l_X,                         //!< output, Q last   in X
                                            int& Q_f_Y,                         //!< output, Q first  in Y
                                            int& Q_l_Y                          //!< output, Q last   in Y
-                                           ) const {
+) const {
   ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
 
   // Initialize return variables.

--- a/RecoMuon/MuonSeedGenerator/src/MuonDTSeedFromRecHits.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonDTSeedFromRecHits.cc
@@ -234,7 +234,9 @@ void MuonDTSeedFromRecHits::computePtWithoutVtx(double* pt, double* spt) const {
           pt[7] = thispt;
           break;
         }
-        default: { break; }
+        default: {
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION

Applying code-format for CMSSW category reco.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/480//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


