### PR TITLE
Fix #28803 (GenParticles2HepMC with exotic LHE) 10_6_X

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -131,7 +131,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   HepMC::GenVertex* vertex1 = nullptr;
   HepMC::GenVertex* vertex2 = nullptr;
-  if ( parton1 == nullptr and parton2 == nullptr ) {
+  if ( parton1 == nullptr || parton2 == nullptr ) {
     // Particle gun samples do not have incident partons. Put dummy incident particle and prod vertex
     // Note: leave parton1 and parton2 as nullptr since it is not used anymore after creating hepmc_parton1 and 2
     const reco::Candidate::LorentzVector nullP4(0,0,0,0);

--- a/GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py
@@ -13,7 +13,7 @@ process.maxEvents = cms.untracked.PSet(
 # Input source
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_9_1_0_pre1/RelValTTbar_13/MINIAODSIM/PU25ns_90X_mcRun2_asymptotic_v5-v1/00000/BE649FEB-C610-E711-AFD5-0CC47A4D769E.root',
+        '/store/relval/CMSSW_9_4_5_cand1/RelValTTbar_13/MINIAODSIM/94X_mc2017_realistic_v14_PU_RelVal_rmaod-v1/10000/84A84D5B-9E2E-E811-B103-0CC47A7C35F4.root',
     ),
 )
 
@@ -22,7 +22,7 @@ process.options = cms.untracked.PSet()
 process.genParticles2HepMC.genParticles = cms.InputTag("mergedGenParticles")
 process.rivetAnalyzer.HepMCCollection = cms.InputTag("genParticles2HepMC:unsmeared")
 
-process.rivetAnalyzer.AnalysisNames = cms.vstring('CMS_2013_I1224539_DIJET')
+process.rivetAnalyzer.AnalysisNames = cms.vstring('CMS_2016_I1459051')
 process.rivetAnalyzer.OutputFile = cms.string('mcfile.yoda')
 
 process.p = cms.Path(process.mergedGenParticles*process.genParticles2HepMC*process.rivetAnalyzer)


### PR DESCRIPTION
#### PR description:

Fixes crash in GenParticles2HepMCConverter (#28803) by adding fake beam particles for exotic LHE files with only one beam-particle candidate. This was used for NeutrinoGun samples (no beam particles) before.

#### PR validation:

* Processed NanoAod from problematic events (in 10_2_X: https://github.com/cms-sw/cmssw/pull/28856)
* Processed MiniAod events to produce Rivet histograms

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/28876