### PR TITLE
Add missing includes  and remove override identifier for non-virtual functions for CondFormats

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
@@ -1,13 +1,13 @@
 #ifndef ECAL_COND_OBJECT_CONTAINER_HH
 #define ECAL_COND_OBJECT_CONTAINER_HH
 
-#include <vector>
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "DataFormats/EcalDetId/interface/EcalContainer.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+
+#include <vector>
 
 template <typename T>
 class EcalCondObjectContainer {

--- a/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
@@ -1,6 +1,8 @@
 #ifndef ECAL_COND_OBJECT_CONTAINER_HH
 #define ECAL_COND_OBJECT_CONTAINER_HH
 
+#include <vector>
+
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "DataFormats/EcalDetId/interface/EcalContainer.h"

--- a/CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h
@@ -9,6 +9,9 @@
 #include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatusCode.h"
 
+#include "DataFormats/EcalDetId/interface/EcalContainer.h"
+#include <vector>
+
 typedef EcalCondObjectContainer<EcalTPGCrystalStatusCode> EcalTPGCrystalStatusMap;
 
 typedef EcalTPGCrystalStatusMap::const_iterator EcalTPGCrystalStatusMapIterator;

--- a/CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h
+++ b/CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h
@@ -10,6 +10,7 @@
 #include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatusCode.h"
 
 #include "DataFormats/EcalDetId/interface/EcalContainer.h"
+
 #include <vector>
 
 typedef EcalCondObjectContainer<EcalTPGCrystalStatusCode> EcalTPGCrystalStatusMap;

--- a/CondFormats/EgammaObjects/interface/ElectronLikelihoodCalibration.h
+++ b/CondFormats/EgammaObjects/interface/ElectronLikelihoodCalibration.h
@@ -5,7 +5,9 @@
 
 #include "CondFormats/EgammaObjects/interface/ElectronLikelihoodCategoryData.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram.h"
+
 #include <vector>
+#include <atomic>
 
 struct ElectronLikelihoodCalibration {
   struct Entry {

--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -1,9 +1,6 @@
 #ifndef HcalCondObjectContainer_h
 #define HcalCondObjectContainer_h
 
-#include <vector>
-#include <string>
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "CondFormats/HcalObjects/interface/HcalDetIdRelationship.h"
 
@@ -12,6 +9,9 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
+
+#include <vector>
+#include <string>
 
 class HcalTopology;
 

--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -1,10 +1,12 @@
 #ifndef HcalCondObjectContainer_h
 #define HcalCondObjectContainer_h
 
+#include <vector>
+#include <string>
+
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "CondFormats/HcalObjects/interface/HcalDetIdRelationship.h"
 
-#include <vector>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalOtherDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"

--- a/CondFormats/HcalObjects/interface/HcalIndexLookup.h
+++ b/CondFormats/HcalObjects/interface/HcalIndexLookup.h
@@ -1,16 +1,16 @@
 #ifndef CondFormats_HcalObjects_HcalIndexLookup_h
 #define CondFormats_HcalObjects_HcalIndexLookup_h
 
-#include <cstdint>
-#include <climits>
-#include <vector>
-
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
 #include "boost/serialization/vector.hpp"
 #include "boost/serialization/utility.hpp"
+
+#include <cstdint>
+#include <climits>
+#include <vector>
 
 //
 // Storable lookup of unsigned index values by unsigned key

--- a/CondFormats/HcalObjects/interface/HcalIndexLookup.h
+++ b/CondFormats/HcalObjects/interface/HcalIndexLookup.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <climits>
+#include <vector>
 
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <array>
+#include <vector>
 
 #include "boost/array.hpp"
 #include "boost/serialization/access.hpp"

--- a/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemArrayColl.h
@@ -1,10 +1,6 @@
 #ifndef CondFormats_HcalObjects_HcalItemArrayColl_h
 #define CondFormats_HcalObjects_HcalItemArrayColl_h
 
-#include <memory>
-#include <array>
-#include <vector>
-
 #include "boost/array.hpp"
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
@@ -16,6 +12,10 @@
 #else
 #include "boost/serialization/boost_array.hpp"
 #endif
+
+#include <memory>
+#include <array>
+#include <vector>
 
 //
 // This collection manages arrays of pointers and references.

--- a/CondFormats/HcalObjects/interface/HcalItemColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemColl.h
@@ -2,6 +2,7 @@
 #define CondFormats_HcalObjects_HcalItemColl_h
 
 #include <memory>
+#include <vector>
 
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"

--- a/CondFormats/HcalObjects/interface/HcalItemColl.h
+++ b/CondFormats/HcalObjects/interface/HcalItemColl.h
@@ -1,13 +1,13 @@
 #ifndef CondFormats_HcalObjects_HcalItemColl_h
 #define CondFormats_HcalObjects_HcalItemColl_h
 
-#include <memory>
-#include <vector>
-
 #include "boost/serialization/access.hpp"
 #include "boost/serialization/version.hpp"
 #include "boost/serialization/shared_ptr.hpp"
 #include "boost/serialization/vector.hpp"
+
+#include <memory>
+#include <vector>
 
 //
 // This collection manages only pointers and references.

--- a/CondFormats/HcalObjects/interface/HcalLUTCorr.h
+++ b/CondFormats/HcalObjects/interface/HcalLUTCorr.h
@@ -3,6 +3,9 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include <vector>
+#include <cstdint>
+
 /*
 \class HcalLUTCorr
 \author Radek Ofierzynski

--- a/CondFormats/HcalObjects/interface/HcalLUTCorrs.h
+++ b/CondFormats/HcalObjects/interface/HcalLUTCorrs.h
@@ -12,6 +12,9 @@ POOL object to store LUT Corrections
 #include "CondFormats/HcalObjects/interface/HcalCondObjectContainer.h"
 #include "CondFormats/HcalObjects/interface/HcalLUTCorr.h"
 
+#include <string>
+#include <cstdint>
+
 //typedef HcalCondObjectContainer<HcalLUTCorr> HcalLUTCorrs;
 
 class HcalLUTCorrs : public HcalCondObjectContainer<HcalLUTCorr> {
@@ -21,7 +24,7 @@ public:
 #endif
   HcalLUTCorrs(const HcalTopology* topo) : HcalCondObjectContainer<HcalLUTCorr>(topo) {}
 
-  std::string myname() const override { return (std::string) "HcalLUTCorrs"; }
+  std::string myname() const { return (std::string) "HcalLUTCorrs"; }
 
 private:
   COND_SERIALIZABLE;

--- a/CondFormats/HcalObjects/interface/HcalLogicalMap.h
+++ b/CondFormats/HcalObjects/interface/HcalLogicalMap.h
@@ -3,7 +3,10 @@
 
 #include "CondFormats/HcalObjects/interface/HcalMappingEntry.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+
 #include <vector>
+#include <memory>
+
 class HcalTopology;
 
 class HcalLogicalMap {

--- a/CondFormats/HcalObjects/interface/HcalPedestals.h
+++ b/CondFormats/HcalObjects/interface/HcalPedestals.h
@@ -12,6 +12,9 @@ POOL container to store Pedestal values 4xCapId, using template
 #include "CondFormats/HcalObjects/interface/HcalPedestal.h"
 #include "CondFormats/HcalObjects/interface/HcalCondObjectContainer.h"
 
+#include <vector>
+#include <string>
+
 //typedef HcalCondObjectContainer<HcalPedestal> HcalPedestals;
 
 class HcalPedestals : public HcalCondObjectContainer<HcalPedestal> {
@@ -28,7 +31,7 @@ public:
   // set unit boolean
   void setUnitADC(bool isADC) { unitIsADC = isADC; }
 
-  std::string myname() const override { return (std::string) "HcalPedestals"; }
+  std::string myname() const { return (std::string) "HcalPedestals"; }
 
 private:
   bool unitIsADC;

--- a/CondFormats/HcalObjects/interface/PiecewiseScalingPolynomial.h
+++ b/CondFormats/HcalObjects/interface/PiecewiseScalingPolynomial.h
@@ -6,6 +6,8 @@
 #include "boost/serialization/vector.hpp"
 #include "boost/serialization/version.hpp"
 
+#include <vector>
+
 class PiecewiseScalingPolynomial {
 public:
   inline PiecewiseScalingPolynomial() {}

--- a/CondFormats/HcalObjects/interface/StorableDoubleMap.h
+++ b/CondFormats/HcalObjects/interface/StorableDoubleMap.h
@@ -1,12 +1,13 @@
 #ifndef CondFormats_HcalObjects_StorableDoubleMap_h
 #define CondFormats_HcalObjects_StorableDoubleMap_h
 
-#include <string>
-#include <memory>
-#include <map>
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "boost/serialization/map.hpp"
+
+#include <string>
+#include <memory>
+#include <map>
 
 template <typename T>
 class StorableDoubleMap {

--- a/CondFormats/HcalObjects/interface/StorableDoubleMap.h
+++ b/CondFormats/HcalObjects/interface/StorableDoubleMap.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <memory>
+#include <map>
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "boost/serialization/map.hpp"

--- a/CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h
@@ -20,6 +20,7 @@ Implementation:
 //
 
 #include <cstdint>
+#include <functional>
 #include <limits>
 
 #include "CondFormats/Serialization/interface/Serializable.h"

--- a/CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h
+++ b/CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h
@@ -19,11 +19,11 @@ Implementation:
 //
 //
 
+#include "CondFormats/Serialization/interface/Serializable.h"
+
 #include <cstdint>
 #include <functional>
 #include <limits>
-
-#include "CondFormats/Serialization/interface/Serializable.h"
 
 class DTCELinkId {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
@@ -4,7 +4,9 @@
 #include <vector>
 #include <unordered_map>
 #include <string>
+#include <map>
 
+#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 

--- a/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h
@@ -1,14 +1,14 @@
 #ifndef SiPixelFedCablingTree_H
 #define SiPixelFedCablingTree_H
 
+#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
+#include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
+
 #include <vector>
 #include <unordered_map>
 #include <string>
 #include <map>
-
-#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelFedCabling.h"
-#include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 
 class SiPixelFedCablingTree final : public SiPixelFedCabling {
 public:

--- a/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h
@@ -7,6 +7,8 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
 #include "CondFormats/SiPixelObjects/interface/PixelFEDCabling.h"
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
+#include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
+#include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <cstdint>


### PR DESCRIPTION
### PR description:
Add missing includes for CondFormats libraries and remove override identifier for non-virtual functions. 

CC: @davidlange6 @vgvassilev   

Tested locally with CXXMODULES IBs and these fixes allowed to enable 29 C++ modules (https://github.com/cms-sw/cmsdist/pull/5600).
