### PR TITLE
DQM: Fix type for DeadChannel.threshold QTest

### DIFF
--- a/DQMServices/Components/plugins/QualityTester.cc
+++ b/DQMServices/Components/plugins/QualityTester.cc
@@ -303,7 +303,7 @@ std::unique_ptr<QCriterion> QualityTester::makeQCriterion(boost::property_tree::
                         auto test = std::make_unique<DeadChannel>(name);
                         test->setWarningProb(config.get<float>("warning", QCriterion::WARNING_PROB_THRESHOLD));
                         test->setErrorProb(config.get<float>("error", QCriterion::ERROR_PROB_THRESHOLD));
-                        test->setThreshold(config.get<int>("threshold"));
+                        test->setThreshold(config.get<float>("threshold"));
                         return test;
                       }},
                      {MeanWithinExpected::getAlgoName(),


### PR DESCRIPTION
#### PR description:

A small bug spotted running DT Online DQM.

This QTest seems to be not used in any offline workflows, else it would have probably blown up there before.

#### PR validation:

Works on online DQM playback system.

No changes in offline expected.