### PR TITLE
Modernized L1GctEmulator

### DIFF
--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.h
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.h
@@ -17,14 +17,17 @@
 // system includes
 
 // EDM includes
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 
 #include "L1Trigger/GlobalCaloTrigger/interface/L1GlobalCaloTrigger.h"
 
-class L1GctEmulator : public edm::EDProducer {
+class L1GctEmulator : public edm::stream::EDProducer<> {
 public:
   /// typedefs
   typedef L1GlobalCaloTrigger::lutPtr lutPtr;
@@ -33,33 +36,30 @@ public:
   /// constructor
   explicit L1GctEmulator(const edm::ParameterSet& ps);
 
-  /// destructor
-  ~L1GctEmulator() override;
-
 private:
-  void beginJob() override;
   void produce(edm::Event& e, const edm::EventSetup& c) override;
-  void endJob() override;
 
   int configureGct(const edm::EventSetup& c);
 
   // input label
   std::string m_inputLabel;
+  edm::EDGetTokenT<L1CaloEmCollection> m_emToken;
+  edm::EDGetTokenT<L1CaloRegionCollection> m_regionToken;
 
   // pointer to the actual emulator
-  L1GlobalCaloTrigger* m_gct;
+  std::unique_ptr<L1GlobalCaloTrigger> m_gct;
 
   // pointers to the jet Et LUTs
   lutPtrVector m_jetEtCalibLuts;
 
   // data output switch
-  bool m_writeInternalData;
+  const bool m_writeInternalData;
 
   // untracked parameters
-  bool m_verbose;
+  const bool m_verbose;
 
   // label for conditions
-  std::string m_conditionsLabel;
+  const std::string m_conditionsLabel;
 
   // tracked parameters
 };


### PR DESCRIPTION

#### PR description:

Made L1GctEmulator a stream module. Switched to using EDGetTokens.
This module is used in integration build release validation and was prohibiting use of the concurrent LuminosityBlock facility.

#### PR validation:

The code compiles.