### PR TITLE
Fix cms::cuda::ESProduct for zero devices

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/ESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/ESProduct.h
@@ -7,9 +7,9 @@
 #include <vector>
 
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "HeterogeneousCore/CUDAServices/interface/numberOfDevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/EventCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/deviceCount.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/currentDevice.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/eventWorkHasCompleted.h"
 
@@ -18,7 +18,7 @@ namespace cms {
     template <typename T>
     class ESProduct {
     public:
-      ESProduct() : gpuDataPerDevice_(deviceCount()) {
+      ESProduct() : gpuDataPerDevice_(numberOfDevices()) {
         for (size_t i = 0; i < gpuDataPerDevice_.size(); ++i) {
           gpuDataPerDevice_[i].m_event = getEventCache().get();
         }

--- a/HeterogeneousCore/CUDAServices/interface/numberOfCUDADevices.h
+++ b/HeterogeneousCore/CUDAServices/interface/numberOfCUDADevices.h
@@ -1,9 +1,0 @@
-#ifndef HeterogeneousCore_CUDAServices_numberOfCUDADevices_h
-#define HeterogeneousCore_CUDAServices_numberOfCUDADevices_h
-
-// Returns the number of CUDA devices
-// The difference wrt. the standard CUDA function is that if
-// CUDAService is disabled, this function returns 0.
-int numberOfCUDADevices();
-
-#endif

--- a/HeterogeneousCore/CUDAServices/interface/numberOfDevices.h
+++ b/HeterogeneousCore/CUDAServices/interface/numberOfDevices.h
@@ -1,0 +1,14 @@
+#ifndef HeterogeneousCore_CUDAServices_numberOfDevices_h
+#define HeterogeneousCore_CUDAServices_numberOfDevices_h
+
+namespace cms {
+  namespace cuda {
+    // Returns the number of CUDA devices
+    // The difference wrt. the standard CUDA function or
+    // cms::cuda::deviceCount() is that if CUDAService is disabled,
+    // this function returns 0.
+    int numberOfDevices();
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/HeterogeneousCore/CUDAServices/src/numberOfCUDADevices.cc
+++ b/HeterogeneousCore/CUDAServices/src/numberOfCUDADevices.cc
@@ -1,8 +1,0 @@
-#include "HeterogeneousCore/CUDAServices/interface/numberOfCUDADevices.h"
-#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
-int numberOfCUDADevices() {
-  edm::Service<CUDAService> cs;
-  return cs->enabled() ? cs->numberOfDevices() : 0;
-}

--- a/HeterogeneousCore/CUDAServices/src/numberOfDevices.cc
+++ b/HeterogeneousCore/CUDAServices/src/numberOfDevices.cc
@@ -1,0 +1,10 @@
+#include "HeterogeneousCore/CUDAServices/interface/numberOfDevices.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+namespace cms::cuda {
+  int numberOfDevices() {
+    edm::Service<CUDAService> cs;
+    return cs->enabled() ? cs->numberOfDevices() : 0;
+  }
+}  // namespace cms::cuda


### PR DESCRIPTION
#### PR description:

This PR
- renames `numberOfCUDADevices()` function to `cms::cuda::numberOfDevices()` to follow the convention established in #28537 (somehow this function slipped through then)
- enables `cms::cuda::ESProduct` to be constructed on a machine without GPUs

#### PR validation:

Unit tests run.