### PR TITLE
Updates for HCAL online TPG LUT and Trigger keys

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
@@ -28,6 +28,7 @@ class LutXml : public XMLDOMBlock {
 public:
   typedef struct _Config {
     _Config();
+    std::string infotype;
     int ieta, iphi, depth, crate, slot, topbottom, fiber, fiberchan, lut_type;
     std::string creationtag;
     std::string creationstamp;

--- a/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
@@ -54,7 +54,7 @@ public:
   //
   //std::vector<unsigned int> getLut( int lut_type, int crate, int slot, int topbottom, int fiber, int fiber_channel );
 
-  HcalSubdetector subdet_from_crate(int crate, int eta, int depth);
+  HcalSubdetector subdet_from_crate(int crate, int slot, int fiber);
   int a_to_i(char* inbuf);
   int create_lut_map(void);
 

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -305,7 +305,7 @@ HcalSubdetector LutXml::subdet_from_crate(int crate_, int slot, int fiber) {
   // HO: 3,6,7,13,18  (+20)
   int crate = crate_ < 20 ? crate_ : crate_ - 20;
   if (crate == 2 || crate == 9 || crate == 12) return HcalForward;
-  else if (crate == 3 || crate == 6 || crate == 7 || crate == 13 || crate == 38) return HcalOuter;
+  else if (crate == 3 || crate == 6 || crate == 7 || crate == 13 || crate == 18) return HcalOuter;
   else if (crate == 0 || crate == 1 || crate == 4 || crate == 5 || crate == 10 || crate == 11 || crate == 14 || crate == 15 || crate == 17) {
       if (slot%3==1) return HcalBarrel;
       else if(slot%3==0) return HcalEndcap; 

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -28,8 +28,7 @@
 using namespace std;
 XERCES_CPP_NAMESPACE_USE
 
-LutXml::Config::_Config()
-{
+LutXml::Config::_Config() {
   infotype = "LUT";
   ieta = -1000;
   iphi = -1000;
@@ -83,7 +82,7 @@ void LutXml::addLut(LutXml::Config &_config, XMLDOMBlock *checksums_xml) {
   brickElem = document->createElement(XMLProcessor::_toXMLCh("CFGBrick"));
   rootElem->appendChild(brickElem);
 
-  addParameter( "INFOTYPE", "string", _config.infotype );
+  addParameter("INFOTYPE", "string", _config.infotype);
   addParameter("CREATIONTAG", "string", _config.creationtag);
   addParameter("CREATIONSTAMP", "string", _config.creationstamp);
   addParameter("FORMATREVISION", "string", _config.formatrevision);
@@ -304,15 +303,22 @@ HcalSubdetector LutXml::subdet_from_crate(int crate_, int slot, int fiber) {
   // HF: 2,9,12  (+20)
   // HO: 3,6,7,13,18  (+20)
   int crate = crate_ < 20 ? crate_ : crate_ - 20;
-  if (crate == 2 || crate == 9 || crate == 12) return HcalForward;
-  else if (crate == 3 || crate == 6 || crate == 7 || crate == 13 || crate == 18) return HcalOuter;
-  else if (crate == 0 || crate == 1 || crate == 4 || crate == 5 || crate == 10 || crate == 11 || crate == 14 || crate == 15 || crate == 17) {
-      if (slot%3==1) return HcalBarrel;
-      else if(slot%3==0) return HcalEndcap; 
-      else if(fiber<12) return HcalBarrel;
-      else return HcalEndcap;
+  if (crate == 2 || crate == 9 || crate == 12)
+    return HcalForward;
+  else if (crate == 3 || crate == 6 || crate == 7 || crate == 13 || crate == 18)
+    return HcalOuter;
+  else if (crate == 0 || crate == 1 || crate == 4 || crate == 5 || crate == 10 || crate == 11 || crate == 14 ||
+           crate == 15 || crate == 17) {
+    if (slot % 3 == 1)
+      return HcalBarrel;
+    else if (slot % 3 == 0)
+      return HcalEndcap;
+    else if (fiber < 12)
+      return HcalBarrel;
+    else
+      return HcalEndcap;
   }
-  return HcalOther; 
+  return HcalOther;
 }
 
 int LutXml::a_to_i(char *inbuf) {

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -318,7 +318,8 @@ HcalSubdetector LutXml::subdet_from_crate(int crate_, int slot, int fiber) {
     else
       return HcalEndcap;
   }
-  return HcalOther;
+  edm::LogWarning("LutXml::subdet_from_crate") << "crate " << crate_ << " is not accounted for";
+  return HcalEmpty;
 }
 
 int LutXml::a_to_i(char *inbuf) {

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -299,37 +299,20 @@ int LutXml::test_access(std::string filename) {
   return 0;
 }
 
-HcalSubdetector LutXml::subdet_from_crate(int crate_, int eta, int depth) {
-  HcalSubdetector result;
-  // HBHE: 0,1,4,5,10,11,14,15,17
-  // HF: 2,9,12
-  // HO: 3,6,7,13
+HcalSubdetector LutXml::subdet_from_crate(int crate_, int slot, int fiber) {
+  // HBHE: 0,1,4,5,10,11,14,15,17 (+20)
+  // HF: 2,9,12  (+20)
+  // HO: 3,6,7,13,18  (+20)
   int crate = crate_ < 20 ? crate_ : crate_ - 20;
-
-  if (crate == 2 || crate == 9 || crate == 12)
-    result = HcalForward;
-  else if (crate == 3 || crate == 6 || crate == 7 || crate == 13)
-    result = HcalOuter;
-  else if (crate == 0 || crate == 1 || crate == 4 || crate == 5 || crate == 10 || crate == 11 || crate == 14 ||
-           crate == 15 || crate == 17) {
-    if (eta < 16)
-      result = HcalBarrel;
-    else if (eta > 16)
-      result = HcalEndcap;
-    else if (eta == 16 && depth < 3)
-      result = HcalBarrel;
-    else if (eta == 16 && depth >= 3)
-      result = HcalEndcap;
-    else {
-      edm::LogError("LutXml") << "Impossible to determine HCAL subdetector!!!";
-      exit(-1);
-    }
-  } else {
-    edm::LogError("LutXml") << "Impossible to determine HCAL subdetector!!!";
-    exit(-1);
+  if (crate == 2 || crate == 9 || crate == 12) return HcalForward;
+  else if (crate == 3 || crate == 6 || crate == 7 || crate == 13 || crate == 38) return HcalOuter;
+  else if (crate == 0 || crate == 1 || crate == 4 || crate == 5 || crate == 10 || crate == 11 || crate == 14 || crate == 15 || crate == 17) {
+      if (slot%3==1) return HcalBarrel;
+      else if(slot%3==0) return HcalEndcap; 
+      else if(fiber<12) return HcalBarrel;
+      else return HcalEndcap;
   }
-
-  return result;
+  return HcalOther; 
 }
 
 int LutXml::a_to_i(char *inbuf) {
@@ -360,6 +343,8 @@ int LutXml::create_lut_map(void) {
       int iphi = -99;
       int depth = -99;
       int crate = -99;
+      int slot = -99;
+      int fiber = -99;
       int lut_type = -99;
       int slb = -99;
       HcalSubdetector subdet;
@@ -374,12 +359,16 @@ int LutXml::create_lut_map(void) {
           depth = a_to_i(XMLString::transcode(aPar->getFirstChild()->getNodeValue()));
         if (strcmp(aName, "CRATE") == 0)
           crate = a_to_i(XMLString::transcode(aPar->getFirstChild()->getNodeValue()));
+        if (strcmp(aName, "SLOT") == 0)
+          slot = a_to_i(XMLString::transcode(aPar->getFirstChild()->getNodeValue()));
+        if (strcmp(aName, "FIBER") == 0)
+          fiber = a_to_i(XMLString::transcode(aPar->getFirstChild()->getNodeValue()));
         if (strcmp(aName, "LUT_TYPE") == 0)
           lut_type = a_to_i(XMLString::transcode(aPar->getFirstChild()->getNodeValue()));
         if (strcmp(aName, "SLB") == 0)
           slb = a_to_i(XMLString::transcode(aPar->getFirstChild()->getNodeValue()));
       }
-      subdet = subdet_from_crate(crate, abs(ieta), depth);
+      subdet = subdet_from_crate(crate, slot, fiber);
       DOMElement *_data = (DOMElement *)(aBrick->getElementsByTagName(XMLString::transcode("Data"))->item(0));
       char *_str = XMLString::transcode(_data->getFirstChild()->getNodeValue());
 

--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -28,7 +28,9 @@
 using namespace std;
 XERCES_CPP_NAMESPACE_USE
 
-LutXml::Config::_Config() {
+LutXml::Config::_Config()
+{
+  infotype = "LUT";
   ieta = -1000;
   iphi = -1000;
   depth = -1;
@@ -81,6 +83,7 @@ void LutXml::addLut(LutXml::Config &_config, XMLDOMBlock *checksums_xml) {
   brickElem = document->createElement(XMLProcessor::_toXMLCh("CFGBrick"));
   rootElem->appendChild(brickElem);
 
+  addParameter( "INFOTYPE", "string", _config.infotype );
   addParameter("CREATIONTAG", "string", _config.creationtag);
   addParameter("CREATIONSTAMP", "string", _config.creationstamp);
   addParameter("FORMATREVISION", "string", _config.formatrevision);

--- a/CaloOnlineTools/HcalOnlineDb/test/cardPhysicsSkeleton.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/cardPhysicsSkeleton.sh
@@ -1,0 +1,25 @@
+Tag="<LUTTAG>"
+Run=1
+GlobalTag="<Globaltag>"
+description="<Description of updates>"
+HOAsciiInput=HO_ped9_inputLUTcoderDec.txt
+
+ElectronicsMap=""
+LutMetadata=""
+LUTCorrs=""
+QIETypes=""
+QIEData=""
+SiPMParameters=""
+TPParameters=""
+TPChannelParameters=""
+
+ChannelQuality=""
+Gains="<TestTagNameOfChangingCondition>"
+Pedestals=""
+RespCorrs=""
+L1TriggerObjects="<TestTagNameOfChangingCondition>"
+
+OldTag="<OldTagToCompareTo>"
+OldRun=1
+
+applyO2O=true

--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -94,7 +94,7 @@ then
     source $card
     for i in ${inputConditions[@]}; do
 	record=$i
-	tag=${!t}
+	tag=${!i}
 	dump 
     done
 

--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -56,8 +56,8 @@ done
 
 dump(){
     CheckParameter record 
-    CheckParameter run
-    CheckParameter GT
+    CheckParameter Run
+    CheckParameter GlobalTag
 
     dumpCmd="cmsRun $CMSSW_RELEASE_BASE/src/CondTools/Hcal/test/runDumpHcalCond_cfg.py geometry=DB prefix="""
 
@@ -68,19 +68,19 @@ dump(){
 
     if [ ! -z $tag ]
     then
-	if ! $dumpCmd dumplist=$record run=$run globaltag=$GT  frontierloc=$frontier frontierlist=Hcal${record}Rcd:$tag  
+	if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag  frontierloc=$frontier frontierlist=Hcal${record}Rcd:$tag  
 	then
 	    exit 1
 	fi
     else 
-	if ! $dumpCmd dumplist=$record run=$run globaltag=$GT 
+	if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag 
 	then
 	    exit 1
 	fi
     fi
 
     mkdir -p $CondDir/$record
-    mv ${record}_Run$run.txt $CondDir/$record/.
+    mv ${record}_Run$Run.txt $CondDir/$record/.
 }
 
 if [[ "$cmd" == "dump" ]]
@@ -93,10 +93,10 @@ then
     CheckFile $card
     source $card
     for i in ${inputConditions[@]}; do
-	t=$i
-	./genLUT.sh dump run=$Run record=$t GT=$GlobalTag tag=${!t}
+	record=$i
+	tag=${!t}
+	dump 
     done
-
 
 
 elif [[ "$cmd" == "generate" ]]
@@ -204,10 +204,8 @@ then
 elif [ "$cmd" == "makeTriggerKey" ]
 then
     CheckParameter card
-    CheckParameter l1totag 
+    CheckParameter l1to
     CheckParameter production
-    CheckParameter o2oL1TriggerObjects
-    CheckParameter o2oInputs
     CheckFile $card
     source $card
     tktag=HCAL_$Tag
@@ -229,12 +227,12 @@ then
     <Parameter type=\"string\" name=\"CREATIONSTAMP\">$dd</Parameter>
     <Parameter type=\"string\" name=\"CREATIONTAG\">$tktag</Parameter> 
     <Parameter type=\"string\" name=\"HCAL_LUT_TAG\">$Tag</Parameter>  
-    <Parameter type=\"boolean\" name=\"updateInputs\">$o2oInputs</Parameter>  
-    <Parameter type=\"boolean\" name=\"updateL1TriggerObjects\">$o2oL1TriggerObjects</Parameter>  
+    <Parameter type=\"boolean\" name=\"updateInputs\">$O2OInputs</Parameter>  
+    <Parameter type=\"boolean\" name=\"updateL1TriggerObjects\">$O2OL1TriggerObjects</Parameter>  
     <Parameter type=\"string\" name=\"GlobalTag\">$GlobalTag</Parameter> 
     <Parameter type=\"string\" name=\"CMSSW\">$CMSSW_VERSION</Parameter> 
     <Parameter type=\"string\" name=\"InputRun\">$Run</Parameter>  
-    <Parameter type=\"string\" name=\"L1TriggerObjects\">$l1totag</Parameter>$inputs
+    <Parameter type=\"string\" name=\"L1TriggerObjects\">$l1to</Parameter>$inputs
     <Data elements=\"1\">$production</Data> 
 </CFGBrick>
 </CFGBrickSet>""" > $CondDir/$Tag/$tktag.xml

--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -208,7 +208,7 @@ then
     CheckParameter production
     CheckFile $card
     source $card
-    tktag=HCAL_$Tag
+    tktag=$Tag
     dd=$(date +"%Y-%m-%d %H:%M:%S")
     inputs=""
     for i in ${inputConditions[@]}; do
@@ -223,7 +223,7 @@ then
     echo """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>
 <CFGBrickSet>
 <CFGBrick>
-    <Parameter type=\"string\" name=\"INFOTYPE\">TriggerKey</Parameter>
+    <Parameter type=\"string\" name=\"INFOTYPE\">TRIGGERKEY</Parameter>
     <Parameter type=\"string\" name=\"CREATIONSTAMP\">$dd</Parameter>
     <Parameter type=\"string\" name=\"CREATIONTAG\">$tktag</Parameter> 
     <Parameter type=\"string\" name=\"HCAL_LUT_TAG\">$Tag</Parameter>  
@@ -235,7 +235,7 @@ then
     <Parameter type=\"string\" name=\"L1TriggerObjects\">$l1to</Parameter>$inputs
     <Data elements=\"1\">$production</Data> 
 </CFGBrick>
-</CFGBrickSet>""" > $CondDir/$Tag/$tktag.xml
+</CFGBrickSet>""" > $CondDir/$Tag/tk_$tktag.xml
     
 
 ##

--- a/CaloOnlineTools/HcalOnlineDb/test/template.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/template.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
 
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-process = cms.Process("TEST", Run2_2018)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("TEST", Run3)
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.categories.append('LUT')

--- a/CaloOnlineTools/HcalOnlineDb/test/template.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/template.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 process = cms.Process("TEST", Run2_2018)


### PR DESCRIPTION
#### PR description:

The PR includes updates for online HCAL LUT and trigger key generation. It should not affect any offline processing. Main changes include:

   * TriggerKey is now generated together with LUTs (as opposed to by a separate online tool)
   * adding typinfo element to both LUT and TriggerKey content to support new online xmldb format. 
   * add input information for LUT generation to TriggerKey content which will be used by O2O for automatic synchronization of online LUTs and corresponding offline conditions updates
   * plus some minor fixes and improvements (input parameters are defined in input card, fix/update  for crate to subdet id function etc. )

 
#### PR validation:
The code has been used to generate past and upcoming online LUTs and trigger keys. 
The PR should not affect any offline workflow. 

