### PR TITLE
Fix string operation in DDCMS

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
@@ -35,7 +35,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   Volume mother = ns.volume(args.parentName());
   string childName = args.value<string>("ChildName");
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
   Volume child = ns.volume(childName);
 
   double delta = 0e0;

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -834,13 +834,13 @@ void Converter<DDLTransform3D>::operator()(xml_h element) const {
   } else if (refRotation.ptr()) {
     string rotName = refRotation.nameStr();
     if (strchr(rotName.c_str(), NAMESPACE_SEP) == nullptr)
-      rotName = ns.name() + rotName;
+      rotName = ns.prepend(rotName);
 
     rot = ns.rotation(rotName);
   } else if (refReflectionRotation.ptr()) {
     string rotName = refReflectionRotation.nameStr();
     if (strchr(rotName.c_str(), NAMESPACE_SEP) == nullptr)
-      rotName = ns.name() + rotName;
+      rotName = ns.prepend(rotName);
 
     rot = ns.rotation(rotName);
   }
@@ -868,11 +868,11 @@ void Converter<DDLPosPart>::operator()(xml_h element) const {
            copy);
 
   if (!parent.isValid() && strchr(parentName.c_str(), NAMESPACE_SEP) == nullptr)
-    parentName = ns.name() + parentName;
+    parentName = ns.prepend(parentName);
   parent = ns.volume(parentName);
 
   if (!child.isValid() && strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
   child = ns.volume(childName, false);
 
   printout(ns.context()->debug_placements ? ALWAYS : DEBUG,
@@ -1558,11 +1558,11 @@ void Converter<DDLDivision>::operator()(xml_h element) const {
   xml_dim_t e(element);
   string childName = e.nameStr();
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
 
   string parentName = ns.attr<string>(e, DD_CMU(parent));
   if (strchr(parentName.c_str(), NAMESPACE_SEP) == nullptr)
-    parentName = ns.name() + parentName;
+    parentName = ns.prepend(parentName);
   string axis = ns.attr<string>(e, DD_CMU(axis));
 
   // If you divide a tube of 360 degrees the offset displaces

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
@@ -24,7 +24,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   dd4hep::Volume mother = ns.volume(args.parentName());
   std::string childName = args.value<std::string>("ChildName");
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
   dd4hep::Volume child = ns.volume(childName);
 
   // Increment

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
@@ -62,7 +62,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   dd4hep::Position tran(xpos, ypos, zpos);
 
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
   dd4hep::Volume child = ns.volume(childName);
   parent.placeVolume(child, copyNumber, dd4hep::Transform3D(rotation, tran));
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

The latest ROOT integration builds failed because of string_view + string operation. 
Seems ns.name() was returning string before but it returns string view now. To be confirmed

#### PR validation:

It compiles with the updated DD4Hep externals (and ROOT)

