### PR TITLE
customization files needed for CSC reco objects study

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
+++ b/RecoLocalMuon/CSCRecHitD/python/customRecHitBuilder.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+def tightenAnodeTimes(process):
+    if hasattr(process,'csc2DRecHits'):
+        process.csc2DRecHits.CSCUseReducedWireTimeWindow = True
+        process.csc2DRecHits.CSCWireTimeWindowLow = 5
+        process.csc2DRecHits.CSCWireTimeWindowHigh = 11
+        return process

--- a/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
+++ b/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
@@ -2,4 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 def widenRoads(process):
    if hasattr(process,'cscSegments'):
-      for ps in process.cscSegments.algo_psets[4].algo_psets: ps.enlarge = True     
+      for ps in process.cscSegments.algo_psets[4].algo_psets: ps.enlarge = True   
+      return process

--- a/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
+++ b/RecoLocalMuon/CSCSegment/python/customSegmentBuilder.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+def widenRoads(process):
+   if hasattr(process,'cscSegments'):
+      for ps in process.cscSegments.algo_psets[4].algo_psets: ps.enlarge = True     


### PR DESCRIPTION
#### PR description:

We've managed to set up 'customize' files for cmsDriver that will implement the tests we'd like to run on CSC local reco:
- loosening roads for association of rechits with segments
- tightening anode time window from 16BX to 8BX when building rechits

