### PR TITLE
Make static function local const in FFTJetObjectFactory

### DIFF
--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetObjectFactory.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetObjectFactory.h
@@ -56,7 +56,7 @@ public:
   typedef typename Factory::Base::base_type base_type;
 
   static const Factory& instance() {
-    static Factory obj;
+    static Factory const obj;
     return obj;
   }
 


### PR DESCRIPTION
#### PR description:

This avoids a static analyzer warning and enforces const correctness.

#### PR validation:

The code compiles.