### PR TITLE
Tracker Alignment: Backport Multi-IOV and condor submission tools

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/alignment_config.ini
@@ -52,8 +52,8 @@ pedeMem        = 32000
 datasetdir     = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/datasetfiles
 configTemplate = universalConfigTemplate.py
 globaltag      = auto:run2_data
-FirstRunForStartGeometry = 0  ; set this to the run from where you want to start
-
+;# set this to the run from where you want to start
+FirstRunForStartGeometry = 0
 
 ;###############################################################################
 ;## weights

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -147,7 +147,7 @@ class BetterConfigParser(ConfigParser.ConfigParser):
                                 knownSimpleOptions = ["levels", "dbOutput","moduleList","modulesToPlot","useDefaultRange","plotOnlyGlobal","plotPng","makeProfilePlots",
                                                       "dx_min","dx_max","dy_min","dy_max","dz_min","dz_max","dr_min","dr_max","rdphi_min","rdphi_max",
                                                       "dalpha_min","dalpha_max","dbeta_min","dbeta_max","dgamma_min","dgamma_max",
-                                                      "jobmode", "3DSubdetector1", "3Dubdetector2", "3DTranslationalScaleFactor", "jobid"])
+                                                      "jobmode", "3DSubdetector1", "3Dubdetector2", "3DTranslationalScaleFactor", "jobid", "multiIOV"])
                 levels = self.get( section, "levels" )
                 dbOutput = self.get( section, "dbOutput" )
                 compares[section.split(":")[1]] = ( levels, dbOutput )

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -44,21 +44,20 @@ process.prefer_conditionsIn.oO[rcdName]Oo. = cms.ESPrefer("PoolDBESSource", "con
 ######################################################################
 ######################################################################
 #batch job execution
-scriptTemplate="""
-#!/bin/bash
+scriptTemplate="""#!/bin/bash
 #init
 #ulimit -v 3072000
 #export STAGE_SVCCLASS=cmscafuser
-#save path to the LSF batch working directory  (/pool/lsf)
+#save path to the condor batch working directory  (/pool/condor)
 
-export LSFWORKDIR=`pwd -P`
-echo LSF working directory is $LSFWORKDIR
+export CONDORWORKDIR=`pwd -P`
+echo CONDOR working directory is $CONDORWORKDIR
 source /afs/cern.ch/cms/caf/setup.sh
 export X509_USER_PROXY=.oO[scriptsdir]Oo./.user_proxy
 cd .oO[CMSSW_BASE]Oo./src
 export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
 eval `scramv1 ru -sh`
-#rfmkdir -p .oO[datadir]Oo. &>! /dev/null
+#mkdir -p .oO[datadir]Oo. &>! /dev/null
 
 #remove possible result file from previous runs
 previous_results=$(ls /eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo.)
@@ -72,12 +71,12 @@ done
 
 if [[ $HOSTNAME = lxplus[0-9]*[.a-z0-9]* ]] # check for interactive mode
 then
-    rfmkdir -p .oO[workdir]Oo.
+    mkdir -p .oO[workdir]Oo.
     rm -f .oO[workdir]Oo./*
     cd .oO[workdir]Oo.
 else
-    mkdir -p $LSFWORKDIR/TkAllInOneTool
-    cd $LSFWORKDIR/TkAllInOneTool
+    mkdir -p $CONDORWORKDIR/TkAllInOneTool
+    cd $CONDORWORKDIR/TkAllInOneTool
 fi
 
 # rm -f .oO[workdir]Oo./*
@@ -86,6 +85,7 @@ fi
 #run
 pwd
 df -h .
+which cmsRun
 .oO[CommandLine]Oo.
 echo "----"
 echo "List of files in $(pwd):"
@@ -95,9 +95,9 @@ echo ""
 
 
 #retrieve
-rfmkdir -p .oO[logdir]Oo. >&! /dev/null
+mkdir -p .oO[logdir]Oo. >&! /dev/null
 gzip -f LOGFILE_*_.oO[name]Oo..log
-find . -maxdepth 1 -name "LOGFILE*.oO[alignmentName]Oo.*" -print | xargs -I {} bash -c "rfcp {} .oO[logdir]Oo."
+find . -maxdepth 1 -name "LOGFILE*.oO[alignmentName]Oo.*" -print | xargs -I {} bash -c "cp {} .oO[logdir]Oo."
 
 #copy root files to eos
 mkdir -p /eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo.
@@ -141,6 +141,8 @@ process = cms.Process(".oO[ProcessName]Oo.")
 .oO[FileOutputTemplate]Oo.
 
 .oO[DefinePath]Oo.
+
+print("Done")
 """
 
 
@@ -218,8 +220,7 @@ process.seqTrackselRefit*.oO[ValidationSequence]Oo.)
 
 ######################################################################
 ######################################################################
-mergeTemplate="""
-#!/bin/bash
+mergeTemplate="""#!/bin/bash
 CWD=`pwd -P`
 cd .oO[CMSSW_BASE]Oo./src
 export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
@@ -268,8 +269,7 @@ find . -name "*.stdout" -exec gzip -f {} \;
 
 ######################################################################
 ######################################################################
-mergeParallelOfflineTemplate="""
-#!/bin/bash
+mergeParallelOfflineTemplate="""#!/bin/bash
 CWD=`pwd -P`
 cd .oO[CMSSW_BASE]Oo./src
 export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
@@ -303,8 +303,8 @@ root_files=$(ls /eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[e
 ######################################################################
 createResultsDirectoryTemplate="""
 #create results-directory and copy used configuration there
-rfmkdir -p .oO[datadir]Oo.
-rfcp .oO[logdir]Oo./usedConfiguration.ini .oO[datadir]Oo.
+mkdir -p .oO[datadir]Oo.
+cp .oO[logdir]Oo./usedConfiguration.ini .oO[datadir]Oo.
 """
 
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -599,7 +599,7 @@ class ParallelValidation(GenericValidation):
 class ValidationWithPlots(GenericValidation):
     @classmethod
     def runPlots(cls, validations):
-        return ("rfcp .oO[plottingscriptpath]Oo. .\n"
+        return ("cp .oO[plottingscriptpath]Oo. .\n"
                 "root -x -b -q .oO[plottingscriptname]Oo.++")
     @abstractmethod
     def appendToPlots(self):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
@@ -37,6 +37,7 @@ class GeometryComparison(GenericValidation):
         "dbeta_max":"-99999",
         "dgamma_min":"-99999",
         "dgamma_max":"-99999",
+        "multiIOV":"False",
         }
     mandatories = {"levels", "dbOutput"}
     valType = "compare"
@@ -159,26 +160,23 @@ class GeometryComparison(GenericValidation):
                 repMap["outputFile"] = (".oO[name]Oo..Comparison_common"+name+".root")
                 repMap["nIndex"] = ("")
                 repMap["runComparisonScripts"] += \
-                    ("rfcp .oO[Alignment/OfflineValidation]Oo."
+                    ("cp .oO[Alignment/OfflineValidation]Oo."
                      "/scripts/comparisonScript.C .\n"
-                     "rfcp .oO[Alignment/OfflineValidation]Oo."
+                     "cp .oO[Alignment/OfflineValidation]Oo."
                      "/scripts/GeometryComparisonPlotter.h .\n"
-                     "rfcp .oO[Alignment/OfflineValidation]Oo."
+                     "cp .oO[Alignment/OfflineValidation]Oo."
                      "/scripts/GeometryComparisonPlotter.cc .\n"
                      "root -b -q 'comparisonScript.C+(\""
                      ".oO[name]Oo..Comparison_common"+name+".root\",\""
                      "./\",\".oO[modulesToPlot]Oo.\",\".oO[alignmentName]Oo.\",\".oO[reference]Oo.\",.oO[useDefaultRange]Oo.,.oO[plotOnlyGlobal]Oo.,.oO[plotPng]Oo.,.oO[makeProfilePlots]Oo."+y_ranges+")'\n"
-                     "rfcp "+path+"/TkAl3DVisualization_.oO[common]Oo._.oO[name]Oo..C .\n"
+                     "cp "+path+"/TkAl3DVisualization_.oO[common]Oo._.oO[name]Oo..C .\n"
                      "root -l -b -q TkAl3DVisualization_.oO[common]Oo._.oO[name]Oo..C+\n")
                 if  self.copyImages:
                    repMap["runComparisonScripts"] += \
-                       ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
-                        ".Comparison_common"+name+"_Images\n")
-                   repMap["runComparisonScripts"] += \
-                       ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
+                       ("mkdir -p .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/Translations\n")
                    repMap["runComparisonScripts"] += \
-                       ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
+                       ("mkdir -p .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/Rotations\n")
 
 
@@ -189,50 +187,50 @@ class GeometryComparison(GenericValidation):
                    if repMap["plotPng"] == "true":
                            repMap["runComparisonScripts"] += \
                                ("find . -maxdepth 1 -name \"*_1*\" "
-                                "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+                                "-print | xargs -I {} bash -c \"cp {} .oO[datadir]Oo."
                                 "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
                            repMap["runComparisonScripts"] += \
                                ("find . -maxdepth 1 -name \"*_2*\" "
-                                "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+                                "-print | xargs -I {} bash -c \"cp {} .oO[datadir]Oo."
                                 "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
 
                            repMap["runComparisonScripts"] += \
                                ("find . -maxdepth 1 -name \"*_3*\" "
-                                "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+                                "-print | xargs -I {} bash -c \"cp {} .oO[datadir]Oo."
                                 "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
                            repMap["runComparisonScripts"] += \
                                ("find . -maxdepth 1 -name \"*_4*\" "
-                                "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+                                "-print | xargs -I {} bash -c \"cp {} .oO[datadir]Oo."
                                 "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
 
                    else:
                            repMap["runComparisonScripts"] += \
                                ("find . -maxdepth 1 -name \"*_1*\" "
-                                "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+                                "-print | xargs -I {} bash -c \"cp {} .oO[datadir]Oo."
                                 "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
 
                            repMap["runComparisonScripts"] += \
                                ("find . -maxdepth 1 -name \"*_2*\" "
-                                "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
+                                "-print | xargs -I {} bash -c \"cp {} .oO[datadir]Oo."
                                 "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
 
                    repMap["runComparisonScripts"] += \
                        ("find . -maxdepth 1 -name "
                         "\"*.tex\" -print | xargs -I {} bash -c"
-                        " \"rfcp {} .oO[datadir]Oo./.oO[name]Oo."
+                        " \"cp {} .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/\" \n")
                    repMap["runComparisonScripts"] += \
                        ("find . -maxdepth 1 -name "
                         "\"TkMap_SurfDeform*.pdf\" -print | xargs -I {} bash -c"
-                        " \"rfcp {} .oO[datadir]Oo./.oO[name]Oo."
+                        " \"cp {} .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/\" \n")
                    repMap["runComparisonScripts"] += \
                        ("find . -maxdepth 1 -name "
                         "\"TkMap_SurfDeform*.png\" -print | xargs -I {} bash -c"
-                        " \"rfcp {} .oO[datadir]Oo./.oO[name]Oo."
+                        " \"cp {} .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/\" \n")
                    repMap["runComparisonScripts"] += \
-                       ("rfcp .oO[Alignment/OfflineValidation]Oo."
+                       ("cp .oO[Alignment/OfflineValidation]Oo."
                         "/macros/makeArrowPlots.C "
                         ".\n"
                         "root -b -q 'makeArrowPlots.C(\""
@@ -240,22 +238,22 @@ class GeometryComparison(GenericValidation):
                         +".root\",\".oO[name]Oo.."
                         +name+"_ArrowPlots\")'\n")
                    repMap["runComparisonScripts"] += \
-                       ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
+                       ("mkdir -p .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/ArrowPlots\n")
                    repMap["runComparisonScripts"] += \
                        ("find .oO[name]Oo.."+name+"_ArrowPlots "
                         "-maxdepth 1 -name \"*.png\" -print | xargs -I {} bash "
-                        "-c \"rfcp {} .oO[datadir]Oo./.oO[name]Oo."
+                        "-c \"cp {} .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/ArrowPlots\"\n")
                    repMap["runComparisonScripts"] += \
                        ("find .oO[name]Oo.."+name+"_ArrowPlots "
                         "-maxdepth 1 -name \"*.pdf\" -print | xargs -I {} bash "
-                        "-c \"rfcp {} .oO[datadir]Oo./.oO[name]Oo."
+                        "-c \"cp {} .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/ArrowPlots\"\n")
                    repMap["runComparisonScripts"] += \
                        ("find . "
                         "-maxdepth 1 -name \".oO[common]Oo._.oO[name]Oo..Visualization_rotated.gif\" -print | xargs -I {} bash "
-                        "-c \"rfcp {} .oO[datadir]Oo./.oO[name]Oo."
+                        "-c \"cp {} .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/.oO[common]Oo._.oO[name]Oo..Visualization.gif\"\n")
 
                 resultingFile = replaceByMap(("/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./compared%s_"
@@ -279,7 +277,7 @@ class GeometryComparison(GenericValidation):
                  "xrdcp .oO[moduleList]Oo. .\n"
         else:
             repMap["CommandLine"]+= \
-                     "rfcp .oO[moduleList]Oo. .\n"
+                     "cp .oO[moduleList]Oo. .\n"
 
         try:
             getCommandOutput2(replaceByMap("cd $(mktemp -d)\n.oO[CommandLine]Oo.\ncat .oO[moduleListBase]Oo.", repMap))
@@ -288,8 +286,8 @@ class GeometryComparison(GenericValidation):
 
         for cfg in self.configFiles:
             # FIXME: produce this line only for enabled dbOutput
-            # postProcess = "rfcp .oO[workdir]Oo./*.db .oO[datadir]Oo.\n"
-            # postProcess = "rfcp *.db .oO[datadir]Oo.\n"
+            # postProcess = "cp .oO[workdir]Oo./*.db .oO[datadir]Oo.\n"
+            # postProcess = "cp *.db .oO[datadir]Oo.\n"
             postProcess = ""
             repMap["CommandLine"]+= \
                 repMap["CommandLineTemplate"]%{"cfgFile":cfg,

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
@@ -19,6 +19,7 @@ class OfflineValidation(GenericValidationData_CTSR, ParallelValidation, Validati
         "stripYResiduals": "False",
         "maxtracks": "0",
         "chargeCut": "0",
+        "multiIOV": "False",
         }
     deprecateddefaults = {
         "DMRMethod":"",
@@ -96,11 +97,13 @@ class OfflineValidation(GenericValidationData_CTSR, ParallelValidation, Validati
     def initMerge(cls):
         from .plottingOptions import PlottingOptions
         outFilePath = replaceByMap(".oO[scriptsdir]Oo./TkAlOfflineJobsMerge.C", PlottingOptions(None, cls.valType))
+        print("outFilePath")
+        print(outFilePath)
         with open(outFilePath, "w") as theFile:
             theFile.write(replaceByMap(configTemplates.mergeOfflineParJobsTemplate, {}))
         result = super(OfflineValidation, cls).initMerge()
         result += ("cp .oO[Alignment/OfflineValidation]Oo./scripts/merge_TrackerOfflineValidation.C .\n"
-                   "rfcp .oO[mergeOfflineParJobsScriptPath]Oo. .\n")
+                   "cp .oO[mergeOfflineParJobsScriptPath]Oo. .\n")
         return result
 
     def appendToMerge(self):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -77,7 +77,7 @@ extendedValidationExecution="""
 #run extended offline validation scripts
 echo -e "\n\nRunning extended offline validation"
 
-rfcp .oO[extendedValScriptPath]Oo. .
+cp .oO[extendedValScriptPath]Oo. .
 root -x -b -q -l TkAlExtendedOfflineValidation.C
 
 """

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -17,7 +17,7 @@ class PreexistingValidation(GenericValidation):
     but should be included in plots.
     """
     defaults = {"title": ".oO[name]Oo."}
-    mandatories = {"file", "color", "style"}
+    mandatories = {"file", "color", "style", "originalValName", "eosdirName", "multiIOV"}
     removemandatories = {"dataset", "maxevents", "trackcollection"}
     def __init__(self, valName, config):
         self.general = config.getGeneral()
@@ -29,6 +29,7 @@ class PreexistingValidation(GenericValidation):
                                                demandPars = self.mandatories)
         self.general.update(theUpdate)
 
+        self.originalValName = self.general["originalValName"]
         self.title = self.general["title"]
         if "|" in self.title or "," in self.title or '"' in self.title:
             msg = "The characters '|', '\"', and ',' cannot be used in the alignment title!"

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidation.py
@@ -18,6 +18,7 @@ class PrimaryVertexValidation(GenericValidationData_CTSR, ParallelValidation, Va
         "doBPix":"True",
         "doFPix":"True",
         "forceBeamSpot":"False",
+        "multiIOV":"False",
         }
     mandatories = {"isda","ismc","runboundary","trackcollection","vertexcollection","lumilist","ptCut","etaCut","runControl","numberOfBins"}
     valType = "primaryvertex"

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -164,8 +164,7 @@ process.p = cms.Path(process.goodvertexSkim*
 
 ####################################################################
 ####################################################################
-PVValidationScriptTemplate="""
-#!/bin/bash
+PVValidationScriptTemplate="""#!/bin/bash
 source /afs/cern.ch/cms/caf/setup.sh
 export X509_USER_PROXY=.oO[scriptsdir]Oo./.user_proxy
 
@@ -182,15 +181,15 @@ export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
 eval `scram runtime -sh`
 cd $cwd
 
-rfmkdir -p .oO[datadir]Oo.
-rfmkdir -p .oO[workingdir]Oo.
-rfmkdir -p .oO[logdir]Oo.
+mkdir -p .oO[datadir]Oo.
+mkdir -p .oO[workingdir]Oo.
+mkdir -p .oO[logdir]Oo.
 rm -f .oO[logdir]Oo./*.stdout
 rm -f .oO[logdir]Oo./*.stderr
 
 if [[ $HOSTNAME = lxplus[0-9]*[.a-z0-9]* ]] # check for interactive mode
 then
-    rfmkdir -p .oO[workdir]Oo.
+    mkdir -p .oO[workdir]Oo.
     rm -f .oO[workdir]Oo./*
     cd .oO[workdir]Oo.
 else
@@ -206,7 +205,7 @@ eos mkdir -p /store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./p
 for RootOutputFile in $(ls *root )
 do
     xrdcp -f ${RootOutputFile} root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./${RootOutputFile}
-    rfcp ${RootOutputFile}  .oO[workingdir]Oo.
+    cp ${RootOutputFile}  .oO[workingdir]Oo.
 done
 
 cp .oO[Alignment/OfflineValidation]Oo./macros/FitPVResiduals.C .
@@ -220,12 +219,12 @@ root -b -q "FitPVResiduals.C(\\"${PWD}/${RootOutputFile}=${theLabel},${PWD}/PVVa
 mkdir -p .oO[plotsdir]Oo.
 for PngOutputFile in $(ls *png ); do
     xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./plots/${PngOutputFile}
-    rfcp ${PngOutputFile}  .oO[plotsdir]Oo.
+    cp ${PngOutputFile}  .oO[plotsdir]Oo.
 done
 
 for PdfOutputFile in $(ls *pdf ); do
     xrdcp -f ${PdfOutputFile}  root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./plots/${PdfOutputFile}
-    rfcp ${PdfOutputFile}  .oO[plotsdir]Oo.
+    cp ${PdfOutputFile}  .oO[plotsdir]Oo.
 done
 
 mkdir .oO[plotsdir]Oo./Biases/
@@ -288,17 +287,17 @@ echo  -----------------------
 PrimaryVertexPlotExecution="""
 #make primary vertex validation plots
 
-rfcp .oO[plottingscriptpath]Oo. .
+cp .oO[plottingscriptpath]Oo. .
 root -x -b -q .oO[plottingscriptname]Oo.++
 
 for PdfOutputFile in $(ls *pdf ); do
     xrdcp -f ${PdfOutputFile}  root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./plots/${PdfOutputFile}
-    rfcp ${PdfOutputFile}  .oO[datadir]Oo./.oO[PlotsDirName]Oo.
+    cp ${PdfOutputFile}  .oO[datadir]Oo./.oO[PlotsDirName]Oo.
 done
 
 for PngOutputFile in $(ls *png ); do
     xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./plots/${PngOutputFile}
-    rfcp ${PngOutputFile}  .oO[datadir]Oo./.oO[PlotsDirName]Oo.
+    cp ${PngOutputFile}  .oO[datadir]Oo./.oO[PlotsDirName]Oo.
 done
 
 """

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
@@ -13,6 +13,7 @@ class TrackSplittingValidation(GenericValidationData_CTSR, ParallelValidation, V
     crabCfgBaseName = "TkAlTrackSplitting"
     resultBaseName = "TrackSplitting"
     outputBaseName = "TrackSplitting"
+    defaults = {"multiIOV":"False"}
     mandatories = {"trackcollection"}
     valType = "split"
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
@@ -28,7 +28,7 @@ TrackSplittingSequence = "process.cosmicValidation"
 trackSplitPlotExecution="""
 #make track splitting plots
 
-rfcp .oO[trackSplitPlotScriptPath]Oo. .
+cp .oO[trackSplitPlotScriptPath]Oo. .
 root -x -b -q TkAlTrackSplitPlot.C++
 
 """

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidation.py
@@ -21,6 +21,9 @@ class ZMuMuValidation(GenericValidationData, ValidationWithPlots):
         "etaminneg" : "-2.4",
         "etamaxpos" : "2.4",
         "etaminpos" : "-2.4",
+        "CustomMinY": "90.85",
+        "CustomMaxY": "91.4",
+        "multiIOV":"False",
         }
     deprecateddefaults = {
         "resonance": "",

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -197,8 +197,7 @@ process.p = cms.Path(
 
 ####################################################################
 ####################################################################
-zMuMuScriptTemplate="""
-#!/bin/bash
+zMuMuScriptTemplate="""#!/bin/bash
 source /afs/cern.ch/cms/caf/setup.sh
 export X509_USER_PROXY=.oO[scriptsdir]Oo./.user_proxy
 
@@ -212,15 +211,15 @@ export SCRAM_ARCH=.oO[SCRAM_ARCH]Oo.
 eval `scram runtime -sh`
 cd $cwd
 
-rfmkdir -p .oO[datadir]Oo.
-rfmkdir -p .oO[workingdir]Oo.
-rfmkdir -p .oO[logdir]Oo.
+mkdir -p .oO[datadir]Oo.
+mkdir -p .oO[workingdir]Oo.
+mkdir -p .oO[logdir]Oo.
 rm -f .oO[logdir]Oo./*.stdout
 rm -f .oO[logdir]Oo./*.stderr
 
 if [[ $HOSTNAME = lxplus[0-9]*[.a-z0-9]* ]] # check for interactive mode
 then
-    rfmkdir -p .oO[workdir]Oo.
+    mkdir -p .oO[workdir]Oo.
     rm -f .oO[workdir]Oo./*
     cd .oO[workdir]Oo.
 else
@@ -253,13 +252,13 @@ eos mkdir -p /store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./p
 for RootOutputFile in $(ls *root )
 do
     xrdcp -f ${RootOutputFile}  root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./
-    rfcp ${RootOutputFile}  .oO[workingdir]Oo.
+    cp ${RootOutputFile}  .oO[workingdir]Oo.
 done
 
 mkdir -p .oO[plotsdir]Oo.
 for PngOutputFile in $(ls *png ); do
     xrdcp -f ${PngOutputFile}  root://eoscms//eos/cms/store/group/alca_trackeralign/AlignmentValidation/.oO[eosdir]Oo./plots/
-    rfcp ${PngOutputFile}  .oO[plotsdir]Oo.
+    cp ${PngOutputFile}  .oO[plotsdir]Oo.
 done
 
 
@@ -275,7 +274,7 @@ echo  -----------------------
 mergeZmumuPlotsExecution="""
 #merge Z->mumu histograms
 
-rfcp .oO[mergeZmumuPlotsScriptPath]Oo. .
+cp .oO[mergeZmumuPlotsScriptPath]Oo. .
 root -l -x -b -q TkAlMergeZmumuPlots.C++
 
 """

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -744,7 +744,10 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     map( lambda job: job.runJob(), jobs )
 
-    ValidationJobMultiIOV.runCondorJobs(outPath)
+    if options.dryRun:
+        pass
+    else:
+        ValidationJobMultiIOV.runCondorJobs(outPath)
 
 
 if __name__ == "__main__":

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -551,11 +551,9 @@ def createMergeScript( path, validations, options ):
                     repMap[(validationtype, validationName, referenceName)]["beforeMerge"] += validationtype.doInitMerge()
                 repMap[(validationtype, validationName, referenceName)]["doMerge"] += validation.doMerge()
                 for f in validation.getRepMap()["outputFiles"]:
-		            longName = os.path.join("/eos/cms/store/group/alca_trackeralign/AlignmentValidation/",
-		                                    validation.getRepMap()["eosdir"], f)
-		            repMap[(validationtype, validationName, referenceName)]["rmUnmerged"] += "    rm "+longName+"\n"
-
-
+                    longName = os.path.join("/eos/cms/store/group/alca_trackeralign/AlignmentValidation/",
+                                            validation.getRepMap()["eosdir"], f)
+                    repMap[(validationtype, validationName, referenceName)]["rmUnmerged"] += "    rm "+longName+"\n"
 
         repMap[(validationtype, validationName, referenceName)]["rmUnmerged"] += ("else\n"
                                                                   "    echo -e \\n\"WARNING: Merging failed, unmerged"

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -19,7 +19,6 @@ import re
 import six
 import Alignment.OfflineValidation.TkAlAllInOneTool.configTemplates \
     as configTemplates
-import Alignment.OfflineValidation.TkAlAllInOneTool.crabWrapper as crabWrapper
 from Alignment.OfflineValidation.TkAlAllInOneTool.TkAlExceptions \
     import AllInOneError
 from Alignment.OfflineValidation.TkAlAllInOneTool.helperFunctions \

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python
 #test execute: export CMSSW_BASE=/tmp/CMSSW && ./validateAlignments.py -c defaultCRAFTValidation.ini,test.ini -n -N test
 from __future__ import print_function
+import subprocess
 import os
 import sys
 import optparse
 import datetime
 import shutil
 import fnmatch
+import fileinput
+import fileinput
+from abc import ABCMeta, abstractmethod
+import copy
+import itertools
+import pprint
+import re
 
 import six
 import Alignment.OfflineValidation.TkAlAllInOneTool.configTemplates \
@@ -41,51 +49,20 @@ from Alignment.OfflineValidation.TkAlAllInOneTool.plottingOptions \
 import Alignment.OfflineValidation.TkAlAllInOneTool.globalDictionaries \
     as globalDictionaries
 from Alignment.OfflineValidation.TkAlAllInOneTool.overlapValidation \
-    import OverlapValidation 
+    import OverlapValidation
 
 ####################--- Classes ---############################
-class ParallelMergeJob(object):
-    
-    def __init__(self, _name, _path, _dependency):
-        self.name=_name
-        self.path=_path
-        self.dependencies=_dependency
-    def addDependency(self,dependency):
-        if isinstance(dependency,list):
-            self.dependencies.extend(dependency)
-        else:
-            self.dependencies.append(dependency)
-    def runJob(self, config):
-        repMap = {
-        "commands": config.getGeneral()["jobmode"].split(",")[1],
-        "jobName": self.name,
-        "logDir": config.getGeneral()["logdir"],
-        "script": self.path,
-        "bsub": "/afs/cern.ch/cms/caf/scripts/cmsbsub",
-        "conditions": '"' + " && ".join(["ended(" + jobId + ")" for jobId in self.dependencies]) + '"'
-        }
-        return getCommandOutput2("%(bsub)s %(commands)s "
-            "-J %(jobName)s "
-            "-o %(logDir)s/%(jobName)s.stdout "
-            "-e %(logDir)s/%(jobName)s.stderr "
-            "-w %(conditions)s "
-            "%(script)s"%repMap)
+#
+class ValidationBase(object):
 
-class ValidationJob(object):
-
-    # these count the jobs of different varieties that are being run
-    crabCount = 0
-    interactCount = 0
-    batchCount = 0
-    batchJobIds = []
-    jobCount = 0
+    __metaclass__ = ABCMeta
 
     def __init__( self, validation, config, options ):
-        self.JobId=[]
+
         if validation[1] == "":
             # intermediate syntax
             valString = validation[0].split( "->" )[0]
-            alignments = validation[0].split( "->" )[1]
+            self.alignments = validation[0].split( "->" )[1]
             # force user to use the normal syntax
             if "->" in validation[0]:
                 msg = ("Instead of using the intermediate syntax\n'"
@@ -96,31 +73,63 @@ class ValidationJob(object):
                 raise AllInOneError(msg)
         else:
             valString = validation[0]
-            alignments = validation[1]
+            self.alignments = validation[1]
         valString = valString.split()
-        self.__valType = valString[0]
-        self.__valName = valString[1]
-        self.__commandLineOptions = options
-        self.__config = config
-        self.__preexisting = ("preexisting" in self.__valType)
-        if self.__valType[0] == "*":
-            self.__valType = self.__valType[1:]
-            self.__preexisting = True
+        self.valType = valString[0]
+        self.valName = valString[1]
+        self.commandLineOptions = options
+        self.config = config
+        self.preexisting = ("preexisting" in self.valType)
+        if self.valType[0] == "*":
+            self.valType = self.valType[1:]
+            self.preexisting = True
 
         # workaround for intermediate parallel version
-        if self.__valType == "offlineParallel":
+        if self.valType == "offlineParallel":
             print ("offlineParallel and offline are now the same.  To run an offline parallel validation,\n"
                    "just set parallelJobs to something > 1.  There is no reason to call it offlineParallel anymore.")
-            self.__valType = "offline"            
-        section = self.__valType + ":" + self.__valName
-        if not self.__config.has_section( section ):
+            self.valType = "offline"
+        self.valSection = self.valType + ":" + self.valName
+        if not self.config.has_section( self.valSection ):
             raise AllInOneError("Validation '%s' of type '%s' is requested in"
-                                  " '[validation]' section, but is not defined."
+                                " '[validation]' section, but is not defined."
                                   "\nYou have to add a '[%s]' section."
-                                  %( self.__valName, self.__valType, section ))
-        self.validation = self.__getValidation( self.__valType, self.__valName,
-                                                alignments, self.__config,
-                                                options )
+                                  %( self.valName, self.valType, self.valSection ))
+
+
+    @abstractmethod
+    def createJob( self ):
+        pass
+
+    @abstractmethod
+    def runJob( self ):
+        pass
+
+    @abstractmethod
+    def getValidation( self ):
+        pass
+
+    @abstractmethod
+    def needsproxy(self):
+        pass
+
+
+class ValidationJob(ValidationBase):
+
+    # these count the jobs of different varieties that are being run
+    interactCount = 0
+    jobCount = 0
+    condorConf = {}
+
+    def __init__( self, validation, config, options, *args, **kwargs ):
+
+        self.start = 0
+        self.end = args
+        self.JobId=[]
+        super(ValidationJob, self).__init__( validation, config, options )
+        self.validation = self.__getValidation( self.valType, self.valName,
+                                                  self.alignments, config,
+                                                  options )
 
     def __getValidation( self, valType, name, alignments, config, options ):
         if valType == "compare":
@@ -133,9 +142,11 @@ class ValidationJob(object):
                                       "<alignment> <reference>'.")
             if len( firstAlignList ) > 1:
                 firstRun = firstAlignList[1]
+            elif config.has_section("IOV"):
+                firstRun = config.get("IOV", "iov")
             else:
                 raise AllInOneError("Have to provide a run number for geometry comparison")
-            firstAlign = Alignment( firstAlignName, self.__config, firstRun )
+            firstAlign = Alignment( firstAlignName, config, firstRun )
             firstAlignName = firstAlign.name
             secondAlignList = alignmentsList[1].split()
             secondAlignName = secondAlignList[0].strip()
@@ -144,39 +155,41 @@ class ValidationJob(object):
             else:
                 if len( secondAlignList ) > 1:
                     secondRun = secondAlignList[1]
+                elif config.has_section("IOV"):
+                    secondRun = config.get("IOV", "iov")
                 else:
                     raise AllInOneError("Have to provide a run number for geometry comparison")
-                secondAlign = Alignment( secondAlignName, self.__config,
+                secondAlign = Alignment( secondAlignName, config,
                                          secondRun )
                 secondAlignName = secondAlign.name
-                
+
             validation = GeometryComparison( name, firstAlign, secondAlign,
-                                             self.__config,
-                                             self.__commandLineOptions.getImages)
+                                             config,
+                                             self.commandLineOptions.getImages)
         elif valType == "offline":
-            validation = OfflineValidation( name, 
-                Alignment( alignments.strip(), self.__config ), self.__config )
+            validation = OfflineValidation( name,
+                Alignment( alignments.strip(), config ), config )
         elif valType == "preexistingoffline":
-            validation = PreexistingOfflineValidation(name, self.__config)
+            validation = PreexistingOfflineValidation(name, config)
         elif valType == "offlineDQM":
-            validation = OfflineValidationDQM( name, 
-                Alignment( alignments.strip(), self.__config ), self.__config )
+            validation = OfflineValidationDQM( name,
+                Alignment( alignments.strip(), config ), config )
         elif valType == "mcValidate":
-            validation = MonteCarloValidation( name, 
-                Alignment( alignments.strip(), self.__config ), self.__config )
+            validation = MonteCarloValidation( name,
+                Alignment( alignments.strip(), config ), config )
         elif valType == "preexistingmcValidate":
-            validation = PreexistingMonteCarloValidation(name, self.__config)
+            validation = PreexistingMonteCarloValidation(name, config)
         elif valType == "split":
-            validation = TrackSplittingValidation( name, 
-                Alignment( alignments.strip(), self.__config ), self.__config )
+            validation = TrackSplittingValidation( name,
+                Alignment( alignments.strip(), config ), config )
         elif valType == "preexistingsplit":
-            validation = PreexistingTrackSplittingValidation(name, self.__config)
+            validation = PreexistingTrackSplittingValidation(name, config)
         elif valType == "zmumu":
-            validation = ZMuMuValidation( name, 
-                Alignment( alignments.strip(), self.__config ), self.__config )
+            validation = ZMuMuValidation( name,
+                Alignment( alignments.strip(), config ), config )
         elif valType == "primaryvertex":
-            validation = PrimaryVertexValidation( name, 
-                Alignment( alignments.strip(), self.__config ), self.__config )
+            validation = PrimaryVertexValidation( name,
+                Alignment( alignments.strip(), config ), config )
         elif valType == "preexistingprimaryvertex":
             validation = PreexistingPrimaryVertexValidation(name, self.__config)
         elif valType == "overlap":
@@ -191,35 +204,39 @@ class ValidationJob(object):
         """This private method creates the needed files for the validation job.
            """
         self.validation.createConfiguration( outpath )
-        if self.__preexisting:
+        if self.preexisting:
             return
-        self.__scripts = sum([addIndex(script, self.validation.NJobs) for script in self.validation.createScript( outpath )], [])
-        if jobMode.split( ',' )[0] == "crab":
-            self.validation.createCrabCfg( outpath )
+        self.scripts = sum([addIndex(script, self.validation.NJobs) for script in self.validation.createScript( outpath )], [])
         return None
 
     def createJob(self):
         """This is the method called to create the job files."""
         self.__createJob( self.validation.jobmode,
-                          os.path.abspath( self.__commandLineOptions.Name) )
+                          os.path.abspath( self.commandLineOptions.Name) )
 
     def runJob( self ):
-        if self.__preexisting:
-            if self.validation.jobid:
-                self.batchJobIds.append(self.validation.jobid)
-            log = ">             " + self.validation.name + " is already validated."
-            print(log)
-            return log
-        else:
-            if self.validation.jobid:
-                print("jobid {} will be ignored, since the validation {} is not preexisting".format(self.validation.jobid, self.validation.name))
-
-        general = self.__config.getGeneral()
+        general = self.config.getGeneral()
         log = ""
-        for script in self.__scripts:
+
+        if self.preexisting:
+            if self.validation.config.has_section("IOV"):
+                iov = self.validation.config.get("IOV", "iov")
+            else:
+                iov = "singleIOV"
+            preexistingValType = self.valType
+            originalValType = preexistingValType.replace('preexisting', '')
+            key = (originalValType, self.validation.originalValName, iov)
+            if key in ValidationJob.condorConf:
+                ValidationJob.condorConf[key].append(("preexisting", "", general["logdir"]))
+            else:
+                ValidationJob.condorConf[key] = [("preexisting", "", general["logdir"])]
+            log = ">             " + self.validation.name + " is already validated."
+            return log
+
+        for script in self.scripts:
             name = os.path.splitext( os.path.basename( script) )[0]
             ValidationJob.jobCount += 1
-            if self.__commandLineOptions.dryRun:
+            if self.commandLineOptions.dryRun:
                 print("%s would run: %s"%( name, os.path.basename( script) ))
                 continue
             log = ">             Validating "+name
@@ -227,62 +244,236 @@ class ValidationJob(object):
             if self.validation.jobmode == "interactive":
                 log += getCommandOutput2( script )
                 ValidationJob.interactCount += 1
-            elif self.validation.jobmode.split(",")[0] == "lxBatch":
-                repMap = { 
-                    "commands": self.validation.jobmode.split(",")[1],
-                    "logDir": general["logdir"],
-                    "jobName": name,
-                    "script": script,
-                    "bsub": "/afs/cern.ch/cms/caf/scripts/cmsbsub"
-                    }
-                for ext in ("stdout", "stderr", "stdout.gz", "stderr.gz"):
-                    oldlog = "%(logDir)s/%(jobName)s."%repMap + ext
-                    if os.path.exists(oldlog):
-                        os.remove(oldlog)
-                bsubOut=getCommandOutput2("%(bsub)s %(commands)s "
-                                          "-J %(jobName)s "
-                                          "-o %(logDir)s/%(jobName)s.stdout "
-                                          "-e %(logDir)s/%(jobName)s.stderr "
-                                          "%(script)s"%repMap)
-                #Attention: here it is assumed that bsub returns a string
-                #containing a job id like <123456789>
-                jobid=bsubOut.split("<")[1].split(">")[0]
-                self.JobId.append(jobid)
-                ValidationJob.batchJobIds.append(jobid)
-                log+=bsubOut
-                ValidationJob.batchCount += 1
-            elif self.validation.jobmode.split( "," )[0] == "crab":
-                os.chdir( general["logdir"] )
-                crabName = "crab." + os.path.basename( script )[:-3]
-                theCrab = crabWrapper.CrabWrapper()
-                options = { "-create": "",
-                            "-cfg": crabName + ".cfg",
-                            "-submit": "" }
-                try:
-                    theCrab.run( options )
-                except AllInOneError as e:
-                    print("crab:", str(e).split("\n")[0])
-                    exit(1)
-                ValidationJob.crabCount += 1
-
+            elif self.validation.jobmode.split( "," )[0] == "condor":
+                if self.validation.config.has_section("IOV"):
+                    iov = self.validation.config.get("IOV", "iov")
+                else:
+                    iov = "singleIOV"
+                scriptPaths = script.split("/")
+                scriptName = scriptPaths[-1]
+                scriptName = scriptName.split(".")
+                jobName = "%s"%scriptName[0] + "_%s"%scriptName[1]+"_%s"%scriptName[2]
+                key = (self.valType, self.valName, iov)
+                if key in ValidationJob.condorConf:
+                    ValidationJob.condorConf[key].append((jobName, script, general["logdir"]))
+                else:
+                    ValidationJob.condorConf[key] = [(jobName, script, general["logdir"])]
             else:
                 raise AllInOneError("Unknown 'jobmode'!\n"
                                       "Please change this parameter either in "
                                       "the [general] or in the ["
-                                      + self.__valType + ":" + self.__valName
+                                      + self.valType + ":" + self.valName
                                       + "] section to one of the following "
                                       "values:\n"
-                                      "\tinteractive\n\tlxBatch, -q <queue>\n"
-                                      "\tcrab, -q <queue>")
+                                      "\tinteractive\n\tcondor, -q <queue>\n")
 
         return log
 
     def getValidation( self ):
         return self.validation
 
-    @property
     def needsproxy(self):
-        return self.validation.needsproxy and not self.__preexisting and not self.__commandLineOptions.dryRun
+        return self.validation.needsproxy and not self.preexisting and not self.commandLineOptions.dryRun
+
+    def __iter__(self):
+        yield self
+
+    def __next__(self):
+        if self.start >= len(self.end):
+            raise StopIteration
+        else:
+            self.start += 1
+            return self.end[self.start-1]
+
+
+class ValidationJobMultiIOV(ValidationBase):
+
+    def __init__( self, validation, config, options, outPath, *args, **kwargs):
+        self.start = 0
+        self.end = args
+        super(ValidationJobMultiIOV, self).__init__( validation, config, options )
+        self.optionMultiIOV = self.config.getboolean( self.valSection, "multiIOV" )
+        if self.optionMultiIOV == True:
+            self.validation = validation
+            self.config = config
+            self.options = options
+            self.outPath = outPath
+            self.validations = self.__performMultiIOV(self.validation, self.alignments, self.config,
+                                                  self.options, self.outPath)
+
+
+    def __performMultiIOV(self, validation, alignments, config, options, outPath):
+        validations = []
+        if self.valType == "compare":
+            alignmentsList = alignments.split( "," )
+            firstAlignList = alignmentsList[0].split()
+            firstAlignName = firstAlignList[0].strip()
+            secondAlignList = alignmentsList[1].split()
+            secondAlignName = secondAlignList[0].strip()
+            compareAlignments = "%s"%firstAlignName + "_vs_%s"%secondAlignName
+            sectionMultiIOV = "multiIOV:compare"
+            if not self.config.has_section(sectionMultiIOV):
+                raise AllInOneError("section'[%s]' not found. Please define the dataset"%sectionMultiIOV)
+            iovList = self.config.get( sectionMultiIOV, "iovs" )
+            iovList = re.sub(r"\s+", "", iovList, flags=re.UNICODE).split( "," )
+            for iov in iovList:
+                    tmpConfig = BetterConfigParser()
+                    tmpConfig.read( options.config )
+                    general = tmpConfig.getGeneral()
+                    tmpConfig.add_section("IOV")
+                    tmpConfig.set("IOV", "iov", iov)
+                    tmpConfig.set("internals","workdir",os.path.join(general["workdir"], options.Name, self.valType + "_%s"%compareAlignments + "_%s"%iov) )
+                    tmpConfig.set("internals","scriptsdir",os.path.join(outPath, self.valType + "_%s"%compareAlignments + "_%s"%iov) )
+                    tmpConfig.set("general","datadir",os.path.join(general["datadir"], options.Name, self.valType + "_%s"%compareAlignments + "_%s"%iov) )
+                    tmpConfig.set("general","logdir",os.path.join(general["logdir"], options.Name, self.valType + "_%s"%compareAlignments + "_%s"%iov) )
+                    tmpConfig.set("general","eosdir",os.path.join("AlignmentValidation", general["eosdir"], options.Name, self.valType + "_%s"%compareAlignments + "_%s"%iov) )
+                    tmpOptions = copy.deepcopy(options)
+                    tmpOptions.Name = os.path.join(options.Name, self.valType + "_%s"%compareAlignments + "_%s"%iov)
+                    tmpOptions.config = tmpConfig
+                    newOutPath = os.path.abspath( tmpOptions.Name )
+                    if not os.path.exists( newOutPath ):
+                        os.makedirs( newOutPath )
+                    elif not os.path.isdir( newOutPath ):
+                        raise AllInOneError("the file %s is in the way rename the Job or move it away"%newOutPath)
+                    job = ValidationJob( validation, tmpConfig, tmpOptions, len(iovList) )
+                    validations.append(job)
+
+            return validations
+
+        if "preexisting" in self.valType:
+            preexistingValType = self.valType
+            preexistingValSection = self.valSection
+            preexistingEosdir = self.config.get( self.valSection, "eosdirName" )
+            originalValType = preexistingValType.replace('preexisting', '')
+            originalValName = self.config.get( self.valSection, "originalValName" )
+            self.valSection = originalValType + ":" + originalValName
+            originalAlignment = self.valName
+
+        datasetList = self.config.get( self.valSection, "dataset" )
+        datasetList = re.sub(r"\s+", "", datasetList, flags=re.UNICODE).split( "," )
+        for dataset in datasetList:
+            sectionMultiIOV = "multiIOV:%s"%dataset
+            if not self.config.has_section(sectionMultiIOV):
+                raise AllInOneError("section'[%s]' not found. Please define the dataset"%sectionMultiIOV)
+            else:
+                datasetBaseName = self.config.get( sectionMultiIOV, "dataset" )
+                iovList = self.config.get( sectionMultiIOV, "iovs" )
+                iovList = re.sub(r"\s+", "", iovList, flags=re.UNICODE).split( "," )
+                for iov in iovList:
+                    datasetName = datasetBaseName+"_since%s"%iov
+                    tmpConfig = BetterConfigParser()
+                    tmpConfig.read( options.config )
+                    general = tmpConfig.getGeneral()
+                    if "preexisting" in self.valType:
+                        valType = originalValType
+                        valName = originalValName
+                    else:
+                        valType = self.valType
+                        valName = self.valName
+                    tmpConfig.add_section("IOV")
+                    tmpConfig.set("IOV", "iov", iov)
+                    tmpConfig.set( self.valSection, "dataset", datasetName )
+                    tmpConfig.set("internals","workdir",os.path.join(general["workdir"], options.Name, valType + "_" + valName + "_%s"%iov) )
+                    tmpConfig.set("internals","scriptsdir",os.path.join(outPath, valType + "_" + valName + "_%s"%iov) )
+                    tmpConfig.set("general","datadir",os.path.join(general["datadir"], options.Name, valType + "_" + valName + "_%s"%iov) )
+                    tmpConfig.set("general","logdir",os.path.join(general["logdir"], options.Name, valType + "_" + valName + "_%s"%iov) )
+                    tmpConfig.set("general","eosdir",os.path.join("AlignmentValidation", general["eosdir"], options.Name, valType + "_" + valName + "_%s"%iov) )
+                    if "preexisting" in self.valType:
+                        if self.valType == "preexistingoffline":
+                            validationClassName = "AlignmentValidation"
+                        #elif self.valType == "preexistingmcValidate":
+                        #    validationClassName = "MonteCarloValidation"
+                        #elif self.valType == "preexistingsplit":
+                        #    validationClassName = "TrackSplittingValidation"
+                        #elif self.valType == "preexistingprimaryvertex":
+                        #    validationClassName = "PrimaryVertexValidation"
+                        else:
+                            raise AllInOneError("Unknown validation mode for preexisting option:'%s'"%self.valType)
+                        preexistingEosdirPath = os.path.join("AlignmentValidation", preexistingEosdir, valType + "_" + valName + "_%s"%iov)
+                        file = "/eos/cms/store/group/alca_trackeralign/AlignmentValidation/" + "%s"%preexistingEosdirPath + "/%s"%validationClassName + "_%s"%originalValName + "_%s"%originalAlignment + ".root"
+                        tmpConfig.set(preexistingValSection, "file", file)
+                    tmpOptions = copy.deepcopy(options)
+                    tmpOptions.Name = os.path.join(options.Name, valType + "_" + valName + "_%s"%iov)
+                    tmpOptions.config = tmpConfig
+                    newOutPath = os.path.abspath( tmpOptions.Name )
+                    if not os.path.exists( newOutPath ):
+                        os.makedirs( newOutPath )
+                    elif not os.path.isdir( newOutPath ):
+                        raise AllInOneError("the file %s is in the way rename the Job or move it away"%newOutPath)
+                    job = ValidationJob( validation, tmpConfig, tmpOptions, len(iovList) )
+                    validations.append(job)
+
+        return validations
+
+    def createJob( self ):
+        map( lambda validation: validation.createJob(), self.validations )
+
+    def runJob( self ):
+        return [validation.runJob() for validation in self.validations]
+
+    @staticmethod
+    def runCondorJobs(outdir):
+        dagmanLog = "{}/daglogs".format(outdir)
+        os.system("mkdir -p {}".format(dagmanLog))
+
+
+        with open("{}/validation.condor".format(outdir), "w") as condor:
+            condor.write("universe = vanilla" + "\n")
+            condor.write("executable = $(scriptName).sh" + "\n")
+            condor.write("log = $(scriptName).log" + "\n")
+            condor.write("error = $(scriptName).stderr" + "\n")
+            condor.write("output = $(scriptName).stdout" + "\n")
+            condor.write('requirements = (OpSysAndVer =?= "CentOS7")' + '\n')
+            condor.write('+JobFlavour = "tomorrow"' + "\n")
+            condor.write('+RequestMemory = {}'.format(1540) + "\n")
+            condor.write('+FileTransferDownloadBytes = {}'.format(1540) + "\n")
+            condor.write('+AccountingGroup     = "group_u_CMS.CAF.ALCA"' + '\n')
+            condor.write("queue")
+
+        with open("{}/validation.dagman".format(outdir), "w") as dagman:
+            parents = {}
+            for (valType, valName, iov), alignments in six.iteritems(ValidationJob.condorConf):
+
+                parents[(valType, valName, iov)] = []
+                for jobInfo in alignments:
+                    if not "preexisting" in jobInfo[0]:
+                        dagman.write("JOB {}_{} {}/validation.condor".format(jobInfo[0], iov, outdir) + "\n")
+                        dagman.write('VARS {}_{} '.format(jobInfo[0], iov) + 'scriptName="{}"'.format('.'.join(jobInfo[1].split('.')[:-1])) + "\n")
+                        parents[(valType, valName, iov)].append('{}_{}'.format(jobInfo[0], iov))
+                        dagman.write("\n")
+
+                path =  os.path.join(jobInfo[2], "TkAlMerge.sh")
+                if os.path.exists( path ):
+                    dagman.write("JOB Merge_{}_{}_{} {}/validation.condor".format(valType, valName, iov, outdir) + "\n")
+                    dagman.write("VARS Merge_{}_{}_{} ".format(valType, valName, iov) + 'scriptName="{}"'.format(os.path.join(jobInfo[2], "TkAlMerge")) + "\n")
+                    dagman.write("\n")
+                else:
+                    raise AllInOneError("Merge script '[%s]' not found!"%path)
+
+            for (valType, valName, iov), alignments in six.iteritems(ValidationJob.condorConf):
+                if len(parents[(valType, valName, iov)]) != 0:
+                    dagman.write('PARENT {} '.format(" ".join([parent for parent in parents[(valType, valName, iov)]])) + 'CHILD Merge_{}_{}_{}'.format(valType, valName, iov) + "\n")
+
+        submitCommands = ["condor_submit_dag -no_submit -outfile_dir {} {}/validation.dagman".format(dagmanLog, outdir), "condor_submit {}/validation.dagman.condor.sub".format(outdir)]
+
+        for command in submitCommands:
+            subprocess.call(command.split(" "))
+
+    def getValidation( self ):
+        return [validation.getValidation() for validation in self.validations]
+
+    def needsproxy( self ):
+        return [validation.needsproxy() for validation in self.validations].join("and") and not self.preexisting and not self.commandLineOptions.dryRun
+
+    def __iter__(self):
+        yield self
+
+    def __next__(self):
+        if self.start >= len(self.end):
+            raise StopIteration
+        else:
+            self.start += 1
+            return self.end[self.start-1]
 
 
 ####################--- Functions ---############################
@@ -290,167 +481,116 @@ def createMergeScript( path, validations, options ):
     if(len(validations) == 0):
         raise AllInOneError("Cowardly refusing to merge nothing!")
 
-    config = validations[0].config
-    repMap = config.getGeneral()
-    repMap.update({
-            "DownloadData":"",
-            "CompareAlignments":"",
-            "RunValidationPlots":"",
-            "CMSSW_BASE": os.environ["CMSSW_BASE"],
-            "SCRAM_ARCH": os.environ["SCRAM_ARCH"],
-            "CMSSW_RELEASE_BASE": os.environ["CMSSW_RELEASE_BASE"],
-            })
+    repMap = {}
 
     comparisonLists = {} # directory of lists containing the validations that are comparable
     for validation in validations:
+        if validation.config.has_section("IOV"):
+            iov = validation.config.get("IOV", "iov")
+            validation.defaultReferenceName = iov
         for referenceName in validation.filesToCompare:
             validationtype = type(validation)
+            validationName = validation.name
+            if validation.config.has_section("IOV") and (referenceName == "Tracker_defaultRange" or referenceName == "Tracker_autoRange"):
+                referenceName = iov
             if issubclass(validationtype, PreexistingValidation):
+                validationName = validation.originalValName
                 #find the actual validationtype
                 for parentclass in validationtype.mro():
                     if not issubclass(parentclass, PreexistingValidation):
                         validationtype = parentclass
                         break
-            key = (validationtype, referenceName)
+            key = (validationtype, validationName, referenceName)
+
+
             if key in comparisonLists:
                 comparisonLists[key].append(validation)
             else:
                 comparisonLists[key] = [validation]
+                repMap[key] = validation.config.getGeneral()
+                repMap[key].update({
+                        "DownloadData":"",
+                        "CompareAlignments":"",
+                        "RunValidationPlots":"",
+                        "CMSSW_BASE": os.environ["CMSSW_BASE"],
+                        "SCRAM_ARCH": os.environ["SCRAM_ARCH"],
+                        "CMSSW_RELEASE_BASE": os.environ["CMSSW_RELEASE_BASE"],
+                        })
 
-    # introduced to merge individual validation outputs separately
-    #  -> avoids problems with merge script
-    repMap["doMerge"] = "mergeRetCode=0\n"
-    repMap["rmUnmerged"] = ("if [[ mergeRetCode -eq 0 ]]; then\n"
+                # introduced to merge individual validation outputs separately
+                #  -> avoids problems with merge script
+                repMap[key]["doMerge"] = "mergeRetCode=0\n"
+                repMap[key]["rmUnmerged"] = ("if [[ mergeRetCode -eq 0 ]]; then\n"
                             "    echo -e \\n\"Merging succeeded, removing original files.\"\n")
-    repMap["beforeMerge"] = ""
-    repMap["mergeParallelFilePrefixes"] = ""
-    repMap["createResultsDirectory"]=""
-    
+                repMap[key]["beforeMerge"] = ""
+                repMap[key]["mergeParallelFilePrefixes"] = ""
+                repMap[key]["createResultsDirectory"]=""
 
+    #print("comparisonLists")
+    #pprint.pprint(comparisonLists)
     anythingToMerge = []
-    
-    
-    #prepare dictionary containing handle objects for parallel merge batch jobs
-    if options.mergeOfflineParallel:
-        parallelMergeObjects={}
-    for (validationType, referencename), validations in six.iteritems(comparisonLists):
+
+    for (validationtype, validationName, referenceName), validations in comparisonLists.iteritems():
+        #pprint.pprint("validations")
+        #pprint.pprint(validations)
+        globalDictionaries.plottingOptions = {}
+        map( lambda validation: validation.getRepMap(), validations )
+        #plotInfo = "plots:offline"
+        #allPlotInfo = dict(validations[0].config.items(plotInfo))
+        #repMap[(validationtype, validationName, referenceName)].update(allPlotInfo)
+
         for validation in validations:
+            validation.getRepMap()
+            #pprint.pprint("validation in validations")
+            #pprint.pprint(validation)
             #parallel merging
-            if (isinstance(validation, PreexistingValidation)
-                or validation.NJobs == 1
-                or not isinstance(validation, ParallelValidation)):
-                    continue
-            if options.mergeOfflineParallel and validationType.valType=='offline' and validation.jobmode.split(",")[0]=="lxBatch":
-                repMapTemp=repMap.copy()
-                if validationType not in anythingToMerge:
-                    anythingToMerge += [validationType]
-                    #create init script
-                    fileName="TkAlMergeInit"
-                    filePath = os.path.join(path, fileName+".sh")
-                    theFile = open( filePath, "w" )
-                    repMapTemp["createResultsDirectory"]="#!/bin/bash"
-                    repMapTemp["createResultsDirectory"]+=replaceByMap(configTemplates.createResultsDirectoryTemplate, repMapTemp)
-                    theFile.write( replaceByMap( configTemplates.createResultsDirectoryTemplate, repMapTemp ) )
-                    theFile.close()
-                    os.chmod(filePath,0o755)
-                    #create handle
-                    parallelMergeObjects["init"]=ParallelMergeJob(fileName, filePath,[])
-                    #clear 'create result directory' code
-                    repMapTemp["createResultsDirectory"]=""
-                
-                #edit repMapTmp as necessary:
-                #fill contents of mergeParallelResults
-                repMapTemp["beforeMerge"] += validationType.doInitMerge()
-                repMapTemp["doMerge"] += '\n\n\n\necho -e "\n\nMerging results from %s jobs with alignment %s"\n\n' % (validationType.valType,validation.alignmentToValidate.name)
-                repMapTemp["doMerge"] += validation.doMerge()
+            if not (isinstance(validation, PreexistingValidation) or validation.NJobs == 1 or not isinstance(validation, ParallelValidation)):
+                if (validationtype, validationName, referenceName) not in anythingToMerge:
+                    anythingToMerge.append((validationtype, validationName, referenceName))
+                    repMap[(validationtype, validationName, referenceName)]["doMerge"] += '\n\n\n\necho -e "\n\nMerging results from %s jobs"\n\n' % validationtype.valType
+                    repMap[(validationtype, validationName, referenceName)]["beforeMerge"] += validationtype.doInitMerge()
+                repMap[(validationtype, validationName, referenceName)]["doMerge"] += validation.doMerge()
                 for f in validation.getRepMap()["outputFiles"]:
-                    longName = os.path.join("/eos/cms/store/group/alca_trackeralign/AlignmentValidation/",
-                                            validation.getRepMap()["eosdir"], f)
-                    repMapTemp["rmUnmerged"] += "    rm "+longName+"\n"
-                
-                repMapTemp["rmUnmerged"] += ("else\n"
-                             "    echo -e \\n\"WARNING: Merging failed, unmerged"
-                             " files won't be deleted.\\n"
-                             "(Ignore this warning if merging was done earlier)\"\n"
-                             "fi\n")
-                
-                #fill mergeParallelResults area of mergeTemplate
-                repMapTemp["DownloadData"] = replaceByMap( configTemplates.mergeParallelResults, repMapTemp )
-                #fill runValidationPlots area of mergeTemplate
-                repMapTemp["RunValidationPlots"] = validationType.doRunPlots(validations)
-                
-                #create script file
-                fileName="TkAlMergeOfflineValidation"+validation.name+validation.alignmentToValidate.name
-                filePath = os.path.join(path, fileName+".sh")
-                theFile = open( filePath, "w" )
-                theFile.write( replaceByMap( configTemplates.mergeParallelOfflineTemplate, repMapTemp ) )
-                theFile.close()
-                os.chmod(filePath,0o755)
-                #create handle object
-                if "parallel" in parallelMergeObjects:
-                    parallelMergeObjects["parallel"].append(ParallelMergeJob(fileName, filePath,[]))
-                else:
-                    parallelMergeObjects["parallel"]=[ParallelMergeJob(fileName, filePath,[])]
-                continue
-                
-                
-            else:
-                if validationType not in anythingToMerge:
-                    anythingToMerge += [validationType]
-                    repMap["doMerge"] += '\n\n\n\necho -e "\n\nMerging results from %s jobs"\n\n' % validationType.valType
-                    repMap["beforeMerge"] += validationType.doInitMerge()
-                repMap["doMerge"] += validation.doMerge()
-                for f in validation.getRepMap()["outputFiles"]:
-                    longName = os.path.join("/eos/cms/store/group/alca_trackeralign/AlignmentValidation/",
-                                            validation.getRepMap()["eosdir"], f)
-                    repMap["rmUnmerged"] += "    rm "+longName+"\n"
-                
-                
-    
-    repMap["rmUnmerged"] += ("else\n"
-                             "    echo -e \\n\"WARNING: Merging failed, unmerged"
-                             " files won't be deleted.\\n"
-                             "(Ignore this warning if merging was done earlier)\"\n"
-                             "fi\n")
-    
-    
-    
-    if anythingToMerge:
-        repMap["DownloadData"] += replaceByMap( configTemplates.mergeParallelResults, repMap )
-    else:
-        repMap["DownloadData"] = ""
+		            longName = os.path.join("/eos/cms/store/group/alca_trackeralign/AlignmentValidation/",
+		                                    validation.getRepMap()["eosdir"], f)
+		            repMap[(validationtype, validationName, referenceName)]["rmUnmerged"] += "    rm "+longName+"\n"
 
-    repMap["RunValidationPlots"] = ""
-    for (validationType, referencename), validations in six.iteritems(comparisonLists):
-        if issubclass(validationType, ValidationWithPlots):
-            repMap["RunValidationPlots"] += validationType.doRunPlots(validations)
 
-    repMap["CompareAlignments"] = "#run comparisons"
-    for (validationType, referencename), validations in six.iteritems(comparisonLists):
-        if issubclass(validationType, ValidationWithComparison):
-            repMap["CompareAlignments"] += validationType.doComparison(validations)
-    
-    #if user wants to merge parallely and if there are valid parallel scripts, create handle for plotting job and set merge script name accordingly
-    if options.mergeOfflineParallel and parallelMergeObjects!={}:
-        parallelMergeObjects["continue"]=ParallelMergeJob("TkAlMergeFinal",os.path.join(path, "TkAlMergeFinal.sh"),[])
-        filePath = os.path.join(path, "TkAlMergeFinal.sh")
-    #if not merging parallel, add code to create results directory and set merge script name accordingly
-    else:
-        repMap["createResultsDirectory"]=replaceByMap(configTemplates.createResultsDirectoryTemplate, repMap)
-        filePath = os.path.join(path, "TkAlMerge.sh")
-    
-    
-    #filePath = os.path.join(path, "TkAlMerge.sh")
-    theFile = open( filePath, "w" )
-    theFile.write( replaceByMap( configTemplates.mergeTemplate, repMap ) )
-    theFile.close()
-    os.chmod(filePath,0o755)
-    
-    if options.mergeOfflineParallel:
-        return {'TkAlMerge.sh':filePath, 'parallelMergeObjects':parallelMergeObjects}
-    else:
-        return filePath
-    
+
+        repMap[(validationtype, validationName, referenceName)]["rmUnmerged"] += ("else\n"
+                                                                  "    echo -e \\n\"WARNING: Merging failed, unmerged"
+                                                                  " files won't be deleted.\\n"
+                                                                  "(Ignore this warning if merging was done earlier)\"\n"
+                                                                  "fi\n")
+
+
+        if anythingToMerge:
+            repMap[(validationtype, validationName, referenceName)]["DownloadData"] += replaceByMap( configTemplates.mergeParallelResults, repMap[(validationtype, validationName, referenceName)] )
+        else:
+            repMap[(validationtype, validationName, referenceName)]["DownloadData"] = ""
+
+        repMap[(validationtype, validationName, referenceName)]["RunValidationPlots"] = ""
+        repMap[(validationtype, validationName, referenceName)]["plottingscriptpath"] = ""
+        if issubclass(validationtype, ValidationWithPlots):
+            repMap[(validationtype, validationName, referenceName)]["RunValidationPlots"] = validationtype.doRunPlots(validations)
+
+        repMap[(validationtype, validationName, referenceName)]["CompareAlignments"] = "#run comparisons"
+        if issubclass(validationtype, ValidationWithComparison):
+            repMap[(validationtype, validationName, referenceName)]["CompareAlignments"] += validationtype.doComparison(validations)
+
+        #if not merging parallel, add code to create results directory and set merge script name accordingly
+        if validations[0].config.has_section("IOV"):
+            repMap[(validationtype, validationName, referenceName)]["createResultsDirectory"]=replaceByMap(configTemplates.createResultsDirectoryTemplate, repMap[(validationtype, validationName, referenceName)])
+            filePath = os.path.join(repMap[(validationtype, validationName, referenceName)]["scriptsdir"], "TkAlMerge.sh")
+        else:
+            repMap[(validationtype, validationName, referenceName)]["createResultsDirectory"]=replaceByMap(configTemplates.createResultsDirectoryTemplate, repMap[(validationtype, validationName, referenceName)])
+            filePath = os.path.join(path, "TkAlMerge.sh")
+
+        theFile = open( filePath, "w" )
+        theFile.write( replaceByMap( configTemplates.mergeTemplate, repMap[(validationtype, validationName, referenceName)]) )
+        theFile.close()
+        os.chmod(filePath,0o755)
+
 def loadTemplates( config ):
     if config.has_section("alternateTemplates"):
         for templateName in config.options("alternateTemplates"):
@@ -460,7 +600,19 @@ def loadTemplates( config ):
             #print "replacing default %s template by %s"%( templateName, newTemplateName)
             configTemplates.alternateTemplate(templateName, newTemplateName)
 
-    
+def flatten(l):
+    flattenList = []
+
+    for item in l:
+        if type(item) == list:
+            flattenList.extend(flatten(item))
+
+        else:
+            flattenList.append(item)
+
+    return flattenList
+
+
 ####################--- Main ---############################
 def main(argv = None):
     if argv == None:
@@ -474,7 +626,7 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
     optParser.add_option("-n", "--dryRun", dest="dryRun", action="store_true", default=False,
                          help="create all scripts and cfg File but do not start jobs (default=False)")
     optParser.add_option( "--getImages", dest="getImages", action="store_true", default=True,
-                          help="get all Images created during the process (default= True)")
+                         help="get all Images created during the process (default= True)")
     defaultConfig = "TkAlConfig.ini"
     optParser.add_option("-c", "--config", dest="config", default = defaultConfig,
                          help="configuration to use (default TkAlConfig.ini) this can be a comma-seperated list of all .ini file you want to merge", metavar="CONFIG")
@@ -482,34 +634,28 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
                          help="Name of this validation (default: alignmentValidation_DATE_TIME)", metavar="NAME")
     optParser.add_option("-r", "--restrictTo", dest="restrictTo",
                          help="restrict validations to given modes (comma seperated) (default: no restriction)", metavar="RESTRICTTO")
-    optParser.add_option("-s", "--status", dest="crabStatus", action="store_true", default = False,
-                         help="get the status of the crab jobs", metavar="STATUS")
     optParser.add_option("-d", "--debug", dest="debugMode", action="store_true",
                          default = False,
                          help="run the tool to get full traceback of errors",
                          metavar="DEBUG")
-    optParser.add_option("-m", "--autoMerge", dest="autoMerge", action="store_true", default = False,
-                         help="submit TkAlMerge.sh to run automatically when all jobs have finished (default=False)."
-                              " Works only for batch jobs")
-    optParser.add_option("--mergeOfflineParallel", dest="mergeOfflineParallel", action="store_true", default = False,
-                         help="Enable parallel merging of offline data. Best used with -m option. Only works with lxBatch-jobmode", metavar="MERGE_PARALLEL")
 
 
     (options, args) = optParser.parse_args(argv)
+
 
     if not options.restrictTo == None:
         options.restrictTo = options.restrictTo.split(",")
 
     options.config = [ os.path.abspath( iniFile ) for iniFile in \
-                       options.config.split( "," ) ]
+                       options.config.split( "," )]
+
     config = BetterConfigParser()
     outputIniFileSet = set( config.read( options.config ) )
     failedIniFiles = [ iniFile for iniFile in options.config if iniFile not in outputIniFileSet ]
 
     # Check for missing ini file
     if options.config == [ os.path.abspath( defaultConfig ) ]:
-        if ( not options.crabStatus ) and \
-               ( not os.path.exists( defaultConfig ) ):
+        if ( not os.path.exists( defaultConfig ) ):
                 raise AllInOneError( "Default 'ini' file '%s' not found!\n"
                                        "You can specify another name with the "
                                        "command line option '-c'/'--config'."
@@ -527,50 +673,18 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     # get the job name
     if options.Name == None:
-        if not options.crabStatus:
-            options.Name = "alignmentValidation_%s"%(datetime.datetime.now().strftime("%y%m%d_%H%M%S"))
-        else:
-            existingValDirs = fnmatch.filter( os.walk( '.' ).next()[1],
+        existingValDirs = fnmatch.filter( os.walk( '.' ).next()[1],
                                               "alignmentValidation_*" )
-            if len( existingValDirs ) > 0:
-                options.Name = existingValDirs[-1]
-            else:
-                print("Cannot guess last working directory!")
-                print ( "Please use the parameter '-N' or '--Name' to specify "
-                        "the task for which you want a status report." )
-                return 1
+        if len( existingValDirs ) > 0:
+            options.Name = existingValDirs[-1]
+        else:
+            print("Cannot guess last working directory!")
+            print ( "Please use the parameter '-N' or '--Name' to specify "
+                    "the task for which you want a status report." )
+            return 1
 
     # set output path
     outPath = os.path.abspath( options.Name )
-
-    # Check status of submitted jobs and return
-    if options.crabStatus:
-        os.chdir( outPath )
-        crabLogDirs = fnmatch.filter( os.walk('.').next()[1], "crab.*" )
-        if len( crabLogDirs ) == 0:
-            print("Found no crab tasks for job name '%s'"%( options.Name ))
-            return 1
-        theCrab = crabWrapper.CrabWrapper()
-        for crabLogDir in crabLogDirs:
-            print()
-            print("*" + "=" * 78 + "*")
-            print ( "| Status report and output retrieval for:"
-                    + " " * (77 - len( "Status report and output retrieval for:" ) )
-                    + "|" )
-            taskName = crabLogDir.replace( "crab.", "" )
-            print("| " + taskName + " " * (77 - len( taskName ) ) + "|")
-            print("*" + "=" * 78 + "*")
-            print()
-            crabOptions = { "-getoutput":"",
-                            "-c": crabLogDir }
-            try:
-                theCrab.run( crabOptions )
-            except AllInOneError as e:
-                print("crab:  No output retrieved for this task.")
-            crabOptions = { "-status": "",
-                            "-c": crabLogDir }
-            theCrab.run( crabOptions )
-        return
 
     general = config.getGeneral()
     config.set("internals","workdir",os.path.join(general["workdir"],options.Name) )
@@ -601,72 +715,39 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
         shutil.copyfile(getCommandOutput2("voms-proxy-info --path").strip(), os.path.join(outPath, ".user_proxy"))
 
     validations = []
+    jobs = []
     for validation in config.items("validation"):
         alignmentList = [validation[1]]
         validationsToAdd = [(validation[0],alignment) \
                                 for alignment in alignmentList]
         validations.extend(validationsToAdd)
-    jobs = [ ValidationJob( validation, config, options) \
-                 for validation in validations ]
+
+
+    for validation in validations:
+        job = ValidationJobMultiIOV(validation, config, options, outPath, len(validations))
+        if (job.optionMultiIOV == True):
+            jobs.extend(job)
+        else:
+            jobs.extend( ValidationJob(validation, config, options, 1) )
+
     for job in jobs:
         if job.needsproxy and not proxyexists:
             raise AllInOneError("At least one job needs a grid proxy, please init one.")
+
     map( lambda job: job.createJob(), jobs )
+
     validations = [ job.getValidation() for job in jobs ]
+    validations = flatten(validations)
 
-    if options.mergeOfflineParallel:
-        parallelMergeObjects=createMergeScript(outPath, validations, options)['parallelMergeObjects']
-    else:
-        createMergeScript(outPath, validations, options)
+    createMergeScript(outPath, validations, options)
 
 
-    print()
     map( lambda job: job.runJob(), jobs )
 
-    if options.autoMerge and ValidationJob.jobCount == ValidationJob.batchCount and config.getGeneral()["jobmode"].split(",")[0] == "lxBatch":
-        print(">             Automatically merging jobs when they have ended")
-        # if everything is done as batch job, also submit TkAlMerge.sh to be run
-        # after the jobs have finished
-        
-        #if parallel merge scripts: manage dependencies
-        if options.mergeOfflineParallel and parallelMergeObjects!={}:
-            initID=parallelMergeObjects["init"].runJob(config).split("<")[1].split(">")[0]
-            parallelIDs=[]
-            for parallelMergeScript in parallelMergeObjects["parallel"]:
-                parallelMergeScript.addDependency(initID)
-                for job in jobs:
-                    if isinstance(job.validation, OfflineValidation) and "TkAlMerge"+job.validation.alignmentToValidate.name==parallelMergeScript.name:
-                        parallelMergeScript.addDependency(job.JobId)
-                parallelIDs.append(parallelMergeScript.runJob(config).split("<")[1].split(">")[0])
-            parallelMergeObjects["continue"].addDependency(parallelIDs)
-            parallelMergeObjects["continue"].addDependency(ValidationJob.batchJobIds)
-            parallelMergeObjects["continue"].runJob(config)
-            
-            
-        
-    
-        else:
-            repMap = {
-                "commands": config.getGeneral()["jobmode"].split(",")[1],
-                "jobName": "TkAlMerge",
-                "logDir": config.getGeneral()["logdir"],
-                "script": "TkAlMerge.sh",
-                "bsub": "/afs/cern.ch/cms/caf/scripts/cmsbsub",
-                "conditions": '"' + " && ".join(["ended(" + jobId + ")" for jobId in ValidationJob.batchJobIds]) + '"'
-                }
-            for ext in ("stdout", "stderr", "stdout.gz", "stderr.gz"):
-                oldlog = "%(logDir)s/%(jobName)s."%repMap + ext
-                if os.path.exists(oldlog):
-                    os.remove(oldlog)
+    ValidationJobMultiIOV.runCondorJobs(outPath)
 
-            #issue job
-            getCommandOutput2("%(bsub)s %(commands)s "
-                            "-o %(logDir)s/%(jobName)s.stdout "
-                            "-e %(logDir)s/%(jobName)s.stderr "
-                            "-w %(conditions)s "
-                            "%(logDir)s/%(script)s"%repMap)
 
-if __name__ == "__main__":        
+if __name__ == "__main__":
     # main(["-n","-N","test","-c","defaultCRAFTValidation.ini,latestObjects.ini","--getImages"])
     if "-d" in sys.argv[1:] or "--debug" in sys.argv[1:]:
         main()

--- a/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_all_ini_one.ini
@@ -6,10 +6,10 @@
 # general settings applying to all validations
 # - one can override `jobmode` in the individual validation's section
 [general]
-jobmode = lxBatch, -q cmscaf1nd
+jobmode = condor
 datadir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/PVValidationTest
 # if you want your root files stored in a subdirectory on eos, put it here:
-# eosdir = Test
+eosdir = Test
 # if you want your logs to be stored somewhere else, put it here:
 # logdir = /afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/data/commonValidation/results/$USER/log
 
@@ -96,7 +96,8 @@ w_dzEtaNormMax = 1.8
 
 [primaryvertex:phase0MC]
 maxevents = 10000
-dataset = /RelValTTbar_13/CMSSW_8_1_0_pre16-TkAlMinBias-81X_mcRun2_asymptotic_v11-v1/ALCARECO 
+multiIOV = false
+dataset = /RelValTTbar_13/CMSSW_11_0_0_pre13-TkAlMinBias-110X_mcRun2_asymptotic_v5-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
 isda = True
@@ -110,6 +111,7 @@ runControl = False
 
 [primaryvertex:phaseIMC]
 maxevents = 10000
+multiIOV = false
 dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -133,6 +135,7 @@ runControl = False
 [primaryvertex:phaseIMC_BPixOnly]
 maxevents = 10000
 dataset =  /QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer17DRPremix-TkAlMinBias-92X_upgrade2017_realistic_v10-v1/ALCARECO
+multiIOV = false
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
 isda = True
@@ -148,6 +151,7 @@ runControl = False
 
 [primaryvertex:run2016data]
 maxevents = 10000
+multiIOV = false
 dataset = /HLTPhysics/Run2016H-TkAlMinBias-PromptReco-v2/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -162,6 +166,7 @@ runControl = True
 
 [primaryvertex:run2018data]
 maxevents = 10000
+multiIOV = false
 dataset = /StreamExpressAlignment/Run2018B-TkAlMinBias-Express-v1/ALCARECO 
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -182,6 +187,7 @@ runControl = False
 
 [primaryvertex:run2018data_forcedBS]
 maxevents = 10000
+multiIOV = false
 dataset = /StreamExpressAlignment/Run2018B-TkAlMinBias-Express-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 vertexcollection = offlinePrimaryVertices
@@ -204,5 +210,3 @@ primaryvertex phaseIMC    : mc_2017
 primaryvertex phaseIMC_BPixOnly : mc_2017_bpixonly
 primaryvertex run2018data : data_2018
 primaryvertex run2018data_forcedBS : data_2018
-
-

--- a/Alignment/OfflineValidation/test/testValidate.ini
+++ b/Alignment/OfflineValidation/test/testValidate.ini
@@ -33,21 +33,28 @@ style = 2402
 # configuration of individual validations
 
 [offline:validation_MinBias]
+multiIOV  = false
 maxevents = 1000
-dataset = /MinimumBias/Run2017A-TkAlMinBias-PromptReco-v1/ALCARECO
+magneticfield = 3.8
+dataset   = /MinimumBias/Run2017A-TkAlMinBias-PromptReco-v1/ALCARECO
 trackcollection = ALCARECOTkAlMinBias
 
 [offline:validation_cosmics]
+multiIOV  = false
 maxevents = 1000
+magneticfield = 3.8
 dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
 trackcollection = ALCARECOTkAlCosmicsCTF0T
 
 [compare:Tracker]
+multiIOV = false
 levels = "Tracker","DetUnit"
 dbOutput = false
 
 [zmumu:some_zmumu_validation]
+multiIOV = false
 maxevents = 1000
+magneticfield = 3.8
 dataset = /DoubleMuon/Run2017A-TkAlZMuMu-PromptReco-v3/ALCARECO
 etamaxneg = 2.4
 etaminneg = -2.4
@@ -55,6 +62,7 @@ etamaxpos = 2.4
 etaminpos = -2.4
 
 [split:some_split_validation]
+multiIOV = false
 maxevents = 1000
 dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
 trackcollection = ALCARECOTkAlCosmicsCTF0T

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -3,4 +3,90 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING Alignment/OfflineValidation ..."
-cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_OfflineValidaiton_cfg.py" $? 
+cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_OfflineValidation_cfg.py" $?
+
+cat <<EOF >> validation_config.ini
+[general]
+jobmode = interactive
+eosdir  = Test
+
+[alignment:prompt]
+title = prompt
+globaltag = 92X_dataRun2_Prompt_v2
+color = 1
+style = 2001
+
+[alignment:express]
+title = express
+globaltag = 92X_dataRun2_Express_v2
+color = 2
+style = 2402
+
+[offline:validation_MinBias]
+multiIOV  = false
+maxevents = 10
+dataset   = /MinimumBias/Run2017A-TkAlMinBias-PromptReco-v1/ALCARECO
+magneticfield = 3.8
+trackcollection = ALCARECOTkAlMinBias
+
+[offline:validation_cosmics]
+multiIOV  = false
+maxevents = 10
+dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
+magneticfield = 3.8
+trackcollection = ALCARECOTkAlCosmicsCTF0T
+
+[compare:Tracker]
+multiIOV = false
+levels = "Tracker","DetUnit"
+dbOutput = false
+
+[zmumu:some_zmumu_validation]
+multiIOV = false
+maxevents = 10
+dataset = /DoubleMuon/Run2017A-TkAlZMuMu-PromptReco-v3/ALCARECO
+etamaxneg = 2.4
+etaminneg = -2.4
+etamaxpos = 2.4
+etaminpos = -2.4
+
+[split:some_split_validation]
+multiIOV = false
+maxevents = 10
+dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
+trackcollection = ALCARECOTkAlCosmicsCTF0T
+
+[plots:offline]
+DMROptions = plain split
+DMRMinimum = 5
+legendoptions = meanerror rmserror modules outside
+customtitle = #CMS{Preliminary}
+customrighttitle = 2017A cosmics and collisions data
+legendheader = header
+bigtext = true
+
+[plots:split]
+outliercut = 0.95
+
+customtitle = #CMS{Preliminary}
+customrighttitle = 2017A 3.8T cosmics data
+legendheader = header
+
+[plots:zmumu]
+customtitle = #CMS{Preliminary}
+customrighttitle = 2016G Z#rightarrow#mu#mu data, |#eta|<2.4
+legendheader = header
+
+[validation]
+offline validation_MinBias : prompt
+offline validation_MinBias : express
+offline validation_cosmics : prompt
+offline validation_cosmics : express
+compare Tracker: prompt 278819, express 278819
+zmumu some_zmumu_validation : prompt
+zmumu some_zmumu_validation : express
+split some_split_validation : prompt
+split some_split_validation : express
+EOF
+
+validateAlignments.py -c validation_config.ini -N testing --dryRun || die "Failure running all-in-one test" $?

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -5,6 +5,10 @@ function die { echo $1: status $2 ; exit $2; }
 echo "TESTING Alignment/OfflineValidation ..."
 cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_OfflineValidation_cfg.py" $?
 
+if test -f "validation_config.ini"; then
+    rm -f validation_config.ini
+fi
+
 cat <<EOF >> validation_config.ini
 [general]
 jobmode = interactive
@@ -89,4 +93,4 @@ split some_split_validation : prompt
 split some_split_validation : express
 EOF
 
-validateAlignments.py -c validation_config.ini -N testing --dryRun || die "Failure running all-in-one test" $?
+validateAlignments.py -c validation_config.ini -N testingAllInOneTool --dryRun || die "Failure running all-in-one test" $?


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/27623  
(+ https://github.com/cms-sw/cmssw/pull/28739 and https://github.com/cms-sw/cmssw/pull/26999 and https://github.com/cms-sw/cmssw/pull/28767/commits/a3779a94bbf78a8c39fb909efe89ae1bfed1a309)

#### PR description:

As part of the Tracker Alignment preparation work for Run3 is expected to happen in the 10.6.X cycle, as the latest and greatest Data and MC samples for 2018 data will be available within the Run2 Ultra-Legacy production, we think it is advisable to have the possibility to submit alignment validation jobs from a 10.6.X release.  
This - at the moment - is not possible as the migration to the condor submission system has happened only in the 11.0.X cycle (via PR https://github.com/cms-sw/cmssw/pull/27623) and the tool in 10.6.X is still relying on the (decommmissioned) LSF submission system. 
This PR introduces that commit (eb3a91953da958250b41556fd16855194b4b1123) *verbatim* into 10.6.X.
We also profit of this PR to backport some other utilities such as the unit tests for the validation package (introduced at https://github.com/cms-sw/cmssw/pull/28739) and a fix to one of the example initialization files in commit https://github.com/cms-sw/cmssw/commit/3f35f199c9e70287da261ac9f7872c05dc64377d.

#### PR validation:
Relies on the unit tests introduced in this PR

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-sw/cmssw/pull/27623  + https://github.com/cms-sw/cmssw/pull/26999 + https://github.com/cms-sw/cmssw/pull/28739 and https://github.com/cms-sw/cmssw/pull/28767/commits/a3779a94bbf78a8c39fb909efe89ae1bfed1a309

cc: 
@connorpa @vbotta @adewit @henriettepetersen 