### PR TITLE
MTD simulation: premixing tuning

### DIFF
--- a/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
+++ b/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
@@ -32,18 +32,18 @@ public:
     constexpr static unsigned energyOffset = 4;
     constexpr static unsigned energyMask = 0x3;
     constexpr static unsigned sampleMask = 0xf;
-    constexpr static unsigned dataMask = 0x7fff;
+    constexpr static unsigned dataMask = 0xffff;
 
-    Data() : indices_(0), data_(0) {}
-    Data(unsigned short ei, unsigned short si, unsigned short d) : indices_((ei << energyOffset) | si), data_(d) {}
+    Data() : data_(0), indices_(0) {}
+    Data(unsigned short ei, unsigned short si, unsigned short d) : data_(d), indices_((ei << energyOffset) | si) {}
 
     unsigned int energyIndex() const { return indices_ >> energyOffset; }
     unsigned int sampleIndex() const { return indices_ & sampleMask; }
     unsigned int data() const { return data_ & dataMask; }
 
   private:
-    unsigned char indices_;
     unsigned short data_;
+    unsigned char indices_;
   };
 
   PMTDSimAccumulator() = default;

--- a/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
+++ b/DataFormats/FTLDigi/interface/PMTDSimAccumulator.h
@@ -29,22 +29,20 @@ public:
   };
   class Data {
   public:
-    constexpr static unsigned energyOffset = 14;
+    constexpr static unsigned energyOffset = 4;
     constexpr static unsigned energyMask = 0x3;
-    constexpr static unsigned sampleOffset = 10;
     constexpr static unsigned sampleMask = 0xf;
-    constexpr static unsigned dataOffset = 0;
-    constexpr static unsigned dataMask = 0x3ff;
+    constexpr static unsigned dataMask = 0x7fff;
 
-    Data() : data_(0) {}
-    Data(unsigned short ei, unsigned short si, unsigned short d)
-        : data_((ei << energyOffset) | (si << sampleOffset) | d) {}
+    Data() : indices_(0), data_(0) {}
+    Data(unsigned short ei, unsigned short si, unsigned short d) : indices_((ei << energyOffset) | si), data_(d) {}
 
-    unsigned int energyIndex() const { return data_ >> energyOffset; }
-    unsigned int sampleIndex() const { return (data_ >> sampleOffset) & sampleMask; }
+    unsigned int energyIndex() const { return indices_ >> energyOffset; }
+    unsigned int sampleIndex() const { return indices_ & sampleMask; }
     unsigned int data() const { return data_ & dataMask; }
 
   private:
+    unsigned char indices_;
     unsigned short data_;
   };
 

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -66,7 +66,7 @@ namespace mtd_digitizer {
 
     const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
     const float maxPackChargeLog = std::log(maxCharge);
-    constexpr uint16_t base = PMTDSimAccumulator::Data::dataMask + 1;
+    constexpr uint16_t base = PMTDSimAccumulator::Data::dataMask;
 
     simResult.reserve(simData.size());
     // mimicking the digitization
@@ -96,7 +96,7 @@ namespace mtd_digitizer {
                                     const float maxCharge) {
     const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
     const float maxPackChargeLog = std::log(maxCharge);
-    constexpr uint16_t base = PMTDSimAccumulator::Data::dataMask + 1;
+    constexpr uint16_t base = PMTDSimAccumulator::Data::dataMask;
 
     for (const auto& detIdIndexHitInfo : simAccumulator) {
       auto foo = simData.emplace(

--- a/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
+++ b/SimFastTiming/FastTimingCommon/interface/MTDDigitizer.h
@@ -66,7 +66,7 @@ namespace mtd_digitizer {
 
     const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
     const float maxPackChargeLog = std::log(maxCharge);
-    constexpr uint16_t base = 1 << PMTDSimAccumulator::Data::sampleOffset;
+    constexpr uint16_t base = PMTDSimAccumulator::Data::dataMask + 1;
 
     simResult.reserve(simData.size());
     // mimicking the digitization
@@ -96,7 +96,7 @@ namespace mtd_digitizer {
                                     const float maxCharge) {
     const float minPackChargeLog = minCharge > 0.f ? std::log(minCharge) : -2;
     const float maxPackChargeLog = std::log(maxCharge);
-    constexpr uint16_t base = 1 << PMTDSimAccumulator::Data::sampleOffset;
+    constexpr uint16_t base = PMTDSimAccumulator::Data::dataMask + 1;
 
     for (const auto& detIdIndexHitInfo : simAccumulator) {
       auto foo = simData.emplace(
@@ -120,7 +120,7 @@ namespace mtd_digitizer {
 
       if (iEn == 0 || iEn == 2) {
         hit_info[iEn][iSample] += value;
-      } else if (hit_info[iEn][iSample] == 0) {
+      } else if (hit_info[iEn][iSample] == 0 || value < hit_info[iEn][iSample]) {
         // For iEn==1 the digitizers just set the TOF of the first SimHit
         hit_info[iEn][iSample] = value;
       }


### PR DESCRIPTION
#### PR description:

The packing of the PU SimHits information in the premixing library has been tuned to fix a bias in the MTD time resolution when running with premixing. Basically, the width of the word, in which the time and energy information is stored, has been increased from 10 to 16 bits.

The figure below shows a comparison of the BTL resolution between the standard PU (WF 22234.0) and the premixed PU (WF 22234.99) for the current code and the proposed changes.

![image](https://user-images.githubusercontent.com/5435977/75256574-ed617000-57e3-11ea-8ecd-e5392bbf4b1e.png)

#### PR validation:

**PU library size:**

   current:
          PMTDSimAccumulator_mix_FTLBarrel_DIGI. 3.46034e+06 2.89781e+06
          PMTDSimAccumulator_mix_FTLEndcap_DIGI. 1.33435e+06 788234

   new:
          PMTDSimAccumulator_mix_FTLBarrel_DIGI. 4.66987e+06 2.82419e+06
          PMTDSimAccumulator_mix_FTLEndcap_DIGI. 1.57796e+06 902263


**Performance:**

The new code affects the steps 2 and 3, it has been tested with WF 22234.99 in CMSSW_11_1_X_2020-02-24-2300.

step 2

MemoryReport> Peak virtual size 4503.98 Mbytes
 Key events increasing vsize: 
[1] run: 1 lumi: 1 event: 1  vsize = 4119.94 deltaVsize = 0 rss = 2456.23 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 4119.95 deltaVsize = 0.015625 rss = 2674.35 delta = 218.117
[4] run: 1 lumi: 1 event: 4  vsize = 4503.96 deltaVsize = 384.008 rss = 2787.09 delta = 112.746
[6] run: 1 lumi: 1 event: 6  vsize = 4503.98 deltaVsize = 0.0195312 rss = 2787.36 delta = 0.265625
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[8] run: 1 lumi: 1 event: 8  vsize = 4503.98 deltaVsize = 0 rss = 2860.68 delta = 73.3164
[7] run: 1 lumi: 1 event: 7  vsize = 4503.98 deltaVsize = 0 rss = 2831.74 delta = 44.3789
[6] run: 1 lumi: 1 event: 6  vsize = 4503.98 deltaVsize = 0.0195312 rss = 2787.36 delta = 0.265625
TimeReport> Time report complete in 844.182 seconds
 Time Summary: 
 - Min event:   61.3985
 - Max event:   116.356
 - Avg event:   74.3752
 - Total loop:  823.047
 - Total init:  21.0407
 - Total job:   844.182
 - EventSetup Lock:   7.72476e-05
 - EventSetup Get:   79.1781
 Event Throughput: 0.01215 ev/s
 CPU Summary: 
 - Total loop:  685.092
 - Total init:  9.92849
 - Total extra: 0
 - Total job:   695.103
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

step 3

MemoryReport> Peak virtual size 4815.11 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 4035.09 deltaVsize = 0 rss = 2976.07 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 4431.09 deltaVsize = 396 rss = 3095.2 delta = 119.129
[3] run: 1 lumi: 1 event: 3  vsize = 4815.11 deltaVsize = 384.02 rss = 3062.52 delta = -32.6836
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[5] run: 1 lumi: 1 event: 5  vsize = 4815.11 deltaVsize = 0 rss = 3238.1 delta = 175.582
[4] run: 1 lumi: 1 event: 4  vsize = 4815.11 deltaVsize = 0 rss = 2982.25 delta = -80.2656
[3] run: 1 lumi: 1 event: 3  vsize = 4815.11 deltaVsize = 384.02 rss = 3062.52 delta = -32.6836
TimeReport> Time report complete in 655.984 seconds
 Time Summary: 
 - Min event:   40.0881
 - Max event:   145.567
 - Avg event:   58.967
 - Total loop:  636.154
 - Total init:  19.2085
 - Total job:   655.984
 - EventSetup Lock:   8.89301e-05
 - EventSetup Get:   78.7761
 Event Throughput: 0.0157195 ev/s
 CPU Summary: 
 - Total loop:  582.007
 - Total init:  12.7771
 - Total extra: 0
 - Total job:   594.932
 Processing Summary: 
 - Number of Events:  10
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1
