### PR TITLE
Bug fix on infinite loop in MuonSinClassifier (Backport)

### DIFF
--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -301,7 +301,11 @@ MuonSimClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		  jm++;
 		  if (mMom->numberOfMothers() > 0) {
 		    mMom = mMom->motherRef();
+		  } else {
+		    LogTrace("MuonSimClassifier") << "\t No Mother is found ";
+		    break;
 		  }
+		  
 		  LogTrace("MuonSimClassifier") 
 		    << "\t\t backtracking mother "<<jm<<", pdgId = "<<mMom->pdgId()<<", status= " <<mMom->status();
 		}


### PR DESCRIPTION
#### PR description:

As reported in https://its.cern.ch/jira/browse/CMSMUONS-312, infinite loop happens in the RECOSIM step, because Gen Muons appear as the first GenParticle in the tree.

This fixes the issue.

Backport https://github.com/cms-sw/cmssw/pull/28802

#### PR validation:
Local test with DR step of
https://cms-pdmv.cern.ch/mcm/chained_requests?contains=PPS-RunIIFall18GS-00004&page=0&shown=15

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
https://github.com/cms-sw/cmssw/pull/28802
