### PR TITLE
Correct ECAL timing calibration for Run2018D

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v10',
+    'run1_data'         :   '111X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v10',
+    'run2_data'         :   '111X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail' : '110X_dataRun2_HEfail_v1',
+    'run2_data_HEfail' : '111X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v10',
+    'run2_data_relval'  :   '111X_dataRun2_relval_v1',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR updates the ECAL timing calibration for Run2018D to include several missing `EcalTimeCalibConstantsRcd` payloads. The validation was presented at the [12 December 2019 PPD meeting](https://indico.cern.ch/event/863633/contributions/3670489/attachments/1961044/3259253/PPD_12_12_2019.pdf). These tags have already been included in the `106X_dataRun2_v26` GT used in the [2018D UL reprocessing](https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVDataReprocessingUL2018#cmsdrivers) but the changes had not yet been propagated to autoCond in master.

In addition, the name of the offline GTs have been updated to reflect that these GTs should be used for 11_1_X only. This isn't really necessary for this PR but rather is done because the name change should have been made already in PR #28825, which was not intended to be backported to 11_0_X.

The GT diffs are as follows:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v10/111X_dataRun2_v1
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_HEfail_v1/111X_dataRun2_HEfail_v1 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v10/111X_dataRun2_relval_v1

#### PR validation:

In addition to the validation mentioned above, a technical test was performed: `runTheMatrix.py -l limited --ibeos`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but it will be backported to 11_0_X.