### PR TITLE
MTD RECO Geometry: fix debug statements in MTDGeometryBuilder

### DIFF
--- a/Geometry/MTDGeometryBuilder/src/MTDGeomBuilderFromGeometricTimingDet.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeomBuilderFromGeometricTimingDet.cc
@@ -51,16 +51,14 @@ MTDGeometry* MTDGeomBuilderFromGeometricTimingDet::build(const GeometricTimingDe
       2, GeometricTimingDet::unknown);  // hardcoded "2" should not be a surprise...
   GeometricTimingDet::ConstGeometricTimingDetContainer subdetgd = gd->components();
 
-  LogDebug("SubDetectorGeometricTimingDetType")
-      << "GeometricTimingDet enumerator values of the subdetectors" << std::endl;
+  LogDebug("SubDetectorGeometricTimingDetType") << "MTD GeometricTimingDet enumerator values of the subdetectors";
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {
     MTDDetId mtdid(subdetgd[i]->geographicalId());
     assert(mtdid.mtdSubDetector() > 0 && mtdid.mtdSubDetector() < 3);
     gdsubdetmap[mtdid.mtdSubDetector() - 1] = subdetgd[i]->type();
-    LogTrace("SubDetectorGeometricTimingDetType")
-        << "subdet " << i << " type " << subdetgd[i]->type() << " detid " << std::hex
-        << subdetgd[i]->geographicalId().rawId() << std::dec << " subdetid " << subdetgd[i]->geographicalId().subdetId()
-        << std::endl;
+    LogTrace("SubDetectorGeometricTimingDetType") << "MTD subdet " << i << " type " << subdetgd[i]->type() << " detid "
+                                                  << std::hex << subdetgd[i]->geographicalId().rawId() << std::dec
+                                                  << " subdetid " << subdetgd[i]->geographicalId().subdetId();
   }
 
   std::vector<const GeometricTimingDet*> dets[2];
@@ -98,11 +96,10 @@ void MTDGeomBuilderFromGeometricTimingDet::buildPixel(
     GeomDetType::SubDetector det,
     const PMTDParameters& ptp)  // in y direction, cols. BIG_PIX_PER_ROC_Y = 0 for SLHC
 {
-  LogDebug("BuildingGeomDetUnits") << " Pixel type. Size of vector: " << gdv.size()
+  LogDebug("BuildingGeomDetUnits") << " MTD Pixel type. Size of vector: " << gdv.size()
                                    << " GeomDetType subdetector: " << det
                                    << " logical subdetector: " << GeomDetEnumerators::subDetGeom[det]
-                                   << " big pix per ROC x: " << 0 << " y: " << 0 << " is upgrade: " << true
-                                   << std::endl;
+                                   << " big pix per ROC x: " << 0 << " y: " << 0 << " is upgrade: " << true;
 
   // this is a hack while we put things into the DDD
   int ROCrows(0), ROCcols(0), ROCSx(0), ROCSy(0);

--- a/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
@@ -44,30 +44,31 @@ MTDGeometry::MTDGeometry(GeometricTimingDet const* gd) : theTrackerDet(gd) {
   }
   GeometricTimingDet::ConstGeometricTimingDetContainer subdetgd = gd->components();
 
-  LogDebug("BuildingSubDetTypeMap") << "GeometricTimingDet and GeomDetEnumerators enumerator values of the subdetectors"
-                                    << std::endl;
+  LogDebug("BuildingSubDetTypeMap")
+      << "MTD GeometricTimingDet and GeomDetEnumerators enumerator values of the subdetectors" << std::endl;
   for (unsigned int i = 0; i < subdetgd.size(); ++i) {
     MTDDetId mtdid(subdetgd[i]->geographicalId());
     assert(mtdid.mtdSubDetector() > 0 && mtdid.mtdSubDetector() < 3);
     theSubDetTypeMap[mtdid.mtdSubDetector() - 1] = geometricDetToGeomDet(subdetgd[i]->type());
     theNumberOfLayers[mtdid.mtdSubDetector() - 1] = subdetgd[i]->components().size();
-    LogTrace("BuildingSubDetTypeMap").log([&](auto& debugstr) {
-      debugstr << "subdet " << i << " Geometric Det type " << subdetgd[i]->type() << " Geom Det type "
-               << theSubDetTypeMap[mtdid.mtdSubDetector() - 1] << " detid " << std::hex
-               << subdetgd[i]->geographicalId().rawId() << std::dec << " subdetid " << mtdid.mtdSubDetector()
-               << " number of layers " << subdetgd[i]->components().size() << std::endl;
-    });
+    LogTrace("BuildingSubDetTypeMap") << "MTD subdet " << i << " Geometric Det type " << subdetgd[i]->type()
+                                      << " Geom Det type " << theSubDetTypeMap[mtdid.mtdSubDetector() - 1] << " detid "
+                                      << std::hex << subdetgd[i]->geographicalId().rawId() << std::dec << " subdetid "
+                                      << mtdid.mtdSubDetector() << " number of layers "
+                                      << subdetgd[i]->components().size();
   }
   LogDebug("SubDetTypeMapContent").log([&](auto& debugstr) {
-    debugstr << "Content of theSubDetTypeMap" << std::endl;
+    debugstr << "MTD Content of theSubDetTypeMap"
+             << "\n";
     for (unsigned int i = 1; i <= 2; ++i) {
-      debugstr << " detid subdet " << i << " Geom Det type " << geomDetSubDetector(i) << std::endl;
+      debugstr << " detid subdet " << i << " Geom Det type " << geomDetSubDetector(i) << "\n";
     }
   });
   LogDebug("NumberOfLayers").log([&](auto& debugstr) {
-    debugstr << "Content of theNumberOfLayers" << std::endl;
+    debugstr << "MTD Content of theNumberOfLayers"
+             << "\n";
     for (unsigned int i = 1; i <= 2; ++i) {
-      debugstr << " detid subdet " << i << " number of layers " << numberOfLayers(i) << std::endl;
+      debugstr << " detid subdet " << i << " number of layers " << numberOfLayers(i) << "\n";
     }
   });
   std::vector<const GeometricTimingDet*> deepcomp;
@@ -75,21 +76,21 @@ MTDGeometry::MTDGeometry(GeometricTimingDet const* gd) : theTrackerDet(gd) {
 
   sort(deepcomp.begin(), deepcomp.end(), DetIdComparator());
 
-  LogDebug("ThicknessAndType") << " Total Number of Detectors " << deepcomp.size() << std::endl;
-  LogDebug("ThicknessAndType") << "Dump of sensors names and bounds" << std::endl;
+  LogDebug("ThicknessAndType") << "MTD Total Number of Detectors " << deepcomp.size() << std::endl;
+  LogDebug("ThicknessAndType") << "MTD Dump of sensors names and bounds" << std::endl;
   LogDebug("ThicknessAndType").log([&](auto& debugstr) {
     for (auto det : deepcomp) {
       fillTestMap(det);
       debugstr << std::hex << det->geographicalId().rawId() << std::dec << " " << det->name() << " "
-               << det->bounds()->thickness();
+               << det->bounds()->thickness() << "\n";
     }
   });
   LogDebug("DetTypeList").log([&](auto& debugstr) {
-    debugstr << " Content of DetTypetList : size " << theDetTypetList.size() << std::endl;
+    debugstr << "MTD Content of DetTypeList : size " << theDetTypetList.size() << "\n";
     for (auto iVal : theDetTypetList) {
       debugstr << " DetId " << std::get<0>(iVal).rawId() << " Type "
                << static_cast<std::underlying_type<MTDGeometry::ModuleType>::type>(std::get<1>(iVal)) << " Thickness "
-               << std::get<2>(iVal) << std::endl;
+               << std::get<2>(iVal) << "\n";
     }
   });
 }

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -4,6 +4,17 @@ process = cms.Process("GeometryTest")
 # empty input service, fire 10 events
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
+# process.MessageLogger = cms.Service("MessageLogger",
+#     destinations = cms.untracked.vstring(
+#         'critical',
+#         'detailedInfo',
+#     ),
+#     detailedInfo = cms.untracked.PSet(
+#         threshold  = cms.untracked.string('DEBUG')
+#     ),
+#     debugModules = cms.untracked.vstring('*')
+# )
+
 process.MessageLogger.cerr.INFO.limit = -1
 
 # Choose Tracker Geometry

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -18,7 +18,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.INFO.limit = -1
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtended2023D35_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D50_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi")
 


### PR DESCRIPTION
#### PR description:

During the development of the MTD RECO geometry for DD4hep and the new ETL, I have realized that the debug statements in ```MTDGeometryBuilder``` are not functional, not even compiling when executing ```USER_CXXFLAGS="-g -D=EDM_ML_DEBUG" scram b -v``` to enable LogDebug.
This PR proposes a simple fix, that makes them functional (the commented addition to the test configuration added can be used).

#### PR validation:

If ```Geometry/MTDGeometryBuilder/test/mtd_cfg.py``` is run enabling the LogDebug in message logger (commented part), the debug messages are produced:

```
%MSG-d BuildingSubDetTypeMap:  MTDDigiGeometryAnalyzer:prod  14-Feb-2020 13:53:55 CET Run: 1 Event: 1 MTDGeometry.cc:47
MTD GeometricTimingDet and GeomDetEnumerators enumerator values of the subdetectors
%MSG
MTD subdet 0 Geometric Det type 1 Geom Det type 18 detid 6280003f subdetid 1 number of layers 1
MTD subdet 1 Geometric Det type 7 Geom Det type 19 detid 63400000 subdetid 2 number of layers 1
MTD subdet 2 Geometric Det type 7 Geom Det type 19 detid 63000000 subdetid 2 number of layers 1
%MSG-d SubDetTypeMapContent:  MTDDigiGeometryAnalyzer:prod  14-Feb-2020 13:53:55 CET Run: 1 Event: 1 MTDGeometry.cc:60
MTD Content of theSubDetTypeMap
 detid subdet 1 Geom Det type 18
 detid subdet 2 Geom Det type 19

%MSG
%MSG-d NumberOfLayers:  MTDDigiGeometryAnalyzer:prod 14-Feb-2020 13:53:55 CET  Run: 1 Event: 1 MTDGeometry.cc:67
MTD Content of theNumberOfLayers
 detid subdet 1 number of layers 1
 detid subdet 2 number of layers 1

%MSG
%MSG-d ThicknessAndType:  MTDDigiGeometryAnalyzer:prod 14-Feb-2020 13:53:55 CET  Run: 1 Event: 1 MTDGeometry.cc:79
MTD Total Number of Detectors 5892
%MSG
%MSG-d ThicknessAndType:  MTDDigiGeometryAnalyzer:prod 14-Feb-2020 13:53:55 CET  Run: 1 Event: 1 MTDGeometry.cc:80
MTD Dump of sensors names and bounds
%MSG
%MSG-d ThicknessAndType:  MTDDigiGeometryAnalyzer:prod 14-Feb-2020 13:53:55 CET  Run: 1 Event: 1 MTDGeometry.cc:81
62810400 BModule1Layer1NegativeZTimingwafer 0.4
62810800 BModule1Layer1NegativeZTimingwafer 0.4
62810c00 BModule1Layer1NegativeZTimingwafer 0.4
62811000 BModule1Layer1NegativeZTimingwafer 0.4
62811400 BModule1Layer1NegativeZTimingwafer 0.4
62811800 BModule1Layer1NegativeZTimingwafer 0.4
62811c00 BModule1Layer1NegativeZTimingwafer 0.4
62812000 BModule1Layer1NegativeZTimingwafer 0.4
62812400 BModule1Layer1NegativeZTimingwafer 0.4
62812800 BModule1Layer1NegativeZTimingwafer 0.4
62812c00 BModule1Layer1NegativeZTimingwafer 0.4
62813000 BModule1Layer1NegativeZTimingwafer 0.4
```