### PR TITLE
Correct ECAL timing calibration for Run2018D [11_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '110X_dataRun2_v9',
+    'run1_data'         :   '110X_dataRun2_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '110X_dataRun2_v9',
+    'run2_data'         :   '110X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '110X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '110X_dataRun2_relval_v11',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '110X_dataRun2_PromptLike_HEfail_v9',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR provides GTs with the correct ECAL timing calibration for Run2018D and is a backport of PR #28981; please see the description of that PR for further details. The GT diffs are as follows:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_v9/110X_dataRun2_v11
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun2_relval_v9/110X_dataRun2_relval_v11

The AlCaReco update contained in the `110X_dataRun2_v10` and `110X_dataRun2_relval_v10` GTs is not included, as the corresponding code changes are not merged in 11_0_X, only 11_1_X.

#### PR validation:

In addition to the physics validation (see PR #28981 for details), a technical test was performed: `runTheMatrix.py -l limited --ibeos` 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is a backport of PR #28981.