### PR TITLE
fixes needd to run RelMon under python3

### DIFF
--- a/Utilities/RelMon/python/authentication.py
+++ b/Utilities/RelMon/python/authentication.py
@@ -12,10 +12,15 @@ from __future__ import print_function
 #                                                                              
 ################################################################################
 
+from sys import version_info
 from os import getenv
 from os.path import exists
-from httplib import HTTPSConnection
-from urllib2  import AbstractHTTPHandler
+if version_info[0]==2:
+  from httplib import HTTPSConnection
+  from urllib2  import AbstractHTTPHandler
+else:
+  from http.client import HTTPSConnection
+  from urllib.request  import AbstractHTTPHandler
 #-------------------------------------------------------------------------------  
 
 class X509CertAuth(HTTPSConnection):

--- a/Utilities/RelMon/python/dirstructure.py
+++ b/Utilities/RelMon/python/dirstructure.py
@@ -18,7 +18,7 @@ from os.path import exists,join
 
 import sys
 argv=sys.argv
-from ROOT import *
+import ROOT
 sys.argv=argv
 
 from .definitions import *
@@ -29,7 +29,7 @@ from .utils import setTDRStyle
 setTDRStyle()
 
 # Do not display the canvases
-gROOT.SetBatch(kTRUE)
+ROOT.gROOT.SetBatch(ROOT.kTRUE)
 
 
 #-------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ class Directory(Weighted):
     Weighted.__init__(self,name)
     self.draw_success=draw_success
     self.do_pngs=do_pngs
-    self.rank_histo=TH1I("rh%s"%name,"",50,-0.01,1.001)
+    self.rank_histo=ROOT.TH1I("rh%s"%name,"",50,-0.01,1.001)
     self.rank_histo.SetDirectory(0)
     self.different_histograms = {}
     self.different_histograms['file1']= {}
@@ -237,13 +237,13 @@ class Directory(Weighted):
     self.__create_on_disk()
     vals=[]
     colors=[]
-    for n,col in zip((self.n_fails,self.n_nulls,self.n_successes,self.n_skiped),(kRed,kYellow,kGreen,kBlue)):
+    for n,col in zip((self.n_fails,self.n_nulls,self.n_successes,self.n_skiped),(ROOT.kRed,ROOT.kYellow,ROOT.kGreen,ROOT.kBlue)):
       if n!=0:
         vals.append(n)
         colors.append(col)
     valsa=array('f',vals)
     colorsa=array('i',colors)
-    can = TCanvas("cpie","TPie test",100,100);
+    can = ROOT.TCanvas("cpie","TPie test",100,100);
     try:
       pie = TPie("ThePie",self.name,len(vals),valsa,colorsa);
       label_n=0
@@ -400,7 +400,7 @@ class Comparison(Weighted):
     if self.rank==-1:
       return 0
    
-    canvas=TCanvas(self.name,self.name,Comparison.canvas_xsize,Comparison.canvas_ysize)
+    canvas=ROOT.TCanvas(self.name,self.name,Comparison.canvas_xsize,Comparison.canvas_ysize)
     objs=(obj1,obj2)
 
     # Add some specifics for the graphs
@@ -416,47 +416,47 @@ class Comparison(Weighted):
       obj2.SetMarkerStyle(8)
       obj2.SetMarkerSize(.8)
 
-      obj1.SetMarkerColor(kBlue)
-      obj1.SetLineColor(kBlue)
+      obj1.SetMarkerColor(ROOT.kBlue)
+      obj1.SetLineColor(ROOT.kBlue)
 
-      obj2.SetMarkerColor(kRed)
-      obj2.SetLineColor(kRed)
+      obj2.SetMarkerColor(ROOT.kRed)
+      obj2.SetLineColor(ROOT.kRed)
 
       obj1.Draw("EP")
       #Statsbox      
       obj2.Draw("HistSames")
-      #gPad.Update()
-      #if 'stats' in map(lambda o: o.GetName(),list(gPad.GetListOfPrimitives())):
+      #ROOT.gPad.Update()
+      #if 'stats' in map(lambda o: o.GetName(),list(ROOT.gPad.GetListOfPrimitives())):
         #st = gPad.GetPrimitive("stats")      
         #st.SetY1NDC(0.575)
         #st.SetY2NDC(0.735)
-        #st.SetLineColor(kRed)
-        #st.SetTextColor(kRed)
+        #st.SetLineColor(ROOT.kRed)
+        #st.SetTextColor(ROOT.kRed)
         #print st      
     else:
       obj1.Draw("Colz")
-      gPad.Update()
-      #if 'stats' in map(lambda o: o.GetName(),list(gPad.GetListOfPrimitives())):
-        #st = gPad.GetPrimitive("stats")      
+      ROOT.gPad.Update()
+      #if 'stats' in map(lambda o: o.GetName(),list(ROOT.gPad.GetListOfPrimitives())):
+        #st = ROOT.gPad.GetPrimitive("stats")      
         #st.SetY1NDC(0.575)
         #st.SetY2NDC(0.735)
-        #st.SetLineColor(kRed)
-        #st.SetTextColor(kRed)
+        #st.SetLineColor(ROOT.kRed)
+        #st.SetTextColor(ROOT.kRed)
         #print st
       obj2.Draw("ColSame")
 
     # Put together the TLatex for the stat test if possible    
-    color=kGreen+2 # which is green, as everybody knows
+    color=ROOT.kGreen+2 # which is green, as everybody knows
     if self.status==FAIL:
       print("This comparison failed %f" %self.rank)
-      color=kRed
+      color=ROOT.kRed
     elif self.status==NULL:
-      color=kYellow
+      color=ROOT.kYellow
     elif self.status==SKIPED:
-      color=kBlue #check if kBlue exists ;)
+      color=ROOT.kBlue #check if kBlue exists ;)
     
     lat_text="#scale[.7]{#color[%s]{%s: %2.2f}}" %(color,self.test_name,self.rank)
-    lat=TLatex(.1,.91,lat_text)
+    lat=ROOT.TLatex(.1,.91,lat_text)
     lat.SetNDC()
     lat.Draw()
   
@@ -473,13 +473,13 @@ class Comparison(Weighted):
       n2="%s"%n2
 
     lat_text1="#scale[.7]{#color[%s]{Entries: %s}}" %(obj1.GetLineColor(),n1)
-    lat1=TLatex(.3,.91,lat_text1)
+    lat1=ROOT.TLatex(.3,.91,lat_text1)
     lat1.SetNDC()
     lat1.Draw()
         
     
     lat_text2="#scale[.7]{#color[%s]{Entries: %s}}" %(obj2.GetLineColor(),n2)
-    lat2=TLatex(.6,.91,lat_text2)
+    lat2=ROOT.TLatex(.6,.91,lat_text2)
     lat2.SetNDC()
     lat2.Draw()
     

--- a/Utilities/RelMon/python/dqm_interfaces.py
+++ b/Utilities/RelMon/python/dqm_interfaces.py
@@ -19,15 +19,17 @@ from re import compile as recompile
 from sys import exit,stderr,version_info
 from threading import Thread,activeCount
 from time import sleep
-from urllib2  import Request,build_opener,urlopen
+if version_info[0]==2:
+  from urllib2  import Request,build_opener,urlopen
+else:
+  from urllib.request  import Request,build_opener,urlopen
 
 import sys
 argv=sys.argv
-from ROOT import *
 import ROOT
 sys.argv=argv
 
-gROOT.SetBatch(True)
+ROOT.gROOT.SetBatch(True)
 
 from .authentication import X509CertOpen
 from .dirstructure import Comparison,Directory,tcanvas_print_processes
@@ -478,7 +480,7 @@ class DQMRootFile(object):
     """
     def __init__(self,rootfilename):
         dqmdatadir="DQMData"
-        self.rootfile=TFile(rootfilename)  
+        self.rootfile=ROOT.TFile(rootfilename)
         self.rootfilepwd=self.rootfile.GetDirectory(dqmdatadir)
         self.rootfileprevpwd=self.rootfile.GetDirectory(dqmdatadir)
         if self.rootfilepwd == None:

--- a/Utilities/RelMon/python/utils.py
+++ b/Utilities/RelMon/python/utils.py
@@ -16,20 +16,22 @@ import array
 import os
 import re
 import sys
-from cPickle import load
+from pickle import load
 from os.path import dirname,basename,join,isfile
 from threading import Thread
 from time import asctime
 
 theargv=sys.argv
 sys.argv=[]
-from ROOT import *
 import ROOT
 ROOT.gErrorIgnoreLevel=1001
 ROOT.gROOT.SetBatch(True)
 sys.argv=theargv
 
-from urllib2  import Request,build_opener,urlopen
+if sys.version_info[0]==2:
+  from urllib2  import Request,build_opener,urlopen
+else:
+  from urllib.request  import Request,build_opener,urlopen
 
 if "RELMON_SA" in os.environ:
   from .definitions import *

--- a/Utilities/RelMon/scripts/compare_using_files.py
+++ b/Utilities/RelMon/scripts/compare_using_files.py
@@ -186,7 +186,7 @@ if options.compare:
     from Utilities.RelMon.dqm_interfaces import DirID,DirWalkerFile,string2blacklist
     from Utilities.RelMon.dirstructure import Directory
 
-  import cPickle
+  import pickle
   from os import mkdir,chdir,getcwd
   from os.path import exists
 
@@ -303,8 +303,8 @@ if options.compare:
   # Dump the directory structure on disk in a pickle
   original_pickle_name="%s.pkl" %fulldirname
   print("Pickleing the directory as %s in dir %s" %(original_pickle_name,getcwd()))
-  output = open(original_pickle_name,"w")
-  cPickle.dump(directory, output, -1)# use highest protocol available for the pickle
+  output = open(original_pickle_name,"wb")
+  pickle.dump(directory, output, -1)# use highest protocol available for the pickle
   output.close()
 
 #-------------------------------------------------------------------------------
@@ -320,7 +320,7 @@ if options.report:
   from os.path import exists
   from os import chdir,mkdir
   import os
-  import cPickle    
+  import pickle    
   
   pickle_name=options.pklfile
   if len(options.pklfile)==0:
@@ -328,7 +328,7 @@ if options.report:
 
   print("Reading directory from %s" %(pickle_name))
   ifile=open(pickle_name,"rb")
-  directory=cPickle.load(ifile)
+  directory=pickle.load(ifile)
   ifile.close()
 
   if not options.compare:


### PR DESCRIPTION
#### PR description:

Pull requests comparion jobs for PY3 IBs do not run (https://github.com/cms-sw/cmsdist/pull/5537#issuecomment-584898831 ) as RelMon scripts are not python3 compatible. 

PyROOT with python3 does not like `from ROOT import *` ( https://github.com/root-project/root/blob/master/bindings/pyroot/ROOT.py#L632-L635) so explicitly import things we use from ROOT. 

#### PR validation:

ReRun pr comparison job locally under PY3 IBs.