### PR TITLE
Use LFN for input file in LumiAlCaRecoProducers

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/test/test_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/test_cfg.py
@@ -13,7 +13,7 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(5))
 
 process.source = cms.Source("PoolSource",
                             fileNames =  cms.untracked.vstring(
-                                'root://xrootd-cms.infn.it//store/data/Commissioning2018/AlCaLumiPixels0/ALCARECO/AlCaPCCRandom-02May2018-v1/70000/6CE65B93-D657-E811-BBB5-FA163E8006EF.root',
+                                '/store/data/Commissioning2018/AlCaLumiPixels0/ALCARECO/AlCaPCCRandom-02May2018-v1/70000/6CE65B93-D657-E811-BBB5-FA163E8006EF.root',
                                 #'file:/eos/cms/store/data/Run2017G/AlCaLumiPixels/ALCARECO/AlCaPCCRandom-17Nov2017-v1/20000/229B17F0-2B93-E811-9506-0025905B8568.root'
                             )
 )


### PR DESCRIPTION
#### PR description:

This PR modifies the input filename for a unit test in `LumiAlCaRecoProducers` so that a LFN is specified instead of explicitly specifying a redirector. This will resolve issue #28983.

#### PR validation:

`scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.