### PR TITLE
[cxxmodules] Workaround missing CLHEP modulemap for JetReco.

### DIFF
--- a/DataFormats/JetReco/src/classes_3.h
+++ b/DataFormats/JetReco/src/classes_3.h
@@ -5,6 +5,12 @@
 
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#if defined __has_feature
+#if __has_feature(modules)
+// Workaround the missing CLHEP.modulemap: CLHEP/Vector/ThreeVector.h:41:7: error: redefinition of 'Hep3Vector'
+#include "DataFormats/JetReco/interface/PFClusterJetCollection.h"
+#endif
+#endif
 #include "DataFormats/JetReco/interface/JPTJetCollection.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"


### PR DESCRIPTION
In the same manner as in cms-sw/cmssw#28925 we force the definition of Hep3Vector to be read from the module that contains it rather than parsing it.

Part of #15248

cc: @davidlange6, @smuzaffar, @oshadura.