### PR TITLE
Changing handling of color indexes and anti particle creation for pythia8 EGun

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -42,7 +42,7 @@ namespace gen {
 
     for (size_t i = 0; i < fPartIDs.size(); i++) {
       int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
-      if ((particleID <= 6 || particleID == 21) && !(fAddAntiParticle)) {
+      if ((particleID <= 5 || particleID == 21) && !(fAddAntiParticle)) {
         throw cms::Exception("PythiaError") << "Attempting to generate quarks or gluons without setting "
                                                "AddAntiParticle to true. This will not handle color properly."
                                             << std::endl;
@@ -63,15 +63,14 @@ namespace gen {
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
-      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 5) {  // quarks
         (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
         if (!fAddAntiParticle)
-          colorindex++;
+          colorindex += 1;
       } else if (std::abs(particleID) == 21) {  // gluons
         (fMasterGen->event).append(21, 23, colorindex, colorindex + 1, px, py, pz, ee, mass);
         if (!fAddAntiParticle) {
-          colorindex++;
-          colorindex++;
+          colorindex += 2;
         }
       }
       // other
@@ -88,13 +87,12 @@ namespace gen {
       // (for example, gamma)
       //
       if (fAddAntiParticle) {
-        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 5) {  // quarks
           (fMasterGen->event).append(-particleID, 23, 0, colorindex, -px, -py, -pz, ee, mass);
-          colorindex++;
+          colorindex += 1;
         } else if (std::abs(particleID) == 21) {  // gluons
           (fMasterGen->event).append(21, 23, colorindex + 1, colorindex, -px, -py, -pz, ee, mass);
-          colorindex++;
-          colorindex++;
+          colorindex += 2;
         } else {
           if ((fMasterGen->particleData).isParticle(-particleID)) {
             (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -42,6 +42,9 @@ namespace gen {
 
     for (size_t i = 0; i < fPartIDs.size(); i++) {
       int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
+      if ( (particleID <= 6 || particleID == 21) && !(fAddAntiParticle) ){
+	throw cms::Exception("PythiaError") << "Attempting to generate quarks or gluons without setting AddAntiParticle to true. This will not handle color properly." << std::endl;
+      }
 
       double phi = (fMaxPhi - fMinPhi) * randomEngine().flat() + fMinPhi;
       double ee = (fMaxE - fMinE) * randomEngine().flat() + fMinE;

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -42,7 +42,7 @@ namespace gen {
 
     for (size_t i = 0; i < fPartIDs.size(); i++) {
       int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
-      if ((particleID <= 5 || particleID == 21) && !(fAddAntiParticle)) {
+      if ((std::abs(particleID) <= 6 || particleID == 21) && !(fAddAntiParticle)) {
         throw cms::Exception("PythiaError") << "Attempting to generate quarks or gluons without setting "
                                                "AddAntiParticle to true. This will not handle color properly."
                                             << std::endl;
@@ -63,7 +63,7 @@ namespace gen {
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
-      if (1 <= std::abs(particleID) && std::abs(particleID) <= 5) {  // quarks
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
         (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
         if (!fAddAntiParticle)
           colorindex += 1;
@@ -87,7 +87,7 @@ namespace gen {
       // (for example, gamma)
       //
       if (fAddAntiParticle) {
-        if (1 <= std::abs(particleID) && std::abs(particleID) <= 5) {  // quarks
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
           (fMasterGen->event).append(-particleID, 23, 0, colorindex, -px, -py, -pz, ee, mass);
           colorindex += 1;
         } else if (std::abs(particleID) == 21) {  // gluons

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -42,8 +42,10 @@ namespace gen {
 
     for (size_t i = 0; i < fPartIDs.size(); i++) {
       int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
-      if ( (particleID <= 6 || particleID == 21) && !(fAddAntiParticle) ){
-	throw cms::Exception("PythiaError") << "Attempting to generate quarks or gluons without setting AddAntiParticle to true. This will not handle color properly." << std::endl;
+      if ((particleID <= 6 || particleID == 21) && !(fAddAntiParticle)) {
+        throw cms::Exception("PythiaError") << "Attempting to generate quarks or gluons without setting "
+                                               "AddAntiParticle to true. This will not handle color properly."
+                                            << std::endl;
       }
 
       double phi = (fMaxPhi - fMinPhi) * randomEngine().flat() + fMinPhi;
@@ -61,13 +63,16 @@ namespace gen {
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
-      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6){ // quarks
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
         (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
-	if (!fAddAntiParticle) colorindex ++;
-      }
-      else if (std::abs(particleID) == 21){ // gluons
-        (fMasterGen->event).append(21, 23, colorindex, colorindex+1, px, py, pz, ee, mass);
-	if (!fAddAntiParticle){colorindex ++; colorindex ++;}
+        if (!fAddAntiParticle)
+          colorindex++;
+      } else if (std::abs(particleID) == 21) {  // gluons
+        (fMasterGen->event).append(21, 23, colorindex, colorindex + 1, px, py, pz, ee, mass);
+        if (!fAddAntiParticle) {
+          colorindex++;
+          colorindex++;
+        }
       }
       // other
       else {
@@ -85,10 +90,11 @@ namespace gen {
       if (fAddAntiParticle) {
         if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
           (fMasterGen->event).append(-particleID, 23, 0, colorindex, -px, -py, -pz, ee, mass);
-	  colorindex ++;
+          colorindex++;
         } else if (std::abs(particleID) == 21) {  // gluons
-          (fMasterGen->event).append(21, 23, colorindex+1, colorindex, -px, -py, -pz, ee, mass);
-	  colorindex ++; colorindex++;
+          (fMasterGen->event).append(21, 23, colorindex + 1, colorindex, -px, -py, -pz, ee, mass);
+          colorindex++;
+          colorindex++;
         } else {
           if ((fMasterGen->particleData).isParticle(-particleID)) {
             (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -53,13 +53,15 @@ namespace gen {
       double py = pp * sin(the) * sin(phi);
       double pz = pp * cos(the);
 
+      int colorindex = 101 + i;
+
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
       if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
-        (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
+        (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
       else if (std::abs(particleID) == 21)  // gluons
-        (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
+        (fMasterGen->event).append(21, 23, colorindex, colorindex+1, px, py, pz, ee, mass);
       // other
       else {
         (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
@@ -75,9 +77,9 @@ namespace gen {
       //
       if (fAddAntiParticle) {
         if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
-          (fMasterGen->event).append(-particleID, 23, 0, 101, -px, -py, -pz, ee, mass);
+          (fMasterGen->event).append(-particleID, 23, 0, colorindex, -px, -py, -pz, ee, mass);
         } else if (std::abs(particleID) == 21) {  // gluons
-          (fMasterGen->event).append(21, 23, 102, 101, -px, -py, -pz, ee, mass);
+          (fMasterGen->event).append(21, 23, colorindex+1, colorindex, -px, -py, -pz, ee, mass);
         } else {
           if ((fMasterGen->particleData).isParticle(-particleID)) {
             (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -38,6 +38,8 @@ namespace gen {
   bool Py8EGun::generatePartonsAndHadronize() {
     fMasterGen->event.reset();
 
+    int colorindex = 101;
+
     for (size_t i = 0; i < fPartIDs.size(); i++) {
       int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
 
@@ -53,14 +55,12 @@ namespace gen {
       double py = pp * sin(the) * sin(phi);
       double pz = pp * cos(the);
 
-      int colorindex = 101 + i;
-
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
-      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) // quarks
         (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
-      else if (std::abs(particleID) == 21)  // gluons
+      else if (std::abs(particleID) == 21) // gluons
         (fMasterGen->event).append(21, 23, colorindex, colorindex+1, px, py, pz, ee, mass);
       // other
       else {
@@ -78,8 +78,10 @@ namespace gen {
       if (fAddAntiParticle) {
         if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
           (fMasterGen->event).append(-particleID, 23, 0, colorindex, -px, -py, -pz, ee, mass);
+	  colorindex ++;
         } else if (std::abs(particleID) == 21) {  // gluons
           (fMasterGen->event).append(21, 23, colorindex+1, colorindex, -px, -py, -pz, ee, mass);
+	  colorindex ++; colorindex++;
         } else {
           if ((fMasterGen->particleData).isParticle(-particleID)) {
             (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -58,10 +58,14 @@ namespace gen {
       if (!((fMasterGen->particleData).isParticle(particleID))) {
         particleID = std::fabs(particleID);
       }
-      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) // quarks
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6){ // quarks
         (fMasterGen->event).append(particleID, 23, colorindex, 0, px, py, pz, ee, mass);
-      else if (std::abs(particleID) == 21) // gluons
+	if (!fAddAntiParticle) colorindex ++;
+      }
+      else if (std::abs(particleID) == 21){ // gluons
         (fMasterGen->event).append(21, 23, colorindex, colorindex+1, px, py, pz, ee, mass);
+	if (!fAddAntiParticle){colorindex ++; colorindex ++;}
+      }
       // other
       else {
         (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);


### PR DESCRIPTION
#### PR description:
Changes for proper treatment of color (conservation and codes):
- Increasing color index after generating one particle (anti particle obtains the same color, just on the anticolor column)
- Adding a check that if only colored particles are generated, the AddAntiParticle option is used to make sure that all colors are balanced
- Only affecting pythia8 EGun

#### PR validation:
Ran some tests locally with a core CMSSW script:
- not set AddAntiParticle at all (does not start, option must be set)
- set option to False (runs but does not generate anything and throws errors)
- set option to True (as expected: anti particle gets same anti color as particle gets color, index is not the same for two different particles)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
