### PR TITLE
customization files needed for CSC reco objects study

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
+++ b/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 def tightenAnodeTimes(process):
     if hasattr(process,'csc2DRecHits'):
-        process.csc2DRecHits.CSCUseReducedWireTimeWindow = cms.bool(True)
-        process.csc2DRecHits.CSCWireTimeWindowLow = cms.int32(5)
-        process.csc2DRecHits.CSCWireTimeWindowHigh = cms.int32(11)
+        process.csc2DRecHits.CSCUseReducedWireTimeWindow = True
+        process.csc2DRecHits.CSCWireTimeWindowLow = 5
+        process.csc2DRecHits.CSCWireTimeWindowHigh = 11
         return process

--- a/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
+++ b/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+def tightenAnodeTimes(process):
+    if hasattr(process,'csc2DRecHits'):
+        process.csc2DRecHits.CSCUseReducedWireTimeWindow = cms.bool(True)
+        process.csc2DRecHits.CSCWireTimeWindowLow = cms.int32(5)
+        process.csc2DRecHits.CSCWireTimeWindowHigh = cms.int32(11)
+        return process

--- a/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
+++ b/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
@@ -2,12 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 def widenRoads(process):
    if hasattr(process,'cscSegments'):
-      process.cscSegments.algo_psets[4].algo_psets[0].enlarge = cms.bool(True)
-      process.cscSegments.algo_psets[4].algo_psets[1].enlarge = cms.bool(True)
-      process.cscSegments.algo_psets[4].algo_psets[2].enlarge = cms.bool(True)
-      process.cscSegments.algo_psets[4].algo_psets[3].enlarge = cms.bool(True)
-      process.cscSegments.algo_psets[4].algo_psets[4].enlarge = cms.bool(True)
-      process.cscSegments.algo_psets[4].algo_psets[5].enlarge = cms.bool(True)
-
+      for ps in process.cscSegments.algo_psets[4].algo_psets: ps.enlarge = True
+     
       return process
 

--- a/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
+++ b/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+def widenRoads(process):
+   if hasattr(process,'cscSegments'):
+      process.cscSegments.algo_psets[4].algo_psets[0].enlarge = cms.bool(True)
+      process.cscSegments.algo_psets[4].algo_psets[1].enlarge = cms.bool(True)
+      process.cscSegments.algo_psets[4].algo_psets[2].enlarge = cms.bool(True)
+      process.cscSegments.algo_psets[4].algo_psets[3].enlarge = cms.bool(True)
+      process.cscSegments.algo_psets[4].algo_psets[4].enlarge = cms.bool(True)
+      process.cscSegments.algo_psets[4].algo_psets[5].enlarge = cms.bool(True)
+
+      return process
+


### PR DESCRIPTION
backport of #28979

We've managed to set up 'customize' files for cmsDriver that will implement the tests we'd like to run on CSC local reco:

    loosening roads for association of rechits with segments
    tightening anode time window from 16BX to 8BX when building rechits

