### PR TITLE
[DD4hep] DDNamespace::name Issue #28949

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
@@ -35,7 +35,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   Volume mother = ns.volume(args.parentName());
   string childName = args.value<string>("ChildName");
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
   Volume child = ns.volume(childName);
 
   double delta = 0e0;

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
@@ -34,8 +34,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
   vector<double> rotateSolid = args.value<vector<double> >("RotateSolid");
   Volume mother = ns.volume(args.parentName());
   string childName = args.value<string>("ChildName");
-  if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.prepend(childName);
+  childName = ns.prepend(childName);
   Volume child = ns.volume(childName);
 
   double delta = 0e0;

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -832,16 +832,10 @@ void Converter<DDLTransform3D>::operator()(xml_h element) const {
     double z = ns.attr<double>(rotation, _U(z));
     rot = RotationZYX(z, y, x);
   } else if (refRotation.ptr()) {
-    string rotName = refRotation.nameStr();
-    if (strchr(rotName.c_str(), NAMESPACE_SEP) == nullptr)
-      rotName = ns.prepend(rotName);
-
+    string rotName = ns.prepend(refRotation.nameStr());
     rot = ns.rotation(rotName);
   } else if (refReflectionRotation.ptr()) {
-    string rotName = refReflectionRotation.nameStr();
-    if (strchr(rotName.c_str(), NAMESPACE_SEP) == nullptr)
-      rotName = ns.prepend(rotName);
-
+    string rotName = ns.prepend(refReflectionRotation.nameStr());
     rot = ns.rotation(rotName);
   }
   *tr = Transform3D(rot, pos);

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -834,13 +834,13 @@ void Converter<DDLTransform3D>::operator()(xml_h element) const {
   } else if (refRotation.ptr()) {
     string rotName = refRotation.nameStr();
     if (strchr(rotName.c_str(), NAMESPACE_SEP) == nullptr)
-      rotName = ns.name() + rotName;
+      rotName = ns.prepend(rotName);
 
     rot = ns.rotation(rotName);
   } else if (refReflectionRotation.ptr()) {
     string rotName = refReflectionRotation.nameStr();
     if (strchr(rotName.c_str(), NAMESPACE_SEP) == nullptr)
-      rotName = ns.name() + rotName;
+      rotName = ns.prepend(rotName);
 
     rot = ns.rotation(rotName);
   }
@@ -868,11 +868,11 @@ void Converter<DDLPosPart>::operator()(xml_h element) const {
            copy);
 
   if (!parent.isValid() && strchr(parentName.c_str(), NAMESPACE_SEP) == nullptr)
-    parentName = ns.name() + parentName;
+    parentName = ns.prepend(parentName);
   parent = ns.volume(parentName);
 
   if (!child.isValid() && strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
   child = ns.volume(childName, false);
 
   printout(ns.context()->debug_placements ? ALWAYS : DEBUG,
@@ -1558,11 +1558,11 @@ void Converter<DDLDivision>::operator()(xml_h element) const {
   xml_dim_t e(element);
   string childName = e.nameStr();
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
 
   string parentName = ns.attr<string>(e, DD_CMU(parent));
   if (strchr(parentName.c_str(), NAMESPACE_SEP) == nullptr)
-    parentName = ns.name() + parentName;
+    parentName = ns.prepend(parentName);
   string axis = ns.attr<string>(e, DD_CMU(axis));
 
   // If you divide a tube of 360 degrees the offset displaces

--- a/Geometry/HGCalCommonData/interface/AHCalParameters.h
+++ b/Geometry/HGCalCommonData/interface/AHCalParameters.h
@@ -11,6 +11,7 @@ class AHCalParameters {
 public:
   /** Create geometry of AHCal */
   AHCalParameters(edm::ParameterSet const&);
+  AHCalParameters() = delete;
   ~AHCalParameters() {}
 
   /// get maximum number of layers
@@ -30,7 +31,6 @@ public:
   static constexpr int kSignRowColumn_ = kSign_ * kRowColumn_;
 
 private:
-  AHCalParameters() = delete;
   const int maxDepth_;
   const double deltaX_, deltaY_, deltaZ_, zFirst_;
 };

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
@@ -64,9 +64,8 @@ static long algorithm(dd4hep::Detector& /* description */,
     edm::LogVerbatim("HGCalGeom") << " [" << i << "] " << tileN[i] << ":" << tileStep[i];
 #endif
   const auto& zMinBlock = args.value<double>("zMinBlock");        // Starting z-value of the block
-  std::string idNameSpace = static_cast<std::string>(ns.name());  // Namespace of this and ALL sub-parts
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalModule: zStart " << zMinBlock << "  NameSpace " << idNameSpace;
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalModule: zStart " << zMinBlock << "  NameSpace " << ns.name();
 #endif
 
   // Mother module

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
@@ -63,7 +63,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   for (unsigned int i = 0; i < tileN.size(); ++i)
     edm::LogVerbatim("HGCalGeom") << " [" << i << "] " << tileN[i] << ":" << tileStep[i];
 #endif
-  const auto& zMinBlock = args.value<double>("zMinBlock");        // Starting z-value of the block
+  const auto& zMinBlock = args.value<double>("zMinBlock");  // Starting z-value of the block
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "DDHGCalModule: zStart " << zMinBlock << "  NameSpace " << ns.name();
 #endif

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
@@ -57,7 +57,6 @@ struct HGCalEEAlgo {
   std::vector<double> slopeT_;          // Slopes at the larger R
   std::vector<double> zFrontT_;         // Starting Z values for the slopes
   std::vector<double> rMaxFront_;       // Corresponding rMax's
-  std::string nameSpace_;               // Namespace of this and ALL sub-parts
   std::unordered_set<int> copies_;      // List of copy #'s
   double alpha_, cosAlpha_;
 
@@ -168,9 +167,8 @@ struct HGCalEEAlgo {
                                     << " Slope " << slopeT_[i];
 #endif
 
-    nameSpace_ = static_cast<std::string>(ns.name());
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalEEAlgo: NameSpace " << nameSpace_;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalEEAlgo: NameSpace " << ns.name();
 #endif
 
     waferType_ = std::make_unique<HGCalWaferType>(
@@ -221,7 +219,7 @@ struct HGCalEEAlgo {
         zz += hthick;
         thickTot += thick_[ii];
 
-        std::string name = nameSpace_ + names_[ii] + std::to_string(copy);
+        std::string name = ns.prepend(names_[ii]) + std::to_string(copy);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalEEAlgo: Layer " << ly << ":" << ii << " Front " << zi << ", " << routF
                                       << " Back " << zo << ", " << rinB << " superlayer thickness " << layerThick_[i];

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
@@ -23,17 +23,14 @@ static long algorithm(dd4hep::Detector& /* description */,
   auto const& m_startCopyNo = args.value<int>("startCopyNo");       // Start copy Number
   auto const& m_incrCopyNo = args.value<int>("incrCopyNo");         // Increment copy Number
   auto const& m_childName = args.value<std::string>("ChildName");   // Children name
-  std::string m_idNameSpace = static_cast<std::string>(ns.name());  // Namespace of this and ALL sub-parts
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalNoTaperEndcap: NameSpace " << m_idNameSpace << "\tParent "
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalNoTaperEndcap: NameSpace " << ns.name() << "\tParent "
                                 << args.parentName();
 #endif
 
   dd4hep::Volume parent = ns.volume(args.parentName());
-  std::string name(m_childName);
-  if (strchr(name.c_str(), NAMESPACE_SEP) == nullptr)
-    name = ns.name() + name;
+  std::string name = ns.prepend(m_childName);
 
   const int ix[4] = {1, -1, -1, 1};
   const int iy[4] = {1, 1, -1, -1};

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
@@ -15,18 +15,17 @@ static long algorithm(dd4hep::Detector& /* description */,
   cms::DDAlgoArguments args(ctxt, e);
   std::string motherName = args.parentName();
 
-  auto const& m_tiltAngle = args.value<double>("tiltAngle");        // Tilt  angle
-  auto const& m_rMin = args.value<double>("rMin");                  // Inner radius
-  auto const& m_rMax = args.value<double>("rMax");                  // Outer radius
-  auto const& m_zoffset = args.value<double>("zoffset");            // Offset in z
-  auto const& m_xyoffset = args.value<double>("xyoffset");          // Offset in x or y
-  auto const& m_startCopyNo = args.value<int>("startCopyNo");       // Start copy Number
-  auto const& m_incrCopyNo = args.value<int>("incrCopyNo");         // Increment copy Number
-  auto const& m_childName = args.value<std::string>("ChildName");   // Children name
+  auto const& m_tiltAngle = args.value<double>("tiltAngle");       // Tilt  angle
+  auto const& m_rMin = args.value<double>("rMin");                 // Inner radius
+  auto const& m_rMax = args.value<double>("rMax");                 // Outer radius
+  auto const& m_zoffset = args.value<double>("zoffset");           // Offset in z
+  auto const& m_xyoffset = args.value<double>("xyoffset");         // Offset in x or y
+  auto const& m_startCopyNo = args.value<int>("startCopyNo");      // Start copy Number
+  auto const& m_incrCopyNo = args.value<int>("incrCopyNo");        // Increment copy Number
+  auto const& m_childName = args.value<std::string>("ChildName");  // Children name
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalNoTaperEndcap: NameSpace " << ns.name() << "\tParent "
-                                << args.parentName();
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalNoTaperEndcap: NameSpace " << ns.name() << "\tParent " << args.parentName();
 #endif
 
   dd4hep::Volume parent = ns.volume(args.parentName());

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
@@ -128,8 +128,7 @@ namespace DDHGCalGeom {
                 if (layerSense[ly] == 1) {
                   dd4hep::Solid solid = ns.solid(covers[0]);
                   std::string name0 = name + "M" + std::to_string(copyx);
-                  if (strchr(name0.c_str(), NAMESPACE_SEP) == nullptr)
-                    name0 = ns.name() + name0;
+		  name0 = ns.prepend(name0);
                   dd4hep::Volume glog1 = dd4hep::Volume(name0, solid, matter);
                   module.placeVolume(glog1, copy, tran);
 #ifdef EDM_ML_DEBUG

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
@@ -128,7 +128,7 @@ namespace DDHGCalGeom {
                 if (layerSense[ly] == 1) {
                   dd4hep::Solid solid = ns.solid(covers[0]);
                   std::string name0 = name + "M" + std::to_string(copyx);
-		  name0 = ns.prepend(name0);
+                  name0 = ns.prepend(name0);
                   dd4hep::Volume glog1 = dd4hep::Volume(name0, solid, matter);
                   module.placeVolume(glog1, copy, tran);
 #ifdef EDM_ML_DEBUG

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
@@ -29,8 +29,7 @@ static long algorithm(dd4hep::Detector& /* description */,
                                   << angles[k] << " detector " << detectorType[k];
 
   std::string idName = args.parentName();                         // Name of the "parent" volume.
-  std::string idNameSpace = static_cast<std::string>(ns.name());  // Namespace of this and ALL sub-parts
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferAlgo debug: Parent " << idName << " NameSpace " << idNameSpace;
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferAlgo debug: Parent " << idName << " NameSpace " << ns.name();
 #endif
 
   dd4hep::Volume mother = ns.volume(args.parentName());
@@ -39,8 +38,7 @@ static long algorithm(dd4hep::Detector& /* description */,
 
   for (unsigned int k = 0; k < positionX.size(); ++k) {
     std::string name(childNames[detectorType[k]]);
-    if (strchr(name.c_str(), NAMESPACE_SEP) == nullptr)
-      name = ns.name() + name;
+    name = ns.prepend(name);
     dd4hep::Rotation3D rotation;
     if (angles[k] != 0) {
       double phi = convertDegToRad(angles[k]);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
@@ -28,7 +28,7 @@ static long algorithm(dd4hep::Detector& /* description */,
     edm::LogVerbatim("HGCalGeom") << "[" << k << "] x " << positionX[k] << " y " << positionY[k] << " angle "
                                   << angles[k] << " detector " << detectorType[k];
 
-  std::string idName = args.parentName();                         // Name of the "parent" volume.
+  std::string idName = args.parentName();  // Name of the "parent" volume.
   edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferAlgo debug: Parent " << idName << " NameSpace " << ns.name();
 #endif
 

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
@@ -23,8 +23,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   double zoffset = args.value<double>("zoffset");        //z offset
   dd4hep::Volume mother = ns.volume(args.parentName());
   std::string childName = args.value<std::string>("ChildName");
-  if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+  childName = ns.prepend(childName);
   dd4hep::Volume child = ns.volume(childName);
 
   // Increment

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapAlgo.cc
@@ -84,7 +84,6 @@ struct HCalEndcapAlgo {
   std::string scintMat;                //Scintillator material
   std::string rotmat;                  //Rotation matrix for positioning
   std::string idName;                  //Name of the "parent" volume.
-  std::string idNameSpace;             //Namespace of this and ALL sub-parts
   int idOffset;                        // Geant4 ID's...    = 4000;
   double tolPos, tolAbs;               //Tolerances
 
@@ -306,11 +305,10 @@ struct HCalEndcapAlgo {
 #endif
 
     idName = args.value<std::string>("MotherName");
-    idNameSpace = static_cast<std::string>(ns.name());
     idOffset = args.value<int>("IdOffset");
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Parent " << args.parentName() << " idName " << idName
-                                 << " NameSpace " << idNameSpace << " Offset " << idOffset;
+                                 << " NameSpace " << ns.name() << " Offset " << idOffset;
 #endif
 
     tolPos = args.value<double>("TolPos");

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
@@ -48,9 +48,9 @@ struct HCalEndcapModuleAlgo {
   std::vector<std::string> phiName;    //Name of Phi sections
   std::vector<std::string> layerName;  //Layer Names
 
-  std::string idName;       //Name of the "parent" volume.
-  std::string modName;      //Module Name
-  int idOffset;             // Geant4 ID's...    = 4000;
+  std::string idName;   //Name of the "parent" volume.
+  std::string modName;  //Module Name
+  int idOffset;         // Geant4 ID's...    = 4000;
 
   struct HcalEndcapPar {
     double yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos;

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
@@ -12,7 +12,6 @@
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DD4hep/DetFactoryHelper.h"
-#include "DetectorDescription/Core/interface/DDSplit.h"
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -50,7 +49,6 @@ struct HCalEndcapModuleAlgo {
   std::vector<std::string> layerName;  //Layer Names
 
   std::string idName;       //Name of the "parent" volume.
-  std::string idNameSpace;  //Namespace of this and ALL sub-parts
   std::string modName;      //Module Name
   int idOffset;             // Geant4 ID's...    = 4000;
 
@@ -154,12 +152,11 @@ struct HCalEndcapModuleAlgo {
       edm::LogVerbatim("HCalGeom") << "LayerName[" << i << "] = " << layerName[i];
 #endif
     idName = args.value<std::string>("MotherName");
-    idNameSpace = static_cast<std::string>(ns.name());
     idOffset = args.value<int>("IdOffset");
     modName = args.value<std::string>("ModName");
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: Parent " << args.parentName() << "   " << modName
-                                 << " idName " << idName << " NameSpace " << idNameSpace << " Offset " << idOffset;
+                                 << " idName " << idName << " NameSpace " << ns.name() << " Offset " << idOffset;
 #endif
 
 #ifdef EDM_ML_DEBUG

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
@@ -15,7 +15,6 @@ static long algorithm(dd4hep::Detector& /* description */,
   cms::DDAlgoArguments args(ctxt, e);
 
   // Header section
-  std::string idNameSpace = static_cast<std::string>(ns.name());  //Namespace of this and ALL sub-parts
   //     <---- Zout ---->
   //  |  ****************     |
   //  |  *              *     Wstep
@@ -64,7 +63,7 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << " and " << convertCmToMm(length2) << ", " << convertCmToMm(width2) << " Gap "
                                << convertCmToMm(gap2);
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Parent " << args.parentName() << " idName " << idName
-                               << " NameSpace " << idNameSpace << " for solids";
+                               << " NameSpace " << ns.name() << " for solids";
 #endif
 
   double alpha = 1._pi / nsectors;

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
@@ -61,8 +61,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   double zpos = dist * cos(theta);
   dd4hep::Position tran(xpos, ypos, zpos);
 
-  if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+  childName = ns.prepend(childName);
   dd4hep::Volume child = ns.volume(childName);
   parent.placeVolume(child, copyNumber, dd4hep::Transform3D(rotation, tran));
 #ifdef EDM_ML_DEBUG

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
@@ -31,8 +31,7 @@ static long algorithm(dd4hep::Detector& /* description */,
                                << "copy nos " << startCopyNo << ", " << incrCopyNo;
 #endif
   std::string childName = args.value<std::string>("ChildName");
-  if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+  childName = ns.prepend(childName);
   dd4hep::Volume parent = ns.volume(args.parentName());
   dd4hep::Volume child = ns.volume(childName);
 #ifdef EDM_ML_DEBUG

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
@@ -24,8 +24,7 @@ static long algorithm(Detector& /* description */,
   string rotns = args.value<string>("RotNameSpace");
   Volume mother = ns.volume(args.parentName());
   string childName = args.value<string>("ChildName");
-  if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+  childName = ns.prepend(childName);
   Volume child = ns.volume(childName);
 
   LogDebug("DDAlgorithm") << "debug: Parameters for positioning:: n " << n << " Start, Step "

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixFwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixFwdDiskAlgo.cc
@@ -50,7 +50,7 @@ static long algorithm(dd4hep::Detector& /* description */,
   flagString = args.value<std::string>("FlagString");
 
   if (strchr(childName.c_str(), NAMESPACE_SEP) == nullptr)
-    childName = ns.name() + childName;
+    childName = ns.prepend(childName);
 
   dd4hep::Volume child = ns.volume(childName);
 


### PR DESCRIPTION
#### PR description:

  * Use ```DDNamespace::prepend(name)``` instead of ```DDNamespace::name()``` in all ```std::string``` operations. 
  * Remove unused ```std::string```s

Addresses issue #28949 and replaces PR #28933

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
