### PR TITLE
Pin the key function in a single object file.

### DIFF
--- a/DataFormats/Common/interface/RefHolderBase.h
+++ b/DataFormats/Common/interface/RefHolderBase.h
@@ -16,7 +16,7 @@ namespace edm {
 
     class RefHolderBase {
     public:
-      RefHolderBase() {}
+      RefHolderBase();
       template <class T>
       T const* getPtr() const;
       virtual ~RefHolderBase();

--- a/DataFormats/Common/src/RefHolder.cc
+++ b/DataFormats/Common/src/RefHolder.cc
@@ -1,0 +1,8 @@
+#include "DataFormats/Common/interface/RefHolderBase.h"
+
+namespace edm {
+  namespace reftobase {
+    // Pin the vtable here.
+    RefHolderBase::RefHolderBase() {}
+  }  // namespace reftobase
+}  // namespace edm


### PR DESCRIPTION
The itanium ABI spec section 5.2.3 Virtual Tables defines a term "key function" as "first non-pure virtual function that is not inline at the point of class definition"

If there is no function the vtable is emitted in every object file. This in turn triggers redundant deserializations from the module files showing a bug in the incremental setup for DataFormats/Provenance.

This patch chooses the key function to be out of line, this the vtable to be pinned in a single object file.

Part of #15248

cc: @davidlange6, @oshadura.