### PR TITLE
Sync with stand-alone Pixel Calibration Code

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -700,7 +700,7 @@ private:
   float cota_current_;  //!< current cot alpha
   float cotb_current_;  //!< current cot beta
   float abs_cotb_;      //!< absolute value of cot beta
-  int Dtype_;           //!< flags BPix (=0) or FPix (=1)
+  int dtype_;           //!< flags BPix (=0) or FPix (=1)
   bool flip_y_;         //!< flip y sign-sensitive quantities
   bool flip_x_;         //!< flip x sign-sensitive quantities
   bool success_;        //!< true if cotalpha, cotbeta are inside of the acceptance (dynamically loaded)

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.h (v10.20)
+//  SiPixelTemplate.h (v10.24)
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -79,6 +79,7 @@
 //  V10.20 - Add directory path selection to the ascii pushfile method
 //  V10.21 - Address runtime issues in pushfile() for gcc 7.X due to using tempfile as char string + misc. cleanup [Petar]
 //  V10.22 - Move templateStore to the heap, fix variable name in pushfile() [Petar]
+//  V10.24 - Add sideload() + associated gymnastics [Petar and Oz]
 
 // Created by Morris Swartz on 10/27/06.
 //
@@ -258,17 +259,24 @@ public:
     index_id_ = -1;
     cota_current_ = 0.;
     cotb_current_ = 0.;
+    entry_sideloaded_ = nullptr; 
   }  //!< Constructor for cases in which template store already exists
 
 // Load the private store with info from the file with the index (int) filenum from directory dir:
 //   ${dir}template_summary_zp${filenum}.out
 #ifdef SI_PIXEL_TEMPLATE_STANDALONE
   static bool pushfile(int filenum, std::vector<SiPixelTemplateStore>& pixelTemp, std::string dir = "");
+
+   // For calibrations only: load precalculated values -- no interpolation.
+   void sideload(SiPixelTemplateEntry* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize);
+
 #else
   static bool pushfile(int filenum,
                        std::vector<SiPixelTemplateStore>& pixelTemp,
                        // *&^%$#@!  Different default dir -- remove once FastSim is updated.
                        std::string dir = "CalibTracker/SiPixelESProducers/data/");
+  
+  //load from DB (default in CMSSW)
   static bool pushfile(const SiPixelTemplateDBObject& dbobject,
                        std::vector<SiPixelTemplateStore>& pixelTemp);  // load the private store with info from db
 #endif
@@ -296,7 +304,7 @@ public:
   //Method to estimate the central pixel of the interpolated x-template
   int cxtemp();
 
-  // new methods to build templates from two interpolated clusters (for splitting)
+  //Methods to build templates from two interpolated clusters (for splitting)
   void ytemp3d_int(int nypix, int& nybins);
 
   void ytemp3d(int j, int k, std::vector<float>& ytemplate);
@@ -682,6 +690,9 @@ private:
   float cota_current_;  //!< current cot alpha
   float cotb_current_;  //!< current cot beta
   float abs_cotb_;      //!< absolute value of cot beta
+  int Dtype_;           //!< flags BPix (=0) or FPix (=1)
+  bool flip_y_;         //!< flip y sign-sensitive quantities
+  bool flip_x_;         //!< flip x sign-sensitive quantities
   bool success_;        //!< true if cotalpha, cotbeta are inside of the acceptance (dynamically loaded)
 
   // Keep results of last interpolation to return through member functions
@@ -706,6 +717,16 @@ private:
   float qmin_;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
   float clsleny_;           //!< y-cluster length of smaller interpolated template in pixels
   float clslenx_;           //!< x-cluster length of smaller interpolated template in pixels
+  float scalexavg_;         //!< average x-error scale factor
+  float scaleyavg_;         //!< average y-error scale factor
+  float delyavg_;           //!< average difference between clsleny_ and cluster length [with threshold effects]
+  float delysig_;           //!< rms of difference between clsleny_ and cluster length [with threshold effects]
+  float scalex_[4];         //!< x-error scale factor in charge bins
+  float scaley_[4];         //!< y-error scale factor in charge bins
+  float offsetx_[4];        //!< x-offset in charge bins
+  float offsety_[4];        //!< y-offset in charge bins
+
+
   float yratio_;            //!< fractional distance in y between cotbeta templates
   float yparl_[2][5];       //!< projected y-pixel uncertainty parameterization for smaller cotbeta
   float yparh_[2][5];       //!< projected y-pixel uncertainty parameterization for larger cotbeta
@@ -774,8 +795,21 @@ private:
   boost::multi_array<float, 2> temp2dy_;  //!< 2d-primitive for spltting 3-d template
   boost::multi_array<float, 2> temp2dx_;  //!< 2d-primitive for spltting 3-d template
 
-  // The actual template store is a std::vector container
+  // Pointers to presently interpolated point:
+  const SiPixelTemplateEntry* enty0_;   // enty[ilow]
+  const SiPixelTemplateEntry* enty1_;   // enty[iylow][ilow]
 
+  const SiPixelTemplateEntry* entx00_ ; // entx[iylow][ilow]
+  const SiPixelTemplateEntry* entx02_ ; 
+  const SiPixelTemplateEntry* entx20_ ;
+  const SiPixelTemplateEntry* entx22_ ;
+  const SiPixelTemplateEntry* entx21_ ;
+
+  // Pointer to the sideloaded Entry: use this one if set.
+  const SiPixelTemplateEntry * entry_sideloaded_ ;
+   
+
+  // The actual template store is a std::vector container
   const std::vector<SiPixelTemplateStore>& thePixelTemp_;
 };
 

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -259,7 +259,7 @@ public:
     index_id_ = -1;
     cota_current_ = 0.;
     cotb_current_ = 0.;
-    entry_sideloaded_ = nullptr; 
+    entry_sideloaded_ = nullptr;
   }  //!< Constructor for cases in which template store already exists
 
 // Load the private store with info from the file with the index (int) filenum from directory dir:
@@ -267,15 +267,25 @@ public:
 #ifdef SI_PIXEL_TEMPLATE_STANDALONE
   static bool pushfile(int filenum, std::vector<SiPixelTemplateStore>& pixelTemp, std::string dir = "");
 
-   // For calibrations only: load precalculated values -- no interpolation.
-   void sideload(SiPixelTemplateEntry* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize);
+  // For calibrations only: load precalculated values -- no interpolation.
+  void sideload(SiPixelTemplateEntry* entry,
+                int iDtype,
+                float locBx,
+                float locBz,
+                float lorwdy,
+                float lorwdx,
+                float q50,
+                float fbin[3],
+                float xsize,
+                float ysize,
+                float zsize);
 
 #else
   static bool pushfile(int filenum,
                        std::vector<SiPixelTemplateStore>& pixelTemp,
                        // *&^%$#@!  Different default dir -- remove once FastSim is updated.
                        std::string dir = "CalibTracker/SiPixelESProducers/data/");
-  
+
   //load from DB (default in CMSSW)
   static bool pushfile(const SiPixelTemplateDBObject& dbobject,
                        std::vector<SiPixelTemplateStore>& pixelTemp);  // load the private store with info from db
@@ -697,35 +707,34 @@ private:
 
   // Keep results of last interpolation to return through member functions
 
-  float qavg_;              //!< average cluster charge for this set of track angles
-  float pixmax_;            //!< maximum pixel charge
-  float qscale_;            //!< charge scaling factor
-  float s50_;               //!< 1/2 of the pixel single col threshold signal in electrons
-  float ss50_;              //!< 1/2 of the pixel double col threshold signal in electrons
-  float symax_;             //!< average pixel signal for y-projection of cluster
-  float syparmax_;          //!< maximum pixel signal for parameterization of y uncertainties
-  float dyone_;             //!< mean offset/correction for one pixel y-clusters
-  float syone_;             //!< rms for one pixel y-clusters
-  float dytwo_;             //!< mean offset/correction for one double-pixel y-clusters
-  float sytwo_;             //!< rms for one double-pixel y-clusters
-  float sxmax_;             //!< average pixel signal for x-projection of cluster
-  float sxparmax_;          //!< maximum pixel signal for parameterization of x uncertainties
-  float dxone_;             //!< mean offset/correction for one pixel x-clusters
-  float sxone_;             //!< rms for one pixel x-clusters
-  float dxtwo_;             //!< mean offset/correction for one double-pixel x-clusters
-  float sxtwo_;             //!< rms for one double-pixel x-clusters
-  float qmin_;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
-  float clsleny_;           //!< y-cluster length of smaller interpolated template in pixels
-  float clslenx_;           //!< x-cluster length of smaller interpolated template in pixels
-  float scalexavg_;         //!< average x-error scale factor
-  float scaleyavg_;         //!< average y-error scale factor
-  float delyavg_;           //!< average difference between clsleny_ and cluster length [with threshold effects]
-  float delysig_;           //!< rms of difference between clsleny_ and cluster length [with threshold effects]
-  float scalex_[4];         //!< x-error scale factor in charge bins
-  float scaley_[4];         //!< y-error scale factor in charge bins
-  float offsetx_[4];        //!< x-offset in charge bins
-  float offsety_[4];        //!< y-offset in charge bins
-
+  float qavg_;        //!< average cluster charge for this set of track angles
+  float pixmax_;      //!< maximum pixel charge
+  float qscale_;      //!< charge scaling factor
+  float s50_;         //!< 1/2 of the pixel single col threshold signal in electrons
+  float ss50_;        //!< 1/2 of the pixel double col threshold signal in electrons
+  float symax_;       //!< average pixel signal for y-projection of cluster
+  float syparmax_;    //!< maximum pixel signal for parameterization of y uncertainties
+  float dyone_;       //!< mean offset/correction for one pixel y-clusters
+  float syone_;       //!< rms for one pixel y-clusters
+  float dytwo_;       //!< mean offset/correction for one double-pixel y-clusters
+  float sytwo_;       //!< rms for one double-pixel y-clusters
+  float sxmax_;       //!< average pixel signal for x-projection of cluster
+  float sxparmax_;    //!< maximum pixel signal for parameterization of x uncertainties
+  float dxone_;       //!< mean offset/correction for one pixel x-clusters
+  float sxone_;       //!< rms for one pixel x-clusters
+  float dxtwo_;       //!< mean offset/correction for one double-pixel x-clusters
+  float sxtwo_;       //!< rms for one double-pixel x-clusters
+  float qmin_;        //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits)
+  float clsleny_;     //!< y-cluster length of smaller interpolated template in pixels
+  float clslenx_;     //!< x-cluster length of smaller interpolated template in pixels
+  float scalexavg_;   //!< average x-error scale factor
+  float scaleyavg_;   //!< average y-error scale factor
+  float delyavg_;     //!< average difference between clsleny_ and cluster length [with threshold effects]
+  float delysig_;     //!< rms of difference between clsleny_ and cluster length [with threshold effects]
+  float scalex_[4];   //!< x-error scale factor in charge bins
+  float scaley_[4];   //!< y-error scale factor in charge bins
+  float offsetx_[4];  //!< x-offset in charge bins
+  float offsety_[4];  //!< y-offset in charge bins
 
   float yratio_;            //!< fractional distance in y between cotbeta templates
   float yparl_[2][5];       //!< projected y-pixel uncertainty parameterization for smaller cotbeta
@@ -796,18 +805,17 @@ private:
   boost::multi_array<float, 2> temp2dx_;  //!< 2d-primitive for spltting 3-d template
 
   // Pointers to presently interpolated point:
-  const SiPixelTemplateEntry* enty0_;   // enty[ilow]
-  const SiPixelTemplateEntry* enty1_;   // enty[iylow][ilow]
+  const SiPixelTemplateEntry* enty0_;  // enty[ilow]
+  const SiPixelTemplateEntry* enty1_;  // enty[iylow][ilow]
 
-  const SiPixelTemplateEntry* entx00_ ; // entx[iylow][ilow]
-  const SiPixelTemplateEntry* entx02_ ; 
-  const SiPixelTemplateEntry* entx20_ ;
-  const SiPixelTemplateEntry* entx22_ ;
-  const SiPixelTemplateEntry* entx21_ ;
+  const SiPixelTemplateEntry* entx00_;  // entx[iylow][ilow]
+  const SiPixelTemplateEntry* entx02_;
+  const SiPixelTemplateEntry* entx20_;
+  const SiPixelTemplateEntry* entx22_;
+  const SiPixelTemplateEntry* entx21_;
 
   // Pointer to the sideloaded Entry: use this one if set.
-  const SiPixelTemplateEntry * entry_sideloaded_ ;
-   
+  const SiPixelTemplateEntry* entry_sideloaded_;
 
   // The actual template store is a std::vector container
   const std::vector<SiPixelTemplateStore>& thePixelTemp_;

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -156,15 +156,15 @@ public:
                 float ysize,
                 float zsize);
 
-
 #else
-   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & pixelTemp , std::string dir = "CalibTracker/SiPixelESProducers/data/");
+  static bool pushfile(int filenum,
+                       std::vector<SiPixelTemplateStore2D>& pixelTemp,
+                       std::string dir = "CalibTracker/SiPixelESProducers/data/");
 
-   // Load from the DB (the default in CMSSW):
-   static bool pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & pixelTemp);
+  // Load from the DB (the default in CMSSW):
+  static bool pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector<SiPixelTemplateStore2D>& pixelTemp);
 
 #endif
-   
 
   //  Initialize things before interpolating
   bool getid(int id);

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -140,15 +140,10 @@ public:
 
   // load the private store with info from the
   // file with the index (int) filenum ${dir}template_summary_zp${filenum}.out
+#ifdef SI_PIXEL_TEMPLATE_STANDALONE
   static bool pushfile(int filenum, std::vector<SiPixelTemplateStore2D>& pixelTemp, std::string dir = "");
 
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-  static bool pushfile(const SiPixel2DTemplateDBObject& dbobject,
-                       std::vector<SiPixelTemplateStore2D>& pixelTemp);  // load the private store with info from db
-#endif
-
-  //  Initialize things before interpolating
-
+  // For calibrations only: load precalculated values -- no interpolation.
   void sideload(SiPixelTemplateEntry2D* entry,
                 int iDtype,
                 float locBx,
@@ -160,6 +155,16 @@ public:
                 float xsize,
                 float ysize,
                 float zsize);
+
+
+#else
+   static bool pushfile(int filenum, std::vector< SiPixelTemplateStore2D > & pixelTemp , std::string dir = "CalibTracker/SiPixelESProducers/data/");
+
+   // Load from the DB (the default in CMSSW):
+   static bool pushfile(const SiPixel2DTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore2D > & pixelTemp);
+
+#endif
+   
 
   //  Initialize things before interpolating
   bool getid(int id);
@@ -350,7 +355,6 @@ private:
   const SiPixelTemplateEntry2D* entry01_;  // Pointer to presently interpolated point [iy,ix+1]
 
   // The actual template store is a std::vector container
-
   const std::vector<SiPixelTemplateStore2D>& thePixelTemp_;
 };
 

--- a/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
@@ -1,0 +1,27 @@
+#ifndef CondFormatsSiPixelTransientSiPixelUtils_h
+#define CondFormatsSiPixelTransientSiPixelUtils_h 1
+
+namespace SiPixelUtils {
+
+  float
+    generic_position_formula( int size,                //!< Size of this projection.
+			      int Q_f,              //!< Charge in the first pixel.
+			      int Q_l,              //!< Charge in the last pixel.
+			      float upper_edge_first_pix, //!< As the name says.
+			      float lower_edge_last_pix,  //!< As the name says.
+			      float lorentz_shift,   //!< L-width
+			      float theThickness,   //detector thickness
+			      float cot_angle,            //!< cot of alpha_ or beta_
+			      float pitch,            //!< thePitchX or thePitchY
+			      bool first_is_big,       //!< true if the first is big
+			      bool last_is_big,        //!< true if the last is big
+			      float eff_charge_cut_low, //!< Use edge if > W_eff (in pix) &&&
+			      float eff_charge_cut_high,//!< Use edge if < W_eff (in pix) &&&
+			      float size_cut           //!< Use edge when size == cuts
+			      );
+
+
+
+}
+
+#endif

--- a/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelUtils.h
@@ -3,24 +3,21 @@
 
 namespace SiPixelUtils {
 
-  float
-    generic_position_formula( int size,                //!< Size of this projection.
-			      int Q_f,              //!< Charge in the first pixel.
-			      int Q_l,              //!< Charge in the last pixel.
-			      float upper_edge_first_pix, //!< As the name says.
-			      float lower_edge_last_pix,  //!< As the name says.
-			      float lorentz_shift,   //!< L-width
-			      float theThickness,   //detector thickness
-			      float cot_angle,            //!< cot of alpha_ or beta_
-			      float pitch,            //!< thePitchX or thePitchY
-			      bool first_is_big,       //!< true if the first is big
-			      bool last_is_big,        //!< true if the last is big
-			      float eff_charge_cut_low, //!< Use edge if > W_eff (in pix) &&&
-			      float eff_charge_cut_high,//!< Use edge if < W_eff (in pix) &&&
-			      float size_cut           //!< Use edge when size == cuts
-			      );
-
-
+  float generic_position_formula(int size,                    //!< Size of this projection.
+                                 int Q_f,                     //!< Charge in the first pixel.
+                                 int Q_l,                     //!< Charge in the last pixel.
+                                 float upper_edge_first_pix,  //!< As the name says.
+                                 float lower_edge_last_pix,   //!< As the name says.
+                                 float lorentz_shift,         //!< L-width
+                                 float theThickness,          //detector thickness
+                                 float cot_angle,             //!< cot of alpha_ or beta_
+                                 float pitch,                 //!< thePitchX or thePitchY
+                                 bool first_is_big,           //!< true if the first is big
+                                 bool last_is_big,            //!< true if the last is big
+                                 float eff_charge_cut_low,    //!< Use edge if > W_eff (in pix) &&&
+                                 float eff_charge_cut_high,   //!< Use edge if < W_eff (in pix) &&&
+                                 float size_cut               //!< Use edge when size == cuts
+  );
 
 }
 

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -1330,7 +1330,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
   // Local variables
   int i, j;
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
-  float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0,
+  float yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0,
       cotbeta0;
   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
 
@@ -1464,11 +1464,11 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     // next, loop over all y-angle entries
 
     ilow = 0;
-    yratio = 0.f;
+    yratio_ = 0.f;
 
     if (cotb >= thePixelTemp_[index_id_].enty[Ny - 1].cotbeta) {
       ilow = Ny - 2;
-      yratio = 1.;
+      yratio_ = 1.;
       success_ = false;
 
     } else {
@@ -1476,7 +1476,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         for (i = 0; i < Ny - 1; ++i) {
           if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
             ilow = i;
-            yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
+            yratio_ = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
                      (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
             break;
           }
@@ -1495,36 +1495,35 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     // Interpolate/store all y-related quantities (flip displacements when flip_y_)
 
-    yratio_ = yratio;
-    qavg_ = (1.f - yratio) * enty0_->qavg + yratio * enty1_->qavg;
+    qavg_ = (1.f - yratio_) * enty0_->qavg + yratio_ * enty1_->qavg;
     qavg_ *= qcorrect;
-    symax = (1.f - yratio) * enty0_->symax + yratio * enty1_->symax;
+    symax = (1.f - yratio_) * enty0_->symax + yratio_ * enty1_->symax;
     syparmax_ = symax;
-    sxmax = (1.f - yratio) * enty0_->sxmax + yratio * enty1_->sxmax;
-    dyone_ = (1.f - yratio) * enty0_->dyone + yratio * enty1_->dyone;
+    sxmax = (1.f - yratio_) * enty0_->sxmax + yratio_ * enty1_->sxmax;
+    dyone_ = (1.f - yratio_) * enty0_->dyone + yratio_ * enty1_->dyone;
     if (flip_y_) {
       dyone_ = -dyone_;
     }
-    syone_ = (1.f - yratio) * enty0_->syone + yratio * enty1_->syone;
-    dytwo_ = (1.f - yratio) * enty0_->dytwo + yratio * enty1_->dytwo;
+    syone_ = (1.f - yratio_) * enty0_->syone + yratio_ * enty1_->syone;
+    dytwo_ = (1.f - yratio_) * enty0_->dytwo + yratio_ * enty1_->dytwo;
     if (flip_y_) {
       dytwo_ = -dytwo_;
     }
-    sytwo_ = (1.f - yratio) * enty0_->sytwo + yratio * enty1_->sytwo;
-    qmin_ = (1.f - yratio) * enty0_->qmin + yratio * enty1_->qmin;
+    sytwo_ = (1.f - yratio_) * enty0_->sytwo + yratio_ * enty1_->sytwo;
+    qmin_ = (1.f - yratio_) * enty0_->qmin + yratio_ * enty1_->qmin;
     qmin_ *= qcorrect;
-    qmin2_ = (1.f - yratio) * enty0_->qmin2 + yratio * enty1_->qmin2;
+    qmin2_ = (1.f - yratio_) * enty0_->qmin2 + yratio_ * enty1_->qmin2;
     qmin2_ *= qcorrect;
-    mpvvav_ = (1.f - yratio) * enty0_->mpvvav + yratio * enty1_->mpvvav;
+    mpvvav_ = (1.f - yratio_) * enty0_->mpvvav + yratio_ * enty1_->mpvvav;
     mpvvav_ *= qcorrect;
-    sigmavav_ = (1.f - yratio) * enty0_->sigmavav + yratio * enty1_->sigmavav;
-    kappavav_ = (1.f - yratio) * enty0_->kappavav + yratio * enty1_->kappavav;
-    mpvvav2_ = (1.f - yratio) * enty0_->mpvvav2 + yratio * enty1_->mpvvav2;
+    sigmavav_ = (1.f - yratio_) * enty0_->sigmavav + yratio_ * enty1_->sigmavav;
+    kappavav_ = (1.f - yratio_) * enty0_->kappavav + yratio_ * enty1_->kappavav;
+    mpvvav2_ = (1.f - yratio_) * enty0_->mpvvav2 + yratio_ * enty1_->mpvvav2;
     mpvvav2_ *= qcorrect;
-    sigmavav2_ = (1.f - yratio) * enty0_->sigmavav2 + yratio * enty1_->sigmavav2;
-    kappavav2_ = (1.f - yratio) * enty0_->kappavav2 + yratio * enty1_->kappavav2;
+    sigmavav2_ = (1.f - yratio_) * enty0_->sigmavav2 + yratio_ * enty1_->sigmavav2;
+    kappavav2_ = (1.f - yratio_) * enty0_->kappavav2 + yratio_ * enty1_->kappavav2;
     clsleny_ = fminf(enty0_->clsleny, enty1_->clsleny);
-    qavg_avg_ = (1.f - yratio) * enty0_->qavg_avg + yratio * enty1_->qavg_avg;
+    qavg_avg_ = (1.f - yratio_) * enty0_->qavg_avg + yratio_ * enty1_->qavg_avg;
     qavg_avg_ *= qcorrect;
     for (i = 0; i < 2; ++i) {
       for (j = 0; j < 5; ++j) {
@@ -1548,31 +1547,31 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     }
 
     for (i = 0; i < 4; ++i) {
-      yavg_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yavg[i] +
-                 yratio * thePixelTemp_[index_id_].enty[ihigh].yavg[i];
+      yavg_[i] = (1.f - yratio_) * thePixelTemp_[index_id_].enty[ilow].yavg[i] +
+                 yratio_ * thePixelTemp_[index_id_].enty[ihigh].yavg[i];
       if (flip_y_) {
         yavg_[i] = -yavg_[i];
       }
-      yavg_[i] = (1.f - yratio) * enty0_->yavg[i] + yratio * enty1_->yavg[i];
+      yavg_[i] = (1.f - yratio_) * enty0_->yavg[i] + yratio_ * enty1_->yavg[i];
       if (flip_y_) {
         yavg_[i] = -yavg_[i];
       }
-      yrms_[i] = (1.f - yratio) * enty0_->yrms[i] + yratio * enty1_->yrms[i];
-      chi2yavg_[i] = (1.f - yratio) * enty0_->chi2yavg[i] + yratio * enty1_->chi2yavg[i];
-      chi2ymin_[i] = (1.f - yratio) * enty0_->chi2ymin[i] + yratio * enty1_->chi2ymin[i];
-      chi2xavg[i] = (1.f - yratio) * enty0_->chi2xavg[i] + yratio * enty1_->chi2xavg[i];
-      chi2xmin[i] = (1.f - yratio) * enty0_->chi2xmin[i] + yratio * enty1_->chi2xmin[i];
-      yavgc2m_[i] = (1.f - yratio) * enty0_->yavgc2m[i] + yratio * enty1_->yavgc2m[i];
+      yrms_[i] = (1.f - yratio_) * enty0_->yrms[i] + yratio_ * enty1_->yrms[i];
+      chi2yavg_[i] = (1.f - yratio_) * enty0_->chi2yavg[i] + yratio_ * enty1_->chi2yavg[i];
+      chi2ymin_[i] = (1.f - yratio_) * enty0_->chi2ymin[i] + yratio_ * enty1_->chi2ymin[i];
+      chi2xavg[i] = (1.f - yratio_) * enty0_->chi2xavg[i] + yratio_ * enty1_->chi2xavg[i];
+      chi2xmin[i] = (1.f - yratio_) * enty0_->chi2xmin[i] + yratio_ * enty1_->chi2xmin[i];
+      yavgc2m_[i] = (1.f - yratio_) * enty0_->yavgc2m[i] + yratio_ * enty1_->yavgc2m[i];
       if (flip_y_) {
         yavgc2m_[i] = -yavgc2m_[i];
       }
-      yrmsc2m_[i] = (1.f - yratio) * enty0_->yrmsc2m[i] + yratio * enty1_->yrmsc2m[i];
-      chi2yavgc2m_[i] = (1.f - yratio) * enty0_->chi2yavgc2m[i] + yratio * enty1_->chi2yavgc2m[i];
+      yrmsc2m_[i] = (1.f - yratio_) * enty0_->yrmsc2m[i] + yratio_ * enty1_->yrmsc2m[i];
+      chi2yavgc2m_[i] = (1.f - yratio_) * enty0_->chi2yavgc2m[i] + yratio_ * enty1_->chi2yavgc2m[i];
       //	      if(flip_y_) {chi2yavgc2m_[i] = -chi2yavgc2m_[i];}
-      chi2yminc2m_[i] = (1.f - yratio) * enty0_->chi2yminc2m[i] + yratio * enty1_->chi2yminc2m[i];
-      //	      xrmsc2m[i]=(1.f - yratio)*enty0_->xrmsc2m[i] + yratio*enty1_->xrmsc2m[i];
-      chi2xavgc2m[i] = (1.f - yratio) * enty0_->chi2xavgc2m[i] + yratio * enty1_->chi2xavgc2m[i];
-      chi2xminc2m[i] = (1.f - yratio) * enty0_->chi2xminc2m[i] + yratio * enty1_->chi2xminc2m[i];
+      chi2yminc2m_[i] = (1.f - yratio_) * enty0_->chi2yminc2m[i] + yratio_ * enty1_->chi2yminc2m[i];
+      //	      xrmsc2m[i]=(1.f - yratio_)*enty0_->xrmsc2m[i] + yratio_*enty1_->xrmsc2m[i];
+      chi2xavgc2m[i] = (1.f - yratio_) * enty0_->chi2xavgc2m[i] + yratio_ * enty1_->chi2xavgc2m[i];
+      chi2xminc2m[i] = (1.f - yratio_) * enty0_->chi2xminc2m[i] + yratio_ * enty1_->chi2xminc2m[i];
       for (j = 0; j < 6; ++j) {
         yflparl_[i][j] = enty0_->yflpar[i][j];
         yflparh_[i][j] = enty1_->yflpar[i][j];
@@ -1588,16 +1587,16 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     //// Single pixel cluster probabilities
 
-    chi2yavgone_ = (1.f - yratio) * enty0_->chi2yavgone + yratio * enty1_->chi2yavgone;
-    chi2yminone_ = (1.f - yratio) * enty0_->chi2yminone + yratio * enty1_->chi2yminone;
-    chi2xavgone = (1.f - yratio) * enty0_->chi2xavgone + yratio * enty1_->chi2xavgone;
-    chi2xminone = (1.f - yratio) * enty0_->chi2xminone + yratio * enty1_->chi2xminone;
+    chi2yavgone_ = (1.f - yratio_) * enty0_->chi2yavgone + yratio_ * enty1_->chi2yavgone;
+    chi2yminone_ = (1.f - yratio_) * enty0_->chi2yminone + yratio_ * enty1_->chi2yminone;
+    chi2xavgone = (1.f - yratio_) * enty0_->chi2xavgone + yratio_ * enty1_->chi2xavgone;
+    chi2xminone = (1.f - yratio_) * enty0_->chi2xminone + yratio_ * enty1_->chi2xminone;
 
-    fracyone_ = (1.f - yratio) * enty0_->fracyone + yratio * enty1_->fracyone;
-    fracytwo_ = (1.f - yratio) * enty0_->fracytwo + yratio * enty1_->fracytwo;
+    fracyone_ = (1.f - yratio_) * enty0_->fracyone + yratio_ * enty1_->fracyone;
+    fracytwo_ = (1.f - yratio_) * enty0_->fracytwo + yratio_ * enty1_->fracytwo;
     //       If using y-spares 
     //       for(i=0; i<10; ++i) {
-    //		    pyspare[i]=(1.f - yratio)*enty0_->yspare[i] + yratio*enty1_->yspare[i];
+    //		    pyspare[i]=(1.f - yratio_)*enty0_->yspare[i] + yratio_*enty1_->yspare[i];
     //       }
 
     // Interpolate and build the y-template
@@ -1611,9 +1610,9 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         // Flip the basic y-template when the cotbeta is negative
 
         if (flip_y_) {
-          ytemp_[8 - i][BYM3 - j] = (1.f - yratio) * enty0_->ytemp[i][j] + yratio * enty1_->ytemp[i][j];
+          ytemp_[8 - i][BYM3 - j] = (1.f - yratio_) * enty0_->ytemp[i][j] + yratio_ * enty1_->ytemp[i][j];
         } else {
-          ytemp_[i][j + 2] = (1.f - yratio) * enty0_->ytemp[i][j] + yratio * enty1_->ytemp[i][j];
+          ytemp_[i][j + 2] = (1.f - yratio_) * enty0_->ytemp[i][j] + yratio_ * enty1_->ytemp[i][j];
         }
       }
     }
@@ -3043,23 +3042,11 @@ int SiPixelTemplate::qbin(int id,
   // for some cosmics, the ususal gymnastics are incorrect
 
   float cota = cotalpha;
-  float cotb = abs_cotb_;
   bool flip_x = false;
-  bool flip_y = false;
-  switch (thePixelTemp_[index_id_].head.Dtype) {
+  //y flipping already taken care of by interpolate 
+  switch (dtype_) {
     case 0:
-      if (cotbeta < 0.f) {
-        flip_y = true;
-      }
-      break;
     case 1:
-      if (locBz < 0.f) {
-        cotb = cotbeta;
-      } else {
-        cotb = -cotbeta;
-        flip_y = true;
-      }
-      break;
     case 2:
     case 3:
     case 4:
@@ -3067,12 +3054,6 @@ int SiPixelTemplate::qbin(int id,
       if (locBx * locBz < 0.f) {
         cota = -cotalpha;
         flip_x = true;
-      }
-      if (locBx > 0.f) {
-        cotb = cotbeta;
-      } else {
-        cotb = -cotbeta;
-        flip_y = true;
       }
       break;
     default:
@@ -3107,44 +3088,25 @@ int SiPixelTemplate::qbin(int id,
   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
 
-  // next, loop over all y-angle entries
-
-  auto ilow = 0;
-  auto ihigh = 0;
-  auto yratio = 0.f;
-
-  {
-    auto j = std::lower_bound(templ.cotbetaY, templ.cotbetaY + Ny, cotb);
-    if (j == templ.cotbetaY + Ny) {
-      --j;
-      yratio = 1.f;
-    } else if (j == templ.cotbetaY) {
-      ++j;
-      yratio = 0.f;
-    } else {
-      yratio = (cotb - (*(j - 1))) / ((*j) - (*(j - 1)));
-    }
-
-  }
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
-  dy1 = (1.f - yratio) * enty0_->dyone + yratio * enty1_->dyone;
-  if (flip_y) {
+  dy1 = (1.f - yratio_) * enty0_->dyone + yratio_ * enty1_->dyone;
+  if (flip_y_) {
     dy1 = -dy1;
   }
-  sy1 = (1.f - yratio) * enty0_->syone + yratio * enty1_->syone;
-  dy2 = (1.f - yratio) * enty0_->dytwo + yratio * enty1_->dytwo;
-  if (flip_y) {
+  sy1 = (1.f - yratio_) * enty0_->syone + yratio_ * enty1_->syone;
+  dy2 = (1.f - yratio_) * enty0_->dytwo + yratio_ * enty1_->dytwo;
+  if (flip_y_) {
     dy2 = -dy2;
   }
-  sy2 = (1.f - yratio) * enty0_->sytwo + yratio * enty1_->sytwo;
+  sy2 = (1.f - yratio_) * enty0_->sytwo + yratio_ * enty1_->sytwo;
 
-  auto qavg = (1.f - yratio) * enty0_->qavg + yratio * enty1_->qavg;
+  auto qavg = (1.f - yratio_) * enty0_->qavg + yratio_ * enty1_->qavg;
   qavg *= qcorrect;
-  auto qmin = (1.f - yratio) * enty0_->qmin + yratio * enty1_->qmin;
+  auto qmin = (1.f - yratio_) * enty0_->qmin + yratio_ * enty1_->qmin;
   qmin *= qcorrect;
-  auto qmin2 = (1.f - yratio) * enty0_->qmin2 + yratio * enty1_->qmin2;
+  auto qmin2 = (1.f - yratio_) * enty0_->qmin2 + yratio_ * enty1_->qmin2;
   qmin2 *= qcorrect;
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
@@ -3181,11 +3143,11 @@ int SiPixelTemplate::qbin(int id,
     }
   }
 
-  auto yavggen = (1.f - yratio) * enty0_->yavggen[binq] + yratio * enty1_->yavggen[binq];
-  if (flip_y) {
+  auto yavggen = (1.f - yratio_) * enty0_->yavggen[binq] + yratio_ * enty1_->yavggen[binq];
+  if (flip_y_) {
     yavggen = -yavggen;
   }
-  auto yrmsgen = (1.f - yratio) * enty0_->yrmsgen[binq] + yratio * enty1_->yrmsgen[binq];
+  auto yrmsgen = (1.f - yratio_) * enty0_->yrmsgen[binq] + yratio_ * enty1_->yrmsgen[binq];
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3209,7 +3171,8 @@ int SiPixelTemplate::qbin(int id,
     iylow = iyhigh - 1;
   }
 
-  // Unneded:  ilow = ihigh = 0;
+  auto ilow = 0;
+  auto ihigh = 0;
   auto xxratio = 0.f;
 
   {
@@ -3514,8 +3477,8 @@ void SiPixelTemplate::temperrors(int id,
   // Local variables
   int i;
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
-  float yratio, yxratio, xxratio;
-  float acotb, cotb;
+  float yxratio, xxratio;
+  float acotb;
   float yrms, xrms;
   //bool flip_y;
 
@@ -3557,23 +3520,7 @@ void SiPixelTemplate::temperrors(int id,
   // Interpolate the absolute value of cot(beta)
 
   acotb = std::abs(cotbeta);
-  // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
 
-  // for some cosmics, the ususal gymnastics are incorrect
-
-  //	if(thePixelTemp_[index].head.Dtype == 0) {
-  cotb = acotb;
-  //flip_y = false;
-  //if(cotbeta < 0.f) {flip_y = true;}
-  //	} else {
-  //	    if(locBz < 0.f) {
-  //			cotb = cotbeta;
-  //			flip_y = false;
-  //		} else {
-  //			cotb = -cotbeta;
-  //			flip_y = true;
-  //		}
-  //	}
 
   // Copy the charge scaling factor to the private variable
 
@@ -3592,29 +3539,12 @@ void SiPixelTemplate::temperrors(int id,
 
   // next, loop over all y-angle entries
 
-  yratio = 0.f;
-
-  if (cotb >= thePixelTemp_[index].enty[Ny - 1].cotbeta) {
-    yratio = 1.f;
-
-  } else {
-    if (cotb >= thePixelTemp_[index].enty[0].cotbeta) {
-      for (i = 0; i < Ny - 1; ++i) {
-        if (thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i + 1].cotbeta) {
-          yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta) /
-                   (thePixelTemp_[index].enty[i + 1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
-          break;
-        }
-      }
-    }
-  }
-
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
-  sy1 = (1.f - yratio) * enty0_->syone + yratio * enty1_->syone;
-  sy2 = (1.f - yratio) * enty0_->sytwo + yratio * enty1_->sytwo;
-  yrms = (1.f - yratio) * enty0_->yrms[qBin] + yratio * enty1_->yrms[qBin];
+  sy1 = (1.f - yratio_) * enty0_->syone + yratio_ * enty1_->syone;
+  sy2 = (1.f - yratio_) * enty0_->sytwo + yratio_ * enty1_->sytwo;
+  yrms = (1.f - yratio_) * enty0_->yrms[qBin] + yratio_ * enty1_->yrms[qBin];
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3707,8 +3637,8 @@ void SiPixelTemplate::qbin_dist(int id,
   // Local variables
   int i;
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
-  float yratio, yxratio, xxratio;
-  float acotb, cotb;
+  float yxratio, xxratio;
+  float acotb;
   float qfrac[4];
   //bool flip_y;
 
@@ -3737,23 +3667,6 @@ void SiPixelTemplate::qbin_dist(int id,
   // Interpolate the absolute value of cot(beta)
 
   acotb = fabs((double)cotbeta);
-  // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
-
-  // for some cosmics, the ususal gymnastics are incorrect
-
-  //	if(thePixelTemp_[index].head.Dtype == 0) {
-  cotb = acotb;
-  //flip_y = false;
-  //if(cotbeta < 0.f) {flip_y = true;}
-  //	} else {
-  //	    if(locBz < 0.f) {
-  //			cotb = cotbeta;
-  //			flip_y = false;
-  //		} else {
-  //			cotb = -cotbeta;
-  //			flip_y = true;
-  //		}
-  //	}
 
   // Copy the charge scaling factor to the private variable
 
@@ -3770,29 +3683,11 @@ void SiPixelTemplate::qbin_dist(int id,
   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
 
-  // next, loop over all y-angle entries
-
-  yratio = 0.f;
-
-  if (cotb >= thePixelTemp_[index].enty[Ny - 1].cotbeta) {
-    yratio = 1.f;
-
-  } else {
-    if (cotb >= thePixelTemp_[index].enty[0].cotbeta) {
-      for (i = 0; i < Ny - 1; ++i) {
-        if (thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i + 1].cotbeta) {
-          yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta) /
-                   (thePixelTemp_[index].enty[i + 1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
-          break;
-        }
-      }
-    }
-  }
 
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
-  ny1_frac = (1.f - yratio) * enty0_->fracyone + yratio * enty1_->fracyone;
-  ny2_frac = (1.f - yratio) * enty0_->fracytwo + yratio * enty1_->fracytwo;
+  ny1_frac = (1.f - yratio_) * enty0_->fracyone + yratio_ * enty1_->fracyone;
+  ny2_frac = (1.f - yratio_) * enty0_->fracytwo + yratio_ * enty1_->fracytwo;
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3860,7 +3755,7 @@ void SiPixelTemplate::qbin_dist(int id,
   qbin_frac[3] = 1.f;
   return;
 
-}  // qbin
+}  // qbin_dist
 
 // *************************************************************************************************************************************
 //! Make simple 2-D templates from track angles set in interpolate and hit position.

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -1332,7 +1332,6 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
   float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0,
       cotbeta0;
-  //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
 
   // If the sideloading is turned on, xtemp_ and ytemp_ are already set to what they need to be.
@@ -1361,7 +1360,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
           // Copy the detector type to the private variable
 
-          Dtype_ = thePixelTemp_[index_id_].head.Dtype;
+          dtype_ = thePixelTemp_[index_id_].head.Dtype;
 
           // Copy the charge scaling factor to the private variable
 
@@ -1409,7 +1408,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     cotb = abs_cotb_ = std::abs(cotbeta);
     flip_x_ = false;
     flip_y_ = false;
-    switch (Dtype_) {
+    switch (dtype_) {
       case 0:
         if (cotbeta < 0.f) {
           flip_y_ = true;
@@ -1440,9 +1439,9 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         break;
       default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-        throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
+        throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << dtype_ << std::endl;
 #else
-        std::cout << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
+        std::cout << "SiPixelTemplate::illegal subdetector ID = " << dtype_ << std::endl;
 #endif
     }
 
@@ -1559,11 +1558,6 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         yavg_[i] = -yavg_[i];
       }
       yrms_[i] = (1.f - yratio) * enty0_->yrms[i] + yratio * enty1_->yrms[i];
-      //	      ygx0_[i]=(1.f - yratio)*enty0_->ygx0[i] + yratio*enty1_->ygx0[i];
-      //	      if(flip_y_) {ygx0_[i] = -ygx0_[i];}
-      //	      ygsig_[i]=(1.f - yratio)*enty0_->ygsig[i] + yratio*enty1_->ygsig[i];
-      //	      xrms[i]=(1.f - yratio)*enty0_->xrms[i] + yratio*enty1_->xrms[i];
-      //	      xgsig[i]=(1.f - yratio)*enty0_->xgsig[i] + yratio*enty1_->xgsig[i];
       chi2yavg_[i] = (1.f - yratio) * enty0_->chi2yavg[i] + yratio * enty1_->chi2yavg[i];
       chi2ymin_[i] = (1.f - yratio) * enty0_->chi2ymin[i] + yratio * enty1_->chi2ymin[i];
       chi2xavg[i] = (1.f - yratio) * enty0_->chi2xavg[i] + yratio * enty1_->chi2xavg[i];
@@ -1601,6 +1595,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     fracyone_ = (1.f - yratio) * enty0_->fracyone + yratio * enty1_->fracyone;
     fracytwo_ = (1.f - yratio) * enty0_->fracytwo + yratio * enty1_->fracytwo;
+    //       If using y-spares 
     //       for(i=0; i<10; ++i) {
     //		    pyspare[i]=(1.f - yratio)*enty0_->yspare[i] + yratio*enty1_->yspare[i];
     //       }
@@ -1744,11 +1739,6 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       xrms_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xrms[i] + xxratio * entx02_->xrms[i]) +
                  yxratio * ((1.f - xxratio) * entx20_->xrms[i] + xxratio * entx22_->xrms[i]);
 
-      //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgx0[i] + xxratio*entx02_->xgx0[i])
-      //		          +yxratio*((1.f - xxratio)*entx20_->xgx0[i] + xxratio*entx22_->xgx0[i]);
-
-      //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgsig[i] + xxratio*entx02_->xgsig[i])
-      //		          +yxratio*((1.f - xxratio)*entx20_->xgsig[i] + xxratio*entx22_->xgsig[i]);
 
       xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xavgc2m[i] + xxratio * entx02_->xavgc2m[i]) +
                     yxratio * ((1.f - xxratio) * entx20_->xavgc2m[i] + xxratio * entx22_->xavgc2m[i]);
@@ -1758,13 +1748,15 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
       xrmsc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xrmsc2m[i] + xxratio * entx02_->xrmsc2m[i]) +
                     yxratio * ((1.f - xxratio) * entx20_->xrmsc2m[i] + xxratio * entx22_->xrmsc2m[i]);
+      //
+      //  Try new interpolation scheme instead
+      //
+      //
       //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xavgc2m[i] + xxratio*entx02_->chi2xavgc2m[i])
       //		          +yxratio*((1.f - xxratio)*entx20_->chi2xavgc2m[i] + xxratio*entx22_->chi2xavgc2m[i]);
 
       //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xminc2m[i] + xxratio*entx02_->chi2xminc2m[i])
       //		          +yxratio*((1.f - xxratio)*entx20_->chi2xminc2m[i] + xxratio*entx22_->chi2xminc2m[i]);
-      //
-      //  Try new interpolation scheme
       //
       //	      chi2xavg_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xavg[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xavg[i]);
       //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xavg[i] != 0.f) {chi2xavg_[i]=chi2xavg_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xavg[i]*chi2xavg[i];}
@@ -1824,6 +1816,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     fracxtwo_ = (1.f - yxratio) * ((1.f - xxratio) * entx00_->fracxtwo + xxratio * entx02_->fracxtwo) +
                 yxratio * ((1.f - xxratio) * entx20_->fracxtwo + xxratio * entx22_->fracxtwo);
 
+    //       If using x-spares
     //       for(i=0; i<10; ++i) {
     //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xspare[i] + xxratio*entx02_->xspare[i])
     //		          +yxratio*((1.f - xxratio)*entx20_->xspare[i] + xxratio*entx22_->xspare[i]);
@@ -1940,7 +1933,7 @@ void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry,
   entx22_ = entry;
   entx21_ = entry;
 
-  Dtype_ = iDtype;
+  dtype_ = iDtype;
   lorywidth_ = lorwdy;
   lorxwidth_ = lorwdx;
   xsize_ = xsize;
@@ -1953,9 +1946,6 @@ void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry,
   }
 
   // Set other class variables
-
-  // adcota_ = 0.f;
-  // adcotb_ = 0.f;
 
   yratio_ = 0.f;
   yxratio_ = 0.f;
@@ -2021,7 +2011,7 @@ void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry,
   flip_x_ = false;
   flip_y_ = false;
   float cotbeta = entry->cotbeta;
-  switch (Dtype_) {
+  switch (dtype_) {
     case 0:
       if (cotbeta < 0.f) {
         flip_y_ = true;
@@ -2044,11 +2034,7 @@ void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry,
       }
       break;
     default:
-      // #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      //         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
-      //#else
-      std::cout << "SiPixelTemplate:illegal subdetector ID = " << Dtype_ << std::endl;
-      //#endif
+      std::cout << "SiPixelTemplate:illegal subdetector ID = " << dtype_ << std::endl;
   }
 
   //  Calculate signed quantities
@@ -3139,8 +3125,6 @@ int SiPixelTemplate::qbin(int id,
       yratio = (cotb - (*(j - 1))) / ((*j) - (*(j - 1)));
     }
 
-    ihigh = j - templ.cotbetaY;
-    ilow = ihigh - 1;
   }
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
@@ -3608,18 +3592,15 @@ void SiPixelTemplate::temperrors(int id,
 
   // next, loop over all y-angle entries
 
-  ilow = 0;
   yratio = 0.f;
 
   if (cotb >= thePixelTemp_[index].enty[Ny - 1].cotbeta) {
-    ilow = Ny - 2;
     yratio = 1.f;
 
   } else {
     if (cotb >= thePixelTemp_[index].enty[0].cotbeta) {
       for (i = 0; i < Ny - 1; ++i) {
         if (thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i + 1].cotbeta) {
-          ilow = i;
           yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta) /
                    (thePixelTemp_[index].enty[i + 1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
           break;
@@ -3628,7 +3609,6 @@ void SiPixelTemplate::temperrors(int id,
     }
   }
 
-  ihigh = ilow + 1;
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
@@ -3792,18 +3772,15 @@ void SiPixelTemplate::qbin_dist(int id,
 
   // next, loop over all y-angle entries
 
-  ilow = 0;
   yratio = 0.f;
 
   if (cotb >= thePixelTemp_[index].enty[Ny - 1].cotbeta) {
-    ilow = Ny - 2;
     yratio = 1.f;
 
   } else {
     if (cotb >= thePixelTemp_[index].enty[0].cotbeta) {
       for (i = 0; i < Ny - 1; ++i) {
         if (thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i + 1].cotbeta) {
-          ilow = i;
           yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta) /
                    (thePixelTemp_[index].enty[i + 1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
           break;
@@ -3812,7 +3789,6 @@ void SiPixelTemplate::qbin_dist(int id,
     }
   }
 
-  ihigh = ilow + 1;
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
   ny1_frac = (1.f - yratio) * enty0_->fracyone + yratio * enty1_->fracyone;

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -1330,8 +1330,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
   // Local variables
   int i, j;
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
-  float yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0,
-      cotbeta0;
+  float yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0, cotbeta0;
   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
 
   // If the sideloading is turned on, xtemp_ and ytemp_ are already set to what they need to be.
@@ -1477,7 +1476,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
           if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
             ilow = i;
             yratio_ = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
-                     (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
+                      (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
             break;
           }
         }
@@ -1594,7 +1593,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     fracyone_ = (1.f - yratio_) * enty0_->fracyone + yratio_ * enty1_->fracyone;
     fracytwo_ = (1.f - yratio_) * enty0_->fracytwo + yratio_ * enty1_->fracytwo;
-    //       If using y-spares 
+    //       If using y-spares
     //       for(i=0; i<10; ++i) {
     //		    pyspare[i]=(1.f - yratio_)*enty0_->yspare[i] + yratio_*enty1_->yspare[i];
     //       }
@@ -1737,7 +1736,6 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
       xrms_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xrms[i] + xxratio * entx02_->xrms[i]) +
                  yxratio * ((1.f - xxratio) * entx20_->xrms[i] + xxratio * entx22_->xrms[i]);
-
 
       xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xavgc2m[i] + xxratio * entx02_->xavgc2m[i]) +
                     yxratio * ((1.f - xxratio) * entx20_->xavgc2m[i] + xxratio * entx22_->xavgc2m[i]);
@@ -3043,7 +3041,7 @@ int SiPixelTemplate::qbin(int id,
 
   float cota = cotalpha;
   bool flip_x = false;
-  //y flipping already taken care of by interpolate 
+  //y flipping already taken care of by interpolate
   switch (dtype_) {
     case 0:
     case 1:
@@ -3087,7 +3085,6 @@ int SiPixelTemplate::qbin(int id,
 #else
   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
-
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
@@ -3521,7 +3518,6 @@ void SiPixelTemplate::temperrors(int id,
 
   acotb = std::abs(cotbeta);
 
-
   // Copy the charge scaling factor to the private variable
 
   Ny = thePixelTemp_[index].head.NTy;
@@ -3538,7 +3534,6 @@ void SiPixelTemplate::temperrors(int id,
 #endif
 
   // next, loop over all y-angle entries
-
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
@@ -3682,8 +3677,6 @@ void SiPixelTemplate::qbin_dist(int id,
 #else
   assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
-
-
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
   ny1_frac = (1.f - yratio_) * enty0_->fracyone + yratio_ * enty1_->fracyone;

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.cc  Version 10.21
+//  SiPixelTemplate.cc  Version 10.24
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -81,6 +81,7 @@
 //  V10.20 - Add directory path selection to the ascii pushfile method
 //  V10.21 - Address runtime issues in pushfile() for gcc 7.X due to using tempfile as char string + misc. cleanup [Petar]
 //  V10.22 - Move templateStore to the heap, fix variable name in pushfile() [Petar]
+//  V10.24 - Add sideload() + associated gymnastics [Petar and Oz]
 
 //  Created by Morris Swartz on 10/27/06.
 //
@@ -1331,9 +1332,16 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
   float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0,
       cotbeta0;
-  bool flip_x, flip_y;
   //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
+
+   // If the sideloading is turned on, xtemp_ and ytemp_ are already set to what they need to be.
+   // So we'll just exit.
+   if ( entry_sideloaded_ != nullptr ) {
+     success_ = true;
+     return success_ ;
+   }
+
 
   // Check to see if interpolation is valid
   if (id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
@@ -1351,6 +1359,10 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         if (id == thePixelTemp_[i].head.ID) {
           index_id_ = i;
           id_current_ = id;
+
+	      // Copy the detector type to the private variable
+            
+	      Dtype_ = thePixelTemp_[index_id_].head.Dtype;
 
           // Copy the charge scaling factor to the private variable
 
@@ -1387,9 +1399,6 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
 #endif
 
-    // Interpolate the absolute value of cot(beta)
-
-    abs_cotb_ = std::abs(cotbeta);
 
     //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)
 
@@ -1399,13 +1408,13 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     // for some cosmics, the ususal gymnastics are incorrect
     cota = cotalpha;
-    cotb = abs_cotb_;
-    flip_x = false;
-    flip_y = false;
-    switch (thePixelTemp_[index_id_].head.Dtype) {
+    cotb = abs_cotb_ = std::abs(cotbeta);
+    flip_x_ = false;
+    flip_y_ = false;
+    switch (Dtype_) {
       case 0:
         if (cotbeta < 0.f) {
-          flip_y = true;
+          flip_y_ = true;
         }
         break;
       case 1:
@@ -1413,7 +1422,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
           cotb = cotbeta;
         } else {
           cotb = -cotbeta;
-          flip_y = true;
+          flip_y_ = true;
         }
         break;
       case 2:
@@ -1422,21 +1431,21 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       case 5:
         if (locBx * locBz < 0.f) {
           cota = -cotalpha;
-          flip_x = true;
+          flip_x_ = true;
         }
         if (locBx > 0.f) {
           cotb = cotbeta;
         } else {
           cotb = -cotbeta;
-          flip_y = true;
+          flip_y_ = true;
         }
         break;
       default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
         throw cms::Exception("DataCorrupt")
-            << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+            << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
 #else
-        std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+        std::cout << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
 #endif
     }
 
@@ -1483,71 +1492,64 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     ihigh = ilow + 1;
 
-    // Interpolate/store all y-related quantities (flip displacements when flip_y)
+    // Use pointers to the three angle pairs used in the interpolation
+    //
+    enty0_ = &thePixelTemp_[index_id_].enty[ilow];
+    enty1_ = &thePixelTemp_[index_id_].enty[ihigh];
+
+    // Interpolate/store all y-related quantities (flip displacements when flip_y_)
+
 
     yratio_ = yratio;
-    qavg_ =
-        (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qavg + yratio * thePixelTemp_[index_id_].enty[ihigh].qavg;
+    qavg_ = (1.f - yratio)*enty0_->qavg + yratio*enty1_->qavg;
     qavg_ *= qcorrect;
-    symax = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].symax +
-            yratio * thePixelTemp_[index_id_].enty[ihigh].symax;
+    symax = (1.f - yratio)*enty0_->symax + yratio*enty1_->symax;
     syparmax_ = symax;
-    sxmax = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sxmax +
-            yratio * thePixelTemp_[index_id_].enty[ihigh].sxmax;
-    dyone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].dyone +
-             yratio * thePixelTemp_[index_id_].enty[ihigh].dyone;
-    if (flip_y) {
+    sxmax = (1.f - yratio)*enty0_->sxmax + yratio*enty1_->sxmax;
+    dyone_ = (1.f - yratio)*enty0_->dyone + yratio*enty1_->dyone;
+    if(flip_y_) {
       dyone_ = -dyone_;
     }
-    syone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].syone +
-             yratio * thePixelTemp_[index_id_].enty[ihigh].syone;
-    dytwo_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].dytwo +
-             yratio * thePixelTemp_[index_id_].enty[ihigh].dytwo;
-    if (flip_y) {
+    syone_ = (1.f - yratio)*enty0_->syone + yratio*enty1_->syone;
+    dytwo_ = (1.f - yratio)*enty0_->dytwo + yratio*enty1_->dytwo;
+    if(flip_y_) {
       dytwo_ = -dytwo_;
     }
-    sytwo_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sytwo +
-             yratio * thePixelTemp_[index_id_].enty[ihigh].sytwo;
-    qmin_ =
-        (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qmin + yratio * thePixelTemp_[index_id_].enty[ihigh].qmin;
+    sytwo_ = (1.f - yratio)*enty0_->sytwo + yratio*enty1_->sytwo;
+    qmin_ = (1.f - yratio)*enty0_->qmin + yratio*enty1_->qmin;
     qmin_ *= qcorrect;
-    qmin2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qmin2 +
-             yratio * thePixelTemp_[index_id_].enty[ihigh].qmin2;
+    qmin2_ = (1.f - yratio)*enty0_->qmin2 + yratio*enty1_->qmin2;
     qmin2_ *= qcorrect;
-    mpvvav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav +
-              yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav;
+    mpvvav_ = (1.f - yratio)*enty0_->mpvvav + yratio*enty1_->mpvvav;
     mpvvav_ *= qcorrect;
-    sigmavav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav +
-                yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav;
-    kappavav_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav +
-                yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav;
-    mpvvav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav2 +
-               yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
+    sigmavav_ = (1.f - yratio)*enty0_->sigmavav + yratio*enty1_->sigmavav;
+    kappavav_ = (1.f - yratio)*enty0_->kappavav + yratio*enty1_->kappavav;
+    mpvvav2_ = (1.f - yratio)*enty0_->mpvvav2 + yratio*enty1_->mpvvav2;
     mpvvav2_ *= qcorrect;
-    sigmavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav2 +
-                 yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
-    kappavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav2 +
-                 yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav2;
-    clsleny_ = fminf(thePixelTemp_[index_id_].enty[ilow].clsleny, thePixelTemp_[index_id_].enty[ihigh].clsleny);
-    qavg_avg_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].qavg_avg +
-                yratio * thePixelTemp_[index_id_].enty[ihigh].qavg_avg;
+    sigmavav2_ = (1.f - yratio)*enty0_->sigmavav2 + yratio*enty1_->sigmavav2;
+    kappavav2_ = (1.f - yratio)*enty0_->kappavav2 + yratio*enty1_->kappavav2;
+    clsleny_ = fminf(enty0_->clsleny, enty1_->clsleny);
+    qavg_avg_ = (1.f - yratio)*enty0_->qavg_avg + yratio*enty1_->qavg_avg;
     qavg_avg_ *= qcorrect;
     for (i = 0; i < 2; ++i) {
-      for (j = 0; j < 5; ++j) {
+        for (j = 0; j < 5; ++j) {
         // Charge loss switches sides when cot(beta) changes sign
-        if (flip_y) {
-          yparl_[1 - i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
-          yparh_[1 - i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
+        
+        
+        
+        if(flip_y_) {
+           yparl_[1-i][j] = enty0_->ypar[i][j];
+           yparh_[1-i][j] = enty1_->ypar[i][j];
         } else {
-          yparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
-          yparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
+           yparl_[i][j] = enty0_->ypar[i][j];
+           yparh_[i][j] = enty1_->ypar[i][j];
         }
-        if (flip_x) {
-          xparly0_[1 - i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
-          xparhy0_[1 - i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
+        if(flip_x_) {
+           xparly0_[1-i][j] = enty0_->xpar[i][j];
+           xparhy0_[1-i][j] = enty1_->xpar[i][j];
         } else {
-          xparly0_[i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
-          xparhy0_[i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
+           xparly0_[i][j] = enty0_->xpar[i][j];
+           xparhy0_[i][j] = enty1_->xpar[i][j];
         }
       }
     }
@@ -1555,48 +1557,42 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     for (i = 0; i < 4; ++i) {
       yavg_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yavg[i] +
                  yratio * thePixelTemp_[index_id_].enty[ihigh].yavg[i];
-      if (flip_y) {
+      if (flip_y_) {
         yavg_[i] = -yavg_[i];
       }
-      yrms_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yrms[i] +
-                 yratio * thePixelTemp_[index_id_].enty[ihigh].yrms[i];
-      //	      ygx0_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ygx0[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].ygx0[i];
-      //	      if(flip_y) {ygx0_[i] = -ygx0_[i];}
-      //	      ygsig_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].ygsig[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].ygsig[i];
-      //	      xrms[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xrms[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xrms[i];
-      //	      xgsig[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xgsig[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xgsig[i];
-      chi2yavg_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yavg[i] +
-                     yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yavg[i];
-      chi2ymin_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2ymin[i] +
-                     yratio * thePixelTemp_[index_id_].enty[ihigh].chi2ymin[i];
-      chi2xavg[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xavg[i] +
-                    yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xavg[i];
-      chi2xmin[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xmin[i] +
-                    yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xmin[i];
-      yavgc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yavgc2m[i] +
-                    yratio * thePixelTemp_[index_id_].enty[ihigh].yavgc2m[i];
-      if (flip_y) {
+      yavg_[i]=(1.f - yratio)*enty0_->yavg[i] + yratio*enty1_->yavg[i];
+      if(flip_y_) {
+        yavg_[i] = -yavg_[i];
+      }
+      yrms_[i]=(1.f - yratio)*enty0_->yrms[i] + yratio*enty1_->yrms[i];
+      //	      ygx0_[i]=(1.f - yratio)*enty0_->ygx0[i] + yratio*enty1_->ygx0[i];
+      //	      if(flip_y_) {ygx0_[i] = -ygx0_[i];}
+      //	      ygsig_[i]=(1.f - yratio)*enty0_->ygsig[i] + yratio*enty1_->ygsig[i];
+      //	      xrms[i]=(1.f - yratio)*enty0_->xrms[i] + yratio*enty1_->xrms[i];
+      //	      xgsig[i]=(1.f - yratio)*enty0_->xgsig[i] + yratio*enty1_->xgsig[i];
+      chi2yavg_[i]=(1.f - yratio)*enty0_->chi2yavg[i] + yratio*enty1_->chi2yavg[i];
+      chi2ymin_[i]=(1.f - yratio)*enty0_->chi2ymin[i] + yratio*enty1_->chi2ymin[i];
+      chi2xavg[i]=(1.f - yratio)*enty0_->chi2xavg[i] + yratio*enty1_->chi2xavg[i];
+      chi2xmin[i]=(1.f - yratio)*enty0_->chi2xmin[i] + yratio*enty1_->chi2xmin[i];
+      yavgc2m_[i]=(1.f - yratio)*enty0_->yavgc2m[i] + yratio*enty1_->yavgc2m[i];
+      if(flip_y_) {
         yavgc2m_[i] = -yavgc2m_[i];
       }
-      yrmsc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].yrmsc2m[i] +
-                    yratio * thePixelTemp_[index_id_].enty[ihigh].yrmsc2m[i];
-      chi2yavgc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yavgc2m[i] +
-                        yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yavgc2m[i];
-      //	      if(flip_y) {chi2yavgc2m_[i] = -chi2yavgc2m_[i];}
-      chi2yminc2m_[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yminc2m[i] +
-                        yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yminc2m[i];
-      //	      xrmsc2m[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].xrmsc2m[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].xrmsc2m[i];
-      chi2xavgc2m[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xavgc2m[i] +
-                       yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xavgc2m[i];
-      chi2xminc2m[i] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xminc2m[i] +
-                       yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xminc2m[i];
+      yrmsc2m_[i]=(1.f - yratio)*enty0_->yrmsc2m[i] + yratio*enty1_->yrmsc2m[i];
+      chi2yavgc2m_[i]=(1.f - yratio)*enty0_->chi2yavgc2m[i] + yratio*enty1_->chi2yavgc2m[i];
+      //	      if(flip_y_) {chi2yavgc2m_[i] = -chi2yavgc2m_[i];}
+      chi2yminc2m_[i]=(1.f - yratio)*enty0_->chi2yminc2m[i] + yratio*enty1_->chi2yminc2m[i];
+      //	      xrmsc2m[i]=(1.f - yratio)*enty0_->xrmsc2m[i] + yratio*enty1_->xrmsc2m[i];
+      chi2xavgc2m[i]=(1.f - yratio)*enty0_->chi2xavgc2m[i] + yratio*enty1_->chi2xavgc2m[i];
+      chi2xminc2m[i]=(1.f - yratio)*enty0_->chi2xminc2m[i] + yratio*enty1_->chi2xminc2m[i];
       for (j = 0; j < 6; ++j) {
-        yflparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].yflpar[i][j];
-        yflparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].yflpar[i][j];
+
+        yflparl_[i][j] = enty0_->yflpar[i][j];
+        yflparh_[i][j] = enty1_->yflpar[i][j];
 
         // Since Q_fl is odd under cotbeta, it flips qutomatically, change only even terms
 
-        if (flip_y && (j == 0 || j == 2 || j == 4)) {
+        if (flip_y_ && (j == 0 || j == 2 || j == 4)) {
           yflparl_[i][j] = -yflparl_[i][j];
           yflparh_[i][j] = -yflparh_[i][j];
         }
@@ -1605,22 +1601,17 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     //// Single pixel cluster probabilities
 
-    chi2yavgone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yavgone +
-                   yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yavgone;
-    chi2yminone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2yminone +
-                   yratio * thePixelTemp_[index_id_].enty[ihigh].chi2yminone;
-    chi2xavgone = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xavgone +
-                  yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xavgone;
-    chi2xminone = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].chi2xminone +
-                  yratio * thePixelTemp_[index_id_].enty[ihigh].chi2xminone;
-
-    fracyone_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].fracyone +
-                yratio * thePixelTemp_[index_id_].enty[ihigh].fracyone;
-    fracytwo_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].fracytwo +
-                yratio * thePixelTemp_[index_id_].enty[ihigh].fracytwo;
+    chi2yavgone_=(1.f - yratio)*enty0_->chi2yavgone + yratio*enty1_->chi2yavgone;
+    chi2yminone_=(1.f - yratio)*enty0_->chi2yminone + yratio*enty1_->chi2yminone;
+    chi2xavgone=(1.f - yratio)*enty0_->chi2xavgone + yratio*enty1_->chi2xavgone;
+    chi2xminone=(1.f - yratio)*enty0_->chi2xminone + yratio*enty1_->chi2xminone;
+    
+    fracyone_ = (1.f - yratio)*enty0_->fracyone + yratio*enty1_->fracyone;
+    fracytwo_ = (1.f - yratio)*enty0_->fracytwo + yratio*enty1_->fracytwo;
     //       for(i=0; i<10; ++i) {
-    //		    pyspare[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yspare[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yspare[i];
+    //		    pyspare[i]=(1.f - yratio)*enty0_->yspare[i] + yratio*enty1_->yspare[i];
     //       }
+      
 
     // Interpolate and build the y-template
 
@@ -1632,13 +1623,11 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       for (j = 0; j < TYSIZE; ++j) {
         // Flip the basic y-template when the cotbeta is negative
 
-        if (flip_y) {
-          ytemp_[8 - i][BYM3 - j] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].ytemp[i][j] +
-                                    yratio * thePixelTemp_[index_id_].enty[ihigh].ytemp[i][j];
-        } else {
-          ytemp_[i][j + 2] = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].ytemp[i][j] +
-                             yratio * thePixelTemp_[index_id_].enty[ihigh].ytemp[i][j];
-        }
+          if(flip_y_) {
+             ytemp_[8-i][BYM3-j]=(1.f - yratio)*enty0_->ytemp[i][j] + yratio*enty1_->ytemp[i][j];
+          } else {
+             ytemp_[i][j+2]=(1.f - yratio)*enty0_->ytemp[i][j] + yratio*enty1_->ytemp[i][j];
+          }
       }
     }
 
@@ -1711,14 +1700,14 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     }
     dxone_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].dxone +
              xxratio * thePixelTemp_[index_id_].entx[0][ihigh].dxone;
-    if (flip_x) {
+    if (flip_x_) {
       dxone_ = -dxone_;
     }
     sxone_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].sxone +
              xxratio * thePixelTemp_[index_id_].entx[0][ihigh].sxone;
     dxtwo_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].dxtwo +
              xxratio * thePixelTemp_[index_id_].entx[0][ihigh].dxtwo;
-    if (flip_x) {
+    if (flip_x_) {
       dxtwo_ = -dxtwo_;
     }
     sxtwo_ = (1.f - xxratio) * thePixelTemp_[index_id_].entx[0][ilow].sxtwo +
@@ -1728,7 +1717,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
     for (i = 0; i < 2; ++i) {
       for (j = 0; j < 5; ++j) {
         // Charge loss switches sides when cot(alpha) changes sign
-        if (flip_x) {
+        if (flip_x_) {
           xpar0_[1 - i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
           xparl_[1 - i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
           xparh_[1 - i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
@@ -1739,57 +1728,52 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         }
       }
     }
+    // Pointers to the currently interpolated point.
+    entx00_ = & thePixelTemp_[index_id_].entx[iylow][ilow];
+    entx02_ = & thePixelTemp_[index_id_].entx[iylow][ihigh];
+    entx20_ = & thePixelTemp_[index_id_].entx[iyhigh][ilow];
+    entx22_ = & thePixelTemp_[index_id_].entx[iyhigh][ihigh];
+    entx21_ = & thePixelTemp_[index_id_].entx[iyhigh][imidy];
+
 
     // pixmax is the maximum allowed pixel charge (used for truncation)
+    pixmax_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->pixmax + xxratio*entx02_->pixmax)
+	             + yxratio  * ((1.f - xxratio)*entx20_->pixmax + xxratio*entx22_->pixmax);
 
-    pixmax_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].pixmax +
-                                 xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].pixmax) +
-              yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].pixmax +
-                         xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].pixmax);
 
-    r_qMeas_qTrue_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].r_qMeas_qTrue +
-                                        xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].r_qMeas_qTrue) +
-                     yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].r_qMeas_qTrue +
-                                xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].r_qMeas_qTrue);
+
+    r_qMeas_qTrue_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->r_qMeas_qTrue + xxratio*entx02_->r_qMeas_qTrue)
+	                    + yxratio  * ((1.f - xxratio)*entx20_->r_qMeas_qTrue + xxratio*entx22_->r_qMeas_qTrue);
 
     for (i = 0; i < 4; ++i) {
-      xavg_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xavg[i] +
-                                    xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xavg[i]) +
-                 yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xavg[i] +
-                            xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavg[i]);
-      if (flip_x) {
+       xavg_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xavg[i] + xxratio*entx02_->xavg[i])
+                         + yxratio  * ((1.f - xxratio)*entx20_->xavg[i] + xxratio*entx22_->xavg[i]);
+      if (flip_x_) {
         xavg_[i] = -xavg_[i];
       }
 
-      xrms_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xrms[i] +
-                                    xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xrms[i]) +
-                 yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xrms[i] +
-                            xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrms[i]);
+      xrms_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xrms[i] + xxratio*entx02_->xrms[i])
+	                 + yxratio  * ((1.f - xxratio)*entx20_->xrms[i] + xxratio*entx22_->xrms[i]);
 
-      //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xgx0[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xgx0[i])
-      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xgx0[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xgx0[i]);
+         //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgx0[i] + xxratio*entx02_->xgx0[i])
+         //		          +yxratio*((1.f - xxratio)*entx20_->xgx0[i] + xxratio*entx22_->xgx0[i]);
+         
+         //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgsig[i] + xxratio*entx02_->xgsig[i])
+         //		          +yxratio*((1.f - xxratio)*entx20_->xgsig[i] + xxratio*entx22_->xgsig[i]);
 
-      //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xgsig[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xgsig[i])
-      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xgsig[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xgsig[i]);
-
-      xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xavgc2m[i] +
-                                       xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xavgc2m[i]) +
-                    yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xavgc2m[i] +
-                               xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavgc2m[i]);
-      if (flip_x) {
+      xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xavgc2m[i] + xxratio*entx02_->xavgc2m[i])
+                            + yxratio  * ((1.f - xxratio)*entx20_->xavgc2m[i] + xxratio*entx22_->xavgc2m[i]);
+      if (flip_x_) {
         xavgc2m_[i] = -xavgc2m_[i];
       }
 
-      xrmsc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].xrmsc2m[i] +
-                                       xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].xrmsc2m[i]) +
-                    yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xrmsc2m[i] +
-                               xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrmsc2m[i]);
-
-      //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].chi2xavgc2m[i])
-      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgc2m[i]);
-
-      //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].chi2xminc2m[i])
-      //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminc2m[i]);
+      xrmsc2m_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xrmsc2m[i] + xxratio*entx02_->xrmsc2m[i])
+                            + yxratio  * ((1.f - xxratio)*entx20_->xrmsc2m[i] + xxratio*entx22_->xrmsc2m[i]);
+        //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xavgc2m[i] + xxratio*entx02_->chi2xavgc2m[i])
+         //		          +yxratio*((1.f - xxratio)*entx20_->chi2xavgc2m[i] + xxratio*entx22_->chi2xavgc2m[i]);
+         
+         //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xminc2m[i] + xxratio*entx02_->chi2xminc2m[i])
+         //		          +yxratio*((1.f - xxratio)*entx20_->chi2xminc2m[i] + xxratio*entx22_->chi2xminc2m[i]);
       //
       //  Try new interpolation scheme
       //
@@ -1799,119 +1783,100 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       //	      chi2xmin_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xmin[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xmin[i]);
       //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i] != 0.f) {chi2xmin_[i]=chi2xmin_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i]*chi2xmin[i];}
       //
-      chi2xavg_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavg[i] +
-                      xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavg[i]);
-      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavg[i] != 0.f) {
-        chi2xavg_[i] = chi2xavg_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavg[i] * chi2xavg[i];
+      chi2xavg_[i] = ((1.f - xxratio) * entx20_->chi2xavg[i] + xxratio*entx22_->chi2xavg[i]);
+      if(entx21_->chi2xavg[i] != 0.f) {
+          chi2xavg_[i]=chi2xavg_[i]/entx21_->chi2xavg[i]*chi2xavg[i];
       }
-
-      chi2xmin_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xmin[i] +
-                      xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xmin[i]);
-      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xmin[i] != 0.f) {
-        chi2xmin_[i] = chi2xmin_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xmin[i] * chi2xmin[i];
+      
+      chi2xmin_[i] = ((1.f - xxratio) * entx20_->chi2xmin[i] + xxratio*entx22_->chi2xmin[i]);
+      if(entx21_->chi2xmin[i] != 0.f) {
+          chi2xmin_[i]=chi2xmin_[i]/entx21_->chi2xmin[i]*chi2xmin[i];
       }
-
-      chi2xavgc2m_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgc2m[i] +
-                         xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgc2m[i]);
-      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgc2m[i] != 0.f) {
-        chi2xavgc2m_[i] =
-            chi2xavgc2m_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgc2m[i] * chi2xavgc2m[i];
+      
+      chi2xavgc2m_[i] = ((1.f - xxratio) * entx20_->chi2xavgc2m[i] + xxratio*entx22_->chi2xavgc2m[i]);
+      if(entx21_->chi2xavgc2m[i] != 0.f) {
+          chi2xavgc2m_[i]=chi2xavgc2m_[i]/entx21_->chi2xavgc2m[i]*chi2xavgc2m[i];
       }
-
-      chi2xminc2m_[i] = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminc2m[i] +
-                         xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminc2m[i]);
-      if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminc2m[i] != 0.f) {
-        chi2xminc2m_[i] =
-            chi2xminc2m_[i] / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminc2m[i] * chi2xminc2m[i];
+      
+      chi2xminc2m_[i] = ((1.f - xxratio) * entx20_->chi2xminc2m[i] + xxratio*entx22_->chi2xminc2m[i]);
+      if(entx21_->chi2xminc2m[i] != 0.f) {
+          chi2xminc2m_[i]=chi2xminc2m_[i]/entx21_->chi2xminc2m[i]*chi2xminc2m[i];
       }
-
-      for (j = 0; j < 6; ++j) {
-        xflparll_[i][j] = thePixelTemp_[index_id_].entx[iylow][ilow].xflpar[i][j];
-        xflparlh_[i][j] = thePixelTemp_[index_id_].entx[iylow][ihigh].xflpar[i][j];
-        xflparhl_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ilow].xflpar[i][j];
-        xflparhh_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ihigh].xflpar[i][j];
+         
+     for(j=0; j<6 ; ++j) {
+        xflparll_[i][j] = entx00_->xflpar[i][j];
+        xflparlh_[i][j] = entx02_->xflpar[i][j];
+        xflparhl_[i][j] = entx20_->xflpar[i][j];
+        xflparhh_[i][j] = entx22_->xflpar[i][j];
         // Since Q_fl is odd under cotalpha, it flips qutomatically, change only even terms
-        if (flip_x && (j == 0 || j == 2 || j == 4)) {
-          xflparll_[i][j] = -xflparll_[i][j];
-          xflparlh_[i][j] = -xflparlh_[i][j];
-          xflparhl_[i][j] = -xflparhl_[i][j];
-          xflparhh_[i][j] = -xflparhh_[i][j];
+        if(flip_x_ && (j == 0 || j == 2 || j == 4)) {
+           xflparll_[i][j] = -xflparll_[i][j];
+           xflparlh_[i][j] = -xflparlh_[i][j];
+           xflparhl_[i][j] = -xflparhl_[i][j];
+           xflparhh_[i][j] = -xflparhh_[i][j];
         }
+     }
       }
-    }
-
-    // Do the spares next
-
-    chi2xavgone_ = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xavgone +
-                    xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xavgone);
-    if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgone != 0.f) {
-      chi2xavgone_ = chi2xavgone_ / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xavgone * chi2xavgone;
-    }
-
-    chi2xminone_ = ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].chi2xminone +
-                    xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].chi2xminone);
-    if (thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone != 0.f) {
-      chi2xminone_ = chi2xminone_ / thePixelTemp_[index_id_].entx[iyhigh][imidy].chi2xminone * chi2xminone;
-    }
-
-    fracxone_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].fracxone +
-                                   xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].fracxone) +
-                yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxone +
-                           xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxone);
-    fracxtwo_ = (1.f - yxratio) * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iylow][ilow].fracxtwo +
-                                   xxratio * thePixelTemp_[index_id_].entx[iylow][ihigh].fracxtwo) +
-                yxratio * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].fracxtwo +
-                           xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].fracxtwo);
-
-    //       for(i=0; i<10; ++i) {
-    //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xspare[i])
-    //		          +yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xspare[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xspare[i]);
-    //       }
-
-    // Interpolate and build the x-template
-
-    //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
-
-    cotbeta0 = thePixelTemp_[index_id_].entx[iyhigh][0].cotbeta;
-    qxtempcor =
-        std::sqrt((1.f + cotbeta * cotbeta + cotalpha * cotalpha) / (1.f + cotbeta0 * cotbeta0 + cotalpha * cotalpha));
-
-    for (i = 0; i < 9; ++i) {
-      xtemp_[i][0] = 0.f;
-      xtemp_[i][1] = 0.f;
-      xtemp_[i][BXM2] = 0.f;
-      xtemp_[i][BXM1] = 0.f;
-      for (j = 0; j < TXSIZE; ++j) {
-        //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
-        //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
-        //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j];
-        if (flip_x) {
-          xtemp_[8 - i][BXM3 - j] =
-              qxtempcor * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] +
-                           xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
-        } else {
-          xtemp_[i][j + 2] = qxtempcor * ((1.f - xxratio) * thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] +
-                                          xxratio * thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
-        }
+      
+      
+      // Do the spares next
+      
+      chi2xavgone_=((1.f - xxratio)*entx20_->chi2xavgone + xxratio*entx22_->chi2xavgone);
+      if(entx21_->chi2xavgone != 0.f) {chi2xavgone_=chi2xavgone_/entx21_->chi2xavgone*chi2xavgone;}
+      
+      chi2xminone_=((1.f - xxratio)*entx20_->chi2xminone + xxratio*entx22_->chi2xminone);
+      if(entx21_->chi2xminone != 0.f) {chi2xminone_=chi2xminone_/entx21_->chi2xminone*chi2xminone;}
+      
+      fracxone_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->fracxone + xxratio*entx02_->fracxone)
+	               + yxratio  * ((1.f - xxratio)*entx20_->fracxone + xxratio*entx22_->fracxone);
+      fracxtwo_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->fracxtwo + xxratio*entx02_->fracxtwo)
+	               + yxratio  * ((1.f - xxratio)*entx20_->fracxtwo + xxratio*entx22_->fracxtwo);
+   
+      //       for(i=0; i<10; ++i) {
+      //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xspare[i] + xxratio*entx02_->xspare[i])
+      //		          +yxratio*((1.f - xxratio)*entx20_->xspare[i] + xxratio*entx22_->xspare[i]);
+      //       }
+      
+      // Interpolate and build the x-template
+      
+      //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
+      
+      cotbeta0 =  thePixelTemp_[index_id_].entx[iyhigh][0].cotbeta;
+      qxtempcor=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta0*cotbeta0+cotalpha*cotalpha));
+      
+      for(i=0; i<9; ++i) {
+         xtemp_[i][0] = 0.f;
+         xtemp_[i][1] = 0.f;
+         xtemp_[i][BXM2] = 0.f;
+         xtemp_[i][BXM1] = 0.f;
+         for(j=0; j<TXSIZE; ++j) {
+            //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
+            //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
+            //		   xtemp_[i][j+2]=(1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j];
+            if(flip_x_) {
+               xtemp_[8-i][BXM3-j] = qxtempcor*((1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j]);
+            } else {
+               xtemp_[i][j+2]      = qxtempcor*((1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j]);
+            }
+         }
       }
-    }
-
-    lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
-    lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
-    lorybias_ = thePixelTemp_[index_id_].head.lorybias;
-    lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
-    if (flip_x) {
-      lorxwidth_ = -lorxwidth_;
-      lorxbias_ = -lorxbias_;
-    }
-    if (flip_y) {
-      lorywidth_ = -lorywidth_;
-      lorybias_ = -lorybias_;
-    }
-  }
-
-  return success_;
-}  // interpolate
+      
+      lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
+      lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
+      lorybias_ = thePixelTemp_[index_id_].head.lorybias;
+      lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
+      if(flip_x_) {
+          lorxwidth_ = -lorxwidth_; lorxbias_ = -lorxbias_;
+      }
+      if(flip_y_) {
+          lorywidth_ = -lorywidth_; lorybias_ = -lorybias_;
+      }
+      
+      
+   }
+   
+   return success_;
+} // interpolate
 
 // ************************************************************************************************************
 //! Interpolate input alpha and beta angles to produce a working template for each individual hit.
@@ -1949,6 +1914,205 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
   float locBx = 1.f;
   return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
 }
+
+// *************************************************************************************************************************************
+//! Load template info for single angle point to invoke template reco for template generation
+//! \param      entry - (input) pointer to template entry
+//! \param      sizex - (input) pixel x-size
+//! \param      sizey - (input) pixel y-size
+//! \param      sizez - (input) pixel z-size
+// *************************************************************************************************************************************
+#ifdef SI_PIXEL_TEMPLATE_STANDALONE
+void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize)
+{
+   // Set class variables to the input parameters
+   entry_sideloaded_ = entry;    // will bypass xtemp_[] and ytemp_[] and use those from this Entry.
+  
+   enty1_ = entry;
+   enty0_ = entry;
+
+   entx00_ = entry;
+   entx02_ = entry;
+   entx20_ = entry;
+   entx22_ = entry;
+   entx21_ = entry;
+
+   Dtype_ = iDtype;
+   lorywidth_ = lorwdy;
+   lorxwidth_ = lorwdx;
+   xsize_ = xsize;
+   ysize_ = ysize;
+   zsize_ = zsize;
+   s50_ = q50;
+   qscale_ = 1.f;
+   for(int i=0; i<3; ++i) {fbin_[i] = fbin[i];}
+   
+   // Set other class variables
+   
+   // adcota_ = 0.f;
+   // adcotb_ = 0.f;
+   
+   yratio_  = 0.f;
+   yxratio_ = 0.f;
+   xxratio_ = 0.f;
+   
+   qavg_ = entry->qavg;
+   qmin_ = 0.f;
+   qmin2_ = 0.f;
+
+   pixmax_ = entry->pixmax;
+   sxmax_ = entry->sxmax;
+   symax_ = entry->symax;
+   clsleny_ = entry->clsleny;
+   clslenx_ = entry->clslenx;
+
+   scaleyavg_ = 1.f;
+   scalexavg_ = 1.f;
+   delyavg_ = 0.f;
+   delysig_ = 0.f;
+
+   
+   dyone_ = entry->dyone;
+   syone_ = entry->syone;
+   dytwo_ = entry->dytwo;
+   sytwo_ = entry->sytwo;
+   
+   dxone_ = entry->dxone;
+   sxone_ = entry->sxone;
+   dxtwo_ = entry->dxtwo;
+   sxtwo_ = entry->sxtwo;
+
+   chi2yminone_ = 0.f;
+   chi2yavgone_ = 0.1;
+   chi2xminone_ = 0.f;
+   chi2xavgone_ = 0.1;
+
+   
+   for(int i=0; i<4 ; ++i) {
+      scalex_[i] = 1.f;
+      scaley_[i] = 1.f;
+      offsetx_[i] = 0.f;
+      offsety_[i] = 0.f;
+      xrms_[i] = 0.f;
+      yrms_[i] = 0.f;
+      xavg_[i] = 0.f;
+      yavg_[i] = 0.f;
+
+      chi2yavg_[i] = 0.1;
+      chi2xavg_[i] = 0.1;
+
+      chi2xmin_[i] = 0.f;
+      chi2ymin_[i] = 0.f;
+
+      for(int j=0; j<6; j++){
+        yflparl_[i][j]  = yflparh_[i][j] = entry->yflpar[i][j];
+        xflparhh_[i][j] = xflparhl_[i][j] = xflparll_[i][j]  = xflparlh_[i][j] = entry->xflpar[i][j];
+      }
+   }
+
+   sxparmax_ = entry->sxmax;
+   syparmax_ = entry->symax;
+   
+   // This works only for IP-related tracks
+   
+   flip_x_ = false;
+   flip_y_ = false;
+   float cotbeta = entry->cotbeta;
+   switch(Dtype_) {
+      case 0:
+         if(cotbeta < 0.f) {
+	   flip_y_ = true;
+	 }
+         break;
+      case 1:
+         if(locBz > 0.f) {
+            flip_y_ = true;
+         }
+         break;
+      case 2:
+      case 3:
+      case 4:
+      case 5:
+         if(locBx*locBz < 0.f) {
+            flip_x_ = true;
+         }
+         if(locBx < 0.f) {
+            flip_y_ = true;
+         }
+         break;
+      default:
+	// #ifndef SI_PIXEL_TEMPLATE_STANDALONE
+	//         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
+	//#else
+         std::cout << "SiPixelTemplate:illegal subdetector ID = " << Dtype_ << std::endl;
+	 //#endif
+   }
+
+
+   //  Calculate signed quantities
+
+   //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
+   // &&& What to do here?
+   // qxtempcor=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta0*cotbeta0+cotalpha*cotalpha));
+   float qxtempcor = 1.f;
+   
+   for(int i=0; i<9; ++i) {
+      xtemp_[i][0] = 0.f;
+      xtemp_[i][1] = 0.f;
+      xtemp_[i][BXM2] = 0.f;
+      xtemp_[i][BXM1] = 0.f;
+      for(int j=0; j<TXSIZE; ++j) {
+         if(flip_x_) {
+	    xtemp_[8-i][BXM3-j] = qxtempcor*entry_sideloaded_->xtemp[i][j];
+         } else {
+	    xtemp_[i][j+2]      = qxtempcor*entry_sideloaded_->xtemp[i][j];
+         }
+      }
+   }
+   
+
+   for(int i=0; i<9; ++i) {
+      ytemp_[i][0] = 0.f;
+      ytemp_[i][1] = 0.f;
+      ytemp_[i][BYM2] = 0.f;
+      ytemp_[i][BYM1] = 0.f;
+      for(int j=0; j<TYSIZE; ++j) {
+         
+         // Flip the basic y-template when the cotbeta is negative
+         
+         if(flip_y_) {
+   	    ytemp_[8-i][BYM3-j] = entry_sideloaded_->ytemp[i][j] ;
+         } else {
+ 	    ytemp_[i][j+2]      = entry_sideloaded_->ytemp[i][j] ;
+         }
+      }
+   }
+
+
+   // Fitted errors params
+   for(int i =0; i<2; i++){
+     for(int j=0; j<5; j++){
+         if(flip_y_){
+            yparl_[1-i][j] = yparh_[1-i][j] = entry->ypar[i][j];
+         }
+         else{
+            yparl_[i][j] = yparh_[i][j] = entry->ypar[i][j];
+         }
+
+         if(flip_x_){
+        xpar0_[1-i][j] =  xparly0_[1-i][j] = xparhy0_[1-i][j] = xparl_[1-i][j] = xparh_[1-i][j] = entry->xpar[i][j];
+         }
+         else{
+        xpar0_[i][j] =  xparly0_[i][j] = xparhy0_[i][j] = xparl_[i][j] = xparh_[i][j] = entry->xpar[i][j];
+         }
+     }
+   }
+
+   return;
+} // sideload
+#endif
+
+
 
 // ************************************************************************************************************
 //! Return vector of y errors (squared) for an input vector of projected signals
@@ -2435,7 +2599,6 @@ void SiPixelTemplate::ytemp(int fybin, int lybin, float ytemplate[41][BYSIZE])
 //! \param xtemplate - (output) a 41x11 output buffer
 // ************************************************************************************************************
 void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE])
-
 {
   // Retrieve already interpolated quantities
 
@@ -2458,51 +2621,49 @@ void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE])
 #else
   assert(lxbin >= 0 && lxbin < 41);
 #endif
-
-  // Build the x-template, the central 25 bins are here in all cases
-
-  for (i = 0; i < 9; ++i) {
-    for (j = 0; j < BXSIZE; ++j) {
-      xtemplate[i + 16][j] = xtemp_[i][j];
-    }
-  }
-  for (i = 0; i < 8; ++i) {
-    xtemplate[i + 8][BXM1] = 0.f;
-    for (j = 0; j < BXM1; ++j) {
-      xtemplate[i + 8][j] = xtemp_[i][j + 1];
-    }
-  }
-  for (i = 1; i < 9; ++i) {
-    xtemplate[i + 24][0] = 0.f;
-    for (j = 0; j < BXM1; ++j) {
-      xtemplate[i + 24][j + 1] = xtemp_[i][j];
-    }
-  }
-
-  //  Add more bins if needed
-
-  if (fxbin < 8) {
-    for (i = 0; i < 8; ++i) {
-      xtemplate[i][BXM2] = 0.f;
-      xtemplate[i][BXM1] = 0.f;
-      for (j = 0; j < BXM2; ++j) {
-        xtemplate[i][j] = xtemp_[i][j + 2];
+   
+   // Build the x-template, the central 25 bins are here in all cases
+   
+   for(i=0; i<9; ++i) {
+      for(j=0; j<BXSIZE; ++j) {
+         xtemplate[i+16][j]=xtemp_[i][j];
       }
-    }
-  }
-  if (lxbin > 32) {
-    for (i = 1; i < 9; ++i) {
-      xtemplate[i + 32][0] = 0.f;
-      xtemplate[i + 32][1] = 0.f;
-      for (j = 0; j < BXM2; ++j) {
-        xtemplate[i + 32][j + 2] = xtemp_[i][j];
+   }
+   for(i=0; i<8; ++i) {
+      xtemplate[i+8][BXM1] = 0.f;
+      for(j=0; j<BXM1; ++j) {
+         xtemplate[i+8][j]=xtemp_[i][j+1];
       }
-    }
-  }
-
-  return;
-
-}  // End xtemp
+   }
+   for(i=1; i<9; ++i) {
+      xtemplate[i+24][0] = 0.f;
+      for(j=0; j<BXM1; ++j) {
+         xtemplate[i+24][j+1]=xtemp_[i][j];
+      }
+   }
+   //  Add more bins if needed
+   if(fxbin < 8) {
+      for(i=0; i<8; ++i) {
+         xtemplate[i][BXM2] = 0.f;
+         xtemplate[i][BXM1] = 0.f;
+         for(j=0; j<BXM2; ++j) {
+            xtemplate[i][j]=xtemp_[i][j+2];
+         }
+      }
+   }
+   if(lxbin > 32) {
+      for(i=1; i<9; ++i) {
+         xtemplate[i+32][0] = 0.f;
+         xtemplate[i+32][1] = 0.f;
+         for(j=0; j<BXM2; ++j) {
+            xtemplate[i+32][j+2]=xtemp_[i][j];
+         }
+      }
+   }
+   
+   return;
+   
+} // End xtemp
 
 // ************************************************************************************************************
 //! Return central pixel of y template pixels above readout threshold
@@ -2864,6 +3025,8 @@ int SiPixelTemplate::qbin(int id,
 {
   // Interpolate for a new set of track angles
 
+  // &&& New approach: use cached pointers.
+   
   // Find the index corresponding to id
 
   int index = -1;
@@ -2987,23 +3150,23 @@ int SiPixelTemplate::qbin(int id,
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
-  dy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dyone + yratio * thePixelTemp_[index].enty[ihigh].dyone;
-  if (flip_y) {
-    dy1 = -dy1;
-  }
-  sy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].syone + yratio * thePixelTemp_[index].enty[ihigh].syone;
-  dy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].dytwo + yratio * thePixelTemp_[index].enty[ihigh].dytwo;
-  if (flip_y) {
-    dy2 = -dy2;
-  }
-  sy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].sytwo + yratio * thePixelTemp_[index].enty[ihigh].sytwo;
-
-  auto qavg = (1.f - yratio) * thePixelTemp_[index].enty[ilow].qavg + yratio * thePixelTemp_[index].enty[ihigh].qavg;
-  qavg *= qcorrect;
-  auto qmin = (1.f - yratio) * thePixelTemp_[index].enty[ilow].qmin + yratio * thePixelTemp_[index].enty[ihigh].qmin;
-  qmin *= qcorrect;
-  auto qmin2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].qmin2 + yratio * thePixelTemp_[index].enty[ihigh].qmin2;
-  qmin2 *= qcorrect;
+   dy1 = (1.f - yratio)*enty0_->dyone + yratio*enty1_->dyone;
+   if(flip_y) {
+       dy1 = -dy1;
+   }
+   sy1 = (1.f - yratio)*enty0_->syone + yratio*enty1_->syone;
+   dy2 = (1.f - yratio)*enty0_->dytwo + yratio*enty1_->dytwo;
+   if(flip_y) {
+       dy2 = -dy2;
+   }
+   sy2 = (1.f - yratio)*enty0_->sytwo + yratio*enty1_->sytwo;
+   
+   auto qavg = (1.f - yratio)*enty0_->qavg + yratio*enty1_->qavg;
+   qavg *= qcorrect;
+   auto qmin = (1.f - yratio)*enty0_->qmin + yratio*enty1_->qmin;
+   qmin *= qcorrect;
+   auto qmin2 = (1.f - yratio)*enty0_->qmin2 + yratio*enty1_->qmin2;
+   qmin2 *= qcorrect;
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
   if (qavg <= 0.f || qmin <= 0.f) {
@@ -3039,13 +3202,11 @@ int SiPixelTemplate::qbin(int id,
     }
   }
 
-  auto yavggen = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yavggen[binq] +
-                 yratio * thePixelTemp_[index].enty[ihigh].yavggen[binq];
+  auto yavggen =(1.f - yratio)*enty0_->yavggen[binq] + yratio*enty1_->yavggen[binq];
   if (flip_y) {
     yavggen = -yavggen;
   }
-  auto yrmsgen = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yrmsgen[binq] +
-                 yratio * thePixelTemp_[index].enty[ihigh].yrmsgen[binq];
+  auto yrmsgen =(1.f - yratio)*enty0_->yrmsgen[binq] + yratio*enty1_->yrmsgen[binq];
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3416,7 +3577,7 @@ void SiPixelTemplate::temperrors(int id,
 
   // Interpolate the absolute value of cot(beta)
 
-  acotb = fabs((double)cotbeta);
+  acotb = std::abs(cotbeta);
   // cotb = cotbeta;   // &&& check with Morris, we reassign it below.
 
   // for some cosmics, the ususal gymnastics are incorrect
@@ -3476,10 +3637,9 @@ void SiPixelTemplate::temperrors(int id,
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
-  sy1 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].syone + yratio * thePixelTemp_[index].enty[ihigh].syone;
-  sy2 = (1.f - yratio) * thePixelTemp_[index].enty[ilow].sytwo + yratio * thePixelTemp_[index].enty[ihigh].sytwo;
-  yrms = (1.f - yratio) * thePixelTemp_[index].enty[ilow].yrms[qBin] +
-         yratio * thePixelTemp_[index].enty[ihigh].yrms[qBin];
+  sy1 = (1.f - yratio)*enty0_->syone + yratio*enty1_->syone;
+  sy2 = (1.f - yratio)*enty0_->sytwo + yratio*enty1_->sytwo;
+  yrms=(1.f - yratio)*enty0_->yrms[qBin] + yratio*enty1_->yrms[qBin];
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3660,10 +3820,8 @@ void SiPixelTemplate::qbin_dist(int id,
   ihigh = ilow + 1;
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
-  ny1_frac =
-      (1.f - yratio) * thePixelTemp_[index].enty[ilow].fracyone + yratio * thePixelTemp_[index].enty[ihigh].fracyone;
-  ny2_frac =
-      (1.f - yratio) * thePixelTemp_[index].enty[ilow].fracytwo + yratio * thePixelTemp_[index].enty[ihigh].fracytwo;
+  ny1_frac = (1.f - yratio)*enty0_->fracyone + yratio*enty1_->fracyone;
+  ny2_frac = (1.f - yratio)*enty0_->fracytwo + yratio*enty1_->fracytwo;
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -4047,8 +4205,9 @@ void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
 
 }  // vavilov_pars
 
-// ************************************************************************************************************
-//! Interpolate beta/alpha angles to produce Vavilov parameters for the 2-cluster charge distribution
+
+// ************************************************************************************************************ 
+//! Interpolate beta/alpha angles to produce Vavilov parameters for the 2-cluster charge distribution 
 //! \param mpv   - (output) the Vavilov most probable charge (well, not really the most probable esp at large kappa)
 //! \param sigma - (output) the Vavilov sigma parameter
 //! \param kappa - (output) the Vavilov kappa parameter [0.01 (Landau-like) < kappa < 10 (Gaussian-like)
@@ -4081,46 +4240,47 @@ void SiPixelTemplate::vavilov2_pars(double& mpv, double& sigma, double& kappa)
 #else
   assert(Ny > 1);
 #endif
-
-  // next, loop over all y-angle entries
-
+   
+  // next, loop over all y-angle entries   
+  
   ilow = 0;
   yratio = 0.f;
-
-  if (cotb >= thePixelTemp_[index_id_].enty[Ny - 1].cotbeta) {
-    ilow = Ny - 2;
-    yratio = 1.f;
-
+  
+  if(cotb >= thePixelTemp_[index_id_].enty[Ny-1].cotbeta) {
+     
+     ilow = Ny-2;
+     yratio = 1.f;
+     
   } else {
-    if (cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
-      for (i = 0; i < Ny - 1; ++i) {
-        if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
-          ilow = i;
-          yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
-                   (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
-          break;
+     
+     if(cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
+        
+        for (i=0; i<Ny-1; ++i) { 
+           
+           if( thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i+1].cotbeta) {
+              
+              ilow = i;
+              yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta)/(thePixelTemp_[index_id_].enty[i+1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
+              break;			 
+           }
         }
-      }
-    }
+     } 
   }
-
-  ihigh = ilow + 1;
-
+  
+  ihigh=ilow + 1;
+  
   // Interpolate Vavilov parameters
-
-  mpvvav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav2 +
-             yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
-  sigmavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav2 +
-               yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
-  kappavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav2 +
-               yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav2;
-
+  
+  mpvvav2_   = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].mpvvav2   + yratio*thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
+  sigmavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sigmavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
+  kappavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].kappavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].kappavav2;
+  
   // Copy to parameter list
-
+  
   mpv = (double)mpvvav2_;
   sigma = (double)sigmavav2_;
   kappa = (double)kappavav2_;
-
+  
   return;
-
-}  // vavilov2_pars
+  
+} // vavilov2_pars

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -1335,13 +1335,12 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
   //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
 
-   // If the sideloading is turned on, xtemp_ and ytemp_ are already set to what they need to be.
-   // So we'll just exit.
-   if ( entry_sideloaded_ != nullptr ) {
-     success_ = true;
-     return success_ ;
-   }
-
+  // If the sideloading is turned on, xtemp_ and ytemp_ are already set to what they need to be.
+  // So we'll just exit.
+  if (entry_sideloaded_ != nullptr) {
+    success_ = true;
+    return success_;
+  }
 
   // Check to see if interpolation is valid
   if (id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
@@ -1360,9 +1359,9 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
           index_id_ = i;
           id_current_ = id;
 
-	      // Copy the detector type to the private variable
-            
-	      Dtype_ = thePixelTemp_[index_id_].head.Dtype;
+          // Copy the detector type to the private variable
+
+          Dtype_ = thePixelTemp_[index_id_].head.Dtype;
 
           // Copy the charge scaling factor to the private variable
 
@@ -1398,7 +1397,6 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 #else
     assert(index_id_ >= 0 && index_id_ < (int)thePixelTemp_.size());
 #endif
-
 
     //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)
 
@@ -1442,8 +1440,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
         break;
       default:
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-        throw cms::Exception("DataCorrupt")
-            << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
+        throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
 #else
         std::cout << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
 #endif
@@ -1499,57 +1496,54 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     // Interpolate/store all y-related quantities (flip displacements when flip_y_)
 
-
     yratio_ = yratio;
-    qavg_ = (1.f - yratio)*enty0_->qavg + yratio*enty1_->qavg;
+    qavg_ = (1.f - yratio) * enty0_->qavg + yratio * enty1_->qavg;
     qavg_ *= qcorrect;
-    symax = (1.f - yratio)*enty0_->symax + yratio*enty1_->symax;
+    symax = (1.f - yratio) * enty0_->symax + yratio * enty1_->symax;
     syparmax_ = symax;
-    sxmax = (1.f - yratio)*enty0_->sxmax + yratio*enty1_->sxmax;
-    dyone_ = (1.f - yratio)*enty0_->dyone + yratio*enty1_->dyone;
-    if(flip_y_) {
+    sxmax = (1.f - yratio) * enty0_->sxmax + yratio * enty1_->sxmax;
+    dyone_ = (1.f - yratio) * enty0_->dyone + yratio * enty1_->dyone;
+    if (flip_y_) {
       dyone_ = -dyone_;
     }
-    syone_ = (1.f - yratio)*enty0_->syone + yratio*enty1_->syone;
-    dytwo_ = (1.f - yratio)*enty0_->dytwo + yratio*enty1_->dytwo;
-    if(flip_y_) {
+    syone_ = (1.f - yratio) * enty0_->syone + yratio * enty1_->syone;
+    dytwo_ = (1.f - yratio) * enty0_->dytwo + yratio * enty1_->dytwo;
+    if (flip_y_) {
       dytwo_ = -dytwo_;
     }
-    sytwo_ = (1.f - yratio)*enty0_->sytwo + yratio*enty1_->sytwo;
-    qmin_ = (1.f - yratio)*enty0_->qmin + yratio*enty1_->qmin;
+    sytwo_ = (1.f - yratio) * enty0_->sytwo + yratio * enty1_->sytwo;
+    qmin_ = (1.f - yratio) * enty0_->qmin + yratio * enty1_->qmin;
     qmin_ *= qcorrect;
-    qmin2_ = (1.f - yratio)*enty0_->qmin2 + yratio*enty1_->qmin2;
+    qmin2_ = (1.f - yratio) * enty0_->qmin2 + yratio * enty1_->qmin2;
     qmin2_ *= qcorrect;
-    mpvvav_ = (1.f - yratio)*enty0_->mpvvav + yratio*enty1_->mpvvav;
+    mpvvav_ = (1.f - yratio) * enty0_->mpvvav + yratio * enty1_->mpvvav;
     mpvvav_ *= qcorrect;
-    sigmavav_ = (1.f - yratio)*enty0_->sigmavav + yratio*enty1_->sigmavav;
-    kappavav_ = (1.f - yratio)*enty0_->kappavav + yratio*enty1_->kappavav;
-    mpvvav2_ = (1.f - yratio)*enty0_->mpvvav2 + yratio*enty1_->mpvvav2;
+    sigmavav_ = (1.f - yratio) * enty0_->sigmavav + yratio * enty1_->sigmavav;
+    kappavav_ = (1.f - yratio) * enty0_->kappavav + yratio * enty1_->kappavav;
+    mpvvav2_ = (1.f - yratio) * enty0_->mpvvav2 + yratio * enty1_->mpvvav2;
     mpvvav2_ *= qcorrect;
-    sigmavav2_ = (1.f - yratio)*enty0_->sigmavav2 + yratio*enty1_->sigmavav2;
-    kappavav2_ = (1.f - yratio)*enty0_->kappavav2 + yratio*enty1_->kappavav2;
+    sigmavav2_ = (1.f - yratio) * enty0_->sigmavav2 + yratio * enty1_->sigmavav2;
+    kappavav2_ = (1.f - yratio) * enty0_->kappavav2 + yratio * enty1_->kappavav2;
     clsleny_ = fminf(enty0_->clsleny, enty1_->clsleny);
-    qavg_avg_ = (1.f - yratio)*enty0_->qavg_avg + yratio*enty1_->qavg_avg;
+    qavg_avg_ = (1.f - yratio) * enty0_->qavg_avg + yratio * enty1_->qavg_avg;
     qavg_avg_ *= qcorrect;
     for (i = 0; i < 2; ++i) {
-        for (j = 0; j < 5; ++j) {
+      for (j = 0; j < 5; ++j) {
         // Charge loss switches sides when cot(beta) changes sign
-        
-        
-        
-        if(flip_y_) {
-           yparl_[1-i][j] = enty0_->ypar[i][j];
-           yparh_[1-i][j] = enty1_->ypar[i][j];
+
+        if (flip_y_) {
+          yparl_[1 - i][j] = enty0_->ypar[i][j];
+          yparh_[1 - i][j] = enty1_->ypar[i][j];
         } else {
-           yparl_[i][j] = enty0_->ypar[i][j];
-           yparh_[i][j] = enty1_->ypar[i][j];
+          yparl_[i][j] = enty0_->ypar[i][j];
+          yparh_[i][j] = enty1_->ypar[i][j];
         }
-        if(flip_x_) {
-           xparly0_[1-i][j] = enty0_->xpar[i][j];
-           xparhy0_[1-i][j] = enty1_->xpar[i][j];
+        if (flip_x_) {
+          xparly0_[1 - i][j] = enty0_->xpar[i][j];
+          xparhy0_[1 - i][j] = enty1_->xpar[i][j];
         } else {
-           xparly0_[i][j] = enty0_->xpar[i][j];
-           xparhy0_[i][j] = enty1_->xpar[i][j];
+          xparly0_[i][j] = enty0_->xpar[i][j];
+          xparhy0_[i][j] = enty1_->xpar[i][j];
         }
       }
     }
@@ -1560,33 +1554,32 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       if (flip_y_) {
         yavg_[i] = -yavg_[i];
       }
-      yavg_[i]=(1.f - yratio)*enty0_->yavg[i] + yratio*enty1_->yavg[i];
-      if(flip_y_) {
+      yavg_[i] = (1.f - yratio) * enty0_->yavg[i] + yratio * enty1_->yavg[i];
+      if (flip_y_) {
         yavg_[i] = -yavg_[i];
       }
-      yrms_[i]=(1.f - yratio)*enty0_->yrms[i] + yratio*enty1_->yrms[i];
+      yrms_[i] = (1.f - yratio) * enty0_->yrms[i] + yratio * enty1_->yrms[i];
       //	      ygx0_[i]=(1.f - yratio)*enty0_->ygx0[i] + yratio*enty1_->ygx0[i];
       //	      if(flip_y_) {ygx0_[i] = -ygx0_[i];}
       //	      ygsig_[i]=(1.f - yratio)*enty0_->ygsig[i] + yratio*enty1_->ygsig[i];
       //	      xrms[i]=(1.f - yratio)*enty0_->xrms[i] + yratio*enty1_->xrms[i];
       //	      xgsig[i]=(1.f - yratio)*enty0_->xgsig[i] + yratio*enty1_->xgsig[i];
-      chi2yavg_[i]=(1.f - yratio)*enty0_->chi2yavg[i] + yratio*enty1_->chi2yavg[i];
-      chi2ymin_[i]=(1.f - yratio)*enty0_->chi2ymin[i] + yratio*enty1_->chi2ymin[i];
-      chi2xavg[i]=(1.f - yratio)*enty0_->chi2xavg[i] + yratio*enty1_->chi2xavg[i];
-      chi2xmin[i]=(1.f - yratio)*enty0_->chi2xmin[i] + yratio*enty1_->chi2xmin[i];
-      yavgc2m_[i]=(1.f - yratio)*enty0_->yavgc2m[i] + yratio*enty1_->yavgc2m[i];
-      if(flip_y_) {
+      chi2yavg_[i] = (1.f - yratio) * enty0_->chi2yavg[i] + yratio * enty1_->chi2yavg[i];
+      chi2ymin_[i] = (1.f - yratio) * enty0_->chi2ymin[i] + yratio * enty1_->chi2ymin[i];
+      chi2xavg[i] = (1.f - yratio) * enty0_->chi2xavg[i] + yratio * enty1_->chi2xavg[i];
+      chi2xmin[i] = (1.f - yratio) * enty0_->chi2xmin[i] + yratio * enty1_->chi2xmin[i];
+      yavgc2m_[i] = (1.f - yratio) * enty0_->yavgc2m[i] + yratio * enty1_->yavgc2m[i];
+      if (flip_y_) {
         yavgc2m_[i] = -yavgc2m_[i];
       }
-      yrmsc2m_[i]=(1.f - yratio)*enty0_->yrmsc2m[i] + yratio*enty1_->yrmsc2m[i];
-      chi2yavgc2m_[i]=(1.f - yratio)*enty0_->chi2yavgc2m[i] + yratio*enty1_->chi2yavgc2m[i];
+      yrmsc2m_[i] = (1.f - yratio) * enty0_->yrmsc2m[i] + yratio * enty1_->yrmsc2m[i];
+      chi2yavgc2m_[i] = (1.f - yratio) * enty0_->chi2yavgc2m[i] + yratio * enty1_->chi2yavgc2m[i];
       //	      if(flip_y_) {chi2yavgc2m_[i] = -chi2yavgc2m_[i];}
-      chi2yminc2m_[i]=(1.f - yratio)*enty0_->chi2yminc2m[i] + yratio*enty1_->chi2yminc2m[i];
+      chi2yminc2m_[i] = (1.f - yratio) * enty0_->chi2yminc2m[i] + yratio * enty1_->chi2yminc2m[i];
       //	      xrmsc2m[i]=(1.f - yratio)*enty0_->xrmsc2m[i] + yratio*enty1_->xrmsc2m[i];
-      chi2xavgc2m[i]=(1.f - yratio)*enty0_->chi2xavgc2m[i] + yratio*enty1_->chi2xavgc2m[i];
-      chi2xminc2m[i]=(1.f - yratio)*enty0_->chi2xminc2m[i] + yratio*enty1_->chi2xminc2m[i];
+      chi2xavgc2m[i] = (1.f - yratio) * enty0_->chi2xavgc2m[i] + yratio * enty1_->chi2xavgc2m[i];
+      chi2xminc2m[i] = (1.f - yratio) * enty0_->chi2xminc2m[i] + yratio * enty1_->chi2xminc2m[i];
       for (j = 0; j < 6; ++j) {
-
         yflparl_[i][j] = enty0_->yflpar[i][j];
         yflparh_[i][j] = enty1_->yflpar[i][j];
 
@@ -1601,17 +1594,16 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 
     //// Single pixel cluster probabilities
 
-    chi2yavgone_=(1.f - yratio)*enty0_->chi2yavgone + yratio*enty1_->chi2yavgone;
-    chi2yminone_=(1.f - yratio)*enty0_->chi2yminone + yratio*enty1_->chi2yminone;
-    chi2xavgone=(1.f - yratio)*enty0_->chi2xavgone + yratio*enty1_->chi2xavgone;
-    chi2xminone=(1.f - yratio)*enty0_->chi2xminone + yratio*enty1_->chi2xminone;
-    
-    fracyone_ = (1.f - yratio)*enty0_->fracyone + yratio*enty1_->fracyone;
-    fracytwo_ = (1.f - yratio)*enty0_->fracytwo + yratio*enty1_->fracytwo;
+    chi2yavgone_ = (1.f - yratio) * enty0_->chi2yavgone + yratio * enty1_->chi2yavgone;
+    chi2yminone_ = (1.f - yratio) * enty0_->chi2yminone + yratio * enty1_->chi2yminone;
+    chi2xavgone = (1.f - yratio) * enty0_->chi2xavgone + yratio * enty1_->chi2xavgone;
+    chi2xminone = (1.f - yratio) * enty0_->chi2xminone + yratio * enty1_->chi2xminone;
+
+    fracyone_ = (1.f - yratio) * enty0_->fracyone + yratio * enty1_->fracyone;
+    fracytwo_ = (1.f - yratio) * enty0_->fracytwo + yratio * enty1_->fracytwo;
     //       for(i=0; i<10; ++i) {
     //		    pyspare[i]=(1.f - yratio)*enty0_->yspare[i] + yratio*enty1_->yspare[i];
     //       }
-      
 
     // Interpolate and build the y-template
 
@@ -1623,11 +1615,11 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       for (j = 0; j < TYSIZE; ++j) {
         // Flip the basic y-template when the cotbeta is negative
 
-          if(flip_y_) {
-             ytemp_[8-i][BYM3-j]=(1.f - yratio)*enty0_->ytemp[i][j] + yratio*enty1_->ytemp[i][j];
-          } else {
-             ytemp_[i][j+2]=(1.f - yratio)*enty0_->ytemp[i][j] + yratio*enty1_->ytemp[i][j];
-          }
+        if (flip_y_) {
+          ytemp_[8 - i][BYM3 - j] = (1.f - yratio) * enty0_->ytemp[i][j] + yratio * enty1_->ytemp[i][j];
+        } else {
+          ytemp_[i][j + 2] = (1.f - yratio) * enty0_->ytemp[i][j] + yratio * enty1_->ytemp[i][j];
+        }
       }
     }
 
@@ -1729,51 +1721,48 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       }
     }
     // Pointers to the currently interpolated point.
-    entx00_ = & thePixelTemp_[index_id_].entx[iylow][ilow];
-    entx02_ = & thePixelTemp_[index_id_].entx[iylow][ihigh];
-    entx20_ = & thePixelTemp_[index_id_].entx[iyhigh][ilow];
-    entx22_ = & thePixelTemp_[index_id_].entx[iyhigh][ihigh];
-    entx21_ = & thePixelTemp_[index_id_].entx[iyhigh][imidy];
-
+    entx00_ = &thePixelTemp_[index_id_].entx[iylow][ilow];
+    entx02_ = &thePixelTemp_[index_id_].entx[iylow][ihigh];
+    entx20_ = &thePixelTemp_[index_id_].entx[iyhigh][ilow];
+    entx22_ = &thePixelTemp_[index_id_].entx[iyhigh][ihigh];
+    entx21_ = &thePixelTemp_[index_id_].entx[iyhigh][imidy];
 
     // pixmax is the maximum allowed pixel charge (used for truncation)
-    pixmax_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->pixmax + xxratio*entx02_->pixmax)
-	             + yxratio  * ((1.f - xxratio)*entx20_->pixmax + xxratio*entx22_->pixmax);
+    pixmax_ = (1.f - yxratio) * ((1.f - xxratio) * entx00_->pixmax + xxratio * entx02_->pixmax) +
+              yxratio * ((1.f - xxratio) * entx20_->pixmax + xxratio * entx22_->pixmax);
 
-
-
-    r_qMeas_qTrue_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->r_qMeas_qTrue + xxratio*entx02_->r_qMeas_qTrue)
-	                    + yxratio  * ((1.f - xxratio)*entx20_->r_qMeas_qTrue + xxratio*entx22_->r_qMeas_qTrue);
+    r_qMeas_qTrue_ = (1.f - yxratio) * ((1.f - xxratio) * entx00_->r_qMeas_qTrue + xxratio * entx02_->r_qMeas_qTrue) +
+                     yxratio * ((1.f - xxratio) * entx20_->r_qMeas_qTrue + xxratio * entx22_->r_qMeas_qTrue);
 
     for (i = 0; i < 4; ++i) {
-       xavg_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xavg[i] + xxratio*entx02_->xavg[i])
-                         + yxratio  * ((1.f - xxratio)*entx20_->xavg[i] + xxratio*entx22_->xavg[i]);
+      xavg_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xavg[i] + xxratio * entx02_->xavg[i]) +
+                 yxratio * ((1.f - xxratio) * entx20_->xavg[i] + xxratio * entx22_->xavg[i]);
       if (flip_x_) {
         xavg_[i] = -xavg_[i];
       }
 
-      xrms_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xrms[i] + xxratio*entx02_->xrms[i])
-	                 + yxratio  * ((1.f - xxratio)*entx20_->xrms[i] + xxratio*entx22_->xrms[i]);
+      xrms_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xrms[i] + xxratio * entx02_->xrms[i]) +
+                 yxratio * ((1.f - xxratio) * entx20_->xrms[i] + xxratio * entx22_->xrms[i]);
 
-         //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgx0[i] + xxratio*entx02_->xgx0[i])
-         //		          +yxratio*((1.f - xxratio)*entx20_->xgx0[i] + xxratio*entx22_->xgx0[i]);
-         
-         //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgsig[i] + xxratio*entx02_->xgsig[i])
-         //		          +yxratio*((1.f - xxratio)*entx20_->xgsig[i] + xxratio*entx22_->xgsig[i]);
+      //	      xgx0_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgx0[i] + xxratio*entx02_->xgx0[i])
+      //		          +yxratio*((1.f - xxratio)*entx20_->xgx0[i] + xxratio*entx22_->xgx0[i]);
 
-      xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xavgc2m[i] + xxratio*entx02_->xavgc2m[i])
-                            + yxratio  * ((1.f - xxratio)*entx20_->xavgc2m[i] + xxratio*entx22_->xavgc2m[i]);
+      //	      xgsig_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xgsig[i] + xxratio*entx02_->xgsig[i])
+      //		          +yxratio*((1.f - xxratio)*entx20_->xgsig[i] + xxratio*entx22_->xgsig[i]);
+
+      xavgc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xavgc2m[i] + xxratio * entx02_->xavgc2m[i]) +
+                    yxratio * ((1.f - xxratio) * entx20_->xavgc2m[i] + xxratio * entx22_->xavgc2m[i]);
       if (flip_x_) {
         xavgc2m_[i] = -xavgc2m_[i];
       }
 
-      xrmsc2m_[i] = (1.f - yxratio) * ((1.f - xxratio)*entx00_->xrmsc2m[i] + xxratio*entx02_->xrmsc2m[i])
-                            + yxratio  * ((1.f - xxratio)*entx20_->xrmsc2m[i] + xxratio*entx22_->xrmsc2m[i]);
-        //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xavgc2m[i] + xxratio*entx02_->chi2xavgc2m[i])
-         //		          +yxratio*((1.f - xxratio)*entx20_->chi2xavgc2m[i] + xxratio*entx22_->chi2xavgc2m[i]);
-         
-         //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xminc2m[i] + xxratio*entx02_->chi2xminc2m[i])
-         //		          +yxratio*((1.f - xxratio)*entx20_->chi2xminc2m[i] + xxratio*entx22_->chi2xminc2m[i]);
+      xrmsc2m_[i] = (1.f - yxratio) * ((1.f - xxratio) * entx00_->xrmsc2m[i] + xxratio * entx02_->xrmsc2m[i]) +
+                    yxratio * ((1.f - xxratio) * entx20_->xrmsc2m[i] + xxratio * entx22_->xrmsc2m[i]);
+      //	      chi2xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xavgc2m[i] + xxratio*entx02_->chi2xavgc2m[i])
+      //		          +yxratio*((1.f - xxratio)*entx20_->chi2xavgc2m[i] + xxratio*entx22_->chi2xavgc2m[i]);
+
+      //	      chi2xminc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->chi2xminc2m[i] + xxratio*entx02_->chi2xminc2m[i])
+      //		          +yxratio*((1.f - xxratio)*entx20_->chi2xminc2m[i] + xxratio*entx22_->chi2xminc2m[i]);
       //
       //  Try new interpolation scheme
       //
@@ -1783,100 +1772,105 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
       //	      chi2xmin_[i]=((1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].chi2xmin[i] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].chi2xmin[i]);
       //		  if(thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i] != 0.f) {chi2xmin_[i]=chi2xmin_[i]/thePixelTemp_[index_id_].entx[imaxx][imidy].chi2xmin[i]*chi2xmin[i];}
       //
-      chi2xavg_[i] = ((1.f - xxratio) * entx20_->chi2xavg[i] + xxratio*entx22_->chi2xavg[i]);
-      if(entx21_->chi2xavg[i] != 0.f) {
-          chi2xavg_[i]=chi2xavg_[i]/entx21_->chi2xavg[i]*chi2xavg[i];
+      chi2xavg_[i] = ((1.f - xxratio) * entx20_->chi2xavg[i] + xxratio * entx22_->chi2xavg[i]);
+      if (entx21_->chi2xavg[i] != 0.f) {
+        chi2xavg_[i] = chi2xavg_[i] / entx21_->chi2xavg[i] * chi2xavg[i];
       }
-      
-      chi2xmin_[i] = ((1.f - xxratio) * entx20_->chi2xmin[i] + xxratio*entx22_->chi2xmin[i]);
-      if(entx21_->chi2xmin[i] != 0.f) {
-          chi2xmin_[i]=chi2xmin_[i]/entx21_->chi2xmin[i]*chi2xmin[i];
+
+      chi2xmin_[i] = ((1.f - xxratio) * entx20_->chi2xmin[i] + xxratio * entx22_->chi2xmin[i]);
+      if (entx21_->chi2xmin[i] != 0.f) {
+        chi2xmin_[i] = chi2xmin_[i] / entx21_->chi2xmin[i] * chi2xmin[i];
       }
-      
-      chi2xavgc2m_[i] = ((1.f - xxratio) * entx20_->chi2xavgc2m[i] + xxratio*entx22_->chi2xavgc2m[i]);
-      if(entx21_->chi2xavgc2m[i] != 0.f) {
-          chi2xavgc2m_[i]=chi2xavgc2m_[i]/entx21_->chi2xavgc2m[i]*chi2xavgc2m[i];
+
+      chi2xavgc2m_[i] = ((1.f - xxratio) * entx20_->chi2xavgc2m[i] + xxratio * entx22_->chi2xavgc2m[i]);
+      if (entx21_->chi2xavgc2m[i] != 0.f) {
+        chi2xavgc2m_[i] = chi2xavgc2m_[i] / entx21_->chi2xavgc2m[i] * chi2xavgc2m[i];
       }
-      
-      chi2xminc2m_[i] = ((1.f - xxratio) * entx20_->chi2xminc2m[i] + xxratio*entx22_->chi2xminc2m[i]);
-      if(entx21_->chi2xminc2m[i] != 0.f) {
-          chi2xminc2m_[i]=chi2xminc2m_[i]/entx21_->chi2xminc2m[i]*chi2xminc2m[i];
+
+      chi2xminc2m_[i] = ((1.f - xxratio) * entx20_->chi2xminc2m[i] + xxratio * entx22_->chi2xminc2m[i]);
+      if (entx21_->chi2xminc2m[i] != 0.f) {
+        chi2xminc2m_[i] = chi2xminc2m_[i] / entx21_->chi2xminc2m[i] * chi2xminc2m[i];
       }
-         
-     for(j=0; j<6 ; ++j) {
+
+      for (j = 0; j < 6; ++j) {
         xflparll_[i][j] = entx00_->xflpar[i][j];
         xflparlh_[i][j] = entx02_->xflpar[i][j];
         xflparhl_[i][j] = entx20_->xflpar[i][j];
         xflparhh_[i][j] = entx22_->xflpar[i][j];
         // Since Q_fl is odd under cotalpha, it flips qutomatically, change only even terms
-        if(flip_x_ && (j == 0 || j == 2 || j == 4)) {
-           xflparll_[i][j] = -xflparll_[i][j];
-           xflparlh_[i][j] = -xflparlh_[i][j];
-           xflparhl_[i][j] = -xflparhl_[i][j];
-           xflparhh_[i][j] = -xflparhh_[i][j];
+        if (flip_x_ && (j == 0 || j == 2 || j == 4)) {
+          xflparll_[i][j] = -xflparll_[i][j];
+          xflparlh_[i][j] = -xflparlh_[i][j];
+          xflparhl_[i][j] = -xflparhl_[i][j];
+          xflparhh_[i][j] = -xflparhh_[i][j];
         }
-     }
       }
-      
-      
-      // Do the spares next
-      
-      chi2xavgone_=((1.f - xxratio)*entx20_->chi2xavgone + xxratio*entx22_->chi2xavgone);
-      if(entx21_->chi2xavgone != 0.f) {chi2xavgone_=chi2xavgone_/entx21_->chi2xavgone*chi2xavgone;}
-      
-      chi2xminone_=((1.f - xxratio)*entx20_->chi2xminone + xxratio*entx22_->chi2xminone);
-      if(entx21_->chi2xminone != 0.f) {chi2xminone_=chi2xminone_/entx21_->chi2xminone*chi2xminone;}
-      
-      fracxone_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->fracxone + xxratio*entx02_->fracxone)
-	               + yxratio  * ((1.f - xxratio)*entx20_->fracxone + xxratio*entx22_->fracxone);
-      fracxtwo_ = (1.f - yxratio) * ((1.f - xxratio)*entx00_->fracxtwo + xxratio*entx02_->fracxtwo)
-	               + yxratio  * ((1.f - xxratio)*entx20_->fracxtwo + xxratio*entx22_->fracxtwo);
-   
-      //       for(i=0; i<10; ++i) {
-      //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xspare[i] + xxratio*entx02_->xspare[i])
-      //		          +yxratio*((1.f - xxratio)*entx20_->xspare[i] + xxratio*entx22_->xspare[i]);
-      //       }
-      
-      // Interpolate and build the x-template
-      
-      //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
-      
-      cotbeta0 =  thePixelTemp_[index_id_].entx[iyhigh][0].cotbeta;
-      qxtempcor=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta0*cotbeta0+cotalpha*cotalpha));
-      
-      for(i=0; i<9; ++i) {
-         xtemp_[i][0] = 0.f;
-         xtemp_[i][1] = 0.f;
-         xtemp_[i][BXM2] = 0.f;
-         xtemp_[i][BXM1] = 0.f;
-         for(j=0; j<TXSIZE; ++j) {
-            //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
-            //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
-            //		   xtemp_[i][j+2]=(1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j];
-            if(flip_x_) {
-               xtemp_[8-i][BXM3-j] = qxtempcor*((1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j]);
-            } else {
-               xtemp_[i][j+2]      = qxtempcor*((1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j]);
-            }
-         }
+    }
+
+    // Do the spares next
+
+    chi2xavgone_ = ((1.f - xxratio) * entx20_->chi2xavgone + xxratio * entx22_->chi2xavgone);
+    if (entx21_->chi2xavgone != 0.f) {
+      chi2xavgone_ = chi2xavgone_ / entx21_->chi2xavgone * chi2xavgone;
+    }
+
+    chi2xminone_ = ((1.f - xxratio) * entx20_->chi2xminone + xxratio * entx22_->chi2xminone);
+    if (entx21_->chi2xminone != 0.f) {
+      chi2xminone_ = chi2xminone_ / entx21_->chi2xminone * chi2xminone;
+    }
+
+    fracxone_ = (1.f - yxratio) * ((1.f - xxratio) * entx00_->fracxone + xxratio * entx02_->fracxone) +
+                yxratio * ((1.f - xxratio) * entx20_->fracxone + xxratio * entx22_->fracxone);
+    fracxtwo_ = (1.f - yxratio) * ((1.f - xxratio) * entx00_->fracxtwo + xxratio * entx02_->fracxtwo) +
+                yxratio * ((1.f - xxratio) * entx20_->fracxtwo + xxratio * entx22_->fracxtwo);
+
+    //       for(i=0; i<10; ++i) {
+    //	      pxspare[i]=(1.f - yxratio)*((1.f - xxratio)*entx00_->xspare[i] + xxratio*entx02_->xspare[i])
+    //		          +yxratio*((1.f - xxratio)*entx20_->xspare[i] + xxratio*entx22_->xspare[i]);
+    //       }
+
+    // Interpolate and build the x-template
+
+    //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
+
+    cotbeta0 = thePixelTemp_[index_id_].entx[iyhigh][0].cotbeta;
+    qxtempcor =
+        std::sqrt((1.f + cotbeta * cotbeta + cotalpha * cotalpha) / (1.f + cotbeta0 * cotbeta0 + cotalpha * cotalpha));
+
+    for (i = 0; i < 9; ++i) {
+      xtemp_[i][0] = 0.f;
+      xtemp_[i][1] = 0.f;
+      xtemp_[i][BXM2] = 0.f;
+      xtemp_[i][BXM1] = 0.f;
+      for (j = 0; j < TXSIZE; ++j) {
+        //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
+        //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
+        //		   xtemp_[i][j+2]=(1.f - xxratio)*entx20_->xtemp[i][j] + xxratio*entx22_->xtemp[i][j];
+        if (flip_x_) {
+          xtemp_[8 - i][BXM3 - j] =
+              qxtempcor * ((1.f - xxratio) * entx20_->xtemp[i][j] + xxratio * entx22_->xtemp[i][j]);
+        } else {
+          xtemp_[i][j + 2] = qxtempcor * ((1.f - xxratio) * entx20_->xtemp[i][j] + xxratio * entx22_->xtemp[i][j]);
+        }
       }
-      
-      lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
-      lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
-      lorybias_ = thePixelTemp_[index_id_].head.lorybias;
-      lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
-      if(flip_x_) {
-          lorxwidth_ = -lorxwidth_; lorxbias_ = -lorxbias_;
-      }
-      if(flip_y_) {
-          lorywidth_ = -lorywidth_; lorybias_ = -lorybias_;
-      }
-      
-      
-   }
-   
-   return success_;
-} // interpolate
+    }
+
+    lorywidth_ = thePixelTemp_[index_id_].head.lorywidth;
+    lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
+    lorybias_ = thePixelTemp_[index_id_].head.lorybias;
+    lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
+    if (flip_x_) {
+      lorxwidth_ = -lorxwidth_;
+      lorxbias_ = -lorxbias_;
+    }
+    if (flip_y_) {
+      lorywidth_ = -lorywidth_;
+      lorybias_ = -lorybias_;
+    }
+  }
+
+  return success_;
+}  // interpolate
 
 // ************************************************************************************************************
 //! Interpolate input alpha and beta angles to produce a working template for each individual hit.
@@ -1923,196 +1917,198 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 //! \param      sizez - (input) pixel z-size
 // *************************************************************************************************************************************
 #ifdef SI_PIXEL_TEMPLATE_STANDALONE
-void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry, int iDtype, float locBx, float locBz, float lorwdy, float lorwdx, float q50, float fbin[3], float xsize, float ysize, float zsize)
-{
-   // Set class variables to the input parameters
-   entry_sideloaded_ = entry;    // will bypass xtemp_[] and ytemp_[] and use those from this Entry.
-  
-   enty1_ = entry;
-   enty0_ = entry;
+void SiPixelTemplate::sideload(SiPixelTemplateEntry* entry,
+                               int iDtype,
+                               float locBx,
+                               float locBz,
+                               float lorwdy,
+                               float lorwdx,
+                               float q50,
+                               float fbin[3],
+                               float xsize,
+                               float ysize,
+                               float zsize) {
+  // Set class variables to the input parameters
+  entry_sideloaded_ = entry;  // will bypass xtemp_[] and ytemp_[] and use those from this Entry.
 
-   entx00_ = entry;
-   entx02_ = entry;
-   entx20_ = entry;
-   entx22_ = entry;
-   entx21_ = entry;
+  enty1_ = entry;
+  enty0_ = entry;
 
-   Dtype_ = iDtype;
-   lorywidth_ = lorwdy;
-   lorxwidth_ = lorwdx;
-   xsize_ = xsize;
-   ysize_ = ysize;
-   zsize_ = zsize;
-   s50_ = q50;
-   qscale_ = 1.f;
-   for(int i=0; i<3; ++i) {fbin_[i] = fbin[i];}
-   
-   // Set other class variables
-   
-   // adcota_ = 0.f;
-   // adcotb_ = 0.f;
-   
-   yratio_  = 0.f;
-   yxratio_ = 0.f;
-   xxratio_ = 0.f;
-   
-   qavg_ = entry->qavg;
-   qmin_ = 0.f;
-   qmin2_ = 0.f;
+  entx00_ = entry;
+  entx02_ = entry;
+  entx20_ = entry;
+  entx22_ = entry;
+  entx21_ = entry;
 
-   pixmax_ = entry->pixmax;
-   sxmax_ = entry->sxmax;
-   symax_ = entry->symax;
-   clsleny_ = entry->clsleny;
-   clslenx_ = entry->clslenx;
+  Dtype_ = iDtype;
+  lorywidth_ = lorwdy;
+  lorxwidth_ = lorwdx;
+  xsize_ = xsize;
+  ysize_ = ysize;
+  zsize_ = zsize;
+  s50_ = q50;
+  qscale_ = 1.f;
+  for (int i = 0; i < 3; ++i) {
+    fbin_[i] = fbin[i];
+  }
 
-   scaleyavg_ = 1.f;
-   scalexavg_ = 1.f;
-   delyavg_ = 0.f;
-   delysig_ = 0.f;
+  // Set other class variables
 
-   
-   dyone_ = entry->dyone;
-   syone_ = entry->syone;
-   dytwo_ = entry->dytwo;
-   sytwo_ = entry->sytwo;
-   
-   dxone_ = entry->dxone;
-   sxone_ = entry->sxone;
-   dxtwo_ = entry->dxtwo;
-   sxtwo_ = entry->sxtwo;
+  // adcota_ = 0.f;
+  // adcotb_ = 0.f;
 
-   chi2yminone_ = 0.f;
-   chi2yavgone_ = 0.1;
-   chi2xminone_ = 0.f;
-   chi2xavgone_ = 0.1;
+  yratio_ = 0.f;
+  yxratio_ = 0.f;
+  xxratio_ = 0.f;
 
-   
-   for(int i=0; i<4 ; ++i) {
-      scalex_[i] = 1.f;
-      scaley_[i] = 1.f;
-      offsetx_[i] = 0.f;
-      offsety_[i] = 0.f;
-      xrms_[i] = 0.f;
-      yrms_[i] = 0.f;
-      xavg_[i] = 0.f;
-      yavg_[i] = 0.f;
+  qavg_ = entry->qavg;
+  qmin_ = 0.f;
+  qmin2_ = 0.f;
 
-      chi2yavg_[i] = 0.1;
-      chi2xavg_[i] = 0.1;
+  pixmax_ = entry->pixmax;
+  sxmax_ = entry->sxmax;
+  symax_ = entry->symax;
+  clsleny_ = entry->clsleny;
+  clslenx_ = entry->clslenx;
 
-      chi2xmin_[i] = 0.f;
-      chi2ymin_[i] = 0.f;
+  scaleyavg_ = 1.f;
+  scalexavg_ = 1.f;
+  delyavg_ = 0.f;
+  delysig_ = 0.f;
 
-      for(int j=0; j<6; j++){
-        yflparl_[i][j]  = yflparh_[i][j] = entry->yflpar[i][j];
-        xflparhh_[i][j] = xflparhl_[i][j] = xflparll_[i][j]  = xflparlh_[i][j] = entry->xflpar[i][j];
+  dyone_ = entry->dyone;
+  syone_ = entry->syone;
+  dytwo_ = entry->dytwo;
+  sytwo_ = entry->sytwo;
+
+  dxone_ = entry->dxone;
+  sxone_ = entry->sxone;
+  dxtwo_ = entry->dxtwo;
+  sxtwo_ = entry->sxtwo;
+
+  chi2yminone_ = 0.f;
+  chi2yavgone_ = 0.1;
+  chi2xminone_ = 0.f;
+  chi2xavgone_ = 0.1;
+
+  for (int i = 0; i < 4; ++i) {
+    scalex_[i] = 1.f;
+    scaley_[i] = 1.f;
+    offsetx_[i] = 0.f;
+    offsety_[i] = 0.f;
+    xrms_[i] = 0.f;
+    yrms_[i] = 0.f;
+    xavg_[i] = 0.f;
+    yavg_[i] = 0.f;
+
+    chi2yavg_[i] = 0.1;
+    chi2xavg_[i] = 0.1;
+
+    chi2xmin_[i] = 0.f;
+    chi2ymin_[i] = 0.f;
+
+    for (int j = 0; j < 6; j++) {
+      yflparl_[i][j] = yflparh_[i][j] = entry->yflpar[i][j];
+      xflparhh_[i][j] = xflparhl_[i][j] = xflparll_[i][j] = xflparlh_[i][j] = entry->xflpar[i][j];
+    }
+  }
+
+  sxparmax_ = entry->sxmax;
+  syparmax_ = entry->symax;
+
+  // This works only for IP-related tracks
+
+  flip_x_ = false;
+  flip_y_ = false;
+  float cotbeta = entry->cotbeta;
+  switch (Dtype_) {
+    case 0:
+      if (cotbeta < 0.f) {
+        flip_y_ = true;
       }
-   }
-
-   sxparmax_ = entry->sxmax;
-   syparmax_ = entry->symax;
-   
-   // This works only for IP-related tracks
-   
-   flip_x_ = false;
-   flip_y_ = false;
-   float cotbeta = entry->cotbeta;
-   switch(Dtype_) {
-      case 0:
-         if(cotbeta < 0.f) {
-	   flip_y_ = true;
-	 }
-         break;
-      case 1:
-         if(locBz > 0.f) {
-            flip_y_ = true;
-         }
-         break;
-      case 2:
-      case 3:
-      case 4:
-      case 5:
-         if(locBx*locBz < 0.f) {
-            flip_x_ = true;
-         }
-         if(locBx < 0.f) {
-            flip_y_ = true;
-         }
-         break;
-      default:
-	// #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-	//         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
-	//#else
-         std::cout << "SiPixelTemplate:illegal subdetector ID = " << Dtype_ << std::endl;
-	 //#endif
-   }
-
-
-   //  Calculate signed quantities
-
-   //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
-   // &&& What to do here?
-   // qxtempcor=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta0*cotbeta0+cotalpha*cotalpha));
-   float qxtempcor = 1.f;
-   
-   for(int i=0; i<9; ++i) {
-      xtemp_[i][0] = 0.f;
-      xtemp_[i][1] = 0.f;
-      xtemp_[i][BXM2] = 0.f;
-      xtemp_[i][BXM1] = 0.f;
-      for(int j=0; j<TXSIZE; ++j) {
-         if(flip_x_) {
-	    xtemp_[8-i][BXM3-j] = qxtempcor*entry_sideloaded_->xtemp[i][j];
-         } else {
-	    xtemp_[i][j+2]      = qxtempcor*entry_sideloaded_->xtemp[i][j];
-         }
+      break;
+    case 1:
+      if (locBz > 0.f) {
+        flip_y_ = true;
       }
-   }
-   
-
-   for(int i=0; i<9; ++i) {
-      ytemp_[i][0] = 0.f;
-      ytemp_[i][1] = 0.f;
-      ytemp_[i][BYM2] = 0.f;
-      ytemp_[i][BYM1] = 0.f;
-      for(int j=0; j<TYSIZE; ++j) {
-         
-         // Flip the basic y-template when the cotbeta is negative
-         
-         if(flip_y_) {
-   	    ytemp_[8-i][BYM3-j] = entry_sideloaded_->ytemp[i][j] ;
-         } else {
- 	    ytemp_[i][j+2]      = entry_sideloaded_->ytemp[i][j] ;
-         }
+      break;
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+      if (locBx * locBz < 0.f) {
+        flip_x_ = true;
       }
-   }
+      if (locBx < 0.f) {
+        flip_y_ = true;
+      }
+      break;
+    default:
+      // #ifndef SI_PIXEL_TEMPLATE_STANDALONE
+      //         throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << Dtype_ << std::endl;
+      //#else
+      std::cout << "SiPixelTemplate:illegal subdetector ID = " << Dtype_ << std::endl;
+      //#endif
+  }
 
+  //  Calculate signed quantities
 
-   // Fitted errors params
-   for(int i =0; i<2; i++){
-     for(int j=0; j<5; j++){
-         if(flip_y_){
-            yparl_[1-i][j] = yparh_[1-i][j] = entry->ypar[i][j];
-         }
-         else{
-            yparl_[i][j] = yparh_[i][j] = entry->ypar[i][j];
-         }
+  //	qxtempcor corrects the total charge to the actual track angles (not actually needed for the template fits, but useful for Guofan)
+  // &&& What to do here?
+  // qxtempcor=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta0*cotbeta0+cotalpha*cotalpha));
+  float qxtempcor = 1.f;
 
-         if(flip_x_){
-        xpar0_[1-i][j] =  xparly0_[1-i][j] = xparhy0_[1-i][j] = xparl_[1-i][j] = xparh_[1-i][j] = entry->xpar[i][j];
-         }
-         else{
-        xpar0_[i][j] =  xparly0_[i][j] = xparhy0_[i][j] = xparl_[i][j] = xparh_[i][j] = entry->xpar[i][j];
-         }
-     }
-   }
+  for (int i = 0; i < 9; ++i) {
+    xtemp_[i][0] = 0.f;
+    xtemp_[i][1] = 0.f;
+    xtemp_[i][BXM2] = 0.f;
+    xtemp_[i][BXM1] = 0.f;
+    for (int j = 0; j < TXSIZE; ++j) {
+      if (flip_x_) {
+        xtemp_[8 - i][BXM3 - j] = qxtempcor * entry_sideloaded_->xtemp[i][j];
+      } else {
+        xtemp_[i][j + 2] = qxtempcor * entry_sideloaded_->xtemp[i][j];
+      }
+    }
+  }
 
-   return;
-} // sideload
+  for (int i = 0; i < 9; ++i) {
+    ytemp_[i][0] = 0.f;
+    ytemp_[i][1] = 0.f;
+    ytemp_[i][BYM2] = 0.f;
+    ytemp_[i][BYM1] = 0.f;
+    for (int j = 0; j < TYSIZE; ++j) {
+      // Flip the basic y-template when the cotbeta is negative
+
+      if (flip_y_) {
+        ytemp_[8 - i][BYM3 - j] = entry_sideloaded_->ytemp[i][j];
+      } else {
+        ytemp_[i][j + 2] = entry_sideloaded_->ytemp[i][j];
+      }
+    }
+  }
+
+  // Fitted errors params
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 5; j++) {
+      if (flip_y_) {
+        yparl_[1 - i][j] = yparh_[1 - i][j] = entry->ypar[i][j];
+      } else {
+        yparl_[i][j] = yparh_[i][j] = entry->ypar[i][j];
+      }
+
+      if (flip_x_) {
+        xpar0_[1 - i][j] = xparly0_[1 - i][j] = xparhy0_[1 - i][j] = xparl_[1 - i][j] = xparh_[1 - i][j] =
+            entry->xpar[i][j];
+      } else {
+        xpar0_[i][j] = xparly0_[i][j] = xparhy0_[i][j] = xparl_[i][j] = xparh_[i][j] = entry->xpar[i][j];
+      }
+    }
+  }
+
+  return;
+}  // sideload
 #endif
-
-
 
 // ************************************************************************************************************
 //! Return vector of y errors (squared) for an input vector of projected signals
@@ -2598,8 +2594,7 @@ void SiPixelTemplate::ytemp(int fybin, int lybin, float ytemplate[41][BYSIZE])
 //! \param fxbin - (input) index of last bin (0-40) to fill
 //! \param xtemplate - (output) a 41x11 output buffer
 // ************************************************************************************************************
-void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE])
-{
+void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE]) {
   // Retrieve already interpolated quantities
 
   // Local variables
@@ -2621,49 +2616,49 @@ void SiPixelTemplate::xtemp(int fxbin, int lxbin, float xtemplate[41][BXSIZE])
 #else
   assert(lxbin >= 0 && lxbin < 41);
 #endif
-   
-   // Build the x-template, the central 25 bins are here in all cases
-   
-   for(i=0; i<9; ++i) {
-      for(j=0; j<BXSIZE; ++j) {
-         xtemplate[i+16][j]=xtemp_[i][j];
+
+  // Build the x-template, the central 25 bins are here in all cases
+
+  for (i = 0; i < 9; ++i) {
+    for (j = 0; j < BXSIZE; ++j) {
+      xtemplate[i + 16][j] = xtemp_[i][j];
+    }
+  }
+  for (i = 0; i < 8; ++i) {
+    xtemplate[i + 8][BXM1] = 0.f;
+    for (j = 0; j < BXM1; ++j) {
+      xtemplate[i + 8][j] = xtemp_[i][j + 1];
+    }
+  }
+  for (i = 1; i < 9; ++i) {
+    xtemplate[i + 24][0] = 0.f;
+    for (j = 0; j < BXM1; ++j) {
+      xtemplate[i + 24][j + 1] = xtemp_[i][j];
+    }
+  }
+  //  Add more bins if needed
+  if (fxbin < 8) {
+    for (i = 0; i < 8; ++i) {
+      xtemplate[i][BXM2] = 0.f;
+      xtemplate[i][BXM1] = 0.f;
+      for (j = 0; j < BXM2; ++j) {
+        xtemplate[i][j] = xtemp_[i][j + 2];
       }
-   }
-   for(i=0; i<8; ++i) {
-      xtemplate[i+8][BXM1] = 0.f;
-      for(j=0; j<BXM1; ++j) {
-         xtemplate[i+8][j]=xtemp_[i][j+1];
+    }
+  }
+  if (lxbin > 32) {
+    for (i = 1; i < 9; ++i) {
+      xtemplate[i + 32][0] = 0.f;
+      xtemplate[i + 32][1] = 0.f;
+      for (j = 0; j < BXM2; ++j) {
+        xtemplate[i + 32][j + 2] = xtemp_[i][j];
       }
-   }
-   for(i=1; i<9; ++i) {
-      xtemplate[i+24][0] = 0.f;
-      for(j=0; j<BXM1; ++j) {
-         xtemplate[i+24][j+1]=xtemp_[i][j];
-      }
-   }
-   //  Add more bins if needed
-   if(fxbin < 8) {
-      for(i=0; i<8; ++i) {
-         xtemplate[i][BXM2] = 0.f;
-         xtemplate[i][BXM1] = 0.f;
-         for(j=0; j<BXM2; ++j) {
-            xtemplate[i][j]=xtemp_[i][j+2];
-         }
-      }
-   }
-   if(lxbin > 32) {
-      for(i=1; i<9; ++i) {
-         xtemplate[i+32][0] = 0.f;
-         xtemplate[i+32][1] = 0.f;
-         for(j=0; j<BXM2; ++j) {
-            xtemplate[i+32][j+2]=xtemp_[i][j];
-         }
-      }
-   }
-   
-   return;
-   
-} // End xtemp
+    }
+  }
+
+  return;
+
+}  // End xtemp
 
 // ************************************************************************************************************
 //! Return central pixel of y template pixels above readout threshold
@@ -3026,7 +3021,7 @@ int SiPixelTemplate::qbin(int id,
   // Interpolate for a new set of track angles
 
   // &&& New approach: use cached pointers.
-   
+
   // Find the index corresponding to id
 
   int index = -1;
@@ -3150,23 +3145,23 @@ int SiPixelTemplate::qbin(int id,
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
-   dy1 = (1.f - yratio)*enty0_->dyone + yratio*enty1_->dyone;
-   if(flip_y) {
-       dy1 = -dy1;
-   }
-   sy1 = (1.f - yratio)*enty0_->syone + yratio*enty1_->syone;
-   dy2 = (1.f - yratio)*enty0_->dytwo + yratio*enty1_->dytwo;
-   if(flip_y) {
-       dy2 = -dy2;
-   }
-   sy2 = (1.f - yratio)*enty0_->sytwo + yratio*enty1_->sytwo;
-   
-   auto qavg = (1.f - yratio)*enty0_->qavg + yratio*enty1_->qavg;
-   qavg *= qcorrect;
-   auto qmin = (1.f - yratio)*enty0_->qmin + yratio*enty1_->qmin;
-   qmin *= qcorrect;
-   auto qmin2 = (1.f - yratio)*enty0_->qmin2 + yratio*enty1_->qmin2;
-   qmin2 *= qcorrect;
+  dy1 = (1.f - yratio) * enty0_->dyone + yratio * enty1_->dyone;
+  if (flip_y) {
+    dy1 = -dy1;
+  }
+  sy1 = (1.f - yratio) * enty0_->syone + yratio * enty1_->syone;
+  dy2 = (1.f - yratio) * enty0_->dytwo + yratio * enty1_->dytwo;
+  if (flip_y) {
+    dy2 = -dy2;
+  }
+  sy2 = (1.f - yratio) * enty0_->sytwo + yratio * enty1_->sytwo;
+
+  auto qavg = (1.f - yratio) * enty0_->qavg + yratio * enty1_->qavg;
+  qavg *= qcorrect;
+  auto qmin = (1.f - yratio) * enty0_->qmin + yratio * enty1_->qmin;
+  qmin *= qcorrect;
+  auto qmin2 = (1.f - yratio) * enty0_->qmin2 + yratio * enty1_->qmin2;
+  qmin2 *= qcorrect;
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
   if (qavg <= 0.f || qmin <= 0.f) {
@@ -3202,11 +3197,11 @@ int SiPixelTemplate::qbin(int id,
     }
   }
 
-  auto yavggen =(1.f - yratio)*enty0_->yavggen[binq] + yratio*enty1_->yavggen[binq];
+  auto yavggen = (1.f - yratio) * enty0_->yavggen[binq] + yratio * enty1_->yavggen[binq];
   if (flip_y) {
     yavggen = -yavggen;
   }
-  auto yrmsgen =(1.f - yratio)*enty0_->yrmsgen[binq] + yratio*enty1_->yrmsgen[binq];
+  auto yrmsgen = (1.f - yratio) * enty0_->yrmsgen[binq] + yratio * enty1_->yrmsgen[binq];
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3637,9 +3632,9 @@ void SiPixelTemplate::temperrors(int id,
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
 
-  sy1 = (1.f - yratio)*enty0_->syone + yratio*enty1_->syone;
-  sy2 = (1.f - yratio)*enty0_->sytwo + yratio*enty1_->sytwo;
-  yrms=(1.f - yratio)*enty0_->yrms[qBin] + yratio*enty1_->yrms[qBin];
+  sy1 = (1.f - yratio) * enty0_->syone + yratio * enty1_->syone;
+  sy2 = (1.f - yratio) * enty0_->sytwo + yratio * enty1_->sytwo;
+  yrms = (1.f - yratio) * enty0_->yrms[qBin] + yratio * enty1_->yrms[qBin];
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -3820,8 +3815,8 @@ void SiPixelTemplate::qbin_dist(int id,
   ihigh = ilow + 1;
 
   // Interpolate/store all y-related quantities (flip displacements when flip_y)
-  ny1_frac = (1.f - yratio)*enty0_->fracyone + yratio*enty1_->fracyone;
-  ny2_frac = (1.f - yratio)*enty0_->fracytwo + yratio*enty1_->fracytwo;
+  ny1_frac = (1.f - yratio) * enty0_->fracyone + yratio * enty1_->fracyone;
+  ny2_frac = (1.f - yratio) * enty0_->fracytwo + yratio * enty1_->fracytwo;
 
   // next, loop over all x-angle entries, first, find relevant y-slices
 
@@ -4205,9 +4200,8 @@ void SiPixelTemplate::vavilov_pars(double& mpv, double& sigma, double& kappa)
 
 }  // vavilov_pars
 
-
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce Vavilov parameters for the 2-cluster charge distribution 
+// ************************************************************************************************************
+//! Interpolate beta/alpha angles to produce Vavilov parameters for the 2-cluster charge distribution
 //! \param mpv   - (output) the Vavilov most probable charge (well, not really the most probable esp at large kappa)
 //! \param sigma - (output) the Vavilov sigma parameter
 //! \param kappa - (output) the Vavilov kappa parameter [0.01 (Landau-like) < kappa < 10 (Gaussian-like)
@@ -4240,47 +4234,46 @@ void SiPixelTemplate::vavilov2_pars(double& mpv, double& sigma, double& kappa)
 #else
   assert(Ny > 1);
 #endif
-   
-  // next, loop over all y-angle entries   
-  
+
+  // next, loop over all y-angle entries
+
   ilow = 0;
   yratio = 0.f;
-  
-  if(cotb >= thePixelTemp_[index_id_].enty[Ny-1].cotbeta) {
-     
-     ilow = Ny-2;
-     yratio = 1.f;
-     
+
+  if (cotb >= thePixelTemp_[index_id_].enty[Ny - 1].cotbeta) {
+    ilow = Ny - 2;
+    yratio = 1.f;
+
   } else {
-     
-     if(cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
-        
-        for (i=0; i<Ny-1; ++i) { 
-           
-           if( thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i+1].cotbeta) {
-              
-              ilow = i;
-              yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta)/(thePixelTemp_[index_id_].enty[i+1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
-              break;			 
-           }
+    if (cotb >= thePixelTemp_[index_id_].enty[0].cotbeta) {
+      for (i = 0; i < Ny - 1; ++i) {
+        if (thePixelTemp_[index_id_].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index_id_].enty[i + 1].cotbeta) {
+          ilow = i;
+          yratio = (cotb - thePixelTemp_[index_id_].enty[i].cotbeta) /
+                   (thePixelTemp_[index_id_].enty[i + 1].cotbeta - thePixelTemp_[index_id_].enty[i].cotbeta);
+          break;
         }
-     } 
+      }
+    }
   }
-  
-  ihigh=ilow + 1;
-  
+
+  ihigh = ilow + 1;
+
   // Interpolate Vavilov parameters
-  
-  mpvvav2_   = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].mpvvav2   + yratio*thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
-  sigmavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].sigmavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
-  kappavav2_ = (1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].kappavav2 + yratio*thePixelTemp_[index_id_].enty[ihigh].kappavav2;
-  
+
+  mpvvav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].mpvvav2 +
+             yratio * thePixelTemp_[index_id_].enty[ihigh].mpvvav2;
+  sigmavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].sigmavav2 +
+               yratio * thePixelTemp_[index_id_].enty[ihigh].sigmavav2;
+  kappavav2_ = (1.f - yratio) * thePixelTemp_[index_id_].enty[ilow].kappavav2 +
+               yratio * thePixelTemp_[index_id_].enty[ihigh].kappavav2;
+
   // Copy to parameter list
-  
+
   mpv = (double)mpvvav2_;
   sigma = (double)sigmavav2_;
   kappa = (double)kappavav2_;
-  
+
   return;
-  
-} // vavilov2_pars
+
+}  // vavilov2_pars

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -973,7 +973,7 @@ void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry,
       }
       break;
     default:
-    std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
+      std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
   }
 
   //  Calculate signed quantities

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -576,7 +576,7 @@ bool SiPixelTemplate2D::getid(int id) {
         index_id_ = i;
         id_current_ = id;
 
-        // Copy the charge scaling factor to the private variable
+        // Copy the detector type to the private variable
 
         Dtype_ = thePixelTemp_[index_id_].head.Dtype;
 
@@ -668,6 +668,7 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
   if (id != id_current_ || cotalpha != cota_current_ || cotbeta != cotb_current_) {
     cota_current_ = cotalpha;
     cotb_current_ = cotbeta;
+    // Try to find the correct template.  Fill the class variable index_id_ .
     success_ = getid(id);
   }
 
@@ -701,7 +702,7 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
     case 4:
     case 5:
       if (locBx * locBz < 0.f) {
-        cota = fabs(cotalpha);
+        cota = std::abs(cotalpha);
         flip_x_ = true;
       }
       if (locBx < 0.f) {
@@ -744,7 +745,7 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
 
   // Interpolate the absolute value of cot(beta)
 
-  acotb = fabs(cotbeta);
+  acotb = std::abs(cotbeta);
 
   if (acotb < cotbeta0_) {
     success_ = false;
@@ -883,6 +884,7 @@ bool SiPixelTemplate2D::interpolate(int id, float cotalpha, float cotbeta, float
 //! \param      sizez - (input) pixel z-size
 // *************************************************************************************************************************************
 
+#ifdef SI_PIXEL_TEMPLATE_STANDALONE
 void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry,
                                  int iDtype,
                                  float locBx,
@@ -971,11 +973,7 @@ void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry,
       }
       break;
     default:
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate2D::illegal subdetector ID = " << iDtype << std::endl;
-#else
-      std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
-#endif
+    std::cout << "SiPixelTemplate:2D:illegal subdetector ID = " << iDtype << std::endl;
   }
 
   //  Calculate signed quantities
@@ -1005,6 +1003,7 @@ void SiPixelTemplate2D::sideload(SiPixelTemplateEntry2D* entry,
   }
   return;
 }
+#endif
 
 // *************************************************************************************************************************************
 //! \param       xhit - (input) x-position of hit relative to the lower left corner of pixel[1][1] (to allow for the "padding" of the two-d clusters in the splitter)

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -1,0 +1,97 @@
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+#include "CondFormats/SiPixelTransient/interface/SiPixelUtils.h"
+#else
+#include "SiPixelUtils.h"
+#endif
+
+#include <cmath>
+
+namespace SiPixelUtils {
+
+  //-----------------------------------------------------------------------------
+  //!  A generic version of the position formula.  Since it works for both
+  //!  X and Y, in the interest of the simplicity of the code, all parameters
+  //!  are passed by the caller.  
+  //-----------------------------------------------------------------------------
+  float
+  generic_position_formula( int size,                //!< Size of this projection.
+			    int Q_f,              //!< Charge in the first pixel.
+			    int Q_l,              //!< Charge in the last pixel.
+			    float upper_edge_first_pix, //!< As the name says.
+			    float lower_edge_last_pix,  //!< As the name says.
+			    float lorentz_shift,   //!< L-shift at half thickness
+			    float theThickness,   //detector thickness
+			    float cot_angle,        //!< cot of alpha_ or beta_
+			    float pitch,            //!< thePitchX or thePitchY
+			    bool first_is_big,       //!< true if the first is big
+			    bool last_is_big,        //!< true if the last is big
+			    float eff_charge_cut_low, //!< Use edge if > W_eff  &&&
+			    float eff_charge_cut_high,//!< Use edge if < W_eff  &&&
+			    float size_cut         //!< Use edge when size == cuts
+			    )
+  {
+    
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
+    
+    float geom_center = 0.5f * ( upper_edge_first_pix + lower_edge_last_pix );
+    
+    //--- The case of only one pixel in this projection is separate.  Note that
+    //--- here first_pix == last_pix, so the average of the two is still the
+    //--- center of the pixel.
+    if ( size == 1 ) {return geom_center;}
+    
+    //--- Width of the clusters minus the edge (first and last) pixels.
+    //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
+    float W_inner      = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+    
+    //--- Predicted charge width from geometry
+    float W_pred = theThickness * cot_angle                     // geometric correction (in cm)
+      - lorentz_shift;                    // (in cm) &&& check fpix!
+    
+    //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
+    
+    //--- Total length of the two edge pixels (first+last)
+    float sum_of_edge = 2.0f;
+    if (first_is_big) sum_of_edge += 1.0f;
+    if (last_is_big)  sum_of_edge += 1.0f;
+    
+    
+    //--- The `effective' charge width -- particle's path in first and last pixels only
+    float W_eff = std::abs( W_pred ) - W_inner;
+    
+    
+    //--- If the observed charge width is inconsistent with the expectations
+    //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
+    //--- it with an *average* effective charge width, which is the average
+    //--- length of the edge pixels.
+    //
+    //  bool usedEdgeAlgo = false;
+    if ( (size >= size_cut) || (
+				( W_eff/pitch < eff_charge_cut_low ) |
+				( W_eff/pitch > eff_charge_cut_high ) ) )
+      {
+	W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+	//  usedEdgeAlgo = true;
+#ifdef EDM_ML_DEBUG
+	nRecHitsUsedEdge_++;
+#endif
+      }
+    
+    
+    //--- Finally, compute the position in this projection
+    float Qdiff = Q_l - Q_f;
+    float Qsum  = Q_l + Q_f;
+    
+    //--- Temporary fix for clusters with both first and last pixel with charge = 0
+    if (Qsum==0)
+      Qsum = 1.0f;
+
+    //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
+    float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff;
+    
+    return hit_pos;
+  }
+
+
+
+} // end of namepspace

--- a/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelUtils.cc
@@ -11,87 +11,80 @@ namespace SiPixelUtils {
   //-----------------------------------------------------------------------------
   //!  A generic version of the position formula.  Since it works for both
   //!  X and Y, in the interest of the simplicity of the code, all parameters
-  //!  are passed by the caller.  
+  //!  are passed by the caller.
   //-----------------------------------------------------------------------------
-  float
-  generic_position_formula( int size,                //!< Size of this projection.
-			    int Q_f,              //!< Charge in the first pixel.
-			    int Q_l,              //!< Charge in the last pixel.
-			    float upper_edge_first_pix, //!< As the name says.
-			    float lower_edge_last_pix,  //!< As the name says.
-			    float lorentz_shift,   //!< L-shift at half thickness
-			    float theThickness,   //detector thickness
-			    float cot_angle,        //!< cot of alpha_ or beta_
-			    float pitch,            //!< thePitchX or thePitchY
-			    bool first_is_big,       //!< true if the first is big
-			    bool last_is_big,        //!< true if the last is big
-			    float eff_charge_cut_low, //!< Use edge if > W_eff  &&&
-			    float eff_charge_cut_high,//!< Use edge if < W_eff  &&&
-			    float size_cut         //!< Use edge when size == cuts
-			    )
-  {
-    
+  float generic_position_formula(int size,                    //!< Size of this projection.
+                                 int Q_f,                     //!< Charge in the first pixel.
+                                 int Q_l,                     //!< Charge in the last pixel.
+                                 float upper_edge_first_pix,  //!< As the name says.
+                                 float lower_edge_last_pix,   //!< As the name says.
+                                 float lorentz_shift,         //!< L-shift at half thickness
+                                 float theThickness,          //detector thickness
+                                 float cot_angle,             //!< cot of alpha_ or beta_
+                                 float pitch,                 //!< thePitchX or thePitchY
+                                 bool first_is_big,           //!< true if the first is big
+                                 bool last_is_big,            //!< true if the last is big
+                                 float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
+                                 float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
+                                 float size_cut               //!< Use edge when size == cuts
+  ) {
     //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
-    
-    float geom_center = 0.5f * ( upper_edge_first_pix + lower_edge_last_pix );
-    
+
+    float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
+
     //--- The case of only one pixel in this projection is separate.  Note that
     //--- here first_pix == last_pix, so the average of the two is still the
     //--- center of the pixel.
-    if ( size == 1 ) {return geom_center;}
-    
+    if (size == 1) {
+      return geom_center;
+    }
+
     //--- Width of the clusters minus the edge (first and last) pixels.
     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-    float W_inner      = lower_edge_last_pix - upper_edge_first_pix;  // in cm
-    
+    float W_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+
     //--- Predicted charge width from geometry
-    float W_pred = theThickness * cot_angle                     // geometric correction (in cm)
-      - lorentz_shift;                    // (in cm) &&& check fpix!
-    
+    float W_pred = theThickness * cot_angle  // geometric correction (in cm)
+                   - lorentz_shift;          // (in cm) &&& check fpix!
+
     //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
-    
+
     //--- Total length of the two edge pixels (first+last)
     float sum_of_edge = 2.0f;
-    if (first_is_big) sum_of_edge += 1.0f;
-    if (last_is_big)  sum_of_edge += 1.0f;
-    
-    
+    if (first_is_big)
+      sum_of_edge += 1.0f;
+    if (last_is_big)
+      sum_of_edge += 1.0f;
+
     //--- The `effective' charge width -- particle's path in first and last pixels only
-    float W_eff = std::abs( W_pred ) - W_inner;
-    
-    
+    float W_eff = std::abs(W_pred) - W_inner;
+
     //--- If the observed charge width is inconsistent with the expectations
     //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
     //--- it with an *average* effective charge width, which is the average
     //--- length of the edge pixels.
     //
     //  bool usedEdgeAlgo = false;
-    if ( (size >= size_cut) || (
-				( W_eff/pitch < eff_charge_cut_low ) |
-				( W_eff/pitch > eff_charge_cut_high ) ) )
-      {
-	W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
-	//  usedEdgeAlgo = true;
+    if ((size >= size_cut) || ((W_eff / pitch < eff_charge_cut_low) | (W_eff / pitch > eff_charge_cut_high))) {
+      W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+                                           //  usedEdgeAlgo = true;
 #ifdef EDM_ML_DEBUG
-	nRecHitsUsedEdge_++;
+      nRecHitsUsedEdge_++;
 #endif
-      }
-    
-    
+    }
+
     //--- Finally, compute the position in this projection
     float Qdiff = Q_l - Q_f;
-    float Qsum  = Q_l + Q_f;
-    
+    float Qsum = Q_l + Q_f;
+
     //--- Temporary fix for clusters with both first and last pixel with charge = 0
-    if (Qsum==0)
+    if (Qsum == 0)
       Qsum = 1.0f;
 
     //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
-    float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff;
-    
+    float hit_pos = geom_center + 0.5f * (Qdiff / Qsum) * W_eff;
+
     return hit_pos;
   }
 
-
-
-} // end of namepspace
+}  // namespace SiPixelUtils

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -97,22 +97,6 @@ private:
   //--------------------------------------------------------------------
   //  Methods.
   //------------------------------------------------------------------
-  float generic_position_formula(int size,                    //!< Size of this projection.
-                                 int Q_f,                     //!< Charge in the first pixel.
-                                 int Q_l,                     //!< Charge in the last pixel.
-                                 float upper_edge_first_pix,  //!< As the name says.
-                                 float lower_edge_last_pix,   //!< As the name says.
-                                 float lorentz_shift,         //!< L-width
-                                 float theThickness,          //detector thickness
-                                 float cot_angle,             //!< cot of alpha_ or beta_
-                                 float pitch,                 //!< thePitchX or thePitchY
-                                 bool first_is_big,           //!< true if the first is big
-                                 bool last_is_big,            //!< true if the last is big
-                                 float eff_charge_cut_low,    //!< Use edge if > W_eff (in pix) &&&
-                                 float eff_charge_cut_high,   //!< Use edge if < W_eff (in pix) &&&
-                                 float size_cut               //!< Use edge when size == cuts
-  ) const;
-
   void collect_edge_charges(ClusterParam &theClusterParam,  //!< input, the cluster
                             int &Q_f_X,                     //!< output, Q first  in X
                             int &Q_l_X,                     //!< output, Q last   in X

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -102,7 +102,7 @@ private:
                             int &Q_l_X,                     //!< output, Q last   in X
                             int &Q_f_Y,                     //!< output, Q first  in Y
                             int &Q_l_Y                      //!< output, Q last   in Y
-  ) const;
+                            ) const;
 
   //--- Errors squared in x and y.  &&& Need to be revisited.
   float err2X(bool &, int &) const;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -102,7 +102,7 @@ private:
                             int &Q_l_X,                     //!< output, Q last   in X
                             int &Q_f_Y,                     //!< output, Q first  in Y
                             int &Q_l_Y                      //!< output, Q last   in Y
-                            ) const;
+  ) const;
 
   //--- Errors squared in x and y.  &&& Need to be revisited.
   float err2X(bool &, int &) const;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -405,7 +405,7 @@ void PixelCPEGeneric::collect_edge_charges(ClusterParam& theClusterParamBase,  /
                                            int& Q_l_X,                         //!< output, Q last   in X
                                            int& Q_f_Y,                         //!< output, Q first  in Y
                                            int& Q_l_Y                          //!< output, Q last   in Y
-                                           ) const {
+) const {
   ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
 
   // Initialize return variables.

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -2,10 +2,13 @@
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
-
-// this is needed to get errors from templates
-#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
 #include "DataFormats/DetId/interface/DetId.h"
+
+// Pixel templates contain the rec hit error parameterizaiton
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+
+// The generic formula
+#include "CondFormats/SiPixelTransient/interface/SiPixelUtils.h"
 
 // Services
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -305,7 +308,7 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
 #endif
 
   float xPos =
-      generic_position_formula(theClusterParam.theCluster->sizeX(),
+    SiPixelUtils::generic_position_formula(theClusterParam.theCluster->sizeX(),
                                Q_f_X,
                                Q_l_X,
                                local_URcorn_LLpix.x(),
@@ -327,9 +330,9 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
   if (theVerboseLevel > 20)
     cout << "\t >>> Generic:: processing Y" << endl;
 #endif
-
+  
   float yPos =
-      generic_position_formula(theClusterParam.theCluster->sizeY(),
+    SiPixelUtils::generic_position_formula(theClusterParam.theCluster->sizeY(),
                                Q_f_Y,
                                Q_l_Y,
                                local_URcorn_LLpix.y(),
@@ -343,11 +346,11 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
                                the_eff_charge_cut_lowY,
                                the_eff_charge_cut_highY,
                                the_size_cutY);  // cut for eff charge width &&&
-
+  
   // apply the lorentz offset correction
   yPos = yPos + shiftY;
-
-  // Apply irradiation corrections. NOT USED FOR NOW
+  
+  // Apply irradiation corrections
   if (IrradiationBiasCorrection_) {
     if (theClusterParam.theCluster->sizeX() == 1) {  // size=1
       // ggiurgiu@jhu.edu, 02/03/09 : for size = 1, the Lorentz shift is already accounted by the irradiation correction
@@ -384,132 +387,12 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
     }
 
   }  // if ( IrradiationBiasCorrection_ )
-
+ 
   //cout<<" in PixelCPEGeneric:localPosition - pos = "<<xPos<<" "<<yPos<<endl; //dk
-
+  
   //--- Now put the two together
   LocalPoint pos_in_local(xPos, yPos);
   return pos_in_local;
-}
-
-//-----------------------------------------------------------------------------
-//!  A generic version of the position formula.  Since it works for both
-//!  X and Y, in the interest of the simplicity of the code, all parameters
-//!  are passed by the caller.  The only class variable used by this method
-//!  is the theThickness, since that's common for both X and Y.
-//-----------------------------------------------------------------------------
-float PixelCPEGeneric::generic_position_formula(int size,                    //!< Size of this projection.
-                                                int Q_f,                     //!< Charge in the first pixel.
-                                                int Q_l,                     //!< Charge in the last pixel.
-                                                float upper_edge_first_pix,  //!< As the name says.
-                                                float lower_edge_last_pix,   //!< As the name says.
-                                                float lorentz_shift,         //!< L-shift at half thickness
-                                                float theThickness,          //detector thickness
-                                                float cot_angle,             //!< cot of alpha_ or beta_
-                                                float pitch,                 //!< thePitchX or thePitchY
-                                                bool first_is_big,           //!< true if the first is big
-                                                bool last_is_big,            //!< true if the last is big
-                                                float eff_charge_cut_low,    //!< Use edge if > W_eff  &&&
-                                                float eff_charge_cut_high,   //!< Use edge if < W_eff  &&&
-                                                float size_cut               //!< Use edge when size == cuts
-) const {
-  //cout<<" in PixelCPEGeneric:generic_position_formula - "<<endl; //dk
-
-  float geom_center = 0.5f * (upper_edge_first_pix + lower_edge_last_pix);
-
-  //--- The case of only one pixel in this projection is separate.  Note that
-  //--- here first_pix == last_pix, so the average of the two is still the
-  //--- center of the pixel.
-  if (size == 1) {
-    return geom_center;
-  }
-
-  //--- Width of the clusters minus the edge (first and last) pixels.
-  //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-  float W_inner = lower_edge_last_pix - upper_edge_first_pix;  // in cm
-
-  //--- Predicted charge width from geometry
-  float W_pred = theThickness * cot_angle  // geometric correction (in cm)
-                 - lorentz_shift;          // (in cm) &&& check fpix!
-
-  //cout<<" in PixelCPEGeneric:generic_position_formula - "<<W_inner<<" "<<W_pred<<endl; //dk
-
-  //--- Total length of the two edge pixels (first+last)
-  float sum_of_edge = 2.0f;
-  if (first_is_big)
-    sum_of_edge += 1.0f;
-  if (last_is_big)
-    sum_of_edge += 1.0f;
-
-  //--- The `effective' charge width -- particle's path in first and last pixels only
-  float W_eff = std::abs(W_pred) - W_inner;
-
-  //--- If the observed charge width is inconsistent with the expectations
-  //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
-  //--- it with an *average* effective charge width, which is the average
-  //--- length of the edge pixels.
-  //
-  //  bool usedEdgeAlgo = false;
-  if ((size >= size_cut) || ((W_eff / pitch < eff_charge_cut_low) | (W_eff / pitch > eff_charge_cut_high))) {
-    W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
-                                         //  usedEdgeAlgo = true;
-#ifdef EDM_ML_DEBUG
-    nRecHitsUsedEdge_++;
-#endif
-  }
-
-  //--- Finally, compute the position in this projection
-  float Qdiff = Q_l - Q_f;
-  float Qsum = Q_l + Q_f;
-
-  //--- Temporary fix for clusters with both first and last pixel with charge = 0
-  if (Qsum == 0)
-    Qsum = 1.0f;
-  //float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
-  float hit_pos = geom_center + 0.5f * (Qdiff / Qsum) * W_eff;
-
-  //cout<<" in PixelCPEGeneric:generic_position_formula - "<<hit_pos<<" "<<lorentz_shift*0.5<<endl; //dk
-
-#ifdef EDM_ML_DEBUG
-  //--- Debugging output
-#warning "Debug printouts in PixelCPEGeneric.cc has been commented because they cannot be compiled"
-  /*   This part is commented because some variables used here are not defined !!
-    if (theVerboseLevel > 20) {
-    if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel || theDetParam.thePart == GeomDetEnumerators::P1PXB ) {
-    cout << "\t >>> We are in the Barrel." ;
-    } else if ( theDetParam.thePart == GeomDetEnumerators::PixelEndcap ||
-    theDetParam.thePart == GeomDetEnumerators::P1PXEC ||
-    theDetParam.thePart == GeomDetEnumerators::P2PXEC ) {
-    cout << "\t >>> We are in the Forward." ;
-    } else {
-    cout << "\t >>> We are in an unexpected subdet " << theDetParam.thePart;
-    }
-    cout
-    << "\n\t >>> cot(angle) = " << cot_angle << "  pitch = " << pitch << "  size = " << size
-    << "\n\t >>> upper_edge_first_pix = " << upper_edge_first_pix
-    << "\n\t >>> lower_edge_last_pix  = " << lower_edge_last_pix
-    << "\n\t >>> geom_center          = " << geom_center
-    << "\n\t >>> half_lorentz_shift   = " << half_lorentz_shift
-    << "\n\t >>> W_inner              = " << W_inner
-    << "\n\t >>> W_pred               = " << W_pred
-    << "\n\t >>> W_eff(orig)          = " << fabs( W_pred ) - W_inner
-    << "\n\t >>> W_eff(used)          = " << W_eff
-    << "\n\t >>> sum_of_edge          = " << sum_of_edge
-    << "\n\t >>> Qdiff = " << Qdiff << "  Qsum = " << Qsum
-    << "\n\t >>> hit_pos              = " << hit_pos
-    << "\n\t >>> RecHits: total = " << nRecHitsTotal_
-    << "  used edge = " << nRecHitsUsedEdge_
-    << endl;
-    if (usedEdgeAlgo)
-    cout << "\n\t >>> Used Edge algorithm." ;
-    else
-    cout << "\n\t >>> Used angle information." ;
-    cout << endl;
-    }
-    */
-#endif
-
-  return hit_pos;
 }
 
 //-----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -307,21 +307,21 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
     cout << "\t >>> Generic:: processing X" << endl;
 #endif
 
-  float xPos =
-    SiPixelUtils::generic_position_formula(theClusterParam.theCluster->sizeX(),
-                               Q_f_X,
-                               Q_l_X,
-                               local_URcorn_LLpix.x(),
-                               local_LLcorn_URpix.x(),
-                               chargeWidthX,  // lorentz shift in cm
-                               theDetParam.theThickness,
-                               theClusterParam.cotalpha,
-                               theDetParam.thePitchX,
-                               theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->minPixelRow()),
-                               theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->maxPixelRow()),
-                               the_eff_charge_cut_lowX,
-                               the_eff_charge_cut_highX,
-                               the_size_cutX);  // cut for eff charge width &&&
+  float xPos = SiPixelUtils::generic_position_formula(
+      theClusterParam.theCluster->sizeX(),
+      Q_f_X,
+      Q_l_X,
+      local_URcorn_LLpix.x(),
+      local_LLcorn_URpix.x(),
+      chargeWidthX,  // lorentz shift in cm
+      theDetParam.theThickness,
+      theClusterParam.cotalpha,
+      theDetParam.thePitchX,
+      theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->minPixelRow()),
+      theDetParam.theRecTopol->isItBigPixelInX(theClusterParam.theCluster->maxPixelRow()),
+      the_eff_charge_cut_lowX,
+      the_eff_charge_cut_highX,
+      the_size_cutX);  // cut for eff charge width &&&
 
   // apply the lorentz offset correction
   xPos = xPos + shiftX;
@@ -330,26 +330,26 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
   if (theVerboseLevel > 20)
     cout << "\t >>> Generic:: processing Y" << endl;
 #endif
-  
-  float yPos =
-    SiPixelUtils::generic_position_formula(theClusterParam.theCluster->sizeY(),
-                               Q_f_Y,
-                               Q_l_Y,
-                               local_URcorn_LLpix.y(),
-                               local_LLcorn_URpix.y(),
-                               chargeWidthY,  // lorentz shift in cm
-                               theDetParam.theThickness,
-                               theClusterParam.cotbeta,
-                               theDetParam.thePitchY,
-                               theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->minPixelCol()),
-                               theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->maxPixelCol()),
-                               the_eff_charge_cut_lowY,
-                               the_eff_charge_cut_highY,
-                               the_size_cutY);  // cut for eff charge width &&&
-  
+
+  float yPos = SiPixelUtils::generic_position_formula(
+      theClusterParam.theCluster->sizeY(),
+      Q_f_Y,
+      Q_l_Y,
+      local_URcorn_LLpix.y(),
+      local_LLcorn_URpix.y(),
+      chargeWidthY,  // lorentz shift in cm
+      theDetParam.theThickness,
+      theClusterParam.cotbeta,
+      theDetParam.thePitchY,
+      theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->minPixelCol()),
+      theDetParam.theRecTopol->isItBigPixelInY(theClusterParam.theCluster->maxPixelCol()),
+      the_eff_charge_cut_lowY,
+      the_eff_charge_cut_highY,
+      the_size_cutY);  // cut for eff charge width &&&
+
   // apply the lorentz offset correction
   yPos = yPos + shiftY;
-  
+
   // Apply irradiation corrections
   if (IrradiationBiasCorrection_) {
     if (theClusterParam.theCluster->sizeX() == 1) {  // size=1
@@ -387,9 +387,9 @@ LocalPoint PixelCPEGeneric::localPosition(DetParam const& theDetParam, ClusterPa
     }
 
   }  // if ( IrradiationBiasCorrection_ )
- 
+
   //cout<<" in PixelCPEGeneric:localPosition - pos = "<<xPos<<" "<<yPos<<endl; //dk
-  
+
   //--- Now put the two together
   LocalPoint pos_in_local(xPos, yPos);
   return pos_in_local;
@@ -405,7 +405,7 @@ void PixelCPEGeneric::collect_edge_charges(ClusterParam& theClusterParamBase,  /
                                            int& Q_l_X,                         //!< output, Q last   in X
                                            int& Q_f_Y,                         //!< output, Q first  in Y
                                            int& Q_l_Y                          //!< output, Q last   in Y
-) const {
+                                           ) const {
   ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
 
   // Initialize return variables.

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -65,7 +65,7 @@
 // Use current version of gsl instead of ROOT::Math
 //#include <gsl/gsl_cdf.h>
 
-static const int theVerboseLevel = 2;   
+static const int theVerboseLevel = 2;
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/VVIObjF.h"
@@ -177,14 +177,14 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
   const double mean1pix = {0.100};
 #ifdef SI_PIXEL_TEMPLATE_STANDALONE
   const double chi21min = {0.};
-#else 
+#else
   const double chi21min = {0.160};
 #endif
 
   // First, interpolate the template needed to analyze this cluster
   // check to see of the track direction is in the physical range of the loaded template
 
-  if(id > 0) { //if id == 0 bypass interpolation (used in calibration)
+  if (id > 0) {  //if id == 0 bypass interpolation (used in calibration)
     if (!templ.interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
       if (theVerboseLevel > 2) {
         LOGDEBUG("SiPixelTemplateReco") << "input cluster direction cot(alpha) = " << cotalpha

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco.cc
@@ -65,19 +65,18 @@
 // Use current version of gsl instead of ROOT::Math
 //#include <gsl/gsl_cdf.h>
 
+static const int theVerboseLevel = 2;   
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
 #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/VVIObjF.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) edm::LogError(x)
 #define LOGDEBUG(x) LogDebug(x)
-static const int theVerboseLevel = 2;
 #define ENDL " "
 #include "FWCore/Utilities/interface/Exception.h"
 #else
 #include "SiPixelTemplateReco.h"
 #include "VVIObjF.h"
-//static int theVerboseLevel = {2};
 #define LOGERROR(x) std::cout << x << ": "
 #define LOGDEBUG(x) std::cout << x << ": "
 #define ENDL std::endl
@@ -175,19 +174,26 @@ int SiPixelTemplateReco::PixelTempReco1D(int id,
 
   // The minimum chi2 for a valid one pixel cluster = pseudopixel contribution only
 
-  const double mean1pix = {0.100}, chi21min = {0.160};
+  const double mean1pix = {0.100};
+#ifdef SI_PIXEL_TEMPLATE_STANDALONE
+  const double chi21min = {0.};
+#else 
+  const double chi21min = {0.160};
+#endif
 
   // First, interpolate the template needed to analyze this cluster
   // check to see of the track direction is in the physical range of the loaded template
 
-  if (!templ.interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
-    if (theVerboseLevel > 2) {
-      LOGDEBUG("SiPixelTemplateReco") << "input cluster direction cot(alpha) = " << cotalpha
-                                      << ", cot(beta) = " << cotbeta << ", local B_z = " << locBz
-                                      << ", local B_x = " << locBx << ", template ID = " << id
-                                      << ", no reconstruction performed" << ENDL;
+  if(id > 0) { //if id == 0 bypass interpolation (used in calibration)
+    if (!templ.interpolate(id, cotalpha, cotbeta, locBz, locBx)) {
+      if (theVerboseLevel > 2) {
+        LOGDEBUG("SiPixelTemplateReco") << "input cluster direction cot(alpha) = " << cotalpha
+                                        << ", cot(beta) = " << cotbeta << ", local B_z = " << locBz
+                                        << ", local B_x = " << locBx << ", template ID = " << id
+                                        << ", no reconstruction performed" << ENDL;
+      }
+      return 20;
     }
-    return 20;
   }
 
   // Check to see if Q probability is selected

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -113,7 +113,7 @@ int SiPixelTemplateReco2D::PixelTempReco2D(int id,
 
   // Extract some relevant info from the 2D template
 
-  if (id > 0) { // if id==0, bypass interpolation (used in calibration)
+  if (id > 0) {  // if id==0, bypass interpolation (used in calibration)
     if (!templ2D.interpolate(id, cotalpha, cotbeta, locBz, locBx))
       return 4;
   }

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateReco2D.cc
@@ -113,7 +113,7 @@ int SiPixelTemplateReco2D::PixelTempReco2D(int id,
 
   // Extract some relevant info from the 2D template
 
-  if (id > 0) {
+  if (id > 0) { // if id==0, bypass interpolation (used in calibration)
     if (!templ2D.interpolate(id, cotalpha, cotbeta, locBz, locBx))
       return 4;
   }


### PR DESCRIPTION
This is a PR to sync with changes made to the pixel calibration procedure. The idea is to call the actual CMSSW functions that are used in the pixel calibrations procedure rather than separately coded versions of them (like was done previously). To do this we needed to modify the objects and code structure a bit. The most significant changes are adding a sideload() function to SiPixelTemplate object to allow loading of partial templates, and moving the generic_position_formula() to a separate file.

These changes are all internal to the pixel code and we expect no changes in output.

We have tested by running the tracking validation and seeing that the PR makes no difference in the output at all.

Slides about this were shown in the pixel offline meeting. [Here](https://indico.cern.ch/event/879467/contributions/3746113/attachments/1985814/3308855/sideload_PR_feb11.pdf)

@cmantill @pmaksim1 @tvami @mmusich @tsusa 