### PR TITLE
Change shared HandleExceptionFactory to be const

### DIFF
--- a/DataFormats/Common/interface/BasicHandle.h
+++ b/DataFormats/Common/interface/BasicHandle.h
@@ -52,7 +52,7 @@ namespace edm {
     BasicHandle(WrapperBase const* iProd, Provenance const* iProv) noexcept(true) : product_(iProd), prov_(iProv) {}
 
     ///Used when the attempt to get the data failed
-    BasicHandle(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed) noexcept(true)
+    BasicHandle(std::shared_ptr<HandleExceptionFactory const> const& iWhyFailed) noexcept(true)
         : product_(), prov_(nullptr), whyFailedFactory_(iWhyFailed) {}
 
     ~BasicHandle() = default;
@@ -79,9 +79,11 @@ namespace edm {
 
     std::shared_ptr<cms::Exception> whyFailed() const { return whyFailedFactory_->make(); }
 
-    std::shared_ptr<HandleExceptionFactory> const& whyFailedFactory() const noexcept(true) { return whyFailedFactory_; }
+    std::shared_ptr<HandleExceptionFactory const> const& whyFailedFactory() const noexcept(true) {
+      return whyFailedFactory_;
+    }
 
-    std::shared_ptr<HandleExceptionFactory>& whyFailedFactory() noexcept(true) { return whyFailedFactory_; }
+    std::shared_ptr<HandleExceptionFactory const>& whyFailedFactory() noexcept(true) { return whyFailedFactory_; }
 
     void clear() noexcept(true) {
       product_ = nullptr;
@@ -96,7 +98,7 @@ namespace edm {
     explicit BasicHandle(bool) : product_(nullptr) {}
     WrapperBase const* product_;
     Provenance const* prov_;
-    std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
+    std::shared_ptr<HandleExceptionFactory const> whyFailedFactory_;
   };
 
   // Free swap function

--- a/DataFormats/Common/interface/ConvertHandle.h
+++ b/DataFormats/Common/interface/ConvertHandle.h
@@ -14,7 +14,7 @@ namespace edm {
 
   namespace handleimpl {
     void throwConvertTypeError(std::type_info const& expected, std::type_info const& actual);
-    std::shared_ptr<edm::HandleExceptionFactory> makeInvalidReferenceException();
+    std::shared_ptr<edm::HandleExceptionFactory const> makeInvalidReferenceException();
   }  // namespace handleimpl
 
   // Convert from handle-to-void to handle-to-T

--- a/DataFormats/Common/interface/Handle.h
+++ b/DataFormats/Common/interface/Handle.h
@@ -39,7 +39,7 @@ namespace edm {
 
     Handle(T const* prod, Provenance const* prov);
 
-    Handle(std::shared_ptr<HandleExceptionFactory>&&);
+    Handle(std::shared_ptr<HandleExceptionFactory const>&&);
     Handle(Handle const&) = default;
     Handle& operator=(Handle&&) = default;
     Handle& operator=(Handle const&) = default;
@@ -60,7 +60,8 @@ namespace edm {
   Handle<T>::Handle(T const* prod, Provenance const* prov) : HandleBase(prod, prov) {}
 
   template <class T>
-  Handle<T>::Handle(std::shared_ptr<edm::HandleExceptionFactory>&& iWhyFailed) : HandleBase(std::move(iWhyFailed)) {}
+  Handle<T>::Handle(std::shared_ptr<edm::HandleExceptionFactory const>&& iWhyFailed)
+      : HandleBase(std::move(iWhyFailed)) {}
 
   template <class T>
   Handle<T>::~Handle() {}

--- a/DataFormats/Common/interface/HandleBase.h
+++ b/DataFormats/Common/interface/HandleBase.h
@@ -78,7 +78,7 @@ namespace edm {
     HandleBase(HandleBase const&) = default;
 
     ///Used when the attempt to get the data failed
-    HandleBase(std::shared_ptr<HandleExceptionFactory>&& iWhyFailed)
+    HandleBase(std::shared_ptr<HandleExceptionFactory const>&& iWhyFailed)
         : product_(), prov_(nullptr), whyFailedFactory_(iWhyFailed) {}
 
     HandleBase& operator=(HandleBase&& rhs) {
@@ -95,7 +95,7 @@ namespace edm {
       return std::shared_ptr<cms::Exception>();
     }
 
-    std::shared_ptr<HandleExceptionFactory> const& whyFailedFactory() const { return whyFailedFactory_; }
+    std::shared_ptr<HandleExceptionFactory const> const& whyFailedFactory() const { return whyFailedFactory_; }
 
     explicit operator bool() const { return isValid(); }
 
@@ -107,7 +107,7 @@ namespace edm {
   private:
     void const* product_;
     Provenance const* prov_;
-    std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
+    std::shared_ptr<HandleExceptionFactory const> whyFailedFactory_;
   };
 
   // Free swap function

--- a/DataFormats/Common/src/ConvertHandle.cc
+++ b/DataFormats/Common/src/ConvertHandle.cc
@@ -4,7 +4,7 @@
 
 namespace edm {
   namespace handleimpl {
-    static std::shared_ptr<HandleExceptionFactory> s_invalidRefFactory =
+    static std::shared_ptr<HandleExceptionFactory const> const s_invalidRefFactory =
         makeHandleExceptionFactory([]() -> std::shared_ptr<cms::Exception> {
           std::shared_ptr<cms::Exception> whyFailed =
               std::make_shared<edm::Exception>(errors::InvalidReference, "NullPointer");
@@ -12,7 +12,7 @@ namespace edm {
           return whyFailed;
         });
 
-    std::shared_ptr<HandleExceptionFactory> makeInvalidReferenceException() { return s_invalidRefFactory; }
+    std::shared_ptr<HandleExceptionFactory const> makeInvalidReferenceException() { return s_invalidRefFactory; }
 
     void throwConvertTypeError(std::type_info const& expected, std::type_info const& actual) {
       throw Exception(errors::LogicError, "TypeMismatch")

--- a/FWCore/Framework/interface/GenericHandle.h
+++ b/FWCore/Framework/interface/GenericHandle.h
@@ -107,7 +107,7 @@ namespace edm {
       whyFailedFactory_ = nullptr;
     }
 
-    void setWhyFailedFactory(std::shared_ptr<HandleExceptionFactory> const& iWhyFailed) {
+    void setWhyFailedFactory(std::shared_ptr<HandleExceptionFactory const> const& iWhyFailed) {
       whyFailedFactory_ = iWhyFailed;
     }
 
@@ -115,7 +115,7 @@ namespace edm {
     TypeWithDict type_;
     ObjectWithDict prod_;
     Provenance const* prov_;
-    std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
+    std::shared_ptr<HandleExceptionFactory const> whyFailedFactory_;
   };
 
   typedef Handle<GenericObject> GenericHandle;

--- a/FWCore/TestProcessor/interface/TestHandle.h
+++ b/FWCore/TestProcessor/interface/TestHandle.h
@@ -34,7 +34,7 @@ namespace edm {
     public:
       explicit TestHandle(T const* product) : product_{product} {}
 
-      explicit TestHandle(std::shared_ptr<HandleExceptionFactory> iFailed)
+      explicit TestHandle(std::shared_ptr<HandleExceptionFactory const> iFailed)
           : product_{nullptr}, whyFailedFactory_{std::move(iFailed)} {}
 
       operator bool() { return product_ != nullptr; }
@@ -56,7 +56,7 @@ namespace edm {
       }
 
       T const* product_;
-      std::shared_ptr<HandleExceptionFactory> whyFailedFactory_;
+      std::shared_ptr<HandleExceptionFactory const> whyFailedFactory_;
     };
 
   }  // namespace test


### PR DESCRIPTION
#### PR description:

All Handle types now use the potentially shared HandleExceptionFactory as a const.
This was pointed out by the static analyzer.

#### PR validation:

All framework packages compile.