### PR TITLE
Add header guards for DYTThrObject.h and Serializable.h

### DIFF
--- a/CondFormats/RecoMuonObjects/interface/DYTThrObject.h
+++ b/CondFormats/RecoMuonObjects/interface/DYTThrObject.h
@@ -1,3 +1,6 @@
+#ifndef CondFormats_RecoMuonObjects_DYTThrObject_h
+#define CondFormats_RecoMuonObjects_DYTThrObject_h
+
 #include "DataFormats/DetId/interface/DetId.h"
 #include <vector>
 #include "CondFormats/Serialization/interface/Serializable.h"
@@ -17,3 +20,4 @@ public:
 
   COND_SERIALIZABLE;
 };
+#endif

--- a/CondFormats/Serialization/interface/Serializable.h
+++ b/CondFormats/Serialization/interface/Serializable.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef CondFormats_Serialization_Serializable_h
+#define CondFormats_Serialization_Serializable_h
 
 #if defined(__GCCXML__)
 
@@ -62,3 +63,4 @@ private:                                                   \
 #define COND_TRANSIENT
 
 #endif /* !defined(__GCCXML__) */
+#endif


### PR DESCRIPTION
For Serializable.h, we should change #pragma once, because it gets the filename and creates a include guard based on it. If it relocates it becomes problematic, because it is could be possible to have two files with the same name in two different locations.
(to avoid such cases we should rely less on #pragma once)

#### PR description:

This PR is a part of https://github.com/cms-sw/cmsdist/pull/5600

cc: @davidlange6 @vgvassilev 