### PR TITLE
Added option firstLuminosityBlockForEachRun to PoolSource

### DIFF
--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -258,7 +258,7 @@ namespace edm {
         }
       }
     }
-    return runHelper_->nextItemType(state(), itemType);
+    return runHelper_->nextItemType(state(), itemType, run, lumi, event);
   }
 
   std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> PoolSource::resourceSharedWithDelayedReader_() {

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -819,7 +819,7 @@ namespace edm {
     }
     if (entryType == IndexIntoFile::kRun) {
       run = indexIntoFileIter_.run();
-      runHelper_->checkForNewRun(run);
+      runHelper_->checkForNewRun(run, indexIntoFileIter_.peekAheadAtLumi());
       return IndexIntoFile::kRun;
     } else if (processingMode_ == InputSource::Runs) {
       indexIntoFileIter_.advanceToNextRun();

--- a/IOPool/Input/src/RunHelper.cc
+++ b/IOPool/Input/src/RunHelper.cc
@@ -17,9 +17,14 @@ namespace edm {
       }
     }
     if (pset.exists("setRunNumberForEachLumi")) {
-      std::vector<RunNumber_t> runs = pset.getUntrackedParameter<std::vector<unsigned int> >("setRunNumberForEachLumi");
+      std::vector<RunNumber_t> runs = pset.getUntrackedParameter<std::vector<unsigned int>>("setRunNumberForEachLumi");
       if (!runs.empty()) {
         return std::make_unique<SetRunForEachLumiHelper>(pset);
+      }
+    }
+    if (pset.exists("firstLuminosityBlockForEachRun")) {
+      if (not pset.getUntrackedParameter<std::vector<LuminosityBlockID>>("firstLuminosityBlockForEachRun").empty()) {
+        return std::make_unique<FirstLuminosityBlockForEachRunHelper>(pset);
       }
     }
     return std::make_unique<DefaultRunHelper>();
@@ -88,7 +93,7 @@ namespace edm {
 
   SetRunForEachLumiHelper::SetRunForEachLumiHelper(ParameterSet const& pset)
       : RunHelperBase(),
-        setRunNumberForEachLumi_(pset.getUntrackedParameter<std::vector<unsigned int> >("setRunNumberForEachLumi")),
+        setRunNumberForEachLumi_(pset.getUntrackedParameter<std::vector<unsigned int>>("setRunNumberForEachLumi")),
         indexOfNextRunNumber_(0),
         realRunNumber_(0),
         fakeNewRun_(false),
@@ -97,7 +102,10 @@ namespace edm {
   SetRunForEachLumiHelper::~SetRunForEachLumiHelper() {}
 
   InputSource::ItemType SetRunForEachLumiHelper::nextItemType(InputSource::ItemType const& previousItemType,
-                                                              InputSource::ItemType const& newItemType) {
+                                                              InputSource::ItemType const& newItemType,
+                                                              RunNumber_t,
+                                                              LuminosityBlockNumber_t,
+                                                              EventNumber_t) {
     if (newItemType == InputSource::IsRun ||
         (newItemType == InputSource::IsLumi && previousItemType != InputSource::IsRun)) {
       if (firstTime_) {
@@ -128,7 +136,7 @@ namespace edm {
     return setRunNumberForEachLumi_.at(indexOfNextRunNumber_);
   }
 
-  void SetRunForEachLumiHelper::checkForNewRun(RunNumber_t run) {
+  void SetRunForEachLumiHelper::checkForNewRun(RunNumber_t run, LuminosityBlockNumber_t) {
     if (realRunNumber_ != 0 && run != realRunNumber_) {
       throw Exception(errors::MismatchedInputFiles, "PoolSource::checkForNewRun")
           << " Parameter 'setRunNumberForEachLumi' can only process a single run.\n"
@@ -155,14 +163,93 @@ namespace edm {
     assert(run == runNumberToUseForThisLumi());
   }
 
+  FirstLuminosityBlockForEachRunHelper::FirstLuminosityBlockForEachRunHelper(ParameterSet const& pset)
+      : lumiToRun_(pset.getUntrackedParameter<std::vector<edm::LuminosityBlockID>>("firstLuminosityBlockForEachRun")),
+        realRunNumber_{0},
+        lastUsedRunNumber_{0},
+        fakeNewRun_{false} {}
+
+  InputSource::ItemType FirstLuminosityBlockForEachRunHelper::nextItemType(InputSource::ItemType const& previousItemType,
+                                                                           InputSource::ItemType const& newItemType,
+                                                                           RunNumber_t,
+                                                                           LuminosityBlockNumber_t iLumi,
+                                                                           EventNumber_t) {
+    if (newItemType == InputSource::IsLumi && previousItemType != InputSource::IsRun) {
+      auto run = findRunFromLumi(iLumi);
+      if (run == 0) {
+        throw Exception(errors::Configuration, "PoolSource")
+            << "'firstLuminosityBlockForEachRun' contains an illegal run number of '0'.\n";
+      }
+      if (lastUsedRunNumber_ != run) {
+        fakeNewRun_ = true;
+        lastUsedRunNumber_ = run;
+        return InputSource::IsRun;
+      }
+    }
+    return newItemType;
+  }
+
+  RunNumber_t FirstLuminosityBlockForEachRunHelper::runNumberToUseForThisLumi() const { return lastUsedRunNumber_; }
+
+  void FirstLuminosityBlockForEachRunHelper::checkForNewRun(RunNumber_t run, LuminosityBlockNumber_t iLumi) {
+    if (realRunNumber_ != 0 && run != realRunNumber_) {
+      throw Exception(errors::MismatchedInputFiles, "PoolSource::checkForNewRun")
+          << " Parameter 'firstLuminosityBlockForEachRun' can only process a single run.\n"
+          << "but this job is processing more than one run.\n";
+    }
+    lastUsedRunNumber_ = findRunFromLumi(iLumi);
+    realRunNumber_ = run;
+    fakeNewRun_ = false;
+  }
+
+  void FirstLuminosityBlockForEachRunHelper::overrideRunNumber(RunID& id) { id = RunID(runNumberToUseForThisLumi()); }
+
+  void FirstLuminosityBlockForEachRunHelper::overrideRunNumber(LuminosityBlockID& id) {
+    id = LuminosityBlockID(runNumberToUseForThisLumi(), id.luminosityBlock());
+  }
+
+  void FirstLuminosityBlockForEachRunHelper::overrideRunNumber(EventID& id, bool isRealData) {
+    if (isRealData) {
+      throw Exception(errors::Configuration, "FirstLuminosityBlockForEachRunHelper::overrideRunNumber()")
+          << "The 'firstLuminosityBlockForEachRun' parameter of PoolSource cannot be used with real data.\n";
+    }
+    id = EventID(runNumberToUseForThisLumi(), id.luminosityBlock(), id.event());
+  }
+
+  void FirstLuminosityBlockForEachRunHelper::checkRunConsistency(RunNumber_t run, RunNumber_t originalRun) const {
+    assert(run == runNumberToUseForThisLumi());
+  }
+
+  RunNumber_t FirstLuminosityBlockForEachRunHelper::findRunFromLumi(LuminosityBlockNumber_t iLumi) const {
+    RunNumber_t run = 0;
+    for (auto const& lumiID : lumiToRun_) {
+      if (lumiID.luminosityBlock() > iLumi) {
+        break;
+      }
+      run = lumiID.run();
+    }
+    if (0 == run) {
+      throw Exception(errors::Configuration, "FirstLuminosityBlockForEachRunHelper::findRunFromLumi()")
+          << "The 'firstLuminosityBlockForEachRun' parameter does not have a matching Run number for LuminosityBlock "
+             "number: "
+          << iLumi << ".\n";
+    }
+    return run;
+  }
+
   void RunHelperBase::fillDescription(ParameterSetDescription& desc) {
     desc.addOptionalNode(ParameterDescription<unsigned int>("setRunNumber", 0U, false) xor
-                             ParameterDescription<std::vector<unsigned int> >(
-                                 "setRunNumberForEachLumi", std::vector<unsigned int>(), false),
+                             ParameterDescription<std::vector<unsigned int>>(
+                                 "setRunNumberForEachLumi", std::vector<unsigned int>(), false) xor
+                             ParameterDescription<std::vector<LuminosityBlockID>>(
+                                 "firstLuminosityBlockForEachRun", std::vector<LuminosityBlockID>(), false),
                          true)
         ->setComment(
             "If 'setRun' is non-zero, change number of first run to this number. Apply same offset to all runs."
             "If 'setRunNumberForEachLumi' is non-empty, use these as run numbers for each lumi respectively."
-            "''setRun' and 'setRunNumberForEachLumi' are mutually exclusive and allowed only for simulation.");
+            "If 'firstLuminosityBlockForEachRun' is non-empty, the LuminosityBlock ID is used to determine which Run "
+            "ID to use. The entries must be ascending values of LuminosityBlock ID."
+            "''setRun', 'setRunNumberForEachLumi' and 'firstLuminosityBlockForEachRun' are mutually exclusive and "
+            "allowed only for simulation.");
   }
 }  // namespace edm

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -66,6 +66,12 @@ diff ${LOCAL_TEST_DIR}/unit_test_outputs/RunPerLumiTest.filtered.txt ${LOCAL_TMP
 cmsRun ${LOCAL_TEST_DIR}/RunPerLumiTest_cfg.py 50 >& ${LOCAL_TMP_DIR}/tooManyLumis.txt && die 'RunPerLumiTest_cfg.py should have failed but did not' $?
 grep "MismatchedInputFiles" ${LOCAL_TMP_DIR}/tooManyLumis.txt || die  'RunPerLumiTest_cfg.py should have failed but did not' $?
 
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRunTest_cfg.py 'file:RunPerLumiTest.root' 25 1 25 1 5 || die 'Failure using firstLuminosityBlockForEachRunTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py firstLumiTest1.root 25 1 100 1 5 || die 'Failure using PrePoolInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py firstLumiTest2.root 25 1 100 6 5 || die 'Failure using PrePoolInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRunTest_cfg.py 'file:firstLumiTest1.root,file:firstLumiTest2.root' 50 1 25 1 5 || die 'Failure using firstLuminosityBlockForEachRunTest_cfg.py with 2 files' $?
+cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRunTest_cfg.py 'file:firstLumiTest1.root,file:firstLumiTest2.root' 50 1 25 1 5 shareRun || die 'Failure using firstLuminosityBlockForEachRunTest_cfg.py with 2 files which share a run' $?
+
 
 #test merging of heterogeneous files with extra provenenace in subsequent files
 

--- a/IOPool/Input/test/firstLuminosityBlockForEachRunTest_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRunTest_cfg.py
@@ -1,0 +1,77 @@
+# The following comments couldn't be translated into the new config version:
+
+# Configuration file for PoolInputTest
+
+import FWCore.ParameterSet.Config as cms
+import sys
+
+import sys
+
+#ignore script name and anything before it
+argv = []
+foundpy = False
+for a in sys.argv:
+    if foundpy:
+        argv.append(a)
+    if ".py" in a:
+        foundpy = True
+
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(int(argv[1]))
+)
+
+firstRun = int(argv[2])
+numberEventsInRun = int(argv[3])
+firstLuminosityBlock = int(argv[4])
+numberEventsInLuminosityBlock = int(argv[5])
+
+if len(argv) > 6:
+  #have first run of second file continue the run
+  runToLumi = ((2,1),(10,3),(20,5), (30, 7), (40, 9) )
+else:
+  #have first run of second file be a new run
+  runToLumi = ((2,1),(10,3),(20,5), (30, 6), (40, 9) )
+
+def findRunForLumi( lumi) :
+  lastRun = runToLumi[0][0]
+  for r,l in runToLumi:
+    if l > lumi:
+      break
+    lastRun = r
+  return lastRun
+
+ids = cms.VEventID()
+numberOfEventsInLumi = 0
+numberOfEventsPerLumi = numberEventsInLuminosityBlock
+lumi = 1
+event=0
+oldRun = 2
+numberOfFiles = len(argv[0].split(","))
+numberOfEventsInFile = int(argv[1])/numberOfFiles
+for i in range(process.maxEvents.input.value()):
+   numberOfEventsInLumi +=1
+   event += 1
+   run = findRunForLumi(lumi)
+   if event > numberOfEventsInFile:
+    event = 1
+   if numberOfEventsInLumi > numberOfEventsPerLumi:
+      numberOfEventsInLumi=1
+      lumi += 1
+      run = findRunForLumi(lumi)
+      if run != oldRun:
+        oldRun = run
+   ids.append(cms.EventID(run,lumi,event))
+process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(ids))
+
+
+process.source = cms.Source("PoolSource",
+    firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
+    fileNames = cms.untracked.vstring(argv[0].split(","))
+)
+
+process.e = cms.EndPath(process.check)
+


### PR DESCRIPTION
#### PR description:

This option is meant to support Run dependent MC. It was described in the Run dependent MC task force document.

#### PR validation:

All framework unit tests pass.