### PR TITLE
DQM: Avoid hoarding lumi MEs in reco jobs.

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -442,6 +442,8 @@ DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& i
     m_indicesTree->Fill();
   }
 
+  dstore->deleteUnusedLumiHistograms(m_enableMultiThread ? m_run : 0, m_lumi);
+
   edm::Service<edm::JobReport> jr;
   jr->reportLumiSection(m_jrToken, m_run, m_lumi);
 }


### PR DESCRIPTION

#### PR description:

An issue discussed in https://its.cern.ch/jira/projects/CMSCOMPPR/issues/CMSCOMPPR-10942 seems to be caused by per-lumi MEs being cloned per lumi, but never actually cleaned up in RECO jobs, since the cleanup operation `deleteUnusedLumiHistograms` is only called in the `DQMFileSaver` which only runs in HARVESTING jobs.

This apparently never caused trouble, since either the amount of per-lumi MEs or lumisections per job was quite small.

#### PR validation:
None so far.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No master PR yet. The relevant code does not exist in master/11_1.

Forward port to 11_0 might bepossible.