### PR TITLE
Bug fix on infinite loop in MuonSimClassifier (Backport to 10_6)

### DIFF
--- a/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
+++ b/SimMuon/MCTruth/plugins/MuonSimClassifier.cc
@@ -320,7 +320,11 @@ void MuonSimClassifier::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
               jm++;
               if (mMom->numberOfMothers() > 0) {
                 mMom = mMom->motherRef();
-              }
+              } else {
+                LogTrace("MuonSimClassifier") << "\t No Mother is found ";
+                break;
+	      }
+
               LogTrace("MuonSimClassifier") << "\t\t backtracking mother " << jm << ", pdgId = " << mMom->pdgId()
                                             << ", status= " << mMom->status();
             }


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/28802 to fix the infinite loop in MuonSinClassifier.
