### PR TITLE
[RPC] fixed error for MWGR#1 release

### DIFF
--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -68,6 +68,9 @@ process.omtfStage2Digis = cms.EDProducer("OmtfUnpacker",
 )
 
 process.load("EventFilter.RPCRawToDigi.RPCDigiMerger_cff")
+process.rpcDigiMerger.inputTagTwinMuxDigis = 'rpcTwinMuxRawToDigi'
+process.rpcDigiMerger.inputTagOMTFDigis = 'omtfStage2Digis'
+process.rpcDigiMerger.inputTagCPPFDigis = 'rpcCPPFRawToDigi'
 
 ################# RPC Rec Hits  #################
 process.load("RecoLocalMuon.RPCRecHit.rpcRecHits_cfi")


### PR DESCRIPTION
#### PR description:

This is the backport of #28963 

This PR is contained about RPC online client crashing with CMSSW_11_0_X which will be used in MWGR1.

The crash[1] is related to absent 'rpcDigiMerger' in the configuration file (which was modified one).

* Note from Francesco Fiori: **the PR needs only to be submitted, no need to be merged**

This solution comes from Felipe Silva and Dilson De Jesus Damiao.


[1]
$ cmsRun rpc_dqm_sourceclient-live_cfg.py inputFiles="root://cms-xrd-global.cern.ch//eos/cms/store/data/Commissioning2019/Cosmics/RAW/v1/000/334/614/00000/E5EBBC44-7DFA-E544-A10E-F7B793CBA6FD.root" runNumber=334614

(crashed before processing event) ------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 334614 lumi: 1451 event: 21634870 stream: 0
   [1] Running path 'p'
   [2] Calling method for module RPCDigiMerger/'rpcDigiMerger'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: MuonDigiCollection<RPCDetId,RPCDigi>
Looking for module label: simMuonRPCDigis
Looking for productInstanceName:

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------


#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
