### PR TITLE
Fix obvious bug in particle boosting - backport of PR #25412 in 9_3_X

### DIFF
--- a/GeneratorInterface/GenFilters/src/MCParticlePairFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCParticlePairFilter.cc
@@ -140,8 +140,7 @@ bool MCParticlePairFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	 double eta1 = mom.eta();
 	 double eta2;
 	 double deltaR;
-	 //HepLorentzVector momentum1 = (*p)->momentum();
-	 //HepLorentzVector totmomentum;
+
 	 double tot_x= 0.;
 	 double tot_y= 0.;
 	 double tot_z= 0.;
@@ -155,9 +154,7 @@ bool MCParticlePairFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	   tot_z=mom.pz();
 	   tot_e=mom.e();
 	   charge1 = charge((*p)->pdg_id());
-	   //totmomentum = momentum1 + typeBpassed[i]->momentum();
-	   //invmass = totmomentum.m();
-      HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(typeBpassed[i]->momentum(),betaBoost);
+           HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(typeBpassed[i]->momentum(),betaBoost);
 	   tot_x += mom_i.px();
 	   tot_y += mom_i.py();
 	   tot_z += mom_i.pz();
@@ -212,8 +209,7 @@ bool MCParticlePairFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	 double eta1 = mom.eta();
 	 double eta2;
 	 double deltaR;
-	 //HepLorentzVector momentum1 = (*p)->momentum();
-	 //HepLorentzVector totmomentum;
+
 	 double tot_x= 0.;
 	 double tot_y= 0.;
 	 double tot_z= 0.;
@@ -228,9 +224,7 @@ bool MCParticlePairFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	     tot_z=mom.pz();
 	     tot_e=mom.e();
 	     charge1 = charge((*p)->pdg_id());
-	     //totmomentum = momentum1 + typeApassed[i]->momentum();
-        //invmass = totmomentum.m();
-        HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(typeApassed[i]->momentum(),betaBoost);
+             HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(typeApassed[i]->momentum(),betaBoost);
 	     tot_x += mom_i.px();
 	     tot_y += mom_i.py();
 	     tot_z += mom_i.pz();

--- a/GeneratorInterface/GenFilters/src/MCParticlePairFilter.cc
+++ b/GeneratorInterface/GenFilters/src/MCParticlePairFilter.cc
@@ -230,7 +230,7 @@ bool MCParticlePairFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	     charge1 = charge((*p)->pdg_id());
 	     //totmomentum = momentum1 + typeApassed[i]->momentum();
         //invmass = totmomentum.m();
-        HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(mom_i,betaBoost);
+        HepMC::FourVector mom_i = MCFilterZboostHelper::zboost(typeApassed[i]->momentum(),betaBoost);
 	     tot_x += mom_i.px();
 	     tot_y += mom_i.py();
 	     tot_z += mom_i.pz();


### PR DESCRIPTION
Backport of #25412 for 2017 MC generation.

Needed to regenerate M(tt)-binned 2017 ttbar samples following issues reported in https://indico.cern.ch/event/891199/contributions/3761256/attachments/1992750/3323265/NTUA_TMGReport_24Feb.pdf

@covarell 