### PR TITLE
Adding parameters needed for PUjetID 94X and 102X v2

### DIFF
--- a/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDCutParams_cfi.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 full_81x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
 
-    #Tight Id            
+    #Tight Id
     Pt010_Tight    = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt1020_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
     Pt2030_Tight   = cms.vdouble( 0.69, -0.35, -0.26, -0.21),
@@ -26,12 +26,23 @@ full_81x_chs_wp  = cms.PSet(
 )
 
 ###########################################################
+## Working points for the 102X training
+###########################################################
+full_102x_chs_wp = full_81x_chs_wp.clone()
+
+###########################################################
+## Working points for the 94X training
+###########################################################
+full_94x_chs_wp = full_81x_chs_wp.clone()
+
+
+###########################################################
 ## Working points for the 80X training
 ###########################################################
 full_80x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
 
-    #Tight Id            
+    #Tight Id
     Pt010_Tight    = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt1020_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
     Pt2030_Tight   = cms.vdouble( 0.26, -0.34, -0.24, -0.26),
@@ -55,8 +66,8 @@ full_80x_chs_wp  = cms.PSet(
 ###########################################################
 full_76x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
-    
-    #Tight Id            
+
+    #Tight Id
     Pt010_Tight    = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt1020_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
     Pt2030_Tight   = cms.vdouble(0.09,-0.37,-0.24,-0.21),
@@ -72,7 +83,7 @@ full_76x_chs_wp  = cms.PSet(
     Pt010_Loose    = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt1020_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
     Pt2030_Loose   = cms.vdouble(-0.96,-0.62,-0.53,-0.49),
-    Pt3050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)   
+    Pt3050_Loose   = cms.vdouble(-0.93,-0.52,-0.39,-0.31)
 )
 
 ###########################################################
@@ -80,24 +91,24 @@ full_76x_chs_wp  = cms.PSet(
 ###########################################################
 full_74x_chs_wp  = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
-                
-    #Tight Id                                                                                                                                                                                 
+
+    #Tight Id
     Pt010_Tight    = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt1020_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt2030_Tight   = cms.vdouble(-0.1,-0.83,-0.83,-0.98),
     Pt3050_Tight   = cms.vdouble(-0.5,-0.77,-0.80,-0.98),
 
-    #Medium Id                                                                                                                                                                                  
+    #Medium Id
     Pt010_Medium   = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt1020_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt2030_Medium  = cms.vdouble(-0.3,-0.87,-0.87,-0.99),
     Pt3050_Medium  = cms.vdouble(-0.6,-0.85,-0.85,-0.99),
 
-    #Loose Id                                                                                                                                                                                   
+    #Loose Id
     Pt010_Loose    = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt1020_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
     Pt2030_Loose   = cms.vdouble(-0.8,-0.97,-0.97,-0.99),
-    Pt3050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)   
+    Pt3050_Loose   = cms.vdouble(-0.8,-0.95,-0.97,-0.99)
 )
 
 ###########################################################
@@ -111,19 +122,19 @@ full_53x_wp  = cms.PSet(
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
     Pt3050_Tight   = cms.vdouble( 0.73, 0.05,-0.26,-0.42),
-    
+
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
     Pt3050_Medium  = cms.vdouble( 0.10,-0.36,-0.54,-0.54),
-    
+
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt2030_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
     Pt3050_Loose   = cms.vdouble(-0.63,-0.60,-0.55,-0.45),
-    
+
     #MET
     Pt010_MET	   = cms.vdouble( 0.  ,-0.6,-0.4,-0.4),
     Pt1020_MET     = cms.vdouble( 0.3 ,-0.2,-0.4,-0.4),
@@ -139,13 +150,13 @@ full_53x_chs_wp  = cms.PSet(
     Pt1020_Tight   = cms.vdouble(-0.83,-0.81,-0.74,-0.81),
     Pt2030_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
     Pt3050_Tight   = cms.vdouble( 0.78, 0.50, 0.17, 0.17),
-    
+
     #Medium Id
     Pt010_Medium   = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt1020_Medium  = cms.vdouble(-0.83,-0.92,-0.90,-0.92),
     Pt2030_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
     Pt3050_Medium  = cms.vdouble(-0.07,-0.09, 0.00,-0.06),
-    
+
     #Loose Id
     Pt010_Loose    = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
     Pt1020_Loose   = cms.vdouble(-0.95,-0.96,-0.94,-0.95),
@@ -154,7 +165,7 @@ full_53x_chs_wp  = cms.PSet(
     )
 
 met_53x_wp  = cms.PSet(
-    
+
     #Tight Id
     Pt010_Tight    = cms.vdouble(-2, -2, -2, -2, -2),
     Pt1020_Tight   = cms.vdouble(-2, -2, -2, -2, -2),
@@ -217,7 +228,7 @@ full_5x_wp = cms.PSet(
 
 simple_5x_wp = cms.PSet(
     #4 Eta Categories  0-2.5 2.5-2.75 2.75-3.0 3.0-5.0
-    
+
     #Tight Id
     Pt010_Tight    = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
     Pt1020_Tight   = cms.vdouble(-0.54,-0.93,-0.93,-0.94),
@@ -235,7 +246,7 @@ simple_5x_wp = cms.PSet(
     Pt1020_Loose   = cms.vdouble(-0.95,-0.97,-0.96,-0.97),
     Pt2030_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84),
     Pt3050_Loose   = cms.vdouble(-0.80,-0.86,-0.80,-0.84)
-    
+
 )
 
 ###########################################################
@@ -364,13 +375,13 @@ PuJetIdCutBased_wp = cms.PSet(
     Pt1020_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt2030_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
     Pt3050_BetaStarTight   = cms.vdouble( 0.15, 0.15, 999., 999.),
-    
+
     #Medium Id => Daniele
     Pt010_BetaStarMedium   = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt2030_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt3050_BetaStarMedium  = cms.vdouble( 0.2, 0.3, 999., 999.),
-    
+
     #Loose Id
     Pt010_BetaStarLoose    = cms.vdouble( 0.2, 0.3, 999., 999.),
     Pt1020_BetaStarLoose   = cms.vdouble( 0.2, 0.3, 999., 999.),
@@ -383,13 +394,13 @@ PuJetIdCutBased_wp = cms.PSet(
     Pt1020_RMSTight        = cms.vdouble( 0.06, 0.07, 0.04, 0.05),
     Pt2030_RMSTight        = cms.vdouble( 0.05, 0.07, 0.03, 0.045),
     Pt3050_RMSTight        = cms.vdouble( 0.05, 0.06, 0.03, 0.04),
-    
+
     #Medium Id => Daniele
     Pt010_RMSMedium        = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt1020_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt2030_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
     Pt3050_RMSMedium       = cms.vdouble( 0.06, 0.03, 0.03, 0.04),
-    
+
     #Loose Id
     Pt010_RMSLoose         = cms.vdouble( 0.06, 0.05, 0.05, 0.07),
     Pt1020_RMSLoose        = cms.vdouble( 0.06, 0.05, 0.05, 0.07),

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -104,6 +104,46 @@ full_81x_chs = cms.PSet(
         label = cms.string("full")
 )
 
+####################################################################################################################
+trainingVariables_102X = [
+                            "nvtx"      ,
+                            "beta"      ,
+                            "dR2Mean"   ,
+                            "frac01"    ,
+                            "frac02"    ,
+                            "frac03"    ,
+                            "frac04"    ,
+                            "majW"      ,
+                            "minW"      ,
+                            "jetR"      ,
+                            "jetRchg"   ,
+                            "nParticles",
+                            "nCharged"  ,
+                            "ptD"       ,
+                            "pull"      ,
+                            ]
+full_102x_chs = full_81x_chs.clone(JetIdParams = full_102x_chs_wp)
+full_102x_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz"
+full_102x_chs.trainings[0].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz"
+full_102x_chs.trainings[1].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz"
+full_102x_chs.trainings[2].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
+full_102x_chs.trainings[3].tmvaVariables = trainingVariables_102X
+
+####################################################################################################################
+trainingVariables_94X = trainingVariables_102X
+full_94x_chs = full_81x_chs.clone(JetIdParams = full_94x_chs_wp)
+full_94x_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz"
+full_94x_chs.trainings[0].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz"
+full_94x_chs.trainings[1].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz"
+full_94x_chs.trainings[2].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
+full_94x_chs.trainings[3].tmvaVariables = trainingVariables_94X
+
 
 ####################################################################################################################
 full_80x_chs = cms.PSet(
@@ -208,7 +248,7 @@ full_80x_chs = cms.PSet(
         label = cms.string("full")
 )
 
-####################################################################################################################                                                                                      
+####################################################################################################################
 full_76x_chs = cms.PSet(
     impactParTkThreshold = cms.double(1.) ,
     cutBased = cms.bool(False),
@@ -310,7 +350,7 @@ full_76x_chs = cms.PSet(
     JetIdParams = full_76x_chs_wp,
     label = cms.string("full")
  )
-####################################################################################################################                                                                                      
+####################################################################################################################
 full_74x_chs = cms.PSet(
     impactParTkThreshold = cms.double(1.) ,
     cutBased = cms.bool(False),
@@ -416,7 +456,7 @@ full_74x_chs = cms.PSet(
     JetIdParams = full_74x_chs_wp,
     label = cms.string("full")
  )
-####################################################################################################################  
+####################################################################################################################
 full_53x = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -426,18 +466,18 @@ full_53x = cms.PSet(
  version = cms.int32(-1),
  tmvaVariables = cms.vstring(
     "nvtx"     ,
-    "dZ"       , 
-    "beta"     , 
-    "betaStar" , 
-    "nCharged" , 
-    "nNeutrals", 
-    "dR2Mean"  , 
-    "ptD"      , 
-    "frac01"   , 
-    "frac02"   , 
-    "frac03"   , 
-    "frac04"   , 
-    "frac05"   , 
+    "dZ"       ,
+    "beta"     ,
+    "betaStar" ,
+    "nCharged" ,
+    "nNeutrals",
+    "dR2Mean"  ,
+    "ptD"      ,
+    "frac01"   ,
+    "frac02"   ,
+    "frac03"   ,
+    "frac04"   ,
+    "frac05"   ,
     ),
  tmvaSpectators = cms.vstring(
     "jetPt",
@@ -447,7 +487,7 @@ full_53x = cms.PSet(
  JetIdParams = full_53x_wp,
  label = cms.string("full53x")
  )
-####################################################################################################################  
+####################################################################################################################
 full_53x_chs = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -458,18 +498,18 @@ full_53x_chs = cms.PSet(
  version = cms.int32(-1),
  tmvaVariables = cms.vstring(
     "nvtx"     ,
-    "dZ"       , 
-    "beta"     , 
-    "betaStar" , 
-    "nCharged" , 
-    "nNeutrals", 
-    "dR2Mean"  , 
-    "ptD"      , 
-    "frac01"   , 
-    "frac02"   , 
-    "frac03"   , 
-    "frac04"   , 
-    "frac05"   , 
+    "dZ"       ,
+    "beta"     ,
+    "betaStar" ,
+    "nCharged" ,
+    "nNeutrals",
+    "dR2Mean"  ,
+    "ptD"      ,
+    "frac01"   ,
+    "frac02"   ,
+    "frac03"   ,
+    "frac04"   ,
+    "frac05"   ,
     ),
  tmvaSpectators = cms.vstring(
     "jetPt",
@@ -479,7 +519,7 @@ full_53x_chs = cms.PSet(
  JetIdParams = full_53x_chs_wp,
  label = cms.string("full")
  )
-####################################################################################################################  
+####################################################################################################################
 met_53x = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -492,24 +532,24 @@ met_53x = cms.PSet(
     "jetPt"    ,
     "jetEta"   ,
     "jetPhi"   ,
-    "dZ"       , 
-    "beta"     , 
-    "betaStar" , 
-    "nCharged" , 
-    "nNeutrals", 
-    "dR2Mean"  , 
-    "ptD"      , 
-    "frac01"   , 
-    "frac02"   , 
-    "frac03"   , 
-    "frac04"   , 
-    "frac05"   , 
+    "dZ"       ,
+    "beta"     ,
+    "betaStar" ,
+    "nCharged" ,
+    "nNeutrals",
+    "dR2Mean"  ,
+    "ptD"      ,
+    "frac01"   ,
+    "frac02"   ,
+    "frac03"   ,
+    "frac04"   ,
+    "frac05"   ,
     ),
  tmvaSpectators = cms.vstring(),
  JetIdParams = met_53x_wp,
  label = cms.string("met53x")
  )
-##################################################################################################################  
+##################################################################################################################
 full_5x = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -539,7 +579,7 @@ full_5x = cms.PSet(
  label = cms.string("full")
  )
 
-##################################################################################################################  
+##################################################################################################################
 full_5x_chs = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
@@ -569,15 +609,15 @@ full_5x_chs = cms.PSet(
  label = cms.string("full")
  )
 
-####################################################################################################################  
-cutbased = cms.PSet( 
+####################################################################################################################
+cutbased = cms.PSet(
  impactParTkThreshold = cms.double(1.),
  cutBased = cms.bool(True),
  JetIdParams = PuJetIdCutBased_wp,
  label = cms.string("cutbased")
  )
 
-####################################################################################################################  
+####################################################################################################################
 PhilV1 = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -105,7 +105,7 @@ full_81x_chs = cms.PSet(
 )
 
 ####################################################################################################################
-trainingVariables_102X = [
+trainingVariables_102X_Eta0To3 = [
                             "nvtx"      ,
                             "beta"      ,
                             "dR2Mean"   ,
@@ -122,27 +122,33 @@ trainingVariables_102X = [
                             "ptD"       ,
                             "pull"      ,
                             ]
+trainingVariables_102X_Eta3To5 = list(trainingVariables_102X_Eta0To3)
+trainingVariables_102X_Eta3To5.remove('beta')
+trainingVariables_102X_Eta3To5.remove('jetRchg')
+trainingVariables_102X_Eta3To5.remove('nCharged')
+
 full_102x_chs = full_81x_chs.clone(JetIdParams = full_102x_chs_wp)
 full_102x_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta0p0To2p5_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[0].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[0].tmvaVariables = trainingVariables_102X_Eta0To3
 full_102x_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p5To2p75_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[1].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[1].tmvaVariables = trainingVariables_102X_Eta0To3
 full_102x_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta2p75To3p0_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[2].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[2].tmvaVariables = trainingVariables_102X_Eta0To3
 full_102x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_102X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
-full_102x_chs.trainings[3].tmvaVariables = trainingVariables_102X
+full_102x_chs.trainings[3].tmvaVariables = trainingVariables_102X_Eta3To5
 
 ####################################################################################################################
-trainingVariables_94X = trainingVariables_102X
+trainingVariables_94X_Eta0To3 = list(trainingVariables_102X_Eta0To3)
+trainingVariables_94X_Eta3To5 = list(trainingVariables_102X_Eta3To5)
 full_94x_chs = full_81x_chs.clone(JetIdParams = full_94x_chs_wp)
 full_94x_chs.trainings[0].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta0p0To2p5_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[0].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[0].tmvaVariables = trainingVariables_94X_Eta0To3
 full_94x_chs.trainings[1].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p5To2p75_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[1].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[1].tmvaVariables = trainingVariables_94X_Eta0To3
 full_94x_chs.trainings[2].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta2p75To3p0_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[2].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[2].tmvaVariables = trainingVariables_94X_Eta0To3
 full_94x_chs.trainings[3].tmvaWeights = "RecoJets/JetProducers/data/pileupJetId_94X_Eta3p0To5p0_chs_BDT.weights.xml.gz"
-full_94x_chs.trainings[3].tmvaVariables = trainingVariables_94X
+full_94x_chs.trainings[3].tmvaVariables = trainingVariables_94X_Eta3To5
 
 
 ####################################################################################################################

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -1,18 +1,20 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoJets.JetProducers.PileupJetIDParams_cfi import * 
+from RecoJets.JetProducers.PileupJetIDParams_cfi import *
 
 #_stdalgos_4x = cms.VPSet(full,   cutbased,PhilV1)
 _stdalgos_5x = cms.VPSet(full_5x,cutbased,PhilV1)
 
-#_chsalgos_4x = cms.VPSet(full,   cutbased) 
+#_chsalgos_4x = cms.VPSet(full,   cutbased)
 _chsalgos_5x = cms.VPSet(full_5x_chs,cutbased)
 _chsalgos_74x = cms.VPSet(full_74x_chs,cutbased)
 _chsalgos_76x = cms.VPSet(full_76x_chs,cutbased)
 _chsalgos_80x = cms.VPSet(full_80x_chs,cutbased)
 _chsalgos_81x = cms.VPSet(full_81x_chs,cutbased)
+_chsalgos_94x = cms.VPSet(full_94x_chs,cutbased)
+_chsalgos_102x = cms.VPSet(full_102x_chs,cutbased)
 
-_stdalgos    = _chsalgos_81x
+_stdalgos    = _chsalgos_102x
 
 # Calculate+store variables and run MVAs
 pileupJetId = cms.EDProducer('PileupJetIdProducer',


### PR DESCRIPTION
#### PR description:

 - Including the files and parameters needed for the latest PUjetID training for 94X and 102X samples.
 - Once merged, we need to backport this PR to the corresponding CMSSW release for the latest nanoAOD.
 - There is also a PR for the new weights for PUJetID cms-data/RecoJets-JetProducers#10 (comment)

This PR superseeds #28827.
Expected changes with this PR: https://indico.cern.ch/event/860457/#17-pujetid-training-and-valida 

FYI: @ahinzmann @lathomas  @camclean 
