### PR TITLE
Slightly refactor PF endcap cluster calibration

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -320,7 +320,7 @@ void PFECALSuperClusterAlgo::buildSuperCluster(CalibClusterPtr& seed, CalibClust
       energyweighttot(0);
   for (auto& clus : clustered) {
     double ePS1 = 0.0;
-    double ePS2 = 0;
+    double ePS2 = 0.0;
     energyweight = clus->energy_nocalib();
     bare_ptrs.push_back(clus->the_ptr().get());
     // update EE calibrated super cluster energies

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -325,52 +325,16 @@ void PFECALSuperClusterAlgo::buildSuperCluster(CalibClusterPtr& seed, CalibClust
     bare_ptrs.push_back(clus->the_ptr().get());
     // update EE calibrated super cluster energies
     if (isEE) {
-      double ps1_energy_sum = 0.;
-      double ps2_energy_sum = 0.;
-      ePS1 = 0.;
-      ePS2 = 0.;
-      int condP1 = 1;
-      int condP2 = 1;
       auto ee_key_val = std::make_pair(clus->the_ptr().key(), edm::Ptr<reco::PFCluster>());
       const auto clustops = std::equal_range(EEtoPS_->begin(), EEtoPS_->end(), ee_key_val, sortByKey);
+      std::vector<reco::PFCluster const*> psClusterPointers;
       for (auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
-        edm::Ptr<reco::PFCluster> psclus(i_ps->second);
-
-        auto const& recH_Frac = psclus->recHitFractions();
-
-        switch (psclus->layer()) {
-          case PFLayer::PS1:
-            ps1_energy_sum += psclus->energy();
-            for (auto const& recH : recH_Frac) {
-              ESDetId strip1 = recH.recHitRef()->detId();
-              if (strip1 != ESDetId(0)) {
-                // getStatusCode() == 1 => dead channel
-                //apply correction if all recHits in dead region
-                if (channelStatus_->getMap().find(strip1)->getStatusCode() == 0)
-                  condP1 = 0;  //active
-              }
-            }
-            break;
-          case PFLayer::PS2:
-            ps2_energy_sum += psclus->energy();
-            for (auto const& recH : recH_Frac) {
-              ESDetId strip2 = recH.recHitRef()->detId();
-              if (strip2 != ESDetId(0)) {
-                if (channelStatus_->getMap().find(strip2)->getStatusCode() == 0)
-                  condP2 = 0;
-              }
-            }
-            break;
-          default:
-            break;
-        }
+        psClusterPointers.push_back(i_ps->second.get());
       }
-      if (condP1 == 1)
-        ePS1 = -1.;
-      if (condP2 == 1)
-        ePS2 = -1.;
-      _pfEnergyCalibration->energyEm(
-          *(clus->the_ptr()), ps1_energy_sum, ps2_energy_sum, ePS1, ePS2, applyCrackCorrections_);
+      auto calibratedEnergies = _pfEnergyCalibration->calibrateEndcapClusterEnergies(
+          *(clus->the_ptr()), psClusterPointers, *channelStatus_, applyCrackCorrections_);
+      ePS1 = calibratedEnergies.ps1Energy;
+      ePS2 = calibratedEnergies.ps2Energy;
     }
 
     if (ePS1 == -1.)

--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -5,6 +5,7 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
+#include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 
 class TF1;
 
@@ -53,6 +54,18 @@ public:
                   double& ps1,
                   double& ps2,
                   bool crackCorrection = true) const;
+
+  struct CalibratedEndcapPFClusterEnergies {
+    double clusterEnergy = 0.;
+    double ps1Energy = 0.;
+    double ps2Energy = 0.;
+  };
+
+  CalibratedEndcapPFClusterEnergies calibrateEndcapClusterEnergies(
+      reco::PFCluster const& eeCluster,
+      std::vector<reco::PFCluster const*> const& psClusterPointers,
+      ESChannelStatus const& channelStatus,
+      bool applyCrackCorrections) const;
 
   // ECAL+HCAL (abc) calibration, with E and eta dependent coefficients, for hadrons
   void energyEmHad(double t, double& e, double& h, double eta, double phi) const;

--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -46,13 +46,6 @@ public:
   // ecal calibration for photons
   double energyEm(const reco::PFCluster& clusterEcal, double ePS1, double ePS2, bool crackCorrection = true) const;
 
-  double energyEm(const reco::PFCluster& clusterEcal,
-                  double ePS1,
-                  double ePS2,
-                  double& ps1,
-                  double& ps2,
-                  bool crackCorrection = true) const;
-
   struct CalibratedEndcapPFClusterEnergies {
     double clusterEnergy = 0.;
     double ps1Energy = 0.;
@@ -77,7 +70,15 @@ public:
 
   friend std::ostream& operator<<(std::ostream& out, const PFEnergyCalibration& calib);
 
-protected:
+private:
+  // ecal calibration for photons
+  double energyEm(const reco::PFCluster& clusterEcal,
+                  double ePS1,
+                  double ePS2,
+                  double& ps1,
+                  double& ps2,
+                  bool crackCorrection = true) const;
+
   // Calibration functions from global tag
   const PerformancePayloadFromTFormula* pfCalibrations = nullptr;
   const ESEEIntercalibConstants* esEEInterCalib_ = nullptr;
@@ -108,7 +109,6 @@ protected:
   std::unique_ptr<TF1> fcEtaEndcapH;
   std::unique_ptr<TF1> fdEtaEndcapH;
 
-private:
   double minimum(double a, double b) const;
   double dCrackPhi(double phi, double eta) const;
   double CorrPhi(double phi, double eta) const;

--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -7,7 +7,7 @@
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 
-class TF1;
+#include <TF1.h>
 
 // -*- C++ -*-
 //
@@ -43,8 +43,6 @@ class PFEnergyCalibration {
 public:
   PFEnergyCalibration();
 
-  ~PFEnergyCalibration();
-
   // ecal calibration for photons
   double energyEm(const reco::PFCluster& clusterEcal, double ePS1, double ePS2, bool crackCorrection = true) const;
 
@@ -70,9 +68,6 @@ public:
   // ECAL+HCAL (abc) calibration, with E and eta dependent coefficients, for hadrons
   void energyEmHad(double t, double& e, double& h, double eta, double phi) const;
 
-  // Initialize default E- and eta-dependent coefficient functional form
-  void initializeCalibrationFunctions();
-
   // Set the run-dependent calibration functions from the global tag
   void setCalibrationFunctions(const PerformancePayloadFromTFormula* thePFCal) { pfCalibrations = thePFCal; }
 
@@ -84,8 +79,8 @@ public:
 
 protected:
   // Calibration functions from global tag
-  const PerformancePayloadFromTFormula* pfCalibrations;
-  const ESEEIntercalibConstants* esEEInterCalib_;
+  const PerformancePayloadFromTFormula* pfCalibrations = nullptr;
+  const ESEEIntercalibConstants* esEEInterCalib_ = nullptr;
 
   // Barrel calibration (eta 0.00 -> 1.48)
   std::unique_ptr<TF1> faBarrel;
@@ -162,7 +157,8 @@ private:
   double dEtaEndcapH(double x) const;
 
   // Threshold correction (offset)
-  double threshE, threshH;
+  const double threshE = 3.5;
+  const double threshH = 2.5;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -45,18 +45,8 @@ public:
   ~PFEnergyCalibration();
 
   // ecal calibration for photons
-  double energyEm(const reco::PFCluster& clusterEcal,
-                  std::vector<double>& EclustersPS1,
-                  std::vector<double>& EclustersPS2,
-                  bool crackCorrection = true) const;
   double energyEm(const reco::PFCluster& clusterEcal, double ePS1, double ePS2, bool crackCorrection = true) const;
 
-  double energyEm(const reco::PFCluster& clusterEcal,
-                  std::vector<double>& EclustersPS1,
-                  std::vector<double>& EclustersPS2,
-                  double& ps1,
-                  double& ps2,
-                  bool crackCorrection = true) const;
   double energyEm(const reco::PFCluster& clusterEcal,
                   double ePS1,
                   double ePS2,

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -614,7 +614,7 @@ std::ostream& operator<<(std::ostream& out, const PFEnergyCalibration& calib) {
 
 //useful to compute the signed distance to the closest crack in the barrel
 double PFEnergyCalibration::minimum(double a, double b) const {
-  if (TMath::Abs(b) < TMath::Abs(a))
+  if (std::abs(b) < std::abs(a))
     a = b;
   return a;
 }
@@ -711,7 +711,7 @@ double PFEnergyCalibration::CorrEta(double eta) const {
 
   for (unsigned i = 0; i <= 4; i++)
     result += a[i] * TMath::Gaus(eta, m[i], s[i]) *
-              (1 + sa[i] * TMath::Sign(1., eta - m[i]) * TMath::Exp(-TMath::Abs(eta - m[i]) / ss[i]));
+              (1 + sa[i] * TMath::Sign(1., eta - m[i]) * TMath::Exp(-std::abs(eta - m[i]) / ss[i]));
 
   return result;
 }
@@ -929,7 +929,7 @@ double PFEnergyCalibration::EcorrPS_ePSNil(double eEcal, double eta) const {
   //so that <feta()> = 1
   constexpr double norm = (p4 + p5 * (2.6 + 1.656) / 2);
 
-  double result = eEcal * (p0 + p1 * TMath::Exp(-TMath::Abs(eEcal - p3) / p2)) * (p4 + p5 * eta) / norm;
+  double result = eEcal * (p0 + p1 * TMath::Exp(-std::abs(eEcal - p3) / p2)) * (p4 + p5 * eta) / norm;
 
   return result;
 }
@@ -973,7 +973,7 @@ double PFEnergyCalibration::Ecorr(
 
   double result = 0;
 
-  eta = TMath::Abs(eta);
+  eta = std::abs(eta);
 
   if (eEcal > 0) {
     if (eta <= endBarrel)
@@ -1013,7 +1013,7 @@ double PFEnergyCalibration::Ecorr(double eEcal,
 
   double result = 0;
 
-  eta = TMath::Abs(eta);
+  eta = std::abs(eta);
 
   if (eEcal > 0) {
     if (eta <= endBarrel)

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -485,15 +485,6 @@ double PFEnergyCalibration::dEtaEndcapEH(double x) const {
     return fdEtaEndcapEH->Eval(x);
   }
 }
-//
-double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
-                                     std::vector<double>& EclustersPS1,
-                                     std::vector<double>& EclustersPS2,
-                                     bool crackCorrection) const {
-  double ePS1(std::accumulate(EclustersPS1.begin(), EclustersPS1.end(), 0.0));
-  double ePS2(std::accumulate(EclustersPS2.begin(), EclustersPS2.end(), 0.0));
-  return energyEm(clusterEcal, ePS1, ePS2, crackCorrection);
-}
 
 double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
                                      double ePS1,
@@ -511,16 +502,6 @@ double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
   return calibrated;
 }
 
-double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
-                                     std::vector<double>& EclustersPS1,
-                                     std::vector<double>& EclustersPS2,
-                                     double& ps1,
-                                     double& ps2,
-                                     bool crackCorrection) const {
-  double ePS1(std::accumulate(EclustersPS1.begin(), EclustersPS1.end(), 0.0));
-  double ePS2(std::accumulate(EclustersPS2.begin(), EclustersPS2.end(), 0.0));
-  return energyEm(clusterEcal, ePS1, ePS2, ps1, ps2, crackCorrection);
-}
 double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
                                      double ePS1,
                                      double ePS2,

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1799,55 +1799,17 @@ reco::SuperCluster PFEGammaAlgo::buildRefinedSuperCluster(const PFEGammaAlgo::Pr
     posZ += cluseraw * cluspos.Z();
     // update EE calibrated super cluster energies
     if (isEE && RO.ecal2ps.count(clus.get())) {
-      double ps1_energy_sum = 0.;
-      double ps2_energy_sum = 0.;
-      ePS1 = 0.;
-      ePS2 = 0.;
-      int condP1 = 1;
-      int condP2 = 1;
-
       const auto& psclusters = RO.ecal2ps.at(clus.get());
 
-      for (auto i_ps = psclusters.begin(); i_ps != psclusters.end(); ++i_ps) {
-        const PFClusterRef& psclus = (*i_ps)->clusterRef();
-
-        auto const& recH_Frac = psclus->recHitFractions();
-
-        switch (psclus->layer()) {
-          case PFLayer::PS1:
-            ps1_energy_sum += psclus->energy();
-            for (auto const& recH : recH_Frac) {
-              ESDetId strip1 = recH.recHitRef()->detId();
-              if (strip1 != ESDetId(0)) {
-                //getStatusCode() == 0 => active channel
-                // apply correction if all recHits are dead
-                if (channelStatus_->getMap().find(strip1)->getStatusCode() == 0)
-                  condP1 = 0;
-              }
-            }
-            break;
-          case PFLayer::PS2:
-            ps2_energy_sum += psclus->energy();
-            for (auto const& recH : recH_Frac) {
-              ESDetId strip2 = recH.recHitRef()->detId();
-              if (strip2 != ESDetId(0)) {
-                if (channelStatus_->getMap().find(strip2)->getStatusCode() == 0)
-                  condP2 = 0;
-              }
-            }
-            break;
-          default:
-            break;
-        }
+      std::vector<reco::PFCluster const*> psClusterPointers;
+      for (auto const& psc : psclusters) {
+        psClusterPointers.push_back(psc->clusterRef().get());
       }
-
-      if (condP1 == 1)
-        ePS1 = -1.;
-      if (condP2 == 1)
-        ePS2 = -1.;
-
-      cluscalibe = thePFEnergyCalibration_.energyEm(
-          *clusptr, ps1_energy_sum, ps2_energy_sum, ePS1, ePS2, cfg_.applyCrackCorrections);
+      auto calibratedEnergies = thePFEnergyCalibration_.calibrateEndcapClusterEnergies(
+          *clusptr, psClusterPointers, *channelStatus_, cfg_.applyCrackCorrections);
+      cluscalibe = calibratedEnergies.clusterEnergy;
+      ePS1 = calibratedEnergies.ps1Energy;
+      ePS2 = calibratedEnergies.ps2Energy;
     }
     if (ePS1 == -1.)
       ePS1 = 0;

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -276,14 +276,9 @@ void ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>
                    ? LinkByRecHit::testTrackAndClusterByRecHit(pfrectrack, clust)
                    : -1.;
 
-        if (dist > 0.) {
-          bool applyCrackCorrections = false;
-          double ps1, ps2;
-          ps1 = ps2 = 0.;
-          if (dist < MinDist) {
-            MinDist = dist;
-            EE_calib = cache->pfcalib_->energyEm(*clus, 0.0, 0.0, ps1, ps2, applyCrackCorrections);
-          }
+        if (dist > 0. && dist < MinDist) {
+          MinDist = dist;
+          EE_calib = cache->pfcalib_->energyEm(*clus, 0.0, 0.0, false);
         }
       }
       if (MinDist > 0. && MinDist < 100000.) {

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -278,13 +278,11 @@ void ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>
 
         if (dist > 0.) {
           bool applyCrackCorrections = false;
-          vector<double> ps1Ene(0);
-          vector<double> ps2Ene(0);
           double ps1, ps2;
           ps1 = ps2 = 0.;
           if (dist < MinDist) {
             MinDist = dist;
-            EE_calib = cache->pfcalib_->energyEm(*clus, ps1Ene, ps2Ene, ps1, ps2, applyCrackCorrections);
+            EE_calib = cache->pfcalib_->energyEm(*clus, 0.0, 0.0, ps1, ps2, applyCrackCorrections);
           }
         }
       }


### PR DESCRIPTION
#### PR description:

In the PFEgammaAlgo, there is still this comment about code "stolen" from the PFECALSuperClusterAlgo:
https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc#L1774

I was thinking of ways to avoid this duplication, but it's not quite trivial because the code diverged a bit. However, a bit part of the duplicate code serves to compute cluster energy corrections, so I could move this into the PFEnergyCalibration class which is used by both algos. I think this is a good step to avoid this code duplication, but I don't want to go further for now to not risk accidentally changing the logic. What do you think?

#### PR validation:

CMSSW compiles and matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.