### PR TITLE
Remove redundant looping of elements for link tests in PFBlockAlgo

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerPSEcal.cc
@@ -139,7 +139,7 @@ void KDTreeLinkerPSEcal::buildTree(const RecHitSet &rechitsSet, KDTreeLinkerAlgo
 }
 
 void KDTreeLinkerPSEcal::searchLinks() {
-  // Must of the code has been taken from LinkByRecHit.cc
+  // Most of the code has been taken from LinkByRecHit.cc
 
   // We iterate over the PS clusters.
   for (BlockEltSet::iterator it = targetSet_.begin(); it != targetSet_.end(); it++) {

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackEcal.cc
@@ -135,7 +135,7 @@ void KDTreeLinkerTrackEcal::buildTree() {
 }
 
 void KDTreeLinkerTrackEcal::searchLinks() {
-  // Must of the code has been taken from LinkByRecHit.cc
+  // Most of the code has been taken from LinkByRecHit.cc
 
   // We iterate over the tracks.
   for (BlockEltSet::iterator it = targetSet_.begin(); it != targetSet_.end(); it++) {

--- a/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
+++ b/RecoParticleFlow/PFProducer/plugins/kdtrees/KDTreeLinkerTrackHcal.cc
@@ -159,7 +159,7 @@ void KDTreeLinkerTrackHcal::buildTree() {
 }
 
 void KDTreeLinkerTrackHcal::searchLinks() {
-  // Must of the code has been taken from LinkByRecHit.cc
+  // Most of the code has been taken from LinkByRecHit.cc
 
   // We iterate over the tracks.
   for (BlockEltSet::iterator it = targetSet_.begin(); it != targetSet_.end(); it++) {
@@ -239,7 +239,7 @@ void KDTreeLinkerTrackHcal::searchLinks() {
 void KDTreeLinkerTrackHcal::updatePFBlockEltWithLinks() {
   //TODO YG : Check if cluster positionREP() is valid ?
 
-  // Here we save in each HCAL cluster the list of phi/eta values of linked clusters.
+  // Here we save in each HCAL cluster the list of phi/eta values of linked clusters (actually tracks).
   for (BlockElt2BlockEltMap::iterator it = cluster2TargetLinks_.begin(); it != cluster2TargetLinks_.end(); ++it) {
     reco::PFMultiLinksTC multitracks(true);
 

--- a/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
@@ -22,17 +22,14 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, PreshowerAndECALLinker, "PreshowerA
 
 bool PreshowerAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  switch (elem1->type()) {
-    case reco::PFBlockElement::PS1:
-    case reco::PFBlockElement::PS2:
-      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
-      break;
-    case reco::PFBlockElement::ECAL:
-      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
-      break;
-    default:
-      break;
-  }
+  // PS-ECAL kdtree-based links are stored to pselem
+  const reco::PFBlockElementCluster* pselem(nullptr);
+  if (elem1->type() < elem2->type())
+    pselem = static_cast<const reco::PFBlockElementCluster*>(elem1);
+  else
+    pselem = static_cast<const reco::PFBlockElementCluster*>(elem2);
+  result = (pselem->isMultilinksValide() && !pselem->getMultilinks().empty());
+  //
   return (useKDTree_ ? result : true);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/PreshowerAndECALLinker.cc
@@ -22,14 +22,18 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, PreshowerAndECALLinker, "PreshowerA
 
 bool PreshowerAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  // PS-ECAL kdtree-based links are stored to pselem
-  const reco::PFBlockElementCluster* pselem(nullptr);
-  if (elem1->type() < elem2->type())
-    pselem = static_cast<const reco::PFBlockElementCluster*>(elem1);
-  else
-    pselem = static_cast<const reco::PFBlockElementCluster*>(elem2);
-  result = (pselem->isMultilinksValide() && !pselem->getMultilinks().empty());
-  //
+  // PS-ECAL KDTree multilinks are stored to PS's elem
+  switch (elem1->type()) {
+    case reco::PFBlockElement::PS1:
+    case reco::PFBlockElement::PS2:
+      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
+      break;
+    case reco::PFBlockElement::ECAL:
+      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
+      break;
+    default:
+      break;
+  }
   return (useKDTree_ ? result : true);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
@@ -23,15 +23,14 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndECALLinker, "TrackAndECALLi
 
 bool TrackAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  switch (elem1->type()) {
-    case reco::PFBlockElement::TRACK:
-      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
-      break;
-    case reco::PFBlockElement::ECAL:
-      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
-    default:
-      break;
-  }
+  // Track-ECAL kdtree-based links are stored to tkelem
+  const reco::PFBlockElementTrack* tkelem(nullptr);
+  if (elem1->type() < elem2->type())
+    tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);
+  else
+    tkelem = static_cast<const reco::PFBlockElementTrack*>(elem2);
+  result = (tkelem->isMultilinksValide() && !tkelem->getMultilinks().empty());
+  //
   return (useKDTree_ ? result : true);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndECALLinker.cc
@@ -23,14 +23,16 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndECALLinker, "TrackAndECALLi
 
 bool TrackAndECALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  // Track-ECAL kdtree-based links are stored to tkelem
-  const reco::PFBlockElementTrack* tkelem(nullptr);
-  if (elem1->type() < elem2->type())
-    tkelem = static_cast<const reco::PFBlockElementTrack*>(elem1);
-  else
-    tkelem = static_cast<const reco::PFBlockElementTrack*>(elem2);
-  result = (tkelem->isMultilinksValide() && !tkelem->getMultilinks().empty());
-  //
+  // Track-ECAL KDTree multilinks are stored to track's elem
+  switch (elem1->type()) {
+    case reco::PFBlockElement::TRACK:
+      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
+      break;
+    case reco::PFBlockElement::ECAL:
+      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
+    default:
+      break;
+  }
   return (useKDTree_ ? result : true);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
@@ -47,14 +47,16 @@ DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndHCALLinker, "TrackAndHCALLi
 
 bool TrackAndHCALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   bool result = false;
-  // Track-HCAL kdtree-based links are stored to hcalelem
-  const reco::PFBlockElementCluster* hcalelem(nullptr);
-  if (elem1->type() < elem2->type())
-    hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
-  else
-    hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
-  result = (hcalelem->isMultilinksValide() && !hcalelem->getMultilinks().empty());
-  //
+  // Track-HCAL KDTree multilinks are stored to HCAL's elem
+  switch (elem1->type()) {
+    case reco::PFBlockElement::TRACK:
+      result = (elem2->isMultilinksValide() && !elem2->getMultilinks().empty());
+      break;
+    case reco::PFBlockElement::HCAL:
+      result = (elem1->isMultilinksValide() && !elem1->getMultilinks().empty());
+    default:
+      break;
+  }
   return (useKDTree_ ? result : true);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/linkers/TrackAndHCALLinker.cc
@@ -29,6 +29,8 @@ public:
     checkExit_ = trajectoryLayerExit_ != reco::PFTrajectoryPoint::Unknown;
   }
 
+  bool linkPrefilter(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
+
   double testLink(const reco::PFBlockElement*, const reco::PFBlockElement*) const override;
 
 private:
@@ -42,6 +44,19 @@ private:
 };
 
 DEFINE_EDM_PLUGIN(BlockElementLinkerFactory, TrackAndHCALLinker, "TrackAndHCALLinker");
+
+bool TrackAndHCALLinker::linkPrefilter(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
+  bool result = false;
+  // Track-HCAL kdtree-based links are stored to hcalelem
+  const reco::PFBlockElementCluster* hcalelem(nullptr);
+  if (elem1->type() < elem2->type())
+    hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem2);
+  else
+    hcalelem = static_cast<const reco::PFBlockElementCluster*>(elem1);
+  result = (hcalelem->isMultilinksValide() && !hcalelem->getMultilinks().empty());
+  //
+  return (useKDTree_ ? result : true);
+}
 
 double TrackAndHCALLinker::testLink(const reco::PFBlockElement* elem1, const reco::PFBlockElement* elem2) const {
   const reco::PFBlockElementCluster* hcalelem(nullptr);

--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -151,8 +151,8 @@ reco::PFBlockCollection PFBlockAlgo::findBlocks() {
   QuickUnion qu(elements_.size());
   const auto elem_size = elements_.size();
   for (unsigned i = 0; i < elem_size; ++i) {
-    for (unsigned j = 0; j < elem_size; ++j) {
-      if (qu.connected(i, j) || j == i)
+    for (unsigned j = i + 1; j < elem_size; ++j) {
+      if (qu.connected(i, j))
         continue;
       if (!linkTests_[linkTestSquare_[elements_[i]->type()][elements_[j]->type()]]) {
         j = ranges_[elements_[j]->type()].second;


### PR DESCRIPTION
#### PR description:

Tuning the looping logic so that we can remove the redundant looping of elements for link tests in PFBlockAlgo. This simple change should make the PFBlockAlgo [one of the most timing consuming part of PF] faster by a factor up to 1.8 with no change in outputs.

Using HLT's OnLine_HLT_GRun.py on:
/eos/cms/store/data/Run2018D/EphemeralHLTPhysics5/RAW/v1/000/324/897/00000/F5F13777-D664-C747-88AA-0459C1E35254.root
(1000 events)
**FastReport**
```
[Before]
CPU time avg.      when run  Real time avg.      when run     Alloc. avg.      when run   Dealloc. avg.      when run  Modules
        44.0 ms        44.0 ms        44.7 ms        44.7 ms       +3349 kB       +3349 kB       -2607 kB       -2607 kB    hltParticleFlowBlock
         0.9 ms        44.0 ms         0.9 ms        44.4 ms         +72 kB       +3434 kB         -55 kB       -2663 kB    hltParticleFlowBlockForTaus
         1.5 ms        43.0 ms         1.6 ms        45.2 ms        +112 kB       +3121 kB         -85 kB       -2381 kB    hltParticleFlowBlockReg

[With this PR]
        24.7 ms        24.7 ms        26.3 ms        26.3 ms       +3349 kB       +3349 kB       -2607 kB       -2607 kB    hltParticleFlowBlock
         0.5 ms        25.2 ms         0.6 ms        28.7 ms         +72 kB       +3438 kB         -56 kB       -2668 kB    hltParticleFlowBlockForTaus
         0.9 ms        24.5 ms         1.0 ms        27.8 ms        +112 kB       +3120 kB         -85 kB       -2382 kB    hltParticleFlowBlockReg
```

And, just for reference, if we also drop PS from PFBlockProducer for HLT as discussed in the TSG meeting, March 4th, (https://github.com/hatakeyamak/cmssw/pull/new/PFBlockProducerDropPS2)
```
        14.7 ms        14.7 ms        15.9 ms        15.9 ms       +1742 kB       +1742 kB       -1400 kB       -1400 kB    hltParticleFlowBlock
         0.3 ms        16.2 ms         0.4 ms        17.3 ms         +36 kB       +1752 kB         -29 kB       -1399 kB    hltParticleFlowBlockForTaus
         0.5 ms        12.6 ms         0.5 ms        12.9 ms         +52 kB       +1460 kB         -41 kB       -1146 kB    hltParticleFlowBlockReg
```

#### PR validation:

Check with 100 events from 2018 data that this change yields the identical list of PF candidates.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not backport.

@bendavid @jsalfeld @jpata 