### PR TITLE
Allow intra-Path parallelism

### DIFF
--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include <algorithm>
 
@@ -25,6 +26,7 @@ namespace edm {
         timesPassed_(),
         timesFailed_(),
         timesExcept_(),
+        failedModuleIndex_(workers.size()),
         state_(hlt::Ready),
         bitpos_(bitpos),
         trptr_(trptr),
@@ -38,6 +40,7 @@ namespace edm {
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
     }
+    modulesToRun_ = workers_.size();
   }
 
   Path::Path(Path const& r)
@@ -45,13 +48,13 @@ namespace edm {
         timesPassed_(r.timesPassed_),
         timesFailed_(r.timesFailed_),
         timesExcept_(r.timesExcept_),
+        failedModuleIndex_(r.failedModuleIndex_),
         state_(r.state_),
         bitpos_(r.bitpos_),
         trptr_(r.trptr_),
         actReg_(r.actReg_),
         act_table_(r.act_table_),
         workers_(r.workers_),
-        earlyDeleteHelpers_(r.earlyDeleteHelpers_),
         pathContext_(r.pathContext_),
         stopProcessingEvent_(r.stopProcessingEvent_),
         pathStatusInserter_(r.pathStatusInserter_),
@@ -59,6 +62,7 @@ namespace edm {
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
     }
+    modulesToRun_ = workers_.size();
   }
 
   bool Path::handleWorkerFailure(cms::Exception& e,
@@ -67,7 +71,7 @@ namespace edm {
                                  bool begin,
                                  BranchType branchType,
                                  ModuleDescription const& desc,
-                                 std::string const& id) {
+                                 std::string const& id) const {
     if (e.context().empty()) {
       exceptionContext(e, isEvent, begin, branchType, desc, id, pathContext_);
     }
@@ -92,10 +96,6 @@ namespace edm {
         break;
       }
       default: {
-        if (isEvent)
-          ++timesExcept_;
-        state_ = hlt::Exception;
-        recordStatus(nwrwue, isEvent);
         if (action == exception_actions::Rethrow) {
           std::string pNF = Exception::codeToString(errors::ProductNotFound);
           if (e.category() == pNF) {
@@ -144,21 +144,52 @@ namespace edm {
     ex.addContext(ost.str());
   }
 
-  void Path::recordStatus(int nwrwue, bool isEvent) {
-    if (isEvent && trptr_) {
-      (*trptr_)[bitpos_] = HLTPathStatus(state_, nwrwue);
+  void Path::threadsafe_setFailedModuleInfo(int nwrwue, std::exception_ptr iExcept) {
+    bool expected = false;
+    while (stateLock_.compare_exchange_strong(expected, true)) {
+      expected = false;
+    }
+    if (iExcept) {
+      if (state_ == hlt::Exception) {
+        if (nwrwue < failedModuleIndex_) {
+          failedModuleIndex_ = nwrwue;
+        }
+      } else {
+        state_ = hlt::Exception;
+        failedModuleIndex_ = nwrwue;
+      }
+    } else {
+      if (state_ != hlt::Exception) {
+        if (nwrwue < failedModuleIndex_) {
+          failedModuleIndex_ = nwrwue;
+        }
+        state_ = hlt::Fail;
+      }
+    }
+
+    stateLock_ = false;
+  }
+
+  void Path::recordStatus(int nwrwue, hlt::HLTState state) {
+    if (trptr_) {
+      (*trptr_)[bitpos_] = HLTPathStatus(state, nwrwue);
     }
   }
 
-  void Path::updateCounters(bool success, bool isEvent) {
-    if (success) {
-      if (isEvent)
+  void Path::updateCounters(hlt::HLTState state) {
+    switch (state) {
+      case hlt::Pass: {
         ++timesPassed_;
-      state_ = hlt::Pass;
-    } else {
-      if (isEvent)
+        break;
+      }
+      case hlt::Fail: {
         ++timesFailed_;
-      state_ = hlt::Fail;
+        break;
+      }
+      case hlt::Exception: {
+        ++timesExcept_;
+      }
+      default:;
     }
   }
 
@@ -169,30 +200,17 @@ namespace edm {
   }
 
   void Path::setEarlyDeleteHelpers(std::map<const Worker*, EarlyDeleteHelper*> const& iWorkerToDeleter) {
-    //we use a temp so we can overset the size but then when moving to earlyDeleteHelpers we only
-    // have to use the space necessary
-    std::vector<EarlyDeleteHelper*> temp;
-    temp.reserve(iWorkerToDeleter.size());
     for (unsigned int index = 0; index != size(); ++index) {
       auto found = iWorkerToDeleter.find(getWorker(index));
       if (found != iWorkerToDeleter.end()) {
-        temp.push_back(found->second);
         found->second->addedToPath();
       }
     }
-    std::vector<EarlyDeleteHelper*> tempCorrectSize(temp.begin(), temp.end());
-    earlyDeleteHelpers_.swap(tempCorrectSize);
   }
 
   void Path::setPathStatusInserter(PathStatusInserter* pathStatusInserter, Worker* pathStatusInserterWorker) {
     pathStatusInserter_ = pathStatusInserter;
     pathStatusInserterWorker_ = pathStatusInserterWorker;
-  }
-
-  void Path::handleEarlyFinish(EventPrincipal const& iEvent) {
-    for (auto helper : earlyDeleteHelpers_) {
-      helper->pathFinished(iEvent);
-    }
   }
 
   void Path::processOneOccurrenceAsync(WaitingTask* iTask,
@@ -202,17 +220,20 @@ namespace edm {
                                        StreamID const& iStreamID,
                                        StreamContext const* iStreamContext) {
     waitingTasks_.reset();
+    modulesToRun_ = workers_.size();
     ++timesRun_;
     waitingTasks_.add(iTask);
     if (actReg_) {
       ServiceRegistry::Operate guard(iToken);
       actReg_->prePathEventSignal_(*iStreamContext, pathContext_);
     }
-    state_ = hlt::Ready;
+    //If the Path succeeds, these are the values we have at the end
+    state_ = hlt::Pass;
+    failedModuleIndex_ = workers_.size() - 1;
 
     if (workers_.empty()) {
       ServiceRegistry::Operate guard(iToken);
-      finished(-1, true, std::exception_ptr(), iStreamContext, iEP, iES, iStreamID);
+      finished(std::exception_ptr(), iStreamContext, iEP, iES, iStreamID);
       return;
     }
 
@@ -269,34 +290,39 @@ namespace edm {
     }
     auto const nextIndex = iModuleIndex + 1;
     if (shouldContinue and nextIndex < workers_.size()) {
-      runNextWorkerAsync(nextIndex, iEP, iES, iToken, iID, iContext);
-      return;
+      if (not worker.runConcurrently()) {
+        --modulesToRun_;
+        runNextWorkerAsync(nextIndex, iEP, iES, iToken, iID, iContext);
+        return;
+      }
     }
 
     if (not shouldContinue) {
+      threadsafe_setFailedModuleInfo(iModuleIndex, finalException);
+    }
+    if (not shouldContinue and not worker.runConcurrently()) {
       //we are leaving the path early
       for (auto it = workers_.begin() + nextIndex, itEnd = workers_.end(); it != itEnd; ++it) {
+        --modulesToRun_;
         it->skipWorker(iEP);
       }
-      handleEarlyFinish(iEP);
     }
-    finished(iModuleIndex, shouldContinue, finalException, iContext, iEP, iES, iID);
+    if (--modulesToRun_ == 0) {
+      //The path should only be marked as finished once all outstanding modules finish
+      finished(finalException, iContext, iEP, iES, iID);
+    }
   }
 
-  void Path::finished(int iModuleIndex,
-                      bool iSucceeded,
-                      std::exception_ptr iException,
+  void Path::finished(std::exception_ptr iException,
                       StreamContext const* iContext,
                       EventPrincipal const& iEP,
                       EventSetupImpl const& iES,
                       StreamID const& streamID) {
-    if (not iException) {
-      updateCounters(iSucceeded, true);
-      recordStatus(iModuleIndex, true);
-    }
+    updateCounters(state_);
+    recordStatus(failedModuleIndex_, state_);
     // Caught exception is propagated via WaitingTaskList
     CMS_SA_ALLOW try {
-      HLTPathStatus status(state_, iModuleIndex);
+      HLTPathStatus status(state_, failedModuleIndex_);
 
       if (pathStatusInserter_) {  // pathStatusInserter is null for EndPaths
         pathStatusInserter_->setPathStatus(streamID, status);
@@ -322,14 +348,21 @@ namespace edm {
                                 ServiceToken const& iToken,
                                 StreamID const& iID,
                                 StreamContext const* iContext) {
-    auto nextTask = make_waiting_task(
-        tbb::task::allocate_root(),
-        [this, iNextModuleIndex, &iEP, &iES, iID, iContext, token = iToken](std::exception_ptr const* iException) {
-          this->workerFinished(iException, iNextModuleIndex, iEP, iES, token, iID, iContext);
-        });
-
-    workers_[iNextModuleIndex].runWorkerAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-        nextTask, iEP, iES, iToken, iID, iContext);
+    //Figure out which next modules can run concurrently
+    const int firstModuleIndex = iNextModuleIndex;
+    int lastModuleIndex = firstModuleIndex;
+    while (lastModuleIndex + 1 != static_cast<int>(workers_.size()) and workers_[lastModuleIndex].runConcurrently()) {
+      ++lastModuleIndex;
+    }
+    for (; lastModuleIndex >= firstModuleIndex; --lastModuleIndex) {
+      auto nextTask = make_waiting_task(
+          tbb::task::allocate_root(),
+          [this, lastModuleIndex, &iEP, &iES, iID, iContext, token = iToken](std::exception_ptr const* iException) {
+            this->workerFinished(iException, lastModuleIndex, iEP, iES, token, iID, iContext);
+          });
+      workers_[lastModuleIndex].runWorkerAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+          nextTask, iEP, iES, iToken, iID, iContext);
+    }
   }
 
 }  // namespace edm

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -116,8 +116,8 @@ namespace edm {
 
     int const bitpos_;
     TrigResPtr const trptr_;
-    std::shared_ptr<ActivityRegistry> const
-        actReg_;  // We do not use propagate_const because the registry itself is mutable.
+    // We do not use propagate_const because the registry itself is mutable.
+    std::shared_ptr<ActivityRegistry> const actReg_;
     ExceptionToActionTable const* const act_table_;
 
     WorkersInPath workers_;

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -86,7 +86,6 @@ namespace edm {
     int timesFailed() const { return timesFailed_; }
     int timesExcept() const { return timesExcept_; }
     //int abortWorker() const { return abortWorker_; }
-    State state() const { return state_; }
 
     size_type size() const { return workers_.size(); }
     int timesVisited(size_type i) const { return workers_.at(i).timesVisited(); }
@@ -109,19 +108,24 @@ namespace edm {
     int timesFailed_;
     int timesExcept_;
     //int abortWorker_;
-    State state_;
+    //When an exception happens, it is possible for multiple modules in a path to fail
+    // and then try to change the state concurrently.
+    std::atomic<bool> stateLock_ = false;
+    CMS_THREAD_GUARD(stateLock_) int failedModuleIndex_;
+    CMS_THREAD_GUARD(stateLock_) State state_;
 
-    int bitpos_;
-    TrigResPtr trptr_;
-    std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
-    ExceptionToActionTable const* act_table_;
+    int const bitpos_;
+    TrigResPtr const trptr_;
+    std::shared_ptr<ActivityRegistry> const
+        actReg_;  // We do not use propagate_const because the registry itself is mutable.
+    ExceptionToActionTable const* const act_table_;
 
     WorkersInPath workers_;
-    std::vector<EarlyDeleteHelper*> earlyDeleteHelpers_;
 
     PathContext pathContext_;
     WaitingTaskList waitingTasks_;
-    std::atomic<bool>* stopProcessingEvent_;
+    std::atomic<bool>* const stopProcessingEvent_;
+    std::atomic<unsigned int> modulesToRun_;
 
     PathStatusInserter* pathStatusInserter_;
     Worker* pathStatusInserterWorker_;
@@ -134,7 +138,7 @@ namespace edm {
                              bool begin,
                              BranchType branchType,
                              ModuleDescription const&,
-                             std::string const& id);
+                             std::string const& id) const;
     static void exceptionContext(cms::Exception& ex,
                                  bool isEvent,
                                  bool begin,
@@ -142,20 +146,15 @@ namespace edm {
                                  ModuleDescription const&,
                                  std::string const& id,
                                  PathContext const&);
-    void recordStatus(int nwrwue, bool isEvent);
-    void updateCounters(bool succeed, bool isEvent);
+    void threadsafe_setFailedModuleInfo(int nwrwue, std::exception_ptr);
+    void recordStatus(int nwrwue, hlt::HLTState state);
+    void updateCounters(hlt::HLTState state);
 
-    void finished(int iModuleIndex,
-                  bool iSucceeded,
-                  std::exception_ptr,
+    void finished(std::exception_ptr,
                   StreamContext const*,
                   EventPrincipal const& iEP,
                   EventSetupImpl const& iES,
                   StreamID const& streamID);
-
-    void handleEarlyFinish(EventPrincipal const&);
-    void handleEarlyFinish(RunPrincipal const&) {}
-    void handleEarlyFinish(LuminosityBlockPrincipal const&) {}
 
     //Handle asynchronous processing
     void workerFinished(std::exception_ptr const* iException,

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -360,7 +360,10 @@ namespace edm {
     }
   }
 
-  void Worker::skipOnPath() {
+  void Worker::skipOnPath(EventPrincipal const& iEvent) {
+    if (earlyDeleteHelper_) {
+      earlyDeleteHelper_->pathFinished(iEvent);
+    }
     if (0 == --numberOfPathsLeftToRun_) {
       waitingTasks_.doneWaiting(cached_exception_);
     }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -165,7 +165,7 @@ namespace edm {
                                          typename T::Context const* context);
 
     void callWhenDoneAsync(WaitingTask* task) { waitingTasks_.add(task); }
-    void skipOnPath();
+    void skipOnPath(EventPrincipal const& iEvent);
     void beginJob();
     void endJob();
     void beginStream(StreamID id, StreamContext& streamContext);

--- a/FWCore/Framework/src/WorkerInPath.cc
+++ b/FWCore/Framework/src/WorkerInPath.cc
@@ -3,14 +3,15 @@
 #include "FWCore/Framework/src/WorkerInPath.h"
 
 namespace edm {
-  WorkerInPath::WorkerInPath(Worker* w, FilterAction theFilterAction, unsigned int placeInPath)
+  WorkerInPath::WorkerInPath(Worker* w, FilterAction theFilterAction, unsigned int placeInPath, bool runConcurrently)
       : timesVisited_(),
         timesPassed_(),
         timesFailed_(),
         timesExcept_(),
         filterAction_(theFilterAction),
         worker_(w),
-        placeInPathContext_(placeInPath) {
+        placeInPathContext_(placeInPath),
+        runConcurrently_(runConcurrently) {
     w->addedToPath();
   }
 

--- a/FWCore/Framework/test/test_multiPathMultiModuleEarlyDelete_cfg.py
+++ b/FWCore/Framework/test/test_multiPathMultiModuleEarlyDelete_cfg.py
@@ -48,6 +48,6 @@ process.waitTillP2Done = cms.EDAnalyzer("IntConsumingAnalyzer",
                                         getFromModule = cms.untracked.InputTag("p2Done"))
 
 
-process.p1 = cms.Path(process.maker+process.f2+process.reader1+process.tester1+process.p1Done)
-process.p2 = cms.Path(process.waitTillP1Done+process.maker+process.p2PreTester+process.f3+process.reader2+process.tester2+process.p2Done)
-process.p3 = cms.Path(process.waitTillP2Done+process.tester3)
+process.p1 = cms.Path(cms.wait(process.maker)+process.f2+cms.wait(process.reader1)+cms.wait(process.tester1)+process.p1Done)
+process.p2 = cms.Path(cms.wait(process.waitTillP1Done)+cms.wait(process.maker)+cms.wait(process.p2PreTester)+process.f3+cms.wait(process.reader2)+cms.wait(process.tester2)+process.p2Done)
+process.p3 = cms.Path(cms.wait(process.waitTillP2Done)+process.tester3)

--- a/FWCore/Framework/test/test_readAfterEarlyDelete_fail_cfg.py
+++ b/FWCore/Framework/test/test_readAfterEarlyDelete_fail_cfg.py
@@ -21,4 +21,5 @@ process.readerFail = cms.EDAnalyzer("DeleteEarlyReader",
                                     tag = cms.untracked.InputTag("maker"))
 
 
-process.p = cms.Path(process.maker+process.reader+process.readerFail)
+process.p = cms.Path(process.maker+cms.wait(process.reader)+process.readerFail)
+process.add_(cms.Service("Tracer"))

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -71,19 +71,19 @@
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
 ++++++ starting: processing path 'p' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ starting: processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ finished: processing event for module: stream = 0 label = 'two' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 6
@@ -99,19 +99,19 @@
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
 ++++++ starting: processing path 'p' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ starting: processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ finished: processing event for module: stream = 0 label = 'two' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 6
@@ -127,19 +127,19 @@
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++++ starting: processing path 'p' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ starting: processing event for module: stream = 0 label = 'two' id = 5
 ++++++++ finished: processing event for module: stream = 0 label = 'two' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 6

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -318,15 +318,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -335,14 +327,23 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -351,8 +352,8 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -367,8 +368,8 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -383,21 +384,20 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
@@ -494,15 +494,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -511,14 +503,23 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -527,8 +528,8 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -543,8 +544,8 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -559,21 +560,20 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
@@ -670,15 +670,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -687,14 +679,23 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -703,8 +704,8 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Prefetching
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -719,8 +720,8 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -735,21 +736,20 @@ StreamContext: StreamID = 0 transition = Event
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Prefetching
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
+    moduleDescription: Module type=TestFindProduct, Module label=a3, Parameter Set ID=354df018ce2f0160ec1374ad6edf1bc8
+    PlaceInPathContext 3
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 2f9cb7fb91f77860cb45771073f1116b
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -368,6 +368,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -380,22 +384,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -417,8 +417,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -427,8 +429,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -441,7 +445,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -451,7 +454,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -485,7 +487,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -495,7 +496,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -530,6 +530,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -542,22 +546,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -579,8 +579,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -589,8 +591,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -603,7 +607,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -613,7 +616,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -647,7 +649,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -657,7 +658,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -692,6 +692,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -704,22 +708,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -741,8 +741,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -751,8 +753,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -765,7 +769,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -775,7 +778,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -809,7 +811,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -819,7 +820,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -854,6 +854,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -866,22 +870,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -903,8 +903,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -913,8 +915,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -927,7 +931,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -937,7 +940,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -971,7 +973,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -981,7 +982,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -1158,6 +1158,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -1170,22 +1174,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -1207,8 +1207,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -1217,8 +1219,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -1231,7 +1235,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -1241,7 +1244,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -1275,7 +1277,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -1285,7 +1286,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -1320,6 +1320,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -1332,22 +1336,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -1369,8 +1369,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -1379,8 +1381,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -1393,7 +1397,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -1403,7 +1406,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -1437,7 +1439,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -1447,7 +1448,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -1482,6 +1482,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -1494,22 +1498,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -1531,8 +1531,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -1541,8 +1543,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -1555,7 +1559,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -1565,7 +1568,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -1599,7 +1601,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -1609,7 +1610,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -1644,6 +1644,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -1656,22 +1660,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -1693,8 +1693,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -1703,8 +1705,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -1717,7 +1721,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -1727,7 +1730,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -1761,7 +1763,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -1771,7 +1772,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -1948,6 +1948,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -1960,22 +1964,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -1997,8 +1997,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -2007,8 +2009,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -2021,7 +2025,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -2031,7 +2034,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -2065,7 +2067,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -2075,7 +2076,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -2110,6 +2110,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -2122,22 +2126,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -2159,8 +2159,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -2169,8 +2171,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -2183,7 +2187,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -2193,7 +2196,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -2227,7 +2229,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -2237,7 +2238,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -2556,6 +2556,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -2568,22 +2572,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -2605,8 +2605,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -2615,8 +2617,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -2629,7 +2633,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -2639,7 +2642,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -2673,7 +2675,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -2683,7 +2684,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -2718,6 +2718,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -2730,22 +2734,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -2767,8 +2767,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -2777,8 +2779,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -2791,7 +2795,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -2801,7 +2804,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -2835,7 +2837,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -2845,7 +2846,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -2880,6 +2880,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -2892,22 +2896,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -2929,8 +2929,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -2939,8 +2941,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -2953,7 +2957,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -2963,7 +2966,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -2997,7 +2999,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -3007,7 +3008,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -3042,6 +3042,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -3054,22 +3058,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -3091,8 +3091,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -3101,8 +3103,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -3115,7 +3119,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -3125,7 +3128,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -3159,7 +3161,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -3169,7 +3170,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -3346,6 +3346,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -3358,22 +3362,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -3395,8 +3395,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -3405,8 +3407,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -3419,7 +3423,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -3429,7 +3432,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -3463,7 +3465,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -3473,7 +3474,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -3508,6 +3508,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -3520,22 +3524,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -3557,8 +3557,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -3567,8 +3569,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -3581,7 +3585,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -3591,7 +3594,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -3625,7 +3627,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -3635,7 +3636,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -3670,6 +3670,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -3682,22 +3686,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -3719,8 +3719,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -3729,8 +3731,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -3743,7 +3747,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -3753,7 +3756,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -3787,7 +3789,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -3797,7 +3798,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -3832,6 +3832,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -3844,22 +3848,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -3881,8 +3881,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -3891,8 +3893,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -3905,7 +3909,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -3915,7 +3918,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -3949,7 +3951,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -3959,7 +3960,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -4136,6 +4136,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -4148,22 +4152,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -4185,8 +4185,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -4195,8 +4197,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -4209,7 +4213,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -4219,7 +4222,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -4253,7 +4255,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -4263,7 +4264,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -4298,6 +4298,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -4310,22 +4314,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -4347,8 +4347,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -4357,8 +4359,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -4371,7 +4375,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -4381,7 +4384,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -4415,7 +4417,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -4425,7 +4426,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -4744,6 +4744,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -4756,22 +4760,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -4793,8 +4793,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -4803,8 +4805,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -4817,7 +4821,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -4827,7 +4830,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -4861,7 +4863,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -4871,7 +4872,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -4906,6 +4906,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -4918,22 +4922,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -4955,8 +4955,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -4965,8 +4967,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -4979,7 +4983,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -4989,7 +4992,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -5023,7 +5025,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -5033,7 +5034,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -5068,6 +5068,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -5080,22 +5084,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -5117,8 +5117,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -5127,8 +5129,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -5141,7 +5145,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -5151,7 +5154,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -5185,7 +5187,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -5195,7 +5196,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -5230,6 +5230,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -5242,22 +5246,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -5279,8 +5279,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -5289,8 +5291,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -5303,7 +5307,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -5313,7 +5316,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -5347,7 +5349,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -5357,7 +5358,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -5534,6 +5534,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -5546,22 +5550,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -5583,8 +5583,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -5593,8 +5595,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -5607,7 +5611,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -5617,7 +5620,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -5651,7 +5653,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -5661,7 +5662,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -5696,6 +5696,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -5708,22 +5712,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -5745,8 +5745,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -5755,8 +5757,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -5769,7 +5773,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -5779,7 +5782,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -5813,7 +5815,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -5823,7 +5824,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -5858,6 +5858,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -5870,22 +5874,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -5907,8 +5907,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -5917,8 +5919,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -5931,7 +5935,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -5941,7 +5944,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -5975,7 +5977,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -5985,7 +5986,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -6020,6 +6020,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -6032,22 +6036,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -6069,8 +6069,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -6079,8 +6081,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -6093,7 +6097,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -6103,7 +6106,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -6137,7 +6139,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -6147,7 +6148,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -6324,6 +6324,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -6336,22 +6340,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -6373,8 +6373,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -6383,8 +6385,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -6397,7 +6401,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -6407,7 +6410,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -6441,7 +6443,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -6451,7 +6452,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
@@ -6486,6 +6486,10 @@
 ++++++ starting: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -6498,22 +6502,18 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
 ++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
@@ -6535,8 +6535,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
@@ -6545,8 +6547,10 @@
 ++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
@@ -6559,7 +6563,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
@@ -6569,7 +6572,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
@@ -6603,7 +6605,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
 ++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
@@ -6613,7 +6614,6 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
 ++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35


### PR DESCRIPTION
#### PR description:

The modules after an EDFilter and before the next EDFilter are allowed to run concurrently. This can be prevented by using cms.wait() on the module in the configuration.

#### PR validation:

All framework related unit tests pass.