### PR TITLE
Add 11_0_X prompt global tag for Run 3 data

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -45,7 +45,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'         :   '106X_dataRun3_Prompt_v5',
+    'run3_data_promptlike'     :   '110X_dataRun3_Prompt_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '110X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR adds the most recent global tag for Run 3 data to `autoCond`, corresponding to the global tag used in the first 2020 MWGR. The changes consist of tags corresponding to new conditions added during the Run 2 UL process, including:

- Update of E/Gamma regression (#27644, #28014)
- Updated PPS conditions (various PRs)
- [Updated GEM e-map](https://indico.cern.ch/event/880783/#4-gem-emap-update)
- Tau ID conditions to moved to GT (#28063, #28134)

The GT diff is as follows:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun3_Prompt_v5/110X_dataRun3_Prompt_v3

None of these changes should result in any changes in the results of Run 3 workflows. The purpose of this PR is to avoid using obsolete GTs in integration workflows.

#### PR validation:

All of the changes have been validated previously. In addition, a technical test on run 3 data was perfomed: `runTheMatrix.py -l 138.1`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but a backport to 11_0_X is planned.