### PR TITLE
[PhysicsTools/PatAlgos] fixed one sanity check in PATTriggerEventProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -114,7 +114,7 @@ void PATTriggerEventProducer::beginRun(const Run& iRun, const EventSetup& iSetup
   // adapt configuration of used input tags
   if (tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*") {
     tagTriggerResults_ = InputTag(tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_);
-  } else if (tagTriggerEvent_.process() != nameProcess_) {
+  } else if (tagTriggerResults_.process() != nameProcess_) {
     LogWarning("triggerResultsTag") << "TriggerResults process name '" << tagTriggerResults_.process()
                                     << "' differs from HLT process name '" << nameProcess_ << "'";
   }


### PR DESCRIPTION
#### PR description:

A simple fix to one sanity check in `PATTriggerEventProducer`
(a check on the value of `tagTriggerEvent_.process()` is currently duplicated, instead of making the relevant check on `tagTriggerResults_.process()`).

#### PR validation:

Only checked that the code compiles.
