### PR TITLE
[ROOT] Add explicitely missing headers in DQM and Fireworks

### DIFF
--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "TPRegexp.h"
+#include "TObjArray.h"
 
 namespace ecaldqm {
   namespace binning {

--- a/Fireworks/Core/src/CSGAction.cc
+++ b/Fireworks/Core/src/CSGAction.cc
@@ -16,6 +16,7 @@
 #include <TQObject.h>
 #include <KeySymbols.h>
 #include <TGMenu.h>
+#include <TVirtualX.h>
 
 // user include files
 #include "Fireworks/Core/interface/CSGAction.h"

--- a/Fireworks/Core/src/CmsShowEDI.cc
+++ b/Fireworks/Core/src/CmsShowEDI.cc
@@ -32,6 +32,7 @@
 #include "TGSlider.h"
 #include "TGMsgBox.h"
 #include "TGComboBox.h"
+#include "TVirtualX.h"
 
 // user include files
 #include "Fireworks/Core/interface/CmsShowEDI.h"

--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -28,6 +28,7 @@
 #include "TEveManager.h"
 #include "TFile.h"
 #include "TGClient.h"
+#include "TVirtualX.h"
 #include <KeySymbols.h>
 
 #include "Fireworks/Core/src/CmsShowMain.h"

--- a/Fireworks/Core/src/CmsShowMainFrame.cc
+++ b/Fireworks/Core/src/CmsShowMainFrame.cc
@@ -26,7 +26,6 @@
 #include <TGStatusBar.h>
 #include <KeySymbols.h>
 #include <TGSlider.h>
-#include "TVirtualX.h"
 #include <TSystem.h>
 #include <TImage.h>
 #include <TEnv.h>

--- a/Fireworks/Core/src/CmsShowMainFrame.cc
+++ b/Fireworks/Core/src/CmsShowMainFrame.cc
@@ -26,10 +26,11 @@
 #include <TGStatusBar.h>
 #include <KeySymbols.h>
 #include <TGSlider.h>
-
+#include "TVirtualX.h"
 #include <TSystem.h>
 #include <TImage.h>
 #include <TEnv.h>
+#include <TVirtualX.h>
 // user include files
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "Fireworks/Core/interface/CSGAction.h"

--- a/Fireworks/Core/src/CmsShowSearchFiles.cc
+++ b/Fireworks/Core/src/CmsShowSearchFiles.cc
@@ -15,6 +15,7 @@
 #include "TSystem.h"
 #include "TVirtualX.h"
 #include "TPRegexp.h"
+#include "TVirtualX.h"
 #include "Fireworks/Core/interface/CmsShowSearchFiles.h"
 #include "Fireworks/Core/interface/fwLog.h"
 #include "Fireworks/Core/interface/fwPaths.h"

--- a/Fireworks/Core/src/FWCollectionSummaryWidget.cc
+++ b/Fireworks/Core/src/FWCollectionSummaryWidget.cc
@@ -16,6 +16,7 @@
 #include <boost/bind.hpp>
 #include "TGButton.h"
 #include "TGResourcePool.h"
+#include "TVirtualX.h"
 #include "Fireworks/Core/src/FWColorSelect.h"
 #include "Fireworks/Core/src/FWBoxIconButton.h"
 #include "Fireworks/Core/src/FWCheckBoxIcon.h"

--- a/Fireworks/Core/src/FWColorSelect.cc
+++ b/Fireworks/Core/src/FWColorSelect.cc
@@ -17,6 +17,7 @@
 #include "TGGC.h"
 #include "TGColorDialog.h"
 #include "TColor.h"
+#include "TVirtualX.h"
 
 #include "Fireworks/Core/src/FWColorSelect.h"
 #include "Fireworks/Core/interface/FWColorManager.h"

--- a/Fireworks/Core/src/FWCustomIconsButton.cc
+++ b/Fireworks/Core/src/FWCustomIconsButton.cc
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <cassert>
 #include "TGPicture.h"
-
+#include "TVirtualX.h"
 // user include files
 #include "Fireworks/Core/interface/FWCustomIconsButton.h"
 

--- a/Fireworks/Core/src/FWGLEventHandler.cc
+++ b/Fireworks/Core/src/FWGLEventHandler.cc
@@ -12,6 +12,7 @@
 #include "TEveGedEditor.h"
 #include "TEveViewer.h"
 #include "FWGeoTopNodeScene.h"
+#include "TVirtualX.h"
 
 FWGLEventHandler::FWGLEventHandler(TGWindow *w, TObject *obj, TEveCaloLego *l)
     : TEveLegoEventHandler(w, obj, l), m_viewer(nullptr) {}

--- a/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
+++ b/Fireworks/Core/src/FWGUIValidatingTextEntry.cc
@@ -16,6 +16,7 @@
 #include "KeySymbols.h"
 #include "TTimer.h"
 #include "TGWindow.h"
+#include "TVirtualX.h"
 
 // user include files
 #include "Fireworks/Core/src/FWGUIValidatingTextEntry.h"

--- a/Fireworks/Core/src/FWGeoTopNode.cc
+++ b/Fireworks/Core/src/FWGeoTopNode.cc
@@ -39,6 +39,7 @@
 #include "TGeoManager.h"
 #include "TGeoMatrix.h"
 #include "TVirtualGeoPainter.h"
+#include "TVirtualX.h"
 
 #include "Fireworks/Core/interface/FWGeoTopNode.h"
 #include "Fireworks/Core/src/FWGeoTopNodeScene.h"

--- a/Fireworks/Core/src/FWGeometryTableManagerBase.cc
+++ b/Fireworks/Core/src/FWGeometryTableManagerBase.cc
@@ -31,7 +31,7 @@
 #include "TGeoShape.h"
 #include "TGeoBBox.h"
 #include "TGeoMatrix.h"
-
+#include "TVirtualX.h"
 #include "TGFrame.h"
 #include "TEveUtil.h"
 #include "boost/lexical_cast.hpp"

--- a/Fireworks/Core/src/FWGeometryTableView.cc
+++ b/Fireworks/Core/src/FWGeometryTableView.cc
@@ -38,7 +38,7 @@
 #include "TGLViewer.h"
 #include "TGeoMatrix.h"
 #include "TGeoBBox.h"
-
+#include "TVirtualX.h"
 #include "TEveViewer.h"
 #include "TEveScene.h"
 #include "TEveSceneInfo.h"

--- a/Fireworks/Core/src/FWGeometryTableViewBase.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewBase.cc
@@ -37,6 +37,7 @@
 #include "TGLViewer.h"
 #include "TGLCamera.h"
 #include "TEveSelection.h"
+#include "TVirtualX.h"
 #ifdef PERFTOOL_BROWSER
 #include <google/profiler.h>
 #endif

--- a/Fireworks/Core/src/FWPopupMenu.cc
+++ b/Fireworks/Core/src/FWPopupMenu.cc
@@ -1,5 +1,6 @@
 #include "TGMenu.h"
 #include "KeySymbols.h"
+#include "TVirtualX.h"
 
 class FWPopupMenu : public TGPopupMenu {
 public:

--- a/Fireworks/Core/src/FWTableView.cc
+++ b/Fireworks/Core/src/FWTableView.cc
@@ -26,6 +26,7 @@
 #include "TGLabel.h"
 #include "TGTextEntry.h"
 #include "TEveWindow.h"
+#include "TVirtualX.h"
 
 // user include files
 #include "Fireworks/Core/interface/FWColorManager.h"

--- a/Fireworks/Core/src/FWTableViewTableManager.cc
+++ b/Fireworks/Core/src/FWTableViewTableManager.cc
@@ -5,6 +5,7 @@
 
 #include "TClass.h"
 #include "TGClient.h"
+#include "TVirtualX.h"
 
 #include "Fireworks/Core/interface/FWTableViewTableManager.h"
 #include "Fireworks/Core/interface/FWTableView.h"

--- a/Fireworks/Core/src/FWTriggerTableView.cc
+++ b/Fireworks/Core/src/FWTriggerTableView.cc
@@ -14,6 +14,7 @@
 #include "TGComboBox.h"
 #include "TGLabel.h"
 #include "TGTextEntry.h"
+#include "TVirtualX.h"
 //#include "TGHorizontalFrame.h"
 
 // user include files

--- a/Fireworks/Core/src/FWViewContextMenuHandlerGL.cc
+++ b/Fireworks/Core/src/FWViewContextMenuHandlerGL.cc
@@ -6,6 +6,7 @@
 #include "TGLAnnotation.h"
 #include "TGLWidget.h"
 #include "TEveVector.h"
+#include "TVirtualX.h"
 
 #include "Fireworks/Core/interface/FWModelId.h"
 #include "Fireworks/Core/interface/FWEventItem.h"

--- a/Fireworks/TableWidget/src/FWTabularWidget.h
+++ b/Fireworks/TableWidget/src/FWTabularWidget.h
@@ -21,6 +21,7 @@
 // system include files
 #include <vector>
 #include "TGFrame.h"
+#include "TVirtualX.h"
 
 // user include files
 


### PR DESCRIPTION
#### PR description:

Adds missing headers for gVirtualX and TObjArray.
In the latest attempt to integrate ROOT master https://github.com/cms-sw/cmsdist/pull/5618
the integration build failed because ROOT trimmed their header usage and whatever was 
indirectly including TVirtualX header doesn't include it anymore. This pr is including it wherever gVirtualX is used within Fireworks.

#### PR validation:

Builds without failure
