### PR TITLE
[cxxmodules] Remove the layering violation in BTauReco.

### DIFF
--- a/DataFormats/BTauReco/interface/FeaturesTagInfo.h
+++ b/DataFormats/BTauReco/interface/FeaturesTagInfo.h
@@ -4,8 +4,6 @@
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
-#include "DataFormats/PatCandidates/interface/Jet.h"
-
 namespace reco {
 
   template <class Features>

--- a/DataFormats/PatCandidates/interface/ioread_packedgen.h
+++ b/DataFormats/PatCandidates/interface/ioread_packedgen.h
@@ -1,3 +1,6 @@
+#ifndef DATAFORMATS_PATCANDIDATES_INTERFACE_IOREAD_PACKEDGEN_H
+#define DATAFORMATS_PATCANDIDATES_INTERFACE_IOREAD_PACKEDGEN_H
+
 #include "DataFormats/Math/interface/libminifloat.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 int16_t convertPackedEtaToPackedY(int16_t packedPt_, int16_t packedEta_, int16_t packedM_) {
@@ -8,3 +11,5 @@ int16_t convertPackedEtaToPackedY(int16_t packedPt_, int16_t packedEta_, int16_t
 
   return int16_t(p4.Rapidity() / 6.0f * std::numeric_limits<int16_t>::max());
 }
+
+#endif  // DATAFORMATS_PATCANDIDATES_INTERFACE_IOREAD_PACKEDGEN_H


### PR DESCRIPTION
PatCandidates depends on BTauReco, not vice-versa.

This patch should allow us to enable the PatCandidates module.

Part of #15248 

cc: @davidlange6, @smuzaffar, @oshadura.