### PR TITLE
Corrected 5 channels of 2016 ECAL intercalibration [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v26',
+    'run1_data'         :   '106X_dataRun2_v27',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v26',
+    'run2_data'         :   '106X_dataRun2_v27',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v24',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v25',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #29023.

This PR corrects five channels of the 2016 ECAL intercalibration that JetMET identified as problematic during the 2016 UL validation. Only the offline data GTs are updated, with only a single tag update, as seen in the GT diffs below:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v26/106X_dataRun2_v27
**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v24/106X_dataRun2_relval_v25

#### PR validation:

See the [presentation at the 10 Feb 2020 AlCaDB meeting](https://indico.cern.ch/event/880783/#3-ul-2016-ecal-intercalibratio) and the [20 Feb 2020 PPD meeting](https://indico.cern.ch/event/889094/#15-slides-only-legacy-2016-jme) for details of the validation.

In addition, a technical test was performed: `runTheMatrix -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #29023. The updates in this PR are included in the 2016 UL reprocessing.