### PR TITLE
HCAL:  HBHE MC 8TS->10TS move for >=Run3 

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/HBHE_revert_8TS_cff.py
+++ b/SimCalorimetry/HcalSimProducers/python/HBHE_revert_8TS_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+#--- reset HB/HE digi frame size to 8TS & SOI=3 (0,1,2,3)
+#--- NB: needs ZS re-adjustment/customization at the same time 
+
+def customise(process):
+    process.mix.digitizers.hcal.hb.readoutFrameSize = 8
+    process.mix.digitizers.hcal.he.readoutFrameSize = 8
+    process.mix.digitizers.hcal.hb.binOfMaximum = cms.int32(4)
+    process.mix.digitizers.hcal.he.binOfMaximum = cms.int32(4)
+    return(process)

--- a/SimCalorimetry/HcalSimProducers/python/HBHE_revert_8TS_cff.py
+++ b/SimCalorimetry/HcalSimProducers/python/HBHE_revert_8TS_cff.py
@@ -6,6 +6,6 @@ import FWCore.ParameterSet.Config as cms
 def customise(process):
     process.mix.digitizers.hcal.hb.readoutFrameSize = 8
     process.mix.digitizers.hcal.he.readoutFrameSize = 8
-    process.mix.digitizers.hcal.hb.binOfMaximum = cms.int32(4)
-    process.mix.digitizers.hcal.he.binOfMaximum = cms.int32(4)
+    process.mix.digitizers.hcal.hb.binOfMaximum = 4
+    process.mix.digitizers.hcal.he.binOfMaximum = 4
     return(process)

--- a/SimCalorimetry/HcalSimProducers/python/HBHE_revert_8TS_cff.py
+++ b/SimCalorimetry/HcalSimProducers/python/HBHE_revert_8TS_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #--- reset HB/HE digi frame size to 8TS & SOI=3 (0,1,2,3)
 #--- NB: needs ZS re-adjustment/customization at the same time 
 
-def customise(process):
+def customise_8TS(process):
     process.mix.digitizers.hcal.hb.readoutFrameSize = 8
     process.mix.digitizers.hcal.he.readoutFrameSize = 8
     process.mix.digitizers.hcal.hb.binOfMaximum = 4

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -164,6 +164,19 @@ run3_HB.toModify( hcalSimParameters,
     )
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify( hcalSimParameters, 
+    hb = dict(
+               readoutFrameSize = cms.int32(10), 
+               binOfMaximum     = cms.int32(6)
+              ),
+    he = dict(
+               readoutFrameSize = cms.int32(10), 
+               binOfMaximum     = cms.int32(6)
+              )
+) 
+
+
 _newFactors = cms.vdouble(
     210.55, 197.93, 186.12, 189.64, 189.63,
     189.96, 190.03, 190.11, 190.18, 190.25,

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/HBHE_ZSrevert_2TS_cff.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/HBHE_ZSrevert_2TS_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+#--- reset HB/HE ZS to 2TS 
+#--- NB: may need appropriate HcalZSThresholds update
+  
+def customise(process):
+    process.simHcalDigis.HBregion = (2,5)
+    process.simHcalDigis.HEregion = (2,5)
+    process.simHcalDigis.use1ts = False
+    return(process)
+

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/HBHE_ZSrevert_2TS_cff.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/HBHE_ZSrevert_2TS_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #--- reset HB/HE ZS to 2TS 
 #--- NB: may need appropriate HcalZSThresholds update
   
-def customise(process):
+def customise_2TS(process):
     process.simHcalDigis.HBregion = (2,5)
     process.simHcalDigis.HEregion = (2,5)
     process.simHcalDigis.use1ts = False

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -42,7 +42,9 @@ run2_HE_2018.toModify( simHcalDigis,
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( simHcalDigis, 
-                             use1ts = cms.bool(True)
+                             use1ts = cms.bool(True),
+                             HBregion = cms.vint32(4,7),
+                             HEregion = cms.vint32(4,7)
 ) 
 
 


### PR DESCRIPTION
#### PR description:

Intended for better description of high SiPMs noise (which is *spread in time* between TS' - Time Slices of 25ns) at the end of Run3 and in Run4 by simulating extended Digi frame (10TS) and using last 8TS of it in local Reco, (omitting the first 2TS' with some noise deficit). Preparatory PR  https://github.com/cms-sw/cmssw/pull/28948  (for Reco repacking of Digi input) merged earlier.
ZS (Zero Suppression) range modified accordingly.

Two (cmsDriver) customization snippets, one per each modified CMSSW package, are provided for possible reverting of both modifications: 
(1) Digi frame size back to 8TS 
(2) ZS algo & range - back to legacy 2TS option  
(+ reverting conditions: tag HcalZSThresholds)
for fully reproducing 11_0_0  Hcal Digis in 11_1_0, if needed : 

 --customise \
SimCalorimetry/HcalSimProducers/HBHE_revert_8TS_cff.customise_8TS, \
SimCalorimetry/HcalZeroSuppressionProducers/HBHE_ZSrevert_2TS_cff.customise_2TS

Some small changes (Digi random generator sequence altered, impacting also MAHI reconstruction results) expected for >= Run3.
Here is a single-pion 0PU calorimetry scan  results (wrt regular 11_1_0_pre3) for Run3 2021:
https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/Run3/11_1_0_pre3_run3_newZS_FlexSOI_10TSSOI5_vs_11_1_0_pre3_run3_SinglePi/ 

#### PR validation:
runTheMatrix.py -l limited

#### if this PR is a backport 

No backport needed 
