### PR TITLE
Change HitPixelLayersTPSelection to use ObjectSelectorStream

### DIFF
--- a/Validation/RecoHI/plugins/HitPixelLayersTPSelector.cc
+++ b/Validation/RecoHI/plugins/HitPixelLayersTPSelector.cc
@@ -1,12 +1,12 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "Validation/RecoHI/plugins/HitPixelLayersTPSelector.h"
 
 namespace reco {
   namespace modules {
 
     // define your producer name
-    typedef ObjectSelector<HitPixelLayersTPSelector, TrackingParticleRefVector> HitPixelLayersTPSelection;
+    typedef ObjectSelectorStream<HitPixelLayersTPSelector, TrackingParticleRefVector> HitPixelLayersTPSelection;
 
     // declare the module as plugin
     DEFINE_FWK_MODULE(HitPixelLayersTPSelection);


### PR DESCRIPTION
#### PR description:

This converts it from a legacy module to a stream module.
This module is used in the integration build release validation jobs.

#### PR validation:

The code compiles.