### PR TITLE
Made L1TStage1Layer2Producer a stream module

### DIFF
--- a/L1Trigger/L1TCalorimeter/interface/CaloConfigHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloConfigHelper.h
@@ -15,7 +15,7 @@ namespace l1t {
     CaloConfigHelper(const CaloConfig& db);
     CaloConfigHelper();
     void UpdatePayload(const CaloConfig* db) { db_ = db; }
-    unsigned fwv() { return db_->uconfig_[0]; }
+    unsigned fwv() const { return db_->uconfig_[0]; }
 
   private:
     const CaloConfig* db_;  // We do not own this pointer...

--- a/L1Trigger/L1TCalorimeter/interface/Cordic.h
+++ b/L1Trigger/L1TCalorimeter/interface/Cordic.h
@@ -9,14 +9,14 @@ public:
   Cordic(const uint32_t& aPhiScale, const uint32_t& aMagnitudeBits, const uint32_t& aSteps);
   virtual ~Cordic();
 
-  void operator()(int32_t aX, int32_t aY, int32_t& aPhi, uint32_t& aMagnitude);
+  void operator()(int32_t aX, int32_t aY, int32_t& aPhi, uint32_t& aMagnitude) const;
 
-  double NormalizePhi(const uint32_t& aPhi);
-  double NormalizeMagnitude(const uint32_t& aMagnitude);
-  int32_t IntegerizeMagnitude(const double& aMagnitude);
+  double NormalizePhi(const uint32_t& aPhi) const;
+  double NormalizeMagnitude(const uint32_t& aMagnitude) const;
+  int32_t IntegerizeMagnitude(const double& aMagnitude) const;
 
 private:
-  uint32_t tower(const double& aRadians);
+  uint32_t tower(const double& aRadians) const;
 
 private:
   uint32_t mPhiScale;

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage1Layer2Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage1Layer2Producer.cc
@@ -14,7 +14,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -65,7 +65,7 @@ using namespace l1t;
 // class declaration
 //
 
-class L1TStage1Layer2Producer : public EDProducer {
+class L1TStage1Layer2Producer : public stream::EDProducer<> {
 public:
   explicit L1TStage1Layer2Producer(const ParameterSet&);
   ~L1TStage1Layer2Producer() override;
@@ -74,10 +74,7 @@ public:
 
 private:
   void produce(Event&, EventSetup const&) override;
-  void beginJob() override;
-  void endJob() override;
   void beginRun(Run const& iR, EventSetup const& iE) override;
-  void endRun(Run const& iR, EventSetup const& iE) override;
 
   // ----------member data ---------------------------
   unsigned long long m_paramsCacheId;  // Cache-ID from current parameters, to check if needs to be updated.
@@ -92,8 +89,8 @@ private:
   std::string m_conditionsLabel;
 
   // to be extended with other "consumes" stuff
-  EDGetToken regionToken;
-  EDGetToken candsToken;
+  EDGetTokenT<BXVector<CaloRegion>> regionToken;
+  EDGetTokenT<BXVector<CaloEmCand>> candsToken;
 };
 
 //
@@ -242,12 +239,6 @@ void L1TStage1Layer2Producer::produce(Event& iEvent, const EventSetup& iSetup) {
   iEvent.put(std::move(hfCounts), "HFBitCounts");
 }
 
-// ------------ method called once each job just before starting event loop ------------
-void L1TStage1Layer2Producer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop ------------
-void L1TStage1Layer2Producer::endJob() {}
-
 // ------------ method called when starting to processes a run ------------
 
 void L1TStage1Layer2Producer::beginRun(Run const& iR, EventSetup const& iE) {
@@ -369,15 +360,15 @@ void L1TStage1Layer2Producer::beginRun(Run const& iR, EventSetup const& iE) {
   }
 }
 
-// ------------ method called when ending the processing of a run ------------
-void L1TStage1Layer2Producer::endRun(Run const& iR, EventSetup const& iE) {}
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void L1TStage1Layer2Producer::fillDescriptions(ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   ParameterSetDescription desc;
-  desc.setUnknown();
+  desc.add<InputTag>("CaloRegions");
+  desc.add<InputTag>("CaloEmCands");
+  desc.add<std::string>("conditionsLabel");
+
   descriptions.addDefault(desc);
 }
 

--- a/L1Trigger/L1TCalorimeter/src/CaloConfigHelper.cc
+++ b/L1Trigger/L1TCalorimeter/src/CaloConfigHelper.cc
@@ -10,7 +10,7 @@ namespace l1t {
   }
   CaloConfigHelper::CaloConfigHelper(const CaloConfig& db) : db_(&db) {}
   CaloConfigHelper::CaloConfigHelper() {
-    static CaloConfig db;
+    static const CaloConfig db;
     db_ = &db;
   }
 }  // namespace l1t

--- a/L1Trigger/L1TCalorimeter/src/firmware/Cordic.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Cordic.cc
@@ -25,15 +25,17 @@ Cordic::Cordic(const uint32_t& aPhiScale, const uint32_t& aMagnitudeBits, const 
 
 Cordic::~Cordic() {}
 
-double Cordic::NormalizePhi(const uint32_t& aPhi) { return double(aPhi) / double(mPhiScale); }
+double Cordic::NormalizePhi(const uint32_t& aPhi) const { return double(aPhi) / double(mPhiScale); }
 
-double Cordic::NormalizeMagnitude(const uint32_t& aMagnitude) { return double(aMagnitude) / double(mMagnitudeScale); }
+double Cordic::NormalizeMagnitude(const uint32_t& aMagnitude) const {
+  return double(aMagnitude) / double(mMagnitudeScale);
+}
 
-int32_t Cordic::IntegerizeMagnitude(const double& aMagnitude) { return int32_t(aMagnitude * mMagnitudeScale); }
+int32_t Cordic::IntegerizeMagnitude(const double& aMagnitude) const { return int32_t(aMagnitude * mMagnitudeScale); }
 
-uint32_t Cordic::tower(const double& aRadians) { return uint32_t(round(mPhiScale * 0.5 * aRadians / mPi)); }
+uint32_t Cordic::tower(const double& aRadians) const { return uint32_t(round(mPhiScale * 0.5 * aRadians / mPi)); }
 
-void Cordic::operator()(int32_t aX, int32_t aY, int32_t& aPhi, uint32_t& aMagnitude) {
+void Cordic::operator()(int32_t aX, int32_t aY, int32_t& aPhi, uint32_t& aMagnitude) const {
   bool lSign(true);
 
   switch (((aY >= 0) ? 0x0 : 0x2) | ((aX >= 0) ? 0x0 : 0x1)) {


### PR DESCRIPTION
#### PR description:

The module is used in integration build release validation test and was preventing the use of concurrent LuminosityBlock processing.

As part of this change, also improved const correctness of related classes as well as a few code modernizations of L1TStage1Layer2Producer.

#### PR validation:

The code compiles.