### PR TITLE
Correct ECAL timing calibration for Run2018D [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v25',
+    'run1_data'         :   '106X_dataRun2_v26',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v25',
+    'run2_data'         :   '106X_dataRun2_v26',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v23',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v24',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This is a backport of PR #28981. Please see that PR for details. This PR contains the `106X_dataRun2_v26` GT, which is already in use for the UL reprocessing.

The comparison with the previous 10_6_X offline GTs show that only the ECAL timing calibration has been updated and the comparison between the 10_6_X GTs and those in master show only expected differences (tau tags added in 11_0_X and AlCaReco trigger bit changes added in 11_1_X).

Comparison with previous 10_6_X GT:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v25/106X_dataRun2_v26 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v23/106X_dataRun2_relval_v24 


Comparison between 10_6_X and master:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_v1/106X_dataRun2_v26  
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_relval_v1/106X_dataRun2_relval_v24 

#### PR validation:

See the description of PR #28981 for details of the validation. In addition, a technical test was performed: `runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of PR #28981. The `106X_dataRun2_v26` GT is already in use for the UL reprocessing and we would like to keep autoCond up-to-date.