### PR TITLE
GEM online DQM bug fix - full GE1/1, backport to 11_0_X

### DIFF
--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -28,7 +28,10 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
-  void endRun(edm::Run const &, edm::EventSetup const &) override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
+                             edm::LuminosityBlock const &,
+                             edm::EventSetup const &);
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
 
   void refineSummaryHistogram(edm::Service<DQMStore> &);
@@ -49,7 +52,10 @@ void GEMDQMHarvester::fillDescriptions(edm::ConfigurationDescriptions &descripti
   descriptions.add("GEMDQMHarvester", desc);
 }
 
-void GEMDQMHarvester::endRun(edm::Run const &, edm::EventSetup const &) {
+void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
+                                            DQMStore::IGetter &,
+                                            edm::LuminosityBlock const &,
+                                            edm::EventSetup const &) {
   edm::Service<DQMStore> store;
   refineSummaryHistogram(store);
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -31,7 +31,7 @@ protected:
   void dqmEndLuminosityBlock(DQMStore::IBooker &,
                              DQMStore::IGetter &,
                              edm::LuminosityBlock const &,
-                             edm::EventSetup const &);
+                             edm::EventSetup const &) override;
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override{};  // Cannot use; it is called after dqmSaver
 
   void refineSummaryHistogram(edm::Service<DQMStore> &);

--- a/DQM/GEM/plugins/GEMDQMSource.cc
+++ b/DQM/GEM/plugins/GEMDQMSource.cc
@@ -40,6 +40,7 @@ private:
   float fGlobYMin_, fGlobYMax_;
 
   int nIdxFirstStrip_;
+  int nClusterSizeBinNum_;
 
   const GEMGeometry* initGeometry(edm::EventSetup const& iSetup);
   int findVFAT(float min_, float max_, float x_, int roll_);
@@ -86,6 +87,7 @@ GEMDQMSource::GEMDQMSource(const edm::ParameterSet& cfg) {
   tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
 
   nIdxFirstStrip_ = cfg.getParameter<int>("idxFirstStrip");
+  nClusterSizeBinNum_ = cfg.getParameter<int>("ClusterSizeBinNum");
 
   fGlobXMin_ = cfg.getParameter<double>("global_x_bound_min");
   fGlobXMax_ = cfg.getParameter<double>("global_x_bound_max");
@@ -98,6 +100,7 @@ void GEMDQMSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
 
   desc.add<int>("idxFirstStrip", 0);
+  desc.add<int>("ClusterSizeBinNum", 9);
 
   desc.add<double>("global_x_bound_min", -350);
   desc.add<double>("global_x_bound_max", 350);
@@ -154,7 +157,8 @@ void GEMDQMSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, e
     string hName_2 = "VFAT_vs_ClusterSize_" + strIdxName;
     string hTitle_2 = "VFAT vs ClusterSize " + strIdxTitle;
     hTitle_2 += ";Cluster size;VFAT";
-    VFAT_vs_ClusterSize_[gid] = ibooker.book2D(hName_2, hTitle_2, 9, 1, 10, 24, 0, 24);
+    VFAT_vs_ClusterSize_[gid] =
+        ibooker.book2D(hName_2, hTitle_2, nClusterSizeBinNum_, 1, nClusterSizeBinNum_ + 1, 24, 0, 24);
 
     string hName_fired = "StripFired_" + strIdxName;
     string hTitle_fired = "StripsFired " + strIdxTitle;
@@ -207,12 +211,12 @@ void GEMDQMSource::analyze(edm::Event const& event, edm::EventSetup const& event
       const auto& recHitsRange = gemRecHits->get(rId);
       auto gemRecHit = recHitsRange.first;
       for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
-        //int nVfat = findVFAT(0.0, 384.0, hit->firstClusterStrip()+0.5*hit->clusterSize(), rId.roll());
         Int_t nIdxStrip = hit->firstClusterStrip() + 0.5 * hit->clusterSize() - nIdxFirstStrip_;
         Int_t nVfat = 8 * ((Int_t)(nIdxStrip / (roll->nstrips() / 3)) + 1) - rId.roll();  // Strip:Start at 0
         recHitME_[cId]->Fill(nVfat);
         rh_vs_eta_[cId]->Fill(hit->localPosition().x(), rId.roll());
-        VFAT_vs_ClusterSize_[cId]->Fill(hit->clusterSize(), nVfat);
+        Int_t nCLSOverflow = (hit->clusterSize() <= nClusterSizeBinNum_ ? hit->clusterSize() : nClusterSizeBinNum_);
+        VFAT_vs_ClusterSize_[cId]->Fill(nCLSOverflow, nVfat);
         for (int i = hit->firstClusterStrip(); i < (hit->firstClusterStrip() + hit->clusterSize()); i++) {
           StripsFired_vs_eta_[cId]->Fill(i, rId.roll());
         }

--- a/DQM/GEM/test/test.py
+++ b/DQM/GEM/test/test.py
@@ -2,9 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 import os
 
-from Configuration.Eras.Era_Phase2_cff import Phase2
-
-process = cms.Process('DQMTEST')
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process('DQM', eras.Run3)
 
 
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/GEM/test/test.py
+++ b/DQM/GEM/test/test.py
@@ -2,11 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 import os
 
-#from Configuration.Eras.Era_Run3_cff import Run3
-#from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-#process = cms.Process('RECO',Run3,run3_GEM)
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('RECO',eras.Run3)
+from Configuration.Eras.Era_Phase2_cff import Phase2
+
+process = cms.Process('DQMTEST')
 
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -17,10 +15,8 @@ process.MessageLogger = cms.Service("MessageLogger",
   )
 )
 
-#process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-process.GlobalTag.globaltag = '110X_dataRun3_HLT_v1'
 
 
 
@@ -30,38 +26,18 @@ process.dqmEnv.eventInfoFolder = "EventInfo"
 process.dqmSaver.path = ""
 process.dqmSaver.tag = "GEM"
 
-#process.source = cms.Source("PoolSource",
-#  fileNames = cms.untracked.vstring(
-#    #'file:/eos/cms/store/express/Commissioning2018/ExpressCosmics/FEVT/Express-v1/000/310/292/00000/6C23251D-4F18-E811-AEC5-02163E01A41D.root'
-#    #'file:/cms/ldap_home/quark2930/Work/dqm/dqmvalidation_latest_200123/src/20011.0_new/step3.root'
-#    'file:/eos/cms/store/data/Commissioning2020/Cosmics/RAW/v1/000/335/685/00000/2DC31764-CAFB-9946-91FD-56452139E982.root'
-#  ),
-#  inputCommands = cms.untracked.vstring(
-#    'keep *',
-#    #'keep FEDRawDataCollection_*_*_*'
-#  )
-#)
-process.source = cms.Source(
-    "NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring("file:/afs/cern.ch/user/b/bko/Public/dat_run335670/run335670_ls0001_streamExpressCosmics_StorageManager.dat"),
-    skipEvents=cms.untracked.uint32(0)
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(
+    'file:/eos/cms/store/express/Commissioning2018/ExpressCosmics/FEVT/Express-v1/000/310/292/00000/6C23251D-4F18-E811-AEC5-02163E01A41D.root'
+  ),
+  inputCommands = cms.untracked.vstring(
+    'keep *',
+    #'keep FEDRawDataCollection_*_*_*'
+  )
 )
 
-import sys
-
-strNameList = sys.argv[ 2 ] if len(sys.argv) > 2 else ""
-
-if strNameList != "": 
-  listSrc = []
-  if strNameList.endswith(".root"): 
-    listSrc.append(strNameList)
-  else: 
-    with open(strNameList) as fSrc: listSrc += [ s for s in fSrc.read().splitlines() if s != "" ]
-  
-  process.source.fileNames = cms.untracked.vstring(listSrc)
-
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(-1)
+  input = cms.untracked.int32(8000)
 )
 
 process.load("EventFilter.GEMRawToDigi.muonGEMDigis_cfi")
@@ -71,27 +47,8 @@ process.load("DQM.GEM.GEMDQM_cff")
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.unPackStatusDigis = True
 
-# dump raw data
-#process.dumpRaw = cms.EDAnalyzer(
-#    "DumpFEDRawDataProduct",
-#    token = cms.untracked.InputTag("rawDataCollector"),
-#    feds = cms.untracked.vint32 ( 1467,1468 ),
-#    dumpPayload = cms.untracked.bool ( False )
-#)
-
-process.output = cms.OutputModule(
-    "PoolOutputModule",
-    outputCommands = cms.untracked.vstring("keep *"),
-    #fileName = cms.untracked.string('gem_EDM.root')
-    fileName = cms.untracked.string('gem_EDM.root')
-)
-
-process.out = cms.EndPath(
-    process.output
-)
-
-#process.GEMDQMStatusDigi.pathOfPrevDQMRoot = "DQM_V0001_GEM_R000030000.root"
-#process.GEMDQMHarvester.fromFile = "DQM_V0001_GEM_R000020150.root"
+process.GEMDQMStatusDigi.pathOfPrevDQMRoot = "DQM_V0001_GEM_R000030000.root"
+process.GEMDQMHarvester.fromFile = "DQM_V0001_GEM_R000020150.root"
 
 ############## DB file ################# 
 #from CondCore.CondDB.CondDB_cfi import *
@@ -107,16 +64,14 @@ process.out = cms.EndPath(
 #)
 ####################################
 process.path = cms.Path(
-  #process.dumpRaw * 
-  process.muonGEMDigis *
-  process.gemRecHits *
+  #process.muonGEMDigis *
+  #process.gemRecHits *
   process.GEMDQM
 )
 
 process.end_path = cms.EndPath(
   process.dqmEnv +
-  process.dqmSaver + 
-  process.output
+  process.dqmSaver
 )
 
 process.schedule = cms.Schedule(

--- a/DQM/GEM/test/test.py
+++ b/DQM/GEM/test/test.py
@@ -2,9 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 import os
 
-from Configuration.Eras.Era_Phase2_cff import Phase2
-
-process = cms.Process('DQMTEST')
+#from Configuration.Eras.Era_Run3_cff import Run3
+#from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+#process = cms.Process('RECO',Run3,run3_GEM)
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process('RECO',eras.Run3)
 
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -15,9 +17,10 @@ process.MessageLogger = cms.Service("MessageLogger",
   )
 )
 
-#process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D35Reco_cff')
+#process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+process.GlobalTag.globaltag = '110X_dataRun3_HLT_v1'
 
 
 
@@ -27,18 +30,38 @@ process.dqmEnv.eventInfoFolder = "EventInfo"
 process.dqmSaver.path = ""
 process.dqmSaver.tag = "GEM"
 
-process.source = cms.Source("PoolSource",
-  fileNames = cms.untracked.vstring(
-    'file:/eos/cms/store/express/Commissioning2018/ExpressCosmics/FEVT/Express-v1/000/310/292/00000/6C23251D-4F18-E811-AEC5-02163E01A41D.root'
-  ),
-  inputCommands = cms.untracked.vstring(
-    'keep *',
-    #'keep FEDRawDataCollection_*_*_*'
-  )
+#process.source = cms.Source("PoolSource",
+#  fileNames = cms.untracked.vstring(
+#    #'file:/eos/cms/store/express/Commissioning2018/ExpressCosmics/FEVT/Express-v1/000/310/292/00000/6C23251D-4F18-E811-AEC5-02163E01A41D.root'
+#    #'file:/cms/ldap_home/quark2930/Work/dqm/dqmvalidation_latest_200123/src/20011.0_new/step3.root'
+#    'file:/eos/cms/store/data/Commissioning2020/Cosmics/RAW/v1/000/335/685/00000/2DC31764-CAFB-9946-91FD-56452139E982.root'
+#  ),
+#  inputCommands = cms.untracked.vstring(
+#    'keep *',
+#    #'keep FEDRawDataCollection_*_*_*'
+#  )
+#)
+process.source = cms.Source(
+    "NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring("file:/afs/cern.ch/user/b/bko/Public/dat_run335670/run335670_ls0001_streamExpressCosmics_StorageManager.dat"),
+    skipEvents=cms.untracked.uint32(0)
 )
 
+import sys
+
+strNameList = sys.argv[ 2 ] if len(sys.argv) > 2 else ""
+
+if strNameList != "": 
+  listSrc = []
+  if strNameList.endswith(".root"): 
+    listSrc.append(strNameList)
+  else: 
+    with open(strNameList) as fSrc: listSrc += [ s for s in fSrc.read().splitlines() if s != "" ]
+  
+  process.source.fileNames = cms.untracked.vstring(listSrc)
+
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(8000)
+  input = cms.untracked.int32(-1)
 )
 
 process.load("EventFilter.GEMRawToDigi.muonGEMDigis_cfi")
@@ -48,8 +71,27 @@ process.load("DQM.GEM.GEMDQM_cff")
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.unPackStatusDigis = True
 
-process.GEMDQMStatusDigi.pathOfPrevDQMRoot = "DQM_V0001_GEM_R000030000.root"
-process.GEMDQMHarvester.fromFile = "DQM_V0001_GEM_R000020150.root"
+# dump raw data
+#process.dumpRaw = cms.EDAnalyzer(
+#    "DumpFEDRawDataProduct",
+#    token = cms.untracked.InputTag("rawDataCollector"),
+#    feds = cms.untracked.vint32 ( 1467,1468 ),
+#    dumpPayload = cms.untracked.bool ( False )
+#)
+
+process.output = cms.OutputModule(
+    "PoolOutputModule",
+    outputCommands = cms.untracked.vstring("keep *"),
+    #fileName = cms.untracked.string('gem_EDM.root')
+    fileName = cms.untracked.string('gem_EDM.root')
+)
+
+process.out = cms.EndPath(
+    process.output
+)
+
+#process.GEMDQMStatusDigi.pathOfPrevDQMRoot = "DQM_V0001_GEM_R000030000.root"
+#process.GEMDQMHarvester.fromFile = "DQM_V0001_GEM_R000020150.root"
 
 ############## DB file ################# 
 #from CondCore.CondDB.CondDB_cfi import *
@@ -65,14 +107,16 @@ process.GEMDQMHarvester.fromFile = "DQM_V0001_GEM_R000020150.root"
 #)
 ####################################
 process.path = cms.Path(
-  #process.muonGEMDigis *
-  #process.gemRecHits *
+  #process.dumpRaw * 
+  process.muonGEMDigis *
+  process.gemRecHits *
   process.GEMDQM
 )
 
 process.end_path = cms.EndPath(
   process.dqmEnv +
-  process.dqmSaver
+  process.dqmSaver + 
+  process.output
 )
 
 process.schedule = cms.Schedule(

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -2,8 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('GEMDQM')
 
-#process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
-process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 process.load("DQM.Integration.config.environment_cfi")

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('GEMDQM')
 
-process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
+#process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 process.load("DQM.Integration.config.environment_cfi")
@@ -19,7 +20,7 @@ process.load("DQM.GEM.GEMDQM_cff")
 
 
 if (process.runType.getRunType() == process.runType.hi_run):
-  process.muonGEMDigis.InputLabel = cms.InputTag("rawDataRepacker")                                                                                                                                          
+  process.muonGEMDigis.InputLabel = cms.InputTag("rawDataRepacker")
 
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.unPackStatusDigis = True

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
-GlobalTag.globaltag = "106X_dataRun3_HLT_v3"
+GlobalTag.globaltag = "110X_dataRun3_HLT_GEMRecoGEO_v1"


### PR DESCRIPTION
#### PR description:
This backport PR to 11_0_X which fixes a bug on the part of onlineDQM for GEM. The previous version uses `endRun` to draw summary plots, which is not a good idea in online DQM. This new version moves it to `dqmEndLuminosityBlock`.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij