### PR TITLE
SiStrip Gains Calibration: add unit test for Multi-Run Harvesting

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -56,7 +56,8 @@ namespace APVGain {
   struct APVGainHistograms {
   public:
     APVGainHistograms()
-        : Charge_Vs_Index(7),
+        : EventStats(),
+          Charge_Vs_Index(7),
           Charge_1(),
           Charge_2(),
           Charge_3(),
@@ -74,6 +75,7 @@ namespace APVGain {
           APVsCollOrdered(),
           APVsColl() {}
 
+    dqm::reco::MonitorElement* EventStats;
     std::vector<dqm::reco::MonitorElement*> Charge_Vs_Index;         /*!< Charge per cm for each detector id */
     std::array<std::vector<dqm::reco::MonitorElement*>, 7> Charge_1; /*!< Charge per cm per layer / wheel */
     std::array<std::vector<dqm::reco::MonitorElement*>, 7> Charge_2; /*!< Charge per cm per layer / wheel without G2 */

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -263,6 +263,10 @@ void SiStripGainsPCLWorker::dqmAnalyze(edm::Event const& iEvent,
 
   int elepos = statCollectionFromMode(m_calibrationMode.c_str());
 
+  histograms.EventStats->Fill(0., 0., 1);
+  histograms.EventStats->Fill(1., 0., trackp->size());
+  histograms.EventStats->Fill(2., 0., charge->size());
+
   unsigned int FirstAmplitude = 0;
   for (unsigned int i = 0; i < charge->size(); i++) {
     FirstAmplitude += (*nstrips)[i];
@@ -560,6 +564,14 @@ void SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker& ibooker,
                                         << std::endl;
 
   ibooker.setCurrentFolder(dqm_dir);
+
+  // this MonitorElement is created to log the number of events / tracks and clusters used
+  // by the calibration algorithm
+
+  histograms.EventStats = ibooker.book2S("EventStats", "Statistics", 3, -0.5, 2.5, 1, 0, 1);
+  histograms.EventStats->setBinLabel(1, "events count", 1);
+  histograms.EventStats->setBinLabel(2, "tracks count", 1);
+  histograms.EventStats->setBinLabel(3, "clusters count", 1);
 
   std::string stag(tag);
   if (!stag.empty() && stag[0] != '_')

--- a/CalibTracker/SiStripChannelGain/test/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/test/BuildFile.xml
@@ -1,5 +1,12 @@
-<bin   name="testSSTGainPCL_fromRECO" file="testSSTGain_PCL_FromRECO.cpp">
-  <flags   TEST_RUNNER_ARGS="/bin/bash
-  CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromRECO.sh"/>
-  <use   name="FWCore/Utilities"/>
-</bin>
+<environment>
+  <bin   name="testSSTGainPCL_fromRECO" file="testSSTGain_PCL_FromRECO.cpp">
+    <flags   TEST_RUNNER_ARGS="/bin/bash
+			       CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromRECO.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
+  <bin name="checkMultiRunHarvestingOutput" file="checkMultiRunHarvesting.cpp">
+    <flags PRE_TEST="testSSTGainPCL_fromRECO"/>
+    <use   name="rootmath"/>
+    <use   name="roothistmatrix"/>
+  </bin>
+</environment>

--- a/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.C
+++ b/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.C
@@ -28,8 +28,8 @@ void checkDQMHarvesting(TString filename) {
         }
         exit(EXIT_FAILURE);
       } else {
-        std::cout << "checkMultiRunHarvesting: this (" << entries << ") corresponds to the expected number of events"
-                  << expected_entries << std::endl;
+        std::cout << "checkMultiRunHarvesting: this (" << entries << ") corresponds to the expected number of events ("
+                  << expected_entries << ")" << std::endl;
       }
     }
   }

--- a/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.C
+++ b/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.C
@@ -1,0 +1,36 @@
+#include "TFile.h"
+#include "TH2S.h"
+#include <iostream>
+#include <string>
+
+static constexpr int expected_entries = 20;
+static constexpr int expected_entries_firstrun = 10;
+
+void checkDQMHarvesting(TString filename) {
+  TFile *f = TFile::Open(filename);
+
+  if (!f) {
+    std::cout << "checkMultiRunHarvesting: ERROR. Could not find the file: " << filename << std::endl;
+    exit(EXIT_FAILURE);
+  } else {
+    std::string searchstring = "DQMData/Run 999999/AlCaReco/Run summary/SiStripGains/EventStats";
+    TH2S *h2 = (TH2S *)f->Get(searchstring.c_str());
+    if (!h2) {
+      std::cout << "checkMultiRunHarvesting: ERROR. Could not find the histogram " << searchstring << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      int entries = h2->GetBinContent(1, 1);  // this logs the number of events
+      if (entries != expected_entries) {
+        std::cout << "checkMultiRunHarvesting: ERROR. This (" << entries
+                  << ") is not the expect amount of events: " << expected_entries << std::endl;
+        if (entries == expected_entries_firstrun) {
+          std::cout << "checkMultiRunHarvesting: looks like only the first run was harvested!! " << std::endl;
+        }
+        exit(EXIT_FAILURE);
+      } else {
+        std::cout << "checkMultiRunHarvesting: this (" << entries << ") corresponds to the expected number of events"
+                  << expected_entries << std::endl;
+      }
+    }
+  }
+}

--- a/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.cpp
+++ b/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+#include <sstream>
+#include "checkMultiRunHarvesting.C"
+
+int main(int argc, char** argv) { checkDQMHarvesting("DQM_V0001_R000999999__Express__PCLTest__ALCAPROMPT.root"); }

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_HARVEST_FromRECO.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_HARVEST_FromRECO.py
@@ -23,7 +23,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:PromptCalibProdSiStripGains.root'),
+    fileNames = cms.untracked.vstring('file:PromptCalibProdSiStripGains_A.root'),
     processingMode = cms.untracked.string('RunsAndLumis'),
     secondaryFileNames = cms.untracked.vstring()
 )

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_MultiRun_ALCAHARVEST.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_MultiRun_ALCAHARVEST.py
@@ -1,0 +1,121 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: testSSTGain_MultiRun_HARVEST --data --conditions auto:run2_data --scenario pp -s ALCAHARVEST:SiStripGainsAAG --filein file:PromptCalibProdSiStripGainsAAG.root -n -1 --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing('analysis')
+options.register('globalTag', "auto:run2_data", VarParsing.multiplicity.singleton, VarParsing.varType.string, "Global tag")
+options.register('dumpStat', False , VarParsing.multiplicity.singleton, VarParsing.varType.bool, "dump the GT stats")
+options.parseArguments()
+
+process = cms.Process('ALCAHARVEST')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.categories.append("SiStripGainsPCLHarvester")
+process.MessageLogger.destinations = cms.untracked.vstring("cout")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("ERROR"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),
+    SiStripGainsPCLHarvester = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+)
+process.MessageLogger.statistics.append('cout')
+
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.AlCaHarvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:PromptCalibProdSiStripGains_A.root',
+        'file:PromptCalibProdSiStripGains_B.root'
+    ),
+    processingMode = cms.untracked.string('RunsAndLumis'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(1)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('testSSTGain_MultiRun_HARVEST nevts:-1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+# Additional output definition
+
+# Other statements
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGainsAAG_dbOutput)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGainsAAG_metadata)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+if(options.dumpStat):
+    process.GlobalTag.DumpStat = cms.untracked.bool(True)
+
+# Path and EndPath definitions
+
+process.ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(process.dqmSaver+process.pclMetadataWriter)
+process.SiStripGains = cms.Path(process.ALCAHARVESTSiStripGains)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.SiStripGains,process.ALCAHARVESTDQMSaveAndMetadataWriter)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# modifications in order to run the multi-run harvesting
+process.dqmSaver.saveByRun=cms.untracked.int32(-1)
+process.dqmSaver.saveAtJobEnd=cms.untracked.bool(True)
+process.dqmSaver.forceRunNumber=cms.untracked.int32(999999)
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
-(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py 0) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py 0' $?
+(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py era=A) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=A' $?
+(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py era=B) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=B' $?
 (cmsRun ${LOCAL_TEST_DIR}/testSSTGain_HARVEST_FromRECO.py 0) || die 'Failure running cmsRun testSSTGain_HARVEST_FromRECO.py 0' $?
+(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_MultiRun_ALCAHARVEST.py globalTag=102X_dataRun2_Express_v3) || die 'Failure running cmsRun testSSTGain_MultiRun_ALCAHARVEST.py 0' $?

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO_cfg.py
@@ -2,17 +2,23 @@ from __future__ import print_function
 # Auto generated configuration file
 # with command line options: stepALCA --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 1000 --dasquery=file dataset=/ZeroBias/Run2016C-SiStripCalMinBias-18Apr2017-v1/ALCARECO run=276243 --no_exec
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing('analysis')
+options.register('era',"A", VarParsing.multiplicity.singleton, VarParsing.varType.string, "input era")
+options.parseArguments()
+
 import os
 
 import Utilities.General.cmssw_das_client as das_client
 
 ###################################################################
-def getFileNames_das_client():
+def getFileNames_das_client(era_name):
 ###################################################################
     """Return files for given DAS query via das_client"""
     files = []
 
-    query = "dataset dataset=/ZeroBias/Run2*SiStripCalMinBias-*/ALCARECO site=T2_CH_CERN" 
+    query = "dataset dataset=/ZeroBias/Run2*"+era_name+"*SiStripCalMinBias-*/ALCARECO site=T2_CH_CERN"
     jsondict = das_client.get_data(query)
     status = jsondict['status']
     if status != 'ok':
@@ -79,7 +85,7 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 
-INPUTFILES=getFileNames_das_client()
+INPUTFILES=getFileNames_das_client(options.era)
 
 if len(INPUTFILES)==0: 
     print("** WARNING: ** According to a DAS query no suitable data for test is available. Skipping test")
@@ -97,13 +103,11 @@ process.options = cms.untracked.PSet()
 
 # Additional output definition
 process.ALCARECOStreamPromptCalibProdSiStripGains = cms.OutputModule("PoolOutputModule",
-                                                                     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')
-                                                                                                       ),
+                                                                     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('pathALCARECOPromptCalibProdSiStripGains')),
                                                                      dataset = cms.untracked.PSet(dataTier = cms.untracked.string('ALCARECO'),
-                                                                                                  filterName = cms.untracked.string('PromptCalibProdSiStripGains')
-                                                                                                  ),
+                                                                                                  filterName = cms.untracked.string('PromptCalibProdSiStripGains')),
                                                                      eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-                                                                     fileName = cms.untracked.string('PromptCalibProdSiStripGains.root'),
+                                                                     fileName = cms.untracked.string('PromptCalibProdSiStripGains_'+options.era+'.root'),
                                                                      outputCommands = cms.untracked.vstring('drop *', 
                                                                                                             'keep *_MEtoEDMConvertSiStripGains_*_*'
                                                                                                             )


### PR DESCRIPTION
#### PR description:

This PR is meant to add the configuration and unit test to run the SiStrip Gains in multi-run harvesting mode. This is intended to avoid to have the algorithm unintentionally broken as it happened recently with PR #28622.
A new `MonitorElement`, `EventStats` is added to the module `SiStripGainsPCLWorker` to collect the number of events, tracks and clusters used by the calibration.
The content of this newly added ME is subsequently used to check in the new unit test `checkMultiRunHarvestingOutput` that the number of events effectively used coincides with the expectations. An hint is offered to the user in case it appears only the first run has been processed.
This PR is meant as a companion of the fix for the to the `EDMtoMEConverter` in #28934.

#### PR validation:

I tested this branch to fail (as expected) in `CMSSW_11_1_X_2020-02-18-2300` while it works correctly when merging commit 2972d1d0c46fc73dd65466834b1f5f0b4441775e locally. 
It also passes `runTheMatrix.py -l 1001.0 -t 4 -j 8 --ibeos`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is meant to be submitted.

**N.B.:  This PR shall be tested together with #28934 to succeed integration tests.**

cc:
@schneiml @pieterdavid @robervalwalsh 



