### PR TITLE
Backport: ECAL cluster seed flags and ability to apply updated seeding thresholds from GT

### DIFF
--- a/CondCore/EcalPlugins/src/plugin.cc
+++ b/CondCore/EcalPlugins/src/plugin.cc
@@ -13,7 +13,6 @@
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
 
-
 #include "CondFormats/EcalObjects/interface/EcalClusterEnergyCorrectionParameters.h"
 #include "CondFormats/DataRecord/interface/EcalClusterEnergyCorrectionParametersRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
@@ -35,7 +34,6 @@
 #include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
 #include "CondFormats/DataRecord/interface/EcalLinearCorrectionsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeDependentCorrections.h"
-
 
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
@@ -155,64 +153,66 @@
 #include "CondFormats/DataRecord/interface/EcalPulseCovariancesRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalPulseSymmCovariances.h"
 #include "CondFormats/DataRecord/interface/EcalPulseSymmCovariancesRcd.h"
+
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalSimPulseShape.h" 
+
+#include "CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
+
+#include "CondFormats/EcalObjects/interface/EcalSimPulseShape.h"
 #include "CondFormats/DataRecord/interface/EcalSimPulseShapeRcd.h"
 
+REGISTER_PLUGIN(EcalPedestalsRcd, EcalCondObjectContainer<EcalPedestal>);
+REGISTER_PLUGIN(EcalWeightXtalGroupsRcd, EcalCondObjectContainer<EcalXtalGroupId>);
+REGISTER_PLUGIN(EcalTBWeightsRcd, EcalTBWeights);
+REGISTER_PLUGIN(EcalGainRatiosRcd, EcalCondObjectContainer<EcalMGPAGainRatio>);
+REGISTER_PLUGIN(EcalLinearCorrectionsRcd, EcalTimeDependentCorrections);
+REGISTER_PLUGIN(EcalIntercalibConstantsRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalIntercalibConstantsMCRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalTimeCalibConstantsRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalTimeCalibErrorsRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalTimeOffsetConstantRcd, EcalTimeOffsetConstant);
+REGISTER_PLUGIN(EcalIntercalibErrorsRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalADCToGeVConstantRcd, EcalADCToGeVConstant);
+REGISTER_PLUGIN(EcalLaserAlphasRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalLaserAPDPNRatiosRcd, EcalLaserAPDPNRatios);
+REGISTER_PLUGIN(EcalLaserAPDPNRatiosRefRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalChannelStatusRcd, EcalCondObjectContainer<EcalChannelStatusCode>);
+REGISTER_PLUGIN(EcalPFRecHitThresholdsRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalPFSeedingThresholdsRcd, EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalClusterCrackCorrParametersRcd, EcalFunParams);
+REGISTER_PLUGIN(EcalClusterLocalContCorrParametersRcd, EcalFunParams);
+REGISTER_PLUGIN(EcalClusterEnergyUncertaintyParametersRcd, EcalFunParams);
+REGISTER_PLUGIN(EcalClusterEnergyCorrectionParametersRcd, EcalFunParams);
+REGISTER_PLUGIN(EcalClusterEnergyCorrectionObjectSpecificParametersRcd, EcalFunParams);
 
-REGISTER_PLUGIN(EcalPedestalsRcd,EcalCondObjectContainer<EcalPedestal>); 
-REGISTER_PLUGIN(EcalWeightXtalGroupsRcd,EcalCondObjectContainer<EcalXtalGroupId>);
-REGISTER_PLUGIN(EcalTBWeightsRcd,EcalTBWeights);
-REGISTER_PLUGIN(EcalGainRatiosRcd,EcalCondObjectContainer<EcalMGPAGainRatio>);
-REGISTER_PLUGIN(EcalLinearCorrectionsRcd,EcalTimeDependentCorrections);
-REGISTER_PLUGIN(EcalIntercalibConstantsRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalIntercalibConstantsMCRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalTimeCalibConstantsRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalTimeCalibErrorsRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalTimeOffsetConstantRcd,EcalTimeOffsetConstant);
-REGISTER_PLUGIN(EcalIntercalibErrorsRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalADCToGeVConstantRcd,EcalADCToGeVConstant);
-REGISTER_PLUGIN(EcalLaserAlphasRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalLaserAPDPNRatiosRcd,EcalLaserAPDPNRatios);
-REGISTER_PLUGIN(EcalLaserAPDPNRatiosRefRcd,EcalCondObjectContainer<float>);
-REGISTER_PLUGIN(EcalChannelStatusRcd,EcalCondObjectContainer<EcalChannelStatusCode>);
-REGISTER_PLUGIN(EcalPFRecHitThresholdsRcd,EcalCondObjectContainer<float>);
+REGISTER_PLUGIN(EcalSimPulseShapeRcd, EcalSimPulseShape);
 
+REGISTER_PLUGIN(EcalMappingElectronicsRcd, EcalCondObjectContainer<EcalMappingElement>);
 
-REGISTER_PLUGIN(EcalClusterCrackCorrParametersRcd,EcalFunParams);
-REGISTER_PLUGIN(EcalClusterLocalContCorrParametersRcd,EcalFunParams);
-REGISTER_PLUGIN(EcalClusterEnergyUncertaintyParametersRcd,EcalFunParams);
-REGISTER_PLUGIN(EcalClusterEnergyCorrectionParametersRcd,EcalFunParams);
-REGISTER_PLUGIN(EcalClusterEnergyCorrectionObjectSpecificParametersRcd,EcalFunParams);
+REGISTER_PLUGIN(EcalTPGPedestalsRcd, EcalCondObjectContainer<EcalTPGPedestal>);
+REGISTER_PLUGIN(EcalTPGFineGrainEBGroupRcd, EcalTPGFineGrainEBGroup);
+REGISTER_PLUGIN(EcalTPGFineGrainEBIdMapRcd, EcalTPGFineGrainEBIdMap);
+REGISTER_PLUGIN(EcalTPGFineGrainStripEERcd, EcalTPGFineGrainStripEE);
+REGISTER_PLUGIN(EcalTPGFineGrainTowerEERcd, EcalTPGFineGrainTowerEE);
+REGISTER_PLUGIN(EcalTPGLinearizationConstRcd, EcalCondObjectContainer<EcalTPGLinearizationConstant>);
+REGISTER_PLUGIN(EcalTPGLutGroupRcd, EcalTPGLutGroup);
+REGISTER_PLUGIN(EcalTPGLutIdMapRcd, EcalTPGLutIdMap);
+REGISTER_PLUGIN(EcalTPGPhysicsConstRcd, EcalTPGPhysicsConst);
+REGISTER_PLUGIN(EcalTPGSlidingWindowRcd, EcalTPGSlidingWindow);
+REGISTER_PLUGIN(EcalTPGWeightGroupRcd, EcalTPGWeightGroup);
+REGISTER_PLUGIN(EcalTPGWeightIdMapRcd, EcalTPGWeightIdMap);
+REGISTER_PLUGIN(EcalTPGCrystalStatusRcd, EcalCondObjectContainer<EcalTPGCrystalStatusCode>);
+REGISTER_PLUGIN(EcalTPGTowerStatusRcd, EcalTPGTowerStatus);
+REGISTER_PLUGIN(EcalTPGStripStatusRcd, EcalTPGStripStatus);
+REGISTER_PLUGIN(EcalTPGSpikeRcd, EcalTPGSpike);
 
-REGISTER_PLUGIN(EcalSimPulseShapeRcd,EcalSimPulseShape);
+REGISTER_PLUGIN(EcalDCSTowerStatusRcd, EcalCondTowerObjectContainer<EcalChannelStatusCode>);
+REGISTER_PLUGIN(EcalDAQTowerStatusRcd, EcalCondTowerObjectContainer<EcalDAQStatusCode>);
 
-
-REGISTER_PLUGIN(EcalMappingElectronicsRcd,EcalCondObjectContainer<EcalMappingElement>);
-
-REGISTER_PLUGIN(EcalTPGPedestalsRcd,EcalCondObjectContainer<EcalTPGPedestal> );
-REGISTER_PLUGIN(EcalTPGFineGrainEBGroupRcd,EcalTPGFineGrainEBGroup);
-REGISTER_PLUGIN(EcalTPGFineGrainEBIdMapRcd,EcalTPGFineGrainEBIdMap);
-REGISTER_PLUGIN(EcalTPGFineGrainStripEERcd,EcalTPGFineGrainStripEE);
-REGISTER_PLUGIN(EcalTPGFineGrainTowerEERcd,EcalTPGFineGrainTowerEE);
-REGISTER_PLUGIN(EcalTPGLinearizationConstRcd,EcalCondObjectContainer<EcalTPGLinearizationConstant>);
-REGISTER_PLUGIN(EcalTPGLutGroupRcd,EcalTPGLutGroup);
-REGISTER_PLUGIN(EcalTPGLutIdMapRcd,EcalTPGLutIdMap);
-REGISTER_PLUGIN(EcalTPGPhysicsConstRcd,EcalTPGPhysicsConst);
-REGISTER_PLUGIN(EcalTPGSlidingWindowRcd,EcalTPGSlidingWindow);
-REGISTER_PLUGIN(EcalTPGWeightGroupRcd,EcalTPGWeightGroup);
-REGISTER_PLUGIN(EcalTPGWeightIdMapRcd,EcalTPGWeightIdMap);
-REGISTER_PLUGIN(EcalTPGCrystalStatusRcd,EcalCondObjectContainer<EcalTPGCrystalStatusCode>);
-REGISTER_PLUGIN(EcalTPGTowerStatusRcd,EcalTPGTowerStatus);
-REGISTER_PLUGIN(EcalTPGStripStatusRcd,EcalTPGStripStatus);
-REGISTER_PLUGIN(EcalTPGSpikeRcd,EcalTPGSpike);
-
-REGISTER_PLUGIN(EcalDCSTowerStatusRcd,EcalCondTowerObjectContainer<EcalChannelStatusCode> );
-REGISTER_PLUGIN(EcalDAQTowerStatusRcd,EcalCondTowerObjectContainer<EcalDAQStatusCode> );
-
-REGISTER_PLUGIN(EcalDQMChannelStatusRcd,EcalCondObjectContainer<EcalDQMStatusCode>);
-REGISTER_PLUGIN(EcalDQMTowerStatusRcd,EcalCondTowerObjectContainer<EcalDQMStatusCode>);
+REGISTER_PLUGIN(EcalDQMChannelStatusRcd, EcalCondObjectContainer<EcalDQMStatusCode>);
+REGISTER_PLUGIN(EcalDQMTowerStatusRcd, EcalCondTowerObjectContainer<EcalDQMStatusCode>);
 
 REGISTER_PLUGIN(EcalSRSettingsRcd, EcalSRSettings);
 REGISTER_PLUGIN(EcalSampleMaskRcd, EcalSampleMask);
@@ -220,6 +220,6 @@ REGISTER_PLUGIN(EcalSampleMaskRcd, EcalSampleMask);
 REGISTER_PLUGIN(EcalTimeBiasCorrectionsRcd, EcalTimeBiasCorrections);
 
 REGISTER_PLUGIN(EcalSamplesCorrelationRcd, EcalSamplesCorrelation);
-REGISTER_PLUGIN(EcalPulseShapesRcd,EcalCondObjectContainer<EcalPulseShape>);
-REGISTER_PLUGIN(EcalPulseCovariancesRcd,EcalCondObjectContainer<EcalPulseCovariance>);
-REGISTER_PLUGIN(EcalPulseSymmCovariancesRcd,EcalCondObjectContainer<EcalPulseSymmCovariance>);
+REGISTER_PLUGIN(EcalPulseShapesRcd, EcalCondObjectContainer<EcalPulseShape>);
+REGISTER_PLUGIN(EcalPulseCovariancesRcd, EcalCondObjectContainer<EcalPulseCovariance>);
+REGISTER_PLUGIN(EcalPulseSymmCovariancesRcd, EcalCondObjectContainer<EcalPulseSymmCovariance>);

--- a/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
+++ b/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
@@ -1,0 +1,7 @@
+#ifndef CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
+#define CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class EcalPFSeedingThresholdsRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalPFSeedingThresholdsRcd> {
+};
+#endif

--- a/CondFormats/DataRecord/src/EcalPFSeedingThresholdsRcd.cc
+++ b/CondFormats/DataRecord/src/EcalPFSeedingThresholdsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalPFSeedingThresholdsRcd);

--- a/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
+++ b/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
@@ -1,0 +1,14 @@
+#ifndef CondFormats_EcalObjects_EcalPFSeedingThresholds_H
+#define CondFormats_EcalObjects_EcalPFSeedingThresholds_H
+/**
+ * Author: Maria Giulia Ratti, ETH Zurich
+ * Created: 05 Sep 2019
+ * $Id: EcalPFSeedingThresholds.h, 2019/09/05 20:21:42 mratti Exp $
+ **/
+#include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
+
+typedef float EcalPFSeedingThreshold;
+typedef EcalFloatCondObjectContainer EcalPFSeedingThresholdsMap;
+typedef EcalPFSeedingThresholdsMap EcalPFSeedingThresholds;
+
+#endif

--- a/DataFormats/EcalRecHit/interface/EcalRecHit.h
+++ b/DataFormats/EcalRecHit/interface/EcalRecHit.h
@@ -17,56 +17,56 @@ public:
   typedef DetId key_type;
 
   // recHit flags
-  enum Flags { 
-          kGood=0,                   // channel ok, the energy and time measurement are reliable
-          kPoorReco,                 // the energy is available from the UncalibRecHit, but approximate (bad shape, large chi2)
-          kOutOfTime,                // the energy is available from the UncalibRecHit (sync reco), but the event is out of time
-          kFaultyHardware,           // The energy is available from the UncalibRecHit, channel is faulty at some hardware level (e.g. noisy)
-          kNoisy,                    // the channel is very noisy
-          kPoorCalib,                // the energy is available from the UncalibRecHit, but the calibration of the channel is poor
-          kSaturated,                // saturated channel (recovery not tried)
-          kLeadingEdgeRecovered,     // saturated channel: energy estimated from the leading edge before saturation
-          kNeighboursRecovered,      // saturated/isolated dead: energy estimated from neighbours
-          kTowerRecovered,           // channel in TT with no data link, info retrieved from Trigger Primitive
-          kDead,                     // channel is dead and any recovery fails
-          kKilled,                   // MC only flag: the channel is killed in the real detector
-          kTPSaturated,              // the channel is in a region with saturated TP
-          kL1SpikeFlag,              // the channel is in a region with TP with sFGVB = 0
-          kWeird,                    // the signal is believed to originate from an anomalous deposit (spike) 
-          kDiWeird,                  // the signal is anomalous, and neighbors another anomalous signal  
-          kHasSwitchToGain6,         // at least one data frame is in G6
-          kHasSwitchToGain1,         // at least one data frame is in G1
-                                     //
-          kUnknown                   // to ease the interface with functions returning flags. 
+  enum Flags {
+    kGood = 0,   // channel ok, the energy and time measurement are reliable
+    kPoorReco,   // the energy is available from the UncalibRecHit, but approximate (bad shape, large chi2)
+    kOutOfTime,  // the energy is available from the UncalibRecHit (sync reco), but the event is out of time
+    kFaultyHardware,  // The energy is available from the UncalibRecHit, channel is faulty at some hardware level (e.g. noisy)
+    kNoisy,           // the channel is very noisy
+    kPoorCalib,  // the energy is available from the UncalibRecHit, but the calibration of the channel is poor
+    kSaturated,  // saturated channel (recovery not tried)
+    kLeadingEdgeRecovered,  // saturated channel: energy estimated from the leading edge before saturation
+    kNeighboursRecovered,   // saturated/isolated dead: energy estimated from neighbours
+    kTowerRecovered,        // channel in TT with no data link, info retrieved from Trigger Primitive
+    kDead,                  // channel is dead and any recovery fails
+    kKilled,                // MC only flag: the channel is killed in the real detector
+    kTPSaturated,           // the channel is in a region with saturated TP
+    kL1SpikeFlag,           // the channel is in a region with TP with sFGVB = 0
+    kWeird,                 // the signal is believed to originate from an anomalous deposit (spike)
+    kDiWeird,               // the signal is anomalous, and neighbors another anomalous signal
+    kHasSwitchToGain6,      // at least one data frame is in G6
+    kHasSwitchToGain1,      // at least one data frame is in G1
+                            //
+    kUnknown                // to ease the interface with functions returning flags.
   };
 
   // ES recHit flags
   enum ESFlags {
-          kESGood,
-          kESDead,
-          kESHot,
-          kESPassBX,
-          kESTwoGoodRatios,
-          kESBadRatioFor12,
-          kESBadRatioFor23Upper,
-          kESBadRatioFor23Lower,
-          kESTS1Largest,
-          kESTS3Largest,
-          kESTS3Negative,
-          kESSaturated,
-          kESTS2Saturated,
-          kESTS3Saturated,
-          kESTS13Sigmas,
-          kESTS15Sigmas
+    kESGood,
+    kESDead,
+    kESHot,
+    kESPassBX,
+    kESTwoGoodRatios,
+    kESBadRatioFor12,
+    kESBadRatioFor23Upper,
+    kESBadRatioFor23Lower,
+    kESTS1Largest,
+    kESTS3Largest,
+    kESTS3Negative,
+    kESSaturated,
+    kESTS2Saturated,
+    kESTS3Saturated,
+    kESTS13Sigmas,
+    kESTS15Sigmas
   };
 
-  EcalRecHit(): energy_(0), time_(0), flagBits_(0) {}
+  EcalRecHit() : energy_(0), time_(0), flagBits_(0) {}
   // by default a recHit is greated with no flag
-  explicit EcalRecHit(const DetId& id, float energy, float time, uint32_t extra = 0, uint32_t flagBits = 0):
-    id_(id), energy_(energy), time_(time), flagBits_(flagBits), extra_(extra) {}
+  explicit EcalRecHit(const DetId& id, float energy, float time, uint32_t extra = 0, uint32_t flagBits = 0)
+      : id_(id), energy_(energy), time_(time), flagBits_(flagBits), extra_(extra) {}
 
   float energy() const { return energy_; }
-  void setEnergy(float energy) { energy_=energy; }
+  void setEnergy(float energy) { energy_ = energy; }
   float time() const { return time_; }
   void setTime(float time) { time_ = time; }
   const DetId& detid() const { return id_; }
@@ -74,21 +74,19 @@ public:
   /// get the id
   // For the moment not returning a specific id for subdetector
   // @TODO why this method?! should use detid()
-  DetId id() const { return DetId(detid());}
+  DetId id() const { return DetId(detid()); }
 
   bool isRecovered() const {
-    return checkFlag(kLeadingEdgeRecovered) || 
-	  checkFlag(kNeighboursRecovered) ||
-	  checkFlag(kTowerRecovered);
+    return checkFlag(kLeadingEdgeRecovered) || checkFlag(kNeighboursRecovered) || checkFlag(kTowerRecovered);
   }
 
   bool isTimeValid() const { return (this->timeError() > 0); }
 
   bool isTimeErrorValid() const {
-    if(!isTimeValid())
+    if (!isTimeValid())
       return false;
 
-    if(timeError() >= 10000)
+    if (timeError() >= 10000)
       return false;
 
     return true;
@@ -106,12 +104,13 @@ public:
   }
 
   static inline int getPower10(float e) {
-    static constexpr float p10[] = {1.e-2f,1.e-1f,1.f,1.e1f,1.e2f,1.e3f,1.e4f,1.e5f,1.e6f};
-    int b = e<p10[4] ? 0 : 5;
-    for (;b<9;++b) if (e<p10[b]) break;
-    return b; 
+    static constexpr float p10[] = {1.e-2f, 1.e-1f, 1.f, 1.e1f, 1.e2f, 1.e3f, 1.e4f, 1.e5f, 1.e6f};
+    int b = e < p10[4] ? 0 : 5;
+    for (; b < 9; ++b)
+      if (e < p10[b])
+        break;
+    return b;
   }
-
 
   /* the new bit structure
    * 0..6   - chi2 in time events (chi2()), offset=0, width=7
@@ -120,23 +119,24 @@ public:
    */
   float chi2() const {
     uint32_t rawChi2 = getMasked(extra_, 0, 7);
-    return (float)rawChi2 / (float)((1<<7)-1) * 64.;
+    return (float)rawChi2 / (float)((1 << 7) - 1) * 64.;
   }
 
   void setChi2(float chi2) {
     // bound the max value of the chi2
-    if (chi2 > 64) chi2 = 64;
+    if (chi2 > 64)
+      chi2 = 64;
 
     // use 7 bits
-    uint32_t rawChi2 = lround(chi2 / 64. * ((1<<7)-1));
+    uint32_t rawChi2 = lround(chi2 / 64. * ((1 << 7) - 1));
     extra_ = setMasked(extra_, rawChi2, 0, 7);
   }
-  
+
   float energyError() const {
     uint32_t rawEnergy = getMasked(extra_, 8, 13);
     uint16_t exponent = rawEnergy >> 10;
-    uint16_t significand = ~(0xE<<9) & rawEnergy;
-    return (float) significand*pow(10,exponent-5);
+    uint16_t significand = ~(0xE << 9) & rawEnergy;
+    return (float)significand * pow(10, exponent - 5);
   }
 
   // set the energy uncertainty
@@ -145,8 +145,8 @@ public:
     uint32_t rawEnergy = 0;
     if (energy > 0.001) {
       uint16_t exponent = getPower10(energy);
-      static constexpr float ip10[] = {1.e5f,1.e4f,1.e3f,1.e2f,1.e1f,1.e0f,1.e-1f,1.e-2f,1.e-3f,1.e-4};
-      uint16_t significand = lround(energy*ip10[exponent]);
+      static constexpr float ip10[] = {1.e5f, 1.e4f, 1.e3f, 1.e2f, 1.e1f, 1.e0f, 1.e-1f, 1.e-2f, 1.e-3f, 1.e-4};
+      uint16_t significand = lround(energy * ip10[exponent]);
       // use 13 bits (3 exponent, 10 significand)
       rawEnergy = exponent << 10 | significand;
       /* here for doc and regression test
@@ -161,52 +161,55 @@ public:
 
     extra_ = setMasked(extra_, rawEnergy, 8, 13);
   }
-  
+
   float timeError() const {
     uint32_t timeErrorBits = getMasked(extra_, 24, 8);
     // all bits off --> time reco bailed out (return negative value)
-    if( (0xFF & timeErrorBits) == 0x00 )
-            return -1;
+    if ((0xFF & timeErrorBits) == 0x00)
+      return -1;
     // all bits on --> time error over 5 ns (return large value)
-    if( (0xFF & timeErrorBits) == 0xFF )
-            return 10000;
+    if ((0xFF & timeErrorBits) == 0xFF)
+      return 10000;
 
     float LSB = 1.26008;
-    uint8_t exponent = timeErrorBits>>5;
-    uint8_t significand = timeErrorBits & ~(0x7<<5);
-    return pow(2.,exponent)*significand*LSB/1000.;
+    uint8_t exponent = timeErrorBits >> 5;
+    uint8_t significand = timeErrorBits & ~(0x7 << 5);
+    return pow(2., exponent) * significand * LSB / 1000.;
   }
 
-  void setTimeError(uint8_t timeErrBits) {
-    extra_ = setMasked(extra_, timeErrBits & 0xFF, 24, 8);
-  }
-  
-  /// set the flags (from Flags or ESFlags) 
-  void setFlag(int flag) {flagBits_|= (0x1 << flag);}
-  void unsetFlag(int flag) {flagBits_ &= ~(0x1 << flag);}
+  void setTimeError(uint8_t timeErrBits) { extra_ = setMasked(extra_, timeErrBits & 0xFF, 24, 8); }
+
+  /// set the flags (from Flags or ESFlags)
+  void setFlag(int flag) { flagBits_ |= (0x1 << flag); }
+  void unsetFlag(int flag) { flagBits_ &= ~(0x1 << flag); }
 
   /// check if the flag is true
-  bool checkFlag(int flag) const {return flagBits_ & ( 0x1<<flag);}
+  bool checkFlag(int flag) const { return flagBits_ & (0x1 << flag); }
 
   /// check if one of the flags in a set is true
   bool checkFlags(const std::vector<int>& flagsvec) const {
-    for (std::vector<int>::const_iterator flagPtr = flagsvec.begin(); 
-      flagPtr!= flagsvec.end(); ++flagPtr) { // check if one of the flags is up
+    for (std::vector<int>::const_iterator flagPtr = flagsvec.begin(); flagPtr != flagsvec.end();
+         ++flagPtr) {  // check if one of the flags is up
 
-      if (checkFlag(*flagPtr)) return true;    
+      if (checkFlag(*flagPtr))
+        return true;
     }
 
     return false;
   }
 
+  uint32_t flagsBits() const { return flagBits_; }
+
   /// apply a bitmask to our flags. Experts only
-  bool checkFlagMask(uint32_t mask) const { return flagBits_&mask; }
+  bool checkFlagMask(uint32_t mask) const { return flagBits_ & mask; }
 
   /// DEPRECATED provided for temporary backward compatibility
   Flags recoFlag() const {
-    for (int i=kUnknown; ; --i){
-      if (checkFlag(i)) return Flags(i);
-      if (i==0) break;
+    for (int i = kUnknown;; --i) {
+      if (checkFlag(i))
+        return Flags(i);
+      if (i == 0)
+        break;
     }
 
     // no flag assigned, assume good
@@ -219,7 +222,7 @@ private:
   float energy_;
   float time_;
 
-  /// store rechit condition (see Flags enum) in a bit-wise way 
+  /// store rechit condition (see Flags enum) in a bit-wise way
   uint32_t flagBits_;
 
   // packed uint32_t for timeError, chi2, energyError

--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -18,7 +18,6 @@
 
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 
-
 namespace reco {
 
   /**\class PFRecHit
@@ -30,7 +29,6 @@ namespace reco {
      Feb 2014 [Michalis: 8 years later!Modifying the class to be able to generalize the neighbours for 3D calorimeters ]
   */
   class PFRecHit {
-
   public:
     using PositionType = GlobalPoint::BasicVectorType;
     using REPPoint = RhoEtaPhi;
@@ -39,73 +37,60 @@ namespace reco {
     using CornersVec = CaloCellGeometry::CornersVec;
 
     struct Neighbours {
-      using Pointer = unsigned int const *;
-      Neighbours(){}
-      Neighbours(Pointer ib, unsigned int n) : b(ib), e(ib+n){}
+      using Pointer = unsigned int const*;
+      Neighbours() {}
+      Neighbours(Pointer ib, unsigned int n) : b(ib), e(ib + n) {}
       Pointer b, e;
-      Pointer begin() const {return b;}
-      Pointer end() const {return e;}
-      unsigned int size() const { return e-b;}
+      Pointer begin() const { return b; }
+      Pointer end() const { return e; }
+      unsigned int size() const { return e - b; }
     };
-    
-    enum {
-      NONE=0
-    };
+
+    enum { NONE = 0 };
     /// default constructor. Sets energy and position to zero
-    PFRecHit(){}
+    PFRecHit() {}
 
-  PFRecHit(std::shared_ptr<const CaloCellGeometry> caloCell, 
-	   unsigned int detId, PFLayer::Layer layer,
-	   float energy) : caloCell_(std::move(caloCell)),  detId_(detId),
-      layer_(layer), energy_(energy){}
+    PFRecHit(std::shared_ptr<const CaloCellGeometry> caloCell,
+             unsigned int detId,
+             PFLayer::Layer layer,
+             float energy,
+             uint32_t flags = 0)
+        : caloCell_(std::move(caloCell)), detId_(detId), layer_(layer), energy_(energy), flags_(flags) {}
 
-
-    
     /// copy
     PFRecHit(const PFRecHit& other) = default;
     PFRecHit(PFRecHit&& other) = default;
-    PFRecHit & operator=(const PFRecHit& other) = default;
-    PFRecHit & operator=(PFRecHit&& other) = default;
-
+    PFRecHit& operator=(const PFRecHit& other) = default;
+    PFRecHit& operator=(PFRecHit&& other) = default;
 
     /// destructor
-    ~PFRecHit()=default;
+    ~PFRecHit() = default;
 
-    void setEnergy( float energy) { energy_ = energy; }
+    void setEnergy(float energy) { energy_ = energy; }
 
-
-    void addNeighbour(short x,short y, short z, unsigned int);
-    unsigned int getNeighbour(short x,short y, short z) const;
-    void setTime( double time) { time_ = time; }
-    void setDepth( int depth) { depth_ = depth; }
+    void addNeighbour(short x, short y, short z, unsigned int);
+    unsigned int getNeighbour(short x, short y, short z) const;
+    void setTime(double time) { time_ = time; }
+    void setDepth(int depth) { depth_ = depth; }
     void clearNeighbours() {
       neighbours_.clear();
       neighbourInfos_.clear();
       neighbours4_ = neighbours8_ = 0;
     }
 
-    Neighbours neighbours4() const {
-      return buildNeighbours(neighbours4_);
-    }
-    Neighbours neighbours8() const {
-	return buildNeighbours(neighbours8_);
-    }
+    Neighbours neighbours4() const { return buildNeighbours(neighbours4_); }
+    Neighbours neighbours8() const { return buildNeighbours(neighbours8_); }
 
-    Neighbours neighbours() const {
-      return buildNeighbours(neighbours_.size());
-    }
+    Neighbours neighbours() const { return buildNeighbours(neighbours_.size()); }
 
-    const std::vector<unsigned short>& neighbourInfos() {
-      return neighbourInfos_;
-    }
-
+    const std::vector<unsigned short>& neighbourInfos() { return neighbourInfos_; }
 
     /// calo cell
-    CaloCellGeometry const & caloCell() const { return  *(caloCell_.get()); }
+    CaloCellGeometry const& caloCell() const { return *(caloCell_.get()); }
     bool hasCaloCell() const { return (caloCell_ != nullptr); }
-    
+
     /// rechit detId
-    unsigned detId() const {return detId_;}
+    unsigned detId() const { return detId_; }
 
     /// rechit layer
     PFLayer::Layer layer() const { return layer_; }
@@ -113,75 +98,77 @@ namespace reco {
     /// rechit energy
     float energy() const { return energy_; }
 
-
     /// timing for cleaned hits
     float time() const { return time_; }
 
     /// depth for segemntation
-    int  depth() const { return depth_; }
+    int depth() const { return depth_; }
 
     /// rechit momentum transverse to the beam, squared.
-    double pt2() const { return energy_ * energy_ *
-	( position().perp2()/ position().mag2());}
+    double pt2() const { return energy_ * energy_ * (position().perp2() / position().mag2()); }
 
+    // Detector-dependent status flag
+    uint32_t flags() const { return flags_; }
+
+    //
+    void setFlags(uint32_t flags) { flags_ = flags; }
 
     /// rechit cell centre x, y, z
     PositionType const& position() const { return caloCell().getPosition().basicVector(); }
-    
-    RhoEtaPhi    const& positionREP() const { return caloCell().repPos(); }
+
+    RhoEtaPhi const& positionREP() const { return caloCell().repPos(); }
 
     /// rechit corners
-    CornersVec  const& getCornersXYZ() const { return caloCell().getCorners(); }    
+    CornersVec const& getCornersXYZ() const { return caloCell().getCorners(); }
 
-    RepCorners  const& getCornersREP() const { return caloCell().getCornersREP();}
- 
- 
+    RepCorners const& getCornersREP() const { return caloCell().getCornersREP(); }
+
     /// comparison >= operator
-    bool operator>=(const PFRecHit& rhs) const { return (energy_>=rhs.energy_); }
+    bool operator>=(const PFRecHit& rhs) const { return (energy_ >= rhs.energy_); }
 
     /// comparison > operator
-    bool operator> (const PFRecHit& rhs) const { return (energy_> rhs.energy_); }
+    bool operator>(const PFRecHit& rhs) const { return (energy_ > rhs.energy_); }
 
     /// comparison <= operator
-    bool operator<=(const PFRecHit& rhs) const { return (energy_<=rhs.energy_); }
+    bool operator<=(const PFRecHit& rhs) const { return (energy_ <= rhs.energy_); }
 
     /// comparison < operator
-    bool operator< (const PFRecHit& rhs) const { return (energy_< rhs.energy_); }
+    bool operator<(const PFRecHit& rhs) const { return (energy_ < rhs.energy_); }
 
- 
   private:
+    Neighbours buildNeighbours(unsigned int n) const { return Neighbours(neighbours_.data(), n); }
 
-    Neighbours buildNeighbours(unsigned int n) const { return  Neighbours(&neighbours_.front(),n);}
-    
     /// cell geometry
-    std::shared_ptr<const CaloCellGeometry> caloCell_=nullptr;
- 
+    std::shared_ptr<const CaloCellGeometry> caloCell_ = nullptr;
+
     ///cell detid
-    unsigned  int        detId_=0;             
+    unsigned int detId_ = 0;
 
     /// rechit layer
-    PFLayer::Layer      layer_=PFLayer::NONE;
+    PFLayer::Layer layer_ = PFLayer::NONE;
 
-    /// rechit energy 
-    float              energy_=0;
+    /// rechit energy
+    float energy_ = 0;
 
     /// time
-    float              time_=-1;
+    float time_ = -1;
 
     /// depth
-    int      depth_=0;
+    int depth_ = 0;
 
-  
     /// indices to existing neighbours (1 common side)
-    std::vector< unsigned int > neighbours_;
-    std::vector< unsigned short >   neighbourInfos_;
+    std::vector<unsigned int> neighbours_;
+    std::vector<unsigned short> neighbourInfos_;
 
     //Caching the neighbours4/8 per request of Lindsey
     unsigned int neighbours4_ = 0;
     unsigned int neighbours8_ = 0;
+
+    // Detector-dependent hit status flag
+    uint32_t flags_ = 0;
   };
 
-}
+}  // namespace reco
 std::ostream& operator<<(std::ostream& out, const reco::PFRecHit& hit);
 
 #endif

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -43,7 +43,8 @@
   </class>
 
 
-  <class name="reco::PFRecHit" ClassVersion="18">
+  <class name="reco::PFRecHit" ClassVersion="19"> 
+   <version ClassVersion="19" checksum="3022044895"/> 
    <version ClassVersion="18" checksum="3122773923"/>
    <version ClassVersion="17" checksum="2606786437"/>
    <version ClassVersion="10" checksum="1807687081"/>
@@ -210,43 +211,7 @@
 
   <class name="edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >"/>
 
-  <class name="pftools::CalibrationResultWrapper" ClassVersion="11">
-   <version ClassVersion="11" checksum="3535169833"/>
-   <version ClassVersion="10" checksum="1290295437"/>
-  </class>
-  <class name="pftools::Calibratable"  ClassVersion="10">
-   <version ClassVersion="10" checksum="594741590"/>
-  </class>
-  <class name="pftools::CalibratableElement"  ClassVersion="10">
-   <version ClassVersion="10" checksum="2434874022"/>
-  </class>
-  <class name="pftools::CandidateWrapper"  ClassVersion="10">
-   <version ClassVersion="10" checksum="683143818"/>
-  </class>
-  <class name="edm::Wrapper<std::vector<pftools::Calibratable> >" />
-  <class name="std::vector<pftools::Calibratable>" />
-  <class name="std::vector<pftools::CalibratableElement>" />
-  <class name="std::vector<pftools::CandidateWrapper>" />
-  <class name="std::vector<pftools::CalibrationResultWrapper>"/>
-  <class name="pftools::CaloWindow"  ClassVersion="10">
-   <version ClassVersion="10" checksum="1050281643"/>
-  </class>
-  <class name="pftools::TestCaloWindow"  ClassVersion="10">
-   <version ClassVersion="10" checksum="2905084716"/>
-  </class>
-  <class name="pftools::CaloRing"  ClassVersion="10">
-   <version ClassVersion="10" checksum="999780310"/>
-  </class>
-  <class name="std::map<unsigned int, pftools::CaloRing>"/>
-  <class name="std::vector<pftools::CaloRing>"/>
-  <class name="pftools::CaloEllipse"  ClassVersion="10">
-   <version ClassVersion="10" checksum="3700172067"/>
-  </class>
-  <class name="pftools::CaloBox"  ClassVersion="10">
-   <version ClassVersion="10" checksum="3682355512"/>
-  </class>
-  <class name="std::pair<unsigned int,pftools::CaloRing>" />  
-  
+
   <class name="pftools::ParticleFiltrationDecision" ClassVersion="11">
    <version ClassVersion="11" checksum="1016852148"/>
    <version ClassVersion="10" checksum="2525480962"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -43,8 +43,8 @@
   </class>
 
 
-  <class name="reco::PFRecHit" ClassVersion="19"> 
-   <version ClassVersion="19" checksum="3022044895"/> 
+  <class name="reco::PFRecHit" ClassVersion="19">
+   <version ClassVersion="19" checksum="3022044895"/>
    <version ClassVersion="18" checksum="3122773923"/>
    <version ClassVersion="17" checksum="2606786437"/>
    <version ClassVersion="10" checksum="1807687081"/>
@@ -211,7 +211,43 @@
 
   <class name="edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >"/>
 
-
+  <class name="pftools::CalibrationResultWrapper" ClassVersion="11">
+   <version ClassVersion="11" checksum="3535169833"/>
+   <version ClassVersion="10" checksum="1290295437"/>
+  </class>
+  <class name="pftools::Calibratable"  ClassVersion="10">
+   <version ClassVersion="10" checksum="594741590"/>
+  </class>
+  <class name="pftools::CalibratableElement"  ClassVersion="10">
+   <version ClassVersion="10" checksum="2434874022"/>
+  </class>
+  <class name="pftools::CandidateWrapper"  ClassVersion="10">
+   <version ClassVersion="10" checksum="683143818"/>
+  </class>
+  <class name="edm::Wrapper<std::vector<pftools::Calibratable> >" />
+  <class name="std::vector<pftools::Calibratable>" />
+  <class name="std::vector<pftools::CalibratableElement>" />
+  <class name="std::vector<pftools::CandidateWrapper>" />
+  <class name="std::vector<pftools::CalibrationResultWrapper>"/>
+  <class name="pftools::CaloWindow"  ClassVersion="10">
+   <version ClassVersion="10" checksum="1050281643"/>
+  </class>
+  <class name="pftools::TestCaloWindow"  ClassVersion="10">
+   <version ClassVersion="10" checksum="2905084716"/>
+  </class>
+  <class name="pftools::CaloRing"  ClassVersion="10">
+   <version ClassVersion="10" checksum="999780310"/>
+  </class>
+  <class name="std::map<unsigned int, pftools::CaloRing>"/>
+  <class name="std::vector<pftools::CaloRing>"/>
+  <class name="pftools::CaloEllipse"  ClassVersion="10">
+   <version ClassVersion="10" checksum="3700172067"/>
+  </class>
+  <class name="pftools::CaloBox"  ClassVersion="10">
+   <version ClassVersion="10" checksum="3682355512"/>
+  </class>
+  <class name="std::pair<unsigned int,pftools::CaloRing>" />  
+  
   <class name="pftools::ParticleFiltrationDecision" ClassVersion="11">
    <version ClassVersion="11" checksum="1016852148"/>
    <version ClassVersion="10" checksum="2525480962"/>

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -5,6 +5,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
@@ -15,228 +17,170 @@
 //
 class PFRecHitQTestThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestThreshold() {
+  PFRecHitQTestThreshold() {}
+
+  PFRecHitQTestThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig), threshold_(iConfig.getParameter<double>("threshold")) {}
+
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
+
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    return fullReadOut or pass(hit);
   }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return pass(hit); }
 
-  PFRecHitQTestThreshold(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    threshold_(iConfig.getParameter<double>("threshold"))
-    {
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return pass(hit); }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return pass(hit); }
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return fullReadOut or pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return pass(hit);
-    }
-
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return pass(hit); }
 
 protected:
   double threshold_;
 
-  bool pass(const reco::PFRecHit& hit){
-    if (hit.energy()>threshold_) return true;
-
-    return false;
-  }
+  bool pass(const reco::PFRecHit& hit) { return hit.energy() > threshold_; }
 };
-
-
 
 //
 //  Quality test that checks threshold read from the DB
 //
 class PFRecHitQTestDBThreshold : public PFRecHitQTestBase {
 public:
-    PFRecHitQTestDBThreshold():eventSetup_(nullptr){
-    }
+  PFRecHitQTestDBThreshold() : eventSetup_(nullptr) {}
 
-    PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig):
-     PFRecHitQTestBase(iConfig),
-     applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),    
-     eventSetup_(nullptr){
-    }
+  PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),
+        eventSetup_(nullptr) {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-        eventSetup_=&iSetup;
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override { eventSetup_ = &iSetup; }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      if (applySelectionsToAllCrystals_) return pass(hit);  
-      return fullReadOut or pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (applySelectionsToAllCrystals_)
       return pass(hit);
-    }
+    return fullReadOut or pass(hit);
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return pass(hit); }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return pass(hit); }
 
 protected:
-    
   bool applySelectionsToAllCrystals_;
-  const edm::EventSetup * eventSetup_;
+  const edm::EventSetup* eventSetup_;
 
-  
-  bool pass(const reco::PFRecHit& hit){
-
+  bool pass(const reco::PFRecHit& hit) {
     edm::ESHandle<EcalPFRecHitThresholds> ths;
     (*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
 
     float threshold = (*ths)[hit.detId()];
-    if (hit.energy()>threshold) return true;
-
-    return false;
+    return hit.energy() > threshold;
   }
 };
-
-
-
 
 //
 //  Quality test that checks kHCAL Severity
 //
 class PFRecHitQTestHCALChannel : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALChannel() {
-  }
+  PFRecHitQTestHCALChannel() {}
 
-  PFRecHitQTestHCALChannel(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig)
-    {
-      thresholds_ = iConfig.getParameter<std::vector<int> >("maxSeverities");
-      cleanThresholds_ = iConfig.getParameter<std::vector<double> >("cleaningThresholds");
-      std::vector<std::string> flags = iConfig.getParameter<std::vector<std::string> >("flags");
-      for (auto & flag : flags) {
-        if (flag =="Standard") {
-          flags_.push_back(-1);
-          depths_.push_back(-1);
-        }
-        else if (flag =="HFInTime") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFInTimeWindow);
-          depths_.push_back(-1);
-        }
-        else if (flag =="HFDigi") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFDigiTime);
-          depths_.push_back(-1);
-        }
-        else if (flag =="HFLong") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFLongShort);
-          depths_.push_back(1);
-        }
-        else if (flag =="HFShort") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFLongShort);
-          depths_.push_back(2);
-        }
-        else {
-          flags_.push_back(-1);
-          depths_.push_back(-1);
-        }
+  PFRecHitQTestHCALChannel(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+    thresholds_ = iConfig.getParameter<std::vector<int> >("maxSeverities");
+    cleanThresholds_ = iConfig.getParameter<std::vector<double> >("cleaningThresholds");
+    std::vector<std::string> flags = iConfig.getParameter<std::vector<std::string> >("flags");
+    for (auto& flag : flags) {
+      if (flag == "Standard") {
+        flags_.push_back(-1);
+        depths_.push_back(-1);
+      } else if (flag == "HFInTime") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFInTimeWindow);
+        depths_.push_back(-1);
+      } else if (flag == "HFDigi") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFDigiTime);
+        depths_.push_back(-1);
+      } else if (flag == "HFLong") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFLongShort);
+        depths_.push_back(1);
+      } else if (flag == "HFShort") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFLongShort);
+        depths_.push_back(2);
+      } else {
+        flags_.push_back(-1);
+        depths_.push_back(-1);
       }
     }
+  }
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-      edm::ESHandle<HcalTopology> topo;
-      iSetup.get<HcalRecNumberingRecord>().get(topo);
-      theHcalTopology_ = topo.product();
-      edm::ESHandle<HcalChannelQuality> hcalChStatus;
-      iSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
-      theHcalChStatus_ = hcalChStatus.product();
-      edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
-      iSetup.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
-      hcalSevLvlComputer_  =  hcalSevLvlComputerHndl.product();
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+    edm::ESHandle<HcalTopology> topo;
+    iSetup.get<HcalRecNumberingRecord>().get(topo);
+    theHcalTopology_ = topo.product();
+    edm::ESHandle<HcalChannelQuality> hcalChStatus;
+    iSetup.get<HcalChannelQualityRcd>().get("withTopo", hcalChStatus);
+    theHcalChStatus_ = hcalChStatus.product();
+    edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
+    iSetup.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
+    hcalSevLvlComputer_ = hcalSevLvlComputerHndl.product();
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return true;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.flags(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.flags(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.flags(), clean);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.flags(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.flags(), clean);
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.flags(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
-    std::vector<int> thresholds_;
-    std::vector<double> cleanThresholds_;
-    std::vector<int> flags_;
-    std::vector<int> depths_;
-    const HcalTopology* theHcalTopology_;
-    const HcalChannelQuality* theHcalChStatus_;
-    const HcalSeverityLevelComputer* hcalSevLvlComputer_;
+  std::vector<int> thresholds_;
+  std::vector<double> cleanThresholds_;
+  std::vector<int> flags_;
+  std::vector<int> depths_;
+  const HcalTopology* theHcalTopology_;
+  const HcalChannelQuality* theHcalChStatus_;
+  const HcalSeverityLevelComputer* hcalSevLvlComputer_;
 
-    bool test(unsigned aDETID, double energy, int flags, bool& clean){
+  bool test(unsigned aDETID, double energy, int flags, bool& clean) {
     HcalDetId detid = (HcalDetId)aDETID;
-    if (theHcalTopology_->getMergePositionFlag() and detid.subdet() == HcalEndcap){
+    if (theHcalTopology_->getMergePositionFlag() and detid.subdet() == HcalEndcap) {
       detid = theHcalTopology_->idFront(detid);
     }
 
     const HcalChannelStatus* theStatus = theHcalChStatus_->getValues(detid);
     unsigned theStatusValue = theStatus->getValue();
     // Now get severity of problems for the given detID, based on the rechit flag word and the channel quality status value
-    for (unsigned int i=0;i<thresholds_.size();++i) {
-      int hitSeverity =0;
+    for (unsigned int i = 0; i < thresholds_.size(); ++i) {
+      int hitSeverity = 0;
       if (energy < cleanThresholds_[i])
         continue;
 
-      if(flags_[i]<0) {
-        hitSeverity=hcalSevLvlComputer_->getSeverityLevel(detid, flags, theStatusValue);
-      }
-      else {
-        hitSeverity=hcalSevLvlComputer_->getSeverityLevel(detid, flags & flags_[i], theStatusValue);
+      if (flags_[i] < 0) {
+        hitSeverity = hcalSevLvlComputer_->getSeverityLevel(detid, flags, theStatusValue);
+      } else {
+        hitSeverity = hcalSevLvlComputer_->getSeverityLevel(detid, flags & flags_[i], theStatusValue);
       }
 
-      if (hitSeverity>thresholds_[i] and ((depths_[i]<0 or (depths_[i]==detid.depth())))) {
-        clean=true;
+      if (hitSeverity > thresholds_[i] and ((depths_[i] < 0 or (depths_[i] == detid.depth())))) {
+        clean = true;
         return false;
       }
     }
     return true;
   }
-
 };
 
 //
@@ -244,200 +188,152 @@ protected:
 //
 class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALTimeVsDepth() {
+  PFRecHitQTestHCALTimeVsDepth() {}
+
+  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+    std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
+    for (auto& pset : psets) {
+      depths_.push_back(pset.getParameter<int>("depth"));
+      minTimes_.push_back(pset.getParameter<double>("minTime"));
+      maxTimes_.push_back(pset.getParameter<double>("maxTime"));
+      thresholds_.push_back(pset.getParameter<double>("threshold"));
+    }
   }
 
-  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig)
-    {
-      std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
-      for (auto & pset : psets) {
-        depths_.push_back(pset.getParameter<int>("depth"));
-        minTimes_.push_back(pset.getParameter<double>("minTime"));
-        maxTimes_.push_back(pset.getParameter<double>("maxTime"));
-        thresholds_.push_back(pset.getParameter<double>("threshold"));
-      }
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return true;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return true;
-    }
-
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
-    std::vector<int> depths_;
-    std::vector<double> minTimes_;
-    std::vector<double> maxTimes_;
-    std::vector<double> thresholds_;
+  std::vector<int> depths_;
+  std::vector<double> minTimes_;
+  std::vector<double> maxTimes_;
+  std::vector<double> thresholds_;
 
-    bool test(unsigned aDETID, double energy, double time, bool& clean){
-      HcalDetId detid(aDETID);
-      for (unsigned int i=0;i<depths_.size();++i) {
-        if (detid.depth() == depths_[i]) {
-          if ((time <minTimes_[i] or time >maxTimes_[i] ) and  energy>thresholds_[i])
-            {
-              clean=true;
-              return false;
-            }
-          break;
+  bool test(unsigned aDETID, double energy, double time, bool& clean) {
+    HcalDetId detid(aDETID);
+    for (unsigned int i = 0; i < depths_.size(); ++i) {
+      if (detid.depth() == depths_[i]) {
+        if ((time < minTimes_[i] or time > maxTimes_[i]) and energy > thresholds_[i]) {
+          clean = true;
+          return false;
         }
+        break;
       }
-      return true;
     }
+    return true;
+  }
 };
-
-
-
 
 //
 //  Quality test that applies threshold  as a function of depth
 //
 class PFRecHitQTestHCALThresholdVsDepth : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALThresholdVsDepth() {
+  PFRecHitQTestHCALThresholdVsDepth() {}
+
+  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+    std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
+    for (auto& pset : psets) {
+      depths_ = pset.getParameter<std::vector<int> >("depth");
+      thresholds_ = pset.getParameter<std::vector<double> >("threshold");
+      detector_ = pset.getParameter<int>("detectorEnum");
+      if (thresholds_.size() != depths_.size()) {
+        throw cms::Exception("InvalidPFRecHitThreshold") << "PFRecHitThreshold mismatch with the numbers of depths";
+      }
+    }
   }
 
-  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig)
-    {
-      std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
-      for (auto & pset : psets) {
-        depths_=pset.getParameter<std::vector<int> >("depth");
-        thresholds_=pset.getParameter<std::vector<double> >("threshold");
-	detector_=pset.getParameter<int>("detectorEnum");
-        if(thresholds_.size()!=depths_.size()) {
-          throw cms::Exception("InvalidPFRecHitThreshold")
-            << "PFRecHitThreshold mismatch with the numbers of depths";
-        }
-      }
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return true;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return true;
-    }
-
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
-    std::vector<int> depths_;
-    std::vector<double> thresholds_;
-    int detector_;
+  std::vector<int> depths_;
+  std::vector<double> thresholds_;
+  int detector_;
 
-    bool test(unsigned aDETID, double energy, double time, bool& clean){
-      HcalDetId detid(aDETID);
+  bool test(unsigned aDETID, double energy, double time, bool& clean) {
+    HcalDetId detid(aDETID);
 
-      for (unsigned int i=0;i<thresholds_.size();++i) {
-	if (detid.depth() == depths_[i] && detid.subdet() == detector_ ) {
-          if (  energy<thresholds_[i])
-            {
-              clean=false;
-              return false;
-            }
-          break;
+    for (unsigned int i = 0; i < thresholds_.size(); ++i) {
+      if (detid.depth() == depths_[i] && detid.subdet() == detector_) {
+        if (energy < thresholds_[i]) {
+          clean = false;
+          return false;
         }
+        break;
       }
-      return true;
     }
+    return true;
+  }
 };
-
-
-
-
 
 //
 //  Quality test that checks HO threshold applying different threshold in rings
 //
 class PFRecHitQTestHOThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHOThreshold():
-    threshold0_(0.),
-    threshold12_(0.)
-  {
-  }
+  PFRecHitQTestHOThreshold() : threshold0_(0.), threshold12_(0.) {}
 
-  PFRecHitQTestHOThreshold(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    threshold0_(iConfig.getParameter<double>("threshold_ring0")),
-    threshold12_(iConfig.getParameter<double>("threshold_ring12"))
-  {
-  }
+  PFRecHitQTestHOThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        threshold0_(iConfig.getParameter<double>("threshold_ring0")),
+        threshold12_(iConfig.getParameter<double>("threshold_ring12")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
     HcalDetId detid(rh.detid());
-    if (abs(detid.ieta())<=4 and hit.energy()>threshold0_)
+    if (abs(detid.ieta()) <= 4 and hit.energy() > threshold0_)
       return true;
-    if (abs(detid.ieta())>4 and hit.energy()>threshold12_)
+    if (abs(detid.ieta()) > 4 and hit.energy() > threshold12_)
       return true;
 
     return false;
   }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const double threshold0_;
   const double threshold12_;
-
 };
 
 //
@@ -449,52 +345,43 @@ protected:
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 class PFRecHitQTestECALMultiThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestECALMultiThreshold() {
-  }
+  PFRecHitQTestECALMultiThreshold() {}
 
-  PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
-    applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals"))
-    {
+  PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
+        applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")) {
     if (thresholds_.size() != EcalRingCalibrationTools::N_RING_TOTAL)
       throw edm::Exception(edm::errors::Configuration, "ValueError")
-        << "thresholds is expected to have " << EcalRingCalibrationTools::N_RING_TOTAL << " elements but has " << thresholds_.size();   
+          << "thresholds is expected to have " << EcalRingCalibrationTools::N_RING_TOTAL << " elements but has "
+          << thresholds_.size();
   }
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     CaloSubdetectorGeometry const* endcapGeometry = pG->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    endcapGeometrySet_=false;
+    endcapGeometrySet_ = false;
     if (endcapGeometry) {
       EcalRingCalibrationTools::setCaloGeometry(&(*pG));
-      endcapGeometrySet_=true;
+      endcapGeometrySet_ = true;
     }
   }
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    if (applySelectionsToAllCrystals_) return pass(hit);
-    else return fullReadOut or pass(hit);
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (applySelectionsToAllCrystals_)
+      return pass(hit);
+    else
+      return fullReadOut or pass(hit);
   }
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const std::vector<double> thresholds_;
@@ -502,18 +389,16 @@ protected:
 
   // apply selections to all crystals
   bool applySelectionsToAllCrystals_;
-  
-  
-  bool pass(const reco::PFRecHit& hit){
 
+  bool pass(const reco::PFRecHit& hit) {
     DetId detId(hit.detId());
 
     // this is to skip endcap ZS for Phase2 until there is a defined geometry
     // apply the loosest ZS threshold, for the first eta-ring in EB
     if (not endcapGeometrySet_) {
-
       // there is only ECAL EB in Phase 2
-      if(detId.subdetId() != EcalBarrel) return true;
+      if (detId.subdetId() != EcalBarrel)
+        return true;
 
       //   0-169: EB  eta-rings
       // 170-208: EE- eta rings
@@ -523,83 +408,62 @@ protected:
     }
 
     int iring = EcalRingCalibrationTools::getRingIndex(detId);
-    if (hit.energy() > thresholds_[iring]) return true;
+    if (hit.energy() > thresholds_[iring])
+      return true;
 
     return false;
   }
 };
 
-
 //
 //  Quality test that checks ecal quality cuts
 //
 class PFRecHitQTestECAL : public PFRecHitQTestBase {
-  public:
-    PFRecHitQTestECAL() {
-    }
+public:
+  PFRecHitQTestECAL() {}
 
-    PFRecHitQTestECAL(const edm::ParameterSet& iConfig):
-      PFRecHitQTestBase(iConfig),
-      thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
-      timingCleaning_(iConfig.getParameter<bool>("timingCleaning")),
-      topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")),
-      skipTTRecoveredHits_(iConfig.getParameter<bool>("skipTTRecoveredHits"))
-  {
-  }
+  PFRecHitQTestECAL(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
+        timingCleaning_(iConfig.getParameter<bool>("timingCleaning")),
+        topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")),
+        skipTTRecoveredHits_(iConfig.getParameter<bool>("skipTTRecoveredHits")) {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    if (skipTTRecoveredHits_ and rh.checkFlag(EcalRecHit::kTowerRecovered))
-    {
-      clean=true;
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (skipTTRecoveredHits_ and rh.checkFlag(EcalRecHit::kTowerRecovered)) {
+      clean = true;
       return false;
     }
-    if (timingCleaning_ and rh.energy() > thresholdCleaning_ and
-        rh.checkFlag(EcalRecHit::kOutOfTime))
-    {
-      clean=true;
+    if (timingCleaning_ and rh.energy() > thresholdCleaning_ and rh.checkFlag(EcalRecHit::kOutOfTime)) {
+      clean = true;
       return false;
     }
 
-    if (topologicalCleaning_ and (
-          rh.checkFlag(EcalRecHit::kWeird) or
-          rh.checkFlag(EcalRecHit::kDiWeird)))
-    {
-      clean=true;
+    if (topologicalCleaning_ and (rh.checkFlag(EcalRecHit::kWeird) or rh.checkFlag(EcalRecHit::kDiWeird))) {
+      clean = true;
       return false;
     }
 
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   double thresholdCleaning_;
   bool timingCleaning_;
   bool topologicalCleaning_;
   bool skipTTRecoveredHits_;
-
 };
 
 //
@@ -607,70 +471,46 @@ protected:
 //
 class PFRecHitQTestES : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestES():
-    thresholdCleaning_(0.),
-    topologicalCleaning_(false)
-  {
-  }
+  PFRecHitQTestES() : thresholdCleaning_(0.), topologicalCleaning_(false) {}
 
-  PFRecHitQTestES(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
-    topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning"))
-  {
-  }
+  PFRecHitQTestES(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
+        topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
-
-    if ( rh.energy() < thresholdCleaning_ ) {
-      clean=false;
+    if (rh.energy() < thresholdCleaning_) {
+      clean = false;
       return false;
     }
 
-    if ( topologicalCleaning_ and
-         ( rh.checkFlag(EcalRecHit::kESDead) or
-           rh.checkFlag(EcalRecHit::kESTS13Sigmas) or
-           rh.checkFlag(EcalRecHit::kESBadRatioFor12) or
-           rh.checkFlag(EcalRecHit::kESBadRatioFor23Upper) or
-           rh.checkFlag(EcalRecHit::kESBadRatioFor23Lower) or
-           rh.checkFlag(EcalRecHit::kESTS1Largest) or
-           rh.checkFlag(EcalRecHit::kESTS3Largest) or
-           rh.checkFlag(EcalRecHit::kESTS3Negative)
-           )) {
-      clean=false;
+    if (topologicalCleaning_ and
+        (rh.checkFlag(EcalRecHit::kESDead) or rh.checkFlag(EcalRecHit::kESTS13Sigmas) or
+         rh.checkFlag(EcalRecHit::kESBadRatioFor12) or rh.checkFlag(EcalRecHit::kESBadRatioFor23Upper) or
+         rh.checkFlag(EcalRecHit::kESBadRatioFor23Lower) or rh.checkFlag(EcalRecHit::kESTS1Largest) or
+         rh.checkFlag(EcalRecHit::kESTS3Largest) or rh.checkFlag(EcalRecHit::kESTS3Negative))) {
+      clean = false;
       return false;
     }
 
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const double thresholdCleaning_;
   const bool topologicalCleaning_;
-
 };
 
 //
@@ -678,47 +518,32 @@ protected:
 //
 class PFRecHitQTestHCALCalib29 : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALCalib29():
-    calibFactor_(0.)
-  {
-  }
+  PFRecHitQTestHCALCalib29() : calibFactor_(0.) {}
 
-  PFRecHitQTestHCALCalib29(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    calibFactor_(iConfig.getParameter<double>("calibFactor"))
-  {
-  }
+  PFRecHitQTestHCALCalib29(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig), calibFactor_(iConfig.getParameter<double>("calibFactor")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    return true;
-  }
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
     HcalDetId detId(hit.detId());
-    if (abs(detId.ieta())==29)
-      hit.setEnergy(hit.energy()*calibFactor_);
+    if (abs(detId.ieta()) == 29)
+      hit.setEnergy(hit.energy() * calibFactor_);
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
     CaloTowerDetId detId(hit.detId());
-    if (detId.ietaAbs()==29)
-      hit.setEnergy(hit.energy()*calibFactor_);
+    if (detId.ietaAbs() == 29)
+      hit.setEnergy(hit.energy() * calibFactor_);
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const float calibFactor_;
@@ -726,58 +551,43 @@ protected:
 
 class PFRecHitQTestThresholdInMIPs : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestThresholdInMIPs():
-    recHitEnergy_keV_(false),
-    threshold_(0.),
-    mip_(0.),
-    recHitEnergyMultiplier_(0.)
-  {
-  }
+  PFRecHitQTestThresholdInMIPs() : recHitEnergy_keV_(false), threshold_(0.), mip_(0.), recHitEnergyMultiplier_(0.) {}
 
-  PFRecHitQTestThresholdInMIPs(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
-    threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
-    mip_(iConfig.getParameter<double>("mipValueInkeV")),
-    recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier"))
-  {
-  }
+  PFRecHitQTestThresholdInMIPs(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
+        threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
+        mip_(iConfig.getParameter<double>("mipValueInkeV")),
+        recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
   bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
 
   bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
   bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
 
   bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
 
   bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
-    const double newE = ( recHitEnergy_keV_ ?
-        1.0e-6*rh.energy()*recHitEnergyMultiplier_ :
-        rh.energy()*recHitEnergyMultiplier_ );
+    const double newE =
+        (recHitEnergy_keV_ ? 1.0e-6 * rh.energy() * recHitEnergyMultiplier_ : rh.energy() * recHitEnergyMultiplier_);
     hit.setEnergy(newE);
     return pass(hit);
   }
@@ -787,145 +597,149 @@ protected:
   const double threshold_, mip_, recHitEnergyMultiplier_;
 
   bool pass(const reco::PFRecHit& hit) {
-    const double hitValueInMIPs = 1e6*hit.energy()/mip_;
+    const double hitValueInMIPs = 1e6 * hit.energy() / mip_;
     return hitValueInMIPs > threshold_;
   }
 };
 
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 class PFRecHitQTestThresholdInThicknessNormalizedMIPs : public PFRecHitQTestBase {
-  public:
-    PFRecHitQTestThresholdInThicknessNormalizedMIPs() :
-      geometryInstance_(""),
-      recHitEnergy_keV_(0.),
-      threshold_(0.),
-      mip_(0.),
-      recHitEnergyMultiplier_(0.) {
-      }
+public:
+  PFRecHitQTestThresholdInThicknessNormalizedMIPs()
+      : geometryInstance_(""), recHitEnergy_keV_(0.), threshold_(0.), mip_(0.), recHitEnergyMultiplier_(0.) {}
 
-    PFRecHitQTestThresholdInThicknessNormalizedMIPs(const edm::ParameterSet& iConfig) :
-      PFRecHitQTestBase(iConfig),
-      geometryInstance_(iConfig.getParameter<std::string>("geometryInstance")),
-      recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
-      threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
-      mip_(iConfig.getParameter<double>("mipValueInkeV")),
-      recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier")) {
-      }
+  PFRecHitQTestThresholdInThicknessNormalizedMIPs(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        geometryInstance_(iConfig.getParameter<std::string>("geometryInstance")),
+        recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
+        threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
+        mip_(iConfig.getParameter<double>("mipValueInkeV")),
+        recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier")) {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-      edm::ESHandle<HGCalGeometry> geoHandle;
-      iSetup.get<IdealGeometryRecord>().get(geometryInstance_, geoHandle);
-      ddd_ = &(geoHandle->topology().dddConstants());
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+    edm::ESHandle<HGCalGeometry> geoHandle;
+    iSetup.get<IdealGeometryRecord>().get(geometryInstance_, geoHandle);
+    ddd_ = &(geoHandle->topology().dddConstants());
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
 
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
-      const double newE = ( recHitEnergy_keV_ ?
-          1.0e-6*rh.energy()*recHitEnergyMultiplier_ :
-          rh.energy()*recHitEnergyMultiplier_ );
-      const int wafer = HGCalDetId(rh.detid()).wafer();
-      const float mult  = (float) ddd_->waferTypeL(wafer); // 1 for 100um, 2 for 200um, 3 for 300um
-      hit.setEnergy(newE);
-      return pass(hit, mult);
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
+    const double newE =
+        (recHitEnergy_keV_ ? 1.0e-6 * rh.energy() * recHitEnergyMultiplier_ : rh.energy() * recHitEnergyMultiplier_);
+    const int wafer = HGCalDetId(rh.detid()).wafer();
+    const float mult = (float)ddd_->waferTypeL(wafer);  // 1 for 100um, 2 for 200um, 3 for 300um
+    hit.setEnergy(newE);
+    return pass(hit, mult);
+  }
 
-  protected:
-    const std::string geometryInstance_;
-    const bool recHitEnergy_keV_;
-    const double threshold_, mip_, recHitEnergyMultiplier_;
-    const HGCalDDDConstants*  ddd_;
+protected:
+  const std::string geometryInstance_;
+  const bool recHitEnergy_keV_;
+  const double threshold_, mip_, recHitEnergyMultiplier_;
+  const HGCalDDDConstants* ddd_;
 
-    bool pass(const reco::PFRecHit& hit, const float mult) {
-      const double hitValueInMIPs = 1e6*hit.energy()/(mult*mip_);
-      return hitValueInMIPs > threshold_;
-    }
+  bool pass(const reco::PFRecHit& hit, const float mult) {
+    const double hitValueInMIPs = 1e6 * hit.energy() / (mult * mip_);
+    return hitValueInMIPs > threshold_;
+  }
 };
 
+class PFRecHitQTestHGCalThresholdSNR : public PFRecHitQTestBase {
+public:
+  PFRecHitQTestHGCalThresholdSNR() : thresholdSNR_(0.) {}
 
-class PFRecHitQTestHGCalThresholdSNR: public PFRecHitQTestBase
-{
-    public:
-        PFRecHitQTestHGCalThresholdSNR() :
-                thresholdSNR_(0.)
-        {
-        }
+  PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR")) {}
 
-        PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig) :
-                PFRecHitQTestBase(iConfig), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR"))
-        {
-        }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-        void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override
-        {
-        }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
 
-        bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
-        bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
 
-        bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
-        bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
 
-        bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
+    return rh.signalOverSigmaNoise() >= thresholdSNR_;
+  }
 
-        bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override
-        {
-            return rh.signalOverSigmaNoise() >= thresholdSNR_;
-        }
+protected:
+  const double thresholdSNR_;
+};
 
-    protected:
-        const double thresholdSNR_;
+//  M.G. Quality test that checks seeding threshold read from the DB
+//
+class PFRecHitQTestDBSeedingThreshold : public PFRecHitQTestBase {
+public:
+  PFRecHitQTestDBSeedingThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")) {}
+
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+    iSetup.get<EcalPFSeedingThresholdsRcd>().get(ths_);
+  }
+
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (applySelectionsToAllCrystals_)
+      return pass(hit);
+    return fullReadOut or pass(hit);
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return pass(hit); }
+
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return pass(hit); }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return pass(hit); }
+
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return pass(hit); }
+
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return pass(hit); }
+
+protected:
+  bool applySelectionsToAllCrystals_;
+  edm::ESHandle<EcalPFSeedingThresholds> ths_;
+
+  bool pass(const reco::PFRecHit& hit) {
+    float threshold = (*ths_)[hit.detId()];
+    return (hit.energy() > threshold);
+  }
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
@@ -3,28 +3,30 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
 #include <string>
 
 class RecHitTopologicalCleanerBase {
- public:
-  RecHitTopologicalCleanerBase(const edm::ParameterSet& conf) { }
-  RecHitTopologicalCleanerBase(const RecHitTopologicalCleanerBase& ) = delete;
+public:
+  RecHitTopologicalCleanerBase(const edm::ParameterSet& conf) {}
+  RecHitTopologicalCleanerBase(const RecHitTopologicalCleanerBase&) = delete;
   virtual ~RecHitTopologicalCleanerBase() = default;
   RecHitTopologicalCleanerBase& operator=(const RecHitTopologicalCleanerBase&) = delete;
 
-  virtual void clean(const edm::Handle<reco::PFRecHitCollection>&, 
-		     std::vector<bool>&) = 0;
+  virtual void clean(const edm::Handle<reco::PFRecHitCollection>&, std::vector<bool>&) = 0;
+  virtual void update(const edm::EventSetup&) {}
 
   const std::string& name() const { return _algoName; }
 
- private:
+private:
   const std::string _algoName;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< RecHitTopologicalCleanerBase* (const edm::ParameterSet&) > RecHitTopologicalCleanerFactory;
+typedef edmplugin::PluginFactory<RecHitTopologicalCleanerBase*(const edm::ParameterSet&)>
+    RecHitTopologicalCleanerFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
@@ -1,0 +1,29 @@
+#include "ECALPFSeedCleaner.h"
+
+ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf) : RecHitTopologicalCleanerBase(conf) {}
+
+void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) { iSetup.get<EcalPFSeedingThresholdsRcd>().get(ths_); }
+
+void ECALPFSeedCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
+  //need to run over energy sorted rechits, as this is order used in seeding step
+  // this can cause ambiguity, isn't it better to index by detid ?
+  auto const& hits = *input;
+  std::vector<unsigned> ordered_hits(hits.size());
+  for (unsigned i = 0; i < hits.size(); ++i)
+    ordered_hits[i] = i;
+
+  std::sort(ordered_hits.begin(), ordered_hits.end(), [&](unsigned i, unsigned j) {
+    return hits[i].energy() > hits[j].energy();
+  });
+
+  for (const auto& idx : ordered_hits) {
+    if (!mask[idx])
+      continue;  // is it useful ?
+    const reco::PFRecHit& rechit = hits[idx];
+
+    float threshold = (*ths_)[rechit.detId()];
+    if (rechit.energy() < threshold)
+      mask[idx] = false;
+
+  }  // rechit loop
+}

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
@@ -1,0 +1,24 @@
+#ifndef __ECALPFSeedCleaner_H__
+#define __ECALPFSeedCleaner_H__
+
+#include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
+#include "CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
+
+class ECALPFSeedCleaner : public RecHitTopologicalCleanerBase {
+public:
+  ECALPFSeedCleaner(const edm::ParameterSet& conf);
+  ECALPFSeedCleaner(const ECALPFSeedCleaner&) = delete;
+  ECALPFSeedCleaner& operator=(const ECALPFSeedCleaner&) = delete;
+
+  void update(const edm::EventSetup&) override;
+
+  void clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) override;
+
+private:
+  edm::ESHandle<EcalPFSeedingThresholds> ths_;
+};
+
+DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory, ECALPFSeedCleaner, "ECALPFSeedCleaner");
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.cc
@@ -1,0 +1,29 @@
+#include "FlagsCleanerECAL.h"
+#include "CommonTools/Utils/interface/StringToEnumValue.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+
+FlagsCleanerECAL::FlagsCleanerECAL(const edm::ParameterSet& conf) : RecHitTopologicalCleanerBase(conf) {
+  const std::vector<std::string> flagnames = conf.getParameter<std::vector<std::string> >("RecHitFlagsToBeExcluded");
+  v_chstatus_excl_ = StringToEnumValue<EcalRecHit::Flags>(flagnames);
+}
+
+void FlagsCleanerECAL::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
+  auto const& hits = *input;
+
+  for (uint16_t idx = 0; idx < hits.size(); ++idx) {
+    if (!mask[idx])
+      continue;  // don't need to re-mask things :-)
+    const reco::PFRecHit& rechit = hits[idx];
+    if (checkFlags(rechit))
+      mask[idx] = false;
+  }
+}
+
+// returns true if one of the flags in the exclusion list is up
+bool FlagsCleanerECAL::checkFlags(const reco::PFRecHit& hit) {
+  for (auto flag : v_chstatus_excl_) {  // check if one of the flags is up
+    if (hit.flags() & (0x1 << flag))
+      return true;
+  }
+  return false;
+}

--- a/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/FlagsCleanerECAL.h
@@ -1,0 +1,22 @@
+#ifndef __FlagsCleanerECAL_H__
+#define __FlagsCleanerECAL_H__
+
+#include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
+
+class FlagsCleanerECAL : public RecHitTopologicalCleanerBase {
+public:
+  FlagsCleanerECAL(const edm::ParameterSet& conf);
+  FlagsCleanerECAL(const FlagsCleanerECAL&) = delete;
+  FlagsCleanerECAL& operator=(const FlagsCleanerECAL&) = delete;
+
+  // mark rechits which are flagged as one of the values provided in the vector
+  void clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) override;
+
+private:
+  std::vector<int> v_chstatus_excl_;  // list of rechit status flags to be excluded from seeding
+  bool checkFlags(const reco::PFRecHit& hit);
+};
+
+DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory, FlagsCleanerECAL, "FlagsCleanerECAL");
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -12,113 +12,118 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf) :
-  _prodInitClusters(conf.getUntrackedParameter<bool>("prodInitialClusters",false))
-{
-  _rechitsLabel = consumes<reco::PFRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsSource")); 
+PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
+    : _prodInitClusters(conf.getUntrackedParameter<bool>("prodInitialClusters", false)) {
+  _rechitsLabel = consumes<reco::PFRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsSource"));
   //setup rechit cleaners
-  const edm::VParameterSet& cleanerConfs = 
-    conf.getParameterSetVector("recHitCleaners");
-  for( const auto& conf : cleanerConfs ) {
-    const std::string& cleanerName = 
-      conf.getParameter<std::string>("algoName");
-    _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName,conf));
+  const edm::VParameterSet& cleanerConfs = conf.getParameterSetVector("recHitCleaners");
+  for (const auto& conf : cleanerConfs) {
+    const std::string& cleanerName = conf.getParameter<std::string>("algoName");
+    _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName, conf));
   }
+
+  if (conf.exists("seedCleaners")) {
+    const edm::VParameterSet& seedcleanerConfs = conf.getParameterSetVector("seedCleaners");
+
+    for (const auto& conf : seedcleanerConfs) {
+      const std::string& seedcleanerName = conf.getParameter<std::string>("algoName");
+      _seedcleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(seedcleanerName, conf));
+    }
+  }
+
   edm::ConsumesCollector sumes = consumesCollector();
 
   // setup seed finding
-  const edm::ParameterSet& sfConf = 
-    conf.getParameterSet("seedFinder");
+  const edm::ParameterSet& sfConf = conf.getParameterSet("seedFinder");
   const std::string& sfName = sfConf.getParameter<std::string>("algoName");
-  _seedFinder = std::unique_ptr<SeedFinderBase>{SeedFinderFactory::get()->create(sfName,sfConf)};
+  _seedFinder = std::unique_ptr<SeedFinderBase>{SeedFinderFactory::get()->create(sfName, sfConf)};
   //setup topo cluster builder
-  const edm::ParameterSet& initConf = 
-    conf.getParameterSet("initialClusteringStep");
+  const edm::ParameterSet& initConf = conf.getParameterSet("initialClusteringStep");
   const std::string& initName = initConf.getParameter<std::string>("algoName");
-  _initialClustering = std::unique_ptr<ICSB>{InitialClusteringStepFactory::get()->create(initName,initConf,sumes)};
+  _initialClustering = std::unique_ptr<InitialClusteringStepBase>{InitialClusteringStepFactory::get()->create(initName, initConf, sumes)};
   //setup pf cluster builder if requested
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
-  if( !pfcConf.empty() ) {
+  if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = std::unique_ptr<PFCBB>{PFClusterBuilderFactory::get()->create(pfcName,pfcConf)};
+    _pfClusterBuilder = std::unique_ptr<PFClusterBuilderBase>{PFClusterBuilderFactory::get()->create(pfcName, pfcConf)};
   }
   //setup (possible) recalcuation of positions
   const edm::ParameterSet& pConf = conf.getParameterSet("positionReCalc");
-  if( !pConf.empty() ) {
+  if (!pConf.empty()) {
     const std::string& pName = pConf.getParameter<std::string>("algoName");
-    _positionReCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(pName,pConf)};
+    _positionReCalc = std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(pName, pConf)};
   }
   // see if new need to apply corrections, setup if there.
-  const edm::ParameterSet& cConf =  conf.getParameterSet("energyCorrector");
-  if( !cConf.empty() ) {
+  const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");
+  if (!cConf.empty()) {
     const std::string& cName = cConf.getParameter<std::string>("algoName");
-    _energyCorrector = std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName,cConf)};
+    _energyCorrector = std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName, cConf)};
   }
-  
 
-  if( _prodInitClusters ) {
+  if (_prodInitClusters) {
     produces<reco::PFClusterCollection>("initialClusters");
   }
   produces<reco::PFClusterCollection>();
 }
 
-void PFClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, 
-					     const edm::EventSetup& es) {
+void PFClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) {
   _initialClustering->update(es);
-  if( _pfClusterBuilder ) _pfClusterBuilder->update(es);
-  if( _positionReCalc ) _positionReCalc->update(es);
-  
+  if (_pfClusterBuilder)
+    _pfClusterBuilder->update(es);
+  if (_positionReCalc)
+    _positionReCalc->update(es);
+  for (const auto& cleaner : _cleaners)
+    cleaner->update(es);
+  for (const auto& cleaner : _seedcleaners)
+    cleaner->update(es);
 }
 
 void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   _initialClustering->reset();
-  if( _pfClusterBuilder ) _pfClusterBuilder->reset();
+  if (_pfClusterBuilder)
+    _pfClusterBuilder->reset();
 
   edm::Handle<reco::PFRecHitCollection> rechits;
-  e.getByToken(_rechitsLabel,rechits);  
-  
+  e.getByToken(_rechitsLabel, rechits);
+
   _initialClustering->updateEvent(e);
 
-  std::vector<bool> mask(rechits->size(),true);
-  for( const auto& cleaner : _cleaners ) {
+  std::vector<bool> mask(rechits->size(), true);
+  for (const auto& cleaner : _cleaners) {
     cleaner->clean(rechits, mask);
   }
 
+  // no seeding on these hits
+  std::vector<bool> seedmask = mask;
+  for (const auto& cleaner : _seedcleaners) {
+    cleaner->clean(rechits, seedmask);
+  }
 
-
-  std::vector<bool> seedable(rechits->size(),false);
-  _seedFinder->findSeeds(rechits,mask,seedable);
-
-
+  std::vector<bool> seedable(rechits->size(), false);
+  _seedFinder->findSeeds(rechits, seedmask, seedable);
 
   auto initialClusters = std::make_unique<reco::PFClusterCollection>();
   _initialClustering->buildClusters(rechits, mask, seedable, *initialClusters);
   LOGVERB("PFClusterProducer::produce()") << *_initialClustering;
 
-
-
-
   auto pfClusters = std::make_unique<reco::PFClusterCollection>();
   pfClusters.reset(new reco::PFClusterCollection);
-  if( _pfClusterBuilder ) { // if we've defined a re-clustering step execute it
+  if (_pfClusterBuilder) {  // if we've defined a re-clustering step execute it
     _pfClusterBuilder->buildClusters(*initialClusters, seedable, *pfClusters);
     LOGVERB("PFClusterProducer::produce()") << *_pfClusterBuilder;
   } else {
-    pfClusters->insert(pfClusters->end(),
-		       initialClusters->begin(),initialClusters->end());
+    pfClusters->insert(pfClusters->end(), initialClusters->begin(), initialClusters->end());
   }
 
-
-
-  
-  if( _positionReCalc ) {
+  if (_positionReCalc) {
     _positionReCalc->calculateAndSetPositions(*pfClusters);
   }
 
-  if( _energyCorrector ) {
+  if (_energyCorrector) {
     _energyCorrector->correctEnergies(*pfClusters);
   }
 
-  if( _prodInitClusters ) e.put(std::move(initialClusters),"initialClusters");
+  if (_prodInitClusters)
+    e.put(std::move(initialClusters), "initialClusters");
   e.put(std::move(pfClusters));
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
@@ -17,27 +17,27 @@
 
 #include <memory>
 
-
 class PFClusterProducer : public edm::stream::EDProducer<> {
   typedef RecHitTopologicalCleanerBase RHCB;
   typedef InitialClusteringStepBase ICSB;
   typedef PFClusterBuilderBase PFCBB;
   typedef PFCPositionCalculatorBase PosCalc;
- public:    
+
+public:
   PFClusterProducer(const edm::ParameterSet&);
   ~PFClusterProducer() override = default;
-  
-  void beginLuminosityBlock(const edm::LuminosityBlock&, 
-				    const edm::EventSetup&) override;
+
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
- private:
+
+private:
   // inputs
   edm::EDGetTokenT<reco::PFRecHitCollection> _rechitsLabel;
   // options
   const bool _prodInitClusters;
   // the actual algorithm
   std::vector<std::unique_ptr<RecHitTopologicalCleanerBase> > _cleaners;
+  std::vector<std::unique_ptr<RecHitTopologicalCleanerBase> > _seedcleaners;
   std::unique_ptr<SeedFinderBase> _seedFinder;
   std::unique_ptr<InitialClusteringStepBase> _initialClustering;
   std::unique_ptr<PFClusterBuilderBase> _pfClusterBuilder;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -34,6 +34,19 @@ _spikeAndDoubleSpikeCleaner_ECAL = cms.PSet(
     )
 )
 
+#flag cleaning to mark hits not to be used for seeding
+_seedsFlagsCleaner_ECAL = cms.PSet(
+    algoName = cms.string("FlagsCleanerECAL"),    
+    #RecHitFlagsToBeExcluded= cms.vstring('kNeighboursRecovered')
+    RecHitFlagsToBeExcluded= cms.vstring() 
+)
+
+# crystal-dependent seeding thresholds
+_seedCleaner_ECAL = cms.PSet(
+     algoName = cms.string("ECALPFSeedCleaner"),
+)
+
+
 #seeding
 _localMaxSeeds_ECAL = cms.PSet(
     algoName = cms.string("LocalMaximumSeedFinder"),
@@ -119,6 +132,8 @@ particleFlowClusterECALUncorrected = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitECAL"),
     recHitCleaners = cms.VPSet(),
+    #seedCleaners = cms.VPSet(_seedsFlagsCleaner_ECAL,_seedCleaner_ECAL),
+    seedCleaners = cms.VPSet(_seedsFlagsCleaner_ECAL),
     seedFinder = _localMaxSeeds_ECAL,
     initialClusteringStep = _topoClusterizer_ECAL,
     pfClusterBuilder = _pfClusterizer_ECAL,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -16,6 +16,7 @@ particleFlowClusterHBHE = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHBHE"),
     recHitCleaners = cms.VPSet(),
+    seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string("LocalMaximumSeedFinder"),
         thresholdsByDetector = cms.VPSet(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHF_cfi.py
@@ -105,6 +105,7 @@ particleFlowClusterHF = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHF"),
     recHitCleaners = cms.VPSet(),
+    seedCleaners = cms.VPSet(),
     seedFinder = _localMaxSeeds_HF,
     initialClusteringStep = _topoClusterizer_HF,
     pfClusterBuilder = _pfClusterizer_HF,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -55,6 +55,7 @@ particleFlowClusterHGCal = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHGC"),
     recHitCleaners = cms.VPSet(),
+    seedCleaners   = cms.VPSet(),
     seedFinder = _passThruSeeds_HGCal,
     initialClusteringStep = _simClusterMapper_HGCal,
     pfClusterBuilder = cms.PSet(),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
@@ -78,6 +78,7 @@ particleFlowClusterHO = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHO"),
     recHitCleaners = cms.VPSet(),
+    seedCleaners  = cms.VPSet(),
     seedFinder = _localMaxSeeds_HO,
     initialClusteringStep = _topoClusterizer_HO,
     pfClusterBuilder = _pfClusterizer_HO,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterPS_cfi.py
@@ -72,6 +72,7 @@ particleFlowClusterPS = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitPS"),
     recHitCleaners = cms.VPSet(),
+    seedCleaners = cms.VPSet(),
     seedFinder = _localMaxSeeds_PS,
     initialClusteringStep = _topoClusterizer_PS,
     pfClusterBuilder = _pfClusterizer_PS,


### PR DESCRIPTION
Backporting PR #28514  with the dependencies #28324, #28502[ @argiro  @mdonega @nancymarinelli ]

In order to validate and backport #28040 we need to backport #27175 and #28514 to make a validation for which PPD will have to advice us on the way how to do it.  #27175 has been successfully backported into 10_6_X via #28831

Carried out the standard tests.
