### PR TITLE
Delete dead branches in CondCore/EcalPlugins

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalPulseCovariances_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPulseCovariances_PayloadInspector.cc
@@ -232,17 +232,8 @@ namespace {
       std::shared_ptr<EcalPulseCovariances> payload = fetchPayload(std::get<1>(iov));
       unsigned int run = std::get<0>(iov);
       if (payload.get()) {
-        //	int chan = 0;
         for (int ieta = -MAX_IETA; ieta <= MAX_IETA; ieta++) {
-          Double_t eta = (Double_t)ieta;
-          if (ieta == 0)
-            continue;
-          else if (ieta > 0.)
-            eta = eta - 0.5;  //   0.5 to 84.5
-          else
-            eta = eta + 0.5;  //  -84.5 to -0.5
           for (int iphi = 1; iphi <= MAX_IPHI; iphi++) {
-            //Double_t phi = (Double_t)iphi - 0.5;
             EBDetId id(ieta, iphi);
             for (int i = 0; i < TEMPLATESAMPLES; ++i) {
               for (int j = 0; j < TEMPLATESAMPLES; ++j) {

--- a/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
@@ -204,17 +204,8 @@ namespace {
       std::shared_ptr<EcalPulseShapes> payload = fetchPayload(std::get<1>(iov));
       unsigned int run = std::get<0>(iov);
       if (payload.get()) {
-        //	int chan = 0;
         for (int ieta = -MAX_IETA; ieta <= MAX_IETA; ieta++) {
-          Double_t eta = (Double_t)ieta;
-          if (ieta == 0)
-            continue;
-          else if (ieta > 0.)
-            eta = eta - 0.5;  //   0.5 to 84.5
-          else
-            eta = eta + 0.5;  //  -84.5 to -0.5
           for (int iphi = 1; iphi <= MAX_IPHI; iphi++) {
-            //Double_t phi = (Double_t)iphi - 0.5;
             EBDetId id(ieta, iphi);
             EcalPulseShape pulse = (*payload)[id.rawId()];
             for (int s = 0; s < TEMPLATESAMPLES; s++) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
@@ -112,8 +112,8 @@ namespace {
             val[1] = it.getEEValue();
 
           } else {
-	    double row = NbRows - 0.5;
-	    align->Fill(0.5, row, it.getEBValue() - val[0]);
+            double row = NbRows - 0.5;
+            align->Fill(0.5, row, it.getEBValue() - val[0]);
             align->Fill(1.5, row, it.getEEValue() - val[1]);
           }
 

--- a/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeOffsetConstant_PayloadInspector.cc
@@ -106,17 +106,15 @@ namespace {
             align = new TH2F("Ecal Time Offset Constant [ns]", "EB          EE", 2, 0, 2, NbRows, 0, NbRows);
 
           EcalTimeOffsetConstant it = (*payload);
-          double row = NbRows - 0.5;
 
           if (irun == 0) {
             val[0] = it.getEBValue();
             val[1] = it.getEEValue();
 
           } else {
-            align->Fill(0.5, row, it.getEBValue() - val[0]);
+	    double row = NbRows - 0.5;
+	    align->Fill(0.5, row, it.getEBValue() - val[0]);
             align->Fill(1.5, row, it.getEEValue() - val[1]);
-
-            row = row - 1.;
           }
 
         }  //  if payload.get()


### PR DESCRIPTION
#### PR description:

There were these dead branches in a few plugins in CondCore/EcalPlugins, spotted by the static analyzer
Their unusefulness was quite obvious, and those extra lines may confuse reading the code: I think they can be safely removed
Since they were dead branches in the code, no difference whatsoever is expected in the final results


#### PR validation:

It compiles
