### PR TITLE
L1T EMTF fix for pT assignment configuration bug in 2016 and 2017

### DIFF
--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -131,10 +131,14 @@ simEmtfDigisData = simEmtfDigisMC.clone(
 simEmtfDigis = simEmtfDigisMC.clone()
 
 
+## Load "Era" modules to adjust RPCEnable and Era (which controls the choice of PtAssignmentEngine)
+## If neither 'Run2_2016' nor 'Run2_2017' are invoked, default 2018 settings are used
+## Era configuration files are located in Configuration/Eras/python
+
 ## Era: Run2_2016
-#from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-#stage2L1Trigger.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(simEmtfDigis, RPCEnable = cms.bool(False), Era = cms.string('Run2_2016'))
 
 ## Era: Run2_2017
-#from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-#stage2L1Trigger_2017.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cms.string('Run2_2017'))
+from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+stage2L1Trigger_2017.toModify(simEmtfDigis, RPCEnable = cms.bool(True), Era = cms.string('Run2_2017'))

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -73,8 +73,8 @@ void PtAssignment::process(EMTFTrackCollection& best_tracks) {
       address = pt_assign_engine_->calculate_address(track);
       xmlpt = pt_assign_engine_->calculate_pt(address);
 
-      // Check address packing / unpacking
-      if (not(fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001)) {
+      // Check address packing / unpacking using PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track)
+      if (pt_assign_engine_->get_pt_lut_version() > 5 && not(fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001)) {
         edm::LogWarning("L1T") << "EMTF pT assignment mismatch: xmlpt = " << xmlpt
                                << ", pt_assign_engine_->calculate_pt(track)) = "
                                << pt_assign_engine_->calculate_pt(track);

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -74,7 +74,8 @@ void PtAssignment::process(EMTFTrackCollection& best_tracks) {
       xmlpt = pt_assign_engine_->calculate_pt(address);
 
       // Check address packing / unpacking using PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track)
-      if (pt_assign_engine_->get_pt_lut_version() > 5 && not(fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001)) {
+      if (pt_assign_engine_->get_pt_lut_version() > 5 &&
+          not(fabs(xmlpt - pt_assign_engine_->calculate_pt(track)) < 0.001)) {
         edm::LogWarning("L1T") << "EMTF pT assignment mismatch: xmlpt = " << xmlpt
                                << ", pt_assign_engine_->calculate_pt(track)) = "
                                << pt_assign_engine_->calculate_pt(track);


### PR DESCRIPTION
Small fix in EMTF config file to enable configuration of pT assignment by global "Era".  Fixes issue where all EMTF muons were being assigned pT = 0 in UL2016 RelVals.

Also suppress a spurious warning which is generated as a result of using the correct PtAssignmentEngine.

@davignon , @BenjaminRS , @rekovic , @jiafulow 