### PR TITLE
[HGCal] backport 11_0_X Add a lower limit to the fraction of recHits energy in realistic SimClusters 

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
@@ -212,13 +212,16 @@ public:
               // hits that belonged completely to the absorbed cluster are redistributed
               // based on the fraction of energy shared in the shared hits
               float sharedFraction = pair.second / totalSharedEnergy;
-              float assignedEnergy = realisticHit.totalEnergy_ * sharedFraction;
-              realisticSimClusters_[pair.first].increaseEnergy(assignedEnergy);
-              realisticSimClusters_[pair.first].addHitAndFraction(hitId, sharedFraction);
-              realisticHit.hitToCluster_.emplace_back(
-                  RealisticHit::HitToCluster{pair.first, 0.f, -1.f, sharedFraction});
-              if (sharedFraction > exclusiveFraction)
-                realisticSimClusters_[pair.first].increaseExclusiveEnergy(assignedEnergy);
+              if(sharedFraction > 1e-6)
+              {
+                float assignedEnergy = realisticHit.totalEnergy_ * sharedFraction;
+                realisticSimClusters_[pair.first].increaseEnergy(assignedEnergy);
+                realisticSimClusters_[pair.first].addHitAndFraction(hitId, sharedFraction);
+                realisticHit.hitToCluster_.emplace_back(
+                    RealisticHit::HitToCluster{pair.first, 0.f, -1.f, sharedFraction});
+                if (sharedFraction > exclusiveFraction)
+                  realisticSimClusters_[pair.first].increaseExclusiveEnergy(assignedEnergy);
+              }
             }
           }
         }

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
@@ -212,8 +212,7 @@ public:
               // hits that belonged completely to the absorbed cluster are redistributed
               // based on the fraction of energy shared in the shared hits
               float sharedFraction = pair.second / totalSharedEnergy;
-              if(sharedFraction > 1e-6)
-              {
+              if (sharedFraction > 1e-6) {
                 float assignedEnergy = realisticHit.totalEnergy_ * sharedFraction;
                 realisticSimClusters_[pair.first].increaseEnergy(assignedEnergy);
                 realisticSimClusters_[pair.first].addHitAndFraction(hitId, sharedFraction);


### PR DESCRIPTION
#### PR description:
Backport of #28976
When a realistic simcluster becomes invisible, all its exclusive rechits are redistributed to every visible simcluster that has at least one hit in common with it.
In pathological events, this could lead to an increase of hits per realistic simcluster, with fractions below 1e-10, making the loop much longer. 
Changes expected: 

- decrease in the running time for pathological events
- decrease in the number of rechits per PFCluster with negligible change in energy

#### PR validation:
I have executed `step3` of wf `23203.0` on one pathological event provided by the HLT upgrade convener @trtomei 