### PR TITLE
[RPC] fixed error for MWGR#1 release

### DIFF
--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -68,6 +68,9 @@ process.omtfStage2Digis = cms.EDProducer("OmtfUnpacker",
 )
 
 process.load("EventFilter.RPCRawToDigi.RPCDigiMerger_cff")
+process.rpcDigiMerger.inputTagTwinMuxDigis = 'rpcTwinMuxRawToDigi'
+process.rpcDigiMerger.inputTagOMTFDigis = 'omtfStage2Digis'
+process.rpcDigiMerger.inputTagCPPFDigis = 'rpcCPPFRawToDigi'
 
 ################# RPC Rec Hits  #################
 process.load("RecoLocalMuon.RPCRecHit.rpcRecHits_cfi")


### PR DESCRIPTION
#### PR description:

This PR is contained about RPC online client crashing with CMSSW_11_0_X which will be used in MWGR1.

The crash[1] is related to absent 'rpcDigiMerger' in the configuration file (which was modified one).

This solution comes from Felipe Silva and Dilson De Jesus Damiao.

[1]
$ cmsRun rpc_dqm_sourceclient-live_cfg.py inputFiles="root://cms-xrd-global.cern.ch//eos/cms/store/data/Commissioning2019/Cosmics/RAW/v1/000/334/614/00000/E5EBBC44-7DFA-E544-A10E-F7B793CBA6FD.root" runNumber=334614

```
(crashed before processing event) ------
An exception of category 'ProductNotFound' occurred while
[0] Processing Event run: 334614 lumi: 1451 event: 21634870 stream: 0
[1] Running path 'p'
[2] Calling method for module RPCDigiMerger/'rpcDigiMerger'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: MuonDigiCollection<RPCDetId,RPCDigi>
Looking for module label: simMuonRPCDigis
Looking for productInstanceName:
Additional Info:
[a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.
----- End Fatal Exception -------------------------------------------------
```
The crash is coming from absent of input tags which need for run3 RPC.
(The test is made using this GT: 110X_dataRun3_HLT_newGEMeMap_v1)

When you see this RAW to DIGI config file
https://github.com/cms-sw/cmssw/blob/master/Configuration/StandardSequences/python/RawToDigi_Data_cff.py#L11-L15
There are input tags for RPC merged Digi.

So when the RPCDigiMerger[1] is loaded, we should use defined input tags together.
Because the RPCDigiMerger should be controlled by the RawToDigi specific for the Data workflow.

[1] (line 68 to 111)
https://github.com/cms-sw/cmssw/blob/8d9690a3dfa810689356645dec92b2b089962970/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc#L68

---------
* RPC DPG meeting on Wednesday, 19th February :
https://indico.cern.ch/event/890821/contributions/3756812/attachments/1990016/3317833/Report_of_RPC_Online_client_changes-20200219.pdf