### PR TITLE
[URGENT] fix for getting clang version which is breaking 11.1.0.pre3 release

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -352,7 +352,7 @@ def get_clang_version():
         return clang_version
     command = "clang --version | grep 'clang version' | sed 's/clang version//'"
     logging.debug("Running: {0}".format(command))
-    (clang_version_major, clang_version_minor, clang_version_patchlevel) = subprocess.check_output(command, shell=True).splitlines()[0].decode('ascii').strip().split('.', 3)
+    (clang_version_major, clang_version_minor, clang_version_patchlevel) = subprocess.check_output(command, shell=True).splitlines()[0].decode('ascii').strip().split(" ")[0].split('.', 3)
     clang_version = (int(clang_version_major), int(clang_version_minor), int(clang_version_patchlevel))
     logging.debug("Detected Clang version: {0}".format(clang_version))
     return clang_version


### PR DESCRIPTION
#### PR description:

11.1.0.pre3 build are failing with error [a]. Looks like, while building release, clang returns something like
```
clang --version | grep 'clang version'
clang version 9.0.1 (/data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_1_0_pre3-slc7_amd64_gcc900/build/CMSSW_11_1_0_pre3-build/BUILD/slc7_amd64_gcc900/external/llvm/9.0.1/llvm-9.0.1-379a43bc841451feccf78db64f2ed5c9e62c7de8/clang 9979c02b51651889403625605dbd1409249d29fd)
```
note the extra `(...)` part which breaks `condformats_serialization_generate.py`. No idea why it is not failing for IBs where clang properly returns
```
>pwd
/build/muz/d/CMSSW_11_1_X_2020-02-12-2300
>clang --version | grep 'clang version'
clang version 9.0.1
```

this change makes sure that we only process the first part of version starting. We need to get this in as soon as possible to get going with 11.1.0.pre3 build

[a]
```
File ".../CMSSW_11_1_0_pre3/src/CondFormats/Serialization/python/condformats_serialization_generate.py", line 355, in get_clang_version
(clang_version_major, clang_version_minor, clang_version_patchlevel) = subprocess.check_output(command, shell=True).splitlines()[0].decode('ascii').strip().split('.', 3) ValueError: too many values to unpack
```