### PR TITLE
Disabled (for offline) some ECAL plots based on the trigger emulator.

### DIFF
--- a/DQM/EcalMonitorClient/interface/TrigPrimClient.h
+++ b/DQM/EcalMonitorClient/interface/TrigPrimClient.h
@@ -17,6 +17,8 @@ namespace ecaldqm {
     int minEntries_;
     float errorFractionThreshold_;
     float TTF4MaskingAlarmThreshold_;
+
+    bool sourceFromEmul_;
   };
 
 }  // namespace ecaldqm

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -11,7 +11,8 @@ ecalTrigPrimClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
         minEntries = cms.untracked.int32(minEntries),
         errorFractionThreshold = cms.untracked.double(errorFractionThreshold),
-        TTF4MaskingAlarmThreshold = cms.untracked.double(TTF4MaskingAlarmThreshold)
+        TTF4MaskingAlarmThreshold = cms.untracked.double(TTF4MaskingAlarmThreshold),
+        sourceFromEmul = cms.untracked.bool(True)
     ),
     sources = cms.untracked.PSet(
         EtEmulError = ecalTrigPrimTask.MEs.EtEmulError,

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -30,7 +30,8 @@ namespace ecaldqm {
 
   void TrigPrimClient::producePlots(ProcessType) {
     MESet* meNonSingleSummary = nullptr;
-    MESet* meTimingSummary = nullptr;;
+    MESet* meTimingSummary = nullptr;
+    ;
     MESet* sEtEmulError = nullptr;
     MESet* sMatchedIndex = nullptr;
 
@@ -56,40 +57,39 @@ namespace ecaldqm {
       bool doMask(meEmulQualitySummary.maskMatches(ttid, mask, statusManager_));
 
       if (sourceFromEmul_) {
-	sEtEmulError = &sources_.at("EtEmulError");
-	sMatchedIndex = &sources_.at("MatchedIndex");
-	meNonSingleSummary = &MEs_.at("NonSingleSummary");
-	meTimingSummary = &MEs_.at("TimingSummary");
-	float towerEntries(0.);
-	float tMax(0.5);
-	float nMax(0.);
-	for (int iBin(0); iBin < 6; iBin++) {
-	  float entries(sMatchedIndex->getBinContent(ttid, iBin + 1));
-	  towerEntries += entries;
+        sEtEmulError = &sources_.at("EtEmulError");
+        sMatchedIndex = &sources_.at("MatchedIndex");
+        meNonSingleSummary = &MEs_.at("NonSingleSummary");
+        meTimingSummary = &MEs_.at("TimingSummary");
+        float towerEntries(0.);
+        float tMax(0.5);
+        float nMax(0.);
+        for (int iBin(0); iBin < 6; iBin++) {
+          float entries(sMatchedIndex->getBinContent(ttid, iBin + 1));
+          towerEntries += entries;
 
-	  if (entries > nMax) {
-	    nMax = entries;
-	    tMax = iBin == 0 ? -0.5 : iBin + 0.5;  // historical reasons.. much clearer to say "no entry = -0.5"
-	  }
-	}
-	meTimingSummary->setBinContent(ttid, tMax);
-	if (towerEntries < minEntries_) {
-	  meEmulQualitySummary.setBinContent(ttid, doMask ? kMUnknown : kUnknown);
-	  continue;
-	}
+          if (entries > nMax) {
+            nMax = entries;
+            tMax = iBin == 0 ? -0.5 : iBin + 0.5;  // historical reasons.. much clearer to say "no entry = -0.5"
+          }
+        }
+        meTimingSummary->setBinContent(ttid, tMax);
+        if (towerEntries < minEntries_) {
+          meEmulQualitySummary.setBinContent(ttid, doMask ? kMUnknown : kUnknown);
+          continue;
+        }
 
-	float nonsingleFraction(1. - nMax / towerEntries);
+        float nonsingleFraction(1. - nMax / towerEntries);
 
-	if (nonsingleFraction > 0.) {
-	  meNonSingleSummary->setBinContent(ttid, nonsingleFraction);
-	}
+        if (nonsingleFraction > 0.) {
+          meNonSingleSummary->setBinContent(ttid, nonsingleFraction);
+        }
 
-	if (sEtEmulError->getBinContent(ttid) / towerEntries > errorFractionThreshold_) {
-	  meEmulQualitySummary.setBinContent(ttid, doMask ? kMBad : kBad);
-	}
-	else {
-	  meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
-	}
+        if (sEtEmulError->getBinContent(ttid) / towerEntries > errorFractionThreshold_) {
+          meEmulQualitySummary.setBinContent(ttid, doMask ? kMBad : kBad);
+        } else {
+          meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
+        }
       }
 
       // Keep count for Occupancy analysis

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -19,16 +19,24 @@ namespace ecaldqm {
     minEntries_ = _params.getUntrackedParameter<int>("minEntries");
     errorFractionThreshold_ = _params.getUntrackedParameter<double>("errorFractionThreshold");
     TTF4MaskingAlarmThreshold_ = _params.getUntrackedParameter<double>("TTF4MaskingAlarmThreshold");
+    sourceFromEmul_ = _params.getUntrackedParameter<bool>("sourceFromEmul");
+    if (!sourceFromEmul_) {
+      MEs_.erase(std::string("NonSingleSummary"));
+      MEs_.erase(std::string("TimingSummary"));
+      sources_.erase(std::string("EtEmulError"));
+      sources_.erase(std::string("MatchedIndex"));
+    }
   }
 
   void TrigPrimClient::producePlots(ProcessType) {
-    MESet& meTimingSummary(MEs_.at("TimingSummary"));
-    MESet& meNonSingleSummary(MEs_.at("NonSingleSummary"));
+    MESet* meNonSingleSummary = nullptr;
+    MESet* meTimingSummary = nullptr;;
+    MESet* sEtEmulError = nullptr;
+    MESet* sMatchedIndex = nullptr;
+
     MESet& meEmulQualitySummary(MEs_.at("EmulQualitySummary"));
     MESet& meTrendTTF4Flags(MEs_.at("TrendTTF4Flags"));
 
-    MESet const& sEtEmulError(sources_.at("EtEmulError"));
-    MESet const& sMatchedIndex(sources_.at("MatchedIndex"));
     MESet const& sTPDigiThrAll(sources_.at("TPDigiThrAll"));
     MESetNonObject const& sLHCStatusByLumi(static_cast<MESetNonObject&>(sources_.at("LHCStatusByLumi")));
 
@@ -47,35 +55,42 @@ namespace ecaldqm {
 
       bool doMask(meEmulQualitySummary.maskMatches(ttid, mask, statusManager_));
 
-      float towerEntries(0.);
-      float tMax(0.5);
-      float nMax(0.);
-      for (int iBin(0); iBin < 6; iBin++) {
-        float entries(sMatchedIndex.getBinContent(ttid, iBin + 1));
-        towerEntries += entries;
+      if (sourceFromEmul_) {
+	sEtEmulError = &sources_.at("EtEmulError");
+	sMatchedIndex = &sources_.at("MatchedIndex");
+	meNonSingleSummary = &MEs_.at("NonSingleSummary");
+	meTimingSummary = &MEs_.at("TimingSummary");
+	float towerEntries(0.);
+	float tMax(0.5);
+	float nMax(0.);
+	for (int iBin(0); iBin < 6; iBin++) {
+	  float entries(sMatchedIndex->getBinContent(ttid, iBin + 1));
+	  towerEntries += entries;
 
-        if (entries > nMax) {
-          nMax = entries;
-          tMax = iBin == 0 ? -0.5 : iBin + 0.5;  // historical reasons.. much clearer to say "no entry = -0.5"
-        }
+	  if (entries > nMax) {
+	    nMax = entries;
+	    tMax = iBin == 0 ? -0.5 : iBin + 0.5;  // historical reasons.. much clearer to say "no entry = -0.5"
+	  }
+	}
+	meTimingSummary->setBinContent(ttid, tMax);
+	if (towerEntries < minEntries_) {
+	  meEmulQualitySummary.setBinContent(ttid, doMask ? kMUnknown : kUnknown);
+	  continue;
+	}
+
+	float nonsingleFraction(1. - nMax / towerEntries);
+
+	if (nonsingleFraction > 0.) {
+	  meNonSingleSummary->setBinContent(ttid, nonsingleFraction);
+	}
+
+	if (sEtEmulError->getBinContent(ttid) / towerEntries > errorFractionThreshold_) {
+	  meEmulQualitySummary.setBinContent(ttid, doMask ? kMBad : kBad);
+	}
+	else {
+	  meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
+	}
       }
-
-      meTimingSummary.setBinContent(ttid, tMax);
-
-      if (towerEntries < minEntries_) {
-        meEmulQualitySummary.setBinContent(ttid, doMask ? kMUnknown : kUnknown);
-        continue;
-      }
-
-      float nonsingleFraction(1. - nMax / towerEntries);
-
-      if (nonsingleFraction > 0.)
-        meNonSingleSummary.setBinContent(ttid, nonsingleFraction);
-
-      if (sEtEmulError.getBinContent(ttid) / towerEntries > errorFractionThreshold_)
-        meEmulQualitySummary.setBinContent(ttid, doMask ? kMBad : kBad);
-      else
-        meEmulQualitySummary.setBinContent(ttid, doMask ? kMGood : kGood);
 
       // Keep count for Occupancy analysis
       unsigned iDCC(dccId(ttid) - 1);

--- a/DQM/EcalMonitorClient/src/TrigPrimClient.cc
+++ b/DQM/EcalMonitorClient/src/TrigPrimClient.cc
@@ -31,7 +31,6 @@ namespace ecaldqm {
   void TrigPrimClient::producePlots(ProcessType) {
     MESet* meNonSingleSummary = nullptr;
     MESet* meTimingSummary = nullptr;
-    ;
     MESet* sEtEmulError = nullptr;
     MESet* sMatchedIndex = nullptr;
 

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -35,6 +35,7 @@ namespace ecaldqm {
       MEs_.erase(std::string("MatchedIndex"));
       MEs_.erase(std::string("EtEmulError"));
       MEs_.erase(std::string("FGEmulError"));
+      MEs_.erase(std::string("RealvEmulEt"));
     }
     lhcStatusInfoCollectionTag_ = _params.getUntrackedParameter<edm::InputTag>(
         "lhcStatusInfoCollectionTag", edm::InputTag("tcdsDigis", "tcdsRecord"));

--- a/DQMOffline/Ecal/python/ecal_dqm_client_offline_cff.py
+++ b/DQMOffline/Ecal/python/ecal_dqm_client_offline_cff.py
@@ -22,3 +22,5 @@ ecal_dqm_client_offline = cms.Sequence(
     ecalzmassclient +
     ecalMEFormatter
 )
+
+ecalMonitorClient.workerParameters.TrigPrimClient.params.sourceFromEmul = False


### PR DESCRIPTION
This emulator is not run offline, so the plots were empty.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->
With this PR, the following ECAL DQM plots, which used to be empty for all offline runs, are no longer saved to the ROOT output:

```
Ecal(Barrel|Endcap)/*SummaryClient/*TTT* Trigger Primitives Non Single Timing summary
Ecal(Barrel|Endcap)/*SummaryClient/*TTT* Trigger Primitives Timing summary
Ecal(Barrel|Endcap)/*TriggerTowerTask/*TTT* Trigger Primitives Non Single Timing summary
```

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

We ran the standard suite of tests:

`runTheMatrix.py --nproc=4 --nThreads=10 -l limited -i all --ibeos`

and noted that the plots in question are not there in the output files anymore.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->
Not a backport.
