### PR TITLE
DQM: Switch L1TStage2EMTF to DQMOneEDAnalyzer.

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -5,7 +5,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
@@ -13,7 +13,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 
-class L1TStage2EMTF : public DQMEDAnalyzer {
+class L1TStage2EMTF : public DQMOneEDAnalyzer<> {
 public:
   L1TStage2EMTF(const edm::ParameterSet& ps);
   ~L1TStage2EMTF() override;


### PR DESCRIPTION
#### PR description:

... to avoid issue #29096.

@benkrikler @rekovic This should prevent the crash, but the code definitely needs some review. Doing a `TH1::Divide` on every event does not seem like a great idea, and in general such operations should happen in harvesting (or be avoided entierely, e.g. by using `TProfile`).

#### PR validation:
None so far.

Changing to `DQMOneEDAnalyzer` should completely return the behaviour to what it was before #28813 .