### PR TITLE
Migrate EcalSimHitsValidation classes to DQMEDAnalyzer

### DIFF
--- a/Validation/EcalHits/interface/EcalBarrelSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalBarrelSimHitsValidation.h
@@ -18,19 +18,16 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimDataFormats/ValidationFormats/interface/PValidationFormats.h"
 
-#include <fstream>
-#include <iostream>
 #include <map>
 #include <vector>
 
-class EcalBarrelSimHitsValidation : public edm::EDAnalyzer {
+class EcalBarrelSimHitsValidation : public DQMEDAnalyzer {
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
@@ -40,18 +37,11 @@ public:
   /// Constructor
   EcalBarrelSimHitsValidation(const edm::ParameterSet &ps);
 
-  /// Destructor
-  ~EcalBarrelSimHitsValidation() override;
-
 protected:
+  void bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) override;
+
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-
-  // BeginJob
-  void beginJob() override;
-
-  // EndJob
-  void endJob(void) override;
 
 private:
   uint32_t getUnitWithMaxEnergy(MapType &themap);
@@ -76,10 +66,6 @@ private:
   edm::EDGetTokenT<PEcalValidInfo> ValidationCollectionToken;
 
   bool verbose_;
-
-  DQMStore *dbe_;
-
-  std::string outputFile_;
 
   int myEntries;
   float eRLength[26];

--- a/Validation/EcalHits/interface/EcalEndcapSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalEndcapSimHitsValidation.h
@@ -20,8 +20,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
@@ -32,28 +31,18 @@
 #include <map>
 #include <vector>
 
-class EcalEndcapSimHitsValidation : public edm::EDAnalyzer {
+class EcalEndcapSimHitsValidation : public DQMEDAnalyzer {
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
-  typedef dqm::legacy::DQMStore DQMStore;
-  typedef dqm::legacy::MonitorElement MonitorElement;
-
   /// Constructor
   EcalEndcapSimHitsValidation(const edm::ParameterSet &ps);
 
-  /// Destructor
-  ~EcalEndcapSimHitsValidation() override;
-
 protected:
+  void bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) override;
+
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-
-  // BeginJob
-  void beginJob() override;
-
-  // EndJob
-  void endJob(void) override;
 
 private:
   uint32_t getUnitWithMaxEnergy(MapType &themap);
@@ -77,10 +66,6 @@ private:
   edm::EDGetTokenT<PEcalValidInfo> ValidationCollectionToken;
 
   bool verbose_;
-
-  DQMStore *dbe_;
-
-  std::string outputFile_;
 
   int myEntries;
   float eRLength[26];

--- a/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
@@ -19,8 +19,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
@@ -32,28 +31,18 @@
 #include <map>
 #include <vector>
 
-class EcalPreshowerSimHitsValidation : public edm::EDAnalyzer {
+class EcalPreshowerSimHitsValidation : public DQMEDAnalyzer {
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
-  typedef dqm::legacy::DQMStore DQMStore;
-  typedef dqm::legacy::MonitorElement MonitorElement;
-
   /// Constructor
   EcalPreshowerSimHitsValidation(const edm::ParameterSet &ps);
 
-  /// Destructor
-  ~EcalPreshowerSimHitsValidation() override;
-
 protected:
+  void bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) override;
+
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-
-  // BeginJob
-  void beginJob() override;
-
-  // EndJob
-  void endJob(void) override;
 
 private:
   std::string HepMCLabel;
@@ -66,10 +55,6 @@ private:
   edm::EDGetTokenT<edm::PCaloHitContainer> ESHitsToken;
 
   bool verbose_;
-
-  DQMStore *dbe_;
-
-  std::string outputFile_;
 
   MonitorElement *menESHits1zp_;
   MonitorElement *menESHits2zp_;

--- a/Validation/EcalHits/interface/EcalSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalSimHitsValidation.h
@@ -19,8 +19,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
@@ -32,33 +31,21 @@
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
-#include <fstream>
-#include <iostream>
 #include <map>
 #include <vector>
 
-class EcalSimHitsValidation : public edm::EDAnalyzer {
+class EcalSimHitsValidation : public DQMEDAnalyzer {
   typedef std::map<uint32_t, float, std::less<uint32_t>> MapType;
 
 public:
-  typedef dqm::legacy::DQMStore DQMStore;
-  typedef dqm::legacy::MonitorElement MonitorElement;
-
   /// Constructor
   EcalSimHitsValidation(const edm::ParameterSet &ps);
 
-  /// Destructor
-  ~EcalSimHitsValidation() override;
-
 protected:
+  void bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) override;
+
   /// Analyze
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-
-  // BeginJob
-  void beginJob() override;
-
-  // EndJob
-  void endJob(void) override;
 
 private:
   std::string g4InfoLabel;
@@ -68,10 +55,6 @@ private:
   edm::EDGetTokenT<edm::PCaloHitContainer> ESHitsCollectionToken;
 
   bool verbose_;
-
-  DQMStore *dbe_;
-
-  std::string outputFile_;
 
   MonitorElement *meGunEnergy_;
   MonitorElement *meGunEta_;

--- a/Validation/EcalHits/python/ecalBarrelSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalBarrelSimHitsValidation_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalBarrelSimHitsValidation = cms.EDAnalyzer("EcalBarrelSimHitsValidation",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ecalBarrelSimHitsValidation = DQMEDAnalyzer("EcalBarrelSimHitsValidation",
     moduleLabelG4 = cms.string('g4SimHits'),
     verbose = cms.untracked.bool(False),
     ValidationCollection = cms.string('EcalValidInfo'),

--- a/Validation/EcalHits/python/ecalEndcapSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalEndcapSimHitsValidation_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalEndcapSimHitsValidation = cms.EDAnalyzer("EcalEndcapSimHitsValidation",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ecalEndcapSimHitsValidation = DQMEDAnalyzer("EcalEndcapSimHitsValidation",
     EEHitsCollection = cms.string('EcalHitsEE'),
     moduleLabelG4 = cms.string('g4SimHits'),
     ValidationCollection = cms.string('EcalValidInfo'),

--- a/Validation/EcalHits/python/ecalPreshowerSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalPreshowerSimHitsValidation_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalPreshowerSimHitsValidation = cms.EDAnalyzer("EcalPreshowerSimHitsValidation",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ecalPreshowerSimHitsValidation = DQMEDAnalyzer("EcalPreshowerSimHitsValidation",
     EEHitsCollection = cms.string('EcalHitsEE'),
     ESHitsCollection = cms.string('EcalHitsES'),
     moduleLabelG4 = cms.string('g4SimHits'),

--- a/Validation/EcalHits/python/ecalSimHitsValidation_cfi.py
+++ b/Validation/EcalHits/python/ecalSimHitsValidation_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalSimHitsValidation = cms.EDAnalyzer("EcalSimHitsValidation",
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+ecalSimHitsValidation = DQMEDAnalyzer("EcalSimHitsValidation",
     ESHitsCollection = cms.string('EcalHitsES'),
-    outputFile = cms.untracked.string(''),
     verbose = cms.untracked.bool(False),
     moduleLabelMC = cms.string('generatorSmeared'),
     EBHitsCollection = cms.string('EcalHitsEB'),

--- a/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
@@ -92,7 +92,7 @@ void EcalBarrelSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run
   histo = "EB E4oE9";
   meEBe4oe9_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
 
-  histo = "EBE9oE16";
+  histo = "EB E9oE16";
   meEBe9oe16_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
 
   histo = "EB E1oE25";

--- a/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
@@ -25,127 +25,84 @@ EcalBarrelSimHitsValidation::EcalBarrelSimHitsValidation(const edm::ParameterSet
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
-  // get hold of back-end interface
-  dbe_ = nullptr;
-  dbe_ = edm::Service<DQMStore>().operator->();
-
-  menEBHits_ = nullptr;
-  menEBCrystals_ = nullptr;
-  meEBOccupancy_ = nullptr;
-  meEBLongitudinalShower_ = nullptr;
-  meEBhitEnergy_ = nullptr;
-  meEBhitLog10Energy_ = nullptr;
-  meEBhitLog10EnergyNorm_ = nullptr;
-  meEBhitLog10Energy25Norm_ = nullptr;
-  meEBhitEnergy2_ = nullptr;
-  meEBcrystalEnergy_ = nullptr;
-  meEBcrystalEnergy2_ = nullptr;
-
-  meEBe1_ = nullptr;
-  meEBe4_ = nullptr;
-  meEBe9_ = nullptr;
-  meEBe16_ = nullptr;
-  meEBe25_ = nullptr;
-
-  meEBe1oe4_ = nullptr;
-  meEBe1oe9_ = nullptr;
-  meEBe4oe9_ = nullptr;
-  meEBe9oe16_ = nullptr;
-  meEBe1oe25_ = nullptr;
-  meEBe9oe25_ = nullptr;
-  meEBe16oe25_ = nullptr;
-
   myEntries = 0;
   for (int myStep = 0; myStep < 26; myStep++) {
     eRLength[myStep] = 0.0;
   }
-
-  Char_t histo[200];
-
-  if (dbe_) {
-    dbe_->setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
-    dbe_->setScope(MonitorElementData::Scope::RUN);
-
-    sprintf(histo, "EB hits multiplicity");
-    menEBHits_ = dbe_->book1D(histo, histo, 50, 0., 5000.);
-
-    sprintf(histo, "EB crystals multiplicity");
-    menEBCrystals_ = dbe_->book1D(histo, histo, 200, 0., 2000.);
-
-    sprintf(histo, "EB occupancy");
-    meEBOccupancy_ = dbe_->book2D(histo, histo, 360, 0., 360., 170, -85., 85.);
-
-    sprintf(histo, "EB longitudinal shower profile");
-    meEBLongitudinalShower_ = dbe_->bookProfile(histo, histo, 26, 0., 26., 100, 0., 20000.);
-
-    sprintf(histo, "EB hits energy spectrum");
-    meEBhitEnergy_ = dbe_->book1D(histo, histo, 4000, 0., 400.);
-
-    sprintf(histo, "EB hits log10energy spectrum");
-    meEBhitLog10Energy_ = dbe_->book1D(histo, histo, 140, -10., 4.);
-
-    sprintf(histo, "EB hits log10energy spectrum vs normalized energy");
-    meEBhitLog10EnergyNorm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
-
-    sprintf(histo, "EB hits log10energy spectrum vs normalized energy25");
-    meEBhitLog10Energy25Norm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
-
-    sprintf(histo, "EB hits energy spectrum 2");
-    meEBhitEnergy2_ = dbe_->book1D(histo, histo, 1000, 0., 0.001);
-
-    sprintf(histo, "EB crystal energy spectrum");
-    meEBcrystalEnergy_ = dbe_->book1D(histo, histo, 5000, 0., 50.);
-
-    sprintf(histo, "EB crystal energy spectrum 2");
-    meEBcrystalEnergy2_ = dbe_->book1D(histo, histo, 1000, 0., 0.001);
-
-    sprintf(histo, "EB E1");
-    meEBe1_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EB E4");
-    meEBe4_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EB E9");
-    meEBe9_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EB E16");
-    meEBe16_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EB E25");
-    meEBe25_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EB E1oE4");
-    meEBe1oe4_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EB E1oE9");
-    meEBe1oe9_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EB E4oE9");
-    meEBe4oe9_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EB E9oE16");
-    meEBe9oe16_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EB E1oE25");
-    meEBe1oe25_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EB E9oE25");
-    meEBe9oe25_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EB E16oE25");
-    meEBe16oe25_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-  }
 }
 
-EcalBarrelSimHitsValidation::~EcalBarrelSimHitsValidation() {}
+void EcalBarrelSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) {
+  ib.setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
+  ib.setScope(MonitorElementData::Scope::RUN);
 
-void EcalBarrelSimHitsValidation::beginJob() {}
+  std::string histo = "EB hits multiplicity";
+  menEBHits_ = ib.book1D(histo, histo, 50, 0., 5000.);
 
-void EcalBarrelSimHitsValidation::endJob() {
-  // for (int myStep=0; myStep<26; myStep++){
-  //  if (meEBLongitudinalShower_) meEBLongitudinalShower_->Fill(float(myStep),
-  //  eRLength[myStep]/myEntries);
-  //}
+  histo = "EB crystals multiplicity";
+  menEBCrystals_ = ib.book1D(histo, histo, 200, 0., 2000.);
+
+  histo = "EB occupancy";
+  meEBOccupancy_ = ib.book2D(histo, histo, 360, 0., 360., 170, -85., 85.);
+
+  histo = "EB longitudinal shower profile";
+  meEBLongitudinalShower_ = ib.bookProfile(histo, histo, 26, 0., 26., 100, 0., 20000.);
+
+  histo = "EB hits energy spectrum";
+  meEBhitEnergy_ = ib.book1D(histo, histo, 4000, 0., 400.);
+
+  histo = "EB hits log10energy spectrum";
+  meEBhitLog10Energy_ = ib.book1D(histo, histo, 140, -10., 4.);
+
+  histo = "EB hits log10energy spectrum vs normalized energy";
+  meEBhitLog10EnergyNorm_ = ib.bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+
+  histo = "EB hits log10energy spectrum vs normalized energy25";
+  meEBhitLog10Energy25Norm_ = ib.bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+
+  histo = "EB hits energy spectrum 2";
+  meEBhitEnergy2_ = ib.book1D(histo, histo, 1000, 0., 0.001);
+
+  histo = "EB crystal energy spectrum";
+  meEBcrystalEnergy_ = ib.book1D(histo, histo, 5000, 0., 50.);
+
+  histo = "EB crystal energy spectrum 2";
+  meEBcrystalEnergy2_ = ib.book1D(histo, histo, 1000, 0., 0.001);
+
+  histo = "EB E1";
+  meEBe1_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EB E4";
+  meEBe4_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EB E9";
+  meEBe9_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EB E16";
+  meEBe16_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EB E25";
+  meEBe25_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EB E1oE4";
+  meEBe1oe4_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EB E1oE9";
+  meEBe1oe9_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EB E4oE9";
+  meEBe4oe9_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EBE9oE16";
+  meEBe9oe16_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EB E1oE25";
+  meEBe1oe25_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EB E9oE25";
+  meEBe9oe25_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EB E16oE25";
+  meEBe16oe25_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
 }
 
 void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
@@ -195,8 +152,7 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
                         << " Track Id = " << isim->geantTrackId() << "\n"
                         << " Energy = " << isim->energy();
 
-    if (meEBOccupancy_)
-      meEBOccupancy_->Fill(ebid.iphi(), ebid.ieta());
+    meEBOccupancy_->Fill(ebid.iphi(), ebid.ieta());
 
     uint32_t crystid = ebid.rawId();
     ebmap[crystid] += isim->energy();
@@ -213,8 +169,7 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
     meEBhitEnergy2_->Fill(isim->energy());
   }
 
-  if (menEBCrystals_)
-    menEBCrystals_->Fill(ebmap.size());
+  menEBCrystals_->Fill(ebmap.size());
   if (meEBcrystalEnergy_) {
     for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = ebmap.begin(); it != ebmap.end(); ++it)
       meEBcrystalEnergy_->Fill((*it).second);
@@ -224,8 +179,7 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
       meEBcrystalEnergy2_->Fill((*it).second);
   }
 
-  if (menEBHits_)
-    menEBHits_->Fill(nEBHits);
+  menEBHits_->Fill(nEBHits);
 
   if (nEBHits > 0) {
     uint32_t ebcenterid = getUnitWithMaxEnergy(ebmap);
@@ -234,14 +188,11 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
     int by = myEBid.iphi();
     int bz = myEBid.zside();
     eb1 = energyInMatrixEB(1, 1, bx, by, bz, ebmap);
-    if (meEBe1_)
-      meEBe1_->Fill(eb1);
+    meEBe1_->Fill(eb1);
     eb9 = energyInMatrixEB(3, 3, bx, by, bz, ebmap);
-    if (meEBe9_)
-      meEBe9_->Fill(eb9);
+    meEBe9_->Fill(eb9);
     eb25 = energyInMatrixEB(5, 5, bx, by, bz, ebmap);
-    if (meEBe25_)
-      meEBe25_->Fill(eb25);
+    meEBe25_->Fill(eb25);
 
     std::vector<uint32_t> ids25;
     ids25 = getIdsAroundMax(5, 5, bx, by, bz, ebmap);
@@ -259,37 +210,35 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
     MapType newebmap;
     if (fillEBMatrix(3, 3, bx, by, bz, newebmap, ebmap)) {
       eb4 = eCluster2x2(newebmap);
-      if (meEBe4_)
-        meEBe4_->Fill(eb4);
+      meEBe4_->Fill(eb4);
     }
     if (fillEBMatrix(5, 5, bx, by, bz, newebmap, ebmap)) {
       eb16 = eCluster4x4(eb9, newebmap);
-      if (meEBe16_)
-        meEBe16_->Fill(eb16);
+      meEBe16_->Fill(eb16);
     }
 
-    if (meEBe1oe4_ && eb4 > 0.1)
+    if (eb4 > 0.1)
       meEBe1oe4_->Fill(eb1 / eb4);
-    if (meEBe1oe9_ && eb9 > 0.1)
+    if (eb9 > 0.1)
       meEBe1oe9_->Fill(eb1 / eb9);
-    if (meEBe4oe9_ && eb9 > 0.1)
+    if (eb9 > 0.1)
       meEBe4oe9_->Fill(eb4 / eb9);
-    if (meEBe9oe16_ && eb16 > 0.1)
+    if (eb16 > 0.1)
       meEBe9oe16_->Fill(eb9 / eb16);
-    if (meEBe1oe25_ && eb25 > 0.1)
+    if (eb25 > 0.1)
       meEBe1oe25_->Fill(eb1 / eb25);
-    if (meEBe9oe25_ && eb25 > 0.1)
+    if (eb25 > 0.1)
       meEBe9oe25_->Fill(eb9 / eb25);
-    if (meEBe16oe25_ && eb25 > 0.1)
+    if (eb25 > 0.1)
       meEBe16oe25_->Fill(eb16 / eb25);
 
-    if (meEBhitLog10EnergyNorm_ && EBEnergy_ != 0) {
+    if (EBEnergy_ != 0) {
       for (int i = 0; i < 140; i++) {
         meEBhitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10., econtr[i] / EBEnergy_);
       }
     }
 
-    if (meEBhitLog10Energy25Norm_ && eb25 != 0) {
+    if (eb25 != 0) {
       for (int i = 0; i < 140; i++) {
         meEBhitLog10Energy25Norm_->Fill(-10. + (float(i) + 0.5) / 10., econtr25[i] / eb25);
       }
@@ -299,12 +248,10 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
   if (MyPEcalValidInfo.isValid()) {
     if (MyPEcalValidInfo->eb1x1() > 0.) {
       std::vector<float> BX0 = MyPEcalValidInfo->bX0();
-      if (meEBLongitudinalShower_)
-        meEBLongitudinalShower_->Reset();
+      meEBLongitudinalShower_->Reset();
       for (int myStep = 0; myStep < 26; myStep++) {
         eRLength[myStep] += BX0[myStep];
-        if (meEBLongitudinalShower_)
-          meEBLongitudinalShower_->Fill(float(myStep), eRLength[myStep] / myEntries);
+        meEBLongitudinalShower_->Fill(float(myStep), eRLength[myStep] / myEntries);
       }
     }
   }

--- a/Validation/EcalHits/src/EcalEndcapSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalEndcapSimHitsValidation.cc
@@ -25,139 +25,93 @@ EcalEndcapSimHitsValidation::EcalEndcapSimHitsValidation(const edm::ParameterSet
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
 
-  // get hold of back-end interface
-  dbe_ = nullptr;
-  dbe_ = edm::Service<DQMStore>().operator->();
-
-  meEEzpHits_ = nullptr;
-  meEEzmHits_ = nullptr;
-  meEEzpCrystals_ = nullptr;
-  meEEzmCrystals_ = nullptr;
-  meEEzpOccupancy_ = nullptr;
-  meEEzmOccupancy_ = nullptr;
-  meEELongitudinalShower_ = nullptr;
-  meEEHitEnergy_ = nullptr;
-  meEEhitLog10Energy_ = nullptr;
-  meEEhitLog10EnergyNorm_ = nullptr;
-  meEEhitLog10Energy25Norm_ = nullptr;
-  meEEHitEnergy2_ = nullptr;
-  meEEcrystalEnergy_ = nullptr;
-  meEEcrystalEnergy2_ = nullptr;
-
-  meEEe1_ = nullptr;
-  meEEe4_ = nullptr;
-  meEEe9_ = nullptr;
-  meEEe16_ = nullptr;
-  meEEe25_ = nullptr;
-
-  meEEe1oe4_ = nullptr;
-  meEEe1oe9_ = nullptr;
-  meEEe4oe9_ = nullptr;
-  meEEe9oe16_ = nullptr;
-  meEEe1oe25_ = nullptr;
-  meEEe9oe25_ = nullptr;
-  meEEe16oe25_ = nullptr;
-
   myEntries = 0;
   for (int myStep = 0; myStep < 26; myStep++) {
     eRLength[myStep] = 0.0;
   }
-
-  Char_t histo[200];
-
-  if (dbe_) {
-    dbe_->setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
-    dbe_->setScope(MonitorElementData::Scope::RUN);
-
-    sprintf(histo, "EE+ hits multiplicity");
-    meEEzpHits_ = dbe_->book1D(histo, histo, 50, 0., 5000.);
-
-    sprintf(histo, "EE- hits multiplicity");
-    meEEzmHits_ = dbe_->book1D(histo, histo, 50, 0., 5000.);
-
-    sprintf(histo, "EE+ crystals multiplicity");
-    meEEzpCrystals_ = dbe_->book1D(histo, histo, 200, 0., 2000.);
-
-    sprintf(histo, "EE- crystals multiplicity");
-    meEEzmCrystals_ = dbe_->book1D(histo, histo, 200, 0., 2000.);
-
-    sprintf(histo, "EE+ occupancy");
-    meEEzpOccupancy_ = dbe_->book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
-
-    sprintf(histo, "EE- occupancy");
-    meEEzmOccupancy_ = dbe_->book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
-
-    sprintf(histo, "EE longitudinal shower profile");
-    meEELongitudinalShower_ = dbe_->bookProfile(histo, histo, 26, 0, 26, 100, 0, 20000);
-
-    sprintf(histo, "EE hits energy spectrum");
-    meEEHitEnergy_ = dbe_->book1D(histo, histo, 4000, 0., 400.);
-
-    sprintf(histo, "EE hits log10energy spectrum");
-    meEEhitLog10Energy_ = dbe_->book1D(histo, histo, 140, -10., 4.);
-
-    sprintf(histo, "EE hits log10energy spectrum vs normalized energy");
-    meEEhitLog10EnergyNorm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
-
-    sprintf(histo, "EE hits log10energy spectrum vs normalized energy25");
-    meEEhitLog10Energy25Norm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
-
-    sprintf(histo, "EE hits energy spectrum 2");
-    meEEHitEnergy2_ = dbe_->book1D(histo, histo, 1000, 0., 0.001);
-
-    sprintf(histo, "EE crystal energy spectrum");
-    meEEcrystalEnergy_ = dbe_->book1D(histo, histo, 5000, 0., 50.);
-
-    sprintf(histo, "EE crystal energy spectrum 2");
-    meEEcrystalEnergy2_ = dbe_->book1D(histo, histo, 1000, 0., 0.001);
-
-    sprintf(histo, "EE E1");
-    meEEe1_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EE E4");
-    meEEe4_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EE E9");
-    meEEe9_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EE E16");
-    meEEe16_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EE E25");
-    meEEe25_ = dbe_->book1D(histo, histo, 400, 0., 400.);
-
-    sprintf(histo, "EE E1oE4");
-    meEEe1oe4_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EE E1oE9");
-    meEEe1oe9_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EE E4oE9");
-    meEEe4oe9_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EE E9oE16");
-    meEEe9oe16_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EE E1oE25");
-    meEEe1oe25_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EE E9oE25");
-    meEEe9oe25_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-
-    sprintf(histo, "EE E16oE25");
-    meEEe16oe25_ = dbe_->book1D(histo, histo, 100, 0.4, 1.1);
-  }
 }
 
-EcalEndcapSimHitsValidation::~EcalEndcapSimHitsValidation() {}
+void EcalEndcapSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) {
+  ib.setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
+  ib.setScope(MonitorElementData::Scope::RUN);
 
-void EcalEndcapSimHitsValidation::beginJob() {}
+  std::string histo = "EE+ hits multiplicity";
+  meEEzpHits_ = ib.book1D(histo, histo, 50, 0., 5000.);
 
-void EcalEndcapSimHitsValidation::endJob() {
-  // for ( int myStep = 0; myStep<26; myStep++){
-  //  if (meEELongitudinalShower_) meEELongitudinalShower_->Fill(float(myStep),
-  //  eRLength[myStep]/myEntries);
-  //}
+  histo = "EE- hits multiplicity";
+  meEEzmHits_ = ib.book1D(histo, histo, 50, 0., 5000.);
+
+  histo = "EE+ crystals multiplicity";
+  meEEzpCrystals_ = ib.book1D(histo, histo, 200, 0., 2000.);
+
+  histo = "EE- crystals multiplicity";
+  meEEzmCrystals_ = ib.book1D(histo, histo, 200, 0., 2000.);
+
+  histo = "EE+ occupancy";
+  meEEzpOccupancy_ = ib.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+
+  histo = "EE- occupancy";
+  meEEzmOccupancy_ = ib.book2D(histo, histo, 100, 0., 100., 100, 0., 100.);
+
+  histo = "EE longitudinal shower profile";
+  meEELongitudinalShower_ = ib.bookProfile(histo, histo, 26, 0, 26, 100, 0, 20000);
+
+  histo = "EE hits energy spectrum";
+  meEEHitEnergy_ = ib.book1D(histo, histo, 4000, 0., 400.);
+
+  histo = "EE hits log10energy spectrum";
+  meEEhitLog10Energy_ = ib.book1D(histo, histo, 140, -10., 4.);
+
+  histo = "EE hits log10energy spectrum vs normalized energy";
+  meEEhitLog10EnergyNorm_ = ib.bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+
+  histo = "EE hits log10energy spectrum vs normalized energy25";
+  meEEhitLog10Energy25Norm_ = ib.bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+
+  histo = "EE hits energy spectrum 2";
+  meEEHitEnergy2_ = ib.book1D(histo, histo, 1000, 0., 0.001);
+
+  histo = "EE crystal energy spectrum";
+  meEEcrystalEnergy_ = ib.book1D(histo, histo, 5000, 0., 50.);
+
+  histo = "EE crystal energy spectrum 2";
+  meEEcrystalEnergy2_ = ib.book1D(histo, histo, 1000, 0., 0.001);
+
+  histo = "EE E1";
+  meEEe1_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EE E4";
+  meEEe4_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EE E9";
+  meEEe9_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EE E16";
+  meEEe16_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EE E25";
+  meEEe25_ = ib.book1D(histo, histo, 400, 0., 400.);
+
+  histo = "EE E1oE4";
+  meEEe1oe4_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EE E1oE9";
+  meEEe1oe9_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EE E4oE9";
+  meEEe4oe9_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EE E9oE16";
+  meEEe9oe16_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EE E1oE25";
+  meEEe1oe25_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EE E9oE25";
+  meEEe9oe25_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
+
+  histo = "EE E16oE25";
+  meEEe16oe25_ = ib.book1D(histo, histo, 100, 0.4, 1.1);
 }
 
 void EcalEndcapSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
@@ -218,48 +172,35 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
       nEEzpHits++;
       EEetzp_ += isim->energy();
       eemapzp[crystid] += isim->energy();
-      if (meEEzpOccupancy_)
-        meEEzpOccupancy_->Fill(eeid.ix(), eeid.iy());
+      meEEzpOccupancy_->Fill(eeid.ix(), eeid.iy());
     } else if (eeid.zside() < 0) {
       nEEzmHits++;
       EEetzm_ += isim->energy();
       eemapzm[crystid] += isim->energy();
-      if (meEEzmOccupancy_)
-        meEEzmOccupancy_->Fill(eeid.ix(), eeid.iy());
+      meEEzmOccupancy_->Fill(eeid.ix(), eeid.iy());
     }
 
-    if (meEEHitEnergy_)
-      meEEHitEnergy_->Fill(isim->energy());
+    meEEHitEnergy_->Fill(isim->energy());
     if (isim->energy() > 0) {
-      if (meEEhitLog10Energy_)
-        meEEhitLog10Energy_->Fill(log10(isim->energy()));
+      meEEhitLog10Energy_->Fill(log10(isim->energy()));
       int log10i = int((log10(isim->energy()) + 10.) * 10.);
       if (log10i >= 0 && log10i < 140)
         econtr[log10i] += isim->energy();
     }
-    if (meEEHitEnergy2_)
-      meEEHitEnergy2_->Fill(isim->energy());
+    meEEHitEnergy2_->Fill(isim->energy());
     eemap[crystid] += isim->energy();
   }
 
-  if (meEEzpCrystals_)
-    meEEzpCrystals_->Fill(eemapzp.size());
-  if (meEEzmCrystals_)
-    meEEzmCrystals_->Fill(eemapzm.size());
+  meEEzpCrystals_->Fill(eemapzp.size());
+  meEEzmCrystals_->Fill(eemapzm.size());
 
-  if (meEEcrystalEnergy_) {
-    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = eemap.begin(); it != eemap.end(); ++it)
-      meEEcrystalEnergy_->Fill((*it).second);
-  }
-  if (meEEcrystalEnergy2_) {
-    for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = eemap.begin(); it != eemap.end(); ++it)
-      meEEcrystalEnergy2_->Fill((*it).second);
-  }
+  for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = eemap.begin(); it != eemap.end(); ++it)
+    meEEcrystalEnergy_->Fill((*it).second);
+  for (std::map<uint32_t, float, std::less<uint32_t>>::iterator it = eemap.begin(); it != eemap.end(); ++it)
+    meEEcrystalEnergy2_->Fill((*it).second);
 
-  if (meEEzpHits_)
-    meEEzpHits_->Fill(nEEzpHits);
-  if (meEEzmHits_)
-    meEEzmHits_->Fill(nEEzmHits);
+  meEEzpHits_->Fill(nEEzpHits);
+  meEEzmHits_->Fill(nEEzmHits);
 
   int nEEHits = nEEzmHits + nEEzpHits;
   if (nEEHits > 0) {
@@ -269,14 +210,11 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
     int by = myEEid.iy();
     int bz = myEEid.zside();
     ee1 = energyInMatrixEE(1, 1, bx, by, bz, eemap);
-    if (meEEe1_)
-      meEEe1_->Fill(ee1);
+    meEEe1_->Fill(ee1);
     ee9 = energyInMatrixEE(3, 3, bx, by, bz, eemap);
-    if (meEEe9_)
-      meEEe9_->Fill(ee9);
+    meEEe9_->Fill(ee9);
     ee25 = energyInMatrixEE(5, 5, bx, by, bz, eemap);
-    if (meEEe25_)
-      meEEe25_->Fill(ee25);
+    meEEe25_->Fill(ee25);
 
     std::vector<uint32_t> ids25;
     ids25 = getIdsAroundMax(5, 5, bx, by, bz, eemap);
@@ -294,37 +232,35 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
     MapType neweemap;
     if (fillEEMatrix(3, 3, bx, by, bz, neweemap, eemap)) {
       ee4 = eCluster2x2(neweemap);
-      if (meEEe4_)
-        meEEe4_->Fill(ee4);
+      meEEe4_->Fill(ee4);
     }
     if (fillEEMatrix(5, 5, bx, by, bz, neweemap, eemap)) {
       ee16 = eCluster4x4(ee9, neweemap);
-      if (meEEe16_)
-        meEEe16_->Fill(ee16);
+      meEEe16_->Fill(ee16);
     }
 
-    if (meEEe1oe4_ && ee4 > 0.1)
+    if (ee4 > 0.1)
       meEEe1oe4_->Fill(ee1 / ee4);
-    if (meEEe1oe9_ && ee9 > 0.1)
+    if (ee9 > 0.1)
       meEEe1oe9_->Fill(ee1 / ee9);
-    if (meEEe4oe9_ && ee9 > 0.1)
+    if (ee9 > 0.1)
       meEEe4oe9_->Fill(ee4 / ee9);
-    if (meEEe9oe16_ && ee16 > 0.1)
+    if (ee16 > 0.1)
       meEEe9oe16_->Fill(ee9 / ee16);
-    if (meEEe16oe25_ && ee25 > 0.1)
+    if (ee25 > 0.1)
       meEEe16oe25_->Fill(ee16 / ee25);
-    if (meEEe1oe25_ && ee25 > 0.1)
+    if (ee25 > 0.1)
       meEEe1oe25_->Fill(ee1 / ee25);
-    if (meEEe9oe25_ && ee25 > 0.1)
+    if (ee25 > 0.1)
       meEEe9oe25_->Fill(ee9 / ee25);
 
-    if (meEEhitLog10EnergyNorm_ && (EEetzp_ + EEetzm_) != 0) {
+    if ((EEetzp_ + EEetzm_) != 0) {
       for (int i = 0; i < 140; i++) {
         meEEhitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10., econtr[i] / (EEetzp_ + EEetzm_));
       }
     }
 
-    if (meEEhitLog10Energy25Norm_ && ee25 != 0) {
+    if (ee25 != 0) {
       for (int i = 0; i < 140; i++) {
         meEEhitLog10Energy25Norm_->Fill(-10. + (float(i) + 0.5) / 10., econtr25[i] / ee25);
       }
@@ -334,12 +270,10 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event &e, const edm::EventS
   if (MyPEcalValidInfo.isValid()) {
     if (MyPEcalValidInfo->ee1x1() > 0.) {
       std::vector<float> EX0 = MyPEcalValidInfo->eX0();
-      if (meEELongitudinalShower_)
-        meEELongitudinalShower_->Reset();
+      meEELongitudinalShower_->Reset();
       for (int myStep = 0; myStep < 26; myStep++) {
         eRLength[myStep] += EX0[myStep];
-        if (meEELongitudinalShower_)
-          meEELongitudinalShower_->Fill(float(myStep), eRLength[myStep] / myEntries);
+        meEELongitudinalShower_->Fill(float(myStep), eRLength[myStep] / myEntries);
       }
     }
   }

--- a/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
@@ -29,93 +29,60 @@ EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(const edm::Parame
       consumes<edm::PCaloHitContainer>(edm::InputTag(std::string(g4InfoLabel), std::string(ESHitsCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
-
-  // get hold of back-end interface
-  dbe_ = nullptr;
-  dbe_ = edm::Service<DQMStore>().operator->();
-
-  menESHits1zp_ = nullptr;
-  menESHits2zp_ = nullptr;
-  menESHits1zm_ = nullptr;
-  menESHits2zm_ = nullptr;
-
-  meESEnergyHits1zp_ = nullptr;
-  meESEnergyHits2zp_ = nullptr;
-  meESEnergyHits1zm_ = nullptr;
-  meESEnergyHits2zm_ = nullptr;
-
-  meEShitLog10Energy_ = nullptr;
-  meEShitLog10EnergyNorm_ = nullptr;
-
-  meE1alphaE2zp_ = nullptr;
-  meE1alphaE2zm_ = nullptr;
-  meEEoverESzp_ = nullptr;
-  meEEoverESzm_ = nullptr;
-
-  me2eszpOver1eszp_ = nullptr;
-  me2eszmOver1eszm_ = nullptr;
-
-  Char_t histo[200];
-
-  if (dbe_) {
-    dbe_->setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
-    dbe_->setScope(MonitorElementData::Scope::RUN);
-
-    sprintf(histo, "ES hits layer 1 multiplicity z+");
-    menESHits1zp_ = dbe_->book1D(histo, histo, 50, 0., 50.);
-
-    sprintf(histo, "ES hits layer 2 multiplicity z+");
-    menESHits2zp_ = dbe_->book1D(histo, histo, 50, 0., 50.);
-
-    sprintf(histo, "ES hits layer 1 multiplicity z-");
-    menESHits1zm_ = dbe_->book1D(histo, histo, 50, 0., 50.);
-
-    sprintf(histo, "ES hits layer 2 multiplicity z-");
-    menESHits2zm_ = dbe_->book1D(histo, histo, 50, 0., 50.);
-
-    sprintf(histo, "ES hits energy layer 1 z+");
-    meESEnergyHits1zp_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
-
-    sprintf(histo, "ES hits energy layer 2 z+");
-    meESEnergyHits2zp_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
-
-    sprintf(histo, "ES hits energy layer 1 z-");
-    meESEnergyHits1zm_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
-
-    sprintf(histo, "ES hits energy layer 2 z-");
-    meESEnergyHits2zm_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
-
-    sprintf(histo, "ES hits log10energy spectrum");
-    meEShitLog10Energy_ = dbe_->book1D(histo, histo, 140, -10., 4.);
-
-    sprintf(histo, "ES hits log10energy spectrum vs normalized energy");
-    meEShitLog10EnergyNorm_ = dbe_->bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
-
-    sprintf(histo, "ES E1+07E2 z+");
-    meE1alphaE2zp_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
-
-    sprintf(histo, "ES E1+07E2 z-");
-    meE1alphaE2zm_ = dbe_->book1D(histo, histo, 100, 0., 0.05);
-
-    sprintf(histo, "EE vs ES z+");
-    meEEoverESzp_ = dbe_->bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
-
-    sprintf(histo, "EE vs ES z-");
-    meEEoverESzm_ = dbe_->bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
-
-    sprintf(histo, "ES ene2oEne1 z+");
-    me2eszpOver1eszp_ = dbe_->book1D(histo, histo, 50, 0., 10.);
-
-    sprintf(histo, "ES ene2oEne1 z-");
-    me2eszmOver1eszm_ = dbe_->book1D(histo, histo, 50, 0., 10.);
-  }
 }
 
-EcalPreshowerSimHitsValidation::~EcalPreshowerSimHitsValidation() {}
+void EcalPreshowerSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) {
+  ib.setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
+  ib.setScope(MonitorElementData::Scope::RUN);
 
-void EcalPreshowerSimHitsValidation::beginJob() {}
+  std::string histo = "ES hits layer 1 multiplicity z+";
+  menESHits1zp_ = ib.book1D(histo, histo, 50, 0., 50.);
 
-void EcalPreshowerSimHitsValidation::endJob() {}
+  histo = "ES hits layer 2 multiplicity z+";
+  menESHits2zp_ = ib.book1D(histo, histo, 50, 0., 50.);
+
+  histo = "ES hits layer 1 multiplicity z-";
+  menESHits1zm_ = ib.book1D(histo, histo, 50, 0., 50.);
+
+  histo = "ES hits layer 2 multiplicity z-";
+  menESHits2zm_ = ib.book1D(histo, histo, 50, 0., 50.);
+
+  histo = "ES hits energy layer 1 z+";
+  meESEnergyHits1zp_ = ib.book1D(histo, histo, 100, 0., 0.05);
+
+  histo = "ES hits energy layer 2 z+";
+  meESEnergyHits2zp_ = ib.book1D(histo, histo, 100, 0., 0.05);
+
+  histo = "ES hits energy layer 1 z-";
+  meESEnergyHits1zm_ = ib.book1D(histo, histo, 100, 0., 0.05);
+
+  histo = "ES hits energy layer 2 z-";
+  meESEnergyHits2zm_ = ib.book1D(histo, histo, 100, 0., 0.05);
+
+  histo = "ES hits log10energy spectrum";
+  meEShitLog10Energy_ = ib.book1D(histo, histo, 140, -10., 4.);
+
+  histo = "ES hits log10energy spectrum vs normalized energy";
+  meEShitLog10EnergyNorm_ = ib.bookProfile(histo, histo, 140, -10., 4., 100, 0., 1.);
+
+  histo = "ES E1+07E2 z+";
+  meE1alphaE2zp_ = ib.book1D(histo, histo, 100, 0., 0.05);
+
+  histo = "ES E1+07E2 z-";
+  meE1alphaE2zm_ = ib.book1D(histo, histo, 100, 0., 0.05);
+
+  histo = "EE vs ES z+";
+  meEEoverESzp_ = ib.bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
+
+  histo = "EE vs ES z-";
+  meEEoverESzm_ = ib.bookProfile(histo, histo, 250, 0., 500., 200, 0., 200.);
+
+  histo = "ES ene2oEne1 z+";
+  me2eszpOver1eszp_ = ib.book1D(histo, histo, 50, 0., 10.);
+
+  histo = "ES ene2oEne1 z-";
+  me2eszmOver1eszm_ = ib.book1D(histo, histo, 50, 0., 10.);
+}
 
 void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
@@ -188,40 +155,32 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e, const edm::Eve
       if (esid.zside() > 0) {
         nESHits1zp++;
         ESet1zp_ += isim->energy();
-        if (meESEnergyHits1zp_)
-          meESEnergyHits1zp_->Fill(isim->energy());
+        meESEnergyHits1zp_->Fill(isim->energy());
       } else if (esid.zside() < 0) {
         nESHits1zm++;
         ESet1zm_ += isim->energy();
-        if (meESEnergyHits1zm_)
-          meESEnergyHits1zm_->Fill(isim->energy());
+        meESEnergyHits1zm_->Fill(isim->energy());
       }
     } else if (esid.plane() == 2) {
       if (esid.zside() > 0) {
         nESHits2zp++;
         ESet2zp_ += isim->energy();
-        if (meESEnergyHits2zp_)
-          meESEnergyHits2zp_->Fill(isim->energy());
+        meESEnergyHits2zp_->Fill(isim->energy());
       } else if (esid.zside() < 0) {
         nESHits2zm++;
         ESet2zm_ += isim->energy();
-        if (meESEnergyHits2zm_)
-          meESEnergyHits2zm_->Fill(isim->energy());
+        meESEnergyHits2zm_->Fill(isim->energy());
       }
     }
   }
 
-  if (menESHits1zp_)
-    menESHits1zp_->Fill(nESHits1zp);
-  if (menESHits1zm_)
-    menESHits1zm_->Fill(nESHits1zm);
+  menESHits1zp_->Fill(nESHits1zp);
+  menESHits1zm_->Fill(nESHits1zm);
 
-  if (menESHits2zp_)
-    menESHits2zp_->Fill(nESHits2zp);
-  if (menESHits2zm_)
-    menESHits2zm_->Fill(nESHits2zm);
+  menESHits2zp_->Fill(nESHits2zp);
+  menESHits2zm_->Fill(nESHits2zm);
 
-  if (meEShitLog10EnergyNorm_ && ESEnergy_ != 0) {
+  if (ESEnergy_ != 0) {
     for (int i = 0; i < 140; i++) {
       meEShitLog10EnergyNorm_->Fill(-10. + (float(i) + 0.5) / 10., econtr[i] / ESEnergy_);
     }
@@ -237,19 +196,15 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event &e, const edm::Eve
     }
 
     if (heta > 1.653 && heta < 2.6) {
-      if (meE1alphaE2zp_)
-        meE1alphaE2zp_->Fill(ESet1zp_ + 0.7 * ESet2zp_);
-      if (meEEoverESzp_)
-        meEEoverESzp_->Fill((ESet1zp_ + 0.7 * ESet2zp_) / 0.00009, EEetzp_);
-      if ((me2eszpOver1eszp_) && (ESet1zp_ != 0.))
+      meE1alphaE2zp_->Fill(ESet1zp_ + 0.7 * ESet2zp_);
+      meEEoverESzp_->Fill((ESet1zp_ + 0.7 * ESet2zp_) / 0.00009, EEetzp_);
+      if (ESet1zp_ != 0.)
         me2eszpOver1eszp_->Fill(ESet2zp_ / ESet1zp_);
     }
     if (heta < -1.653 && heta > -2.6) {
-      if (meE1alphaE2zm_)
-        meE1alphaE2zm_->Fill(ESet1zm_ + 0.7 * ESet2zm_);
-      if (meEEoverESzm_)
-        meEEoverESzm_->Fill((ESet1zm_ + 0.7 * ESet2zm_) / 0.00009, EEetzm_);
-      if ((me2eszmOver1eszm_) && (ESet1zm_ != 0.))
+      meE1alphaE2zm_->Fill(ESet1zm_ + 0.7 * ESet2zm_);
+      meEEoverESzm_->Fill((ESet1zm_ + 0.7 * ESet2zm_) / 0.00009, EEetzm_);
+      if (ESet1zm_ != 0.)
         me2eszmOver1eszm_->Fill(ESet2zm_ / ESet1zm_);
     }
   }

--- a/Validation/EcalHits/src/EcalSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalSimHitsValidation.cc
@@ -27,65 +27,32 @@ EcalSimHitsValidation::EcalSimHitsValidation(const edm::ParameterSet &ps)
   ESHitsCollectionToken =
       consumes<edm::PCaloHitContainer>(edm::InputTag(g4InfoLabel, ps.getParameter<std::string>("ESHitsCollection")));
 
-  // DQM ROOT output
-  outputFile_ = ps.getUntrackedParameter<std::string>("outputFile", "");
-
-  if (!outputFile_.empty()) {
-    edm::LogInfo("OutputInfo") << " Ecal SimHits Task histograms will be saved to " << outputFile_.c_str();
-  } else {
-    edm::LogInfo("OutputInfo") << " Ecal SimHits Task histograms will NOT be saved";
-  }
-
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
-
-  // DQMServices
-  dbe_ = nullptr;
-
-  // get hold of back-end interface
-  dbe_ = edm::Service<DQMStore>().operator->();
-
-  meGunEnergy_ = nullptr;
-  meGunEta_ = nullptr;
-  meGunPhi_ = nullptr;
-  meEBEnergyFraction_ = nullptr;
-  meEEEnergyFraction_ = nullptr;
-  meESEnergyFraction_ = nullptr;
-
-  Char_t histo[200];
-
-  if (dbe_) {
-    dbe_->setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
-    dbe_->setScope(MonitorElementData::Scope::RUN);
-
-    sprintf(histo, "EcalSimHitsValidation Gun Momentum");
-    meGunEnergy_ = dbe_->book1D(histo, histo, 100, 0., 1000.);
-
-    sprintf(histo, "EcalSimHitsValidation Gun Eta");
-    meGunEta_ = dbe_->book1D(histo, histo, 700, -3.5, 3.5);
-
-    sprintf(histo, "EcalSimHitsValidation Gun Phi");
-    meGunPhi_ = dbe_->book1D(histo, histo, 360, 0., 360.);
-
-    sprintf(histo, "EcalSimHitsValidation Barrel fraction of energy");
-    meEBEnergyFraction_ = dbe_->book1D(histo, histo, 100, 0., 1.1);
-
-    sprintf(histo, "EcalSimHitsValidation Endcap fraction of energy");
-    meEEEnergyFraction_ = dbe_->book1D(histo, histo, 100, 0., 1.1);
-
-    sprintf(histo, "EcalSimHitsValidation Preshower fraction of energy");
-    meESEnergyFraction_ = dbe_->book1D(histo, histo, 60, 0., 0.001);
-  }
 }
 
-EcalSimHitsValidation::~EcalSimHitsValidation() {
-  if (!outputFile_.empty() && dbe_)
-    dbe_->save(outputFile_);
+void EcalSimHitsValidation::bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &c) {
+  ib.setCurrentFolder("EcalHitsV/EcalSimHitsValidation");
+  ib.setScope(MonitorElementData::Scope::RUN);
+
+  std::string histo = "EcalSimHitsValidation Gun Momentum";
+  meGunEnergy_ = ib.book1D(histo, histo, 100, 0., 1000.);
+
+  histo = "EcalSimHitsValidation Gun Eta";
+  meGunEta_ = ib.book1D(histo, histo, 700, -3.5, 3.5);
+
+  histo = "EcalSimHitsValidation Gun Phi";
+  meGunPhi_ = ib.book1D(histo, histo, 360, 0., 360.);
+
+  histo = "EcalSimHitsValidation Barrel fraction of energy";
+  meEBEnergyFraction_ = ib.book1D(histo, histo, 100, 0., 1.1);
+
+  histo = "EcalSimHitsValidation Endcap fraction of energy";
+  meEEEnergyFraction_ = ib.book1D(histo, histo, 100, 0., 1.1);
+
+  histo = "EcalSimHitsValidation Preshower fraction of energy";
+  meESEnergyFraction_ = ib.book1D(histo, histo, 60, 0., 0.001);
 }
-
-void EcalSimHitsValidation::beginJob() {}
-
-void EcalSimHitsValidation::endJob() {}
 
 void EcalSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &c) {
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
@@ -119,12 +86,9 @@ void EcalSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &
     LogDebug("EventInfo") << "Particle gun type form MC = " << abs((*p)->pdg_id()) << "\n"
                           << "Energy = " << (*p)->momentum().e() << " Eta = " << heta << " Phi = " << hphi;
 
-    if (meGunEnergy_)
-      meGunEnergy_->Fill((*p)->momentum().e());
-    if (meGunEta_)
-      meGunEta_->Fill(heta);
-    if (meGunPhi_)
-      meGunPhi_->Fill(hphi);
+    meGunEnergy_->Fill((*p)->momentum().e());
+    meGunEta_->Fill(heta);
+    meGunPhi_->Fill(hphi);
   }
 
   double EBEnergy_ = 0.;
@@ -162,12 +126,7 @@ void EcalSimHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &
     fracES = ESEnergy_ / etot;
   }
 
-  if (meEBEnergyFraction_)
-    meEBEnergyFraction_->Fill(fracEB);
-
-  if (meEEEnergyFraction_)
-    meEEEnergyFraction_->Fill(fracEE);
-
-  if (meESEnergyFraction_)
-    meESEnergyFraction_->Fill(fracES);
+  meEBEnergyFraction_->Fill(fracEB);
+  meEEEnergyFraction_->Fill(fracEE);
+  meESEnergyFraction_->Fill(fracES);
 }


### PR DESCRIPTION
#### PR description:

Inspired by the discussion in https://github.com/cms-sw/cmssw/pull/28920 this PR migrates four legacy DQM analyzers in `Validation/EcalHits` that are being run in matrix workflows to `DQMEDAnalyzer`.

There are two functional changes
- The analyzers do not run without `DQMStore` service
  * Previously the code had an attempt to be able to run without `DQMStore` by booking the MonitorElements only if `DQMStore` is present, and in the `analyze()` by protecting (almost) all the `Fill()` calls
- `EcalSimHitsValidation`'s ability to save the `DQMStore` state into a file in the destructor of the analyzer is removed

#### PR validation:

Matrix workflow 25.0 (and more, but I did not explicitly test the limited matrix) runs.
