### PR TITLE
Added the gen filter for the run-II pMSSM effort - backport of #28201 to 102X

### DIFF
--- a/GeneratorInterface/GenFilters/python/pMSSMFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/pMSSMFilter_cfi.py
@@ -1,0 +1,25 @@
+#Configuration file fragment used for pMSSMFilter module (GeneratorInterface/GenFilters/src/pMSSMFilter.cc) initalisation
+#pMSSMFilter_cfi GeneratorInterface/GenFilters/python/pMSSMFilter_cfi.py
+
+import FWCore.ParameterSet.Config as cms
+
+
+pMSSMFilter = cms.EDFilter("pMSSMFilter",
+	gpssrc = cms.InputTag("genParticles"),    # input genParticle collection
+ 	jetsrc = cms.InputTag("ak4GenJets"),  # input genJets collection
+  genHTcut = cms.double(140.0),                # genHT cut
+  jetEtaCut = cms.double(5.0),                 # genJet eta cut for HT
+	jetPtCut = cms.double(30.0),                 # genJet pT cut for HT			   
+	elEtaCut = cms.double(2.5),                  # gen electron eta cut for single electron trigger
+	elPtCut = cms.double(15.0),                  # gen electron pT cut for single electron trigger
+	gammaEtaCut = cms.double(2.5),               # gen photon eta cut for single photon trigger
+	gammaPtCut = cms.double(70.0),               # gen photon pT cut for single photon trigger
+	muEtaCut = cms.double(2.5),                  # gen muon eta cut for single muon trigger
+	muPtCut = cms.double(15.0),                  # gen muon pT cut for single muon trigger
+  tauEtaCut = cms.double(2.5),                 # gen tau eta cut for di-tau trigger
+	tauPtCut = cms.double(30.0),                 # gen tau pT cut for di-tau trigger
+	loosemuPtCut = cms.double(2.5),              # gen muon pT cut for soft object trigger
+	looseelPtCut = cms.double(5.0),              # gen electron pT cut for soft object trigger
+	loosegammaPtCut = cms.double(30.0),          # gen photon pT cut for soft object trigger
+	veryloosegammaPtCut = cms.double(18.0)       # gen photon pT cut for di-photon trigger
+  )

--- a/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
+++ b/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
@@ -101,35 +101,35 @@ bool pMSSMFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
       continue;
     }
     if (gp.isLastCopy()) {
-      if (abs(gp.pdgId()) == 13) {
-        if (gp.pt() > muPtCut_ && abs(gp.eta()) < muEtaCut_) {
+      if (fabs(gp.pdgId()) == 13) {
+        if (gp.pt() > muPtCut_ && fabs(gp.eta()) < muEtaCut_) {
           return true;
         }
-        if (gp.pt() > loosemuPtCut_ && abs(gp.eta()) < muEtaCut_) {
+        if (gp.pt() > loosemuPtCut_ && fabs(gp.eta()) < muEtaCut_) {
           loosemu_ += 1;
         }
       }
-      if (abs(gp.pdgId()) == 11) {
-        if (gp.pt() > elPtCut_ && abs(gp.eta()) < elEtaCut_) {
+      if (fabs(gp.pdgId()) == 11) {
+        if (gp.pt() > elPtCut_ && fabs(gp.eta()) < elEtaCut_) {
           return true;
         }
-        if (gp.pt() > looseelPtCut_ && abs(gp.eta()) < elEtaCut_) {
+        if (gp.pt() > looseelPtCut_ && fabs(gp.eta()) < elEtaCut_) {
           looseel_ += 1;
         }
       }
-      if (abs(gp.pdgId()) == 22) {
-        if (gp.pt() > gammaPtCut_ && abs(gp.eta()) < gammaEtaCut_) {
+      if (fabs(gp.pdgId()) == 22) {
+        if (gp.pt() > gammaPtCut_ && fabs(gp.eta()) < gammaEtaCut_) {
           return true;
         }
-        if (gp.pt() > loosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_) {
+        if (gp.pt() > loosegammaPtCut_ && fabs(gp.eta()) < gammaEtaCut_) {
           loosegamma_ += 1;
         } else {
-          if (gp.pt() > veryloosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_) {
+          if (gp.pt() > veryloosegammaPtCut_ && fabs(gp.eta()) < gammaEtaCut_) {
             veryloosegamma_ += 1;
           }
         }
       }
-      if (abs(gp.pdgId()) == 1000024) {
+      if (fabs(gp.pdgId()) == 1000024) {
         if (gp.numberOfDaughters() > 0) {
           decaylength = sqrt(pow(gp.vx() - gp.daughter(0)->vx(), 2) + pow(gp.vy() - gp.daughter(0)->vy(), 2));
           if (decaylength > 300) {
@@ -151,7 +151,7 @@ bool pMSSMFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
   for (std::vector<reco::GenJet>::const_iterator it = generatedJets->begin(); it != generatedJets->end(); ++it) {
     const reco::GenJet& gjet = *it;
     //Add GenJet pt to genHT if GenJet complies with given HT definition
-    if (gjet.pt() > jetPtCut_ && abs(gjet.eta()) < jetEtaCut_) {
+    if (gjet.pt() > jetPtCut_ && fabs(gjet.eta()) < jetEtaCut_) {
       genHT += gjet.pt();
     }
   }

--- a/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
+++ b/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
@@ -1,0 +1,167 @@
+/*
+Package:    GeneralInterface/GenFilters/pMSSMFilter
+Class:      pMSSMFilter
+
+class pMSSMFilter pMSSMFilter.cc GeneratorInterface/GenFilters/src/pMSSMFilter.cc
+
+Description: EDFilter which checks the event passes a baseline selection for the run-II pMSSM effort.
+
+Implementation: 
+
+The following input parameters are used 
+  gpssrc = cms.InputTag("X") : gen particle collection label as input
+  jetsrc  = cms.InputTag("X") : genjet collection collection label as input
+  jetPtCut = cms.double(#) : GenJet pT cut for HT
+  jetEtaCut = cms.double(#) : GenJet eta cut for HT
+  genHTcut = cms.double(#) : GenHT cut
+  muPtCut = cms.double(#) : muon pT cut
+  muEtaCut = cms.double(#) : muon eta cut
+  elPtCut = cms.double(#) : electron pT cut
+  elEtaCut = cms.double(#) : electron eta cut
+  gammaPtCut = cms.double(#) : photon pT cut
+  gammaEtaCut = cms.double(#) : photon eta cut
+  loosemuPtCut = cms.double(#) : loose muon pT cut
+  looseelPtCut = cms.double(#) : loose electron pT cut
+  loosegammaPtCut = cms.double(#) : loose photon pT cut
+  veryloosegammaPtCut = cms.double(#) : even looser photon pT cut
+Original Author:  Malte Mrowietz
+         Created:  Jun 2019
+*/
+
+//System include files
+#include <memory>
+#include <vector>
+#include <math.h>
+//User include files
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+
+//Class declaration
+class pMSSMFilter : public edm::EDFilter {
+public:
+  explicit pMSSMFilter(const edm::ParameterSet&);
+  ~pMSSMFilter() override;
+
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+
+  //Member data
+  edm::EDGetTokenT<reco::GenParticleCollection> token_;
+  edm::EDGetTokenT<reco::GenJetCollection> token2_;
+  double muPtCut_, muEtaCut_,elPtCut_,elEtaCut_,gammaPtCut_,gammaEtaCut_,loosemuPtCut_,looseelPtCut_,loosegammaPtCut_,veryloosegammaPtCut_,jetPtCut_, jetEtaCut_, genHTcut_;
+};
+
+//Constructor
+pMSSMFilter::pMSSMFilter(const edm::ParameterSet& params)
+  :  token_(consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("gpssrc"))),
+     token2_(consumes<reco::GenJetCollection>(params.getParameter<edm::InputTag>("jetsrc"))),
+     muPtCut_(params.getParameter<double>("muPtCut")),
+     muEtaCut_(params.getParameter<double>("muEtaCut")),
+     elPtCut_(params.getParameter<double>("elPtCut")),
+     elEtaCut_(params.getParameter<double>("elEtaCut")),
+     gammaPtCut_(params.getParameter<double>("gammaPtCut")),
+     gammaEtaCut_(params.getParameter<double>("gammaEtaCut")),
+     loosemuPtCut_(params.getParameter<double>("loosemuPtCut")),
+     looseelPtCut_(params.getParameter<double>("looseelPtCut")),
+     loosegammaPtCut_(params.getParameter<double>("loosegammaPtCut")),
+     veryloosegammaPtCut_(params.getParameter<double>("veryloosegammaPtCut")),
+     jetPtCut_(params.getParameter<double>("jetPtCut")),
+     jetEtaCut_(params.getParameter<double>("jetEtaCut")),
+     genHTcut_(params.getParameter<double>("genHTcut")){}
+
+
+//Destructor
+pMSSMFilter::~pMSSMFilter() {}
+
+bool pMSSMFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
+    using namespace std;
+    using namespace edm;
+    using namespace reco;
+    edm::Handle<reco::GenParticleCollection> gps; 
+    evt.getByToken(token_, gps);
+    edm::Handle<reco::GenJetCollection> generatedJets;
+    evt.getByToken(token2_, generatedJets);
+    int looseel_ = 0;
+    int loosemu_ = 0;
+    int loosegamma_ = 0;
+    int veryloosegamma_ = 0;
+    float decaylength;
+    for (std::vector<reco::GenParticle>::const_iterator it = gps->begin(); it != gps->end(); ++it) {
+        const reco::GenParticle& gp = *it;
+        if (gp.status() != 1){
+            continue;
+        }
+        if (gp.isLastCopy()){
+            if (abs(gp.pdgId()) == 13){
+                if (gp.pt() > muPtCut_ && abs(gp.eta()) < muEtaCut_) {
+                    return true;
+                }
+                if (gp.pt() > loosemuPtCut_ && abs(gp.eta()) < muEtaCut_) {
+                    loosemu_ +=1;
+                }
+            }
+            if (abs(gp.pdgId()) == 11){
+                if (gp.pt() > elPtCut_ && abs(gp.eta()) < elEtaCut_) {
+                    return true;
+                }
+                if (gp.pt() > looseelPtCut_ && abs(gp.eta()) < elEtaCut_) {
+                    looseel_ += 1;
+                }
+            }
+            if (abs(gp.pdgId()) == 22){
+                if (gp.pt() > gammaPtCut_ && abs(gp.eta()) < gammaEtaCut_){
+                    return true;
+                }
+                if (gp.pt() > loosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_){
+                    loosegamma_ += 1;
+                }
+                else{
+                    if (gp.pt() > veryloosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_){
+                        veryloosegamma_ += 1;
+                    }
+                }
+            }
+            if (abs(gp.pdgId())==1000024) {
+                if (gp.numberOfDaughters()>0){
+                    decaylength = sqrt(pow(gp.vx() - gp.daughter(0)->vx(),2) + pow(gp.vy() - gp.daughter(0)->vy(),2));
+                    if (decaylength > 300){
+                        return true;
+                    }
+                }
+                else {
+                    return true;
+                }
+            }
+        }
+    
+    }
+    if (looseel_ + loosemu_ + loosegamma_ > 1){
+        return true;
+    }
+    if (loosegamma_ >0 && veryloosegamma_ > 0) {
+        return true;
+    }
+    double genHT = 0.0;
+    for(std::vector<reco::GenJet>::const_iterator it = generatedJets->begin(); it != generatedJets->end(); ++it)
+    {
+        const reco::GenJet& gjet = *it;
+        //Add GenJet pt to genHT if GenJet complies with given HT definition
+        if(gjet.pt() > jetPtCut_ && abs(gjet.eta()) < jetEtaCut_) 
+        {
+            genHT += gjet.pt();
+        }
+    }
+    return (genHT > genHTcut_);
+}
+
+// Define module as a plug-in
+DEFINE_FWK_MODULE(pMSSMFilter);

--- a/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
+++ b/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
@@ -57,7 +57,7 @@ private:
   //Member data
   edm::EDGetTokenT<reco::GenParticleCollection> token_;
   edm::EDGetTokenT<reco::GenJetCollection> token2_;
-  double muPtCut_, muEtaCut_, elPtCut_, elEtaCut_, gammaPtCut_, gammaEtaCut_, loosemuPtCut_, looseelPtCut_,
+  double muPtCut_, muEtaCut_, tauPtCut_, tauEtaCut_, elPtCut_, elEtaCut_, gammaPtCut_, gammaEtaCut_, loosemuPtCut_, looseelPtCut_,
       loosegammaPtCut_, veryloosegammaPtCut_, jetPtCut_, jetEtaCut_, genHTcut_;
 };
 
@@ -67,6 +67,8 @@ pMSSMFilter::pMSSMFilter(const edm::ParameterSet& params)
       token2_(consumes<reco::GenJetCollection>(params.getParameter<edm::InputTag>("jetsrc"))),
       muPtCut_(params.getParameter<double>("muPtCut")),
       muEtaCut_(params.getParameter<double>("muEtaCut")),
+      tauPtCut_(params.getParameter<double>("tauPtCut")),
+      tauEtaCut_(params.getParameter<double>("tauEtaCut")),
       elPtCut_(params.getParameter<double>("elPtCut")),
       elEtaCut_(params.getParameter<double>("elEtaCut")),
       gammaPtCut_(params.getParameter<double>("gammaPtCut")),
@@ -97,10 +99,12 @@ bool pMSSMFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
   float decaylength;
   for (std::vector<reco::GenParticle>::const_iterator it = gps->begin(); it != gps->end(); ++it) {
     const reco::GenParticle& gp = *it;
-    if (gp.status() != 1) {
-      continue;
-    }
     if (gp.isLastCopy()) {
+      if (fabs(gp.pdgId()) == 15) {
+        if (gp.pt() > tauPtCut_ && fabs(gp.eta()) < tauEtaCut_) {
+          return true;
+        }
+      }
       if (fabs(gp.pdgId()) == 13) {
         if (gp.pt() > muPtCut_ && fabs(gp.eta()) < muEtaCut_) {
           return true;

--- a/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
+++ b/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
@@ -29,9 +29,9 @@ Original Author:  Malte Mrowietz
 */
 
 //System include files
+#include <cmath>
 #include <memory>
 #include <vector>
-#include <math.h>
 //User include files
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -57,110 +57,105 @@ private:
   //Member data
   edm::EDGetTokenT<reco::GenParticleCollection> token_;
   edm::EDGetTokenT<reco::GenJetCollection> token2_;
-  double muPtCut_, muEtaCut_,elPtCut_,elEtaCut_,gammaPtCut_,gammaEtaCut_,loosemuPtCut_,looseelPtCut_,loosegammaPtCut_,veryloosegammaPtCut_,jetPtCut_, jetEtaCut_, genHTcut_;
+  double muPtCut_, muEtaCut_, elPtCut_, elEtaCut_, gammaPtCut_, gammaEtaCut_, loosemuPtCut_, looseelPtCut_,
+      loosegammaPtCut_, veryloosegammaPtCut_, jetPtCut_, jetEtaCut_, genHTcut_;
 };
 
 //Constructor
 pMSSMFilter::pMSSMFilter(const edm::ParameterSet& params)
-  :  token_(consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("gpssrc"))),
-     token2_(consumes<reco::GenJetCollection>(params.getParameter<edm::InputTag>("jetsrc"))),
-     muPtCut_(params.getParameter<double>("muPtCut")),
-     muEtaCut_(params.getParameter<double>("muEtaCut")),
-     elPtCut_(params.getParameter<double>("elPtCut")),
-     elEtaCut_(params.getParameter<double>("elEtaCut")),
-     gammaPtCut_(params.getParameter<double>("gammaPtCut")),
-     gammaEtaCut_(params.getParameter<double>("gammaEtaCut")),
-     loosemuPtCut_(params.getParameter<double>("loosemuPtCut")),
-     looseelPtCut_(params.getParameter<double>("looseelPtCut")),
-     loosegammaPtCut_(params.getParameter<double>("loosegammaPtCut")),
-     veryloosegammaPtCut_(params.getParameter<double>("veryloosegammaPtCut")),
-     jetPtCut_(params.getParameter<double>("jetPtCut")),
-     jetEtaCut_(params.getParameter<double>("jetEtaCut")),
-     genHTcut_(params.getParameter<double>("genHTcut")){}
-
+    : token_(consumes<reco::GenParticleCollection>(params.getParameter<edm::InputTag>("gpssrc"))),
+      token2_(consumes<reco::GenJetCollection>(params.getParameter<edm::InputTag>("jetsrc"))),
+      muPtCut_(params.getParameter<double>("muPtCut")),
+      muEtaCut_(params.getParameter<double>("muEtaCut")),
+      elPtCut_(params.getParameter<double>("elPtCut")),
+      elEtaCut_(params.getParameter<double>("elEtaCut")),
+      gammaPtCut_(params.getParameter<double>("gammaPtCut")),
+      gammaEtaCut_(params.getParameter<double>("gammaEtaCut")),
+      loosemuPtCut_(params.getParameter<double>("loosemuPtCut")),
+      looseelPtCut_(params.getParameter<double>("looseelPtCut")),
+      loosegammaPtCut_(params.getParameter<double>("loosegammaPtCut")),
+      veryloosegammaPtCut_(params.getParameter<double>("veryloosegammaPtCut")),
+      jetPtCut_(params.getParameter<double>("jetPtCut")),
+      jetEtaCut_(params.getParameter<double>("jetEtaCut")),
+      genHTcut_(params.getParameter<double>("genHTcut")) {}
 
 //Destructor
 pMSSMFilter::~pMSSMFilter() {}
 
 bool pMSSMFilter::filter(edm::Event& evt, const edm::EventSetup& params) {
-    using namespace std;
-    using namespace edm;
-    using namespace reco;
-    edm::Handle<reco::GenParticleCollection> gps; 
-    evt.getByToken(token_, gps);
-    edm::Handle<reco::GenJetCollection> generatedJets;
-    evt.getByToken(token2_, generatedJets);
-    int looseel_ = 0;
-    int loosemu_ = 0;
-    int loosegamma_ = 0;
-    int veryloosegamma_ = 0;
-    float decaylength;
-    for (std::vector<reco::GenParticle>::const_iterator it = gps->begin(); it != gps->end(); ++it) {
-        const reco::GenParticle& gp = *it;
-        if (gp.status() != 1){
-            continue;
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  edm::Handle<reco::GenParticleCollection> gps;
+  evt.getByToken(token_, gps);
+  edm::Handle<reco::GenJetCollection> generatedJets;
+  evt.getByToken(token2_, generatedJets);
+  int looseel_ = 0;
+  int loosemu_ = 0;
+  int loosegamma_ = 0;
+  int veryloosegamma_ = 0;
+  float decaylength;
+  for (std::vector<reco::GenParticle>::const_iterator it = gps->begin(); it != gps->end(); ++it) {
+    const reco::GenParticle& gp = *it;
+    if (gp.status() != 1) {
+      continue;
+    }
+    if (gp.isLastCopy()) {
+      if (abs(gp.pdgId()) == 13) {
+        if (gp.pt() > muPtCut_ && abs(gp.eta()) < muEtaCut_) {
+          return true;
         }
-        if (gp.isLastCopy()){
-            if (abs(gp.pdgId()) == 13){
-                if (gp.pt() > muPtCut_ && abs(gp.eta()) < muEtaCut_) {
-                    return true;
-                }
-                if (gp.pt() > loosemuPtCut_ && abs(gp.eta()) < muEtaCut_) {
-                    loosemu_ +=1;
-                }
-            }
-            if (abs(gp.pdgId()) == 11){
-                if (gp.pt() > elPtCut_ && abs(gp.eta()) < elEtaCut_) {
-                    return true;
-                }
-                if (gp.pt() > looseelPtCut_ && abs(gp.eta()) < elEtaCut_) {
-                    looseel_ += 1;
-                }
-            }
-            if (abs(gp.pdgId()) == 22){
-                if (gp.pt() > gammaPtCut_ && abs(gp.eta()) < gammaEtaCut_){
-                    return true;
-                }
-                if (gp.pt() > loosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_){
-                    loosegamma_ += 1;
-                }
-                else{
-                    if (gp.pt() > veryloosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_){
-                        veryloosegamma_ += 1;
-                    }
-                }
-            }
-            if (abs(gp.pdgId())==1000024) {
-                if (gp.numberOfDaughters()>0){
-                    decaylength = sqrt(pow(gp.vx() - gp.daughter(0)->vx(),2) + pow(gp.vy() - gp.daughter(0)->vy(),2));
-                    if (decaylength > 300){
-                        return true;
-                    }
-                }
-                else {
-                    return true;
-                }
-            }
+        if (gp.pt() > loosemuPtCut_ && abs(gp.eta()) < muEtaCut_) {
+          loosemu_ += 1;
         }
-    
-    }
-    if (looseel_ + loosemu_ + loosegamma_ > 1){
-        return true;
-    }
-    if (loosegamma_ >0 && veryloosegamma_ > 0) {
-        return true;
-    }
-    double genHT = 0.0;
-    for(std::vector<reco::GenJet>::const_iterator it = generatedJets->begin(); it != generatedJets->end(); ++it)
-    {
-        const reco::GenJet& gjet = *it;
-        //Add GenJet pt to genHT if GenJet complies with given HT definition
-        if(gjet.pt() > jetPtCut_ && abs(gjet.eta()) < jetEtaCut_) 
-        {
-            genHT += gjet.pt();
+      }
+      if (abs(gp.pdgId()) == 11) {
+        if (gp.pt() > elPtCut_ && abs(gp.eta()) < elEtaCut_) {
+          return true;
         }
+        if (gp.pt() > looseelPtCut_ && abs(gp.eta()) < elEtaCut_) {
+          looseel_ += 1;
+        }
+      }
+      if (abs(gp.pdgId()) == 22) {
+        if (gp.pt() > gammaPtCut_ && abs(gp.eta()) < gammaEtaCut_) {
+          return true;
+        }
+        if (gp.pt() > loosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_) {
+          loosegamma_ += 1;
+        } else {
+          if (gp.pt() > veryloosegammaPtCut_ && abs(gp.eta()) < gammaEtaCut_) {
+            veryloosegamma_ += 1;
+          }
+        }
+      }
+      if (abs(gp.pdgId()) == 1000024) {
+        if (gp.numberOfDaughters() > 0) {
+          decaylength = sqrt(pow(gp.vx() - gp.daughter(0)->vx(), 2) + pow(gp.vy() - gp.daughter(0)->vy(), 2));
+          if (decaylength > 300) {
+            return true;
+          }
+        } else {
+          return true;
+        }
+      }
     }
-    return (genHT > genHTcut_);
+  }
+  if (looseel_ + loosemu_ + loosegamma_ > 1) {
+    return true;
+  }
+  if (loosegamma_ > 0 && veryloosegamma_ > 0) {
+    return true;
+  }
+  double genHT = 0.0;
+  for (std::vector<reco::GenJet>::const_iterator it = generatedJets->begin(); it != generatedJets->end(); ++it) {
+    const reco::GenJet& gjet = *it;
+    //Add GenJet pt to genHT if GenJet complies with given HT definition
+    if (gjet.pt() > jetPtCut_ && abs(gjet.eta()) < jetEtaCut_) {
+      genHT += gjet.pt();
+    }
+  }
+  return (genHT > genHTcut_);
 }
 
 // Define module as a plug-in

--- a/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
+++ b/GeneratorInterface/GenFilters/src/pMSSMFilter.cc
@@ -57,8 +57,8 @@ private:
   //Member data
   edm::EDGetTokenT<reco::GenParticleCollection> token_;
   edm::EDGetTokenT<reco::GenJetCollection> token2_;
-  double muPtCut_, muEtaCut_, tauPtCut_, tauEtaCut_, elPtCut_, elEtaCut_, gammaPtCut_, gammaEtaCut_, loosemuPtCut_, looseelPtCut_,
-      loosegammaPtCut_, veryloosegammaPtCut_, jetPtCut_, jetEtaCut_, genHTcut_;
+  double muPtCut_, muEtaCut_, tauPtCut_, tauEtaCut_, elPtCut_, elEtaCut_, gammaPtCut_, gammaEtaCut_, loosemuPtCut_,
+      looseelPtCut_, loosegammaPtCut_, veryloosegammaPtCut_, jetPtCut_, jetEtaCut_, genHTcut_;
 };
 
 //Constructor


### PR DESCRIPTION
#### PR description:
Backport of #28201.
Added a pythia8 gen-level filter to be used for the run-II pMSSM signal production.

#### PR validation:

Standard tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

#28201
