### PR TITLE
DQM: Re-add harvesting test tools.

### DIFF
--- a/DQMServices/Components/test/dqmiofilecopy.sh
+++ b/DQMServices/Components/test/dqmiofilecopy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# like '/SingleElectron/Run2017D-09Aug2019_UL2017-v1/DQMIO'
+DATASET=$1
+# like 302663
+RUN=$2
+
+SOURCE='root://cms-xrd-global.cern.ch/'
+
+DIR=$(echo $DATASET | tr / _)
+
+FILES=$(dasgoclient -query="file dataset=$DATASET run=$RUN" -limit=-1)
+mkdir $DIR
+
+echo 'process.source.fileNames = cms.untracked.vstring('
+for f in $FILES; do
+  edmCopyUtil "$SOURCE$f" $DIR &
+  echo "  'file:$DIR/$(basename $f)',"
+done
+echo ')'
+
+# wait for parallel transfers to complete
+wait
+
+
+
+
+

--- a/DQMServices/Components/test/test_reharvest_from_dqmio.sh
+++ b/DQMServices/Components/test/test_reharvest_from_dqmio.sh
@@ -1,0 +1,20 @@
+# DQMIO dataset to take data from and run to look at
+RUN=302663
+DATASET=/SingleElectron/Run2017D-09Aug2019_UL2017-v1/DQMIO
+# Workflow to take the HARVESTING step from
+WORKFLOW=136.834
+
+# run cmsDriver to generate baseline harvesting config
+$(runTheMatrix.py -l 136.834 -ne | fgrep 'HARVESTING:' | grep -o 'cmsDriver.*') --no_exec
+pythonname=$(echo step*_HARVESTING.py)
+
+# copy data to local folder and add it to config
+./dqmiofilecopy.sh $DATASET $RUN >> $pythonname
+
+# no idea where this is injected in the prod setup, but it must be somewhere.
+echo "process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange('$RUN:1-$(($RUN+1)):0')" >> $pythonname
+
+echo '### Got all data, starting cmsRun!'
+
+cmsRun $pythonname
+


### PR DESCRIPTION
#### PR description:

These got accidentally deleted in the big DQM test cleanup (#28612), originally added in #28002.

The files are not used for any automated tests (primarily because we don't have any data reliably available), but can be useful to debug issues on real data. Downloading the DQMIO files before running the job should no longer be required (the input source now supports opening remote files), but it still helps to remove some unknowns from the test setup.

#### PR validation:

No changes to existing workflows. `dqmiofilecopy.py` still works to download DQMIO files when supplied with a dataset currently on disk.