### PR TITLE
MTD premixing: fix hit time in signal-PU merging

### DIFF
--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -120,7 +120,7 @@ namespace mtd_digitizer {
 
       if (iEn == 0 || iEn == 2) {
         hit_info[iEn][iSample] += value;
-      } else if (hit_info[iEn][iSample] == 0) {
+      } else if (hit_info[iEn][iSample] == 0 || value < hit_info[iEn][iSample]) {
         // For iEn==1 the digitizers just set the TOF of the first SimHit
         hit_info[iEn][iSample] = value;
       }


### PR DESCRIPTION
#### PR description:
This PR fixes a minor bug which affects the MTD hit times when merging signal and premixed PU hits.

#### PR validation:

Neither the performance nor the disk usage are affected. 
This is the global effect on the BTL time resolution:
![RecHits_BtlTimeRes](https://user-images.githubusercontent.com/5435977/74525579-b2c52100-4f21-11ea-9fc0-fa9f375bc89f.png)




