### PR TITLE
Corrected 5 channels of 2016 ECAL intercalibration

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '111X_dataRun2_v1',
+    'run1_data'         :   '111X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '111X_dataRun2_v1',
+    'run2_data'         :   '111X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail' : '111X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'  :   '111X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '111X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '111X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR corrects five channels of the 2016 ECAL intercalibration that JetMET identified as problematic during the 2016 UL validation. Only the offline data GTs are updated, with only a single tag update, as seen in the GT diffs below:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_v1/111X_dataRun2_v2
**Offline data with emulation of HEM failure**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_HEfail_v1/111X_dataRun2_HEfail_v2
**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun2_relval_v1/111X_dataRun2_relval_v2

#### PR validation:

See the [presentation at the 10 Feb 2020 AlCaDB meeting](https://indico.cern.ch/event/880783/#3-ul-2016-ecal-intercalibratio) and the [20 Feb 2020 PPD meeting](https://indico.cern.ch/event/889094/#15-slides-only-legacy-2016-jme) for details of the validation.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but it will be backported to 10_6_X for use in the UL reprocessing. For consistency, the bug fix will also be propagated to 11_0_X.