### PR TITLE
Fix bug in PoolSource when skipping events with a missing file

### DIFF
--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -151,13 +151,14 @@ namespace edm {
 
     initFile(input_.skipBadFiles());
 
-    if (rootFile()) {
-      // make sure the new product registry is compatible with the main one
-      std::string mergeInfo =
-          input_.productRegistryUpdate().merge(*rootFile()->productRegistry(), fileName(), branchesMustMatch_);
-      if (!mergeInfo.empty()) {
-        throw Exception(errors::MismatchedInputFiles, "RootPrimaryFileSequence::nextFile()") << mergeInfo;
-      }
+    if (not rootFile()) {
+      return false;
+    }
+    // make sure the new product registry is compatible with the main one
+    std::string mergeInfo =
+        input_.productRegistryUpdate().merge(*rootFile()->productRegistry(), fileName(), branchesMustMatch_);
+    if (!mergeInfo.empty()) {
+      throw Exception(errors::MismatchedInputFiles, "RootPrimaryFileSequence::nextFile()") << mergeInfo;
     }
     return true;
   }

--- a/IOPool/Input/test/PoolInputTest_skip_with_failure_cfg.py
+++ b/IOPool/Input/test/PoolInputTest_skip_with_failure_cfg.py
@@ -1,0 +1,27 @@
+# The following comments couldn't be translated into the new config version:
+
+# Configuration file for PoolInputTest
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+
+process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
+
+process.source = cms.Source("PoolSource",
+                            skipBadFiles = cms.untracked.bool(True),
+                            skipEvents = cms.untracked.uint32(15), #skips all events in first file
+                            setRunNumber = cms.untracked.uint32(621),
+                            fileNames = cms.untracked.vstring('file:PoolInputTest.root', 
+                                                              'file:this_file_doesnt_exist.root')
+)
+
+process.p = cms.Path(process.OtherThing*process.Analysis)
+
+

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -22,6 +22,7 @@ cp PoolInputTest.root PoolInputOther.root
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_cfg.py || die 'Failure using PoolInputTest_cfg.py' $?
 cmsRun  ${LOCAL_TEST_DIR}/PoolInputTest_noDelay_cfg.py >& ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt || die 'Failure using PoolInputTest_noDelay_cfg.py' $?
 grep 'event delayed read from source' ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt && die 'Failure in PoolInputTest_noDelay_cfg.py, found delay reads from source' 1
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skip_with_failure_cfg.py || die 'Failure using PoolInputTest_skip_with_failure_cfg.py' $?
 
 cmsRun ${LOCAL_TEST_DIR}/PrePool2FileInputTest_cfg.py || die 'Failure using PrePool2FileInputTest_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/Pool2FileInputTest_cfg.py || die 'Failure using Pool2FileInputTest_cfg.py' $?


### PR DESCRIPTION
#### PR description:

If the configuration has N input files and skipEvents causes us to skip N-1 files and the last file can not be opened, the job would crash.

#### PR validation:

All framework unit tests pass.