### PR TITLE
DQM: Fix EDMtoMEConverter.

### DIFF
--- a/DQMServices/Components/plugins/EDMtoMEConverter.cc
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.cc
@@ -149,18 +149,17 @@ namespace {
 
       if (me) {
         auto histo = HistoTraits<T>::get(me);
-        if (histo && me->getTH1()->CanExtendAllAxes()) {
-          TList list;
-          list.Add(metoedmobject);
-          if (histo->Merge(&list) == -1)
-            std::cout << "ERROR EDMtoMEConverter::getData(): merge failed for '" << metoedmobject->GetName() << "'"
-                      << std::endl;
-          return me;
-        }
+        assert(histo);
+        TList list;
+        list.Add(metoedmobject);
+        if (histo->Merge(&list) == -1)
+          edm::LogError("EDMtoMEConverter") << "ERROR EDMtoMEConverter::getData(): merge failed for '"
+                                            << metoedmobject->GetName() << "'" << std::endl;
+        return me;
+      } else {
+        iBooker.setCurrentFolder(dir);
+        return HistoTraits<T>::book(iBooker, metoedmobject->GetName(), metoedmobject);
       }
-
-      iBooker.setCurrentFolder(dir);
-      return HistoTraits<T>::book(iBooker, metoedmobject->GetName(), metoedmobject);
     }
   };
 


### PR DESCRIPTION
#### PR description:

This PR fixes a problem pointed out by @mmusich related to the AlCa multi-run harvesting workflows, caused by #28622.

In the past, the DQMStore, when used with "collate" mode, would
automatically merge the `TH1` object passed into a `book*()` call with an
existing object. However, the merge logic in the `DQMStore` is rather
conservative and didn't merge objects with `SetCanExtend` set. So, to
work around this, `EDMtoMEConverter` would merge these objects itself.

The new `DQMStore` does not have the "collate" mode any more and all the
merging has to happen in the input modules. This fixes
`EDMtoMEConverter` to *always* use its local merge logic.

Arguably the ME merge logic should be factored out of DQMRootSource and
EDMtoMEConverter and shared between the two, but for now this small fix
should work to get the AlCa workflows working again.

#### PR validation:

Privately provided test configuration seems to provide correct results, needs further testing by AlCa.

I have not much confidence that the `EDMtoMEConverter` behaves correctly for all combinations of settings, but in the end this module is there to support the AlCa workflows dating back to Run1 and the only thing that matters is that these work correctly.