### PR TITLE
PPS: simulation input from GenParticleCollection

### DIFF
--- a/IOMC/EventVertexGenerators/src/BeamDivergenceVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BeamDivergenceVtxGenerator.cc
@@ -16,6 +16,8 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSBeamParameters.h"
 #include "CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h"
 
@@ -25,26 +27,45 @@
 
 class BeamDivergenceVtxGenerator : public edm::stream::EDProducer<> {
 public:
-  explicit BeamDivergenceVtxGenerator(const edm::ParameterSet&);
+  explicit BeamDivergenceVtxGenerator(const edm::ParameterSet &);
   ~BeamDivergenceVtxGenerator() override = default;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
   edm::EDGetTokenT<edm::HepMCProduct> sourceToken_;
+  std::vector<edm::EDGetTokenT<reco::GenParticleCollection>> genParticleTokens_;
 
   bool simulateVertex_;
   bool simulateBeamDivergence_;
+
+  struct SmearingParameters {
+    double vtx_x, vtx_y, vtx_z;                 // cm
+    double bd_x_45, bd_y_45, bd_x_56, bd_y_56;  // rad
+  };
+
+  template <typename T>
+  static HepMC::FourVector smearMomentum(const T &mom, const SmearingParameters &sp);
+
+  void applySmearingHepMC(const SmearingParameters &sp, HepMC::GenEvent *genEvt);
+
+  void addSmearedGenParticle(const reco::GenParticle &gp, const SmearingParameters &sp, HepMC::GenEvent *genEvt);
 };
 
 //----------------------------------------------------------------------------------------------------
 
-BeamDivergenceVtxGenerator::BeamDivergenceVtxGenerator(const edm::ParameterSet& iConfig)
-    : sourceToken_(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("src"))),
-      simulateVertex_(iConfig.getParameter<bool>("simulateVertex")),
+BeamDivergenceVtxGenerator::BeamDivergenceVtxGenerator(const edm::ParameterSet &iConfig)
+    : simulateVertex_(iConfig.getParameter<bool>("simulateVertex")),
       simulateBeamDivergence_(iConfig.getParameter<bool>("simulateBeamDivergence")) {
+  const edm::InputTag tagSrcHepMC = iConfig.getParameter<edm::InputTag>("src");
+  if (tagSrcHepMC.label() != "")
+    sourceToken_ = consumes<edm::HepMCProduct>(tagSrcHepMC);
+
+  for (const auto &it : iConfig.getParameter<std::vector<edm::InputTag>>("srcGenParticle"))
+    genParticleTokens_.push_back(consumes<reco::GenParticleCollection>(it));
+
   edm::Service<edm::RandomNumberGenerator> rng;
   if (!rng.isAvailable())
     throw cms::Exception("Configuration")
@@ -58,85 +79,138 @@ BeamDivergenceVtxGenerator::BeamDivergenceVtxGenerator(const edm::ParameterSet& 
 
 //----------------------------------------------------------------------------------------------------
 
-void BeamDivergenceVtxGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void BeamDivergenceVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("src", edm::InputTag("generator", "unsmeared"))
+      ->setComment("input collection in HepMC format");
+
+  desc.add<std::vector<edm::InputTag>>("srcGenParticle", std::vector<edm::InputTag>())
+      ->setComment("input collections in GenParticle format");
+
+  desc.add<bool>("simulateBeamDivergence", true)->setComment("account for the beam angular divergence?");
+  desc.add<bool>("simulateVertex", true)->setComment("account for the vertex transverse smearing?");
+
+  descriptions.add("beamDivergenceVtxGenerator", desc);
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void BeamDivergenceVtxGenerator::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get random engine
   edm::Service<edm::RandomNumberGenerator> rng;
-  CLHEP::HepRandomEngine* rnd = &(rng->getEngine(iEvent.streamID()));
+  CLHEP::HepRandomEngine *rnd = &(rng->getEngine(iEvent.streamID()));
 
   // get conditions
   edm::ESHandle<CTPPSBeamParameters> hBeamParameters;
   iSetup.get<CTPPSBeamParametersRcd>().get(hBeamParameters);
 
-  // get input
-  edm::Handle<edm::HepMCProduct> hepUnsmearedMCEvt;
-  iEvent.getByToken(sourceToken_, hepUnsmearedMCEvt);
+  // get HepMC input (if given)
+  HepMC::GenEvent *genEvt;
+  if (sourceToken_.isUninitialized()) {
+    genEvt = new HepMC::GenEvent();
+  } else {
+    edm::Handle<edm::HepMCProduct> hepUnsmearedMCEvt;
+    iEvent.getByToken(sourceToken_, hepUnsmearedMCEvt);
 
-  // prepare output
-  HepMC::GenEvent* genevt = new HepMC::GenEvent(*hepUnsmearedMCEvt->GetEvent());
-  std::unique_ptr<edm::HepMCProduct> pEvent(new edm::HepMCProduct(genevt));
-
-  // apply vertex smearing
-  if (simulateVertex_) {
-    // NB: the separtion between effective offsets in LHC sectors 45 and 56 cannot be applied, thus the values for 45 are used
-    const double vtx_x =
-        hBeamParameters->getVtxOffsetX45() + CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getVtxStddevX();
-    const double vtx_y =
-        hBeamParameters->getVtxOffsetY45() + CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getVtxStddevY();
-    const double vtx_z =
-        hBeamParameters->getVtxOffsetZ45() + CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getVtxStddevZ();
-
-    HepMC::FourVector shift(vtx_x * 1E1, vtx_y * 1E1, vtx_z * 1E1, 0.);  // conversions: cm to mm
-    pEvent->applyVtxGen(&shift);
+    genEvt = new HepMC::GenEvent(*hepUnsmearedMCEvt->GetEvent());
   }
 
-  // apply beam divergence
+  // prepare output
+  std::unique_ptr<edm::HepMCProduct> output(new edm::HepMCProduct(genEvt));
+
+  // generate smearing parameters
+  SmearingParameters sp;
+
+  if (simulateVertex_) {
+    // NB: the separtion between effective offsets in LHC sectors 45 and 56 cannot be applied, thus the values for 45 are used
+    sp.vtx_x = hBeamParameters->getVtxOffsetX45() + CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getVtxStddevX();
+    sp.vtx_y = hBeamParameters->getVtxOffsetY45() + CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getVtxStddevY();
+    sp.vtx_z = hBeamParameters->getVtxOffsetZ45() + CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getVtxStddevZ();
+  }
+
   if (simulateBeamDivergence_) {
-    const double bd_x_45 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceX45();
-    const double bd_x_56 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceX56();
+    sp.bd_x_45 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceX45();
+    sp.bd_x_56 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceX56();
+    sp.bd_y_45 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceY45();
+    sp.bd_y_56 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceY56();
+  }
 
-    const double bd_y_45 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceY45();
-    const double bd_y_56 = CLHEP::RandGauss::shoot(rnd) * hBeamParameters->getBeamDivergenceY56();
+  // apply smearing
+  applySmearingHepMC(sp, genEvt);
 
-    for (HepMC::GenEvent::particle_iterator part = genevt->particles_begin(); part != genevt->particles_end(); ++part) {
-      const HepMC::FourVector mom = (*part)->momentum();
+  for (const auto &token : genParticleTokens_) {
+    edm::Handle<reco::GenParticleCollection> hGPCollection;
+    iEvent.getByToken(token, hGPCollection);
 
-      // TODO: this is an oversimplified implemetation
-      // the TOTEM smearing module should be taken as reference
-
-      double th_x = mom.x() / mom.z();
-      double th_y = mom.y() / mom.z();
-
-      if (mom.z() > 0.) {
-        th_x += bd_x_45;
-        th_y += bd_y_45;
-      } else {
-        th_x += bd_x_56;
-        th_y += bd_y_56;
-      }
-
-      // calculate consistent p_z component
-      const double sign = (mom.z() > 0.) ? 1. : -1.;
-      const double p_z = sign * mom.rho() / sqrt(1. + th_x * th_x + th_y * th_y);
-
-      // set smeared momentum
-      (*part)->set_momentum(HepMC::FourVector(p_z * th_x, p_z * th_y, p_z, mom.e()));
-    }
+    for (const auto &gp : *hGPCollection)
+      addSmearedGenParticle(gp, sp, genEvt);
   }
 
   // save output
-  iEvent.put(std::move(pEvent));
+  iEvent.put(std::move(output));
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void BeamDivergenceVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src", edm::InputTag("generator", "unsmeared"))
-      ->setComment("input collection where to retrieve outgoing particles kinematics to be smeared");
-  desc.add<bool>("simulateBeamDivergence", true)->setComment("account for the beam angular divergence?");
-  desc.add<bool>("simulateVertex", true)->setComment("account for the vertex transverse smearing?");
+template <typename T>
+HepMC::FourVector BeamDivergenceVtxGenerator::smearMomentum(const T &mom, const SmearingParameters &sp) {
+  // TODO: this is an oversimplified implemetation
+  // the TOTEM smearing module should be taken as reference
 
-  descriptions.add("beamDivergenceVtxGenerator", desc);
+  double th_x = mom.x() / mom.z();
+  double th_y = mom.y() / mom.z();
+
+  if (mom.z() > 0.) {
+    th_x += sp.bd_x_45;
+    th_y += sp.bd_y_45;
+  } else {
+    th_x += sp.bd_x_56;
+    th_y += sp.bd_y_56;
+  }
+
+  // calculate consistent p_z component
+  const double sign = (mom.z() > 0.) ? 1. : -1.;
+  const double p = sqrt(mom.x() * mom.x() + mom.y() * mom.y() + mom.z() * mom.z());
+  const double p_z = sign * p / sqrt(1. + th_x * th_x + th_y * th_y);
+
+  return HepMC::FourVector(p_z * th_x, p_z * th_y, p_z, mom.e());
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void BeamDivergenceVtxGenerator::applySmearingHepMC(const SmearingParameters &sp, HepMC::GenEvent *genEvt) {
+  if (simulateVertex_) {
+    for (HepMC::GenEvent::vertex_iterator vit = genEvt->vertices_begin(); vit != genEvt->vertices_end(); ++vit) {
+      const auto &pos = (*vit)->position();
+      (*vit)->set_position(HepMC::FourVector(pos.x() + sp.vtx_x * 1E1,  // conversion: cm to mm
+                                             pos.y() + sp.vtx_y * 1E1,
+                                             pos.z() + sp.vtx_z * 1E1,
+                                             pos.t()));
+    }
+  }
+
+  if (simulateBeamDivergence_) {
+    for (HepMC::GenEvent::particle_iterator part = genEvt->particles_begin(); part != genEvt->particles_end(); ++part)
+      (*part)->set_momentum(smearMomentum((*part)->momentum(), sp));
+  }
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void BeamDivergenceVtxGenerator::addSmearedGenParticle(const reco::GenParticle &gp,
+                                                       const SmearingParameters &sp,
+                                                       HepMC::GenEvent *genEvt) {
+  // add vertex of the particle
+  HepMC::GenVertex *vtx = new HepMC::GenVertex(HepMC::FourVector((gp.vx() + sp.vtx_x) * 1E1,  // conversion: cm to mm
+                                                                 (gp.vy() + sp.vtx_y) * 1E1,
+                                                                 (gp.vz() + sp.vtx_z) * 1E1,
+                                                                 0.));
+  genEvt->add_vertex(vtx);
+
+  // add the particle itself
+  HepMC::GenParticle *particle = new HepMC::GenParticle(smearMomentum(gp.p4(), sp), gp.pdgId(), gp.status());
+  vtx->add_particle_out(particle);
 }
 
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

This PR adds a possibility to run fast ("direct") forward-proton simulation starting with GenParticleCollection, for details see https://twiki.cern.ch/twiki/bin/view/CMS/TaggedProtonsDirectSimulation.

No changes are expected in the results of the standard workflows.

#### PR validation:

Since the updated module is not present in the standard sequences, tests with runTheMatrix were not performed.

Instead, the new functionality was tested with this config file:
  https://github.com/CTPPS/cmssw/tree/pps_zx_mc_10_6/test-simu-GenParticle

