### PR TITLE
[DD4hep] Add a converter from a vector<string> to a vector<double>

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -163,6 +163,11 @@ namespace cms {
     template <typename T>
     T get(const std::string&, const std::string&) const;
 
+    //! convert an attribute value from SpecPar
+    //  without passing it through an evaluator,
+    //  e.g. the original values have no units
+    std::vector<double> get(const std::string&, const std::string&) const;
+
     std::string_view getString(const std::string&) const;
 
     //! return the stack of sibling numbers which indicates

--- a/DetectorDescription/DDCMS/interface/DDSpecParRegistry.h
+++ b/DetectorDescription/DDCMS/interface/DDSpecParRegistry.h
@@ -14,6 +14,7 @@ namespace cms {
   struct DDSpecPar {
     std::string_view strValue(const std::string&) const;
     bool hasValue(const std::string& key) const;
+    bool hasPath(const std::string& path) const;
     double dblValue(const std::string&) const;
 
     template <typename T>
@@ -22,6 +23,7 @@ namespace cms {
     DDPaths paths;
     DDPartSelectionMap spars;
     DDVectorsMap numpars;
+    std::string_view name;
   };
 
   using DDSpecParMap = tbb::concurrent_unordered_map<std::string, DDSpecPar>;
@@ -31,6 +33,7 @@ namespace cms {
     void filter(DDSpecParRefs&, std::string_view, std::string_view) const;
     void filter(DDSpecParRefs&, std::string_view) const;
     std::vector<std::string_view> names() const;
+    std::vector<std::string_view> names(const std::string& path) const;
     bool hasSpecPar(std::string_view) const;
     const DDSpecPar* specPar(std::string_view) const;
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc
@@ -37,7 +37,11 @@ void DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup) 
   LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag << " for attribute " << m_attribute
                           << " and value " << m_value;
   LogVerbatim("Geometry") << "DD SpecPar Registry size: " << registry->specpars.size();
-
+  std::cout << "*** Check names in a path:\n";
+  std::vector<std::string_view> namesInPath = registry->names("//ME11AlumFrame");
+  for (auto i : namesInPath) {
+    std::cout << i << "\n";
+  }
   DDSpecParRefs myReg;
   if (m_value.empty())
     registry->filter(myReg, m_attribute);
@@ -60,6 +64,12 @@ void DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup) 
       }
     }
   });
+  std::cout << "*** Check names in a path after filtering:\n";
+  for (auto it : myReg) {
+    if (it->hasPath("//ME11AlumFrame")) {
+      std::cout << it->name << "\n";
+    }
+  }
 }
 
 DEFINE_FWK_MODULE(DDTestSpecParsFilter);

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -391,6 +391,15 @@ std::vector<std::string> DDFilteredView::get<std::vector<std::string>>(const str
     return std::vector<std::string>();
 }
 
+std::vector<double> DDFilteredView::get(const string& name, const string& key) const {
+  std::vector<std::string> stringVector = get<std::vector<std::string>>(name, key);
+  std::vector<double> doubleVector(stringVector.size());
+  std::transform(stringVector.begin(), stringVector.end(), doubleVector.begin(), [](const std::string& val) {
+    return std::stod(val);
+  });
+  return doubleVector;
+}
+
 std::string_view DDFilteredView::getString(const std::string& key) const {
   assert(currentFilter_);
   assert(currentFilter_->spec);

--- a/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
+++ b/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
@@ -21,6 +21,14 @@ bool DDSpecPar::hasValue(const string& key) const {
     return false;
 }
 
+bool DDSpecPar::hasPath(const string& path) const {
+  auto result = std::find(std::begin(paths), std::end(paths), path);
+  if (result != end(paths))
+    return true;
+  else
+    return false;
+}
+
 template <>
 std::vector<double> DDSpecPar::value<std::vector<double>>(const string& key) const {
   std::vector<double> result;
@@ -70,7 +78,7 @@ double DDSpecPar::dblValue(const string& key) const {
 
 void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute, string_view value) const {
   bool found(false);
-  for_each(begin(specpars), end(specpars), [&refs, &attribute, &value, &found](const auto& k) {
+  for_each(begin(specpars), end(specpars), [&refs, &attribute, &value, &found](auto& k) {
     found = false;
     for_each(begin(k.second.spars), end(k.second.spars), [&](const auto& l) {
       if (l.first == attribute) {
@@ -81,6 +89,7 @@ void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute, strin
       }
     });
     if (found) {
+      k.second.name = k.first;
       refs.emplace_back(&k.second);
     }
   });
@@ -88,7 +97,7 @@ void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute, strin
 
 void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute) const {
   bool found(false);
-  for_each(begin(specpars), end(specpars), [&refs, &attribute, &found](const auto& k) {
+  for_each(begin(specpars), end(specpars), [&refs, &attribute, &found](auto& k) {
     found = false;
     for_each(begin(k.second.spars), end(k.second.spars), [&](const auto& l) {
       if (l.first == attribute) {
@@ -96,9 +105,19 @@ void DDSpecParRegistry::filter(DDSpecParRefs& refs, string_view attribute) const
       }
     });
     if (found) {
+      k.second.name = k.first;
       refs.emplace_back(&k.second);
     }
   });
+}
+
+std::vector<std::string_view> DDSpecParRegistry::names(const std::string& path) const {
+  std::vector<std::string_view> result;
+  for_each(begin(specpars), end(specpars), [&](const auto& i) {
+    if (i.second.hasPath(path))
+      result.emplace_back(i.first);
+  });
+  return result;
 }
 
 std::vector<std::string_view> DDSpecParRegistry::names() const {

--- a/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
@@ -117,4 +117,20 @@ void testDDFilteredView::checkFilteredView() {
     CPPUNIT_ASSERT(i.compare(refsLongFL_[count]) == 0);
     count++;
   }
+
+  cout << "Get CSC upar parameters for ChamberSpecs_ME11 as a vector of strings:\n";
+  std::vector<std::string> cscsPars = fview.get<std::vector<std::string>>("ChamberSpecs_ME11", "upar");
+  for (auto const& i : cscsPars) {
+    std::cout << i << ", ";
+    count++;
+  }
+  std::cout << "\n";
+
+  cout << "Get CSC upar parameters for ChamberSpecs_ME11 as a vector of doubles:\n";
+  std::vector<double> upars = fview.get("ChamberSpecs_ME11", "upar");
+  for (auto const& i : upars) {
+    std::cout << i << ", ";
+    count++;
+  }
+  std::cout << "\n";
 }

--- a/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
@@ -49,7 +49,7 @@ process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProduce
 process.test = cms.EDAnalyzer("DDTestSpecParsFilter",
                               DDDetector = cms.ESInputTag('','CMS'),
                               attribute = cms.untracked.string('MuStructure'),
-                              value = cms.untracked.string('MuonBarrelDT')
+                              value = cms.untracked.string('MuonEndcapCSC') ###'MuonBarrelDT')
                               )
 
 process.p = cms.Path(process.test)


### PR DESCRIPTION
#### PR description:

Addresses an issue:
https://github.com/cms-sw/cmssw/issues/28871

```c++
std::vector<double> upars = fview.get("ChamberSpecs_ME11", "upar");
```
Here is an example how to get a vector of names for a specific path:
```c++
std::vector<std::string_view> namesInPath = registry->names("//ME11AlumFrame");
```
@slomeo - FYI

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
