### PR TITLE
[11.0.X] DQMCertCommon is not used, customize DQMCertTrackerPixel instead

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
@@ -41,7 +41,7 @@ DQMCertCommon = cms.Sequence( DQMCertTrackerStrip *
 from DQM.SiPixelPhase1Config.SiPixelPhase1OfflineDQM_harvesting_cff import *
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
-phase1Pixel.toReplaceWith(DQMCertCommon, DQMCertCommon.copyAndExclude([ # FIXME
+phase1Pixel.toReplaceWith(DQMCertTrackerPixel,DQMCertTrackerPixel.copyAndExclude([ # FIXME
     sipixelCertification # segfaults when included
 ]))
 


### PR DESCRIPTION
backport of #29021

#### PR description:

Minimal fix for issue described at https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2161.html.
`DQMCertCommon` is de facto not used (https://github.com/cms-sw/cmssw/search?q=DQMCertCommon&unscoped_q=DQMCertCommon) and can be removed. 

#### PR validation:

I tested with `runTheMatrix.py -l limited -i all -t 4 -j 8 --ibeos`


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backported from #29021
