### PR TITLE
remove tuple copies

### DIFF
--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -94,7 +94,7 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) : theTrackerDet(gd) {
     LogDebug("ThicknessAndType") << det->geographicalId() << " " << det->name() << " " << det->bounds()->thickness();
   }
   LogDebug("DetTypeList") << " Content of DetTypetList : size " << theDetTypetList.size();
-  for (auto iVal : theDetTypetList) {
+  for (const auto & iVal : theDetTypetList) {
     LogDebug("DetTypeList") << " DetId " << std::get<0>(iVal) << " Type "
                             << static_cast<std::underlying_type<TrackerGeometry::ModuleType>::type>(std::get<1>(iVal))
                             << " Thickness " << std::get<2>(iVal);
@@ -245,7 +245,7 @@ void TrackerGeometry::fillTestMap(const GeometricDet* gd) {
 }
 
 TrackerGeometry::ModuleType TrackerGeometry::getDetectorType(DetId detid) const {
-  for (auto iVal : theDetTypetList) {
+  for (const auto & iVal : theDetTypetList) {
     DetId detid_max = std::get<0>(iVal);
     if (detid.rawId() <= detid_max.rawId())
       return std::get<1>(iVal);
@@ -254,7 +254,7 @@ TrackerGeometry::ModuleType TrackerGeometry::getDetectorType(DetId detid) const 
 }
 
 float TrackerGeometry::getDetectorThickness(DetId detid) const {
-  for (auto iVal : theDetTypetList) {
+  for (const auto & iVal : theDetTypetList) {
     DetId detid_max = std::get<0>(iVal);
     if (detid.rawId() <= detid_max.rawId())
       return std::get<2>(iVal);

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -94,7 +94,7 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) : theTrackerDet(gd) {
     LogDebug("ThicknessAndType") << det->geographicalId() << " " << det->name() << " " << det->bounds()->thickness();
   }
   LogDebug("DetTypeList") << " Content of DetTypetList : size " << theDetTypetList.size();
-  for (const auto & iVal : theDetTypetList) {
+  for (const auto& iVal : theDetTypetList) {
     LogDebug("DetTypeList") << " DetId " << std::get<0>(iVal) << " Type "
                             << static_cast<std::underlying_type<TrackerGeometry::ModuleType>::type>(std::get<1>(iVal))
                             << " Thickness " << std::get<2>(iVal);
@@ -245,7 +245,7 @@ void TrackerGeometry::fillTestMap(const GeometricDet* gd) {
 }
 
 TrackerGeometry::ModuleType TrackerGeometry::getDetectorType(DetId detid) const {
-  for (const auto & iVal : theDetTypetList) {
+  for (const auto& iVal : theDetTypetList) {
     DetId detid_max = std::get<0>(iVal);
     if (detid.rawId() <= detid_max.rawId())
       return std::get<1>(iVal);
@@ -254,7 +254,7 @@ TrackerGeometry::ModuleType TrackerGeometry::getDetectorType(DetId detid) const 
 }
 
 float TrackerGeometry::getDetectorThickness(DetId detid) const {
-  for (const auto & iVal : theDetTypetList) {
+  for (const auto& iVal : theDetTypetList) {
     DetId detid_max = std::get<0>(iVal);
     if (detid.rawId() <= detid_max.rawId())
       return std::get<2>(iVal);


### PR DESCRIPTION
perhaps saves 8% of a hl-lhc premixing job

http://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/premix_d35_1040mtd5/test_06_perf/43

(probably the same issue is in the MTD geometry since they've copied all the tracker code by value)