### PR TITLE
[Sim] Reduce a TruncTubs cutaway box to a reasonable size

### DIFF
--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -442,8 +442,8 @@ G4VSolid *DDG4SolidConverter::trunctubs(const DDSolid &solid) {
                                 << ' ' << startPhi / CLHEP::deg << ' ' << deltaPhi / CLHEP::deg;
   LogDebug("SimG4CoreGeometry") << solid;
   // length & hight of the box
-  double boxX(30. * rOut),
-      boxY(20. * rOut);  // exaggerate dimensions - does not matter, it's subtracted!
+  double boxX(rOut * std::sqrt(2) * 1.1),
+      boxY(rOut * std::sqrt(2) * 1.1);  // exaggerate dimensions - does not matter, it's subtracted!
 
   // width of the box > width of the tubs
   double boxZ(1.1 * zHalf);


### PR DESCRIPTION
#### PR description:

TruncTubs is a CMS-specific shape widely used in both CMS MagneticField geometry and CMS detector descriptions. It's defined as follows:

![41044065-a0689338-69a5-11e8-879c-90a69f9d9634](https://user-images.githubusercontent.com/1390682/76075270-fea53c00-5f9c-11ea-9d49-3d151091fa15.jpg)
![41044066-a0a6e48a-69a5-11e8-9c51-b5ef932542e5](https://user-images.githubusercontent.com/1390682/76075272-ffd66900-5f9c-11ea-8db3-fabd00ed8985.jpg)
![41044067-a0d71ed4-69a5-11e8-8437-67e72babc581](https://user-images.githubusercontent.com/1390682/76075273-ffd66900-5f9c-11ea-95e9-d9ccbc0f9ea6.jpg)

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
