### PR TITLE
Pr 111x L1t Phase2 DataFormats step1

### DIFF
--- a/DataFormats/L1TVertex/BuildFile.xml
+++ b/DataFormats/L1TVertex/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="DataFormats/Common"/>
+<use name="DataFormats/L1TrackTrigger"/>
+
+<export>
+  <lib name="1"/>
+</export>
+

--- a/DataFormats/L1TVertex/interface/Vertex.h
+++ b/DataFormats/L1TVertex/interface/Vertex.h
@@ -1,0 +1,39 @@
+#ifndef DataFormats_L1TVertex_Vertex_h
+#define DataFormats_L1TVertex_Vertex_h
+
+
+#include <vector>
+
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+namespace l1t {
+
+class Vertex;
+typedef std::vector<Vertex> VertexCollection;
+typedef edm::Ref<VertexCollection> VertexRef;
+
+class Vertex {
+public:
+  typedef TTTrack<Ref_Phase2TrackerDigi_> Track_t;
+
+  Vertex();
+  Vertex(float z0, const std::vector<edm::Ptr<Track_t>>& tracks);
+  ~Vertex();
+
+  float z0() const;
+
+  const std::vector<edm::Ptr<Track_t>>& tracks() const;
+
+private:
+
+  float z0_;
+  std::vector<edm::Ptr<Track_t>> tracks_;
+};
+
+}
+
+#endif
+

--- a/DataFormats/L1TVertex/src/Vertex.cc
+++ b/DataFormats/L1TVertex/src/Vertex.cc
@@ -1,0 +1,36 @@
+
+#include "DataFormats/L1TVertex/interface/Vertex.h"
+
+
+
+namespace l1t {
+
+Vertex::Vertex() :
+  z0_(0.0)
+{
+}
+
+Vertex::Vertex(float z0, const std::vector<edm::Ptr<Track_t>>& tracks) :
+  z0_(z0),
+  tracks_(tracks)
+{
+}
+
+
+Vertex::~Vertex()
+{
+}
+
+
+float Vertex::z0() const
+{
+  return z0_;
+}
+
+
+const std::vector<edm::Ptr<Vertex::Track_t>>& Vertex::tracks() const
+{
+  return tracks_;
+}
+
+}

--- a/DataFormats/L1TVertex/src/classes.h
+++ b/DataFormats/L1TVertex/src/classes.h
@@ -1,0 +1,10 @@
+
+#include "DataFormats/L1TVertex/interface/Vertex.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+
+namespace { struct dictionary {
+  l1t::VertexCollection dummy0;
+  edm::Wrapper<l1t::VertexCollection> dummy1;
+  l1t::VertexRef dummy2;
+};}

--- a/DataFormats/L1TVertex/src/classes_def.xml
+++ b/DataFormats/L1TVertex/src/classes_def.xml
@@ -1,0 +1,6 @@
+<lcgdict>
+ <class name="l1t::Vertex"/>
+ <class name="std::vector<l1t::Vertex>"/>
+ <class name="edm::Wrapper<std::vector<l1t::Vertex> >"/>
+ <class name="edm::Ref<std::vector<l1t::Vertex> >"/>  
+</lcgdict>

--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -3,8 +3,10 @@
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/Phase2TrackerDigi"/>
-<use   name="DataFormats/SiStripDetId"/>
-<use   name="DataFormats/TrackerCommon"/>
+<use   name="DataFormats/L1Trigger"/>
+<use   name="boost"/>
+<use   name="rootrflx"/>
+<use   name="clhep"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h
@@ -1,0 +1,80 @@
+#ifndef L1TkTrigger_L1CaloTkTauParticle_h
+#define L1TkTrigger_L1CaloTkTauParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1CaloTkTauParticle
+// 
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace l1t { 
+
+  class L1CaloTkTauParticle ;
+  
+  typedef std::vector< L1CaloTkTauParticle > L1CaloTkTauParticleCollection ;
+  
+  typedef edm::Ref< L1CaloTkTauParticleCollection > L1CaloTkTauParticleRef ;
+  typedef edm::RefVector< L1CaloTkTauParticleCollection > L1CaloTkTauParticleRefVector ;
+  typedef std::vector< L1CaloTkTauParticleRef > L1CaloTkTauParticleVectorRef ;
+  
+  typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+  typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+  typedef edm::Ptr< L1TTTrackType > L1TTTrackRefPtr;
+  typedef std::vector< L1TTTrackRefPtr > L1TTTrackRefPtr_Collection;
+
+  class L1CaloTkTauParticle : public L1Candidate
+  {     
+    
+  public:
+    
+    L1CaloTkTauParticle();
+
+    L1CaloTkTauParticle( const LorentzVector& p4, // caloTau calibrated p4
+			 const LorentzVector& tracksP4,
+			 const std::vector< L1TTTrackRefPtr >& clustTracks,
+			 Tau& caloTau,
+			 float vtxIso = -999.); 
+			 //float Et = -999. ); // calibrated Et
+
+    virtual ~L1CaloTkTauParticle() {}
+    
+    // ---------- const member functions ---------------------
+
+    const L1TTTrackRefPtr getSeedTrk() const { return clustTracks_.at(0); }
+
+    float getVtxIso() const { return vtxIso_ ; } 
+    
+    LorentzVector getTrackBasedP4() const { return tracksP4_ ; } 
+
+    float getTrackBasedEt() const { return tracksP4_.Et() ; } 
+    
+    Tau getCaloTau() const { return caloTau_; }    
+    
+    // ---------- member functions ---------------------------
+    
+    void setVtxIso(float VtxIso)  { vtxIso_ = VtxIso ; }
+
+    //void setEt(float Et)  { Et_ = Et ; }
+        
+  private:
+    LorentzVector tracksP4_;
+    std::vector< L1TTTrackRefPtr > clustTracks_;
+    Tau caloTau_;
+    float vtxIso_;
+    //float Et_; // calibrated Et
+
+  };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h
@@ -5,7 +5,7 @@
 //
 // Package:     L1Trigger
 // Class  :     L1CaloTkTauParticle
-// 
+//
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -16,65 +16,59 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-namespace l1t { 
+namespace l1t {
 
-  class L1CaloTkTauParticle ;
-  
-  typedef std::vector< L1CaloTkTauParticle > L1CaloTkTauParticleCollection ;
-  
-  typedef edm::Ref< L1CaloTkTauParticleCollection > L1CaloTkTauParticleRef ;
-  typedef edm::RefVector< L1CaloTkTauParticleCollection > L1CaloTkTauParticleRefVector ;
-  typedef std::vector< L1CaloTkTauParticleRef > L1CaloTkTauParticleVectorRef ;
-  
-  typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-  typedef std::vector< L1TTTrackType > L1TTTrackCollection;
-  typedef edm::Ptr< L1TTTrackType > L1TTTrackRefPtr;
-  typedef std::vector< L1TTTrackRefPtr > L1TTTrackRefPtr_Collection;
+  class L1CaloTkTauParticle;
 
-  class L1CaloTkTauParticle : public L1Candidate
-  {     
-    
+  typedef std::vector<L1CaloTkTauParticle> L1CaloTkTauParticleCollection;
+
+  typedef edm::Ref<L1CaloTkTauParticleCollection> L1CaloTkTauParticleRef;
+  typedef edm::RefVector<L1CaloTkTauParticleCollection> L1CaloTkTauParticleRefVector;
+  typedef std::vector<L1CaloTkTauParticleRef> L1CaloTkTauParticleVectorRef;
+
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollection;
+  typedef edm::Ptr<L1TTTrackType> L1TTTrackRefPtr;
+  typedef std::vector<L1TTTrackRefPtr> L1TTTrackRefPtr_Collection;
+
+  class L1CaloTkTauParticle : public L1Candidate {
   public:
-    
     L1CaloTkTauParticle();
 
-    L1CaloTkTauParticle( const LorentzVector& p4, // caloTau calibrated p4
-			 const LorentzVector& tracksP4,
-			 const std::vector< L1TTTrackRefPtr >& clustTracks,
-			 Tau& caloTau,
-			 float vtxIso = -999.); 
-			 //float Et = -999. ); // calibrated Et
+    L1CaloTkTauParticle(const LorentzVector& p4,  // caloTau calibrated p4
+                        const LorentzVector& tracksP4,
+                        const std::vector<L1TTTrackRefPtr>& clustTracks,
+                        Tau& caloTau,
+                        float vtxIso = -999.);
+    //float Et = -999. ); // calibrated Et
 
     virtual ~L1CaloTkTauParticle() {}
-    
+
     // ---------- const member functions ---------------------
 
     const L1TTTrackRefPtr getSeedTrk() const { return clustTracks_.at(0); }
 
-    float getVtxIso() const { return vtxIso_ ; } 
-    
-    LorentzVector getTrackBasedP4() const { return tracksP4_ ; } 
+    float getVtxIso() const { return vtxIso_; }
 
-    float getTrackBasedEt() const { return tracksP4_.Et() ; } 
-    
-    Tau getCaloTau() const { return caloTau_; }    
-    
+    LorentzVector getTrackBasedP4() const { return tracksP4_; }
+
+    float getTrackBasedEt() const { return tracksP4_.Et(); }
+
+    Tau getCaloTau() const { return caloTau_; }
+
     // ---------- member functions ---------------------------
-    
-    void setVtxIso(float VtxIso)  { vtxIso_ = VtxIso ; }
+
+    void setVtxIso(float VtxIso) { vtxIso_ = VtxIso; }
 
     //void setEt(float Et)  { Et_ = Et ; }
-        
+
   private:
     LorentzVector tracksP4_;
-    std::vector< L1TTTrackRefPtr > clustTracks_;
+    std::vector<L1TTTrackRefPtr> clustTracks_;
     Tau caloTau_;
     float vtxIso_;
     //float Et_; // calibrated Et
-
   };
-}
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h
@@ -1,0 +1,46 @@
+#ifndef L1TrackTrigger_L1TkBsCandidate_h
+#define L1TrackTrigger_L1TkBsCandidate_h
+
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1TrackerTrigger
+// Class:       L1TkBsCandidate
+// 
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace l1t {         
+  class L1TkBsCandidate: public L1Candidate {
+  public:
+    
+    L1TkBsCandidate();
+    L1TkBsCandidate(const LorentzVector& p4,
+		    L1TkPhiCandidate cand1,
+		    L1TkPhiCandidate cand2);
+    
+    virtual ~L1TkBsCandidate() {}
+    
+    // ---------- const member functions ---------------------    
+    const L1TkPhiCandidate& getPhiCandidate(size_t i) const { return phiCandList_.at(i); }
+    
+    // ---------- member functions ---------------------------
+
+    // deltaR between track pair
+    double dRPhiPair() const;
+
+    // position difference between track pair
+    double dxyPhiPair() const;
+    double dzPhiPair() const;
+
+  private:
+    
+    L1TkPhiCandidateCollection phiCandList_;
+  };
+}
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h
@@ -5,7 +5,7 @@
 //
 // Package:     DataFormats/L1TrackerTrigger
 // Class:       L1TkBsCandidate
-// 
+//
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
@@ -15,20 +15,17 @@
 #include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-namespace l1t {         
-  class L1TkBsCandidate: public L1Candidate {
+namespace l1t {
+  class L1TkBsCandidate : public L1Candidate {
   public:
-    
     L1TkBsCandidate();
-    L1TkBsCandidate(const LorentzVector& p4,
-		    L1TkPhiCandidate cand1,
-		    L1TkPhiCandidate cand2);
-    
+    L1TkBsCandidate(const LorentzVector& p4, L1TkPhiCandidate cand1, L1TkPhiCandidate cand2);
+
     virtual ~L1TkBsCandidate() {}
-    
-    // ---------- const member functions ---------------------    
+
+    // ---------- const member functions ---------------------
     const L1TkPhiCandidate& getPhiCandidate(size_t i) const { return phiCandList_.at(i); }
-    
+
     // ---------- member functions ---------------------------
 
     // deltaR between track pair
@@ -39,8 +36,7 @@ namespace l1t {
     double dzPhiPair() const;
 
   private:
-    
     L1TkPhiCandidateCollection phiCandList_;
   };
-}
+}  // namespace l1t
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkBsCandidateFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkBsCandidateFwd.h
@@ -1,0 +1,22 @@
+#ifndef L1TrackTrigger_L1TkBsCandidateFwd_h
+#define L1TrackTrigger_L1TkBsCandidateFwd_h
+
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1TrackTrigger
+// File:        L1TkBsCandidateFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+namespace l1t {
+  class L1TkBsCandidate;
+  
+  using L1TkBsCandidateCollection = std::vector<L1TkBsCandidate>;
+  using L1TkBsCandidateRef        = edm::Ref<L1TkBsCandidateCollection>;
+  using L1TkBsCandidateRefVector  = edm::RefVector<L1TkBsCandidateCollection>;
+  using L1TkBsCandidateVectorRef  = std::vector<L1TkBsCandidateRef>;
+}
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkBsCandidateFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkBsCandidateFwd.h
@@ -5,7 +5,7 @@
 //
 // Package:     DataFormats/L1TrackTrigger
 // File:        L1TkBsCandidateFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
@@ -13,10 +13,10 @@
 
 namespace l1t {
   class L1TkBsCandidate;
-  
+
   using L1TkBsCandidateCollection = std::vector<L1TkBsCandidate>;
-  using L1TkBsCandidateRef        = edm::Ref<L1TkBsCandidateCollection>;
-  using L1TkBsCandidateRefVector  = edm::RefVector<L1TkBsCandidateCollection>;
-  using L1TkBsCandidateVectorRef  = std::vector<L1TkBsCandidateRef>;
-}
+  using L1TkBsCandidateRef = edm::Ref<L1TkBsCandidateCollection>;
+  using L1TkBsCandidateRefVector = edm::RefVector<L1TkBsCandidateCollection>;
+  using L1TkBsCandidateVectorRef = std::vector<L1TkBsCandidateRef>;
+}  // namespace l1t
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h
@@ -1,0 +1,77 @@
+#ifndef L1TkTrigger_L1TkEGTauParticle_h
+#define L1TkTrigger_L1TkEGTauParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEGTauParticle
+// 
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace l1t { 
+
+  class L1TkEGTauParticle ;
+  
+  typedef std::vector< L1TkEGTauParticle > L1TkEGTauParticleCollection ;
+  
+  typedef edm::Ref< L1TkEGTauParticleCollection > L1TkEGTauParticleRef ;
+  typedef edm::RefVector< L1TkEGTauParticleCollection > L1TkEGTauParticleRefVector ;
+  typedef std::vector< L1TkEGTauParticleRef > L1TkEGTauParticleVectorRef ;
+  
+  typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+  typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+  typedef edm::Ptr< L1TTTrackType > L1TTTrackRefPtr;
+  typedef std::vector< L1TTTrackRefPtr > L1TTTrackRefPtr_Collection;
+  typedef edm::Ref< EGammaBxCollection > EGammaRef ;
+  typedef std::vector< EGammaRef > EGammaVectorRef ;
+
+  class L1TkEGTauParticle : public L1Candidate
+  {     
+    
+  public:
+    
+    L1TkEGTauParticle();
+    
+
+    L1TkEGTauParticle( const LorentzVector& p4,
+		    const std::vector< L1TTTrackRefPtr >& clustTracks,
+		    const std::vector< EGammaRef >& clustEGs,
+		    float iso = -999. );
+
+    virtual ~L1TkEGTauParticle() {}
+      
+    // ---------- const member functions ---------------------
+
+    const L1TTTrackRefPtr getSeedTrk() const { return clustTracks_.at(0); }
+
+    const std::vector< L1TTTrackRefPtr > getTrks() const { return clustTracks_; }
+    
+    const std::vector< EGammaRef > getEGs() const { return clustEGs_; }
+
+    float getIso() const { return iso_ ; }     
+
+    // ---------- member functions ---------------------------
+    
+    void setVtxIso(float iso)  { iso_ = iso ; }
+    
+    //	 int bx() const;
+    
+  private:
+    std::vector< L1TTTrackRefPtr > clustTracks_;
+    std::vector< EGammaRef > clustEGs_;
+    float iso_;
+
+  };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h
@@ -5,7 +5,7 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEGTauParticle
-// 
+//
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -16,62 +16,55 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-namespace l1t { 
+namespace l1t {
 
-  class L1TkEGTauParticle ;
-  
-  typedef std::vector< L1TkEGTauParticle > L1TkEGTauParticleCollection ;
-  
-  typedef edm::Ref< L1TkEGTauParticleCollection > L1TkEGTauParticleRef ;
-  typedef edm::RefVector< L1TkEGTauParticleCollection > L1TkEGTauParticleRefVector ;
-  typedef std::vector< L1TkEGTauParticleRef > L1TkEGTauParticleVectorRef ;
-  
-  typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-  typedef std::vector< L1TTTrackType > L1TTTrackCollection;
-  typedef edm::Ptr< L1TTTrackType > L1TTTrackRefPtr;
-  typedef std::vector< L1TTTrackRefPtr > L1TTTrackRefPtr_Collection;
-  typedef edm::Ref< EGammaBxCollection > EGammaRef ;
-  typedef std::vector< EGammaRef > EGammaVectorRef ;
+  class L1TkEGTauParticle;
 
-  class L1TkEGTauParticle : public L1Candidate
-  {     
-    
+  typedef std::vector<L1TkEGTauParticle> L1TkEGTauParticleCollection;
+
+  typedef edm::Ref<L1TkEGTauParticleCollection> L1TkEGTauParticleRef;
+  typedef edm::RefVector<L1TkEGTauParticleCollection> L1TkEGTauParticleRefVector;
+  typedef std::vector<L1TkEGTauParticleRef> L1TkEGTauParticleVectorRef;
+
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollection;
+  typedef edm::Ptr<L1TTTrackType> L1TTTrackRefPtr;
+  typedef std::vector<L1TTTrackRefPtr> L1TTTrackRefPtr_Collection;
+  typedef edm::Ref<EGammaBxCollection> EGammaRef;
+  typedef std::vector<EGammaRef> EGammaVectorRef;
+
+  class L1TkEGTauParticle : public L1Candidate {
   public:
-    
     L1TkEGTauParticle();
-    
 
-    L1TkEGTauParticle( const LorentzVector& p4,
-		    const std::vector< L1TTTrackRefPtr >& clustTracks,
-		    const std::vector< EGammaRef >& clustEGs,
-		    float iso = -999. );
+    L1TkEGTauParticle(const LorentzVector& p4,
+                      const std::vector<L1TTTrackRefPtr>& clustTracks,
+                      const std::vector<EGammaRef>& clustEGs,
+                      float iso = -999.);
 
     virtual ~L1TkEGTauParticle() {}
-      
+
     // ---------- const member functions ---------------------
 
     const L1TTTrackRefPtr getSeedTrk() const { return clustTracks_.at(0); }
 
-    const std::vector< L1TTTrackRefPtr > getTrks() const { return clustTracks_; }
-    
-    const std::vector< EGammaRef > getEGs() const { return clustEGs_; }
+    const std::vector<L1TTTrackRefPtr> getTrks() const { return clustTracks_; }
 
-    float getIso() const { return iso_ ; }     
+    const std::vector<EGammaRef> getEGs() const { return clustEGs_; }
+
+    float getIso() const { return iso_; }
 
     // ---------- member functions ---------------------------
-    
-    void setVtxIso(float iso)  { iso_ = iso ; }
-    
-    //	 int bx() const;
-    
-  private:
-    std::vector< L1TTTrackRefPtr > clustTracks_;
-    std::vector< EGammaRef > clustEGs_;
-    float iso_;
 
+    void setVtxIso(float iso) { iso_ = iso; }
+
+    //	 int bx() const;
+
+  private:
+    std::vector<L1TTTrackRefPtr> clustTracks_;
+    std::vector<EGammaRef> clustEGs_;
+    float iso_;
   };
-}
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h
@@ -1,0 +1,66 @@
+#ifndef L1TkTrigger_L1ElectronParticle_h
+#define L1TkTrigger_L1ElectronParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+         
+namespace l1t {
+         
+  class L1TkElectronParticle : public L1TkEmParticle 
+  {
+    
+  public:
+    
+    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+    typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+    
+    
+    L1TkElectronParticle();
+    
+    L1TkElectronParticle( const LorentzVector& p4,
+			  const edm::Ref< EGammaBxCollection > & egRef,
+			  const edm::Ptr< L1TTTrackType >& trkPtr,
+			  float tkisol = -999. );
+    
+    virtual ~L1TkElectronParticle() {}
+    
+    // ---------- const member functions ---------------------
+    
+    const edm::Ptr< L1TTTrackType >& getTrkPtr() const
+    { return trkPtr_ ; }
+    
+    float getTrkzVtx() const { return TrkzVtx_ ; }
+    double trackCurvature()  const { return trackCurvature_;}
+    
+    // ---------- member functions ---------------------------
+    
+    void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
+    void setTrackCurvature(double trackCurvature) { trackCurvature_=trackCurvature;} 
+   
+ 
+  private:
+    
+    edm::Ptr< L1TTTrackType > trkPtr_ ;
+    float TrkzVtx_ ;
+    double trackCurvature_;
+
+  };
+}
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h
@@ -5,7 +5,7 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEmParticle
-// 
+//
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
@@ -17,50 +17,38 @@
 
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-
-         
 namespace l1t {
-         
-  class L1TkElectronParticle : public L1TkEmParticle 
-  {
-    
+
+  class L1TkElectronParticle : public L1TkEmParticle {
   public:
-    
-    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-    typedef std::vector< L1TTTrackType > L1TTTrackCollection;
-    
-    
+    typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+    typedef std::vector<L1TTTrackType> L1TTTrackCollection;
+
     L1TkElectronParticle();
-    
-    L1TkElectronParticle( const LorentzVector& p4,
-			  const edm::Ref< EGammaBxCollection > & egRef,
-			  const edm::Ptr< L1TTTrackType >& trkPtr,
-			  float tkisol = -999. );
-    
+
+    L1TkElectronParticle(const LorentzVector& p4,
+                         const edm::Ref<EGammaBxCollection>& egRef,
+                         const edm::Ptr<L1TTTrackType>& trkPtr,
+                         float tkisol = -999.);
+
     virtual ~L1TkElectronParticle() {}
-    
+
     // ---------- const member functions ---------------------
-    
-    const edm::Ptr< L1TTTrackType >& getTrkPtr() const
-    { return trkPtr_ ; }
-    
-    float getTrkzVtx() const { return TrkzVtx_ ; }
-    double trackCurvature()  const { return trackCurvature_;}
-    
+
+    const edm::Ptr<L1TTTrackType>& getTrkPtr() const { return trkPtr_; }
+
+    float getTrkzVtx() const { return TrkzVtx_; }
+    double trackCurvature() const { return trackCurvature_; }
+
     // ---------- member functions ---------------------------
-    
-    void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
-    void setTrackCurvature(double trackCurvature) { trackCurvature_=trackCurvature;} 
-   
- 
+
+    void setTrkzVtx(float TrkzVtx) { TrkzVtx_ = TrkzVtx; }
+    void setTrackCurvature(double trackCurvature) { trackCurvature_ = trackCurvature; }
+
   private:
-    
-    edm::Ptr< L1TTTrackType > trkPtr_ ;
-    float TrkzVtx_ ;
+    edm::Ptr<L1TTTrackType> trkPtr_;
+    float TrkzVtx_;
     double trackCurvature_;
-
   };
-}
+}  // namespace l1t
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h
@@ -1,0 +1,27 @@
+#ifndef L1TkTrigger_L1ElectronParticleFwd_h
+#define L1TkTrigger_L1ElectronParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkElectronParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+
+namespace l1t {
+  class L1TkElectronParticle ;
+  
+  typedef std::vector< L1TkElectronParticle > L1TkElectronParticleCollection ;
+  
+  typedef edm::Ref< L1TkElectronParticleCollection > L1TkElectronParticleRef ;
+  typedef edm::RefVector< L1TkElectronParticleCollection > L1TkElectronParticleRefVector ;
+  typedef std::vector< L1TkElectronParticleRef > L1TkElectronParticleVectorRef ;
+}
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h
@@ -5,23 +5,19 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkElectronParticleFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
-
-
 namespace l1t {
-  class L1TkElectronParticle ;
-  
-  typedef std::vector< L1TkElectronParticle > L1TkElectronParticleCollection ;
-  
-  typedef edm::Ref< L1TkElectronParticleCollection > L1TkElectronParticleRef ;
-  typedef edm::RefVector< L1TkElectronParticleCollection > L1TkElectronParticleRefVector ;
-  typedef std::vector< L1TkElectronParticleRef > L1TkElectronParticleVectorRef ;
-}
+  class L1TkElectronParticle;
+
+  typedef std::vector<L1TkElectronParticle> L1TkElectronParticleCollection;
+
+  typedef edm::Ref<L1TkElectronParticleCollection> L1TkElectronParticleRef;
+  typedef edm::RefVector<L1TkElectronParticleCollection> L1TkElectronParticleRefVector;
+  typedef std::vector<L1TkElectronParticleRef> L1TkElectronParticleVectorRef;
+}  // namespace l1t
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h
@@ -1,0 +1,76 @@
+#ifndef L1TkTrigger_L1EmParticle_h
+#define L1TkTrigger_L1EmParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+namespace l1t {
+         
+   class L1TkEmParticle : public L1Candidate
+   {     
+         
+      public:
+           
+         L1TkEmParticle();
+
+	 L1TkEmParticle( const LorentzVector& p4,
+			    const edm::Ref< EGammaBxCollection >& egRef,
+			    float tkisol = -999. );
+
+       L1TkEmParticle( const LorentzVector& p4,
+                      const edm::Ref< EGammaBxCollection >& egRef,
+                      float tkisol = -999. , float tkisolPV = -999);
+
+
+	virtual ~L1TkEmParticle() {}
+
+         // ---------- const member functions ---------------------
+
+	 const edm::Ref< EGammaBxCollection >& getEGRef() const
+	 { return egRef_ ; }
+
+         const double l1RefEta() const
+         { return egRef_->eta() ; }
+
+         const double l1RefPhi() const
+         { return egRef_->phi() ; }
+
+         const double l1RefEt() const
+         { return egRef_->et() ; }
+
+	 float getTrkIsol() const { return TrkIsol_ ; } // not constrained to the PV, just track ptSum 
+
+       float getTrkIsolPV() const { return TrkIsolPV_ ; } // constrained to the PV by DZ
+ 
+
+
+         // ---------- member functions ---------------------------
+
+	 void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
+       void setTrkIsolPV(float TrkIsolPV)  { TrkIsolPV_ = TrkIsolPV ; }
+
+     //	 int bx() const;
+
+      private:
+
+	 edm::Ref< EGammaBxCollection > egRef_ ;
+	 float TrkIsol_;
+       float TrkIsolPV_;
+
+    };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h
@@ -5,7 +5,7 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEmParticle
-// 
+//
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -14,63 +14,47 @@
 
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-
 namespace l1t {
-         
-   class L1TkEmParticle : public L1Candidate
-   {     
-         
-      public:
-           
-         L1TkEmParticle();
 
-	 L1TkEmParticle( const LorentzVector& p4,
-			    const edm::Ref< EGammaBxCollection >& egRef,
-			    float tkisol = -999. );
+  class L1TkEmParticle : public L1Candidate {
+  public:
+    L1TkEmParticle();
 
-       L1TkEmParticle( const LorentzVector& p4,
-                      const edm::Ref< EGammaBxCollection >& egRef,
-                      float tkisol = -999. , float tkisolPV = -999);
+    L1TkEmParticle(const LorentzVector& p4, const edm::Ref<EGammaBxCollection>& egRef, float tkisol = -999.);
 
+    L1TkEmParticle(const LorentzVector& p4,
+                   const edm::Ref<EGammaBxCollection>& egRef,
+                   float tkisol = -999.,
+                   float tkisolPV = -999);
 
-	virtual ~L1TkEmParticle() {}
+    virtual ~L1TkEmParticle() {}
 
-         // ---------- const member functions ---------------------
+    // ---------- const member functions ---------------------
 
-	 const edm::Ref< EGammaBxCollection >& getEGRef() const
-	 { return egRef_ ; }
+    const edm::Ref<EGammaBxCollection>& getEGRef() const { return egRef_; }
 
-         const double l1RefEta() const
-         { return egRef_->eta() ; }
+    const double l1RefEta() const { return egRef_->eta(); }
 
-         const double l1RefPhi() const
-         { return egRef_->phi() ; }
+    const double l1RefPhi() const { return egRef_->phi(); }
 
-         const double l1RefEt() const
-         { return egRef_->et() ; }
+    const double l1RefEt() const { return egRef_->et(); }
 
-	 float getTrkIsol() const { return TrkIsol_ ; } // not constrained to the PV, just track ptSum 
+    float getTrkIsol() const { return TrkIsol_; }  // not constrained to the PV, just track ptSum
 
-       float getTrkIsolPV() const { return TrkIsolPV_ ; } // constrained to the PV by DZ
- 
+    float getTrkIsolPV() const { return TrkIsolPV_; }  // constrained to the PV by DZ
 
+    // ---------- member functions ---------------------------
 
-         // ---------- member functions ---------------------------
+    void setTrkIsol(float TrkIsol) { TrkIsol_ = TrkIsol; }
+    void setTrkIsolPV(float TrkIsolPV) { TrkIsolPV_ = TrkIsolPV; }
 
-	 void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
-       void setTrkIsolPV(float TrkIsolPV)  { TrkIsolPV_ = TrkIsolPV ; }
+    //	 int bx() const;
 
-     //	 int bx() const;
-
-      private:
-
-	 edm::Ref< EGammaBxCollection > egRef_ ;
-	 float TrkIsol_;
-       float TrkIsolPV_;
-
-    };
-}
+  private:
+    edm::Ref<EGammaBxCollection> egRef_;
+    float TrkIsol_;
+    float TrkIsolPV_;
+  };
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1EmParticleFwd_h
+#define L1TkTrigger_L1EmParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1t {
+
+   class L1TkEmParticle ;
+
+   typedef std::vector< L1TkEmParticle > L1TkEmParticleCollection ;
+
+   typedef edm::Ref< L1TkEmParticleCollection > L1TkEmParticleRef ;
+   typedef edm::RefVector< L1TkEmParticleCollection > L1TkEmParticleRefVector ;
+   typedef std::vector< L1TkEmParticleRef > L1TkEmParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h
@@ -5,24 +5,21 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEmParticleFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
-
 namespace l1t {
 
-   class L1TkEmParticle ;
+  class L1TkEmParticle;
 
-   typedef std::vector< L1TkEmParticle > L1TkEmParticleCollection ;
+  typedef std::vector<L1TkEmParticle> L1TkEmParticleCollection;
 
-   typedef edm::Ref< L1TkEmParticleCollection > L1TkEmParticleRef ;
-   typedef edm::RefVector< L1TkEmParticleCollection > L1TkEmParticleRefVector ;
-   typedef std::vector< L1TkEmParticleRef > L1TkEmParticleVectorRef ;
-}
+  typedef edm::Ref<L1TkEmParticleCollection> L1TkEmParticleRef;
+  typedef edm::RefVector<L1TkEmParticleCollection> L1TkEmParticleRefVector;
+  typedef std::vector<L1TkEmParticleRef> L1TkEmParticleVectorRef;
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h
@@ -1,0 +1,79 @@
+#ifndef L1TkTrigger_L1TkEtMissParticle_h
+#define L1TkTrigger_L1TkEtMissParticle_h
+// Package:     L1Trigger
+// Class  :     L1TkEtMissParticle
+// Original Author:  E. Perez
+//         Created:  Nov 14, 2013
+
+// system include files
+// user include files
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+
+namespace l1t {
+  class L1TkEtMissParticle : public L1Candidate {
+    public:
+      enum EtMissType{ kMET, kMHT, kNumTypes } ;
+      L1TkEtMissParticle();
+      L1TkEtMissParticle(
+        const LorentzVector& p4,
+        EtMissType type,
+        const double& etTotal,
+        const double& etMissPU,
+        const double& etTotalPU,
+        const edm::Ref< L1TkPrimaryVertexCollection >& aVtxRef = edm::Ref< L1TkPrimaryVertexCollection >(),
+        int bx = 0 ) ;
+
+        L1TkEtMissParticle(
+          const LorentzVector& p4,
+          EtMissType type,
+          const double& etTotal,
+          const double& etMissPU,
+          const double& etTotalPU,
+          int bx = 0 ) ;
+
+        // ---------- const member functions ---------------------
+        EtMissType type() const { return type_ ; }  // kET or kHT
+        // For type = kET, this is |MET|; for type = kHT, this is |MHT|
+        double etMiss() const {
+          return et();
+        }
+        // For type = kET, this is total ET; for type = kHT, this is total HT
+        const double& etTotal() const {
+          return etTot_;
+        }
+        // EtMiss and EtTot from PU vertices
+        double etMissPU() const {
+          return etMissPU_;
+        }
+        double etTotalPU() const {
+          return etTotalPU_;
+        }
+        int bx() const {
+          return bx_;
+        }
+          const edm::Ref< L1TkPrimaryVertexCollection >& getVtxRef() const {
+          return vtxRef_;
+        }
+
+        // ---------- member functions ---------------------------
+        void setEtTotal( const double& etTotal ) {
+          etTot_ = etTotal;
+        }
+        void setBx( int bx ) {
+          bx_ = bx;
+        }
+
+      private:
+        // ---------- member data --------------------------------
+        EtMissType type_ ;
+        double etTot_ ;
+        double etMissPU_ ;
+        double etTotalPU_ ;
+        edm::Ref< L1TkPrimaryVertexCollection > vtxRef_ ;
+        int bx_ ;
+    };
+  }
+
+  #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h
@@ -13,67 +13,49 @@
 
 namespace l1t {
   class L1TkEtMissParticle : public L1Candidate {
-    public:
-      enum EtMissType{ kMET, kMHT, kNumTypes } ;
-      L1TkEtMissParticle();
-      L1TkEtMissParticle(
-        const LorentzVector& p4,
-        EtMissType type,
-        const double& etTotal,
-        const double& etMissPU,
-        const double& etTotalPU,
-        const edm::Ref< L1TkPrimaryVertexCollection >& aVtxRef = edm::Ref< L1TkPrimaryVertexCollection >(),
-        int bx = 0 ) ;
+  public:
+    enum EtMissType { kMET, kMHT, kNumTypes };
+    L1TkEtMissParticle();
+    L1TkEtMissParticle(const LorentzVector& p4,
+                       EtMissType type,
+                       const double& etTotal,
+                       const double& etMissPU,
+                       const double& etTotalPU,
+                       const edm::Ref<L1TkPrimaryVertexCollection>& aVtxRef = edm::Ref<L1TkPrimaryVertexCollection>(),
+                       int bx = 0);
 
-        L1TkEtMissParticle(
-          const LorentzVector& p4,
-          EtMissType type,
-          const double& etTotal,
-          const double& etMissPU,
-          const double& etTotalPU,
-          int bx = 0 ) ;
+    L1TkEtMissParticle(const LorentzVector& p4,
+                       EtMissType type,
+                       const double& etTotal,
+                       const double& etMissPU,
+                       const double& etTotalPU,
+                       int bx = 0);
 
-        // ---------- const member functions ---------------------
-        EtMissType type() const { return type_ ; }  // kET or kHT
-        // For type = kET, this is |MET|; for type = kHT, this is |MHT|
-        double etMiss() const {
-          return et();
-        }
-        // For type = kET, this is total ET; for type = kHT, this is total HT
-        const double& etTotal() const {
-          return etTot_;
-        }
-        // EtMiss and EtTot from PU vertices
-        double etMissPU() const {
-          return etMissPU_;
-        }
-        double etTotalPU() const {
-          return etTotalPU_;
-        }
-        int bx() const {
-          return bx_;
-        }
-          const edm::Ref< L1TkPrimaryVertexCollection >& getVtxRef() const {
-          return vtxRef_;
-        }
+    // ---------- const member functions ---------------------
+    EtMissType type() const { return type_; }  // kET or kHT
+    // For type = kET, this is |MET|; for type = kHT, this is |MHT|
+    double etMiss() const { return et(); }
+    // For type = kET, this is total ET; for type = kHT, this is total HT
+    const double& etTotal() const { return etTot_; }
+    // EtMiss and EtTot from PU vertices
+    double etMissPU() const { return etMissPU_; }
+    double etTotalPU() const { return etTotalPU_; }
+    int bx() const { return bx_; }
+    const edm::Ref<L1TkPrimaryVertexCollection>& getVtxRef() const { return vtxRef_; }
 
-        // ---------- member functions ---------------------------
-        void setEtTotal( const double& etTotal ) {
-          etTot_ = etTotal;
-        }
-        void setBx( int bx ) {
-          bx_ = bx;
-        }
+    // ---------- member functions ---------------------------
+    void setEtTotal(const double& etTotal) { etTot_ = etTotal; }
+    void setBx(int bx) { bx_ = bx; }
 
-      private:
-        // ---------- member data --------------------------------
-        EtMissType type_ ;
-        double etTot_ ;
-        double etMissPU_ ;
-        double etTotalPU_ ;
-        edm::Ref< L1TkPrimaryVertexCollection > vtxRef_ ;
-        int bx_ ;
-    };
-  }
+  private:
+    // ---------- member data --------------------------------
+    EtMissType type_;
+    double etTot_;
+    double etMissPU_;
+    double etTotalPU_;
+    edm::Ref<L1TkPrimaryVertexCollection> vtxRef_;
+    int bx_;
+  };
+}  // namespace l1t
 
-  #endif
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h
@@ -1,0 +1,21 @@
+#ifndef L1TkTrigger_L1TkEtMissParticleFwd_h
+#define L1TkTrigger_L1TkEtMissParticleFwd_h
+// Package:     L1Trigger
+// Class  :     L1TkEtMissParticleFwd
+
+// system include files
+// user include files
+// forward declarations
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+namespace l1t {
+   class L1TkEtMissParticle ;
+   typedef std::vector< L1TkEtMissParticle > L1TkEtMissParticleCollection ;
+   //typedef edm::RefProd< L1TkEtMissParticle > L1TkEtMissParticleRefProd ;
+   //typedef edm::Ref< L1TkEtMissParticleCollection > L1TkEtMissParticleRef ;
+   //typedef edm::RefVector< L1TkEtMissParticleCollection > L1TkEtMissParticleRefVector ;
+   //typedef std::vector< L1TkEtMissParticleRef > L1TkEtMissParticleVectorRef ;
+}
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h
@@ -11,11 +11,11 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace l1t {
-   class L1TkEtMissParticle ;
-   typedef std::vector< L1TkEtMissParticle > L1TkEtMissParticleCollection ;
-   //typedef edm::RefProd< L1TkEtMissParticle > L1TkEtMissParticleRefProd ;
-   //typedef edm::Ref< L1TkEtMissParticleCollection > L1TkEtMissParticleRef ;
-   //typedef edm::RefVector< L1TkEtMissParticleCollection > L1TkEtMissParticleRefVector ;
-   //typedef std::vector< L1TkEtMissParticleRef > L1TkEtMissParticleVectorRef ;
-}
+  class L1TkEtMissParticle;
+  typedef std::vector<L1TkEtMissParticle> L1TkEtMissParticleCollection;
+  //typedef edm::RefProd< L1TkEtMissParticle > L1TkEtMissParticleRefProd ;
+  //typedef edm::Ref< L1TkEtMissParticleCollection > L1TkEtMissParticleRef ;
+  //typedef edm::RefVector< L1TkEtMissParticleCollection > L1TkEtMissParticleRefVector ;
+  //typedef std::vector< L1TkEtMissParticleRef > L1TkEtMissParticleVectorRef ;
+}  // namespace l1t
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticle.h
@@ -1,0 +1,83 @@
+#ifndef L1TkTrigger_L1GlbMuonParticle_h
+#define L1TkTrigger_L1GlbMuonParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkGlbMuonParticle
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+namespace l1t
+{
+  class L1TkGlbMuonParticle : public L1Candidate
+  {
+    public:
+
+    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+    typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+
+      L1TkGlbMuonParticle() : theIsolation(-999.), TrkzVtx_(999.), quality_(999) {}
+
+      L1TkGlbMuonParticle( const LorentzVector& p4,
+   		        const edm::Ref< MuonBxCollection >& muRef,
+		        const edm::Ptr< L1TTTrackType >& trkPtr,
+		        float tkisol = -999. );
+
+      //! more basic constructor, in case refs/ptrs can't be set or to be set separately
+      L1TkGlbMuonParticle(const L1Candidate& cand) : L1Candidate(cand), theIsolation(-999.), TrkzVtx_(999.), quality_(999) {}
+
+      virtual ~L1TkGlbMuonParticle() {}
+
+
+      const edm::Ptr< L1TTTrackType >& getTrkPtr() const
+         { return trkPtr_ ; }
+
+      const edm::Ref< MuonBxCollection >& getMuRef() const
+	{ return muRef_ ; }
+    
+      float getTrkIsol() const { return theIsolation; }
+      float getTrkzVtx() const { return TrkzVtx_ ; }
+
+      float dR()  const { return dR_;}
+      int nTracksMatched() const { return nTracksMatch_;}
+
+      unsigned int quality()  const {return quality_;}
+
+      void setTrkPtr(const edm::Ptr< L1TTTrackType >& p) {trkPtr_ = p;}
+      
+      void setTrkzVtx(float TrkzVtx) { TrkzVtx_ = TrkzVtx ; }
+      void setTrkIsol(float TrkIsol) { theIsolation = TrkIsol ; }
+
+      void setdR(float dR) { dR_=dR;}
+      void setNTracksMatched(int nTracksMatch) { nTracksMatch_=nTracksMatch;}
+
+      void setQuality(unsigned int q){ quality_ = q;}
+
+    private:
+
+
+	// used for the Naive producer
+      edm::Ref< MuonBxCollection > muRef_ ;
+
+      edm::Ptr< L1TTTrackType > trkPtr_ ;
+
+      float theIsolation;
+      float TrkzVtx_ ;
+      unsigned int quality_;
+      float dR_;
+      int nTracksMatch_;
+
+  };
+}
+
+#endif
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticle.h
@@ -13,71 +13,61 @@
 #include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
 #include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
 
-
 #include "DataFormats/L1Trigger/interface/Muon.h"
 
-namespace l1t
-{
-  class L1TkGlbMuonParticle : public L1Candidate
-  {
-    public:
+namespace l1t {
+  class L1TkGlbMuonParticle : public L1Candidate {
+  public:
+    typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+    typedef std::vector<L1TTTrackType> L1TTTrackCollection;
 
-    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-    typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+    L1TkGlbMuonParticle() : theIsolation(-999.), TrkzVtx_(999.), quality_(999) {}
 
-      L1TkGlbMuonParticle() : theIsolation(-999.), TrkzVtx_(999.), quality_(999) {}
+    L1TkGlbMuonParticle(const LorentzVector& p4,
+                        const edm::Ref<MuonBxCollection>& muRef,
+                        const edm::Ptr<L1TTTrackType>& trkPtr,
+                        float tkisol = -999.);
 
-      L1TkGlbMuonParticle( const LorentzVector& p4,
-   		        const edm::Ref< MuonBxCollection >& muRef,
-		        const edm::Ptr< L1TTTrackType >& trkPtr,
-		        float tkisol = -999. );
+    //! more basic constructor, in case refs/ptrs can't be set or to be set separately
+    L1TkGlbMuonParticle(const L1Candidate& cand)
+        : L1Candidate(cand), theIsolation(-999.), TrkzVtx_(999.), quality_(999) {}
 
-      //! more basic constructor, in case refs/ptrs can't be set or to be set separately
-      L1TkGlbMuonParticle(const L1Candidate& cand) : L1Candidate(cand), theIsolation(-999.), TrkzVtx_(999.), quality_(999) {}
+    virtual ~L1TkGlbMuonParticle() {}
 
-      virtual ~L1TkGlbMuonParticle() {}
+    const edm::Ptr<L1TTTrackType>& getTrkPtr() const { return trkPtr_; }
 
+    const edm::Ref<MuonBxCollection>& getMuRef() const { return muRef_; }
 
-      const edm::Ptr< L1TTTrackType >& getTrkPtr() const
-         { return trkPtr_ ; }
+    float getTrkIsol() const { return theIsolation; }
+    float getTrkzVtx() const { return TrkzVtx_; }
 
-      const edm::Ref< MuonBxCollection >& getMuRef() const
-	{ return muRef_ ; }
-    
-      float getTrkIsol() const { return theIsolation; }
-      float getTrkzVtx() const { return TrkzVtx_ ; }
+    float dR() const { return dR_; }
+    int nTracksMatched() const { return nTracksMatch_; }
 
-      float dR()  const { return dR_;}
-      int nTracksMatched() const { return nTracksMatch_;}
+    unsigned int quality() const { return quality_; }
 
-      unsigned int quality()  const {return quality_;}
+    void setTrkPtr(const edm::Ptr<L1TTTrackType>& p) { trkPtr_ = p; }
 
-      void setTrkPtr(const edm::Ptr< L1TTTrackType >& p) {trkPtr_ = p;}
-      
-      void setTrkzVtx(float TrkzVtx) { TrkzVtx_ = TrkzVtx ; }
-      void setTrkIsol(float TrkIsol) { theIsolation = TrkIsol ; }
+    void setTrkzVtx(float TrkzVtx) { TrkzVtx_ = TrkzVtx; }
+    void setTrkIsol(float TrkIsol) { theIsolation = TrkIsol; }
 
-      void setdR(float dR) { dR_=dR;}
-      void setNTracksMatched(int nTracksMatch) { nTracksMatch_=nTracksMatch;}
+    void setdR(float dR) { dR_ = dR; }
+    void setNTracksMatched(int nTracksMatch) { nTracksMatch_ = nTracksMatch; }
 
-      void setQuality(unsigned int q){ quality_ = q;}
+    void setQuality(unsigned int q) { quality_ = q; }
 
-    private:
+  private:
+    // used for the Naive producer
+    edm::Ref<MuonBxCollection> muRef_;
 
+    edm::Ptr<L1TTTrackType> trkPtr_;
 
-	// used for the Naive producer
-      edm::Ref< MuonBxCollection > muRef_ ;
-
-      edm::Ptr< L1TTTrackType > trkPtr_ ;
-
-      float theIsolation;
-      float TrkzVtx_ ;
-      unsigned int quality_;
-      float dR_;
-      int nTracksMatch_;
-
+    float theIsolation;
+    float TrkzVtx_;
+    unsigned int quality_;
+    float dR_;
+    int nTracksMatch_;
   };
-}
+}  // namespace l1t
 
 #endif
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1GlbMuonParticleFwd_h
+#define L1TkTrigger_L1GlbMuonParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkGlbMuonParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1t {
+
+   class L1TkGlbMuonParticle ;
+
+   typedef std::vector< L1TkGlbMuonParticle > L1TkGlbMuonParticleCollection ;
+
+   typedef edm::Ref< L1TkGlbMuonParticleCollection > L1TkGlbMuonParticleRef ;
+   typedef edm::RefVector< L1TkGlbMuonParticleCollection > L1TkGlbMuonParticleRefVector ;
+   typedef std::vector< L1TkGlbMuonParticleRef > L1TkGlbMuonParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticleFwd.h
@@ -5,24 +5,21 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkGlbMuonParticleFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
-
 namespace l1t {
 
-   class L1TkGlbMuonParticle ;
+  class L1TkGlbMuonParticle;
 
-   typedef std::vector< L1TkGlbMuonParticle > L1TkGlbMuonParticleCollection ;
+  typedef std::vector<L1TkGlbMuonParticle> L1TkGlbMuonParticleCollection;
 
-   typedef edm::Ref< L1TkGlbMuonParticleCollection > L1TkGlbMuonParticleRef ;
-   typedef edm::RefVector< L1TkGlbMuonParticleCollection > L1TkGlbMuonParticleRefVector ;
-   typedef std::vector< L1TkGlbMuonParticleRef > L1TkGlbMuonParticleVectorRef ;
-}
+  typedef edm::Ref<L1TkGlbMuonParticleCollection> L1TkGlbMuonParticleRef;
+  typedef edm::RefVector<L1TkGlbMuonParticleCollection> L1TkGlbMuonParticleRefVector;
+  typedef std::vector<L1TkGlbMuonParticleRef> L1TkGlbMuonParticleVectorRef;
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h
@@ -1,0 +1,87 @@
+#ifndef L1TkTrigger_L1TkHTMissParticle_h
+#define L1TkTrigger_L1TkHTMissParticle_h
+// Package:     L1Trigger
+// Class  :     L1TkHTMissParticle
+// Original Author:  E. Perez
+//         Created:  Nov 14, 2013
+
+// system include files
+// user include files
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h"
+
+namespace l1t {
+  class L1TkHTMissParticle : public L1Candidate {
+    public:
+      L1TkHTMissParticle();
+      L1TkHTMissParticle(
+        const LorentzVector& p4,
+        const double& EtTotal,
+        const edm::RefProd< L1TkJetParticleCollection >& jetCollRef = edm::RefProd< L1TkJetParticleCollection >(),
+        const edm::Ref< L1TkPrimaryVertexCollection >& aVtxRef = edm::Ref< L1TkPrimaryVertexCollection >(),
+        int bx = 0 ) ;
+
+        // ---------- const member functions ---------------------
+        double EtMiss() const { 	// HTM (missing HT)
+          return et();
+        }
+        const double& EtTotal() const {
+          return EtTot_;
+        }
+        // HTM and HT from PU vertices
+        double EtMissPU() const {
+          return EtMissPU_;
+        }
+        double EtTotalPU() const {
+          return EtTotalPU_;
+        }
+        int bx() const {
+          return bx_;
+        }
+        float getVtx()  const {
+          return zvtx_;
+        }
+        const edm::RefProd< L1TkJetParticleCollection >& getjetCollectionRef() const {
+          return jetCollectionRef_;
+        }
+        const edm::Ref< L1TkPrimaryVertexCollection >& getVtxRef() const {
+          return vtxRef_;
+        }
+
+        // ---------- member functions ---------------------------
+        void setEtTotal( const double& EtTotal ) {
+          EtTot_ = EtTotal;
+        }
+        void setEtTotalPU( const double& EtTotalPU ) {
+          EtTotalPU_ = EtTotalPU;
+        }
+        void setEtMissPU( const double& EtMissPU ) {
+          EtMissPU_ = EtMissPU;
+        }
+        void setVtx( const float& zvtx ) {
+          zvtx_ = zvtx;
+        }
+        void setBx( int bx ) {
+          bx_ = bx;
+        }
+
+      private:
+        // ---------- member data --------------------------------
+        float zvtx_;		// zvtx used to constrain the jets
+        double EtTot_ ;		// HT
+        double EtMissPU_ ;	// HTM form jets that don't come from zvtx
+        double EtTotalPU_ ;	// HT from jets that don't come from zvtx
+
+        edm::RefProd< L1TkJetParticleCollection > jetCollectionRef_ ;
+        edm::Ref< L1TkPrimaryVertexCollection > vtxRef_ ;
+
+        int bx_ ;
+    };
+  }
+
+  #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h
@@ -17,71 +17,47 @@
 
 namespace l1t {
   class L1TkHTMissParticle : public L1Candidate {
-    public:
-      L1TkHTMissParticle();
-      L1TkHTMissParticle(
+  public:
+    L1TkHTMissParticle();
+    L1TkHTMissParticle(
         const LorentzVector& p4,
         const double& EtTotal,
-        const edm::RefProd< L1TkJetParticleCollection >& jetCollRef = edm::RefProd< L1TkJetParticleCollection >(),
-        const edm::Ref< L1TkPrimaryVertexCollection >& aVtxRef = edm::Ref< L1TkPrimaryVertexCollection >(),
-        int bx = 0 ) ;
+        const edm::RefProd<L1TkJetParticleCollection>& jetCollRef = edm::RefProd<L1TkJetParticleCollection>(),
+        const edm::Ref<L1TkPrimaryVertexCollection>& aVtxRef = edm::Ref<L1TkPrimaryVertexCollection>(),
+        int bx = 0);
 
-        // ---------- const member functions ---------------------
-        double EtMiss() const { 	// HTM (missing HT)
-          return et();
-        }
-        const double& EtTotal() const {
-          return EtTot_;
-        }
-        // HTM and HT from PU vertices
-        double EtMissPU() const {
-          return EtMissPU_;
-        }
-        double EtTotalPU() const {
-          return EtTotalPU_;
-        }
-        int bx() const {
-          return bx_;
-        }
-        float getVtx()  const {
-          return zvtx_;
-        }
-        const edm::RefProd< L1TkJetParticleCollection >& getjetCollectionRef() const {
-          return jetCollectionRef_;
-        }
-        const edm::Ref< L1TkPrimaryVertexCollection >& getVtxRef() const {
-          return vtxRef_;
-        }
+    // ---------- const member functions ---------------------
+    double EtMiss() const {  // HTM (missing HT)
+      return et();
+    }
+    const double& EtTotal() const { return EtTot_; }
+    // HTM and HT from PU vertices
+    double EtMissPU() const { return EtMissPU_; }
+    double EtTotalPU() const { return EtTotalPU_; }
+    int bx() const { return bx_; }
+    float getVtx() const { return zvtx_; }
+    const edm::RefProd<L1TkJetParticleCollection>& getjetCollectionRef() const { return jetCollectionRef_; }
+    const edm::Ref<L1TkPrimaryVertexCollection>& getVtxRef() const { return vtxRef_; }
 
-        // ---------- member functions ---------------------------
-        void setEtTotal( const double& EtTotal ) {
-          EtTot_ = EtTotal;
-        }
-        void setEtTotalPU( const double& EtTotalPU ) {
-          EtTotalPU_ = EtTotalPU;
-        }
-        void setEtMissPU( const double& EtMissPU ) {
-          EtMissPU_ = EtMissPU;
-        }
-        void setVtx( const float& zvtx ) {
-          zvtx_ = zvtx;
-        }
-        void setBx( int bx ) {
-          bx_ = bx;
-        }
+    // ---------- member functions ---------------------------
+    void setEtTotal(const double& EtTotal) { EtTot_ = EtTotal; }
+    void setEtTotalPU(const double& EtTotalPU) { EtTotalPU_ = EtTotalPU; }
+    void setEtMissPU(const double& EtMissPU) { EtMissPU_ = EtMissPU; }
+    void setVtx(const float& zvtx) { zvtx_ = zvtx; }
+    void setBx(int bx) { bx_ = bx; }
 
-      private:
-        // ---------- member data --------------------------------
-        float zvtx_;		// zvtx used to constrain the jets
-        double EtTot_ ;		// HT
-        double EtMissPU_ ;	// HTM form jets that don't come from zvtx
-        double EtTotalPU_ ;	// HT from jets that don't come from zvtx
+  private:
+    // ---------- member data --------------------------------
+    float zvtx_;        // zvtx used to constrain the jets
+    double EtTot_;      // HT
+    double EtMissPU_;   // HTM form jets that don't come from zvtx
+    double EtTotalPU_;  // HT from jets that don't come from zvtx
 
-        edm::RefProd< L1TkJetParticleCollection > jetCollectionRef_ ;
-        edm::Ref< L1TkPrimaryVertexCollection > vtxRef_ ;
+    edm::RefProd<L1TkJetParticleCollection> jetCollectionRef_;
+    edm::Ref<L1TkPrimaryVertexCollection> vtxRef_;
 
-        int bx_ ;
-    };
-  }
+    int bx_;
+  };
+}  // namespace l1t
 
-  #endif
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h
@@ -1,0 +1,23 @@
+#ifndef L1TkTrigger_L1TkHTMissParticleFwd_h
+#define L1TkTrigger_L1TkHTMissParticleFwd_h
+// Package:     L1Trigger
+// Class  :     L1TkHTMissParticleFwd
+
+// system include files
+// user include files
+
+// forward declarations
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+namespace l1t {
+  class L1TkHTMissParticle ;
+  typedef std::vector< L1TkHTMissParticle > L1TkHTMissParticleCollection;
+  //typedef edm::RefProd< L1TkHTMissParticle > L1TkHTMissParticleRefProd ;
+  //typedef edm::Ref< L1TkHTMissParticleCollection > L1TkHTMissParticleRef ;
+  //typedef edm::RefVector< L1TkHTMissParticleCollection > L1TkHTMissParticleRefVector ;
+  //typedef std::vector< L1TkHTMissParticleRef > L1TkHTMissParticleVectorRef ;
+}
+
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h
@@ -12,12 +12,12 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace l1t {
-  class L1TkHTMissParticle ;
-  typedef std::vector< L1TkHTMissParticle > L1TkHTMissParticleCollection;
+  class L1TkHTMissParticle;
+  typedef std::vector<L1TkHTMissParticle> L1TkHTMissParticleCollection;
   //typedef edm::RefProd< L1TkHTMissParticle > L1TkHTMissParticleRefProd ;
   //typedef edm::Ref< L1TkHTMissParticleCollection > L1TkHTMissParticleRef ;
   //typedef edm::RefVector< L1TkHTMissParticleCollection > L1TkHTMissParticleRefVector ;
   //typedef std::vector< L1TkHTMissParticleRef > L1TkHTMissParticleVectorRef ;
-}
+}  // namespace l1t
 
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h
@@ -1,0 +1,72 @@
+#ifndef L1TkTrigger_L1JetParticle_h
+#define L1TkTrigger_L1JetParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkJetParticle
+// 
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/Jet.h"
+//#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleDisp.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+
+namespace l1t {
+  
+  class L1TkJetParticle : public L1Candidate
+    {
+      
+    public:
+      
+      typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+      typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+      
+      L1TkJetParticle();
+      
+      L1TkJetParticle( const LorentzVector& p4,
+		       const edm::Ref< JetBxCollection >& jetRef,
+		       const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
+		       float jetvtx = -999. );
+      L1TkJetParticle( const LorentzVector& p4,
+		       const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
+		       float jetvtx = -999. ,
+		unsigned int ntracks=0,unsigned int tighttracks=0,unsigned int displacedtracks=0,unsigned int tightdisplacedtracks=0	
+			);
+      
+      virtual ~L1TkJetParticle() {}
+      
+      // ---------- const member functions ---------------------
+      
+      const edm::Ref< JetBxCollection >& getJetRef() const { return jetRef_ ; }
+      
+      const std::vector< edm::Ptr< L1TTTrackType > >& getTrkPtrs() const { return trkPtrs_; }
+      
+      float getJetVtx() const  { return JetVtx_ ; }
+      unsigned int getNtracks() const {return ntracks_;}
+      unsigned int getNTighttracks() const {return tighttracks_;}
+      unsigned int getNDisptracks() const {return displacedtracks_;}
+      unsigned int getNTightDisptracks() const {return tightdisplacedtracks_;} 
+   
+     // ---------- member functions ---------------------------
+ //     void setDispCounters(L1TkJetParticleDisp counters){ counters_=counters;};
+   //   L1TkJetParticleDisp getDispCounters() const { return counters_;};
+      void setJetVtx(float JetVtx) { JetVtx_ = JetVtx ; }
+            
+      int bx() const;
+      
+    private:
+      edm::Ref< JetBxCollection > jetRef_ ;
+      std::vector< edm::Ptr< L1TTTrackType > >  trkPtrs_;
+      //L1TkJetParticleDisp counters_;
+      float JetVtx_ ;
+     unsigned int ntracks_,tighttracks_,displacedtracks_,tightdisplacedtracks_;
+    };
+}
+
+#endif
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h
@@ -5,7 +5,7 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkJetParticle
-// 
+//
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -14,59 +14,55 @@
 //#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleDisp.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-
-
 namespace l1t {
-  
-  class L1TkJetParticle : public L1Candidate
-    {
-      
-    public:
-      
-      typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-      typedef std::vector< L1TTTrackType > L1TTTrackCollection;
-      
-      L1TkJetParticle();
-      
-      L1TkJetParticle( const LorentzVector& p4,
-		       const edm::Ref< JetBxCollection >& jetRef,
-		       const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
-		       float jetvtx = -999. );
-      L1TkJetParticle( const LorentzVector& p4,
-		       const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
-		       float jetvtx = -999. ,
-		unsigned int ntracks=0,unsigned int tighttracks=0,unsigned int displacedtracks=0,unsigned int tightdisplacedtracks=0	
-			);
-      
-      virtual ~L1TkJetParticle() {}
-      
-      // ---------- const member functions ---------------------
-      
-      const edm::Ref< JetBxCollection >& getJetRef() const { return jetRef_ ; }
-      
-      const std::vector< edm::Ptr< L1TTTrackType > >& getTrkPtrs() const { return trkPtrs_; }
-      
-      float getJetVtx() const  { return JetVtx_ ; }
-      unsigned int getNtracks() const {return ntracks_;}
-      unsigned int getNTighttracks() const {return tighttracks_;}
-      unsigned int getNDisptracks() const {return displacedtracks_;}
-      unsigned int getNTightDisptracks() const {return tightdisplacedtracks_;} 
-   
-     // ---------- member functions ---------------------------
- //     void setDispCounters(L1TkJetParticleDisp counters){ counters_=counters;};
-   //   L1TkJetParticleDisp getDispCounters() const { return counters_;};
-      void setJetVtx(float JetVtx) { JetVtx_ = JetVtx ; }
-            
-      int bx() const;
-      
-    private:
-      edm::Ref< JetBxCollection > jetRef_ ;
-      std::vector< edm::Ptr< L1TTTrackType > >  trkPtrs_;
-      //L1TkJetParticleDisp counters_;
-      float JetVtx_ ;
-     unsigned int ntracks_,tighttracks_,displacedtracks_,tightdisplacedtracks_;
-    };
-}
+
+  class L1TkJetParticle : public L1Candidate {
+  public:
+    typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+    typedef std::vector<L1TTTrackType> L1TTTrackCollection;
+
+    L1TkJetParticle();
+
+    L1TkJetParticle(const LorentzVector& p4,
+                    const edm::Ref<JetBxCollection>& jetRef,
+                    const std::vector<edm::Ptr<L1TTTrackType> >& trkPtrs,
+                    float jetvtx = -999.);
+    L1TkJetParticle(const LorentzVector& p4,
+                    const std::vector<edm::Ptr<L1TTTrackType> >& trkPtrs,
+                    float jetvtx = -999.,
+                    unsigned int ntracks = 0,
+                    unsigned int tighttracks = 0,
+                    unsigned int displacedtracks = 0,
+                    unsigned int tightdisplacedtracks = 0);
+
+    virtual ~L1TkJetParticle() {}
+
+    // ---------- const member functions ---------------------
+
+    const edm::Ref<JetBxCollection>& getJetRef() const { return jetRef_; }
+
+    const std::vector<edm::Ptr<L1TTTrackType> >& getTrkPtrs() const { return trkPtrs_; }
+
+    float getJetVtx() const { return JetVtx_; }
+    unsigned int getNtracks() const { return ntracks_; }
+    unsigned int getNTighttracks() const { return tighttracks_; }
+    unsigned int getNDisptracks() const { return displacedtracks_; }
+    unsigned int getNTightDisptracks() const { return tightdisplacedtracks_; }
+
+    // ---------- member functions ---------------------------
+    //     void setDispCounters(L1TkJetParticleDisp counters){ counters_=counters;};
+    //   L1TkJetParticleDisp getDispCounters() const { return counters_;};
+    void setJetVtx(float JetVtx) { JetVtx_ = JetVtx; }
+
+    int bx() const;
+
+  private:
+    edm::Ref<JetBxCollection> jetRef_;
+    std::vector<edm::Ptr<L1TTTrackType> > trkPtrs_;
+    //L1TkJetParticleDisp counters_;
+    float JetVtx_;
+    unsigned int ntracks_, tighttracks_, displacedtracks_, tightdisplacedtracks_;
+  };
+}  // namespace l1t
 
 #endif
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h
@@ -1,0 +1,30 @@
+#ifndef L1TkTrigger_L1JetParticleFwd_h
+#define L1TkTrigger_L1JetParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkJetParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1t {
+
+   class L1TkJetParticle ;
+
+   typedef edm::RefProd< L1TkJetParticle > L1TkJetParticleRefProd ;
+
+   typedef std::vector< L1TkJetParticle > L1TkJetParticleCollection ;
+
+   typedef edm::Ref< L1TkJetParticleCollection > L1TkJetParticleRef ;
+   typedef edm::RefVector< L1TkJetParticleCollection > L1TkJetParticleRefVector ;
+   typedef std::vector< L1TkJetParticleRef > L1TkJetParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h
@@ -5,26 +5,23 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkJetParticleFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
-
 namespace l1t {
 
-   class L1TkJetParticle ;
+  class L1TkJetParticle;
 
-   typedef edm::RefProd< L1TkJetParticle > L1TkJetParticleRefProd ;
+  typedef edm::RefProd<L1TkJetParticle> L1TkJetParticleRefProd;
 
-   typedef std::vector< L1TkJetParticle > L1TkJetParticleCollection ;
+  typedef std::vector<L1TkJetParticle> L1TkJetParticleCollection;
 
-   typedef edm::Ref< L1TkJetParticleCollection > L1TkJetParticleRef ;
-   typedef edm::RefVector< L1TkJetParticleCollection > L1TkJetParticleRefVector ;
-   typedef std::vector< L1TkJetParticleRef > L1TkJetParticleVectorRef ;
-}
+  typedef edm::Ref<L1TkJetParticleCollection> L1TkJetParticleRef;
+  typedef edm::RefVector<L1TkJetParticleCollection> L1TkJetParticleRefVector;
+  typedef std::vector<L1TkJetParticleRef> L1TkJetParticleVectorRef;
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h
@@ -1,0 +1,58 @@
+#ifndef L1TrackTrigger_L1TkPhiCandidate_h
+#define L1TrackTrigger_L1TkPhiCandidate_h
+
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1TrackTrigger
+// Class:       L1TkPhiCandidate
+// 
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace l1t {         
+
+  class L1TkPhiCandidate: public L1Candidate {
+  public:
+    
+    static constexpr double kmass = 0.493; // GeV
+    static constexpr double phi_polemass = 1.019445; // GeV
+
+    using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
+    using L1TTTrackCollection = std::vector<L1TTTrackType>;
+    
+    L1TkPhiCandidate();
+    L1TkPhiCandidate(const LorentzVector& p4,
+                     const edm::Ptr<L1TTTrackType>& trkPtr1,
+                     const edm::Ptr<L1TTTrackType>& trkPtr2);
+    
+    virtual ~L1TkPhiCandidate() {}
+    
+    // ---------- const member functions ---------------------    
+    const edm::Ptr<L1TTTrackType>& getTrkPtr(size_t i) const { return trkPtrList_.at(i); }
+
+    // ---------- member functions ---------------------------
+
+    // deltaR between track pair
+    double dRTrkPair() const;
+
+    // difference from nominal mass
+    double dmass() const;
+
+    // position difference between track pair
+    double dxyTrkPair() const;
+    double dzTrkPair() const;
+
+    double vx() const override;
+    double vy() const override;
+    double vz() const override;
+
+  private:
+    
+    std::vector<edm::Ptr<L1TTTrackType>> trkPtrList_;
+  };
+}
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h
@@ -5,7 +5,7 @@
 //
 // Package:     DataFormats/L1TrackTrigger
 // Class:       L1TkPhiCandidate
-// 
+//
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
@@ -13,25 +13,24 @@
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-namespace l1t {         
+namespace l1t {
 
-  class L1TkPhiCandidate: public L1Candidate {
+  class L1TkPhiCandidate : public L1Candidate {
   public:
-    
-    static constexpr double kmass = 0.493; // GeV
-    static constexpr double phi_polemass = 1.019445; // GeV
+    static constexpr double kmass = 0.493;            // GeV
+    static constexpr double phi_polemass = 1.019445;  // GeV
 
     using L1TTTrackType = TTTrack<Ref_Phase2TrackerDigi_>;
     using L1TTTrackCollection = std::vector<L1TTTrackType>;
-    
+
     L1TkPhiCandidate();
     L1TkPhiCandidate(const LorentzVector& p4,
                      const edm::Ptr<L1TTTrackType>& trkPtr1,
                      const edm::Ptr<L1TTTrackType>& trkPtr2);
-    
+
     virtual ~L1TkPhiCandidate() {}
-    
-    // ---------- const member functions ---------------------    
+
+    // ---------- const member functions ---------------------
     const edm::Ptr<L1TTTrackType>& getTrkPtr(size_t i) const { return trkPtrList_.at(i); }
 
     // ---------- member functions ---------------------------
@@ -51,8 +50,7 @@ namespace l1t {
     double vz() const override;
 
   private:
-    
     std::vector<edm::Ptr<L1TTTrackType>> trkPtrList_;
   };
-}
+}  // namespace l1t
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h
@@ -1,0 +1,22 @@
+#ifndef L1TrackTrigger_L1TkPhiCandidateFwd_h
+#define L1TrackTrigger_L1TkPhiCandidateFwd_h
+
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1TrackTrigger
+// Class  :     L1TkPhiCandidateFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+namespace l1t {
+  class L1TkPhiCandidate;
+  
+  using L1TkPhiCandidateCollection = std::vector<L1TkPhiCandidate>;
+  using L1TkPhiCandidateRef        = edm::Ref<L1TkPhiCandidateCollection>;
+  using L1TkPhiCandidateRefVector  = edm::RefVector<L1TkPhiCandidateCollection>;
+  using L1TkPhiCandidateVectorRef  = std::vector<L1TkPhiCandidateRef>;
+}
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h
@@ -5,7 +5,7 @@
 //
 // Package:     DataFormats/L1TrackTrigger
 // Class  :     L1TkPhiCandidateFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
@@ -13,10 +13,10 @@
 
 namespace l1t {
   class L1TkPhiCandidate;
-  
+
   using L1TkPhiCandidateCollection = std::vector<L1TkPhiCandidate>;
-  using L1TkPhiCandidateRef        = edm::Ref<L1TkPhiCandidateCollection>;
-  using L1TkPhiCandidateRefVector  = edm::RefVector<L1TkPhiCandidateCollection>;
-  using L1TkPhiCandidateVectorRef  = std::vector<L1TkPhiCandidateRef>;
-}
+  using L1TkPhiCandidateRef = edm::Ref<L1TkPhiCandidateCollection>;
+  using L1TkPhiCandidateRefVector = edm::RefVector<L1TkPhiCandidateCollection>;
+  using L1TkPhiCandidateVectorRef = std::vector<L1TkPhiCandidateRef>;
+}  // namespace l1t
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h
@@ -1,0 +1,35 @@
+#ifndef L1TkTrigger_L1TkPrimaryVertex_h
+#define L1TkTrigger_L1TkPrimaryVertex_h
+
+
+// Nov 12, 2013
+// First version of a class for L1-zvertex
+
+namespace l1t {
+         
+  class L1TkPrimaryVertex {
+    
+  public:
+    
+    L1TkPrimaryVertex() : zvertex(-999), sum(-999) {}
+    
+    ~L1TkPrimaryVertex() { }
+    
+    L1TkPrimaryVertex(float z, float s) : zvertex(z), sum(s) { }
+    
+    
+    float getZvertex() const { return zvertex ; } 
+    float getSum() const { return sum ; }
+    
+  private:
+    float zvertex;
+    float sum;
+    
+  };
+  
+#include <vector>
+
+typedef std::vector<L1TkPrimaryVertex> L1TkPrimaryVertexCollection ;
+
+}
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h
@@ -1,35 +1,30 @@
 #ifndef L1TkTrigger_L1TkPrimaryVertex_h
 #define L1TkTrigger_L1TkPrimaryVertex_h
 
-
 // Nov 12, 2013
 // First version of a class for L1-zvertex
 
 namespace l1t {
-         
+
   class L1TkPrimaryVertex {
-    
   public:
-    
     L1TkPrimaryVertex() : zvertex(-999), sum(-999) {}
-    
-    ~L1TkPrimaryVertex() { }
-    
-    L1TkPrimaryVertex(float z, float s) : zvertex(z), sum(s) { }
-    
-    
-    float getZvertex() const { return zvertex ; } 
-    float getSum() const { return sum ; }
-    
+
+    ~L1TkPrimaryVertex() {}
+
+    L1TkPrimaryVertex(float z, float s) : zvertex(z), sum(s) {}
+
+    float getZvertex() const { return zvertex; }
+    float getSum() const { return sum; }
+
   private:
     float zvertex;
     float sum;
-    
   };
-  
+
 #include <vector>
 
-typedef std::vector<L1TkPrimaryVertex> L1TkPrimaryVertexCollection ;
+  typedef std::vector<L1TkPrimaryVertex> L1TkPrimaryVertexCollection;
 
-}
+}  // namespace l1t
 #endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h
@@ -1,0 +1,81 @@
+#ifndef L1TkTrigger_L1TauParticle_h
+#define L1TkTrigger_L1TauParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkTauParticle
+//
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+#include "DataFormats/L1Trigger/interface/Tau.h"
+
+
+namespace l1t {
+         
+   class L1TkTauParticle : public L1Candidate
+   {     
+         
+      public:
+
+    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+    typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+           
+         L1TkTauParticle();
+
+	 L1TkTauParticle( const LorentzVector& p4,
+			    const edm::Ref< TauBxCollection >& tauCaloRef,   // null for stand-alone TkTaus
+			    const edm::Ptr< L1TTTrackType >& trkPtr,
+                            const edm::Ptr< L1TTTrackType >& trkPtr2,	// null for tau -> 1 prong
+                            const edm::Ptr< L1TTTrackType >& trkPtr3,	// null for tau -> 1 prong
+			    float tkisol = -999. );
+
+	virtual ~L1TkTauParticle() {}
+
+         // ---------- const member functions ---------------------
+
+         const edm::Ref< TauBxCollection >& gettauCaloRef() const
+	  { return tauCaloRef_  ; }
+
+         const edm::Ptr< L1TTTrackType >& getTrkPtr() const
+         { return trkPtr_ ; }
+
+         const edm::Ptr< L1TTTrackType >& getTrkPtr2() const
+         { return trkPtr2_ ; }
+         const edm::Ptr< L1TTTrackType >& getTrkPtr3() const
+         { return trkPtr3_ ; }
+
+ 	 float getTrkzVtx() const { return TrkzVtx_ ; }
+         float getTrkIsol() const { return TrkIsol_ ; }
+
+
+         // ---------- member functions ---------------------------
+
+	 void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
+         void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
+         int bx() const;
+
+      private:
+
+	 edm::Ref< TauBxCollection > tauCaloRef_ ;
+
+         edm::Ptr< L1TTTrackType > trkPtr_ ;
+         edm::Ptr< L1TTTrackType > trkPtr2_ ;
+         edm::Ptr< L1TTTrackType > trkPtr3_ ;
+
+         float TrkIsol_;
+	 float TrkzVtx_ ;
+	
+    };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h
@@ -17,65 +17,52 @@
 
 #include "DataFormats/L1Trigger/interface/Tau.h"
 
-
 namespace l1t {
-         
-   class L1TkTauParticle : public L1Candidate
-   {     
-         
-      public:
 
-    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-    typedef std::vector< L1TTTrackType > L1TTTrackCollection;
-           
-         L1TkTauParticle();
+  class L1TkTauParticle : public L1Candidate {
+  public:
+    typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+    typedef std::vector<L1TTTrackType> L1TTTrackCollection;
 
-	 L1TkTauParticle( const LorentzVector& p4,
-			    const edm::Ref< TauBxCollection >& tauCaloRef,   // null for stand-alone TkTaus
-			    const edm::Ptr< L1TTTrackType >& trkPtr,
-                            const edm::Ptr< L1TTTrackType >& trkPtr2,	// null for tau -> 1 prong
-                            const edm::Ptr< L1TTTrackType >& trkPtr3,	// null for tau -> 1 prong
-			    float tkisol = -999. );
+    L1TkTauParticle();
 
-	virtual ~L1TkTauParticle() {}
+    L1TkTauParticle(const LorentzVector& p4,
+                    const edm::Ref<TauBxCollection>& tauCaloRef,  // null for stand-alone TkTaus
+                    const edm::Ptr<L1TTTrackType>& trkPtr,
+                    const edm::Ptr<L1TTTrackType>& trkPtr2,  // null for tau -> 1 prong
+                    const edm::Ptr<L1TTTrackType>& trkPtr3,  // null for tau -> 1 prong
+                    float tkisol = -999.);
 
-         // ---------- const member functions ---------------------
+    virtual ~L1TkTauParticle() {}
 
-         const edm::Ref< TauBxCollection >& gettauCaloRef() const
-	  { return tauCaloRef_  ; }
+    // ---------- const member functions ---------------------
 
-         const edm::Ptr< L1TTTrackType >& getTrkPtr() const
-         { return trkPtr_ ; }
+    const edm::Ref<TauBxCollection>& gettauCaloRef() const { return tauCaloRef_; }
 
-         const edm::Ptr< L1TTTrackType >& getTrkPtr2() const
-         { return trkPtr2_ ; }
-         const edm::Ptr< L1TTTrackType >& getTrkPtr3() const
-         { return trkPtr3_ ; }
+    const edm::Ptr<L1TTTrackType>& getTrkPtr() const { return trkPtr_; }
 
- 	 float getTrkzVtx() const { return TrkzVtx_ ; }
-         float getTrkIsol() const { return TrkIsol_ ; }
+    const edm::Ptr<L1TTTrackType>& getTrkPtr2() const { return trkPtr2_; }
+    const edm::Ptr<L1TTTrackType>& getTrkPtr3() const { return trkPtr3_; }
 
+    float getTrkzVtx() const { return TrkzVtx_; }
+    float getTrkIsol() const { return TrkIsol_; }
 
-         // ---------- member functions ---------------------------
+    // ---------- member functions ---------------------------
 
-	 void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
-         void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
-         int bx() const;
+    void setTrkzVtx(float TrkzVtx) { TrkzVtx_ = TrkzVtx; }
+    void setTrkIsol(float TrkIsol) { TrkIsol_ = TrkIsol; }
+    int bx() const;
 
-      private:
+  private:
+    edm::Ref<TauBxCollection> tauCaloRef_;
 
-	 edm::Ref< TauBxCollection > tauCaloRef_ ;
+    edm::Ptr<L1TTTrackType> trkPtr_;
+    edm::Ptr<L1TTTrackType> trkPtr2_;
+    edm::Ptr<L1TTTrackType> trkPtr3_;
 
-         edm::Ptr< L1TTTrackType > trkPtr_ ;
-         edm::Ptr< L1TTTrackType > trkPtr2_ ;
-         edm::Ptr< L1TTTrackType > trkPtr3_ ;
-
-         float TrkIsol_;
-	 float TrkzVtx_ ;
-	
-    };
-}
+    float TrkIsol_;
+    float TrkzVtx_;
+  };
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1TauParticleFwd_h
+#define L1TkTrigger_L1TauParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkTauParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1t {
+
+   class L1TkTauParticle ;
+
+   typedef std::vector< L1TkTauParticle > L1TkTauParticleCollection ;
+
+   typedef edm::Ref< L1TkTauParticleCollection > L1TkTauParticleRef ;
+   typedef edm::RefVector< L1TkTauParticleCollection > L1TkTauParticleRefVector ;
+   typedef std::vector< L1TkTauParticleRef > L1TkTauParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h
@@ -5,24 +5,21 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkTauParticleFwd
-// 
+//
 
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
-
 namespace l1t {
 
-   class L1TkTauParticle ;
+  class L1TkTauParticle;
 
-   typedef std::vector< L1TkTauParticle > L1TkTauParticleCollection ;
+  typedef std::vector<L1TkTauParticle> L1TkTauParticleCollection;
 
-   typedef edm::Ref< L1TkTauParticleCollection > L1TkTauParticleRef ;
-   typedef edm::RefVector< L1TkTauParticleCollection > L1TkTauParticleRefVector ;
-   typedef std::vector< L1TkTauParticleRef > L1TkTauParticleVectorRef ;
-}
+  typedef edm::Ref<L1TkTauParticleCollection> L1TkTauParticleRef;
+  typedef edm::RefVector<L1TkTauParticleCollection> L1TkTauParticleRefVector;
+  typedef std::vector<L1TkTauParticleRef> L1TkTauParticleVectorRef;
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h
@@ -1,0 +1,71 @@
+#ifndef L1TkTrigger_L1TrkTauParticle_h
+#define L1TkTrigger_L1TrkTauParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TrkTauParticle
+// 
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace l1t { 
+
+  class L1TrkTauParticle ;
+  
+  typedef std::vector< L1TrkTauParticle > L1TrkTauParticleCollection ;
+  
+  typedef edm::Ref< L1TrkTauParticleCollection > L1TrkTauParticleRef ;
+  typedef edm::RefVector< L1TrkTauParticleCollection > L1TrkTauParticleRefVector ;
+  typedef std::vector< L1TrkTauParticleRef > L1TrkTauParticleVectorRef ;
+  
+  typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+  typedef std::vector< L1TTTrackType > L1TTTrackCollection;
+  typedef edm::Ptr< L1TTTrackType > L1TTTrackRefPtr;
+  typedef std::vector< L1TTTrackRefPtr > L1TTTrackRefPtr_Collection;
+
+  class L1TrkTauParticle : public L1Candidate
+  {     
+    
+  public:
+    
+    L1TrkTauParticle();
+    
+
+    L1TrkTauParticle( const LorentzVector& p4,
+		    const std::vector< L1TTTrackRefPtr >& clustTracks,
+		    float iso = -999. );
+
+    virtual ~L1TrkTauParticle() {}
+      
+    // ---------- const member functions ---------------------
+
+    const L1TTTrackRefPtr getSeedTrk() const { return clustTracks_.at(0); }
+
+    const std::vector< L1TTTrackRefPtr > getTrks() const { return clustTracks_; }
+
+    float getIso() const { return iso_ ; } 
+    
+    // ---------- member functions ---------------------------
+    
+    void setIso(float iso)  { iso_ = iso ; }
+    
+    //	 int bx() const;
+    
+  private:
+    std::vector< L1TTTrackRefPtr > clustTracks_;
+    float iso_;
+
+  };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h
@@ -5,7 +5,7 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TrkTauParticle
-// 
+//
 
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/Common/interface/Ref.h"
@@ -16,56 +16,47 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-namespace l1t { 
+namespace l1t {
 
-  class L1TrkTauParticle ;
-  
-  typedef std::vector< L1TrkTauParticle > L1TrkTauParticleCollection ;
-  
-  typedef edm::Ref< L1TrkTauParticleCollection > L1TrkTauParticleRef ;
-  typedef edm::RefVector< L1TrkTauParticleCollection > L1TrkTauParticleRefVector ;
-  typedef std::vector< L1TrkTauParticleRef > L1TrkTauParticleVectorRef ;
-  
-  typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
-  typedef std::vector< L1TTTrackType > L1TTTrackCollection;
-  typedef edm::Ptr< L1TTTrackType > L1TTTrackRefPtr;
-  typedef std::vector< L1TTTrackRefPtr > L1TTTrackRefPtr_Collection;
+  class L1TrkTauParticle;
 
-  class L1TrkTauParticle : public L1Candidate
-  {     
-    
+  typedef std::vector<L1TrkTauParticle> L1TrkTauParticleCollection;
+
+  typedef edm::Ref<L1TrkTauParticleCollection> L1TrkTauParticleRef;
+  typedef edm::RefVector<L1TrkTauParticleCollection> L1TrkTauParticleRefVector;
+  typedef std::vector<L1TrkTauParticleRef> L1TrkTauParticleVectorRef;
+
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+  typedef std::vector<L1TTTrackType> L1TTTrackCollection;
+  typedef edm::Ptr<L1TTTrackType> L1TTTrackRefPtr;
+  typedef std::vector<L1TTTrackRefPtr> L1TTTrackRefPtr_Collection;
+
+  class L1TrkTauParticle : public L1Candidate {
   public:
-    
     L1TrkTauParticle();
-    
 
-    L1TrkTauParticle( const LorentzVector& p4,
-		    const std::vector< L1TTTrackRefPtr >& clustTracks,
-		    float iso = -999. );
+    L1TrkTauParticle(const LorentzVector& p4, const std::vector<L1TTTrackRefPtr>& clustTracks, float iso = -999.);
 
     virtual ~L1TrkTauParticle() {}
-      
+
     // ---------- const member functions ---------------------
 
     const L1TTTrackRefPtr getSeedTrk() const { return clustTracks_.at(0); }
 
-    const std::vector< L1TTTrackRefPtr > getTrks() const { return clustTracks_; }
+    const std::vector<L1TTTrackRefPtr> getTrks() const { return clustTracks_; }
 
-    float getIso() const { return iso_ ; } 
-    
+    float getIso() const { return iso_; }
+
     // ---------- member functions ---------------------------
-    
-    void setIso(float iso)  { iso_ = iso ; }
-    
-    //	 int bx() const;
-    
-  private:
-    std::vector< L1TTTrackRefPtr > clustTracks_;
-    float iso_;
 
+    void setIso(float iso) { iso_ = iso; }
+
+    //	 int bx() const;
+
+  private:
+    std::vector<L1TTTrackRefPtr> clustTracks_;
+    float iso_;
   };
-}
+}  // namespace l1t
 
 #endif
-
-

--- a/DataFormats/L1TrackTrigger/src/L1CaloTkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1CaloTkTauParticle.cc
@@ -1,0 +1,36 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1CaloTkTauParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h"
+
+
+using namespace l1t ;
+
+
+L1CaloTkTauParticle::L1CaloTkTauParticle()
+{
+}
+
+L1CaloTkTauParticle::L1CaloTkTauParticle( const LorentzVector& p4,
+					  const LorentzVector& tracksP4,
+					  const std::vector< L1TTTrackRefPtr >& clustTracks,
+					  Tau& caloTau,
+					  float vtxIso)
+					  //float Et)
+  : L1Candidate  ( p4 ),
+    tracksP4_    ( tracksP4 ),
+    clustTracks_ ( clustTracks ),
+    caloTau_     ( caloTau ),
+    vtxIso_      ( vtxIso )
+    //Et_          ( Et)
+{
+
+}
+
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1CaloTkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1CaloTkTauParticle.cc
@@ -2,35 +2,24 @@
 //
 // Package:     L1Trigger
 // Class  :     L1CaloTkTauParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h"
 
+using namespace l1t;
 
-using namespace l1t ;
+L1CaloTkTauParticle::L1CaloTkTauParticle() {}
 
-
-L1CaloTkTauParticle::L1CaloTkTauParticle()
-{
-}
-
-L1CaloTkTauParticle::L1CaloTkTauParticle( const LorentzVector& p4,
-					  const LorentzVector& tracksP4,
-					  const std::vector< L1TTTrackRefPtr >& clustTracks,
-					  Tau& caloTau,
-					  float vtxIso)
-					  //float Et)
-  : L1Candidate  ( p4 ),
-    tracksP4_    ( tracksP4 ),
-    clustTracks_ ( clustTracks ),
-    caloTau_     ( caloTau ),
-    vtxIso_      ( vtxIso )
-    //Et_          ( Et)
-{
-
-}
-
-
-
-
-
+L1CaloTkTauParticle::L1CaloTkTauParticle(const LorentzVector& p4,
+                                         const LorentzVector& tracksP4,
+                                         const std::vector<L1TTTrackRefPtr>& clustTracks,
+                                         Tau& caloTau,
+                                         float vtxIso)
+    //float Et)
+    : L1Candidate(p4),
+      tracksP4_(tracksP4),
+      clustTracks_(clustTracks),
+      caloTau_(caloTau),
+      vtxIso_(vtxIso)
+//Et_          ( Et)
+{}

--- a/DataFormats/L1TrackTrigger/src/L1TkBsCandidate.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkBsCandidate.cc
@@ -1,0 +1,39 @@
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1TrackTrigger
+// Class  :     L1TkBsCandidate
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+using namespace l1t;
+
+L1TkBsCandidate::L1TkBsCandidate()
+{
+}
+L1TkBsCandidate::L1TkBsCandidate(const LorentzVector& p4,
+				 L1TkPhiCandidate cand1,
+				 L1TkPhiCandidate cand2)
+: L1Candidate(p4)
+{
+  phiCandList_.push_back(cand1);  
+  phiCandList_.push_back(cand2);  
+}
+// deltaR between the Phi pair
+double L1TkBsCandidate::dRPhiPair() const {
+  const LorentzVector& lva = getPhiCandidate(0).p4();
+  const LorentzVector& lvb = getPhiCandidate(1).p4();
+  return reco::deltaR(lva, lvb);
+}
+// position difference between track pair
+double L1TkBsCandidate::dxyPhiPair() const {
+  const L1TkPhiCandidate& phia = getPhiCandidate(0); 
+  const L1TkPhiCandidate& phib = getPhiCandidate(1); 
+  return std::sqrt(std::pow(phia.vx() - phib.vx(), 2) 
+                 + std::pow(phia.vy() - phib.vy(), 2));
+}
+double L1TkBsCandidate::dzPhiPair() const {
+  return (getPhiCandidate(0).vz() - getPhiCandidate(1).vz());
+}

--- a/DataFormats/L1TrackTrigger/src/L1TkBsCandidate.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkBsCandidate.cc
@@ -2,7 +2,7 @@
 //
 // Package:     DataFormats/L1TrackTrigger
 // Class  :     L1TkBsCandidate
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h"
 #include "DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h"
@@ -10,16 +10,11 @@
 
 using namespace l1t;
 
-L1TkBsCandidate::L1TkBsCandidate()
-{
-}
-L1TkBsCandidate::L1TkBsCandidate(const LorentzVector& p4,
-				 L1TkPhiCandidate cand1,
-				 L1TkPhiCandidate cand2)
-: L1Candidate(p4)
-{
-  phiCandList_.push_back(cand1);  
-  phiCandList_.push_back(cand2);  
+L1TkBsCandidate::L1TkBsCandidate() {}
+L1TkBsCandidate::L1TkBsCandidate(const LorentzVector& p4, L1TkPhiCandidate cand1, L1TkPhiCandidate cand2)
+    : L1Candidate(p4) {
+  phiCandList_.push_back(cand1);
+  phiCandList_.push_back(cand2);
 }
 // deltaR between the Phi pair
 double L1TkBsCandidate::dRPhiPair() const {
@@ -29,11 +24,8 @@ double L1TkBsCandidate::dRPhiPair() const {
 }
 // position difference between track pair
 double L1TkBsCandidate::dxyPhiPair() const {
-  const L1TkPhiCandidate& phia = getPhiCandidate(0); 
-  const L1TkPhiCandidate& phib = getPhiCandidate(1); 
-  return std::sqrt(std::pow(phia.vx() - phib.vx(), 2) 
-                 + std::pow(phia.vy() - phib.vy(), 2));
+  const L1TkPhiCandidate& phia = getPhiCandidate(0);
+  const L1TkPhiCandidate& phib = getPhiCandidate(1);
+  return std::sqrt(std::pow(phia.vx() - phib.vx(), 2) + std::pow(phia.vy() - phib.vy(), 2));
 }
-double L1TkBsCandidate::dzPhiPair() const {
-  return (getPhiCandidate(0).vz() - getPhiCandidate(1).vz());
-}
+double L1TkBsCandidate::dzPhiPair() const { return (getPhiCandidate(0).vz() - getPhiCandidate(1).vz()); }

--- a/DataFormats/L1TrackTrigger/src/L1TkEGTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEGTauParticle.cc
@@ -1,0 +1,32 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEGTauParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h"
+
+
+using namespace l1t ;
+
+
+L1TkEGTauParticle::L1TkEGTauParticle()
+{
+}
+
+L1TkEGTauParticle::L1TkEGTauParticle( const LorentzVector& p4,
+				      const std::vector< L1TTTrackRefPtr >& clustTracks,
+				      const std::vector< EGammaRef >& clustEGs,
+				      float iso )
+  : L1Candidate  ( p4 ),
+    clustTracks_ ( clustTracks ),
+    clustEGs_ ( clustEGs ),
+    iso_      ( iso ) 
+{
+
+}
+
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkEGTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEGTauParticle.cc
@@ -2,31 +2,16 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEGTauParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h"
 
+using namespace l1t;
 
-using namespace l1t ;
+L1TkEGTauParticle::L1TkEGTauParticle() {}
 
-
-L1TkEGTauParticle::L1TkEGTauParticle()
-{
-}
-
-L1TkEGTauParticle::L1TkEGTauParticle( const LorentzVector& p4,
-				      const std::vector< L1TTTrackRefPtr >& clustTracks,
-				      const std::vector< EGammaRef >& clustEGs,
-				      float iso )
-  : L1Candidate  ( p4 ),
-    clustTracks_ ( clustTracks ),
-    clustEGs_ ( clustEGs ),
-    iso_      ( iso ) 
-{
-
-}
-
-
-
-
-
+L1TkEGTauParticle::L1TkEGTauParticle(const LorentzVector& p4,
+                                     const std::vector<L1TTTrackRefPtr>& clustTracks,
+                                     const std::vector<EGammaRef>& clustEGs,
+                                     float iso)
+    : L1Candidate(p4), clustTracks_(clustTracks), clustEGs_(clustEGs), iso_(iso) {}

--- a/DataFormats/L1TrackTrigger/src/L1TkElectronParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkElectronParticle.cc
@@ -1,0 +1,33 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+
+
+using namespace l1t ;
+
+
+L1TkElectronParticle::L1TkElectronParticle()
+{
+}
+
+L1TkElectronParticle::L1TkElectronParticle( const LorentzVector& p4,
+         const edm::Ref< EGammaBxCollection >& egRef,
+         const edm::Ptr< L1TTTrackType >& trkPtr,
+	 float tkisol )
+   : L1TkEmParticle( p4, egRef, tkisol,-999) ,
+     trkPtr_ ( trkPtr )
+
+{
+
+ if ( trkPtr_.isNonnull() ) {
+	float z = getTrkPtr() -> getPOCA().z();
+	setTrkzVtx( z );
+ }
+}
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkElectronParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkElectronParticle.cc
@@ -2,32 +2,24 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEmParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
 
+using namespace l1t;
 
-using namespace l1t ;
+L1TkElectronParticle::L1TkElectronParticle() {}
 
-
-L1TkElectronParticle::L1TkElectronParticle()
-{
-}
-
-L1TkElectronParticle::L1TkElectronParticle( const LorentzVector& p4,
-         const edm::Ref< EGammaBxCollection >& egRef,
-         const edm::Ptr< L1TTTrackType >& trkPtr,
-	 float tkisol )
-   : L1TkEmParticle( p4, egRef, tkisol,-999) ,
-     trkPtr_ ( trkPtr )
+L1TkElectronParticle::L1TkElectronParticle(const LorentzVector& p4,
+                                           const edm::Ref<EGammaBxCollection>& egRef,
+                                           const edm::Ptr<L1TTTrackType>& trkPtr,
+                                           float tkisol)
+    : L1TkEmParticle(p4, egRef, tkisol, -999),
+      trkPtr_(trkPtr)
 
 {
-
- if ( trkPtr_.isNonnull() ) {
-	float z = getTrkPtr() -> getPOCA().z();
-	setTrkzVtx( z );
- }
+  if (trkPtr_.isNonnull()) {
+    float z = getTrkPtr()->getPOCA().z();
+    setTrkzVtx(z);
+  }
 }
-
-
-

--- a/DataFormats/L1TrackTrigger/src/L1TkEmParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEmParticle.cc
@@ -1,0 +1,44 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+
+using namespace l1t ;
+
+
+L1TkEmParticle::L1TkEmParticle()
+{
+}
+
+L1TkEmParticle::L1TkEmParticle( const LorentzVector& p4,
+         const edm::Ref< EGammaBxCollection >& egRef,
+	 float tkisol )
+   : L1Candidate( p4 ),
+     egRef_ ( egRef ),
+     TrkIsol_ ( tkisol ), 
+     TrkIsolPV_ ( -999 )
+{
+
+}
+
+L1TkEmParticle::L1TkEmParticle( const LorentzVector& p4,
+         const edm::Ref< EGammaBxCollection >& egRef,
+       float tkisol , float tkisolPV)
+   : L1Candidate( p4 ),
+     egRef_ ( egRef ),
+     TrkIsol_ ( tkisol ), 
+     TrkIsolPV_ ( tkisolPV )
+{
+
+}
+
+
+
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkEmParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEmParticle.cc
@@ -2,43 +2,19 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEmParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
 
+using namespace l1t;
 
-using namespace l1t ;
+L1TkEmParticle::L1TkEmParticle() {}
 
+L1TkEmParticle::L1TkEmParticle(const LorentzVector& p4, const edm::Ref<EGammaBxCollection>& egRef, float tkisol)
+    : L1Candidate(p4), egRef_(egRef), TrkIsol_(tkisol), TrkIsolPV_(-999) {}
 
-L1TkEmParticle::L1TkEmParticle()
-{
-}
-
-L1TkEmParticle::L1TkEmParticle( const LorentzVector& p4,
-         const edm::Ref< EGammaBxCollection >& egRef,
-	 float tkisol )
-   : L1Candidate( p4 ),
-     egRef_ ( egRef ),
-     TrkIsol_ ( tkisol ), 
-     TrkIsolPV_ ( -999 )
-{
-
-}
-
-L1TkEmParticle::L1TkEmParticle( const LorentzVector& p4,
-         const edm::Ref< EGammaBxCollection >& egRef,
-       float tkisol , float tkisolPV)
-   : L1Candidate( p4 ),
-     egRef_ ( egRef ),
-     TrkIsol_ ( tkisol ), 
-     TrkIsolPV_ ( tkisolPV )
-{
-
-}
-
-
-
-
-
-
-
+L1TkEmParticle::L1TkEmParticle(const LorentzVector& p4,
+                               const edm::Ref<EGammaBxCollection>& egRef,
+                               float tkisol,
+                               float tkisolPV)
+    : L1Candidate(p4), egRef_(egRef), TrkIsol_(tkisol), TrkIsolPV_(tkisolPV) {}

--- a/DataFormats/L1TrackTrigger/src/L1TkEtMissParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEtMissParticle.cc
@@ -1,0 +1,41 @@
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
+
+using namespace l1t ;
+
+L1TkEtMissParticle::L1TkEtMissParticle()
+{
+}
+
+L1TkEtMissParticle::L1TkEtMissParticle(
+        const LorentzVector& p4,
+        EtMissType type,
+        const double& etTotal,
+        const double& etMissPU,
+        const double& etTotalPU,
+        const edm::Ref< L1TkPrimaryVertexCollection >& avtxRef,
+        int bx )
+   : L1Candidate( p4 ),
+     type_( type ),
+     etTot_( etTotal ),
+     etMissPU_ ( etMissPU ),
+     etTotalPU_ ( etTotalPU ),
+     vtxRef_( avtxRef ),
+     bx_( bx )
+{
+}
+
+L1TkEtMissParticle::L1TkEtMissParticle(
+        const LorentzVector& p4,
+        EtMissType type,
+        const double& etTotal,
+        const double& etMissPU,
+        const double& etTotalPU,
+        int bx )
+   : L1Candidate( p4 ),
+     type_( type ),
+     etTot_( etTotal ),
+     etMissPU_ ( etMissPU ),
+     etTotalPU_ ( etTotalPU ),
+     bx_( bx )
+{
+}

--- a/DataFormats/L1TrackTrigger/src/L1TkEtMissParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEtMissParticle.cc
@@ -1,41 +1,28 @@
 #include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
 
-using namespace l1t ;
+using namespace l1t;
 
-L1TkEtMissParticle::L1TkEtMissParticle()
-{
-}
+L1TkEtMissParticle::L1TkEtMissParticle() {}
 
-L1TkEtMissParticle::L1TkEtMissParticle(
-        const LorentzVector& p4,
-        EtMissType type,
-        const double& etTotal,
-        const double& etMissPU,
-        const double& etTotalPU,
-        const edm::Ref< L1TkPrimaryVertexCollection >& avtxRef,
-        int bx )
-   : L1Candidate( p4 ),
-     type_( type ),
-     etTot_( etTotal ),
-     etMissPU_ ( etMissPU ),
-     etTotalPU_ ( etTotalPU ),
-     vtxRef_( avtxRef ),
-     bx_( bx )
-{
-}
+L1TkEtMissParticle::L1TkEtMissParticle(const LorentzVector& p4,
+                                       EtMissType type,
+                                       const double& etTotal,
+                                       const double& etMissPU,
+                                       const double& etTotalPU,
+                                       const edm::Ref<L1TkPrimaryVertexCollection>& avtxRef,
+                                       int bx)
+    : L1Candidate(p4),
+      type_(type),
+      etTot_(etTotal),
+      etMissPU_(etMissPU),
+      etTotalPU_(etTotalPU),
+      vtxRef_(avtxRef),
+      bx_(bx) {}
 
-L1TkEtMissParticle::L1TkEtMissParticle(
-        const LorentzVector& p4,
-        EtMissType type,
-        const double& etTotal,
-        const double& etMissPU,
-        const double& etTotalPU,
-        int bx )
-   : L1Candidate( p4 ),
-     type_( type ),
-     etTot_( etTotal ),
-     etMissPU_ ( etMissPU ),
-     etTotalPU_ ( etTotalPU ),
-     bx_( bx )
-{
-}
+L1TkEtMissParticle::L1TkEtMissParticle(const LorentzVector& p4,
+                                       EtMissType type,
+                                       const double& etTotal,
+                                       const double& etMissPU,
+                                       const double& etTotalPU,
+                                       int bx)
+    : L1Candidate(p4), type_(type), etTot_(etTotal), etMissPU_(etMissPU), etTotalPU_(etTotalPU), bx_(bx) {}

--- a/DataFormats/L1TrackTrigger/src/L1TkGlbMuonParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkGlbMuonParticle.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkGlbMuonParticle
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticle.h"
+
+using namespace l1t;
+
+
+L1TkGlbMuonParticle::L1TkGlbMuonParticle( const LorentzVector& p4,
+         const edm::Ref< MuonBxCollection > &muRef,
+         const edm::Ptr< L1TTTrackType >& trkPtr,
+         float tkisol )
+   : L1Candidate( p4 ),
+     muRef_ ( muRef ) ,	
+     trkPtr_ ( trkPtr ) ,
+     theIsolation ( tkisol ),
+     TrkzVtx_(999),
+     quality_(999)
+{
+
+ if ( trkPtr_.isNonnull() ) {
+	float z = getTrkPtr() -> getPOCA().z();
+	setTrkzVtx( z );
+ }
+}
+

--- a/DataFormats/L1TrackTrigger/src/L1TkGlbMuonParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkGlbMuonParticle.cc
@@ -7,22 +7,13 @@
 
 using namespace l1t;
 
-
-L1TkGlbMuonParticle::L1TkGlbMuonParticle( const LorentzVector& p4,
-         const edm::Ref< MuonBxCollection > &muRef,
-         const edm::Ptr< L1TTTrackType >& trkPtr,
-         float tkisol )
-   : L1Candidate( p4 ),
-     muRef_ ( muRef ) ,	
-     trkPtr_ ( trkPtr ) ,
-     theIsolation ( tkisol ),
-     TrkzVtx_(999),
-     quality_(999)
-{
-
- if ( trkPtr_.isNonnull() ) {
-	float z = getTrkPtr() -> getPOCA().z();
-	setTrkzVtx( z );
- }
+L1TkGlbMuonParticle::L1TkGlbMuonParticle(const LorentzVector& p4,
+                                         const edm::Ref<MuonBxCollection>& muRef,
+                                         const edm::Ptr<L1TTTrackType>& trkPtr,
+                                         float tkisol)
+    : L1Candidate(p4), muRef_(muRef), trkPtr_(trkPtr), theIsolation(tkisol), TrkzVtx_(999), quality_(999) {
+  if (trkPtr_.isNonnull()) {
+    float z = getTrkPtr()->getPOCA().z();
+    setTrkzVtx(z);
+  }
 }
-

--- a/DataFormats/L1TrackTrigger/src/L1TkHTMissParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkHTMissParticle.cc
@@ -1,0 +1,29 @@
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
+
+using namespace l1t ;
+
+L1TkHTMissParticle::L1TkHTMissParticle()
+{
+}
+
+L1TkHTMissParticle::L1TkHTMissParticle(
+        const LorentzVector& p4,
+        const double& etTotal,
+	const edm::RefProd< L1TkJetParticleCollection >& jetCollRef,
+        const edm::Ref< L1TkPrimaryVertexCollection >& avtxRef,
+        int bx )
+   : L1Candidate(p4 ),
+     EtTot_( etTotal ),
+     jetCollectionRef_( jetCollRef ),
+     vtxRef_( avtxRef ),
+     bx_( bx )
+{
+
+   if ( vtxRef_.isNonnull() ) {
+	float z = getVtxRef() -> getZvertex() ;
+	setVtx( z );
+   }
+
+}
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkHTMissParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkHTMissParticle.cc
@@ -1,29 +1,17 @@
 #include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
 
-using namespace l1t ;
+using namespace l1t;
 
-L1TkHTMissParticle::L1TkHTMissParticle()
-{
+L1TkHTMissParticle::L1TkHTMissParticle() {}
+
+L1TkHTMissParticle::L1TkHTMissParticle(const LorentzVector& p4,
+                                       const double& etTotal,
+                                       const edm::RefProd<L1TkJetParticleCollection>& jetCollRef,
+                                       const edm::Ref<L1TkPrimaryVertexCollection>& avtxRef,
+                                       int bx)
+    : L1Candidate(p4), EtTot_(etTotal), jetCollectionRef_(jetCollRef), vtxRef_(avtxRef), bx_(bx) {
+  if (vtxRef_.isNonnull()) {
+    float z = getVtxRef()->getZvertex();
+    setVtx(z);
+  }
 }
-
-L1TkHTMissParticle::L1TkHTMissParticle(
-        const LorentzVector& p4,
-        const double& etTotal,
-	const edm::RefProd< L1TkJetParticleCollection >& jetCollRef,
-        const edm::Ref< L1TkPrimaryVertexCollection >& avtxRef,
-        int bx )
-   : L1Candidate(p4 ),
-     EtTot_( etTotal ),
-     jetCollectionRef_( jetCollRef ),
-     vtxRef_( avtxRef ),
-     bx_( bx )
-{
-
-   if ( vtxRef_.isNonnull() ) {
-	float z = getVtxRef() -> getZvertex() ;
-	setVtx( z );
-   }
-
-}
-
-

--- a/DataFormats/L1TrackTrigger/src/L1TkJetParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkJetParticle.cc
@@ -1,0 +1,63 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkJetParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+
+
+using namespace l1t ;
+
+
+L1TkJetParticle::L1TkJetParticle()
+{
+}
+
+L1TkJetParticle::L1TkJetParticle( const LorentzVector& p4,
+				  const edm::Ref< JetBxCollection >& jetRef,
+				  const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
+				  float jetvtx )
+: L1Candidate( p4 ),
+  jetRef_ ( jetRef ),
+  trkPtrs_ ( trkPtrs ),
+  JetVtx_ ( jetvtx )
+{
+}
+L1TkJetParticle::L1TkJetParticle( const LorentzVector& p4,
+//				  const edm::Ref< JetBxCollection >& jetRef,
+				  const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
+				  float jetvtx,
+				  unsigned int ntracks,unsigned int tighttracks,unsigned int displacedtracks,unsigned int tightdisplacedtracks
+				 // L1TkJetParticleDisp counters
+				)
+: L1Candidate( p4 ),
+  //jetRef_ ( jetRef ),
+  trkPtrs_ ( trkPtrs ),
+  JetVtx_ ( jetvtx ),
+  ntracks_(ntracks),
+  tighttracks_(tighttracks),
+  displacedtracks_(displacedtracks),
+  tightdisplacedtracks_(tightdisplacedtracks)
+{
+                //L1TkJetParticleDisp DispCounters(ntracks,tighttracks, displacedtracks, tightdisplacedtracks);
+		//setDispCounters(DispCounters);
+}
+int L1TkJetParticle::bx() const {
+
+  // in the producer L1TkJetProducer.cc, we keep only jets with bx = 0 
+  int dummy = 0;
+  return dummy;
+  
+  /*
+    int dummy = -999;
+    if ( jetRef_.isNonnull() ) {
+    return (getJetRef() -> bx()) ;
+    }
+    else {
+    return dummy;
+    
+    }
+  */
+}
+

--- a/DataFormats/L1TrackTrigger/src/L1TkJetParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkJetParticle.cc
@@ -2,53 +2,45 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkJetParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
 
+using namespace l1t;
 
-using namespace l1t ;
+L1TkJetParticle::L1TkJetParticle() {}
 
-
-L1TkJetParticle::L1TkJetParticle()
-{
-}
-
-L1TkJetParticle::L1TkJetParticle( const LorentzVector& p4,
-				  const edm::Ref< JetBxCollection >& jetRef,
-				  const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
-				  float jetvtx )
-: L1Candidate( p4 ),
-  jetRef_ ( jetRef ),
-  trkPtrs_ ( trkPtrs ),
-  JetVtx_ ( jetvtx )
-{
-}
-L1TkJetParticle::L1TkJetParticle( const LorentzVector& p4,
-//				  const edm::Ref< JetBxCollection >& jetRef,
-				  const std::vector< edm::Ptr< L1TTTrackType > >& trkPtrs,
-				  float jetvtx,
-				  unsigned int ntracks,unsigned int tighttracks,unsigned int displacedtracks,unsigned int tightdisplacedtracks
-				 // L1TkJetParticleDisp counters
-				)
-: L1Candidate( p4 ),
-  //jetRef_ ( jetRef ),
-  trkPtrs_ ( trkPtrs ),
-  JetVtx_ ( jetvtx ),
-  ntracks_(ntracks),
-  tighttracks_(tighttracks),
-  displacedtracks_(displacedtracks),
-  tightdisplacedtracks_(tightdisplacedtracks)
-{
-                //L1TkJetParticleDisp DispCounters(ntracks,tighttracks, displacedtracks, tightdisplacedtracks);
-		//setDispCounters(DispCounters);
+L1TkJetParticle::L1TkJetParticle(const LorentzVector& p4,
+                                 const edm::Ref<JetBxCollection>& jetRef,
+                                 const std::vector<edm::Ptr<L1TTTrackType> >& trkPtrs,
+                                 float jetvtx)
+    : L1Candidate(p4), jetRef_(jetRef), trkPtrs_(trkPtrs), JetVtx_(jetvtx) {}
+L1TkJetParticle::L1TkJetParticle(const LorentzVector& p4,
+                                 //				  const edm::Ref< JetBxCollection >& jetRef,
+                                 const std::vector<edm::Ptr<L1TTTrackType> >& trkPtrs,
+                                 float jetvtx,
+                                 unsigned int ntracks,
+                                 unsigned int tighttracks,
+                                 unsigned int displacedtracks,
+                                 unsigned int tightdisplacedtracks
+                                 // L1TkJetParticleDisp counters
+                                 )
+    : L1Candidate(p4),
+      //jetRef_ ( jetRef ),
+      trkPtrs_(trkPtrs),
+      JetVtx_(jetvtx),
+      ntracks_(ntracks),
+      tighttracks_(tighttracks),
+      displacedtracks_(displacedtracks),
+      tightdisplacedtracks_(tightdisplacedtracks) {
+  //L1TkJetParticleDisp DispCounters(ntracks,tighttracks, displacedtracks, tightdisplacedtracks);
+  //setDispCounters(DispCounters);
 }
 int L1TkJetParticle::bx() const {
-
-  // in the producer L1TkJetProducer.cc, we keep only jets with bx = 0 
+  // in the producer L1TkJetProducer.cc, we keep only jets with bx = 0
   int dummy = 0;
   return dummy;
-  
+
   /*
     int dummy = -999;
     if ( jetRef_.isNonnull() ) {
@@ -60,4 +52,3 @@ int L1TkJetParticle::bx() const {
     }
   */
 }
-

--- a/DataFormats/L1TrackTrigger/src/L1TkPhiCandidate.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkPhiCandidate.cc
@@ -1,0 +1,61 @@
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1TrackTrigger
+// Class  :     L1TkPhiCandidate
+// 
+#include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+using namespace l1t;
+
+L1TkPhiCandidate::L1TkPhiCandidate()
+{
+}
+L1TkPhiCandidate::L1TkPhiCandidate(const LorentzVector& p4,
+				   const edm::Ptr<L1TTTrackType>& trkPtr1,
+				   const edm::Ptr<L1TTTrackType>& trkPtr2)
+: L1Candidate(p4)
+{
+  trkPtrList_.push_back(trkPtr1);  
+  trkPtrList_.push_back(trkPtr2);  
+}
+// deltaR between track pair
+double L1TkPhiCandidate::dRTrkPair() const {
+  const edm::Ptr<L1TTTrackType>& itrk = getTrkPtr(0); 
+  const edm::Ptr<L1TTTrackType>& jtrk = getTrkPtr(1); 
+
+  math::PtEtaPhiMLorentzVector itrkP4(itrk->getMomentum().perp(), 
+				      itrk->getMomentum().eta(), 
+				      itrk->getMomentum().phi(), 
+				      kmass);
+  math::PtEtaPhiMLorentzVector jtrkP4(jtrk->getMomentum().perp(), 
+				      jtrk->getMomentum().eta(), 
+				      jtrk->getMomentum().phi(), 
+				      kmass);
+  return reco::deltaR(itrkP4, jtrkP4);
+}
+
+// difference from nominal mass
+double L1TkPhiCandidate::dmass() const {
+  return std::fabs(phi_polemass - mass());
+}
+// position difference between track pair
+double L1TkPhiCandidate::dxyTrkPair() const {
+  const edm::Ptr<L1TTTrackType>& itrk = getTrkPtr(0); 
+  const edm::Ptr<L1TTTrackType>& jtrk = getTrkPtr(1); 
+
+  return std::sqrt(std::pow(itrk->getPOCA(5).x() - jtrk->getPOCA(5).x(), 2) 
+                 + std::pow(itrk->getPOCA(5).y() - jtrk->getPOCA(5).y(), 2));
+}
+double L1TkPhiCandidate::dzTrkPair() const {
+  return (getTrkPtr(0)->getPOCA(5).z() - getTrkPtr(1)->getPOCA(5).z());
+}
+double L1TkPhiCandidate::vx() const {
+  return 0.5 * (getTrkPtr(0)->getPOCA(5).x() + getTrkPtr(1)->getPOCA(5).x());
+}
+double L1TkPhiCandidate::vy() const {
+  return 0.5 * (getTrkPtr(0)->getPOCA(5).y() + getTrkPtr(1)->getPOCA(5).y());
+}
+double L1TkPhiCandidate::vz() const {
+  return 0.5 * (getTrkPtr(0)->getPOCA(5).z() + getTrkPtr(1)->getPOCA(5).z());
+}

--- a/DataFormats/L1TrackTrigger/src/L1TkPhiCandidate.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkPhiCandidate.cc
@@ -2,60 +2,43 @@
 //
 // Package:     DataFormats/L1TrackTrigger
 // Class  :     L1TkPhiCandidate
-// 
+//
 #include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
 using namespace l1t;
 
-L1TkPhiCandidate::L1TkPhiCandidate()
-{
-}
+L1TkPhiCandidate::L1TkPhiCandidate() {}
 L1TkPhiCandidate::L1TkPhiCandidate(const LorentzVector& p4,
-				   const edm::Ptr<L1TTTrackType>& trkPtr1,
-				   const edm::Ptr<L1TTTrackType>& trkPtr2)
-: L1Candidate(p4)
-{
-  trkPtrList_.push_back(trkPtr1);  
-  trkPtrList_.push_back(trkPtr2);  
+                                   const edm::Ptr<L1TTTrackType>& trkPtr1,
+                                   const edm::Ptr<L1TTTrackType>& trkPtr2)
+    : L1Candidate(p4) {
+  trkPtrList_.push_back(trkPtr1);
+  trkPtrList_.push_back(trkPtr2);
 }
 // deltaR between track pair
 double L1TkPhiCandidate::dRTrkPair() const {
-  const edm::Ptr<L1TTTrackType>& itrk = getTrkPtr(0); 
-  const edm::Ptr<L1TTTrackType>& jtrk = getTrkPtr(1); 
+  const edm::Ptr<L1TTTrackType>& itrk = getTrkPtr(0);
+  const edm::Ptr<L1TTTrackType>& jtrk = getTrkPtr(1);
 
-  math::PtEtaPhiMLorentzVector itrkP4(itrk->getMomentum().perp(), 
-				      itrk->getMomentum().eta(), 
-				      itrk->getMomentum().phi(), 
-				      kmass);
-  math::PtEtaPhiMLorentzVector jtrkP4(jtrk->getMomentum().perp(), 
-				      jtrk->getMomentum().eta(), 
-				      jtrk->getMomentum().phi(), 
-				      kmass);
+  math::PtEtaPhiMLorentzVector itrkP4(
+      itrk->getMomentum().perp(), itrk->getMomentum().eta(), itrk->getMomentum().phi(), kmass);
+  math::PtEtaPhiMLorentzVector jtrkP4(
+      jtrk->getMomentum().perp(), jtrk->getMomentum().eta(), jtrk->getMomentum().phi(), kmass);
   return reco::deltaR(itrkP4, jtrkP4);
 }
 
 // difference from nominal mass
-double L1TkPhiCandidate::dmass() const {
-  return std::fabs(phi_polemass - mass());
-}
+double L1TkPhiCandidate::dmass() const { return std::fabs(phi_polemass - mass()); }
 // position difference between track pair
 double L1TkPhiCandidate::dxyTrkPair() const {
-  const edm::Ptr<L1TTTrackType>& itrk = getTrkPtr(0); 
-  const edm::Ptr<L1TTTrackType>& jtrk = getTrkPtr(1); 
+  const edm::Ptr<L1TTTrackType>& itrk = getTrkPtr(0);
+  const edm::Ptr<L1TTTrackType>& jtrk = getTrkPtr(1);
 
-  return std::sqrt(std::pow(itrk->getPOCA(5).x() - jtrk->getPOCA(5).x(), 2) 
-                 + std::pow(itrk->getPOCA(5).y() - jtrk->getPOCA(5).y(), 2));
+  return std::sqrt(std::pow(itrk->getPOCA(5).x() - jtrk->getPOCA(5).x(), 2) +
+                   std::pow(itrk->getPOCA(5).y() - jtrk->getPOCA(5).y(), 2));
 }
-double L1TkPhiCandidate::dzTrkPair() const {
-  return (getTrkPtr(0)->getPOCA(5).z() - getTrkPtr(1)->getPOCA(5).z());
-}
-double L1TkPhiCandidate::vx() const {
-  return 0.5 * (getTrkPtr(0)->getPOCA(5).x() + getTrkPtr(1)->getPOCA(5).x());
-}
-double L1TkPhiCandidate::vy() const {
-  return 0.5 * (getTrkPtr(0)->getPOCA(5).y() + getTrkPtr(1)->getPOCA(5).y());
-}
-double L1TkPhiCandidate::vz() const {
-  return 0.5 * (getTrkPtr(0)->getPOCA(5).z() + getTrkPtr(1)->getPOCA(5).z());
-}
+double L1TkPhiCandidate::dzTrkPair() const { return (getTrkPtr(0)->getPOCA(5).z() - getTrkPtr(1)->getPOCA(5).z()); }
+double L1TkPhiCandidate::vx() const { return 0.5 * (getTrkPtr(0)->getPOCA(5).x() + getTrkPtr(1)->getPOCA(5).x()); }
+double L1TkPhiCandidate::vy() const { return 0.5 * (getTrkPtr(0)->getPOCA(5).y() + getTrkPtr(1)->getPOCA(5).y()); }
+double L1TkPhiCandidate::vz() const { return 0.5 * (getTrkPtr(0)->getPOCA(5).z() + getTrkPtr(1)->getPOCA(5).z()); }

--- a/DataFormats/L1TrackTrigger/src/L1TkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkTauParticle.cc
@@ -1,0 +1,41 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h"
+
+
+using namespace l1t;
+
+
+L1TkTauParticle::L1TkTauParticle()
+{
+}
+
+L1TkTauParticle::L1TkTauParticle( const LorentzVector& p4,
+	 const edm::Ref< TauBxCollection > &tauCaloRef,
+         const edm::Ptr< L1TTTrackType >& trkPtr,
+         const edm::Ptr< L1TTTrackType >& trkPtr2,
+         const edm::Ptr< L1TTTrackType >& trkPtr3,
+	 float tkisol )
+   : L1Candidate( p4 ),
+     tauCaloRef_ ( tauCaloRef ) ,
+     trkPtr_ ( trkPtr ) ,
+     trkPtr2_ ( trkPtr2 ) ,
+     trkPtr3_ ( trkPtr3 ) ,
+     TrkIsol_ ( tkisol )
+
+{
+
+ if ( trkPtr_.isNonnull() ) {
+	float z = getTrkPtr() -> getPOCA().z();
+	setTrkzVtx( z );
+ }
+}
+
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkTauParticle.cc
@@ -2,40 +2,30 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TkEmParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h"
 
-
 using namespace l1t;
 
+L1TkTauParticle::L1TkTauParticle() {}
 
-L1TkTauParticle::L1TkTauParticle()
-{
-}
-
-L1TkTauParticle::L1TkTauParticle( const LorentzVector& p4,
-	 const edm::Ref< TauBxCollection > &tauCaloRef,
-         const edm::Ptr< L1TTTrackType >& trkPtr,
-         const edm::Ptr< L1TTTrackType >& trkPtr2,
-         const edm::Ptr< L1TTTrackType >& trkPtr3,
-	 float tkisol )
-   : L1Candidate( p4 ),
-     tauCaloRef_ ( tauCaloRef ) ,
-     trkPtr_ ( trkPtr ) ,
-     trkPtr2_ ( trkPtr2 ) ,
-     trkPtr3_ ( trkPtr3 ) ,
-     TrkIsol_ ( tkisol )
+L1TkTauParticle::L1TkTauParticle(const LorentzVector& p4,
+                                 const edm::Ref<TauBxCollection>& tauCaloRef,
+                                 const edm::Ptr<L1TTTrackType>& trkPtr,
+                                 const edm::Ptr<L1TTTrackType>& trkPtr2,
+                                 const edm::Ptr<L1TTTrackType>& trkPtr3,
+                                 float tkisol)
+    : L1Candidate(p4),
+      tauCaloRef_(tauCaloRef),
+      trkPtr_(trkPtr),
+      trkPtr2_(trkPtr2),
+      trkPtr3_(trkPtr3),
+      TrkIsol_(tkisol)
 
 {
-
- if ( trkPtr_.isNonnull() ) {
-	float z = getTrkPtr() -> getPOCA().z();
-	setTrkzVtx( z );
- }
+  if (trkPtr_.isNonnull()) {
+    float z = getTrkPtr()->getPOCA().z();
+    setTrkzVtx(z);
+  }
 }
-
-
-
-
-

--- a/DataFormats/L1TrackTrigger/src/L1TrkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TrkTauParticle.cc
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TrkTauParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h"
+
+
+using namespace l1t ;
+
+
+L1TrkTauParticle::L1TrkTauParticle()
+{
+}
+
+L1TrkTauParticle::L1TrkTauParticle( const LorentzVector& p4,
+				    const std::vector< L1TTTrackRefPtr >& clustTracks,
+				    float iso )
+  : L1Candidate  ( p4 ),
+    clustTracks_ ( clustTracks ),
+    iso_      ( iso ) 
+{
+
+}
+
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TrkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TrkTauParticle.cc
@@ -2,29 +2,13 @@
 //
 // Package:     L1Trigger
 // Class  :     L1TrkTauParticle
-// 
+//
 
 #include "DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h"
 
+using namespace l1t;
 
-using namespace l1t ;
+L1TrkTauParticle::L1TrkTauParticle() {}
 
-
-L1TrkTauParticle::L1TrkTauParticle()
-{
-}
-
-L1TrkTauParticle::L1TrkTauParticle( const LorentzVector& p4,
-				    const std::vector< L1TTTrackRefPtr >& clustTracks,
-				    float iso )
-  : L1Candidate  ( p4 ),
-    clustTracks_ ( clustTracks ),
-    iso_      ( iso ) 
-{
-
-}
-
-
-
-
-
+L1TrkTauParticle::L1TrkTauParticle(const LorentzVector& p4, const std::vector<L1TTTrackRefPtr>& clustTracks, float iso)
+    : L1Candidate(p4), clustTracks_(clustTracks), iso_(iso) {}

--- a/DataFormats/L1TrackTrigger/src/classes.h
+++ b/DataFormats/L1TrackTrigger/src/classes.h
@@ -54,74 +54,82 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-namespace 
-{
+namespace {
   struct dictionary1 {
     /// Main template type
-    Ref_Phase2TrackerDigi_  PD;
-    std::vector< Ref_Phase2TrackerDigi_ >                              V_PD;
+    Ref_Phase2TrackerDigi_ PD;
+    std::vector<Ref_Phase2TrackerDigi_> V_PD;
   };
 
   struct dictionary2 {
     /// TTCluster and containers
-    TTCluster< Ref_Phase2TrackerDigi_ >                                               C_PD;
-    std::vector< TTCluster< Ref_Phase2TrackerDigi_ > >                              V_C_PD;
-    edm::Wrapper< std::vector< TTCluster< Ref_Phase2TrackerDigi_ > > >            W_V_C_PD;
-    edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >                   SDV_C_PD;
-    edm::Wrapper< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > W_SDV_C_PD;
+    TTCluster<Ref_Phase2TrackerDigi_> C_PD;
+    std::vector<TTCluster<Ref_Phase2TrackerDigi_> > V_C_PD;
+    edm::Wrapper<std::vector<TTCluster<Ref_Phase2TrackerDigi_> > > W_V_C_PD;
+    edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> > SDV_C_PD;
+    edm::Wrapper<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> > > W_SDV_C_PD;
 
     /// edm::Ref to TTCluster in edmNew::DetSetVector and containers
-    edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > >                                    R_C_PD;
-    edm::Wrapper< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > >                  W_R_C_PD;
-    std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > >                   V_R_C_PD;
-    edm::Wrapper< std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > > W_V_R_C_PD;
+    edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> >, TTCluster<Ref_Phase2TrackerDigi_> > R_C_PD;
+    edm::Wrapper<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> >, TTCluster<Ref_Phase2TrackerDigi_> > >
+        W_R_C_PD;
+    std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> >, TTCluster<Ref_Phase2TrackerDigi_> > >
+        V_R_C_PD;
+    edm::Wrapper<std::vector<
+        edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> >, TTCluster<Ref_Phase2TrackerDigi_> > > >
+        W_V_R_C_PD;
   };
 
   struct dictionary3 {
     /// TTStub and containers
-    TTStub< Ref_Phase2TrackerDigi_ >                                               S_PD;
-    std::vector< TTStub< Ref_Phase2TrackerDigi_ > >                              V_S_PD;
-    edm::Wrapper< std::vector< TTStub< Ref_Phase2TrackerDigi_ > > >            W_V_S_PD;
-    edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >                   SDV_S_PD;
-    edm::Wrapper< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > > > W_SDV_S_PD;
+    TTStub<Ref_Phase2TrackerDigi_> S_PD;
+    std::vector<TTStub<Ref_Phase2TrackerDigi_> > V_S_PD;
+    edm::Wrapper<std::vector<TTStub<Ref_Phase2TrackerDigi_> > > W_V_S_PD;
+    edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> > SDV_S_PD;
+    edm::Wrapper<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> > > W_SDV_S_PD;
 
     /// edm::Ref to TTStub in edmNew::DetSetVector and containers
-    edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > >                                    R_S_PD;
-    edm::Wrapper< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > >                  W_R_S_PD;
-    std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > >                   V_R_S_PD;
-    edm::Wrapper< std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > > W_V_R_S_PD;
+    edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > R_S_PD;
+    edm::Wrapper<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+        W_R_S_PD;
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+        V_R_S_PD;
+    edm::Wrapper<
+        std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > > >
+        W_V_R_S_PD;
   };
-
 
   struct dictionarytrack {
     /// TTTrack and containers
-    TTTrack< Ref_Phase2TrackerDigi_ >                                               T_PD;
-    std::vector< TTTrack< Ref_Phase2TrackerDigi_ > >                              V_T_PD;
-    edm::Wrapper< std::vector< TTTrack< Ref_Phase2TrackerDigi_ > > >            W_V_T_PD;
-    edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >                   SDV_T_PD;
-    edm::Wrapper< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > > > W_SDV_T_PD;
+    TTTrack<Ref_Phase2TrackerDigi_> T_PD;
+    std::vector<TTTrack<Ref_Phase2TrackerDigi_> > V_T_PD;
+    edm::Wrapper<std::vector<TTTrack<Ref_Phase2TrackerDigi_> > > W_V_T_PD;
+    edmNew::DetSetVector<TTTrack<Ref_Phase2TrackerDigi_> > SDV_T_PD;
+    edm::Wrapper<edmNew::DetSetVector<TTTrack<Ref_Phase2TrackerDigi_> > > W_SDV_T_PD;
 
     /// edm::Ref to TTTrack in edmNew::DetSetVector and containers
-    edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > >                                    R_T_PD;
-    edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >                                                                                               P_T_PD;
-    edm::Wrapper< edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > > >                  W_R_T_PD;
-    std::vector< edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > > >                   V_R_T_PD;
-    edm::Wrapper< std::vector< edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > > > > W_V_R_T_PD;
+    edm::Ref<edmNew::DetSetVector<TTTrack<Ref_Phase2TrackerDigi_> >, TTTrack<Ref_Phase2TrackerDigi_> > R_T_PD;
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > P_T_PD;
+    edm::Wrapper<edm::Ref<edmNew::DetSetVector<TTTrack<Ref_Phase2TrackerDigi_> >, TTTrack<Ref_Phase2TrackerDigi_> > >
+        W_R_T_PD;
+    std::vector<edm::Ref<edmNew::DetSetVector<TTTrack<Ref_Phase2TrackerDigi_> >, TTTrack<Ref_Phase2TrackerDigi_> > >
+        V_R_T_PD;
+    edm::Wrapper<
+        std::vector<edm::Ref<edmNew::DetSetVector<TTTrack<Ref_Phase2TrackerDigi_> >, TTTrack<Ref_Phase2TrackerDigi_> > > >
+        W_V_R_T_PD;
   };
 
-
-//  L1TrackTriggerObjects stuff :
+  //  L1TrackTriggerObjects stuff :
 
   struct dictionaryl1tkobj {
     // L1 Primary Vertex
     l1t::L1TkPrimaryVertex trzvtx;
     edm::Wrapper<l1t::L1TkPrimaryVertexCollection> trzvtxColl;
-    edm::Ref<l1t::L1TkPrimaryVertexCollection > trkvtxRef ;
-    
-    
+    edm::Ref<l1t::L1TkPrimaryVertexCollection> trkvtxRef;
+
     // L1TkEtMiss... following L1EtMiss...
-    l1t::L1TkEtMissParticle TketMiss ;
-    l1t::L1TkEtMissParticleCollection TketMissColl ;
+    l1t::L1TkEtMissParticle TketMiss;
+    l1t::L1TkEtMissParticleCollection TketMissColl;
     edm::Wrapper<l1t::L1TkEtMissParticle> w_TketMiss;
     edm::Wrapper<l1t::L1TkEtMissParticleCollection> w_TketMissColl;
     //l1t::L1TkEtMissParticleRef refTkEtMiss ;
@@ -130,63 +138,63 @@ namespace
     //l1t::L1TkEtMissParticleRefProd refTkProdEtMiss ;
     //edm::reftobase::Holder<reco::Candidate, l1t::L1TkEtMissParticleRef> rtbTkm1;
     //edm::reftobase::Holder<reco::Candidate, l1t::L1TkEtMissParticleRefProd> rtbTkm2;
-    
+
     // L1TkEmParticle
-    l1t::L1TkEmParticleCollection trkemColl ;
+    l1t::L1TkEmParticleCollection trkemColl;
     edm::Wrapper<l1t::L1TkEmParticleCollection> w_trkemColl;
-    l1t::L1TkEmParticleRef reftrkEm ;
+    l1t::L1TkEmParticleRef reftrkEm;
     //l1t::L1TkEmParticleRefVector refVectrkEmColl ;
     //l1t::L1TkEmParticleVectorRef vecReftrkEmColl ;
     //edm::reftobase::Holder<reco::Candidate, l1t::L1TkEmParticleRef> rtbtrke;
 
     // L1TkEGTauParticle
-    l1t::L1TkEGTauParticleCollection trkegColl ;
+    l1t::L1TkEGTauParticleCollection trkegColl;
     edm::Wrapper<l1t::L1TkEGTauParticleCollection> w_trkegColl;
-    l1t::L1TkEGTauParticleRef reftrkEG ;
+    l1t::L1TkEGTauParticleRef reftrkEG;
 
     // L1TrkTauParticle
-    l1t::L1TrkTauParticleCollection tktauColl ;
+    l1t::L1TrkTauParticleCollection tktauColl;
     edm::Wrapper<l1t::L1TrkTauParticleCollection> w_tktauColl;
-    l1t::L1TrkTauParticleRef reftkTau ;
-    
+    l1t::L1TrkTauParticleRef reftkTau;
+
     // L1CaloTkTauParticle
-    l1t::L1CaloTkTauParticleCollection calotrktauColl ;
+    l1t::L1CaloTkTauParticleCollection calotrktauColl;
     edm::Wrapper<l1t::L1CaloTkTauParticleCollection> w_calotrktauColl;
-    l1t::L1CaloTkTauParticleRef refcalotrkTau ;
+    l1t::L1CaloTkTauParticleRef refcalotrkTau;
 
     // L1TkElectronParticle
-    l1t::L1TkElectronParticleCollection trkeleColl ;
+    l1t::L1TkElectronParticleCollection trkeleColl;
     edm::Wrapper<l1t::L1TkElectronParticleCollection> w_trkeleColl;
-    l1t::L1TkElectronParticleRef reftrkEle ;
-    
+    l1t::L1TkElectronParticleRef reftrkEle;
+
     // L1TkJetParticle
-    l1t::L1TkJetParticleCollection trkjetColl ;
+    l1t::L1TkJetParticleCollection trkjetColl;
     edm::Wrapper<l1t::L1TkJetParticleCollection> w_trkjetColl;
-    l1t::L1TkJetParticleRef reftrkJet ;
-    l1t::L1TkJetParticleRefProd refTkProdJet ;
-    
+    l1t::L1TkJetParticleRef reftrkJet;
+    l1t::L1TkJetParticleRefProd refTkProdJet;
+
     // L1TkHTMissParticle
-     l1t::L1TkHTMissParticle TkHTMiss ;
-    l1t::L1TkHTMissParticleCollection TkHTMissColl ;
+    l1t::L1TkHTMissParticle TkHTMiss;
+    l1t::L1TkHTMissParticleCollection TkHTMissColl;
     edm::Wrapper<l1t::L1TkHTMissParticle> w_TkHTMiss;
     edm::Wrapper<l1t::L1TkHTMissParticleCollection> w_TkHTMissColl;
-    
+
     /*
     // L1TkMuonParticle
     l1t::L1TkMuonParticleCollection trkmuColl ;
     edm::Wrapper<l1t::L1TkMuonParticleCollection> w_trkmuColl;
     l1t::L1TkMuonParticleRef reftrkMu ;
     */
-    
+
     // L1TkGlbMuonParticle
-    l1t::L1TkGlbMuonParticleCollection trkglbmuColl ;
+    l1t::L1TkGlbMuonParticleCollection trkglbmuColl;
     edm::Wrapper<l1t::L1TkGlbMuonParticleCollection> w_trkglbmuColl;
-    l1t::L1TkGlbMuonParticleRef reftrkGlbMu ;
-    
+    l1t::L1TkGlbMuonParticleRef reftrkGlbMu;
+
     // L1TkTauParticle
-    l1t::L1TkTauParticleCollection trktauColl ;
+    l1t::L1TkTauParticleCollection trktauColl;
     edm::Wrapper<l1t::L1TkTauParticleCollection> w_trktauColl;
-    l1t::L1TkTauParticleRef reftrkTau ;
+    l1t::L1TkTauParticleRef reftrkTau;
 
     // L1TkPhiCandidate
     l1t::L1TkPhiCandidateCollection trkPhiColl;
@@ -199,8 +207,7 @@ namespace
     edm::Wrapper<l1t::L1TkBsCandidateCollection> w_trkBsColl;
     l1t::L1TkBsCandidateRef reftrkBs;
     //l1t::L1TkBsCandidateRefProd refTkProdBs;
-    
   };
-}
+}  // namespace
 
 #endif

--- a/DataFormats/L1TrackTrigger/src/classes.h
+++ b/DataFormats/L1TrackTrigger/src/classes.h
@@ -13,7 +13,194 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+// includes needed for the L1TrackTriggerObjects
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEGTauParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TrkTauParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1CaloTkTauParticle.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h"
+
+//#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h"
+//#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkGlbMuonParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidate.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkPhiCandidateFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkBsCandidate.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkBsCandidateFwd.h"
+
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
+
+namespace 
+{
+  struct dictionary1 {
+    /// Main template type
+    Ref_Phase2TrackerDigi_  PD;
+    std::vector< Ref_Phase2TrackerDigi_ >                              V_PD;
+  };
+
+  struct dictionary2 {
+    /// TTCluster and containers
+    TTCluster< Ref_Phase2TrackerDigi_ >                                               C_PD;
+    std::vector< TTCluster< Ref_Phase2TrackerDigi_ > >                              V_C_PD;
+    edm::Wrapper< std::vector< TTCluster< Ref_Phase2TrackerDigi_ > > >            W_V_C_PD;
+    edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >                   SDV_C_PD;
+    edm::Wrapper< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > W_SDV_C_PD;
+
+    /// edm::Ref to TTCluster in edmNew::DetSetVector and containers
+    edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > >                                    R_C_PD;
+    edm::Wrapper< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > >                  W_R_C_PD;
+    std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > >                   V_R_C_PD;
+    edm::Wrapper< std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > > W_V_R_C_PD;
+  };
+
+  struct dictionary3 {
+    /// TTStub and containers
+    TTStub< Ref_Phase2TrackerDigi_ >                                               S_PD;
+    std::vector< TTStub< Ref_Phase2TrackerDigi_ > >                              V_S_PD;
+    edm::Wrapper< std::vector< TTStub< Ref_Phase2TrackerDigi_ > > >            W_V_S_PD;
+    edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >                   SDV_S_PD;
+    edm::Wrapper< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > > > W_SDV_S_PD;
+
+    /// edm::Ref to TTStub in edmNew::DetSetVector and containers
+    edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > >                                    R_S_PD;
+    edm::Wrapper< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > >                  W_R_S_PD;
+    std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > >                   V_R_S_PD;
+    edm::Wrapper< std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > > W_V_R_S_PD;
+  };
+
+
+  struct dictionarytrack {
+    /// TTTrack and containers
+    TTTrack< Ref_Phase2TrackerDigi_ >                                               T_PD;
+    std::vector< TTTrack< Ref_Phase2TrackerDigi_ > >                              V_T_PD;
+    edm::Wrapper< std::vector< TTTrack< Ref_Phase2TrackerDigi_ > > >            W_V_T_PD;
+    edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >                   SDV_T_PD;
+    edm::Wrapper< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > > > W_SDV_T_PD;
+
+    /// edm::Ref to TTTrack in edmNew::DetSetVector and containers
+    edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > >                                    R_T_PD;
+    edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >                                                                                               P_T_PD;
+    edm::Wrapper< edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > > >                  W_R_T_PD;
+    std::vector< edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > > >                   V_R_T_PD;
+    edm::Wrapper< std::vector< edm::Ref< edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > >, TTTrack< Ref_Phase2TrackerDigi_ > > > > W_V_R_T_PD;
+  };
+
+
+//  L1TrackTriggerObjects stuff :
+
+  struct dictionaryl1tkobj {
+    // L1 Primary Vertex
+    l1t::L1TkPrimaryVertex trzvtx;
+    edm::Wrapper<l1t::L1TkPrimaryVertexCollection> trzvtxColl;
+    edm::Ref<l1t::L1TkPrimaryVertexCollection > trkvtxRef ;
+    
+    
+    // L1TkEtMiss... following L1EtMiss...
+    l1t::L1TkEtMissParticle TketMiss ;
+    l1t::L1TkEtMissParticleCollection TketMissColl ;
+    edm::Wrapper<l1t::L1TkEtMissParticle> w_TketMiss;
+    edm::Wrapper<l1t::L1TkEtMissParticleCollection> w_TketMissColl;
+    //l1t::L1TkEtMissParticleRef refTkEtMiss ;
+    //l1t::L1TkEtMissParticleRefVector refTkVecEtMiss ;
+    //l1t::L1TkEtMissParticleVectorRef vecTkRefEtMissColl ;
+    //l1t::L1TkEtMissParticleRefProd refTkProdEtMiss ;
+    //edm::reftobase::Holder<reco::Candidate, l1t::L1TkEtMissParticleRef> rtbTkm1;
+    //edm::reftobase::Holder<reco::Candidate, l1t::L1TkEtMissParticleRefProd> rtbTkm2;
+    
+    // L1TkEmParticle
+    l1t::L1TkEmParticleCollection trkemColl ;
+    edm::Wrapper<l1t::L1TkEmParticleCollection> w_trkemColl;
+    l1t::L1TkEmParticleRef reftrkEm ;
+    //l1t::L1TkEmParticleRefVector refVectrkEmColl ;
+    //l1t::L1TkEmParticleVectorRef vecReftrkEmColl ;
+    //edm::reftobase::Holder<reco::Candidate, l1t::L1TkEmParticleRef> rtbtrke;
+
+    // L1TkEGTauParticle
+    l1t::L1TkEGTauParticleCollection trkegColl ;
+    edm::Wrapper<l1t::L1TkEGTauParticleCollection> w_trkegColl;
+    l1t::L1TkEGTauParticleRef reftrkEG ;
+
+    // L1TrkTauParticle
+    l1t::L1TrkTauParticleCollection tktauColl ;
+    edm::Wrapper<l1t::L1TrkTauParticleCollection> w_tktauColl;
+    l1t::L1TrkTauParticleRef reftkTau ;
+    
+    // L1CaloTkTauParticle
+    l1t::L1CaloTkTauParticleCollection calotrktauColl ;
+    edm::Wrapper<l1t::L1CaloTkTauParticleCollection> w_calotrktauColl;
+    l1t::L1CaloTkTauParticleRef refcalotrkTau ;
+
+    // L1TkElectronParticle
+    l1t::L1TkElectronParticleCollection trkeleColl ;
+    edm::Wrapper<l1t::L1TkElectronParticleCollection> w_trkeleColl;
+    l1t::L1TkElectronParticleRef reftrkEle ;
+    
+    // L1TkJetParticle
+    l1t::L1TkJetParticleCollection trkjetColl ;
+    edm::Wrapper<l1t::L1TkJetParticleCollection> w_trkjetColl;
+    l1t::L1TkJetParticleRef reftrkJet ;
+    l1t::L1TkJetParticleRefProd refTkProdJet ;
+    
+    // L1TkHTMissParticle
+     l1t::L1TkHTMissParticle TkHTMiss ;
+    l1t::L1TkHTMissParticleCollection TkHTMissColl ;
+    edm::Wrapper<l1t::L1TkHTMissParticle> w_TkHTMiss;
+    edm::Wrapper<l1t::L1TkHTMissParticleCollection> w_TkHTMissColl;
+    
+    /*
+    // L1TkMuonParticle
+    l1t::L1TkMuonParticleCollection trkmuColl ;
+    edm::Wrapper<l1t::L1TkMuonParticleCollection> w_trkmuColl;
+    l1t::L1TkMuonParticleRef reftrkMu ;
+    */
+    
+    // L1TkGlbMuonParticle
+    l1t::L1TkGlbMuonParticleCollection trkglbmuColl ;
+    edm::Wrapper<l1t::L1TkGlbMuonParticleCollection> w_trkglbmuColl;
+    l1t::L1TkGlbMuonParticleRef reftrkGlbMu ;
+    
+    // L1TkTauParticle
+    l1t::L1TkTauParticleCollection trktauColl ;
+    edm::Wrapper<l1t::L1TkTauParticleCollection> w_trktauColl;
+    l1t::L1TkTauParticleRef reftrkTau ;
+
+    // L1TkPhiCandidate
+    l1t::L1TkPhiCandidateCollection trkPhiColl;
+    edm::Wrapper<l1t::L1TkPhiCandidateCollection> w_trkPhiColl;
+    l1t::L1TkPhiCandidateRef reftrkPhi;
+    //l1t::L1TkPhiCandidateRefProd refTkProdPhi;
+
+    // L1TkBsCandidate
+    l1t::L1TkBsCandidateCollection trkBsColl;
+    edm::Wrapper<l1t::L1TkBsCandidateCollection> w_trkBsColl;
+    l1t::L1TkBsCandidateRef reftrkBs;
+    //l1t::L1TkBsCandidateRefProd refTkProdBs;
+    
+  };
+}
 
 #endif

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -1,3 +1,4 @@
+
 <lcgdict>
   <class name="TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
   <class name="TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >" />
@@ -20,6 +21,147 @@
   <class name="vector<TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTStub<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
   <class name="vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >" />
+  <class pattern="TTCluster<*>" />
+  <class pattern="std::vector<TTCluster<*>>" />
+  <class pattern="edm::Wrapper<std::vector<TTCluster<*>>>" />
+  <class pattern="edmNew::DetSetVector<TTCluster<*>>" />
+  <class pattern="edm::Wrapper<edmNew::DetSetVector<TTCluster<*>>>" />
+  <class pattern="edm::Ref<edmNew::DetSetVector<TTCluster<*>>,TTCluster<*>,edmNew::DetSetVector<TTCluster<*>>::FindForDetSetVector>" />
+  <class pattern="edm::Wrapper<edm::Ref<edmNew::DetSetVector<TTCluster<*>>,TTCluster<*>,edmNew::DetSetVector<TTCluster<*>>::FindForDetSetVector>>" />
+  <class pattern="TTStub<*>" />
+  <class pattern="std::vector<TTStub<*>>" />
+  <class pattern="edm::Wrapper<std::vector<TTStub<*>>>" />
+  <class pattern="edmNew::DetSetVector<TTStub<*>>" />
+  <class pattern="edm::Wrapper<edmNew::DetSetVector<TTStub<*>>>" />
+  <class pattern="edm::Ref<edmNew::DetSetVector<TTStub<*>>,TTStub<*>,edmNew::DetSetVector<TTStub<*>>::FindForDetSetVector>" />
+  <class pattern="edm::Wrapper<edm::Ref<edmNew::DetSetVector<TTStub<*>>,TTStub<*>,edmNew::DetSetVector<TTStub<*>>::FindForDetSetVector>>" />
+  <class pattern="TTTrack<*>" />
+  <class pattern="std::vector<TTTrack<*>>" />
+  <class pattern="edm::Wrapper<std::vector<TTTrack<*>>>" />
+  <class pattern="edmNew::DetSetVector<TTTrack<*>>" />
+  <class pattern="edm::Wrapper<edmNew::DetSetVector<TTTrack<*>>>" />
+  <class pattern="edm::Ref<edmNew::DetSetVector<TTTrack<*>>,TTTrack<*>,edmNew::DetSetVector<TTTrack<*>>::FindForDetSetVector>" />
+  <class pattern="edm::Wrapper<edm::Ref<edmNew::DetSetVector<TTTrack<*>>,TTTrack<*>,edmNew::DetSetVector<TTTrack<*>>::FindForDetSetVector>>" />
+
+ <class name="l1t::L1TkPrimaryVertex" ClassVersion="12">
+  <version ClassVersion="12" checksum="515857374"/>
+ </class>
+ <class name="std::vector<l1t::L1TkPrimaryVertex>"/>
+ <class name="edm::Wrapper<std::vector<l1t::L1TkPrimaryVertex> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkPrimaryVertex>,l1t::L1TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkPrimaryVertex>,l1t::L1TkPrimaryVertex> >"/>
+
+  <class name="l1t::L1TkEtMissParticle" ClassVersion="15">
+   <version ClassVersion="15" checksum="2000954037"/>
+  </class>
+  <class name="std::vector<l1t::L1TkEtMissParticle>"/>
+ <class name="edm::Wrapper<l1t::L1TkEtMissParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkEtMissParticle> >"/>
+
+  <class name="l1t::L1TkEmParticle" ClassVersion="15">
+   <version ClassVersion="15" checksum="2840464053"/>
+   <version ClassVersion="14" checksum="725108714"/>
+  </class>
+  <class name="std::vector<l1t::L1TkEmParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkEmParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkEmParticle>,l1t::L1TkEmParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkEmParticle>,l1t::L1TkEmParticle> >"/>
+
+  <class name="l1t::L1TkEGTauParticle" ClassVersion="15">
+   <version ClassVersion="15" checksum="1844281045"/>
+   <version ClassVersion="14" checksum="2553371049"/>
+  </class>
+  <class name="std::vector<l1t::L1TkEGTauParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkEGTauParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkEGTauParticle>,l1t::L1TkEGTauParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkEGTauParticle>,l1t::L1TkEGTauParticle> >"/>
+
+  <class name="l1t::L1TrkTauParticle" ClassVersion="15">
+   <version ClassVersion="15" checksum="1831183512"/>
+   <version ClassVersion="14" checksum="2199737658"/>
+  </class>
+  <class name="std::vector<l1t::L1TrkTauParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TrkTauParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TrkTauParticle>,l1t::L1TrkTauParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TrkTauParticle>,l1t::L1TrkTauParticle> >"/>
+
+  <class name="l1t::L1CaloTkTauParticle" ClassVersion="17">
+   <version ClassVersion="17" checksum="4265295581"/> 
+   <version ClassVersion="17" checksum="1859218518"/> 
+   <version ClassVersion="16" checksum="3866766711"/> 
+   <version ClassVersion="15" checksum="3464188151"/>
+   <version ClassVersion="14" checksum="848433433"/>
+  </class>
+  <class name="std::vector<l1t::L1CaloTkTauParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1CaloTkTauParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1CaloTkTauParticle>,l1t::L1CaloTkTauParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1CaloTkTauParticle>,l1t::L1CaloTkTauParticle> >"/>
+
+  <class name="l1t::L1TkElectronParticle" ClassVersion="16">
+   <version ClassVersion="16" checksum="1303027420"/>
+   <version ClassVersion="15" checksum=" 733765513"/>
+   <version ClassVersion="14" checksum="1208575695"/>
+  </class>
+  <class name="edm::Ptr<TTTrack< Ref_Phase2TrackerDigi_ > >"/>
+  <class name="std::vector<l1t::L1TkElectronParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkElectronParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkElectronParticle>,l1t::L1TkElectronParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkElectronParticle>,l1t::L1TkElectronParticle> >"/>
+
+  <class name="l1t::L1TkJetParticle" ClassVersion="14">
+   <version ClassVersion="14" checksum="580173330"/>
+   <version ClassVersion="13" checksum="3035102634"/>
+  </class>
+  <class name="std::vector<l1t::L1TkJetParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkJetParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkJetParticle>,l1t::L1TkJetParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkJetParticle>,l1t::L1TkJetParticle> >"/>
+
+  <class name="edm::RefProd< std::vector<l1t::L1TkJetParticle> >"/>
+
+  <class name="l1t::L1TkHTMissParticle" ClassVersion="15">
+   <version ClassVersion="15" checksum="1645583494"/>
+  </class>
+  <class name="std::vector<l1t::L1TkHTMissParticle>"/>
+  <class name="edm::Wrapper<l1t::L1TkHTMissParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkHTMissParticle> >"/>
+
+  <!--
+  <class name="l1t::L1TkMuonParticle" ClassVersion="20">
+   <version ClassVersion="20" checksum="2252639058"/>
+   <version ClassVersion="19" checksum="1627050265"/>
+   <version ClassVersion="16" checksum="496411268"/>
+   <version ClassVersion="15" checksum="2096101246"/>
+   <version ClassVersion="14" checksum="818052779"/>
+   <version ClassVersion="13" checksum="3532596056"/>
+   <version ClassVersion="12" checksum="1571385768"/>
+  </class>
+  <class name="std::vector<l1t::L1TkMuonParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkMuonParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkMuonParticle>,l1t::L1TkMuonParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkMuonParticle>,l1t::L1TkMuonParticle> >"/>
+  -->
+
+  <class name="l1t::L1TkGlbMuonParticle" ClassVersion="0">
+   <version ClassVersion="0"  checksum="1258760671"/>
+   <version ClassVersion="-1" checksum="1209763769"/>
+  </class>
+  <class name="std::vector<l1t::L1TkGlbMuonParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkGlbMuonParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkGlbMuonParticle>,l1t::L1TkGlbMuonParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkGlbMuonParticle>,l1t::L1TkGlbMuonParticle> >"/>
+
+  <class name="l1t::L1TkTauParticle" ClassVersion="14">
+   <version ClassVersion="14" checksum="916039889"/>
+  </class>
+  <class name="std::vector<l1t::L1TkTauParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1t::L1TkTauParticle> >"/>
+  <class name="edm::Ref<std::vector<l1t::L1TkTauParticle>,l1t::L1TkTauParticle,edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkTauParticle>,l1t::L1TkTauParticle> >"/>
+
+  <class name="l1t::L1TkPhiCandidate" ClassVersion="-1">
+    <version ClassVersion="-1" checksum="206816256" />
+  </class>
+  <class name="std::vector<l1t::L1TkPhiCandidate>" />
+  <class name="edm::Wrapper<std::vector<l1t::L1TkPhiCandidate>>" />
+  <class name="edm::Ref<std::vector<l1t::L1TkPhiCandidate>, l1t::L1TkPhiCandidate, edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkPhiCandidate>, l1t::L1TkPhiCandidate>>" />
+
+  <class name="l1t::L1TkBsCandidate" ClassVersion="-1">
+    <version ClassVersion="-1" checksum="1151008742" />
+  </class>
+  <class name="std::vector<l1t::L1TkBsCandidate>" />
+  <class name="edm::Wrapper<std::vector<l1t::L1TkBsCandidate>>" />
+  <class name="edm::Ref<std::vector<l1t::L1TkBsCandidate>, l1t::L1TkBsCandidate, edm::refhelper::FindUsingAdvance<std::vector<l1t::L1TkBsCandidate>, l1t::L1TkBsCandidate>>" />
 
 </lcgdict>
 

--- a/DataFormats/Phase2L1CaloTrig/BuildFile.xml
+++ b/DataFormats/Phase2L1CaloTrig/BuildFile.xml
@@ -1,0 +1,17 @@
+<flags   GENREFLEX_ARGS="--"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/Math"/>
+<use   name="DataFormats/SiPixelDetId"/>
+<use   name="DataFormats/L1Trigger"/>
+<use   name="boost"/>
+<use   name="rootrflx"/>
+<use   name="hepmc"/>
+<use   name="clhep"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
+<export>
+  <lib   name="1"/>
+</export>
+

--- a/DataFormats/Phase2L1CaloTrig/interface/L1CaloJet.h
+++ b/DataFormats/Phase2L1CaloTrig/interface/L1CaloJet.h
@@ -1,0 +1,60 @@
+#ifndef L1CaloJets_h
+#define L1CaloJets_h
+
+#include <vector>
+#include <map>
+#include <string>
+#include <algorithm>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+
+namespace l1slhc
+{
+
+  class L1CaloJet : public l1t::L1Candidate {
+    public:
+      L1CaloJet() : l1t::L1Candidate(), calibratedPt_(0.), hovere_(0.), iso_(0.), PUcorrPt_(0.) {};
+
+      L1CaloJet(const PolarLorentzVector& p4, float calibratedPt, float hovere, float iso, 
+            float PUcorrPt = 0. ) :
+                    l1t::L1Candidate(p4), calibratedPt_(calibratedPt), hovere_(hovere), iso_(iso),
+                    PUcorrPt_(PUcorrPt) {};
+
+      // For decay mode related checks with CaloTaus
+      std::vector< std::vector< float > > associated_l1EGs;
+
+      virtual ~L1CaloJet() {};
+      inline float calibratedPt() const { return calibratedPt_; };
+      inline float hovere() const { return hovere_; };
+      inline float isolation() const { return iso_; };
+      inline float PUcorrPt() const { return PUcorrPt_; };
+      void SetExperimentalParams(const std::map<std::string, float> &params) { experimentalParams_ = params; };
+      const std::map<std::string, float> GetExperimentalParams() const { return experimentalParams_; };
+      inline float GetExperimentalParam(std::string name) const {
+         try { return experimentalParams_.at(name); }
+         catch (...) { 
+            std::cout << "Error: no mapping for ExperimentalParam: " << name << std::endl;
+            return -99.; 
+         }
+      };
+
+
+    
+    private:
+      // pT calibrated to get
+      float calibratedPt_;
+      // HCal energy in region behind cluster (for size, look in producer) / ECal energy in cluster
+      float hovere_;
+      // ECal isolation (for outer window size, again look in producer)
+      float iso_;
+      // Pileup-corrected energy deposit, not studied carefully yet, don't use
+      float PUcorrPt_;
+      // For investigating novel algorithm parameters
+      std::map<std::string, float> experimentalParams_;
+  };
+  
+  
+  // Concrete collection of output objects (with extra tuning information)
+  typedef std::vector<l1slhc::L1CaloJet> L1CaloJetsCollection;
+}
+#endif
+

--- a/DataFormats/Phase2L1CaloTrig/interface/L1CaloTower.h
+++ b/DataFormats/Phase2L1CaloTrig/interface/L1CaloTower.h
@@ -1,0 +1,43 @@
+//
+// T. Ruggles
+// 17 Sept 2018
+//
+// Description: Collection representing remaining ECAL energy post-L1EG clustering
+// and the associated HCAL tower. The ECAL crystal TPs "simEcalEBTriggerPrimitiveDigis"
+// within a 5x5 tower region are clustered to retain this ECAL energy info for passing 
+// to the GCT or further algos. The HCAL energy from the "simHcalTriggerPrimitiveDigis" 
+// is not specifically used in the L1EG algo beyond H/E, so the HCAL values here
+// correspond to the full, initial HCAL TP energy.
+
+
+#ifndef L1CaloTower_HH
+#define L1CaloTower_HH
+
+
+
+class L1CaloTower
+{
+    public:
+        float ecal_tower_et = 0.0;
+        float hcal_tower_et = 0.0;
+        int tower_iPhi = -99;
+        int tower_iEta = -99;
+        float tower_phi = -99;
+        float tower_eta = -99;
+
+        // L1EG info
+        float l1eg_tower_et = 0.0;
+        int n_l1eg = 0;
+        int l1eg_trkSS = 0;
+        int l1eg_trkIso = 0;
+        int l1eg_standaloneSS = 0;
+        int l1eg_standaloneIso = 0;
+
+        bool isBarrel = false;
+};
+  
+  
+// Collection of either ECAL or HCAL TPs with the Layer1 calibration constant attached, et_calibration
+typedef std::vector<L1CaloTower> L1CaloTowerCollection;
+
+#endif

--- a/DataFormats/Phase2L1CaloTrig/interface/L1EGCrystalCluster.h
+++ b/DataFormats/Phase2L1CaloTrig/interface/L1EGCrystalCluster.h
@@ -1,0 +1,113 @@
+#ifndef L1EGammaCrystalsCluster_h
+#define L1EGammaCrystalsCluster_h
+
+#include <vector>
+#include <map>
+#include <string>
+#include <algorithm>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+namespace l1slhc
+{
+
+  class L1EGCrystalCluster : public l1t::L1Candidate {
+    public:
+      L1EGCrystalCluster() : l1t::L1Candidate(), calibratedPt_(0.), hovere_(0.), iso_(0.), PUcorrPt_(0.), bremStrength_(0.),
+            e2x2_(0.), e2x5_(0.), e3x5_(0.), e5x5_(0.), standaloneWP_(0.), electronWP98_(0.), photonWP80_(0.), electronWP90_(0.),
+            looseL1TkMatchWP_(0.), stage2effMatch_(0.) {};
+
+      L1EGCrystalCluster(const PolarLorentzVector& p4, float calibratedPt, float hovere, float iso, DetId seedCrystal, 
+            float PUcorrPt = 0., float bremStrength = 0., float e2x2 = 0., float e2x5 = 0.,
+            float e3x5 = 0., float e5x5 = 0., bool standaloneWP = false, bool electronWP98 = false, bool photonWP80 = false,
+            bool electronWP90 = false, bool looseL1TkMatchWP = false, bool stage2effMatch = false ) :
+                    l1t::L1Candidate(p4), calibratedPt_(calibratedPt), hovere_(hovere), iso_(iso), seedCrystal_(seedCrystal),
+                    PUcorrPt_(PUcorrPt), bremStrength_(bremStrength), e2x2_(e2x2), e2x5_(e2x5),
+                    e3x5_(e3x5), e5x5_(e5x5), standaloneWP_(standaloneWP), electronWP98_(electronWP98), photonWP80_(photonWP80),
+                    electronWP90_(electronWP90), looseL1TkMatchWP_(looseL1TkMatchWP),
+                    stage2effMatch_(stage2effMatch) {};
+
+      virtual ~L1EGCrystalCluster() {};
+      inline float calibratedPt() const { return calibratedPt_; };
+      inline float hovere() const { return hovere_; };
+      inline float isolation() const { return iso_; };
+      inline float PUcorrPt() const { return PUcorrPt_; };
+      inline float bremStrength() const { return bremStrength_; };
+      inline DetId seedCrystal() const { return seedCrystal_; };
+      void SetCrystalPtInfo(std::vector<float> &info) {
+         std::sort(info.begin(), info.end());
+         std::reverse(info.begin(), info.end());
+         crystalPt_ = info;
+      };
+      void SetExperimentalParams(const std::map<std::string, float> &params) { experimentalParams_ = params; };
+      const std::map<std::string, float> GetExperimentalParams() const { return experimentalParams_; };
+      inline float GetExperimentalParam(std::string name) const {
+         try { return experimentalParams_.at(name); }
+         catch (...) { 
+            std::cout << "Error: no mapping for ExperimentalParam: " << name << std::endl;
+            return -99.; 
+         }
+      };
+
+      inline float e2x2() const { return e2x2_; };
+      inline float e2x5() const { return e2x5_; };
+      inline float e3x5() const { return e3x5_; };
+      inline float e5x5() const { return e5x5_; };
+      inline float standaloneWP() const { return standaloneWP_; };
+      inline float electronWP98() const { return electronWP98_; };
+      inline float photonWP80() const { return photonWP80_; };
+      inline float electronWP90() const { return electronWP90_; };
+      inline float looseL1TkMatchWP() const { return looseL1TkMatchWP_; };
+      inline float stage2effMatch() const { return stage2effMatch_; };
+
+      // The index range depends on the algorithm eta,phi window, currently 3x5
+      // The pt should always be ordered.
+      inline float GetCrystalPt(unsigned int index) const { return (index < crystalPt_.size()) ? crystalPt_[index] : 0.; };
+    
+    private:
+      // pT calibrated to Stage-2 (Phase-I) L1EG Objects.  NOTE
+      // all working points are defined with respect to cluster.pt(),
+      // not cluster.calibratedPt()
+      float calibratedPt_;
+      // HCal energy in region behind cluster (for size, look in producer) / ECal energy in cluster
+      float hovere_;
+      // ECal isolation (for outer window size, again look in producer)
+      float iso_;
+      // DetId of seed crystal used to make cluster (could be EBDetId or EEDetId)
+      DetId seedCrystal_;
+      // Pileup-corrected energy deposit, not studied carefully yet, don't use
+      float PUcorrPt_;
+      // Bremstrahlung strength, should be proportional to the likelihood of a brem.
+      float bremStrength_;
+      // Shower shape variable - max 2x2 energy containing seed crystal
+      float e2x2_;
+      // Shower shape variable - max 2x5 energy containing seed crystal, phi centered
+      float e2x5_;
+      // Shower shape variable - 3x5 energy containing seed crystal, phi centered
+      float e3x5_;
+      // Shower shape variable - 5x5 energy containing centered on seed crystal
+      float e5x5_;
+      // Standalone L1EG WP
+      bool standaloneWP_;
+      // 98% efficient electron WP, for electrons above 35 GeV
+      bool electronWP98_;
+      // 80% efficient photon WP, for photons above 35 GeV
+      bool photonWP80_;
+      // 90% efficient electron based WP, early rise to efficiency plateau
+      bool electronWP90_;
+      // loose isolation and shower shape requirements to be used in conjunction with L1Trk matching
+      bool looseL1TkMatchWP_;
+      // Stage-2 L1EG efficiency matched WP, for rate comparisons
+      bool stage2effMatch_;
+      // Crystal pt (in order of strength) for all crystals in the cluster
+      std::vector<float> crystalPt_;
+      // For investigating novel algorithm parameters
+      std::map<std::string, float> experimentalParams_;
+  };
+  
+  
+  // Concrete collection of output objects (with extra tuning information)
+  typedef std::vector<l1slhc::L1EGCrystalCluster> L1EGCrystalClusterCollection;
+}
+#endif
+

--- a/DataFormats/Phase2L1CaloTrig/src/classes.h
+++ b/DataFormats/Phase2L1CaloTrig/src/classes.h
@@ -1,0 +1,39 @@
+/// ////////////////////////////////////////
+/// Stacked Tracker Simulations          ///
+/// ////////////////////////////////////////
+
+#include "DataFormats/Common/interface/Wrapper.h"
+
+
+/*********************/
+/** L1 CALO TRIGGER **/
+/*********************/
+
+#include "DataFormats/Phase2L1CaloTrig/interface/L1EGCrystalCluster.h"
+#include "DataFormats/Phase2L1CaloTrig/interface/L1CaloTower.h"
+#include "DataFormats/Phase2L1CaloTrig/interface/L1CaloJet.h"
+
+
+namespace {
+  namespace {
+
+
+    l1slhc::L1EGCrystalCluster                       egcrystalcluster;
+    std::vector<l1slhc::L1EGCrystalCluster>         l1egcrystalclustervec;
+    l1slhc::L1EGCrystalClusterCollection            l1egcrystalclustercoll;
+    edm::Wrapper<l1slhc::L1EGCrystalClusterCollection>   wl1egcrystalclustercoll;
+
+    L1CaloTower                                     l1CaloTower;
+    std::vector<L1CaloTower>                        l1CaloTowervec;
+    L1CaloTowerCollection                           l1CaloTowercoll;
+    edm::Wrapper<L1CaloTowerCollection>             wl1CaloTowercoll;
+
+    l1slhc::L1CaloJet                               l1calojet;
+    std::vector<l1slhc::L1CaloJet>                  l1calojetvec;
+    l1slhc::L1CaloJetsCollection                    l1calojetcoll;
+    edm::Wrapper<l1slhc::L1CaloJetsCollection>      wl1calojetcoll;
+
+
+  }
+}
+

--- a/DataFormats/Phase2L1CaloTrig/src/classes_def.xml
+++ b/DataFormats/Phase2L1CaloTrig/src/classes_def.xml
@@ -1,0 +1,23 @@
+<!-- *********************************** -->
+<!-- Phase-2 Calo data dictionaries      -->
+<!-- *********************************** -->
+
+<lcgdict>
+
+  <class name="l1slhc::L1EGCrystalCluster" />
+  <class name="std::vector<l1slhc::L1EGCrystalCluster>" />
+  <class name="l1slhc::L1EGCrystalClusterCollection" />
+  <class name="edm::Wrapper<l1slhc::L1EGCrystalClusterCollection>" />
+
+  <class name="L1CaloTower" />
+  <class name="std::vector<L1CaloTower>" />
+  <class name="L1CaloTowerCollection" />
+  <class name="edm::Wrapper<L1CaloTowerCollection>" />
+
+  <class name="l1slhc::L1CaloJet" /> 
+  <class name="std::vector<l1slhc::L1CaloJet>" />
+  <class name="l1slhc::L1CaloJetsCollection" />
+  <class name="edm::Wrapper<l1slhc::L1CaloJetsCollection>" />
+
+</lcgdict>
+

--- a/DataFormats/Phase2L1ParticleFlow/BuildFile.xml
+++ b/DataFormats/Phase2L1ParticleFlow/BuildFile.xml
@@ -1,0 +1,9 @@
+<use   name="DataFormats/L1Trigger"/>
+<use   name="DataFormats/L1TrackTrigger"/>
+<use   name="DataFormats/L1THGCal"/>
+<use   name="DataFormats/Phase2L1CaloTrig"/>
+<use   name="rootrflx"/>
+<export>
+  <lib   name="1"/>
+</export>
+

--- a/DataFormats/Phase2L1ParticleFlow/interface/PFCandidate.h
+++ b/DataFormats/Phase2L1ParticleFlow/interface/PFCandidate.h
@@ -1,0 +1,51 @@
+#ifndef DataFormats_Phase2L1ParticleFlow_PFCandidate_h
+#define DataFormats_Phase2L1ParticleFlow_PFCandidate_h
+
+#include <vector>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFTrack.h"
+
+namespace l1t
+{
+
+  class PFCandidate : public L1Candidate {
+      public:
+          typedef edm::Ptr<l1t::Muon> MuonRef;
+          enum Kind { ChargedHadron=0, Electron=1, NeutralHadron=2, Photon=3, Muon=4 };
+
+          PFCandidate() {}
+          PFCandidate(Kind kind, int charge, const LorentzVector & p, float puppiWeight=-1, int hwpt=0, int hweta=0, int hwphi=0) :
+                PFCandidate(kind, charge, PolarLorentzVector(p), puppiWeight, hwpt, hweta, hwphi) {}
+          PFCandidate(Kind kind, int charge, const PolarLorentzVector & p, float puppiWeight=-1, int hwpt=0, int hweta=0, int hwphi=0) ; 
+
+          Kind id() const { return Kind(hwQual()); }
+
+          const PFTrackRef & pfTrack() const { return trackRef_; }
+          void setPFTrack(const PFTrackRef & ref) { trackRef_ = ref; }
+
+          const PFClusterRef & pfCluster() const { return clusterRef_; }
+          void setPFCluster(const PFClusterRef & ref) { clusterRef_ = ref; }
+
+          const MuonRef & muon() const { return muonRef_; }
+          void setMuon(const MuonRef & ref) { muonRef_ = ref; }
+
+          /// PUPPI weight (-1 if not available)
+          float puppiWeight() const { return puppiWeight_; }
+
+      private:
+          PFClusterRef clusterRef_;
+          PFTrackRef trackRef_;
+          MuonRef muonRef_;
+          float puppiWeight_;
+
+          void setPdgIdFromKind_(int charge, Kind kind);
+  };
+  
+  typedef std::vector<l1t::PFCandidate> PFCandidateCollection;
+  typedef edm::Ref<l1t::PFCandidateCollection> PFCandidateRef;
+  typedef edm::RefVector<l1t::PFCandidateCollection> PFCandidateRefVector;
+}
+#endif
+

--- a/DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h
+++ b/DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h
@@ -1,0 +1,68 @@
+#ifndef DataFormats_Phase2L1ParticleFlow_PFCluster_h
+#define DataFormats_Phase2L1ParticleFlow_PFCluster_h
+
+#include <vector>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+namespace l1t
+{
+
+  class PFCluster : public L1Candidate {
+      public:
+          /// constituent information. note that this is not going to be available in the hardware!
+          typedef std::pair<edm::Ptr<l1t::L1Candidate>, float> ConstituentAndFraction;
+          typedef std::vector<ConstituentAndFraction> ConstituentsAndFractions;
+
+          PFCluster() {}
+          PFCluster(float pt, float eta, float phi, float hOverE = 0, bool isEM = false, float ptError = 0, int hwpt=0, int hweta=0, int hwphi=0) : 
+              L1Candidate(PolarLorentzVector(pt,eta,phi,0), hwpt, hweta, hwphi, /*hwQuality=*/isEM ? 1 : 0),
+              hOverE_(hOverE), ptError_(ptError) {
+                setPdgId(isEM ? 22 : 130);
+              }
+          PFCluster(const LorentzVector & p4, float hOverE, bool isEM, float ptError = 0, int hwpt=0, int hweta=0, int hwphi=0) : 
+              L1Candidate(p4, hwpt, hweta, hwphi, /*hwQuality=*/isEM ? 1 : 0),
+              hOverE_(hOverE), ptError_(ptError) {
+                setPdgId(isEM ? 22 : 130);
+              }
+
+          float hOverE() const { return hOverE_; }
+          void setHOverE(float hOverE) { hOverE_ = hOverE; }
+
+          float emEt() const { 
+              if (hOverE_ == -1) return 0;
+              return pt() / ( 1 + hOverE_ );
+          }
+
+          // change the pt. H/E also recalculated to keep emEt constant
+          void calibratePt(float newpt, float preserveEmEt=true) ;
+
+          /// constituent information. note that this is not going to be available in the hardware!
+          const ConstituentsAndFractions & constituentsAndFractions() const { return constituents_; }
+          /// adds a candidate to this cluster; note that this only records the information, it's up to you to also set the 4-vector appropriately
+          void addConstituent(const edm::Ptr<l1t::L1Candidate> & cand, float fraction = 1.0) {
+              constituents_.emplace_back(cand, fraction);
+          }
+
+          float ptError() const { return ptError_; }
+          void setPtError(float ptError) { ptError_ = ptError; }
+
+          bool isEM() const { return hwQual() == 1; }
+          void setIsEM(bool isEM) { setHwQual(isEM ? 1 : 0); }
+
+          float egVsPionMVAOut() const { return egVsPionMVAOut_; }
+          void setEgVsPionMVAOut(float egVsPionMVAOut) { egVsPionMVAOut_ = egVsPionMVAOut; }
+          
+          float egVsPUMVAOut() const { return egVsPUMVAOut_; }
+          void setEgVsPUMVAOut(float egVsPUMVAOut) { egVsPUMVAOut_ = egVsPUMVAOut; }
+
+      private:
+          float hOverE_, ptError_, egVsPionMVAOut_, egVsPUMVAOut_;
+          ConstituentsAndFractions constituents_;
+  };
+  
+  typedef std::vector<l1t::PFCluster> PFClusterCollection;
+  typedef edm::Ref<l1t::PFClusterCollection> PFClusterRef;
+}
+#endif
+

--- a/DataFormats/Phase2L1ParticleFlow/interface/PFJet.h
+++ b/DataFormats/Phase2L1ParticleFlow/interface/PFJet.h
@@ -1,0 +1,51 @@
+#ifndef DataFormats_Phase2L1ParticleFlow_PFJet_h
+#define DataFormats_Phase2L1ParticleFlow_PFJet_h
+
+#include <vector>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+namespace l1t
+{
+
+  class PFJet : public L1Candidate {
+      public:
+          /// constituent information. note that this is not going to be available in the hardware!
+          typedef std::vector<edm::Ptr<l1t::L1Candidate>> Constituents;
+
+          PFJet() {}
+          PFJet(float pt, float eta, float phi, float mass = 0, int hwpt=0, int hweta=0, int hwphi=0) : 
+              L1Candidate(PolarLorentzVector(pt,eta,phi,mass), hwpt, hweta, hwphi, /*hwQuality=*/0), rawPt_(pt) {}
+
+          PFJet(const LorentzVector & p4, int hwpt=0, int hweta=0, int hwphi=0) : 
+              L1Candidate(p4, hwpt, hweta, hwphi, /*hwQuality=*/0), rawPt_(p4.Pt()) {}
+
+          // change the pt (but doesn't change the raw pt)
+          void calibratePt(float newpt) ;
+
+          // return the raw pT()
+          float rawPt() const { return rawPt_; }
+
+          /// constituent information. note that this is not going to be available in the hardware!
+          const Constituents & constituents() const { return constituents_; }
+          /// adds a candidate to this cluster; note that this only records the information, it's up to you to also set the 4-vector appropriately
+          void addConstituent(const edm::Ptr<l1t::L1Candidate> & cand) {
+              constituents_.emplace_back(cand);
+          }
+
+          // candidate interface
+          size_t numberOfDaughters() const override { return constituents_.size(); }
+          const reco::Candidate * daughter( size_type i ) const override { return constituents_[i].get(); }
+          using reco::LeafCandidate::daughter; // avoid hiding the base
+          edm::Ptr<l1t::L1Candidate> daughterPtr( size_type i ) const { return constituents_[i]; }
+
+      private:
+          float rawPt_;
+          Constituents constituents_;
+  };
+  
+  typedef std::vector<l1t::PFJet> PFJetCollection;
+  typedef edm::Ref<l1t::PFJetCollection> PFJetRef;
+}
+#endif
+

--- a/DataFormats/Phase2L1ParticleFlow/interface/PFTau.h
+++ b/DataFormats/Phase2L1ParticleFlow/interface/PFTau.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_Phase2L1ParticleFlow_PFTau_h
+#define DataFormats_Phase2L1ParticleFlow_PFTau_h
+
+#include <algorithm>
+#include <vector>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+
+namespace l1t
+{
+
+  class PFTau : public L1Candidate {
+      public:
+          PFTau() {}
+	  enum  { unidentified=0, oneprong=1, oneprongpi0=2, threeprong=3};
+          PFTau(const LorentzVector & p, float iso=-1, float fulliso=-1, int id=0,int hwpt=0, int hweta=0, int hwphi=0) :
+   	  PFTau(PolarLorentzVector(p), iso, id, hwpt, hweta, hwphi) {}
+		PFTau(const PolarLorentzVector & p, float iso=-1, float fulliso=-1,int id=0, int hwpt=0, int hweta=0, int hwphi=0) ; 
+          float chargedIso() const { return iso_; }
+          float fullIso()    const { return fullIso_; }
+	  int   id()         const { return id_; }
+	  bool  passLooseNN()  const { return iso_*(0.1+0.2*(min(pt(),100.)))*1./20.1 > 0.05;}
+	  bool  passLoosePF()  const { return fullIso_ < 10.0;}
+	  bool  passTightNN()  const { return iso_*(0.1+0.2*(min(pt(),100.)))*1./20.1 > 0.25;}
+	  bool  passTightPF()  const { return fullIso_ < 5.0;}
+	  
+
+      private:
+          float iso_;
+          float fullIso_;
+	  int   id_;
+  };
+  
+  typedef std::vector<l1t::PFTau> PFTauCollection;
+}
+#endif
+

--- a/DataFormats/Phase2L1ParticleFlow/interface/PFTrack.h
+++ b/DataFormats/Phase2L1ParticleFlow/interface/PFTrack.h
@@ -1,0 +1,74 @@
+#ifndef DataFormats_Phase2L1ParticleFlow_PFTrack_h
+#define DataFormats_Phase2L1ParticleFlow_PFTrack_h
+
+#include <vector>
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"     
+#include "DataFormats/Common/interface/Ref.h"
+
+namespace l1t
+{
+
+  class PFTrack : public L1Candidate {
+      public:
+          typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
+          typedef edm::Ref<std::vector<L1TTTrackType>> TrackRef;
+
+          PFTrack() {}
+          PFTrack(int charge, const reco::Particle::LorentzVector & p4, const reco::Particle::Point & vtx, const TrackRef & tkPtr, int nPar, float caloEta, float caloPhi, float trkPtError=-1, float caloPtError=-1, int quality=1, bool isMuon=false, int hwpt=0, int hweta=0, int hwphi=0) : 
+              L1Candidate(p4, hwpt, hweta, hwphi, quality),
+              trackRef_(tkPtr),
+              caloEta_(caloEta),
+              caloPhi_(caloPhi),
+              trkPtError_(trkPtError),
+              caloPtError_(caloPtError),
+              isMuon_(isMuon),
+              nPar_(nPar)
+              {
+                setCharge(charge);
+                setVertex(vtx);
+              }
+
+          const TrackRef & track() const { return trackRef_; }
+          void setTrack(const TrackRef & ref) { trackRef_ = ref; }
+
+          /// eta coordinate propagated at the calorimeter surface used for track-cluster matching
+          float caloEta() const { return caloEta_; }
+          /// phi coordinate propagated at the calorimeter surface used for track-cluster matching
+          float caloPhi() const { return caloPhi_; }
+          void setCaloEtaPhi(float eta, float phi) { caloEta_ = eta; caloPhi_ = phi; }
+
+          /// uncertainty on track pt 
+          float trkPtError() const { return trkPtError_; }
+          void setTrkPtError(float ptErr) { trkPtError_ = ptErr; }
+
+          /// uncertainty on calorimetric response for a hadron with pt equal to this track's pt
+          float caloPtError() const { return caloPtError_; }
+          void setCaloPtError(float ptErr) { caloPtError_ = ptErr; }
+
+          bool isMuon() const { return isMuon_; }
+          void setIsMuon(bool isMuon) { isMuon_ = isMuon; } 
+
+          int quality() const { return hwQual(); }
+          void setQuality(int quality) { setHwQual(quality); }
+
+          unsigned int nPar() const { return nPar_; }
+          unsigned int nStubs() const { return track()->getStubRefs().size(); }
+          float normalizedChi2() const { return track()->getChi2Red(nPar()); }
+          float chi2() const { return track()->getChi2(nPar()); }
+
+      private:
+          TrackRef trackRef_;
+          float caloEta_, caloPhi_;
+          float trkPtError_;
+          float caloPtError_;
+          bool isMuon_;
+          unsigned int nPar_;
+  };
+  
+  typedef std::vector<l1t::PFTrack> PFTrackCollection;
+  typedef edm::Ref<l1t::PFTrackCollection> PFTrackRef;
+}
+#endif
+

--- a/DataFormats/Phase2L1ParticleFlow/src/PFCandidate.cc
+++ b/DataFormats/Phase2L1ParticleFlow/src/PFCandidate.cc
@@ -1,0 +1,18 @@
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCandidate.h"
+
+l1t::PFCandidate::PFCandidate(Kind kind, int charge, const PolarLorentzVector & p, float puppiWeight, int hwpt, int hweta, int hwphi) :
+        L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)),
+        puppiWeight_(puppiWeight) {
+    setCharge(charge);
+    setPdgIdFromKind_(charge,kind);
+}
+
+void l1t::PFCandidate::setPdgIdFromKind_(int charge, Kind kind) {
+    switch(kind) {
+        case ChargedHadron: setPdgId(charge > 0 ? 211 : -211); break;
+        case Electron: setPdgId(charge > 0 ? -11 : +11); break;
+        case NeutralHadron: setPdgId(130); break;
+        case Photon: setPdgId(22); break;
+        case Muon: setPdgId(charge > 0 ? -13 : +13); break;
+    };
+}

--- a/DataFormats/Phase2L1ParticleFlow/src/PFCluster.cc
+++ b/DataFormats/Phase2L1ParticleFlow/src/PFCluster.cc
@@ -1,0 +1,13 @@
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h"
+
+void l1t::PFCluster::calibratePt(float newpt, float preserveEmEt) {
+    float currEmEt = emEt();
+    ptError_ *= newpt / pt();
+    setP4(PolarLorentzVector(newpt, eta(), phi(), mass()));
+    if (preserveEmEt) {
+        float hNew = std::max<float>(pt() - currEmEt, 0);
+        hOverE_ = (currEmEt > 0 ? hNew/currEmEt : -1);
+    }
+}
+
+

--- a/DataFormats/Phase2L1ParticleFlow/src/PFJet.cc
+++ b/DataFormats/Phase2L1ParticleFlow/src/PFJet.cc
@@ -1,0 +1,7 @@
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFJet.h"
+
+void l1t::PFJet::calibratePt(float newpt) {
+    setP4(PolarLorentzVector(newpt, eta(), phi(), mass()));
+}
+
+

--- a/DataFormats/Phase2L1ParticleFlow/src/PFTau.cc
+++ b/DataFormats/Phase2L1ParticleFlow/src/PFTau.cc
@@ -1,0 +1,9 @@
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFTau.h"
+
+l1t::PFTau::PFTau(const PolarLorentzVector & p, float iso, float fulliso, int id, int hwpt, int hweta, int hwphi) :
+        L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(0)),
+        iso_(iso),
+        fullIso_(fulliso),
+        id_(id) {
+	}
+

--- a/DataFormats/Phase2L1ParticleFlow/src/PFTrack.cc
+++ b/DataFormats/Phase2L1ParticleFlow/src/PFTrack.cc
@@ -1,0 +1,1 @@
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFTrack.h"

--- a/DataFormats/Phase2L1ParticleFlow/src/classes.h
+++ b/DataFormats/Phase2L1ParticleFlow/src/classes.h
@@ -1,0 +1,44 @@
+#include "Rtypes.h"
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCluster.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFTrack.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCandidate.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFJet.h"
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFTau.h"
+
+
+namespace DataFormats_Phase2L1ParticleFlow {
+  struct dictionary {
+    l1t::PFCluster l1clus;
+    l1t::PFTrack l1trk;
+    l1t::PFCandidate l1pfc;
+    l1t::PFJet l1pfj;
+    l1t::PFTau l1pft;
+
+    l1t::PFClusterCollection l1PFClusterCollection;
+    l1t::PFTrackCollection l1PFTrackCollection;
+    l1t::PFCandidateCollection l1PFCandidateCollection;
+    l1t::PFJetCollection l1PFJetCollection;
+    l1t::PFTauCollection l1PFTauCollection;
+
+    edm::Wrapper<l1t::PFClusterCollection>   wl1PFClusterCollection;
+    edm::Wrapper<l1t::PFTrackCollection>   wl1PFTrackCollection;
+    edm::Wrapper<l1t::PFCandidateCollection>   wl1PFCandidateCollection;
+    edm::Wrapper<l1t::PFJetCollection>   wl1PFJetCollection;
+    edm::Wrapper<l1t::PFTauCollection>   wl1PFTauCollection;
+
+    edm::Ref<l1t::PFClusterCollection> l1PFClusterRef;
+    edm::Ref<l1t::PFTrackCollection> l1PFTrackRef;
+    edm::Ref<l1t::PFCandidateCollection> l1PFCandidateRef;
+    edm::Ref<l1t::PFJetCollection> l1PFJetRef;
+    edm::Ref<l1t::PFTauCollection> l1PFTauRef;
+
+    edm::RefVector<l1t::PFClusterCollection> l1PFClusterRefVector;
+    edm::RefVector<l1t::PFTrackCollection> l1PFTrackRefVector;
+    edm::RefVector<l1t::PFCandidateCollection> l1PFCandidateRefVector;
+    edm::RefVector<l1t::PFJetCollection> l1PFJetRefVector;
+    edm::RefVector<l1t::PFTauCollection> l1PFTauRefVector;
+  };
+}
+

--- a/DataFormats/Phase2L1ParticleFlow/src/classes_def.xml
+++ b/DataFormats/Phase2L1ParticleFlow/src/classes_def.xml
@@ -1,0 +1,45 @@
+<lcgdict>
+                      
+  <class name="l1t::PFCluster" ClassVersion="5">
+        <version ClassVersion="5" checksum="1668592434"/>
+        <version ClassVersion="4" checksum="387028836"/>
+        <version ClassVersion="3" checksum="2630618461"/>
+  </class> 
+  <class name="l1t::PFClusterCollection"/>
+  <class name="edm::Wrapper<l1t::PFClusterCollection>" />
+  <class name="edm::Ref<l1t::PFClusterCollection>" />
+  <class name="edm::RefVector<l1t::PFClusterCollection>" /> 
+
+  <class name="l1t::PFTrack::TrackRef" />
+  <class name="l1t::PFTrack"  ClassVersion="3">
+        <version ClassVersion="3" checksum="2332162612"/>
+  </class>
+  <class name="l1t::PFTrackCollection" />
+  <class name="edm::Wrapper<l1t::PFTrackCollection>" />
+  <class name="edm::Ref<l1t::PFTrackCollection>" />
+  <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
+
+  <class name="l1t::PFCandidate"  ClassVersion="3">
+        <version ClassVersion="3" checksum="4253860178"/>
+  </class>
+  <class name="l1t::PFCandidateCollection" />
+  <class name="edm::Wrapper<l1t::PFCandidateCollection>" />
+  <class name="edm::Ref<l1t::PFCandidateCollection>" />
+  <class name="edm::RefVector<l1t::PFCandidateCollection>" />
+
+  <class name="l1t::PFJet"  ClassVersion="3">
+        <version ClassVersion="3" checksum="133342988"/>
+  </class>
+  <class name="l1t::PFJetCollection" />
+  <class name="edm::Wrapper<l1t::PFJetCollection>" />
+  <class name="edm::Ref<l1t::PFJetCollection>" />
+  <class name="edm::RefVector<l1t::PFJetCollection>" />
+
+  <class name="l1t::PFTau" />
+  <class name="l1t::PFTauCollection" />
+  <class name="edm::Wrapper<l1t::PFTauCollection>" />
+  <class name="edm::Ref<l1t::PFTauCollection>" /> 
+  <class name="edm::RefVector<l1t::PFTauCollection>" /> 
+
+</lcgdict>
+

--- a/DataFormats/Phase2L1Taus/BuildFile.xml
+++ b/DataFormats/Phase2L1Taus/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/L1TVertex"/>
+<use   name="DataFormats/Phase2L1ParticleFlow"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/DataFormats/Phase2L1Taus/interface/L1HPSPFTau.h
+++ b/DataFormats/Phase2L1Taus/interface/L1HPSPFTau.h
@@ -1,0 +1,154 @@
+#ifndef DataFormats_Phase2L1Taus_L1HPSPFTau_H
+#define DataFormats_Phase2L1Taus_L1HPSPFTau_H
+
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFCandidate.h"    // l1t::PFCandidate, l1t::PFCandidateRef, l1t::PFCandidateRefVector
+#include "DataFormats/Phase2L1ParticleFlow/interface/PFJet.h"          // l1t::PFJet, l1t::PFJetCollection, l1t::PFJetRef 
+#include "DataFormats/Candidate/interface/LeafCandidate.h"             // reco::LeafCandidate 
+#include "DataFormats/Candidate/interface/Particle.h"                  // reco::Particle::LorentzVector
+#include "DataFormats/L1TVertex/interface/Vertex.h"                    // l1t::Vertex, l1t::VertexRef
+
+#include <ostream>
+
+// forward declation needed in order to declare L1HPSPFTauBuilder class as friend (that has access to private data-members)
+class L1HPSPFTauBuilder;
+
+namespace l1t
+{
+
+class L1HPSPFTau : public reco::LeafCandidate 
+{
+ public:
+  /// default constructor
+  L1HPSPFTau();
+    
+  /// destructor
+  ~L1HPSPFTau();
+
+  /// accessor functions for reco level quantities
+  bool isChargedPFCandSeeded() const { return seedChargedPFCand_.isNonnull(); }   
+  bool isPFJetSeeded()         const { return seedPFJet_.isNonnull();         } 
+
+  const l1t::PFCandidateRef& seedChargedPFCand() const { return seedChargedPFCand_; }
+  const l1t::PFJetRef& seedPFJet()              const { return seedPFJet_;         }
+  const l1t::PFCandidateRef& leadChargedPFCand() const { return leadChargedPFCand_; }
+
+  const l1t::PFCandidateRefVector& signalAllL1PFCandidates() const { return signalAllL1PFCandidates_; }
+  const l1t::PFCandidateRefVector& signalChargedHadrons()    const { return signalChargedHadrons_;    }
+  const l1t::PFCandidateRefVector& signalElectrons()         const { return signalElectrons_;         }
+  const l1t::PFCandidateRefVector& signalNeutralHadrons()    const { return signalNeutralHadrons_;    }
+  const l1t::PFCandidateRefVector& signalPhotons()           const { return signalPhotons_;           }
+  const l1t::PFCandidateRefVector& signalMuons()             const { return signalMuons_;             }
+  
+  const l1t::PFCandidateRefVector& stripAllL1PFCandidates()  const { return stripAllL1PFCandidates_;  }
+  const l1t::PFCandidateRefVector& stripElectrons()          const { return stripElectrons_;          }
+  const l1t::PFCandidateRefVector& stripPhotons()            const { return stripPhotons_;            }
+
+  const l1t::PFCandidateRefVector& isoAllL1PFCandidates()    const { return isoAllL1PFCandidates_;    }
+  const l1t::PFCandidateRefVector& isoChargedHadrons()       const { return isoChargedHadrons_;       }
+  const l1t::PFCandidateRefVector& isoElectrons()            const { return isoElectrons_;            }
+  const l1t::PFCandidateRefVector& isoNeutralHadrons()       const { return isoNeutralHadrons_;       }
+  const l1t::PFCandidateRefVector& isoPhotons()              const { return isoPhotons_;              }
+  const l1t::PFCandidateRefVector& isoMuons()                const { return isoMuons_;                }
+  
+  const l1t::PFCandidateRefVector& sumAllL1PFCandidates()    const { return sumAllL1PFCandidates_;    }
+  const l1t::PFCandidateRefVector& sumChargedHadrons()       const { return sumChargedHadrons_;       }
+  const l1t::PFCandidateRefVector& sumElectrons()            const { return sumElectrons_;            }
+  const l1t::PFCandidateRefVector& sumNeutralHadrons()       const { return sumNeutralHadrons_;       }
+  const l1t::PFCandidateRefVector& sumPhotons()              const { return sumPhotons_;              }
+  const l1t::PFCandidateRefVector& sumMuons()                const { return sumMuons_;                }
+
+  const l1t::VertexRef&            primaryVertex()           const { return primaryVertex_;           }
+
+  enum Kind { kUndefined, kOneProng0Pi0, kOneProng1Pi0, kThreeProng0Pi0, kThreeProng1Pi0 };
+  Kind tauType() const { return tauType_; }
+
+  const reco::Particle::LorentzVector& strip_p4() const { return strip_p4_; }
+  
+  float sumAllL1PFCandidates_pt() const { return sumAllL1PFCandidates_pt_; }
+  float signalConeSize()          const { return signalConeSize_;          }
+  float isolationConeSize()       const { return signalConeSize_;          }
+
+  float sumChargedIso()           const { return sumChargedIso_;           }
+  float sumNeutralIso()           const { return sumNeutralIso_;           }
+  float sumCombinedIso()          const { return sumCombinedIso_;          }
+  float sumChargedIsoPileup()     const { return sumChargedIsoPileup_;     }
+  float rhoCorr()                 const { return rhoCorr_;                 }
+  
+  bool passTightIso()     const { return passTightIso_;     }
+  bool passMediumIso()    const { return passMediumIso_;    }
+  bool passLooseIso()     const { return passLooseIso_;     }
+  bool passVLooseIso()    const { return passVLooseIso_;    }
+  
+  bool passTightRelIso()  const { return passTightRelIso_;  }
+  bool passMediumRelIso() const { return passMediumRelIso_; }
+  bool passLooseRelIso()  const { return passLooseRelIso_;  }
+  bool passVLooseRelIso() const { return passVLooseRelIso_; }
+  
+  friend class ::L1HPSPFTauBuilder;
+
+ private:
+  l1t::PFCandidateRef seedChargedPFCand_;
+  l1t::PFJetRef seedPFJet_;
+  l1t::PFCandidateRef leadChargedPFCand_;
+
+  l1t::PFCandidateRefVector signalAllL1PFCandidates_;
+  l1t::PFCandidateRefVector signalChargedHadrons_;
+  l1t::PFCandidateRefVector signalElectrons_;
+  l1t::PFCandidateRefVector signalNeutralHadrons_;
+  l1t::PFCandidateRefVector signalPhotons_;
+  l1t::PFCandidateRefVector signalMuons_;
+  
+  l1t::PFCandidateRefVector stripAllL1PFCandidates_;
+  l1t::PFCandidateRefVector stripElectrons_;
+  l1t::PFCandidateRefVector stripPhotons_;
+
+  l1t::PFCandidateRefVector isoAllL1PFCandidates_;
+  l1t::PFCandidateRefVector isoChargedHadrons_;
+  l1t::PFCandidateRefVector isoElectrons_;
+  l1t::PFCandidateRefVector isoNeutralHadrons_;
+  l1t::PFCandidateRefVector isoPhotons_;
+  l1t::PFCandidateRefVector isoMuons_;
+  
+  l1t::PFCandidateRefVector sumAllL1PFCandidates_;
+  l1t::PFCandidateRefVector sumChargedHadrons_;
+  l1t::PFCandidateRefVector sumElectrons_;
+  l1t::PFCandidateRefVector sumNeutralHadrons_;
+  l1t::PFCandidateRefVector sumPhotons_;
+  l1t::PFCandidateRefVector sumMuons_;
+
+  l1t::VertexRef primaryVertex_;
+
+  Kind tauType_;
+
+  reco::Particle::LorentzVector strip_p4_;
+
+  float sumAllL1PFCandidates_pt_;
+  float signalConeSize_;
+  float isolationConeSize_;
+
+  float sumChargedIso_;
+  float sumNeutralIso_;
+  float sumCombinedIso_;
+  float sumChargedIsoPileup_; // charged PFCands failing dz cut (maybe useful to correct neutral isolation for pile-up contributions by applying delta-beta corrections)
+  float rhoCorr_;             // rho correction (maybe useful for applying pile-up corrections to neutral isolation)
+
+  bool passTightIso_;
+  bool passMediumIso_;
+  bool passLooseIso_;
+  bool passVLooseIso_;
+  
+  bool passTightRelIso_;
+  bool passMediumRelIso_;
+  bool passLooseRelIso_;
+  bool passVLooseRelIso_;
+};
+
+}
+
+/// print to stream
+std::ostream& operator<<(std::ostream& os, const l1t::L1HPSPFTau& l1PFTau);
+
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::VertexRef& primaryVertex);
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z);
+
+#endif 

--- a/DataFormats/Phase2L1Taus/interface/L1HPSPFTauFwd.h
+++ b/DataFormats/Phase2L1Taus/interface/L1HPSPFTauFwd.h
@@ -1,0 +1,11 @@
+#ifndef DataFormats_Phase2L1Taus_L1HPSPFTauFwd_H
+#define DataFormats_Phase2L1Taus_L1HPSPFTauFwd_H
+
+#include "DataFormats/Phase2L1Taus/interface/L1HPSPFTau.h"
+
+namespace l1t
+{
+  typedef std::vector<L1HPSPFTau> L1HPSPFTauCollection;
+}
+
+#endif 

--- a/DataFormats/Phase2L1Taus/src/L1HPSPFTau.cc
+++ b/DataFormats/Phase2L1Taus/src/L1HPSPFTau.cc
@@ -1,0 +1,93 @@
+#include "DataFormats/Phase2L1Taus/interface/L1HPSPFTau.h"
+
+// default constructor
+l1t::L1HPSPFTau::L1HPSPFTau() 
+  : tauType_(kUndefined)
+  , sumChargedIso_(0.)
+  , sumNeutralIso_(0.)
+  , sumCombinedIso_(0.)
+  , sumChargedIsoPileup_(0.)
+  , rhoCorr_(0.)
+  , passTightIso_(false)
+  , passMediumIso_(false)
+  , passLooseIso_(false)
+  , passVLooseIso_(false)
+  , passTightRelIso_(false)
+  , passMediumRelIso_(false)
+  , passLooseRelIso_(false)
+  , passVLooseRelIso_(false)
+{}
+
+// destructor
+l1t::L1HPSPFTau::~L1HPSPFTau() 
+{}
+
+// print to stream
+ostream& operator<<(ostream& os, const l1t::L1HPSPFTau& l1PFTau) 
+{
+  os << "pT = " << l1PFTau.pt()  << ", eta = " << l1PFTau.eta() << ", phi = " << l1PFTau.phi() 
+     << " (type = " << l1PFTau.tauType() << ")" << std::endl;
+  os << "lead. ChargedPFCand:" << std::endl;
+  if ( l1PFTau.leadChargedPFCand().isNonnull() ) 
+  {
+    printPFCand(os, *l1PFTau.leadChargedPFCand(), l1PFTau.primaryVertex());
+  }
+  else
+  {
+    os << " N/A" << std::endl;
+  }
+  os << "seed:";
+  if ( l1PFTau.isChargedPFCandSeeded() ) 
+  {
+    os << " chargedPFCand";
+  }
+  else if ( l1PFTau.isPFJetSeeded() ) 
+  {
+    os << " PFJet";
+  }
+  else assert(0);
+  os << std::endl;
+  os << "signalPFCands:" << std::endl;
+  for ( auto l1PFCand : l1PFTau.signalAllL1PFCandidates() )
+  {
+    printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
+  }
+  os << "stripPFCands:" << std::endl;
+  for ( auto l1PFCand : l1PFTau.stripAllL1PFCandidates() )
+  {
+    printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
+  }
+  os << "strip pT = " << l1PFTau.strip_p4().pt() << std::endl;
+  os << "isolationPFCands:" << std::endl;
+  for ( auto l1PFCand : l1PFTau.isoAllL1PFCandidates() )
+  {
+    printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
+  }
+  os << "isolation pT-sum: charged = " << l1PFTau.sumChargedIso() << ", neutral = " << l1PFTau.sumNeutralIso() 
+     << " (charged from pileup = " << l1PFTau.sumChargedIsoPileup() << ")" << std::endl;
+  return os;
+}
+
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::VertexRef& primaryVertex)
+{
+  float primaryVertex_z = ( primaryVertex.isNonnull() ) ? primaryVertex->z0() : 0.;
+  printPFCand(os, l1PFCand, primaryVertex_z);
+}
+
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z)
+{
+  std::string type_string;
+  if      ( l1PFCand.id() == l1t::PFCandidate::ChargedHadron ) type_string = "PFChargedHadron";
+  else if ( l1PFCand.id() == l1t::PFCandidate::Electron      ) type_string = "PFElectron";
+  else if ( l1PFCand.id() == l1t::PFCandidate::NeutralHadron ) type_string = "PFNeutralHadron";
+  else if ( l1PFCand.id() == l1t::PFCandidate::Photon        ) type_string = "PFPhoton";
+  else if ( l1PFCand.id() == l1t::PFCandidate::Muon          ) type_string = "PFMuon";
+  else                                                         type_string = "N/A";
+  os << " " << type_string << " with pT = " << l1PFCand.pt()  << ", eta = " << l1PFCand.eta() << ", phi = " << l1PFCand.phi() << "," 
+     << " mass = " << l1PFCand.mass() << ", charge = " << l1PFCand.charge();
+  if ( l1PFCand.charge() != 0 && primaryVertex_z != 0. ) 
+  {
+    os << " (dz = " << std::fabs(l1PFCand.pfTrack()->vertex().z() - primaryVertex_z) << ")";
+  }
+  os << std::endl;
+}

--- a/DataFormats/Phase2L1Taus/src/classes.h
+++ b/DataFormats/Phase2L1Taus/src/classes.h
@@ -1,0 +1,14 @@
+#include "Rtypes.h"
+
+#include "DataFormats/Phase2L1Taus/interface/L1HPSPFTau.h"
+#include "DataFormats/Phase2L1Taus/interface/L1HPSPFTauFwd.h"
+
+namespace DataFormats_Phase2L1Taus
+{
+  struct dictionary 
+  {
+    l1t::L1HPSPFTau l1hpspftau;
+    l1t::L1HPSPFTauCollection l1hpspftauCollection;
+    edm::Wrapper<l1t::L1HPSPFTauCollection> l1hpspftauCWrapper;
+  };
+}

--- a/DataFormats/Phase2L1Taus/src/classes_def.xml
+++ b/DataFormats/Phase2L1Taus/src/classes_def.xml
@@ -1,0 +1,7 @@
+<lcgdict>
+  <class name="l1t::L1HPSPFTau" ClassVersion="10">
+   <version ClassVersion="10" checksum="2335886114"/>
+  </class>
+  <class name="l1t::L1HPSPFTauCollection"/>
+  <class name="edm::Wrapper<l1t::L1HPSPFTauCollection>"/>
+</lcgdict>


### PR DESCRIPTION
#### PR description:
Testing only!

Add Phase2 L1T DataFormats - step 1
=============
- L1TVertex 
- L1TrackTrigger (correlator L1Track+Object) 
- Phase2L1CaloTrig 
- Phase2L1Taus. 
- Phase2L1ParticleFlow

Note:  
Working from branch `cms-l1t-offline phase2-l1t-integration-CMSSW_10_6_1_patch2` and tag  `cms-l1t-offline:l1t-phase2-v2.37.2`.
Commented out L1TkMuonParticle and removed files from DataFormats/L1TrackTrigger/:
- DataFormats/L1TrackTrigger/src/L1TkMuonParticle.cc  
- DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h 
- DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h 

Next:
Step 2 will have DataFormats/L1TMuon which needs to be moved to DataFormats/Phase2L1TMuon


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
