### PR TITLE
Run3-hcx250 Remove regex in the start of a string

### DIFF
--- a/Geometry/HcalCommonData/data/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering.xml
@@ -95,7 +95,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2015/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2015/hcalSimNumbering.xml
@@ -95,7 +95,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2016/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2016/hcalSimNumbering.xml
@@ -97,7 +97,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2016a/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2016a/hcalSimNumbering.xml
@@ -95,7 +95,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2017Plan0/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2017Plan0/hcalSimNumbering.xml
@@ -95,7 +95,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2017Plan1/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2017Plan1/hcalSimNumbering.xml
@@ -100,7 +100,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2018/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2018/hcalSimNumbering.xml
@@ -108,7 +108,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2018Plan36/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2018Plan36/hcalSimNumbering.xml
@@ -95,7 +95,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2021/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2021/hcalSimNumbering.xml
@@ -92,7 +92,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2026/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2026/hcalSimNumbering.xml
@@ -111,7 +111,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//HES.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>


### PR DESCRIPTION
#### PR description:

Remove unnecessary regular expression at the beginning of a string for the names of SD elements of hadron calorimeter

#### PR validation:

Tested the effect of removing this by looking into the parameters with and without the change

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special